### PR TITLE
Add osd profiles

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3424,14 +3424,32 @@
     "osdSetupUnsupportedNote2": {
         "message": "Note that some flight controllers have an onboard <a href=\"https://www.youtube.com/watch?v=ikKH_6SQ-Tk\" target=\"_blank\">MinimOSD</a> that can be flashed and configured with <a href=\"https://github.com/ShikOfTheRa/scarab-osd/releases/latest\" target='_blank'>scarab-osd</a>, however the MinimOSD cannot be configured through this interface."
     },
+    "osdSetupProfilesTitle": {
+        "message": "OSD Profile number",
+        "description": "Description of the header of the OSD elements column associated to each profile"
+    },
     "osdSetupElementsTitle": {
         "message": "Elements"
     },
-    "osdSetupElementsSwitchAll": {
-      "message": "Switch all"
-    },
     "osdSetupPreviewTitle": {
-        "message": "Preview (drag to change position)"
+        "message": "Drag elements to change position",
+        "description": "Indicates in the preview window of the OSD that the user can drag the elements to reorder them"
+    },
+    "osdSetupPreviewSelectProfileTitle": {
+        "message": "Preview for",
+        "description": "Label of the selector for the OSD Profile in the preview"
+    },
+    "osdSetupSelectedProfileTitle": {
+        "message": "Active OSD Profile",
+        "description": "Title of the box to select the current active OSD profile"
+    },
+    "osdSetupSelectedProfileLabel": {
+        "message": "Current:",
+        "description": "Label for the selection of the curren active OSD profile"
+    },
+    "osdSetupPreviewSelectProfileElement": {
+        "message": "OSD Profile {{profileNumber}}",
+        "description": "Content of the selector for the OSD Profile in the preview"
     },
     "osdSetupPreviewTitleTip": {
         "message": "Show or hide the logo in the preview window. This will not change any settings on the flight controller."

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1247,6 +1247,17 @@ dialog {
     font-family: 'open_sanssemibold', Arial;
 }
 
+.gui_box_bottombar {
+    background-color: #e4e4e4;
+    border-radius: 0px 0px 3px 3px;
+    font-size: 13px;
+    width: 100%;
+    height: 27px;
+    padding-top: 0px;
+    float: left;
+    font-family: 'open_sanssemibold', Arial;
+}
+
 .spacer_box {
     padding: 10px;
     margin-bottom: 3px;

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -26,6 +26,10 @@
   float: none;
 }
 
+.tab-osd .spacer_box_title .profileOsdHeader {
+    padding: 6px;
+}
+
 .tab-osd .info {
   float: left;
   width: 100%;
@@ -298,6 +302,10 @@
   position: relative;
 }
 
+.tab-osd .preview .gui_box_bottombar {
+  text-align: center;
+}
+
 .tab-osd .preview .char {
   display: inline-block;
   padding: 0;
@@ -426,12 +434,14 @@ button {
 }
 
 .tab-osd .switchable-field input {
-  float: right;
-  width: 50px;
   border-radius: 3px;
   border: 1px solid #ddd;
   padding:2px;
   margin-top: -2px;
+}
+
+.tab-osd .switchable-field input[type=number] {
+  float: right;
   display: none;
 }
 

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -232,6 +232,19 @@ FONT.symbol = function (hexVal) {
 
 var OSD = OSD || {};
 
+OSD.getNumberOfProfiles = function() {
+    return OSD.data.osd_profiles.number;
+}
+
+OSD.getCurrentPreviewProfile = function() {
+    let osdprofile_e = $('.osdprofile-selector');
+    if (osdprofile_e) {
+        return osdprofile_e.val();
+    } else {
+        return 0;
+    }
+}
+
 // parsed fc output and output to fc, used by to OSD.msp.encode
 OSD.initData = function () {
     OSD.data = {
@@ -245,7 +258,8 @@ OSD.initData = function () {
         last_positions: {},
         preview_logo: true,
         preview: [],
-        tooltips: []
+        tooltips: [],
+        osd_profiles: {}
     };
 };
 OSD.initData();
@@ -1364,10 +1378,14 @@ OSD.msp = {
                 if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
                     // size * y + x
                     display_item.position = positionable ? FONT.constants.SIZES.LINE * ((bits >> 5) & 0x001F) + (bits & 0x001F) : default_position;
-                    display_item.isVisible = (bits & OSD.constants.VISIBLE) != 0;
+                    
+                    display_item.isVisible = [];
+                    for (let osd_profile = 0; osd_profile < OSD.getNumberOfProfiles(); osd_profile++) {
+                        display_item.isVisible[osd_profile] = (bits & (OSD.constants.VISIBLE << osd_profile)) != 0;
+                    }
                 } else {
                     display_item.position = (bits === -1) ? default_position : bits;
-                    display_item.isVisible = bits !== -1;
+                    display_item.isVisible = [bits !== -1];
                 }
 
                 return display_item;
@@ -1386,9 +1404,14 @@ OSD.msp = {
                 var isVisible = display_item.isVisible;
                 var position = display_item.position;
                 if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-                    return (isVisible ? 0x0800 : 0) | (((position / FONT.constants.SIZES.LINE) & 0x001F) << 5) | (position % FONT.constants.SIZES.LINE);
+
+                    let packed_visible = 0;
+                    for (let osd_profile = 0; osd_profile < OSD.getNumberOfProfiles(); osd_profile++) {
+                        packed_visible |= isVisible[osd_profile] ? OSD.constants.VISIBLE << osd_profile : 0;
+                    }
+                    return packed_visible | (((position / FONT.constants.SIZES.LINE) & 0x001F) << 5) | (position % FONT.constants.SIZES.LINE);
                 } else {
-                    return isVisible ? (position == -1 ? 0 : position) : -1;
+                    return isVisible[0] ? (position == -1 ? 0 : position) : -1;
                 }
             },
             timer: function (timer) {
@@ -1421,8 +1444,11 @@ OSD.msp = {
                 result.push16(warningFlags);
                 if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
                     result.push32(warningFlags);
+
+                    result.push8(OSD.data.osd_profiles.selected + 1);
                 }
             }
+            
         }
         return result;
     },
@@ -1488,33 +1514,16 @@ OSD.msp = {
         d.warnings = [];
         d.timers = [];
 
-        // Parse display element positions
-        while (view.offset < view.byteLength && d.display_items.length < displayItemsCountActual) {
+        // Read display element positions, the parsing is done later because we need the number of profiles
+        var items_positions_read = [];
+        while (view.offset < view.byteLength && items_positions_read.length < displayItemsCountActual) {
             var v = null;
             if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
                 v = view.readU16();
             } else {
                 v = view.read16();
             }
-            var j = d.display_items.length;
-            var c;
-            var suffix;
-            var ignoreSize = false;
-            if (d.display_items.length < OSD.constants.DISPLAY_FIELDS.length) {
-                c = OSD.constants.DISPLAY_FIELDS[j];
-            } else {
-                c = OSD.constants.UNKNOWN_DISPLAY_FIELD;
-                suffix = "" + (1 + d.display_items.length - OSD.constants.DISPLAY_FIELDS.length);
-                ignoreSize = true;
-            }
-            d.display_items.push($.extend({
-                name: suffix ? c.name + suffix : c.name,
-                desc: c.desc,
-                index: j,
-                draw_order: c.draw_order,
-                preview: suffix ? c.preview + suffix : c.preview,
-                ignoreSize: ignoreSize
-            }, this.helpers.unpack.position(v, c)));
+            items_positions_read.push(v);
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
@@ -1578,6 +1587,38 @@ OSD.msp = {
 
                 }
             }
+        }
+
+        // OSD profiles
+        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            d.osd_profiles.number = view.readU8();
+            d.osd_profiles.selected = view.readU8() - 1;
+        } else {
+            d.osd_profiles.number = 1;
+            d.osd_profiles.selected = 0;
+        }
+
+        // Now we have the number of profiles, process the OSD elements
+        for (let item of items_positions_read) {
+            var j = d.display_items.length;
+            var c;
+            var suffix;
+            var ignoreSize = false;
+            if (d.display_items.length < OSD.constants.DISPLAY_FIELDS.length) {
+                c = OSD.constants.DISPLAY_FIELDS[j];
+            } else {
+                c = OSD.constants.UNKNOWN_DISPLAY_FIELD;
+                suffix = "" + (1 + d.display_items.length - OSD.constants.DISPLAY_FIELDS.length);
+                ignoreSize = true;
+            }
+            d.display_items.push($.extend({
+                name: suffix ? c.name + suffix : c.name,
+                desc: c.desc,
+                index: j,
+                draw_order: c.draw_order,
+                preview: suffix ? c.preview + suffix : c.preview,
+                ignoreSize: ignoreSize
+            }, this.helpers.unpack.position(item, c)));
         }
 
         // Generate OSD element previews and positionable that are defined by a function
