### PR TITLE
warning cpu load too high

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -474,6 +474,9 @@
     "versionLabelConfigurator": {
         "message": "Configurator"
     },
+    "cpuLoadTooHigh": {
+        "message": "Your CPU usage is too high. Make sure to lower loop times or disable certain features you don't want to use until the CPU load % is low enough."
+    },
 
     "notifications_app_just_updated_to_version": {
         "message": "Application just updated to version: $1"

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -109,6 +109,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 $('span.i2c-error').text(CONFIG.i2cError);
                 $('span.cycle-time').text(CONFIG.cycleTime);
                 $('span.cpu-load').text(i18n.getMessage('statusbar_cpu_load', [CONFIG.cpuload]));
+                if (CONFIG.cpuload >= 30) {
+                    GUI.log(i18n.getMessage('cpuLoadTooHigh'));
+                }
                 break;
 
             case MSPCodes.MSP_RAW_IMU:


### PR DESCRIPTION
Implements #717 . 

This will show a message in the GUI.log that CPU load is too high if it is at or above 30, hopefully preventing support questions about CPU usage.