### PR TITLE
Add missing icon taskbar/window

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "gulp": "gulp"
   },
   "window": {
-    "show": false
+    "show": false,
+    "icon": "images/bf_icon_128.png"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This adds the missing icon to the taskbar and window, at least it works in
windows 10 for me.

In slack some people claim that the icon is missing. Someone with missing icon can test it?