### PR TITLE
Make drag-and-drop in osd tab mobile-friendly

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -676,7 +676,7 @@ OSD.GUI.preview = {
   onDrop: function(e) {
     var ev = e.originalEvent;
     var position = $(this).removeAttr('style').data('position');
-    var field_id = parseInt(ev.dataTransfer.getData('text'))
+    var field_id = parseInt(ev.dataTransfer.getData('text/plain'))
     var display_item = OSD.data.display_items[field_id];
     var overflows_line = FONT.constants.SIZES.LINE - ((position % FONT.constants.SIZES.LINE) + display_item.preview.length);
     if (overflows_line < 0) {
@@ -931,7 +931,7 @@ TABS.osd.initialize = function (callback) {
                 var field = OSD.data.preview[i][0];
                 var charCode = OSD.data.preview[i][1];
               }
-              var $img = $('<div class="char"><img src='+FONT.draw(charCode)+'></img></div>')
+              var $img = $('<div class="char" draggable><img src='+FONT.draw(charCode)+'></img></div>')
                 .on('mouseenter', OSD.GUI.preview.onMouseEnter)
                 .on('mouseleave', OSD.GUI.preview.onMouseLeave)
                 .on('dragover', OSD.GUI.preview.onDragOver)


### PR DESCRIPTION
Add draggable attribute to draggable div's in osd tab, and fix data-type mismatch when setting / retrieving data.

Most mobile shims for drag-and-drop assumes that you're either dragging an img-tag or an element with the draggable attribute. When not specified, the event-target will be the nested img instead of the div.

On mobile platforms (atleast iOS), no data is returned when dropping an element if getData() and setData() uses different types.