### PR TITLE
Integrate GPS Rescue Mode for Betaflight - Options menu in the GUI

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -1,3 +1,30 @@
+<span>2018.06.23 - 10.3.0 - BetaFlight</span>
+<ul>
+	<li>added support for customised OSD boot logo</li>
+	<li>fixed MSP_RX controls</li>
+	<li>added current / consumption information into the 'Motors' tab</li>
+	<li>added translations for Japanese and Portugese</li>
+	<li>added support for moving the artificial horizon / crosshairs to OSD, and other OSD improvements</li>
+	<li>added local caching for downloaded firmware files</li>
+	<li>added support for tab completion for commands in the CLI</li>
+	<li>added support for downloading / installing development builds / builds for special version branches (e.g. AKK/RDQ support) from the CI server</li>
+	<li>changed the installation to be uncompressed to achieve faster startup</li>
+</ul>
+
+<span>2018.02.28 - 10.2.0 - BetaFlight</span>
+<ul>
+	<li>added support for 6 rateprofiles</li>
+	<li>removed setting to disallow disarming on throttle above low</li>
+        <li>added disabling of runaway takeoff prevention</li>
+        <li>added peripheral device entry 'Benewake LIDAR'</li>
+        <li>added Dshot beacon configuration</li>
+        <li>added markdown processing for GitHub release notes</li>
+        <li>made language user selectable in the application</li>
+        <li>added translations for Chinese, Italian, and Latvian</li>
+        <li>added installers for RedHat linux</li>
+        <li>added markdown processing for GitHub release notes. Lots of fixes to the standalone applications</li>
+</ul>
+
 <span>2018.01.16 - 10.1.0 - BetaFlight</span>
 <ul>
     <li>Lots of fixes to the standalone applications</li>

--- a/locales/ca/messages.json
+++ b/locales/ca/messages.json
@@ -2932,12 +2932,6 @@
     "osdSetupCustomLogoInfoUploadHint": {
         "message": "Prem <b>$t(osdSetupUploadFont.message)<\/b> per a desar la imatge personalitzada"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Mida de la imatge invàlida; s'esperava $1×$2 en comptes de $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "La imatge conté una paleta de colors invàlida (només verd, negre i blanc són permesos)"
-    },
     "osdSetupUploadFont": {
         "message": "Pujar Font"
     },

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -3022,12 +3022,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "Das Bild verwendet eine ungültige Farbpalette (nur grün, schwarz und weiß sind erlaubt)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Ungültige Bildgröße; Es wird $1 x $2 statt $3 x $4 erwartet"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "Das Bild verwendet eine Ungültige Farbpalette (nur grün, schwarz und weiß sind erlaubt)"
-    },
     "osdSetupUploadFont": {
         "message": "Schriftart hochladen"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3119,12 +3119,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "The image contains an invalid color palette (only green, black and white are allowed)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Invalid image size; expected $1×$2 instead of $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "The image contains an invalid color palette (only green, black and white are allowed)"
-    },
     "osdSetupUploadFont": {
         "message": "Upload Font"
     },

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "La imagen contiene una paleta de colores no válida (sólo se permite verde, blanco y negro)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Tamaño de imagen no válido; se esperaba $1×$2 en vez de $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "La imagen contiene una paleta de colores no válida (sólo se permite verde, blanco y negro)"
-    },
     "osdSetupUploadFont": {
         "message": "Cargar Fuente"
     },

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -3025,12 +3025,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "La palette couleurs de l'image n'est pas valide (seuls le vert, le noir et le blanc sont autorisés)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Taille de l'image invalide; requise $1×$2 au lieu de $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "La palette couleurs de l'image n'est pas valide (seuls le vert, le noir et le blanc sont autorisés)"
-    },
     "osdSetupUploadFont": {
         "message": "Charger le fichier de police"
     },

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -2908,12 +2908,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "L'immagine contiene una tavolozza colori non valida (sono ammessi solo verde, nero e bianco)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Dimensione immagine non valida; previsto $1×$2 invece di $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "L'immagine contiene una palette colori non valida (sono ammessi solo verde, nero e bianco)"
-    },
     "osdSetupUploadFont": {
         "message": "Carica carattere"
     },

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "画像に無効なカラーが含まれています\n (緑・黒・白のみ有効)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "画像サイズが無効; 既定サイズ $1×$2 無効サイズ $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "画像に無効なカラーパレットが含まれています \n(緑、黒、白のみが許可)"
-    },
     "osdSetupUploadFont": {
         "message": "フォントアップロード"
     },

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "이미지가 유효하지 않은 색상표를 포함하고 있습니다 (오직 녹색, 검정 및 흰색만 허용됨)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "유효하지 않은 이미지 크기; $3×$4 대신 $1×$2 예상"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "이미지가 유효하지 않은 색상표를 포함하고 있습니다 (오직 녹색, 검정 및 흰색만 허용됨)"
-    },
     "osdSetupUploadFont": {
         "message": "글꼴 업로드"
     },

