### PR TITLE
Add new filters Stage 2

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2618,71 +2618,68 @@
     "pidTuningNonProfileFilterSettings": {
         "message": "Profile independent Filter Settings"
     },
+    "pidTuningGyroLowpassFiltersGroup": {
+        "message": "Gyro Lowpass Filters"
+    },
     "pidTuningGyroLowpassFrequency": {
-        "message": "Gyro Soft Lowpass Frequency [Hz]"
+        "message": "Gyro Lowpass 1 Cutoff Frequency [Hz]"
     },
-    "pidTuningGyroLowpassFrequencyHelp": {
-        "message": "Gyro Soft Lowpass Frequency [Hz]"
+    "pidTuningGyroLowpassType": {
+        "message": "Gyro Lowpass 1 Filter Type"
     },
-    "pidTuningGyroNotch1Enable": {
-        "message": "Enable Gyro Notch Filter 1"
+    "pidTuningGyroLowpass2Frequency": {
+        "message": "Gyro Lowpass 2 Cutoff Frequency [Hz]"
+    },
+    "pidTuningGyroLowpass2Type": {
+        "message": "Gyro Lowpass 2 Filter Type"
+    },
+    "pidTuningGyroNotchFiltersGroup": {
+        "message": "Gyro Notch Filters"
     },
     "pidTuningGyroNotch1Frequency": {
-        "message": "Gyro Notch Filter 1 Frequency [Hz]"
-    },
-    "pidTuningGyroNotch2Enable": {
-        "message": "Enable Gyro Notch Filter 2"
+        "message": "Gyro Notch Filter 1 Center Frequency [Hz]"
     },
     "pidTuningGyroNotch2Frequency": {
-        "message": "Gyro Notch Filter 2 Frequency [Hz]"
-    },
-    "pidTuningGyroNotchFrequencyHelp": {
-        "message": "Gyro Notch Filter Frequency in Hz"
+        "message": "Gyro Notch Filter 2 Center Frequency [Hz]"
     },
     "pidTuningGyroNotch1Cutoff": {
-        "message": "Gyro Notch Filter Cutoff 1 Frequency [Hz]"
+        "message": "Gyro Notch Filter 1 Cutoff Frequency [Hz]"
     },
     "pidTuningGyroNotch2Cutoff": {
-        "message": "Gyro Notch Filter Cutoff 2 Frequency [Hz]"
+        "message": "Gyro Notch Filter 2 Cutoff Frequency [Hz]"
     },
-    "pidTuningGyroNotchCutoffHelp": {
-        "message": "Gyro Notch Filter Cutoff Frequency in Hz (This is where notch filter starts. For example with notch filter 160 and notch Hz of 260 it means the range is 160-360Hz with most attenuation around center)"
+    "pidTuningNotchFilterHelp": {
+        "message": "The Notch Filter has a Center and a Cutoff. The filter is symmetrical. The Center Frequency is the center of the filter and the Cutoff Frequency is where Notch filter starts. For example with Notch Cutoff of 160 and Notch Center of 260 it means the range is 160-360Hz with most attenuation around center"
     },
     "pidTuningFilterSettings": {
-        "message": "Filter Settings"
+        "message": "Profile dependent Filter Settings"
     },
+    "pidTuningDTermLowpassFiltersGroup": {
+        "message": "D Term Lowpass Filters"
+    },    
     "pidTuningDTermLowpassType": {
-        "message": "D-Term Lowpass Filter"
-    },
-    "pidTuningDTermLowpassTypeTip": {
-        "message": "Select D-Term lowpass filter type to use. Default is BIQUAD"
+        "message": "D Term Lowpass 1 Filter Type"
     },
     "pidTuningDTermLowpassFrequency": {
-        "message": "D Term Lowpass Frequency [Hz]"
+        "message": "D Term Lowpass 1 Cutoff Frequency [Hz]"
     },
-    "pidTuningDTermLowpassFrequencyHelp": {
-        "message": "D Term Lowpass Frequency [Hz] (0 means disabled)"
+    "pidTuningDTermLowpass2Frequency": {
+        "message": "D Term Lowpass 2 Cutoff Frequency [Hz]"
     },
-    "pidTuningDTermNotchEnable": {
-        "message": "Enable D Term Notch Filter"
-    },
+    "pidTuningDTermNotchFiltersGroup": {
+        "message": "D Term Notch Filters"
+    },    
     "pidTuningDTermNotchFrequency": {
-        "message": "D Term Notch Filter Frequency [Hz]"
-    },
-    "pidTuningDTermNotchFrequencyHelp": {
-        "message": "D Term Notch Filter Frequency [Hz] (0 means disabled)"
+        "message": "D Term Notch Filter Center Frequency [Hz]"
     },
     "pidTuningDTermNotchCutoff": {
-        "message": "D Term Notch Filter Cutoff [Hz]"
+        "message": "D Term Notch Filter Cutoff Frequency [Hz]"
     },
-    "pidTuningDTermNotchCutoffHelp": {
-        "message": "D Term Notch Filter Cutoff in Hz (This is where notch filter starts. For example with notch filter 160 and notch Hz of 260 it means the range is 160-360Hz with most attenuation around center)"
-    },
+    "pidTuningYawLospassFiltersGroup": {
+        "message": "Yaw Lowpass Filters"
+    },    
     "pidTuningYawLowpassFrequency": {
-        "message": "Yaw Lowpass Frequency [Hz]"
-    },
-    "pidTuningYawLowpassFrequencyHelp": {
-        "message": "Yaw Lowpass Frequency [Hz] (Yaw axis can sometimes be noiser than the rest. This filter only affects the P of yaw)"
+        "message": "Yaw Lowpass Cutoff Frequency [Hz]"
     },
     "pidTuningVbatPidCompensation": {
         "message": "Vbat PID Compensation"

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -330,6 +330,13 @@
     padding-right: 5px;
 }
 
+.tab-pid_tuning table .groupSwitchValue {
+    display: inline-flex;
+}
+
+.tab-pid_tuning table .groupSwitchValue .inputValue {
+    width: 80px;
+}
 .tab-pid_tuning table input {
     display: block;
     width: calc(100% - 0px);
@@ -338,6 +345,10 @@
     text-align: right;
     border: 0px solid #ccc;
     border-radius: 0px;
+}
+
+.tab-pid_tuning table select {
+    text-align-last: right;
 }
 
 .tab-pid_tuning .tab_container {
@@ -440,7 +451,7 @@
 
 .pid_mode {
     width: calc(100% - 5px);
-    height: 20px;
+    height: 18px;
     background-color: #D6D6D6;
     float: left;
     margin: 0px;
@@ -448,7 +459,7 @@
     text-align: left;
     padding-left: 5px;
     line-height: 13px;
-    padding-top: 8px;
+    padding-top: 5px;
     font-size: 12px;
     border-bottom: 1px solid #ccc;
     color: #828282;
@@ -459,6 +470,10 @@
         rgba(255, 255, 255, .2) 60%, rgba(255, 255, 255, .2) 70%, transparent 70%, transparent 80%,
         rgba(255, 255, 255, .2) 80%, rgba(255, 255, 255, .2) 90%, transparent 90%, transparent 100%,
         rgba(255, 255, 255, .2) 100%, transparent);
+}
+
+.pid_mode > div:first-child {
+    float: left;
 }
 
 .pid_titlebar {
@@ -743,6 +758,25 @@ width: 40%;
 
 .tab-pid_tuning .filter {
     padding-left: 5px;
+}
+
+.subtab-filter table tr td:first-child {
+    text-align: right;
+    padding-left: 5px;
+    width: 1%;
+}
+.subtab-filter .two_columns {
+    display: flex;
+}
+
+.subtab-filter .two_columns .two_columns_first {
+    margin-right: 10px;
+    height: fit-content;
+}
+
+.subtab-filter .two_columns .two_columns_second{
+    margin-left: 10px;
+    height: fit-content;
 }
 
 .tab-pid_tuning .tabboarder {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -333,16 +333,22 @@ var FC = {
         };
 
         FILTER_CONFIG = {
-            gyro_soft_lpf_hz:           0,
-            dterm_lpf_hz:               0,
-            yaw_lpf_hz:                 0,
-            gyro_soft_notch_hz_1:       0,
-            gyro_soft_notch_cutoff_1:   0,
+            gyro_hardware_lpf:          0,
+            gyro_32khz_hardware_lpf:    0,
+            gyro_lowpass_hz:            0,
+            gyro_lowpass_type:          0,
+            gyro_lowpass2_hz:           0,
+            gyro_lowpass2_type:         0,
+            gyro_notch_hz:              0,
+            gyro_notch_cutoff:          0,
+            gyro_notch2_hz:             0,
+            gyro_notch2_cutoff:         0,
+            dterm_lowpass_hz:           0,
+            dterm_lowpass_type:         0,
+            dterm_lowpass2_hz:          0,
             dterm_notch_hz:             0,
             dterm_notch_cutoff:         0,
-            gyro_soft_notch_hz_2:       0,
-            gyro_soft_notch_cutoff_2:   0,
-            dterm_filter_type:          0,
+            yaw_lowpass_hz:             0,
         };
 
         ADVANCED_TUNING = {
@@ -399,12 +405,20 @@ var FC = {
         RXFAIL_CONFIG = [];
 
         DEFAULT = {
-            gyro_soft_notch_cutoff_1:       300,
-            gyro_soft_notch_hz_1:           400,
-            gyro_soft_notch_cutoff_2:       100,
-            gyro_soft_notch_hz_2:           200,
+            gyro_lowpass_hz:                100,
+            gyro_lowpass_type:                0,
+            gyro_lowpass2_hz:               500,
+            gyro_lowpass2_type:               0,
+            gyro_notch_cutoff:              300,
+            gyro_notch_hz:                  400,
+            gyro_notch2_cutoff:             100,
+            gyro_notch2_hz:                 200,
+            dterm_lowpass_hz:               100,
+            dterm_lowpass_type:               0,
+            dterm_lowpass2_hz:              300,
             dterm_notch_cutoff:             160,
             dterm_notch_hz:                 260,
+            yaw_lowpass_hz:                 100,
         };
     }
 };

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -822,20 +822,29 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 break;
             case MSPCodes.MSP_FILTER_CONFIG:
-                FILTER_CONFIG.gyro_soft_lpf_hz = data.readU8();
-                FILTER_CONFIG.dterm_lpf_hz = data.readU16();
-                FILTER_CONFIG.yaw_lpf_hz = data.readU16();
+                FILTER_CONFIG.gyro_lowpass_hz = data.readU8();
+                FILTER_CONFIG.dterm_lowpass_hz = data.readU16();
+                FILTER_CONFIG.yaw_lowpass_hz = data.readU16();
                 if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                    FILTER_CONFIG.gyro_soft_notch_hz_1 = data.readU16();
-                    FILTER_CONFIG.gyro_soft_notch_cutoff_1 = data.readU16();
+                    FILTER_CONFIG.gyro_notch_hz = data.readU16();
+                    FILTER_CONFIG.gyro_notch_cutoff = data.readU16();
                     FILTER_CONFIG.dterm_notch_hz = data.readU16();
                     FILTER_CONFIG.dterm_notch_cutoff = data.readU16();
                     if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-                        FILTER_CONFIG.gyro_soft_notch_hz_2 = data.readU16();
-                        FILTER_CONFIG.gyro_soft_notch_cutoff_2 = data.readU16();
+                        FILTER_CONFIG.gyro_notch2_hz = data.readU16();
+                        FILTER_CONFIG.gyro_notch2_cutoff = data.readU16();
                     }
                     if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                        FILTER_CONFIG.dterm_filter_type = data.readU8();
+                        FILTER_CONFIG.dterm_lowpass_type = data.readU8();
+                    }
+                    if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+                        FILTER_CONFIG.gyro_hardware_lpf = data.readU8();
+                        FILTER_CONFIG.gyro_32khz_hardware_lpf = data.readU8();
+                        FILTER_CONFIG.gyro_soft_lpf_hz = data.readU16();
+                        FILTER_CONFIG.gyro_lowpass2_hz = data.readU16();
+                        FILTER_CONFIG.gyro_lowpass_type = data.readU8();
+                        FILTER_CONFIG.gyro_lowpass2_type = data.readU8();
+                        FILTER_CONFIG.dterm_lowpass2_hz = data.readU16();
                     }
                 }
                 break;
@@ -1455,19 +1464,28 @@ MspHelper.prototype.crunch = function(code) {
             break;
         case MSPCodes.MSP_SET_FILTER_CONFIG:
             buffer.push8(FILTER_CONFIG.gyro_soft_lpf_hz)
-                .push16(FILTER_CONFIG.dterm_lpf_hz)
-                .push16(FILTER_CONFIG.yaw_lpf_hz);
+                .push16(FILTER_CONFIG.dterm_lowpass_hz)
+                .push16(FILTER_CONFIG.yaw_lowpass_hz);
             if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                buffer.push16(FILTER_CONFIG.gyro_soft_notch_hz_1)
-                    .push16(FILTER_CONFIG.gyro_soft_notch_cutoff_1)
+                buffer.push16(FILTER_CONFIG.gyro_notch_hz)
+                    .push16(FILTER_CONFIG.gyro_notch_cutoff)
                     .push16(FILTER_CONFIG.dterm_notch_hz)
                     .push16(FILTER_CONFIG.dterm_notch_cutoff);
                 if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-                    buffer.push16(FILTER_CONFIG.gyro_soft_notch_hz_2)
-                        .push16(FILTER_CONFIG.gyro_soft_notch_cutoff_2)
+                    buffer.push16(FILTER_CONFIG.gyro_notch2_hz)
+                        .push16(FILTER_CONFIG.gyro_notch2_cutoff)
                 }
                 if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                    buffer.push8(FILTER_CONFIG.dterm_filter_type);
+                    buffer.push8(FILTER_CONFIG.dterm_lowpass_type);
+                }
+                if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+                    buffer.push8(FILTER_CONFIG.gyro_hardware_lpf)
+                          .push8(FILTER_CONFIG.gyro_32khz_hardware_lpf)
+                          .push16(FILTER_CONFIG.gyro_lowpass_hz)
+                          .push16(FILTER_CONFIG.gyro_lowpass2_hz)
+                          .push8(FILTER_CONFIG.gyro_lowpass_type)
+                          .push8(FILTER_CONFIG.gyro_lowpass2_type)
+                          .push16(FILTER_CONFIG.dterm_lowpass2_hz);
                 }
             }
             break;

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -214,9 +214,9 @@ TABS.pid_tuning.initialize = function (callback) {
 
         if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
             $('.pid_tuning input[name="rc_rate_yaw"]').val(RC_tuning.rcYawRate.toFixed(2));
-            $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_soft_lpf_hz);
-            $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.dterm_lpf_hz);
-            $('.pid_filter input[name="yawLowpassFrequency"]').val(FILTER_CONFIG.yaw_lpf_hz);
+            $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
+            $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.dterm_lowpass_hz);
+            $('.pid_filter input[name="yawLowpassFrequency"]').val(FILTER_CONFIG.yaw_lowpass_hz);
         } else {
             $('.tab-pid_tuning .subtab-filter').hide();
             $('.tab-pid_tuning .tab_container').hide();
@@ -231,8 +231,8 @@ TABS.pid_tuning.initialize = function (callback) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-            $('.pid_filter input[name="gyroNotch1Frequency"]').val(FILTER_CONFIG.gyro_soft_notch_hz_1);
-            $('.pid_filter input[name="gyroNotch1Cutoff"]').val(FILTER_CONFIG.gyro_soft_notch_cutoff_1);
+            $('.pid_filter input[name="gyroNotch1Frequency"]').val(FILTER_CONFIG.gyro_notch_hz);
+            $('.pid_filter input[name="gyroNotch1Cutoff"]').val(FILTER_CONFIG.gyro_notch_cutoff);
             $('.pid_filter input[name="dTermNotchFrequency"]').val(FILTER_CONFIG.dterm_notch_hz);
             $('.pid_filter input[name="dTermNotchCutoff"]').val(FILTER_CONFIG.dterm_notch_cutoff);
 
@@ -256,8 +256,8 @@ TABS.pid_tuning.initialize = function (callback) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-            $('.pid_filter input[name="gyroNotch2Frequency"]').val(FILTER_CONFIG.gyro_soft_notch_hz_2);
-            $('.pid_filter input[name="gyroNotch2Cutoff"]').val(FILTER_CONFIG.gyro_soft_notch_cutoff_2);
+            $('.pid_filter input[name="gyroNotch2Frequency"]').val(FILTER_CONFIG.gyro_notch2_hz);
+            $('.pid_filter input[name="gyroNotch2Cutoff"]').val(FILTER_CONFIG.gyro_notch2_cutoff);
         } else {
             $('.pid_filter .gyroNotch2').hide();
         }
