### PR TITLE
Change slider behaviour

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -135,7 +135,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
             $('input[name="dtermSetpoint-number"]').val(ADVANCED_TUNING.dtermSetpointWeight / 100);
             $('input[name="dtermSetpoint-range"]').val(ADVANCED_TUNING.dtermSetpointWeight / 100)
-                                                  .change(); // trigger adjustRangeElement()
+                                                  .trigger('input'); // trigger adjustRangeElement()
         } else {
             $('.pid_filter .newFilter').hide();
         }
@@ -215,37 +215,37 @@ TABS.pid_tuning.initialize = function (callback) {
             var absoluteControlGainNumberElement = $('input[name="absoluteControlGain-number"]');
             var absoluteControlGainRangeElement = $('input[name="absoluteControlGain-range"]');
 
-            absoluteControlGainNumberElement.change(function () {
+            absoluteControlGainNumberElement.on('input', function () {
                 absoluteControlGainRangeElement.val($(this).val());
             });
-            absoluteControlGainRangeElement.change(function () {
+            absoluteControlGainRangeElement.on('input', function () {
                 absoluteControlGainNumberElement.val($(this).val());
             });
-            absoluteControlGainNumberElement.val(ADVANCED_TUNING.absoluteControlGain).change();
+            absoluteControlGainNumberElement.val(ADVANCED_TUNING.absoluteControlGain).trigger('input');
 
             // Throttle Boost
             var throttleBoostNumberElement = $('input[name="throttleBoost-number"]');
             var throttleBoostRangeElement = $('input[name="throttleBoost-range"]');
 
-            throttleBoostNumberElement.change(function () {
+            throttleBoostNumberElement.on('input', function () {
                 throttleBoostRangeElement.val($(this).val());
             });
-            throttleBoostRangeElement.change(function () {
+            throttleBoostRangeElement.on('input', function () {
                 throttleBoostNumberElement.val($(this).val());
             });
-            throttleBoostNumberElement.val(ADVANCED_TUNING.throttleBoost).change();
+            throttleBoostNumberElement.val(ADVANCED_TUNING.throttleBoost).trigger('input');
 
             // Acro Trainer
             var acroTrainerAngleLimitNumberElement = $('input[name="acroTrainerAngleLimit-number"]');
             var acroTrainerAngleLimitRangeElement = $('input[name="acroTrainerAngleLimit-range"]');
 
-            acroTrainerAngleLimitNumberElement.change(function () {
+            acroTrainerAngleLimitNumberElement.on('input', function () {
                 acroTrainerAngleLimitRangeElement.val($(this).val());
             });
-            acroTrainerAngleLimitRangeElement.change(function () {
+            acroTrainerAngleLimitRangeElement.on('input', function () {
                 acroTrainerAngleLimitNumberElement.val($(this).val());
             });
-            acroTrainerAngleLimitNumberElement.val(ADVANCED_TUNING.acroTrainerAngleLimit).change();
+            acroTrainerAngleLimitNumberElement.val(ADVANCED_TUNING.acroTrainerAngleLimit).trigger('input');
 
             // Yaw D
             $('.pid_tuning .YAW input[name="d"]').val(PIDs[2][2]); // PID Yaw D
@@ -261,10 +261,10 @@ TABS.pid_tuning.initialize = function (callback) {
             feedforwardTransitionNumberElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
             feedforwardTransitionRangeElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
 
-            feedforwardTransitionNumberElement.change(function () {
+            feedforwardTransitionNumberElement.on('input', function () {
                 feedforwardTransitionRangeElement.val($(this).val());
             });
-            feedforwardTransitionRangeElement.change(function () {
+            feedforwardTransitionRangeElement.on('input', function () {
                 feedforwardTransitionNumberElement.val($(this).val());
             });
 
@@ -825,11 +825,11 @@ TABS.pid_tuning.initialize = function (callback) {
             }
             checkUpdateDtermTransitionWarning(dtermTransitionNumberElement.val());
 
-            dtermTransitionNumberElement.change(function () {
+            dtermTransitionNumberElement.on('input', function () {
                 checkUpdateDtermTransitionWarning($(this).val());
                 dtermTransitionRangeElement.val($(this).val());
             });
-            dtermTransitionRangeElement.change(function () {
+            dtermTransitionRangeElement.on('input', function () {
                 checkUpdateDtermTransitionWarning($(this).val());
                 dtermTransitionNumberElement.val($(this).val());
             });
@@ -846,12 +846,12 @@ TABS.pid_tuning.initialize = function (callback) {
                 }
             }
 
-            dtermNumberElement.change(function () {
+            dtermNumberElement.on('input', function () {
                 var value = $(this).val();
                 adjustRangeElement(value);
                 dtermRangeElement.val(value);
             });
-            dtermRangeElement.change(function () {
+            dtermRangeElement.on('input', function () {
                 var value = $(this).val();
                 adjustRangeElement(value);
                 dtermNumberElement.val(value);

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -214,7 +214,8 @@ TABS.pid_tuning.initialize = function (callback) {
             // Absolute Control
             var absoluteControlGainNumberElement = $('input[name="absoluteControlGain-number"]');
             var absoluteControlGainRangeElement = $('input[name="absoluteControlGain-range"]');
-
+			
+			//Use 'input' event for coupled controls to allow synchronized update
             absoluteControlGainNumberElement.on('input', function () {
                 absoluteControlGainRangeElement.val($(this).val());
             });
@@ -226,7 +227,8 @@ TABS.pid_tuning.initialize = function (callback) {
             // Throttle Boost
             var throttleBoostNumberElement = $('input[name="throttleBoost-number"]');
             var throttleBoostRangeElement = $('input[name="throttleBoost-range"]');
-
+			
+			//Use 'input' event for coupled controls to allow synchronized update
             throttleBoostNumberElement.on('input', function () {
                 throttleBoostRangeElement.val($(this).val());
             });
@@ -238,7 +240,8 @@ TABS.pid_tuning.initialize = function (callback) {
             // Acro Trainer
             var acroTrainerAngleLimitNumberElement = $('input[name="acroTrainerAngleLimit-number"]');
             var acroTrainerAngleLimitRangeElement = $('input[name="acroTrainerAngleLimit-range"]');
-
+			
+			//Use 'input' event for coupled controls to allow synchronized update
             acroTrainerAngleLimitNumberElement.on('input', function () {
                 acroTrainerAngleLimitRangeElement.val($(this).val());
             });
@@ -260,7 +263,8 @@ TABS.pid_tuning.initialize = function (callback) {
 
             feedforwardTransitionNumberElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
             feedforwardTransitionRangeElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
-
+			
+			//Use 'input' event for coupled controls to allow synchronized update
             feedforwardTransitionNumberElement.on('input', function () {
                 feedforwardTransitionRangeElement.val($(this).val());
             });
@@ -824,7 +828,8 @@ TABS.pid_tuning.initialize = function (callback) {
                 }
             }
             checkUpdateDtermTransitionWarning(dtermTransitionNumberElement.val());
-
+			
+			//Use 'input' event for coupled controls to allow synchronized update
             dtermTransitionNumberElement.on('input', function () {
                 checkUpdateDtermTransitionWarning($(this).val());
                 dtermTransitionRangeElement.val($(this).val());
@@ -845,7 +850,8 @@ TABS.pid_tuning.initialize = function (callback) {
                     dtermRangeElement.attr('max', self.SETPOINT_WEIGHT_RANGE_LOW);
                 }
             }
-
+			
+			//Use 'input' event for coupled controls to allow synchronized update
             dtermNumberElement.on('input', function () {
                 var value = $(this).val();
                 adjustRangeElement(value);

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -215,7 +215,7 @@ TABS.pid_tuning.initialize = function (callback) {
             var absoluteControlGainNumberElement = $('input[name="absoluteControlGain-number"]');
             var absoluteControlGainRangeElement = $('input[name="absoluteControlGain-range"]');
 			
-			//Use 'input' event for coupled controls to allow synchronized update
+            //Use 'input' event for coupled controls to allow synchronized update
             absoluteControlGainNumberElement.on('input', function () {
                 absoluteControlGainRangeElement.val($(this).val());
             });
@@ -228,7 +228,7 @@ TABS.pid_tuning.initialize = function (callback) {
             var throttleBoostNumberElement = $('input[name="throttleBoost-number"]');
             var throttleBoostRangeElement = $('input[name="throttleBoost-range"]');
 			
-			//Use 'input' event for coupled controls to allow synchronized update
+            //Use 'input' event for coupled controls to allow synchronized update
             throttleBoostNumberElement.on('input', function () {
                 throttleBoostRangeElement.val($(this).val());
             });
@@ -241,7 +241,7 @@ TABS.pid_tuning.initialize = function (callback) {
             var acroTrainerAngleLimitNumberElement = $('input[name="acroTrainerAngleLimit-number"]');
             var acroTrainerAngleLimitRangeElement = $('input[name="acroTrainerAngleLimit-range"]');
 			
-			//Use 'input' event for coupled controls to allow synchronized update
+            //Use 'input' event for coupled controls to allow synchronized update
             acroTrainerAngleLimitNumberElement.on('input', function () {
                 acroTrainerAngleLimitRangeElement.val($(this).val());
             });
@@ -264,7 +264,7 @@ TABS.pid_tuning.initialize = function (callback) {
             feedforwardTransitionNumberElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
             feedforwardTransitionRangeElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
 			
-			//Use 'input' event for coupled controls to allow synchronized update
+            //Use 'input' event for coupled controls to allow synchronized update
             feedforwardTransitionNumberElement.on('input', function () {
                 feedforwardTransitionRangeElement.val($(this).val());
             });
@@ -829,7 +829,7 @@ TABS.pid_tuning.initialize = function (callback) {
             }
             checkUpdateDtermTransitionWarning(dtermTransitionNumberElement.val());
 			
-			//Use 'input' event for coupled controls to allow synchronized update
+            //Use 'input' event for coupled controls to allow synchronized update
             dtermTransitionNumberElement.on('input', function () {
                 checkUpdateDtermTransitionWarning($(this).val());
                 dtermTransitionRangeElement.val($(this).val());
@@ -851,7 +851,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 }
             }
 			
-			//Use 'input' event for coupled controls to allow synchronized update
+            //Use 'input' event for coupled controls to allow synchronized update
             dtermNumberElement.on('input', function () {
                 var value = $(this).val();
                 adjustRangeElement(value);


### PR DESCRIPTION
Use on input event instead of change. Change only fires when mousebutton is released.
This let's you see the value changing when dragging the slider and the slider moving when changing the value. Sliders in the motors tab already behave like this. 