### PR TITLE
Support for failsafe-switch-mode

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2765,6 +2765,15 @@
     "failsafeKillSwitchHelp": {
         "message": "Set this option to make the failsafe switch (Modes Tab) act as a direct kill switch, bypassing the selected failsafe procedure. <strong>Note:</strong> Arming is blocked with the failsafe kill switch in the ON position"
     },
+    "failsafeSwitchTitle": {
+        "message": "Failsafe Switch"
+    },
+    "failsafeSwitchModeItem": {
+        "message": "Failsafe Switch Action"
+    },
+    "failsafeSwitchModeHelp": {
+        "message": "This option determines what happens when Failsafe is activated through AUX switch:<br/><strong>Stage 1</strong> activates Stage 1 failsafe. This is useful if you want to simulate the exact signal loss failsafe behavior.<br/><strong>Stage 2</strong> skips Stage 1 and activates the Stage 2 procedure immediately<br/><strong>Kill</strong> disarms instantly (your craft will crash)"
+    },
 
     "powerButtonSave": {
         "message": "Save"

--- a/src/css/tabs/failsafe.css
+++ b/src/css/tabs/failsafe.css
@@ -287,6 +287,17 @@
     width: 100%;
 }
 
+.tab-failsafe .selectSwitchMode {
+    clear: left;
+    width: 100%;
+    float: left;
+}
+
+.tab-failsafe .switchMode {
+    border: 1px solid silver;
+    margin-right: 5px;
+    width: 80px;
+}
 
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {
 

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -605,7 +605,7 @@ function configuration_restore(callback) {
                     failsafe_delay:                 10,
                     failsafe_off_delay:             200,
                     failsafe_throttle:              1000,
-                    failsafe_kill_switch:           0,
+                    failsafe_switch_mode:           0,
                     failsafe_throttle_low_delay:    100,
                     failsafe_procedure:             0
                 };

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -391,7 +391,7 @@ var FC = {
             failsafe_delay:                 0,
             failsafe_off_delay:             0,
             failsafe_throttle:              0,
-            failsafe_kill_switch:           0,
+            failsafe_switch_mode:           0,
             failsafe_throttle_low_delay:    0,
             failsafe_procedure:             0.
         };

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -788,7 +788,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FAILSAFE_CONFIG.failsafe_off_delay = data.readU8();
                 FAILSAFE_CONFIG.failsafe_throttle = data.readU16();
                 if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                    FAILSAFE_CONFIG.failsafe_kill_switch = data.readU8();
+                    FAILSAFE_CONFIG.failsafe_switch_mode = data.readU8();
                     FAILSAFE_CONFIG.failsafe_throttle_low_delay = data.readU16();
                     FAILSAFE_CONFIG.failsafe_procedure = data.readU8();
                 }
@@ -1366,7 +1366,7 @@ MspHelper.prototype.crunch = function(code) {
                 .push8(FAILSAFE_CONFIG.failsafe_off_delay)
                 .push16(FAILSAFE_CONFIG.failsafe_throttle);
             if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                buffer.push8(FAILSAFE_CONFIG.failsafe_kill_switch)
+                buffer.push8(FAILSAFE_CONFIG.failsafe_switch_mode)
                     .push16(FAILSAFE_CONFIG.failsafe_throttle_low_delay)
                     .push8(FAILSAFE_CONFIG.failsafe_procedure);
             }

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -261,8 +261,17 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 break;
         }
 
-        // set stage 2 kill switch option
-        $('input[name="failsafe_kill_switch"]').prop('checked', FAILSAFE_CONFIG.failsafe_kill_switch);
+        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+            // `failsafe_kill_switch` has been renamed to `failsafe_switch_mode`.
+            // It is backwards compatible with `failsafe_kill_switch`
+            $('select[name="failsafe_switch_mode"]').val(FAILSAFE_CONFIG.failsafe_switch_mode);
+            $('div.kill_switch').hide();
+        }
+        else {
+            $('input[name="failsafe_kill_switch"]').prop('checked', FAILSAFE_CONFIG.failsafe_switch_mode);
+            $('div.failsafe_switch').hide();
+        }
+
 
 
         $('a.save').click(function () {
@@ -284,7 +293,12 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 FAILSAFE_CONFIG.failsafe_procedure = 1;
             }
 
-            FAILSAFE_CONFIG.failsafe_kill_switch = $('input[name="failsafe_kill_switch"]').is(':checked') ? 1 : 0;
+            if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+                FAILSAFE_CONFIG.failsafe_switch_mode = $('select[name="failsafe_switch_mode"]').val();
+            }
+            else {
+                FAILSAFE_CONFIG.failsafe_switch_mode = $('input[name="failsafe_kill_switch"]').is(':checked') ? 1 : 0;
+            }
 
             function save_failssafe_config() {
                 MSP.send_message(MSPCodes.MSP_SET_FAILSAFE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FAILSAFE_CONFIG), false, save_rxfail_config);

--- a/src/tabs/failsafe.html
+++ b/src/tabs/failsafe.html
@@ -42,6 +42,24 @@
             </div>
         </div>
         <div class="rightWrapper">
+            <div class="gui_box grey failsafe_switch">
+                <div class="gui_box_titlebar">
+                    <div class="spacer_box_title" i18n="failsafeSwitchTitle"></div>
+                </div>
+                <div class="spacer_box">
+                    <div class="selectSwitchMode">
+                        <label>
+                            <select class="switchMode" name="failsafe_switch_mode">
+                                <option value="0">Stage 1</option>
+                                <option value="2">Stage 2</option>
+                                <option value="1">Kill</option>
+                            </select>
+                            <span i18n="failsafeSwitchModeItem"></span>
+                            <div class="helpicon cf_tip" i18n_title="failsafeSwitchModeHelp"></div>
+                        </label>
+                    </div>
+                </div>
+            </div>
             <div class="gui_box grey">
                 <div class="gui_box_titlebar">
                     <div class="spacer_box_title" i18n="failsafeStageTwoSettingsTitle"></div>
@@ -52,7 +70,7 @@
                             <!-- table generated here -->
                         </tbody>
                     </table>
-                    <div class="checkbox stage2">
+                    <div class="checkbox stage2 kill_switch">
                         <div class="numberspacer" >
                             <input type="checkbox" name="failsafe_kill_switch" class="toggle" id="failsafe_kill_switch" />
                         </div>


### PR DESCRIPTION
Implements support for https://github.com/betaflight/betaflight/pull/5998

The switch option has been moved to a separate gui_box because it does not fit conceptually in the Stage 2 Settings.

I've simply renamed the parameter `failsafe_kill_switch` -> `failsafe_swtich_mode` but I'm not sure if this is the correct way to do it. For example I don't know what will happen if one tries to restore exported config with the old name.

Any suggestions are welcome!