### PR TITLE
Add Betaflight Configurator as window title

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2,6 +2,10 @@
     "translation_version": {
         "message": "0"
     },
+    "windowTitle": {
+        "message": "Betaflight Configurator",
+        "description": "Title of the application window, usually not translated"
+    },
     "warningTitle": {
         "message": "Warning"
     },

--- a/eventPage.js
+++ b/eventPage.js
@@ -9,6 +9,7 @@ function startApplication() {
     chrome.app.window.create('main.html', {
         id: 'main-window',
         frame: 'chrome',
+        title: chrome.i18n.getMessage('windowTitle'),
         innerBounds: {
             minWidth: 1024,
             minHeight: 550


### PR DESCRIPTION
This fixes https://github.com/betaflight/betaflight-configurator/issues/807

I've hardcoded the string, I think that this must not be in the messages file and must not be translated. I'm right?