### PR TITLE
Remove unused and conflictive logo strings

### DIFF
--- a/locales/ca/messages.json
+++ b/locales/ca/messages.json
@@ -2932,12 +2932,6 @@
     "osdSetupCustomLogoInfoUploadHint": {
         "message": "Prem <b>$t(osdSetupUploadFont.message)<\/b> per a desar la imatge personalitzada"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Mida de la imatge invàlida; s'esperava $1×$2 en comptes de $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "La imatge conté una paleta de colors invàlida (només verd, negre i blanc són permesos)"
-    },
     "osdSetupUploadFont": {
         "message": "Pujar Font"
     },

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -3022,12 +3022,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "Das Bild verwendet eine ungültige Farbpalette (nur grün, schwarz und weiß sind erlaubt)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Ungültige Bildgröße; Es wird $1 x $2 statt $3 x $4 erwartet"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "Das Bild verwendet eine Ungültige Farbpalette (nur grün, schwarz und weiß sind erlaubt)"
-    },
     "osdSetupUploadFont": {
         "message": "Schriftart hochladen"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3119,12 +3119,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "The image contains an invalid color palette (only green, black and white are allowed)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Invalid image size; expected $1×$2 instead of $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "The image contains an invalid color palette (only green, black and white are allowed)"
-    },
     "osdSetupUploadFont": {
         "message": "Upload Font"
     },

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "La imagen contiene una paleta de colores no válida (sólo se permite verde, blanco y negro)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Tamaño de imagen no válido; se esperaba $1×$2 en vez de $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "La imagen contiene una paleta de colores no válida (sólo se permite verde, blanco y negro)"
-    },
     "osdSetupUploadFont": {
         "message": "Cargar Fuente"
     },

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -3025,12 +3025,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "La palette couleurs de l'image n'est pas valide (seuls le vert, le noir et le blanc sont autorisés)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Taille de l'image invalide; requise $1×$2 au lieu de $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "La palette couleurs de l'image n'est pas valide (seuls le vert, le noir et le blanc sont autorisés)"
-    },
     "osdSetupUploadFont": {
         "message": "Charger le fichier de police"
     },

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -2908,12 +2908,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "L'immagine contiene una tavolozza colori non valida (sono ammessi solo verde, nero e bianco)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Dimensione immagine non valida; previsto $1×$2 invece di $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "L'immagine contiene una palette colori non valida (sono ammessi solo verde, nero e bianco)"
-    },
     "osdSetupUploadFont": {
         "message": "Carica carattere"
     },

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "画像に無効なカラーが含まれています\n (緑・黒・白のみ有効)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "画像サイズが無効; 既定サイズ $1×$2 無効サイズ $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "画像に無効なカラーパレットが含まれています \n(緑、黒、白のみが許可)"
-    },
     "osdSetupUploadFont": {
         "message": "フォントアップロード"
     },

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "이미지가 유효하지 않은 색상표를 포함하고 있습니다 (오직 녹색, 검정 및 흰색만 허용됨)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "유효하지 않은 이미지 크기; $3×$4 대신 $1×$2 예상"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "이미지가 유효하지 않은 색상표를 포함하고 있습니다 (오직 녹색, 검정 및 흰색만 허용됨)"
-    },
     "osdSetupUploadFont": {
         "message": "글꼴 업로드"
     },

--- a/locales/lv/messages.json
+++ b/locales/lv/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "Šis attēls satur nederīgu krāsu paleti (tikai zaļa, melna un balta krāsa atļauta)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Nederīgs attēla izmērs; sagaidu $1×$2 šī vietā $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "Šis attēls satur nederīgu krāsu paleti (tikai zaļa, melna un balta krāsa atļauta)"
-    },
     "osdSetupUploadFont": {
         "message": "Augšupielādēt fontu"
     },

--- a/locales/pt/messages.json
+++ b/locales/pt/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "A imagem contém uma paleta de cores inválida (somente verde, preto e branco são permitidos)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Tamanho da imagem inválida; era esperado $1x$2 ao invés de $3x$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "A imagem contém uma palheta de cores inválida (somente é permitido verde, preto e branco)"
-    },
     "osdSetupUploadFont": {
         "message": "Carregar Fonte"
     },

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "图像包含无效的颜色 (仅允许绿色、黑色和白色)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "图像大小无效：应该是 $1×$2 而不是 $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "图像包含无效调色板 (仅允许绿色、黑色和白色)"
-    },
     "osdSetupUploadFont": {
         "message": "更新字体"
     },


### PR DESCRIPTION
This PR removes two unused strings from the logo system and fixes  https://github.com/betaflight/betaflight-configurator/issues/1073 too

The `$1x$2` produces and error in the old chrome i18n framework. The original string was not affected because the `x` was a slightly different special symbol `$1×$2` so only German and Portuguese system, that changed the symbol were affected.