### PR TITLE
NWJS: Fixed app window hocks and enabled restore window state on startup

### DIFF
--- a/main_nwjs.html
+++ b/main_nwjs.html
@@ -1,0 +1,6 @@
+<script>
+    // Closing empty default nw.js window; we use the chrome window created in eventPage.js.
+    // The window created in eventPage.js also has some hocks to cleanup stuff when closing.
+    // Restoring window size, position and state also works out-of-the-box.
+    window.close();
+</script>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "betaflight-configurator",
   "description": "Crossplatform configuration tool for Betaflight flight control system.",
   "version": "10.0.1",
-  "main": "main.html",
+  "main": "main_nwjs.html",
+  "bg-script": "eventPage.js",
   "default_locale": "en",
   "scripts": {
     "start": "node node_modules/gulp/bin/gulp.js debug",
@@ -11,11 +12,7 @@
     "gulp": "gulp"
   },
   "window": {
-    "title": "Betaflight Configurator",
-    "icon": "images/bf_icon_128.png",
-    "toolbar": true,
-    "width": 1280,
-    "height": 800
+    "show": false
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
While trying some solutions to restore windows state on startup, I discovered that nw.js creates it's own window based on the settings in `package.json` and doesn't use `eventPage.js`.
The chrome app uses `eventPage.js` to create the application window and set some events e.g. to clean-up on closing. 
This PR disables the nw.js window creation on startup and uses the `eventPage.js` to create the app window, just like the chrome app. Additional advantage is that restoring window size, position and state now works out-of-the-box.
