### PR TITLE
Add ability to do CI builds for Windows platform.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,13 +23,7 @@ steps:
 - script: gulp debug-no-start --win32
   displayName: 'Gulp debug-no-start'
 
-# Testing publishing using different task
-#- task: ArchiveFiles@2
-#  inputs:
-#    archiveFile: '$(Build.ArtifactStagingDirectory)/betaflight-configurator.zip'
-#    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/debug'
-#    includeRootFolder: false
-
 - task: PublishPipelineArtifact@0
   inputs: 
-    targetPath: '$(System.DefaultWorkingDirectory)/debug'
+    artifactName: betaflight-configurator
+    targetPath: '$(System.DefaultWorkingDirectory)/debug/betaflight-configurator'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -23,13 +23,13 @@ steps:
 - script: gulp debug-no-start --win32
   displayName: 'Gulp debug-no-start'
 
-# Testing direct download using different task
+# Testing publishing using different task
 #- task: ArchiveFiles@2
 #  inputs:
 #    archiveFile: '$(Build.ArtifactStagingDirectory)/betaflight-configurator.zip'
 #    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/debug'
 #    includeRootFolder: false
 
-- task: DownloadPipelineArtifact@0
+- task: PublishPipelineArtifact@0
   inputs: 
     targetPath: '$(System.DefaultWorkingDirectory)/debug'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,11 +20,8 @@ steps:
 - script: npm install
   displayName: 'NPM install'
 
-# Whilst no-exec isn't a valid platform, is avoids executing configurator
-# as more than one platform is passed. Gulp will stay happy as long as one
-# valid platform is passed along.
-- script: gulp debug --win32 --no-exec
-  displayName: 'Gulp debug'
+- script: gulp debug-no-start --win32
+  displayName: 'Gulp debug-no-start'
 
 # Testing direct download using different task
 #- task: ArchiveFiles@2
@@ -35,5 +32,4 @@ steps:
 
 - task: DownloadPipelineArtifact@0
   inputs: 
-    artifactName: 'betaflight-configurator'
     targetPath: '$(System.DefaultWorkingDirectory)/debug'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,32 @@
+
+trigger:
+- azure-pipelines
+
+pool:
+  vmImage: 'vs2017-win2016'
+
+steps:
+- task: NodeTool@0
+  inputs:
+    versionSpec: '8.11.2'    
+  displayName: 'Install Node.js'
+
+- script: npm install -g npm@6.0.1
+  displayName: 'Install NPM'
+
+- script: npm install -g gulp
+  displayName: 'Install Gulp'
+
+- script: npm install
+  displayName: 'NPM install'
+
+- script: gulp release --win32
+  displayName: 'Gulp release'
+
+- task: ArchiveFiles@2
+  inputs:
+    archiveFile: '$(Build.ArtifactStagingDirectory)/betaflight-configurator-$(Build.BuildId).zip'
+    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/release'
+    includeRootFolder: false
+
+- task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -20,13 +20,20 @@ steps:
 - script: npm install
   displayName: 'NPM install'
 
-- script: gulp release --win32
-  displayName: 'Gulp release'
+# Whilst no-exec isn't a valid platform, is avoids executing configurator
+# as more than one platform is passed. Gulp will stay happy as long as one
+# valid platform is passed along.
+- script: gulp debug --win32 --no-exec
+  displayName: 'Gulp debug'
 
-- task: ArchiveFiles@2
-  inputs:
-    archiveFile: '$(Build.ArtifactStagingDirectory)/betaflight-configurator-$(Build.BuildId).zip'
-    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/release'
-    includeRootFolder: false
+# Testing direct download using different task
+#- task: ArchiveFiles@2
+#  inputs:
+#    archiveFile: '$(Build.ArtifactStagingDirectory)/betaflight-configurator.zip'
+#    rootFolderOrFile: '$(System.DefaultWorkingDirectory)/debug'
+#    includeRootFolder: false
 
-- task: PublishBuildArtifacts@1
+- task: DownloadPipelineArtifact@0
+  inputs: 
+    artifactName: 'betaflight-configurator'
+    targetPath: '$(System.DefaultWorkingDirectory)/debug'

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -75,6 +75,9 @@ gulp.task('apps', appsBuild);
 var debugBuild = gulp.series(distBuild, debug, gulp.parallel(listPostBuildTasks(DEBUG_DIR)), start_debug)
 gulp.task('debug', debugBuild);
 
+var debugBuild = gulp.series(distBuild, debug, gulp.parallel(listPostBuildTasks(DEBUG_DIR)))
+gulp.task('debug-no-start', debugBuild);
+
 var releaseBuild = gulp.series(gulp.parallel(clean_release, appsBuild), gulp.parallel(listReleaseTasks()));
 gulp.task('release', releaseBuild);
 


### PR DESCRIPTION
Use [Azure-Pipelines](https://github.com/marketplace/azure-pipelines) to perform Windows CI builds.

[Demo site](https://si618.visualstudio.com/betaflight-configurator-win) and [latest installer build](https://si618.visualstudio.com/_apis/resources/Containers/1196408?itemPath=drop%2Fbetaflight-configurator-21.zip) from my fork. 

At the moment `gulp release` task is used, as `gulp debug` was spawning configurator exe process, causing the build to hang. If deploying debug build files instead release installer is preferred, or both debug and release builds are wanted, I suggest adding an option to the gulp file to skip spawning.

We should be able to deploy the build(s) somewhere else if needed, and the build artifact names should append version number to match linux CI builds, so will tinker and update this PR after comments.  

Note that `trigger:` value in yml file will need to point to master branch once betaflight devs have the pipeline configured.