### PR TITLE
Add D Min feature to PIDs tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1379,6 +1379,34 @@
     "pidTuningAntiGravityThres": {
         "message": "Anti Gravity Threshold"
     },
+    "pidTuningDMinHelp": {
+        "message": "D Min provides a way to have a lower level of D in normal flight and a higher level for quick manoeuvres that might cause overshoot, like flips and rolls. It also brings D up during prop wash. The craft will have a dynamic D Term varying from D Min (under normal flight) to the standard D (under fast roll and flips). A value of zero will disable the feature. The Gain determines how strongly D is boosted during quick stick inputs. The Advance speeds up of onset of the boost effect. This can be helpful if you have overshoot with very high rate flips on very responsive quads.",
+        "description": "Help message for D Min feature"
+    },
+    "pidTuningDMin": {
+        "message": "D Min",
+       "description": "Table header of the D Min feature in the PIDs tab" 
+    },
+    "pidTuningDMinRoll": {
+       "message": "Roll",
+       "description": "Axis to apply D Min feature" 
+    },
+    "pidTuningDMinPitch": {
+       "message": "Pitch",
+       "description": "Axis to apply D Min feature"
+    },
+    "pidTuningDMinYaw": {
+       "message": "Yaw",
+       "description": "Axis to apply D Min feature"
+    },
+    "pidTuningDMinGain": {
+       "message": "Gain",
+       "description": "Gain of the D Min feature"
+    },
+    "pidTuningDMinAdvance": {
+       "message": "Advance",
+       "description": "Advane of the D Min feature"
+    },
 
     "pidTuningPidSettings": {
         "message": "PID Controller Settings"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -401,6 +401,13 @@ var FC = {
             feedforwardYaw:             0,
             feedforwardTransition:      0,
             antiGravityMode:            0,
+            dMinRoll:                   0,
+            dMinPitch:                  0,
+            dMinYaw:                    0,
+            dMinGain:                   0,
+            dMinAdvance:                0,
+            useIntegratedYaw:           0,
+            integratedYawRelax:         0,
         };
 
         SENSOR_CONFIG = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1023,6 +1023,16 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                     ADVANCED_TUNING.feedforwardPitch = data.readU16();
                                     ADVANCED_TUNING.feedforwardYaw   = data.readU16();
                                     ADVANCED_TUNING.antiGravityMode  = data.readU8();
+                                    
+                                    if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                                        ADVANCED_TUNING.dMinRoll = data.readU8();
+                                        ADVANCED_TUNING.dMinPitch = data.readU8();
+                                        ADVANCED_TUNING.dMinYaw = data.readU8();
+                                        ADVANCED_TUNING.dMinGain = data.readU8();
+                                        ADVANCED_TUNING.dMinAdvance = data.readU8();
+                                        ADVANCED_TUNING.useIntegratedYaw = data.readU8();
+                                        ADVANCED_TUNING.integratedYawRelax = data.readU8();
+                                    }
                                 }
                             }
                         }
@@ -1749,6 +1759,16 @@ MspHelper.prototype.crunch = function(code) {
                                       .push16(ADVANCED_TUNING.feedforwardPitch)
                                       .push16(ADVANCED_TUNING.feedforwardYaw)
                                       .push8(ADVANCED_TUNING.antiGravityMode);
+
+                                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                                    buffer.push8(ADVANCED_TUNING.dMinRoll)
+                                          .push8(ADVANCED_TUNING.dMinPitch)
+                                          .push8(ADVANCED_TUNING.dMinYaw)
+                                          .push8(ADVANCED_TUNING.dMinGain)
+                                          .push8(ADVANCED_TUNING.dMinAdvance)
+                                          .push8(ADVANCED_TUNING.useIntegratedYaw)
+                                          .push8(ADVANCED_TUNING.integratedYawRelax);
+                                }
                             }
                         }
                     }

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -324,13 +324,47 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_filter input[name="dtermLowpassDynMaxFrequency"]').val(FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
             $('.pid_filter select[name="dtermLowpassDynType"]').val(FILTER_CONFIG.dterm_lowpass_type);
 
