### PR TITLE
Fix errors in failsafe parameter ranges

### DIFF
--- a/src/tabs/failsafe.html
+++ b/src/tabs/failsafe.html
@@ -85,7 +85,7 @@
                         <div class="helpicon cf_tip" i18n_title="failsafeDelayHelp"></div>
                     </div>
                     <div class="number stage2">
-                        <label> <input type="number" name="failsafe_throttle_low_delay" min="0" max="2000" /> <span
+                        <label> <input type="number" name="failsafe_throttle_low_delay" min="0" max="300" /> <span
                             i18n="failsafeThrottleLowItem"></span>
                         </label>
                         <div class="helpicon cf_tip" i18n_title="failsafeThrottleLowHelp"></div>
@@ -108,7 +108,7 @@
                                 </label>
                             </div>
                             <div class="number">
-                                <label> <input type="number" name="failsafe_off_delay" min="0" max="2000" /> <span
+                                <label> <input type="number" name="failsafe_off_delay" min="0" max="200" /> <span
                                     i18n="failsafeOffDelayItem"></span>
                                 </label>
                                 <div class="helpicon cf_tip" i18n_title="failsafeOffDelayHelp"></div>


### PR DESCRIPTION
Erroneous ranges for `failsafe_throttle_low_delay` and `failsafe_off_delay` would allow parameter corruption.