### PR TITLE
Fix show unstable releases

### DIFF
--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -31,7 +31,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
 
         $('input.show_development_releases').click(function(){
-            buildFirmwareOptions();
+            buildBoardOptions();
         });
 
         var buildBoardOptions = function(){


### PR DESCRIPTION
Rename call to buildBoardOptions() to buildFirmwareOptions(), as this function got renamed.
~~I know BF only has stable-flagged releases, so if this will always be the case, the whole functionality might as well be removed altogether from the configurator.~~