### PR TITLE
Removed cleaning steps from 'debug' build.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -60,13 +60,14 @@ gulp.task('clean-release', clean_release);
 
 gulp.task('clean-cache', clean_cache);
 
-var distBuild = gulp.series(clean_dist, dist_src, dist_locale, dist_libraries, dist_resources);
-gulp.task('dist', distBuild);
+var distBuild = gulp.series(dist_src, dist_locale, dist_libraries, dist_resources);
+var distRebuild = gulp.series(clean_dist, distBuild);
+gulp.task('dist', distRebuild);
 
-var appsBuild = gulp.series(gulp.parallel(clean_apps, distBuild), apps, gulp.parallel(listPostBuildTasks(APPS_DIR)));
+var appsBuild = gulp.series(gulp.parallel(clean_apps, distRebuild), apps, gulp.parallel(listPostBuildTasks(APPS_DIR)));
 gulp.task('apps', appsBuild);
 
-var debugBuild = gulp.series(gulp.parallel(clean_debug, distBuild), debug, gulp.parallel(listPostBuildTasks(DEBUG_DIR)), start_debug)
+var debugBuild = gulp.series(distBuild, debug, gulp.parallel(listPostBuildTasks(DEBUG_DIR)), start_debug)
 gulp.task('debug', debugBuild);
 
 var releaseBuild = gulp.series(gulp.parallel(clean_release, appsBuild), gulp.parallel(listReleaseTasks()));


### PR DESCRIPTION
This brings down the build time for `debug` from 16 s to ~6 s on my machine, for not really any downside - the problem with left over artefacts from different platforms does not apply for the debug build, as building this only ever makes sense to build for the platform it's running on.