### PR TITLE
Gating TARGET_CUSTOM SerialRx support on MSP Version

### DIFF
--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -456,7 +456,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             serialRXtypes.push('Spektrum Bidir SRXL');
         }
 
-        if (semver.gte(CONFIG.flightControllerVersion, "3.2.0"))  {
+        if (semver.gte(CONFIG.apiVersion, "1.35.0"))  {
             serialRXtypes.push('TARGET_CUSTOM');
         }
 


### PR DESCRIPTION
Mistakenly wrapped support for TARGET_CUSTOM SerialRx protocol by a check for FC version, when it should be MSP version