### PR TITLE
Blackbox download crc error packet retry - version 2

### DIFF
--- a/js/msp.js
+++ b/js/msp.js
@@ -11,6 +11,7 @@ var MSP = {
     message_buffer_uint8_view:  null,
     message_checksum:           0,
     messageIsJumboFrame:        false,
+    crcError:                   false,
 
     callbacks:                  [],
     packet_error:               0,
@@ -109,19 +110,19 @@ var MSP = {
                     }
                     break;
                 case 9:
-                    if (this.message_checksum == data[i]) {
-                        // message received, store dataview
-                        this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
-                    } else {
+                    if (this.message_checksum != data[i]) {
                         console.log('code: ' + this.code + ' - crc failed');
-                        this.dataView = null;
                         this.packet_error++;
+                        this.crcError = true;
                     }
+                    // message received, store dataview
+                    this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
                     // Reset variables
                     this.message_length_received = 0;
                     this.state = 0;
                     this.messageIsJumboFrame = false;
                     this.notify();
+                    this.crcError = false;
                     break;
 
                 default:

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -52,6 +52,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
     var data = dataHandler.dataView; // DataView (allowing us to view arrayBuffer as struct/union)
     var code = dataHandler.code;
+    var crcError = dataHandler.crcError;
     if (!dataHandler.unsupported) switch (code) {
         case MSPCodes.MSP_STATUS:
             CONFIG.cycleTime = data.readU16();
@@ -957,7 +958,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
             dataHandler.callbacks.splice(i, 1);
 
             // fire callback
-            if (callback) callback({'command': code, 'data': data, 'length': data.byteLength});
+            if (callback) callback({'command': code, 'data': data, 'length': data.byteLength, 'crcError': crcError});
         }
     }
 }
@@ -1279,14 +1280,17 @@ MspHelper.prototype.dataflashRead = function(address, blockSize, onDataCallback)
             dataCompressionType = response.data.readU8();
         }
 
-        // Verify that the address of the memory returned matches what the caller asked for
-        if (chunkAddress == address) {
+        // Verify that the address of the memory returned matches what the caller asked for and there was not a CRC error
+        if ((chunkAddress == address) && !(response.crcError)) {
             /* Strip that address off the front of the reply and deliver it separately so the caller doesn't have to
              * figure out the reply format:
              */
             onDataCallback(address, new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize));
         } else {
             // Report error
+            if (response.crcError) {
+              console.log('CRC error for address ' + address + ' - retrying');
+            }
             onDataCallback(address, null);
         }
     });


### PR DESCRIPTION
Related to https://github.com/betaflight/betaflight-configurator/issues/411

Revised version of the patches to enable retrying MSP blackbox download packets in the event of a CRC error.  Resolves the problem of the blackbox download freezing for some people when using jumbo frames in BF 3.1 or later.

Revised the patches to include a `crcError` flag in the callback response rather than using the dataCompressionType byte in the payload.  This will also enable other MSP message types to utilize the `crcError` flag to retransmit if appropriate (future implementation).

Tested on CP210x (including high baud rates) and VCP targets.