### PR TITLE
Use locale US in PayPal donation link

### DIFF
--- a/tabs/landing.html
+++ b/tabs/landing.html
@@ -24,7 +24,7 @@
                     <h3 i18n="defaultDonateHead"></h3>
                     <div i18n="defaultDonateText"></div>
                     <div class="donate">
-                        <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=dreambb1982%40gmail%2ecom&lc=NL&item_name=Betaflight&no_note=0&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest"
+                        <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=dreambb1982%40gmail%2ecom&lc=US&item_name=Betaflight&no_note=0&currency_code=USD&bn=PP%2dDonationsBF%3abtn_donateCC_LG%2egif%3aNonHostedGuest"
                             target="_blank" title="Donate"><img src="./images/btn-donate.png" alt="Paypal"
                             height="30" /></a>
                         </li>


### PR DESCRIPTION
Facilitate making PayPal donations by linking to the English version of the donations page.