### PR TITLE
Fix amperage offset units (mA)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2957,7 +2957,7 @@
         "message": "Scale [1/10th mV/A]"
     },
     "powerAmperageOffset": {
-        "message": "Offset [mV]"
+        "message": "Offset [mA]"
     },
 
     "powerBatteryHead": {


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1007

It seems that the issue is correct, seeing the code https://github.com/betaflight/betaflight/blob/40e8f77fed0c47a110c8ef14bbe7b7e3f3fd1770/src/main/sensors/current.c#L117-L118