@@ -270,28 +270,47 @@ TABS.pid_tuning.initialize = function (callback) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-            $('.profile select[name="dtermFilterType"]').val(FILTER_CONFIG.dterm_filter_type);
+            $('.pid_filter select[name="dtermLowpassType"]').val(FILTER_CONFIG.dterm_lowpass_type);
             $('.antigravity input[name="itermThrottleThreshold"]').val(ADVANCED_TUNING.itermThrottleThreshold);
             $('.antigravity input[name="itermAcceleratorGain"]').val(ADVANCED_TUNING.itermAcceleratorGain / 1000);
         } else {
-            $('.dtermfiltertype').hide();
+            $('.dtermLowpassType').hide();
             $('.antigravity').hide();
+        }
+
+        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+
+            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FILTER_CONFIG.gyro_lowpass2_hz);
+            $('.pid_filter select[name="gyroLowpassType"]').val(FILTER_CONFIG.gyro_lowpass_type);
+            $('.pid_filter select[name="gyroLowpass2Type"]').val(FILTER_CONFIG.gyro_lowpass2_type);
+            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FILTER_CONFIG.dterm_lowpass2_hz);
+
+            // We load it again because the limits are now bigger than in 1.16.0
+            $('.pid_filter input[name="gyroLowpassFrequency"]').attr("max","16000");
+            $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
+
+        } else {
+            $('.gyroLowpass2').hide();
+            $('.gyroLowpass2Type').hide();
+            $('.dtermLowpass2').hide();
         }
 
         $('input[id="gyroNotch1Enabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var hz = FILTER_CONFIG.gyro_soft_notch_hz_1 > 0 ? FILTER_CONFIG.gyro_soft_notch_hz_1 : DEFAULT.gyro_soft_notch_hz_1;
-            var cutoff = FILTER_CONFIG.gyro_soft_notch_cutoff_1 > 0 ? FILTER_CONFIG.gyro_soft_notch_cutoff_1 : DEFAULT.gyro_soft_notch_cutoff_1;
+            var hz = FILTER_CONFIG.gyro_notch_hz > 0 ? FILTER_CONFIG.gyro_notch_hz : DEFAULT.gyro_notch_hz;
+            var cutoff = FILTER_CONFIG.gyro_notch_cutoff > 0 ? FILTER_CONFIG.gyro_notch_cutoff : DEFAULT.gyro_notch_cutoff;
             
             $('.pid_filter input[name="gyroNotch1Frequency"]').val(checked ? hz : 0).attr('disabled', !checked);
+            $('.pid_filter input[name="gyroNotch1Cutoff"]').attr('disabled', !checked);
         });
 
         $('input[id="gyroNotch2Enabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var hz = FILTER_CONFIG.gyro_soft_notch_hz_2 > 0 ? FILTER_CONFIG.gyro_soft_notch_hz_2 : DEFAULT.gyro_soft_notch_hz_2;
-            var cutoff = FILTER_CONFIG.gyro_soft_notch_cutoff_2 > 0 ? FILTER_CONFIG.gyro_soft_notch_cutoff_2 : DEFAULT.gyro_soft_notch_cutoff_2;
+            var hz = FILTER_CONFIG.gyro_notch2_hz > 0 ? FILTER_CONFIG.gyro_notch2_hz : DEFAULT.gyro_notch2_hz;
+            var cutoff = FILTER_CONFIG.gyro_notch2_cutoff > 0 ? FILTER_CONFIG.gyro_notch2_cutoff : DEFAULT.gyro_notch2_cutoff;
 
             $('.pid_filter input[name="gyroNotch2Frequency"]').val(checked ? hz : 0).attr('disabled', !checked);
+            $('.pid_filter input[name="gyroNotch2Cutoff"]').attr('disabled', !checked);
         });
 
         $('input[id="dtermNotchEnabled"]').change(function() {
@@ -300,11 +319,83 @@ TABS.pid_tuning.initialize = function (callback) {
             var cutoff = FILTER_CONFIG.dterm_notch_cutoff > 0 ? FILTER_CONFIG.dterm_notch_cutoff : DEFAULT.dterm_notch_cutoff;
 
             $('.pid_filter input[name="dTermNotchFrequency"]').val(checked ? hz : 0).attr('disabled', !checked);
+            $('.pid_filter input[name="dTermNotchCutoff"]').attr('disabled', !checked);
         });
 
-        $('input[id="gyroNotch1Enabled"]').prop('checked', FILTER_CONFIG.gyro_soft_notch_hz_1 != 0).change();
-        $('input[id="gyroNotch2Enabled"]').prop('checked', FILTER_CONFIG.gyro_soft_notch_hz_2 != 0).change();
+        $('input[id="gyroLowpassEnabled"]').change(function() {
+            var checked = $(this).is(':checked');
+            var cutoff = FILTER_CONFIG.gyro_lowpass_hz > 0 ? FILTER_CONFIG.gyro_lowpass_hz : DEFAULT.gyro_lowpass_hz;
+            var type = FILTER_CONFIG.gyro_lowpass_type > 0 ? FILTER_CONFIG.gyro_lowpass_type : DEFAULT.gyro_lowpass_type;
+
+            $('.pid_filter input[name="gyroLowpassFrequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
+            $('.pid_filter select[name="gyroLowpassType"]').val(checked ? type : 0).attr('disabled', !checked);
+        });
+
+        $('input[id="gyroLowpass2Enabled"]').change(function() {
+            var checked = $(this).is(':checked');
+            var cutoff = FILTER_CONFIG.gyro_lowpass2_hz > 0 ? FILTER_CONFIG.gyro_lowpass2_hz : DEFAULT.gyro_lowpass2_hz;
+            var type = FILTER_CONFIG.gyro_lowpass2_type > 0 ? FILTER_CONFIG.gyro_lowpass2_type : DEFAULT.gyro_lowpass2_type;
+
+            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
+            $('.pid_filter select[name="gyroLowpass2Type"]').val(checked ? type : 0).attr('disabled', !checked);
+        });
+
+        $('input[id="dtermLowpassEnabled"]').change(function() {
+            var checked = $(this).is(':checked');
+            var cutoff = FILTER_CONFIG.dterm_lowpass_hz > 0 ? FILTER_CONFIG.dterm_lowpass_hz : DEFAULT.dterm_lowpass_hz;
+            var type = FILTER_CONFIG.dterm_lowpass_type > 0 ? FILTER_CONFIG.dterm_lowpass_type : DEFAULT.dterm_lowpass_type;
+
+            $('.pid_filter input[name="dtermLowpassFrequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
+            $('.pid_filter select[name="dtermLowpassType"]').val(checked ? type : 0).attr('disabled', !checked);
+        });
+
+        $('input[id="dtermLowpass2Enabled"]').change(function() {
+            var checked = $(this).is(':checked');
+            var cutoff = FILTER_CONFIG.dterm_lowpass2_hz > 0 ? FILTER_CONFIG.dterm_lowpass2_hz : DEFAULT.dterm_lowpass2_hz;
+
+            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
+        });
+
+        $('input[id="yawLowpassEnabled"]').change(function() {
+            var checked = $(this).is(':checked');
+            var cutoff = FILTER_CONFIG.yaw_lowpass_hz > 0 ? FILTER_CONFIG.yaw_lowpass_hz : DEFAULT.yaw_lowpass_hz;
+
+            $('.pid_filter input[name="yawLowpassFrequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
+        });
+
+        // The notch cutoff must be smaller than the notch frecuency
+        function adjustNotchCutoff(frequencyName, cutoffName) {
+            var frecuency = $(".pid_filter input[name='" + frequencyName + "']").val();
+            var cutoff = $(".pid_filter input[name='" + cutoffName + "']").val();
+
+            // Change the max and refresh the value if needed
+            $(".pid_filter input[name='" + cutoffName + "']").attr("max",frecuency - 1);
+            if (cutoff >= frecuency) {
+                $(".pid_filter input[name='" + cutoffName + "']").val(frecuency - 1);
+            }
+        }
+
+        $('input[name="gyroNotch1Frequency"]').change(function() {
+            adjustNotchCutoff("gyroNotch1Frequency", "gyroNotch1Cutoff");
+        }).change();
+
+        $('input[name="gyroNotch2Frequency"]').change(function() {
+            adjustNotchCutoff("gyroNotch2Frequency", "gyroNotch2Cutoff");
+        }).change();
+
+        $('input[name="dTermNotchFrequency"]').change(function() {
+            adjustNotchCutoff("dTermNotchFrequency", "dTermNotchCutoff");
+        }).change();
+
+        // Initial state of the filters: enabled or disabled
+        $('input[id="gyroNotch1Enabled"]').prop('checked', FILTER_CONFIG.gyro_notch_hz != 0).change();
+        $('input[id="gyroNotch2Enabled"]').prop('checked', FILTER_CONFIG.gyro_notch2_hz != 0).change();
         $('input[id="dtermNotchEnabled"]').prop('checked', FILTER_CONFIG.dterm_notch_hz != 0).change();
+        $('input[id="gyroLowpassEnabled"]').prop('checked', FILTER_CONFIG.gyro_lowpass_hz != 0).change();
+        $('input[id="gyroLowpass2Enabled"]').prop('checked', FILTER_CONFIG.gyro_lowpass2_hz != 0).change();
+        $('input[id="dtermLowpassEnabled"]').prop('checked', FILTER_CONFIG.dterm_lowpass_hz != 0).change();
+        $('input[id="dtermLowpass2Enabled"]').prop('checked', FILTER_CONFIG.dterm_lowpass2_hz != 0).change();
+        $('input[id="yawLowpassEnabled"]').prop('checked', FILTER_CONFIG.yaw_lowpass_hz != 0).change();
     }
 
     function form_to_pid_and_rc() {
@@ -381,9 +472,9 @@ TABS.pid_tuning.initialize = function (callback) {
 
         RC_tuning.dynamic_THR_PID = parseFloat($('.tpa input[name="tpa"]').val());
         RC_tuning.dynamic_THR_breakpoint = parseInt($('.tpa input[name="tpa-breakpoint"]').val());
-        FILTER_CONFIG.gyro_soft_lpf_hz = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
-        FILTER_CONFIG.dterm_lpf_hz = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
-        FILTER_CONFIG.yaw_lpf_hz = parseInt($('.pid_filter input[name="yawLowpassFrequency"]').val());
+        FILTER_CONFIG.gyro_lowpass_hz = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());        
+        FILTER_CONFIG.dterm_lowpass_hz = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
+        FILTER_CONFIG.yaw_lowpass_hz = parseInt($('.pid_filter input[name="yawLowpassFrequency"]').val());
 
         if (semver.gte(CONFIG.apiVersion, "1.16.0") && !semver.gte(CONFIG.apiVersion, "1.20.0")) {
             FEATURE_CONFIG.features.updateData($('input[name="SUPEREXPO_RATES"]'));
@@ -401,13 +492,13 @@ TABS.pid_tuning.initialize = function (callback) {
             ADVANCED_TUNING.dtermSetpointTransition = parseInt($('input[name="dtermSetpointTransition-number"]').val() * 100);
             ADVANCED_TUNING.dtermSetpointWeight = parseInt($('input[name="dtermSetpoint-number"]').val() * 100);
 
-            FILTER_CONFIG.gyro_soft_notch_hz_1 = parseInt($('.pid_filter input[name="gyroNotch1Frequency"]').val());
-            FILTER_CONFIG.gyro_soft_notch_cutoff_1 = parseInt($('.pid_filter input[name="gyroNotch1Cutoff"]').val());
+            FILTER_CONFIG.gyro_notch_hz = parseInt($('.pid_filter input[name="gyroNotch1Frequency"]').val());
+            FILTER_CONFIG.gyro_notch_cutoff = parseInt($('.pid_filter input[name="gyroNotch1Cutoff"]').val());
             FILTER_CONFIG.dterm_notch_hz = parseInt($('.pid_filter input[name="dTermNotchFrequency"]').val());
             FILTER_CONFIG.dterm_notch_cutoff = parseInt($('.pid_filter input[name="dTermNotchCutoff"]').val());
             if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-                FILTER_CONFIG.gyro_soft_notch_hz_2 = parseInt($('.pid_filter input[name="gyroNotch2Frequency"]').val());
-                FILTER_CONFIG.gyro_soft_notch_cutoff_2 = parseInt($('.pid_filter input[name="gyroNotch2Cutoff"]').val());
+                FILTER_CONFIG.gyro_notch2_hz = parseInt($('.pid_filter input[name="gyroNotch2Frequency"]').val());
+                FILTER_CONFIG.gyro_notch2_cutoff = parseInt($('.pid_filter input[name="gyroNotch2Cutoff"]').val());
             }
         }
 
@@ -417,9 +508,16 @@ TABS.pid_tuning.initialize = function (callback) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-            FILTER_CONFIG.dterm_filter_type = $('.profile select[name="dtermFilterType"]').val();
+            FILTER_CONFIG.dterm_lowpass_type = $('.pid_filter select[name="dtermLowpassType"]').val();
             ADVANCED_TUNING.itermThrottleThreshold = parseInt($('.antigravity input[name="itermThrottleThreshold"]').val());
             ADVANCED_TUNING.itermAcceleratorGain = parseInt($('.antigravity input[name="itermAcceleratorGain"]').val() * 1000);
+        }
+
+        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+            FILTER_CONFIG.gyro_lowpass2_hz = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
+            FILTER_CONFIG.gyro_lowpass_type = parseInt($('.pid_filter select[name="gyroLowpassType"]').val());
+            FILTER_CONFIG.gyro_lowpass2_type = parseInt($('.pid_filter select[name="gyroLowpass2Type"]').val());
+            FILTER_CONFIG.dterm_lowpass2_hz = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
         }
     }
 
@@ -719,6 +817,29 @@ TABS.pid_tuning.initialize = function (callback) {
             }
           }
         });
