### PR TITLE
avoid highlighting items in the Post Flight Statistics

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1935,11 +1935,11 @@ OSD.GUI = {};
 OSD.GUI.preview = {
     onMouseEnter: function () {
         if (!$(this).data('field')) { return; }
-        $('.field-' + $(this).data('field').index).addClass('mouseover')
+        $('#element-fields .field-' + $(this).data('field').index).addClass('mouseover')
     },
     onMouseLeave: function () {
         if (!$(this).data('field')) { return; }
-        $('.field-' + $(this).data('field').index).removeClass('mouseover')
+        $('#element-fields .field-' + $(this).data('field').index).removeClass('mouseover')
     },
     onDragStart: function (e) {
         var ev = e.originalEvent;


### PR DESCRIPTION
When you mouse over an item on the OSD preview it highlights the relevant element on the left, that's good.

It also highlights an item on the Post Flight Statistics.

This makes it so that only the element-fields item is selected.

![image](https://user-images.githubusercontent.com/190571/61202969-e6934c00-a69d-11e9-9875-ba5f64460336.png)



