### PR TITLE
Changed RC rate minimum to be 0.01.

### DIFF
--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -95,7 +95,7 @@
                                 <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
                                 <td rowspan="2" style="background-color:white;">
-                                    <input type="number" name="rc_rate" step="0.01" min="0" max="2.55" />
+                                    <input type="number" name="rc_rate" step="0.01" min="0.01" max="2.55" />
                                     <div class="bracket"></div>
                                 </td>
                                 <td class="roll_rate"><input type="number" name="roll_rate" step="0.01" min="0" max="1.00" /></td>
@@ -113,7 +113,7 @@
                                 <td class="pid_data"><input type="number" name="i" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
-                                <td><input type="number" name="rc_rate_pitch" step="0.01" min="0" max="2.55" /></td>
+                                <td><input type="number" name="rc_rate_pitch" step="0.01" min="0.01" max="2.55" /></td>
                                 <td class="pitch_rate"><input type="number" name="pitch_rate" step="0.01" min="0" max="1.00" /></td>
                                 <td class="new_rates maxAngularVelPitch"></td>
                                 <td><input type="number" name="rc_pitch_expo" step="0.01" min="0" max="1" /></td>
@@ -125,7 +125,7 @@
                                 <td class="pid_data"><input type="number" name="i" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
-                                <td rowspan="1"><input type="number" name="rc_rate_yaw" step="0.01" min="0" max="2.55" /></td>
+                                <td rowspan="1"><input type="number" name="rc_rate_yaw" step="0.01" min="0.01" max="2.55" /></td>
                                 <td><input type="number" name="yaw_rate" step="0.01" min="0" max="2.55" /></td>
                                 <td class="new_rates maxAngularVelYaw"></td>
                                 <td><input type="number" name="rc_yaw_expo" step="0.01" min="0" max="1" /></td>


### PR DESCRIPTION
Setting an RC rate to 0 means that there is no control input for this axis, which does not have any practical use.

Increasing the minimum to 0.01 avoids division by zero errors like betaflight/betaflight-configurator#1223.