### PR TITLE
Switched dshot beacon input to address issue #975

### DIFF
--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -239,7 +239,16 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         var dshotBeeper_e = $('.tab-configuration .dshotbeeper');
         var dshotBeacon_e = $('.tab-configuration .dshotbeacon');
         var dshotBeeperSwitch = $('#dshotBeeperSwitch');
-        var dshotBeeperBeaconTone = $('#dshotBeeperBeaconTone');
+        var dshotBeeperBeaconTone = $('select.dshotBeeperBeaconTone');
+
+        if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+            for (var i = 1; i <= 5; i++) {
+                dshotBeeperBeaconTone.append('<option value="' + (i) + '">'+ (i) + '</option>');
+            }
+            dshotBeeper_e.show();
+        } else {
+            dshotBeeper_e.hide();
+        }
 
         dshotBeeperSwitch.change(function() {
             if ($(this).is(':checked')) {
@@ -259,12 +268,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         dshotBeeperBeaconTone.val(BEEPER_CONFIG.dshotBeaconTone);
         dshotBeeperSwitch.prop('checked', BEEPER_CONFIG.dshotBeaconTone !== 0).change();
-
-        if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-            dshotBeeper_e.show();
-        } else {
-            dshotBeeper_e.hide();
-        }
 
         // Analog Beeper
         var template = $('.beepers .beeper-template');

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -703,9 +703,12 @@
                                         </tr>
                                         <tr class="dshotbeacon">
                                             <td>
-                                                <div class="number">
+                                                <div class="select">
                                                     <div style="float: left; height: 20px; margin-right: 10px;">
-                                                        <input type="number" id="dshotBeeperBeaconTone" step="1" min="1" max="5" />
+                                                        <select class="dshotBeeperBeaconTone">
+                                                            <option value="0" hidden></option>
+                                                            <!-- list generated here --> 
+                                                        </select>
                                                     </div>
                                                     <label for="dshotBeeperBeaconTone">
                                                         <span i18n="configurationDshotBeaconTone"></span>


### PR DESCRIPTION
It looks like the conditional that's checks (dshotBeeperBeaconTone.val() == 0) when enabling the "Use DSHOT beacon" switch is never true, as dshotBeeperBeaconTone.val defaults to 1 (the min value in the input tag). This means that users clicking the switch expecting the default value that is shown don't end up actually enabling a tone other then 0. If you change the value of the input from something else then to 1 it works fine. 

I think this may be better as a dropdown selection, as this addresses the bug and this way you can't set the value outside of the list of beacon tones. Currently you can set an invalid beacon tone if you type in an invalid number then click save/reboot without clicking out of the input box first.
# # #975 