### PR TITLE
Fix layout of PID tab

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -227,7 +227,7 @@
     margin: 0 4px 0px 0;
     height: 100%;
     min-height: 250px;
-    min-width: 250px;
+    min-width: 200px;
     border: 1px solid silver;
     border-radius: 3px;
     background-image: url(../../images/paper.jpg);
@@ -261,6 +261,8 @@
     border: 0px;
     height: 10px;
     font-weight: normal;
+    text-overflow: ellipsis;
+    overflow: hidden;
 }
 
 .tab-pid_tuning .pid_titlebar th {


### PR DESCRIPTION
Fixes some glitches in the layout of the PID tab that appears at certain width, as reported by @hydra:

![image](https://user-images.githubusercontent.com/2673520/51178258-5331b780-18c2-11e9-8f2a-5a74841ba418.png)

It ends like:
![image](https://user-images.githubusercontent.com/2673520/51178383-a60b6f00-18c2-11e9-88c9-23076925b5aa.png)



