### PR TITLE
Better update system adding remove info

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -340,7 +340,7 @@ gulp.task('debug', ['dist', 'clean-debug'], function (done) {
 });
 
 // Create installer package for windows platforms
-function releaseWin(arch) {
+function release_win(arch) {
 
     // Create the output directory, with write permissions
     fs.mkdir(releaseDir, '0775', function(err) {
@@ -454,11 +454,11 @@ gulp.task('release', ['apps', 'clean-release'], function () {
     }
 
     if (platforms.indexOf('win32') !== -1) {
-        releaseWin('win32');
+        release_win('win32');
     }
     
     if (platforms.indexOf('win64') !== -1) {
-        releaseWin('win64');
+        release_win('win64');
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
     "gulp-install": "^1.1.0",
     "inflection": "1.12.0",
     "jquery-ui-npm": "1.12.0",
+    "makensis": "^0.9.0",
     "nw-builder": "^3.4.1",
     "os": "^0.1.1",
     "platform-dependent-modules": "0.0.14",
     "run-sequence": "^2.2.0",
-    "temp": "^0.8.3",
-    "makensis": "^0.9.0"
+    "temp": "^0.8.3"
   },
   "config": {
     "platformDependentModules": {


### PR DESCRIPTION
This PR changes the installer adding a better update system.

The older version, deletes all the files in the destination directory. This directory can be the same as the older version, or not. And can contain other files by error, and all of them will be removed, and can let the old version by error if the new installation directory is different.

This modification adds three things:
- Detects the older version installation directory, and suggests it as the default folder for the installation
- Removes the content of the older version installation directory, if there's any.
- After the installation of the new version, adds the info of the configurator to the add/remove programs:
![image](https://user-images.githubusercontent.com/2673520/34490852-7ba0c34c-efe1-11e7-8405-952d59fbb05a.png)

With this, the update system is a lot more robust than before.