### PR TITLE
Additional fix for initial run when configurator is first loaded

### DIFF
--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -304,7 +304,7 @@ function read_serial(info) {
 function sensor_status(sensors_detected) {
     // initialize variable (if it wasn't)
     if (!sensor_status.previous_sensors_detected) {
-        sensor_status.previous_sensors_detected = 0;
+        sensor_status.previous_sensors_detected = -1; // Otherwise first iteration will not be run if sensors_detected == 0
     }
 
     // update UI (if necessary)
@@ -326,7 +326,7 @@ function sensor_status(sensors_detected) {
         $('.accicon', e_sensor_status).removeClass('active');
     }
 
-    if (have_sensor(sensors_detected, 'gyro')) {
+    if (true) { // Gyro status is not reported by FC
         $('.gyro', e_sensor_status).addClass('on');
         $('.gyroicon', e_sensor_status).addClass('active');
     } else {
@@ -379,8 +379,6 @@ function have_sensor(sensors_detected, sensor_code) {
             return bit_check(sensors_detected, 3);
         case 'sonar':
             return bit_check(sensors_detected, 4);
-          case 'gyro':
-            return true; // Gyro status is never reported by FC
     }
     return false;
 }


### PR DESCRIPTION
An additional fix for the other PR. First time configurator is run it will not update sensor status if status 0 is reported.