### PR TITLE
Add Home Distance to OSD

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -456,12 +456,19 @@ OSD.constants = {
       preview: FONT.symbol(SYM.FLY_M) + '02:07'
     },
     HOME_DIR: {
-        name: 'HOME_DIR',
+        name: 'HOME_DIRECTION',
         default_position: -1,        
         positionable: true,
         preview: FONT.symbol(SYM.ARROW_SOUTH + 2)
-      }    
-
+    },
+    HOME_DIST: {
+        name: 'HOME_DISTANCE',
+        default_position: -1,        
+        positionable: true,
+        preview:  function(osd_data) {
+            return '43' + FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE)
+        }
+    }    
   },
 
   ALL_STATISTIC_FIELDS: {
@@ -550,7 +557,8 @@ OSD.chooseFields = function () {
                 F.MAIN_BATT_USAGE,
                 F.ARMED_TIME,
                 F.DISARMED,
-                F.HOME_DIR
+                F.HOME_DIR,
+                F.HOME_DIST
               ]);
             }
           }


### PR DESCRIPTION
This adds support to show the distance to HOME in the OSD. This needs this PR:
https://github.com/betaflight/betaflight/pull/3266
merged into BF to work.