### PR TITLE
Fixed references to map.js after code cleanup

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -45,7 +45,7 @@
         "partitions": [
             {
                 "name": "map",
-                "accessible_resources" : ["tabs/map.html", "tabs/map.js", "/images/icons/cf_icon_position.png"]
+                "accessible_resources" : ["tabs/map.html", "js/tabs/map.js", "/images/icons/cf_icon_position.png"]
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "name": "map",
         "accessible_resources": [
           "tabs/map.html",
-          "tabs/map.js",
+          "js/tabs/map.js",
           "/images/icons/cf_icon_position.png"
         ]
       }

--- a/src/main.html
+++ b/src/main.html
@@ -90,6 +90,7 @@
     <script type="text/javascript" src="./js/tabs/adjustments.js"></script>
     <script type="text/javascript" src="./js/tabs/servos.js"></script>
     <script type="text/javascript" src="./js/tabs/gps.js"></script>
+    <script type="text/javascript" src="./js/tabs/map.js"></script>
     <script type="text/javascript" src="./js/tabs/motors.js"></script>
     <script type="text/javascript" src="./js/tabs/led_strip.js"></script>
     <script type="text/javascript" src="./js/tabs/sensors.js"></script>

--- a/src/tabs/map.html
+++ b/src/tabs/map.html
@@ -11,7 +11,7 @@
         padding: 0px;
       }
     </style>
-    <script src="map.js"></script>
+    <script src="/js/tabs/map.js"></script>
   </head>
   <body>
     <div id="map-canvas"></div>


### PR DESCRIPTION
When *.js was moved to the js folder per cleanup efforts, it cause an issue with the webview control in the GPS tab
I have made the needed changes to make the map "Light up" after 3D fix was attained @basdelfos @fujin 