### PR TITLE
Rates Graph Enhancements

### DIFF
--- a/tabs/pid_tuning.css
+++ b/tabs/pid_tuning.css
@@ -204,6 +204,8 @@
 .tab-pid_tuning .rate_curve {
     margin: 0 4px 0px 0;
     height: 100%;
+    min-height: 250px;
+    min-width: 250px;
     border: 1px solid silver;
     border-radius: 3px;
     background-image: url(../images/paper.jpg);

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -350,8 +350,8 @@
                                         <td>
                                             <div class="spacer" style="margin-top: 10px;">
                                                 <div class="rate_curve" style="position:relative;" >
-                                                    <canvas height="120px" style="position:absolute; top: 0; left: 0; z-index: 0; height:100%; width:100%;"></canvas>
-                                                    <canvas height="120px" style="position:absolute; top: 0; left: 0; z-index: 1; height:100%; width:100%;"></canvas>
+                                                    <canvas id="rate_curve_layer0" height="120px" style="position:absolute; top: 0; left: 0; z-index: 0; height:100%; width:100%;"></canvas>
+                                                    <canvas id="rate_curve_layer1" height="120px" style="position:absolute; top: 0; left: 0; z-index: 1; height:100%; width:100%;"></canvas>
                                                 </div>
                                             </div>
                                         </td>

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -349,8 +349,9 @@
                                     <tr>
                                         <td>
                                             <div class="spacer" style="margin-top: 10px;">
-                                                <div class="rate_curve">
-                                                    <canvas height="120px" style="width: 100%; height: 100%"></canvas>
+                                                <div class="rate_curve" style="position:relative;" >
+                                                    <canvas height="120px" style="position:absolute; top: 0; left: 0; z-index: 0; height:100%; width:100%;"></canvas>
+                                                    <canvas height="120px" style="position:absolute; top: 0; left: 0; z-index: 1; height:100%; width:100%;"></canvas>
                                                 </div>
                                             </div>
                                         </td>


### PR DESCRIPTION
Some changes to the rates graph to add dynamic font re-sizing and stick position indicators

1. Prevent the balloon labels from overlapping,
1. Modified label transparency to improve curve visibility.
1. Add dynamic stick position indicators to rates graph including current value in deg/s.
1. Add minimum font size to text (for low DPI monitors).
1. Extend the length of the pointer on the balloons.
1. Remove 360deg/s axes lines.
1. Stick indicators and value labels are now on a separate canvas layer to maximise redraw performance.

<img width="1440" alt="rates graps - stick values" src="https://cloud.githubusercontent.com/assets/7362663/18606749/5c03da2e-7cb0-11e6-9f77-0a688f7c8284.png">

Hopefully the dynamic fonts will help low DPI resolution monitors issues #282 and #283;
