### PR TITLE
fixed spaces between boxes

### DIFF
--- a/main.css
+++ b/main.css
@@ -1155,7 +1155,7 @@ dialog {
     background-color: #FFFFFF;
     float: left;
     width: calc(100% - 2px);
-    margin-bottom: 50px;
+    margin-bottom: 10px;
     font-family: 'open_sansregular', Arial;
 }
 


### PR DESCRIPTION
brings back normal spaces between two boxes on firmware flasher tab, setup tab, power tab, sensors tab and blackbox tab.

here's an example before (50px):
![before](https://cloud.githubusercontent.com/assets/20139767/25782601/65119bb0-334e-11e7-89a6-7b7c2732db54.jpg)

and after fix (10px):
![after](https://cloud.githubusercontent.com/assets/20139767/25782600/5ffe2fa8-334e-11e7-8484-ebc8f2025353.jpg)
