### PR TITLE
Configure Small_angle

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -679,6 +679,12 @@
     "configurationAccelTrimPitch": {
         "message": "Accelerometer Pitch Trim"
     },
+    "configurationArming": {
+        "message": "Arming"
+    },
+    "configurationArmingHelp": {
+        "message": "Some Arming options may require accelerometer be enabled"
+    },
     "configurationMagDeclination": {
         "message": "Magnetometer Declination [deg]"
     },
@@ -2595,6 +2601,12 @@
     },
     "configurationMagHardware": {
         "message": "Magnetometer (if supported)"
+    },
+    "configurationSmallAngle": {
+        "message": "Maximum ARM Angle [degrees]"
+    },
+    "configurationSmallAngleHelp": {
+        "message": "Craft will not ARM if tilted more than specified number of degrees. Only applies if accelerometer is enabled. Setting to 180 will effectivly disable check"
     },
     "configurationBatteryVoltage": {
         "message": "Battery Voltage"

--- a/js/fc.js
+++ b/js/fc.js
@@ -229,6 +229,7 @@ var FC = {
         ARMING_CONFIG = {
             auto_disarm_delay:          0,
             disarm_kill_switch:         0,
+            small_angle:                0,
         };
 
         FC_CONFIG = {

--- a/js/msp/MSPHelper.js
+++ b/js/msp/MSPHelper.js
@@ -322,6 +322,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     ARMING_CONFIG.auto_disarm_delay = data.readU8();
                     ARMING_CONFIG.disarm_kill_switch = data.readU8();
                 }
+                if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+                    ARMING_CONFIG.small_angle = data.readU8();
+                }
                 break;
             case MSPCodes.MSP_LOOP_TIME:
                 if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
@@ -1251,6 +1254,9 @@ MspHelper.prototype.crunch = function(code) {
         case MSPCodes.MSP_SET_ARMING_CONFIG:
             buffer.push8(ARMING_CONFIG.auto_disarm_delay)
                 .push8(ARMING_CONFIG.disarm_kill_switch);
+            if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+                buffer.push8(ARMING_CONFIG.small_angle);
+            }
             break;
         case MSPCodes.MSP_SET_LOOP_TIME:
             buffer.push16(FC_CONFIG.loopTime);

--- a/tabs/configuration.css
+++ b/tabs/configuration.css
@@ -500,8 +500,14 @@
 }
 
 .tab-configuration ._3dSettings {
-    margin-top: 10px; 
-    float: left; 
+    margin-top: 10px;
+    float: left;
+    width: 100%;
+}
+
+.tab-configuration ._smallAngle {
+    margin-top: 10px;
+    float: left;
     width: 100%;
 }
 

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -314,6 +314,23 @@
                                 </div>
                             </div>
                         </div>
+                        <div class="gui_box grey">
+                            <div class="gui_box_titlebar">
+                                <div class="spacer_box_title" i18n="configurationArming"></div>
+                                <div class="helpicon cf_tip" i18n_title="configurationArmingHelp"></div>
+                            </div>
+                            <div class="spacer_box">
+                              <div class="_smallAngle">
+                                <div class="number">
+                                    <label>
+                                        <input type="number" id="configurationSmallAngle" step="1" min="1" max="180" />
+                                        <span i18n="configurationSmallAngle"></span>
+                                        <div class="helpicon cf_tip" i18n_title="configurationSmallAngleHelp"></div>
+                                    </label>
+                                </div>
+                              </div>
+                            </div>
+                        </div>
                     </div>
                 
                 </td>

--- a/tabs/configuration.js
+++ b/tabs/configuration.js
@@ -609,6 +609,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             $('div.cycles').show();
         }
+        if(semver.gte(CONFIG.apiVersion, "1.37.0")) {
+            $('input[id="configurationSmallAngle"]').val(ARMING_CONFIG.small_angle);
+            if (SENSOR_CONFIG.acc_hardware !== 1) {
+              $('._smallAngle').show();
+            } else {
+              $('._smallAngle').hide();
+            }
+        }
 
         // fill throttle
         $('input[name="minthrottle"]').val(MOTOR_CONFIG.minthrottle);
@@ -796,6 +804,17 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
         });
 
+        $('input[id="accHardwareSwitch"]').change(function() {
+            if(semver.gte(CONFIG.apiVersion, "1.37.0")) {
+              var checked = $(this).is(':checked');
+              if (checked) {
+                $('._smallAngle').show()
+              } else {
+                $('._smallAngle').hide()
+              }
+            }
+        });
+
         $(features_e).filter('select').change(function () {
             var element = $(this);
 
@@ -851,6 +870,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             if(semver.gte(CONFIG.apiVersion, "1.8.0")) {
                 ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
                 ARMING_CONFIG.disarm_kill_switch = $('input[id="disarmkillswitch"]').is(':checked') ? 1 : 0;
+            }
+            if(semver.gte(CONFIG.apiVersion, "1.37.0")) {
+                ARMING_CONFIG.small_angle = parseInt($('input[id="configurationSmallAngle"]').val());
             }
 
             MOTOR_CONFIG.minthrottle = parseInt($('input[name="minthrottle"]').val());


### PR DESCRIPTION
Implements #617 
Depends on betaflight/betaflight#3868

---

I haven't touched javascript in years, and this code is way outside my comfort zone. I give this a 25% chance that I did this correctly. 

Suggestions greatly appreciated. 

### Additional Information

I put this in a new 'Arming'  block inside the configuration tab. Mikeller in slack suggested this eventually be combined with other configs. I'll leave that for another pull request. 
>Looking at the Configuration tab, we could / should probably rename 'System configuration' to something like 'Performance tuning', and then combine 'Personalisation', 'Camera', and 'RSSI' into 'System Configuration' or 'Various', and add 'Max arming angle' in there. (Also, 'Board and Sensor Alignment' and 'Accelerometer trim' should really be combined into 'Alignment'.)

I have verified that this shows up correctly in the betaflight-configurator, but I am not sure how to actually test this without compiling https://github.com/betaflight/betaflight/pull/3868 and flashing to a board


![screenshot 2017-08-16 10 47 26](https://user-images.githubusercontent.com/242382/29395316-28c068c0-82cd-11e7-9482-c33c64076c62.png)

### TODO

- [x] Show/Hide/Grey-out box if accelerometer is enabled/disabled
- [x] Test somehow
- [x] Squash commits
- [x] Change hard coded value 42 to get real value if possible ( default to 25 if not) `42 : 180)`
- [x] Default to 25 degrees if not running api version capable of getting actual value