### PR TITLE
Add ability to detect installed OSD font in the future.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3333,7 +3333,7 @@
         "message": "Upload Font"
     },
     "osdSetupDownloadFont": {
-        "message": "Download Font"
+        "message": "Load Font from EEPROM"
     },
     "osdSetupSave": {
         "message": "Save"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3332,6 +3332,9 @@
     "osdSetupUploadFont": {
         "message": "Upload Font"
     },
+    "osdSetupDownloadFont": {
+        "message": "Download Font"
+    },
     "osdSetupSave": {
         "message": "Save"
     },

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -235,6 +235,15 @@
   background-color: #b8b8b8;
 }
 
+.tab-osd .buttons a.read_font.locked {
+  background-color: #b8b8b8;
+}
+
+.tab-osd .buttons a.read_font.locked:hover {
+  cursor: default;
+  background-color: #b8b8b8;
+}
+
 .tab-osd .buttons a.load_remote_file.locked {
   background-color: #b8b8b8;
 }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1201,6 +1201,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log('OSD config set');
                 break;
             case MSPCodes.MSP_OSD_CHAR_READ:
+                console.log('OSD char downloaded');
                 break;
             case MSPCodes.MSP_OSD_CHAR_WRITE:
                 console.log('OSD char uploaded');

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -142,7 +142,7 @@ FONT.parseEEPROMCharData = function(data) {
     character_bits = [];
     character_bytes = [];
   };
-  for (var i = 0; i < FONT.constants.SIZES.MAX_NVM_FONT_CHAR_SIZE; i++) {
+  for (var i = 0; i < FONT.constants.SIZES.MAX_NVM_FONT_CHAR_FIELD_SIZE; i++) {
     var line = data.getUint8(i);
     var binLine = '00000000'.concat(line.toString(2)).slice(-8)
     FONT.data.hexstring.push('0x' + line.toString(16));

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2077,7 +2077,9 @@ TABS.osd.initialize = function (callback) {
           });
         });
         
