### PR TITLE
Bump version to 3.2.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "minimum_chrome_version": "38",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "author": "Betaflight Squad",
     "name": "Betaflight - Configurator",
     "short_name": "Betaflight",


### PR DESCRIPTION
Currently there are two different 3.2.0 versions, one on github master and one on Chrome store. We can not have it that way, there must be something to tell the difference. 
Also, there are no 3.2.0 on the release page on github, despite it being released to Chrome. Order in chaos there must be. 
