### PR TITLE
3.1.x fixes

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2480,8 +2480,6 @@
     "configurationMagHardware": {
         "message": "Magnetometer (if supported)"
     },
-    // ---------------------------------------------
-    // Remove this when we officialy retire BF 3.1.x
     "configurationBatteryVoltage": {
         "message": "Battery Voltage"
     },
@@ -2518,7 +2516,6 @@
     "configurationBatteryMultiwiiCurrent": {
         "message": "Enable support for legacy Multiwii MSP current output"
     },
-    // --------------------------------------------- END
     "pidTuningProfile": {
         "message": "Profile"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2480,6 +2480,45 @@
     "configurationMagHardware": {
         "message": "Magnetometer (if supported)"
     },
+    // ---------------------------------------------
+    // Remove this when we officialy retire BF 3.1.x
+    "configurationBatteryVoltage": {
+        "message": "Battery Voltage"
+    },
+    "configurationBatteryCurrent": {
+        "message": "Battery Current"
+    },
+    "configurationBatteryMeterType": {
+        "message": "Battery Meter Type"
+    },
+    "configurationBatteryMinimum": {
+        "message": "Minimum Cell Voltage"
+    },
+    "configurationBatteryMaximum": {
+        "message": "Maximum Cell Voltage"
+    },
+    "configurationBatteryWarning": {
+        "message": "Warning Cell Voltage"
+    },
+    "configurationBatteryScale": {
+        "message": "Voltage Scale"
+    },
+    "configurationCurrentMeterType": {
+        "message": "Current Meter Type"
+    },
+    "configurationCurrent": {
+        "message": "Current Sensor"
+    },
+    "configurationCurrentScale": {
+        "message": "Scale the output voltage to milliamps [1/10th mV/A]"
+    },
+    "configurationCurrentOffset": {
+        "message": "Offset in millivolt steps"
+    },
+    "configurationBatteryMultiwiiCurrent": {
+        "message": "Enable support for legacy Multiwii MSP current output"
+    },
+    // --------------------------------------------- END
     "pidTuningProfile": {
         "message": "Profile"
     },

--- a/changelog.html
+++ b/changelog.html
@@ -1,8 +1,8 @@
-<span>2016.07.29 - 3.1.2 - BetaFlight</span>
+<span>2017.07.29 - 3.1.3 - BetaFlight</span>
 <ul>
-    <li>First version suitable for 3.2 features</li>
+    <li>Fixed incompatibility issues with BF 3.1.x</li>
 </ul>
-<span>2016.03.09 - 3.1.1 - BetaFlight</span>
+<span>2017.07.28 - 3.1.1 - BetaFlight</span>
 <ul>
     <li>Changed donation page to english</li>
 </ul>

--- a/js/fc.js
+++ b/js/fc.js
@@ -2,6 +2,7 @@
 
 // define all the global variables that are uses to hold FC state
 var CONFIG;
+var BF_CONFIG;          // Remove when we officialy retire BF 3.1
 var FEATURE_CONFIG;
 var BEEPER_CONFIG;
 var MIXER_CONFIG;
@@ -77,6 +78,13 @@ var FC = {
             numProfiles:                3,
             rateProfile:                0,
             boardType:                  0,
+        };
+
+        BF_CONFIG = {
+            currentscale:           0,
+            currentoffset:          0,
+            currentmetertype:       0,
+            batterycapacity:        0,
         };
 
         FEATURE_CONFIG = {
@@ -228,6 +236,7 @@ var FC = {
             vbatmincellvoltage:         0,
             vbatmaxcellvoltage:         0,
             vbatwarningcellvoltage:     0,
+            batterymetertype:           1, // 1=ADC, 2=ESC
         };
         MOTOR_CONFIG = {
             minthrottle:                0,

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -557,7 +557,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP_MIXER_CONFIG:
                 MIXER_CONFIG.mixer = data.readU8();
-                MIXER_CONFIG.reverseMotorDir = data.readU8();
+                if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+                    MIXER_CONFIG.reverseMotorDir = data.readU8();
+                }
                 break;
 
             case MSPCodes.MSP_FEATURE_CONFIG:
@@ -1161,7 +1163,9 @@ MspHelper.prototype.crunch = function(code) {
             break;
         case MSPCodes.MSP_SET_MIXER_CONFIG:
             buffer.push8(MIXER_CONFIG.mixer)
-                .push8(MIXER_CONFIG.reverseMotorDir);
+            if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+                buffer.push8(MIXER_CONFIG.reverseMotorDir);
+            }
             break;
         case MSPCodes.MSP_SET_BOARD_ALIGNMENT_CONFIG:
             buffer.push16(BOARD_ALIGNMENT_CONFIG.roll)

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -557,7 +557,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP_MIXER_CONFIG:
                 MIXER_CONFIG.mixer = data.readU8();
-                if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+                if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                     MIXER_CONFIG.reverseMotorDir = data.readU8();
                 }
                 break;
@@ -1163,7 +1163,7 @@ MspHelper.prototype.crunch = function(code) {
             break;
         case MSPCodes.MSP_SET_MIXER_CONFIG:
             buffer.push8(MIXER_CONFIG.mixer)
-            if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                 buffer.push8(MIXER_CONFIG.reverseMotorDir);
             }
             break;

--- a/main.js
+++ b/main.js
@@ -470,10 +470,17 @@ function updateTabList(features) {
     } else {
         $('#tabs ul.mode-connected li.tab_transponder').hide();
     }
+
     if (features.isEnabled('OSD')) {
         $('#tabs ul.mode-connected li.tab_osd').show();
     } else {
         $('#tabs ul.mode-connected li.tab_osd').hide();
+    }
+
+    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        $('#tabs ul.mode-connected li.tab_power').show();
+    } else {
+        $('#tabs ul.mode-connected li.tab_power').hide();
     }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "minimum_chrome_version": "38",
