### PR TITLE
Add beeper RC SMOOTHING INIT FAIL

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1096,6 +1096,9 @@
     "beeperCAM_CONNECTION_CLOSE": {
         "message": "Beep when the 5 key camera control is exited"
     },
+    "beeperRC_SMOOTHING_INIT_FAIL": {
+        "message": "Beep when armed and rc smoothing has not initialized filters"
+    },
     "configuration3d": {
         "message": "3D ESC/Motor Features"
     },

--- a/src/js/Beepers.js
+++ b/src/js/Beepers.js
@@ -33,6 +33,12 @@ var Beepers = function (config, supportedConditions) {
         );
     }
 
+    if (semver.gte(config.apiVersion, "1.39.0")) {
+        beepers.push(
+            {bit: 22, name: 'RC_SMOOTHING_INIT_FAIL', visible: true},
+        );
+    }
+
     if (supportedConditions) {
         self._beepers = [];
         beepers.forEach(function (beeper) {


### PR DESCRIPTION
It seems that the beeper sound for RC SMOOTHING INIT FAIL was added in the firmware but not in the configurator, for version 3.4. 

Reference PR: https://github.com/betaflight/betaflight/pull/6299