### PR TITLE
Added tooltip explaining the delay when feature DISPLAY is enabled with no display device.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -515,6 +515,9 @@
     "featureDISPLAY": {
         "message": "OLED Screen Display"
     },
+    "featureDISPLAYTip": {
+        "message": "If this feature is enabled, and no display device is connected (or the display device is not powered up), there will be a delay of approx. 10 seconds on every reboot of the flight controller."
+    },
     "featureONESHOT125": {
         "message": "ONESHOT ESC support"
     },

--- a/js/Features.js
+++ b/js/Features.js
@@ -20,7 +20,7 @@ var Features = function (config) {
         {bit: 14, group: 'rxMode', mode: 'select', name: 'RX_MSP'},
         {bit: 15, group: 'rssi', name: 'RSSI_ADC'},
         {bit: 16, group: 'other', name: 'LED_STRIP'},
-        {bit: 17, group: 'other', name: 'DISPLAY'},
+        {bit: 17, group: 'other', name: 'DISPLAY', haveTip: true},
         {bit: 19, group: 'other', name: 'BLACKBOX', haveTip: true}
     ];
 


### PR DESCRIPTION
Workaround for https://github.com/betaflight/betaflight/issues/2049 .