### PR TITLE
Fixed OSD element display, added missing elements.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3567,8 +3567,8 @@
     "osdDescElementLinkQuality": {
         "message": "Alternative indicator for 'link quality' based on frame loss - use with caution"
     },
-    "osdDescElementTotalDist": {
-        "message": "Total distance flown during this flight."
+    "osdDescElementFlightDist": {
+        "message": "Distance flown during this flight."
     },
     "osdDescElementTimer1" : {
         "message": "Shows the value of timer 1"
@@ -3658,7 +3658,7 @@
     "osdDescStatMinLinkQuality": {
         "message": "Minimum of the alternative indicator for 'link quality' based on frame loss"
     },
-    "osdDescStatTotalDistance": {
+    "osdDescStatFlightDistance": {
         "message": "Total distance travelled during the flight"
     },
     

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3655,6 +3655,12 @@
     "osdDescStatEscRpm": {
         "message": "Max ESC RPM"
     },
+    "osdDescStatMinLinkQuality": {
+        "message": "Minimum of the alternative indicator for 'link quality' based on frame loss"
+    },
+    "osdDescStatTotalDistance": {
+        "message": "Total distance travelled during the flight"
+    },
     
 
     "osdTimerSource": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3564,6 +3564,12 @@
     "osdDescElementFlipArrow": {
         "message": "Arrow showing which side motors are up in turtle mode"
     },
+    "osdDescElementLinkQuality": {
+        "message": "Alternative indicator for 'link quality' based on frame loss - use with caution"
+    },
+    "osdDescElementTotalDist": {
+        "message": "Total distance flown during this flight."
+    },
     "osdDescElementTimer1" : {
         "message": "Shows the value of timer 1"
     },
@@ -3584,6 +3590,9 @@
     },
     "osdDescGForce": {
         "message": "Shows how much G-Force the craft is experiencing"
+    },
+    "osdDescElementMotorDiag": {
+        "message": "Shows a graph of the output of each motor"
     },
     "osdDescElementLogStatus": {
         "message": "Blackbox number and warnings"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -802,7 +802,7 @@ OSD.constants = {
         preview: '1.0G'
     },
     MOTOR_DIAG: {
-        name: 'MOTOR_DIAG',
+        name: 'MOTOR_DIAGNOSTICS',
         desc: 'osdDescElementMotorDiag',
         default_position: -1,
         draw_order: 325,
@@ -837,7 +837,7 @@ OSD.constants = {
       preview: '8'
     },
     TOTAL_DIST: {
-      name: 'TOTAL_DIST',
+      name: 'TOTAL_DISTANCE',
       desc: 'osdDescElementTotalDist',
       default_position: -1,
       draw_order: 360,
@@ -930,6 +930,14 @@ OSD.constants = {
     MAX_ESC_RPM: {
       name: 'MAX_ESC_RPM',
       desc: 'osdDescStatEscRpm'
+    },
+    MIN_LINK_QUALITY: {
+      name: 'MIN_LINK_QUALITY',
+      desc: 'osdDescStatMinLinkQuality'
+    },
+    TOTAL_DISTANCE: {
+      name: 'TOTAL_DISTANCE',
+      desc: 'osdDescStatTotalDistance'
     }
   },
   ALL_WARNINGS: {
@@ -1167,8 +1175,10 @@ OSD.chooseFields = function () {
     ];
     if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
       OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([
-        F.MAX_ESC_TEMP,
-        F.MAX_ESC_RPM
+          F.MAX_ESC_TEMP,
+          F.MAX_ESC_RPM,
+          F.MIN_LINK_QUALITY,
+          F.TOTAL_DISTANCE
       ]);
     }
   }

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -801,6 +801,17 @@ OSD.constants = {
         positionable: true,
         preview: '1.0G'
     },
+    MOTOR_DIAG: {
+        name: 'MOTOR_DIAG',
+        desc: 'osdDescElementMotorDiag',
+        default_position: -1,
+        draw_order: 325,
+        positionable: true,
+        preview: FONT.symbol(0x84)
+            + FONT.symbol(0x85)
+            + FONT.symbol(0x84)
+            + FONT.symbol(0x83)
+    },
     LOG_STATUS: {
         name: 'LOG_STATUS',
         desc: 'osdDescElementLogStatus',
@@ -816,6 +827,24 @@ OSD.constants = {
       draw_order: 340,
       positionable: true,
       preview: FONT.symbol(SYM.ARROW_EAST)
+    },
+    LINK_QUALITY: {
+      name: 'LINK_QUALITY',
+      desc: 'osdDescElementLinkQuality',
+      default_position: -1,
+      draw_order: 350,
+      positionable: true,
+      preview: '8'
+    },
+    TOTAL_DIST: {
+      name: 'TOTAL_DIST',
+      desc: 'osdDescElementTotalDist',
+      default_position: -1,
+      draw_order: 360,
+      positionable: true,
+      preview: function(osd_data) {
+          return '653' + FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+      }
     },
   },
   UNKNOWN_DISPLAY_FIELD: {
@@ -1046,13 +1075,16 @@ OSD.chooseFields = function () {
                   if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
                       OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                           F.G_FORCE,
-                          F.LOG_STATUS,
-                        ]);
-                    if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                        OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
-                            F.FLIP_ARROW,
+                      ]);
+                      if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                          OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
+                              F.MOTOR_DIAG,
+                              F.LOG_STATUS,
+                              F.FLIP_ARROW,
+                              F.LINK_QUALITY,
+                              F.TOTAL_DIST,
                           ]);
-                    }
+                      }
                   }
                 }
               }

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -836,9 +836,9 @@ OSD.constants = {
       positionable: true,
       preview: '8'
     },
-    TOTAL_DIST: {
-      name: 'TOTAL_DISTANCE',
-      desc: 'osdDescElementTotalDist',
+    FLIGHT_DIST: {
+      name: 'FLIGHT_DISTANCE',
+      desc: 'osdDescElementFlightDist',
       default_position: -1,
       draw_order: 360,
       positionable: true,
@@ -935,9 +935,9 @@ OSD.constants = {
       name: 'MIN_LINK_QUALITY',
       desc: 'osdDescStatMinLinkQuality'
     },
-    TOTAL_DISTANCE: {
-      name: 'TOTAL_DISTANCE',
-      desc: 'osdDescStatTotalDistance'
+    FLIGHT_DISTANCE: {
+      name: 'FLIGHT_DISTANCE',
+      desc: 'osdDescStatFlightDistance'
     }
   },
   ALL_WARNINGS: {
@@ -1090,7 +1090,7 @@ OSD.chooseFields = function () {
                               F.LOG_STATUS,
                               F.FLIP_ARROW,
                               F.LINK_QUALITY,
-                              F.TOTAL_DIST,
+                              F.FLIGHT_DIST,
                           ]);
                       }
                   }
@@ -1178,7 +1178,7 @@ OSD.chooseFields = function () {
           F.MAX_ESC_TEMP,
           F.MAX_ESC_RPM,
           F.MIN_LINK_QUALITY,
-          F.TOTAL_DISTANCE
+          F.FLIGHT_DISTANCE
       ]);
     }
   }


### PR DESCRIPTION
To go with betaflight/betaflight#7177.

Adding the configurator part for the OSD elements missed in betaflight/betaflight#6114, betaflight/betaflight#6480, and betaflight/betaflight#7043.

OSD statistics elements will be done in a separate pull request.