### PR TITLE
Blackbox download crc error packet retry

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -11,6 +11,7 @@ var MSP = {
     message_buffer_uint8_view:  null,
     message_checksum:           0,
     messageIsJumboFrame:        false,
+    
 
     callbacks:                  [],
     packet_error:               0,
@@ -109,14 +110,14 @@ var MSP = {
                     }
                     break;
                 case 9:
-                    if (this.message_checksum == data[i]) {
-                        // message received, store dataview
-                        this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
-                    } else {
+                    if (this.message_checksum != data[i]) {
                         console.log('code: ' + this.code + ' - crc failed');
-                        this.dataView = null;
                         this.packet_error++;
+                        if (this.code == MSPCodes.MSP_DATAFLASH_READ) {
+                            this.message_buffer_uint8_view[6] = 255;
+			}
                     }
+                    this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
                     // Reset variables
                     this.message_length_received = 0;
                     this.state = 0;

--- a/js/msp.js
+++ b/js/msp.js
@@ -11,7 +11,6 @@ var MSP = {
     message_buffer_uint8_view:  null,
     message_checksum:           0,
     messageIsJumboFrame:        false,
-    
 
     callbacks:                  [],
     packet_error:               0,
@@ -113,6 +112,10 @@ var MSP = {
                     if (this.message_checksum != data[i]) {
                         console.log('code: ' + this.code + ' - crc failed');
                         this.packet_error++;
+                        
+                        // if this is a dataflash read packet then use
+                        // the compressionType byte as a flag to indicate
+                        // that a crc error occurred and the packet should retry
                         if (this.code == MSPCodes.MSP_DATAFLASH_READ) {
                             this.message_buffer_uint8_view[6] = 255;
 			}

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1280,13 +1280,18 @@ MspHelper.prototype.dataflashRead = function(address, blockSize, onDataCallback)
         }
 
         // Verify that the address of the memory returned matches what the caller asked for
-        if (chunkAddress == address) {
+        // also check to see if the packet had a crc error - if so, retry by
+        // returning an empty buffer to the callback
+        if ((chunkAddress == address) && (dataCompressionType != 255)) {
             /* Strip that address off the front of the reply and deliver it separately so the caller doesn't have to
              * figure out the reply format:
              */
             onDataCallback(address, new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize));
         } else {
             // Report error
+            if (dataCompressionType == 255) {
+		console.log('CRC error for address ' + address + ' - retrying');
+            }
             onDataCallback(address, null);
         }
     });


### PR DESCRIPTION
This is my first pull request so I hope I did it right :)

This is a quick and dirty patch to allow the dataflash download to retry any packets that have crc errors detected.  Previously the crc error was unhanded and led to javascript runtime errors and the blackbox download would hang.  Tested this patch with both CP210x and VCP targets.  Used large (4096) block sizes and even high baud rates (500000) with 100% success - no more freezes on blackbox download and the improvements to increase the speed are retained.

References issue 411 - https://github.com/betaflight/betaflight-configurator/issues/411