### PR TITLE
Order OSD elements in alphabetical order

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2275,7 +2275,19 @@ TABS.osd.initialize = function (callback) {
                                     }))
                             );
                         }
-                        $displayFields.append($field);
+
+                        // Insert in alphabetical order
+                        let added = false;
+                        $displayFields.children().each(function() {
+                            if ($(this).text() > $field.text()) {
+                                $(this).before($field);
+                                added = true;
+                                return false;
+                            }
+                        });
+                        if(!added) {
+                            $displayFields.append($field);
+                        }
                     }
 
                     GUI.switchery();


### PR DESCRIPTION
Now that we have A LOT of OSD elements to display, is difficult to find them. This PR reorders the elements to appear in alphabetical order, at least, in this way is easier to find them.

![image](https://user-images.githubusercontent.com/2673520/59258511-6873fd80-8c38-11e9-9b57-cb85b2970ae5.png)

I'm thinking if it is interesting to translate the texts too to other languages. Thoughts?