### PR TITLE
add support for connect over raw tcp socket

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
     "pages": ["tabs/map.html"]
     },
          
-        "permissions": [
+    "permissions": [
         "https://maps.googleapis.com/*",    
         "https://*.github.com/",
         "https://*.githubusercontent.com/",
@@ -40,6 +40,11 @@
             {"vendorId": 1155, "productId": 57105}
         ]}
     ],
+    "sockets": {
+        "tcp": {
+            "connect": "*:*"
+        }
+    },
 
     "icons": {
         "128": "images/bf_icon_128.png"


### PR DESCRIPTION
use esp8266 as wifi-to-serial transparent bridge.
test with [esp-link v2.2.3](https://github.com/jeelabs/esp-link/releases/tag/v2.2.3)
I had disabled debug log, not test with debug log on.
(web setting page >> Debug log >> off, see: [https://github.com/jeelabs/esp-link/issues/83](https://github.com/jeelabs/esp-link/issues/83) )

#### usage:
select `Manual Selection`
type `tcp://esp-ip:port` (esp-link default: `tcp://192.168.4.1:2323`)
and click `connect`
