### PR TITLE
Fix window title chromeapp

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2,6 +2,10 @@
     "translation_version": {
         "message": "0"
     },
+    "windowTitle": {
+        "message": "Betaflight Configurator",
+        "description": "Title of the application window, usually not translated"
+    },
     "warningTitle": {
         "message": "Warning"
     },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2,10 +2,6 @@
     "translation_version": {
         "message": "0"
     },
-    "windowTitle": {
-        "message": "Betaflight Configurator",
-        "description": "Title of the application window, usually not translated"
-    },
     "warningTitle": {
         "message": "Warning"
     },

--- a/eventPage.js
+++ b/eventPage.js
@@ -9,7 +9,6 @@ function startApplication() {
     chrome.app.window.create('main.html', {
         id: 'main-window',
         frame: 'chrome',
-        title: chrome.i18n.getMessage('windowTitle'),
         innerBounds: {
             minWidth: 1024,
             minHeight: 550

--- a/main.html
+++ b/main.html
@@ -1,4 +1,4 @@
-﻿<!DOCTYPE html>
+﻿﻿<!DOCTYPE html>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>
@@ -98,7 +98,7 @@
     <script type="text/javascript" src="./tabs/osd.js"></script>
     <script type="text/javascript" src="./tabs/power.js"></script>
     <script type="text/javascript" src="./tabs/transponder.js"></script>
-    <title></title>
+    <title i18n="windowTitle"></title>
 </head>
 <body>
 <div id="main-wrapper">


### PR DESCRIPTION
I've seen that my previous PR, that added the title to the standalone apps, breaks the start of the chrome apps (the `title` property is not valid in chrome, but it is in nw).

This is a workaround, that adds the title to standalone apps (the chrome version continues without title, but it seems it has never got one).

If this is merged, I will make the same PR for the blackbox explorer, has copied the same code and thus has the same problem.