@@ -1982,13 +2023,38 @@ TABS.osd.initialize = function (callback) {
                         $('.requires-osd-feature').hide();
                     }
 
+                    let numberOfProfiles = OSD.getNumberOfProfiles();
+
+                    // Header for the switches
+                    let headerSwitches_e = $('.elements').find('.osd-profiles-header');
+                    if (headerSwitches_e.children().length == 0) {
+                        for (let profileNumber = 0; profileNumber < numberOfProfiles; profileNumber++) {
+                            headerSwitches_e.append('<span class="profileOsdHeader">' + (profileNumber + 1) + '</span>');
+                        }
+                    }
+
+                    // Populate the profiles selector preview and current active
+                    let osdProfileSelector_e = $('.osdprofile-selector');
+                    let osdProfileActive_e = $('.osdprofile-active');
+                    if (osdProfileSelector_e.children().length == 0) {
+                        for (let profileNumber = 0; profileNumber < numberOfProfiles; profileNumber++) {
+                            let optionText = i18n.getMessage('osdSetupPreviewSelectProfileElement', {profileNumber : (profileNumber + 1)});
+                            osdProfileSelector_e.append(new Option(optionText, profileNumber));
+                            osdProfileActive_e.append(new Option(optionText, profileNumber));
+                        }
+                    }
+
+                    // Select the current OSD profile
+                    osdProfileActive_e.val(OSD.data.osd_profiles.selected);
+
                     // display fields on/off and position
                     var $displayFields = $('#element-fields').empty();
                     var enabledCount = 0;
                     for (let field of OSD.data.display_items) {
                         // versioning related, if the field doesn't exist at the current flight controller version, just skip it
                         if (!field.name) { continue; }
-                        if (field.isVisible) { enabledCount++; }
+
+                        if (field.isVisible[OSD.getCurrentPreviewProfile()]) { enabledCount++; }
 
                         var $field = $('<div class="switchable-field field-' + field.index + '"/>');
                         var desc = null;
@@ -1999,27 +2065,31 @@ TABS.osd.initialize = function (callback) {
                             $field[0].classList.add('osd_tip');
                             $field.attr('title', desc);
                         }
-                        $field.append(
-                            $('<input type="checkbox" name="' + field.name + '" class="togglesmall"></input>')
-                                .data('field', field)
-                                .attr('checked', field.isVisible)
-                                .change(function (e) {
-                                    var field = $(this).data('field');
-                                    var $position = $(this).parent().find('.position.' + field.name);
-                                    field.isVisible = !field.isVisible;
-                                    if (field.isVisible) {
-                                        $position.show();
-                                    } else {
-                                        $position.hide();
-                                    }
-                                    MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, OSD.msp.encodeLayout(field))
-                                        .then(function () {
-                                            updateOsdView();
-                                        });
-                                })
-                        );
+                        for (let osd_profile = 0; osd_profile < OSD.getNumberOfProfiles(); osd_profile++) {
+                            $field.append(
+                                    $('<input type="checkbox" name="' + field.name + '"></input>')
+                                        .data('field', field)
+                                        .data('osd_profile', osd_profile)
+                                        .attr('checked', field.isVisible[osd_profile])
+                                        .change(function (e) {
+                                            var field = $(this).data('field');
+                                            var profile = $(this).data('osd_profile');
+                                            var $position = $(this).parent().find('.position.' + field.name);
+                                            field.isVisible[profile] = !field.isVisible[profile];
+                                            if (field.isVisible[OSD.getCurrentPreviewProfile()]) {
+                                                $position.show();
+                                            } else {
+                                                $position.hide();
+                                            }
+                                            MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, OSD.msp.encodeLayout(field))
+                                                .then(function () {
+                                                    updateOsdView();
+                                                });
+                                        })
+                                );
+                        }
                         $field.append('<label for="' + field.name + '" class="char-label">' + inflection.titleize(field.name) + '</label>');
