### PR TITLE
Fix javascript error map.js

### DIFF
--- a/src/main.html
+++ b/src/main.html
@@ -90,7 +90,6 @@
     <script type="text/javascript" src="./js/tabs/adjustments.js"></script>
     <script type="text/javascript" src="./js/tabs/servos.js"></script>
     <script type="text/javascript" src="./js/tabs/gps.js"></script>
-    <script type="text/javascript" src="./js/tabs/map.js"></script>
     <script type="text/javascript" src="./js/tabs/motors.js"></script>
     <script type="text/javascript" src="./js/tabs/led_strip.js"></script>
     <script type="text/javascript" src="./js/tabs/sensors.js"></script>


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/950

The `map.js` is loaded in the `map.html` directly:

https://github.com/betaflight/betaflight-configurator/blob/e8544110f8fc7ecaad5c85a9d2a3b551f5b8b22e/src/tabs/map.html#L14

So I think is not needed in the `main.html`. This seems to fix the issue but:
- I've not tested if the map is working, my GPS is dead so I can't test it.
- I don't know if there's other feature that needs the `map.js`, I haven't found one.