### PR TITLE
Generate RPM packages

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,8 @@ const del = require('del');
 const NwBuilder = require('nw-builder');
 const makensis = require('makensis');
 const deb = require('gulp-debian');
+const buildRpm = require('rpm-builder');
+const commandExistsSync = require('command-exists').sync;
 
 const gulp = require('gulp');
 const concat = require('gulp-concat');
@@ -323,6 +325,12 @@ function start_debug(done) {
 // Create installer package for windows platforms
 function release_win(arch, done) {
 
+    // Check if makensis exists
+    if (!commandExistsSync('makensis')) {
+        console.warn('makensis command not found, not generating win package for ' + arch);
+        return done();
+    }
+
     // The makensis does not generate the folder correctly, manually
     createDirIfNotExists(RELEASE_DIR);
 
@@ -371,21 +379,12 @@ function compressFiles(srcPath, basePath, outputFile, zipFolder) {
                .pipe(gulp.dest(RELEASE_DIR));
 }
 
-function release_deb(arch) {
+function release_deb(arch, done) {
 
-    var debArch;
-
-    switch (arch) {
-    case 'linux32':
-        debArch = 'i386';
-        break;
-    case 'linux64':
-        debArch = 'amd64';
-        break;
-    default:
-        console.error("Deb package error, arch: " + arch);
-        process.exit(1);
-        break;
+    // Check if dpkg-deb exists
+    if (!commandExistsSync('dpkg-deb')) {
+        console.warn('dpkg-deb command not found, not generating deb package for ' + arch);
+        return done();
     }
 
     return gulp.src([path.join(APPS_DIR, pkg.name, arch, '*')])
@@ -394,7 +393,7 @@ function release_deb(arch) {
              version: pkg.version,
              section: 'base',
              priority: 'optional',
-             architecture: debArch,
+             architecture: getLinuxPackageArch('deb', arch),
              maintainer: pkg.author,
              description: pkg.description,
              postinst: ['xdg-desktop-menu install /opt/betaflight/betaflight-configurator/betaflight-configurator.desktop'],
@@ -408,6 +407,68 @@ function release_deb(arch) {
     }));
 }
 
+function release_rpm(arch, done) {
+
+    // Check if dpkg-deb exists
+    if (!commandExistsSync('rpmbuild')) {
+        console.warn('rpmbuild command not found, not generating rpm package for ' + arch);
+        return done();
+    }
+
+    // The makensis does not generate the folder correctly, manually
+    createDirIfNotExists(RELEASE_DIR);
+
+    var options = {
+             name: pkg.name,
+             version: pkg.version,
+             buildArch: getLinuxPackageArch('rpm', arch),
+             vendor: pkg.author,
+             summary: pkg.description,
+             license: 'GNU General Public License v3.0',
+             requires: 'libgconf-2-4',
+             prefix: '/opt',
+             files:
+                 [ { cwd: path.join(APPS_DIR, pkg.name, arch),
+                     src: '**',
+                     dest: '/opt/betaflight/betaflight-configurator' } ],
+             postInstallScript: ['xdg-desktop-menu install /opt/betaflight/betaflight-configurator/betaflight-configurator.desktop'],
+             preUninstallScript: ['xdg-desktop-menu uninstall betaflight-configurator.desktop'],
+             tempDir: path.join(RELEASE_DIR,'tmp-rpm-build-' + arch),
+             keepTemp: false,
+             verbose: false,
+             rpmDest: RELEASE_DIR
+    };
+
+    buildRpm(options, function(err, rpm) {
+        if (err) {
+          console.error("Error generating rpm package: " + err);
+        }
+        done();
+    });
+}
+
+function getLinuxPackageArch(type, arch) {
+    var packArch;
+
+    switch (arch) {
+    case 'linux32':
+        packArch = 'i386';
+        break;
+    case 'linux64':
+        if (type == 'rpm') {
+            packArch = 'x86_64';
+        } else {
+            packArch = 'amd64';
+        }
+        break;
+    default:
+        console.error("Package error, arch: " + arch);
+        process.exit(1);
+        break;
+    }
+
+    return packArch;
+}
 // Create distribution package for macOS platform
 function release_osx64() {
     var appdmg = require('gulp-appdmg');
@@ -463,12 +524,14 @@ function listReleaseTasks(done) {
 
     if (platforms.indexOf('linux64') !== -1) {
         releaseTasks.push(function release_linux64_zip(){ return release_zip('linux64') });
-        releaseTasks.push(function release_linux64_deb(){ return release_deb('linux64') });
+        releaseTasks.push(function release_linux64_deb(done){ return release_deb('linux64', done) });
+        releaseTasks.push(function release_linux64_rpm(done){ return release_rpm('linux64', done) });
     }
 
     if (platforms.indexOf('linux32') !== -1) {
         releaseTasks.push(function release_linux32_zip(){ return release_zip('linux32') });
-        releaseTasks.push(function release_linux32_deb(){ return release_deb('linux32') });
+        releaseTasks.push(function release_linux32_deb(done){ return release_deb('linux32', done) });
+        releaseTasks.push(function release_linux32_rpm(done){ return release_rpm('linux32', done) });
     }
 
     if (platforms.indexOf('osx64') !== -1) {
@@ -478,7 +541,7 @@ function listReleaseTasks(done) {
     if (platforms.indexOf('win32') !== -1) {
         releaseTasks.push(function release_win32(done){ return release_win('win32', done) });
     }
-    
+
     if (platforms.indexOf('win64') !== -1) {
         releaseTasks.push(function release_win64(done){ return release_win('win64', done) });
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -929,6 +929,12 @@
         "delayed-stream": "1.0.0"
       }
     },
+    "command-exists": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.2.tgz",
+      "integrity": "sha1-EoGcZPr5VEbsCuB/5sr7brNwiyI=",
+      "dev": true
+    },
     "component-emitter": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -4099,6 +4105,12 @@
         }
       }
     },
+    "lodash": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+      "dev": true
+    },
     "lodash._basecopy": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
@@ -4450,6 +4462,12 @@
           "dev": true
         }
       }
