### PR TITLE
Adds a Tooltip to the Aux Rssi Channel Dropdown

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1767,7 +1767,7 @@
         "message": "RSSI Channel"
     },
 	"receiverHelpRssiChannel": {
-	        "message": "AUX channel on which you have configured RSSI forwarding.  <p><strong>If AUX channel gets disabled after saving, check if ADC_RSSI is enabled in the Configuration tab.</strong></p>  ADC_RSSI has priority, and is enabled by default on boards that support it."
+	        "message": "Channel on which you have configured RSSI forwarding.  <p><strong>If AUX channel gets disabled after saving, check if ADC_RSSI is enabled in the Configuration tab.</strong></p>  ADC_RSSI has priority, and is enabled by default on boards that support it."
 	    },
     "receiverRssiChannelDisabledOption": {
         "message": "Disabled"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1766,9 +1766,6 @@
     "receiverRssiChannel": {
         "message": "RSSI Channel"
     },
-	"receiverHelpRssiChannel": {
-	        "message": "AUX channel on which you have configured RSSI forwarding.  <p><strong>If AUX channel gets disabled after saving, check if ADC_RSSI is enabled in the Configuration tab.</strong></p>  ADC_RSSI has priority, and is enabled by default on boards that support it."
-	    },
     "receiverRssiChannelDisabledOption": {
         "message": "Disabled"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1766,6 +1766,9 @@
     "receiverRssiChannel": {
         "message": "RSSI Channel"
     },
+	"receiverHelpRssiChannel": {
+	        "message": "AUX channel on which you have configured RSSI forwarding.  <p><strong>If AUX channel gets disabled after saving, check if ADC_RSSI is enabled in the Configuration tab.</strong></p>  ADC_RSSI has priority, and is enabled by default on boards that support it."
+	    },
     "receiverRssiChannelDisabledOption": {
         "message": "Disabled"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1766,9 +1766,9 @@
     "receiverRssiChannel": {
         "message": "RSSI Channel"
     },
-	"receiverHelpRssiChannel": {
-	        "message": "Channel on which you have configured RSSI forwarding.  <p><strong>If AUX channel gets disabled after saving, check if ADC_RSSI is enabled in the Configuration tab.</strong></p>  ADC_RSSI has priority, and is enabled by default on boards that support it."
-	    },
+    "receiverHelpRssiChannel": {
+        "message": "Channel on which you have configured RSSI forwarding.  <p><strong>If AUX channel gets disabled after saving, check if ADC_RSSI is enabled in the Configuration tab.</strong></p>  ADC_RSSI has priority, and is enabled by default on boards that support it."
+    },
     "receiverRssiChannelDisabledOption": {
         "message": "Disabled"
     },

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -14,9 +14,10 @@
         <div class="fc_column half" style="margin-left: 20px;">
             <div class="rssi_channel_wrapper">
                 <div class="head" i18n="receiverRssiChannel"></div>
-                <select name="rssi_channel">
+                <select name="rssi_channel" style="width: 70%;">
                     <!-- list generated here -->
                 </select>
+				<div class="helpicon cf_tip" i18n_title="receiverHelpRssiChannel"></div>
             </div>
             <div class="rcmap_wrapper">
                 <div class="head">

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -14,10 +14,9 @@
         <div class="fc_column half" style="margin-left: 20px;">
             <div class="rssi_channel_wrapper">
                 <div class="head" i18n="receiverRssiChannel"></div>
-                <select name="rssi_channel" style="width: 70%;">
+                <select name="rssi_channel">
                     <!-- list generated here -->
                 </select>
-				<div class="helpicon cf_tip" i18n_title="receiverHelpRssiChannel"></div>
             </div>
             <div class="rcmap_wrapper">
                 <div class="head">

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -17,7 +17,7 @@
                 <select name="rssi_channel" style="width: 70%;">
                     <!-- list generated here -->
                 </select>
-				<div class="helpicon cf_tip" i18n_title="receiverHelpRssiChannel"></div>
+                <div class="helpicon cf_tip" i18n_title="receiverHelpRssiChannel"></div>
             </div>
             <div class="rcmap_wrapper">
                 <div class="head">


### PR DESCRIPTION
This tooltip briefly explains the function of the feature, and that saving an "invalid" configuration will reset the field. Provides the likely reason why selection was reset. If there's another case that can make AUX RSSI channel invalid, please tell me so I'll add it.

Contents of Tooltip:
"Channel on which you have configured RSSI forwarding.  ** If AUX channel gets disabled after saving, check if ADC_RSSI is enabled in the Configuration tab.**  ADC_RSSI has priority, and is enabled by default on boards that support it."

In context:
<img width="796" alt="Screenshot 2019-05-12 at 15 50 13" src="https://user-images.githubusercontent.com/4053708/57583189-5c2c4180-74ce-11e9-8057-bd4b01719692.png">
Cell padding has the same value as most others on that page, but it's a percent of div width, so the padding is visually slightly different in every cell.
<img width="229" alt="Screenshot 2019-05-12 at 15 54 56" src="https://user-images.githubusercontent.com/4053708/57583191-60f0f580-74ce-11e9-8e5e-830575f349aa.png">

Step towards mitigating https://github.com/betaflight/betaflight/issues/8028