### PR TITLE
Sync max with ßF settings.

### DIFF
--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -90,10 +90,10 @@
                             <tr class="ROLL">
                                 <!-- 0 -->
                                 <td bgcolor="#FF8080"></td>
-                                <td class="pid_data"><input type="number" name="p" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="i" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="d" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="f" step="1" min="0" max="255" /></td>
+                                <td class="pid_data"><input type="number" name="p" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="i" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
                                 <td rowspan="2" style="background-color:white;">
                                     <input type="number" name="rc_rate" step="0.01" min="0" max="2.55" />
                                     <div class="bracket"></div>
@@ -109,20 +109,20 @@
                             <tr class="PITCH">
                                 <!-- 1 -->
                                 <td bgcolor="#80FF80"></td>
-                                <td class="pid_data"><input type="number" name="p" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="i" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="d" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="f" step="1" min="0" max="255" /></td>
+                                <td class="pid_data"><input type="number" name="p" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="i" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
                                 <td class="pitch_rate"><input type="number" name="pitch_rate" step="0.01" min="0" max="1.00" /></td>
                                 <td class="new_rates maxAngularVelPitch"></td>
                             </tr>
                             <tr class="YAW">
                                 <!-- 2 -->
                                 <td bgcolor="#8080FF"></td>
-                                <td class="pid_data"><input type="number" name="p" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="i" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="d" step="1" min="0" max="255" /></td>
-                                <td class="pid_data"><input type="number" name="f" step="1" min="0" max="255" /></td>
+                                <td class="pid_data"><input type="number" name="p" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="i" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
                                 <td rowspan="1"><input type="number" name="rc_rate_yaw" step="0.01" min="0" max="2.55" /></td>
                                 <td><input type="number" name="yaw_rate" step="0.01" min="0" max="2.55" /></td>
                                 <td class="new_rates maxAngularVelYaw"></td>


### PR DESCRIPTION
Noticed discrepancies between ßF configurator maximum value for some pids compared with ßF settings. 

e.g. f_yaw is 255 in ßFC: https://github.com/betaflight/betaflight-configurator/blob/master/src/tabs/pid_tuning.html#L125
vs 2000 in ßF: https://github.com/betaflight/betaflight/blob/master/src/main/interface/settings.c#L848

f max look like they need to increase from 255 up to 2000, with p, i & d max reduced from 255 down to 200.