### PR TITLE
Fixed blackbox_device setting via onboard_logging tab

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -1553,7 +1553,7 @@ MspHelper.prototype.dataflashRead = function(address, blockSize, onDataCallback)
                  * figure out the reply format:
                  */
                 if (dataCompressionType == 0) {
-                    onDataCallback(address, new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize), dataSize);
+                    onDataCallback(address, new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize));
                 } else if (dataCompressionType == 1) {
                     // Read compressed char count to avoid decoding stray bit sequences as bytes
                     var compressedCharCount = response.data.readU16();

--- a/main.html
+++ b/main.html
@@ -51,6 +51,8 @@
     <script type="text/javascript" src="./js/libraries/jquery.ba-throttle-debounce.min.js"></script>
     <script type="text/javascript" src="./js/libraries/inflection.min.js"></script>
     <script type="text/javascript" src="./js/injected_methods.js"></script>
+    <script type="text/javascript" src="./js/data_storage.js"></script>
+    <script type="text/javascript" src="./js/fc.js"></script>
     <script type="text/javascript" src="./js/port_handler.js"></script>
     <script type="text/javascript" src="./js/port_usage.js"></script>
     <script type="text/javascript" src="./js/serial.js"></script>
@@ -59,8 +61,6 @@
     <script type="text/javascript" src="./js/default_huffman_tree.js"></script>
     <script type="text/javascript" src="./js/model.js"></script>
     <script type="text/javascript" src="./js/serial_backend.js"></script>
-    <script type="text/javascript" src="./js/data_storage.js"></script>
-    <script type="text/javascript" src="./js/fc.js"></script>
     <script type="text/javascript" src="./js/msp/MSPCodes.js"></script>
     <script type="text/javascript" src="./js/msp.js"></script>
     <script type="text/javascript" src="./js/msp/MSPHelper.js"></script>

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -363,10 +363,7 @@ TABS.onboard_logging.initialize = function (callback) {
     
     function flash_save_begin() {
         if (GUI.connected_to) {
-            if (GUI.operating_system == "MacOS") {
-                // Address Chrome for macOS issue with large serial reads
-                self.blockSize = self.VCP_BLOCK_SIZE_3_0;
-            } else if (BOARD.find_board_definition(CONFIG.boardIdentifier).vcp) {
+            if (BOARD.find_board_definition(CONFIG.boardIdentifier).vcp) {
                 if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
                     self.blockSize = self.VCP_BLOCK_SIZE;
                 } else {

--- a/tabs/onboard_logging.js
+++ b/tabs/onboard_logging.js
@@ -121,13 +121,14 @@ TABS.onboard_logging.initialize = function (callback) {
             if (BLACKBOX.supported) {
                 $(".tab-onboard_logging a.save-settings").click(function() {
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                        BLACKBOX.blackboxPDenom = loggingRatesSelect.val();
+                        BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);
                     } else {
                         var rate = loggingRatesSelect.val().split('/');
                         BLACKBOX.blackboxRateNum = parseInt(rate[0], 10);
                         BLACKBOX.blackboxRateDenom = parseInt(rate[1], 10);
-                        BLACKBOX.blackboxDevice = parseInt(deviceSelect.val(), 10);
                     }
+
+                    BLACKBOX.blackboxDevice = parseInt(deviceSelect.val(), 10);
                     
                     MSP.send_message(MSPCodes.MSP_SET_BLACKBOX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BLACKBOX_CONFIG), false, save_to_eeprom);
                 });


### PR DESCRIPTION
Turns out wrong code got caught in an `else` clause for `apiVersion` added recently, resulting in `blackboxDevice` being never set.

Fixes https://github.com/betaflight/betaflight/issues/3712