### PR TITLE
Added new features and settings for BF 3.2

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -545,7 +545,7 @@
         "message": "Configure via the BlackBox tab after enabling."
     },
     "featureESC_SENSOR": {
-        "message": "Use KISS ESC 24A telemetry as sensor"
+        "message": "Use KISS/BLHeli_32 ESC telemetry as sensor"
     },
     "featureCHANNEL_FORWARDING": {
         "message": "Forward aux channels to servo outputs"
@@ -570,6 +570,12 @@
     },
     "featureVTX": {
         "message": "Video Transmitter"
+    },
+    "featureANTI_GRAVITY": {
+        "message": "Temporary boost I-Term on high throttle changes"
+    },
+    "featureDYNAMIC_FILTER": {
+        "message": "Dynamic gyro notch filtering"
     },
     "featureFAILSAFE": {
         "message": "Enable Failsafe Stage 2"
@@ -842,6 +848,14 @@
     "pidTuningNonProfilePidSettings": {
         "message": "Profile independent PID Controller Settings"
     },
+
+    "pidTuningAntiGravityGain": {
+        "message": "Anti Gravity Gain"
+    },
+    "pidTuningAntiGravityThres": {
+        "message": "Anti Gravity Threshold"
+    },
+
     "pidTuningPidSettings": {
         "message": "PID Controller Settings"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -741,19 +741,19 @@
     },
 
     "portsIdentifier": {
-      "message": "Identifier"
+        "message": "Identifier"
     },
     "portsConfiguration": {
-      "message": "Configuration/MSP"
+        "message": "Configuration/MSP"
     },
     "portsSerialRx": {
-      "message": "Serial Rx"
+        "message": "Serial Rx"
     },
     "portsSensorIn": {
-      "message": "Sensor Input"
+        "message": "Sensor Input"
     },
     "portsTelemetryOut": {
-      "message": "Telemetry Output"
+        "message": "Telemetry Output"
     },
     "portsPeripherals": {
         "message": "Peripherals"
@@ -921,10 +921,10 @@
         "message": "Frequency"
     },
     "pidTuningRatesCurve": {
-	    "message": "Rates"
+        "message": "Rates"
     },
     "throttle": {
-	    "message": "Throttle"
+        "message": "Throttle"
     },
     "pidTuningButtonSave": {
         "message": "Save"
@@ -1239,13 +1239,13 @@
     "transponderHelp2": {
         "message": "For more information please visit <a href=\"http://www.arcitimer.com/\" title=\"aRCiTimer\" target=\"_blank\">aRCiTimer site</a>"
     },
-	"transponderDataHelp3": {
+    "transponderDataHelp3": {
         "message": "Choose ERLT ID 0-63"
     },
     "transponderHelp3": {
         "message": "For more information please visit <a href=\"https://github.com/polyvision/EasyRaceLapTimer\" title=\"aRCiTimer\" target=\"_blank\">EasyRaceLapTimer site</a>"
     },
-	"transponderButtonSave": {
+    "transponderButtonSave": {
         "message": "Save"
     },
     "transponderButtonSaveReboot": {
@@ -1387,7 +1387,7 @@
     "cliSaveToFileBtn": {
         "message": "Save to File"
     },
-    
+
     "loggingNote": {
         "message": "Data will be logged in this tab <span style=\"color: red\">only</span>, leaving the tab will <span style=\"color: red\">cancel</span> logging and application will return to its normal <strong>\"configurator\"</strong> state.<br /> You are free to select the global update period, data will be written into the log file every <strong>1</strong> second for performance reasons."
     },
@@ -1671,73 +1671,73 @@
         "message": "VTX (uses vtx frequency to assign color)"
     },
     "ledStripFunctionSection": {
-      "message": "LED Functions"
+        "message": "LED Functions"
     },
     "ledStripFunctionTitle": {
-      "message": "Function"
+        "message": "Function"
     },
     "ledStripColorModifierTitle": {
-      "message": "Color modifier"
+        "message": "Color modifier"
     },
     "ledStripThrottleFunction": {
-      "message": "Throttle"
+        "message": "Throttle"
     },
     "ledStripVtxFunction": {
-      "message": "Larson scanner"
+        "message": "Larson scanner"
     },
     "ledStripBlinkTitle": {
-      "message": "Blink"
+        "message": "Blink"
     },
     "ledStripBlinkAlwaysOverlay": {
-      "message": "Blink always"
+        "message": "Blink always"
     },
     "ledStripBlinkLandingOverlay": {
-      "message": "Blink on landing"
+        "message": "Blink on landing"
     },
     "ledStripOverlayTitle": {
-      "message": "Overlay"
+        "message": "Overlay"
     },
     "ledStripWarningsOverlay": {
-      "message": "Warnings"
+        "message": "Warnings"
     },
     "ledStripIndecatorOverlay": {
-      "message": "Indicator (uses position on matrix)"
+        "message": "Indicator (uses position on matrix)"
     },
     "ledStripVtxOverlay": {
         "message": "VTX (uses vtx frequency to assign color)"
     },
     "ledStripFunctionSection": {
-      "message": "LED Functions"
+        "message": "LED Functions"
     },
     "ledStripFunctionTitle": {
-      "message": "Function"
+        "message": "Function"
     },
     "ledStripColorModifierTitle": {
-      "message": "Color modifier"
+        "message": "Color modifier"
     },
     "ledStripThrottleFunction": {
-      "message": "Throttle"
+        "message": "Throttle"
     },
     "ledStripVtxFunction": {
-      "message": "Larson scanner"
+        "message": "Larson scanner"
     },
     "ledStripBlinkTitle": {
-      "message": "Blink"
+        "message": "Blink"
     },
     "ledStripBlinkAlwaysOverlay": {
-      "message": "Blink always"
+        "message": "Blink always"
     },
     "ledStripBlinkLandingOverlay": {
-      "message": "Blink on landing"
+        "message": "Blink on landing"
     },
     "ledStripOverlayTitle": {
-      "message": "Overlay"
+        "message": "Overlay"
     },
     "ledStripWarningsOverlay": {
-      "message": "Warnings"
+        "message": "Warnings"
     },
     "ledStripIndecatorOverlay": {
-      "message": "Indicator (uses position on matrix)"
+        "message": "Indicator (uses position on matrix)"
     },
 
     "controlAxisRoll": {
@@ -1849,60 +1849,66 @@
     "pidTuningLevelHelp": {
         "message": "The values below change the behaviour of the ANGLE and HORIZON flight modes. Different PID controllers handle the values differently. Please check the documentation."
     },
-  "pidTuningNonProfileFilterSettings": {
-    "message": "Profile independent Filter Settings"
-  },
-  "pidTuningGyroLowpassFrequency": {
-    "message": "Gyro Soft Lowpass Frequency [Hz]"
-  },
-  "pidTuningGyroLowpassFrequencyHelp": {
-    "message": "Gyro Soft Lowpass Frequency [Hz]"
-  },
-  "pidTuningGyroNotch1Frequency": {
-      "message": "Gyro Notch Filter 1 Frequency [Hz]"
-  },
-  "pidTuningGyroNotch2Frequency": {
-      "message": "Gyro Notch Filter 2 Frequency [Hz]"
-  },
-  "pidTuningGyroNotchFrequencyHelp": {
-    "message": "Gyro Notch Filter Frequency in Hz (0 means disabled)"
-  },
-  "pidTuningGyroNotch1Cutoff": {
+    "pidTuningNonProfileFilterSettings": {
+        "message": "Profile independent Filter Settings"
+    },
+    "pidTuningGyroLowpassFrequency": {
+        "message": "Gyro Soft Lowpass Frequency [Hz]"
+    },
+    "pidTuningGyroLowpassFrequencyHelp": {
+        "message": "Gyro Soft Lowpass Frequency [Hz]"
+    },
+    "pidTuningGyroNotch1Frequency": {
+        "message": "Gyro Notch Filter 1 Frequency [Hz]"
+    },
+    "pidTuningGyroNotch2Frequency": {
+        "message": "Gyro Notch Filter 2 Frequency [Hz]"
+    },
+    "pidTuningGyroNotchFrequencyHelp": {
+        "message": "Gyro Notch Filter Frequency in Hz (0 means disabled)"
+    },
+    "pidTuningGyroNotch1Cutoff": {
         "message": "Gyro Notch Filter Cutoff 1 Frequency [Hz]"
     },
     "pidTuningGyroNotch2Cutoff": {
         "message": "Gyro Notch Filter Cutoff 2 Frequency [Hz]"
     },
     "pidTuningGyroNotchCutoffHelp": {
-    "message": "Gyro Notch Filter Cutoff Frequency in Hz (This is where notch filter starts. For example with notch filter 160 and notch hz of 260 it means the range is 160-360hz with most attenuation around center)"
-  },
-  "pidTuningFilterSettings": {
-    "message": "Filter Settings"
-  },
-  "pidTuningDTermLowpassFrequency": {
-    "message": "D Term Lowpass Frequency [Hz]"
-  },
-  "pidTuningDTermLowpassFrequencyHelp": {
-    "message": "D Term Lowpass Frequency [Hz] (0 means disabled)"
-  },
-  "pidTuningDTermNotchFrequency": {
-    "message": "D Term Notch Filter Frequency [Hz]"
-  },
-  "pidTuningDTermNotchFrequencyHelp": {
-    "message": "D Term Notch Filter Frequency [Hz] (0 means disabled)"
-  },
-  "pidTuningDTermNotchCutoff": {
-    "message": "D Term Notch Filter Cutoff [Hz]"
-  },
-  "pidTuningDTermNotchCutoffHelp": {
-    "message": "D Term Notch Filter Cutoff in Hz (This is where notch filter starts. For example with notch filter 160 and notch hz of 260 it means the range is 160-360hz with most attenuation around center)"
-  },
-  "pidTuningYawLowpassFrequency": {
-    "message": "Yaw Lowpass Frequency [Hz]"
-  },
-  "pidTuningYawLowpassFrequencyHelp": {
-    "message": "Yaw Lowpass Frequency [Hz] (Yaw axis can sometimes be noiser than the rest. This filter only affects the P of yaw)"
-  },
+        "message": "Gyro Notch Filter Cutoff Frequency in Hz (This is where notch filter starts. For example with notch filter 160 and notch hz of 260 it means the range is 160-360hz with most attenuation around center)"
+    },
+    "pidTuningFilterSettings": {
+        "message": "Filter Settings"
+    },
+    "pidTuningDTermLowpassType": {
+        "message": "D-Term Lowpass Filter"
+    },
+    "pidTuningDTermLowpassTypeTip": {
+        "message": "Select D-Term lowpass filter type to use. Default is BIQUAD"
+    },
+    "pidTuningDTermLowpassFrequency": {
+        "message": "D Term Lowpass Frequency [Hz]"
+    },
+    "pidTuningDTermLowpassFrequencyHelp": {
+        "message": "D Term Lowpass Frequency [Hz] (0 means disabled)"
+    },
+    "pidTuningDTermNotchFrequency": {
+        "message": "D Term Notch Filter Frequency [Hz]"
+    },
+    "pidTuningDTermNotchFrequencyHelp": {
+        "message": "D Term Notch Filter Frequency [Hz] (0 means disabled)"
+    },
+    "pidTuningDTermNotchCutoff": {
+        "message": "D Term Notch Filter Cutoff [Hz]"
+    },
+    "pidTuningDTermNotchCutoffHelp": {
+        "message": "D Term Notch Filter Cutoff in Hz (This is where notch filter starts. For example with notch filter 160 and notch hz of 260 it means the range is 160-360hz with most attenuation around center)"
+    },
+    "pidTuningYawLowpassFrequency": {
+        "message": "Yaw Lowpass Frequency [Hz]"
+    },
+    "pidTuningYawLowpassFrequencyHelp": {
+        "message": "Yaw Lowpass Frequency [Hz] (Yaw axis can sometimes be noiser than the rest. This filter only affects the P of yaw)"
+    },
     "pidTuningVbatPidCompensation": {
         "message": "Vbat PID Compensation"
     },
@@ -2474,22 +2480,22 @@
         "message": "FPV Camera Angle [degrees]"
     },
     "onboardLoggingBlackbox": {
-    	"message": "Blackbox logging device"
+        "message": "Blackbox logging device"
     },
-      "onboardLoggingRateOfLogging": {
-    	"message": "Blackbox logging rate"
+    "onboardLoggingRateOfLogging": {
+        "message": "Blackbox logging rate"
     },
-      "onboardLoggingSerialLogger": {
-    	"message": "Outboard serial logging device"
+    "onboardLoggingSerialLogger": {
+        "message": "Outboard serial logging device"
     },
-      "onboardLoggingFlashLogger": {
-    	"message": "Onboard dataflash chip"
+    "onboardLoggingFlashLogger": {
+        "message": "Onboard dataflash chip"
     },
-      "onboardLoggingEraseInProgress": {
-    	"message": "Erase in progress, please wait..."
+    "onboardLoggingEraseInProgress": {
+        "message": "Erase in progress, please wait..."
     },
-      "onboardLoggingOnboardSDCard": {
-    	"message": "Onboard SD card"
+    "onboardLoggingOnboardSDCard": {
+        "message": "Onboard SD card"
     }
 
 

--- a/js/Features.js
+++ b/js/Features.js
@@ -80,7 +80,14 @@ var Features = function (config) {
         if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
             features.push(
                 {bit: 27, group: 'other', name: 'ESC_SENSOR'}
-            )
+            );
+        }
+
+        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            features.push(
+                {bit: 28, group: 'other', name: 'ANTI_GRAVITY'},
+                {bit: 29, group: 'other', name: 'DYNAMIC_FILTER'}
+            );
         }
     }
 

--- a/js/fc.js
+++ b/js/fc.js
@@ -331,6 +331,8 @@ var FC = {
             pidMaxVelocityYaw:          0,
             levelAngleLimit:            0,
             levelSensitivity:           0,
+            itermThrottleThreshold:     0,
+            itermAcceleratorGain:       0,
         };
 
         SENSOR_CONFIG = {

--- a/js/fc.js
+++ b/js/fc.js
@@ -77,21 +77,21 @@ var FC = {
             rateProfile:                0,
             boardType:                  0,
         };
-        
+
         FEATURE_CONFIG = {
             features:                   0,
         };
-        
+
         MIXER_CONFIG = {
             mixer:                      0,
-        }; 
+        };
 
         BOARD_ALIGNMENT_CONFIG = {
             roll:                       0,
             pitch:                      0,
             yaw:                        0,
         };
-        
+
         LED_STRIP =                     [];
         LED_COLORS =                    [];
         LED_MODE_COLORS =               [];
@@ -192,7 +192,7 @@ var FC = {
         VOLTAGE_METER_CONFIGS =         [];
         CURRENT_METERS =                [];
         CURRENT_METER_CONFIGS =         [];
-        
+
         BATTERY_STATE = {};
         BATTERY_CONFIG = {
             vbatmincellvoltage:         0,
@@ -202,7 +202,7 @@ var FC = {
             voltageMeterSource:         0,
             currentMeterSource:         0,
         };
-        
+
         ARMING_CONFIG = {
             auto_disarm_delay:          0,
             disarm_kill_switch:         0,
@@ -211,7 +211,7 @@ var FC = {
         FC_CONFIG = {
             loopTime:                   0
         };
-        
+
         MISC = {
             // DEPRECATED = only used to store values that are written back to the fc as-is, do NOT use for any other purpose
             failsafe_throttle:          0,
@@ -228,14 +228,14 @@ var FC = {
             maxthrottle:                0,
             mincommand:                 0,
         };
-        
+
         GPS_CONFIG = {
             provider:                   0,
             ublox_sbas:                 0,
             auto_config:                0,
             auto_baud:                  0,
         };
-        
+
         COMPASS_CONFIG = {
             mag_declination:            0,
         };
@@ -243,7 +243,7 @@ var FC = {
         RSSI_CONFIG = {
             channel:                    0,
         };
-        
+
         MOTOR_3D_CONFIG = {
             deadband3d_low:             0,
             deadband3d_high:            0,
@@ -313,6 +313,7 @@ var FC = {
             dterm_notch_cutoff:         0,
             gyro_soft_notch_hz_2:       0,
             gyro_soft_notch_cutoff_2:   0,
+            dterm_filter_type:         0,
         };
 
         ADVANCED_TUNING = {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -788,6 +788,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         FILTER_CONFIG.gyro_soft_notch_hz_2 = data.readU16();
                         FILTER_CONFIG.gyro_soft_notch_cutoff_2 = data.readU16();
                     }
+                    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                        FILTER_CONFIG.dterm_filter_type = data.readU8();
+                    }
                 }
                 break;
             case MSPCodes.MSP_SET_PID_ADVANCED:
@@ -1387,6 +1390,9 @@ MspHelper.prototype.crunch = function(code) {
                 if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
                     buffer.push16(FILTER_CONFIG.gyro_soft_notch_hz_2)
                         .push16(FILTER_CONFIG.gyro_soft_notch_cutoff_2)
+                }
+                if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                    buffer.push8(FILTER_CONFIG.dterm_filter_type);
                 }
             }
             break;

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -810,10 +810,14 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     ADVANCED_TUNING.itermThrottleGain = data.readU8();
                     ADVANCED_TUNING.pidMaxVelocity = data.readU16();
                     ADVANCED_TUNING.pidMaxVelocityYaw = data.readU16();
-                }
-                if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
-                    ADVANCED_TUNING.levelAngleLimit = data.readU8();
-                    ADVANCED_TUNING.levelSensitivity = data.readU8();
+                    if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
+                        ADVANCED_TUNING.levelAngleLimit = data.readU8();
+                        ADVANCED_TUNING.levelSensitivity = data.readU8();
+                    }
+                    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                        ADVANCED_TUNING.itermThrottleThreshold = data.readU16();
+                        ADVANCED_TUNING.itermAcceleratorGain = data.readU16();
+                    }
                 }
                 break;
             case MSPCodes.MSP_SENSOR_CONFIG:
@@ -1413,6 +1417,10 @@ MspHelper.prototype.crunch = function(code) {
                 if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
                     buffer.push8(ADVANCED_TUNING.levelAngleLimit)
                         .push8(ADVANCED_TUNING.levelSensitivity);
+                }
+                if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                    buffer.push16(ADVANCED_TUNING.itermThrottleThreshold)
+                        .push16(ADVANCED_TUNING.itermAcceleratorGain);
                 }
             }
             // only supports 1 version pre bf 3.0

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -434,6 +434,21 @@
                         <p i18n="tuningHelp"></p>
                     </div>
                 </div>
+
+                <div class="dtermfiltertype cf_column twothird">
+                    <div class="profile single-field" style="width:200px; margin-bottom: 0px;">
+                        <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpassTypeTip" style="margin-top: 5px;"></div>
+                        <div class="head" i18n="pidTuningDTermLowpassType"></div>
+                        <div class="bottomarea">
+                            <select name="dtermFilterType">
+                                <option value="0" class="PT1">PT1</option>
+                                <option value="1" class="BIQUAD">BIQUAD</option>
+                                <option value="2" class="FIR">FIR</option>
+                            </select>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="cf_column twothird">
                     <div class="gui_box grey topspacer pid_filter">
                         <table class="pid_titlebar new_rates">

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -326,6 +326,24 @@
                                 </td>
                         </table>
                     </div>
+
+                    <div class="antigravity topspacer tpa">
+                        <table class="cf">
+                            <thead>
+                                <tr>
+                                    <th i18n="pidTuningAntiGravityGain"></th>
+                                    <th i18n="pidTuningAntiGravityThres"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr style="height: 35px;">
+                                    <td><input type="number" name="itermAcceleratorGain" step="0.1" min="1" max="30" /></td>
+                                    <td><input type="number" name="itermThrottleThreshold" step="10" min="20" max="1000" /></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
                     <div class="gui_box grey topspacer">
                         <table class="pid_titlebar">
                             <thead>

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -258,6 +258,12 @@ TABS.pid_tuning.initialize = function (callback) {
         } else {
             $('.pid_sensitivity').hide();
         }
+
+        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            $('.profile select[name="dtermFilterType"]').val(FILTER_CONFIG.dterm_filter_type);
+        } else {
+            $('.dtermfiltertype').hide();
+        }
     }
 
     function form_to_pid_and_rc() {
@@ -367,6 +373,10 @@ TABS.pid_tuning.initialize = function (callback) {
         if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
             ADVANCED_TUNING.levelAngleLimit = parseInt($('.pid_tuning input[name="angleLimit"]').val());
             ADVANCED_TUNING.levelSensitivity = parseInt($('.pid_tuning input[name="sensitivity"]').val());
+        }
+
+        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            FILTER_CONFIG.dterm_filter_type = $('.profile select[name="dtermFilterType"]').val();
         }
     }
 
