### PR TITLE
Simplify Acro Trainer Slider

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2829,7 +2829,7 @@
         "message": "Acro Trainer Angle Limit"
     },
     "pidTuningAcroTrainerAngleLimitHelp": {
-        "message": "Adds a new angle limiting mode for pilots who are learning to fly in acro mode. The range valid is 10-80 (a value of 0 deactivates it)"
+        "message": "Adds a new angle limiting mode for pilots who are learning to fly in acro mode. The range valid is 10-80 and must be activated with a switch in the $t(tabAuxiliary.message) tab."
     },
 
     "configHelp2": {

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -234,20 +234,11 @@ TABS.pid_tuning.initialize = function (callback) {
             var acroTrainerAngleLimitNumberElement = $('input[name="acroTrainerAngleLimit-number"]');
             var acroTrainerAngleLimitRangeElement = $('input[name="acroTrainerAngleLimit-range"]');
 
-            var validateAcroTrainerAngle = function(value) {
-                // The minimum acro trainer angle is 10, but we must let zero too to deactivate it
-                if (value > 0 && value < 10) {
-                    value = 10;
-                }
-                acroTrainerAngleLimitRangeElement.val(value);
-                acroTrainerAngleLimitNumberElement.val(value);
-            }
-
             acroTrainerAngleLimitNumberElement.change(function () {
-                validateAcroTrainerAngle($(this).val());
+                acroTrainerAngleLimitRangeElement.val($(this).val());
             });
             acroTrainerAngleLimitRangeElement.change(function () {
-                validateAcroTrainerAngle($(this).val());
+                acroTrainerAngleLimitNumberElement.val($(this).val());
             });
             acroTrainerAngleLimitNumberElement.val(ADVANCED_TUNING.acroTrainerAngleLimit).change();
 

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -340,8 +340,8 @@
                             </tr>
 
                             <tr class="acroTrainerAngleLimit">
-                                <td><input type="number" name="acroTrainerAngleLimit-number" step="1" min="0" max="80"/></td>
-                                <td class="slider"><input type="range" name="acroTrainerAngleLimit-range" step="1" min="0" max="80"/></td>
+                                <td><input type="number" name="acroTrainerAngleLimit-number" step="1" min="10" max="80"/></td>
+                                <td class="slider"><input type="range" name="acroTrainerAngleLimit-range" step="1" min="10" max="80"/></td>
                                  <td colspan="2">
                                     <div>
                                         <label>


### PR DESCRIPTION
Limit the range to 10-80 (actually was 0, 10-80).

After talking with @etracer65 it has no sense let select the zero value. Is easier to let only 10-80 because the user must activate it in the modes tab. 