### PR TITLE
3D msp fix, corresponding to firmware in MSP_SET_RC_DEADBAND

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -1629,6 +1629,10 @@ MSP.crunch = function (code) {
             buffer.push(RC_deadband.deadband);
             buffer.push(RC_deadband.yaw_deadband); 
             buffer.push(RC_deadband.alt_hold_deadband);
+            if (semver.gte(CONFIG.apiVersion, "1.17.0")) {
+                buffer.push(lowByte(_3D.deadband3d_throttle));
+                buffer.push(highByte(_3D.deadband3d_throttle));
+            }
             break;
 
         case MSP_codes.MSP_SET_SENSOR_ALIGNMENT:


### PR DESCRIPTION
MSP protocol should now be consistent again, so expected and transmitted data match.
3D throttle deadband does not get displayed anywhere in the configurator, this still needs to be done, but at least msp packets don't cause corrupt data anymore.