### PR TITLE
 Run app after debug build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ apps/
 dist/
 debug/
 release/
+
+# artefacts for Visual Studio Code
+/.vscode/

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -67,6 +67,27 @@ function getPlatforms() {
     return platforms;
 }
 
+function getRunDebugAppCommand() {
+    switch (os.platform()) {
+    case 'darwin':
+        return 'open ' + path.join(debugDir, pkg.name, 'osx64', pkg.name + '.app');
+
+        break;
+    case 'linux':
+        return path.join(debugDir, pkg.name, 'linux64', pkg.name);
+
+        break;
+    case 'win32':
+        return path.join(debugDir, pkg.name, 'win32', pkg.name + '.exe');
+
+        break;
+
+    default:
+    return '';
+        break;
+    }
+}
+
 function get_release_filename(platform, ext) {
     return 'Betaflight-Configurator_' + platform + '_' + pkg.version + '.' + ext;
 }
@@ -275,6 +296,10 @@ gulp.task('debug', ['dist', 'clean-debug'], function (done) {
                 process.exit(1);
             });
         }
+        var exec = require('child_process').exec;
+        var run = getRunDebugAppCommand();
+        console.log('Starting debug app (' + run + ')...');
+        exec(run);
         done();
     });
 });


### PR DESCRIPTION
In VSCode, default build task is set to `debug`: Use `Shift-Cmd-B` to build the debug app and start it after successfull build.

Tested on macOS. Could someone test if this also works on Linux and Windows?
Use `gulp debug` or build from within VSCode.