+
+
+        // DTerm filter options
+        function loadFilterTypeValues() {
+            var filterTypeValues = [];
+            filterTypeValues.push("PT1");
+            filterTypeValues.push("BIQUAD");
+            if (semver.lt(CONFIG.apiVersion, "1.39.0")) {
+                filterTypeValues.push("FIR");
+            }
+            return filterTypeValues;
+        }
+
+        function populateFilterTypeSelector(name, selectDtermValues) {
+            var dtermFilterSelect = $('select[name="' + name + '"]');
+            selectDtermValues.forEach(function(value, key) {
+                dtermFilterSelect.append('<option value="' + key + '">' + value + '</option>');
+            });
+        }
+
+        populateFilterTypeSelector('gyroLowpassType', loadFilterTypeValues());
+        populateFilterTypeSelector('gyroLowpass2Type', loadFilterTypeValues());
+        populateFilterTypeSelector('dtermLowpassType', loadFilterTypeValues());
 
         pid_and_rc_to_form();
 

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -458,66 +458,108 @@
                     </div>
                 </div>
 
-                <div class="dtermfiltertype cf_column twothird">
-                    <div class="profile single-field" style="width:200px; margin-bottom: 0px;">
-                        <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpassTypeTip" style="margin-top: 5px;"></div>
-                        <div class="head" i18n="pidTuningDTermLowpassType"></div>
-                        <div class="bottomarea">
-                            <select name="dtermFilterType">
-                                <option value="0" class="PT1">PT1</option>
-                                <option value="1" class="BIQUAD">BIQUAD</option>
-                                <option value="2" class="FIR">FIR</option>
-                            </select>
-                        </div>
-                    </div>
-                </div>
-
-                <div class="cf_column twothird">
-                    <div class="gui_box grey topspacer pid_filter">
+                <div class="cf_column two_columns">
+                    <div class="gui_box grey topspacer pid_filter two_columns_first">
                         <table class="pid_titlebar new_rates">
                             <tr>
                                 <th i18n="pidTuningNonProfileFilterSettings"></th>
                             </tr>
                         </table>
