### PR TITLE
Make absolute path in osd tab (implicitly absolute) relative

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -979,7 +979,7 @@ TABS.osd.initialize = function (callback) {
           if (!$(this).data('font-file')) { return; }
           $fontPicker.removeClass('active');
           $(this).addClass('active');
-          $.get('/resources/osd/' + $(this).data('font-file') + '.mcm', function(data) {
+          $.get('./resources/osd/' + $(this).data('font-file') + '.mcm', function(data) {
             FONT.parseMCMFontFile(data);
             FONT.preview($preview);
             updateOsdView();


### PR DESCRIPTION
This change is needed in repos that use this repo as a submodule, and thereby have other base urls.
All instances of $.load() already have relative paths.