### PR TITLE
Moved switching of 'FEATURE_SUPEREXPO_RATES' to PID tab.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -530,7 +530,10 @@
         "message": "Configure via the Race Transponder tab after enabling."
     },
     "featureSUPEREXPO_RATES": {
-        "message": "Rate value adds instead of rate also Super Expo. Mid stick stays same. Rc rate is always linear"
+        "message": "Use Super Expo rates curve"
+    },
+    "featureSUPEREXPO_RATESTip": {
+        "message": "Rate value adds instead of rate also Super Expo. Mid stick stays same. Rc rate is always linear. You can modify this setting in the PID tuning tab."
     },
     "featureAIRMODE": {
         "message": "Airmode always enabled!"
@@ -1597,11 +1600,11 @@
     "pidTuningYaw": {
         "message": "Yaw (Hz)"
     },
-    "pidTuningShowRatesWithSuperExpo": {
-        "message": "Show rates with SuperExpo"
+    "pidTuningSuperExpo": {
+        "message": "Enable SuperExpo"
     },
     "pidTuningRatesSuperExpoHelp": {
-        "message": "To enable SuperExpo, enable 'SUPEREXPO_RATES' in 'Other Features' on the 'Configuration' tab."
+        "message": "This setting controls the feature 'SUPEREXPO_RATES'"
     },
     "configHelp2": {
         "message": "Arbitrary board rotation in degrees, to allow mounting it sideways / upside down / rotated etc. When running external sensors, use the sensor alignments (Gyro, Acc, Mag) to define sensor position independent from board orientation. "

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -157,10 +157,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             );
         }
 
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.0")) {
+        if (CONFIG.flightControllerIdentifier === "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.0")) {
              features.push(
                 {bit: 22, group: 'other', name: 'AIRMODE'},
-                {bit: 23, group: 'other', name: 'SUPEREXPO_RATES'}
+                {bit: 23, group: 'other', mode: 'readonly', name: 'SUPEREXPO_RATES', haveTip: true}
             );
         }
 
@@ -201,13 +201,20 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                         + feature_tip_html + '</td></tr>');
                 radioGroups.push(features[i].group);
             } else {
+                var readonlyModifier = '';
+                if (features[i].mode === 'readonly') {
+                    readonlyModifier = ' readonly';
+                }
+
                 row_e = $('<tr><td><input class="feature toggle"'
                         + i
                         + '" name="'
                         + features[i].name
                         + '" title="'
                         + features[i].name
-                        + '" type="checkbox"/></td><td><label for="feature-'
+                        + '" type="checkbox"'
+			+ readonlyModifier
+                        + '/></td><td><label for="feature-'
                         + i
                         + '">'
                         + features[i].name

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -62,6 +62,19 @@
                                 </div>
                             </th>
                         </tr>
+                            <tr class="new_rates">
+                                <td colspan=7>
+                                    <div class="checkbox super_expo_checkbox"  style="margin-top: 10px;">
+                                        <div style="float: left; margin-right: 5px; margin-left: 3px; margin-bottom: 5px;">
+                                            <input type="checkbox" name="show_superexpo_rates" class="toggle" />
+                                        </div>
+                                        <label for="showSuperExpoRates">
+                                            <span i18n="pidTuningSuperExpo"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRatesSuperExpoHelp"></div>
+                                    </div>
+                                </td>
+			    </tr>
                         <tr class="ROLL">
                             <!-- 0 -->
                             <td bgcolor="#FF8080"></td>
@@ -282,19 +295,6 @@
 				    <td i18n="pidTuningMaxAngularVelYaw"></td>
 				    <td class="maxAngularVelYaw"></td>
                             </tr>
-                            <tr class="new_rates">
-                                <td colspan=2>
-                                    <div class="checkbox super_expo_checkbox"  style="margin-top: 10px;">
-                                        <div style="float: left; margin-right: 5px; margin-left: 3px; margin-bottom: 5px;">
-                                            <input type="checkbox" name="show_superexpo_rates" class="toggle" />
-                                        </div>
-                                        <label for="showSuperExpoRates">
-                                            <span i18n="pidTuningShowRatesWithSuperExpo"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningRatesSuperExpoHelp"></div>
-                                    </div>
-                                </td>
-			    </tr>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
I've left the feature in the list in the Config tab, but made it readonly, and added a hint to it stating that it can be changed in the PID tab. This way, existing users will not be confounded because they can't find it where it used to be.