### PR TITLE
Fix Show Log translation message

### DIFF
--- a/src/main.html
+++ b/src/main.html
@@ -208,7 +208,7 @@
     <div class="clear-both"></div>
     <div id="log">
         <div class="logswitch">
-            <a href="#" id="showlog">Show Log</a>
+            <a href="#" id="showlog" i18n="logActionShow"></a>
         </div>
         <div id="scrollicon"></div>
         <div class="wrapper"></div>


### PR DESCRIPTION
When the application is opened with the log closed, the message appears
in English and not translated.

Thanks to @tonymannaro for detecting that :)