### PR TITLE
Remove unused PIDs

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -49,142 +49,19 @@ TABS.pid_tuning.initialize = function (callback) {
         }
 
         // Fill in the data from PIDs array
-        var i = 0;
-        $('.pid_tuning .ROLL input').each(function () {
-            switch (i) {
-                case 0:
-                    $(this).val(PIDs[0][i++]);
-                    break;
-                case 1:
-                    $(this).val(PIDs[0][i++]);
-                    break;
-                case 2:
-                    $(this).val(PIDs[0][i++]);
-                    break;
-            }
-        });
 
-        i = 0;
-        $('.pid_tuning .PITCH input').each(function () {
-            switch (i) {
-                case 0:
-                    $(this).val(PIDs[1][i++]);
-                    break;
-                case 1:
-                    $(this).val(PIDs[1][i++]);
-                    break;
-                case 2:
-                    $(this).val(PIDs[1][i++]);
-                    break;
-            }
-        });
+        // For each pid name
+        PID_names.forEach(function(elementPid, indexPid) {
 
-        i = 0;
-        $('.pid_tuning .YAW input').each(function () {
-            switch (i) {
-                case 0:
-                    $(this).val(PIDs[2][i++]);
-                    break;
-                case 1:
-                    $(this).val(PIDs[2][i++]);
-                    break;
-            }
-        });
-        $('.pid_tuning .YAW_JUMP_PREVENTION input').each(function () {
-            switch (i) {
-                case 2:
-                    $(this).val(PIDs[2][i++]);
-                    break;
-            }
-        });
+            // Look into the PID table to a row with the name of the pid
+            var searchRow = $('.pid_tuning .' + elementPid + ' input');
 
-        i = 0;
-        $('.pid_tuning .ALT input').each(function () {
-            switch (i) {
-                case 0:
-                    $(this).val(PIDs[3][i++]);
-                    break;
-                case 1:
-                    $(this).val(PIDs[3][i++]);
-                    break;
-                case 2:
-                    $(this).val(PIDs[3][i++]);
-                    break;
-            }
-        });
-
-        i = 0;
-        $('.pid_tuning .Pos input').each(function () {
-            $(this).val(PIDs[4][i++]);
-        });
-
-        i = 0;
-        $('.pid_tuning .PosR input').each(function () {
-            switch (i) {
-                case 0:
-                    $(this).val(PIDs[5][i++]);
-                    break;
-                case 1:
-                    $(this).val(PIDs[5][i++]);
-                    break;
-                case 2:
-                    $(this).val(PIDs[5][i++]);
-                    break;
-            }
-        });
-
-        i = 0;
-        $('.pid_tuning .NavR input').each(function () {
-            switch (i) {
-                case 0:
-                    $(this).val(PIDs[6][i++]);
-                    break;
-                case 1:
-                    $(this).val(PIDs[6][i++]);
-                    break;
-                case 2:
-                    $(this).val(PIDs[6][i++]);
-                    break;
-            }
-        });
-
-        i = 0;
-        $('.pid_tuning .ANGLE input').each(function () {
-            switch (i) {
-                case 0:
-                    $(this).val(PIDs[7][i++]);
-                    break;
-            }
-        });
-        $('.pid_tuning .HORIZON input').each(function () {
-            switch (i) {
-                case 1:
-                    $(this).val(PIDs[7][i++]);
-                    break;
-                case 2:
-                    $(this).val(PIDs[7][i++]);
-                    break;
-            }
-        });
-
-        i = 0;
-        $('.pid_tuning .MAG input').each(function () {
-            $(this).val(PIDs[8][i++]);
-        });
-
-        i = 0;
-        $('.pid_tuning .Vario input').each(function () {
-            switch (i) {
-                case 0:
-                    $(this).val(PIDs[9][i++]);
-                    break;
-                case 1:
-                    $(this).val(PIDs[9][i++]);
-                    break;
-                case 2:
-                    $(this).val(PIDs[9][i++]);
-                    break;
-            }
+            // Assign each value
+            searchRow.each(function (indexInput) {
+                if (PIDs[indexPid][indexInput] !== undefined) {
+                    $(this).val(PIDs[indexPid][indexInput]);
+                }
+            });
         });
 
         // Fill in data from RC_tuning object
@@ -519,60 +396,19 @@ TABS.pid_tuning.initialize = function (callback) {
     function form_to_pid_and_rc() {
         // Fill in the data from PIDs array
         // Catch all the changes and stuff the inside PIDs array
-        var i = 0;
-        $('table.pid_tuning tr.ROLL .pid_data input').each(function () {
-            PIDs[0][i++] = parseFloat($(this).val());
-        });
 
-        i = 0;
-        $('table.pid_tuning tr.PITCH .pid_data input').each(function () {
-            PIDs[1][i++] = parseFloat($(this).val());
-        });
+        // For each pid name
+        PID_names.forEach(function(elementPid, indexPid) {
 
-        i = 0;
-        $('table.pid_tuning tr.YAW .pid_data input').each(function () {
-            PIDs[2][i++] = parseFloat($(this).val());
-        });
-        $('table.pid_tuning tr.YAW_JUMP_PREVENTION .pid_data input').each(function () {
-            PIDs[2][i++] = parseFloat($(this).val());
-        });
+            // Look into the PID table to a row with the name of the pid
+            var searchRow = $('.pid_tuning .' + elementPid + ' input');
 
-        i = 0;
-        $('table.pid_tuning tr.ALT input').each(function () {
-            PIDs[3][i++] = parseFloat($(this).val());
-        });
-
-        i = 0;
-        $('table.pid_tuning tr.Vario input').each(function () {
-            PIDs[9][i++] = parseFloat($(this).val());
-        });
-
-        i = 0;
-        $('table.pid_tuning tr.Pos input').each(function () {
-            PIDs[4][i++] = parseFloat($(this).val());
-        });
-
-        i = 0;
-        $('table.pid_tuning tr.PosR input').each(function () {
-            PIDs[5][i++] = parseFloat($(this).val());
-        });
-
-        i = 0;
-        $('table.pid_tuning tr.NavR input').each(function () {
-            PIDs[6][i++] = parseFloat($(this).val());
-        });
-
-        i = 0;
-        $('div.pid_tuning tr.ANGLE input').each(function () {
-            PIDs[7][i++] = parseFloat($(this).val());
-        });
-        $('div.pid_tuning tr.HORIZON input').each(function () {
-            PIDs[7][i++] = parseFloat($(this).val());
-        });
-
-        i = 0;
-        $('div.pid_tuning tr.MAG input').each(function () {
-            PIDs[8][i++] = parseFloat($(this).val());
+            // Assign each value
+            searchRow.each(function (indexInput) {
+                if ($(this).val()) {
+                    PIDs[indexPid][indexInput] = parseFloat($(this).val());
+                }
+            });
         });
 
         // catch RC_tuning changes
@@ -661,37 +497,54 @@ TABS.pid_tuning.initialize = function (callback) {
     }
 
     function showAllPids() {
-        $('.tab-pid_tuning .pid_tuning').show();
+
+        // Hide all optional elements
+        $('.pid_optional tr').hide(); // Hide all rows
+        $('.pid_optional table').hide(); // Hide tables
+        $('.pid_optional').hide(); // Hide general div
+
+        // Only show rows supported by the firmware
+        PID_names.forEach(function(elementPid) {
+            // Show rows for the PID
+            $('.pid_tuning .' + elementPid).show();
+
+            // Show titles and other elements needed by the PID
+            $('.needed_by_' + elementPid).show();
+        });
+
+        // Special case
+        if (semver.lt(CONFIG.apiVersion, "1.24.0")) {
+            $('#pid_sensitivity').hide();
+        }
+
     }
 
     function hideUnusedPids() {
-        $('.tab-pid_tuning .pid_tuning').hide();
 
-        $('#pid_main').show();
-
-        if (have_sensor(CONFIG.activeSensors, 'acc')) {
-            $('#pid_accel').show();
-            $('#pid_level').show();
-            $('#pid_sensitivity').show();
+        if (!have_sensor(CONFIG.activeSensors, 'acc')) {
+            $('#pid_accel').hide();
         }
 
-        var showTitle = false;
-        if (have_sensor(CONFIG.activeSensors, 'baro') ||
-            have_sensor(CONFIG.activeSensors, 'sonar')) {
-            $('#pid_baro').show();
-            showTitle = true;
-        }
-        if (have_sensor(CONFIG.activeSensors, 'mag')) {
-            $('#pid_mag').show();
-            showTitle = true;
-        }
-        if (FEATURE_CONFIG.features.isEnabled('GPS')) {
-            $('#pid_gps').show();
-            showTitle = true;
+        var hideSensorPid = function(element, sensorReady) {
+            var isVisible = element.is(":visible");
+            if (!isVisible || !sensorReady) {
+                element.hide();
+                isVisible = false;
+            }
+
+            return isVisible;
         }
 
-        if (showTitle) {
-            $('#pid_optional').show();
+        var isVisibleBaroMagGps = false;
+
+        isVisibleBaroMagGps |= hideSensorPid($('#pid_baro'), have_sensor(CONFIG.activeSensors, 'baro') || have_sensor(CONFIG.activeSensors, 'sonar'));
+
+        isVisibleBaroMagGps |= hideSensorPid($('#pid_mag'), have_sensor(CONFIG.activeSensors, 'mag'));
+
+        isVisibleBaroMagGps |= hideSensorPid($('#pid_gps'), have_sensor(CONFIG.activeSensors, 'GPS'));
+
+        if (!isVisibleBaroMagGps) {
+            $('#pid_baro_mag_gps').hide();
         }
     }
 
@@ -873,6 +726,7 @@ TABS.pid_tuning.initialize = function (callback) {
             }
         }
 
+        showAllPids();
         updatePidDisplay();
 
         showAllButton.on('click', function(){
@@ -981,12 +835,16 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.tab-pid_tuning .note').hide();
 		}
 
+        // Add a name to each row of PIDs if empty
         $('.pid_tuning tr').each(function(){
-          for(i = 0; i < PID_names.length; i++) {
-            if($(this).hasClass(PID_names[i])) {
-              $(this).find('td:first').text(PID_names[i]);
+            for(i = 0; i < PID_names.length; i++) {
+                if($(this).hasClass(PID_names[i])) {
+                    var firstColumn = $(this).find('td:first');
+                    if (!firstColumn.text()) {
+                        firstColumn.text(PID_names[i]);
+                    }
+                }
             }
-          }
         });
 
 

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -33,7 +33,7 @@
                 </div>
             </div>
             <div class="cf_column right">
-                <div class="default_btn show">
+                <div class="default_btn show showAllPids">
                     <a href="#" id="showAllPids" i18n="pidTuningShowAllPids"></a>
                 </div>
                 <div class="default_btn resetbt">
@@ -139,17 +139,17 @@
                             </tr>
                         </table>
                     </div>
-                    <div id="pid_optional" class="gui_box grey topspacer pid_tuning">
-                        <table class="pid_titlebar">
-                            <tr>
+                    <div id="pid_baro_mag_gps" class="pid_optional needed_by_ALT needed_by_VEL needed_by_MAG needed_by_Pos needed_by_PosR needed_by_NavR gui_box grey topspacer pid_tuning">
+                        <table class="pid_titlebar needed_by_ALT needed_by_VEL needed_by_MAG">
+                            <tr class="needed_by_ALT needed_by_VEL needed_by_MAG">
                                 <th class="name"></th>
                                 <th class="proportional" i18n="pidTuningProportional"></th>
                                 <th class="integral" i18n="pidTuningIntegral"></th>
                                 <th class="derivative" i18n="pidTuningDerivative"></th>
                             </tr>
                         </table>
-                        <table id="pid_baro" class="pid_tuning">
-                            <tr>
+                        <table id="pid_baro" class="pid_tuning needed_by_ALT needed_by_VEL">
+                            <tr class="needed_by_ALT needed_by_VEL">
                                 <th colspan="4">
                                     <div class="pid_mode" i18n="pidTuningAltitude"></div>
                                 </th>
@@ -161,16 +161,16 @@
                                 <td><input type="number" name="i" step="1" min="0" max="255" /></td>
                                 <td><input type="number" name="d" step="1" min="0" max="255" /></td>
                             </tr>
-                            <tr class="Vario">
+                            <tr class="VEL">
                                 <!-- 9 -->
-                                <td>VEL</td>
+                                <td></td>
                                 <td><input type="number" name="p" step="1" min="0" max="255" /></td>
                                 <td><input type="number" name="i" step="1" min="0" max="255" /></td>
                                 <td><input type="number" name="d" step="1" min="0" max="255" /></td>
                             </tr>
                         </table>
-                        <table id="pid_mag" class="pid_tuning">
-                            <tr>
+                        <table id="pid_mag" class="pid_tuning needed_by_MAG">
+                            <tr class="needed_by_MAG">
                                 <th colspan="4">
                                     <div class="pid_mode" i18n="pidTuningMag"></div>
                                 </th>
@@ -183,8 +183,8 @@
                                 <td></td>
                             </tr>
                         </table>
-                        <table id="pid_gps" class="pid_tuning">
-                            <tr>
+                        <table id="pid_gps" class="pid_tuning needed_by_Pos needed_by_PosR needed_by_NavR">
+                            <tr class="needed_by_Pos needed_by_PosR needed_by_NavR">
                                 <th colspan="4">
                                     <div class="pid_mode" i18n="pidTuningGps"></div>
                                 </th>
@@ -213,9 +213,9 @@
                             </tr>
                         </table>
                     </div>
-                    <div id="pid_accel" class="gui_box grey topspacer pid_tuning">
-                        <table id="pid_level" class="pid_tuning">
-                            <tr>
+                    <div id="pid_accel" class="pid_optional needed_by_LEVEL gui_box grey topspacer pid_tuning">
+                        <table id="pid_level" class="pid_tuning needed_by_LEVEL">
+                            <tr class="needed_by_LEVEL">
                                 <th colspan="3">
                                     <div class="pid_mode">
                                         <div i18n="pidTuningLevel" style="float:left;"></div>
@@ -224,42 +224,43 @@
                                 </th>
                             </tr>
                         </table>
-                        <table class="pid_titlebar">
-                            <tr>
+                        <table class="pid_titlebar needed_by_LEVEL">
+                            <tr class="needed_by_LEVEL">
                                 <th class="third"></th>
                                 <th class="third" i18n="pidTuningStrength" style="width: 33%;"></th>
                                 <th class="third" i18n="pidTuningTransition" style="width: 33%;"></th>
                             </tr>
                         </table>
-                        <table>
-                            <tr class="ANGLE">
+                        <table class="needed_by_LEVEL">
+                            <tr class="LEVEL">
                                 <!-- 7 -->
                                 <td class="third" i18n="pidTuningAngle"></td>
                                 <td class="third"><input type="number" name="p" step="1" min="0" max="255" /></td>
                                 <td class="third"></td>
                             </tr>
-                            <tr class="HORIZON">
+                            <tr class="LEVEL">
                                 <!-- 7 -->
                                 <td class="third" i18n="pidTuningHorizon"></td>
                                 <td class="third"><input type="number" name="i" step="1" min="0" max="255" /></td>
                                 <td class="third"><input type="number" name="d" step="1" min="0" max="255" /></td>
                             </tr>
                         </table>
-                        <table class="pid_titlebar pid_sensitivity">
-                            <tr>
+                        <table class="needed_by_LEVEL pid_titlebar pid_sensitivity">
+                            <tr class="needed_by_LEVEL">
                                 <th class="third"></th>
                                 <th class="third" i18n="pidTuningLevelAngleLimit" style="width: 33%;"></th>
                                 <th class="third levelSensitivityHeader" i18n="pidTuningLevelSensitivity" style="width: 33%;"></th>
                             </tr>
                         </table>
-                        <table id="pid_sensitivity" class="pid_tuning pid_sensitivity">
-                            <tr>
+                        <table id="pid_sensitivity" class="needed_by_LEVEL pid_tuning pid_sensitivity">
+                            <tr class="needed_by_LEVEL">
                                 <td class="third"></td>
                                 <td class="third"><input type="number" name="angleLimit" step="1" min="10" max="200" /></td>
                                 <td class="third"><input type="number" name="sensitivity" step="1" min="10" max="120" /></td>
                             </tr>
                         </table>
                     </div>
+
                     <div class="gui_box grey topspacer pidTuningFeatures">
                         <table class="pid_titlebar new_rates">
                             <tr>


### PR DESCRIPTION
Removes unused PIDs from https://github.com/betaflight/betaflight/pull/6409

@mikeller I have associated this to the MSP 1.39 and not 1.40 (the version of the Betaflight PR) because these PIDs are not valid in 1.39 neither, so I think is better to hide them to the user since this version. Is that right?