### PR TITLE
New crash flag in 4.1 jostles the disarm flags

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -789,6 +789,10 @@
         "message": "Runway Takeoff Prevention has been triggered",
         "description": "Description of the RUNAWAY_TAKEOFF arming disable flag"
     },
+    "initialSetupArmingDisableFlagsTooltipCRASH": {
+        "message": "Disarmed via crash detection",
+        "description": "Description of the CRASH arming disable flag"
+    },
     "initialSetupArmingDisableFlagsTooltipTHROTTLE": {
         "message": "Throttle channel is too high",
         "description": "Description of the THROTTLE arming disable flag"

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -233,6 +233,9 @@ TABS.setup.initialize = function (callback) {
                 disarmFlagElements.splice(disarmFlagElements.indexOf('OSD_MENU'), 1);
                 disarmFlagElements = disarmFlagElements.concat(['RESC']);
             }
+            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                disarmFlagElements.splice(disarmFlagElements.indexOf('THROTTLE'), 0, 'CRASH');
+            }
 
             // Always the latest element
             disarmFlagElements = disarmFlagElements.concat(['ARM_SWITCH']);


### PR DESCRIPTION
related to https://github.com/betaflight/betaflight/commit/760a52402754ec43a6698be9bdba546e3fc706f4

Note: initialSetupArmingDisableFlagsTooltipCRASH.message might need to get handled somewhere. Maybe people could just not crash with the configurator open...