-        // load the first font when we change tabs
+        // load the font when we change tabs
+        // first check if we can detect the font in the EEPROM 
+        // and if not load the default
         FONT.checkEEPROMHash().then(function(x){
           var eeprom_font;
           OSD.constants.FONT_TYPES.forEach(function(e, i) {
@@ -2089,6 +2091,8 @@ TABS.osd.initialize = function (callback) {
             $.get('./resources/osd/' + eeprom_font.file + '.mcm', function(data) {
               FONT.parseMCMFontFile(data);
             });
+            // if we detected the font hide the warning
+            $('.note').fadeOut();
           } else {
             var $font = $('.fontpresets option:selected');
             $.get('./resources/osd/' + $font.data('font-file') + '.mcm', function(data) {

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -249,8 +249,10 @@ FONT.checkEEPROMHash = function() {
   return Promise.mapSeries([1,2,3,4], function(data, i){
     return MSP.promise(MSPCodes.MSP_OSD_CHAR_READ, [data])
     .then(function(info){
-      for(var i = 54; i < 64; ++i){
-        FONT.EEPROMHash += String.fromCharCode(info.data.getUint8(i));
+      if(info.length > 0){
+        for(var i = 54; i < 64; ++i){
+          FONT.EEPROMHash += String.fromCharCode(info.data.getUint8(i));
+        }
       }
     });
   });

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2095,6 +2095,7 @@ TABS.osd.initialize = function (callback) {
                   FONT.preview($preview);
                   LogoManager.drawPreview();
                   updateOsdView();
+                  $('a.read_font').removeClass('disabled');
               });
           }
       });

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -45,6 +45,7 @@ FONT.initData = function() {
   if (FONT.data) {
     return;
   }
+  FONT.EEPROMHash = "";
   FONT.data = {
     // default font file name
     loaded_font_file: 'default',
@@ -62,7 +63,7 @@ FONT.constants = {
   SIZES: {
     /** NVM ram size for one font char, actual character bytes **/
     MAX_NVM_FONT_CHAR_SIZE: 54,
-    /** NVM ram field size for one font char, last 10 bytes dont matter **/
+    /** NVM ram field size for one font char, last 10 bytes not used for character data **/
     MAX_NVM_FONT_CHAR_FIELD_SIZE: 64,
     CHAR_HEIGHT: 18,
     CHAR_WIDTH: 12,
@@ -83,6 +84,7 @@ FONT.constants = {
  * Each line is composed of 8 asci 1 or 0, representing 1 bit each for a total of 1 byte per line
  */
 FONT.parseMCMFontFile = function(data) {
+  FONT.hash = objectHash.sha1(data);
   var data = data.split("\n");
   FONT.ClearData();
   // make sure the font file is valid
@@ -107,7 +109,7 @@ FONT.parseMCMFontFile = function(data) {
     var line = data[i];
     // hexstring is for debugging
     FONT.data.hexstring.push('0x' + parseInt(line, 2).toString(16));
-    // every 64 bytes (line) is a char, we're counting chars though, which are 2 bits
+    // every 64 bytes (64 lines) is a char, we're counting pixels though, which are 2 bits
     if (character_bits.length == FONT.constants.SIZES.MAX_NVM_FONT_CHAR_FIELD_SIZE * (8 / 2)) {
       pushChar()
     }
@@ -218,7 +220,16 @@ FONT.draw = function(charAddress) {
 
 FONT.msp = {
   encode: function(charAddress) {
-    return [charAddress].concat(FONT.data.characters_bytes[charAddress].slice(0,FONT.constants.SIZES.MAX_NVM_FONT_CHAR_SIZE));
+    var x  = [charAddress].concat(FONT.data.characters_bytes[charAddress].slice(0,FONT.constants.SIZES.MAX_NVM_FONT_CHAR_FIELD_SIZE));
+    if (charAddress > 0 && charAddress < 5){
+      x = x.slice(0, 55)
+      var start = (charAddress * 10) - 10
+      for (var i = start; i < start + 10; ++i) {
+        var code = FONT.hash.charCodeAt(i);
+        x = x.concat(code);
+      }
+    }
+    return x
   }
 };
 
@@ -230,6 +241,18 @@ FONT.upload = function($progress) {
   .then(function() {
     OSD.GUI.jbox.close();
     return MSP.promise(MSPCodes.MSP_SET_REBOOT);
+  });
+};
+
+FONT.checkEEPROMHash = function() {
+  FONT.EEPROMHash = "";
+  return Promise.mapSeries([1,2,3,4], function(data, i){
+    return MSP.promise(MSPCodes.MSP_OSD_CHAR_READ, [data])
+    .then(function(info){
+      for(var i = 54; i < 64; ++i){
+        FONT.EEPROMHash += String.fromCharCode(info.data.getUint8(i));
+      }
+    });
   });
 };
 
@@ -953,14 +976,14 @@ OSD.constants = {
 
   },
   FONT_TYPES: [
-    { file: "default", name: "Default" },
-    { file: "bold", name: "Bold" },
-    { file: "large", name: "Large" },
-    { file: "extra_large", name: "Extra Large" },
-    { file: "betaflight", name: "Betaflight" },
-    { file: "digital", name: "Digital" },
-    { file: "clarity", name: "Clarity" },
-    { file: "vision", name: "Vision" }
+    { file: "default", name: "Default", hash: "2ad1c6488898ca85ce1611cd13d54502ce5b2ba3" },
+    { file: "bold", name: "Bold", hash: "0c494c1536edda39519800b722d78bc2c2947af1" },
+    { file: "large", name: "Large", hash: "a2fddee48a166481e28d57eaa330a40e434c7b73"},
+    { file: "extra_large", name: "Extra Large", hash: "c5c1edfc2f73599e60c401feae3e6b5fe54eae14" },
+    { file: "betaflight", name: "Betaflight", hash: "54f9b83674e29c968d8ef517281fdc223a9998ed" },
+    { file: "digital", name: "Digital", hash: "30b062fcdabcd2455a5d9dfa16cfbad50c666227" },
+    { file: "clarity", name: "Clarity", hash: "db7764279c22b8192ecf489d4a4f3156f9f2bbed"},
+    { file: "vision", name: "Vision", hash: "5fb84b0dabcd209e945a4a689b40c5ba8618d7f6" }
   ]
 };
 
@@ -1558,7 +1581,7 @@ TABS.osd.initialize = function (callback) {
         // Open modal window
         OSD.GUI.jbox = new jBox('Modal', {
             width: 720,
-            height: 455,
+            height: 470,
             closeButton: 'title',
             animation: false,
             attach: $('#fontmanager'),
@@ -2055,14 +2078,29 @@ TABS.osd.initialize = function (callback) {
         });
         
         // load the first font when we change tabs
-        var $font = $('.fontpresets option:selected');
-        $.get('./resources/osd/' + $font.data('font-file') + '.mcm', function(data) {
-          FONT.parseMCMFontFile(data);
+        FONT.checkEEPROMHash().then(function(x){
+          var eeprom_font;
+          OSD.constants.FONT_TYPES.forEach(function(e, i) {
+            if(e.hash == FONT.EEPROMHash){
+              eeprom_font = e;
+            }
+          })
+          if(eeprom_font){
+            $.get('./resources/osd/' + eeprom_font.file + '.mcm', function(data) {
+              FONT.parseMCMFontFile(data);
+            });
+          } else {
+            var $font = $('.fontpresets option:selected');
+            $.get('./resources/osd/' + $font.data('font-file') + '.mcm', function(data) {
+              FONT.parseMCMFontFile(data);
+            });
+          }
           FONT.preview($preview);
+          LogoManager.init(FONT);
           LogoManager.drawPreview();
           updateOsdView();
         });
-
+        
         $('button.load_font_file').click(function() {
           FONT.openFontFile().then(function() {
             FONT.preview($preview);

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -157,9 +157,12 @@
                         </div>
                     </div>
                     <!-- Upload button -->
-                    <div class="default_btn green" style="width:100%; float:left;
-                        ">
+                    <div class="default_btn green" style="width:100%; float:left;">
                         <a class="flash_font active" i18n="osdSetupUploadFont" />
+                    </div>
+                    <!-- Info Character Read Test button -->
+                    <div class="default_btn green" style="width:100%; float:left;">
+                        <a class="read_font active" i18n="osdSetupDownloadFont" />
                     </div>
                 </div>
 


### PR DESCRIPTION
This depends on https://github.com/betaflight/betaflight/pull/6545 and adds the ability to detect which font is intalled going forward.

On uploading the font we use the spare 10 bytes in characters 1-4 to store a sha1 hash of the font file. On loading the OSD tab we try and fetch the first 4 bytes from the EEPROM, reconstuct the hash and use this to lookup the font in our internal array. If this fails we fall back to the old way of just loading the first font in the dropdown.

This won't help until after the first font upload by the user with this new version, but doing it his way requires no changes to the font files themselves.

This also incorporates #1150 as this change is based on that.