### PR TITLE
Add switch to show/hide unused modes

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1504,6 +1504,9 @@
     "auxiliaryHelp": {
         "message": "Use ranges to define the switches on your transmitter and corresponding mode assignments.  A receiver channel that gives a reading between a range min/max will activate the mode.  Remember to save your settings using the Save button."
     },
+    "auxiliaryToggleUnused": {
+        "message": "Show/hide unused modes"
+    },
     "auxiliaryMin": {
         "message": "Min"
     },

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -244,8 +244,9 @@ TABS.auxiliary.initialize = function (callback) {
         }
 
         function update_ui() {
-            for (var i = 0; i < AUX_CONFIG.length; i++) {
-                var modeElement = $('#mode-' + i); 
+            let hasUsedMode = false;
+            for (let i = 0; i < AUX_CONFIG.length; i++) {
+                let modeElement = $('#mode-' + i);
                 if (modeElement.find(' .range').length == 0) {
                     // if the mode is unused, skip it
                     modeElement.removeClass('off').removeClass('on');
@@ -257,7 +258,16 @@ TABS.auxiliary.initialize = function (callback) {
                 } else {
                     $('.mode .name').eq(i).data('modeElement').removeClass('on').addClass('off');
                 }
+                hasUsedMode = true;
             }
+
+            let hideUnused = hideUnusedModes && hasUsedMode;
+            for (let i = 0; i < AUX_CONFIG.length; i++) {
+                let modeElement = $('#mode-' + i);
+                if (modeElement.find(' .range').length == 0) {
+                    modeElement.toggle(!hideUnused);
+                }
+            }    
 
             auto_select_channel(RC.channels);
 
@@ -306,6 +316,18 @@ TABS.auxiliary.initialize = function (callback) {
             return fillPrevChannelsValues();
         }
 
+        let hideUnusedModes = false;
+        chrome.storage.local.get('hideUnusedModes', function (result) {
+            $("input#switch-toggle-unused")
+                .change(function() {
+                    hideUnusedModes = $(this).prop("checked");
+                    chrome.storage.local.set({ hideUnusedModes: hideUnusedModes });
+                    update_ui();
+                })
+                .prop("checked", !!result.hideUnusedModes)
+                .change();
+        });    
+    
         // update ui instantly on first load
         update_ui();
 

--- a/src/tabs/auxiliary.html
+++ b/src/tabs/auxiliary.html
@@ -7,6 +7,12 @@
         <div class="note spacebottom">
             <div class="note_spacer">
                 <p i18n="auxiliaryHelp"></p>
+                <p>
+                    <form>
+                        <input type="checkbox" id="switch-toggle-unused" name="switch-toggle-unused" class="togglesmall"></input>
+                        <label for="switch-toggle-unused"><span i18n="auxiliaryToggleUnused" /></label>
+                    </form>
+                </p>
             </div>
         </div>
         <table class="modes">


### PR DESCRIPTION
This PR adds an option to hide unused modes on the Modes tab. Hopefully this would save the user some time (less scrolling, less mouse moves) when only configuring the ranges for used modes or just wanna check what is configured.