### PR TITLE
Fix slowdown looking for usb devices

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -142,7 +142,7 @@ PortHandler.check = function () {
         GUI.updateManualPortVisibility();
         setTimeout(function () {
             self.check();
-        }, 250);
+        }, 500);
     });
 };
 

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const TIMEOUT_CHECK = 500; // With 250 it seems that it produces a memory leak and slowdown in some versions, reason unknown
+
 var usbDevices = { filters: [
     {'vendorId': 1155, 'productId': 57105},
     {'vendorId': 10473, 'productId': 393}
@@ -13,7 +15,7 @@ var PortHandler = new function () {
 };
 
 PortHandler.initialize = function () {
-    // start listening, check after 250ms
+    // start listening, check after TIMEOUT_CHECK ms
     this.check();
 };
 
@@ -142,7 +144,7 @@ PortHandler.check = function () {
         GUI.updateManualPortVisibility();
         setTimeout(function () {
             self.check();
-        }, 500);
+        }, TIMEOUT_CHECK);
     });
 };
 


### PR DESCRIPTION
We have some reporting that when the Configurator is open for a long time, it has slowdowns. It seems is related in some way with the search of new usb devices connected. Changing the timeout for the execution of this method seems to fix it.