### PR TITLE
Filter switches (take two)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1949,14 +1949,20 @@
     "pidTuningGyroLowpassFrequencyHelp": {
         "message": "Gyro Soft Lowpass Frequency [Hz]"
     },
+    "pidTuningGyroNotch1Enable": {
+        "message": "Enable Gyro Notch Filter 1"
+    },
     "pidTuningGyroNotch1Frequency": {
         "message": "Gyro Notch Filter 1 Frequency [Hz]"
+    },
+    "pidTuningGyroNotch2Enable": {
+        "message": "Enable Gyro Notch Filter 2"
     },
     "pidTuningGyroNotch2Frequency": {
         "message": "Gyro Notch Filter 2 Frequency [Hz]"
     },
     "pidTuningGyroNotchFrequencyHelp": {
-        "message": "Gyro Notch Filter Frequency in Hz (0 means disabled)"
+        "message": "Gyro Notch Filter Frequency in Hz"
     },
     "pidTuningGyroNotch1Cutoff": {
         "message": "Gyro Notch Filter Cutoff 1 Frequency [Hz]"
@@ -1970,17 +1976,14 @@
     "pidTuningFilterSettings": {
         "message": "Filter Settings"
     },
-    "pidTuningDTermLowpassType": {
-        "message": "D-Term Lowpass Filter"
-    },
-    "pidTuningDTermLowpassTypeTip": {
-        "message": "Select D-Term lowpass filter type to use. Default is BIQUAD"
-    },
     "pidTuningDTermLowpassFrequency": {
         "message": "D Term Lowpass Frequency [Hz]"
     },
     "pidTuningDTermLowpassFrequencyHelp": {
         "message": "D Term Lowpass Frequency [Hz] (0 means disabled)"
+    },
+    "pidTuningDTermNotchEnable": {
+        "message": "Enable D Term Notch Filter"
     },
     "pidTuningDTermNotchFrequency": {
         "message": "D Term Notch Filter Frequency [Hz]"

--- a/js/fc.js
+++ b/js/fc.js
@@ -337,7 +337,7 @@ var FC = {
             dterm_notch_cutoff:         0,
             gyro_soft_notch_hz_2:       0,
             gyro_soft_notch_cutoff_2:   0,
-            dterm_filter_type:         0,
+            dterm_filter_type:          0,
         };
 
         ADVANCED_TUNING = {

--- a/js/fc.js
+++ b/js/fc.js
@@ -56,6 +56,7 @@ var FILTER_CONFIG;
 var ADVANCED_TUNING;
 var SENSOR_CONFIG;
 var COPY_PROFILE;
+var DEFAULT;
 
 var FC = {
     resetState: function() {
@@ -392,5 +393,14 @@ var FC = {
         };
 
         RXFAIL_CONFIG = [];
+
+        DEFAULT = {
+            gyro_soft_notch_cutoff_1:       300,
+            gyro_soft_notch_hz_1:           400,
+            gyro_soft_notch_cutoff_2:       200,
+            gyro_soft_notch_hz_2:           300,
+            dterm_notch_cutoff:             160,
+            dterm_notch_hz:                 260,
+        };
     }
 };

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -826,11 +826,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
                         FILTER_CONFIG.gyro_soft_notch_hz_2 = data.readU16();
                         FILTER_CONFIG.gyro_soft_notch_cutoff_2 = data.readU16();
-                        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                            FILTER_CONFIG.enable_gyro_soft_notch_1 = data.readU8();
-                            FILTER_CONFIG.enable_gyro_soft_notch_2 = data.readU8();
-                            FILTER_CONFIG.enable_dterm_notch = data.readU8();
-                        }
                     }
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                         FILTER_CONFIG.dterm_filter_type = data.readU8();
@@ -1454,11 +1449,6 @@ MspHelper.prototype.crunch = function(code) {
                 if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
                     buffer.push16(FILTER_CONFIG.gyro_soft_notch_hz_2)
                         .push16(FILTER_CONFIG.gyro_soft_notch_cutoff_2)
-                    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                        buffer.push8(FILTER_CONFIG.enable_gyro_soft_notch_1)
-                            .push8(FILTER_CONFIG.enable_gyro_soft_notch_2)
-                            .push8(FILTER_CONFIG.enable_dterm_notch);
-                    }
                 }
                 if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                     buffer.push8(FILTER_CONFIG.dterm_filter_type);

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -826,6 +826,11 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
                         FILTER_CONFIG.gyro_soft_notch_hz_2 = data.readU16();
                         FILTER_CONFIG.gyro_soft_notch_cutoff_2 = data.readU16();
