### PR TITLE
BF/CF - Adding TARGET_CUSTOM SerialRx protocol option

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -456,6 +456,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             serialRXtypes.push('Spektrum Bidir SRXL');
         }
 
+        if (semver.gte(CONFIG.flightControllerVersion, "3.2.0"))  {
+            serialRXtypes.push('TARGET_CUSTOM');
+        }
+
         var serialRX_e = $('select.serialRX');
         for (var i = 0; i < serialRXtypes.length; i++) {
             serialRX_e.append('<option value="' + i + '">' + serialRXtypes[i] + '</option>');


### PR DESCRIPTION
Allows configurator to choose to use custom target-defined serialRx
protocols. Requires target support.