### PR TITLE
fix gulp tasks such that yarn gets its lock file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 
 sudo: false
 
-dist: trusty
+dist: bionic
 
 addons:
   apt:
@@ -17,13 +17,10 @@ git:
 language: node_js
 
 node_js:
-  - 8.11.2
+  - 10
 
 addons:
   chrome: stable
-
-before_install:
-  - npm i -g npm@6.0.1
 
 script:
   - yarn test

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -74,7 +74,8 @@ gulp.task('clean-cache', clean_cache);
 const getChangesetId = gulp.series(getHash, writeChangesetId);
 gulp.task('get-changeset-id', getChangesetId);
 
-var distBuild = gulp.series(dist_src, dist_locale, dist_libraries, dist_resources, getChangesetId);
+// dist_yarn MUST be done after dist_src
+var distBuild = gulp.series(dist_src, dist_yarn, dist_locale, dist_libraries, dist_resources, getChangesetId);
 var distRebuild = gulp.series(clean_dist, distBuild);
 gulp.task('dist', distRebuild);
 
@@ -202,23 +203,23 @@ function getReleaseFilename(platform, ext) {
 
 function clean_dist() {
     return del([DIST_DIR + '**'], { force: true });
-};
+}
 
 function clean_apps() {
     return del([APPS_DIR + '**'], { force: true });
-};
+}
 
 function clean_debug() {
     return del([DEBUG_DIR + '**'], { force: true });
-};
+}
 
 function clean_release() {
     return del([RELEASE_DIR + '**'], { force: true });
-};
+}
 
 function clean_cache() {
     return del(['./cache/**'], { force: true });
-};
+}
 
 // Real work for dist task. Done in another task to call it via
 // run-sequence.
@@ -240,12 +241,17 @@ function dist_src() {
         .pipe(gulp.src('manifest.json', { passthrougth: true }))
         .pipe(gulp.src('yarn.lock', { passthrougth: true }))
         .pipe(gulp.src('changelog.html', { passthrougth: true }))
-        .pipe(gulp.dest(DIST_DIR))
+        .pipe(gulp.dest(DIST_DIR));
+}
+
+// This function relies on files from the dist_src function
+function dist_yarn() {
+    return gulp.src(['./dist/package.json', './dist/yarn.lock'])
+        .pipe(gulp.dest('./dist'))
         .pipe(yarn({
-            production: true,
-            ignoreScripts: true
+            production: true
         }));
-};
+}
 
 function dist_locale() {
     return gulp.src('./locales/**/*', { base: 'locales'})


### PR DESCRIPTION
I noticed that when running the dist task, yarn would be started before `yarn.lock` is available there, slowing things down by about 10 seconds.

macbook pro, From 16s down to 6s
crappybox from 24s down to 14s, last try was 6.68, maybe lets ignore this result.

I'm also going to try removing the command that installs `npm@6.0.1` as it removes some packages just before `yarn` is called.
and switch from `trusty` to `xenial`. I'll revert the last one if there are problems.