--- a/locales/lv/messages.json
+++ b/locales/lv/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "Šis attēls satur nederīgu krāsu paleti (tikai zaļa, melna un balta krāsa atļauta)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Nederīgs attēla izmērs; sagaidu $1×$2 šī vietā $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "Šis attēls satur nederīgu krāsu paleti (tikai zaļa, melna un balta krāsa atļauta)"
-    },
     "osdSetupUploadFont": {
         "message": "Augšupielādēt fontu"
     },

--- a/locales/pt/messages.json
+++ b/locales/pt/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "A imagem contém uma paleta de cores inválida (somente verde, preto e branco são permitidos)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "Tamanho da imagem inválida; era esperado $1x$2 ao invés de $3x$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "A imagem contém uma palheta de cores inválida (somente é permitido verde, preto e branco)"
-    },
     "osdSetupUploadFont": {
         "message": "Carregar Fonte"
     },

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -3028,12 +3028,6 @@
     "osdSetupCustomLogoColorMapError": {
         "message": "图像包含无效的颜色 (仅允许绿色、黑色和白色)"
     },
-    "osdSetupReplaceLogoImageSizeError": {
-        "message": "图像大小无效：应该是 $1×$2 而不是 $3×$4"
-    },
-    "osdSetupReplaceLogoImageColorsError": {
-        "message": "图像包含无效调色板 (仅允许绿色、黑色和白色)"
-    },
     "osdSetupUploadFont": {
         "message": "更新字体"
     },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
     "manifest_version": 2,
     "minimum_chrome_version": "38",
-    "version": "10.3.0",
+    "version": "10.3.1",
     "author": "Betaflight Squad",
     "name": "Betaflight - Configurator",
     "short_name": "Betaflight",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "betaflight-configurator",
   "description": "Crossplatform configuration tool for Betaflight flight control system.",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "main": "main_nwjs.html",
   "bg-script": "js/eventPage.js",
   "default_locale": "en",

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -843,7 +843,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
                         FILTER_CONFIG.gyro_hardware_lpf = data.readU8();
                         FILTER_CONFIG.gyro_32khz_hardware_lpf = data.readU8();
-                        FILTER_CONFIG.gyro_soft_lpf_hz = data.readU16();
+                        FILTER_CONFIG.gyro_lowpass_hz = data.readU16();
                         FILTER_CONFIG.gyro_lowpass2_hz = data.readU16();
                         FILTER_CONFIG.gyro_lowpass_type = data.readU8();
                         FILTER_CONFIG.gyro_lowpass2_type = data.readU8();
@@ -1472,7 +1472,7 @@ MspHelper.prototype.crunch = function(code) {
             }
             break;
         case MSPCodes.MSP_SET_FILTER_CONFIG:
-            buffer.push8(FILTER_CONFIG.gyro_soft_lpf_hz)
+            buffer.push8(FILTER_CONFIG.gyro_lowpass_hz)
                 .push16(FILTER_CONFIG.dterm_lowpass_hz)
                 .push16(FILTER_CONFIG.yaw_lowpass_hz);
             if (semver.gte(CONFIG.apiVersion, "1.20.0")) {


### PR DESCRIPTION
Hello,
there will soon be a small set of options in the GUI,
where you can use the "Integrate GPS Rescue Mode".

So far, this only works on the CLI.
As under
https://diegofpv.com/gps-rescue-mode-for-betaflight-setup-guide/
explained

This is really a great feature for beginners.
Beginners are a little harder with the CLI.
Therefore my question to you professionals.

Maybe you can still do that for the Betaflight Release 3.5

**_Thanks again for the great work you are doing!_**

Best regards, Xillius