### PR TITLE
Accept interpolation of i18next

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -371,7 +371,8 @@
     },
 
     "infoVersions": {
-        "message" : "Running - OS: <strong>$1</strong>, Chrome: <strong>$2</strong>, Configurator: <strong>$3</strong>"
+        "message" : "Running - OS: <strong>{{operatingSystem}}</strong>, Chrome: <strong>{{chromeVersion}}</strong>, Configurator: <strong>{{configuratorVersion}}</strong>",
+        "description": "Message that appears in the GUI log panel indicating operating system, Chrome version and Configurator version"
     },
     "releaseCheckLoaded": {
         "message" : "Loaded release information for $1 from GitHub."

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -39,9 +39,19 @@ i18n.init = function(cb) {
 }
 
 i18n.getMessage = function(messageID, parameters) {
-    var translatedString =  i18next.t(messageID + '.message');
 
-    if (parameters !== undefined) {
+    var translatedString;
+
+    // Option 1, no parameters or Object as parameters (i18Next type parameters)
+    if ((parameters === undefined) || ((parameters.constructor !== Array) && (parameters instanceof Object))) {
+        translatedString =  i18next.t(messageID + '.message', parameters);
+
+    // Option 2: parameters as $1, $2, etc.
+    // (deprecated, from the old Chrome i18n
+    } else {
+
+        translatedString =  i18next.t(messageID + '.message');
+
         if (parameters.constructor !== Array) {
             parameters = [parameters];
         }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -18,7 +18,9 @@ function startProcess() {
     i18n.localizePage();
 
     // alternative - window.navigator.appVersion.match(/Chrome\/([0-9.]*)/)[1];
-    GUI.log(i18n.getMessage('infoVersions',[GUI.operating_system, window.navigator.appVersion.replace(/.*Chrome\/([0-9.]*).*/, "$1"), getManifestVersion()]));
+    GUI.log(i18n.getMessage('infoVersions',{operatingSystem: GUI.operating_system, 
+                                            chromeVersion: window.navigator.appVersion.replace(/.*Chrome\/([0-9.]*).*/, "$1"), 
+                                            configuratorVersion: getManifestVersion()}));
 
     $('#logo .version').text(getManifestVersion());
     updateStatusBarVersion();


### PR DESCRIPTION
The i18Next library for localization accepts parameters by name (interpolation in i18next language). More info here: https://www.i18next.com/interpolation.html

This PR adds compatibility with this option.

Until now, the messages phrases were as:
```Json
    "infoVersions": {
        "message" : "Running - OS: <strong>$1</strong>, Chrome: <strong>$2</strong>, Configurator: <strong>$3</strong>"
    },
```

And the use as:
```Javascript
    GUI.log(i18n.getMessage('infoVersions',[GUI.operating_system, window.navigator.appVersion.replace(/.*Chrome\/([0-9.]*).*/, "$1"), getManifestVersion()]));
```

Now we can define name for the parameters. The code is longer but clear:
```Json
    "infoVersions": {
        "message" : "Running - OS: <strong>{{operatingSystem}}</strong>, Chrome: <strong>{{chromeVersion}}</strong>, Configurator: <strong>{{configuratorVersion}}</strong>",
        "description": "Message that appears in the GUI log panel indicating operating system, Chrome version and Configurator version"
    },
```

And used as:
```Javascript
    GUI.log(i18n.getMessage('infoVersions',{operatingSystem: GUI.operating_system, 
                                            chromeVersion: window.navigator.appVersion.replace(/.*Chrome\/([0-9.]*).*/, "$1"), 
                                            configuratorVersion: getManifestVersion()}));
```

So the parameters must be passed in Object form.

I've modified one message in the `messages.json` file as example, but maybe is better to let it in the old form to not translate it again to all languages. But is only one phrase and may serve to learn to the translators.