### PR TITLE
Match visible CLI output history with the history kept in memory

### DIFF
--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -316,6 +316,10 @@ TABS.cli.read = function (readInfo) {
     if (!CONFIGURATOR.cliValid && validateText.indexOf('CLI') !== -1) {
         GUI.log(i18n.getMessage('cliEnter'));
         CONFIGURATOR.cliValid = true;
+        // begin output history with the prompt (last line of welcome message)
+        // this is to match the content of the history with what the user sees on this tab
+        const lastLine = validateText.split("\n").pop();
+        this.outputHistory = lastLine;
         validateText = "";
     }
 


### PR DESCRIPTION
I was curious why saved dumps begin with the generating command and thus result in a needles execution of the command when restoring the config. While including the generating command is a good idea, I think it should be commented out, just like it is in the visible output on the CLI tab. This PR aims to fix this and make the visible output match with the one saved to file. Basically it's just that the first prompt `#` character was missing from the output history, making it different from what the user sees.