### PR TITLE
Workaround for bug in CLI with 29 lenght + space

### DIFF
--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -190,6 +190,7 @@ TABS.cli.initialize = function (callback, nwGui) {
                     return new Promise(function (resolve) {
                         GUI.timeout_add('CLI_send_slowly', function () {
                             var processingDelay = self.lineDelayMs;
+                            line = line.trim();
                             if (line.toLowerCase().startsWith('profile')) {
                                 processingDelay = self.profileSwitchDelayMs;
                             }


### PR DESCRIPTION
Workaround for the problem detected here: https://github.com/betaflight/betaflight-configurator/pull/1329 that occurs when sending in CLI a command with 29 characters length and an space in the end. This PR removes the final space and all seems to work.

This is a workaround until some update on the serial part fixes the underlying real problem.