### PR TITLE
undo defaults notch2 values to reflect fc defaults

### DIFF
--- a/js/fc.js
+++ b/js/fc.js
@@ -397,8 +397,8 @@ var FC = {
         DEFAULT = {
             gyro_soft_notch_cutoff_1:       300,
             gyro_soft_notch_hz_1:           400,
-            gyro_soft_notch_cutoff_2:       200,
-            gyro_soft_notch_hz_2:           300,
+            gyro_soft_notch_cutoff_2:       100,
+            gyro_soft_notch_hz_2:           200,
             dterm_notch_cutoff:             160,
             dterm_notch_hz:                 260,
         };


### PR DESCRIPTION
@basdelfos again something was wrong in #576

fc defaults dump output:
```
set gyro_notch1_hz = 400
set gyro_notch1_cutoff = 300
set gyro_notch2_hz = 200
set gyro_notch2_cutoff = 100
```
