### PR TITLE
Add DSHOT option

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -190,6 +190,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             escprotocols.push('BRUSHED');
         }
 
+        if (CONFIG.flightControllerIdentifier == "BTFL" && semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+            escprotocols.push('DSHOT');
+        }
+
         var esc_protocol_e = $('select.escprotocol');
 
         for (var i = 0; i < escprotocols.length; i++) {


### PR DESCRIPTION
Usefull for testers. It will work with PR https://github.com/betaflight/betaflight/pull/1282

@mikeller 
I know its based on version checking, but we dont have a new MSP version yet for this option. 3.1 builds are still beta