### PR TITLE
Fix 32khz MSP command

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -966,7 +966,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         FILTER_CONFIG.gyro_lowpass2_type = data.readU8();
                         FILTER_CONFIG.dterm_lowpass2_hz = data.readU16();
                         if (semver.lt(CONFIG.apiVersion, "1.41.0")) {
-                            FILTER_CONFIG.gyro_32khz_hardware_lpf = data.readU8();
+                            FILTER_CONFIG.gyro_32khz_hardware_lpf = gyro_32khz_hardware_lpf;
+                        } else {
+                            FILTER_CONFIG.gyro_32khz_hardware_lpf = 0;
                         }
                     }
                 }


### PR DESCRIPTION
@mikeller I think there is a bug in the 32khz MSP command. I added the else too because I think the code is clear (and will be needed to add the new dyn filters, so it is not too bad to add it now).