### PR TITLE
i18n final statistics from OSD

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4249,77 +4249,177 @@
         "message": "Unknown element (details to be added in a future release)"
     },
 
+    "osdTextStatMaxSpeed": {
+        "message": "Speed maximum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatMaxSpeed": {
         "message": "Maximum recorded speed"
+    },
+    "osdTextStatMinBattery": {
+        "message": "Battery voltage minimum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatMinBattery": {
         "message": "Minimum recorded main battery voltage"
     },
+    "osdTextStatMinRssi": {
+        "message": "RSSI minimum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatMinRssi": {
         "message": "Minimum recorded RSSI"
+    },
+    "osdTextStatMaxCurrent": {
+        "message": "Battery current draw maximum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatMaxCurrent": {
         "message": "Maximum recorded current draw"
     },
+    "osdTextStatUsedMah": {
+        "message": "Battery mAh used",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatUsedMah": {
         "message": "Battery capacity used"
+    },
+    "osdTextStatMaxAltitude": {
+        "message": "Altitude maximum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatMaxAltitude": {
         "message": "Maximum recorded altitude"
     },
+    "osdTextStatBlackbox": {
+        "message": "Blackbox usage",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatBlackbox": {
         "message": "Percentage of total blackbox use"
+    },
+    "osdTextStatEndBattery": {
+        "message": "Battery voltage end",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatEndBattery": {
         "message": "Battery voltage at time of disarm"
     },
+    "osdTextStatFlyTime": {
+        "message": "Fly time total",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatFlyTime": {
         "message": "Total time craft has been armed on current power cycle"
+    },
+    "osdTextStatArmedTime": {
+        "message": "Fly time last armed",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatArmedTime": {
         "message": "Time since craft was last armed"
     },
+    "osdTextStatMaxDistance": {
+        "message": "Home distance maximum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatMaxDistance": {
         "message": "Maximum distance from home location"
+    },
+    "osdTextStatBlackboxLogNumber": {
+        "message": "Blackbox number",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatBlackboxLogNumber": {
         "message": "Log number for this flights Blackbox log"
     },
+    "osdTextStatTimer1": {
+        "message": "Timer 1",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatTimer1": {
         "message": "Value of timer 1 at time of disarming"
+    },
+    "osdTextStatTimer2": {
+        "message": "Timer 2",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatTimer2": {
         "message": "Value of timer 2 at time of disarming"
     },
+    "osdTextStatRtcDateTime": {
+        "message": "RTC date and time",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatRtcDateTime": {
         "message": "Date and time from real time clock"
+    },
+    "osdTextStatBattery": {
+        "message": "Battery voltage",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatBattery": {
         "message": "Voltage of the battery in real time"
     },
+    "osdTextStatGForce": {
+        "message": "G force maximum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatGForce": {
         "message": "Max G-Force experienced by the craft"
+    },
+    "osdTextStatEscTemperature": {
+        "message": "ESC temperature maximum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatEscTemperature": {
         "message": "Max ESC temperature"
     },
+    "osdTextStatEscRpm": {
+        "message": "ESC RPM maximum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatEscRpm": {
         "message": "Max ESC RPM"
+    },
+    "osdTextStatMinLinkQuality": {
+        "message": "Link quality minimum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatMinLinkQuality": {
         "message": "Minimum of the alternative indicator for 'link quality' based on frame loss"
     },
+    "osdTextStatFlightDistance": {
+        "message": "Flight distance",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatFlightDistance": {
         "message": "Total distance travelled during the flight"
+    },
+    "osdTextStatMaxFFT": {
+        "message": "FFT maximum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatMaxFFT": {
         "message": "Peak FFT frequency"
     },
+    "osdTextStatTotalFlights": {
+        "message": "Flights count total",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatTotalFlights": {
         "message": "Total number of flights"
     },
+    "osdTextStatTotalFlightTime": {
+        "message": "Fly time total",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
     "osdDescStatTotalFlightTime": {
         "message": "Total time spent flying"
+    },
+    "osdTextStatTotalFlightDistance": {
+        "message": "Flight distance total",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
     },
     "osdDescStatTotalFlightDistance": {
         "message": "Total distance traveled"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1111,102 +1111,127 @@ OSD.constants = {
     ALL_STATISTIC_FIELDS: {
         MAX_SPEED: {
             name: 'MAX_SPEED',
+            text: 'osdTextStatMaxSpeed',
             desc: 'osdDescStatMaxSpeed'
         },
         MIN_BATTERY: {
             name: 'MIN_BATTERY',
+            text: 'osdTextStatMinBattery',
             desc: 'osdDescStatMinBattery'
         },
         MIN_RSSI: {
             name: 'MIN_RSSI',
+            text: 'osdTextStatMinRssi',
             desc: 'osdDescStatMinRssi'
         },
         MAX_CURRENT: {
             name: 'MAX_CURRENT',
+            text: 'osdTextStatMaxCurrent',
             desc: 'osdDescStatMaxCurrent'
         },
         USED_MAH: {
             name: 'USED_MAH',
+            text: 'osdTextStatUsedMah',
             desc: 'osdDescStatUsedMah'
         },
         MAX_ALTITUDE: {
             name: 'MAX_ALTITUDE',
+            text: 'osdTextStatMaxAltitude',
             desc: 'osdDescStatMaxAltitude'
         },
         BLACKBOX: {
             name: 'BLACKBOX',
+            text: 'osdTextStatBlackbox',
             desc: 'osdDescStatBlackbox'
         },
         END_BATTERY: {
             name: 'END_BATTERY',
+            text: 'osdTextStatEndBattery',
             desc: 'osdDescStatEndBattery'
         },
         FLYTIME: {
             name: 'FLY_TIME',
+            text: 'osdTextStatFlyTime',
             desc: 'osdDescStatFlyTime'
         },
         ARMEDTIME: {
             name: 'ARMED_TIME',
+            text: 'osdTextStatArmedTime',
             desc: 'osdDescStatArmedTime'
         },
         MAX_DISTANCE: {
             name: 'MAX_DISTANCE',
+            text: 'osdTextStatMaxDistance',
             desc: 'osdDescStatMaxDistance'
         },
         BLACKBOX_LOG_NUMBER: {
             name: 'BLACKBOX_LOG_NUMBER',
+            text: 'osdTextStatBlackboxLogNumber',
             desc: 'osdDescStatBlackboxLogNumber'
         },
         TIMER_1: {
             name: 'TIMER_1',
+            text: 'osdTextStatTimer1',
             desc: 'osdDescStatTimer1'
         },
         TIMER_2: {
             name: 'TIMER_2',
+            text: 'osdTextStatTimer2',
             desc: 'osdDescStatTimer2'
         },
         RTC_DATE_TIME: {
             name: 'RTC_DATE_TIME',
+            text: 'osdTextStatRtcDateTime',
             desc: 'osdDescStatRtcDateTime'
         },
         STAT_BATTERY: {
             name: 'BATTERY_VOLTAGE',
+            text: 'osdTextStatBattery',
             desc: 'osdDescStatBattery'
         },
         MAX_G_FORCE: {
             name: 'MAX_G_FORCE',
+            text: 'osdTextStatGForce',
             desc: 'osdDescStatGForce'
         },
         MAX_ESC_TEMP: {
             name: 'MAX_ESC_TEMP',
+            text: 'osdTextStatEscTemperature',
             desc: 'osdDescStatEscTemperature'
         },
         MAX_ESC_RPM: {
             name: 'MAX_ESC_RPM',
+            text: 'osdTextStatEscRpm',
             desc: 'osdDescStatEscRpm'
         },
         MIN_LINK_QUALITY: {
             name: 'MIN_LINK_QUALITY',
+            text: 'osdTextStatMinLinkQuality',
             desc: 'osdDescStatMinLinkQuality'
         },
         FLIGHT_DISTANCE: {
             name: 'FLIGHT_DISTANCE',
-            desc: 'osdDescStatFlightDistance'
+            text: 'osdTextStatFlightDistance',
+            desc: 'osdTextStatFlightDistance'
         },
         MAX_FFT: {
             name: 'MAX_FFT',
+            text: 'osdTextStatMaxFFT',
             desc: 'osdDescStatMaxFFT'
         },
         TOTAL_FLIGHTS: {
             name: 'TOTAL_FLIGHTS',
+            text: 'osdTextStatTotalFlights',
             desc: 'osdDescStatTotalFlights'
         },
         TOTAL_FLIGHT_TIME: {
             name: 'TOTAL_FLIGHT_TIME',
+            text: 'osdTextStatTotalFlightTime',
             desc: 'osdDescStatTotalFlightTime'
         },
         TOTAL_FLIGHT_DIST: {
             name: 'TOTAL_FLIGHT_DIST',
+            text: 'osdTextStatTotalFlightDistance',
             desc: 'osdDescStatTotalFlightDistance'
         }
     },
@@ -2066,11 +2091,11 @@ TABS.osd.initialize = function (callback) {
         $('.warnings-container div.cf_tip').attr('title', i18n.getMessage('osdSectionHelpWarnings'));
 
         function titleizeField(field) {
-            let finalFieldName = inflection.titleize(field.name); 
+            let finalFieldName = null; 
             if (field.text) {
                 if (Array.isArray(field.text) && i18n.existsMessage(field.text[0])) {
                     finalFieldName = i18n.getMessage(field.text[0], field.text.slice(1));
-                } else if (i18n.existsMessage(field.text)) {
+                } else {
                     finalFieldName = i18n.getMessage(field.text);
                 }
             }
@@ -2273,9 +2298,9 @@ TABS.osd.initialize = function (callback) {
                                                 });
                                         })
                                 );
-                                $field.append('<label for="' + field.name + '" class="char-label">' + inflection.titleize(field.name) + '</label>');
+                                $field.append('<label for="' + field.name + '" class="char-label">' + titleizeField(field) + '</label>');
 
-                                $statsFields.append($field);
+                                insertOrdered($statsFields, $field);
                             }
 
                             // Warnings


### PR DESCRIPTION
i18n the final statistics of the OSD.

Again, I have modified the texts to group them when reordered by alphabetical order. It will be great if someone with better English knowledge can check them to see if they are correct. I paste a capture to simplify the review:
![image](https://user-images.githubusercontent.com/2673520/59606298-0a9c5580-9111-11e9-8e95-a07950762784.png)
