### PR TITLE
Add categories to desktop file

### DIFF
--- a/assets/linux/betaflight-configurator.desktop
+++ b/assets/linux/betaflight-configurator.desktop
@@ -5,3 +5,4 @@ Exec=/opt/betaflight/betaflight-configurator/betaflight-configurator
 Icon=/opt/betaflight/betaflight-configurator/icon/bf_icon_128.png
 Terminal=false
 Type=Application
+Categories=Utility


### PR DESCRIPTION
Every .desktop file should contain a main category from the [freedesktop menu spec](https://specifications.freedesktop.org/menu-spec/latest/apa.html), so that it does not show up as uncategorized.