### PR TITLE
i18n profiles and rateprofiles select

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1121,6 +1121,13 @@
     "portsFunction_RUNCAM_DEVICE_CONTROL": {
         "message": "RunCam Device"
     },
+
+    "pidTuningProfileOption": {
+        "message": "Profile $1"
+    },
+    "pidTuningRateProfileOption": {
+        "message": "Rateprofile $1"
+    },
     "pidTuningUpgradeFirmwareToChangePidController": {
         "message": "<span class=\"message-negative\">Changing PID controller disabled - you can change it via the CLI.</span>  You have firmware with API version <span class=\"message-negative\">$1</span>, but this functionality requires <span class=\"message-positive\">$2</span>."
     },
@@ -1248,6 +1255,12 @@
     },
     "pidTuningCopyRateProfile": {
         "message": "Copy rateprofile values"
+    },
+    "dialogCopyProfileText": {
+        "message": "Copy values from current profile to"
+    },
+    "dialogCopyRateProfileText": {
+        "message": "Copy values from current rateprofile to"
     },
     "dialogCopyProfileTitle": {
         "message": "Copy Profile Values"

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -557,6 +557,56 @@ TABS.pid_tuning.initialize = function (callback) {
             $(this).addClass('active');
         });
 
+        
+        function loadProfilesList() {
+            var numberOfProfiles = 3;
+            if (semver.gte(CONFIG.apiVersion, "1.20.0")
+                 && CONFIG.numProfiles === 2) {
+                    numberOfProfiles = 2;
+            }
+
+            var profileElements = [];
+            for (var i=0; i<numberOfProfiles; i++) {
+                profileElements.push(i18n.getMessage("pidTuningProfileOption",[(i + 1)]));
+            }
+            return profileElements;
+        }
+
+        function loadRateProfilesList() {
+            var numberOfRateProfiles = 6;
+            if (semver.lt(CONFIG.apiVersion, "1.37.0")) {
+                numberOfRateProfiles = 3;
+            }
+
+            var rateProfileElements = [];
+            for (var i=0; i<numberOfRateProfiles; i++) {
+                rateProfileElements.push(i18n.getMessage("pidTuningRateProfileOption",[(i + 1)]));
+            }
+            return rateProfileElements;
+        }
+
+        // This vars are used here for populate the profile (and rate profile) selector AND in the copy profile (and rate profile) window
+        var selectRateProfileValues = loadRateProfilesList();
+        var selectProfileValues = loadProfilesList();
+        
+        function populateProfilesSelector(selectProfileValues) {
+            var profileSelect = $('select[name="profile"]');
+            selectProfileValues.forEach(function(value, key) {
+                profileSelect.append('<option value="' + key + '">' + value + '</option>');
+            });
+        }
+
+        populateProfilesSelector(selectProfileValues);
+
+        function populateRateProfilesSelector(selectRateProfileValues) {
+            var rateProfileSelect = $('select[name="rate_profile"]');
+            selectRateProfileValues.forEach(function(value, key) {
+                rateProfileSelect.append('<option value="' + key + '">' + value + '</option>');
+            });
+        }
+
+        populateRateProfilesSelector(selectRateProfileValues);
+
         var showAllButton = $('#showAllPids');
 
         function updatePidDisplay() {
@@ -872,9 +922,6 @@ TABS.pid_tuning.initialize = function (callback) {
         var DIALOG_MODE_RATEPROFILE = 1;
         var dialogCopyProfileMode;
 
-        var selectProfileValues = { "0": "Profile 1", "1": "Profile 2", "2": "Profile 3" };
-        var selectRateProfileValues = { "0": "Rateprofile 1", "1": "Rateprofile 2", "2": "Rateprofile 3" };
-        
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
 
             var selectProfile = $('.selectProfile');
@@ -1092,16 +1139,6 @@ TABS.pid_tuning.checkUpdateProfile = function (updateRateProfile) {
     var self = this;
 
     if (GUI.active_tab === 'pid_tuning') {
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")
-                && CONFIG.numProfiles === 2) {
-                $('.tab-pid_tuning select[name="profile"] .profile3').hide();
-        }
-
-        if (semver.lt(CONFIG.apiVersion, "1.37.0")) {
-            $('.tab-pid_tuning select[name="rate_profile"] .RateProfile4').hide();
-            $('.tab-pid_tuning select[name="rate_profile"] .RateProfile5').hide();
-            $('.tab-pid_tuning select[name="rate_profile"] .RateProfile6').hide();
-        }
 
         if (!self.updating && !self.dirty) {
             var changedProfile = false;

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -10,9 +10,7 @@
                 <div class="head" i18n="pidTuningProfile"></div>
                 <div class="bottomarea">
                     <select name="profile">
-                        <option value="0" class="profile1">Profile 1</option>
-                        <option value="1" class="profile2">Profile 2</option>
-                        <option value="2" class="profile3">Profile 3</option>
+                        <!--  list generated here -->
                     </select>
                 </div>
             </div>
@@ -21,12 +19,7 @@
                 <div class="head" i18n="pidTuningRateProfile"></div>
                 <div class="bottomarea">
                     <select name="rate_profile">
-                        <option value="0" class="RateProfile1">Rateprofile 1</option>
-                        <option value="1" class="RateProfile2">Rateprofile 2</option>
-                        <option value="2" class="RateProfile3">Rateprofile 3</option>
-                        <option value="3" class="RateProfile4">Rateprofile 4</option>
-                        <option value="4" class="RateProfile5">Rateprofile 5</option>
-                        <option value="5" class="RateProfile6">Rateprofile 6</option>
+                        <!--  list generated here -->
                     </select>
                 </div>
             </div>
@@ -147,7 +140,7 @@
                     <div id="pid_optional" class="gui_box grey topspacer pid_tuning">
                         <table class="pid_titlebar">
                             <tr>
-                                <th class="name" i18n="pidTuningName"></th>
+                                <th class="name"></th>
                                 <th class="proportional" i18n="pidTuningProportional"></th>
                                 <th class="integral" i18n="pidTuningIntegral"></th>
                                 <th class="derivative" i18n="pidTuningDerivative"></th>
@@ -231,7 +224,7 @@
                         </table>
                         <table class="pid_titlebar">
                             <tr>
-                                <th class="third" i18n="pidTuningName"></th>
+                                <th class="third"></th>
                                 <th class="third" i18n="pidTuningStrength" style="width: 33%;"></th>
                                 <th class="third" i18n="pidTuningTransition" style="width: 33%;"></th>
                             </tr>
@@ -592,9 +585,9 @@
                                 <td>
                                     <div>
                                         <label>
-                                            <span i18n="pidTuningDtermLowpassFrequency"></span>
+                                            <span i18n="pidTuningDTermLowpassFrequency"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDtermLowpassFrequencyHelp"></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpassFrequencyHelp"></div>
                                     </div>
                                 </td>
                             </tr>
@@ -673,13 +666,13 @@
 
             <div class="contentProfile" style="margin-top:20px;">
                 <div>
-                    Copy values from current profile to <select class="selectProfile"></select>
+                    <span i18n="dialogCopyProfileText"></span> <select class="selectProfile"></select>
                 </div>
             </div>
 
             <div class="contentRateProfile" style="margin-top:20px;">
                 <div>
-                    Copy values from current rateprofile to <select class="selectRateProfile"></select>
+                    <span i18n="dialogCopyRateProfileText"></span> <select class="selectRateProfile"></select>
                 </div>
             </div>
 


### PR DESCRIPTION
As asked here: https://github.com/betaflight/betaflight-configurator/pull/881

I've localized the profiles and rateprofiles selector.

I have done various tests, and all seems to work, but it will be great if some other can test it too because the PR changes several things:
- Now the profiles and rateprofile are generated programmatically and only when loading the tab. Before that, they were static with the maximum size and the options were hidden with the polling of the FC (continuously). I don't see a situation where the number of profiles change without exiting the pid tuning tab. Am i wrong?
- I've seen that we forgot to modify the number of rateprofiles to 6 in the copy profile window in the other PR. This PR addresses it too.
- Other little i18n fixes.
