### PR TITLE
Msp additional improvements/cleanup

### DIFF
--- a/js/injected_methods.js
+++ b/js/injected_methods.js
@@ -10,3 +10,48 @@ Array.prototype.push16 = function(val) {
   // chainable
   return this;
 };
+DataView.prototype.offset = 0;
+DataView.prototype.readU8 = function() {
+    if (this.byteLength >= this.offset+1) {
+        return this.getUint8(this.offset++);
+    } else {
+        return null;
+    }
+}
+DataView.prototype.readU16 = function() {
+    if (this.byteLength >= this.offset+2) {
+        return this.readU8() + this.readU8()*256;
+    } else {
+        return null;
+    }
+}
+DataView.prototype.readU32 = function() {
+    if (this.byteLength >= this.offset+4) {
+        return this.readU16() + this.readU16()*65536;
+    } else {
+        return null;
+    }
+}
+DataView.prototype.read8 = function() {
+    if (this.byteLength >= this.offset+1) {
+        return this.getInt8(this.offset++, 1);
+    } else {
+        return null;
+    }
+}
+DataView.prototype.read16 = function() {
+    this.offset += 2;
+    if (this.byteLength >= this.offset) {
+        return this.getInt16(this.offset-2, 1); 
+    } else {
+        return null;
+    }
+}
+DataView.prototype.read32 = function() {
+    this.offset += 4;
+    if (this.byteLength >= this.offset) {
+        return this.getInt32(this.offset-4, 1); 
+    } else {
+        return null;
+    }
+}


### PR DESCRIPTION
Removed the need to handle needle/offset in the process_data function. It reduces the code needed for handling incoming MSP data and reduces possibility to make mistakes. It will also make MSP handling a bit more robust since reading out of range for offset is not possible. 

- Use `readUX()` instead of `getUintX(offset)`
- Use `readX()` instead of `getIntX(offset)`
