### PR TITLE
Add option to reopen last tab on connect

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -60,6 +60,9 @@
     "permanentExpertMode": {
         "message": "Permanently enable Expert Mode"
     },
+    "rememberLastTab": {
+        "message": "Reopen last tab on connect"
+    },
     "userLanguageSelect": {
         "message": "Language (need to restart the application for the changes to take effect)"
     },

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -321,5 +321,21 @@ GUI_control.prototype.content_ready = function (callback) {
     if (callback) callback();
 }
 
+GUI_control.prototype.selectDefaultTabWhenConnected = function() {
+    chrome.storage.local.get(['rememberLastTab', 'lastTab'], function (result) {
+        let fallbackTab = '#tabs ul.mode-connected .tab_setup a'; 
+        if (!(result.rememberLastTab && !!result.lastTab)) {
+            $(fallbackTab).click();
+            return;
+        }
+        let $savedTab = $("#tabs ul.mode-connected ." + result.lastTab + " a");
+        if (!!$savedTab.data("ignore-reopen")) {
+            $(fallbackTab).click();
+        } else {
+            $savedTab.click();
+        }
+    });    
+};
+
 // initialize object into GUI variable
 var GUI = new GUI_control();

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -323,17 +323,11 @@ GUI_control.prototype.content_ready = function (callback) {
 
 GUI_control.prototype.selectDefaultTabWhenConnected = function() {
     chrome.storage.local.get(['rememberLastTab', 'lastTab'], function (result) {
-        let fallbackTab = '#tabs ul.mode-connected .tab_setup a'; 
         if (!(result.rememberLastTab && !!result.lastTab)) {
-            $(fallbackTab).click();
+            $('#tabs ul.mode-connected .tab_setup a').click();
             return;
         }
-        let $savedTab = $("#tabs ul.mode-connected ." + result.lastTab + " a");
-        if (!!$savedTab.data("ignore-reopen")) {
-            $(fallbackTab).click();
-        } else {
-            $savedTab.click();
-        }
+        $("#tabs ul.mode-connected ." + result.lastTab + " a").click();
     });    
 };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -86,19 +86,19 @@ function startProcess() {
                 return;
             }
 
+            $("#tabs ul.mode-connected li").click(function() {
+                // store the first class of the current tab (omit things like ".active")
+                chrome.storage.local.set({
+                    lastTab: $(this).attr("class").split(' ')[0]
+                });
+            });
+        
             GUI.tab_switch_in_progress = true;
 
             GUI.tab_switch_cleanup(function () {
                 // disable previously active tab highlight
                 $('li', ui_tabs).removeClass('active');
                 
-                // store last active tab only when connected
-                if (GUI.connected_to) {
-                    chrome.storage.local.set({
-                        lastTab: $(self).parent().attr("class")
-                    });
-                }
-        
                 // Highlight selected tab
                 $(self).parent().addClass('active');
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -91,7 +91,14 @@ function startProcess() {
             GUI.tab_switch_cleanup(function () {
                 // disable previously active tab highlight
                 $('li', ui_tabs).removeClass('active');
-
+                
+                // store last active tab only when connected
+                if (GUI.connected_to) {
+                    chrome.storage.local.set({
+                        lastTab: $(self).parent().attr("class")
+                    });
+                }
+        
                 // Highlight selected tab
                 $(self).parent().addClass('active');
 
@@ -215,6 +222,13 @@ function startProcess() {
                         }
 
                     }).change();
+                });
+
+                chrome.storage.local.get('rememberLastTab', function (result) {
+                    $('div.rememberLastTab input')
+                        .prop('checked', !!result.rememberLastTab)
+                        .change(function() { chrome.storage.local.set({rememberLastTab: $(this).is(':checked')}) })
+                        .change();
                 });
 
                 if (GUI.operating_system !== 'ChromeOS') {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -98,7 +98,7 @@ function startProcess() {
             GUI.tab_switch_cleanup(function () {
                 // disable previously active tab highlight
                 $('li', ui_tabs).removeClass('active');
-                
+
                 // Highlight selected tab
                 $(self).parent().addClass('active');
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -299,7 +299,7 @@ function finishOpen() {
 
     onConnect();
 
-    $('#tabs ul.mode-connected .tab_setup a').click();
+    GUI.selectDefaultTabWhenConnected();
 }
 
 function connectCli() {

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -45,7 +45,11 @@ TABS.motors.initialize = function (callback) {
     }
 
     function load_motor_data() {
-        MSP.send_message(MSPCodes.MSP_MOTOR, false, false, load_html);
+        MSP.send_message(MSPCodes.MSP_MOTOR, false, false, load_mixer_config);
+    }
+
+    function load_mixer_config() {
+        MSP.send_message(MSPCodes.MSP_MIXER_CONFIG, false, false, load_html);
     }
 
     function load_html() {

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -39,8 +39,12 @@ TABS.pid_tuning.initialize = function (callback) {
     }).then(function() {
         return MSP.promise(MSPCodes.MSP_RC_DEADBAND);
     }).then(function() {
-        $('#content').load("./tabs/pid_tuning.html", process_html);
+        MSP.send_message(MSPCodes.MSP_MIXER_CONFIG, false, false, load_html);
     });
+
+    function load_html() {
+        $('#content').load("./tabs/pid_tuning.html", process_html);        
+    }
 
     function pid_and_rc_to_form() {
         self.setProfile();

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -40,12 +40,16 @@ TABS.receiver.initialize = function (callback) {
     }
 
     function load_rx_config() {
-        var next_callback = load_html;
+        var next_callback = load_mixer_config;
         if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
             MSP.send_message(MSPCodes.MSP_RX_CONFIG, false, false, next_callback);
         } else {
             next_callback();
         }
+    }
+
+    function load_mixer_config() {
+        MSP.send_message(MSPCodes.MSP_MIXER_CONFIG, false, false, load_html);
     }
 
     function load_html() {

--- a/src/main.html
+++ b/src/main.html
@@ -268,7 +268,9 @@
                 -->
             </ul>
             <ul class="mode-connected mode-connected-cli">
-                <li class="tab_cli"><a href="#" i18n="tabCLI" class="tabicon ic_cli" i18n_title="tabCLI"></a></li>
+                <li class="tab_cli">
+                    <a href="#" i18n="tabCLI" class="tabicon ic_cli" i18n_title="tabCLI" data-ignore-reopen="true"></a>
+                </li>
             </ul>
         </div>
         <div class="clear-both"></div>

--- a/src/main.html
+++ b/src/main.html
@@ -269,7 +269,7 @@
             </ul>
             <ul class="mode-connected mode-connected-cli">
                 <li class="tab_cli">
-                    <a href="#" i18n="tabCLI" class="tabicon ic_cli" i18n_title="tabCLI" data-ignore-reopen="true"></a>
+                    <a href="#" i18n="tabCLI" class="tabicon ic_cli" i18n_title="tabCLI"></a>
                 </li>
             </ul>
         </div>

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -4,6 +4,9 @@
 <div class="checkForConfiguratorUnstableVersions">
     <label><input type="checkbox" /><span i18n="checkForConfiguratorUnstableVersions"></span></label>
 </div>
+<div class="rememberLastTab">
+    <label><input type="checkbox" /><span i18n="rememberLastTab"></span></label>
+</div>
 <div class="separator"></div>
 <div class="userLanguage">
     <label>


### PR DESCRIPTION
This PR adds an option to reopen last used tab upon connect. The option can be toggled in the cog menu (in the upper right corner). Possible use cases include:
* user wants to use multiple CLI commands that require reboot
* user wants to retrieve blackbox logs during a tuning session one after another