### PR TITLE
Prettified JSON backup files

### DIFF
--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -198,7 +198,7 @@ function configuration_backup(callback) {
                         chosenFileEntry = fileEntryWritable;
 
                         // crunch the config object
-                        var serialized_config_object = JSON.stringify(configuration);
+                        var serialized_config_object = JSON.stringify(configuration, null, '\t');
                         var blob = new Blob([serialized_config_object], {type: 'text/plain'}); // first parameter for Blob needs to be an array
 
                         chosenFileEntry.createWriter(function (writer) {


### PR DESCRIPTION
When saving a backup of the configuration the output JSON is currently not formatted at all. I changed this to tab formatting.

The reason for me was that I am regularly doing diffs of my backup files to determine what I have changed. This is very difficult to see on unformatted JSON. The file gets a bit bigger with formatting but these few kb should not harm anyone, but the file readability and diffability is getting way better.

What do you think?