### PR TITLE
Use i18next as i18n framework

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1883,13 +1883,15 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1899,18 +1901,21 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1920,42 +1925,49 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -1964,7 +1976,8 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -1972,7 +1985,8 @@
         },
         "boom": {
           "version": "2.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -1980,7 +1994,8 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -1989,29 +2004,34 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -2019,22 +2039,26 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "requires": {
             "boom": "2.10.1"
@@ -2042,7 +2066,8 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2051,7 +2076,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -2059,7 +2085,8 @@
         },
         "debug": {
           "version": "2.6.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2068,30 +2095,35 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.2.tgz",
+          "integrity": "sha1-ca1dIEvxempsqPRQxhRUBm70YeE=",
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2100,24 +2132,28 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2128,12 +2164,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -2144,7 +2182,8 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2155,7 +2194,8 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2171,7 +2211,8 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2180,7 +2221,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -2188,7 +2230,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2201,18 +2244,21 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2222,13 +2268,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "requires": {
             "boom": "2.10.1",
@@ -2239,12 +2287,14 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2255,7 +2305,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -2264,18 +2315,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -2283,24 +2337,28 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2309,19 +2367,22 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2330,19 +2391,22 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2354,7 +2418,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -2362,12 +2427,14 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -2375,7 +2442,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -2383,12 +2451,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -2396,13 +2466,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.39",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.39.tgz",
+          "integrity": "sha512-OsJV74qxnvz/AMGgcfZoDaeDXKD3oY3QVIbBmwszTFkRisTSXbMQyn4UWzUMOtA5SVhrBZOTp0wcoSBgfMfMmQ==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2421,7 +2493,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2431,7 +2504,8 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2443,24 +2517,28 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -2468,19 +2546,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2490,35 +2571,41 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2530,7 +2617,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2538,7 +2626,8 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -2552,7 +2641,8 @@
         },
         "request": {
           "version": "2.81.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2582,7 +2672,8 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -2590,30 +2681,35 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -2621,7 +2717,8 @@
         },
         "sshpk": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2638,7 +2735,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -2646,7 +2744,8 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -2656,7 +2755,8 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -2664,13 +2764,15 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -2678,13 +2780,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -2694,7 +2798,8 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2710,7 +2815,8 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2719,7 +2825,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2728,30 +2835,35 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2760,7 +2872,8 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2769,7 +2882,8 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
@@ -3424,6 +3538,16 @@
         "jsprim": "1.4.1",
         "sshpk": "1.13.1"
       }
+    },
+    "i18next": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-10.3.0.tgz",
+      "integrity": "sha1-aGbRT2rns2KZIfeLwCjQSRTwZUw="
+    },
+    "i18next-xhr-backend": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/i18next-xhr-backend/-/i18next-xhr-backend-1.5.1.tgz",
+      "integrity": "sha512-9OLdC/9YxDvTFcgsH5t2BHCODHEotHCa6h7Ly0EUlUC7Y2GS09UeoHOGj3gWKQ3HCqXz8NlH4gOrK3NNc9vPuw=="
     },
     "imurmurhash": {
       "version": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,10 @@
   },
   "author": "The Betaflight open source project.",
   "license": "GPL-3.0",