+
                         <table>
                             <tr>
+                                <th colspan="2">
+                                    <div class="pid_mode" i18n="pidTuningGyroLowpassFiltersGroup"/>
+                                </th>
+                            </tr>
+
+                            <tr>
                                 <td>
-                                    <input type="number" class="nonProfile" name="gyroLowpassFrequency" step="1" min="0" max="255"/>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="gyroLowpassEnabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequency" step="1" min="1" max="255"/></span>
+                                    </span>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
                                             <span i18n="pidTuningGyroLowpassFrequency"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningGyroLowpassFrequencyHelp"></div>
                                     </div>
                                 </td>
                             </tr>
-                            <tr class="switchGyroNotch1">
-                                <td style="text-align: right;">
-                                    <input type="checkbox" id="gyroNotch1Enabled" class="toggle" />
+
+                            <tr>
+                                <td>
+                                    <select name="gyroLowpassType">
+                                        <!--  Populated on execution -->
+                                    </select>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
-                                            <span i18n="pidTuningGyroNotch1Enable"></span>
+                                            <span i18n="pidTuningGyroLowpassType"></span>
                                         </label>
                                     </div>
                                 </td>
                             </tr>
+
+                            <tr class="gyroLowpass2">
+                                <td>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="gyroLowpass2Enabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2Frequency" step="1" min="1" max="16000"/></span>
+                                    </span>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningGyroLowpass2Frequency"></span>
+                                        </label>
+                                    </div>
+                                </td>
+                            </tr>
+
+                            <tr class="gyroLowpass2Type">
+                                <td>
+                                    <select name="gyroLowpass2Type">
+                                        <!--  Populated on execution -->
+                                    </select>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningGyroLowpass2Type"></span>
+                                        </label>
+                                    </div>
+                                </td>
+                            </tr>
+
+                            <tr>
+                                <th colspan="2">
+                                    <div class="pid_mode">
+                                        <div i18n="pidTuningGyroNotchFiltersGroup" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" />
+                                    </div>
+                                </th>
+                            </tr>
+
                             <tr class="newFilter">
                                 <td>
