### PR TITLE
Fix RX MSP window size

### DIFF
--- a/src/css/tabs/receiver_msp.css
+++ b/src/css/tabs/receiver_msp.css
@@ -3,6 +3,7 @@ body {
     font-size: 12px;
     color: #303030;
     margin: 10px;
+    overflow: hidden;
 }
 
 .control-gimbals {

--- a/src/css/tabs/receiver_msp.css
+++ b/src/css/tabs/receiver_msp.css
@@ -12,6 +12,7 @@ body {
     padding: 25px;
     padding-bottom: 0;
     text-align: center;
+    display: inline-flex;
 }
 
 .control-gimbal {
@@ -109,6 +110,11 @@ a:hover {
 }
 
 .button-enable a {
+    /* Center the button */
+    position: absolute;
+    left: 50%;
+    transform: translate(-50%);
+
     /*  common styles for content toolbar buttons */
     margin-top: 0px;
     margin-bottom: 0px;

--- a/src/js/tabs/receiver_msp.js
+++ b/src/js/tabs/receiver_msp.js
@@ -132,7 +132,7 @@ function localizeAxisNames() {
 }
 
 $(document).ready(function() {
-    $(".button-enable").click(function() {
+    $(".button-enable .btn").click(function() {
         var
             shrinkHeight = $(".warning").height();
         

--- a/src/tabs/receiver_msp.html
+++ b/src/tabs/receiver_msp.html
@@ -50,8 +50,8 @@
     </div>
     <div class="warning">
         <p i18n="receiverMspWarningText"></p>
-        <div class="button-enable btn">
-            <a class="button-enable" href="#" i18n="receiverMspEnableButton"></a>
+        <div class="button-enable">
+            <a class="btn" href="#" i18n="receiverMspEnableButton"></a>
         </div>
     </div>
 </body>


### PR DESCRIPTION
When pressing the button in the  RX MSP window, it reduces too much de height of the window appearing scrolls. It was caused because the `click` event was fired twice. This fixes it. This PR centers the button too because it appears a little strange to the left.