### PR TITLE
Fix for saving alarms in osd tab on Betaflight 3.2.2

### DIFF
--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -928,9 +928,11 @@ OSD.msp = {
       result.push16(OSD.data.alarms.alt.value);
       if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
         var warningFlags = 0;
-        for (var i = 0; i < OSD.constants.WARNINGS.length; i++) {
-          if (OSD.data.warnings[i].enabled) {
-            warningFlags |= (1 << i);
+        if(OSD.constants.WARNINGS.length === OSD.data.warnings.length){
+          for (var i = 0; i < OSD.constants.WARNINGS.length; i++) {
+            if (OSD.data.warnings[i].enabled) {
+              warningFlags |= (1 << i);
+            }
           }
         }
         console.log(warningFlags);

--- a/tabs/osd.js
+++ b/tabs/osd.js
@@ -926,13 +926,11 @@ OSD.msp = {
         result.push16(0);
       }
       result.push16(OSD.data.alarms.alt.value);
-      if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+      if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
         var warningFlags = 0;
-        if(OSD.constants.WARNINGS.length === OSD.data.warnings.length){
-          for (var i = 0; i < OSD.constants.WARNINGS.length; i++) {
-            if (OSD.data.warnings[i].enabled) {
-              warningFlags |= (1 << i);
-            }
+        for (var i = 0; i < OSD.constants.WARNINGS.length; i++) {
+          if (OSD.data.warnings[i].enabled) {
+            warningFlags |= (1 << i);
           }
         }
         console.log(warningFlags);


### PR DESCRIPTION
The new configurable osd warnings are not present in the 3.2.2 firmware and this is causing an error when saving the osd config due to the OSD.data.warnings array being empty.
As a result of this error the osd alarm values are not written to the FC on save.

The api version is 1.36.0 across both 3.2.2 and 3.3.x firmwares, so instead of checking the api version here I've added a check to ensure that the warnings exist in both the OSD.data.warnings and OSD.constants.WARNINGS arrays before attempting to read their enabled state.