### PR TITLE
Fix dynamic adjustments with version

### DIFF
--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -20,7 +20,6 @@ TABS.adjustments.initialize = function (callback) {
     }
 
     function load_html() {
-        self.adjust_template();
         $('#content').load("./tabs/adjustments.html", process_html);
     }
 
@@ -153,6 +152,8 @@ TABS.adjustments.initialize = function (callback) {
 
     function process_html() {
 
+        self.adjust_template();
+
         var auxChannelCount = RC.active_channels - 4;
 
         var modeTableBodyElement = $('.tab-adjustments .adjustments tbody');
@@ -272,14 +273,20 @@ TABS.adjustments.cleanup = function (callback) {
 };
 
 TABS.adjustments.adjust_template = function () {
-    var availableFunctionCount;
-    if (semver.lt(CONFIG.apiVersion, "1.31.0")) {
-        availableFunctionCount = 21; // Available in betaflight 2.9
+
+    var selectFunction = $('#functionSelectionSelect');
+    var elementsNumber;
+
+    if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+        elementsNumber = 26; // PID Audio
+    } else if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+        elementsNumber = 25; // Horizon Strength
     } else {
-        availableFunctionCount = 24; // RC rate Yaw / D setpoint / D setpoint transition added to 3.1.0
+        elementsNumber = 24; // Setpoint transition
     }
-    var template = $('#tab-adjustments-templates .adjustments .adjustment');
-    var functionList = $(template).find('.functionSelection .function');
-    var functionListOptions = $(functionList).find('option').slice(0,availableFunctionCount);
-    functionList.empty().append(functionListOptions);
+
+    for (let i = 0; i < elementsNumber; i++) {
+        selectFunction.append(new Option(i18n.getMessage('adjustmentsFunction' + i), i));
+    }
+
 };

--- a/src/tabs/adjustments.html
+++ b/src/tabs/adjustments.html
@@ -66,34 +66,11 @@
                         <div class="marker"></div>
                     </div>
                 </td>
-                <td class="functionSelection"><select class="function">
-                    <option value="0" i18n="adjustmentsFunction0"></option>
-                    <option value="1" i18n="adjustmentsFunction1"></option>
-                    <option value="2" i18n="adjustmentsFunction2"></option>
-                    <option value="3" i18n="adjustmentsFunction3"></option>
-                    <option value="4" i18n="adjustmentsFunction4"></option>
-                    <option value="5" i18n="adjustmentsFunction5"></option>
-                    <option value="6" i18n="adjustmentsFunction6"></option>
-                    <option value="7" i18n="adjustmentsFunction7"></option>
-                    <option value="8" i18n="adjustmentsFunction8"></option>
-                    <option value="9" i18n="adjustmentsFunction9"></option>
-                    <option value="10" i18n="adjustmentsFunction10"></option>
-                    <option value="11" i18n="adjustmentsFunction11"></option>
-                    <option value="12" i18n="adjustmentsFunction12"></option>
-                    <option value="13" i18n="adjustmentsFunction13"></option>
-                    <option value="14" i18n="adjustmentsFunction14"></option>
-                    <option value="15" i18n="adjustmentsFunction15"></option>
-                    <option value="16" i18n="adjustmentsFunction16"></option>
-                    <option value="17" i18n="adjustmentsFunction17"></option>
-                    <option value="18" i18n="adjustmentsFunction18"></option>
-                    <option value="19" i18n="adjustmentsFunction19"></option>
-                    <option value="20" i18n="adjustmentsFunction20"></option>
-                    <option value="21" i18n="adjustmentsFunction21"></option>
-                    <option value="22" i18n="adjustmentsFunction22"></option>
-                    <option value="23" i18n="adjustmentsFunction23"></option>
-                    <option value="24" i18n="adjustmentsFunction24"></option>
-                    <option value="25" i18n="adjustmentsFunction25"></option>
-                </select></td>
+                <td class="functionSelection">
+                    <select id="functionSelectionSelect" class="function">
+                        <!--  Generated values go here -->
+                    </select>
+                </td>
                 <td class="adjustmentSlot"><select class="slot">
                     <option value="0" i18n="adjustmentsSlot0"></option>
                     <option value="1" i18n="adjustmentsSlot1"></option>


### PR DESCRIPTION
The list of adjustments tries to modify the number of possibilities depending on the version, but is being done BEFORE loading the HTML, so it was not working. This method makes it after loading the HTML and refactors a little the code.