### PR TITLE
Add throttle limit to PID Tuning tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1440,6 +1440,27 @@
     "pidTuningTPABreakPoint": {
         "message": "TPA Breakpoint"
     },
+    "pidTuningThrottleLimitType": {
+        "message": "Throttle Limit"
+    },
+    "pidTuningThrottleLimitPercent": {
+        "message": "Throttle Limit %"
+    },
+    "pidTuningThrottleLimitTypeOff": {
+        "message": "OFF"
+    },
+    "pidTuningThrottleLimitTypeScale": {
+        "message": "SCALE"
+    },
+    "pidTuningThrottleLimitTypeClip": {
+        "message": "CLIP"
+    },
+    "pidTuningThrottleLimitTypeTip": {
+        "message": "Select the type of throttle limiting. <b>OFF</b> disables the feature, <b>SCALE</b> will transform the throttle range from 0 to the selected percentage using the full stick travel, <b>CLIP</b> will set a max throttle percentage and stick travel above that will have no additional effect"
+    },
+    "pidTuningThrottleLimitPercentTip": {
+        "message": "Set the desired throttle limit percentage. Setting to 100% disables the feature."
+    },
     "pidTuningFilter": {
         "message": "Filter"
     },

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -8,6 +8,16 @@
     text-align: left;
 }
 
+.tab-pid_tuning .throttle_limit th {
+    background-color: #828885;
+    padding: 4px;
+    border-left: 0px solid #ccc;
+    border-bottom: 1px solid #ccc;
+    font-weight: bold;
+    color: white;
+    text-align: left;
+}
+
 .tab-pid_tuning .cf tr {
     background-color: #DEDEDE;
 }
@@ -175,6 +185,18 @@
 }
 
 .tab-pid_tuning .tpa th:last-child {
+    border-top-right-radius: 3px;
+}
+
+.tab-pid_tuning .throttle_limit th:nth-child(2) {
+    border-top-left-radius: 3px;
+}
+
+.tab-pid_tuning .throttle_limit th:first-child {
+    border-top-left-radius: 3px;
+}
+
+.tab-pid_tuning .throttle_limit th:last-child {
     border-top-right-radius: 3px;
 }
 
@@ -433,6 +455,11 @@
 }
 
 .tab-pid_tuning .tpa {
+    float: right;
+    width: calc(100% - 2px); /* - ( "virtual" margin) */
+}
+
+.tab-pid_tuning .throttle_limit {
     float: right;
     width: calc(100% - 2px); /* - ( "virtual" margin) */
 }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -320,6 +320,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     RC_tuning.rcPitchRate = 0;
                     RC_tuning.RC_PITCH_EXPO = 0;
                 }
+                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                    RC_tuning.throttleLimitType = data.readU8();
+                    RC_tuning.throttleLimitPercent = data.readU8();
+                }
                 break;
             case MSPCodes.MSP_PID:
                 // PID data arrived, we need to scale it and save to appropriate bank / array
@@ -1346,6 +1350,10 @@ MspHelper.prototype.crunch = function(code) {
             if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
                 buffer.push8(Math.round(RC_tuning.rcPitchRate * 100));
                 buffer.push8(Math.round(RC_tuning.RC_PITCH_EXPO * 100));
+            }
+            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                buffer.push8(RC_tuning.throttleLimitType);
+                buffer.push8(RC_tuning.throttleLimitPercent);
             }
             break;
         case MSPCodes.MSP_SET_RX_MAP:

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -308,6 +308,13 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.antigravity  table td:first-child').hide();
         }
 
+        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            $('select[id="throttleLimitType"]').val(RC_tuning.throttleLimitType);
+            $('.throttle_limit input[name="throttleLimitPercent"]').val(RC_tuning.throttleLimitPercent);
+        } else {
+            $('.throttle_limit').hide();
+        }
+
         $('input[id="gyroNotch1Enabled"]').change(function() {
             var checked = $(this).is(':checked');
             var hz = FILTER_CONFIG.gyro_notch_hz > 0 ? FILTER_CONFIG.gyro_notch_hz : DEFAULT.gyro_notch_hz;
@@ -520,6 +527,12 @@ TABS.pid_tuning.initialize = function (callback) {
 
             ADVANCED_TUNING.antiGravityMode = $('select[id="antiGravityMode"]').val();
         }
+
+        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            RC_tuning.throttleLimitType = $('select[id="throttleLimitType"]').val();
+            RC_tuning.throttleLimitPercent = parseInt($('.throttle_limit input[name="throttleLimitPercent"]').val());
+        }
+
     }
 
     function showAllPids() {

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -582,6 +582,39 @@
                             </tbody>
                         </table>
                     </div>
+                    <div class="spacer_left topspacer throttle_limit">
+                        <table class="cf">
+                            <thead>
+                                <tr>
+                                    <th>
+                                        <div>
+                                            <div i18n="pidTuningThrottleLimitType" style="float:left;"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningThrottleLimitTypeTip"></div>
+                                        </div>
+                                    </th>
+                                    <th>
+                                        <div>
+                                            <div i18n="pidTuningThrottleLimitPercent" style="float:left;"></div>
+                                            <div class="helpicon cf_tip" i18n_title="pidTuningThrottleLimitPercentTip"></div>
+                                        </div>
+                                    </th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr style="height: 35px;">
+                                    <td>
+                                        <select id="throttleLimitType">
+                                            <option i18n="pidTuningThrottleLimitTypeOff" value="0">
+                                            <option i18n="pidTuningThrottleLimitTypeScale" value="1">
+                                            <option i18n="pidTuningThrottleLimitTypeClip" value="2">
+                                        </select>
+
+                                    </td>
+                                    <td><input type="number" name="throttleLimitPercent" step="1" min="25" max="100" /></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
 


### PR DESCRIPTION
Dependent on https://github.com/betaflight/betaflight/pull/7122

Adds the throttle limit settings as part of the rate profile to the PID Tuning tab.

Example screenshot:

![screen shot 2018-11-24 at 8 05 31 pm](https://user-images.githubusercontent.com/17088539/48974381-e23df400-f024-11e8-9249-c18b49b8f81c.png)
