### PR TITLE
Reopen next tab when explicitly leaving CLI, otherwise open setup tab

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -323,7 +323,9 @@ GUI_control.prototype.content_ready = function (callback) {
 
 GUI_control.prototype.selectDefaultTabWhenConnected = function() {
     chrome.storage.local.get(['rememberLastTab', 'lastTab'], function (result) {
-        if (!(result.rememberLastTab && !!result.lastTab)) {
+        if (!(result.rememberLastTab 
+                && !!result.lastTab 
+                && result.lastTab.substring(4) != "cli")) {
             $('#tabs ul.mode-connected .tab_setup a').click();
             return;
         }


### PR DESCRIPTION
Considering the fact that users may wish to return to the CLI tab much less often than the opposite, this change will make the selected tab reopen when CLI tab is left via explicitly switching to another tab or Setup tab will be reopened in other cases (ie. a command causing a reboot).