### PR TITLE
Chrome Apps don't get window.localStorage

### DIFF
--- a/src/js/ConfigStorage.js
+++ b/src/js/ConfigStorage.js
@@ -5,6 +5,9 @@
 var ConfigStorage = {
     // key can be one string, or array of strings
     get: function(key, callback) {
+      if (GUI.isChromeApp()) {
+        chrome.storage.local.get(key,callback);
+      } else {
         //console.log('Abstraction.get',key);
         if (Array.isArray(key)) {
             var obj = {};
@@ -30,12 +33,17 @@ var ConfigStorage = {
                 callback({});
             }
         }
+      }
     },
     // set takes an object like {'userLanguageSelect':'DEFAULT'}
     set: function(input) {
+      if (GUI.isChromeApp()) {
+          chrome.storage.local.set(input);
+      } else {
         //console.log('Abstraction.set',input);
         Object.keys(input).forEach(function (element) {
             window.localStorage.setItem(element, JSON.stringify(input));
         });
+      }
     }
 }

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -59,7 +59,26 @@ var GUI_control = function () {
     else if (navigator.appVersion.indexOf("Linux") != -1)   this.operating_system = "Linux";
     else if (navigator.appVersion.indexOf("X11") != -1)     this.operating_system = "UNIX";
     else this.operating_system = "Unknown";
+
+    // Check the method of execution
+    this.nwGui = null;
+    try {
+      this.nwGui = require('nw.gui');
+      this.Mode = GUI_Modes.NWJS;
+    } catch (ex) {
+      if (window.chrome && chrome.storage && chrome.storage.local) {
+        this.Mode = GUI_Modes.ChromeApp;
+      } else {
+        this.Mode = GUI_Modes.Other;
+      }
+    }
 };
+
+const GUI_Modes = {
+  NWJS: "NW.js",
+  ChromeApp: "Chrome",
+  Other: "Other"
+}
 
 // Timer managing methods
 
@@ -357,6 +376,17 @@ GUI_control.prototype.selectDefaultTabWhenConnected = function() {
         $("#tabs ul.mode-connected ." + result.lastTab + " a").click();
     });    
 };
+
+GUI_control.prototype.isChromeApp = function () {
+  return this.Mode == GUI_Modes.ChromeApp;
+}
+GUI_control.prototype.isNWJS = function () {
+  return this.Mode == GUI_Modes.NWJS;
+}
+GUI_control.prototype.isOther = function () {
+  return this.Mode == GUI_Modes.Other;
+}
+
 
 // initialize object into GUI variable
 var GUI = new GUI_control();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var nwGui = getNwGui();
-
 var googleAnalytics = analytics;
 var analytics = undefined;
 
@@ -15,17 +13,6 @@ $(document).ready(function () {
         });
     });
 });
-
-function getNwGui() {
-    var gui = null;
-    try {
-        gui = require('nw.gui');
-    } catch (ex) {
-        console.log("Could not require 'nw.gui', maybe inside chrome");
-    }
-
-    return gui;
-}
 
 function checkSetupAnalytics(callback) {
     if (!analytics) {
@@ -44,7 +31,7 @@ function checkSetupAnalytics(callback) {
 };
 
 function getBuildType() {
-    return nwGui ? 'NW.js' : 'Chrome';
+    return GUI.Mode;
 }
 
 function setupAnalytics(result) {
@@ -79,8 +66,8 @@ function setupAnalytics(result) {
         analytics.sendEvent(analytics.EVENT_CATEGORIES.APPLICATION, 'AppClose', { sessionControl: 'end' })
     }
 
-    if (nwGui) {
-        var win = nwGui.Window.get();
+    if (GUI.isNWJS()) {
+        var win = GUI.nwGui.Window.get();
         win.on('close', function () {
             sendCloseEvent();
 
@@ -90,7 +77,7 @@ function setupAnalytics(result) {
             // do not open the window
             policy.ignore();
             // and open it in external browser
-            nwGui.Shell.openExternal(url);
+            GUI.nwGui.Shell.openExternal(url);
         });
     } else {
         // Looks like we're in Chrome - but the event does not actually get fired
@@ -293,7 +280,7 @@ function startProcess() {
                         TABS.onboard_logging.initialize(content_ready);
                         break;
                     case 'cli':
-                        TABS.cli.initialize(content_ready, nwGui);
+                        TABS.cli.initialize(content_ready, GUI.nwGui);
                         break;
 
                     default:


### PR DESCRIPTION
Fixes #1562 
So, turns out Chrome Apps don't provide localStorage. In their quest to migrate people away from Apps I guess they didn't consider that people might use the same code for multiple run methods....

`window.localStorage is not available in packaged apps. Use chrome.storage.local instead.`


I think we could check like `if (!nwGui && chrome.storage && chrome.storage.local) {` if we want to use localStorage on the nwjs build.