### PR TITLE
Tag versions during the development cycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "betaflight-configurator",
   "description": "Crossplatform configuration tool for Betaflight flight control system.",
-  "version": "10.6.0",
+  "version": "10.6.0-development",
   "main": "main_nwjs.html",
   "bg-script": "js/eventPage.js",
   "default_locale": "en",


### PR DESCRIPTION
Its a bit late in the development cycle, but I figure I'd submit my idea anyways. Maybe the idea can be applied to the next version.

Right now if a user runs into a problem with the 10.5.1 configurator, they can run the `master` branch either building it themselves, or downloading a build from [ci.betaflight.tech](https://ci.betaflight.tech/job/BetaFlight_Configurator/). These are have the version of `10.6.0`

I believe that this runs into trouble when the proper `10.6.0` comes out, as these users wont receive notification that their configurator is out of date. I'd like to add a suffix to the version during the development cycle.

I've tested `10.5.1-beta1` `10.5.1-development` and `10.5.1-whatwhat` to verify that it'd complain, and `10.6.0-development` and `10.6.0-beta1` to verify that a newer version does not complain.

![image](https://user-images.githubusercontent.com/190571/61475907-b1f2ef00-a940-11e9-8a81-1568f272c8a9.png)
