### PR TITLE
Replace invalid filesystem characters in suggested backup filename

### DIFF
--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -164,7 +164,7 @@ function configuration_backup(callback) {
         var chosenFileEntry = null;
 
         var accepts = [{
-            extensions: ['txt']
+            extensions: ['json']
         }];
 
         // generate timestamp for the backup file

--- a/js/backup_restore.js
+++ b/js/backup_restore.js
@@ -170,6 +170,9 @@ function configuration_backup(callback) {
         // generate timestamp for the backup file
         var now = new Date().toISOString().split(".")[0];
 
+        // replace invalid filesystem characters
+        now = now.replace(new RegExp(':', 'g'), '_');
+
         // create or load the file
         chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: 'betaflight_backup_' + now + '.json', accepts: accepts}, function (fileEntry) {
             if (chrome.runtime.lastError) {


### PR DESCRIPTION
Fixes issue https://github.com/betaflight/betaflight-configurator/issues/458 by replacing invalid filesystem characters in the suggested backup filename.