### PR TITLE
Fix OSD preview under low resolutions

### DIFF
--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -477,9 +477,10 @@ button {
 
 .tab-osd .preview {
   width: 360px;
-}
+  float: left; 
+  position: sticky;
+  top: 0px;
 
-.tab-osd .preview {
   /* please don't copy the generic background image from another project
    * and replace the one that @nathantsoi took :)
    */

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -33,7 +33,7 @@
                 </div>
                 <div class="cf_column twothird">
 
-                    <div class="gui_box grey preview requires-osd-feature" style="float: left; position: fixed;">
+                    <div class="gui_box grey preview requires-osd-feature">
 
                         <div class="gui_box_titlebar image">
                             <div class="spacer_box_title">


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1297 removing the major part of the empty space in top of the preview.