### PR TITLE
filter out bad characters in craft_name for saving files

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -713,7 +713,7 @@ function generateFilename(prefix, suffix) {
             filename = CONFIG.flightControllerIdentifier + '_' + filename;
         }
         if(CONFIG.name && CONFIG.name.trim() !== '') {
-            filename = filename + '_' + CONFIG.name.trim().replace(' ', '_');
+            filename = filename + '_' + CONFIG.name.trim().replace(/[<>:"/\\|?* ]/g, '_');
         }
     }
 


### PR DESCRIPTION
Fixes #1414 

Even though OSX and Linux don't really care about file names, e-mail systems might. 