### PR TITLE
Add OSD_WARNING_ESC_FAIL

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3312,6 +3312,9 @@
     "osdWarningCrashFlipMode": {
         "message": "Warns when flip over after crash mode is activated"
     },
+    "osdWarningEscFail": {
+        "message": "Enumerates a list with the ESCs/motors that are failing (RPM or temperature are out of the configured threshold)"
+    },
 
     "osdSectionHelpElements": {
         "message": "Enable or disable OSD elements."

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1007,7 +1007,12 @@ OSD.constants = {
     CRASH_FLIP_MODE: {
       name: 'CRASH_FLIP_MODE',
       desc: 'osdWarningCrashFlipMode'
+    },
+    ESC_FAIL: {
+      name: 'OSD_WARNING_ESC_FAIL',
+      desc: 'osdWarningEscFail'
     }
+
   },
   FONT_TYPES: [
     { file: "default", name: "Default" },
@@ -1175,6 +1180,11 @@ OSD.chooseFields = function () {
     F.VISUAL_BEEPER,
     F.CRASH_FLIP_MODE
   ];
+  if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+      OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
+          F.ESC_FAIL
+      ]);
+    }
 };
 
 OSD.updateDisplaySize = function() {


### PR DESCRIPTION
Adds the OSD_WARNING_ESC_FAIL to the list of configurable OSD warnings. Syncs with the firmware PR https://github.com/betaflight/betaflight/pull/5550