### PR TITLE
CSS the hide modes tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1609,7 +1609,7 @@
         "message": "Use ranges to define the switches on your transmitter and corresponding mode assignments.  A receiver channel that gives a reading between a range min/max will activate the mode.  Remember to save your settings using the Save button."
     },
     "auxiliaryToggleUnused": {
-        "message": "Show/hide unused modes"
+        "message": "Hide unused modes"
     },
     "auxiliaryMin": {
         "message": "Min"

--- a/src/css/tabs/auxiliary.css
+++ b/src/css/tabs/auxiliary.css
@@ -9,6 +9,12 @@
     margin-bottom: 10px;
 }
 
+.tab-auxiliary .toolbox {
+    font-weight: bold;
+    color: rgb(105, 99, 99);
+    padding: 10px 5px;
+}
+
 .tab-auxiliary .range .marker, .tab-auxiliary .channel-slider .noUi-connect {
     background: #ffbb00;
     border-radius: 3px;

--- a/src/tabs/auxiliary.html
+++ b/src/tabs/auxiliary.html
@@ -7,14 +7,16 @@
         <div class="note spacebottom">
             <div class="note_spacer">
                 <p i18n="auxiliaryHelp"></p>
-                <p>
-                    <form>
-                        <input type="checkbox" id="switch-toggle-unused" name="switch-toggle-unused" class="togglesmall"></input>
-                        <label for="switch-toggle-unused"><span i18n="auxiliaryToggleUnused" /></label>
-                    </form>
-                </p>
             </div>
         </div>
+
+        <div class="toolbox">
+            <form>
+                <input type="checkbox" id="switch-toggle-unused" name="switch-toggle-unused" class="toggle"></input>
+                <label for="switch-toggle-unused"><span i18n="auxiliaryToggleUnused" /></label>
+            </form>
+        </div>
+
         <table class="modes">
             <tbody>
             </tbody>


### PR DESCRIPTION
One of the more useful features of the old version of the configurator is almost hidden in the header text of the modes tab, so is difficult to see.

This PR is to give a little more of visibility to the switch. I have changed the text too to show only what the switch does and not the two possibilities (in this way you don't know if activating it the modes are shown or are hide).

This is the before and after:
![image](https://user-images.githubusercontent.com/2673520/47436024-f41e4400-d7a5-11e8-85dd-9b1346bb426a.png)

