### PR TITLE
Add button to reset CLI output history

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2093,6 +2093,9 @@
     "cliSaveToFileBtn": {
         "message": "Save to File"
     },
+    "cliClearOutputHistoryBtn": {
+        "message": "Clear output history"
+    },
 
     "loggingNote": {
         "message": "Data will be logged in this tab <span class=\"message-negative\">only</span>, leaving the tab will <span class=\"message-negative\">cancel</span> logging and application will return to its normal <strong>\"configurator\"</strong> state.<br /> You are free to select the global update period, data will be written into the log file every <strong>1</strong> second for performance reasons."

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -102,6 +102,11 @@ TABS.cli.initialize = function (callback) {
             });
         });
 
+        $('.tab-cli .clear').click(function() {
+            self.outputHistory = "";
+            $('.tab-cli .window .wrapper').empty();
+        });
+
         // Tab key detection must be on keydown,
         // `keypress`/`keyup` happens too late, as `textarea` will have already lost focus.
         textarea.keydown(function (event) {

--- a/src/tabs/cli.html
+++ b/src/tabs/cli.html
@@ -16,6 +16,7 @@
     <div class="content_toolbar">
         <div class="btn save_btn pull-right">
             <a class="save" href="#" i18n="cliSaveToFileBtn"></a>
+            <a class="clear" href="#" i18n="cliClearOutputHistoryBtn"></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This is a minor feature that adds a new button to the CLI tab with which the user can clear the output history. This could be used to save the output of multiple commands into separate files without rebooting. Eg. I sometimes like to create both a diff and a dump.