### PR TITLE
Add MSP_REBOOT_MSC_UTC reboot type to reboot into mass storage using UTC timestamps

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -31,7 +31,8 @@ function MspHelper () {
     self.REBOOT_TYPES = {
         FIRMWARE: 0,
         BOOTLOADER: 1,
-        MSC: 2
+        MSC: 2,
+        MSC_UTC: 3
     };
 }
 
@@ -647,7 +648,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
             case MSPCodes.MSP_SET_REBOOT:
                 if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
                     var rebootType = data.read8();
-                    if (rebootType === self.REBOOT_TYPES.MSC) {
+                    if ((rebootType === self.REBOOT_TYPES.MSC) || (rebootType === self.REBOOT_TYPES.MSC_UTC)) {
                         if (data.read8() === 0) {
                             console.log('Storage device not ready.');
 

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -156,7 +156,17 @@ TABS.onboard_logging.initialize = function (callback) {
                          analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'RebootMsc');
 
                         var buffer = [];
-                        buffer.push(2);
+                        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                            if (GUI.operating_system === "Linux") {
+                                // Reboot into MSC using UTC time offset instead of user timezone
+                                // Linux seems to expect that the FAT file system timestamps are UTC based
+                                buffer.push(mspHelper.REBOOT_TYPES.MSC_UTC);
+                            } else {
+                                buffer.push(mspHelper.REBOOT_TYPES.MSC);
+                            }
+                        } else {
+                            buffer.push(mspHelper.REBOOT_TYPES.MSC);
+                        }
                         MSP.send_message(MSPCodes.MSP_SET_REBOOT, buffer, false);
                     });
                 }

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -70,7 +70,7 @@ TABS.setup.initialize = function (callback) {
 
             $('a.rebootBootloader').click(function () {
                 var buffer = [];
-                buffer.push(1);
+                buffer.push(mspHelper.REBOOT_TYPES.BOOTLOADER);
                 MSP.send_message(MSPCodes.MSP_SET_REBOOT, buffer, false);
             });
         } else {


### PR DESCRIPTION
The FAT filesystem is not timezone aware so timestamps are expected to be in the user's local time. However Linux implementations seem to expect the timestamps to be in UTC and then apply the user's computer timezone offset.

Adds an alternate reboot method used when the platform is "Linux" that prevents mass storage mode from adjusting the time to local time and instead uses UTC.