### PR TITLE
Adjust dmin limit logic

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -357,11 +357,12 @@ TABS.pid_tuning.initialize = function (callback) {
             var dValue = parseInt(dElement.val());
             var dMinValue = parseInt(dMinElement.val());
 
-            if (dMinValue >= dValue) {
-                dMinElement.val(0);
+            var dMinLimit = dValue > 0 ? dValue - 1 : 0;
+            if (dMinValue > dMinLimit) {
+                dMinElement.val(dMinLimit);
             }
 
-            dMinElement.attr("max", dValue > 0? dValue - 1 : 0);
+            dMinElement.attr("max", dMinLimit);
         }
 
         $('.pid_tuning .ROLL input[name="d"]').change(function() {


### PR DESCRIPTION
Previously dmin values would reset to 0 if the user decreased the D value below the current setting for dmin on a given axis. Now adjust the max for the dmin value to be D - 1 and set the dmin value to that. Prevents unexpected resets of dmin to 0 when adjusting the D gains.