### PR TITLE
Changed version to 10.1.0.

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "minimum_chrome_version": "38",
-    "version": "10.0.1",
+    "version": "10.1.0",
     "author": "Betaflight Squad",
     "name": "Betaflight - Configurator",
     "short_name": "Betaflight",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "betaflight-configurator",
   "description": "Crossplatform configuration tool for Betaflight flight control system.",
-  "version": "10.0.1",
+  "version": "10.1.0",
   "main": "main_nwjs.html",
   "bg-script": "eventPage.js",
   "default_locale": "en",


### PR DESCRIPTION
Rationale:
- npm requires SemVer;
- our configurator releases are normally a mix of bugfixes and improvements, so 'minor release' seems to be a better match than 'bugfix release';
- we keep the option open to, if the need for an urgent bugfix arises, patch this on a branch off the latest release, and push as a bugfix release.