### PR TITLE
Remove versionchecks for apiVersion <= 1.16

### DIFF
--- a/js/Features.js
+++ b/js/Features.js
@@ -22,20 +22,10 @@ var Features = function (config) {
         {bit: 15, group: 'rssi', name: 'RSSI_ADC'},
         {bit: 16, group: 'other', name: 'LED_STRIP'},
         {bit: 17, group: 'other', name: 'DISPLAY'},
-        {bit: 19, group: 'other', name: 'BLACKBOX', haveTip: true}
+        {bit: 19, group: 'other', name: 'BLACKBOX', haveTip: true},
+        {bit: 20, group: 'other', name: 'CHANNEL_FORWARDING'},
+        {bit: 21, group: 'other', name: 'TRANSPONDER', haveTip: true}
     ];
-
-    if (semver.gte(config.apiVersion, "1.12.0")) {
-        features.push(
-            {bit: 20, group: 'other', name: 'CHANNEL_FORWARDING'}
-        );
-    }
-
-    if (semver.gte(config.apiVersion, "1.16.0")) {
-        features.push(
-            {bit: 21, group: 'other', name: 'TRANSPONDER', haveTip: true}
-        );
-    }
 
     if (config.flightControllerVersion !== '' && semver.gte(config.flightControllerVersion, "3.0.0")) {
         features.push(
@@ -52,19 +42,19 @@ var Features = function (config) {
 
     self._features = features;
     self._featureMask = 0;
-}
+};
 
 Features.prototype.getMask = function () {
     var self = this;
 
     return self._featureMask;
-}
+};
 
 Features.prototype.setMask = function (featureMask) {
     var self = this;
 
     self._featureMask = featureMask;
-}
+};
 
 Features.prototype.isEnabled = function (featureName) {
     var self = this;
@@ -75,7 +65,7 @@ Features.prototype.isEnabled = function (featureName) {
         }
     }
     return false;
-}
+};
 
 Features.prototype.generateElements = function (featuresElements) {
     var self = this;
@@ -144,7 +134,7 @@ Features.prototype.generateElements = function (featuresElements) {
             $(this).prop('checked', state);
         });
     }
-}
+};
 
 Features.prototype.updateData = function (featureElement) {
     var self = this;
@@ -175,4 +165,4 @@ Features.prototype.updateData = function (featureElement) {
             });
             break;
     }
-}
+};

--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -22,14 +22,8 @@ function configuration_backup(callback) {
     ];
 
     function update_profile_specific_data_list() {
-        if (semver.lt(CONFIG.apiVersion, "1.12.0")) {
-            profileSpecificData.push(MSPCodes.MSP_CHANNEL_FORWARDING);
-         } else {            
-            profileSpecificData.push(MSPCodes.MSP_SERVO_MIX_RULES);
-        }
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-            profileSpecificData.push(MSPCodes.MSP_RC_DEADBAND);
-        }
+        profileSpecificData.push(MSPCodes.MSP_SERVO_MIX_RULES);
+        profileSpecificData.push(MSPCodes.MSP_RC_DEADBAND);
     }
     
     update_profile_specific_data_list();
@@ -69,10 +63,7 @@ function configuration_backup(callback) {
                             'ModeRanges': jQuery.extend(true, [], MODE_RANGES),
                             'AdjustmentRanges': jQuery.extend(true, [], ADJUSTMENT_RANGES)
                         });
-
-                        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                            configuration.profiles[fetchingProfile].RCdeadband = jQuery.extend(true, {}, RC_deadband);
-                        }
+                        configuration.profiles[fetchingProfile].RCdeadband = jQuery.extend(true, {}, RC_deadband);
                         codeKey = 0;
                         fetchingProfile++;
 
@@ -98,19 +89,13 @@ function configuration_backup(callback) {
     ];
 
     function update_unique_data_list() {
-        if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
-            uniqueData.push(MSPCodes.MSP_LOOP_TIME);
-            uniqueData.push(MSPCodes.MSP_ARMING_CONFIG);
-        }
-        if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
-            uniqueData.push(MSPCodes.MSP_3D);
-        }
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-            uniqueData.push(MSPCodes.MSP_SENSOR_ALIGNMENT);
-            uniqueData.push(MSPCodes.MSP_RX_CONFIG);
-            uniqueData.push(MSPCodes.MSP_FAILSAFE_CONFIG);
-            uniqueData.push(MSPCodes.MSP_RXFAIL_CONFIG);
-        }
+        uniqueData.push(MSPCodes.MSP_LOOP_TIME);
+        uniqueData.push(MSPCodes.MSP_ARMING_CONFIG);
+        uniqueData.push(MSPCodes.MSP_3D);
+        uniqueData.push(MSPCodes.MSP_SENSOR_ALIGNMENT);
+        uniqueData.push(MSPCodes.MSP_RX_CONFIG);
+        uniqueData.push(MSPCodes.MSP_FAILSAFE_CONFIG);
+        uniqueData.push(MSPCodes.MSP_RXFAIL_CONFIG);
         if (semver.gte(CONFIG.apiVersion, "1.19.0")) {
             uniqueData.push(MSPCodes.MSP_LED_STRIP_MODECOLOR);
         }
@@ -138,19 +123,14 @@ function configuration_backup(callback) {
                 if (semver.gte(CONFIG.apiVersion, "1.19.0")) {
                     configuration.LED_MODE_COLORS = jQuery.extend(true, [], LED_MODE_COLORS);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
-                    configuration.FC_CONFIG = jQuery.extend(true, {}, FC_CONFIG);
-                    configuration.ARMING_CONFIG = jQuery.extend(true, {}, ARMING_CONFIG);
-                }
-                if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
-                    configuration._3D = jQuery.extend(true, {}, _3D);
-                }
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                    configuration.SENSOR_ALIGNMENT = jQuery.extend(true, {}, SENSOR_ALIGNMENT);
-                    configuration.RX_CONFIG = jQuery.extend(true, {}, RX_CONFIG);
-                    configuration.FAILSAFE_CONFIG = jQuery.extend(true, {}, FAILSAFE_CONFIG);
-                    configuration.RXFAIL_CONFIG = jQuery.extend(true, [], RXFAIL_CONFIG);
-                }
+
+                configuration.FC_CONFIG = jQuery.extend(true, {}, FC_CONFIG);
+                configuration.ARMING_CONFIG = jQuery.extend(true, {}, ARMING_CONFIG);
+                configuration._3D = jQuery.extend(true, {}, _3D);
+                configuration.SENSOR_ALIGNMENT = jQuery.extend(true, {}, SENSOR_ALIGNMENT);
+                configuration.RX_CONFIG = jQuery.extend(true, {}, RX_CONFIG);
+                configuration.FAILSAFE_CONFIG = jQuery.extend(true, {}, FAILSAFE_CONFIG);
+                configuration.RXFAIL_CONFIG = jQuery.extend(true, [], RXFAIL_CONFIG);
 
                 save();
             }
@@ -381,8 +361,8 @@ function configuration_restore(callback) {
                 }
                 
                 // Roll and pitch rates were split
