### PR TITLE
Ports tab: Add missing blackbox baud rates: 1Mbps, 1.5Mbps, 2.47Mbps

### DIFF
--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -96,7 +96,10 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         '57600',
         '115200',
         '230400',
-        '250000'
+        '250000',
+        '1500000',
+        '2000000',
+        '2470000'
     ];
 
     var columns = ['configuration', 'peripherals', 'sensors', 'telemetry', 'rx'];


### PR DESCRIPTION
It looks like these were missed around the time of https://github.com/betaflight/betaflight/pull/1316 and https://github.com/betaflight/betaflight-configurator/pull/318

I've been suggesting OpenLager a little for high frequency logging and went to try to configure one today and saw it was capped at the usual 250000 baud.

Just testing now.