### PR TITLE
Build Type select for firmware flasher

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2137,6 +2137,9 @@
     "firmwareFlasherNoReboot": {
         "message": "No reboot sequence"
     },
+    "firmwareFlasherOnlineSelectBuildType": {
+        "message": "Select build type to see available boards."
+    },
     "firmwareFlasherOnlineSelectBoardDescription": {
         "message": "Select your board to see available online firmware releases - Select the correct firmware appropriate for your board."
     },
@@ -2184,6 +2187,21 @@
     },
     "firmwareFlasherOptionLoading": {
         "message": "Loading ..."
+    },
+    "firmwareFlasherOptionLabelBuildTypeRelease": {
+        "message": "Release"
+    },
+    "firmwareFlasherOptionLabelBuildTypeReleaseCandidate": {
+        "message": "Release And Release Candidate"
+    },
+    "firmwareFlasherOptionLabelBuildTypeDevelopment": {
+        "message": "Development"
+    },
+    "firmwareFlasherOptionLabelBuildTypeAKK3_3": {
+        "message": "3.3 AKK & RDQ VTX Patch"
+    },
+    "firmwareFlasherOptionLabelBuildTypeAKK3_4": {
+        "message": "3.4 AKK & RDQ VTX Patch"
     },
     "firmwareFlasherOptionLabelSelectFirmware": {
         "message": "Choose a Firmware / Board"

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -198,7 +198,7 @@ input[type="number"]::-webkit-inner-spin-button {
     width: 136px;
 }
 
-#port-picker .auto_connect {
+#port-picker .auto_connect, .gray {
     color: #ddd;
 }
 

--- a/src/js/jenkins_loader.js
+++ b/src/js/jenkins_loader.js
@@ -1,0 +1,97 @@
+ 'use strict;'
+
+var JenkinsLoader = function (url, jobName) {
+    var self = this;
+    
+    self._url = url;
+    self._jobName = jobName;
+    self._jobUrl = self._url + '/job/' + self._jobName;
+    self._buildsRequest = '/api/json?tree=builds[number,result,timestamp,artifacts[relativePath],changeSet[items[commitId,msg]]]';
+    self._builds = {};
+
+    self._buildsDataTag = `${self._jobUrl}BuildsData`;
+    self._cacheLastUpdateTag = `${self._jobUrl}BuildsLastUpdate`
+}
+
+JenkinsLoader.prototype.loadBuilds = function (callback) {
+    var self = this;
+
+    chrome.storage.local.get([self._cacheLastUpdateTag, self._buildsDataTag], function (result) {
+        var buildsDataTimestamp = $.now();
+        var cachedBuildsData = result[self._buildsDataTag];
+        var cachedBuildsLastUpdate = result[self._cacheLastUpdateTag];
+
+        if (!cachedBuildsData || !cachedBuildsLastUpdate || buildsDataTimestamp - cachedBuildsLastUpdate > 3600 * 1000) {
+            var request = self._jobUrl + self._buildsRequest;
+
+            $.get(request, function (buildsInfo) {
+                // filter successful builds
+                self._builds = buildsInfo.builds.filter(build => build.result == 'SUCCESS')
+                    .map(build => ({
+                        number: build.number,
+                        artifacts: build.artifacts.map(artifact => artifact.relativePath),
+                        changes: build.changeSet.items.map(item => '* ' + item.msg).join('<br>\n'),
+                        date: new Date(build.timestamp)
+                    }));
+
+                self._parseBuilds(callback);
+            }).fail(function (data) {
+                GUI.log(i18n.getMessage('releaseCheckFailed', [self._jobName, 'failed to load builds']));
+            
+                self._builds = cachedBuildsData;
+                self._parseBuilds(callback);
+            });
+        } else {
+            if (cachedBuildsData) {
+                GUI.log(i18n.getMessage('releaseCheckCached', [self._jobName]));
+            }
+
+            self._builds = cachedBuildsData;
+            self._parseBuilds(callback);
+        }
+    });
+}
+
+JenkinsLoader.prototype._parseBuilds = function (callback) {
+    var self = this;
+
+    // convert from `build -> targets` to `target -> builds` mapping
+    var targetBuilds = {};
+
+    var targetFromFilenameExpression = /betaflight_([\d.]+)?_?(\w+)(\-.*)?\.(.*)/;
+
+    self._builds.forEach(build => {
+        build.artifacts.forEach(relativePath => {
+            var match = targetFromFilenameExpression.exec(relativePath);
+
+            if (!match) {
+                return;
+            }
+
+            var version = match[1];
+            var target = match[2];
+
+            var formattedDate = ("0" + build.date.getDate()).slice(-2) + "-" + ("0" + (build.date.getMonth()+1)).slice(-2) + "-" +
+                build.date.getFullYear() + " " + ("0" + build.date.getHours()).slice(-2) + ":" + ("0" + build.date.getMinutes()).slice(-2);
+
+            var descriptor = {
+                'releaseUrl': self._jobUrl + '/' + build.number,
+                'name'      : self._jobName + ' #' + build.number,
+                'version'   : version + ' #' + build.number,
+                'url'       : self._jobUrl + '/' + build.number + '/artifact/' + relativePath,
+                'file'      : relativePath.split('/').slice(-1)[0],
+                'target'    : target,
+                'date'      : formattedDate,
+                'notes'     : build.changes
+            };
+
+            if (targetBuilds[target]) {
+                targetBuilds[target].push(descriptor);
+            } else {
+                targetBuilds[target] = [ descriptor ];
+            }
+        });
+    });
+
+    callback(targetBuilds);
+}

