### PR TITLE
Fix debian packages (copyright needed)

### DIFF
--- a/assets/linux/copyright
+++ b/assets/linux/copyright
@@ -1,0 +1,4 @@
+This package was created by the Betaflight open source flight controller firmware project (https://github.com/betaflight/betaflight).
+
+All of the code is covered under the terms of the GPL version 3. See the
+file /usr/share/common-licenses/GPL-3 for more information.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -506,6 +506,7 @@ function release_deb(arch) {
              changelog: [],
              _target: 'opt/betaflight/betaflight-configurator',
              _out: RELEASE_DIR,
+             _copyright: 'assets/linux/copyright',
              _clean: true
     }));
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "del": "^3.0.0",
     "gulp": "~4.0.0",
     "gulp-concat": "~2.6.1",
-    "gulp-debian": "~0.1.7",
+    "gulp-debian": "~0.1.8",
     "gulp-install": "^1.1.0",
     "gulp-rename": "~1.2.2",
     "gulp-zip": "^4.1.0",


### PR DESCRIPTION
The gulp-debian package has added a new _mandatory_ parameter: 
>_copyright: string - The path to plain copyright file (mandatory) see Debian policy.

It seems that Debian says that a copyright file must be added to each debian package: https://www.debian.org/doc/debian-policy/#copyright-information

I've limited the `gulp-debian` package to version 0.1.7 (the latest without this new param) buy maybe is better to add this copyright file. If someone is capable of generating it, I can add it. My knowledge about that is nothing...