### PR TITLE
Add "button" to camera control modes.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2793,10 +2793,10 @@
         "message": "Cancel"
     },
     "modeCameraWifi": {
-        "message": "CAMERA WI-FI"
+        "message": "CAMERA WI-FI BUTTON"
     },
     "modeCameraPower": {
-        "message": "CAMERA POWER"
+        "message": "CAMERA POWER BUTTON"
     },
     "modeCameraChangeMode": {
         "message": "CAMERA CHANGE MODE"


### PR DESCRIPTION
Clarifies what the mode is for. Without "button", camera power is confusing.