### PR TITLE
CI builds using azure pipelines.

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,104 @@
+# Builds Betaflight Configurator on Windows, Linux and OSX platforms.
+#
+# After building, artifacts are released to a seperate repository.
+#
+# Requires Azure Pipelines added to Github repositories:
+# https://azure.microsoft.com/services/devops/pipelines/
+#
+# Azure Pipelines requires tasks to be installed:
+# - Github Release: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release
+# - File content to variable: https://marketplace.visualstudio.com/items?itemName=maikvandergaag.maikvandergaag-file-to-variable
+
+trigger:
+# TODO: change to master once pull request merged
+- azure-pipelines
+
+jobs:
+- job: 'Windows'
+
+  pool:
+    vmImage: 'vs2017-win2016'
+
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.11.2'    
+    displayName: 'Install Node.js'
+
+  - script: npm install -g npm@6.0.1
+    displayName: 'Install NPM'
+
+  - script: npm install -g gulp
+    displayName: 'Install Gulp'
+
+  - script: npm install
+    displayName: 'Run npm install'
+
+  - script: gulp release --win32
+    displayName: 'Run gulp release'
+
+  - powershell: Set-Content -Path '$(System.DefaultWorkingDirectory)/release/log.txt' -Value $env:BUILD_SOURCEVERSIONMESSAGE
+
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Windows release'
+    inputs: 
+      artifactName: betaflight-configurator-windows
+      targetPath: '$(System.DefaultWorkingDirectory)/release'
+
+- job: 'Linux'
+
+  pool:
+    vmImage: 'ubuntu-16.04'
+
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.11.2'    
+    displayName: 'Install Node.js'
+
+  - script: npm install -g npm@6.0.1
+    displayName: 'Install NPM'
+
+  - script: npm install -g gulp
+    displayName: 'Install Gulp'
+
+  - script: npm install
+    displayName: 'Run npm install'
+
+  - script: gulp release --linux32 --linux64
+    displayName: 'run gulp release'
+
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish Linux release'
+    inputs: 
+      artifactName: betaflight-configurator-linux
+      targetPath: '$(System.DefaultWorkingDirectory)/release'
+
+- job: 'MacOS'
+
+  pool:
+    vmImage: 'macos-10.13'
+
+  steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '8.11.2'    
+    displayName: 'Install Node.js'
+
+  - script: npm install -g npm@6.0.1
+    displayName: 'Install NPM'
+
+  - script: npm install -g gulp
+    displayName: 'Install Gulp'
+
+  - script: npm install
+    displayName: 'Run rpm install'
+
+  - script: gulp release --osx64
+    displayName: 'Run gulp release'
+
+  - task: PublishPipelineArtifact@0
+    displayName: 'Publish MacOS release'
+    inputs: 
+      artifactName: betaflight-configurator-macos
+      targetPath: '$(System.DefaultWorkingDirectory)/release'


### PR DESCRIPTION
Builds Betaflight Configurator on Windows, Linux and OSX using Azure Pipelines, which can then be published as a new Github release.

Example build pipeline:  https://si618.visualstudio.com/betaflight-configurator-ci
Example release repo: https://github.com/si618/betaflight-configurator-ci

Apologies for stuffing up the last pull request, I think this one is ok.  Have added Linux and OSX builds as I figured having all the platforms in one spot is better than spreading them out, but easy enough to change if not needed.