### PR TITLE
Make font manager dialog a bit wider to fit font buttons

### DIFF
--- a/tabs/osd.html
+++ b/tabs/osd.html
@@ -114,7 +114,7 @@
                     </div>
                 </div>
             </div>
-            <div id="fontmanagercontent" style="display:none; width:600px;">
+            <div id="fontmanagercontent" style="display:none; width:720px;">
                 <div class="font-picker" style="margin-bottom: 10px;">
                     <h1 class="tab_title">Font presets:</h1>
                     <div class="content_wrapper font-preview"></div>

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -1060,7 +1060,7 @@ TABS.osd.initialize = function (callback) {
 
         // Open modal window
         OSD.GUI.jbox = new jBox('Modal', {
-            width: 600,
+            width: 720,
             height: 240,
             closeButton: 'title',
             animation: false,


### PR DESCRIPTION
The font buttons overlap the label in the font manager dialog on the OSD tab.

The layout is rather fixed, so it does not automatically make space for new font buttons, and thus the recently added fonts make the button row overlap the text label on the left.

An ideal solution would be to drop those buttons below the text headline and horizontal line, but I am not sure how to do that properly yet. This workaround avoids the overlap however, and the dialog still seems to fit in a minimum sized configurator window.