-                RC.roll_rate = RC.roll_pitch_rate;
-                RC.pitch_rate = RC.roll_pitch_rate;
+                RC.roll_rate = 0; //TODO rework/remove this
+                RC.pitch_rate = 0;
             }
             
             migratedVersion = '0.63.0';
@@ -474,13 +454,6 @@ function configuration_restore(callback) {
         if (semver.lt(migratedVersion, '0.66.0')) {
             // api 1.12 updated servo configuration protocol and added servo mixer rules
             for (var profileIndex = 0; profileIndex < configuration.profiles.length; profileIndex++) {
-                
-                if (semver.eq(configuration.apiVersion, '1.10.0')) {
-                    // drop two unused servo configurations
-                    while (configuration.profiles[profileIndex].ServoConfig.length > 8) {
-                        configuration.profiles[profileIndex].ServoConfig.pop();
-                    } 
-                }
                 
                 for (var i = 0; i < configuration.profiles[profileIndex].ServoConfig.length; i++) {
                     var servoConfig = profiles[profileIndex].ServoConfig;
@@ -647,9 +620,8 @@ function configuration_restore(callback) {
                 MSPCodes.MSP_SET_ACC_TRIM
             ];
 
-            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                profileSpecificData.push(MSPCodes.MSP_SET_RC_DEADBAND);
-            }
+            profileSpecificData.push(MSPCodes.MSP_SET_RC_DEADBAND);
+
 
             MSP.send_message(MSPCodes.MSP_STATUS, false, false, function () {
                 activeProfile = CONFIG.profile;
@@ -732,18 +704,12 @@ function configuration_restore(callback) {
                 ];
                 
                 function update_unique_data_list() {
-                    if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
-                        uniqueData.push(MSPCodes.MSP_SET_LOOP_TIME);
-                        uniqueData.push(MSPCodes.MSP_SET_ARMING_CONFIG);
-                    }
-                    if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
-                        uniqueData.push(MSPCodes.MSP_SET_3D);
-                    }
-                    if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                        uniqueData.push(MSPCodes.MSP_SET_SENSOR_ALIGNMENT);
-                        uniqueData.push(MSPCodes.MSP_SET_RX_CONFIG);
-                        uniqueData.push(MSPCodes.MSP_SET_FAILSAFE_CONFIG);
-                    }
+                    uniqueData.push(MSPCodes.MSP_SET_LOOP_TIME);
+                    uniqueData.push(MSPCodes.MSP_SET_ARMING_CONFIG);
+                    uniqueData.push(MSPCodes.MSP_SET_3D);
+                    uniqueData.push(MSPCodes.MSP_SET_SENSOR_ALIGNMENT);
+                    uniqueData.push(MSPCodes.MSP_SET_RX_CONFIG);
+                    uniqueData.push(MSPCodes.MSP_SET_FAILSAFE_CONFIG);
                 }
                 
                 function load_objects() {
@@ -798,11 +764,7 @@ function configuration_restore(callback) {
             }
             
             function send_rxfail_config() {
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                    mspHelper.sendRxFailConfig(save_to_eeprom);
-                } else {
-                    save_to_eeprom();
-                }
+                mspHelper.sendRxFailConfig(save_to_eeprom);
             }
 
             function save_to_eeprom() {

--- a/js/data_storage.js
+++ b/js/data_storage.js
@@ -1,12 +1,6 @@
 'use strict';
 
 var CONFIGURATOR = {
-    // all versions are specified and compared using semantic versioning http://semver.org/
-    'apiVersionAccepted': '1.2.1',
-    'backupRestoreMinApiVersionAccepted': '1.5.0',
-    'pidControllerChangeMinApiVersion': '1.5.0',
-    'backupFileMinVersionAccepted': '0.55.0', // chrome.runtime.getManifest().version is stored as string, so does this one
-    
     'connectionValid': false,
     'connectionValidCliOnly': false,
     'cliActive': false,

--- a/js/fc.js
+++ b/js/fc.js
@@ -103,8 +103,7 @@ var FC = {
         RC_tuning = {
             RC_RATE:         0,
             RC_EXPO:         0,
-            roll_pitch_rate: 0, // pre 1.7 api only
-            roll_rate:       0, 
+            roll_rate:       0,
             pitch_rate:      0,
             yaw_rate:        0,
             dynamic_THR_PID: 0,

--- a/js/msp/MSPCodes.js
+++ b/js/msp/MSPCodes.js
@@ -11,8 +11,8 @@ var MSPCodes = {
     MSP_NAME:                   10,
     MSP_SET_NAME:               11,
 
-    MSP_CHANNEL_FORWARDING:     32,
-    MSP_SET_CHANNEL_FORWARDING: 33,
+    MSP_CHANNEL_FORWARDING:     32, // Not used
+    MSP_SET_CHANNEL_FORWARDING: 33, // Not used
     MSP_MODE_RANGES:            34,
     MSP_SET_MODE_RANGE:         35,
 

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -383,10 +383,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
             }
             break;
 
-        case MSPCodes.MSP_SET_CHANNEL_FORWARDING:
-            console.log('Channel forwarding saved');
-            break;
-
         case MSPCodes.MSP_CF_SERIAL_CONFIG:
             var supportedBaudRates = [ // 0 based index.
                                        'AUTO',
@@ -456,17 +452,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     auxSwitchChannelIndex: data.readU8()
                 };
                 ADJUSTMENT_RANGES.push(adjustmentRange);
-            }
-            break;
-
-        case MSPCodes.MSP_CHANNEL_FORWARDING:
-            for (var i = 0; i < data.byteLength && i < SERVO_CONFIG.length; i ++) {
-                var channelIndex = data.readU8();
-                if (channelIndex < 255) {
-                    SERVO_CONFIG[i].indexOfChannelToForward = channelIndex;
-                } else {
-                    SERVO_CONFIG[i].indexOfChannelToForward = undefined;
-                }
             }
             break;
 
@@ -950,15 +935,6 @@ MspHelper.prototype.crunch = function(code) {
             }
             break;
 
-        case MSPCodes.MSP_SET_CHANNEL_FORWARDING:
-            for (var i = 0; i < SERVO_CONFIG.length; i++) {
-                var out = SERVO_CONFIG[i].indexOfChannelToForward;
-                if (out == undefined) {
-                    out = 255; // Cleanflight defines "CHANNEL_FORWARDING_DISABLED" as "(uint8_t)0xFF"
-                }
-                buffer.push8(out);
-            }
-            break;
         case MSPCodes.MSP_SET_CF_SERIAL_CONFIG:
             var supportedBaudRates = [ // 0 based index.
                                        'AUTO',
@@ -1175,22 +1151,6 @@ MspHelper.prototype.sendServoConfigurations = function(onCompleteCallback) {
         }
 
         MSP.send_message(MSPCodes.MSP_SET_SERVO_CONFIGURATION, buffer, false, nextFunction);
-    }
-    
-    function send_channel_forwarding() {
-        var buffer = [];
-
-        for (var i = 0; i < SERVO_CONFIG.length; i++) {
-            var out = SERVO_CONFIG[i].indexOfChannelToForward;
-            if (out == undefined) {
-                out = 255; // Cleanflight defines "CHANNEL_FORWARDING_DISABLED" as "(uint8_t)0xFF"
-            }
-            buffer.push8(out);
-        }
-
-        nextFunction = onCompleteCallback;
-
-        MSP.send_message(MSPCodes.MSP_SET_CHANNEL_FORWARDING, buffer, false, nextFunction);
     }
 };
 

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -190,52 +190,41 @@ function onOpen(openInfo) {
         MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
             GUI.log(chrome.i18n.getMessage('apiVersionReceived', [CONFIG.apiVersion]));
 
-            if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.apiVersionAccepted)) {
+            MSP.send_message(MSPCodes.MSP_FC_VARIANT, false, false, function () {
+                if (CONFIG.flightControllerIdentifier === 'BTFL') {
+                    MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
 
-                MSP.send_message(MSPCodes.MSP_FC_VARIANT, false, false, function () {
-                    if (CONFIG.flightControllerIdentifier === 'BTFL') {
-                        MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
+                        GUI.log(chrome.i18n.getMessage('fcInfoReceived', [CONFIG.flightControllerIdentifier, CONFIG.flightControllerVersion]));
 
-                            GUI.log(chrome.i18n.getMessage('fcInfoReceived', [CONFIG.flightControllerIdentifier, CONFIG.flightControllerVersion]));
+                        MSP.send_message(MSPCodes.MSP_BUILD_INFO, false, false, function () {
 
-                            MSP.send_message(MSPCodes.MSP_BUILD_INFO, false, false, function () {
+                            GUI.log(chrome.i18n.getMessage('buildInfoReceived', [CONFIG.buildInfo]));
 
-                                GUI.log(chrome.i18n.getMessage('buildInfoReceived', [CONFIG.buildInfo]));
+                            MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, function () {
 
-                                MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, function () {
+                                GUI.log(chrome.i18n.getMessage('boardInfoReceived', [CONFIG.boardIdentifier, CONFIG.boardVersion]));
 
-                                    GUI.log(chrome.i18n.getMessage('boardInfoReceived', [CONFIG.boardIdentifier, CONFIG.boardVersion]));
+                                MSP.send_message(MSPCodes.MSP_UID, false, false, function () {
+                                    GUI.log(chrome.i18n.getMessage('uniqueDeviceIdReceived', [CONFIG.uid[0].toString(16) + CONFIG.uid[1].toString(16) + CONFIG.uid[2].toString(16)]));
 
-                                    MSP.send_message(MSPCodes.MSP_UID, false, false, function () {
-                                        GUI.log(chrome.i18n.getMessage('uniqueDeviceIdReceived', [CONFIG.uid[0].toString(16) + CONFIG.uid[1].toString(16) + CONFIG.uid[2].toString(16)]));
+                                    // continue as usually
+                                    CONFIGURATOR.connectionValid = true;
+                                    GUI.allowedTabs = GUI.defaultAllowedTabsWhenConnected.slice();
 
-                                        // continue as usually
-                                        CONFIGURATOR.connectionValid = true;
-                                        GUI.allowedTabs = GUI.defaultAllowedTabsWhenConnected.slice();
-                                        if (semver.lt(CONFIG.apiVersion, "1.4.0")) {
-                                            GUI.allowedTabs.splice(GUI.allowedTabs.indexOf('led_strip'), 1);
-                                        }
+                                    onConnect();
 
-                                        onConnect();
-
-                                        $('#tabs ul.mode-connected .tab_setup a').click();
-                                    });
+                                    $('#tabs ul.mode-connected .tab_setup a').click();
                                 });
                             });
                         });
-                    } else {
-                        GUI.show_modal(chrome.i18n.getMessage('warningTitle'),
-                            chrome.i18n.getMessage('firmwareTypeNotSupported'));
+                    });
+                } else {
+                    GUI.show_modal(chrome.i18n.getMessage('warningTitle'),
+                        chrome.i18n.getMessage('firmwareTypeNotSupported'));
 
-                        connectCli();
-                    }
-                });
-            } else {
-                GUI.show_modal(chrome.i18n.getMessage('warningTitle'),
-                    chrome.i18n.getMessage('firmwareVersionNotSupported', [CONFIGURATOR.apiVersionAccepted]));
-
-                connectCli();
-            }
+                    connectCli();
+                }
+            });
         });
     } else {
         console.log('Failed to open serial port');

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -10,16 +10,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     }
 
     function load_config() {
-        MSP.send_message(MSPCodes.MSP_BF_CONFIG, false, false, load_serial_config);
-    }
-
-    function load_serial_config() {
-        var next_callback = load_rc_map;
-        if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
-            MSP.send_message(MSPCodes.MSP_CF_SERIAL_CONFIG, false, false, next_callback);
-        } else {
-            next_callback();
-        }
+        MSP.send_message(MSPCodes.MSP_BF_CONFIG, false, false, load_rc_map);
     }
 
     function load_rc_map() {
@@ -35,30 +26,15 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     }
 
     function load_arming_config() {
-        var next_callback = load_loop_time;
-        if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
-            MSP.send_message(MSPCodes.MSP_ARMING_CONFIG, false, false, next_callback);
-        } else {
-            next_callback();
-        }
+        MSP.send_message(MSPCodes.MSP_ARMING_CONFIG, false, false, load_loop_time);
     }
     
     function load_loop_time() {
-        var next_callback = load_3d;
-        if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
-            MSP.send_message(MSPCodes.MSP_LOOP_TIME, false, false, next_callback);
-        } else {
-            next_callback();
-        }
+        MSP.send_message(MSPCodes.MSP_LOOP_TIME, false, false, load_3d);
     }
 
     function load_3d() {
-        var next_callback = esc_protocol;
-        if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
-            MSP.send_message(MSPCodes.MSP_3D, false, false, next_callback);
-        } else {
-            next_callback();
-        }
+        MSP.send_message(MSPCodes.MSP_3D, false, false, esc_protocol);
     }
 
     function esc_protocol() {
@@ -80,12 +56,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     }
     
     function load_sensor_alignment() {
-        var next_callback = load_name;
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-            MSP.send_message(MSPCodes.MSP_SENSOR_ALIGNMENT, false, false, next_callback);
-        } else {
-            next_callback();
-        }
+        MSP.send_message(MSPCodes.MSP_SENSOR_ALIGNMENT, false, false, load_name);
     }
     
     function load_name() {
@@ -153,20 +124,16 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         var orientation_gyro_e = $('select.gyroalign');
         var orientation_acc_e = $('select.accalign');
         var orientation_mag_e = $('select.magalign');
-        
 
-        if (semver.lt(CONFIG.apiVersion, "1.15.0")) {
-            $('.tab-configuration .sensoralignment').hide();
-        } else {
-            for (var i = 0; i < alignments.length; i++) {
-                orientation_gyro_e.append('<option value="' + (i+1) + '">'+ alignments[i] + '</option>');
-                orientation_acc_e.append('<option value="' + (i+1) + '">'+ alignments[i] + '</option>');
-                orientation_mag_e.append('<option value="' + (i+1) + '">'+ alignments[i] + '</option>');
-            }
-            orientation_gyro_e.val(SENSOR_ALIGNMENT.align_gyro);
-            orientation_acc_e.val(SENSOR_ALIGNMENT.align_acc);
-            orientation_mag_e.val(SENSOR_ALIGNMENT.align_mag);
+        for (var i = 0; i < alignments.length; i++) {
+            orientation_gyro_e.append('<option value="' + (i+1) + '">'+ alignments[i] + '</option>');
+            orientation_acc_e.append('<option value="' + (i+1) + '">'+ alignments[i] + '</option>');
+            orientation_mag_e.append('<option value="' + (i+1) + '">'+ alignments[i] + '</option>');
         }
+        orientation_gyro_e.val(SENSOR_ALIGNMENT.align_gyro);
+        orientation_acc_e.val(SENSOR_ALIGNMENT.align_acc);
+        orientation_mag_e.val(SENSOR_ALIGNMENT.align_mag);
+
         
         // ESC protocols 
         
@@ -320,16 +287,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         for (var i = 0; i < gpsBaudRates.length; i++) {
             gps_baudrate_e.append('<option value="' + gpsBaudRates[i] + '">' + gpsBaudRates[i] + '</option>');
         }
-    
-        if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
-            gps_baudrate_e.change(function () {
-                SERIAL_CONFIG.gpsBaudRate = parseInt($(this).val());
-            });
-            gps_baudrate_e.val(SERIAL_CONFIG.gpsBaudRate);
-        } else {
-            gps_baudrate_e.prop("disabled", true);
-            gps_baudrate_e.parent().hide();
-        }
+
+        gps_baudrate_e.prop("disabled", true);
+        gps_baudrate_e.parent().hide();
         
         
         var gps_ubx_sbas_e = $('select.gps_ubx_sbas');
@@ -355,9 +315,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'XBUS_MODE_B_RJ01'
         ];
 
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-            serialRXtypes.push('IBUS');
-        }
+        serialRXtypes.push('IBUS');
+
 
         if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "2.6.0"))  {
             serialRXtypes.push('JETIEXBUS');
@@ -392,19 +351,17 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         // fill magnetometer
         $('input[name="mag_declination"]').val(MISC.mag_declination.toFixed(2));
 
-        //fill motor disarm params and FC loop time        
-        if(semver.gte(CONFIG.apiVersion, "1.8.0")) {
-            $('input[name="autodisarmdelay"]').val(ARMING_CONFIG.auto_disarm_delay);
-            $('input[name="disarmkillswitch"]').prop('checked', ARMING_CONFIG.disarm_kill_switch);
-            $('div.disarm').show();            
-            if (BF_CONFIG.features.isEnabled('MOTOR_STOP')) {
-                $('div.disarmdelay').show();
-            } else {
-                $('div.disarmdelay').hide();
-            }
-
-            $('div.cycles').show();
+        //fill motor disarm params and FC loop time
+        $('input[name="autodisarmdelay"]').val(ARMING_CONFIG.auto_disarm_delay);
+        $('input[name="disarmkillswitch"]').prop('checked', ARMING_CONFIG.disarm_kill_switch);
+        $('div.disarm').show();
+        if (BF_CONFIG.features.isEnabled('MOTOR_STOP')) {
+            $('div.disarmdelay').show();
+        } else {
+            $('div.disarmdelay').hide();
         }
+
+        $('div.cycles').show();
         
         // fill throttle
         $('input[name="midrc"]').val(MISC.midrc);
@@ -424,18 +381,15 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[name="multiwiicurrentoutput"]').prop('checked', MISC.multiwiicurrentoutput);
 
         //fill 3D
-        if (semver.lt(CONFIG.apiVersion, "1.14.0")) {
-            $('.tab-configuration .3d').hide();
+        $('input[name="3ddeadbandlow"]').val(_3D.deadband3d_low);
+        $('input[name="3ddeadbandhigh"]').val(_3D.deadband3d_high);
+        $('input[name="3dneutral"]').val(_3D.neutral3d);
+        if (semver.lt(CONFIG.apiVersion, "1.17.0")) {
+            $('input[name="3ddeadbandthrottle"]').val(_3D.deadband3d_throttle);
         } else {
-            $('input[name="3ddeadbandlow"]').val(_3D.deadband3d_low);
-            $('input[name="3ddeadbandhigh"]').val(_3D.deadband3d_high);
-            $('input[name="3dneutral"]').val(_3D.neutral3d);
-            if (semver.lt(CONFIG.apiVersion, "1.17.0")) {
-                $('input[name="3ddeadbandthrottle"]').val(_3D.deadband3d_throttle);
-            } else {
-                $('.3ddeadbandthrottle').hide();
-            }
+            $('.3ddeadbandthrottle').hide();
         }
+
 
         // UI hooks
         $('input.feature', features_e).change(function () {
@@ -472,11 +426,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             MISC.mag_declination = parseFloat($('input[name="mag_declination"]').val());
             
             // motor disarm
-            if(semver.gte(CONFIG.apiVersion, "1.8.0")) {
-                ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
-                ARMING_CONFIG.disarm_kill_switch = ~~$('input[name="disarmkillswitch"]').is(':checked'); // ~~ boolean to decimal conversion
-            }
-            
+            ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
+            ARMING_CONFIG.disarm_kill_switch = ~~$('input[name="disarmkillswitch"]').is(':checked'); // ~~ boolean to decimal conversion
+
             MISC.midrc = parseInt($('input[name="midrc"]').val());
             MISC.minthrottle = parseInt($('input[name="minthrottle"]').val());
             MISC.maxthrottle = parseInt($('input[name="maxthrottle"]').val());
@@ -509,34 +461,16 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             PID_ADVANCED_CONFIG.gyro_sync_denom = parseInt(gyro_select_e.val());
             PID_ADVANCED_CONFIG.pid_process_denom = parseInt(pid_select_e.val());
 
-            function save_serial_config() {
-                if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
-                    MSP.send_message(MSPCodes.MSP_SET_CF_SERIAL_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_CF_SERIAL_CONFIG), false, save_misc);
-                } else {
-                    save_misc();
-                }
-            }
-
             function save_misc() {
                 MSP.send_message(MSPCodes.MSP_SET_MISC, mspHelper.crunch(MSPCodes.MSP_SET_MISC), false, save_3d);
             }
             
             function save_3d() {
-                var next_callback = save_sensor_alignment;
-                if(semver.gte(CONFIG.apiVersion, "1.14.0")) {
-                   MSP.send_message(MSPCodes.MSP_SET_3D, mspHelper.crunch(MSPCodes.MSP_SET_3D), false, next_callback);
-                } else {
-                   next_callback();
-                }     
+                MSP.send_message(MSPCodes.MSP_SET_3D, mspHelper.crunch(MSPCodes.MSP_SET_3D), false, save_sensor_alignment);
             }
             
             function save_sensor_alignment() {
-                var next_callback = save_esc_protocol;
-                if(semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                   MSP.send_message(MSPCodes.MSP_SET_SENSOR_ALIGNMENT, mspHelper.crunch(MSPCodes.MSP_SET_SENSOR_ALIGNMENT), false, next_callback);
-                } else {
-                   next_callback();
-                }     
+                MSP.send_message(MSPCodes.MSP_SET_SENSOR_ALIGNMENT, mspHelper.crunch(MSPCodes.MSP_SET_SENSOR_ALIGNMENT), false, save_esc_protocol);
             }
             function save_esc_protocol() {
                 var next_callback = save_acc_trim;
@@ -548,8 +482,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function save_acc_trim() {
-                MSP.send_message(MSPCodes.MSP_SET_ACC_TRIM, mspHelper.crunch(MSPCodes.MSP_SET_ACC_TRIM), false
-                                , semver.gte(CONFIG.apiVersion, "1.8.0") ? save_arming_config : save_to_eeprom);
+                MSP.send_message(MSPCodes.MSP_SET_ACC_TRIM, mspHelper.crunch(MSPCodes.MSP_SET_ACC_TRIM), false, save_arming_config);
             }
 
             function save_arming_config() {
@@ -620,7 +553,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 }
             }
 
-            MSP.send_message(MSPCodes.MSP_SET_BF_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BF_CONFIG), false, save_serial_config);
+            MSP.send_message(MSPCodes.MSP_SET_BF_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BF_CONFIG), false, save_misc);
             
         });
 

