### PR TITLE
Added querying of Firmware jobs

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -389,6 +389,15 @@
         "message" : "Running - OS: <strong>{{operatingSystem}}</strong>, Chrome: <strong>{{chromeVersion}}</strong>, Configurator: <strong>{{configuratorVersion}}</strong>",
         "description": "Message that appears in the GUI log panel indicating operating system, Chrome version and Configurator version"
     },
+    "buildServerLoaded": {
+        "message" : "Loaded builds information for $1 from build server."
+    },
+    "buildServerLoadFailed": {
+        "message" : "<b>Build server query for $1 releases failed, using cached information. Reason: <code>$2</code></b>"
+    },
+    "buildServerUsingCached": {
+        "message" : "Using cached builds information for $1."
+    },
     "releaseCheckLoaded": {
         "message" : "Loaded release information for $1 from GitHub."
     },
@@ -2242,7 +2251,7 @@
         "message": "Baud Rate"
     },    
     "firmwareFlasherShowDevelopmentReleases":{
-        "message": "Show unstable releases"
+        "message": "Show unstable and additional releases"
     },
     "firmwareFlasherShowDevelopmentReleasesDescription":{
         "message": "Show Release-Candidates and Development Releases."

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
         "https://*.githubusercontent.com/",
         "http://*.baseflight.net/",
         "https://*.amazonaws.com/",
+        "https://*.betaflight.tech/",
         "serial",
         "usb",
         "storage",


### PR DESCRIPTION
Configurator now queries `/view/Firmware` for jobs.
Also fixed jobs and builds caching which wasn't saving anything in local storage, me and @etracer65 noticed it once.

New translations required for Build Server messages (they are very similar to Release Checker messages), and also changes `Show unstable releases` to `Show unstable and additional releases`.

![image](https://user-images.githubusercontent.com/1427681/43763744-36a95634-9a34-11e8-85ca-8fda028e10b4.png)