### PR TITLE
once hardware selected, default to/encourage latest firmware

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -343,6 +343,9 @@ TABS.firmware_flasher.initialize = function (callback) {
                         versions_e.append(select_e);
                     });
                 }
+
+                // Assume flashing latest, so default to it.
+                versions_e.prop("selectedIndex", 1).change();
             }
             chrome.storage.local.set({'selected_board': target});
         });


### PR DESCRIPTION
Originally discussed in https://github.com/cleanflight/cleanflight-configurator/pull/527