+                        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                            FILTER_CONFIG.enable_gyro_soft_notch_1 = data.readU8();
+                            FILTER_CONFIG.enable_gyro_soft_notch_2 = data.readU8();
+                            FILTER_CONFIG.enable_dterm_notch = data.readU8();
+                        }
                     }
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                         FILTER_CONFIG.dterm_filter_type = data.readU8();
@@ -1449,6 +1454,11 @@ MspHelper.prototype.crunch = function(code) {
                 if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
                     buffer.push16(FILTER_CONFIG.gyro_soft_notch_hz_2)
                         .push16(FILTER_CONFIG.gyro_soft_notch_cutoff_2)
+                    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                        buffer.push8(FILTER_CONFIG.enable_gyro_soft_notch_1)
+                            .push8(FILTER_CONFIG.enable_gyro_soft_notch_2)
+                            .push8(FILTER_CONFIG.enable_dterm_notch);
+                    }
                 }
                 if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                     buffer.push8(FILTER_CONFIG.dterm_filter_type);

--- a/tabs/pid_tuning.css
+++ b/tabs/pid_tuning.css
@@ -326,7 +326,8 @@
 
 .tab-pid_tuning table tr td {
     text-align: left;
-    padding-left: 0px;
+    padding-left: 5px;
+    padding-right: 5px;
 }
 
 .tab-pid_tuning table input {
@@ -636,7 +637,7 @@
 
 
 .tab-pid_tuning .controller {
-    width: 150px; 
+    width: 150px;
 }
 
 .tab-pid_tuning .controller select {
@@ -646,7 +647,7 @@
 }
 
 .tab-pid_tuning .delta {
-    width: 150px; 
+    width: 150px;
 }
 
 .tab-pid_tuning .delta select {

--- a/tabs/pid_tuning.html
+++ b/tabs/pid_tuning.html
@@ -451,6 +451,9 @@
                     </div>
                 </div>
             </div>
+
+            <!-- FILTER SUBTAB -->
+
             <div class="subtab-filter" style="display: none;">
                 <div class="clear-both"></div>
                 <div class="note topspacer" style="margin-top: 0px;">
@@ -494,6 +497,18 @@
                                     </div>
                                 </td>
                             </tr>
+                            <tr class="switchGyroNotch1">
+                                <td style="text-align: right;">
+                                    <input type="checkbox" id="gyroNotch1Enabled" class="toggle" />
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningGyroNotch1Enable"></span>
+                                        </label>
+                                    </div>
+                                </td>
+                            </tr>
                             <tr class="newFilter">
                                 <td>
                                     <input type="number" class="nonProfile" name="gyroNotch1Frequency" step="1" min="0" max="16000"/>
@@ -520,6 +535,18 @@
                                     </div>
                                 </td>
                             </tr>
+                            <tr class="switchGyroNotch2">
+                                <td style="text-align: right;">
+                                    <input type="checkbox" id="gyroNotch2Enabled" class="toggle" />
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningGyroNotch2Enable"></span>
+                                        </label>
+                                    </div>
+                                </td>
+                            <tr>
                             <tr class="newFilter gyroNotch2">
                                 <td>
                                     <input type="number" class="nonProfile" name="gyroNotch2Frequency" step="1" min="0" max="16000"/>
@@ -568,6 +595,18 @@
                                     </div>
                                 </td>
                             </tr>
+                            <tr class="switchDTermNotch">
+                                <td style="text-align: right;">
+                                    <input type="checkbox" id="dtermNotchEnabled" class="toggle" />
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningDTermNotchEnable"></span>
+                                        </label>
+                                    </div>
+                                </td>
+                            <tr>
                             <tr class="newFilter">
                                 <td>
                                     <input type="number" name="dTermNotchFrequency" step="1" min="0" max="16000"/>

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -292,15 +292,9 @@ TABS.pid_tuning.initialize = function (callback) {
                 .attr('disabled', !checked);
         });
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-            $('input[id="gyroNotch1Enabled"]').prop('checked', FILTER_CONFIG.gyro_soft_notch_cutoff_1 != 0).change();
-            $('input[id="gyroNotch2Enabled"]').prop('checked', FILTER_CONFIG.gyro_soft_notch_cutoff_2 != 0).change();
-            $('input[id="dtermNotchEnabled"]').prop('checked', FILTER_CONFIG.dterm_notch_cutoff != 0).change();
-        } else {
-            $('.switchGyroNotch1').hide();
-            $('.switchGyroNotch2').hide();
-            $('.switchDTermNotch').hide();
-        }
+        $('input[id="gyroNotch1Enabled"]').prop('checked', FILTER_CONFIG.gyro_soft_notch_cutoff_1 != 0).change();
+        $('input[id="gyroNotch2Enabled"]').prop('checked', FILTER_CONFIG.gyro_soft_notch_cutoff_2 != 0).change();
+        $('input[id="dtermNotchEnabled"]').prop('checked', FILTER_CONFIG.dterm_notch_cutoff != 0).change();
     }
 
     function form_to_pid_and_rc() {

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -259,7 +259,6 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_sensitivity').hide();
         }
 
