### PR TITLE
Use language in native form for options

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -55,22 +55,22 @@
         "message": "Default"
     },
     "language_ca": {
-        "message": "Catalan"
+        "message": "Catal\u00e0 (ca)"
     },
     "language_de": {
-        "message": "German"
+        "message": "Deutsch (de)"
     },
     "language_en": {
-        "message": "English"
+        "message": "English (en)"
     },
     "language_es": {
-        "message": "Spanish"
+        "message": "Espa\u00f1ol (es)"
     },
     "language_fr": {
-        "message": "French"
+        "message": "Fran\u00e7ais (fr)"
     },
     "language_ko": {
-        "message": "Korean"
+        "message": "\ud55c\uad6d\uc5b4 (ko)"
     },
 
     "sensorStatusGyro": {


### PR DESCRIPTION
After a talk in the slack chat, we decided that is better to let the language in the "native" form in the options menu. The final conclusion was to let the language in native form and add the locale.

The initial idea was to add the locale "programmatically" but when doing it, I thinked it will be easier to add it directly to the messages file, this gives us more flexibility if some of them need something different (maybe left-to-right languages or similar). The programmatically way don't give us nothing.

The second part of this PR has been done in the OneSky portal, hiding these phrases, in this way they will not be translated and will remain in this "native" form.