### PR TITLE
Add current info to motors tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1758,6 +1758,25 @@
         "message": "Qty"
     },
 
+    "motorsVoltage": {
+        "message": "Voltage:"
+    },
+    "motorsADrawing": {
+        "message": "Amperage:"
+    },
+    "motorsmAhDrawn": {
+        "message": "Amp. drawn:"
+    },
+    "motorsVoltageValue": {
+        "message": "$1 V"
+    },
+    "motorsADrawingValue": {
+        "message": "$1 A"
+    },
+    "motorsmAhDrawnValue": {
+        "message": "$1 mAh"
+    },
+
     "motorsText":{
         "message": "Motors"
     },

--- a/src/css/tabs/motors.css
+++ b/src/css/tabs/motors.css
@@ -108,6 +108,23 @@
     background-color: #00D800;
 }
 
+/* Power info */
+.tab-motors .power_info {
+    float: left;
+    margin-left: 1em;
+}
+
+.tab-motors .power_info .power_text {
+    font-weight: bold;
+}
+
+.tab-motors .power_info .power_value {
+    margin-right: 10px;
+    width: 50px;
+    display: inline-block;
+    text-align: right;
+}
+
 /*Motors*/
 
 .tab-motors svg {

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -230,6 +230,11 @@ TABS.motors.initialize = function (callback) {
         accel_offset = [0, 0, 0],
         accel_offset_established = false;
 
+        // cached elements
+        var motor_voltage_e = $('.motors-bat-voltage'),
+            motor_mah_drawing_e = $('.motors-bat-mah-drawing'),
+            motor_mah_drawn_e = $('.motors-bat-mah-drawn');
+            
 
         var raw_data_text_ements = {
                 x: [],
@@ -310,7 +315,7 @@ TABS.motors.initialize = function (callback) {
             var rate = parseInt($('.tab-motors select[name="rate"]').val(), 10);
             var scale = parseFloat($('.tab-motors select[name="scale"]').val());
 
-            GUI.interval_kill_all(['motor_and_status_pull']);
+            GUI.interval_kill_all(['motor_and_status_pull','motors_power_data_pull_slow']);
 
             switch(TABS.motors.sensor) {
             case "gyro":
@@ -392,6 +397,15 @@ TABS.motors.initialize = function (callback) {
                 raw_data_text_ements.rms[0].text(rms.toFixed(4));
             }
         });
+
+        // Amperage
+        function power_data_pull() {
+            motor_voltage_e.text(i18n.getMessage('motorsVoltageValue', [ANALOG.voltage]));
+            motor_mah_drawing_e.text(i18n.getMessage('motorsADrawingValue', [ANALOG.amperage.toFixed(2)]));
+            motor_mah_drawn_e.text(i18n.getMessage('motorsmAhDrawnValue', [ANALOG.mAhdrawn]));
+            
+        }
+        GUI.interval_add('motors_power_data_pull_slow', power_data_pull, 250, true); // 4 fps
 
         $('a.reset_max').click(function () {
             gyro_max_read = [0, 0, 0];

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -99,6 +99,13 @@
                   </div>
                 </div>
             </div>
+
+            <div class="power_info">
+                <span i18n="motorsVoltage" class="power_text"></span><span class="motors-bat-voltage power_value"></span>
+                <span i18n="motorsADrawing" class="power_text"></span><span class="motors-bat-mah-drawing power_value"></span>
+                <span i18n="motorsmAhDrawn" class="power_text"></span><span class="motors-bat-mah-drawn power_value"></span>
+            </div>
+
           </div>
         </div>
         <div class="gui_box motorblock">


### PR DESCRIPTION
Adds the voltage, current and current drawn to the motors tab:
![image](https://user-images.githubusercontent.com/2673520/37240108-efc286ea-2446-11e8-860c-a27d73834e88.png)

This fixes https://github.com/betaflight/betaflight-configurator/issues/965 and replaces PR https://github.com/betaflight/betaflight-configurator/pull/967
