### PR TITLE
Removed unsupported adjustment ranges

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1097,60 +1097,6 @@
     "adjustmentsFunction20": {
         "message": "Roll D Adjustment"
     },
-    "adjustmentsFunction21": {
-        "message": "Alt P Adjustment"
-    },
-    "adjustmentsFunction22": {
-        "message": "Alt I Adjustment"
-    },
-    "adjustmentsFunction23": {
-        "message": "Alt D Adjustment"
-    },
-    "adjustmentsFunction24": {
-        "message": "Vel P Adjustment"
-    },
-    "adjustmentsFunction25": {
-        "message": "Vel I Adjustment"
-    },
-    "adjustmentsFunction26": {
-        "message": "Vel D Adjustment"
-    },
-    "adjustmentsFunction27": {
-        "message": "MAG P Adjustment"
-    },
-    "adjustmentsFunction28": {
-        "message": "Pos P Adjustment"
-    },
-    "adjustmentsFunction29": {
-        "message": "Pos I Adjustment"
-    },
-    "adjustmentsFunction30": {
-        "message": "PosR P Adjustment"
-    },
-    "adjustmentsFunction31": {
-        "message": "PosR I Adjustment"
-    },
-    "adjustmentsFunction32": {
-        "message": "PosR D Adjustment"
-    },
-    "adjustmentsFunction33": {
-        "message": "NavR P Adjustment"
-    },
-    "adjustmentsFunction34": {
-        "message": "NavR I Adjustment"
-    },
-    "adjustmentsFunction35": {
-        "message": "NavR D Adjustment"
-    },
-    "adjustmentsFunction36": {
-        "message": "Level P Adjustment"
-    },
-    "adjustmentsFunction37": {
-        "message": "Level I Adjustment"
-    },
-    "adjustmentsFunction38": {
-        "message": "Level D Adjustment"
-    },
     "adjustmentsSave": {
         "message": "Save"
     },

--- a/tabs/adjustments.html
+++ b/tabs/adjustments.html
@@ -88,24 +88,6 @@
                         <option value="18" i18n="adjustmentsFunction18"></option>
                         <option value="19" i18n="adjustmentsFunction19"></option>
                         <option value="20" i18n="adjustmentsFunction20"></option>
-                        <option value="21" i18n="adjustmentsFunction21"></option>
-                        <option value="22" i18n="adjustmentsFunction22"></option>
-                        <option value="23" i18n="adjustmentsFunction23"></option>
-                        <option value="24" i18n="adjustmentsFunction24"></option>
-                        <option value="25" i18n="adjustmentsFunction25"></option>
-                        <option value="26" i18n="adjustmentsFunction26"></option>
-                        <option value="27" i18n="adjustmentsFunction27"></option>
-                        <option value="28" i18n="adjustmentsFunction28"></option>
-                        <option value="29" i18n="adjustmentsFunction29"></option>
-                        <option value="30" i18n="adjustmentsFunction30"></option>
-                        <option value="31" i18n="adjustmentsFunction31"></option>
-                        <option value="32" i18n="adjustmentsFunction32"></option>
-                        <option value="33" i18n="adjustmentsFunction33"></option>
-                        <option value="34" i18n="adjustmentsFunction34"></option>
-                        <option value="35" i18n="adjustmentsFunction35"></option>
-                        <option value="36" i18n="adjustmentsFunction36"></option>
-                        <option value="37" i18n="adjustmentsFunction37"></option>
-                        <option value="38" i18n="adjustmentsFunction38"></option>
                 </select></td>
                 <td class="adjustmentSlot"><select class="slot">
                         <option value="0" i18n="adjustmentsSlot0"></option>

--- a/tabs/adjustments.js
+++ b/tabs/adjustments.js
@@ -59,28 +59,8 @@ TABS.adjustments.initialize = function (callback) {
         //
         
         var functionList = $(newAdjustment).find('.functionSelection .function');
-        
-        // update list of selected functions        
-        var functionListOptions = $(functionList).find('option');
-        var availableFunctionCount = 13;
-        
-        if (semver.gte(CONFIG.flightControllerVersion, '1.8.0')) {
-            availableFunctionCount += 2; // pitch and roll rate
-            if (semver.gte(CONFIG.flightControllerVersion, '1.9.0')) {
-                availableFunctionCount += 6; // pitch p,i,d and roll p,i,d
-                if(semver.gte(CONFIG.apiVersion, "1.15.0")){
-                   availableFunctionCount += 18;
-                }
-            }
-        }
-        
-        var functionListOptions = $(functionListOptions).slice(0,availableFunctionCount);
-        functionList.empty().append(functionListOptions);
-        
         functionList.val(adjustmentRange.adjustmentFunction);
         
-        
-
         //
         // populate function channel select box
         //


### PR DESCRIPTION
There is a long list of adjustment functions currently not supported in Betaflight firmware. However current configurator displays thems as available. This PR syncs available adjustment functions with FW. 