### PR TITLE
Disable "Loading firmware [Online]" button when downloading

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1478,6 +1478,9 @@
     "firmwareFlasherButtonLoadOnline": {
         "message": "Load Firmware [Online]"
     },
+    "firmwareFlasherButtonDownloading": {
+        "message": "Downloading..."
+    },
     "firmwareFlasherFlashFirmware": {
         "message": "Flash Firmware"
     },

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -274,12 +274,18 @@ TABS.firmware_flasher.initialize = function (callback) {
             function failed_to_load() {
                 $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherFailedToLoadOnlineFirmware'));
                 $('a.flash_firmware').addClass('disabled');
+                $("a.load_remote_file").removeClass('disabled');
+                $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoadOnline'));
             }
 
             var summary = $('select[name="firmware_version"] option:selected').data('summary');
             if (summary) { // undefined while list is loading or while running offline
+                $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonDownloading'));
+                $("a.load_remote_file").addClass('disabled');
                 $.get(summary.url, function (data) {
                     process_hex(data, summary);
+                    $("a.load_remote_file").removeClass('disabled');
+                    $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoadOnline'));
                 }).fail(failed_to_load);
             } else {
                 $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherFailedToLoadOnlineFirmware'));


### PR DESCRIPTION
Disable "Loading firmware [Online]" button when downloading and enable when finish/fail to prevent multiple download at same time.