### PR TITLE
Add voltage and amperage scale calibration

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3383,11 +3383,44 @@
     "powerBatteryWarning": {
         "message": "Warning Cell Voltage"
     },
+    "powerCalibrationManagerButton": {
+        "message": "Calibration"
+    },
+    "powerCalibrationManagerHelp": {
+        "message": "To calibrate, use a multimeter to measure the actual voltage / current draw on your craft (with a battery plugged in), and enter the values below. Then, with the same battery still plugged in, click [Calibrate]."
+    },
+    "powerCalibrationManagerNote": {
+        "message": "<strong>Note:</strong> Before calibrating the scale make sure that divider and multiplier for voltage and offset for amperage is set properly.<br>Leaving the values at 0 will not apply calibration.</br><strong>Remember to remove propellers before plugging in a battery!</strong>"
+    },
+    "powerCalibrationManagerWarning": {
+        "message": "<span class=\"message-negative\">Warning:</span> The battery <span class=\"message-negative\">is not plugged in</span> or voltage and amperage meter sources are <span class=\"message-negative\">not set properly.</span> Make sure that the voltage and/or amperage are reading a value above 0. Otherwise you will not be able to calibrate using this tool."
+    },
+    "powerCalibrationManagerSourceNote": {
+        "message": "<span class=\"message-negative\">Warning:</span> Voltage and/or amperage meter sources <strong>have been changed but not saved.</strong> Please set the correct meter sources and save them before trying to calibrate."
+    },
+    "powerCalibrationSave": {
+        "message": "Calibrate"
+    },
+    "powerCalibrationApply": {
+        "message": "Apply Calibration"
+    },
+    "powerCalibrationDiscard": {
+        "message": "Discard Calibration"
+    },
+    "powerCalibrationConfirmHelp": {
+        "message": "New calibrated scales are shown here. <br>Applying them will set the scales but <strong>will not save them.</strong></br> <br>After saving make sure that the new voltage and current are correct.</br>"
+    },
     "powerVoltageHead": {
         "message": "Voltage Meter"
     },
     "powerVoltageValue": {
         "message": "$1 V"
+    },
+    "powerVoltageCalibration": {
+        "message": "Measured Voltage"
+    },
+    "powerVoltageCalibratedScale": {
+        "message": "Calibrated Voltage Scale:"
     },
     "powerAmperageValue": {
         "message": "$1 A"
@@ -3533,6 +3566,12 @@
     },
     "powerAmperageOffset": {
         "message": "Offset [mA]"
+    },
+    "powerAmperageCalibration": {
+        "message": "Measured Amperage"
+    },
+    "powerAmperageCalibratedScale": {
+        "message": "Calibrated Amperage Scale:"
     },
 
     "powerBatteryHead": {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1019,7 +1019,7 @@ dialog {
     background-color: #fff7cd;
     border: 1px solid #ffe55f;
     margin-bottom: 7px;
-    margin-top: 3px;
+    margin-top: 0px;
     border-radius: 3px;
     font-size: 11px;
     font-family: 'open_sansregular', Arial;
@@ -1352,6 +1352,10 @@ dialog {
     background-color: #ffcc3f;
     transition: all ease 0.0s;
     box-shadow: inset 0px 1px 5px rgba(0, 0, 0, 0.35);
+}
+
+.margin-top5 {
+    margin-top: 5px;
 }
 
 .regular-button {

--- a/src/tabs/power.html
+++ b/src/tabs/power.html
@@ -95,6 +95,9 @@
         <div class="btn save_btn">
             <a class="save" href="#" i18n="powerButtonSave"></a>
         </div>
+        <div class="btn calibration">
+            <a class="calibrationmanager" id="calibrationmanager" href="#" i18n="powerCalibrationManagerButton" />
+        </div>
     </div>
 </div>
 
@@ -207,3 +210,74 @@
         </div>
     </div>
 </div>
+
+<div class="tab-power" id="calibrationmanagercontent">
+    <div class = "note">
+        <div class="note_spacer">
+            <p i18n="powerCalibrationManagerHelp"></p>
+        </div>
+    </div>
+    <div class = "note">
+        <div class="note_spacer">
+            <p i18n="powerCalibrationManagerNote"></p>
+        </div>
+    </div>
+    <div class = "note nocalib">
+        <div class="note_spacer">
+            <p i18n="powerCalibrationManagerWarning"></p>
+        </div>
+    </div>
+    <div class = "note srcchange">
+        <div class="note_spacer">
+            <p i18n="powerCalibrationManagerSourceNote"></p>
+        </div>
+    </div>
+    <div class="vbatcalibration">
+        <div class="number">
+            <label> <input type="number" name="vbatcalibration" step="0.01" min="0" max="255" /> <span
+                i18n="powerVoltageCalibration"></span>
+            </label>
+        </div>
+    </div>
+    <div class="amperagecalibration">
+        <div class="number">
+            <label> <input type="number" name="amperagecalibration" step="0.01" min="0" max="255" /> <span
+                i18n="powerAmperageCalibration"></span>
+            </label>
+        </div>
+    </div>
+    <div class="default_btn margin-top5">
+        <a class="calibrate" id="calibrate" href="#" i18n="powerCalibrationSave" />
+    </div>
+</div>
+
+<div class="tab-power" id="calibrationmanagerconfirmcontent">
+    <div class = "note">
+        <div class="note_spacer">
+            <p i18n="powerCalibrationConfirmHelp"></p>
+        </div>
+    </div>
+    <div class="vbatcalibration">
+        <div class="number tab_title">
+            <label> 
+                <span i18n="powerVoltageCalibratedScale"></span>
+                <output type="number" name="vbatnewscale"></output> 
+            </label>
+        </div>
+    </div>
+    <div class="amperagecalibration">
+        <div class="number tab_title">
+            <label> 
+                <span i18n="powerAmperageCalibratedScale"></span>
+                <output type="number" name="amperagenewscale"></output> 
+            </label>
+        </div>
+    </div>
+    
+    <div class="default_btn margin-top5">
+        <a class="applycalibration" id="applycalibration" href="#" i18n="powerCalibrationApply" />
+    </div>
+    <div class="default_btn">
+        <a class="discardcalibration" id="discardcalibration" href="#" i18n="powerCalibrationDiscard" />
+    </div>
+</div> 


### PR DESCRIPTION
Adds voltage meter scale calibration by setting the actual battery voltage.
Setting the parameter to anything but zero will adjust scale automatically after saving.