### PR TITLE
Fix OSD Home Distance preview

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -805,7 +805,7 @@ OSD.loadDisplayFields = function() {
             draw_order: 840,
             positionable: true,
             preview: function (osd_data) {
-                return FONT.symbol(SYM.HOMEFLAG) + '43' + FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE) + (semver.gte(CONFIG.apiVersion, "1.37.0") ? '    ' : '');
+                return FONT.symbol(SYM.HOMEFLAG) + '432' + FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE);
             }
         },
         NUMERICAL_HEADING: {


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1486

Now it has a maximum of three chars length since https://github.com/betaflight/betaflight/pull/8471

I have removed the blank padding between versions. In the OSD preview we usually ignore versions, we try to be reliable only for latest version, but I don't know if we want to start to change that. We have some previews like this, but is the exception.