### PR TITLE
Add unknown OSD warnings

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3687,6 +3687,9 @@
         "message": "Select the timer alarm threshold in minutes, when the time exceeds this value the OSD element will blink, setting this to 0 disables the alarm"
     },
 
+    "osdWarningUnknown": {
+        "message": "Unknown warning (details to be added in a future release)"
+    },
     "osdWarningArmingDisabled": {
         "message": "Reports the most severe reason for not arming"
     },

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1342,7 +1342,7 @@ OSD.msp = {
             result.push16(OSD.data.alarms.alt.value);
             if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
                 var warningFlags = 0;
-                for (var i = 0; i < OSD.constants.WARNINGS.length; i++) {
+                for (var i = 0; i < OSD.data.warnings.length; i++) {
                     if (OSD.data.warnings[i].enabled) {
                         warningFlags |= (1 << i);
                     }
@@ -1485,14 +1485,25 @@ OSD.msp = {
             }
 
             // Parse enabled warnings
+            var warningCount = OSD.constants.WARNINGS.length;
             var warningFlags = view.readU16();
             if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                var warningCount = view.readU8();
+                warningCount = view.readU8();
                 // the flags were replaced with a 32bit version
                 warningFlags = view.readU32();
             }
-            for (var i = 0; i < OSD.constants.WARNINGS.length; i++) {
-                d.warnings.push($.extend(OSD.constants.WARNINGS[i], { enabled: (warningFlags & (1 << i)) != 0 }));
+            for (var i = 0; i < warningCount; i++) {
+
+                // Known warning field
+                if (i < OSD.constants.WARNINGS.length) {
+                    d.warnings.push($.extend(OSD.constants.WARNINGS[i], { enabled: (warningFlags & (1 << i)) != 0 }));
+
+                // Push Unknown Warning field
+                } else {
+                    var warningNumber = i - OSD.constants.WARNINGS.length + 1;
+                    d.warnings.push({name: 'UNKNOWN_' + warningNumber, desc: 'osdWarningUnknown', enabled: (warningFlags & (1 << i)) != 0 });
+
+                }
             }
         }
 


### PR DESCRIPTION
Follow up of https://github.com/betaflight/betaflight-configurator/pull/1278 made by @etracer65 

This PR adds UNKNOWN elements where the warning is not known. In this way the save maintains the status of each warning.

![image](https://user-images.githubusercontent.com/2673520/51470643-cdf04c00-1d74-11e9-8b73-623067716344.png)

A strange thing that I have observed while working on this is that the warnings state and the OSD elements are being saved without the need to push the `save` button. Is that intended or is a bug?