-    "version": "3.1.2",
+    "version": "3.1.3",
     "author": "Betaflight Squad",
     "name": "Betaflight - Configurator",
     "short_name": "Betaflight",

--- a/tabs/configuration.css
+++ b/tabs/configuration.css
@@ -291,11 +291,19 @@
     width: 150px;
 }
 
-.tab-configuration .currentMeterSource {
+.tab-configuration .currentmetertype {
     border: 1px solid silver;
     margin-right: 5px;
     float: left;
     width: 150px;
+}
+
+.tab-configuration .vbatmonitoring {
+    margin-top: 5px;
+}
+
+.tab-configuration .currentMonitoring {
+    margin-top: 5px;
 }
 
 .tab-configuration .rssi td:nth-child(2) {

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -31,7 +31,7 @@
                                     </select>
                                 </div>
                             </div>
-                            <div class="spacer_box">
+                            <div class="spacer_box reverseMotor">
                                 <div class="checkbox" style="border-top: 1px solid #ddd; padding-top: 5px;">
                                     <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                         <input type="checkbox" id="reverseMotorSwitch" class="toggle" />
@@ -530,11 +530,10 @@
             </tr>
             <tr class="oldBatteryConfig">
                 <td style="width:calc(50%);vertical-align:top;">
-                    <!-- ROW 4 - LEFT PANE - ONLY NEEDED FOR BATTERY/CURRENT PART FOR PRE BF3.2 -->
+                    <!-- ROW 4 - LEFT PANE -->
 
-                    <!-- -------------------------------------------------------- -->
-                    <!-- Remove this part when we officialy retire BF 3.1.x       -->
-                    <div class="rightWrapper current voltage">
+                    <!-- BATTERY CONFIG FOR PRE BF 3.2 -->
+                    <div class="voltage">
                         <div class="gui_box grey">
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationBatteryVoltage"></div>
@@ -585,7 +584,15 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="gui_box grey">
+                    </div>
+
+                </td>
+                <td style="width:calc(50%);vertical-align:top;">
+                    <!-- ROW 4 - RIGHT PANE -->
+
+                    <!-- CURRENT CONFIG FOR PRE BF 3.2 -->
+                    <div class="current">
+                       <div class="gui_box grey">
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationCurrent"></div>
                             </div>
@@ -633,17 +640,17 @@
                                 </div>
                             </div>
                         </div>
+
                     </div>
-                    <!-- -------------------------------------------------------- -->
 
                 </td>
             </tr>
-            <tr>
+            <tr class="beepers">
                 <td style="width:calc(100%)" colspan="2">
                     <!-- ROW 4 - FULL WIDTH PANE -->
             
                     <!-- BEEPER -->
-                    <div class="leftWrapper beepers" style="width: calc(100% - 20px);">
+                    <div class="beepers" style="width: calc(100%);">
                         <div class="gui_box grey" style="margin-top:10px;">
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationBeeper"></div>
@@ -668,150 +675,11 @@
                             </div>
                         </div>
                     </div>
-<<<<<<< HEAD
 
                 </td>
             </tr>
         </table>
 
-=======
-                </div>
-            </div>
-            <div class="clear-both"></div>
-        </div>
-        
-
-        <!-- -------------------------------------------------------- -->
-        <!-- Remove this part when we officialy retire BF 3.1.x       -->
-        <div class="rightWrapper current voltage oldBatteryConfig">
-            <div class="gui_box grey">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" i18n="configurationBatteryVoltage"></div>
-                </div>
-                <div class="spacer_box">
-                    <table cellpadding="0" cellspacing="0">
-                        <thead>
-                            <tr>
-                                <th i18n="configurationFeatureEnabled"></th>
-                                <th i18n="configurationFeatureDescription"></th>
-                                <th i18n="configurationFeatureName"></th>
-                            </tr>
-                        </thead>
-                        <tbody class="features batteryVoltage">
-                            <!-- table generated here -->
-                        </tbody>
-                    </table>
-                    <div class="select batterymetertype vbatmonitoring">
-                        <label>
-                            <select class="batterymetertype"><!-- list generated here --></select>
-                            <span i18n="configurationBatteryMeterType"></span>
-                        </label>
-                    </div>
-                    <div class="number vbatmonitoring">
-                        <label> <input type="number" name="mincellvoltage" step="0.1" min="1" max="5" /> <span
-                            i18n="configurationBatteryMinimum"></span>
-                        </label>
-                    </div>
-                    <div class="number vbatmonitoring">
-                        <label> <input type="number" name="maxcellvoltage" step="0.1" min="1" max="5" /> <span
-                            i18n="configurationBatteryMaximum"></span>
-                        </label>
-                    </div>
-                    <div class="number vbatmonitoring">
-                        <label> <input type="number" name="warningcellvoltage" step="0.1" min="1" max="5" /> <span
-                            i18n="configurationBatteryWarning"></span>
-                        </label>
-                    </div>
-                    <div class="number vbatmonitoring vbatCalibration">
-                        <label> <input type="number" name="voltagescale" step="1" min="10" max="255" /> <span
-                            i18n="configurationBatteryScale"></span>
-                        </label>
-                    </div>
-                    <div class="number vbatmonitoring">
-                        <label> <input type="text" name="batteryvoltage" readonly class="disabled" /> <span
-                            i18n="configurationBatteryVoltage"></span>
-                        </label>
-                    </div>
-                </div>
-            </div>
-            <div class="gui_box grey">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" i18n="configurationCurrent"></div>
-                </div>
-                <div class="spacer_box">
-                    <table cellpadding="0" cellspacing="0">
-                        <thead>
-                            <tr>
-                                <th i18n="configurationFeatureEnabled"></th>
-                                <th i18n="configurationFeatureDescription"></th>
-                                <th i18n="configurationFeatureName"></th>
-                            </tr>
-                        </thead>
-                        <tbody class="features batteryCurrent">
-                            <!-- table generated here -->
-                        </tbody>
-                    </table>
-                    <div class="select currentMonitoring">
-                        <label>
-                            <select class="currentmetertype"><!-- list generated here --></select>
-                            <span i18n="configurationCurrentMeterType"></span>
-                        </label>
-                    </div>
-                    <div class="number currentMonitoring currentCalibration">
-                        <label> <input type="number" name="currentscale" step="1" min="-16000" max="16000" /> <span
-                            i18n="configurationCurrentScale"></span>
-                        </label>
-                    </div>
-                    <div class="number currentMonitoring currentCalibration">
-                        <label> <input type="number" name="currentoffset" step="1" min="-1600" max="16000" /> <span
-                            i18n="configurationCurrentOffset"></span>
-                        </label>
-                    </div>
-                    <div class="number currentMonitoring currentOutput">
-                        <label>
-                        <input type="text" name="batterycurrent" readonly class="disabled" /> <span
-                            i18n="configurationBatteryCurrent"></span>
-                        </label>
-                    </div>
-                    <div class="checkbox currentMonitoring currentOutput">
-                        <div class="numberspacer">
-                            <input type="checkbox" name="multiwiicurrentoutput" class="toggle" />
-                        </div>
-                        <label> <span i18n="configurationBatteryMultiwiiCurrent"></span>
-                        </label>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <!-- -------------------------------------------------------- -->
-
-        <div class="leftWrapper beepers" style="width: calc(100% - 20px);">
-            <div class="gui_box grey" style="margin-top:10px;">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" i18n="configurationBeeper"></div>
-                </div>
-                <div class="spacer_box">
-                    <table cellpadding="0" cellspacing="0">
-                        <tbody class="beeper-configuration" id="noline">
-                            <tr class="beeper-template" style="display:none">
-                                <td>
-                                    <input class="beeper toggle" id="" name="" title="" type="checkbox" />
-                                </td>
-                                <td>
-                                    <label for=""></label>
-                                </td>
-                                <td>
-                                    <span i18n=""></span>
-                                </td>
-                            </tr>
-                            <!-- table generated here -->
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-        <div class="clear-both"></div>
->>>>>>> Several fixes for compatibility with BF 3.1.x
         <div class="content_toolbar">
             <div class="btn save_btn">
                 <a class="save" href="#" i18n="configurationButtonSave"></a>

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -668,11 +668,150 @@
                             </div>
                         </div>
                     </div>
+<<<<<<< HEAD
 
                 </td>
             </tr>
         </table>
 
+=======
+                </div>
+            </div>
+            <div class="clear-both"></div>
+        </div>
+        
+
+        <!-- -------------------------------------------------------- -->
+        <!-- Remove this part when we officialy retire BF 3.1.x       -->
+        <div class="rightWrapper current voltage oldBatteryConfig">
+            <div class="gui_box grey">
+                <div class="gui_box_titlebar">
+                    <div class="spacer_box_title" i18n="configurationBatteryVoltage"></div>
+                </div>
+                <div class="spacer_box">
+                    <table cellpadding="0" cellspacing="0">
+                        <thead>
+                            <tr>
+                                <th i18n="configurationFeatureEnabled"></th>
+                                <th i18n="configurationFeatureDescription"></th>
+                                <th i18n="configurationFeatureName"></th>
+                            </tr>
+                        </thead>
+                        <tbody class="features batteryVoltage">
+                            <!-- table generated here -->
+                        </tbody>
+                    </table>
+                    <div class="select batterymetertype vbatmonitoring">
+                        <label>
+                            <select class="batterymetertype"><!-- list generated here --></select>
+                            <span i18n="configurationBatteryMeterType"></span>
+                        </label>
+                    </div>
+                    <div class="number vbatmonitoring">
+                        <label> <input type="number" name="mincellvoltage" step="0.1" min="1" max="5" /> <span
+                            i18n="configurationBatteryMinimum"></span>
+                        </label>
+                    </div>
+                    <div class="number vbatmonitoring">
+                        <label> <input type="number" name="maxcellvoltage" step="0.1" min="1" max="5" /> <span
+                            i18n="configurationBatteryMaximum"></span>
+                        </label>
+                    </div>
+                    <div class="number vbatmonitoring">
+                        <label> <input type="number" name="warningcellvoltage" step="0.1" min="1" max="5" /> <span
+                            i18n="configurationBatteryWarning"></span>
+                        </label>
+                    </div>
+                    <div class="number vbatmonitoring vbatCalibration">
+                        <label> <input type="number" name="voltagescale" step="1" min="10" max="255" /> <span
+                            i18n="configurationBatteryScale"></span>
+                        </label>
+                    </div>
+                    <div class="number vbatmonitoring">
+                        <label> <input type="text" name="batteryvoltage" readonly class="disabled" /> <span
+                            i18n="configurationBatteryVoltage"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+            <div class="gui_box grey">
+                <div class="gui_box_titlebar">
+                    <div class="spacer_box_title" i18n="configurationCurrent"></div>
+                </div>
+                <div class="spacer_box">
+                    <table cellpadding="0" cellspacing="0">
+                        <thead>
+                            <tr>
+                                <th i18n="configurationFeatureEnabled"></th>
+                                <th i18n="configurationFeatureDescription"></th>
+                                <th i18n="configurationFeatureName"></th>
+                            </tr>
+                        </thead>
+                        <tbody class="features batteryCurrent">
+                            <!-- table generated here -->
+                        </tbody>
+                    </table>
+                    <div class="select currentMonitoring">
+                        <label>
+                            <select class="currentmetertype"><!-- list generated here --></select>
+                            <span i18n="configurationCurrentMeterType"></span>
+                        </label>
+                    </div>
+                    <div class="number currentMonitoring currentCalibration">
+                        <label> <input type="number" name="currentscale" step="1" min="-16000" max="16000" /> <span
+                            i18n="configurationCurrentScale"></span>
+                        </label>
+                    </div>
+                    <div class="number currentMonitoring currentCalibration">
+                        <label> <input type="number" name="currentoffset" step="1" min="-1600" max="16000" /> <span
+                            i18n="configurationCurrentOffset"></span>
+                        </label>
+                    </div>
+                    <div class="number currentMonitoring currentOutput">
+                        <label>
+                        <input type="text" name="batterycurrent" readonly class="disabled" /> <span
+                            i18n="configurationBatteryCurrent"></span>
+                        </label>
+                    </div>
+                    <div class="checkbox currentMonitoring currentOutput">
+                        <div class="numberspacer">
+                            <input type="checkbox" name="multiwiicurrentoutput" class="toggle" />
+                        </div>
+                        <label> <span i18n="configurationBatteryMultiwiiCurrent"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <!-- -------------------------------------------------------- -->
+
+        <div class="leftWrapper beepers" style="width: calc(100% - 20px);">
+            <div class="gui_box grey" style="margin-top:10px;">
+                <div class="gui_box_titlebar">
+                    <div class="spacer_box_title" i18n="configurationBeeper"></div>
+                </div>
+                <div class="spacer_box">
+                    <table cellpadding="0" cellspacing="0">
+                        <tbody class="beeper-configuration" id="noline">
+                            <tr class="beeper-template" style="display:none">
+                                <td>
+                                    <input class="beeper toggle" id="" name="" title="" type="checkbox" />
+                                </td>
+                                <td>
+                                    <label for=""></label>
+                                </td>
+                                <td>
+                                    <span i18n=""></span>
+                                </td>
+                            </tr>
+                            <!-- table generated here -->
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div class="clear-both"></div>
+>>>>>>> Several fixes for compatibility with BF 3.1.x
         <div class="content_toolbar">
             <div class="btn save_btn">
                 <a class="save" href="#" i18n="configurationButtonSave"></a>

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -324,7 +324,7 @@
                     <!-- RECEIVER -->
                     <!-- FIXME move receiver and RSSI to receiver tab -->
                     <div class="receiver">
-                                <div class="gui_box grey" style="margin-bottom:10px;">
+                        <div class="gui_box grey" style="margin-bottom:10px;">
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationReceiver"></div>
                             </div>
@@ -411,7 +411,7 @@
                     </div>
 
                 </td>
-                 <td style="width:calc(50%);vertical-align:top;">
+                <td style="width:calc(50%);vertical-align:top;">
                     <!-- ROW 3 - RIGHT PANE -->
                     
                     <!-- 3D -->
@@ -525,6 +525,116 @@
                             </div>
                         </div>
                     </div>
+
+                </td>
+            </tr>
+            <tr class="oldBatteryConfig">
+                <td style="width:calc(50%);vertical-align:top;">
+                    <!-- ROW 4 - LEFT PANE - ONLY NEEDED FOR BATTERY/CURRENT PART FOR PRE BF3.2 -->
+
+                    <!-- -------------------------------------------------------- -->
+                    <!-- Remove this part when we officialy retire BF 3.1.x       -->
+                    <div class="rightWrapper current voltage">
+                        <div class="gui_box grey">
+                            <div class="gui_box_titlebar">
+                                <div class="spacer_box_title" i18n="configurationBatteryVoltage"></div>
+                            </div>
+                            <div class="spacer_box">
+                                <table cellpadding="0" cellspacing="0">
+                                    <thead>
+                                        <tr>
+                                            <th i18n="configurationFeatureEnabled"></th>
+                                            <th i18n="configurationFeatureDescription"></th>
+                                            <th i18n="configurationFeatureName"></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="features batteryVoltage">
+                                        <!-- table generated here -->
+                                    </tbody>
+                                </table>
+                                <div class="select batterymetertype vbatmonitoring">
+                                    <label>
+                                        <select class="batterymetertype"><!-- list generated here --></select>
+                                        <span i18n="configurationBatteryMeterType"></span>
+                                    </label>
+                                </div>
+                                <div class="number vbatmonitoring">
+                                    <label> <input type="number" name="mincellvoltage" step="0.1" min="1" max="5" /> <span
+                                        i18n="configurationBatteryMinimum"></span>
+                                    </label>
+                                </div>
+                                <div class="number vbatmonitoring">
+                                    <label> <input type="number" name="maxcellvoltage" step="0.1" min="1" max="5" /> <span
+                                        i18n="configurationBatteryMaximum"></span>
+                                    </label>
+                                </div>
+                                <div class="number vbatmonitoring">
+                                    <label> <input type="number" name="warningcellvoltage" step="0.1" min="1" max="5" /> <span
+                                        i18n="configurationBatteryWarning"></span>
+                                    </label>
+                                </div>
+                                <div class="number vbatmonitoring vbatCalibration">
+                                    <label> <input type="number" name="voltagescale" step="1" min="10" max="255" /> <span
+                                        i18n="configurationBatteryScale"></span>
+                                    </label>
+                                </div>
+                                <div class="number vbatmonitoring">
+                                    <label> <input type="text" name="batteryvoltage" readonly class="disabled" /> <span
+                                        i18n="configurationBatteryVoltage"></span>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="gui_box grey">
+                            <div class="gui_box_titlebar">
+                                <div class="spacer_box_title" i18n="configurationCurrent"></div>
+                            </div>
+                            <div class="spacer_box">
+                                <table cellpadding="0" cellspacing="0">
+                                    <thead>
+                                        <tr>
+                                            <th i18n="configurationFeatureEnabled"></th>
+                                            <th i18n="configurationFeatureDescription"></th>
+                                            <th i18n="configurationFeatureName"></th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="features batteryCurrent">
+                                        <!-- table generated here -->
+                                    </tbody>
+                                </table>
+                                <div class="select currentMonitoring">
+                                    <label>
+                                        <select class="currentmetertype"><!-- list generated here --></select>
+                                        <span i18n="configurationCurrentMeterType"></span>
+                                    </label>
+                                </div>
+                                <div class="number currentMonitoring currentCalibration">
+                                    <label> <input type="number" name="currentscale" step="1" min="-16000" max="16000" /> <span
+                                        i18n="configurationCurrentScale"></span>
+                                    </label>
+                                </div>
+                                <div class="number currentMonitoring currentCalibration">
+                                    <label> <input type="number" name="currentoffset" step="1" min="-1600" max="16000" /> <span
+                                        i18n="configurationCurrentOffset"></span>
+                                    </label>
+                                </div>
+                                <div class="number currentMonitoring currentOutput">
+                                    <label>
+                                    <input type="text" name="batterycurrent" readonly class="disabled" /> <span
+                                        i18n="configurationBatteryCurrent"></span>
+                                    </label>
+                                </div>
+                                <div class="checkbox currentMonitoring currentOutput">
+                                    <div class="numberspacer">
+                                        <input type="checkbox" name="multiwiicurrentoutput" class="toggle" />
+                                    </div>
+                                    <label> <span i18n="configurationBatteryMultiwiiCurrent"></span>
+                                    </label>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <!-- -------------------------------------------------------- -->
 
                 </td>
             </tr>

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -177,7 +177,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             var reverse = "";
             
             if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
-                MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
+                reverse = MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
             }
             
             $('.mixerPreview img').attr('src', './resources/motor_order/' + mixerList[mixer - 1].image + reverse + '.svg');

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -160,8 +160,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
     }
 
