### PR TITLE
Better copyright debian file

### DIFF
--- a/assets/linux/copyright
+++ b/assets/linux/copyright
@@ -1,4 +1,23 @@
-This package was created by the Betaflight open source flight controller firmware project (https://github.com/betaflight/betaflight).
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: Betaflight Configurator
+Source: https://github.com/betaflight/betaflight-configurator
 
-All of the code is covered under the terms of the GPL version 3. See the
-file /usr/share/common-licenses/GPL-3 for more information.
+Files: *
+Copyright: Copyright 2018 The Betaflight open source project
+License: GPL-3
+
+License: GPL-3
+ This program is free software: you can redistribute it and/or modify it under
+ the terms of the GNU General Public License as published by the Free Software
+ Foundation, either version 3 of the License, or (at your option) any later
+ version.
+ .
+ This program is distributed in the hope that it will be useful, but WITHOUT ANY
+ WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ PARTICULAR PURPOSE. See the GNU General Public License for more details.
+ .
+ You should have received a copy of the GNU General Public License along with
+ this program. If not, see <http://www.gnu.org/licenses/>.
+ .
+ On Debian systems, the complete text of the GNU General Public License
+ can be found in `/usr/share/common-licenses/GPL-3'.


### PR DESCRIPTION
The copyright file must conform some standard: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/

This change seems to NOT fix this: https://github.com/betaflight/betaflight-configurator/issues/989 but at least is better than before.