### PR TITLE
Migration to Gulp 4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,22 +24,19 @@
   "dependencies": {},
   "devDependencies": {
     "del": "^3.0.0",
-    "gulp": "~3.9.1",
+    "gulp": "~4.0.0",
     "gulp-concat": "~2.6.1",
-    "gulp-debian": "~0.1.6",
+    "gulp-debian": "~0.1.7",
     "gulp-install": "^1.1.0",
     "gulp-rename": "~1.2.2",
     "gulp-zip": "^4.1.0",
     "inflection": "1.12.0",
     "jquery-ui-npm": "1.12.0",
     "makensis": "^0.9.0",
-    "merge-stream": "^1.0.1",
     "nw-builder": "^3.4.1",
     "os": "^0.1.1",
     "platform-dependent-modules": "0.0.14",
-    "run-sequence": "^2.2.0",
-    "temp": "^0.8.3",
-    "title-case": "^2.1.0"
+    "temp": "^0.8.3"
   },
   "config": {
     "platformDependentModules": {


### PR DESCRIPTION
This changes the `gulpfile.js` to use the version 4 of `gulp`.

The version 4 is a different approach, some benefits:
- We can determine the serial and parallel tasks (in gulp 3 all of them were parallel making things a little more complex). This give us a lot of power.
- We don't need to use the runSequencial and merge-stream, with the tools of gulp 4 we can done something similar.
- Can use sync tasks easily as async gulp tasks, for example the `release_win`, in parallel with other tasks. Now we can build all files at the same time.

I'm using parts of code from https://github.com/betaflight/betaflight-configurator/pull/830 so maybe is better to finish the other PR, and then I will rebase this.

I think that the the way our gulpfile works is not the best. We can parallelize the tasks to release, but each of them must be a simple `pipe` of tasks, without temporary folders in the middle. Maybe in a future I will play with it to see if I can get to something better and make a new PR but by the moment this works well :)
