### PR TITLE
Add GPS Rescue option to Failsafe tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3008,6 +3008,47 @@
     "failsafeProcedureItemSelect2": {
         "message": "Drop"
     },
+    "failsafeProcedureItemSelect4": {
+        "message": "GPS Rescue"
+    },
+
+    "failsafeGpsRescueItemAngle": {
+        "message": "Angle"
+    },
+    "failsafeGpsRescueItemInitialAltitude": {
+        "message": "Initial altitude (meters)"
+    },
+    "failsafeGpsRescueItemDescentDistance": {
+        "message": "Descent distance (meters)"
+    },
+    "failsafeGpsRescueItemGroundSpeed": {
+        "message": "Ground speed (meters/second)"
+    },
+    "failsafeGpsRescueItemThrottleMin": {
+        "message": "Throttle minimum"
+    },
+    "failsafeGpsRescueItemThrottleMax": {
+        "message": "Throttle maximum"
+    },
+    "failsafeGpsRescueItemThrottleHover": {
+        "message": "Throttle hover"
+    },
+    "failsafeGpsRescueItemMinSats": {
+        "message": "Minimum satellites"
+    },
+    "failsafeGpsRescueItemSanityChecks": {
+        "message": "Sanity checks"
+    },
+    "failsafeGpsRescueItemSanityChecksOff": {
+        "message": "Off"
+    },
+    "failsafeGpsRescueItemSanityChecksOn": {
+        "message": "On"
+    },
+    "failsafeGpsRescueItemSanityChecksFSOnly": {
+        "message": "Failsafe only"
+    },
+
     "failsafeKillSwitchItem": {
         "message": "Failsafe Kill Switch (setup Failsafe in Modes Tab)"
     },

--- a/src/css/tabs/failsafe.css
+++ b/src/css/tabs/failsafe.css
@@ -63,7 +63,8 @@
     background-color: #ededed;
     margin-bottom: 0;
     margin-top: 5px;
-    height: 150px;
+    min-height: 90px;
+    padding-bottom: 10px;
 }
 
 .tab-failsafe .radiobuttons {
@@ -248,10 +249,6 @@
     padding-bottom: 7px;
 }
 
-.tab-failsafe .pro1 {
-    height: 90px;
-}
-
 .tab-failsafe .featuresNew {
     width: 100%;
 }
@@ -296,7 +293,7 @@
 .tab-failsafe .switchMode {
     border: 1px solid silver;
     margin-right: 5px;
-    width: 80px;
+    min-width: 80px;
 }
 
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -50,6 +50,7 @@ var RC_DEADBAND_CONFIG;
 var SENSOR_ALIGNMENT;
 var RX_CONFIG;
 var FAILSAFE_CONFIG;
+var GPS_RESCUE;
 var RXFAIL_CONFIG;
 var PID_ADVANCED_CONFIG;
 var FILTER_CONFIG;
