### PR TITLE
Change order flashing buttons

### DIFF
--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -128,13 +128,13 @@
             <span class="progressLabel" i18n="firmwareFlasherLoadFirmwareFile"></span>
         </div>
         <div class="btn">
-            <a class="load_file" href="#" i18n="firmwareFlasherButtonLoadLocal"></a>
+            <a class="flash_firmware disabled" href="#progressbar" i18n="firmwareFlasherFlashFirmware"></a>
         </div>
         <div class="btn">
             <a class="load_remote_file disabled" href="#" i18n="firmwareFlasherButtonLoadOnline"></a>
         </div>
         <div class="btn">
-            <a class="flash_firmware disabled" href="#progressbar" i18n="firmwareFlasherFlashFirmware"></a>
+            <a class="load_file" href="#" i18n="firmwareFlasherButtonLoadLocal"></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes the change of order buttons detected here: https://github.com/betaflight/betaflight-configurator/pull/1437

It seemed some CSS changed the real order in the older code (maybe some `float`) but is better to not change order to the user.