### PR TITLE
Do not change dyn_lpf_gyro_max_hz when gyro dyn lpf is disabled.

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -430,7 +430,7 @@ TABS.pid_tuning.initialize = function (callback) {
             var type = FILTER_CONFIG.gyro_lowpass_type > 0 ? FILTER_CONFIG.gyro_lowpass_type : DEFAULT.gyro_lowpass_type;
 
             $('.pid_filter input[name="gyroLowpassDynMinFrequency"]').val(checked ? cutoff_min : 0).attr('disabled', !checked);
-            $('.pid_filter input[name="gyroLowpassDynMaxFrequency"]').val(checked ? cutoff_max : 0).attr('disabled', !checked);
+            $('.pid_filter input[name="gyroLowpassDynMaxFrequency"]').attr('disabled', !checked);
             $('.pid_filter select[name="gyroLowpassDynType"]').val(checked ? type : 0).attr('disabled', !checked);
 
             if (checked) {


### PR DESCRIPTION
When the dynamic notch range is set to auto, the dynamic notch sampling frequency is set according to dyn_lpf_gyro_max_hz.  The configurator is setting this value to 0 when disabling the dynamic gyro lowpass, forcing the the dynamic notch range to low.