### PR TITLE
feature vtx got removed with 1.35 and is active by default

### DIFF
--- a/js/Features.js
+++ b/js/Features.js
@@ -73,8 +73,12 @@ var Features = function (config) {
         if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
             features.push(
                 {bit: 18, group: 'other', name: 'OSD'},
-                {bit: 24, group: 'other', name: 'VTX'}
             );
+            if (!semver.gte(CONFIG.apiVersion, "1.35.0")) {
+              features.push(
+                {bit: 24, group: 'other', name: 'VTX'}
+              )
+            }
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.31.0")) {


### PR DESCRIPTION
we should check the full feature list

bit 1 VBAT isnt a feature anymore
bit 8 Failsafe isnt a feature anymore 
bit 23 SDCARD isnt a feature anymore

i think the failsafe feature got removed with 3.2 and is enabled by default and for the others i dont know
