### PR TITLE
Adding a hint to SERVO_TILT feature to mention CAMSTAB mode

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -915,6 +915,9 @@
     "featureSERVO_TILT": {
         "message": "Servo gimbal"
     },
+    "featureSERVO_TILTTip": {
+        "message": "This feature enables CAMSTAB mode, which can be used to hold up to two axis steady using the accelerometer"
+    },
     "featureSOFTSERIAL": {
         "message": "Enable CPU based serial ports"
     },

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -8,7 +8,7 @@ var Features = function (config) {
         {bit: 2, group: 'other', name: 'INFLIGHT_ACC_CAL'},
         {bit: 3, group: 'rxMode', mode: 'select', name: 'RX_SERIAL'},
         {bit: 4, group: 'esc', name: 'MOTOR_STOP'},
-        {bit: 5, group: 'other', name: 'SERVO_TILT'},
+        {bit: 5, group: 'other', name: 'SERVO_TILT', haveTip: true},
         {bit: 6, group: 'other', name: 'SOFTSERIAL', haveTip: true},
         {bit: 7, group: 'gps', name: 'GPS', haveTip: true},
         {bit: 9, group: 'other', name: 'SONAR'},


### PR DESCRIPTION
It came up in slack that the SERVO_TILT feature is designed for camera stability. I'd never heard of it. 

![image](https://user-images.githubusercontent.com/190571/60552176-ae296080-9ce2-11e9-92bb-6750cf1bcd49.png)

Maybe its better to add a mention to [Modes.md](https://github.com/betaflight/betaflight/blob/master/docs/Modes.md)