-    // -----------------------------------------------
-    // Remove this when we officily retire BF 3.1.x
     function load_battery() {
         var next_callback = load_current;
         if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
@@ -178,8 +176,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         } else {
             next_callback();
         }
-    }
-    // -----------------------------------------------
+    }   
 
     function load_rx_config() {
         var next_callback = load_html;
@@ -592,8 +589,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[name="maxthrottle"]').val(MOTOR_CONFIG.maxthrottle);
         $('input[name="mincommand"]').val(MOTOR_CONFIG.mincommand);
 
-        // -----------------------------------------------
-        // Remove this when we officily retire BF 3.1.x
         // fill battery
         if (self.SHOW_OLD_BATTERY_CONFIG) {
             if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
@@ -689,7 +684,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 $('.currentMonitoring').hide();
             }
         }
-        // ------------------------------------------------
 
         //fill 3D
         if (semver.lt(CONFIG.apiVersion, "1.14.0")) {
@@ -980,8 +974,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 MSP.send_message(MSPCodes.MSP_SET_NAME, mspHelper.crunch(MSPCodes.MSP_SET_NAME), false, next_callback);
             }
 
-            // -----------------------------------------------
-            // Remove this when we officily retire BF 3.1.x
             function save_battery() {
                 var next_callback = save_current;
                 if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
@@ -999,7 +991,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                     next_callback();
                 }
             }
