### PR TITLE
Change MSP version of OSD G-Force

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1014,7 +1014,7 @@ OSD.chooseFields = function () {
                   OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                     F.ANTI_GRAVITY
                   ]);
-                  if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+                  if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                         F.G_FORCE
                     ]);


### PR DESCRIPTION
Simply to not forget this. A new version 3.5 is going to be released, so the elements of version 4.0 need to be on other MSP version. The G-Force was merged in the firmware some time ago.

Don't merge until the final version of MSP is sure.
