### PR TITLE
Add support for 32bit OSD warnings bitmask; add missing warnings elements

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3705,6 +3705,24 @@
     "osdWarningEscFail": {
         "message": "Enumerates a list with the ESCs/motors that are failing (RPM or temperature are out of the configured threshold)"
     },
+    "osdWarningCoreTemperature": {
+        "message": "Warns when MCU core temperature exceeds a configured threshold"
+    },
+    "osdWarningRcSmoothingFailure": {
+        "message": "Warns when RC Smoothing initialization failed"
+    },
+    "osdWarningFailsafe": {
+        "message": "Warns when failsafe occurs"
+    },
+    "osdWarningLaunchControl": {
+        "message": "Warns when Launch Control mode is activated"
+    },
+    "osdWarningGpsRescueUnavailable": {
+        "message": "Warns when GPS Rescue is not available and cannot be activated"
+    },
+    "osdWarningGpsRescueDisabled": {
+        "message": "Warns when GPS Rescue is disabled"
+    },
 
     "osdSectionHelpElements": {
         "message": "Enable or disable OSD elements."


### PR DESCRIPTION
Adds support for 32 warnings instead of just 16.

Adds a warnings count to MSP to support future improvements to handle unknown warnings better.

Added missing warnings where support was added to the firmware but not in the configurator.

Related to https://github.com/betaflight/betaflight/pull/7423