### PR TITLE
Allow OSD Character set download from EEPROM

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3333,7 +3333,7 @@
         "message": "Upload Font"
     },
     "osdSetupDownloadFont": {
-        "message": "Download Font"
+        "message": "Load Font from EEPROM"
     },
     "osdSetupSave": {
         "message": "Save"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3332,6 +3332,9 @@
     "osdSetupUploadFont": {
         "message": "Upload Font"
     },
+    "osdSetupDownloadFont": {
+        "message": "Download Font"
+    },
     "osdSetupSave": {
         "message": "Save"
     },

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -235,6 +235,15 @@
   background-color: #b8b8b8;
 }
 
+.tab-osd .buttons a.read_font.locked {
+  background-color: #b8b8b8;
+}
+
+.tab-osd .buttons a.read_font.locked:hover {
+  cursor: default;
+  background-color: #b8b8b8;
+}
+
 .tab-osd .buttons a.load_remote_file.locked {
   background-color: #b8b8b8;
 }

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -142,7 +142,7 @@ FONT.parseEEPROMCharData = function(data) {
     character_bits = [];
     character_bytes = [];
   };
-  for (var i = 0; i < FONT.constants.SIZES.MAX_NVM_FONT_CHAR_SIZE; i++) {
+  for (var i = 0; i < FONT.constants.SIZES.MAX_NVM_FONT_CHAR_FIELD_SIZE; i++) {
     var line = data.getUint8(i);
     var binLine = '00000000'.concat(line.toString(2)).slice(-8)
     FONT.data.hexstring.push('0x' + line.toString(16));

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2095,6 +2095,7 @@ TABS.osd.initialize = function (callback) {
                   FONT.preview($preview);
                   LogoManager.drawPreview();
                   updateOsdView();
+                  $('a.read_font').removeClass('disabled');
               });
           }
       });

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -157,9 +157,12 @@
                         </div>
                     </div>
                     <!-- Upload button -->
-                    <div class="default_btn green" style="width:100%; float:left;
-                        ">
+                    <div class="default_btn green" style="width:100%; float:left;">
                         <a class="flash_font active" i18n="osdSetupUploadFont" />
+                    </div>
+                    <!-- Info Character Read Test button -->
+                    <div class="default_btn green" style="width:100%; float:left;">
+                        <a class="read_font active" i18n="osdSetupDownloadFont" />
                     </div>
                 </div>
 


### PR DESCRIPTION
Opening PR early for discussion.

This adds the ability to read the OSD character set out of EEPROM which is a pre-requisite for https://github.com/betaflight/betaflight/pull/3461.

https://github.com/betaflight/betaflight/pull/6545 needs to be merged before this.