-<<<<<<< HEAD
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
             $('.profile select[name="dtermFilterType"]').val(FILTER_CONFIG.dterm_filter_type);
             $('.antigravity input[name="itermThrottleThreshold"]').val(ADVANCED_TUNING.itermThrottleThreshold);
@@ -267,34 +266,40 @@ TABS.pid_tuning.initialize = function (callback) {
         } else {
             $('.dtermfiltertype').hide();
             $('.antigravity').hide();
-=======
+        }
+
         $('input[id="gyroNotch1Enabled"]').change(function() {
-            FILTER_CONFIG.enable_gyro_soft_notch_1 = $(this).is(':checked') ? 1 : 0;
-            $('.pid_filter input[name="gyroNotch1Frequency"]').attr('disabled', !FILTER_CONFIG.enable_gyro_soft_notch_1);
-            $('.pid_filter input[name="gyroNotch1Cutoff"]').attr('disabled', !FILTER_CONFIG.enable_gyro_soft_notch_1);
+            var checked = $(this).is(':checked');
+            $('.pid_filter input[name="gyroNotch1Frequency"]').val(checked ? DEFAULT.gyro_soft_notch_hz_1 : 0)
+                .attr('disabled', !checked);
+            $('.pid_filter input[name="gyroNotch1Cutoff"]').val($(this).is(':checked') ? DEFAULT.gyro_soft_notch_cutoff_1 : 0)
+                .attr('disabled', !checked);
         });
 
         $('input[id="gyroNotch2Enabled"]').change(function() {
-            FILTER_CONFIG.enable_gyro_soft_notch_2 = $(this).is(':checked') ? 1 : 0;
-            $('.pid_filter input[name="gyroNotch2Frequency"]').attr('disabled', !FILTER_CONFIG.enable_gyro_soft_notch_2);
-            $('.pid_filter input[name="gyroNotch2Cutoff"]').attr('disabled', !FILTER_CONFIG.enable_gyro_soft_notch_2);
+            var checked = $(this).is(':checked');
+            $('.pid_filter input[name="gyroNotch2Frequency"]').val(checked ? DEFAULT.gyro_soft_notch_hz_2 : 0)
+                .attr('disabled', !checked);
+            $('.pid_filter input[name="gyroNotch2Cutoff"]').val(checked ? DEFAULT.gyro_soft_notch_cutoff_2 : 0)
+                .attr('disabled', !checked);
         });
 
         $('input[id="dtermNotchEnabled"]').change(function() {
-            FILTER_CONFIG.enable_dterm_notch = $(this).is(':checked') ? 1 : 0;
-            $('.pid_filter input[name="dTermNotchFrequency"]').attr('disabled', !FILTER_CONFIG.enable_dterm_notch);
-            $('.pid_filter input[name="dTermNotchCutoff"]').attr('disabled', !FILTER_CONFIG.enable_dterm_notch);
+            var checked = $(this).is(':checked');
+            $('.pid_filter input[name="dTermNotchFrequency"]').val(checked ? DEFAULT.dterm_notch_hz : 0)
+                .attr('disabled', !checked);
+            $('.pid_filter input[name="dTermNotchCutoff"]').val(checked ? DEFAULT.dterm_notch_cutoff : 0)
+                .attr('disabled', !checked);
         });
 
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-            $('input[id="gyroNotch1Enabled"]').prop('checked', FILTER_CONFIG.enable_gyro_soft_notch_1 != 0).change();
-            $('input[id="gyroNotch2Enabled"]').prop('checked', FILTER_CONFIG.enable_gyro_soft_notch_2 != 0).change();
-            $('input[id="dtermNotchEnabled"]').prop('checked', FILTER_CONFIG.enable_dterm_notch != 0).change();
+            $('input[id="gyroNotch1Enabled"]').prop('checked', FILTER_CONFIG.gyro_soft_notch_cutoff_1 != 0).change();
+            $('input[id="gyroNotch2Enabled"]').prop('checked', FILTER_CONFIG.gyro_soft_notch_cutoff_2 != 0).change();
+            $('input[id="dtermNotchEnabled"]').prop('checked', FILTER_CONFIG.dterm_notch_cutoff != 0).change();
         } else {
             $('.switchGyroNotch1').hide();
             $('.switchGyroNotch2').hide();
             $('.switchDTermNotch').hide();
->>>>>>> Added switches to turn on/off gyro notch 1/2 and dterm notch filters
         }
     }
 

