### PR TITLE
From cleanflight: Support reading OSD logos from local files.

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -214,7 +214,11 @@ var openLogoImage = function() {
                 reject(error);
             };
             fileEntry.file(function(file) {
-                img.src = "file://" + file.path;
+                var fr = new FileReader();
+                fr.onload = function () {
+                    img.src = fr.result;
+                }
+                fr.readAsDataURL(file);
             });
         });
     });


### PR DESCRIPTION
It was broken due to chrome permissions.