### PR TITLE
Fix ordering locale with underscore

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2120,8 +2120,9 @@ TABS.osd.initialize = function (callback) {
                 fieldList.append(field);
             } else {
                 let added = false;
+                let currentLocale = i18n.getCurrentLocale().replace('_', '-');
                 fieldList.children().each(function() {
-                    if ($(this).text().localeCompare(field.text(), i18n.getCurrentLocale(), { sensitivity: 'base' }) > 0) {
+                    if ($(this).text().localeCompare(field.text(), currentLocale, { sensitivity: 'base' }) > 0) {
                         $(this).before(field);
                         added = true;
                         return false;


### PR DESCRIPTION
Fixes ordering when the locale has a underscore. It seems we need the underscore for some things (chrome localization, i18next, etc.), and the hyphen for others :(

I have searched at Google and is not clear what is the "standard", maybe the hyphen has more adepts.