### PR TITLE
Fix throttle position preview

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -342,7 +342,7 @@ OSD.constants = {
       default_position: -9,
       draw_order: 110,
       positionable: true,
-      preview: FONT.symbol(SYM.THR) + FONT.symbol(SYM.THR1) + '69'
+      preview: FONT.symbol(SYM.THR) + FONT.symbol(SYM.THR1) + ' 69'
     },
     CPU_LOAD: {
       name: 'CPU_LOAD',


### PR DESCRIPTION
Actual throttle position element drawn by the firmware is one digit wider than in the OSD preview, this PR aims to fix this.

![screenshot from 2018-07-16 17-31-04](https://user-images.githubusercontent.com/33358/42767835-4e84311a-891e-11e8-81cd-971ae91c8ab2.png)
![screenshot from 2018-07-16 17-29-22](https://user-images.githubusercontent.com/33358/42767858-53c049de-891e-11e8-8b99-73a70b806b94.png)