-                                    <input type="number" class="nonProfile" name="gyroNotch1Frequency" step="1" min="0" max="16000"/>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="gyroNotch1Enabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroNotch1Frequency" step="1" min="1" max="16000"/></span>
+                                    </span>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
                                             <span i18n="pidTuningGyroNotch1Frequency"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningGyroNotchFrequencyHelp"></div>
                                     </div>
                                 </td>
                             </tr>
+
                             <tr class="newFilter">
                                 <td>
                                     <input type="number" class="nonProfile" name="gyroNotch1Cutoff" step="1" min="0" max="16000"/>
@@ -527,35 +569,26 @@
                                         <label>
                                             <span i18n="pidTuningGyroNotch1Cutoff"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningGyroNotchCutoffHelp"></div>
                                     </div>
                                 </td>
                             </tr>
-                            <tr class="switchGyroNotch2">
-                                <td style="text-align: right;">
-                                    <input type="checkbox" id="gyroNotch2Enabled" class="toggle" />
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningGyroNotch2Enable"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                            <tr>
+
                             <tr class="newFilter gyroNotch2">
                                 <td>
-                                    <input type="number" class="nonProfile" name="gyroNotch2Frequency" step="1" min="0" max="16000"/>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="gyroNotch2Enabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroNotch2Frequency" step="1" min="1" max="16000"/></span>
+                                    </span>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
                                             <span i18n="pidTuningGyroNotch2Frequency"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningGyroNotchFrequencyHelp"></div>
                                     </div>
                                 </td>
                             </tr>
