### PR TITLE
Handle extended sensor bits (gyro) in MSP_STATU_EX

### DIFF
--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -389,7 +389,7 @@ function sensor_status(sensors_detected) {
         $('.accicon', e_sensor_status).removeClass('active');
     }
 
-    if (CONFIG.boardType == 0 || CONFIG.boardType == 2) { // Gyro status is not reported by FC 
+    if ((CONFIG.boardType == 0 || CONFIG.boardType == 2) && have_sensor(sensors_detected, 'gyro')) {
         $('.gyro', e_sensor_status).addClass('on');
         $('.gyroicon', e_sensor_status).addClass('active');
     } else {
@@ -443,6 +443,18 @@ function have_sensor(sensors_detected, sensor_code) {
         case 'sonar':
             return bit_check(sensors_detected, 4);
     }
+
+    if (bit_check(sensors_detected, 5)) {
+        switch (sensor_code) {
+        case 'gyro':
+            return bit_check(sensors_detected, 6);
+        }
+    }
+
+    if (sensor_code == 'gyro) {
+        return true;
+    }
+
     return false;
 }
 

--- a/js/serial_backend.js
+++ b/js/serial_backend.js
@@ -442,19 +442,13 @@ function have_sensor(sensors_detected, sensor_code) {
             return bit_check(sensors_detected, 3);
         case 'sonar':
             return bit_check(sensors_detected, 4);
-    }
-
-    if (bit_check(sensors_detected, 5)) {
-        switch (sensor_code) {
         case 'gyro':
-            return bit_check(sensors_detected, 6);
-        }
+            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                return bit_check(sensors_detected, 5);
+            } else {
+                return true;
+            }
     }
-
-    if (sensor_code == 'gyro) {
-        return true;
-    }
-
     return false;
 }
 


### PR DESCRIPTION
Per betaflight/betaflight#3391

In detected sensor field (16-bits), lower 5-bits (bits 0-4) represents
traditional sensors (ACC, BARO, MAG, GPS and SONAR).

Bit 5 is an extension bit, and if present, bit 6 indicates gyro
detection status.