@@ -590,7 +600,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('#pid-tuning .ptermSetpoint').hide();
             $('#pid-tuning .dtermSetpoint').hide();
         }
-        
+
         if (!semver.gte(CONFIG.apiVersion, "1.16.0")) {
             $('#pid-tuning .delta').hide();
             $('.tab-pid_tuning .note').hide();

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -261,8 +261,11 @@ TABS.pid_tuning.initialize = function (callback) {
 
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
             $('.profile select[name="dtermFilterType"]').val(FILTER_CONFIG.dterm_filter_type);
+            $('.antigravity input[name="itermThrottleThreshold"]').val(ADVANCED_TUNING.itermThrottleThreshold);
+            $('.antigravity input[name="itermAcceleratorGain"]').val(ADVANCED_TUNING.itermAcceleratorGain / 1000);
         } else {
             $('.dtermfiltertype').hide();
+            $('.antigravity').hide();
         }
     }
 
@@ -377,6 +380,8 @@ TABS.pid_tuning.initialize = function (callback) {
 
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
             FILTER_CONFIG.dterm_filter_type = $('.profile select[name="dtermFilterType"]').val();
+            ADVANCED_TUNING.itermThrottleThreshold = parseInt($('.antigravity input[name="itermThrottleThreshold"]').val());
+            ADVANCED_TUNING.itermAcceleratorGain = parseInt($('.antigravity input[name="itermAcceleratorGain"]').val() * 1000);
         }
     }
 


### PR DESCRIPTION
New features and settings for BF 3.2

- Added selection of dterm lowpass filter type (PT1/BIQUAD/FIR).

![image](https://user-images.githubusercontent.com/334779/28116997-d83e83d2-670b-11e7-81f2-6e6c492dae27.png)

- Added switches to enable/disable ANTI_GRAVITY and DYNAMIC_FILTER to Configuration tab.

![image](https://user-images.githubusercontent.com/334779/28117028-fd30f940-670b-11e7-9b39-0e6cc8858bfd.png)

- Added inputs for changing anti-gravity settings to PID Tuning tab.

![image](https://user-images.githubusercontent.com/334779/28117055-1c638d50-670c-11e7-8c6d-90c235b5c1ee.png)

This PR also needs some changes to MSP command to work, see Betaflight PR: https://github.com/betaflight/betaflight/pull/3500