### PR TITLE
Decorate CLI error messages to make them more visible

### DIFF
--- a/src/css/tabs/cli.css
+++ b/src/css/tabs/cli.css
@@ -61,6 +61,11 @@
     white-space: pre-wrap;
 }
 
+.tab-cli .window .error_message {
+    color: red;
+    font-weight: bold;
+}
+
 .tab-cli .save {
     color: white;
 }

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -215,7 +215,11 @@ function writeToOutput(text) {
 }
 
 function writeLineToOutput(text) {
-    writeToOutput(text + "<br>");
+    if (text.startsWith("###ERROR: ")) {
+        writeToOutput('<span class="error_message">' + text + '</span><br>');
+    } else {
+        writeToOutput(text + "<br>");
+    }
 }
 
 function setPrompt(text) {


### PR DESCRIPTION
Now that we've standardized the CLI error messages it's simple to parse these when displayed in the CLI window and make them more visible. This change makes the CLI error messages red and use a bold font.

Example:

![screen shot 2019-03-07 at 10 56 12 am](https://user-images.githubusercontent.com/17088539/53970261-4c584180-40c8-11e9-938a-31d79163ca3c.png)
