### PR TITLE
Fix storage key name for caching the jenkins builds list.

### DIFF
--- a/src/js/jenkins_loader.js
+++ b/src/js/jenkins_loader.js
@@ -13,8 +13,8 @@ JenkinsLoader.prototype.loadJobs = function (viewName, callback) {
     var self = this;
 
     var viewUrl = `${self._url}/view/${viewName}`;
-    var jobsDataTag = '${viewUrl}JobsData';
-    var cacheLastUpdateTag = '${viewUrl}JobsLastUpdate';
+    var jobsDataTag = `${viewUrl}_JobsData`;
+    var cacheLastUpdateTag = `${viewUrl}_JobsLastUpdate`;
 
     var wrappedCallback = jobs => {
         self._jobs = jobs;


### PR DESCRIPTION
Due to regular quotes being used in `jenkins_loader.js` instead of backticks the current JobsData is cached as the following keys:
"${viewUrl}JobsData"
"${viewUrl}JobsLastUpdate"

Instead of something like:
"https://ci.betaflight.tech/view/Firmware_JobsData"
"https://ci.betaflight.tech/view/Firmware_JobsLastUpdate"

Another idea would be to do "jenkinsJobsData" and "jenkinsJobsLastUpdate" to match with the other cache keys

I've chosen to add an underscore in between the URL and the rest of the key to make it easier to look at.

This can be used to get a list of keys in chrome.storage.local
```javascript
chrome.storage.local.get(null, function(items) {
    var allKeys = Object.keys(items);
    console.log(allKeys);
});
```