### PR TITLE
add a default handler for serial errors (disconnect)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -306,6 +306,13 @@
         "message": "Show Log"
     },
 
+    "serialErrorFrameError": {
+        "message": "Serial connection error: bad framing"
+    },
+    "serialErrorParityError": {
+        "message": "Serial connection error: bad parity"
+    },
+
     "serialPortOpened": {
         "message": "Serial port <span class=\"message-positive\">successfully</span> opened with ID: $1"
     },

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var serial = {
-	connected:       false,
+    connected:       false,
     connectionId:    false,
     openRequested:   false,
     openCanceled:    false,
@@ -39,7 +39,7 @@ var serial = {
             }
 
             if (connectionInfo && !self.openCanceled) {
-	            self.connected = true;
+                self.connected = true;
                 self.connectionId = connectionInfo.connectionId;
                 self.bitrate = connectionInfo.bitrate;
                 self.bytesReceived = 0;
@@ -52,8 +52,6 @@ var serial = {
                 });
 
                 self.onReceiveError.addListener(function watch_for_on_receive_errors(info) {
-                    console.error(info);
-
                     switch (info.error) {
                         case 'system_error': // we might be able to recover from this one
                             if (!self.failed++) {
@@ -84,8 +82,6 @@ var serial = {
                             }
                             break;
 
-                        //case 'break':
-                            // This occurs on F1 boards with old firmware during reboot
                         case 'overrun':
                             // wait 50 ms and attempt recovery
                             self.error = info.error;
@@ -112,13 +108,19 @@ var serial = {
                                 });
                             }, 50);
                             break;
-                            
+
                         case 'timeout':
-                            // TODO
+                            // No data has been received for receiveTimeout milliseconds.
+                            // We will do nothing.
                             break;
-                            
+
                         case 'break': // This seems to be the error that is thrown under NW.js in Windows when the device reboots after typing 'exit' in CLI
+                        case 'disconnected':
                         case 'device_lost':
+                        case 'frame_error':
+                        case 'parity_error':
+                        default:
+                            console.log("serial disconnecting: " + info.error);
                             CONFIG.armingDisabled = false;
                             CONFIG.runawayTakeoffPreventionDisabled = false;
 
@@ -127,10 +129,6 @@ var serial = {
                             } else {
                                 self.disconnect();
                             }
-                            break;
-                            
-                        case 'disconnected':
-                            // TODO
                             break;
                     }
                 });
@@ -307,7 +305,7 @@ var serial = {
             // store inside separate variables in case array gets destroyed
             var data = self.outputBuffer[0].data,
                 callback = self.outputBuffer[0].callback;
-            
+
             if (!self.connected) {
                 console.log('attempting to send when disconnected');
                 if (callback) callback({
@@ -327,7 +325,7 @@ var serial = {
                    });
                    return;
                 }
-                
+
                 // tcp send error
                 if (self.connectionType == 'tcp' && sendInfo.resultCode < 0) {
                     var error = 'system_error';

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -114,11 +114,12 @@ var serial = {
                             // We will do nothing.
                             break;
 
+                        case 'frame_error':
+                        case 'parity_error':
+                            GUI.log(i18n.getMessage('serialError' + inflection.camelize(info.error)));
                         case 'break': // This seems to be the error that is thrown under NW.js in Windows when the device reboots after typing 'exit' in CLI
                         case 'disconnected':
                         case 'device_lost':
-                        case 'frame_error':
-                        case 'parity_error':
                         default:
                             console.log("serial disconnecting: " + info.error);
                             CONFIG.armingDisabled = false;


### PR DESCRIPTION
Also cleaned up some tabs and extra spaces in the file. The 'disconnected' case has been moved, to respect its current status of doing nothing.

This might be a solution to fix #1264 I guess if it doesn't @hydra can just reopen it? 