### PR TITLE
Lets count those LEDs properly

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1071,9 +1071,17 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
 
                 var ledCount = data.byteLength / 7; // v1.4.0 and below incorrectly reported 4 bytes per led.
-                if (semver.gte(CONFIG.apiVersion, "1.20.0"))
+                if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
                     ledCount = data.byteLength / 4;
-
+                }
+                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                    // According to betaflight/src/main/msp/msp.c
+                    // API 1.41 - add indicator for advanced profile support and the current profile selection
+                    // 0 = basic ledstrip available
+                    // 1 = advanced ledstrip available
+                    // Following byte is the current LED profile
+                    ledCount = (data.byteLength - 2) / 4;
+                }
                 for (var i = 0; i < ledCount; i++) {
 
                     if (semver.lt(CONFIG.apiVersion, "1.20.0")) {


### PR DESCRIPTION
Seems odd having the LED_STRIP tab saying that there are 33 remaining, while its actually 32

Also there is some sort of led profile option that may or may not be handled. Was thinking of adding a bit of a note about it to make sure that ledCount isn't 32.5...
```javascript
                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
                    // According to betaflight/src/main/msp/msp.c
                    // API 1.41 - add indicator for advanced profile support and the current profile selection
                    // 0 = basic ledstrip available
                    // 1 = advanced ledstrip available
                    // Following byte is the current LED profile
                    ledCount = (data.byteLength - 2) / 4;
                }
```

https://github.com/betaflight/betaflight/blob/4bec60e05b86d4563e448e91f8c3743a62afaef4/src/main/msp/msp.c#L1300-L1308