### PR TITLE
tidy up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,18 +1,29 @@
-.DS_store
-nbproject/
-.idea
-.project
-.settings/
+# node.js npm related
+
 node_modules/
-npm-debug.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Configurator Build process
 cache/
 apps/
 dist/
 debug/
 release/
 
-# Font template bitmaps
-resources/osd/*.png
+# OSX
+.DS_store
 
 # artefacts for Visual Studio Code
 /.vscode/
+
+# NetBeans
+nbproject/
+
+# IntelliJ
+.idea
+
+# Eclipse
+.project
+.settings/


### PR DESCRIPTION
I'm using VIM and Notepad++ as my editors of choice for the configurator, so I was curious about the items in `.gitnore` I've done my best to look up the individual items. Also since we're using yarn we should ignore its error logs.

Also since we're generating pngs in `resources/[1,2]/....png` it makes sense to drop the ignore for `resources/*.png`