### PR TITLE
Remove the OSD preview logo switch

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3616,9 +3616,6 @@
         "message": "Font {{fontName}}",
         "description": "Content of the selector for the OSD Font in the preview"
     },
-    "osdSetupPreviewTitleTip": {
-        "message": "Show or hide the logo in the preview window. This will not change any settings on the flight controller."
-    },
     "osdSetupVideoFormatTitle": {
         "message": "Video Format"
     },

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -349,11 +349,6 @@
   cursor: move;
 }
 
-.tab-osd .preview-logo {
-  position: absolute;
-  right: 0;
-}
-
 .tab-osd .preview .row {
   height: 18px;
 }

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -271,7 +271,6 @@ OSD.initData = function () {
         display_items: [],
         timers: [],
         last_positions: {},
-        preview_logo: true,
         preview: [],
         tooltips: [],
         osd_profiles: {}
@@ -1947,17 +1946,6 @@ TABS.osd.initialize = function (callback) {
                     }
                     $('.supported').fadeIn();
 
-                    // show Betaflight logo in preview
-                    var $previewLogo = $('.preview-logo').empty();
-                    $previewLogo.append(
-                        $('<label for="preview-logo">Logo: </label><input type="checkbox" name="preview-logo" class="togglesmall"></input>')
-                            .attr('checked', OSD.data.preview_logo)
-                            .change(function (e) {
-                                OSD.data.preview_logo = $(this).attr('checked') == undefined;
-                                updateOsdView();
-                            })
-                    );
-
                     // video mode
                     var $videoTypes = $('.video-types').empty();
                     for (var i = 0; i < OSD.constants.VIDEO_TYPES.length; i++) {
@@ -2302,14 +2290,6 @@ TABS.osd.initialize = function (callback) {
                     // clear the buffer
                     for (var i = 0; i < OSD.data.display_size.total; i++) {
                         OSD.data.preview.push([null, ' '.charCodeAt(0), null, null]);
-                    }
-                    // logo first, so it gets overwritten by subsequent elements
-                    if (OSD.data.preview_logo) {
-                        var x = 160;
-                        for (var i = 1; i < 5; i++) {
-                            for (var j = 3; j < 27; j++)
-                                OSD.data.preview[i * 30 + j] = [{ name: 'LOGO', positionable: false }, x++, i, j];
-                        }
                     }
 
                     // draw all the displayed items and the drag and drop preview images

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -37,7 +37,7 @@
 
                         <div class="gui_box_titlebar image">
                             <div class="spacer_box_title">
-                               <span i18n_title="osdSetupPreviewForTitle">
+                               <span class="cf_tip" i18n_title="osdSetupPreviewForTitle">
                                    <label id="osdprofile-selector-label" i18n="osdSetupPreviewSelectProfileTitle"/>
                                    <select class="osdprofile-selector">
                                        <!--  Populated at runtime -->
@@ -46,7 +46,6 @@
                                        <!-- Populated at runtime -->
                                    </select>
                                </span>
-                                <span class="preview-logo cf_tip" i18n_title="osdSetupPreviewTitleTip"></span>
                             </div>
                         </div>
 


### PR DESCRIPTION
Follow up of https://github.com/betaflight/betaflight-configurator/pull/1463 and fixes https://github.com/betaflight/betaflight-configurator/issues/1462

This PR removes the logo switch from the OSD preview.