### PR TITLE
Fix for Config save suggesting filename not including vesselName

### DIFF
--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -137,9 +137,13 @@ TABS.setup.initialize = function (callback) {
                 return;
             }
 
-            configuration_backup(function () {
-                GUI.log(chrome.i18n.getMessage('initialSetupBackupSuccess'));
-            });
+            if (semver.gte(CONFIG.flightControllerVersion, "3.0.0")) {
+            	MSP.send_message(MSPCodes.MSP_NAME, false, false, function () {
+            		configuration_backup(function () {
+                        GUI.log(chrome.i18n.getMessage('initialSetupBackupSuccess'));
+                    });
+            	}
+            }
         });
 
         $('#content .restore').click(function () {

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -142,7 +142,7 @@ TABS.setup.initialize = function (callback) {
             		configuration_backup(function () {
                         GUI.log(chrome.i18n.getMessage('initialSetupBackupSuccess'));
                     });
-            	}
+            	});
             }
         });
 


### PR DESCRIPTION
If 'save config' is chosen from the setup tab before going to the configuration tab, the suggested file name will not include the CONFIG.name value. This PR should fix that.

I saw a reference in an earlier PR about not using flightControllerVersion anymore to check version, but this is what is used in load_name() in configuration.js already. Any input or suggestions welcome. 