### PR TITLE
Add arming disable flags to setup tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -436,6 +436,12 @@
     "initialSetupRSSIValue": {
         "message": "$1 %"
     },
+    "initialSetupArmingDisableFlags": {
+        "message": "Arming Disable Flags:"
+    },
+    "initialSetupArmingAllowed": {
+        "message": "Arming Allowed"
+    },
     "initialSetupGPSHead": {
         "message": "GPS"
     },

--- a/js/fc.js
+++ b/js/fc.js
@@ -78,6 +78,7 @@ var FC = {
             numProfiles:                3,
             rateProfile:                0,
             boardType:                  0,
+            armingDisableFlags:         0,
         };
 
         BF_CONFIG = {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -83,6 +83,18 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     CONFIG.numProfiles = data.readU8();
                     CONFIG.rateProfile = data.readU8();
 
+                    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                      // Read flight mode flags
+                      var byteCount = data.readU8();
+                      for (var i = 0; i < byteCount; i++) {
+                        data.readU8();
+                      }
+
+                      // Read arming disable flags
+                      data.readU8(); // Flag count
+                      CONFIG.armingDisableFlags = data.readU32();
+                    }
+
                     TABS.pid_tuning.checkUpdateProfile(true);
                 }
 

--- a/tabs/setup.html
+++ b/tabs/setup.html
@@ -96,6 +96,10 @@
                         <table width="100%" border="0" cellpadding="0" cellspacing="0" class="cf_table">
                             <tbody>
                                 <tr>
+                                    <td i18n="initialSetupArmingDisableFlags"></td>
+                                    <td class="arming-disable-flags">0</td>
+                                </tr>
+                                <tr>
                                     <td i18n="initialSetupBattery"></td>
                                     <td class="bat-voltage">0 V</td>
                                 </tr>

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -156,6 +156,7 @@ TABS.setup.initialize = function (callback) {
             bat_mah_drawn_e = $('.bat-mah-drawn'),
             bat_mah_drawing_e = $('.bat-mah-drawing'),
             rssi_e = $('.rssi'),
+            arming_disable_flags_e = $('.arming-disable-flags'),
             gpsFix_e = $('.gpsFix'),
             gpsSats_e = $('.gpsSats'),
             gpsLat_e = $('.gpsLat'),
@@ -164,8 +165,14 @@ TABS.setup.initialize = function (callback) {
             pitch_e = $('dd.pitch'),
             heading_e = $('dd.heading');
 
+        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+            arming_disable_flags_e.hide();
+        }
+
         function get_slow_data() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
+            MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
+                arming_disable_flags_e.text(CONFIG.armingDisableFlags == 0 ? chrome.i18n.getMessage('initialSetupArmingAllowed') : CONFIG.armingDisableFlags.toString(2));
+            });
 
             MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
                 bat_voltage_e.text(chrome.i18n.getMessage('initialSetupBatteryValue', [ANALOG.voltage]));


### PR DESCRIPTION
To go along side https://github.com/betaflight/betaflight/pull/3766

Currently only shows the binary representation of the flags (when non zero).
Ideally I'd like to add a new message to retrieve the names of the disable flags.