### PR TITLE
Clarify arming disable readout in setup tab

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -457,6 +457,9 @@
     "initialSetupArmingAllowed": {
         "message": "Arming Allowed"
     },
+    "initialSetupArmingDisableFlagsTooltip": {
+        "message": "List of flags indicating why arming is currently not allowed. Please refer to the Wiki for a description of what these flags mean."
+    },
     "initialSetupGPSHead": {
         "message": "GPS"
     },

--- a/tabs/setup.html
+++ b/tabs/setup.html
@@ -95,7 +95,7 @@
                     <div class="spacer_box">
                         <table width="100%" border="0" cellpadding="0" cellspacing="0" class="cf_table">
                             <tbody>
-                                <tr>
+                                <tr id="arming-disable-flag-row" class="cf_tip">
                                     <td i18n="initialSetupArmingDisableFlags"></td>
                                     <td class="arming-disable-flags">0</td>
                                 </tr>

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -59,6 +59,9 @@ TABS.setup.initialize = function (callback) {
 
         self.initializeInstruments();
 
+
+        $('#arming-disable-flag-row').attr('title', chrome.i18n.getMessage('initialSetupArmingDisableFlagsTooltip'));
+
         // UI Hooks
         $('a.calibrateAccel').click(function () {
             var self = $(this);

--- a/tabs/setup.js
+++ b/tabs/setup.js
@@ -182,7 +182,19 @@ TABS.setup.initialize = function (callback) {
 
         function get_slow_data() {
             MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
-                arming_disable_flags_e.text(CONFIG.armingDisableFlags == 0 ? chrome.i18n.getMessage('initialSetupArmingAllowed') : CONFIG.armingDisableFlags.toString(2));
+                var armingString = '';
+                if (CONFIG.armingDisableFlags == 0) {
+                  armingString = chrome.i18n.getMessage('initialSetupArmingAllowed');
+                } else {
+                  var flagIndicies = [];
+                  for (var i = 0; i < 32; i++) {
+                    if (CONFIG.armingDisableFlags & (1 << i)) {
+                      flagIndicies.push(i);
+                    }
+                  }
+                  armingString = flagIndicies;
+                }
+                arming_disable_flags_e.text(armingString);
             });
 
             MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {


### PR DESCRIPTION
- Lists the flags without having to interpret the bit mask manually
- Adds a tooltip directing users to the Wiki