### PR TITLE
clarify message for configurationDisarmKillSwitch  (fixes betaflight/betaflight-configurator#597)

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -683,7 +683,7 @@
         "message": "Disarm motors after set delay [seconds] (Requires MOTOR_STOP feature)"
     },
     "configurationDisarmKillSwitch": {
-        "message": "Disarm motors regardless of throttle value (When arming via AUX channel)"
+        "message": "Arm/Disarm motors regardless of throttle value when using AUX channel"
     },
     "configurationDigitalIdlePercent": {
         "message": "Motor Idle Throttle Value [percent]"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -683,7 +683,10 @@
         "message": "Disarm motors after set delay [seconds] (Requires MOTOR_STOP feature)"
     },
     "configurationDisarmKillSwitch": {
-        "message": "Arm/Disarm motors regardless of throttle value when using AUX channel"
+        "message": "Disarm motors regardless of throttle value (When ARM is configured in Modes tab via AUX channel)"
+    },
+    "configurationDisarmKillSwitchHelp": {
+        "message": "Arming is always disabled when the throttle is not low. Be careful as you could disarm accidentally with a switch while flying with this option active."
     },
     "configurationDigitalIdlePercent": {
         "message": "Motor Idle Throttle Value [percent]"

--- a/tabs/configuration.html
+++ b/tabs/configuration.html
@@ -186,6 +186,7 @@
                                         </div>
                                         <label for="disarmkillswitch"> <span class="freelabel"
                                             i18n="configurationDisarmKillSwitch"></span>
+						 <div class="helpicon cf_tip" i18n_title="cconfigurationDisarmKillSwitcHelp"></div>
                                         </label>
                                     </div>
                                     <div class="number disarmdelay" style="display: none; margin-bottom: 5px;">


### PR DESCRIPTION
Changing message for noob users like me to clarify the ESC/Motors features option when arming or disarming with a switch via AUX channel.
origin message : 
`"Disarm motors regardless of throttle value (When arming via AUX channel)"`
change by : 
`"Arm/Disarm motors regardless of throttle value when using AUX channel"`
