### PR TITLE
Add an ability to handle multiple DFU device types

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -34,7 +34,8 @@
         "notifications",
         "alwaysOnTopWindows",
         {"usbDevices": [
-            {"vendorId": 1155, "productId": 57105}
+            {"vendorId": 1155, "productId": 57105},
+            {"vendorId": 10473, "productId": 393}
         ]},
         "webview",
         "unlimitedStorage"

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var usbDevices = {
-    STM32DFU: {'vendorId': 1155, 'productId': 57105}
-};
+var usbDevices = { filters: [
+    {'vendorId': 1155, 'productId': 57105},
+    {'vendorId': 10473, 'productId': 393}
+] };
 
 var PortHandler = new function () {
     this.initial_ports = false;
@@ -146,7 +147,7 @@ PortHandler.check = function () {
 };
 
 PortHandler.check_usb_devices = function (callback) {
-    chrome.usb.getDevices(usbDevices.STM32DFU, function (result) {
+    chrome.usb.getDevices(usbDevices, function (result) {
         if (result.length) {
             if (!$("div#port-picker #port [value='DFU']").length) {
                 $('div#port-picker #port').append($('<option/>', {value: "DFU", text: "DFU", data: {isDFU: true}}));

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -497,7 +497,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         } else {
                             analytics.sendEvent(analytics.EVENT_CATEGORIES.FIRMWARE, 'Flashing');
 
-                            STM32DFU.connect(usbDevices.STM32DFU, parsed_hex, options);
+                            STM32DFU.connect(usbDevices, parsed_hex, options);
                         }
                     } else {
                         $('span.progressLabel').text(i18n.getMessage('firmwareFlasherFirmwareNotLoaded'));


### PR DESCRIPTION
This PR adds capability to handle an additional DFU device type.

Multiple simultaneous DFU devices are still not supported.

-----
The original initial message:

In an attempt to handle additional DFU devices in the configurator, I tried to leverage the `chrome.usb.getDevices`'s ability to accept `array of DeviceFilter` for the argument `option`.

However, the call fails with
```
Error in response to serial.getDevices: Error: Invocation of form usb.getDevices(array, function) doesn't match definition usb.getDevices(object options, function callback)
    at Object.PortHandler.check_usb_devices (chrome-extension://xxx/js/port_handler.js:150:16)
```~

Looks like it only supports old way of calling?

Here's the `chrome.usb.getDevices` documentation.
https://developer.chrome.com/apps/usb#method-getDevices