+
                             <tr class="newFilter gyroNotch2">
                                 <td>
                                     <input type="number" class="nonProfile" name="gyroNotch2Cutoff" step="1" min="0" max="16000"/>
@@ -565,57 +598,101 @@
                                         <label>
                                             <span i18n="pidTuningGyroNotch2Cutoff"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningGyroNotchCutoffHelp"></div>
                                     </div>
                                 </td>
                             </tr>
                         </table>
                     </div>
-                    <div class="gui_box grey topspacer pid_filter">
+                    <div class="gui_box grey topspacer pid_filter two_columns_second">
                         <table class="pid_titlebar new_rates">
                             <tr>
                                 <th i18n="pidTuningFilterSettings"></th>
                             </tr>
                         </table>
+
                         <table>
+
+                            <tr>
+                                <th colspan="2">
+                                    <div class="pid_mode">
+                                        <div i18n="pidTuningDTermLowpassFiltersGroup" />
+                                    </div>
+                                </th>
+                            </tr>
+
                             <tr>
                                 <td>
-                                    <input type="number" name="dtermLowpassFrequency" step="1" min="0" max="16000"/>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="dtermLowpassEnabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequency" step="1" min="1" max="16000"/></span>
+                                    </span>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
                                             <span i18n="pidTuningDTermLowpassFrequency"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpassFrequencyHelp"></div>
                                     </div>
                                 </td>
                             </tr>
