### PR TITLE
Cleanup and lower the flasher default baud rate to 115200 regardless what OS we are running on.

### DIFF
--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -341,19 +341,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                             if (String($('div#port-picker #port').val()) != '0') {
                                 var port = String($('div#port-picker #port').val()),
                                     baud;
-
-                                switch (GUI.operating_system) {
-                                    case 'Windows':
-                                    case 'MacOS':
-                                    case 'ChromeOS':
-                                    case 'Linux':
-                                    case 'UNIX':
-                                        baud = 921600;
-                                        break;
-
-                                    default:
-                                        baud = 115200;
-                                }
+                                baud = 115200;
 
                                 if ($('input.updating').is(':checked')) {
                                     options.no_reboot = true;


### PR DESCRIPTION
Communication with boot loader on for example SPRF3 target usually fails unless manually setting 115200 baud rate. BFC sets 961600 or 115200 by default, depending on OS. This PR cleans up all that special case handling and sets 115200 for all. 

Based on ST app note AN 3155 section 2.2 max tested baudrate is 115200.
www.st.com/resource/en/application_note/cd00264342.pdf

I have yet not found any _specified_ max baud rate, only the max _tested_ as of above. Could be different, but if ST does not test more than 115200, I do not think we should try anything faster either.
