### PR TITLE
Add integrated yaw to the Configurator

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3122,6 +3122,15 @@
     "pidTuningAcroTrainerAngleLimitHelp": {
         "message": "Adds a new angle limiting mode for pilots who are learning to fly in acro mode. The range valid is 10-80 and must be activated with a switch in the $t(tabAuxiliary.message) tab."
     },
+    "pidTuningIntegratedYaw": {
+        "message": "Integrated Yaw"
+    },
+    "pidTuningIntegratedYawCaution": {
+        "message": "<span class=\"message-negative\">CAUTION</span>: if you enable this feature, you must adjust the YAW PID accordingly. More info <a href=\"https://github.com/betaflight/betaflight/wiki/Integrated-Yaw\" target=\"_blank\">here</a>"
+    },
+    "pidTuningIntegratedYawHelp": {
+        "message": "Integrated Yaw is a feature which corrects a fundamental issue with quad control: while the pitch and roll axis are controlled by the thrust differentials the props generate yaw is different. Integrated Yaw fixes this by integrating the output of the yaw pid before applying them to the mixer. This normalizes the way the pids work. You can now tune as any other axis. It requires use of absolute control since no I is needed with Integrated Yaw."
+    },
 
     "configHelp2": {
         "message": "Arbitrary board rotation in degrees, to allow mounting it sideways / upside down / rotated etc. When running external sensors, use the sensor alignments (Gyro, Acc, Mag) to define sensor position independent from board orientation. "

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -330,6 +330,8 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.dminGroup input[name="dMinGain"]').val(ADVANCED_TUNING.dMinGain);
             $('.dminGroup input[name="dMinAdvance"]').val(ADVANCED_TUNING.dMinAdvance);
 
+            $('input[id="useIntegratedYaw"]').prop('checked', ADVANCED_TUNING.useIntegratedYaw !== 0);
+
         } else {
             $('.throttle_limit').hide();
 
@@ -338,7 +340,14 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.dtermLowpass2TypeGroup').hide();
 
             $('.dminGroup').hide();
+
+            $('.integratedYaw').hide();
         }
+
+        $('input[id="useIntegratedYaw"]').change(function() {
+            var checked = $(this).is(':checked');
+            $('#pidTuningIntegratedYawCaution').toggle(checked);
+        }).change();
 
         function adjustDMin(dElement, dMinElement) {
             var dValue = parseInt(dElement.val());
@@ -653,6 +662,7 @@ TABS.pid_tuning.initialize = function (callback) {
             ADVANCED_TUNING.dMinGain = parseInt($('.dminGroup input[name="dMinGain"]').val());
             ADVANCED_TUNING.dMinAdvance = parseInt($('.dminGroup input[name="dMinAdvance"]').val());
 
+            ADVANCED_TUNING.useIntegratedYaw = $('input[id="useIntegratedYaw"]').is(':checked') ? 1 : 0;
         }
 
     }

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -492,6 +492,23 @@
                                 </td>
                             </tr>
 
+                            <tr class="integratedYaw">
+                                <td><input type="checkbox" id="useIntegratedYaw" class="toggle" /></td>
+                                <td colspan="2">
+
+                                    <span>
+                                        <label for="useIntegratedYaw">
+                                            <span i18n="pidTuningIntegratedYaw" />
+                                        </label>
+                                    </span>
+
+                                    <span class="suboption" id="pidTuningIntegratedYawCaution" i18n="pidTuningIntegratedYawCaution" />
+
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningIntegratedYawHelp"></div>
+
+                                </td>
+                            </tr>
+
                         </table>
                     </div>
 


### PR DESCRIPTION
Adds integrated YAW to the Configurator. When enabled, it shows a CAUTION message to be sure the user reads the wiki about the correct PID for YAW.

![image](https://user-images.githubusercontent.com/2673520/54305835-631afe80-45c8-11e9-8d9e-ad5e023191a8.png)