-                            <tr class="switchDTermNotch">
-                                <td style="text-align: right;">
-                                    <input type="checkbox" id="dtermNotchEnabled" class="toggle" />
+
+                            <tr>
+                                <td>
+                                    <select name="dtermLowpassType">
+                                        <!--  Populated on execution -->
+                                    </select>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
-                                            <span i18n="pidTuningDTermNotchEnable"></span>
+                                            <span i18n="pidTuningDTermLowpassType"></span>
                                         </label>
                                     </div>
                                 </td>
+                            </tr>
+
+                            <tr class="dtermLowpass2">
+                                <td>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="dtermLowpass2Enabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpass2Frequency" step="1" min="1" max="16000"/></span>
+                                    </span>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningDTermLowpass2Frequency"></span>
+                                        </label>
+                                    </div>
+                                </td>
+                            </tr>
+
                             <tr>
+                                <th colspan="2">
+                                    <div class="pid_mode">
+                                        <div  i18n="pidTuningDTermNotchFiltersGroup" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" />
+                                    </div>
+                                    
+                                </th>
+                            </tr>
+
                             <tr class="newFilter">
                                 <td>
-                                    <input type="number" name="dTermNotchFrequency" step="1" min="0" max="16000"/>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="dtermNotchEnabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" name="dTermNotchFrequency" step="1" min="1" max="16000"/></span>
+                                    </span>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
                                             <span i18n="pidTuningDTermNotchFrequency"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDTermNotchFrequencyHelp"></div>
                                     </div>
                                 </td>
                             </tr>