-                        if (field.positionable && field.isVisible) {
+                        if (field.positionable && field.isVisible[OSD.getCurrentPreviewProfile()]) {
                             $field.append(
                                 $('<input type="number" class="' + field.index + ' position"></input>')
                                     .data('field', field)
@@ -2037,9 +2107,6 @@ TABS.osd.initialize = function (callback) {
                         }
                         $displayFields.append($field);
                     }
-                    //Set Switch all checkbox defaults based on the majority of the switches
-                    var checked = enabledCount >= (OSD.data.display_items.length / 2);
-                    $('input#switch-all').prop('checked', checked).change();
 
                     GUI.switchery();
                     // buffer the preview
@@ -2067,7 +2134,7 @@ TABS.osd.initialize = function (callback) {
                     // draw all the displayed items and the drag and drop preview images
                     for (let field of OSD.data.display_items) {
 
-                        if (!field.preview || !field.isVisible) {
+                        if (!field.preview || !field.isVisible[OSD.getCurrentPreviewProfile()]) {
                             continue;
                         }
 
@@ -2192,6 +2259,15 @@ TABS.osd.initialize = function (callback) {
                 });
         };
 
+        $('.osdprofile-selector').change(updateOsdView);
+        $('.osdprofile-active').change(function() {
+            OSD.data.osd_profiles.selected = parseInt($(this).val());
+            MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, OSD.msp.encodeOther())
+                .then(function () {
+                    updateOsdView();
+                });
+        });
+
         $('a.save').click(function () {
             var self = this;
             MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
@@ -2262,26 +2338,6 @@ TABS.osd.initialize = function (callback) {
                 })
                 .catch(error => console.error(error));
         });
-
-        //Switch all elements
-        $('input#switch-all').change(function (event) {
-            //if we just change value based on the majority of the switches
-            if (event.isTrigger) return;
-
-            var new_state = $(this).is(':checked');
-
-            var updateList = [];
-            $('#element-fields input[type=checkbox]').each(function () {
-                var field = $(this).data('field');
-                field.isVisible = new_state;
-
-                updateList.push(MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, OSD.msp.encodeLayout(field)));
-            })
-
-            Promise.all(updateList).then(function () {
-                updateOsdView();
-            });
-        })
 
         $(document).on('click', 'span.progressLabel a.save_font', function () {
             chrome.fileSystem.chooseEntry({ type: 'saveFile', suggestedName: 'baseflight', accepts: [{ description: 'MCM files', extensions: ['mcm'] }] }, function (fileEntry) {

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -17,13 +17,12 @@
                 <div class="cf_column third_left elements requires-osd-feature">
                     <div class="spacer_right">
                         <div class="gui_box grey">
-                            <div class="gui_box_titlebar cf_tip" style="margin-bottom: 0px;">
+                            <div class="gui_box_titlebar" style="margin-bottom: 0px;">
                                 <div class="spacer_box_title">
-                                    <span i18n="osdSetupElementsTitle" />
-                                    <span class="switch-all-elements">
-                                        <label for="switch-all"><span i18n="osdSetupElementsSwitchAll" />: </label>
-                                        <input type="checkbox" id="switch-all" name="switch-all" class="togglesmall"></input>
+                                    <span class="osd-profiles-header cf_tip" i18n_title="osdSetupProfilesTitle" >
+                                        <!--  Generated profiles header here -->
                                     </span>
+                                    <span i18n="osdSetupElementsTitle" />
                                 </div>
                             </div>
                             <div class="spacer_box">
@@ -33,21 +32,47 @@
                     </div>
                 </div>
                 <div class="cf_column twothird">
+
                     <div class="gui_box grey preview requires-osd-feature" style="float: left; position: fixed;">
+
                         <div class="gui_box_titlebar image">
                             <div class="spacer_box_title">
-                                <span i18n="osdSetupPreviewTitle" />
+                               <span>
+                                   <label id="osdprofile-selector-label" i18n="osdSetupPreviewSelectProfileTitle"/>
+                                   <select class="osdprofile-selector">
+                                       <!--  Populated at runtime -->
+                                   </select>
+                               </span>
                                 <span class="preview-logo cf_tip" i18n_title="osdSetupPreviewTitleTip"></span>
                             </div>
                         </div>
+
                         <div class="display-layout">
                             <div class="col right">
                                 <div class="preview">
                                 </div>
                             </div>
                         </div>
+
+                        <div class="gui_box_bottombar">
+                            <div class="spacer_box_title">
+                                <span i18n="osdSetupPreviewTitle" />
+                            </div>
+                        </div>
+
                     </div>
                     <div class="cf_column third_right" style="width: calc(100% - 377px);">
+                        <div class="gui_box osdprofile-selected-container grey requires-max7456">
+                            <div class="gui_box_titlebar cf_tip">
+                                <div class="spacer_box_title" i18n="osdSetupSelectedProfileTitle" />
+                            </div>
+                            <div class="spacer_box">
+                                <label i18n="osdSetupSelectedProfileLabel"/>
+                                <select class="osdprofile-active">
+                                    <!--  Populated at runtime -->
+                                </select>
+                            </div>
+                        </div>
                         <div class="gui_box videomode-container grey requires-max7456">
                             <div class="gui_box_titlebar cf_tip">
                                 <div class="spacer_box_title" i18n="osdSetupVideoFormatTitle" />


### PR DESCRIPTION
This PR lets the user configure the preview for the three different OSD switches.

The PR is working but this is a work in progress because maybe some elements need to be modified in the user interface, and I want to get some feedback:

![image](https://user-images.githubusercontent.com/2673520/51821736-6d17c500-22da-11e9-8a8d-11b8319ba3d0.png)

Some things to think ;):
1. I have let the combo for all Betaflight versions, limited to 1 profile in the old versions and 3 profiles for Betaflight 4.0. In this way users of old versions can see what they are loosing and updating to the newest version. Maybe is better to hide it?
2. Related with the number 1, is there an MSP command to get the number of OSD profiles available? Maybe in 4.0 this feature has been removed for some F3 or similar...
3. The 1, 2, 3 over the switches is not beautiful, but the space is limited, more thinking in the possible translations. The title has not the habitual style but being dynamic is a problem (can be fixable, but the code will be more complicated).
4. The switches maybe are better if I change them for checkboxes. I'm trying to do it but is not as easy as it seems.

What do you think?
