### PR TITLE
Add HOME DIR to OSD

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -454,7 +454,14 @@ OSD.constants = {
       default_position: -1,
       positionable: true,
       preview: FONT.symbol(SYM.FLY_M) + '02:07'
-    }
+    },
+    HOME_DIR: {
+        name: 'HOME_DIR',
+        default_position: -1,        
+        positionable: true,
+        preview: FONT.symbol(SYM.ARROW_SOUTH + 2)
+      }    
+
   },
 
   ALL_STATISTIC_FIELDS: {
@@ -542,7 +549,8 @@ OSD.chooseFields = function () {
               OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                 F.MAIN_BATT_USAGE,
                 F.ARMED_TIME,
-                F.DISARMED
+                F.DISARMED,
+                F.HOME_DIR
               ]);
             }
           }


### PR DESCRIPTION
This PR adds support to this: https://github.com/betaflight/betaflight/pull/3240

Adds an arrow with the HOME DIRECTION to the OSD