+
                             <tr class="newFilter">
                                 <td>
                                     <input type="number" name="dTermNotchCutoff" step="1" min="0" max="16000"/>
@@ -625,20 +702,28 @@
                                         <label>
                                             <span i18n="pidTuningDTermNotchCutoff"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDTermNotchCutoffHelp"></div>
                                     </div>
                                 </td>
                             </tr>
+
+                            <tr>
+                                <th colspan="2">
+                                    <div class="pid_mode" i18n="pidTuningYawLospassFiltersGroup" />
+                                </th>
+                            </tr>
+
                             <tr>
                                 <td>
-                                    <input type="number" name="yawLowpassFrequency" step="1" min="0" max="500"/>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="yawLowpassEnabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" name="yawLowpassFrequency" step="1" min="1" max="500"/></span>
+                                    </span>
                                 </td>
                                 <td>
                                     <div>
                                         <label>
                                             <span i18n="pidTuningYawLowpassFrequency"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningYawLowpassFrequencyHelp"></div>
                                     </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
This code adds the possibility to configure the new filters (Stage 2) of Betaflight.

This is a work in progress, because I have some doubts:
- The gyro lpf stage 1 is being only sent as U8 in the firmware and must be sended as U16 because it now is bigger (limit 16000).
- I think is a good idea to give a more "detailed" explanation in the tooltip of the filters. But I don't know exactly what to put there.
- Is a little strange than the Notch filters have a switch and all the others not. I think is better to add this to all filters or remove them from all. Thoughts?
- Is some other filter parameter interesting to be here and not only CLI? I'm talking about the type of gyro LPF, hardware filters, etc.

![image](https://user-images.githubusercontent.com/2673520/40916404-e0d4c6b4-67ff-11e8-84ef-0f1f201e4de6.png)
