### PR TITLE
remove extra Byte order mark from beginning of src/main.html

### DIFF
--- a/src/main.html
+++ b/src/main.html
@@ -1,4 +1,4 @@
-﻿﻿<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8"/>


### PR DESCRIPTION
If the extra byte order mark in src/main.html makes it to chrome, there is a rendering issue. 
Fixes #1489 

Before:
```
[/Web/betaflight-configurator] # hexdump -C src/main.html  | head
00000000  ef bb bf ef bb bf 3c 21  44 4f 43 54 59 50 45 20  |......<!DOCTYPE |
00000010  68 74 6d 6c 3e 0a 3c 68  74 6d 6c 3e 0a 3c 68 65  |html>.<html>.<he|
00000020  61 64 3e 0a 20 20 20 20  3c 6d 65 74 61 20 68 74  |ad>.    <meta ht|
00000030  74 70 2d 65 71 75 69 76  3d 22 43 6f 6e 74 65 6e  |tp-equiv="Conten|
00000040  74 2d 54 79 70 65 22 20  63 6f 6e 74 65 6e 74 3d  |t-Type" content=|
00000050  22 74 65 78 74 2f 68 74  6d 6c 3b 20 63 68 61 72  |"text/html; char|
00000060  73 65 74 3d 75 74 66 2d  38 22 2f 3e 0a 20 20 20  |set=utf-8"/>.   |
00000070  20 3c 6d 65 74 61 20 6e  61 6d 65 3d 22 61 75 74  | <meta name="aut|
00000080  68 6f 72 22 20 63 6f 6e  74 65 6e 74 3d 22 63 54  |hor" content="cT|
00000090  6e 22 2f 3e 0a 20 20 20  20 3c 6c 69 6e 6b 20 74  |n"/>.    <link t|
```

After:
```
[/Web/betaflight-configurator] # hexdump -C src/main.html  | head
00000000  ef bb bf 3c 21 44 4f 43  54 59 50 45 20 68 74 6d  |...<!DOCTYPE htm|
00000010  6c 3e 0a 3c 68 74 6d 6c  3e 0a 3c 68 65 61 64 3e  |l>.<html>.<head>|
00000020  0a 20 20 20 20 3c 6d 65  74 61 20 68 74 74 70 2d  |.    <meta http-|
00000030  65 71 75 69 76 3d 22 43  6f 6e 74 65 6e 74 2d 54  |equiv="Content-T|
00000040  79 70 65 22 20 63 6f 6e  74 65 6e 74 3d 22 74 65  |ype" content="te|
00000050  78 74 2f 68 74 6d 6c 3b  20 63 68 61 72 73 65 74  |xt/html; charset|
00000060  3d 75 74 66 2d 38 22 2f  3e 0a 20 20 20 20 3c 6d  |=utf-8"/>.    <m|
00000070  65 74 61 20 6e 61 6d 65  3d 22 61 75 74 68 6f 72  |eta name="author|
00000080  22 20 63 6f 6e 74 65 6e  74 3d 22 63 54 6e 22 2f  |" content="cTn"/|
00000090  3e 0a 20 20 20 20 3c 6c  69 6e 6b 20 74 79 70 65  |>.    <link type|
```