### PR TITLE
Refactor version checks

### DIFF
--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -23,12 +23,12 @@ function configuration_backup(callback) {
     ];
 
     function update_profile_specific_data_list() {
-        if (semver.lt(CONFIG.apiVersion, "1.12.0")) {
+        if (!FC.apiVersion.gte('1.12.0')) {
             profileSpecificData.push(MSP_codes.MSP_CHANNEL_FORWARDING);
-         } else {            
+        } else {
             profileSpecificData.push(MSP_codes.MSP_SERVO_MIX_RULES);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (FC.apiVersion.gte('1.15.0')) {
             profileSpecificData.push(MSP_codes.MSP_RC_DEADBAND);
         }
     }
@@ -71,7 +71,7 @@ function configuration_backup(callback) {
                             'AdjustmentRanges': jQuery.extend(true, [], ADJUSTMENT_RANGES)
                         });
 
-                        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                        if (FC.apiVersion.gte('1.15.0')) {
                             configuration.profiles[fetchingProfile].RCdeadband = jQuery.extend(true, {}, RC_deadband);
                         }
                         codeKey = 0;
@@ -98,14 +98,14 @@ function configuration_backup(callback) {
     ];
 
     function update_unique_data_list() {
-        if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+        if (FC.apiVersion.gte('1.8.0')) {
             uniqueData.push(MSP_codes.MSP_LOOP_TIME);
             uniqueData.push(MSP_codes.MSP_ARMING_CONFIG);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
+        if (FC.apiVersion.gte('1.14.0')) {
             uniqueData.push(MSP_codes.MSP_3D);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (FC.apiVersion.gte('1.15.0')) {
             uniqueData.push(MSP_codes.MSP_SENSOR_ALIGNMENT);
             uniqueData.push(MSP_codes.MSP_RX_CONFIG);
             uniqueData.push(MSP_codes.MSP_FAILSAFE_CONFIG);
@@ -130,15 +130,15 @@ function configuration_backup(callback) {
                 configuration.BF_CONFIG = jQuery.extend(true, {}, BF_CONFIG);
                 configuration.SERIAL_CONFIG = jQuery.extend(true, {}, SERIAL_CONFIG);
                 configuration.LED_STRIP = jQuery.extend(true, [], LED_STRIP);
-                
-                if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+
+                if (FC.apiVersion.gte('1.8.0')) {
                     configuration.FC_CONFIG = jQuery.extend(true, {}, FC_CONFIG);
                     configuration.ARMING_CONFIG = jQuery.extend(true, {}, ARMING_CONFIG);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
+                if (FC.apiVersion.gte('1.14.0')) {
                     configuration._3D = jQuery.extend(true, {}, _3D);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                if (FC.apiVersion.gte('1.15.0')) {
                     configuration.SENSOR_ALIGNMENT = jQuery.extend(true, {}, SENSOR_ALIGNMENT);
                     configuration.RX_CONFIG = jQuery.extend(true, {}, RX_CONFIG);
                     configuration.FAILSAFE_CONFIG = jQuery.extend(true, {}, FAILSAFE_CONFIG);
@@ -495,8 +495,8 @@ function configuration_restore(callback) {
 
             appliedMigrationsCount++;
         }
-        
-        if (semver.lt(configuration.apiVersion, '1.14.0') && semver.gte(CONFIG.apiVersion, "1.14.0")) {
+
+        if (semver.lt(configuration.apiVersion, '1.14.0') && FC.apiVersion.gte('1.14.0')) {
             // api 1.14 removed old pid controllers
             for (var profileIndex = 0; profileIndex < configuration.profiles.length; profileIndex++) {
                 var newPidControllerIndex = configuration.profiles[profileIndex].PID.controller;
@@ -622,7 +622,7 @@ function configuration_restore(callback) {
                 MSP_codes.MSP_SET_ACC_TRIM
             ];
 
-            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+            if (FC.apiVersion.gte('1.15.0')) {
                 profileSpecificData.push(MSP_codes.MSP_SET_RC_DEADBAND);
             }
 
@@ -709,22 +709,22 @@ function configuration_restore(callback) {
                     MSP_codes.MSP_SET_BF_CONFIG,
                     MSP_codes.MSP_SET_CF_SERIAL_CONFIG
                 ];
-                
+
                 function update_unique_data_list() {
-                    if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+                    if (FC.apiVersion.gte('1.8.0')) {
                         uniqueData.push(MSP_codes.MSP_SET_LOOP_TIME);
                         uniqueData.push(MSP_codes.MSP_SET_ARMING_CONFIG);
                     }
-                    if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
+                    if (FC.apiVersion.gte('1.14.0')) {
                         uniqueData.push(MSP_codes.MSP_SET_3D);
                     }
-                    if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                    if (FC.apiVersion.gte('1.15.0')) {
                         uniqueData.push(MSP_codes.MSP_SET_SENSOR_ALIGNMENT);
                         uniqueData.push(MSP_codes.MSP_SET_RX_CONFIG);
                         uniqueData.push(MSP_codes.MSP_SET_FAILSAFE_CONFIG);
                     }
                 }
-                
+
                 function load_objects() {
                     MISC = configuration.MISC;
                     RC_MAP = configuration.RCMAP;
@@ -762,9 +762,9 @@ function configuration_restore(callback) {
             function send_led_strip_config() {
                 MSP.sendLedStripConfig(send_rxfail_config);
             }
-            
+
             function send_rxfail_config() {
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                if (FC.apiVersion.gte('1.15.0')) {
                     MSP.sendRxFailConfig(save_to_eeprom);
                 } else {
                     save_to_eeprom();

--- a/js/fc.js
+++ b/js/fc.js
@@ -1,5 +1,24 @@
 'use strict';
 
+var VersionChecker = function (base_version) {
+    this.eq = function (candidate) { 
+        return semver.eq(base_version(), candidate);
+    };
+
+    this.gt = function (candidate) {
+        return semver.gt(base_version(), candidate);
+    };
+
+    this.gte = function (candidate) {
+        return semver.gte(base_version(), candidate);
+    };
+
+    this.between = function (candidate1, candidate2) {
+        return semver.gte(base_version(), candidate1) &&
+               semver.lte(base_version(), candidate2);
+    };
+};
+
 // define all the global variables that are uses to hold FC state
 var CONFIG;
 var BF_CONFIG;
@@ -42,6 +61,13 @@ var SPECIAL_PARAMETERS;
 var SENSOR_CONFIG;
 
 var FC = {
+    version:    new VersionChecker(function () { return CONFIG.flightControllerVersion; }),
+    apiVersion: new VersionChecker(function () { return CONFIG.apiVersion; }),
+    
+    isBetaFlight: function () {
+        return CONFIG.flightControllerIdentifier === 'BTFL';
+    },
+
     resetState: function() {
         CONFIG = {
             apiVersion:    "0.0.0",

--- a/js/msp.js
+++ b/js/msp.js
@@ -357,7 +357,7 @@ var MSP = {
                 var offset = 0;
                 RC_tuning.RC_RATE = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
                 RC_tuning.RC_EXPO = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
-                if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
+                if (!FC.apiVersion.gte('1.7.0')) {
                     RC_tuning.roll_pitch_rate = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
                     RC_tuning.pitch_rate = 0;
                     RC_tuning.roll_rate = 0;
@@ -370,13 +370,13 @@ var MSP = {
                 RC_tuning.dynamic_THR_PID = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
                 RC_tuning.throttle_MID = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
                 RC_tuning.throttle_EXPO = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
-                if (semver.gte(CONFIG.apiVersion, "1.7.0")) {
+                if (FC.apiVersion.gte('1.7.0')) {
                     RC_tuning.dynamic_THR_breakpoint = data.getUint16(offset, 1);
                     offset += 2;
                 } else {
                     RC_tuning.dynamic_THR_breakpoint = 0;
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
+                if (FC.apiVersion.gte('1.10.0')) {
                     RC_tuning.RC_YAW_EXPO = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
                 } else {
                     RC_tuning.RC_YAW_EXPO = 0;
@@ -424,13 +424,13 @@ var MSP = {
                 break;
             */
             case MSP_codes.MSP_ARMING_CONFIG:
-                if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+                if (FC.apiVersion.gte('1.8.0')) {
                     ARMING_CONFIG.auto_disarm_delay = data.getUint8(0, 1);
                     ARMING_CONFIG.disarm_kill_switch = data.getUint8(1);
                 }
                 break;
             case MSP_codes.MSP_LOOP_TIME:
-                if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+                if (FC.apiVersion.gte('1.8.0')) {
                     FC_CONFIG.loopTime = data.getInt16(0, 1);
                 }
                 break;
@@ -451,11 +451,11 @@ var MSP = {
                 MISC.gps_ubx_sbas = data.getInt8(offset++);
                 MISC.multiwiicurrentoutput = data.getUint8(offset++);
                 MISC.rssi_channel = data.getUint8(offset++);
-                MISC.placeholder2 = data.getUint8(offset++);                
-                if (semver.lt(CONFIG.apiVersion, "1.18.0"))
+                MISC.placeholder2 = data.getUint8(offset++);
+                if (!FC.apiVersion.gte('1.18.0'))
                     MISC.mag_declination = data.getInt16(offset, 1) / 10; // -1800-1800
                 else
-                    MISC.mag_declination = data.getInt16(offset, 1) / 100; // -18000-18000                
+                    MISC.mag_declination = data.getInt16(offset, 1) / 100; // -18000-18000
                 offset += 2;
                 MISC.vbatscale = data.getUint8(offset++, 1); // 10-200
                 MISC.vbatmincellvoltage = data.getUint8(offset++, 1) / 10; // 10-50
@@ -469,8 +469,8 @@ var MSP = {
                 _3D.deadband3d_high = data.getUint16(offset, 1);
                 offset += 2;
                 _3D.neutral3d = data.getUint16(offset, 1);
-                
-                if (semver.lt(CONFIG.apiVersion, "1.17.0")) {
+
+                if (!FC.apiVersion.gte('1.17.0')) {
                     offset += 2;
                     _3D.deadband3d_throttle = data.getUint16(offset, 1);
                 }
@@ -524,7 +524,7 @@ var MSP = {
             case MSP_codes.MSP_SERVO_CONFIGURATIONS:
                 SERVO_CONFIG = []; // empty the array as new data is coming in
 
-                if (semver.gte(CONFIG.apiVersion, "1.12.0")) {
+                if (FC.apiVersion.gte('1.12.0')) {
                     if (data.byteLength % 14 == 0) {
                         for (var i = 0; i < data.byteLength; i += 14) {
                             var arr = {
@@ -558,12 +558,12 @@ var MSP = {
                             SERVO_CONFIG.push(arr);
                         }
                     }
-                    
-                    if (semver.eq(CONFIG.apiVersion, '1.10.0')) {
+
+                    if (FC.apiVersion.eq('1.10.0')) {
                         // drop two unused servo configurations due to MSP rx buffer to small)
                         while (SERVO_CONFIG.length > 8) {
                             SERVO_CONFIG.pop();
-                        } 
+                        }
                     }
                 }
                 break;
@@ -736,8 +736,8 @@ var MSP = {
                 break;
 
             case MSP_codes.MSP_CF_SERIAL_CONFIG:
-                
-                if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+
+                if (!FC.apiVersion.gte('1.6.0')) {
                     SERIAL_CONFIG.ports = [];
                     var offset = 0;
                     var serialPortCount = (data.byteLength - (4 * 4)) / 2;
@@ -859,7 +859,7 @@ var MSP = {
                 offset++;
                 FAILSAFE_CONFIG.failsafe_throttle = data.getUint16(offset, 1);
                 offset += 2;
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                if (FC.apiVersion.gte('1.15.0')) {
                     FAILSAFE_CONFIG.failsafe_kill_switch = data.getUint8(offset, 1);
                     offset++;
                     FAILSAFE_CONFIG.failsafe_throttle_low_delay = data.getUint16(offset, 1);
@@ -901,7 +901,7 @@ var MSP = {
                 break;
 
             case MSP_codes.MSP_ADVANCED_TUNING:
-                if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.2")) {
+                if (FC.version.gte('2.8.2')) {
                     var offset = 0;
                     ADVANCED_TUNING.rollPitchItermIgnoreRate = data.getUint16(offset, 1);
                     offset += 2;
@@ -917,7 +917,7 @@ var MSP = {
             case MSP_codes.MSP_SPECIAL_PARAMETERS:
                 var offset = 0;
                 SPECIAL_PARAMETERS.RC_RATE_YAW = parseFloat((data.getUint8(offset++) / 100).toFixed(2));
-                if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.2")) {
+                if (FC.version.gte('2.8.2')) {
                     SPECIAL_PARAMETERS.airModeActivateThreshold = data.getUint16(offset, 1);
                     offset += 2;
                     SPECIAL_PARAMETERS.rcSmoothInterval = data.getUint8(offset++, 1)
@@ -1264,7 +1264,7 @@ MSP.crunch = function (code) {
         case MSP_codes.MSP_SET_RC_TUNING:
             buffer.push(Math.round(RC_tuning.RC_RATE * 100));
             buffer.push(Math.round(RC_tuning.RC_EXPO * 100));
-            if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
+            if (!FC.apiVersion.gte('1.7.0')) {
                 buffer.push(Math.round(RC_tuning.roll_pitch_rate * 100));
             } else {
                 buffer.push(Math.round(RC_tuning.roll_rate * 100));
@@ -1274,11 +1274,11 @@ MSP.crunch = function (code) {
             buffer.push(Math.round(RC_tuning.dynamic_THR_PID * 100));
             buffer.push(Math.round(RC_tuning.throttle_MID * 100));
             buffer.push(Math.round(RC_tuning.throttle_EXPO * 100));
-            if (semver.gte(CONFIG.apiVersion, "1.7.0")) {
+            if (FC.apiVersion.gte('1.7.0')) {
                 buffer.push(lowByte(RC_tuning.dynamic_THR_breakpoint));
                 buffer.push(highByte(RC_tuning.dynamic_THR_breakpoint));
             }
-            if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
+            if (FC.apiVersion.gte('1.10.0')) {
                 buffer.push(Math.round(RC_tuning.RC_YAW_EXPO * 100));
             }
             break;
@@ -1327,10 +1327,10 @@ MSP.crunch = function (code) {
             buffer.push(MISC.multiwiicurrentoutput);
             buffer.push(MISC.rssi_channel);
             buffer.push(MISC.placeholder2);
-            if (semver.lt(CONFIG.apiVersion, "1.18.0")) {
+            if (!FC.apiVersion.gte('1.18.0')) {
                 buffer.push(lowByte(Math.round(MISC.mag_declination * 10)));
                 buffer.push(highByte(Math.round(MISC.mag_declination * 10)));
-            } else {            
+            } else {
                 buffer.push(lowByte(Math.round(MISC.mag_declination * 100)));
                 buffer.push(highByte(Math.round(MISC.mag_declination * 100)));
             }
@@ -1360,7 +1360,7 @@ MSP.crunch = function (code) {
             buffer.push(FAILSAFE_CONFIG.failsafe_off_delay);
             buffer.push(lowByte(FAILSAFE_CONFIG.failsafe_throttle));
             buffer.push(highByte(FAILSAFE_CONFIG.failsafe_throttle));
-            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+            if (FC.apiVersion.gte('1.15.0')) {
                 buffer.push(FAILSAFE_CONFIG.failsafe_kill_switch);
                 buffer.push(lowByte(FAILSAFE_CONFIG.failsafe_throttle_low_delay));
                 buffer.push(highByte(FAILSAFE_CONFIG.failsafe_throttle_low_delay));
@@ -1384,7 +1384,7 @@ MSP.crunch = function (code) {
             }
             break;
         case MSP_codes.MSP_SET_CF_SERIAL_CONFIG:
-            if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+            if (!FC.apiVersion.gte('1.6.0')) {
 
                 for (var i = 0; i < SERIAL_CONFIG.ports.length; i++) {
                     buffer.push(SERIAL_CONFIG.ports[i].scenario);
@@ -1433,7 +1433,7 @@ MSP.crunch = function (code) {
             buffer.push(highByte(_3D.deadband3d_high));
             buffer.push(lowByte(_3D.neutral3d));
             buffer.push(highByte(_3D.neutral3d));
-            if (semver.lt(CONFIG.apiVersion, "1.17.0")) {
+            if (!FC.apiVersion.gte('1.17.0')) {
                 buffer.push(lowByte(_3D.deadband3d_throttle));
                 buffer.push(highByte(_3D.deadband3d_throttle));
             }
@@ -1464,7 +1464,7 @@ MSP.crunch = function (code) {
               .push16(FILTER_CONFIG.yaw_lpf_hz);
             break;
         case MSP_codes.MSP_SET_ADVANCED_TUNING:
-            if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.2")) {
+            if (FC.version.gte('2.8.2')) {
                 buffer.push16(ADVANCED_TUNING.rollPitchItermIgnoreRate)
                 .push16(ADVANCED_TUNING.yawItermIgnoreRate)
                 .push16(ADVANCED_TUNING.yaw_p_limit)
@@ -1474,7 +1474,7 @@ MSP.crunch = function (code) {
             break;
         case MSP_codes.MSP_SET_SPECIAL_PARAMETERS:
             buffer.push(Math.round(SPECIAL_PARAMETERS.RC_RATE_YAW * 100));
-            if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.2")) {
+            if (FC.version.gte('2.8.2')) {
                 buffer.push16(SPECIAL_PARAMETERS.airModeActivateThreshold);
                 buffer.push(SPECIAL_PARAMETERS.rcSmoothInterval);
                 buffer.push16(SPECIAL_PARAMETERS.escDesyncProtection);
@@ -1561,10 +1561,10 @@ MSP.sendServoConfigurations = function(onCompleteCallback) {
 
 
     function send_next_servo_configuration() {
-        
+
         var buffer = [];
 
-        if (semver.lt(CONFIG.apiVersion, "1.12.0")) {
+        if (!FC.apiVersion.gte('1.12.0')) {
             // send all in one go
             // 1.9.0 had a bug where the MSP input buffer was too small, limit to 8.
             for (var i = 0; i < SERVO_CONFIG.length && i < 8; i++) {

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -184,7 +184,7 @@ function onOpen(openInfo) {
         MSP.send_message(MSP_codes.MSP_API_VERSION, false, false, function () {
             GUI.log(chrome.i18n.getMessage('apiVersionReceived', [CONFIG.apiVersion]));
 
-            if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.apiVersionAccepted)) {
+            if (FC.apiVersion.gte(CONFIGURATOR.apiVersionAccepted)) {
 
                 MSP.send_message(MSP_codes.MSP_FC_VARIANT, false, false, function () {
 
@@ -206,11 +206,11 @@ function onOpen(openInfo) {
                                     // continue as usually
                                     CONFIGURATOR.connectionValid = true;
                                     GUI.allowedTabs = GUI.defaultAllowedTabsWhenConnected.slice();
-                                    if (semver.lt(CONFIG.apiVersion, "1.4.0")) {
+                                    if (!FC.apiVersion.gte('1.4.0')) {
                                         GUI.allowedTabs.splice(GUI.allowedTabs.indexOf('led_strip'), 1);
                                     }
 
-                                    GUI.canChangePidController = semver.gte(CONFIG.apiVersion, CONFIGURATOR.pidControllerChangeMinApiVersion);
+                                    GUI.canChangePidController = FC.apiVersion.gte(CONFIGURATOR.pidControllerChangeMinApiVersion)
 
                                     onConnect();
 

--- a/tabs/adjustments.js
+++ b/tabs/adjustments.js
@@ -64,11 +64,11 @@ TABS.adjustments.initialize = function (callback) {
         var functionListOptions = $(functionList).find('option');
         var availableFunctionCount = 13;
         
-        if (semver.gte(CONFIG.flightControllerVersion, '1.8.0')) {
+        if (FC.version.gte('1.8.0')) {
             availableFunctionCount += 2; // pitch and roll rate
-            if (semver.gte(CONFIG.flightControllerVersion, '1.9.0')) {
+            if (FC.version.gte('1.9.0')) {
                 availableFunctionCount += 6; // pitch p,i,d and roll p,i,d
-                if(semver.gte(CONFIG.apiVersion, "1.15.0")){
+                if(FC.apiVersion.gte('1.15.0')) {
                    availableFunctionCount += 18;
                 }
             }

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -15,7 +15,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_serial_config() {
         var next_callback = load_rc_map;
-        if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+        if (!FC.apiVersion.gte('1.6.0')) {
             MSP.send_message(MSP_codes.MSP_CF_SERIAL_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -29,23 +29,23 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     function load_misc() {
         MSP.send_message(MSP_codes.MSP_MISC, false, false, load_acc_trim);
     }
-    
+
     function load_acc_trim() {
         MSP.send_message(MSP_codes.MSP_ACC_TRIM, false, false, load_arming_config);
     }
 
     function load_arming_config() {
         var next_callback = load_loop_time;
-        if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+        if (FC.apiVersion.gte('1.8.0')) {
             MSP.send_message(MSP_codes.MSP_ARMING_CONFIG, false, false, next_callback);
         } else {
             next_callback();
         }
     }
-    
+
     function load_loop_time() {
         var next_callback = load_3d;
-        if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+        if (FC.apiVersion.gte('1.8.0')) {
             MSP.send_message(MSP_codes.MSP_LOOP_TIME, false, false, next_callback);
         } else {
             next_callback();
@@ -54,7 +54,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_3d() {
         var next_callback = esc_protocol;
-        if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
+        if (FC.apiVersion.gte('1.14.0')) {
             MSP.send_message(MSP_codes.MSP_3D, false, false, next_callback);
         } else {
             next_callback();
@@ -63,25 +63,25 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function esc_protocol() {
         var next_callback = sensor_config;
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.1")) {
+        if (FC.version.gte('2.8.1')) {
             MSP.send_message(MSP_codes.MSP_PID_ADVANCED_CONFIG, false, false, next_callback);
         } else {
             next_callback();
-        }        
+        }
     }
-    
+
     function sensor_config() {
         var next_callback = load_sensor_alignment;
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.2")) {
+        if (FC.version.gte('2.8.2')) {
             MSP.send_message(MSP_codes.MSP_SENSOR_CONFIG, false, false, next_callback);
         } else {
             next_callback();
         }
     }
-    
+
     function load_sensor_alignment() {
         var next_callback = load_advanced_tuning;
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (FC.apiVersion.gte('1.15.0')) {
             MSP.send_message(MSP_codes.MSP_SENSOR_ALIGNMENT, false, false, next_callback);
         } else {
             next_callback();
@@ -90,7 +90,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     
     function load_advanced_tuning() {
         var next_callback = load_html;
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.1")) {
+        if (FC.version.gte('2.8.1')) {
             MSP.send_message(MSP_codes.MSP_ADVANCED_TUNING, false, false, next_callback);
         } else {
             next_callback();
@@ -153,20 +153,20 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             {bit: 17, group: 'other', name: 'DISPLAY'},
             {bit: 19, group: 'other', name: 'BLACKBOX', haveTip: true}
         ];
-        
-        if (semver.gte(CONFIG.apiVersion, "1.12.0")) {
+
+        if (FC.apiVersion.gte('1.12.0')) {
             features.push(
                 {bit: 20, group: 'other', name: 'CHANNEL_FORWARDING'}
             );
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+        if (FC.apiVersion.gte('1.16.0')) {
             features.push(
                 {bit: 21, group: 'other', name: 'TRANSPONDER', haveTip: true}
             );
         }
 
-        if (CONFIG.flightControllerIdentifier === "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.0")) {
+        if (FC.version.gte('2.8.0')) {
              features.push(
                 {bit: 22, group: 'other', name: 'AIRMODE'}
             );
@@ -262,15 +262,15 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'CW 180° flip',
             'CW 270° flip'
         ];
-        
-        
-        
+
+
+
         var orientation_gyro_e = $('select.gyroalign');
         var orientation_acc_e = $('select.accalign');
         var orientation_mag_e = $('select.magalign');
-        
 
-        if (semver.lt(CONFIG.apiVersion, "1.15.0")) {
+
+        if (!FC.apiVersion.gte('1.15.0')) {
             $('.tab-configuration .sensoralignment').hide();
         } else {
             for (var i = 0; i < alignments.length; i++) {
@@ -282,17 +282,17 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             orientation_acc_e.val(SENSOR_ALIGNMENT.align_acc);
             orientation_mag_e.val(SENSOR_ALIGNMENT.align_mag);
         }
-        
-        // ESC protocols 
-        
+
+        // ESC protocols
+
         var escprotocols = [
             'PWM',
             'ONESHOT125',
             'ONESHOT42',
             'MULTISHOT'
         ];
-        
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "3.0.0")) {
+
+        if (FC.version.gte('3.0.0')) {
             escprotocols.push('BRUSHED');
         }
 
@@ -378,13 +378,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
 
         // Only show these sections for supported FW
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.lt(CONFIG.flightControllerVersion, "2.8.1")) {
+        if (!FC.version.gte('2.8.1')) {
             $('.selectProtocol').hide();
             $('.checkboxPwm').hide();
             $('.selectPidProcessDenom').hide();
         }
-        
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.lt(CONFIG.flightControllerVersion, "2.8.2")) {
+
+        if (!FC.version.gte('2.8.2')) {
             $('.hardwareSelection').hide();
         }
 
@@ -422,14 +422,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         });
 
         gps_protocol_e.val(MISC.gps_type);
-        
-        
+
+
         var gps_baudrate_e = $('select.gps_baudrate');
         for (var i = 0; i < gpsBaudRates.length; i++) {
             gps_baudrate_e.append('<option value="' + gpsBaudRates[i] + '">' + gpsBaudRates[i] + '</option>');
         }
-    
-        if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+
+        if (!FC.apiVersion.gte('1.6.0')) {
             gps_baudrate_e.change(function () {
                 SERIAL_CONFIG.gpsBaudRate = parseInt($(this).val());
             });
@@ -463,11 +463,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'XBUS_MODE_B_RJ01'
         ];
 
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (FC.apiVersion.gte('1.15.0')) {
             serialRXtypes.push('IBUS');
         }
 
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.6.0"))  {
+        if (FC.version.gte('2.6.0'))  {
             serialRXtypes.push('JETIEXBUS');
         }
 
@@ -500,11 +500,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         // fill magnetometer
         $('input[name="mag_declination"]').val(MISC.mag_declination.toFixed(2));
 
-        //fill motor disarm params and FC loop time        
-        if(semver.gte(CONFIG.apiVersion, "1.8.0")) {
+        //fill motor disarm params and FC loop time
+        if(FC.apiVersion.gte('1.8.0')) {
             $('input[name="autodisarmdelay"]').val(ARMING_CONFIG.auto_disarm_delay);
             $('input[name="disarmkillswitch"]').prop('checked', ARMING_CONFIG.disarm_kill_switch);
-            $('div.disarm').show();            
+            $('div.disarm').show();
             if(bit_check(BF_CONFIG.features, 4))//MOTOR_STOP
                 $('div.disarmdelay').show();
             else
@@ -532,13 +532,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[name="multiwiicurrentoutput"]').prop('checked', MISC.multiwiicurrentoutput);
 
         //fill 3D
-        if (semver.lt(CONFIG.apiVersion, "1.14.0")) {
+        if (!FC.apiVersion.gte('1.14.0')) {
             $('.tab-configuration .3d').hide();
         } else {
             $('input[name="3ddeadbandlow"]').val(_3D.deadband3d_low);
             $('input[name="3ddeadbandhigh"]').val(_3D.deadband3d_high);
             $('input[name="3dneutral"]').val(_3D.neutral3d);
-            if (semver.lt(CONFIG.apiVersion, "1.17.0")) {
+            if (!FC.apiVersion.gte('1.17.0')) {
                 $('input[name="3ddeadbandthrottle"]').val(_3D.deadband3d_throttle);
             } else {
                 $('.3ddeadbandthrottle').hide();
@@ -602,13 +602,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             CONFIG.accelerometerTrims[1] = parseInt($('input[name="roll"]').val());
             CONFIG.accelerometerTrims[0] = parseInt($('input[name="pitch"]').val());
             MISC.mag_declination = parseFloat($('input[name="mag_declination"]').val());
-            
+
             // motor disarm
-            if(semver.gte(CONFIG.apiVersion, "1.8.0")) {
+            if(FC.apiVersion.gte('1.8.0')) {
                 ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
                 ARMING_CONFIG.disarm_kill_switch = ~~$('input[name="disarmkillswitch"]').is(':checked'); // ~~ boolean to decimal conversion
             }
-            
+
             MISC.midrc = parseInt($('input[name="midrc"]').val());
             MISC.minthrottle = parseInt($('input[name="minthrottle"]').val());
             MISC.maxthrottle = parseInt($('input[name="maxthrottle"]').val());
@@ -626,7 +626,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             _3D.deadband3d_low = parseInt($('input[name="3ddeadbandlow"]').val());
             _3D.deadband3d_high = parseInt($('input[name="3ddeadbandhigh"]').val());
             _3D.neutral3d = parseInt($('input[name="3dneutral"]').val());
-            if (semver.lt(CONFIG.apiVersion, "1.17.0")) {
+            if (!FC.apiVersion.gte('1.17.0')) {
                 _3D.deadband3d_throttle = ($('input[name="3ddeadbandthrottle"]').val());
             }
 
@@ -642,7 +642,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             PID_ADVANCED_CONFIG.pid_process_denom = parseInt(pid_select_e.val());
 
             function save_serial_config() {
-                if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+                if (!FC.apiVersion.gte('1.6.0')) {
                     MSP.send_message(MSP_codes.MSP_SET_CF_SERIAL_CONFIG, MSP.crunch(MSP_codes.MSP_SET_CF_SERIAL_CONFIG), false, save_misc);
                 } else {
                     save_misc();
@@ -652,27 +652,27 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             function save_misc() {
                 MSP.send_message(MSP_codes.MSP_SET_MISC, MSP.crunch(MSP_codes.MSP_SET_MISC), false, save_3d);
             }
-            
+
             function save_3d() {
                 var next_callback = save_sensor_alignment;
-                if(semver.gte(CONFIG.apiVersion, "1.14.0")) {
+                if(FC.apiVersion.gte('1.14.0')) {
                    MSP.send_message(MSP_codes.MSP_SET_3D, MSP.crunch(MSP_codes.MSP_SET_3D), false, next_callback);
                 } else {
                    next_callback();
-                }     
+                }
             }
-            
+
             function save_sensor_alignment() {
                 var next_callback = save_esc_protocol;
-                if(semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                if(FC.apiVersion.gte('1.15.0')) {
                    MSP.send_message(MSP_codes.MSP_SET_SENSOR_ALIGNMENT, MSP.crunch(MSP_codes.MSP_SET_SENSOR_ALIGNMENT), false, next_callback);
                 } else {
                    next_callback();
-                }     
+                }
             }
             function save_esc_protocol() {
                 var next_callback = save_acc_trim;
-                if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.1")) {
+                if (FC.version.gte('2.8.1')) {
                     MSP.send_message(MSP_codes.MSP_SET_PID_ADVANCED_CONFIG, MSP.crunch(MSP_codes.MSP_SET_PID_ADVANCED_CONFIG), false, next_callback);
                 } else {
                    next_callback();
@@ -681,7 +681,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_acc_trim() {
                 MSP.send_message(MSP_codes.MSP_SET_ACC_TRIM, MSP.crunch(MSP_codes.MSP_SET_ACC_TRIM), false
-                                , semver.gte(CONFIG.apiVersion, "1.8.0") ? save_arming_config : save_to_eeprom);
+                                , FC.apiVersion.gte('1.8.0') ? save_arming_config : save_to_eeprom);
             }
 
             function save_arming_config() {
@@ -690,7 +690,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_looptime_config() {
                 var next_callback = save_sensor_config;
-                if (CONFIG.flightControllerIdentifier == "BTFL" && semver.lt(CONFIG.flightControllerVersion, "2.8.1")) {
+                if (!FC.version.gte('2.8.1')) {
                     FC_CONFIG.loopTime = PID_ADVANCED_CONFIG.gyro_sync_denom * 125;
                     MSP.send_message(MSP_codes.MSP_SET_LOOP_TIME, MSP.crunch(MSP_codes.MSP_SET_LOOP_TIME), false, next_callback);
                 } else {
@@ -699,8 +699,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
             function save_sensor_config() {
                 var next_callback = save_advanced_tuning;
-                
-                if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.2")) {
+
+                if (FC.version.gte('2.8.2')) {
                     SENSOR_CONFIG.acc_hardware = $('input[name="accHardwareSwitch"]').is(':checked')?0:1;
                     SENSOR_CONFIG.baro_hardware = $('input[name="baroHardwareSwitch"]').is(':checked')?0:1;
                     SENSOR_CONFIG.mag_hardware = $('input[name="magHardwareSwitch"]').is(':checked')?0:1
@@ -713,7 +713,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             function save_advanced_tuning() {
                 var next_callback = save_to_eeprom;
                 
-                if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.1")) {
+                if (FC.version.gte('2.8.1')) {
 
                     ADVANCED_TUNING.vbatPidCompensation = $('input[name="vbatpidcompensation"]').is(':checked') ? 1 : 0;
 

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -51,7 +51,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         $('#content').load("./tabs/failsafe.html", process_html);
     }
 
-    var apiVersionGte1_15_0 = semver.gte(CONFIG.apiVersion, "1.15.0");
+    var apiVersionGte1_15_0 = FC.apiVersion.gte('1.15.0');
 
     // Uncomment next line for testing older functionality on newer API version
     //apiVersionGte1_15_0 = false;

--- a/tabs/led_strip.js
+++ b/tabs/led_strip.js
@@ -286,14 +286,14 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             }
 
         });
-        
-        if (CONFIG.apiVersion < '1.18.0') {
+
+        if (!FC.apiVersion.gte('1.18.0')) {
             $(".extra_functions").hide();
         }
-        
+
         GUI.content_ready(callback);
     }
-    
+
     function findLed(x, y) {
         for (var ledIndex = 0; ledIndex < LED_STRIP.length; ledIndex++) {
             var led = LED_STRIP[ledIndex];

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -19,22 +19,22 @@ TABS.motors.initialize = function (callback) {
     function get_arm_status() {
         MSP.send_message(MSP_codes.MSP_STATUS, false, false, load_config);
     }
-    
+
     function load_config() {
         MSP.send_message(MSP_codes.MSP_BF_CONFIG, false, false, load_3d);
     }
-    
+
     function load_3d() {
         var next_callback = get_motor_data;
-        if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
+        if (FC.apiVersion.gte('1.14.0')) {
             self.feature3DSupported = true;
             MSP.send_message(MSP_codes.MSP_3D, false, false, next_callback);
         } else {
             next_callback();
         }
-        
+
     }
-    
+
     function get_motor_data() {
         update_arm_status();
         MSP.send_message(MSP_codes.MSP_MOTOR, false, false, load_html);

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -17,7 +17,7 @@ TABS.onboard_logging.initialize = function (callback) {
 
     if (CONFIGURATOR.connectionValid) {
         // Blackbox was introduced in 1.5.0, dataflash API was introduced in 1.8.0, BLACKBOX/SDCARD MSP APIs in 1.11.0
-        TABS.onboard_logging.available = semver.gte(CONFIG.flightControllerVersion, "1.5.0");
+        TABS.onboard_logging.available = FC.version.gte('1.5.0');
         
         if (!TABS.onboard_logging.available) {
             load_html();
@@ -25,9 +25,9 @@ TABS.onboard_logging.initialize = function (callback) {
         }
         
         MSP.send_message(MSP_codes.MSP_BF_CONFIG, false, false, function() {
-            if (semver.gte(CONFIG.flightControllerVersion, "1.8.0")) {
+            if (FC.version.gte('1.8.0')) {
                 MSP.send_message(MSP_codes.MSP_DATAFLASH_SUMMARY, false, false, function() {
-                    if (semver.gte(CONFIG.flightControllerVersion, "1.11.0")) {
+                    if (FC.version.gte('1.11.0')) {
                         MSP.send_message(MSP_codes.MSP_SDCARD_SUMMARY, false, false, function() {
                             MSP.send_message(MSP_codes.MSP_BLACKBOX_CONFIG, false, false, load_html);
                         });
@@ -93,10 +93,9 @@ TABS.onboard_logging.initialize = function (callback) {
              * 
              * The best we can do on those targets is check the BLACKBOX feature bit to identify support for Blackbox instead.
              */
-            if (BLACKBOX.supported || DATAFLASH.supported 
-                    || semver.gte(CONFIG.flightControllerVersion, "1.5.0") && semver.lte(CONFIG.flightControllerVersion, "1.10.0") && bit_check(BF_CONFIG.features, 19)) {
+            if (BLACKBOX.supported || DATAFLASH.supported  || FC.version.between('1.5.0', '1.10.0') && bit_check(BF_CONFIG.features, 19)) {
                 blackboxSupport = 'yes';
-            } else if (semver.gte(CONFIG.flightControllerVersion, "1.5.0") && semver.lte(CONFIG.flightControllerVersion, "1.10.0")) {
+            } else if (FC.version.between('1.5.0', '1.10.0')) {
                 blackboxSupport = 'maybe';
             } else {
                 blackboxSupport = 'no';

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -32,7 +32,7 @@ TABS.pid_tuning.initialize = function (callback) {
         return MSP.promise(MSP_codes.MSP_FILTER_CONFIG);
     }).then(function() {
         var promise = true;
-        if (CONFIG.flightControllerIdentifier === "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.0")) {
+        if (FC.version.gte('2.8.0')) {
             promise = MSP.promise(MSP_codes.MSP_BF_CONFIG);
         }
 
@@ -42,7 +42,7 @@ TABS.pid_tuning.initialize = function (callback) {
     });
 
     function pid_and_rc_to_form() {
-        if (CONFIG.flightControllerIdentifier === "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.0")) {
+        if (FC.version.gte('2.8.0')) {
             //This will need to be reworked to remove BF_CONFIG reference eventually
             $('.pid_tuning input[name="show_superexpo_rates"]').prop(
                 'checked', bit_check(BF_CONFIG.features, SUPEREXPO_FEATURE_BIT));
@@ -199,7 +199,7 @@ TABS.pid_tuning.initialize = function (callback) {
         $('.tpa input[name="tpa"]').val(RC_tuning.dynamic_THR_PID.toFixed(2));
         $('.tpa input[name="tpa-breakpoint"]').val(RC_tuning.dynamic_THR_breakpoint);
 
-        if (semver.lt(CONFIG.apiVersion, "1.10.0")) {
+        if (!FC.apiVersion.gte('1.10.0')) {
             $('.pid_tuning input[name="rc_yaw_expo"]').hide();
             $('.pid_tuning input[name="rc_expo"]').attr("rowspan", "3");
         }
@@ -208,14 +208,14 @@ TABS.pid_tuning.initialize = function (callback) {
         $('.pid_tuning input[name="dterm"]').val(FILTER_CONFIG.dterm_lpf_hz);
         $('.pid_tuning input[name="yaw"]').val(FILTER_CONFIG.yaw_lpf_hz);
 
-        if (CONFIG.flightControllerIdentifier !== "BTFL" || semver.lt(CONFIG.flightControllerVersion, "2.8.1")) {
+        if (!FC.version.gte('2.8.1')) {
             $('.pid_filter').hide();
             $('.pid_tuning input[name="rc_rate_yaw"]').hide();
         }
     }
 
     function form_to_pid_and_rc() {
-        if (CONFIG.flightControllerIdentifier === "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.0")) {
+        if (FC.version.gte('2.8.0')) {
             //This will need to be reworked to remove BF_CONFIG reference eventually
             if ($('.pid_tuning input[name="show_superexpo_rates"]').is(':checked')) {
                 BF_CONFIG.features = bit_set(BF_CONFIG.features, SUPEREXPO_FEATURE_BIT);
@@ -308,7 +308,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('#pid_main').show();
 
-        if (CONFIG.flightControllerIdentifier === "BTFL" || semver.ge(CONFIG.flightControllerVersion, "2.9.0")) {
+        if (FC.version.gte('2.9.0')) {
             $('#pid_filter').show();
         }
 
@@ -394,7 +394,7 @@ TABS.pid_tuning.initialize = function (callback) {
     }
 
     var useLegacyCurve = false;
-    if (CONFIG.flightControllerIdentifier !== "BTFL" || semver.lt(CONFIG.flightControllerVersion, "2.8.0")) {
+    if (!FC.version.gte('2.8.0')) {
         useLegacyCurve = true;
     }
 
@@ -431,11 +431,11 @@ TABS.pid_tuning.initialize = function (callback) {
             superexpo:   bit_check(BF_CONFIG.features, SUPEREXPO_FEATURE_BIT)
         };
 
-        if (CONFIG.flightControllerIdentifier !== "BTFL" || semver.lt(CONFIG.flightControllerVersion, "2.8.1")) {
+        if (!FC.version.gte('2.8.1')) {
             self.currentRates.rc_rate_yaw = self.currentRates.rc_rate;
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
+        if (!FC.apiVersion.gte('1.7.0')) {
             self.currentRates.roll_rate = RC_tuning.roll_pitch_rate;
             self.currentRates.pitch_rate = RC_tuning.roll_pitch_rate;
         }
@@ -467,7 +467,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         var pidControllerList;
 
-        if (semver.lt(CONFIG.apiVersion, "1.14.0")) {
+        if (!FC.apiVersion.gte('1.14.0')) {
             pidControllerList = [
                 { name: "MultiWii (Old)"},
                 { name: "MultiWii (rewrite)"},
@@ -501,7 +501,7 @@ TABS.pid_tuning.initialize = function (callback) {
             pidController_e.prop('disabled', true);
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
+        if (!FC.apiVersion.gte('1.7.0')) {
             $('.tpa .tpa-breakpoint').hide();
 
             $('.pid_tuning .roll_rate').hide();
@@ -537,11 +537,11 @@ TABS.pid_tuning.initialize = function (callback) {
                     updateNeeded = true;
                 }
 
-                if (targetElement.attr('name') === 'rc_rate' && CONFIG.flightControllerIdentifier !== "BTFL" || semver.lt(CONFIG.flightControllerVersion, "2.8.1")) {
+                if (targetElement.attr('name') === 'rc_rate' && !FC.version.gte('2.8.1')) {
                     self.currentRates.rc_rate_yaw = targetValue;
                 }
 
-                if (targetElement.attr('name') === 'roll_pitch_rate' && semver.lt(CONFIG.apiVersion, "1.7.0")) {
+                if (targetElement.attr('name') === 'roll_pitch_rate' && !FC.apiVersion.gte('1.7.0')) {
                     self.currentRates.roll_rate = targetValue;
                     self.currentRates.pitch_rate = targetValue;
 
@@ -657,7 +657,7 @@ TABS.pid_tuning.initialize = function (callback) {
             ADVANCED_TUNING.deltaMethod = $(this).val();
         });
 
-        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.lt(CONFIG.flightControllerVersion, "2.8.2")) {
+        if (!FC.version.gte('2.8.2')) {
             $('.delta').hide();
             $('.note').hide();
         }
@@ -677,7 +677,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 if (TABS.pid_tuning.controllerChanged) { return; }
                 MSP.promise(MSP_codes.MSP_SET_PID, MSP.crunch(MSP_codes.MSP_SET_PID)).then(function() {
                     if (TABS.pid_tuning.controllerChanged) { Promise.reject('pid controller changed'); }
-                    if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.1")) {
+                    if (FC.version.gte('2.8.1')) {
                         return MSP.promise(MSP_codes.MSP_SET_SPECIAL_PARAMETERS, MSP.crunch(MSP_codes.MSP_SET_SPECIAL_PARAMETERS));
                     }
                 }).then(function() {
@@ -685,14 +685,14 @@ TABS.pid_tuning.initialize = function (callback) {
                     return MSP.promise(MSP_codes.MSP_SET_ADVANCED_TUNING, MSP.crunch(MSP_codes.MSP_SET_ADVANCED_TUNING));
                 }).then(function() {
                     if (TABS.pid_tuning.controllerChanged) { Promise.reject('pid controller changed'); }
-                    if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.1")) {
+                    if (FC.version.gte('2.8.1')) {
                         return MSP.promise(MSP_codes.MSP_SET_FILTER_CONFIG, MSP.crunch(MSP_codes.MSP_SET_FILTER_CONFIG));
                     }
                 }).then(function() {
                     return MSP.promise(MSP_codes.MSP_SET_RC_TUNING, MSP.crunch(MSP_codes.MSP_SET_RC_TUNING));
                 }).then(function() {
 		    var promise = true;
-                    if (CONFIG.flightControllerIdentifier === "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.8.0")) {
+                    if (FC.version.gte('2.8.0')) {
                         promise = MSP.promise(MSP_codes.MSP_SET_BF_CONFIG, MSP.crunch(MSP_codes.MSP_SET_BF_CONFIG));
                     }
 

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -17,7 +17,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
          {name: 'BLACKBOX',             groups: ['logging', 'blackbox'], sharableWith: ['msp'], notSharableWith: ['telemetry'], maxPorts: 1},
     ];
 
-    if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+    if (FC.apiVersion.gte('1.15.0')) {
         var ltmFunctionRule = {name: 'TELEMETRY_LTM',        groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1};
         functionRules.push(ltmFunctionRule);
     } else {
@@ -25,7 +25,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         functionRules.push(mspFunctionRule);
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.18.0")) {
+    if (FC.apiVersion.gte('1.18.0')) {
         var mavlinkFunctionRule = {name: 'TELEMETRY_MAVLINK',    groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1};
         functionRules.push(mavlinkFunctionRule);
     }
@@ -88,9 +88,9 @@ TABS.ports.initialize = function (callback, scrollPosition) {
     }
 
     function update_ui() {
-        
-        if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
-            
+
+        if (!FC.apiVersion.gte('1.6.0')) {
+
             $(".tab-ports").removeClass("supported");
             return;
         }

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -38,7 +38,7 @@ TABS.receiver.initialize = function (callback) {
 
     function load_rc_configs() {
         var next_callback = load_html;
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (FC.apiVersion.gte('1.15.0')) {
             MSP.send_message(MSP_codes.MSP_RC_DEADBAND, false, false, next_callback);
         } else {
             next_callback();
@@ -63,7 +63,7 @@ TABS.receiver.initialize = function (callback) {
             }
         });
 
-        if (semver.lt(CONFIG.apiVersion, "1.15.0")) {
+        if (!FC.apiVersion.gte('1.15.0')) {
             $('.deadband').hide();
         } else {
             $('.deadband input[name="yaw_deadband"]').val(RC_deadband.yaw_deadband);
@@ -208,7 +208,7 @@ TABS.receiver.initialize = function (callback) {
         });
 
         $('a.update').click(function () {
-            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+            if (FC.apiVersion.gte('1.15.0')) {
                RC_deadband.yaw_deadband = parseInt($('.deadband input[name="yaw_deadband"]').val());
                RC_deadband.deadband = parseInt($('.deadband input[name="deadband"]').val());
             }
@@ -230,7 +230,7 @@ TABS.receiver.initialize = function (callback) {
 
             function save_rc_configs() {
                 var next_callback = save_to_eeprom;
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                if (FC.apiVersion.gte('1.15.0')) {
                    MSP.send_message(MSP_codes.MSP_SET_RC_DEADBAND, MSP.crunch(MSP_codes.MSP_SET_RC_DEADBAND), false, next_callback);
                 } else {
                    next_callback();
@@ -404,11 +404,11 @@ TABS.receiver.initModelPreview = function () {
     this.model = new Model($('.model_preview'), $('.model_preview canvas'));
 
     this.useSuperExpo = false;
-    if (CONFIG.flightControllerIdentifier === 'BTFL' && semver.gte(CONFIG.flightControllerVersion, '2.8.0')) {
+    if (FC.version.gte('2.8.0')) {
         this.useSuperExpo = bit_check(BF_CONFIG.features, SUPEREXPO_FEATURE_BIT);
     }
 
-    this.rateCurve = new RateCurve(CONFIG.flightControllerIdentifier !== 'BTFL' || semver.lt(CONFIG.flightControllerVersion, '2.8.0'));
+    this.rateCurve = new RateCurve(!FC.version.gte('2.8.0'));
 
     $(window).on('resize', $.proxy(this.model.resize, this.model));
 };

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -18,10 +18,10 @@ TABS.servos.initialize = function (callback) {
 
     function get_channel_forwarding() {
         var nextFunction = get_rc_data;
-        
-        if (semver.lt(CONFIG.apiVersion, "1.12.0")) {
+
+        if (!FC.apiVersion.gte('1.12.0')) {
             MSP.send_message(MSP_codes.MSP_CHANNEL_FORWARDING, false, false, nextFunction);
-        } else { 
+        } else {
             nextFunction();
         }
     }
@@ -37,19 +37,19 @@ TABS.servos.initialize = function (callback) {
     function load_html() {
         $('#content').load("./tabs/servos.html", process_html);
     }
-    
+
     MSP.send_message(MSP_codes.MSP_IDENT, false, false, get_servo_configurations);
-    
+
     function update_ui() {
-            
-        if (semver.lt(CONFIG.apiVersion, "1.12.0") || SERVO_CONFIG.length == 0) {
-            
+
+        if (!FC.apiVersion.gte('1.12.0') || SERVO_CONFIG.length == 0) {
+
             $(".tab-servos").removeClass("supported");
             return;
         }
-        
+
         $(".tab-servos").addClass("supported");
-            
+
         var servoCheckbox = '';
         var servoHeader = '';
         for (var i = 0; i < RC.active_channels-4; i++) {

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -37,7 +37,7 @@ TABS.setup.initialize = function (callback) {
         // translate to user-selected language
         localize();
 
-        if (semver.lt(CONFIG.apiVersion, CONFIGURATOR.backupRestoreMinApiVersionAccepted)) {
+        if (!FC.apiVersion.gte(CONFIGURATOR.backupRestoreMinApiVersionAccepted)) {
             $('#content .backup').addClass('disabled');
             $('#content .restore').addClass('disabled');
 

--- a/tabs/transponder.js
+++ b/tabs/transponder.js
@@ -12,8 +12,8 @@ TABS.transponder.initialize = function (callback, scrollPosition) {
     }
 
     // transponder supported added in MSP API Version 1.16.0
-    TABS.transponder.available = semver.gte(CONFIG.apiVersion, "1.16.0");
-    
+    TABS.transponder.available = FC.apiVersion.gte('1.16.0');
+
     if (!TABS.transponder.available) {
         load_html();
         return;


### PR DESCRIPTION
This PR adds 2 little function for version checks leveraging already included `semver` and getting rid of duplication.

The only bit I'm not sure about is

``` javascript
if (CONFIG.flightControllerIdentifier === "BTFL" || semver.ge(CONFIG.flightControllerVersion, "2.9.0")) {
  $('#pid_filter').show();
}
```

I guess `||` here is a typo, right?
