### PR TITLE
Spektrum SRXL menu selection string change. 

### DIFF
--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -576,7 +576,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.24.0"))  {
-            serialRXtypes.push('Spektrum Bidir SRXL');
+            serialRXtypes.push('SPEKTRUM2048/SRXL');
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.35.0"))  {


### PR DESCRIPTION
Preparing to avoid future possible clash with the "Bidir" string. This change also marks that we are actually using a mix of old Satellite or "Remote Rx" protocol for RC input and SRXL only for telemetry output. This change also adheres the old names `SPEKTRUM1024 `and `SPEKTRUM2048 `used in BFC.

Background, Spektrum will add a new protocol, currently under the name "SRXL Bi-Dir". We must avoid using a name similar to that, not to confuse our users. There will be a new Spektrum Tx menu "Rx Output" with selections "Remote Rx", "SRXL" and "SRXL Bi-Dir", where the first is the default protocol and the one compatible with what we currently use in BF. 

WiKi needs an update matching this PR, once merged and released.
