### PR TITLE
CliAutoComplete refining `set`

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -307,12 +307,25 @@ CliAutoComplete._initTextcomplete = function() {
             }
         }),
 
+        strategy({ // "set ="
+            match: /^(\s*set\s+\w*\s*)$/i,
+            search:  function(term, callback) {
+                sendOnEnter = false;
+                searcher('', callback, ['='], false);
+            },
+            replace: function(value) {
+                self.openLater();
+                return basicReplacer(value);
+            }
+        }),
+
         strategy({ // "set with value"
-            match: /^(\s*set\s+(\w+)\s*=\s*)(\w*)$/i,
+            match: /^(\s*set\s+(\w+))\s*=\s*(.*)$/i,
             search: function(term, callback, match) {
                 var arr = [];
                 var settingName = match[2].toLowerCase();
                 this.isSettingValueArray = false;
+                this.value = match[3];
                 sendOnEnter = !!term;
 
                 if (settingName in cache.settingsAcceptedValues) {
@@ -335,9 +348,12 @@ CliAutoComplete._initTextcomplete = function() {
                 callback(arr);
             },
             replace: function (value) {
-                if (this.isSettingValueArray) {
-                    return basicReplacer(value);
+                if (!this.isSettingValueArray) {
+                    // `value` is the tooltip text, so use the saved match
+                    value = this.value;
                 }
+
+                return '$1 = ' + value; // cosmetic - make sure we have spaces around the `=`
             },
             index: 3,
             isSettingValueArray: false


### PR DESCRIPTION
#1424 followup

Auto completing `set` values now formats the `=` with spaces on both sides.

Yet, one can still override this if the value suggestion list is closed with `Esc` before `Enter` - executing the command in this state will send the command verbatim, without formatting the `=`.

Also, I've included completion for the `=` itself. Pressing `Tab` after `set <name>` will add the `=` but other than that, no suggestion list about the `=` pops up.
Please, give it a try.