### PR TITLE
Fixed channel bars in receiver tab when no rx is configured

### DIFF
--- a/tabs/receiver.js
+++ b/tabs/receiver.js
@@ -110,7 +110,9 @@ TABS.receiver.initialize = function (callback) {
             bar_container = $('.tab-receiver .bars'),
             aux_index = 1;
 
-        for (var i = 0; i < RC.active_channels; i++) {
+        var num_bars = (RC.active_channels > 0) ? RC.active_channels : 8;
+
+        for (var i = 0; i < num_bars; i++) {
             var name;
             if (i < bar_names.length) {
                 name = bar_names[i];
@@ -124,7 +126,7 @@ TABS.receiver.initialize = function (callback) {
                     <li class="meter">\
                         <div class="meter-bar">\
                             <div class="label"></div>\
-                            <div class="fill">\
+                            <div class="fill' + (RC.active_channels == 0 ? 'disabled' : '') + '">\
                                 <div class="label"></div>\
                             </div>\
                         </div>\


### PR DESCRIPTION
When no RX is configured the receiver tab didn't show the channel bars resulting in a odd looking screen. This PR fixes this by displaying 8 channels in disabled mode.

![image](https://user-images.githubusercontent.com/334779/28756824-50563a5e-7576-11e7-94cb-7d8034bb8d46.png)
