### PR TITLE
Fixed overlays on led tab

### DIFF
--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -872,7 +872,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 var ledFunctionLetters =        ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l']; // in LSB bit order
                 var ledBaseFunctionLetters =    ['c', 'f', 'a', 'l', 's', 'g', 'r']; // in LSB bit
                 if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
-                    var ledOverlayLetters =     ['t', 'o', 'b', 'w', 'i', 'w']; // in LSB bit
+                    var ledOverlayLetters =     ['t', 'o', 'b', 'n', 'i', 'w']; // in LSB bit
                 } else {
                     var ledOverlayLetters =     ['t', 'o', 'b', 'v', 'i', 'w']; // in LSB bit
                 }

--- a/tabs/led_strip.js
+++ b/tabs/led_strip.js
@@ -18,7 +18,11 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     } else {
         TABS.led_strip.functions = ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l', 'o', 'n'];
         TABS.led_strip.baseFuncs = ['c', 'f', 'a', 'l', 's', 'g', 'r'];
-        TABS.led_strip.overlays =  ['t', 'o', 'b', 'v', 'i', 'w'];
+        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+            TABS.led_strip.overlays =  ['t', 'o', 'b', 'n', 'i', 'w'];
+        } else {
+            TABS.led_strip.overlays =  ['t', 'o', 'b', 'v', 'i', 'w'];
+        }
     }
 
     TABS.led_strip.wireMode = false;
@@ -72,9 +76,9 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             if (semver.lte(CONFIG.apiVersion, "1.19.0")) {
                 theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-s"> </span><span class="overlay-w"> </span><span class="overlay-i"> </span><span class="overlay-color"> </span></div>');
             } else if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
-                theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-o"> </span><span class="overlay-b"> </span><span class="overlay-n"> </span><span class="overlay-w"> </span><span class="overlay-i"> </span><span class="overlay-color"> </span></div>');
+                theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-o"> </span><span class="overlay-b"> </span><span class="overlay-n"> </span><span class="overlay-i"> </span><span class="overlay-w"> </span><span class="overlay-color"> </span></div>');
             } else {
-                theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-o"> </span><span class="overlay-b"> </span><span class="overlay-n"> </span><span class="overlay-v"> </span><span class="overlay-i"> </span><span class="overlay-color"> </span></div>');
+                theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-o"> </span><span class="overlay-b"> </span><span class="overlay-v"> </span><span class="overlay-i"> </span><span class="overlay-w"> </span><span class="overlay-color"> </span></div>');
             }
         }
         $('.mainGrid').html(theHTML.join(''));


### PR DESCRIPTION
since bf 3.2.0 the warnings overlay was not shown ... also on bf 3.1.7 was the blink on landing overlay not shown ... this one fix both issue ... imho this issue comes with #521 

edit: tested on both bf versions and working now correct