-            // -----------------------------------------------
 
             function save_rx_config() {
                 var next_callback = save_to_eeprom;

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -176,7 +176,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             var mixer = MIXER_CONFIG.mixer
             var reverse = "";
             
-            if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                 reverse = MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
             }
             

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -1,7 +1,8 @@
 'use strict';
 
 TABS.configuration = {
-    DSHOT_PROTOCOL_MIN_VALUE: 5
+    DSHOT_PROTOCOL_MIN_VALUE: 5,
+    SHOW_OLD_BATTERY_CONFIG: false
 };
 
 TABS.configuration.initialize = function (callback, scrollPosition) {
@@ -9,6 +10,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     if (GUI.active_tab != 'configuration') {
         GUI.active_tab = 'configuration';
+    }
+
+    if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+        //Show old battery configuration for pre-BF-3.2
+        self.SHOW_OLD_BATTERY_CONFIG = true;
+    } else {
+        self.SHOW_OLD_BATTERY_CONFIG = false;
     }
 
     function load_config() {
@@ -140,12 +148,38 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_name() {
         var next_callback = load_rx_config;
+
+        if (self.SHOW_OLD_BATTERY_CONFIG) {
+            next_callback = load_battery;
+        }
+
         if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
             MSP.send_message(MSPCodes.MSP_NAME, false, false, next_callback);
         } else {
             next_callback();
         }
     }
