### PR TITLE
Update the OSD warning element tooltip

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2297,7 +2297,7 @@
         "message": "Time since the craft was last armed"
     },
     "osdDescElementWarnings": {
-        "message": "Alerts (e.g. low battery) and warnings for potential problems (e.g. critically low battery), and visual beeper."
+        "message": "Alerts (e.g. low battery), warnings (e.g. reasons for not arming, critically low battery) and visual beeper (4 flashing asterisks)."
     },
     "osdDescElementEscTemperature": {
         "message": "Temperature reported by ESC telemetry"


### PR DESCRIPTION
Mentions that it can show arming disable conditions and clarify what the visual beeper looks like.