--- a/tabs/failsafe.html
+++ b/tabs/failsafe.html
@@ -10,25 +10,7 @@
                 </p>
             </div>
         </div>
-        <div class="note oldpane">
-            <div class="note_spacer">
-                <p i18n="failsafeFeaturesHelpOld"></p>
-                </p>
-            </div>
-        </div>
         <div class="leftWrapper">
-            <div class="gui_box grey oldpane">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" i18n="failsafePaneTitleOld"></div>
-                </div>
-                <div class="spacer_box">
-                    <div class="number">
-                        <label> <input type="number" name="failsafe_throttle_old" min="0" max="2000" /> <span
-                            i18n="failsafeThrottleItemOld"></span>
-                        </label>
-                    </div>
-                </div>
-            </div>
             <div class="gui_box grey newpane">
                 <div class="gui_box_titlebar">
                     <div class="spacer_box_title" i18n="failsafePulsrangeTitle"></div>

--- a/tabs/failsafe.js
+++ b/tabs/failsafe.js
@@ -37,7 +37,6 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         MSP.send_message(MSPCodes.MSP_RC, false, false, load_config);
     }
 
-    // BEGIN Support for pre API version 1.15.0
     function load_config() {
         MSP.send_message(MSPCodes.MSP_BF_CONFIG, false, false, load_misc);
     }
