### PR TITLE
disable stats

### DIFF
--- a/eventPage.js
+++ b/eventPage.js
@@ -14,10 +14,6 @@ function startApplication() {
             minHeight: 550
         }
     }, function (createdWindow) {
-        createdWindow.contentWindow.addEventListener('load', function () {
-            createdWindow.contentWindow.catch_startup_time(applicationStartTime);
-        });
-
         createdWindow.onClosed.addListener(function () {
             // automatically close the port when application closes
             // save connectionId in separate variable before createdWindow.contentWindow is destroyed

--- a/js/protocols/stm32.js
+++ b/js/protocols/stm32.js
@@ -163,8 +163,6 @@ STM32_protocol.prototype.initialize = function () {
             $('span.progressLabel').text('STM32 - timed out, programming: FAILED');
             self.progress_bar_e.addClass('invalid');
 
-            googleAnalytics.sendEvent('Flashing', 'Programming', 'timeout');
-
             // protocol got stuck, clear timer and disconnect
             GUI.interval_remove('STM32_timeout');
 
@@ -700,7 +698,6 @@ STM32_protocol.prototype.upload_procedure = function (step) {
                         if (verify) {
                             console.log('Programming: SUCCESSFUL');
                             $('span.progressLabel').text('Programming: SUCCESSFUL');
-                            googleAnalytics.sendEvent('Flashing', 'Programming', 'success');
 
                             // update progress bar
                             self.progress_bar_e.addClass('valid');
@@ -710,7 +707,6 @@ STM32_protocol.prototype.upload_procedure = function (step) {
                         } else {
                             console.log('Programming: FAILED');
                             $('span.progressLabel').text('Programming: FAILED');
-                            googleAnalytics.sendEvent('Flashing', 'Programming', 'fail');
 
                             // update progress bar
                             self.progress_bar_e.addClass('invalid');

--- a/js/protocols/stm32usbdfu.js
+++ b/js/protocols/stm32usbdfu.js
@@ -714,7 +714,6 @@ STM32DFU_protocol.prototype.upload_procedure = function (step) {
                         if (verify) {
                             console.log('Programming: SUCCESSFUL');
                             $('span.progressLabel').text('Programming: SUCCESSFUL');
-                            googleAnalytics.sendEvent('Flashing', 'Programming', 'success');
 
                             // update progress bar
                             self.progress_bar_e.addClass('valid');
@@ -724,7 +723,6 @@ STM32DFU_protocol.prototype.upload_procedure = function (step) {
                         } else {
                             console.log('Programming: FAILED');
                             $('span.progressLabel').text('Programming: FAILED');
-                            googleAnalytics.sendEvent('Flashing', 'Programming', 'fail');
 
                             // update progress bar
                             self.progress_bar_e.addClass('invalid');

--- a/js/serial.js
+++ b/js/serial.js
@@ -35,7 +35,6 @@ var serial = {
 
                 self.onReceiveError.addListener(function watch_for_on_receive_errors(info) {
                     console.error(info);
-                    googleAnalytics.sendException('Serial: ' + info.error, false);
 
                     switch (info.error) {
                         case 'system_error': // we might be able to recover from this one
@@ -45,13 +44,11 @@ var serial = {
                                         if (info) {
                                             if (!info.paused) {
                                                 console.log('SERIAL: Connection recovered from last onReceiveError');
-                                                googleAnalytics.sendException('Serial: onReceiveError - recovered', false);
 
                                                 self.failed = 0;
                                             } else {
                                                 console.log('SERIAL: Connection did not recover from last onReceiveError, disconnecting');
                                                 GUI.log('Unrecoverable <span style="color: red">failure</span> of serial connection, disconnecting...');
-                                                googleAnalytics.sendException('Serial: onReceiveError - unrecoverable', false);
 
                                                 if (GUI.connected_to || GUI.connecting_to) {
                                                     $('a.connect').click();
@@ -82,7 +79,6 @@ var serial = {
                                                 // assume unrecoverable, disconnect
                                                 console.log('SERIAL: Connection did not recover from ' + self.error + ' condition, disconnecting');
                                                 GUI.log('Unrecoverable <span style="color: red">failure</span> of serial connection, disconnecting...');
-                                                googleAnalytics.sendException('Serial: ' + self.error + ' - unrecoverable', false);
     
                                                 if (GUI.connected_to || GUI.connecting_to) {
                                                     $('a.connect').click();
@@ -92,7 +88,6 @@ var serial = {
                                             }
                                             else {
                                                 console.log('SERIAL: Connection recovered from ' + self.error + ' condition');
-                                                googleAnalytics.sendException('Serial: ' + self.error + ' - recovered', false);
                                             }
                                         }
                                     });
@@ -144,7 +139,6 @@ var serial = {
             } else {
                 self.openRequested = false;
                 console.log('SERIAL: Failed to open serial port');
-                googleAnalytics.sendException('Serial: FailedToOpen', false);
                 if (callback) callback(false);
             }
         });
@@ -173,7 +167,6 @@ var serial = {
                     console.log('SERIAL: Connection with ID: ' + self.connectionId + ' closed, Sent: ' + self.bytesSent + ' bytes, Received: ' + self.bytesReceived + ' bytes');
                 } else {
                     console.log('SERIAL: Failed to close connection with ID: ' + self.connectionId + ' closed, Sent: ' + self.bytesSent + ' bytes, Received: ' + self.bytesReceived + ' bytes');
-                    googleAnalytics.sendException('Serial: FailedToClose', false);
                 }
 
                 self.connectionId = false;

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -190,17 +190,14 @@ function onOpen(openInfo) {
 
                     MSP.send_message(MSP_codes.MSP_FC_VERSION, false, false, function () {
 
-                        googleAnalytics.sendEvent('Firmware', 'Variant', CONFIG.flightControllerIdentifier + ',' + CONFIG.flightControllerVersion);
                         GUI.log(chrome.i18n.getMessage('fcInfoReceived', [CONFIG.flightControllerIdentifier, CONFIG.flightControllerVersion]));
 
                         MSP.send_message(MSP_codes.MSP_BUILD_INFO, false, false, function () {
 
-                            googleAnalytics.sendEvent('Firmware', 'Using', CONFIG.buildInfo);
                             GUI.log(chrome.i18n.getMessage('buildInfoReceived', [CONFIG.buildInfo]));
 
                             MSP.send_message(MSP_codes.MSP_BOARD_INFO, false, false, function () {
 
-                                googleAnalytics.sendEvent('Board', 'Using', CONFIG.boardIdentifier + ',' + CONFIG.boardVersion);
                                 GUI.log(chrome.i18n.getMessage('boardInfoReceived', [CONFIG.boardIdentifier, CONFIG.boardVersion]));
 
                                 MSP.send_message(MSP_codes.MSP_UID, false, false, function () {

--- a/main.js
+++ b/main.js
@@ -1,13 +1,5 @@
 'use strict';
 
-// Google Analytics
-var googleAnalyticsService = analytics.getService('ice_cream_app');
-var googleAnalytics = googleAnalyticsService.getTracker(atob("VUEtNTI4MjA5MjAtMQ=="));
-var googleAnalyticsConfig = false;
-googleAnalyticsService.getConfig().addCallback(function (config) {
-    googleAnalyticsConfig = config;
-});
-
 $(document).ready(function () {
     // translate to user-selected language
     localize();
@@ -54,11 +46,6 @@ $(document).ready(function () {
     // it would seem the webgl "enabling" through advanced settings will be ignored in the future
     // and webgl will be supported if gpu supports it by default (canary 40.0.2175.0), keep an eye on this one
     var canvas = document.createElement('canvas');
-    if (window.WebGLRenderingContext && (canvas.getContext('webgl') || canvas.getContext('experimental-webgl'))) {
-        googleAnalytics.sendEvent('Capability', 'WebGL', 'true');
-    } else {
-        googleAnalytics.sendEvent('Capability', 'WebGL', 'false');
-    }
 
     // log library versions in console to make version tracking easier
     console.log('Libraries: jQuery - ' + $.fn.jquery + ', d3 - ' + d3.version + ', three.js - ' + THREE.REVISION);
@@ -194,8 +181,6 @@ $(document).ready(function () {
             el.after('<div id="options-window"></div>');
 
             $('div#options-window').load('./tabs/options.html', function () {
-                googleAnalytics.sendAppView('Options');
-
                 // translate to user-selected language
                 localize();
 
@@ -208,21 +193,17 @@ $(document).ready(function () {
 
                 $('div.notifications input').change(function () {
                     var check = $(this).is(':checked');
-                    googleAnalytics.sendEvent('Settings', 'Notifications', check);
 
                     chrome.storage.local.set({'update_notify': check});
                 });
 
                 // if tracking is enabled, check the statistics checkbox
-                if (googleAnalyticsConfig.isTrackingPermitted()) {
-                    $('div.statistics input').prop('checked', true);
-                }
-
-                $('div.statistics input').change(function () {
-                    var check = $(this).is(':checked');
-                    googleAnalytics.sendEvent('Settings', 'GoogleAnalytics', check);
-                    googleAnalyticsConfig.setTrackingPermitted(check);
-                });
+                //if (googleAnalyticsConfig.isTrackingPermitted()) {
+                //    $('div.statistics input').prop('checked', false);
+                //}
+                //$('div.statistics input').change(function () {
+                //    var check = $(this).is(':checked');
+                //});
 
                 function close_and_cleanup(e) {
                     if (e.type == 'click' && !$.contains($('div#options-window')[0], e.target) || e.type == 'keyup' && e.keyCode == 27) {
@@ -356,13 +337,6 @@ $(document).ready(function () {
         });
     });
 });
-
-function catch_startup_time(startTime) {
-    var endTime = new Date().getTime(),
-        timeSpent = endTime - startTime;
-
-    googleAnalytics.sendTiming('Load Times', 'Application Startup', timeSpent);
-}
 
 function microtime() {
     var now = new Date().getTime() / 1000;

--- a/manifest.json
+++ b/manifest.json
@@ -23,7 +23,6 @@
     },
          
         "permissions": [
-        "https://www.google-analytics.com/",
         "https://maps.googleapis.com/*",    
         "https://*.github.com/",
         "https://*.githubusercontent.com/",

--- a/tabs/adjustments.js
+++ b/tabs/adjustments.js
@@ -5,7 +5,6 @@ TABS.adjustments = {};
 TABS.adjustments.initialize = function (callback) {
     GUI.active_tab_ref = this;
     GUI.active_tab = 'adjustments';
-    googleAnalytics.sendAppView('Adjustments');
     
     function get_adjustment_ranges() {
         MSP.send_message(MSP_codes.MSP_ADJUSTMENT_RANGES, false, false, get_box_ids);

--- a/tabs/auxiliary.js
+++ b/tabs/auxiliary.js
@@ -5,7 +5,6 @@ TABS.auxiliary = {};
 TABS.auxiliary.initialize = function (callback) {
     GUI.active_tab_ref = this;
     GUI.active_tab = 'auxiliary';
-    googleAnalytics.sendAppView('Auxiliary');
     
     function get_mode_ranges() {
         MSP.send_message(MSP_codes.MSP_MODE_RANGES, false, false, get_box_ids);

--- a/tabs/cli.js
+++ b/tabs/cli.js
@@ -11,7 +11,6 @@ TABS.cli.initialize = function (callback) {
 
     if (GUI.active_tab != 'cli') {
         GUI.active_tab = 'cli';
-        googleAnalytics.sendAppView('CLI');
     }
     
     $('#content').load("./tabs/cli.html", function () {

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -7,7 +7,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     if (GUI.active_tab != 'configuration') {
         GUI.active_tab = 'configuration';
-        googleAnalytics.sendAppView('Configuration');
     }
 
     function load_config() {
@@ -499,19 +498,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             SENSOR_ALIGNMENT.align_gyro = parseInt(orientation_gyro_e.val());
             SENSOR_ALIGNMENT.align_acc = parseInt(orientation_acc_e.val());
             SENSOR_ALIGNMENT.align_mag = parseInt(orientation_mag_e.val());
-
-            // track feature usage
-            if (isFeatureEnabled('RX_SERIAL')) {
-                googleAnalytics.sendEvent('Setting', 'SerialRxProvider', serialRXtypes[BF_CONFIG.serialrx_type]);
-            }
-            
-            for (var i = 0; i < features.length; i++) {
-                var featureName = features[i].name;
-                if (isFeatureEnabled(featureName)) {
-                    googleAnalytics.sendEvent('Setting', 'Feature', featureName);
-                }
-            }
-
 
             function save_serial_config() {
                 if (semver.lt(CONFIG.apiVersion, "1.6.0")) {

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -7,7 +7,6 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
 
     if (GUI.active_tab != 'failsafe') {
         GUI.active_tab = 'failsafe';
-        googleAnalytics.sendAppView('Failsafe');
     }
 
     function load_rx_config() {

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -6,7 +6,6 @@ TABS.firmware_flasher.initialize = function (callback) {
 
     if (GUI.active_tab != 'firmware_flasher') {
         GUI.active_tab = 'firmware_flasher';
-        googleAnalytics.sendAppView('Firmware Flasher');
     }
 
 
@@ -194,7 +193,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                                     parsed_hex = data;
 
                                     if (parsed_hex) {
-                                        googleAnalytics.sendEvent('Flashing', 'Firmware', 'local');
                                         $('a.flash_firmware').removeClass('disabled');
 
                                         $('span.progressLabel').text('Loaded Local Firmware: (' + parsed_hex.bytes_total + ' bytes)');
@@ -239,7 +237,6 @@ TABS.firmware_flasher.initialize = function (callback) {
                     if (parsed_hex) {
                         var url;
 
-                        googleAnalytics.sendEvent('Flashing', 'Firmware', 'online');
                         $('span.progressLabel').html('<a class="save_firmware" href="#" title="Save Firmware">Loaded Online Firmware: (' + parsed_hex.bytes_total + ' bytes)</a>');
 
                         $('a.flash_firmware').removeClass('disabled');

--- a/tabs/gps.js
+++ b/tabs/gps.js
@@ -6,7 +6,6 @@ TABS.gps.initialize = function (callback) {
 
     if (GUI.active_tab != 'gps') {
         GUI.active_tab = 'gps';
-        googleAnalytics.sendAppView('GPS');
     }
 
     function load_html() {

--- a/tabs/help.js
+++ b/tabs/help.js
@@ -6,7 +6,6 @@ TABS.help.initialize = function (callback) {
 
     if (GUI.active_tab != 'help') {
         GUI.active_tab = 'help';
-        googleAnalytics.sendAppView('help');
     }
 
     $('#content').load("./tabs/help.html", function () {

--- a/tabs/landing.js
+++ b/tabs/landing.js
@@ -6,7 +6,6 @@ TABS.landing.initialize = function (callback) {
 
     if (GUI.active_tab != 'landing') {
         GUI.active_tab = 'landing';
-        googleAnalytics.sendAppView('Landing');
     }
 
     $('#content').load("./tabs/landing.html", function () {
@@ -15,10 +14,6 @@ TABS.landing.initialize = function (callback) {
 
         // load changelog content
         $('#changelog .log').load('./changelog.html');
-
-        $('div.welcome a, div.sponsors a').click(function () {
-            googleAnalytics.sendEvent('ExternalUrls', 'Click', $(this).prop('href'));
-        });
 
         /** changelog trigger **/
         $("#changelog_toggle").on('click', function() {

--- a/tabs/led_strip.js
+++ b/tabs/led_strip.js
@@ -13,7 +13,6 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
     if (GUI.active_tab != 'led_strip') {
         GUI.active_tab = 'led_strip';
-        googleAnalytics.sendAppView('LED Strip');
     }
 
     function load_led_config() {

--- a/tabs/logging.js
+++ b/tabs/logging.js
@@ -6,7 +6,6 @@ TABS.logging.initialize = function (callback) {
 
     if (GUI.active_tab != 'logging') {
         GUI.active_tab = 'logging';
-        googleAnalytics.sendAppView('Logging');
     }
 
     var requested_properties = [],

--- a/tabs/modes.js
+++ b/tabs/modes.js
@@ -8,7 +8,6 @@ TABS.modes.initialize = function (callback) {
 
     if (GUI.active_tab != 'modes') {
         GUI.active_tab = 'modes';
-        googleAnalytics.sendAppView('Modes');
     }
 
     function get_box_data() {

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -14,7 +14,6 @@ TABS.motors.initialize = function (callback) {
     
     if (GUI.active_tab != 'motors') {
         GUI.active_tab = 'motors';
-        googleAnalytics.sendAppView('Motors');
     }
 
     function get_arm_status() {

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -13,7 +13,6 @@ TABS.onboard_logging.initialize = function (callback) {
 
     if (GUI.active_tab != 'onboard_logging') {
         GUI.active_tab = 'onboard_logging';
-        googleAnalytics.sendAppView('onboard_logging');
     }
 
     if (CONFIGURATOR.connectionValid) {

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -9,7 +9,6 @@ TABS.pid_tuning.initialize = function (callback) {
 
     if (GUI.active_tab != 'pid_tuning') {
         GUI.active_tab = 'pid_tuning';
-        googleAnalytics.sendAppView('PID Tuning');
     }
 
     function get_pid_controller() {

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -72,7 +72,6 @@ TABS.ports.initialize = function (callback, scrollPosition) {
 
     if (GUI.active_tab != 'ports') {
         GUI.active_tab = 'ports';
-        googleAnalytics.sendAppView('Ports');
     }
 
     load_configuration_from_fc();

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -9,7 +9,6 @@ TABS.receiver.initialize = function (callback) {
 
     if (GUI.active_tab != 'receiver') {
         GUI.active_tab = 'receiver';
-        googleAnalytics.sendAppView('Receiver');
     }
 
     function get_misc_data() {

--- a/tabs/sensors.js
+++ b/tabs/sensors.js
@@ -6,7 +6,6 @@ TABS.sensors.initialize = function (callback) {
 
     if (GUI.active_tab != 'sensors') {
         GUI.active_tab = 'sensors';
-        googleAnalytics.sendAppView('Sensors');
     }
 
     function initSensorData(){

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -6,7 +6,6 @@ TABS.servos.initialize = function (callback) {
 
     if (GUI.active_tab != 'servos') {
         GUI.active_tab = 'servos';
-        googleAnalytics.sendAppView('Servos');
     }
 
     function get_servo_configurations() {

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -9,7 +9,6 @@ TABS.setup.initialize = function (callback) {
 
     if (GUI.active_tab != 'setup') {
         GUI.active_tab = 'setup';
-        googleAnalytics.sendAppView('Setup');
     }
 
     function load_status() {
@@ -139,7 +138,6 @@ TABS.setup.initialize = function (callback) {
             }
             configuration_backup(function () {
                 GUI.log(chrome.i18n.getMessage('initialSetupBackupSuccess'));
-                googleAnalytics.sendEvent('Configuration', 'Backup', 'true');
             });
         });
 
@@ -149,7 +147,6 @@ TABS.setup.initialize = function (callback) {
             }
             configuration_restore(function () {
                 GUI.log(chrome.i18n.getMessage('initialSetupRestoreSuccess'));
-                googleAnalytics.sendEvent('Configuration', 'Restore', 'true');
 
                 // get latest settings
                 TABS.setup.initialize();

--- a/tabs/transponder.js
+++ b/tabs/transponder.js
@@ -9,7 +9,6 @@ TABS.transponder.initialize = function (callback, scrollPosition) {
 
     if (GUI.active_tab != 'transponder') {
         GUI.active_tab = 'transponder';
-        googleAnalytics.sendAppView('Transponder');
     }
 
     // transponder supported added in MSP API Version 1.16.0


### PR DESCRIPTION
currently, we're using the cleanflight google analytics tracking id, but i dont think we want to send stats to some place we have no permission to view them :)

this has bugged me for a long time, but i don't think it's cool 1 person can see everyones hardware uuids. (also feature usage, computer properties, etc.) if we value privacy, we should merge this. alternatively, making these stats public would be fine as well.

![screen shot 2016-06-15 at 10 32 35 pm](https://cloud.githubusercontent.com/assets/399770/16106417/22d4f8e2-3349-11e6-86ca-661040b7bbe9.png)

i usually just remove the google analytics permission from my local copy, but this should fixup the issue for everyone.

if we do ever want (hopefully open) analytics, just `git revert` this commit and update the ga tracking id.

