### PR TITLE
Clarify Spektrum SRXL menu entry.

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -453,7 +453,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.24.0"))  {
-            serialRXtypes.push('SRXL');
+            serialRXtypes.push('Spektrum Bidir SRXL');
         }
 
         var serialRX_e = $('select.serialRX');


### PR DESCRIPTION
Serial Rx Provider menu entry "SRXL" made a bit more specific "Spektrum Bidir SRXL" not to be mixed up and confused with Multiplex SRXL. Last issue on this subject: https://github.com/betaflight/betaflight/issues/2884#issuecomment-294311395
Not sure if also the XBUS entries should be clarified, another PR maybe.
