### PR TITLE
Added loading of craft name on startup.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -190,10 +190,13 @@
         "message": "Firmware Version: <strong>$1</strong>"
     },
     "apiVersionReceived": {
-        "message": "MultiWii API version <span style=\"color: #ffbb00\">received</span> - <strong>$1</strong>"
+        "message": "MultiWii API version: <strong>$1</strong>"
     },
     "uniqueDeviceIdReceived": {
-        "message": "Unique device ID <span style=\"color: #ffbb00\">received</span> - <strong>0x$1</strong>"
+        "message": "Unique device ID: <strong>0x$1</strong>"
+    },
+    "craftNameReceived": {
+        "message": "Craft name: <strong>$1</strong>"
     },
     "boardInfoReceived": {
         "message": "Board: <strong>$1</strong>, version: <strong>$2</strong>"

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -208,16 +208,15 @@ function onOpen(openInfo) {
                                     MSP.send_message(MSPCodes.MSP_UID, false, false, function () {
                                         GUI.log(chrome.i18n.getMessage('uniqueDeviceIdReceived', [CONFIG.uid[0].toString(16) + CONFIG.uid[1].toString(16) + CONFIG.uid[2].toString(16)]));
 
-                                        // continue as usually
-                                        CONFIGURATOR.connectionValid = true;
-                                        GUI.allowedTabs = GUI.defaultAllowedFCTabsWhenConnected.slice();
-                                        if (semver.lt(CONFIG.apiVersion, "1.4.0")) {
-                                            GUI.allowedTabs.splice(GUI.allowedTabs.indexOf('led_strip'), 1);
+                                        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+                                            MSP.send_message(MSPCodes.MSP_NAME, false, false, function () {
+                                                GUI.log(chrome.i18n.getMessage('craftNameReceived', [CONFIG.name]));
+
+                                                finishOpen();
+                                            });
+                                        } else {
+                                            finishOpen();
                                         }
-
-                                        onConnect();
-
-                                        $('#tabs ul.mode-connected .tab_setup a').click();
                                     });
                                 });
                             });
@@ -249,6 +248,18 @@ function onOpen(openInfo) {
         // reset data
         $('div#connectbutton a.connect').data("clicks", false);
     }
+}
+
+function finishOpen() {
+    CONFIGURATOR.connectionValid = true;
+    GUI.allowedTabs = GUI.defaultAllowedFCTabsWhenConnected.slice();
+    if (semver.lt(CONFIG.apiVersion, "1.4.0")) {
+        GUI.allowedTabs.splice(GUI.allowedTabs.indexOf('led_strip'), 1);
+    }
+
+    onConnect();
+
+    $('#tabs ul.mode-connected .tab_setup a').click();
 }
 
 function connectCli() {


### PR DESCRIPTION
This enables generation of backup / blackbox / CLI dump filename suggestions that contain the craft name, even if the Configuration tab hasn't been loaded.