### PR TITLE
Open new windows in external browser

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,5 +1,21 @@
 'use strict';
 
+// Open new windows in external browser
+try {
+    var gui = require('nw.gui');
+
+    //Get the current window
+    var win = gui.Window.get();
+
+    //Listen to the new window event
+    win.on('new-win-policy', function (frame, url, policy) {
+      gui.Shell.openExternal(url);
+      policy.ignore();
+    });
+} catch (ex) {
+    console.log("require does not exist, maybe inside chrome");
+}
+
 $(document).ready(function () {
     // translate to user-selected language
     localize();


### PR DESCRIPTION
Now when a user clicks a link, the link opens in a new nw window (you cannot track the downloads, without toolbar, add to favorites, forward, backward, refresh, etc.). I think is better to open the link in a new external browser. What do you think?

This code changes this behaviour, it has been tested on windows, as standalone and as chrome app, but I think it needs more testing (linux and mac at least).