### PR TITLE
Updated firmware flasher release update handling

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1459,7 +1459,9 @@
     "firmwareFlasherFailedToLoadOnlineFirmware": {
         "message": "Failed to load remote firmware"
     },
-
+    "firmwareFlasherHelpReleaseUpdate": {
+        "message": "The available releases are being updated once a day. The button \"Force Release update\" triggers the update manually"
+    },
     "ledStripHelp": {
         "message": "The flight controller can control colors and effects of individual LEDs on a strip. Configure LEDs on the grid, configure wiring order then attach LEDs on your aircraft according to grid positions. LEDs without wire ordering number will not be saved."
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1459,6 +1459,9 @@
     "firmwareFlasherHelpReleaseUpdate": {
         "message": "The available releases are being updated once a day. The button \"Force Release update\" triggers the update manually"
     },
+    "firmwareFlasherButtonUpdateReleasesList": {
+        "message": "Force Release update"
+    },
     "ledStripHelp": {
         "message": "The flight controller can control colors and effects of individual LEDs on a strip. Configure LEDs on the grid, configure wiring order then attach LEDs on your aircraft according to grid positions. LEDs without wire ordering number will not be saved."
     },
@@ -1694,10 +1697,10 @@
     },
       "PIDTip": {
         "message": "<b>Derivative from Error</b> provides more direct stick response and is mostly prefered for Racing.<br><br><b>Derivative from Measurement</b> provides smoother stick response what is more usefull for freestyling"
-    }  
-    
+    }
 
-    
-    
+
+
+
 
 }

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -9,9 +9,10 @@
                         </select></td>
                         <td>
                             <span class="description" i18n="firmwareFlasherOnlineReleasesDescription"></span>
-                            <div class="btn">
+                            <div class="btn small">
                                 <a class="updateReleasesList" href="#" i18n="firmwareFlasherButtonUpdateReleasesList"></a>
                             </div>
+                            <div class="helpicon cf_tip" i18n_title="firmwareFlasherHelpReleaseUpdate"></div>
                         </td>
                     </tr>
                     <tr>

--- a/tabs/firmware_flasher.html
+++ b/tabs/firmware_flasher.html
@@ -7,7 +7,6 @@
                         <td><select name="release">
                                 <option value="0">Loading ...</option>
                         </select></td>
-<<<<<<< HEAD
                         <td>
                             <span class="description" i18n="firmwareFlasherOnlineReleasesDescription"></span>
                             <div class="btn small">
@@ -15,9 +14,6 @@
                             </div>
                             <div class="helpicon cf_tip" i18n_title="firmwareFlasherHelpReleaseUpdate"></div>
                         </td>
-=======
-                        <td><span class="description" i18n="firmwareFlasherOnlineReleasesDescription"></span></td>
->>>>>>> upstream/master
                     </tr>
                     <tr>
                         <td><label> <input class="updating toggle" type="checkbox" /> <span
@@ -28,7 +24,7 @@
                     <tr class="option flash_on_connect_wrapper">
                         <td><label> <input class="flash_on_connect toggle" type="checkbox" /> <span
                                 i18n="firmwareFlasherFlashOnConnect"></span></label></td>
-                        
+
                         <td><span class="description" i18n="firmwareFlasherFlashOnConnectDescription"></span></td>
                     </tr>
                     <tr class="option">
@@ -111,7 +107,7 @@
                 <p i18n="firmwareFlasherRecoveryText"></p>
             </div>
         </div>
-            
+
         <div class="info"><a name="progressbar"></a>
             <progress class="progress" value="0" min="0" max="100"></progress>
             <span class="progressLabel" i18n="firmwareFlasherLoadFirmwareFile"></span>


### PR DESCRIPTION
Added caching for the releases list. This prevents hitting githubs API limits. Releases are automatically refreshed 24 hours after the last refresh. There is also a button (with tooltip) for a forced update