### PR TITLE
Custom boot logo: Add more detailed info about wrong colors

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3120,7 +3120,7 @@
         "message": "Invalid image size: {{width}}×{{height}} (expected $t(logoWidthPx)×$t(logoHeightPx))"
     },
     "osdSetupCustomLogoColorMapError": {
-        "message": "The image contains an invalid color palette (only green, black and white are allowed)"
+        "message": "The image contains an invalid pixel: rgb({{valueR}}, {{valueG}}, {{valueB}}) at coordinates {{posX}}×{{posY}}"
     },
     "osdSetupUploadFont": {
         "message": "Upload Font"

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -336,7 +336,7 @@
 #font-logo-preview-container {
   background:rgba(0, 255, 0, 0.4);
   margin-bottom: 10px;
-  width: 50%;
+  width: 45%;
   float: left;
 }
 
@@ -347,6 +347,7 @@
 }
 
 #font-logo-info {
+  width: 45%;
   margin-left: 18px;
   font-size: 125%;
   line-height: 150%;

--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -80,7 +80,13 @@ LogoManager.init = function (font, logoStartIndex) {
                         var rgbPixel = ctx.getImageData(x, y, 1, 1).data.slice(0, 3),
                             colorKey = rgbPixel.join("-");
                         if (!this.constants.MCM_COLORMAP[colorKey]) {
-                            GUI.log(i18n.getMessage("osdSetupCustomLogoColorMapError"));
+                            GUI.log(i18n.getMessage("osdSetupCustomLogoColorMapError", {
+                                valueR: rgbPixel[0],
+                                valueG: rgbPixel[1],
+                                valueB: rgbPixel[2],
+                                posX: x,
+                                posY: y,
+                            }));
                             return false;
                         }
                     }
@@ -162,7 +168,7 @@ LogoManager.openImage = function () {
                         this.showConstraintSatisfied(constraint);
                     } else {
                         this.showConstraintNotSatisfied(constraint);
-                        reject();
+                        reject("Boot logo image constraint violation");
                         return;
                     }
                 }


### PR DESCRIPTION
Related to #1077. Both the wrong RGB values and the coordinates of the erroneous pixel are now outputted to GUI log.