### PR TITLE
Move flash progress to toolbar

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2656,6 +2656,9 @@
     "firmwareFlasherFirmwareLocalLoaded": {
         "message": "Loaded Local Firmware: ($1 bytes)"
     },
+    "firmwareFlasherFirmwareOnlineLoaded": {
+        "message": "Loaded Online Firmware: ($1 bytes)"
+    },
     "firmwareFlasherHexCorrupted": {
         "message": "HEX file appears to be corrupted"
     },
@@ -3671,6 +3674,10 @@
     "osdSetupUploadFont": {
         "message": "Upload Font"
     },
+    "osdSetupUploadingFont": {
+        "message": "Uploading..."
+    },
+    
     "osdSetupSave": {
         "message": "Save"
     },

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1111,10 +1111,15 @@ dialog {
 }
 
 .toolbar_fixed_bottom .content_toolbar {
+    display: flex;
     position: absolute;
     bottom: 0;
     left: 0;
     z-index: 2000; /* for fancy toggle buttons */
+}
+
+.toolbar_fixed_bottom .content_toolbar div:first-child {
+    margin-left: auto;
 }
 
 /* Colums  START> */

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -1,18 +1,19 @@
 .tab-firmware_flasher .info {
-    margin: 10px 0 0 0;
+    padding: 2px 18px;
     position: relative;
 }
 
 .tab-firmware_flasher .info .progressLabel {
     position: absolute;
-    width: 100%;
+    width: calc(100% - 36px);
     height: 26px;
-    top: 0px;
+    top: 2px;
     left: 0;
     text-align: center;
     line-height: 24px;
     color: white;
     font-weight: bold;
+    margin-left: 18px;
 
     /* text-shadow: 1px 0px 2px rgba(0, 0, 0, 0.9);*/
 }
@@ -26,8 +27,7 @@
 }
 
 .tab-firmware_flasher .info {
-    float: left;
-    width: 100%;
+    flex-grow: 100;
 }
 
 .tab-firmware_flasher .info .progressLabel a {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -63,7 +63,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                         FirmwareCache.put(summary, intel_hex);
                     }
 
-                    $('span.progressLabel').html('<a class="save_firmware" href="#" title="Save Firmware">Loaded Online Firmware: (' + parsed_hex.bytes_total + ' bytes)</a>');
+                    $('span.progressLabel').html('<a class="save_firmware" href="#" title="Save Firmware">' + i18n.getMessage('firmwareFlasherFirmwareOnlineLoaded', parsed_hex.bytes_total) + '</a>');
 
                     self.enableFlashing(true);
 

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2448,7 +2448,7 @@ TABS.osd.initialize = function (callback) {
         $('a.flash_font').click(function () {
             if (!GUI.connect_lock) { // button disabled while flashing is in progress
                 $('a.flash_font').addClass('disabled');
-                $('.progressLabel').text('Uploading...');
+                $('.progressLabel').text(i18n.getMessage('osdSetupUploadingFont'));
                 FONT.upload($('.progress').val(0)).then(function () {
                     var msg = 'Uploaded all ' + FONT.data.characters.length + ' characters';
                     console.log(msg);

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -121,12 +121,12 @@
             </div>
         </div>
             
+    </div>
+    <div class="content_toolbar">
         <div class="info"><a name="progressbar"></a>
             <progress class="progress" value="0" min="0" max="100"></progress>
             <span class="progressLabel" i18n="firmwareFlasherLoadFirmwareFile"></span>
         </div>
-    </div>
-    <div class="content_toolbar">
         <div class="btn">
             <a class="load_file" href="#" i18n="firmwareFlasherButtonLoadLocal"></a>
         </div>


### PR DESCRIPTION
This a intent of fix some problems with the progress bars in the Configurator. This PR makes:
- Move the flash progress bar to the bottom toolbar. In this way it is not hidden by the scroll while flashing.
- i18n some strings in the flash and osd tabs.

The color change in the progress bar uses a hack to overlay a div with the color, and does not change the real progress bar color. The css of different tabs modify the color at the same time because they are not defined right, but I will look into it maybe in a future PR, my first tests to fix it were not good and I don't want to complicate this PR.