### PR TITLE
Changed build to install the app uncompressed.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -33,7 +33,8 @@ var nwBuilderOptions = {
     files: './dist/**/*',
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},
-    winIco: './src/images/bf_icon.ico'
+    winIco: './src/images/bf_icon.ico',
+    zip: false
 };
 
 var nwArmVersion = '0.27.6';


### PR DESCRIPTION
Fixes #1056.

This changes the Windows and linux builds to install the app uncompressed. The released binaries won't increase in size, since they are compressed anyway, but the size on the hard drive will increase. The benefit of it is that the time it takes for the application to start is reduced.
