### PR TITLE
fixed floating scrollbar on blackbox tab

### DIFF
--- a/main.css
+++ b/main.css
@@ -1467,9 +1467,9 @@ dialog {
 }
 
 /* fixing padding for all Tabs*/
-.tab-setup, .tab-landing, .tab-adjustments, .tab-auxiliary, .tab-cli, .tab-configuration, .tab-failsafe, .tab-onboard_logging,
-    .tab-firmware_flasher, .tab-gps, .tab-help, .tab-led-strip, .tab-logging, .tab-modes, .tab-motors, .tab-pid_tuning,
-    .tab-ports, .tab-receiver, .tab-sensors, .tab-servos, .tab-osd, .tab-power {
+.tab-setup, .tab-landing, .tab-adjustments, .tab-auxiliary, .tab-cli, .tab-configuration, .tab-failsafe, .tab-firmware_flasher,
+    .tab-gps, .tab-help, .tab-led-strip, .tab-logging, .tab-modes, .tab-motors, .tab-pid_tuning, .tab-ports, .tab-receiver,
+    .tab-sensors, .tab-servos, .tab-osd, .tab-power {
     height: 100%;
     position: relative;
 }


### PR DESCRIPTION
if the configurator is minimized the bottom end of right scrollbar is floating in the air