### PR TITLE
Configuration page motor PWM protocal fix for V3.0

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -278,7 +278,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'ONESHOT42',
             'MULTISHOT'
         ];
-        
+
+        if (semver.gte(CONFIG.apiVersion, "1.17.0")) {
+            escprotocols.push('BRUSHED');
+        }
+
         var esc_protocol_e = $('select.escprotocol');
 
         for (var i = 0; i < escprotocols.length; i++) {


### PR DESCRIPTION
I brushed motors are selected in BF v3.0 and something is save from the configuration page the motor_pwm_protocol parameter is messed up in the FC. This update will fix this problem. Her is the related issue for BetaFlight: https://github.com/betaflight/betaflight/issues/563