### PR TITLE
Fix superExpo in the receiver preview

### DIFF
--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -549,8 +549,8 @@ TABS.receiver.initModelPreview = function () {
     this.model = new Model($('.model_preview'), $('.model_preview canvas'));
 
     this.useSuperExpo = false;
-    if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-        this.useSuperExpo = FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES');
+    if (semver.gte(CONFIG.apiVersion, "1.20.0") || (semver.gte(CONFIG.apiVersion, "1.16.0") && FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES'))) {
+        this.useSuperExpo = true;
     }
 
     var useOldRateCurve = false;


### PR DESCRIPTION
The preview in the receiver tab is broken if you use the super rate, because it is only calculated when super expo feature is enabled. The result is that the preview is moving very slow and not at the maximum rate.