### PR TITLE
Fix MSP receiver control page

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1401,6 +1401,13 @@
         "message": "Preview"
     },
 
+    "receiverMspWarningText": {
+        "message": "These sticks allow BetaFlight to be armed and tested without a transmitter or receiver being present. However, <strong>this feature is not intended for flight and propellers must not be attached.</strong><br><br>This feature does not guarantee reliable control of your craft. <strong>Serious injury is likely to result if propellers are left on.</strong>"
+    },
+    "receiverMspEnableButton": {
+        "message": "Enable controls"
+    },
+
     "auxiliaryHelp": {
         "message": "Use ranges to define the switches on your transmitter and corresponding mode assignments.  A receiver channel that gives a reading between a range min/max will activate the mode.  Remember to save your settings using the Save button."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1402,7 +1402,7 @@
     },
 
     "receiverMspWarningText": {
-        "message": "These sticks allow BetaFlight to be armed and tested without a transmitter or receiver being present. However, <strong>this feature is not intended for flight and propellers must not be attached.</strong><br><br>This feature does not guarantee reliable control of your craft. <strong>Serious injury is likely to result if propellers are left on.</strong>"
+        "message": "These sticks allow Betaflight to be armed and tested without a transmitter or receiver being present. However, <strong>this feature is not intended for flight and propellers must not be attached.</strong><br><br>This feature does not guarantee reliable control of your craft. <strong>Serious injury is likely to result if propellers are left on.</strong>"
     },
     "receiverMspEnableButton": {
         "message": "Enable controls"

--- a/src/js/tabs/receiver_msp.js
+++ b/src/js/tabs/receiver_msp.js
@@ -31,14 +31,26 @@ var
     
     // First the vertical axis, then the horizontal:
     gimbals = [
-        ["throttle", "yaw"],
-        ["pitch", "roll"],
+        ["Throttle", "Yaw"],
+        ["Pitch", "Roll"],
     ],
     
     gimbalElems,
     sliderElems,
     
     enableTX = false;
+
+// This is a hack to get the i18n var of the parent, but the localizePage not works
+const i18n = opener.i18n;
+
+$(document).ready(function () {
+    $('[i18n]:not(.i18n-replaced)').each(function() {
+        var element = $(this);
+
+        element.html(i18n.getMessage(element.attr('i18n')));
+        element.addClass('i18n-replaced');
+    });
+})
 
 function transmitChannels() {
     var 

--- a/src/tabs/receiver_msp.html
+++ b/src/tabs/receiver_msp.html
@@ -1,16 +1,16 @@
 <html>
 <head>
-<link type="text/css" rel="stylesheet" href="../css/opensans_webfontkit/fonts.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/css/opensans_webfontkit/fonts.css" media="all" />
 <script type="text/javascript" src="/js/libraries/jquery-2.1.4.min.js"></script>
 <script type="text/javascript" src="/js/libraries/jquery-ui-1.11.4.min.js"></script>
 <script type="text/javascript" src="/js/libraries/jquery.nouislider.all.min.js"></script>
 
-<script type="text/javascript" src="receiver_msp.js"></script>
+<script type="text/javascript" src="/js/tabs/receiver_msp.js"></script>
 
 <link type="text/css" rel="stylesheet" href="/js/libraries/jquery.nouislider.min.css">
 <link type="text/css" rel="stylesheet" href="/js/libraries/jquery.nouislider.pips.min.css">
 
-<link type="text/css" rel="stylesheet" href="receiver_msp.css" media="all" />
+<link type="text/css" rel="stylesheet" href="/css/tabs/receiver_msp.css" media="all" />
 </head>
 <body>
     <div class="control-gimbals">
@@ -49,16 +49,9 @@
         </div>
     </div>
     <div class="warning">
-        <p>
-            These sticks allow BetaFlight to be armed and tested without a transmitter or receiver being present.
-            However, <strong>this feature is not intended for flight and propellers must not be attached.</strong>
-        </p>
-        <p>
-            This feature does not guarantee reliable control of your craft. <strong>Serious injury is likely to
-                result if propellers are left on.</strong>
-        </p>
+        <p i18n="receiverMspWarningText"></p>
         <div class="button-enable btn">
-            <a class="button-enable" href="#">Enable controls</a>
+            <a class="button-enable" href="#" i18n="receiverMspEnableButton"></a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
The MSP receiver control page is broken. This fixes https://github.com/betaflight/betaflight-configurator/issues/922

I've made a hack to use the i18n object of the opener page, but the `localizePage()` method does not work, so I made the localization by my own. Maybe there's a better way, but now I can't look into it and this fixes the problem.