### PR TITLE
RC Range values applied to RateCurve for correctness

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -338,7 +338,7 @@
         "message": "Restore"
     },
     "initialSetupBackupRestoreText": {
-        "message": "<strong>Backup</strong> your configuration in case of an accident, <strong>CLI</strong> settings are <span style=\"color: red\">not</span> included - See 'dump' cli command"
+        "message": "<strong>Backup</strong> your configuration in case of an accident, <strong>CLI</strong> settings are <span style=\"color: red\">not</span> included - See 'diff all' cli command"
     },
     "initialSetupBackupSuccess": {
         "message": "Backup saved <span style=\"color: #ffbb00\">successfully</span>"


### PR DESCRIPTION
While trying my brand-new EzUHF I noticed that custom RC center values are ignored by the 3D model and Rate Curve in configurator.
Now they correctly take `RX_CONFIG.midrc`, `MISC.mincommand`, and `MISC.maxthrottle` into account.
As a bonus, changed the backup caption on `Setup` tab to point user at `diff all` instead of `dump`.