### PR TITLE
FirmwareCache: add method to manually purge cache and maintenance

### DIFF
--- a/src/js/FirmwareCache.js
+++ b/src/js/FirmwareCache.js
@@ -81,9 +81,11 @@ let FirmwareCache = (function () {
             let cached = typeof obj === "object" && obj.hasOwnProperty(cacheKey)
                 ? obj[cacheKey]
                 : null;
+            if (cached === null) {
+                return;
+            }
             chrome.storage.local.remove(cacheKey, () => {
                 onRemoveFromCache(cached.release);
-                console.debug("Cache data removed: " + cacheKey);
             });
         });
         return oldest;
@@ -139,7 +141,6 @@ let FirmwareCache = (function () {
             hexdata: hexdata,
         };
         chrome.storage.local.set(obj, () => {
-            console.info("Release put to cache: " + key);
             onPutToCache(release);
         });
     }
@@ -169,12 +170,38 @@ let FirmwareCache = (function () {
     }
 
     /**
+     * Remove all cached data
+     */
+    function destroy() {
+        let cacheKeys = [];
+        for (let key of journal.keys()) {
+            cacheKeys.push(withCachePrefix(key));
+        }
+        chrome.storage.local.get(cacheKeys, obj => {
+            if (typeof obj !== "object") {
+                return;
+            }
+            for (let cacheKey of cacheKeys) {
+                if (obj.hasOwnProperty(cacheKey)) {
+                    /** @type {CacheItem} */
+                    let item = obj[cacheKey];
+                    onRemoveFromCache(item.release);
+                }
+            }
+            chrome.storage.local.remove(cacheKeys);
+        });
+        journal.clear();
+        JournalStorage.persist(journal.toJSON());    
+    }
+
+    /**
      * @param {Descriptor} release 
      */
     function onPutToCache(release) {
         if (typeof onPutToCacheCallback === "function") {
             onPutToCacheCallback(release);
         }
+        console.info("Release put to cache: " + keyOf(release));
     }
 
     /**
@@ -184,6 +211,7 @@ let FirmwareCache = (function () {
         if (typeof onRemoveFromCacheCallback === "function") {
             onRemoveFromCacheCallback(release);
         }
+        console.debug("Cache data removed: " + keyOf(release));
     }
 
     /**
@@ -212,5 +240,6 @@ let FirmwareCache = (function () {
             JournalStorage.persist(journal.toJSON());
             journal.clear();
         },
+        destroy: destroy,
     };
 })();

--- a/src/js/FirmwareCache.js
+++ b/src/js/FirmwareCache.js
@@ -172,7 +172,7 @@ let FirmwareCache = (function () {
     /**
      * Remove all cached data
      */
-    function destroy() {
+    function invalidate() {
         if (!journalLoaded) {
             console.warn("Cache journal not yet loaded");
             return undefined;
@@ -240,10 +240,10 @@ let FirmwareCache = (function () {
         load: () => {
             JournalStorage.load(onEntriesLoaded);
         },
-        flush: () => {
+        unload: () => {
             JournalStorage.persist(journal.toJSON());
             journal.clear();
         },
-        destroy: destroy,
+        invalidate: invalidate,
     };
 })();

--- a/src/js/FirmwareCache.js
+++ b/src/js/FirmwareCache.js
@@ -173,6 +173,10 @@ let FirmwareCache = (function () {
      * Remove all cached data
      */
     function destroy() {
+        if (!journalLoaded) {
+            console.warn("Cache journal not yet loaded");
+            return undefined;
+        }
         let cacheKeys = [];
         for (let key of journal.keys()) {
             cacheKeys.push(withCachePrefix(key));

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -545,7 +545,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
 TABS.firmware_flasher.cleanup = function (callback) {
     PortHandler.flush_callbacks();
-    FirmwareCache.flush();
+    FirmwareCache.unload();
 
     // unbind "global" events
     $(document).unbind('keypress');


### PR DESCRIPTION
It's just a new method that can be called from the console and removes all cached data. It can be used for debugging or possibly be triggered by a user event in the future. There was also a bit of maintenance done.