+    },
+    "natives": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/natives/-/natives-1.1.1.tgz",
+      "integrity": "sha512-8eRaxn8u/4wN8tGkhlc2cgwwvOLMLUMUn4IYTexMgWd+LyUDfeXVkk2ygQR0hvIHbJQXgHujia3ieUUDwNGkEA==",
+      "dev": true
     },
     "ncp": {
       "version": "2.0.0",
@@ -5535,6 +5553,153 @@
         "glob": "7.1.2"
       }
     },
+    "rpm-builder": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/rpm-builder/-/rpm-builder-0.6.1.tgz",
+      "integrity": "sha1-6XenqBtxjo0Ib+9nmOnM8RbgNN4=",
+      "dev": true,
+      "requires": {
+        "chalk": "0.5.1",
+        "fs-extra": "0.16.5",
+        "globby": "1.2.0",
+        "lodash": "3.10.1",
+        "shortid": "2.2.8"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+          "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+          "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94=",
+          "dev": true
+        },
+        "async": {
+          "version": "0.9.2",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+          "dev": true
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "1.1.0",
+            "escape-string-regexp": "1.0.5",
+            "has-ansi": "0.1.0",
+            "strip-ansi": "0.3.0",
+            "supports-color": "0.2.0"
+          }
+        },
+        "fs-extra": {
+          "version": "0.16.5",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.16.5.tgz",
+          "integrity": "sha1-GtZh+myGyWCM0bSe/G/Og0k5p1A=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "3.0.11",
+            "jsonfile": "2.4.0",
+            "rimraf": "2.6.2"
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "2.0.10",
+            "once": "1.4.0"
+          }
+        },
+        "globby": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-1.2.0.tgz",
+          "integrity": "sha1-x8l60cxvhZSBHaHrgpBqhSukfaQ=",
+          "dev": true,
+          "requires": {
+            "array-union": "1.0.2",
+            "async": "0.9.2",
+            "glob": "4.5.3",
+            "object-assign": "2.1.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "3.0.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.11.tgz",
+          "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
+          "dev": true,
+          "requires": {
+            "natives": "1.1.1"
+          }
+        },
+        "has-ansi": {
+          "version": "0.1.0",
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+          "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11"
+          },
+          "dependencies": {
+            "graceful-fs": {
+              "version": "4.1.11",
+              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+              "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "1.1.8"
+          }
+        },
+        "object-assign": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz",
+          "integrity": "sha1-Q8NuXVaf+OSBbE76i+AtJpZ8GKo=",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+          "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "0.2.1"
+          }
+        },
+        "supports-color": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+          "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo=",
+          "dev": true
+        }
+      }
+    },
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -5619,6 +5784,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "shortid": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.8.tgz",
+      "integrity": "sha1-AzsRfWoul1gE9vCWnb59PQs1UTE=",
       "dev": true
     },
     "sigmund": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "i18next-xhr-backend": "^1.5.1"
   },
   "devDependencies": {
+    "command-exists": "^1.2.2",
     "del": "^3.0.0",
     "gulp": "~4.0.0",
     "gulp-concat": "~2.6.1",
@@ -51,6 +52,7 @@
     "nw-builder": "^3.4.1",
     "os": "^0.1.1",
     "platform-dependent-modules": "0.0.14",
+    "rpm-builder": "^0.6.1",
     "temp": "^0.8.3"
   },
   "config": {


### PR DESCRIPTION
This is a work in progress.

It works as is to generate linux64 packages in a linux64 machine (tested), and I suppose that can generate linux32 in a linux32 machine, but in my tests I can't generate linux32 rpm packages in a linux64 machine. Maybe is only a configuration, but I need to do more tests.

I have pushed the PR in this state to see if someone more expertise in linux has some advice. In the worst case the linux32 is not a "officially supported" architecture for the betaflight configurator.

I've added a verification to the creation of windows (makensis), debian and rpm to see if the command needed exists, if not a message appears and the generation is not done.