--- a/tabs/pid_tuning.js
+++ b/tabs/pid_tuning.js
@@ -259,6 +259,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_sensitivity').hide();
         }
 
+<<<<<<< HEAD
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
             $('.profile select[name="dtermFilterType"]').val(FILTER_CONFIG.dterm_filter_type);
             $('.antigravity input[name="itermThrottleThreshold"]').val(ADVANCED_TUNING.itermThrottleThreshold);
@@ -266,6 +267,34 @@ TABS.pid_tuning.initialize = function (callback) {
         } else {
             $('.dtermfiltertype').hide();
             $('.antigravity').hide();
+=======
+        $('input[id="gyroNotch1Enabled"]').change(function() {
+            FILTER_CONFIG.enable_gyro_soft_notch_1 = $(this).is(':checked') ? 1 : 0;
+            $('.pid_filter input[name="gyroNotch1Frequency"]').attr('disabled', !FILTER_CONFIG.enable_gyro_soft_notch_1);
+            $('.pid_filter input[name="gyroNotch1Cutoff"]').attr('disabled', !FILTER_CONFIG.enable_gyro_soft_notch_1);
+        });
+
+        $('input[id="gyroNotch2Enabled"]').change(function() {
+            FILTER_CONFIG.enable_gyro_soft_notch_2 = $(this).is(':checked') ? 1 : 0;
+            $('.pid_filter input[name="gyroNotch2Frequency"]').attr('disabled', !FILTER_CONFIG.enable_gyro_soft_notch_2);
+            $('.pid_filter input[name="gyroNotch2Cutoff"]').attr('disabled', !FILTER_CONFIG.enable_gyro_soft_notch_2);
+        });
+
+        $('input[id="dtermNotchEnabled"]').change(function() {
+            FILTER_CONFIG.enable_dterm_notch = $(this).is(':checked') ? 1 : 0;
+            $('.pid_filter input[name="dTermNotchFrequency"]').attr('disabled', !FILTER_CONFIG.enable_dterm_notch);
+            $('.pid_filter input[name="dTermNotchCutoff"]').attr('disabled', !FILTER_CONFIG.enable_dterm_notch);
+        });
+
+        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            $('input[id="gyroNotch1Enabled"]').prop('checked', FILTER_CONFIG.enable_gyro_soft_notch_1 != 0).change();
+            $('input[id="gyroNotch2Enabled"]').prop('checked', FILTER_CONFIG.enable_gyro_soft_notch_2 != 0).change();
+            $('input[id="dtermNotchEnabled"]').prop('checked', FILTER_CONFIG.enable_dterm_notch != 0).change();
+        } else {
+            $('.switchGyroNotch1').hide();
+            $('.switchGyroNotch2').hide();
+            $('.switchDTermNotch').hide();
+>>>>>>> Added switches to turn on/off gyro notch 1/2 and dterm notch filters
         }
     }
 


### PR DESCRIPTION
New take on enabling/disabling notch filters with a switch.
This is configurator side only. 

- When disabling a filter the `_hz` and `_cutoff` values are both set to 0. 
- When enabling a filter the `_hz` and `_cutoff` values are both reset to the default values.

This way it is more convenient for users to disable notch filters and it still uses the same method for disabling settings as used in BF.

Enabled notch filters:
![image](https://user-images.githubusercontent.com/334779/28754218-7d26ee32-7541-11e7-8c83-1ea4775f42fd.png)

Disabled notch filters:
![image](https://user-images.githubusercontent.com/334779/28754221-920e97d2-7541-11e7-8bb4-3814816d86b4.png)
