### PR TITLE
Update nw.js to version 0.28.3

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -26,7 +26,7 @@ const DEBUG_DIR = './debug/';
 const RELEASE_DIR = './release/';
 
 var nwBuilderOptions = {
-    version: '0.27.4',
+    version: '0.28.3',
     files: './dist/**/*',
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},


### PR DESCRIPTION
Now that we're going to enter in the RC phase of the Betaflight firmware (so I suppose that the same for the configurator), I think that is the moment to update the `nw.js` to the latest stable version available, to be tested during this phase until the final release.