### PR TITLE
Fix button order in tabs

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1122,6 +1122,13 @@ dialog {
     margin-left: auto;
 }
 
+/** Hack to change the "display: none" by a "visibility:hidden", to apply 
+    the margin-left: auto needed by the first element to align to the right the buttons */
+.toolbar_fixed_bottom .content_toolbar div[style='display: none;'] {
+    visibility: hidden;
+    display: block !important;
+}
+
 /* Colums  START> */
 .cf_column {
     min-height: 20px;

--- a/src/tabs/logging.html
+++ b/src/tabs/logging.html
@@ -68,14 +68,14 @@
         </div>
     </div>
     <div class="content_toolbar">
+        <div class="btn file_btn">
+            <a class="log_file" href="#" i18n="loggingButtonLogFile"></a>
+        </div>
         <div class="btn back_btn">
             <a class="back" href="#" i18n="loggingBack"></a>
         </div>
         <div class="btn logging_btn">
             <a class="logging" href="#" i18n="loggingStart"></a>
-        </div>
-        <div class="btn file_btn">
-            <a class="log_file" href="#" i18n="loggingButtonLogFile"></a>
         </div>
     </div>
 </div>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1078,11 +1078,11 @@
         <div class="clear-both"></div>
     </div>
     <div class="content_toolbar">
-        <div class="btn save_btn">
-            <a class="update" href="#" i18n="pidTuningButtonSave"></a>
-        </div>
         <div class="btn refresh_btn">
             <a class="refresh" href="#" i18n="pidTuningButtonRefresh"></a>
+        </div>
+        <div class="btn save_btn">
+            <a class="update" href="#" i18n="pidTuningButtonSave"></a>
         </div>
     </div>
 

--- a/src/tabs/power.html
+++ b/src/tabs/power.html
@@ -92,12 +92,13 @@
     </div>
 
     <div class="content_toolbar">
-        <div class="btn save_btn">
-            <a class="save" href="#" i18n="powerButtonSave"></a>
-        </div>
         <div class="btn calibration">
             <a class="calibrationmanager" id="calibrationmanager" href="#" i18n="powerCalibrationManagerButton" />
         </div>
+        <div class="btn save_btn">
+            <a class="save" href="#" i18n="powerButtonSave"></a>
+        </div>
+        
     </div>
 </div>
 

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -289,14 +289,14 @@
         </div>
     </div>
     <div class="content_toolbar">
-        <div class="btn update_btn">
-            <a class="update" href="#" i18n="receiverButtonSave"></a>
+        <div class="btn sticks_btn">
+            <a class="sticks" href="#" i18n="receiverButtonSticks"></a>
         </div>
         <div class="btn refresh_btn">
             <a class="refresh" href="#" i18n="receiverButtonRefresh"></a>
         </div>
-        <div class="btn sticks_btn">
-            <a class="sticks" href="#" i18n="receiverButtonSticks"></a>
+        <div class="btn update_btn">
+            <a class="update" href="#" i18n="receiverButtonSave"></a>
         </div>
     </div>
 </div>


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1468

This was produced by https://github.com/betaflight/betaflight-configurator/pull/1437 that changed the CSS and since then the buttons are shown in the same order than in the HTML (as expected).