@@ -420,7 +421,19 @@ var FC = {
             failsafe_throttle:              0,
             failsafe_switch_mode:           0,
             failsafe_throttle_low_delay:    0,
-            failsafe_procedure:             0.
+            failsafe_procedure:             0,
+        };
+
+        GPS_RESCUE = {
+            angle:                          0,
+            initialAltitudeM:               0,
+            descentDistanceM:               0,
+            rescueGroundspeed:              0,
+            throttleMin:                    0,
+            throttleMax:                    0,
+            throttleHover:                  0,
+            sanityChecks:                   0,
+            minSats:                        0,
         };
 
         RXFAIL_CONFIG = [];

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -110,6 +110,7 @@ var MSPCodes = {
     MSP_MOTOR_CONFIG:               131,
     MSP_GPS_CONFIG:                 132,
     MSP_COMPASS_CONFIG:             133,
+    MSP_GPS_RESCUE:                 135,
 
     MSP_STATUS_EX:                  150,
 
@@ -145,6 +146,7 @@ var MSPCodes = {
     MSP_SET_MOTOR_CONFIG:           222,
     MSP_SET_GPS_CONFIG:             223,
     MSP_SET_COMPASS_CONFIG:         224,
+    MSP_SET_GPS_RESCUE:             225,
 
     MSP_SET_ACC_TRIM:               239,
     MSP_ACC_TRIM:                   240,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -382,6 +382,17 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     GPS_CONFIG.auto_baud = data.readU8();
                 }
                 break;
+            case MSPCodes.MSP_GPS_RESCUE:
+                GPS_RESCUE.angle             = data.readU16();
+                GPS_RESCUE.initialAltitudeM  = data.readU16();
+                GPS_RESCUE.descentDistanceM  = data.readU16();
+                GPS_RESCUE.rescueGroundspeed = data.readU16();
+                GPS_RESCUE.throttleMin       = data.readU16();
+                GPS_RESCUE.throttleMax       = data.readU16();
+                GPS_RESCUE.throttleHover     = data.readU16();
+                GPS_RESCUE.sanityChecks      = data.readU8();
+                GPS_RESCUE.minSats           = data.readU8();
+                break;
             case MSPCodes.MSP_RSSI_CONFIG:
                 RSSI_CONFIG.channel = data.readU8();
                 break;
@@ -1390,6 +1401,17 @@ MspHelper.prototype.crunch = function(code) {
                 buffer.push8(GPS_CONFIG.auto_config)
                     .push8(GPS_CONFIG.auto_baud);
             }
+            break;
+        case MSPCodes.MSP_SET_GPS_RESCUE:
+            buffer.push16(GPS_RESCUE.angle)
+                  .push16(GPS_RESCUE.initialAltitudeM)
+                  .push16(GPS_RESCUE.descentDistanceM)
+                  .push16(GPS_RESCUE.rescueGroundspeed)
+                  .push16(GPS_RESCUE.throttleMin)
+                  .push16(GPS_RESCUE.throttleMax)
+                  .push16(GPS_RESCUE.throttleHover)
+                  .push8(GPS_RESCUE.sanityChecks)
+                  .push8(GPS_RESCUE.minSats);
             break;
         case MSPCodes.MSP_SET_COMPASS_CONFIG:
             buffer.push16(Math.round(COMPASS_CONFIG.mag_declination * 100));

--- a/src/tabs/failsafe.html
+++ b/src/tabs/failsafe.html
@@ -115,6 +115,63 @@
                             </div>
                         </div>
                     </div>
+                    <div class="radioarea pro4 stage2">
+                        <div class="radiobuttons"><input class="procedure" id="gps_rescue" name="group1" type="radio" checked/>
+                            <label for="gps_rescue" i18n="failsafeProcedureItemSelect4"></label>
+                        </div>
+                        <div class="proceduresettings">
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_angle" min="0" max="200" /> <span
+                                    i18n="failsafeGpsRescueItemAngle"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_initial_altitude" min="20" max="100" /> <span
+                                    i18n="failsafeGpsRescueItemInitialAltitude"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_descent_distance" min="30" max="500" /> <span
+                                    i18n="failsafeGpsRescueItemDescentDistance"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_ground_speed" min="0.30" max="30.00" step="0.01"/> <span
+                                    i18n="failsafeGpsRescueItemGroundSpeed"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_throttle_min" min="1000" max="2000" /> <span
+                                    i18n="failsafeGpsRescueItemThrottleMin"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_throttle_max" min="1000" max="2000" /> <span
+                                    i18n="failsafeGpsRescueItemThrottleMax"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_throttle_hover" min="1000" max="2000" /> <span
+                                    i18n="failsafeGpsRescueItemThrottleHover"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_min_sats" min="0" max="50" /> <span
+                                    i18n="failsafeGpsRescueItemMinSats"></span>
+                                </label>
+                            </div>
+                            <div class="selectSwitchMode">
+                                <label>
+                                    <select class="switchMode" name="gps_rescue_sanity_checks">
+                                        <option value="0" i18n="failsafeGpsRescueItemSanityChecksOff"></option>
+                                        <option value="1" i18n="failsafeGpsRescueItemSanityChecksOn"></option>
+                                        <option value="2" i18n="failsafeGpsRescueItemSanityChecksFSOnly"></option>
+                                    </select>
+                                <span i18n="failsafeGpsRescueItemSanityChecks"></span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1225

Adds the GPS Rescue option to the failsafe tab. With all parameters enabled for MSP 1.41 (Betaflight 4.0), with only the procedure selection and not any parameter for MSP 1.40 (Betaflight 3.5).

https://github.com/betaflight/betaflight/pull/7083 to be merged first to work.

![image](https://user-images.githubusercontent.com/2673520/48350051-44dadb80-e686-11e8-878d-369b4aa42182.png)
