### PR TITLE
Fix min limit of gps_rescue_min_sats to 5

### DIFF
--- a/src/tabs/failsafe.html
+++ b/src/tabs/failsafe.html
@@ -156,7 +156,7 @@
                                 </label>
                             </div>
                             <div class="number">
-                                <label> <input type="number" name="gps_rescue_min_sats" min="0" max="50" /> <span
+                                <label> <input type="number" name="gps_rescue_min_sats" min="5" max="50" /> <span
                                     i18n="failsafeGpsRescueItemMinSats"></span>
                                 </label>
                             </div>


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1471

In version 3.5.7 the min value is 0, but we don't let it to be configured in the application. The configuration only appears for version 4.0.0 and later, and since this version the min value is 5.