### PR TITLE
Fixed flashing on MacOS by updating NW.js.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,7 +32,7 @@ const RELEASE_DIR = './release/';
 const LINUX_INSTALL_DIR = '/opt/betaflight';
 
 var nwBuilderOptions = {
-    version: '0.35.3',
+    version: '0.36.4',
     files: './dist/**/*',
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},

--- a/package-lock.json
+++ b/package-lock.json
@@ -2206,9 +2206,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.7.tgz",
+      "integrity": "sha512-Pxm6sI2MeBD7RdD12RYsqaP0nMiwx8eZBXCa6z2L+mRHm2DYrOYwihmhjpkdjUHwQhslWQjRpEgNq4XvBmaAuw==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -2235,7 +2235,7 @@
           "optional": true
         },
         "are-we-there-yet": {
-          "version": "1.1.4",
+          "version": "1.1.5",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2261,7 +2261,7 @@
           }
         },
         "chownr": {
-          "version": "1.0.1",
+          "version": "1.1.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2300,7 +2300,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.5.1",
+          "version": "0.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2349,7 +2349,7 @@
           }
         },
         "glob": {
-          "version": "7.1.2",
+          "version": "7.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2369,12 +2369,12 @@
           "optional": true
         },
         "iconv-lite": {
-          "version": "0.4.21",
+          "version": "0.4.24",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safer-buffer": "^2.1.0"
+            "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "ignore-walk": {
@@ -2439,17 +2439,17 @@
           "optional": true
         },
         "minipass": {
-          "version": "2.2.4",
+          "version": "2.3.5",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
           }
         },
         "minizlib": {
-          "version": "1.1.0",
+          "version": "1.2.1",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2473,7 +2473,7 @@
           "optional": true
         },
         "needle": {
-          "version": "2.2.0",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2484,18 +2484,18 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.10.0",
+          "version": "0.10.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
             "detect-libc": "^1.0.2",
             "mkdirp": "^0.5.1",
-            "needle": "^2.2.0",
+            "needle": "^2.2.1",
             "nopt": "^4.0.1",
             "npm-packlist": "^1.1.6",
             "npmlog": "^4.0.2",
-            "rc": "^1.1.7",
+            "rc": "^1.2.7",
             "rimraf": "^2.6.1",
             "semver": "^5.3.0",
             "tar": "^4"
@@ -2512,13 +2512,13 @@
           }
         },
         "npm-bundled": {
-          "version": "1.0.3",
+          "version": "1.0.5",
           "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
-          "version": "1.1.10",
+          "version": "1.2.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -2595,12 +2595,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.7",
+          "version": "1.2.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "^0.5.1",
+            "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
             "minimist": "^1.2.0",
             "strip-json-comments": "~2.0.1"
@@ -2630,16 +2630,16 @@
           }
         },
         "rimraf": {
-          "version": "2.6.2",
+          "version": "2.6.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "glob": "^7.0.5"
+            "glob": "^7.1.3"
           }
         },
         "safe-buffer": {
-          "version": "5.1.1",
+          "version": "5.1.2",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2657,7 +2657,7 @@
           "optional": true
         },
         "semver": {
-          "version": "5.5.0",
+          "version": "5.6.0",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -2710,17 +2710,17 @@
           "optional": true
         },
         "tar": {
-          "version": "4.4.1",
+          "version": "4.4.8",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "chownr": "^1.0.1",
+            "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
-            "minipass": "^2.2.4",
-            "minizlib": "^1.1.0",
+            "minipass": "^2.3.4",
+            "minizlib": "^1.1.1",
             "mkdirp": "^0.5.0",
-            "safe-buffer": "^5.1.1",
+            "safe-buffer": "^5.1.2",
             "yallist": "^3.0.2"
           }
         },
@@ -2731,12 +2731,12 @@
           "optional": true
         },
         "wide-align": {
-          "version": "1.1.2",
+          "version": "1.1.3",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "string-width": "^1.0.2"
+            "string-width": "^1.0.2 || 2"
           }
         },
         "wrappy": {
@@ -2746,7 +2746,7 @@
           "optional": true
         },
         "yallist": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4296,9 +4296,9 @@
       }
     },
     "marked": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.0.tgz",
-      "integrity": "sha512-HduzIW2xApSXKXJSpCipSxKyvMbwRRa/TwMbepmlZziKdH8548WSoDP4SxzulEKjlo8BE39l+2fwJZuRKOln6g=="
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.2.tgz",
+      "integrity": "sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA=="
     },
     "matchdep": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "i18next": "^14.1.1",
     "i18next-xhr-backend": "^2.0.0",
     "lru_map": "^0.3.3",
-    "marked": "^0.6.0",
+    "marked": "^0.6.2",
     "object-hash": "^1.3.1",
     "short-unique-id": "^1.1.1",
     "universal-ga": "^1.2.0"


### PR DESCRIPTION
NW.js 0.35.3 throws an error when trying to flash on MacOS:

```
USB DFU detected with ID: 0
stm32usbdfu.js:133 Device opened with Handle ID: 1
stm32usbdfu.js:107 reporting chrome error: Error claiming interface.
stm32usbdfu.js:159 Failed to claim USB device!
stm32usbdfu.js:977 Script finished after: 0.011 seconds
stm32usbdfu.js:163 Claimed interface: 0
stm32usbdfu.js:173 Released interface: 0
main.html#progressbar:1 Unchecked runtime.lastError while running usb.releaseInterface: Error releasing interface.
    at STM32DFU_protocol.releaseInterface (chrome-extension://ajdoecjhplhoahggfmgflfnlechcljoc/js/protocols/stm32usbdfu.js:172:16)
    at STM32DFU_protocol.upload_procedure (chrome-extension://ajdoecjhplhoahggfmgflfnlechcljoc/js/protocols/stm32usbdfu.js:971:18)
    at Object.claimed [as callback] (chrome-extension://ajdoecjhplhoahggfmgflfnlechcljoc/js/protocols/stm32usbdfu.js:160:18)
stm32usbdfu.js:148 Device closed with Handle ID: 1
stm32usbdfu.js:107 reporting chrome error: No such connection.
main.html#progressbar:1 Error in response to usb.controlTransfer: TypeError: Cannot read property 'resultCode' of undefined
    at Object.callback (chrome-extension://ajdoecjhplhoahggfmgflfnlechcljoc/js/protocols/stm32usbdfu.js:269:72)
    at STM32DFU_protocol.getInterfaceDescriptor (chrome-extension://ajdoecjhplhoahggfmgflfnlechcljoc/js/protocols/stm32usbdfu.js:259:16)
    at getDescriptorString (chrome-extension://ajdoecjhplhoahggfmgflfnlechcljoc/js/protocols/stm32usbdfu.js:229:9)
    at Object.callback (chrome-extension://ajdoecjhplhoahggfmgflfnlechcljoc/js/protocols/stm32usbdfu.js:252:2)
```

Reverting to 0.32.2 is not a good option, as this will show an error popup on startup for users who had already installed the 10.5.0 version, because the NW.js config is newer than the NW.js version.