+
+    // -----------------------------------------------
+    // Remove this when we officily retire BF 3.1.x
+    function load_battery() {
+        var next_callback = load_current;
+        if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+            MSP.send_message(MSPCodes.MSP_VOLTAGE_METER_CONFIG, false, false, next_callback);
+        } else {
+            next_callback();
+        }
+    }
+
+    function load_current() {
+        var next_callback = load_rx_config;
+        if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+            MSP.send_message(MSPCodes.MSP_CURRENT_METER_CONFIG, false, false, next_callback);
+        } else {
+            next_callback();
+        }
+    }
+    // -----------------------------------------------
 
     function load_rx_config() {
         var next_callback = load_html;
@@ -558,6 +592,105 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[name="maxthrottle"]').val(MOTOR_CONFIG.maxthrottle);
         $('input[name="mincommand"]').val(MOTOR_CONFIG.mincommand);
 
+        // -----------------------------------------------
+        // Remove this when we officily retire BF 3.1.x
+        // fill battery
+        if (self.SHOW_OLD_BATTERY_CONFIG) {
+            if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+                var batteryMeterTypes = [
+                    'Onboard ADC',
+                    'ESC Sensor'
+                ];
+
+                var batteryMeterType_e = $('select.batterymetertype');
+                for (i = 0; i < batteryMeterTypes.length; i++) {
+                    batteryMeterType_e.append('<option value="' + i + '">' + batteryMeterTypes[i] + '</option>');
+                }
+
+                batteryMeterType_e.change(function () {
+                    MISC.batterymetertype = parseInt($(this).val());
+                    checkUpdateVbatControls();
+                });
+                batteryMeterType_e.val(MISC.batterymetertype).change();
+            } else {
+                $('div.batterymetertype').hide();
+            }
+
+            $('input[name="mincellvoltage"]').val(MISC.vbatmincellvoltage);
+            $('input[name="maxcellvoltage"]').val(MISC.vbatmaxcellvoltage);
+            $('input[name="warningcellvoltage"]').val(MISC.vbatwarningcellvoltage);
+            $('input[name="voltagescale"]').val(MISC.vbatscale);
+
+            // fill current
+            var currentMeterTypes = [
+                'None',
+                'Onboard ADC',
+                'Virtual'
+            ];
+
+            if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+                currentMeterTypes.push('ESC Sensor');
+            }
+
+            var currentMeterType_e = $('select.currentmetertype');
+            for (i = 0; i < currentMeterTypes.length; i++) {
+                currentMeterType_e.append('<option value="' + i + '">' + currentMeterTypes[i] + '</option>');
+            }
+
+            currentMeterType_e.change(function () {
+                BF_CONFIG.currentmetertype = parseInt($(this).val());
+                checkUpdateCurrentControls();
+            });
+            currentMeterType_e.val(BF_CONFIG.currentmetertype).change();
+
+            $('input[name="currentscale"]').val(BF_CONFIG.currentscale);
+            $('input[name="currentoffset"]').val(BF_CONFIG.currentoffset);
+            $('input[name="multiwiicurrentoutput"]').prop('checked', MISC.multiwiicurrentoutput !== 0);
+        } else {
+            $('.oldBatteryConfig').hide();
+        }
+
+        function checkUpdateVbatControls() {
+            if (FEATURE_CONFIG.features.isEnabled('VBAT')) {
+                $('.vbatmonitoring').show();
+
+                if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+                     $('select.batterymetertype').show();
+
+                    if (MISC.batterymetertype !== 0) {
+                        $('.vbatCalibration').hide();
+                     }
+                } else {
+                    $('select.batterymetertype').hide();
+                }
+            } else {
+                $('.vbatmonitoring').hide();
+            }
+        }
+
+        function checkUpdateCurrentControls() {
+            if (FEATURE_CONFIG.features.isEnabled('CURRENT_METER')) {
+                $('.currentMonitoring').show();
+
+                switch(BF_CONFIG.currentmetertype) {
+                    case 0:
+                        $('.currentCalibration').hide();
+                        $('.currentOutput').hide();
+
+                        break;
+                    case 3:
+                        $('.currentCalibration').hide();
+                }
+
+                if (BF_CONFIG.currentmetertype !== 1 && BF_CONFIG.currentmetertype !== 2) {
+                    $('.currentCalibration').hide();
+                }
+            } else {
+                $('.currentMonitoring').hide();
+            }
+        }
+        // ------------------------------------------------
+
         //fill 3D
         if (semver.lt(CONFIG.apiVersion, "1.14.0")) {
             $('.tab-configuration ._3d').hide();
@@ -611,6 +744,17 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                     checkShowDisarmDelay();
                     break;
 
+                case 'VBAT':
+                    if (self.SHOW_OLD_BATTERY_CONFIG) {
+                        checkUpdateVbatControls();
+                    }
+
+                    break;
+                case 'CURRENT_METER':
+                    if (self.SHOW_OLD_BATTERY_CONFIG) {
+                        checkUpdateCurrentControls();
+                    }
+
                 case 'GPS':
                     checkUpdateGpsControls();
                     break;
@@ -650,6 +794,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         checkUpdateGpsControls();
         checkUpdate3dControls();
 
+        if (self.SHOW_OLD_BATTERY_CONFIG) {
+            checkUpdateVbatControls();
+            checkUpdateCurrentControls();
+        }
+
         $("input[id='unsyncedPWMSwitch']").change(function() {
             if ($(this).is(':checked')) {
                 $('div.unsyncedpwmfreq').show();
@@ -677,6 +826,17 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             MOTOR_CONFIG.minthrottle = parseInt($('input[name="minthrottle"]').val());
             MOTOR_CONFIG.maxthrottle = parseInt($('input[name="maxthrottle"]').val());
             MOTOR_CONFIG.mincommand = parseInt($('input[name="mincommand"]').val());
+
+            if(self.SHOW_OLD_BATTERY_CONFIG) {
+                MISC.vbatmincellvoltage = parseFloat($('input[name="mincellvoltage"]').val());
+                MISC.vbatmaxcellvoltage = parseFloat($('input[name="maxcellvoltage"]').val());
+                MISC.vbatwarningcellvoltage = parseFloat($('input[name="warningcellvoltage"]').val());
+                MISC.vbatscale = parseInt($('input[name="voltagescale"]').val());
+
+                BF_CONFIG.currentscale = parseInt($('input[name="currentscale"]').val());
+                BF_CONFIG.currentoffset = parseInt($('input[name="currentoffset"]').val());
+                MISC.multiwiicurrentoutput = $('input[name="multiwiicurrentoutput"]').is(':checked') ? 1 : 0;
+            }
 
             if(semver.gte(CONFIG.apiVersion, "1.14.0")) {
                 MOTOR_3D_CONFIG.deadband3d_low = parseInt($('input[name="3ddeadbandlow"]').val());
@@ -812,9 +972,34 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             function save_name() {
                 var next_callback = save_rx_config;
 
+                if(self.SHOW_OLD_BATTERY_CONFIG) {
+                    next_callback = save_battery;
+                }
+
                 CONFIG.name = $.trim($('input[name="craftName"]').val());
                 MSP.send_message(MSPCodes.MSP_SET_NAME, mspHelper.crunch(MSPCodes.MSP_SET_NAME), false, next_callback);
             }
+
+            // -----------------------------------------------
+            // Remove this when we officily retire BF 3.1.x
+            function save_battery() {
+                var next_callback = save_current;
+                if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+                    MSP.send_message(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG), false, next_callback);
+                } else {
+                    next_callback();
+                }
+            }
+
+            function save_current() {
+                var next_callback = save_rx_config;
+                if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+                    MSP.send_message(MSPCodes.MSP_SET_CURRENT_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_CURRENT_METER_CONFIG), false, next_callback);
+                } else {
+                    next_callback();
+                }
+            }
+            // -----------------------------------------------
 
             function save_rx_config() {
                 var next_callback = save_to_eeprom;

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -174,12 +174,17 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         function refreshMixerPreview() {
             var mixer = MIXER_CONFIG.mixer
-            var reverse = MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
-
+            var reverse = "";
+            
+            if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+                MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
+            }
+            
             $('.mixerPreview img').attr('src', './resources/motor_order/' + mixerList[mixer - 1].image + reverse + '.svg');
         };
 
         var reverseMotorSwitch_e = $('#reverseMotorSwitch');
+        var reverseMotor_e = $('.reverseMotor');
 
         reverseMotorSwitch_e.change(function() {
             MIXER_CONFIG.reverseMotorDir = $(this).prop('checked') ? 1 : 0;
@@ -208,6 +213,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             BEEPER_CONFIG.beepers.generateElements(template, destination);
         } else {
             beeper_e.hide();
+            reverseMotor_e.hide();
         }
 
         // translate to user-selected language

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -170,7 +170,7 @@ TABS.motors.initialize = function (callback) {
     function update_model(mixer) {
         var reverse = "";
         
-        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
             reverse = MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
         }
         

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -42,7 +42,14 @@ TABS.motors.initialize = function (callback) {
         $('#content').load("./tabs/motors.html", process_html);
     }
 
-    MSP.send_message(MSPCodes.MSP_MOTOR_CONFIG, false, false, get_arm_status);
+    // Get information from Betaflight
+    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        // BF 3.2.0+
+        MSP.send_message(MSPCodes.MSP_MOTOR_CONFIG, false, false, get_arm_status);
+    } else {
+        // BF 3.1.x or older
+        MSP.send_message(MSPCodes.MSP_MISC, false, false, get_arm_status);
+    }
 
     function update_arm_status() {
         self.armed = bit_check(CONFIG.mode, 0);

--- a/tabs/motors.js
+++ b/tabs/motors.js
@@ -167,8 +167,14 @@ TABS.motors.initialize = function (callback) {
         lines.attr('d', graphHelpers.line);
     }
 
-    function update_model(val) {
-        $('.mixerPreview img').attr('src', './resources/motor_order/' + mixerList[val - 1].image + '.svg');
+    function update_model(mixer) {
+        var reverse = "";
+        
+        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+            reverse = MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
+        }
+        
+        $('.mixerPreview img').attr('src', './resources/motor_order/' + mixerList[mixer - 1].image + reverse + '.svg');
     }
     
     function process_html() {


### PR DESCRIPTION
Fixes incompatibility with BF 3.1.x.

- Fixed Motor tab.
- Hide Power & Battery tab when pre-BF 3.2.0.
- Added old battery / current configuration back for pre-BF 3.2.0 in Configuration tab.
- Bumped version number to 3.1.3 and added version information.
- Hide reverse motor direction checkbox for pre-BF 3.2.0 (and show correct motor preview on Motor tab).

I've tested this with 2 quads running BF 3.1.7 and BF 3.2.0 (master from this afternoon) and both seem to work now. If someone want to test it also before we release this version, that would be great.