### PR TITLE
Fix OSD logo switch tooltip

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3619,6 +3619,10 @@
     "osdSetupPreviewTitleTip": {
         "message": "Show or hide the logo in the preview window. This will not change any settings on the flight controller."
     },
+    "osdSetupPreviewLogo": {
+        "message": "Logo:",
+        "description": "KEEP IT SHORT!!!! Option to select or hide the Betaflight logo in the OSD preview."
+    },
     "osdSetupVideoFormatTitle": {
         "message": "Video Format"
     },

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1931,6 +1931,14 @@ TABS.osd.initialize = function (callback) {
         $('.stats-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpStats'));
         $('.warnings-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpWarnings'));
 
+        // show Betaflight logo in preview
+        var previewLogoCheck = $('.preview-logo :input');
+        previewLogoCheck.attr('checked', OSD.data.preview_logo)
+                .change(function (e) {
+                    OSD.data.preview_logo = $(this).prop('checked');
+                    updateOsdView();
+                });
+
         // 2 way binding... sorta
         function updateOsdView() {
             // ask for the OSD config data
@@ -1946,17 +1954,6 @@ TABS.osd.initialize = function (callback) {
                         return;
                     }
                     $('.supported').fadeIn();
-
-                    // show Betaflight logo in preview
-                    var $previewLogo = $('.preview-logo').empty();
-                    $previewLogo.append(
-                        $('<label for="preview-logo">Logo: </label><input type="checkbox" name="preview-logo" class="togglesmall"></input>')
-                            .attr('checked', OSD.data.preview_logo)
-                            .change(function (e) {
-                                OSD.data.preview_logo = $(this).attr('checked') == undefined;
-                                updateOsdView();
-                            })
-                    );
 
                     // video mode
                     var $videoTypes = $('.video-types').empty();

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -37,7 +37,7 @@
 
                         <div class="gui_box_titlebar image">
                             <div class="spacer_box_title">
-                               <span i18n_title="osdSetupPreviewForTitle">
+                               <span class="cf_tip" i18n_title="osdSetupPreviewForTitle">
                                    <label id="osdprofile-selector-label" i18n="osdSetupPreviewSelectProfileTitle"/>
                                    <select class="osdprofile-selector">
                                        <!--  Populated at runtime -->
@@ -46,7 +46,10 @@
                                        <!-- Populated at runtime -->
                                    </select>
                                </span>
-                                <span class="preview-logo cf_tip" i18n_title="osdSetupPreviewTitleTip"></span>
+                                <span class="preview-logo cf_tip" i18n_title="osdSetupPreviewTitleTip">
+                                    <label for="preview-logo" i18n="osdSetupPreviewLogo"/>
+                                    <input type="checkbox" name="preview-logo" class="togglesmall"/>
+                                </span>
                             </div>
                         </div>
 


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1462

The OSD preview logo switch tooltip remains fixed in the screen under some circumstances. This
fixes it.

For some reason, the logo switch is created at runtime. This, and the OSD preview refresh produced the strange behaviour. This PR adds the switch to the HTML page and fixes it.

This PR modifies too the style of the other tooltip in the preview window, to have both the same appearance.