### PR TITLE
Arming disabled flags into text

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -737,7 +737,91 @@
         "message": "Arming Allowed"
     },
     "initialSetupArmingDisableFlagsTooltip": {
-        "message": "List of flags indicating why arming is currently not allowed. The first and most important value corresponds to the number of warning beeps that sound when arming is attempted. Please refer to the Wiki ('Arming Sequence & Safety' page) for a description of what these flags mean."
+        "message": "List of flags indicating why arming is currently not allowed. Pass the mouse over the flag or refer to the Wiki ('Arming Sequence & Safety' page) for more info."
+    },
+    "initialSetupArmingDisableFlagsTooltipNO_GYRO": {
+        "message": "A gyro was not detected",
+        "description": "Description of the NO GYRO arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipFAILSAFE": {
+        "message": "Failsafe is active",
+        "description": "Description of the FAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRX_FAILSAFE": {
+        "message": "No valid receiver signal is detected",
+        "description": "Description of the RX_FAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBAD_RX_RECOVERY": {
+        "message": "Your receiver has just recovered from receiver failsafe but the arm switch is on",
+        "description": "Description of the BAD_RX_RECOVERY arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBOXFAILSAFE": {
+        "message": "The 'FAILSAFE' switch was activated",
+        "description": "Description of the BOXFAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRUNAWAY_TAKEOFF": {
+        "message": "Runway Takeoff Prevention has been triggered",
+        "description": "Description of the RUNAWAY_TAKEOFF arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipTHROTTLE": {
+        "message": "Throttle channel is too high",
+        "description": "Description of the THROTTLE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipANGLE": {
+        "message": "Craft is not level (enough)",
+        "description": "Description of the ANGLE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBOOT_GRACE_TIME": {
+        "message": "Arming too soon after power on",
+        "description": "Description of the BOOT_GRACE_TIME arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNOPREARM": {
+        "message": "Prearm switch is not activated or prearm has not been toggled after disarm",
+        "description": "Description of the NOPREARM arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipLOAD": {
+        "message": "System load is too high for safe flight",
+        "description": "Description of the LOAD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCALIBRATING": {
+        "message": "Sensor calibration is still ongoing",
+        "description": "Description of the CALIBRATING arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCLI": {
+        "message": "CLI is active",
+        "description": "Description of the CLI arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCMS_MENU": {
+        "message": "CMS (config menu) is Active - over OSD or other display -",
+        "description": "Description of the CMS_MENU arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipOSD_MENU": {
+        "message": "OSD menu is active",
+        "description": "Description of the OSD_MENU arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBST": {
+        "message": "A Black Sheep Telemetry device (TBS Core Pro for example) disarmed and is preventing arming",
+        "description": "Description of the BST arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipMSP": {
+        "message": "MSP connection is active, probably with this Betaflight Configurator",
+        "description": "Description of the MSP arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipPARALYZE": {
+        "message": "Paralyze mode has been activated",
+        "description": "Description of the PARALYZE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipGPS": {
+        "message": "GPS rescue mode is configured but required number of satellites has not been fixed",
+        "description": "Description of the GPS arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRESC": {
+        "message": "The 'GPS Rescue' switch was activated",
+        "description": "Description of the RESC arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipARM_SWITCH": {
+        "message": "One of the others disarm flags is active when arming",
+        "description": "Description of the ARM_SWITCH arming disable flag"
     },
     "initialSetupGPSHead": {
         "message": "GPS"

--- a/src/css/tabs/setup.css
+++ b/src/css/tabs/setup.css
@@ -309,3 +309,9 @@
 .tab-setup dialog h3 {
     margin-bottom: 0.5em;
 }
+
+.disarm-flag {
+    padding-left: 5px;
+}
+
+}

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -81,6 +81,7 @@ var FC = {
             numProfiles:                      3,
             rateProfile:                      0,
             boardType:                        0,
+            armingDisableCount:               0,
             armingDisableFlags:               0,
             armingDisabled:                   false,
             runawayTakeoffPreventionDisabled: false,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -99,7 +99,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                       }
 
                       // Read arming disable flags
-                      data.readU8(); // Flag count
+                      CONFIG.armingDisableCount = data.readU8(); // Flag count
                       CONFIG.armingDisableFlags = data.readU32();
                     }
 

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -101,9 +101,9 @@
                     <div class="spacer_box">
                         <table width="100%" border="0" cellpadding="0" cellspacing="0" class="cf_table">
                             <tbody>
-                                <tr id="arming-disable-flag-row" class="cf_tip">
-                                    <td i18n="initialSetupArmingDisableFlags"></td>
-                                    <td class="arming-disable-flags">0</td>
+                                <tr>
+                                    <td id="arming-disable-flag" i18n="initialSetupArmingDisableFlags" class="cf_tip"></td>
+                                    <td class="arming-disable-flags"></td>
                                 </tr>
                                 <tr>
                                     <td i18n="initialSetupBattery"></td>


### PR DESCRIPTION
This PR is a draft to discuss if this change is needed (if we accept it, then I will refactor and change a little the code).

Now, the disarm flags in the configurator only shows the number of beeps that the disarm reason will throw, and the user must go to the wiki and search for it. I think is easier to show it as text:

![image](https://user-images.githubusercontent.com/2673520/51260896-8b62f400-19af-11e9-895e-97e38d995b84.png)

What do others think? The problem with this is:
- We must maintain it (easy for additions, more complex if some of them disappear because the text changes).
- I don't know if it is a good idea to translate it into the user language. Thoughts?
