### PR TITLE
Clarify the purpose of the save button on CLI tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1367,7 +1367,7 @@
         "message": "CLI reboot detected"
     },
     "cliSaveToFileBtn": {
-        "message": "Save"  
+        "message": "Save to File"  
     },
     "loggingNote": {
         "message": "Data will be logged in this tab <span style=\"color: red\">only</span>, leaving the tab will <span style=\"color: red\">cancel</span> logging and application will return to its normal <strong>\"configurator\"</strong> state.<br /> You are free to select the global update period, data will be written into the log file every <strong>1</strong> second for performance reasons."


### PR DESCRIPTION
At the moment the text is just "Save". This implies that it does the normal "save and reboot" that a similar looking button does on other tabs. Whereas it actually take the console output and saves it to file.