+            $('.dminGroup input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
+            $('.dminGroup input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
+            $('.dminGroup input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
+            $('.dminGroup input[name="dMinGain"]').val(ADVANCED_TUNING.dMinGain);
+            $('.dminGroup input[name="dMinAdvance"]').val(ADVANCED_TUNING.dMinAdvance);
+
         } else {
             $('.throttle_limit').hide();
 
             $('.gyroLowpassDyn').hide();
             $('.dtermLowpassDyn').hide();
             $('.dtermLowpass2TypeGroup').hide();
+
+            $('.dminGroup').hide();
         }
+
+        function adjustDMin(dElement, dMinElement) {
+            var dValue = parseInt(dElement.val());
+            var dMinValue = parseInt(dMinElement.val());
+
+            if (dMinValue >= dValue) {
+                dMinElement.val(0);
+            }
+
+            dMinElement.attr("max", dValue > 0? dValue - 1 : 0);
+        }
+
+        $('.pid_tuning .ROLL input[name="d"]').change(function() {
+            var dMinElement= $('.dminGroup input[name="dMinRoll"]');
+            adjustDMin($(this), dMinElement);
+        }).change();
+
+        $('.pid_tuning .PITCH input[name="d"]').change(function() {
+            var dMinElement= $('.dminGroup input[name="dMinPitch"]');
+            adjustDMin($(this), dMinElement);
+        }).change();
+
+        $('.pid_tuning .YAW input[name="d"]').change(function() {
+            var dMinElement= $('.dminGroup input[name="dMinYaw"]');
+            adjustDMin($(this), dMinElement);
+        }).change();
 
         $('input[id="gyroNotch1Enabled"]').change(function() {
             var checked = $(this).is(':checked');
@@ -612,6 +646,13 @@ TABS.pid_tuning.initialize = function (callback) {
             if (FILTER_CONFIG.dterm_lowpass_dyn_min_hz > 0 && FILTER_CONFIG.dterm_lowpass_dyn_min_hz < FILTER_CONFIG.dterm_lowpass_dyn_max_hz ) {
                 FILTER_CONFIG.dterm_lowpass_type = $('.pid_filter select[name="dtermLowpassDynType"]').val();
             }
+
+            ADVANCED_TUNING.dMinRoll = parseInt($('.dminGroup input[name="dMinRoll"]').val());
+            ADVANCED_TUNING.dMinPitch = parseInt($('.dminGroup input[name="dMinPitch"]').val());
+            ADVANCED_TUNING.dMinYaw = parseInt($('.dminGroup input[name="dMinYaw"]').val());
+            ADVANCED_TUNING.dMinGain = parseInt($('.dminGroup input[name="dMinGain"]').val());
+            ADVANCED_TUNING.dMinAdvance = parseInt($('.dminGroup input[name="dMinAdvance"]').val());
+
         }
 
     }

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -264,6 +264,46 @@
                         </table>
                     </div>
 
+                    <div class="dminGroup topspacer tpa">
+                        <table class="cf">
+                            <thead>
+                                <tr>
+                                    <th colspan="5">
+                                        <span i18n="pidTuningDMin" />
+                                        <span class="helpicon cf_tip" i18n_title="pidTuningDMinHelp" />
+                                    </th>
+                                </tr>
+
+                                <tr>
+                                    <th i18n="pidTuningDMinRoll" />
+                                    <th i18n="pidTuningDMinPitch" />
+                                    <th i18n="pidTuningDMinYaw" />
+                                    <th i18n="pidTuningDMinGain" />
+                                    <th i18n="pidTuningDMinAdvance" />
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td>
+                                        <input type="number" name="dMinRoll" step="1" min="0" max="100" />
+                                    </td>
+                                    <td>
+                                        <input type="number" name="dMinPitch" step="1" min="0" max="100" />
+                                    </td>
+                                    <td>
+                                        <input type="number" name="dMinYaw" step="1" min="0" max="100" />
+                                    </td>
+                                    <td>
+                                        <input type="number" name="dMinGain" step="1" min="0" max="100" />
+                                    </td>
+                                    <td>
+                                        <input type="number" name="dMinAdvance" step="1" min="0" max="200" />
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
                     <div class="gui_box grey topspacer pidTuningFeatures">
                         <table class="pid_titlebar new_rates">
                             <tr>


### PR DESCRIPTION
This adds the possibility to configure d_min in the Configurator.

The ideal will be to add a column to the PID table, but we have too many columns and it will be difficult for some screen resolutions, so I added it to a new table. If someone has time, the perfect solution will be to move the rates and the graph of rates to a new subtab, to get some space, but I don't have now time to do it.

The result is like this:
![image](https://user-images.githubusercontent.com/2673520/54201777-ca548800-44ce-11e9-9d83-0372d9f79199.png)

I have added the MSP commands for integrated yaw too in this PR because is needed by the firmware to no ignore the values and write them.