@@ -45,232 +44,205 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
     function load_misc() {
         MSP.send_message(MSPCodes.MSP_MISC, false, false, load_html);
     }
-    // END (Support for pre API version 1.15.0
 
     function load_html() {
         $('#content').load("./tabs/failsafe.html", process_html);
     }
 
-    var apiVersionGte1_15_0 = semver.gte(CONFIG.apiVersion, "1.15.0");
+    load_rx_config();
 
-    // Uncomment next line for testing older functionality on newer API version
-    //apiVersionGte1_15_0 = false;
-
-    if(apiVersionGte1_15_0) {
-        load_rx_config();
-    } else {
-        load_config();
-    }
 
     function process_html() {
-        // Conditionally hide the old or the new control pane's
-        if(apiVersionGte1_15_0) {
-            var oldPane = $('div.oldpane');
-            oldPane.prop("disabled", true);
-            oldPane.hide();
-        } else {
-            var newPane = $('div.newpane');
-            newPane.prop("disabled", true);
-            newPane.hide();
+
+        // generate labels for assigned aux modes
+        var auxAssignment = [],
+            i,
+            element;
+
+        for (var channelIndex = 0; channelIndex < RC.active_channels - 4; channelIndex++) {
+            auxAssignment.push("");
         }
 
-        if (apiVersionGte1_15_0) {
-            // generate labels for assigned aux modes
-            var auxAssignment = [],
-                i,
-                element;
+        for (var modeIndex = 0; modeIndex < AUX_CONFIG.length; modeIndex++) {
 
-            for (var channelIndex = 0; channelIndex < RC.active_channels - 4; channelIndex++) {
-                auxAssignment.push("");
-            }
+            var modeId = AUX_CONFIG_IDS[modeIndex];
 
-            for (var modeIndex = 0; modeIndex < AUX_CONFIG.length; modeIndex++) {
+            // scan mode ranges to find assignments
+            for (var modeRangeIndex = 0; modeRangeIndex < MODE_RANGES.length; modeRangeIndex++) {
+                var modeRange = MODE_RANGES[modeRangeIndex];
 
-                var modeId = AUX_CONFIG_IDS[modeIndex];
-
-                // scan mode ranges to find assignments
-                for (var modeRangeIndex = 0; modeRangeIndex < MODE_RANGES.length; modeRangeIndex++) {
-                    var modeRange = MODE_RANGES[modeRangeIndex];
-
-                    if (modeRange.id != modeId) {
-                        continue;
-                    }
-
-                    var range = modeRange.range;
-                    if (!(range.start < range.end)) {
-                        continue; // invalid!
-                    }
-
-                    auxAssignment[modeRange.auxChannelIndex] += "<span class=\"modename\">" + AUX_CONFIG[modeIndex] + "</span>";
+                if (modeRange.id != modeId) {
+                    continue;
                 }
-            }
 
-            // generate full channel list
-            var channelNames = [
-                    chrome.i18n.getMessage('controlAxisRoll'),
-                    chrome.i18n.getMessage('controlAxisPitch'),
-                    chrome.i18n.getMessage('controlAxisYaw'),
-                    chrome.i18n.getMessage('controlAxisThrottle')
-                ],
-                fullChannels_e = $('div.activechannellist'),
-                aux_index = 1,
-                aux_assignment_index = 0;
-
-            for (i = 0; i < RXFAIL_CONFIG.length; i++) {
-                if (i < channelNames.length) {
-                    fullChannels_e.append('\
-                        <div class="number">\
-                            <div class="channelprimary">\
-                                <span>' + channelNames[i] + '</span>\
-                            </div>\
-                            <div class="cf_tip channelsetting" title="' + chrome.i18n.getMessage("failsafeChannelFallbackSettingsAuto") + '">\
-                                <select class="aux_set" id="' + i + '">\
-                                    <option value="0">Auto</option>\
-                                    <option value="1">Hold</option>\
-                                </select>\
-                            </div>\
-                        </div>\
-                    ');
-                } else {
-                    fullChannels_e.append('\
-                        <div class="number">\
-                            <div class="channelauxiliary">\
-                                <span class="channelname">' + chrome.i18n.getMessage("controlAxisAux" + (aux_index++)) + '</span>\
-                                ' + auxAssignment[aux_assignment_index++] + '\
-                            </div>\
-                            <div class="cf_tip channelsetting" title="' + chrome.i18n.getMessage("failsafeChannelFallbackSettingsHold") + '">\
-                                <select class="aux_set" id="' + i + '">\
-                                    <option value="1">Hold</option>\
-                                    <option value="2">Set</option>\
-                                </select>\
-                            </div>\
-                            <div class="auxiliary"><input type="number" name="aux_value" min="750" max="2250" id="' + i + '"/></div>\
-                        </div>\
-                    ');
+                var range = modeRange.range;
+                if (!(range.start < range.end)) {
+                    continue; // invalid!
                 }
+
+                auxAssignment[modeRange.auxChannelIndex] += "<span class=\"modename\">" + AUX_CONFIG[modeIndex] + "</span>";
             }
-
-            var channel_mode_array = [];
-            $('.number', fullChannels_e).each(function () {
-                channel_mode_array.push($('select.aux_set' , this));
-            });
-
-            var channel_value_array = [];
-            $('.number', fullChannels_e).each(function () {
-                channel_value_array.push($('input[name="aux_value"]' , this));
-            });
-
-            var channelMode = $('select.aux_set');
-            var channelValue = $('input[name="aux_value"]');
-
-            // UI hooks
-            channelMode.change(function () {
-                var currentMode = parseInt($(this).val());
-                var i = parseInt($(this).prop("id"));
-                RXFAIL_CONFIG[i].mode = currentMode;
-                if (currentMode == 2) {
-                    channel_value_array[i].prop("disabled", false);
-                    channel_value_array[i].show();
-                } else {
-                    channel_value_array[i].prop("disabled", true);
-                    channel_value_array[i].hide();
-                }
-            });
-
-            // UI hooks
-            channelValue.change(function () {
-                var i = parseInt($(this).prop("id"));
-                RXFAIL_CONFIG[i].value = parseInt($(this).val());
-            });
-
-            // for some odd reason chrome 38+ changes scroll according to the touched select element
-            // i am guessing this is a bug, since this wasn't happening on 37
-            // code below is a temporary fix, which we will be able to remove in the future (hopefully)
-            $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
-
-            // fill stage 1 Valid Pulse Range Settings
-            $('input[name="rx_min_usec"]').val(RX_CONFIG.rx_min_usec);
-            $('input[name="rx_max_usec"]').val(RX_CONFIG.rx_max_usec);
-
-            // fill fallback settings (mode and value) for all channels
-            for (i = 0; i < RXFAIL_CONFIG.length; i++) {
-                channel_value_array[i].val(RXFAIL_CONFIG[i].value);
-                channel_mode_array[i].val(RXFAIL_CONFIG[i].mode);
-                channel_mode_array[i].change();
-            }
-
-            $('input[name="failsafe_throttle"]').val(FAILSAFE_CONFIG.failsafe_throttle);
-            $('input[name="failsafe_off_delay"]').val(FAILSAFE_CONFIG.failsafe_off_delay);
-            $('input[name="failsafe_throttle_low_delay"]').val(FAILSAFE_CONFIG.failsafe_throttle_low_delay);
-            $('input[name="failsafe_delay"]').val(FAILSAFE_CONFIG.failsafe_delay);
-
-            // set stage 2 failsafe procedure
-            $('input[type="radio"].procedure').change(function () {
-                var element = $(this),
-                    checked = element.is(':checked'),
-                    id = element.attr('id');
-                switch(id) {
-                    case 'drop':
-                        if (checked) {
-                            $('input[name="failsafe_throttle"]').prop("disabled", true);
-                            $('input[name="failsafe_off_delay"]').prop("disabled", true);
-                        }
-                        break;
-
-                    case 'land':
-                        if (checked) {
-                            $('input[name="failsafe_throttle"]').prop("disabled", false);
-                            $('input[name="failsafe_off_delay"]').prop("disabled", false);
-                        }
-                        break;
-                }
-            });
-
-            switch(FAILSAFE_CONFIG.failsafe_procedure) {
-                default:
-                case 0:
-                    element = $('input[id="land"]') ;
-                    element.prop('checked', true);
-                    element.change();
-                    break;
-                case 1:
-                    element = $('input[id="drop"]');
-                    element.prop('checked', true);
-                    element.change();
-                    break;
-            }
-
-            // set stage 2 kill switch option
-            $('input[name="failsafe_kill_switch"]').prop('checked', FAILSAFE_CONFIG.failsafe_kill_switch);
-
-        } else {
-            // fill failsafe_throttle field (pre API 1.15.0)
-            $('input[name="failsafe_throttle_old"]').val(MISC.failsafe_throttle);
         }
+
+        // generate full channel list
+        var channelNames = [
+                chrome.i18n.getMessage('controlAxisRoll'),
+                chrome.i18n.getMessage('controlAxisPitch'),
+                chrome.i18n.getMessage('controlAxisYaw'),
+                chrome.i18n.getMessage('controlAxisThrottle')
+            ],
+            fullChannels_e = $('div.activechannellist'),
+            aux_index = 1,
+            aux_assignment_index = 0;
+
+        for (i = 0; i < RXFAIL_CONFIG.length; i++) {
+            if (i < channelNames.length) {
+                fullChannels_e.append('\
+                    <div class="number">\
+                        <div class="channelprimary">\
+                            <span>' + channelNames[i] + '</span>\
+                        </div>\
+                        <div class="cf_tip channelsetting" title="' + chrome.i18n.getMessage("failsafeChannelFallbackSettingsAuto") + '">\
+                            <select class="aux_set" id="' + i + '">\
+                                <option value="0">Auto</option>\
+                                <option value="1">Hold</option>\
+                            </select>\
+                        </div>\
+                    </div>\
+                ');
+            } else {
+                fullChannels_e.append('\
+                    <div class="number">\
+                        <div class="channelauxiliary">\
+                            <span class="channelname">' + chrome.i18n.getMessage("controlAxisAux" + (aux_index++)) + '</span>\
+                            ' + auxAssignment[aux_assignment_index++] + '\
+                        </div>\
+                        <div class="cf_tip channelsetting" title="' + chrome.i18n.getMessage("failsafeChannelFallbackSettingsHold") + '">\
+                            <select class="aux_set" id="' + i + '">\
+                                <option value="1">Hold</option>\
+                                <option value="2">Set</option>\
+                            </select>\
+                        </div>\
+                        <div class="auxiliary"><input type="number" name="aux_value" min="750" max="2250" id="' + i + '"/></div>\
+                    </div>\
+                ');
+            }
+        }
+
+        var channel_mode_array = [];
+        $('.number', fullChannels_e).each(function () {
+            channel_mode_array.push($('select.aux_set' , this));
+        });
+
+        var channel_value_array = [];
+        $('.number', fullChannels_e).each(function () {
+            channel_value_array.push($('input[name="aux_value"]' , this));
+        });
+
+        var channelMode = $('select.aux_set');
+        var channelValue = $('input[name="aux_value"]');
+
+        // UI hooks
+        channelMode.change(function () {
+            var currentMode = parseInt($(this).val());
+            var i = parseInt($(this).prop("id"));
+            RXFAIL_CONFIG[i].mode = currentMode;
+            if (currentMode == 2) {
+                channel_value_array[i].prop("disabled", false);
+                channel_value_array[i].show();
+            } else {
+                channel_value_array[i].prop("disabled", true);
+                channel_value_array[i].hide();
+            }
+        });
+
+        // UI hooks
+        channelValue.change(function () {
+            var i = parseInt($(this).prop("id"));
+            RXFAIL_CONFIG[i].value = parseInt($(this).val());
+        });
+
+        // for some odd reason chrome 38+ changes scroll according to the touched select element
+        // i am guessing this is a bug, since this wasn't happening on 37
+        // code below is a temporary fix, which we will be able to remove in the future (hopefully)
+        $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
+
+        // fill stage 1 Valid Pulse Range Settings
+        $('input[name="rx_min_usec"]').val(RX_CONFIG.rx_min_usec);
+        $('input[name="rx_max_usec"]').val(RX_CONFIG.rx_max_usec);
+
+        // fill fallback settings (mode and value) for all channels
+        for (i = 0; i < RXFAIL_CONFIG.length; i++) {
+            channel_value_array[i].val(RXFAIL_CONFIG[i].value);
+            channel_mode_array[i].val(RXFAIL_CONFIG[i].mode);
+            channel_mode_array[i].change();
+        }
+
+        $('input[name="failsafe_throttle"]').val(FAILSAFE_CONFIG.failsafe_throttle);
+        $('input[name="failsafe_off_delay"]').val(FAILSAFE_CONFIG.failsafe_off_delay);
+        $('input[name="failsafe_throttle_low_delay"]').val(FAILSAFE_CONFIG.failsafe_throttle_low_delay);
+        $('input[name="failsafe_delay"]').val(FAILSAFE_CONFIG.failsafe_delay);
+
+        // set stage 2 failsafe procedure
+        $('input[type="radio"].procedure').change(function () {
+            var element = $(this),
+                checked = element.is(':checked'),
+                id = element.attr('id');
+            switch(id) {
+                case 'drop':
+                    if (checked) {
+                        $('input[name="failsafe_throttle"]').prop("disabled", true);
+                        $('input[name="failsafe_off_delay"]').prop("disabled", true);
+                    }
+                    break;
+
+                case 'land':
+                    if (checked) {
+                        $('input[name="failsafe_throttle"]').prop("disabled", false);
+                        $('input[name="failsafe_off_delay"]').prop("disabled", false);
+                    }
+                    break;
+            }
+        });
+
+        switch(FAILSAFE_CONFIG.failsafe_procedure) {
+            default:
+            case 0:
+                element = $('input[id="land"]') ;
+                element.prop('checked', true);
+                element.change();
+                break;
+            case 1:
+                element = $('input[id="drop"]');
+                element.prop('checked', true);
+                element.change();
+                break;
+        }
+
+        // set stage 2 kill switch option
+        $('input[name="failsafe_kill_switch"]').prop('checked', FAILSAFE_CONFIG.failsafe_kill_switch);
+
+
 
         $('a.save').click(function () {
             // gather data that doesn't have automatic change event bound
 
-            if(apiVersionGte1_15_0) {
-                RX_CONFIG.rx_min_usec = parseInt($('input[name="rx_min_usec"]').val());
-                RX_CONFIG.rx_max_usec = parseInt($('input[name="rx_max_usec"]').val());
+            RX_CONFIG.rx_min_usec = parseInt($('input[name="rx_min_usec"]').val());
+            RX_CONFIG.rx_max_usec = parseInt($('input[name="rx_max_usec"]').val());
 
-                FAILSAFE_CONFIG.failsafe_throttle = parseInt($('input[name="failsafe_throttle"]').val());
-                FAILSAFE_CONFIG.failsafe_off_delay = parseInt($('input[name="failsafe_off_delay"]').val());
-                FAILSAFE_CONFIG.failsafe_throttle_low_delay = parseInt($('input[name="failsafe_throttle_low_delay"]').val());
-                FAILSAFE_CONFIG.failsafe_delay = parseInt($('input[name="failsafe_delay"]').val());
+            FAILSAFE_CONFIG.failsafe_throttle = parseInt($('input[name="failsafe_throttle"]').val());
+            FAILSAFE_CONFIG.failsafe_off_delay = parseInt($('input[name="failsafe_off_delay"]').val());
+            FAILSAFE_CONFIG.failsafe_throttle_low_delay = parseInt($('input[name="failsafe_throttle_low_delay"]').val());
+            FAILSAFE_CONFIG.failsafe_delay = parseInt($('input[name="failsafe_delay"]').val());
 
-                if( $('input[id="land"]').is(':checked')) {
-                    FAILSAFE_CONFIG.failsafe_procedure = 0;
-                } else if( $('input[id="drop"]').is(':checked')) {
-                    FAILSAFE_CONFIG.failsafe_procedure = 1;
-                }
-
-                FAILSAFE_CONFIG.failsafe_kill_switch = $('input[name="failsafe_kill_switch"]').is(':checked') ? 1 : 0;
-            } else {
-                // get failsafe_throttle field value (pre API 1.15.0)
-                MISC.failsafe_throttle = parseInt($('input[name="failsafe_throttle_old"]').val());
+            if( $('input[id="land"]').is(':checked')) {
+                FAILSAFE_CONFIG.failsafe_procedure = 0;
+            } else if( $('input[id="drop"]').is(':checked')) {
+                FAILSAFE_CONFIG.failsafe_procedure = 1;
             }
+
+            FAILSAFE_CONFIG.failsafe_kill_switch = $('input[name="failsafe_kill_switch"]').is(':checked') ? 1 : 0;
+
 
             function save_failssafe_config() {
                 MSP.send_message(MSPCodes.MSP_SET_FAILSAFE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FAILSAFE_CONFIG), false, save_rxfail_config);
@@ -320,12 +292,8 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                     },1500); // 1500 ms seems to be just the right amount of delay to prevent data request timeouts
                 }
             }
+            MSP.send_message(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG), false, save_failssafe_config);
 
-            if(apiVersionGte1_15_0) {
-                MSP.send_message(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG), false, save_failssafe_config);
-            } else {
-                MSP.send_message(MSPCodes.MSP_SET_BF_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BF_CONFIG), false, save_misc);
-            }
         });
 
         // translate to user-selected language

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -25,14 +25,8 @@ TABS.motors.initialize = function (callback) {
     }
     
     function load_3d() {
-        var next_callback = get_motor_data;
-        if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
-            self.feature3DSupported = true;
-            MSP.send_message(MSPCodes.MSP_3D, false, false, next_callback);
-        } else {
-            next_callback();
-        }
-        
+        self.feature3DSupported = true;
+        MSP.send_message(MSPCodes.MSP_3D, false, false, get_motor_data);
     }
     
     function get_motor_data() {

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -85,7 +85,6 @@
                                 <div class="bracket"></div>
                             </td>
                             <td class="roll_rate"><input type="number" name="roll_rate" step="0.01" min="0" max="1.00" /></td>
-                            <td class="roll_pitch_rate" rowspan="2"><input type="number" name="roll_pitch_rate" step="0.01" min="0" max="1.00" /></td>
                             <td rowspan="2" style="background-color:white;">
                                 <input type="number" name="rc_expo" step="0.01" min="0" max="1" />
                                 <div class="bracket"></div>

--- a/tabs/ports.js
+++ b/tabs/ports.js
@@ -8,22 +8,15 @@ TABS.ports.initialize = function (callback, scrollPosition) {
     var board_definition = {};
 
     var functionRules = [
-         {name: 'MSP',                  groups: ['data', 'msp'], maxPorts: 2},
-         {name: 'GPS',                  groups: ['gps'], maxPorts: 1},
-         {name: 'TELEMETRY_FRSKY',      groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
-         {name: 'TELEMETRY_HOTT',       groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
-         {name: 'TELEMETRY_SMARTPORT',  groups: ['telemetry'], maxPorts: 1},
-         {name: 'RX_SERIAL',            groups: ['rx'], maxPorts: 1},
-         {name: 'BLACKBOX',             groups: ['logging', 'blackbox'], sharableWith: ['msp'], notSharableWith: ['telemetry'], maxPorts: 1},
+        {name: 'MSP',                  groups: ['data', 'msp'], maxPorts: 2},
+        {name: 'GPS',                  groups: ['gps'], maxPorts: 1},
+        {name: 'TELEMETRY_FRSKY',      groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
+        {name: 'TELEMETRY_HOTT',       groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1},
+        {name: 'TELEMETRY_SMARTPORT',  groups: ['telemetry'], maxPorts: 1},
+        {name: 'RX_SERIAL',            groups: ['rx'], maxPorts: 1},
+        {name: 'BLACKBOX',             groups: ['logging', 'blackbox'], sharableWith: ['msp'], notSharableWith: ['telemetry'], maxPorts: 1},
+        {name: 'TELEMETRY_LTM',        groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1}
     ];
-
-    if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-        var ltmFunctionRule = {name: 'TELEMETRY_LTM',        groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1};
-        functionRules.push(ltmFunctionRule);
-    } else {
-        var mspFunctionRule = {name: 'TELEMETRY_MSP',        groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1};
-        functionRules.push(mspFunctionRule);
-    }
 
     if (semver.gte(CONFIG.apiVersion, "1.18.0")) {
         var mavlinkFunctionRule = {name: 'TELEMETRY_MAVLINK',    groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['blackbox'], maxPorts: 1};
@@ -88,12 +81,6 @@ TABS.ports.initialize = function (callback, scrollPosition) {
     }
 
     function update_ui() {
-        
-        if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
-            
-            $(".tab-ports").removeClass("supported");
-            return;
-        }
         
         $(".tab-ports").addClass("supported");
         

--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -33,12 +33,7 @@ TABS.receiver.initialize = function (callback) {
     }
 
     function load_rc_configs() {
-        var next_callback = load_html;
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-            MSP.send_message(MSPCodes.MSP_RC_DEADBAND, false, false, next_callback);
-        } else {
-            next_callback();
-        }
+        MSP.send_message(MSPCodes.MSP_RC_DEADBAND, false, false, load_html);
     }
 
     function load_html() {
@@ -59,12 +54,9 @@ TABS.receiver.initialize = function (callback) {
             }
         });
 
-        if (semver.lt(CONFIG.apiVersion, "1.15.0")) {
-            $('.deadband').hide();
-        } else {
-            $('.deadband input[name="yaw_deadband"]').val(RC_deadband.yaw_deadband);
-            $('.deadband input[name="deadband"]').val(RC_deadband.deadband);
-        }
+        $('.deadband input[name="yaw_deadband"]').val(RC_deadband.yaw_deadband);
+        $('.deadband input[name="deadband"]').val(RC_deadband.deadband);
+
 
         // generate bars
         var bar_names = [
@@ -204,10 +196,8 @@ TABS.receiver.initialize = function (callback) {
         });
 
         $('a.update').click(function () {
-            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-               RC_deadband.yaw_deadband = parseInt($('.deadband input[name="yaw_deadband"]').val());
-               RC_deadband.deadband = parseInt($('.deadband input[name="deadband"]').val());
-            }
+           RC_deadband.yaw_deadband = parseInt($('.deadband input[name="yaw_deadband"]').val());
+           RC_deadband.deadband = parseInt($('.deadband input[name="deadband"]').val());
 
             // catch rc map
             var RC_MAP_Letters = ['A', 'E', 'R', 'T', '1', '2', '3', '4'];
@@ -225,12 +215,7 @@ TABS.receiver.initialize = function (callback) {
             }
 
             function save_rc_configs() {
-                var next_callback = save_to_eeprom;
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                   MSP.send_message(MSPCodes.MSP_SET_RC_DEADBAND, mspHelper.crunch(MSPCodes.MSP_SET_RC_DEADBAND), false, next_callback);
-                } else {
-                   next_callback();
-                }
+                MSP.send_message(MSPCodes.MSP_SET_RC_DEADBAND, mspHelper.crunch(MSPCodes.MSP_SET_RC_DEADBAND), false, save_to_eeprom);
             }
 
             function save_to_eeprom() {

--- a/tabs/servos.js
+++ b/tabs/servos.js
@@ -13,17 +13,7 @@ TABS.servos.initialize = function (callback) {
     }
 
     function get_servo_mix_rules() {
-        MSP.send_message(MSPCodes.MSP_SERVO_MIX_RULES, false, false, get_channel_forwarding);
-    }
-
-    function get_channel_forwarding() {
-        var nextFunction = get_rc_data;
-        
-        if (semver.lt(CONFIG.apiVersion, "1.12.0")) {
-            MSP.send_message(MSPCodes.MSP_CHANNEL_FORWARDING, false, false, nextFunction);
-        } else { 
-            nextFunction();
-        }
+        MSP.send_message(MSPCodes.MSP_SERVO_MIX_RULES, false, false, get_rc_data);
     }
 
     function get_rc_data() {
@@ -41,7 +31,7 @@ TABS.servos.initialize = function (callback) {
     
     function update_ui() {
             
-        if (semver.lt(CONFIG.apiVersion, "1.12.0") || SERVO_CONFIG.length == 0) {
+        if (SERVO_CONFIG.length == 0) { //TODO, probably remove this?
             
             $(".tab-servos").removeClass("supported");
             return;

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -33,13 +33,6 @@ TABS.setup.initialize = function (callback) {
         // translate to user-selected language
         localize();
 
-        if (semver.lt(CONFIG.apiVersion, CONFIGURATOR.backupRestoreMinApiVersionAccepted)) {
-            $('#content .backup').addClass('disabled');
-            $('#content .restore').addClass('disabled');
-
-            GUI.log(chrome.i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [CONFIG.apiVersion, CONFIGURATOR.backupRestoreMinApiVersionAccepted]));
-        }
-
         // initialize 3D Model
         self.initModel();
 

--- a/tabs/transponder.js
+++ b/tabs/transponder.js
@@ -12,7 +12,7 @@ TABS.transponder.initialize = function (callback, scrollPosition) {
     }
 
     // transponder supported added in MSP API Version 1.16.0
-    TABS.transponder.available = semver.gte(CONFIG.apiVersion, "1.16.0");
+    TABS.transponder.available = true;
     
     if (!TABS.transponder.available) {
         load_html();


### PR DESCRIPTION
Betaflight 2.1.0 used apiVersion 1.13. 
2.4.0 uses 1.16
3.0 uses 1.20

This PR removes all old checks prior to apiVersion 1.16, thus cleans up the code. 