### PR TITLE
Update Display name description string to "as set by the cli command"

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3625,7 +3625,7 @@
         "message": "Craft name as set in Configuration tab"
     },
     "osdDescElementDisplayName": {
-        "message": "Display name as set in Configuration tab"
+        "message": "Display name as set by the \"display_name\" cli command"
     },
     "osdDescElementAltitude": {
         "message": "Current altitude (flashes when above alarm threshold)"


### PR DESCRIPTION
In case no one address the issue #1316 in time for the new configurator release, this should be merged to properly reflect the functionality, and for translators to have the proper time to translate it; Otherwise, please ignore this.