--- a/src/main.html
+++ b/src/main.html
@@ -78,6 +78,7 @@
     <script type="text/javascript" src="./js/Features.js"></script>
     <script type="text/javascript" src="./js/Beepers.js"></script>
     <script type="text/javascript" src="./js/release_checker.js"></script>
+    <script type="text/javascript" src="./js/jenkins_loader.js"></script>
     <script type="text/javascript" src="./js/main.js"></script>
     <script type="text/javascript" src="./js/tabs/landing.js"></script>
     <script type="text/javascript" src="./js/tabs/setup.js"></script>

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -3,6 +3,20 @@
         <div class="options gui_box">
             <div class="spacer">
                 <table class="cf_table" style="margin-top: 10px;">
+                    <tr class="option">
+                        <td><label> <input class="show_development_releases toggle" type="checkbox" /> <span
+                                i18n="firmwareFlasherShowDevelopmentReleases"></span>
+                        </label></td>
+                        <td><span class="description" i18n="firmwareFlasherShowDevelopmentReleasesDescription"></span></td>
+                    </tr>
+                    <tr class="build_type">
+                        <td>
+                            <select name="build_type">
+                                <!-- options generated at runtime -->
+                            </select>
+                        </td>
+                        <td><span class="description" i18n="firmwareFlasherOnlineSelectBuildType"></span></td>
+                    </tr>
                     <tr>
                         <td><select name="board">
                                 <option value="0" i18n="firmwareFlasherOptionLoading">Loading ...</option>
@@ -33,7 +47,7 @@
                         </label></td>
                         <td><span class="description" i18n="firmwareFlasherFullChipEraseDescription"></span></td>
                     </tr>
-                    <tr class="option manual_baud_rate">
+                    <tr class="option manual_baud_rate noboarder">
                         <td><label> <input class="flash_manual_baud toggle" type="checkbox" /> <span
                                 i18n="firmwareFlasherManualBaud"></span> <select id="flash_manual_baud_rate"
                                 i18n_title="firmwareFlasherBaudRate">
@@ -49,12 +63,6 @@
                             </select>
                         </label></td>
                         <td><span class="description" i18n="firmwareFlasherManualBaudDescription"></span></td>
-                    </tr>
-                    <tr class="option noboarder">
-                        <td><label> <input class="show_development_releases toggle" type="checkbox" /> <span
-                                i18n="firmwareFlasherShowDevelopmentReleases"></span>
-                        </label></td>
-                        <td><span class="description" i18n="firmwareFlasherShowDevelopmentReleasesDescription"></span></td>
                     </tr>
                 </table>
             </div>


### PR DESCRIPTION
This PR adds build type select to existing firmware flasher tab with following options:
* Release
* Release Candidate
* Development (ci.betaflight.tech)
* AKK-RDQ Patch (ci.betaflight.tech)

Lacks messages, translations and probably a dynamic description field to explain user the intricacies of each choice.

![image](https://user-images.githubusercontent.com/1427681/39075260-8e4058e8-44fd-11e8-8bfd-57ec13f4958e.png)

![image](https://user-images.githubusercontent.com/1427681/39075266-94fcadd0-44fd-11e8-887e-6bd6323ed26c.png)
