### PR TITLE
CliAutocomplete fix mouse activation #1481

### DIFF
--- a/src/css/tabs-dark/cli-dark.css
+++ b/src/css/tabs-dark/cli-dark.css
@@ -24,7 +24,6 @@
 .cli-textcomplete-dropdown a {
     color: white;
 }
-.cli-textcomplete-dropdown li:hover,
 .cli-textcomplete-dropdown .active {
     background-color: var(--quietHeader);
 }

--- a/src/css/tabs/cli.css
+++ b/src/css/tabs/cli.css
@@ -121,7 +121,6 @@
     padding: 2px 5px;
 }
 
-.cli-textcomplete-dropdown li:hover,
 .cli-textcomplete-dropdown .active {
     background-color: rgb(255, 187, 0);
 }


### PR DESCRIPTION
Not a very pretty solution but I couldn't think of better without resorting to modifying the `textcomplete` library itself.
If someone has better idea, I'm all ears.

The solution is simple: just save and remove the `mouseover` handler (which is responsible for the auto-selecting behavior) and listen for `mousemove`, then reinstall back the `mouseover`

It works fine but problems can emerge in some future moment:
* the private method `jQuery._data` is needed to get the currently installed `mouseover` handler.
* the overall solution depends on the knowledge of how `textcomplete` uses the `mouseover` event.

Also a small bug has been fixed, showing empty line in the suggestions when autocompleting `get` without any name.