-  "dependencies": {},
+  "dependencies": {
+    "i18next": "^10.3.0",
+    "i18next-xhr-backend": "^1.5.1"
+  },
   "devDependencies": {
     "del": "^3.0.0",
     "gulp": "~4.0.0",

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -306,7 +306,7 @@ function configuration_restore(callback) {
                     if (typeof configuration.generatedBy !== 'undefined' && compareVersions(configuration.generatedBy, CONFIGURATOR.backupFileMinVersionAccepted)) {
                                                 
                         if (!compareVersions(configuration.generatedBy, "1.14.0") && !migrate(configuration)) {
-                            GUI.log(chrome.i18n.getMessage('backupFileUnmigratable'));
+                            GUI.log(i18n.getMessage('backupFileUnmigratable'));
                             return;
                         }
 
@@ -319,7 +319,7 @@ function configuration_restore(callback) {
                         configuration_upload(configuration, callback);
                         
                     } else {
-                        GUI.log(chrome.i18n.getMessage('backupFileIncompatible'));
+                        GUI.log(i18n.getMessage('backupFileIncompatible'));
                     }
 
                     
@@ -341,7 +341,7 @@ function configuration_restore(callback) {
     function migrate(configuration) {
         var appliedMigrationsCount = 0;
         var migratedVersion = configuration.generatedBy;
-        GUI.log(chrome.i18n.getMessage('configMigrationFrom', [migratedVersion]));
+        GUI.log(i18n.getMessage('configMigrationFrom', [migratedVersion]));
         
         if (!compareVersions(migratedVersion, '0.59.1')) {
             
@@ -350,7 +350,7 @@ function configuration_restore(callback) {
             configuration.MISC.rssi_aux_channel = undefined;
             
             migratedVersion = '0.59.1';
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
         
@@ -362,7 +362,7 @@ function configuration_restore(callback) {
             }
             
             migratedVersion = '0.60.1';
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
         
@@ -377,7 +377,7 @@ function configuration_restore(callback) {
             }
             
             migratedVersion = '0.61.0';
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
 
@@ -408,7 +408,7 @@ function configuration_restore(callback) {
             }
             
             migratedVersion = '0.63.0';
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
 
@@ -464,7 +464,7 @@ function configuration_restore(callback) {
                 ports: ports 
             };
             
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
         
@@ -484,7 +484,7 @@ function configuration_restore(callback) {
                 };
             }
 
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
         
@@ -525,7 +525,7 @@ function configuration_restore(callback) {
             
             migratedVersion = '0.66.0';
 
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
         
@@ -543,7 +543,7 @@ function configuration_restore(callback) {
                 configuration.profiles[profileIndex].PID.controller = newPidControllerIndex;
             }
 
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
         
@@ -560,7 +560,7 @@ function configuration_restore(callback) {
                 };
             }
 
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
         
@@ -628,7 +628,7 @@ function configuration_restore(callback) {
                 }
             }
 
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
 
@@ -639,7 +639,7 @@ function configuration_restore(callback) {
             }
             migratedVersion = '1.2.0';
 
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
 
@@ -655,12 +655,12 @@ function configuration_restore(callback) {
 
             migratedVersion = '1.3.1';
 
-            GUI.log(chrome.i18n.getMessage('configMigratedTo', [migratedVersion]));
+            GUI.log(i18n.getMessage('configMigratedTo', [migratedVersion]));
             appliedMigrationsCount++;
         }
         
         if (appliedMigrationsCount > 0) {
-            GUI.log(chrome.i18n.getMessage('configMigrationSuccessful', [appliedMigrationsCount]));
+            GUI.log(i18n.getMessage('configMigrationSuccessful', [appliedMigrationsCount]));
         }        
         return true;
     }
@@ -852,7 +852,7 @@ function configuration_restore(callback) {
             }
 
             function reboot() {
-                GUI.log(chrome.i18n.getMessage('eeprom_saved_ok'));
+                GUI.log(i18n.getMessage('eeprom_saved_ok'));
 
                 GUI.tab_switch_cleanup(function() {
                     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitialize);
@@ -860,11 +860,11 @@ function configuration_restore(callback) {
             }
 
             function reinitialize() {
-                GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+                GUI.log(i18n.getMessage('deviceRebooting'));
 
                 GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
                     MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
-                        GUI.log(chrome.i18n.getMessage('deviceReady'));
+                        GUI.log(i18n.getMessage('deviceReady'));
                         if (callback) callback();
                     });
                 }, 1500); // 1500 ms seems to be just the right amount of delay to prevent data request timeouts

--- a/src/js/eventPage.js
+++ b/src/js/eventPage.js
@@ -1,5 +1,7 @@
 /*
     If an id is also specified and a window with a matching id has been shown before, the remembered bounds of the window will be used instead.
+
+    In this JS we cannot use the i18n wrapper used in the rest of the application (it is not available). We must remain with the chrome one.
 */
 'use strict';
 

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -1,12 +1,66 @@
 'use strict';
 
-function localize() {
+/*
+ * Wrapper around the i18n system
+ */
+
+var i18n = {}
+
+/**
+ * Functions that depend on the i18n framework
+ */
+i18n.init = function(cb) {
+
+    var defaultLocale = window.navigator.userLanguage || window.navigator.language;
+
+    i18next
+        .use(i18nextXHRBackend)
+        .init({
+            lng: defaultLocale,
+            getAsync: false,
+            debug: true,
+            ns: ['messages'],
+            defaultNS:['messages'],
+            fallbackLng: 'en',
+            backend: { loadPath: '/_locales/{{lng}}/{{ns}}.json' }
+            }, function(err, t) {
+                if (err !== undefined) {
+                    console.error('Error loading i18n ' + err);
+                } else {
+                    console.log('i18n system loaded');
+                }
+                if (cb !== undefined) {
+                    cb();
+                }
+        });
+}
+
+i18n.getMessage = function(messageID, parameters) {
+    var translatedString =  i18next.t(messageID + '.message');
+
+    if (parameters !== undefined) {
+        parameters.forEach(function(element, index) {
+            translatedString = translatedString.replace('$' + (index + 1), element);
+        });
+    }
+    
+    return translatedString;
+
+    
+}
+
+/**
+ * Helper functions, don't depend of the i18n framework
+ */
+
+i18n.localizePage = function() {
+
     var localized = 0;
 
     var translate = function(messageID) {
         localized++;
 
-        return chrome.i18n.getMessage(messageID);
+        return i18n.getMessage(messageID);
     };
 
     $('[i18n]:not(.i18n-replaced)').each(function() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,27 +1,23 @@
 'use strict';
 
-// Open new windows in external browser
-try {
-    var gui = require('nw.gui');
+openNewWindowsInExternalBrowser();
 
-    //Get the current window
-    var win = gui.Window.get();
-
-    //Listen to the new window event
-    win.on('new-win-policy', function (frame, url, policy) {
-      gui.Shell.openExternal(url);
-      policy.ignore();
-    });
-} catch (ex) {
-    console.log("require does not exist, maybe inside chrome");
-}
-
+//Asynchronous configuration to be done.
+//When finish the startProcess() function must be called 
 $(document).ready(function () {
+    i18n.init(function() {
+        startProcess();
+        initializeSerialBackend();
+    });
+});
+
+//Process to execute to real start the app
+function startProcess() {
     // translate to user-selected language
-    localize();
+    i18n.localizePage();
 
     // alternative - window.navigator.appVersion.match(/Chrome\/([0-9.]*)/)[1];
-    GUI.log(chrome.i18n.getMessage('infoVersions',[GUI.operating_system, window.navigator.appVersion.replace(/.*Chrome\/([0-9.]*).*/, "$1"), getManifestVersion()]));
+    GUI.log(i18n.getMessage('infoVersions',[GUI.operating_system, window.navigator.appVersion.replace(/.*Chrome\/([0-9.]*).*/, "$1"), getManifestVersion()]));
 
     $('#logo .version').text(getManifestVersion());
     updateStatusBarVersion();
@@ -73,17 +69,17 @@ $(document).ready(function () {
             var tabName = $(self).text();
 
             if (tabRequiresConnection && !CONFIGURATOR.connectionValid) {
-                GUI.log(chrome.i18n.getMessage('tabSwitchConnectionRequired'));
+                GUI.log(i18n.getMessage('tabSwitchConnectionRequired'));
                 return;
             }
 
             if (GUI.connect_lock) { // tab switching disabled while operation is in progress
-                GUI.log(chrome.i18n.getMessage('tabSwitchWaitForOperation'));
+                GUI.log(i18n.getMessage('tabSwitchWaitForOperation'));
                 return;
             }
 
             if (GUI.allowedTabs.indexOf(tab) < 0) {
-                GUI.log(chrome.i18n.getMessage('tabSwitchUpgradeRequired', [tabName]));
+                GUI.log(i18n.getMessage('tabSwitchUpgradeRequired', [tabName]));
                 return;
             }
 
@@ -198,7 +194,7 @@ $(document).ready(function () {
 
             $('div#options-window').load('./tabs/options.html', function () {
                 // translate to user-selected language
-                localize();
+                i18n.localizePage();
 
                 chrome.storage.local.get('permanentExpertMode', function (result) {
                     if (result.permanentExpertMode) {
@@ -353,7 +349,7 @@ $(document).ready(function () {
 
             state = true;
         }
-        $(this).text(state ? chrome.i18n.getMessage('logActionHide') : chrome.i18n.getMessage('logActionShow'));
+        $(this).text(state ? i18n.getMessage('logActionHide') : i18n.getMessage('logActionShow'));
         $(this).data('state', state);
     });
 
@@ -368,7 +364,7 @@ $(document).ready(function () {
             }
         }).change();
     });
-});
+}
 
 function checkForConfiguratorUpdates() {
     var releaseChecker = new ReleaseChecker('configurator', 'https://api.github.com/repos/betaflight/betaflight-configurator/releases');
@@ -396,11 +392,11 @@ function notifyOutdatedVersion(releaseData) {
         });
 
         if (versions.length > 0 && semver.lt(getManifestVersion(), versions[0].tag_name)) {
-            GUI.log(chrome.i18n.getMessage('configuratorUpdateNotice', [versions[0].tag_name, versions[0].html_url]));
+            GUI.log(i18n.getMessage('configuratorUpdateNotice', [versions[0].tag_name, versions[0].html_url]));
 
             var dialog = $('.dialogConfiguratorUpdate')[0];
 
-            $('.dialogConfiguratorUpdate-content').html(chrome.i18n.getMessage('configuratorUpdateNotice', [versions[0].tag_name, versions[0].html_url]));
+            $('.dialogConfiguratorUpdate-content').html(i18n.getMessage('configuratorUpdateNotice', [versions[0].tag_name, versions[0].html_url]));
 
             $('.dialogConfiguratorUpdate-closebtn').click(function() {
                 dialog.close();
@@ -535,10 +531,10 @@ function generateFilename(prefix, suffix) {
 
     if (CONFIG) {
         if (CONFIG.flightControllerIdentifier) {
-        	filename = CONFIG.flightControllerIdentifier + '_' + filename;
+            filename = CONFIG.flightControllerIdentifier + '_' + filename;
         }
         if(CONFIG.name && CONFIG.name.trim() !== '') {
-        	filename = filename + '_' + CONFIG.name.trim().replace(' ', '_');
+            filename = filename + '_' + CONFIG.name.trim().replace(' ', '_');
         }
     }
 
@@ -556,10 +552,10 @@ function getFirmwareVersion(firmwareVersion, firmwareId, hardwareId) {
     var versionText = '';
 
     if (firmwareVersion) {
-        versionText += chrome.i18n.getMessage('versionLabelFirmware') + ': ' + firmwareId + ' ' + firmwareVersion;
+        versionText += i18n.getMessage('versionLabelFirmware') + ': ' + firmwareId + ' ' + firmwareVersion;
 
         if (hardwareId) {
-           versionText += ' (' + chrome.i18n.getMessage('versionLabelTarget') + ': ' + hardwareId + ')';
+           versionText += ' (' + i18n.getMessage('versionLabelTarget') + ': ' + hardwareId + ')';
         }
     }
 
@@ -567,7 +563,7 @@ function getFirmwareVersion(firmwareVersion, firmwareId, hardwareId) {
 }
 
 function getConfiguratorVersion() {
-    return chrome.i18n.getMessage('versionLabelConfigurator') + ': ' + getManifestVersion();
+    return i18n.getMessage('versionLabelConfigurator') + ': ' + getManifestVersion();
 }
 
 function updateTopBarVersion(firmwareVersion, firmwareId, hardwareId) {
@@ -603,4 +599,22 @@ function getManifestVersion(manifest) {
     }
 
     return version;
+}
+
+function openNewWindowsInExternalBrowser() {
+ // Open new windows in external browser
+    try {
+        var gui = require('nw.gui');
+
+        //Get the current window
+        var win = gui.Window.get();
+
+        //Listen to the new window event
+        win.on('new-win-policy', function (frame, url, policy) {
+          gui.Shell.openExternal(url);
+          policy.ignore();
+        });
+    } catch (ex) {
+        console.warn("require does not exist, maybe inside chrome");
+    }
 }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -101,7 +101,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 sensor_status(CONFIG.activeSensors);
                 $('span.i2c-error').text(CONFIG.i2cError);
                 $('span.cycle-time').text(CONFIG.cycleTime);
-                $('span.cpu-load').text(chrome.i18n.getMessage('statusbar_cpu_load', [CONFIG.cpuload]));
+                $('span.cpu-load').text(i18n.getMessage('statusbar_cpu_load', [CONFIG.cpuload]));
                 break;
 
             case MSPCodes.MSP_RAW_IMU:
@@ -2028,9 +2028,9 @@ MspHelper.prototype.setArmingEnabled = function(doEnable, onCompleteCallback) {
 
         MSP.send_message(MSPCodes.MSP_ARMING_DISABLE, mspHelper.crunch(MSPCodes.MSP_ARMING_DISABLE), false, function () {
             if (doEnable) {
-                GUI.log(chrome.i18n.getMessage('armingEnabled'));
+                GUI.log(i18n.getMessage('armingEnabled'));
             } else {
-                GUI.log(chrome.i18n.getMessage('armingDisabled'));
+                GUI.log(i18n.getMessage('armingDisabled'));
             }
 
             if (onCompleteCallback) {

--- a/src/js/peripherals.js
+++ b/src/js/peripherals.js
@@ -17,11 +17,11 @@ function adjustBoxNameIfPeripheralWithModeID(modeId, defaultName) {
     if (isPeripheralSelected("RUNCAM_DEVICE_CONTROL")) {
         switch (modeId) {
         case 32: // BOXCAMERA1
-            return chrome.i18n.getMessage('modeCameraWifi');
+            return i18n.getMessage('modeCameraWifi');
         case 33: // BOXCAMERA2
-            return chrome.i18n.getMessage('modeCameraPower');
+            return i18n.getMessage('modeCameraPower');
         case 34: // BOXCAMERA3
-            return chrome.i18n.getMessage('modeCameraChangeMode');
+            return i18n.getMessage('modeCameraChangeMode');
         default:
             return defaultName;
         }

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -171,7 +171,7 @@ PortHandler.update_port_select = function (ports) {
         $('div#port-picker #port').append($("<option/>", {value: ports[i], text: ports[i], data: {isManual: false}}));
     }
 
-    $('div#port-picker #port').append($("<option/>", {value: 'manual', text: chrome.i18n.getMessage('portsSelectManual'), data: {isManual: true}}));
+    $('div#port-picker #port').append($("<option/>", {value: 'manual', text: i18n.getMessage('portsSelectManual'), data: {isManual: true}}));
 };
 
 PortHandler.port_detected = function(name, code, timeout, ignore_timeout) {

--- a/src/js/port_usage.js
+++ b/src/js/port_usage.js
@@ -20,11 +20,11 @@ var PortUsage = {
             this.previous_sent = serial.bytesSent;
 
             // update UI
-            $('span.port_usage_down').text(chrome.i18n.getMessage('statusbar_usage_download', [port_usage_down]));
-            $('span.port_usage_up').text(chrome.i18n.getMessage('statusbar_usage_upload', [port_usage_up]));
+            $('span.port_usage_down').text(i18n.getMessage('statusbar_usage_download', [port_usage_down]));
+            $('span.port_usage_up').text(i18n.getMessage('statusbar_usage_upload', [port_usage_up]));
         } else {
-            $('span.port_usage_down').text(chrome.i18n.getMessage('statusbar_usage_download', [0]));
-            $('span.port_usage_up').text(chrome.i18n.getMessage('statusbar_usage_upload', [0]));
+            $('span.port_usage_down').text(i18n.getMessage('statusbar_usage_download', [0]));
+            $('span.port_usage_up').text(i18n.getMessage('statusbar_usage_upload', [0]));
         }
     },
     reset: function() {

--- a/src/js/protocols/stm32usbdfu.js
+++ b/src/js/protocols/stm32usbdfu.js
@@ -119,16 +119,16 @@ STM32DFU_protocol.prototype.openDevice = function (device) {
     chrome.usb.openDevice(device, function (handle) {
         if(self.checkChromeError()) {
             console.log('Failed to open USB device!');
-            GUI.log(chrome.i18n.getMessage('usbDeviceOpenFail'));
+            GUI.log(i18n.getMessage('usbDeviceOpenFail'));
             if(GUI.operating_system === 'Linux') {
-                GUI.log(chrome.i18n.getMessage('usbDeviceUdevNotice'));
+                GUI.log(i18n.getMessage('usbDeviceUdevNotice'));
             }
             return;
         }
 
         self.handle = handle;
 
-        GUI.log(chrome.i18n.getMessage('usbDeviceOpened', handle.handle.toString()));
+        GUI.log(i18n.getMessage('usbDeviceOpened', handle.handle.toString()));
         console.log('Device opened with Handle ID: ' + handle.handle);
         self.claimInterface(0);
     });
@@ -140,10 +140,10 @@ STM32DFU_protocol.prototype.closeDevice = function () {
     chrome.usb.closeDevice(this.handle, function closed() {
         if(self.checkChromeError()) {
             console.log('Failed to close USB device!');
-            GUI.log(chrome.i18n.getMessage('usbDeviceCloseFail'));
+            GUI.log(i18n.getMessage('usbDeviceCloseFail'));
         }
 
-        GUI.log(chrome.i18n.getMessage('usbDeviceClosed'));
+        GUI.log(i18n.getMessage('usbDeviceClosed'));
         console.log('Device closed with Handle ID: ' + self.handle.handle);
 
         self.handle = null;
@@ -518,10 +518,10 @@ STM32DFU_protocol.prototype.upload_procedure = function (step) {
                     self.flash_layout = chipInfo.internal_flash;
                     self.available_flash_size = self.flash_layout.total_size - (self.hex.start_linear_address - self.flash_layout.start_address);
 
-                    GUI.log(chrome.i18n.getMessage('dfu_device_flash_info', (self.flash_layout.total_size / 1024).toString()));
+                    GUI.log(i18n.getMessage('dfu_device_flash_info', (self.flash_layout.total_size / 1024).toString()));
 
                     if (self.hex.bytes_total > self.available_flash_size) {
-                        GUI.log(chrome.i18n.getMessage('dfu_error_image_size', 
+                        GUI.log(i18n.getMessage('dfu_error_image_size', 
                             [(self.hex.bytes_total / 1024.0).toFixed(1), 
                             (self.available_flash_size / 1024.0).toFixed(1)]));
                         self.upload_procedure(99);
@@ -724,7 +724,7 @@ STM32DFU_protocol.prototype.upload_procedure = function (step) {
 
                                             if(page == erase_pages.length) {
                                                 console.log("Erase: complete");
-                                                GUI.log(chrome.i18n.getMessage('dfu_erased_kilobytes', (total_erased / 1024).toString()));
+                                                GUI.log(i18n.getMessage('dfu_erased_kilobytes', (total_erased / 1024).toString()));
                                                 self.upload_procedure(4);
                                             }
                                             else

--- a/src/js/release_checker.js
+++ b/src/js/release_checker.js
@@ -19,7 +19,7 @@ ReleaseChecker.prototype.loadReleaseData = function (processFunction) {
         var cachedReleaseLastUpdate = result[self._releaseLastUpdateTag];
         if (!cacheReleaseData || !cachedReleaseLastUpdate || releaseDataTimestamp - cachedReleaseLastUpdate > 3600 * 1000) {
             $.get(self._releaseUrl, function (releaseData) {
-                GUI.log(chrome.i18n.getMessage('releaseCheckLoaded',[self._releaseName]));
+                GUI.log(i18n.getMessage('releaseCheckLoaded',[self._releaseName]));
 
                 var data = {};
                 data[self._releaseDataTag] = releaseData
@@ -32,13 +32,13 @@ ReleaseChecker.prototype.loadReleaseData = function (processFunction) {
                 if (data['responseJSON']) {
                     message = data['responseJSON'].message;
                 }
-                GUI.log(chrome.i18n.getMessage('releaseCheckFailed',[self._releaseName,message]));
+                GUI.log(i18n.getMessage('releaseCheckFailed',[self._releaseName,message]));
             
                 self._processReleaseData(cacheReleaseData, processFunction);
             });
         } else {
             if (cacheReleaseData) {
-                GUI.log(chrome.i18n.getMessage('releaseCheckCached',[self._releaseName]));
+                GUI.log(i18n.getMessage('releaseCheckCached',[self._releaseName]));
             }
 
             self._processReleaseData(cacheReleaseData, processFunction);
@@ -51,7 +51,7 @@ ReleaseChecker.prototype._processReleaseData = function (releaseData, processFun
     if (releaseData) {
         processFunction(releaseData);
     } else {
-        GUI.log(chrome.i18n.getMessage('releaseCheckNoInfo',[self._releaseName]));
+        GUI.log(i18n.getMessage('releaseCheckNoInfo',[self._releaseName]));
 
         processFunction();
     }

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -66,7 +66,7 @@ var serial = {
                                                 self.failed = 0;
                                             } else {
                                                 console.log('SERIAL: Connection did not recover from last onReceiveError, disconnecting');
-                                                GUI.log(chrome.i18n.getMessage('serialUnrecoverable'));
+                                                GUI.log(i18n.getMessage('serialUnrecoverable'));
 
                                                 if (GUI.connected_to || GUI.connecting_to) {
                                                     $('a.connect').click();
@@ -96,7 +96,7 @@ var serial = {
                                             if (info.paused) {
                                                 // assume unrecoverable, disconnect
                                                 console.log('SERIAL: Connection did not recover from ' + self.error + ' condition, disconnecting');
-                                                GUI.log(chrome.i18n.getMessage('serialUnrecoverable'));
+                                                GUI.log(i18n.getMessage('serialUnrecoverable'));
     
                                                 if (GUI.connected_to || GUI.connecting_to) {
                                                     $('a.connect').click();

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1,7 +1,7 @@
 'use strict';
 var mspHelper;
 
-$(document).ready(function () {
+function initializeSerialBackend() {
 
     GUI.updateManualPortVisibility = function(){
         var selected_port = $('div#port-picker #port option:selected');
@@ -48,7 +48,7 @@ $(document).ready(function () {
                     $('#port-override').val() :
                     String($('div#port-picker #port').val());
             if (selected_port === 'DFU') {
-                GUI.log(chrome.i18n.getMessage('dfu_connect_message'));
+                GUI.log(i18n.getMessage('dfu_connect_message'));
             }
             else if (selected_port != '0') {
                 if (!clicks) {
@@ -57,7 +57,7 @@ $(document).ready(function () {
 
                     // lock port select & baud while we are connecting / connected
                     $('div#port-picker #port, div#port-picker #baud, div#port-picker #delay').prop('disabled', true);
-                    $('div.connect_controls a.connect_state').text(chrome.i18n.getMessage('connecting'));
+                    $('div.connect_controls a.connect_state').text(i18n.getMessage('connecting'));
 
                     serial.connect(selected_port, {bitrate: selected_baud}, onOpen);
 
@@ -85,7 +85,7 @@ $(document).ready(function () {
             GUI.auto_connect = true;
 
             $('input.auto_connect').prop('checked', true);
-            $('input.auto_connect, span.auto_connect').prop('title', chrome.i18n.getMessage('autoConnectEnabled'));
+            $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectEnabled'));
 
             $('select#baud').val(115200).prop('disabled', true);
         } else {
@@ -93,7 +93,7 @@ $(document).ready(function () {
             GUI.auto_connect = false;
 
             $('input.auto_connect').prop('checked', false);
-            $('input.auto_connect, span.auto_connect').prop('title', chrome.i18n.getMessage('autoConnectDisabled'));
+            $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectDisabled'));
         }
 
         // bind UI hook to auto-connect checkbos
@@ -102,11 +102,11 @@ $(document).ready(function () {
 
             // update title/tooltip
             if (GUI.auto_connect) {
-                $('input.auto_connect, span.auto_connect').prop('title', chrome.i18n.getMessage('autoConnectEnabled'));
+                $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectEnabled'));
 
                 $('select#baud').val(115200).prop('disabled', true);
             } else {
-                $('input.auto_connect, span.auto_connect').prop('title', chrome.i18n.getMessage('autoConnectDisabled'));
+                $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectDisabled'));
 
                 if (!GUI.connected_to && !GUI.connecting_to) $('select#baud').prop('disabled', false);
             }
@@ -117,7 +117,7 @@ $(document).ready(function () {
 
     PortHandler.initialize();
     PortUsage.initialize();
-});
+}
 
 function finishClose(finishedCallback) {
     var wasConnected = CONFIGURATOR.connectionValid;
@@ -141,7 +141,7 @@ function finishClose(finishedCallback) {
 
     // reset connect / disconnect button
     $('div.connect_controls a.connect').removeClass('active');
-    $('div.connect_controls a.connect_state').text(chrome.i18n.getMessage('connect'));
+    $('div.connect_controls a.connect_state').text(i18n.getMessage('connect'));
 
     // reset active sensor indicators
     sensor_status(0);
@@ -165,7 +165,7 @@ function onOpen(openInfo) {
         // reset connecting_to
         GUI.connecting_to = false;
 
-        GUI.log(chrome.i18n.getMessage('serialPortOpened', [openInfo.connectionId]));
+        GUI.log(i18n.getMessage('serialPortOpened', [openInfo.connectionId]));
 
         // save selected port with chrome.storage if the port differs
         chrome.storage.local.get('last_used_port', function (result) {
@@ -185,7 +185,7 @@ function onOpen(openInfo) {
         // disconnect after 10 seconds with error if we don't get IDENT data
         GUI.timeout_add('connecting', function () {
             if (!CONFIGURATOR.connectionValid) {
-                GUI.log(chrome.i18n.getMessage('noConfigurationReceived'));
+                GUI.log(i18n.getMessage('noConfigurationReceived'));
 
                 $('div.connect_controls a.connect').click(); // disconnect
             }
@@ -198,7 +198,7 @@ function onOpen(openInfo) {
 
         // request configuration data
         MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
-            GUI.log(chrome.i18n.getMessage('apiVersionReceived', [CONFIG.apiVersion]));
+            GUI.log(i18n.getMessage('apiVersionReceived', [CONFIG.apiVersion]));
 
             if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.apiVersionAccepted)) {
 
@@ -206,26 +206,26 @@ function onOpen(openInfo) {
                     if (CONFIG.flightControllerIdentifier === 'BTFL') {
                         MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
 
-                            GUI.log(chrome.i18n.getMessage('fcInfoReceived', [CONFIG.flightControllerIdentifier, CONFIG.flightControllerVersion]));
+                            GUI.log(i18n.getMessage('fcInfoReceived', [CONFIG.flightControllerIdentifier, CONFIG.flightControllerVersion]));
                             updateStatusBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier);
                             updateTopBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier);
 
                             MSP.send_message(MSPCodes.MSP_BUILD_INFO, false, false, function () {
 
-                                GUI.log(chrome.i18n.getMessage('buildInfoReceived', [CONFIG.buildInfo]));
+                                GUI.log(i18n.getMessage('buildInfoReceived', [CONFIG.buildInfo]));
 
                                 MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, function () {
 
-                                    GUI.log(chrome.i18n.getMessage('boardInfoReceived', [CONFIG.boardIdentifier, CONFIG.boardVersion]));
+                                    GUI.log(i18n.getMessage('boardInfoReceived', [CONFIG.boardIdentifier, CONFIG.boardVersion]));
                                     updateStatusBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier, CONFIG.boardIdentifier);
                                     updateTopBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier, CONFIG.boardIdentifier);
 
                                     MSP.send_message(MSPCodes.MSP_UID, false, false, function () {
-                                        GUI.log(chrome.i18n.getMessage('uniqueDeviceIdReceived', [CONFIG.uid[0].toString(16) + CONFIG.uid[1].toString(16) + CONFIG.uid[2].toString(16)]));
+                                        GUI.log(i18n.getMessage('uniqueDeviceIdReceived', [CONFIG.uid[0].toString(16) + CONFIG.uid[1].toString(16) + CONFIG.uid[2].toString(16)]));
 
                                         if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
                                             MSP.send_message(MSPCodes.MSP_NAME, false, false, function () {
-                                                GUI.log(chrome.i18n.getMessage('craftNameReceived', [CONFIG.name]));
+                                                GUI.log(i18n.getMessage('craftNameReceived', [CONFIG.name]));
 
                                                 CONFIG.arming_disabled = false;
                                                 mspHelper.setArmingEnabled(false, finishOpen);
@@ -240,7 +240,7 @@ function onOpen(openInfo) {
                     } else {
                         var dialog = $('.dialogConnectWarning')[0];
 
-                        $('.dialogConnectWarning-content').html(chrome.i18n.getMessage('firmwareTypeNotSupported'));
+                        $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareTypeNotSupported'));
 
                         $('.dialogConnectWarning-closebtn').click(function() {
                             dialog.close();
@@ -254,7 +254,7 @@ function onOpen(openInfo) {
             } else {
                 var dialog = $('.dialogConnectWarning')[0];
 
-                $('.dialogConnectWarning-content').html(chrome.i18n.getMessage('firmwareVersionNotSupported', [CONFIGURATOR.apiVersionAccepted]));
+                $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareVersionNotSupported', [CONFIGURATOR.apiVersionAccepted]));
 
                 $('.dialogConnectWarning-closebtn').click(function() {
                     dialog.close();
@@ -267,9 +267,9 @@ function onOpen(openInfo) {
         });
     } else {
         console.log('Failed to open serial port');
-        GUI.log(chrome.i18n.getMessage('serialPortOpenFail'));
+        GUI.log(i18n.getMessage('serialPortOpenFail'));
 
-        $('div#connectbutton a.connect_state').text(chrome.i18n.getMessage('connect'));
+        $('div#connectbutton a.connect_state').text(i18n.getMessage('connect'));
         $('div#connectbutton a.connect').removeClass('active');
 
         // unlock port select & baud
@@ -301,7 +301,7 @@ function connectCli() {
 
 function onConnect() {
     GUI.timeout_remove('connecting'); // kill connecting timer
-    $('div#connectbutton a.connect_state').text(chrome.i18n.getMessage('disconnect')).addClass('active');
+    $('div#connectbutton a.connect_state').text(i18n.getMessage('disconnect')).addClass('active');
     $('div#connectbutton a.connect').addClass('active');
 
     $('#tabs ul.mode-disconnected').hide();
@@ -359,9 +359,9 @@ function onConnect() {
 
 function onClosed(result) {
     if (result) { // All went as expected
-        GUI.log(chrome.i18n.getMessage('serialPortClosedOk'));
+        GUI.log(i18n.getMessage('serialPortClosedOk'));
     } else { // Something went wrong
-        GUI.log(chrome.i18n.getMessage('serialPortClosedFail'));
+        GUI.log(i18n.getMessage('serialPortClosedFail'));
     }
 
     $('#tabs ul.mode-connected').hide();
@@ -449,7 +449,7 @@ function sensor_status(sensors_detected) {
 
     if (have_sensor(sensors_detected, 'gps')) {
         $('.gps', e_sensor_status).addClass('on');
-	$('.gpsicon', e_sensor_status).addClass('active');
+    $('.gpsicon', e_sensor_status).addClass('active');
     } else {
         $('.gps', e_sensor_status).removeClass('on');
         $('.gpsicon', e_sensor_status).removeClass('active');

--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -162,7 +162,7 @@ TABS.adjustments.initialize = function (callback) {
         }
         
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // UI Hooks
         $('a.save').click(function () {
@@ -215,7 +215,7 @@ TABS.adjustments.initialize = function (callback) {
             
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    GUI.log(chrome.i18n.getMessage('adjustmentsEepromSaved'));
+                    GUI.log(i18n.getMessage('adjustmentsEepromSaved'));
                 });
             }
 

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -58,7 +58,7 @@ TABS.auxiliary.initialize = function (callback) {
 
         //add value to autodetect channel
         var channelOption = channelOptionTemplate.clone();
-        channelOption.text(chrome.i18n.getMessage('auxiliaryAutoChannelSelect'));
+        channelOption.text(i18n.getMessage('auxiliaryAutoChannelSelect'));
         channelOption.val(-1);
         channelList.append(channelOption);
 
@@ -161,7 +161,7 @@ TABS.auxiliary.initialize = function (callback) {
         });
                 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // UI Hooks
         $('a.save').click(function () {
@@ -211,7 +211,7 @@ TABS.auxiliary.initialize = function (callback) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    GUI.log(chrome.i18n.getMessage('auxiliaryEepromSaved'));
+                    GUI.log(i18n.getMessage('auxiliaryEepromSaved'));
                 });
             }
         });

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -20,7 +20,7 @@ TABS.cli.initialize = function (callback) {
 
     $('#content').load("./tabs/cli.html", function () {
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         CONFIGURATOR.cliActive = true;
 
@@ -203,8 +203,8 @@ TABS.cli.read = function (readInfo) {
             if (this.currentLine == 'Rebooting') {
                 CONFIGURATOR.cliActive = false;
                 CONFIGURATOR.cliValid = false;
-                GUI.log(chrome.i18n.getMessage('cliReboot'));
-                GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+                GUI.log(i18n.getMessage('cliReboot'));
+                GUI.log(i18n.getMessage('deviceRebooting'));
 
                 if (BOARD.find_board_definition(CONFIG.boardIdentifier).vcp) { // VCP-based flight controls may crash old drivers, we catch and reconnect
                     $('a.connect').click();
@@ -215,7 +215,7 @@ TABS.cli.read = function (readInfo) {
 
                     GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
                         MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
-                            GUI.log(chrome.i18n.getMessage('deviceReady'));
+                            GUI.log(i18n.getMessage('deviceReady'));
                             if (!GUI.tab_switch_in_progress) {
                                 $('#tabs ul.mode-connected .tab_setup a').click();
                             }
@@ -231,7 +231,7 @@ TABS.cli.read = function (readInfo) {
     }
 
     if (!CONFIGURATOR.cliValid && this.validateText.indexOf('CLI') != -1) {
-        GUI.log(chrome.i18n.getMessage('cliEnter'));
+        GUI.log(i18n.getMessage('cliEnter'));
         CONFIGURATOR.cliValid = true;
         this.validateText = "";
     }

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -248,7 +248,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         var alignments = [
             'CW 0°',
@@ -1082,7 +1082,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
-                GUI.log(chrome.i18n.getMessage('configurationEepromSaved'));
+                GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
                     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitialize);
@@ -1090,7 +1090,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function reinitialize() {
-                GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+                GUI.log(i18n.getMessage('deviceRebooting'));
 
                 if (BOARD.find_board_definition(CONFIG.boardIdentifier).vcp) { // VCP-based flight controls may crash old drivers, we catch and reconnect
                     $('a.connect').click();
@@ -1101,7 +1101,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
                     GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
                         MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
-                            GUI.log(chrome.i18n.getMessage('deviceReady'));
+                            GUI.log(i18n.getMessage('deviceReady'));
                             TABS.configuration.initialize(false, $('#content').scrollTop());
                         });
                     },1500); // 1500 ms seems to be just the right amount of delay to prevent data request timeouts

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -115,10 +115,10 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
 
         // generate full channel list
         var channelNames = [
-                chrome.i18n.getMessage('controlAxisRoll'),
-                chrome.i18n.getMessage('controlAxisPitch'),
-                chrome.i18n.getMessage('controlAxisYaw'),
-                chrome.i18n.getMessage('controlAxisThrottle')
+                i18n.getMessage('controlAxisRoll'),
+                i18n.getMessage('controlAxisPitch'),
+                i18n.getMessage('controlAxisYaw'),
+                i18n.getMessage('controlAxisThrottle')
             ],
             fullChannels_e = $('div.activechannellist'),
             aux_index = 1,
@@ -131,7 +131,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                         <div class="channelprimary">\
                             <span>' + channelNames[i] + '</span>\
                         </div>\
-                        <div class="cf_tip channelsetting" title="' + chrome.i18n.getMessage("failsafeChannelFallbackSettingsAuto") + '">\
+                        <div class="cf_tip channelsetting" title="' + i18n.getMessage("failsafeChannelFallbackSettingsAuto") + '">\
                             <select class="aux_set" id="' + i + '">\
                                 <option value="0">Auto</option>\
                                 <option value="1">Hold</option>\
@@ -143,10 +143,10 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 fullChannels_e.append('\
                     <div class="number">\
                         <div class="channelauxiliary">\
-                            <span class="channelname">' + chrome.i18n.getMessage("controlAxisAux" + (aux_index++)) + '</span>\
+                            <span class="channelname">' + i18n.getMessage("controlAxisAux" + (aux_index++)) + '</span>\
                             ' + auxAssignment[aux_assignment_index++] + '\
                         </div>\
-                        <div class="cf_tip channelsetting" title="' + chrome.i18n.getMessage("failsafeChannelFallbackSettingsHold") + '">\
+                        <div class="cf_tip channelsetting" title="' + i18n.getMessage("failsafeChannelFallbackSettingsHold") + '">\
                             <select class="aux_set" id="' + i + '">\
                                 <option value="1">Hold</option>\
                                 <option value="2">Set</option>\
@@ -303,7 +303,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
 
             function reboot() {
-                GUI.log(chrome.i18n.getMessage('configurationEepromSaved'));
+                GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
                     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitialize);
@@ -311,7 +311,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             }
 
             function reinitialize() {
-                GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+                GUI.log(i18n.getMessage('deviceRebooting'));
 
                 if (BOARD.find_board_definition(CONFIG.boardIdentifier).vcp) { // VCP-based flight controls may crash old drivers, we catch and reconnect
                     $('a.connect').click();
@@ -322,7 +322,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
 
                     GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
                         MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
-                            GUI.log(chrome.i18n.getMessage('deviceReady'));
+                            GUI.log(i18n.getMessage('deviceReady'));
                             TABS.failsafe.initialize(false, $('#content').scrollTop());
                         });
                     },1500); // 1500 ms seems to be just the right amount of delay to prevent data request timeouts
@@ -333,7 +333,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         });
 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // status data pulled via separate timer with static speed
         GUI.interval_add('status_pull', function status_pull() {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -37,10 +37,10 @@ TABS.firmware_flasher.initialize = function (callback) {
             } else {
                 var boards_e = $('select[name="board"]').empty();
                 var showDevReleases = ($('input.show_development_releases').is(':checked'));
-                boards_e.append($("<option value='0'>{0}</option>".format(chrome.i18n.getMessage('firmwareFlasherOptionLabelSelectBoard'))));
+                boards_e.append($("<option value='0'>{0}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectBoard'))));
 
                 var versions_e = $('select[name="firmware_version"]').empty();
-                versions_e.append($("<option value='0'>{0}</option>".format(chrome.i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion'))));
+                versions_e.append($("<option value='0'>{0}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion'))));
 
                 var releases = {};
                 var sortedTargets = [];
@@ -128,7 +128,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         };
 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // bind events
         $('input.show_development_releases').click(function () {
@@ -141,16 +141,16 @@ TABS.firmware_flasher.initialize = function (callback) {
 
             if (!GUI.connect_lock) {
                 $('.progress').val(0).removeClass('valid invalid');
-                $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherLoadFirmwareFile'));
+                $('span.progressLabel').text(i18n.getMessage('firmwareFlasherLoadFirmwareFile'));
                 $('div.git_info').slideUp();
                 $('div.release_info').slideUp();
                 $('a.flash_firmware').addClass('disabled');
 
                 var versions_e = $('select[name="firmware_version"]').empty();
                 if(target == 0) {
-                    versions_e.append($("<option value='0'>{0}</option>".format(chrome.i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion'))));
+                    versions_e.append($("<option value='0'>{0}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersion'))));
                 } else {
-                    versions_e.append($("<option value='0'>{0} {1}</option>".format(chrome.i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersionFor'), target)));
+                    versions_e.append($("<option value='0'>{0} {1}</option>".format(i18n.getMessage('firmwareFlasherOptionLabelSelectFirmwareVersionFor'), target)));
                 }
 
                 TABS.firmware_flasher.releases[target].forEach(function(descriptor) {
@@ -208,7 +208,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                                         $('span.progressLabel').text('Loaded Local Firmware: (' + parsed_hex.bytes_total + ' bytes)');
                                     } else {
-                                        $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherHexCorrupted'));
+                                        $('span.progressLabel').text(i18n.getMessage('firmwareFlasherHexCorrupted'));
                                     }
                                 });
                             }
@@ -237,7 +237,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         $('a.load_remote_file').click(function (evt) {
 
             if ($('select[name="firmware_version"]').val() == "0") {
-                GUI.log(chrome.i18n.getMessage('firmwareFlasherNoFirmwareSelected'));
+                GUI.log(i18n.getMessage('firmwareFlasherNoFirmwareSelected'));
                 return;
             }
 
@@ -266,29 +266,29 @@ TABS.firmware_flasher.initialize = function (callback) {
                         $('div.release_info').slideDown();
 
                     } else {
-                        $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherHexCorrupted'));
+                        $('span.progressLabel').text(i18n.getMessage('firmwareFlasherHexCorrupted'));
                     }
                 });
             }
 
             function failed_to_load() {
-                $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherFailedToLoadOnlineFirmware'));
+                $('span.progressLabel').text(i18n.getMessage('firmwareFlasherFailedToLoadOnlineFirmware'));
                 $('a.flash_firmware').addClass('disabled');
                 $("a.load_remote_file").removeClass('disabled');
-                $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoadOnline'));
+                $("a.load_remote_file").text(i18n.getMessage('firmwareFlasherButtonLoadOnline'));
             }
 
             var summary = $('select[name="firmware_version"] option:selected').data('summary');
             if (summary) { // undefined while list is loading or while running offline
-                $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonDownloading'));
+                $("a.load_remote_file").text(i18n.getMessage('firmwareFlasherButtonDownloading'));
                 $("a.load_remote_file").addClass('disabled');
                 $.get(summary.url, function (data) {
                     process_hex(data, summary);
                     $("a.load_remote_file").removeClass('disabled');
-                    $("a.load_remote_file").text(chrome.i18n.getMessage('firmwareFlasherButtonLoadOnline'));
+                    $("a.load_remote_file").text(i18n.getMessage('firmwareFlasherButtonLoadOnline'));
                 }).fail(failed_to_load);
             } else {
-                $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherFailedToLoadOnlineFirmware'));
+                $('span.progressLabel').text(i18n.getMessage('firmwareFlasherFailedToLoadOnlineFirmware'));
             }
         });
 
@@ -322,13 +322,13 @@ TABS.firmware_flasher.initialize = function (callback) {
                                 STM32.connect(port, baud, parsed_hex, options);
                             } else {
                                 console.log('Please select valid serial port');
-                                GUI.log(chrome.i18n.getMessage('firmwareFlasherNoValidPort'));
+                                GUI.log(i18n.getMessage('firmwareFlasherNoValidPort'));
                             }
                         } else {
                             STM32DFU.connect(usbDevices.STM32DFU, parsed_hex, options);
                         }
                     } else {
-                        $('span.progressLabel').text(chrome.i18n.getMessage('firmwareFlasherFirmwareNotLoaded'));
+                        $('span.progressLabel').text(i18n.getMessage('firmwareFlasherFirmwareNotLoaded'));
                     }
                 }
             }
@@ -373,7 +373,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                             });
                         } else {
                             console.log('You don\'t have write permissions for this file, sorry.');
-                            GUI.log(chrome.i18n.getMessage('firmwareFlasherWritePermissions'));
+                            GUI.log(i18n.getMessage('firmwareFlasherWritePermissions'));
                         }
                     });
                 });
@@ -442,7 +442,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         var port = result[0];
 
                         if (!GUI.connect_lock) {
-                            GUI.log(chrome.i18n.getMessage('firmwareFlasherFlashTrigger', [port]));
+                            GUI.log(i18n.getMessage('firmwareFlasherFlashTrigger', [port]));
                             console.log('Detected: ' + port + ' - triggering flash on connect');
 
                             // Trigger regular Flashing sequence
@@ -450,7 +450,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                 $('a.flash_firmware').click();
                             }, 100); // timeout so bus have time to initialize after being detected by the system
                         } else {
-                            GUI.log(chrome.i18n.getMessage('firmwareFlasherPreviousDevice', [port]));
+                            GUI.log(i18n.getMessage('firmwareFlasherPreviousDevice', [port]));
                         }
 
                         // Since current port_detected request was consumed, create new one

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -28,7 +28,7 @@ TABS.gps.initialize = function (callback) {
     
     function process_html() {
         // translate to user-selected languageconsole.log('Online');
-        localize();
+        i18n.localizePage();
 
         function get_raw_gps_data() {
             MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, get_comp_gps_data);
@@ -47,7 +47,7 @@ TABS.gps.initialize = function (callback) {
             var lon = GPS_DATA.lon / 10000000;
             var url = 'https://maps.google.com/?q=' + lat + ',' + lon;
 
-            $('.GPS_info td.fix').html((GPS_DATA.fix) ? chrome.i18n.getMessage('gpsFixTrue') : chrome.i18n.getMessage('gpsFixFalse'));
+            $('.GPS_info td.fix').html((GPS_DATA.fix) ? i18n.getMessage('gpsFixTrue') : i18n.getMessage('gpsFixFalse'));
             $('.GPS_info td.alt').text((GPS_DATA.alt / 10) + ' m');
             $('.GPS_info td.lat a').prop('href', url).text(lat.toFixed(4) + ' deg');
             $('.GPS_info td.lon a').prop('href', url).text(lon.toFixed(4) + ' deg');

--- a/src/js/tabs/help.js
+++ b/src/js/tabs/help.js
@@ -9,7 +9,7 @@ TABS.help.initialize = function (callback) {
     }
 
     $('#content').load("./tabs/help.html", function () {
-        localize();
+        i18n.localizePage();
 
         GUI.content_ready(callback);
     });

--- a/src/js/tabs/landing.js
+++ b/src/js/tabs/landing.js
@@ -10,7 +10,7 @@ TABS.landing.initialize = function (callback) {
 
     $('#content').load("./tabs/landing.html", function () {
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // load changelog content
         $('#changelog .log').load('./changelog.html');
@@ -28,7 +28,7 @@ TABS.landing.initialize = function (callback) {
                 $("#content").addClass('log_open');
                 state = true;
             }
-            $(this).text(state ? chrome.i18n.getMessage('close') : chrome.i18n.getMessage('defaultChangelogAction'));
+            $(this).text(state ? i18n.getMessage('close') : i18n.getMessage('defaultChangelogAction'));
             $(this).data('state2', state);
         });
 

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -67,7 +67,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
     function process_html() {
 
-        localize();
+        i18n.localizePage();
 
         // Build Grid
         var theHTML = [];
@@ -591,7 +591,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
-                    GUI.log(chrome.i18n.getMessage('ledStripEepromSaved'));
+                    GUI.log(i18n.getMessage('ledStripEepromSaved'));
                 });
             }
 

--- a/src/js/tabs/logging.js
+++ b/src/js/tabs/logging.js
@@ -27,7 +27,7 @@ TABS.logging.initialize = function (callback) {
 
     function process_html() {
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // UI hooks
         $('a.log_file').click(prepare_file);
@@ -80,23 +80,23 @@ TABS.logging.initialize = function (callback) {
                             }, 1000);
 
                             $('.speed').prop('disabled', true);
-                            $(this).text(chrome.i18n.getMessage('loggingStop'));
+                            $(this).text(i18n.getMessage('loggingStop'));
                             $(this).data("clicks", !clicks);
                         } else {
-                            GUI.log(chrome.i18n.getMessage('loggingErrorOneProperty'));
+                            GUI.log(i18n.getMessage('loggingErrorOneProperty'));
                         }
                     } else {
                         GUI.interval_kill_all();
 
                         $('.speed').prop('disabled', false);
-                        $(this).text(chrome.i18n.getMessage('loggingStart'));
+                        $(this).text(i18n.getMessage('loggingStart'));
                         $(this).data("clicks", !clicks);
                     }
                 } else {
-                    GUI.log(chrome.i18n.getMessage('loggingErrorLogFile'));
+                    GUI.log(i18n.getMessage('loggingErrorLogFile'));
                 }
             } else {
-                GUI.log(chrome.i18n.getMessage('loggingErrorNotConnected'));
+                GUI.log(i18n.getMessage('loggingErrorNotConnected'));
             }
         });
 
@@ -292,7 +292,7 @@ TABS.logging.initialize = function (callback) {
 
             if (retaining) {
                 chrome.fileSystem.getDisplayPath(fileEntry, function (path) {
-                    GUI.log(chrome.i18n.getMessage('loggingAutomaticallyRetained', [path]));
+                    GUI.log(i18n.getMessage('loggingAutomaticallyRetained', [path]));
                 });
             }
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -198,7 +198,7 @@ TABS.motors.initialize = function (callback) {
 
     function process_html() {
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         update_arm_status();
 

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -46,7 +46,7 @@ TABS.onboard_logging.initialize = function (callback) {
     }
 
     function reboot() {
-        GUI.log(chrome.i18n.getMessage('configurationEepromSaved'));
+        GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
             MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitialize);
@@ -54,7 +54,7 @@ TABS.onboard_logging.initialize = function (callback) {
     }
 
     function reinitialize() {
-        GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+        GUI.log(i18n.getMessage('deviceRebooting'));
 
         if (BOARD.find_board_definition(CONFIG.boardIdentifier).vcp) { // VCP-based flight controls may crash old drivers, we catch and reconnect
             $('a.connect').click();
@@ -65,7 +65,7 @@ TABS.onboard_logging.initialize = function (callback) {
 
             GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
                 MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
-                    GUI.log(chrome.i18n.getMessage('deviceReady'));
+                    GUI.log(i18n.getMessage('deviceReady'));
                     TABS.onboard_logging.initialize(false, $('#content').scrollTop());
                 });
             },1500); // 1500 ms seems to be just the right amount of delay to prevent data request timeouts
@@ -75,7 +75,7 @@ TABS.onboard_logging.initialize = function (callback) {
     function load_html() {
         $('#content').load("./tabs/onboard_logging.html", function() {
             // translate to user-selected language
-            localize();
+            i18n.localizePage();
            
             var 
                 dataflashPresent = DATAFLASH.totalSize > 0,
@@ -155,21 +155,21 @@ TABS.onboard_logging.initialize = function (callback) {
         deviceSelect.empty();
 
         if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
-            deviceSelect.append('<option value="0">' + chrome.i18n.getMessage('blackboxLoggingNone') + '</option>');
+            deviceSelect.append('<option value="0">' + i18n.getMessage('blackboxLoggingNone') + '</option>');
             if (DATAFLASH.supported) {
-                deviceSelect.append('<option value="1">' + chrome.i18n.getMessage('blackboxLoggingFlash') + '</option>');
+                deviceSelect.append('<option value="1">' + i18n.getMessage('blackboxLoggingFlash') + '</option>');
             }
             if (SDCARD.supported) {
-                deviceSelect.append('<option value="2">' + chrome.i18n.getMessage('blackboxLoggingSdCard') + '</option>');
+                deviceSelect.append('<option value="2">' + i18n.getMessage('blackboxLoggingSdCard') + '</option>');
             }
-            deviceSelect.append('<option value="3">' + chrome.i18n.getMessage('blackboxLoggingSerial') + '</option>');
+            deviceSelect.append('<option value="3">' + i18n.getMessage('blackboxLoggingSerial') + '</option>');
         } else {
-            deviceSelect.append('<option value="0">' + chrome.i18n.getMessage('blackboxLoggingSerial') + '</option>');
+            deviceSelect.append('<option value="0">' + i18n.getMessage('blackboxLoggingSerial') + '</option>');
             if (DATAFLASH.ready) {
-                deviceSelect.append('<option value="1">' + chrome.i18n.getMessage('blackboxLoggingFlash') + '</option>');
+                deviceSelect.append('<option value="1">' + i18n.getMessage('blackboxLoggingFlash') + '</option>');
             }
             if (SDCARD.supported) {
-                deviceSelect.append('<option value="2">' + chrome.i18n.getMessage('blackboxLoggingSdCard') + '</option>');
+                deviceSelect.append('<option value="2">' + i18n.getMessage('blackboxLoggingSdCard') + '</option>');
             }
         }
 
@@ -276,11 +276,11 @@ TABS.onboard_logging.initialize = function (callback) {
     }
     
     function update_html() {
-        update_bar_width($(".tab-onboard_logging .dataflash-used"), DATAFLASH.usedSize, DATAFLASH.totalSize, chrome.i18n.getMessage('dataflashUsedSpace'), false);
-        update_bar_width($(".tab-onboard_logging .dataflash-free"), DATAFLASH.totalSize - DATAFLASH.usedSize, DATAFLASH.totalSize, chrome.i18n.getMessage('dataflashFreeSpace'), false);
+        update_bar_width($(".tab-onboard_logging .dataflash-used"), DATAFLASH.usedSize, DATAFLASH.totalSize, i18n.getMessage('dataflashUsedSpace'), false);
+        update_bar_width($(".tab-onboard_logging .dataflash-free"), DATAFLASH.totalSize - DATAFLASH.usedSize, DATAFLASH.totalSize, i18n.getMessage('dataflashFreeSpace'), false);
 
-        update_bar_width($(".tab-onboard_logging .sdcard-other"), SDCARD.totalSizeKB - SDCARD.freeSizeKB, SDCARD.totalSizeKB, chrome.i18n.getMessage('dataflashUnavSpace'), true);
-        update_bar_width($(".tab-onboard_logging .sdcard-free"), SDCARD.freeSizeKB, SDCARD.totalSizeKB, chrome.i18n.getMessage('dataflashLogsSpace'), true);
+        update_bar_width($(".tab-onboard_logging .sdcard-other"), SDCARD.totalSizeKB - SDCARD.freeSizeKB, SDCARD.totalSizeKB, i18n.getMessage('dataflashUnavSpace'), true);
+        update_bar_width($(".tab-onboard_logging .sdcard-free"), SDCARD.freeSizeKB, SDCARD.totalSizeKB, i18n.getMessage('dataflashLogsSpace'), true);
 
         $(".btn a.erase-flash, .btn a.save-flash").toggleClass("disabled", DATAFLASH.usedSize === 0);
         
@@ -291,22 +291,22 @@ TABS.onboard_logging.initialize = function (callback) {
         
         switch (SDCARD.state) {
             case MSP.SDCARD_STATE_NOT_PRESENT:
-                $(".sdcard-status").text(chrome.i18n.getMessage('sdcardStatusNoCard'));
+                $(".sdcard-status").text(i18n.getMessage('sdcardStatusNoCard'));
             break;
             case MSP.SDCARD_STATE_FATAL:
-                $(".sdcard-status").html(chrome.i18n.getMessage('sdcardStatusReboot'));
+                $(".sdcard-status").html(i18n.getMessage('sdcardStatusReboot'));
             break;
             case MSP.SDCARD_STATE_READY:
-                $(".sdcard-status").text(chrome.i18n.getMessage('sdcardStatusReady'));
+                $(".sdcard-status").text(i18n.getMessage('sdcardStatusReady'));
             break;
             case MSP.SDCARD_STATE_CARD_INIT:
-                $(".sdcard-status").text(chrome.i18n.getMessage('sdcardStatusStarting'));
+                $(".sdcard-status").text(i18n.getMessage('sdcardStatusStarting'));
             break;
             case MSP.SDCARD_STATE_FS_INIT:
-                $(".sdcard-status").text(chrome.i18n.getMessage('sdcardStatusFileSystem'));
+                $(".sdcard-status").text(i18n.getMessage('sdcardStatusFileSystem'));
             break;
             default:
-                $(".sdcard-status").text(chrome.i18n.getMessage('sdcardStatusUnknown',[SDCARD.state]));
+                $(".sdcard-status").text(i18n.getMessage('sdcardStatusUnknown',[SDCARD.state]));
         }
         
         if (SDCARD.supported && !sdcardTimer) {
@@ -440,7 +440,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 console.error(error.message);
                 
                 if (error.message !== "User cancelled") {
-                    GUI.log(chrome.i18n.getMessage('dataflashFileWriteFailed'));
+                    GUI.log(i18n.getMessage('dataflashFileWriteFailed'));
                 }
                 return;
             }
@@ -461,7 +461,7 @@ TABS.onboard_logging.initialize = function (callback) {
             }, function (e) {
                 // File is not readable or does not exist!
                 console.error(e);
-                GUI.log(chrome.i18n.getMessage('dataflashFileWriteFailed'));
+                GUI.log(i18n.getMessage('dataflashFileWriteFailed'));
             });
         });
     }

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1227,7 +1227,7 @@ TABS.osd.initialize = function (callback) {
         fontbuttons.append($('<button>', { class: "load_font_file", i18n: "osdSetupOpenFont" }));
 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // Open modal window
         OSD.GUI.jbox = new jBox('Modal', {
@@ -1240,13 +1240,13 @@ TABS.osd.initialize = function (callback) {
             content: $('#fontmanagercontent')
         });
 
-        $('.elements-container div.cf_tip').attr('title', chrome.i18n.getMessage('osdSectionHelpElements'));
-        $('.videomode-container div.cf_tip').attr('title', chrome.i18n.getMessage('osdSectionHelpVideoMode'));
-        $('.units-container div.cf_tip').attr('title', chrome.i18n.getMessage('osdSectionHelpUnits'));
-        $('.timers-container div.cf_tip').attr('title', chrome.i18n.getMessage('osdSectionHelpTimers'));
-        $('.alarms-container div.cf_tip').attr('title', chrome.i18n.getMessage('osdSectionHelpAlarms'));
-        $('.stats-container div.cf_tip').attr('title', chrome.i18n.getMessage('osdSectionHelpStats'));
-        $('.warnings-container div.cf_tip').attr('title', chrome.i18n.getMessage('osdSectionHelpWarnings'));
+        $('.elements-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpElements'));
+        $('.videomode-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpVideoMode'));
+        $('.units-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpUnits'));
+        $('.timers-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpTimers'));
+        $('.alarms-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpAlarms'));
+        $('.stats-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpStats'));
+        $('.warnings-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpWarnings'));
 
         // 2 way binding... sorta
         function updateOsdView() {
@@ -1348,8 +1348,8 @@ TABS.osd.initialize = function (callback) {
 
                   // Source
                   var sourceTimerTableData = $('<td class="osd_tip"></td>');
-                  sourceTimerTableData.attr('title', chrome.i18n.getMessage('osdTimerSourceTooltip'));
-                  sourceTimerTableData.append('<label for="timerSource_' + tim.index + '" class="char-label">' + chrome.i18n.getMessage('osdTimerSource') + '</label>');
+                  sourceTimerTableData.attr('title', i18n.getMessage('osdTimerSourceTooltip'));
+                  sourceTimerTableData.append('<label for="timerSource_' + tim.index + '" class="char-label">' + i18n.getMessage('osdTimerSource') + '</label>');
                   var src = $('<select class="timer-option" id="timerSource_' + tim.index + '"></select>');
                   OSD.constants.TIMER_TYPES.forEach(function(e, i) {
                     src.append('<option value="' + i + '">' + e + '</option>');
@@ -1370,8 +1370,8 @@ TABS.osd.initialize = function (callback) {
                   timerTableRow = $('<tr />');
                   timerTable.append(timerTableRow);
                   var precisionTimerTableData = $('<td class="osd_tip"></td>');
-                  precisionTimerTableData.attr('title', chrome.i18n.getMessage('osdTimerPrecisionTooltip'));
-                  precisionTimerTableData.append('<label for="timerPrec_' + tim.index + '" class="char-label">' + chrome.i18n.getMessage('osdTimerPrecision') + '</label>');
+                  precisionTimerTableData.attr('title', i18n.getMessage('osdTimerPrecisionTooltip'));
+                  precisionTimerTableData.append('<label for="timerPrec_' + tim.index + '" class="char-label">' + i18n.getMessage('osdTimerPrecision') + '</label>');
                   var precision = $('<select class="timer-option osd_tip" id="timerPrec_' + tim.index + '"></select>');
                   OSD.constants.TIMER_PRECISION.forEach(function(e, i) {
                     precision.append('<option value="' + i + '">' + e + '</option>');
@@ -1393,8 +1393,8 @@ TABS.osd.initialize = function (callback) {
                   timerTableRow = $('<tr />');
                   timerTable.append(timerTableRow);
                   var alarmTimerTableData = $('<td class="osd_tip"></td>');
-                  alarmTimerTableData.attr('title', chrome.i18n.getMessage('osdTimerAlarmTooltip'));
-                  alarmTimerTableData.append('<label for="timerAlarm_' + tim.index + '" class="char-label">' + chrome.i18n.getMessage('osdTimerAlarm') + '</label>');
+                  alarmTimerTableData.attr('title', i18n.getMessage('osdTimerAlarmTooltip'));
+                  alarmTimerTableData.append('<label for="timerAlarm_' + tim.index + '" class="char-label">' + i18n.getMessage('osdTimerAlarm') + '</label>');
                   var alarm = $('<input class="timer-option osd_tip" name="alarm" type="number" min=0 id="timerAlarm_' + tim.index + '"/>');
                   alarm[0].value = tim.alarm;
                   alarm.blur(function(e) {
@@ -1422,7 +1422,7 @@ TABS.osd.initialize = function (callback) {
                   var $field = $('<div class="switchable-field field-'+field.index+'"/>');
                   var desc = null;
                   if (field.desc && field.desc.length) {
-                    desc = chrome.i18n.getMessage(field.desc);
+                    desc = i18n.getMessage(field.desc);
                   }
                   if (desc && desc.length) {
                     $field[0].classList.add('osd_tip');
@@ -1456,7 +1456,7 @@ TABS.osd.initialize = function (callback) {
                   var $field = $('<div class="switchable-field field-'+field.index+'"/>');
                   var desc = null;
                   if (field.desc && field.desc.length) {
-                    desc = chrome.i18n.getMessage(field.desc);
+                    desc = i18n.getMessage(field.desc);
                   }
                   if (desc && desc.length) {
                     $field[0].classList.add('osd_tip');
@@ -1501,7 +1501,7 @@ TABS.osd.initialize = function (callback) {
               var $field = $('<div class="switchable-field field-'+field.index+'"/>');
               var desc = null;
               if (field.desc && field.desc.length) {
-                desc = chrome.i18n.getMessage(field.desc);
+                desc = i18n.getMessage(field.desc);
               }
               if (desc && desc.length) {
                 $field[0].classList.add('osd_tip');
@@ -1678,7 +1678,7 @@ TABS.osd.initialize = function (callback) {
         $('a.save').click(function() {
           var self = this;
           MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
-          GUI.log(chrome.i18n.getMessage('osdSettingsSaved'));
+          GUI.log(i18n.getMessage('osdSettingsSaved'));
           var oldText = $(this).text();
           $(this).html("Saved");
           setTimeout(function () {
@@ -1786,7 +1786,7 @@ TABS.osd.initialize = function (callback) {
                             });
                         } else {
                             console.log('You don\'t have write permissions for this file, sorry.');
-                            GUI.log(chrome.i18n.getMessage('osdWritePermissions'));
+                            GUI.log(i18n.getMessage('osdWritePermissions'));
                         }
                     });
                 });

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -225,9 +225,9 @@ TABS.pid_tuning.initialize = function (callback) {
 
         if (semver.gte(CONFIG.apiVersion, "1.20.0")
             || semver.gte(CONFIG.apiVersion, "1.16.0") && FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES')) {
-            $('#pid-tuning .rate').text(chrome.i18n.getMessage("pidTuningSuperRate"));
+            $('#pid-tuning .rate').text(i18n.getMessage("pidTuningSuperRate"));
         } else {
-            $('#pid-tuning .rate').text(chrome.i18n.getMessage("pidTuningRate"));
+            $('#pid-tuning .rate').text(i18n.getMessage("pidTuningRate"));
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
@@ -507,7 +507,7 @@ TABS.pid_tuning.initialize = function (callback) {
         }
 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // Local cache of current rates
         self.currentRates = {
@@ -563,11 +563,11 @@ TABS.pid_tuning.initialize = function (callback) {
             if (!self.showAllPids) {
                 hideUnusedPids();
 
-                showAllButton.text(chrome.i18n.getMessage("pidTuningShowAllPids"));
+                showAllButton.text(i18n.getMessage("pidTuningShowAllPids"));
             } else {
                 showAllPids();
 
-                showAllButton.text(chrome.i18n.getMessage("pidTuningHideUnusedPids"));
+                showAllButton.text(i18n.getMessage("pidTuningHideUnusedPids"));
             }
         }
 
@@ -585,7 +585,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 self.refresh(function () {
                     self.updating = false;
 
-                    GUI.log(chrome.i18n.getMessage('pidTuningProfileReset'));
+                    GUI.log(i18n.getMessage('pidTuningProfileReset'));
                 });
             });
         });
@@ -601,7 +601,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     $('.tab-pid_tuning select[name="profile"]').prop('disabled', 'false');
                     CONFIG.profile = self.currentProfile;
 
-                    GUI.log(chrome.i18n.getMessage('pidTuningLoadedProfile', [self.currentProfile + 1]));
+                    GUI.log(i18n.getMessage('pidTuningLoadedProfile', [self.currentProfile + 1]));
                 });
             });
         });
@@ -618,7 +618,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         $('.tab-pid_tuning select[name="rate_profile"]').prop('disabled', 'false');
                         CONFIG.rateProfile = self.currentRateProfile;
 
-                        GUI.log(chrome.i18n.getMessage('pidTuningLoadedRateProfile', [self.currentRateProfile + 1]));
+                        GUI.log(i18n.getMessage('pidTuningLoadedRateProfile', [self.currentRateProfile + 1]));
                     });
                 });
             });
@@ -699,7 +699,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
                 self.updatePidControllerParameters();
             } else {
-                GUI.log(chrome.i18n.getMessage('pidTuningUpgradeFirmwareToChangePidController', [CONFIG.apiVersion, CONFIGURATOR.pidControllerChangeMinApiVersion]));
+                GUI.log(i18n.getMessage('pidTuningUpgradeFirmwareToChangePidController', [CONFIG.apiVersion, CONFIGURATOR.pidControllerChangeMinApiVersion]));
 
                 pidController_e.empty();
                 pidController_e.append('<option value="">Unknown</option>');
@@ -854,7 +854,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('a.refresh').click(function () {
             self.refresh(function () {
-                GUI.log(chrome.i18n.getMessage('pidTuningDataRefreshed'));
+                GUI.log(i18n.getMessage('pidTuningDataRefreshed'));
             });
         });
 
@@ -982,7 +982,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 self.updating = false;
                 self.setDirty(false);
 
-                GUI.log(chrome.i18n.getMessage('pidTuningEepromSaved'));
+                GUI.log(i18n.getMessage('pidTuningEepromSaved'));
             });
         });
 
@@ -1117,12 +1117,12 @@ TABS.pid_tuning.checkUpdateProfile = function (updateRateProfile) {
             if (changedProfile || changedRateProfile) {
                 self.refresh(function () {
                     if (changedProfile) {
-                        GUI.log(chrome.i18n.getMessage('pidTuningReceivedProfile', [CONFIG.profile + 1]));
+                        GUI.log(i18n.getMessage('pidTuningReceivedProfile', [CONFIG.profile + 1]));
                         CONFIG.profile = self.currentProfile;
                     }
 
                     if (changedRateProfile) {
-                        GUI.log(chrome.i18n.getMessage('pidTuningReceivedRateProfile', [CONFIG.rateProfile + 1]));
+                        GUI.log(i18n.getMessage('pidTuningReceivedRateProfile', [CONFIG.rateProfile + 1]));
                         CONFIG.rateProfile = self.currentRateProfile
                     }
                 });

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -48,7 +48,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
     }
 
     for (var i = 0; i < functionRules.length; i++) {
-        functionRules[i].displayName = chrome.i18n.getMessage('portsFunction_' + functionRules[i].name);
+        functionRules[i].displayName = i18n.getMessage('portsFunction_' + functionRules[i].name);
     }
 
     var mspBaudRates = [
@@ -228,7 +228,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
                         if (select_e.size() == 0) {
                             functions_e.prepend('<span class="function"><select name="' + selectElementName + '" /></span>');
                             select_e = functions_e.find(selectElementSelector);
-                            var disabledText = chrome.i18n.getMessage('portsTelemetryDisabled');
+                            var disabledText = i18n.getMessage('portsTelemetryDisabled');
                             select_e.append('<option value="">' + disabledText + '</option>');
                         }
                         select_e.append('<option value="' + functionName + '">' + functionRule.displayName + '</option>');
@@ -246,7 +246,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
 
     function on_tab_loaded_handler() {
 
-        localize();
+        i18n.localizePage();
 
         update_ui();
 
@@ -317,7 +317,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         }
 
         function on_saved_handler() {
-            GUI.log(chrome.i18n.getMessage('configurationEepromSaved'));
+            GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             GUI.tab_switch_cleanup(function() {
                 MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, on_reboot_success_handler);
@@ -325,7 +325,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         }
 
         function on_reboot_success_handler() {
-            GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+            GUI.log(i18n.getMessage('deviceRebooting'));
 
             if (BOARD.find_board_definition(CONFIG.boardIdentifier).vcp) { // VCP-based flight controls may crash old drivers, we catch and reconnect
                 $('a.connect').click();
@@ -335,7 +335,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
             } else {
                 GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
                     MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
-                        GUI.log(chrome.i18n.getMessage('deviceReady'));
+                        GUI.log(i18n.getMessage('deviceReady'));
                         TABS.ports.initialize(false, $('#content').scrollTop());
                     });
                },  1500); // seems to be just the right amount of delay to prevent data request timeouts

--- a/src/js/tabs/power.js
+++ b/src/js/tabs/power.js
@@ -80,7 +80,7 @@ TABS.power.initialize = function (callback) {
             var meterElement = template.clone();
             $(meterElement).attr('id', 'voltage-meter-' + index);
 
-            var message = chrome.i18n.getMessage('powerVoltageId' + VOLTAGE_METERS[index].id);
+            var message = i18n.getMessage('powerVoltageId' + VOLTAGE_METERS[index].id);
             $(meterElement).find('.label').text(message)
             destination.append(meterElement);
 
@@ -130,7 +130,7 @@ TABS.power.initialize = function (callback) {
             var meterElement = template.clone();
             $(meterElement).attr('id', 'amperage-meter-' + index);
 
-            var message = chrome.i18n.getMessage('powerAmperageId' + CURRENT_METERS[index].id);
+            var message = i18n.getMessage('powerAmperageId' + CURRENT_METERS[index].id);
             $(meterElement).find('.label').text(message)
             destination.append(meterElement);
 
@@ -189,12 +189,12 @@ TABS.power.initialize = function (callback) {
         var haveFc = (semver.lt(CONFIG.apiVersion, "1.35.0") || (CONFIG.boardType == 0 || CONFIG.boardType == 2));
 
         var batteryMeterTypes = [
-            chrome.i18n.getMessage('powerBatteryVoltageMeterTypeNone'),
-            chrome.i18n.getMessage('powerBatteryVoltageMeterTypeAdc'),
+            i18n.getMessage('powerBatteryVoltageMeterTypeNone'),
+            i18n.getMessage('powerBatteryVoltageMeterTypeAdc'),
         ];
 
         if (haveFc) {
-            batteryMeterTypes.push(chrome.i18n.getMessage('powerBatteryVoltageMeterTypeEsc'));
+            batteryMeterTypes.push(i18n.getMessage('powerBatteryVoltageMeterTypeEsc'));
         }
 
         var batteryMeterType_e = $('select.batterymetersource');
@@ -205,16 +205,16 @@ TABS.power.initialize = function (callback) {
 
         // fill current
         var currentMeterTypes = [
-            chrome.i18n.getMessage('powerBatteryCurrentMeterTypeNone'),
-            chrome.i18n.getMessage('powerBatteryCurrentMeterTypeAdc'),
+            i18n.getMessage('powerBatteryCurrentMeterTypeNone'),
+            i18n.getMessage('powerBatteryCurrentMeterTypeAdc'),
         ];
 
         if (haveFc) {
-            currentMeterTypes.push(chrome.i18n.getMessage('powerBatteryCurrentMeterTypeVirtual'));
-            currentMeterTypes.push(chrome.i18n.getMessage('powerBatteryCurrentMeterTypeEsc'));
+            currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeVirtual'));
+            currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeEsc'));
             
             if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                currentMeterTypes.push(chrome.i18n.getMessage('powerBatteryCurrentMeterTypeMsp'));
+                currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeMsp'));
             }
         }
 
@@ -247,7 +247,7 @@ TABS.power.initialize = function (callback) {
                 for (var i = 0; i < VOLTAGE_METERS.length; i++) {
                     var elementName = '#voltage-meter-' + i + ' .value';
                     var element = $(elementName);
-                    element.text(chrome.i18n.getMessage('powerVoltageValue', [VOLTAGE_METERS[i].voltage]));
+                    element.text(i18n.getMessage('powerVoltageValue', [VOLTAGE_METERS[i].voltage]));
                 }
             });
 
@@ -255,7 +255,7 @@ TABS.power.initialize = function (callback) {
                 for (var i = 0; i < CURRENT_METERS.length; i++) {
                     var elementName = '#amperage-meter-' + i + ' .value';
                     var element = $(elementName);
-                    element.text(chrome.i18n.getMessage('powerAmperageValue', [CURRENT_METERS[i].amperage.toFixed(2)]));
+                    element.text(i18n.getMessage('powerAmperageValue', [CURRENT_METERS[i].amperage.toFixed(2)]));
                 }
             });
 
@@ -264,13 +264,13 @@ TABS.power.initialize = function (callback) {
                 var element;
 
                 element = $(elementPrefix + '-connection-state .value');
-                element.text(BATTERY_STATE.cellCount > 0 ? chrome.i18n.getMessage('powerBatteryConnectedValueYes', [BATTERY_STATE.cellCount]) : chrome.i18n.getMessage('powerBatteryConnectedValueNo'));
+                element.text(BATTERY_STATE.cellCount > 0 ? i18n.getMessage('powerBatteryConnectedValueYes', [BATTERY_STATE.cellCount]) : i18n.getMessage('powerBatteryConnectedValueNo'));
                 element = $(elementPrefix + '-voltage .value');
-                element.text(chrome.i18n.getMessage('powerVoltageValue', [BATTERY_STATE.voltage]));
+                element.text(i18n.getMessage('powerVoltageValue', [BATTERY_STATE.voltage]));
                 element = $(elementPrefix + '-mah-drawn .value');
-                element.text(chrome.i18n.getMessage('powerMahValue', [BATTERY_STATE.mAhDrawn]));
+                element.text(i18n.getMessage('powerMahValue', [BATTERY_STATE.mAhDrawn]));
                 element = $(elementPrefix + '-amperage .value');
-                element.text(chrome.i18n.getMessage('powerAmperageValue', [BATTERY_STATE.amperage]));
+                element.text(i18n.getMessage('powerAmperageValue', [BATTERY_STATE.amperage]));
             });
 
         }
@@ -317,7 +317,7 @@ TABS.power.initialize = function (callback) {
             }
 
             function save_completed() {
-                GUI.log(chrome.i18n.getMessage('configurationEepromSaved'));
+                GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 TABS.power.initialize();
             }
@@ -332,7 +332,7 @@ TABS.power.initialize = function (callback) {
         initDisplay();
 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         GUI.content_ready(callback);
     }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -56,7 +56,7 @@ TABS.receiver.initialize = function (callback) {
 
     function process_html() {
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         chrome.storage.local.get('rx_refresh_rate', function (result) {
             if (result.rx_refresh_rate) {
@@ -102,10 +102,10 @@ TABS.receiver.initialize = function (callback) {
 
         // generate bars
         var bar_names = [
-                chrome.i18n.getMessage('controlAxisRoll'),
-                chrome.i18n.getMessage('controlAxisPitch'),
-                chrome.i18n.getMessage('controlAxisYaw'),
-                chrome.i18n.getMessage('controlAxisThrottle')
+                i18n.getMessage('controlAxisRoll'),
+                i18n.getMessage('controlAxisPitch'),
+                i18n.getMessage('controlAxisYaw'),
+                i18n.getMessage('controlAxisThrottle')
             ],
             bar_container = $('.tab-receiver .bars'),
             aux_index = 1;
@@ -117,7 +117,7 @@ TABS.receiver.initialize = function (callback) {
             if (i < bar_names.length) {
                 name = bar_names[i];
             } else {
-                name = chrome.i18n.getMessage("controlAxisAux" + (aux_index++));
+                name = i18n.getMessage("controlAxisAux" + (aux_index++));
             }
 
             bar_container.append('\
@@ -225,10 +225,10 @@ TABS.receiver.initialize = function (callback) {
 
         // rssi
         var rssi_channel_e = $('select[name="rssi_channel"]');
-        rssi_channel_e.append('<option value="0">' + chrome.i18n.getMessage("receiverRssiChannelDisabledOption") + '</option>');
+        rssi_channel_e.append('<option value="0">' + i18n.getMessage("receiverRssiChannelDisabledOption") + '</option>');
         //1-4 reserved for Roll Pitch Yaw & Throttle, starting at 5
         for (var i = 5; i < RC.active_channels + 1; i++) {
-            rssi_channel_e.append('<option value="' + i + '">' + chrome.i18n.getMessage("controlAxisAux" + (i-4)) + '</option>');
+            rssi_channel_e.append('<option value="' + i + '">' + i18n.getMessage("controlAxisAux" + (i-4)) + '</option>');
         }
 
         $('select[name="rssi_channel"]').val(RSSI_CONFIG.channel);
@@ -291,7 +291,7 @@ TABS.receiver.initialize = function (callback) {
 
             function save_to_eeprom() {
                 MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                    GUI.log(chrome.i18n.getMessage('receiverEepromSaved'));
+                    GUI.log(i18n.getMessage('receiverEepromSaved'));
                 });
             }
 

--- a/src/js/tabs/receiver_msp.js
+++ b/src/js/tabs/receiver_msp.js
@@ -110,12 +110,12 @@ function localizeAxisNames() {
         var 
             gimbal = gimbalElems.get(gimbalIndex);
         
-        $(".gimbal-label-vert", gimbal).text(chrome.i18n.getMessage("controlAxis" + gimbals[gimbalIndex][0]));
-        $(".gimbal-label-horz", gimbal).text(chrome.i18n.getMessage("controlAxis" + gimbals[gimbalIndex][1]));
+        $(".gimbal-label-vert", gimbal).text(i18n.getMessage("controlAxis" + gimbals[gimbalIndex][0]));
+        $(".gimbal-label-horz", gimbal).text(i18n.getMessage("controlAxis" + gimbals[gimbalIndex][1]));
     }
     
     for (var sliderIndex = 0; sliderIndex < 4; sliderIndex++) {
-        $(".slider-label", sliderElems.get(sliderIndex)).text(chrome.i18n.getMessage("controlAxisAux" + (sliderIndex + 1)));
+        $(".slider-label", sliderElems.get(sliderIndex)).text(i18n.getMessage("controlAxisAux" + (sliderIndex + 1)));
     }
 }
 

--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -181,7 +181,7 @@ TABS.sensors.initialize = function (callback) {
 
     $('#content').load("./tabs/sensors.html", function load_html() {
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         // disable graphs for sensors that are missing
         var checkboxes = $('.tab-sensors .info .checkboxes input');

--- a/src/js/tabs/servos.js
+++ b/src/js/tabs/servos.js
@@ -136,7 +136,7 @@ TABS.servos.initialize = function (callback) {
             function save_to_eeprom() {
                 if (save_configuration_to_eeprom) {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function () {
-                        GUI.log(chrome.i18n.getMessage('servosEepromSave'));
+                        GUI.log(i18n.getMessage('servosEepromSave'));
                     });
                 }
             }
@@ -169,7 +169,7 @@ TABS.servos.initialize = function (callback) {
         update_ui();
 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
         
         // status data pulled via separate timer with static speed
         GUI.interval_add('status_pull', function () {

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -27,24 +27,24 @@ TABS.setup.initialize = function (callback) {
 
     function process_html() {
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         if (semver.lt(CONFIG.apiVersion, CONFIGURATOR.backupRestoreMinApiVersionAccepted)) {
             $('#content .backup').addClass('disabled');
             $('#content .restore').addClass('disabled');
 
-            GUI.log(chrome.i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [CONFIG.apiVersion, CONFIGURATOR.backupRestoreMinApiVersionAccepted]));
+            GUI.log(i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [CONFIG.apiVersion, CONFIGURATOR.backupRestoreMinApiVersionAccepted]));
         }
 
         // initialize 3D Model
         self.initModel();
 
 		// set roll in interactive block
-        $('span.roll').text(chrome.i18n.getMessage('initialSetupAttitude', [0]));
+        $('span.roll').text(i18n.getMessage('initialSetupAttitude', [0]));
 		// set pitch in interactive block
-        $('span.pitch').text(chrome.i18n.getMessage('initialSetupAttitude', [0]));
+        $('span.pitch').text(i18n.getMessage('initialSetupAttitude', [0]));
         // set heading in interactive block
-        $('span.heading').text(chrome.i18n.getMessage('initialSetupAttitude', [0]));
+        $('span.heading').text(i18n.getMessage('initialSetupAttitude', [0]));
 
         // check if we have accelerometer and magnetometer
         if (!have_sensor(CONFIG.activeSensors, 'acc')) {
@@ -60,7 +60,7 @@ TABS.setup.initialize = function (callback) {
         self.initializeInstruments();
 
 
-        $('#arming-disable-flag-row').attr('title', chrome.i18n.getMessage('initialSetupArmingDisableFlagsTooltip'));
+        $('#arming-disable-flag-row').attr('title', i18n.getMessage('initialSetupArmingDisableFlagsTooltip'));
 
         // UI Hooks
         $('a.calibrateAccel').click(function () {
@@ -73,7 +73,7 @@ TABS.setup.initialize = function (callback) {
                 // until this operation finishes, sending more commands through data_poll() will result in serial buffer overflow
                 GUI.interval_pause('setup_data_pull');
                 MSP.send_message(MSPCodes.MSP_ACC_CALIBRATION, false, false, function () {
-                    GUI.log(chrome.i18n.getMessage('initialSetupAccelCalibStarted'));
+                    GUI.log(i18n.getMessage('initialSetupAccelCalibStarted'));
                     $('#accel_calib_running').show();
                     $('#accel_calib_rest').hide();
                 });
@@ -81,7 +81,7 @@ TABS.setup.initialize = function (callback) {
                 GUI.timeout_add('button_reset', function () {
                     GUI.interval_resume('setup_data_pull');
 
-                    GUI.log(chrome.i18n.getMessage('initialSetupAccelCalibEnded'));
+                    GUI.log(i18n.getMessage('initialSetupAccelCalibEnded'));
                     self.removeClass('calibrating');
                     $('#accel_calib_running').hide();
                     $('#accel_calib_rest').show();
@@ -96,13 +96,13 @@ TABS.setup.initialize = function (callback) {
                 self.addClass('calibrating');
 
                 MSP.send_message(MSPCodes.MSP_MAG_CALIBRATION, false, false, function () {
-                    GUI.log(chrome.i18n.getMessage('initialSetupMagCalibStarted'));
+                    GUI.log(i18n.getMessage('initialSetupMagCalibStarted'));
                     $('#mag_calib_running').show();
                     $('#mag_calib_rest').hide();
                 });
 
                 GUI.timeout_add('button_reset', function () {
-                    GUI.log(chrome.i18n.getMessage('initialSetupMagCalibEnded'));
+                    GUI.log(i18n.getMessage('initialSetupMagCalibEnded'));
                     self.removeClass('calibrating');
                     $('#mag_calib_running').hide();
                     $('#mag_calib_rest').show();
@@ -123,7 +123,7 @@ TABS.setup.initialize = function (callback) {
         $('.dialogConfirmReset-confirmbtn').click(function() {
             dialogConfirmReset.close();
             MSP.send_message(MSPCodes.MSP_RESET_CONF, false, false, function () {
-                GUI.log(chrome.i18n.getMessage('initialSetupSettingsRestored'));
+                GUI.log(i18n.getMessage('initialSetupSettingsRestored'));
 
                 GUI.tab_switch_cleanup(function () {
                     TABS.setup.initialize();
@@ -132,12 +132,12 @@ TABS.setup.initialize = function (callback) {
         });
 
         // display current yaw fix value (important during tab re-initialization)
-        $('div#interactive_block > a.reset').text(chrome.i18n.getMessage('initialSetupButtonResetZaxisValue', [self.yaw_fix]));
+        $('div#interactive_block > a.reset').text(i18n.getMessage('initialSetupButtonResetZaxisValue', [self.yaw_fix]));
 
         // reset yaw button hook
         $('div#interactive_block > a.reset').click(function () {
             self.yaw_fix = SENSOR_DATA.kinematics[2] * - 1.0;
-            $(this).text(chrome.i18n.getMessage('initialSetupButtonResetZaxisValue', [self.yaw_fix]));
+            $(this).text(i18n.getMessage('initialSetupButtonResetZaxisValue', [self.yaw_fix]));
 
             console.log('YAW reset to 0 deg, fix: ' + self.yaw_fix + ' deg');
         });
@@ -148,7 +148,7 @@ TABS.setup.initialize = function (callback) {
             }
 
             configuration_backup(function () {
-                GUI.log(chrome.i18n.getMessage('initialSetupBackupSuccess'));
+                GUI.log(i18n.getMessage('initialSetupBackupSuccess'));
             });
         });
 
@@ -161,7 +161,7 @@ TABS.setup.initialize = function (callback) {
                 // get latest settings
                 TABS.setup.initialize();
 
-                GUI.log(chrome.i18n.getMessage('initialSetupRestoreSuccess'));
+                GUI.log(i18n.getMessage('initialSetupRestoreSuccess'));
             });
         });
 
@@ -187,7 +187,7 @@ TABS.setup.initialize = function (callback) {
             MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
                 var armingString = '';
                 if (CONFIG.armingDisableFlags == 0) {
-                  armingString = chrome.i18n.getMessage('initialSetupArmingAllowed');
+                  armingString = i18n.getMessage('initialSetupArmingAllowed');
                 } else {
                   var flagIndicies = [];
                   for (var i = 0; i < 32; i++) {
@@ -201,15 +201,15 @@ TABS.setup.initialize = function (callback) {
             });
 
             MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
-                bat_voltage_e.text(chrome.i18n.getMessage('initialSetupBatteryValue', [ANALOG.voltage]));
-                bat_mah_drawn_e.text(chrome.i18n.getMessage('initialSetupBatteryMahValue', [ANALOG.mAhdrawn]));
-                bat_mah_drawing_e.text(chrome.i18n.getMessage('initialSetupBatteryAValue', [ANALOG.amperage.toFixed(2)]));
-                rssi_e.text(chrome.i18n.getMessage('initialSetupRSSIValue', [((ANALOG.rssi / 1023) * 100).toFixed(0)]));
+                bat_voltage_e.text(i18n.getMessage('initialSetupBatteryValue', [ANALOG.voltage]));
+                bat_mah_drawn_e.text(i18n.getMessage('initialSetupBatteryMahValue', [ANALOG.mAhdrawn]));
+                bat_mah_drawing_e.text(i18n.getMessage('initialSetupBatteryAValue', [ANALOG.amperage.toFixed(2)]));
+                rssi_e.text(i18n.getMessage('initialSetupRSSIValue', [((ANALOG.rssi / 1023) * 100).toFixed(0)]));
             });
 
             if (have_sensor(CONFIG.activeSensors, 'gps')) {
                 MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, function () {
-                    gpsFix_e.html((GPS_DATA.fix) ? chrome.i18n.getMessage('gpsFixTrue') : chrome.i18n.getMessage('gpsFixFalse'));
+                    gpsFix_e.html((GPS_DATA.fix) ? i18n.getMessage('gpsFixTrue') : i18n.getMessage('gpsFixFalse'));
                     gpsSats_e.text(GPS_DATA.numSat);
                     gpsLat_e.text((GPS_DATA.lat / 10000000).toFixed(4) + ' deg');
                     gpsLon_e.text((GPS_DATA.lon / 10000000).toFixed(4) + ' deg');
@@ -219,9 +219,9 @@ TABS.setup.initialize = function (callback) {
 
         function get_fast_data() {
             MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, function () {
-	            roll_e.text(chrome.i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[0]]));
-	            pitch_e.text(chrome.i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[1]]));
-                heading_e.text(chrome.i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[2]]));
+	            roll_e.text(i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[0]]));
+	            pitch_e.text(i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[1]]));
+                heading_e.text(i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[2]]));
 
                 self.renderModel();
                 self.updateInstruments();

--- a/src/js/tabs/setup_osd.js
+++ b/src/js/tabs/setup_osd.js
@@ -33,11 +33,11 @@ TABS.setup_osd.initialize = function (callback) {
         ];
 
         // translate to user-selected language
-        localize();
+        i18n.localizePage();
 
         $('a.resetSettings').click(function () {
             MSP.send_message(MSPCodes.MSP_RESET_CONF, false, false, function () {
-                GUI.log(chrome.i18n.getMessage('initialSetupSettingsRestored'));
+                GUI.log(i18n.getMessage('initialSetupSettingsRestored'));
 
                 GUI.tab_switch_cleanup(function () {
                     TABS.setup_osd.initialize();
@@ -55,7 +55,7 @@ TABS.setup_osd.initialize = function (callback) {
                 element.text(osdVideoMode);
                 
                 element = $('.camera-connected');
-                element.text(OSD_VIDEO_STATE.camera_connected ? chrome.i18n.getMessage('osdSetupCameraConnectedValueYes') : chrome.i18n.getMessage('osdSetupCameraConnectedValueNo'));
+                element.text(OSD_VIDEO_STATE.camera_connected ? i18n.getMessage('osdSetupCameraConnectedValueYes') : i18n.getMessage('osdSetupCameraConnectedValueNo'));
             });
             */
         }

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -164,7 +164,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
         //build radio buttons
         if (transponderProviders.length > 1) {
             transponderTypeSelect.append(
-                $('<option>').attr('value', 0).html(chrome.i18n.getMessage("transponderType0")) // NONE
+                $('<option>').attr('value', 0).html(i18n.getMessage("transponderType0")) // NONE
             );
         }
 
@@ -173,7 +173,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
             if ( transponderProvider.hasOwnProperty('id') ) {
                 transponderTypeSelect.append(
-                    $('<option>').attr('value', transponderProvider.id).html(chrome.i18n.getMessage("transponderType" + transponderProvider.id))
+                    $('<option>').attr('value', transponderProvider.id).html(i18n.getMessage("transponderType" + transponderProvider.id))
                 );
             }
         }
@@ -193,12 +193,12 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
         let template = $('#transponder-configuration-template').clone();
 
-        template.find('.spacer_box_title').html(chrome.i18n.getMessage("transponderData" + transponderProvider.id));
-        template.find('.dataHelp').html(chrome.i18n.getMessage("transponderDataHelp" + transponderProvider.id));
+        template.find('.spacer_box_title').html(i18n.getMessage("transponderData" + transponderProvider.id));
+        template.find('.dataHelp').html(i18n.getMessage("transponderDataHelp" + transponderProvider.id));
 
 
-        if ( chrome.i18n.getMessage("transponderHelp" + transponderProvider.id).length ) {
-            $('#transponderHelp').html(chrome.i18n.getMessage("transponderHelp" + transponderProvider.id));
+        if ( i18n.getMessage("transponderHelp" + transponderProvider.id).length ) {
+            $('#transponderHelp').html(i18n.getMessage("transponderHelp" + transponderProvider.id));
             $('#transponderHelpBox').show();
         }
 
@@ -282,7 +282,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
     function process_html() {
         $(".tab-transponder").toggleClass("transponder-supported", TABS.transponder.available && TRANSPONDER.supported);
 
-        localize();
+        i18n.localizePage();
 
         if ( TABS.transponder.available && TRANSPONDER.providers.length > 0 ) {
 
@@ -301,7 +301,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
 
                 function save_to_eeprom() {
                     MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
-                        GUI.log(chrome.i18n.getMessage('transponderEepromSaved'));
+                        GUI.log(i18n.getMessage('transponderEepromSaved'));
                         if ( $(_this).hasClass('reboot') ) {
                             GUI.tab_switch_cleanup(function() {
                                 MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitialize);
@@ -313,7 +313,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
                 if (TRANSPONDER.provider !== "0" && TRANSPONDER.data.length !== TRANSPONDER.providers.find(function(provider) {
                         return provider.id == TRANSPONDER.provider;
                     }).dataLength ) {
-                    GUI.log(chrome.i18n.getMessage('transponderDataInvalid'));
+                    GUI.log(i18n.getMessage('transponderDataInvalid'));
                 } else {
                     save_transponder_data();
                 }
@@ -321,7 +321,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
         }
 
         function reinitialize() {
-            GUI.log(chrome.i18n.getMessage('deviceRebooting'));
+            GUI.log(i18n.getMessage('deviceRebooting'));
             if ( BOARD.find_board_definition(CONFIG.boardIdentifier).vcp ) {
                 $('a.connect').click();
                 GUI.timeout_add('start_connection', function start_connection() {
@@ -330,7 +330,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
             } else {
                 GUI.timeout_add('waiting_for_bootup', function waiting_for_bootup() {
                     MSP.send_message(MSPCodes.MSP_IDENT, false, false, function() {
-                        GUI.log(chrome.i18n.getMessage('deviceReady'));
+                        GUI.log(i18n.getMessage('deviceReady'));
                         TABS.configuration.initialize(false, $('#content').scrollTop());
                     });
                 }, 1500);

--- a/src/main.html
+++ b/src/main.html
@@ -35,6 +35,8 @@
     <link type="text/css" rel="stylesheet" href="./css/dropdown-lists/css/style_lists.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./js/libraries/switchery/switchery.css" media="all"/>
     <link rel="stylesheet" type="text/css" href="./js/libraries/jbox/jBox.css"/>
+    <script type="text/javascript" src="./node_modules/i18next/i18next.js"></script>
+    <script type="text/javascript" src="./node_modules/i18next-xhr-backend/i18nextXHRBackend.js"></script>
     <script type="text/javascript" src="./js/libraries/q.js"></script>
     <script type="text/javascript" src="./js/libraries/jquery-2.1.4.min.js"></script>
     <script type="text/javascript" src="./js/libraries/jquery-ui-1.11.4.min.js"></script>


### PR DESCRIPTION
The i18n framework of Google Chrome is limited to some languages:

https://developer.chrome.com/webstore/i18n?csw=1#localeTable

A lot of languages are missing, some are mainstream. To support more locales, this PR changes the i18n by other, a lot more powerful: `i18next`.

This PR gives us three bigs advantages:
- The first is not limit us to a certain number of locales.
- The second is that now, the i18n functions are all wrapped in the `localization.js` file. If in a future we decide to change to another i18n framework (or return to the chrome one) we only will need to modify this file.
- Finally, an external i18n framework, will let us add to the options a combo with the selection of the language to the user, a very demanded feature request. This part has not been done, maybe in a future...

The "disadvantage" since now are:
- We maintain the `messages.json` format of chrome, not using the advanced formats of `i18next`, but for now I don't think they are necessary...
- The `eventPage.js` is loaded before the application, so the `i18next` is not available here, so if some phrase must be shown to the user the chrome i18n will do it, and will use only the languages availables for chrome (fallback to english). By now only the message of new version available to chrome users.

I've made several tests, and all seems to be working, but other tests are welcome.