### PR TITLE
Added support for new rate curves.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -793,11 +793,8 @@
     "pidTuningFilterFrequency": {
         "message": "Frequency"
     },
-    "pidTuningRcCurve": {
-	"message": "RC Curve"
-    },
-    "pidTuningRcYawCurve": {
-	"message": "RC Yaw Curve"
+    "pidTuningRatesCurve": {
+	"message": "Rates"
     },
     "throttle": {
 	"message": "Throttle"
@@ -1575,6 +1572,12 @@
     },
     "pidTuningYaw": {
         "message": "Yaw (Hz)"
+    },
+    "pidTuningShowRatesWithSuperExpo": {
+        "message": "Show rates with SuperExpo"
+    },
+    "pidTuningRatesSuperExpoHelp": {
+        "message": "To enable SuperExpo, enable 'SUPEREXPO_RATES' in 'Other Features' on the 'Configuration' tab."
     },
     "configHelp2": {
         "message": "Arbitrary board rotation in degrees, to allow mounting it sideways / upside down / rotated etc. When running external sensors, use the sensor alignments (Gyro, Acc, Mag) to define sensor position independent from board orientation. "

--- a/tabs/pid_tuning.css
+++ b/tabs/pid_tuning.css
@@ -201,40 +201,7 @@
     border-top-right-radius: 3px;
 }
 
-.tab-pid_tuning .pitch_roll_curve {
-    margin: 0 4px 0px 0;
-    height: 100%;
-    border: 1px solid silver;
-    border-radius: 3px;
-    background-image: url(../images/paper.jpg);
-    background-size: 200%;
-    background-position: center;
-}
-
-.tab-pid_tuning .rc_yaw_curve {
-    float: right;
-    width: calc(100% - 2px); /* - ( "virtual" margin) */
-}
-
-.tab-pid_tuning .rc_yaw_curve th {
-    background-color: #828885;
-    padding: 4px;
-    border-left: 0px solid #ccc;
-    border-bottom: 1px solid #ccc;
-    font-weight: bold;
-    color: white;
-    text-align: left;
-}
-
-.tab-pid_tuning .rc_yaw_curve th:first-child {
-    border-top-left-radius: 3px;
-}
-
-.tab-pid_tuning .rc_yaw_curve th:last-child {
-    border-top-right-radius: 3px;
-}
-
-.tab-pid_tuning .yaw_curve {
+.tab-pid_tuning .rate_curve {
     margin: 0 4px 0px 0;
     height: 100%;
     border: 1px solid silver;

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -60,7 +60,7 @@
                         </tr>
                         <tr class="ROLL">
                             <!-- 0 -->
-                            <td></td>
+                            <td bgcolor="#FF8080"></td>
                             <td><input type="number" name="p" step="1" min="0" max="255" /></td>
                             <td><input type="number" name="i" step="1" min="0" max="255" /></td>
                             <td><input type="number" name="d" step="1" min="0" max="255" /></td>
@@ -77,7 +77,7 @@
                         </tr>
                         <tr class="PITCH">
                             <!-- 1 -->
-                            <td></td>
+                            <td bgcolor="#80FF80"></td>
                             <td><input type="number" name="p" step="1" min="0" max="255" /></td>
                             <td><input type="number" name="i" step="1" min="0" max="255" /></td>
                             <td><input type="number" name="d" step="1" min="0" max="255" /></td>
@@ -85,7 +85,7 @@
                         </tr>
                         <tr class="YAW">
                             <!-- 2 -->
-                            <td></td>
+                            <td bgcolor="#8080FF"></td>
                             <td><input type="number" name="p" step="1" min="0" max="255" /></td>
                             <td><input type="number" name="i" step="1" min="0" max="255" /></td>
                             <td><input type="number" name="d" step="1" min="0" max="255" /></td>
@@ -221,73 +221,76 @@
                         </tr>
                     </table>
                 </div>
-                <div class="cf_column half topspacer">
-                    <div>
-                        <table class="rc_curve cf">
-                            <thead>
-                                <tr>
-                                    <th i18n="pidTuningRcCurve"></th>
-                                </tr>
-                            </thead>
-                            </tbody>
+                <div class="gui_box grey topspacer">
+                    <table class="pid_titlebar">
+                        <thead>
                             <tr>
-                                <td>
-                                    <div class="spacer" style="margin-top: 10px; margin-bottom: 10px;">
-                                        <div class="pitch_roll_curve">
-                                            <canvas height="120px" style="width: 100%; height: 100%"></canvas>
-                                        </div>
+                                <th i18n="pidTuningRatesPreview"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td class="rates_preview_cell">
+                                    <div class="rates_preview">
+                                        <canvas id="canvas"></canvas>
                                     </div>
                                 </td>
                             </tr>
-                            </tbody>
-                        </table>
-                        <div class="clear-both"></div>
-                    </div>
-                    <div class="topspacer">
-                        <table class="rc_yaw_curve cf">
-                            <thead>
-                                <tr>
-                                    <th i18n="pidTuningRcYawCurve"></th>
-                                </tr>
-                            </thead>
-                            </tbody>
-                            <tr>
-                                <td>
-                                    <div class="spacer" style="margin-top: 10px; margin-bottom: 10px;">
-                                        <div class="yaw_curve">
-                                            <canvas height="120px" style="width: 100%; height: 100%"></canvas>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                            </tbody>
-                        </table>
-                        <div class="clear-both"></div>
-                    </div>
-                </div>
-                <div class="cf_column half topspacer">
-                    <div class="spacer_left">
-                        <table class="tpa cf">
-                            <thead>
-                                <tr>
-                                    <th i18n="pidTuningRatesPreview" style="font-weight: bold;"></th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td class="rates_preview_cell">
-                                        <div class="rates_preview">
-                                            <canvas id="canvas"></canvas>
-                                        </div>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
+                        </tbody>
+                    </table>
                 </div>
             </div>
             <div class="cf_column third_right">
-                <div class="spacer_left throttle">
+                <div class="spacer_left rc_curve">
+                    <table class="cf">
+                        <thead>
+                            <tr>
+                                <th i18n="pidTuningRatesCurve"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td>
+                                    <div class="spacer" style="margin-top: 10px; margin-bottom: 10px;">
+                                        <div class="rate_curve">
+                                            <canvas height="120px" style="width: 100%; height: 100%"></canvas>
+                                        </div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <div class="checkbox super_expo_checkbox">
+                                        <div style="float: left; margin-right: 5px; margin-left: 3px; margin-bottom: 5px;">
+                                            <input type="checkbox" name="show_superexpo_rates" class="toggle" />
+                                        </div>
+                                        <label for="showSuperExpoRates">
+                                            <span i18n="pidTuningShowRatesWithSuperExpo"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRatesSuperExpoHelp"></div>
+                                    </div>
+                                </td>
+			    </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="spacer_left topspacer throttle">
+                    <table class="cf">
+                        <thead>
+                            <tr>
+                                <th i18n="receiverThrottleMid"></th>
+                                <th i18n="receiverThrottleExpo"></th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr>
+                                <td><input type="number" name="mid" step="0.01" min="0" max="1" /></td>
+                                <td><input type="number" name="expo" step="0.01" min="0" max="1" /></td>
+                            </tr>
+                        </tbody>
+                    </table>
+                </div>
+                <div class="spacer_left topspacer throttle">
                     <table class="cf">
                         <thead>
                             <tr>
@@ -307,24 +310,8 @@
                         </tbody>
                     </table>
                 </div>
-                <div class="spacer_left topspacer throttle">
-                    <table class="tpa cf">
-                        <thead>
-                            <tr>
-                                <th i18n="receiverThrottleMid"></th>
-                                <th i18n="receiverThrottleExpo"></th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td><input type="number" name="mid" step="0.01" min="0" max="1" /></td>
-                                <td><input type="number" name="expo" step="0.01" min="0" max="1" /></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </div>
-                <div class="spacer_left topspacer">
-                    <table class="tpa cf">
+                <div class="spacer_left topspacer tpa">
+                    <table class="cf">
                         <thead>
                             <tr>
                                 <th i18n="pidTuningTPA"></th>


### PR DESCRIPTION
This is the first version of the new rate curve graph (switchable with the old cleanflight rates graph, dependant on firmware version). It also combines the pitch / roll / yaw curves into one diagram and color codes them.
Thanks a lot to @GaryKeeble, who provided the code for the new rate curves in #58.

This is the first version, it should be good enough for release to users. There is a bunch of improvements that I want to do when I get time:
- find better colour scheme to illustrate the association between axes and graphs (@skaman82, help appreciated);
- make graphs scale relative to each other (currently they all autoscale to fill the diagram, so relative rates are not really visible)
- show deg/second for min / max stick position (outside of graph)

I am also thinking of tying the 'Show with SuperExpo rates' slider to the SuperExpo Feature, but I am not sure if moving that feature from the config tab into the PID tab is the right thing to do. As an alternative, the slider could be made read only, and dependant on if the feature is enabled or not. Or we could leave it as it is now. What are your thoughts, @borisbstyle?