### PR TITLE
Added markdown processing for GitHub release notes.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4295,6 +4295,11 @@
         "object-visit": "1.0.1"
       }
     },
+    "marked": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.12.tgz",
+      "integrity": "sha512-k4NaW+vS7ytQn6MgJn3fYpQt20/mOgYM5Ft9BYMfQJDz2QT6yEeS9XJ8k2Nw8JTeWK/znPPW2n3UJGzyYEiMoA=="
+    },
     "matchdep": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/matchdep/-/matchdep-2.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "license": "GPL-3.0",
   "dependencies": {
     "i18next": "^10.3.0",
-    "i18next-xhr-backend": "^1.5.1"
+    "i18next-xhr-backend": "^1.5.1",
+    "marked": "^0.3.12"
   },
   "devDependencies": {
     "command-exists": "^1.2.2",

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -260,8 +260,12 @@ TABS.firmware_flasher.initialize = function (callback) {
                         $('div.release_info .status').text(summary.status);
                         $('div.release_info .file').text(summary.file).prop('href', summary.url);
 
-                        var formattedNotes = summary.notes.trim('\r').replace(/\r/g, '<br />');
+                        var formattedNotes = summary.notes.replace(/#(\d+)/g, '[#$1](https://github.com/betaflight/betaflight/pull/$1)');
+                        formattedNotes = marked(formattedNotes);
                         $('div.release_info .notes').html(formattedNotes);
+                        $('div.release_info .notes').find('a').each(function() {
+                            $(this).attr('target', '_blank');
+                        });
 
                         $('div.release_info').slideDown();
 

--- a/src/main.html
+++ b/src/main.html
@@ -37,6 +37,7 @@
     <link rel="stylesheet" type="text/css" href="./js/libraries/jbox/jBox.css"/>
     <script type="text/javascript" src="./node_modules/i18next/i18next.js"></script>
     <script type="text/javascript" src="./node_modules/i18next-xhr-backend/i18nextXHRBackend.js"></script>
+    <script type="text/javascript" src="./node_modules/marked/marked.min.js"></script>
     <script type="text/javascript" src="./js/libraries/q.js"></script>
     <script type="text/javascript" src="./js/libraries/jquery-2.1.4.min.js"></script>
     <script type="text/javascript" src="./js/libraries/jquery-ui-1.11.4.min.js"></script>


### PR DESCRIPTION
This still looks somewhat fugly, but at least the pull request links work now, making it easier for users to look at pull requests referenced in release notes. Note: Issue links in release notes will result in a 404, since there is no way for the configurator to tell if a `#<number>` reference is a pull request or an issue, and it's hardcoding for pull requests.