### PR TITLE
Show/Hide gyro elements

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1042,7 +1042,10 @@
     "configurationSensorGyroToUse": {
         "message": "GYRO/ACCEL"
     },
-    "configurationSensorGyroToUseDefaultOption": {
+    "configurationSensorGyroToUseNotFound": {
+        "message": "Warning: No Gyro/Acc found"
+    },
+    "configurationSensorGyroToUseFirst": {
         "message": "First"
     },
     "configurationSensorGyroToUseSecond": {

--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -216,7 +216,6 @@
 .tab-configuration .gyro_alignment_inputs {
     margin-bottom: 5px;
     padding-bottom: 5px;
-    border-bottom: 1px solid #ddd;
     width: 33.3%;
     float: left;
     white-space: nowrap;
@@ -492,12 +491,11 @@
     margin-top: 3px;
 }
 
+.tab-configuration .board_align_content,
 .tab-configuration .gyro_align_content {
     width: 100%;
-}
-
-.tab-configuration .board_align_content {
-    width: 100%;
+    border-bottom: 1px solid #ddd;
+    display: inline-block;
 }
 
 .tab-configuration .sensoralignment span {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -336,7 +336,7 @@ var FC = {
             align_gyro:                 0,
             align_acc:                  0,
             align_mag:                  0,
-            use_multi_gyro:             0,
+            gyro_detection_flags:       0,
             gyro_to_use:                0,
             gyro_1_align:               0,
             gyro_2_align:               0,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -538,7 +538,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 SENSOR_ALIGNMENT.align_mag = data.readU8();
 
                 if (semver.gte(CONFIG.apiVersion, '1.41.0')) {
-                    SENSOR_ALIGNMENT.use_multi_gyro = data.readU8();
+                    SENSOR_ALIGNMENT.gyro_detection_flags = data.readU8();
                     SENSOR_ALIGNMENT.gyro_to_use = data.readU8();
                     SENSOR_ALIGNMENT.gyro_1_align = data.readU8();
                     SENSOR_ALIGNMENT.gyro_2_align = data.readU8();

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -272,32 +272,36 @@
                                      </div>
                                 </div>
                                 <div class="gyro_align_content">
-                                    <div class="gyro_alignment_inputs">
+                                    <div class="gyro_alignment_inputs gyro_alignment_inputs_selection">
                                         <label>
                                             <select class="gyro_to_use">
-                                                <option i18n="configurationSensorGyroToUseDefaultOption" value="0"></option>
                                                 <!-- list generated here -->
                                             </select>
                                             <span i18n="configurationSensorGyroToUse"></span>
                                         </label>
                                     </div>
-                                    <div class="gyro_alignment_inputs">
+                                    <div class="gyro_alignment_inputs gyro_alignment_inputs_first">
                                         <label>
-                                            <select class="gyro_1_align">
-                                                <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
-                                                <!-- list generated here -->
-                                            </select>
-                                            <span i18n="configurationSensorAlignmentGyro1"></span>
+                                            <span>
+                                                <select class="gyro_1_align">
+                                                    <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
+                                                    <!-- list generated here -->
+                                                </select>
+                                                <span i18n="configurationSensorAlignmentGyro1"></span>
+                                            </span>
                                         </label>
                                     </div>
-                                    <div class="gyro_alignment_inputs">
-                                        <label>                                            
+                                    <div class="gyro_alignment_inputs gyro_alignment_inputs_second">
+                                        <label>
                                             <select class="gyro_2_align">
                                                 <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
                                                 <!-- list generated here -->
                                             </select>
                                             <span i18n="configurationSensorAlignmentGyro2"></span>
                                         </label>
+                                    </div>
+                                    <div class="gyro_alignment_inputs gyro_alignment_inputs_notfound">
+                                        <span class="message-negative" i18n="configurationSensorGyroToUseNotFound"/>
                                     </div>
                                 </div>
                                 <div class="sensor_align_content">


### PR DESCRIPTION
This is a follow up of: https://github.com/betaflight/betaflight-configurator/pull/1338 is better to wait to merge it (and maybe to do a rebase of this) before reviewing the code.

But I opened it soon to discuss some things I've found while doing it.

This PR aims to show/hide some elements of the gyro configuration if don't needed. The BOTH option for example if not supported of the gyro1/gyro2 if not detected.

I have no FC with BOTH option so this has not been tested.

I decided to show the gyro selection element in the case we only have 1 gyro, because the gyro orientation is numbered so I think all has more sense:
![image](https://user-images.githubusercontent.com/2673520/55624122-4166fe80-57a5-11e9-8453-b2af628f7c07.png)

I've observed that the firmware does not send the value 0 when the align is the default one. I don't know if it is a secondary effect of the unified targets of Betaflight 4.0 or a bug in the firmware. Is zero a valid value for the firmware talking about alignment? If not I need to remove the Default option from the combo:
![image](https://user-images.githubusercontent.com/2673520/55624187-72dfca00-57a5-11e9-811d-869baa488492.png)

I've added an error message too if no gyro is detected.