### PR TITLE
Add debug modes to blackbox tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4822,6 +4822,9 @@
     "onboardLoggingDebugMode": {
         "message": "Blackbox debug mode"
     },
+    "onboardLoggingDebugModeUnknown": {
+        "message": "UNKNOWN"
+    },
     "onboardLoggingSerialLogger": {
         "message": "Outboard serial logging device"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4819,6 +4819,9 @@
     "onboardLoggingRateOfLogging": {
         "message": "Blackbox logging rate"
     },
+    "onboardLoggingDebugMode": {
+        "message": "Blackbox debug mode"
+    },
     "onboardLoggingSerialLogger": {
         "message": "Outboard serial logging device"
     },

--- a/src/css/tabs-dark/onboard_logging-dark.css
+++ b/src/css/tabs-dark/onboard_logging-dark.css
@@ -27,6 +27,7 @@
 }
 
 .tab-onboard_logging .blackboxRate select,
+.tab-onboard_logging .blackboxDebugMode select,
 .tab-onboard_logging .blackboxDevice select {
     border: 1px solid #9c9c9c;
     background-color: #3a3a3a;

--- a/src/css/tabs/onboard_logging.css
+++ b/src/css/tabs/onboard_logging.css
@@ -292,6 +292,7 @@
     clear: left;
 }
 .tab-onboard_logging .blackboxRate select,
+.tab-onboard_logging .blackboxDebugMode select,
 .tab-onboard_logging .blackboxDevice select {
     float: left;
     width: 180px;
@@ -300,6 +301,7 @@
     border: 1px solid silver;
 }
 .tab-onboard_logging .blackboxRate span,
+.tab-onboard_logging .blackboxDebugMode span,
 .tab-onboard_logging .blackboxDevice span {
     line-height: 20px;
 }

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -353,6 +353,15 @@ var FC = {
             motor_pwm_rate:             0,
             digitalIdlePercent:         0,
             gyroUse32kHz:               0,
+            motorPwmInversion:          0,
+            gyroToUse:                  0,
+            gyroHighFsr:                0,
+            gyroMovementCalibThreshold: 0,
+            gyroCalibDuration:          0,
+            gyroOffsetYaw:              0,
+            gyroCheckOverflow:          0,
+            debugMode:                  0,
+            debugModeCount:             0,
         };
 
         FILTER_CONFIG = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -949,6 +949,17 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         let gyroUse32kHz = data.readU8();
                         if (semver.lt(CONFIG.apiVersion, "1.41.0")) {
                             PID_ADVANCED_CONFIG.gyroUse32kHz = gyroUse32kHz;
+                        } 
+                        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                            PID_ADVANCED_CONFIG.motorPwmInversion = data.readU8();
+                            PID_ADVANCED_CONFIG.gyroToUse = data.readU8();
+                            PID_ADVANCED_CONFIG.gyroHighFsr = data.readU8();
+                            PID_ADVANCED_CONFIG.gyroMovementCalibThreshold = data.readU8();
+                            PID_ADVANCED_CONFIG.gyroCalibDuration = data.readU16();
+                            PID_ADVANCED_CONFIG.gyroOffsetYaw = data.readU16();
+                            PID_ADVANCED_CONFIG.gyroCheckOverflow = data.readU8();
+                            PID_ADVANCED_CONFIG.debugMode = data.readU8();
+                            PID_ADVANCED_CONFIG.debugModeCount = data.readU8();
                         }
                     }
                 }
@@ -1236,6 +1247,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 BLACKBOX.blackboxRateDenom = data.readU8();
                 if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                     BLACKBOX.blackboxPDenom = data.readU16();
+
                 }
                 break;
             case MSPCodes.MSP_SET_BLACKBOX_CONFIG:
@@ -1704,6 +1716,16 @@ MspHelper.prototype.crunch = function(code) {
                         gyroUse32kHz = PID_ADVANCED_CONFIG.gyroUse32kHz;
                     }
                     buffer.push8(gyroUse32kHz);
+                    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                        buffer.push8(PID_ADVANCED_CONFIG.motorPwmInversion)
+                              .push8(PID_ADVANCED_CONFIG.gyroToUse)
+                              .push8(PID_ADVANCED_CONFIG.gyroHighFsr)
+                              .push8(PID_ADVANCED_CONFIG.gyroMovementCalibThreshold)
+                              .push16(PID_ADVANCED_CONFIG.gyroCalibDuration)
+                              .push16(PID_ADVANCED_CONFIG.gyroOffsetYaw)
+                              .push8(PID_ADVANCED_CONFIG.gyroCheckOverflow)
+                              .push8(PID_ADVANCED_CONFIG.debugMode);
+                    }
                 }
             }
             break;

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -328,7 +328,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 if (i < debugModes.length) {
                     debugModeSelect.append(new Option(debugModes[i].text, i));
                 } else {
-                    debugModeSelect.append(new Option("UNKNOWN", i));
+                    debugModeSelect.append(new Option(i18n.getMessage('onboardLoggingDebugModeUnknown'), i));
                 }
             }
 

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -100,6 +100,7 @@ TABS.onboard_logging.initialize = function (callback) {
 
             var deviceSelect = $(".blackboxDevice select");
             var loggingRatesSelect = $(".blackboxRate select");
+            var debugModeSelect = $(".blackboxDebugMode select");
 
             if (BLACKBOX.supported) {
                 $(".tab-onboard_logging a.save-settings").click(function() {
@@ -110,15 +111,18 @@ TABS.onboard_logging.initialize = function (callback) {
                         BLACKBOX.blackboxRateNum = parseInt(rate[0], 10);
                         BLACKBOX.blackboxRateDenom = parseInt(rate[1], 10);
                     }
-
                     BLACKBOX.blackboxDevice = parseInt(deviceSelect.val(), 10);
-                    
+                    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                        PID_ADVANCED_CONFIG.debugMode = parseInt(debugModeSelect.val());
+                        MSP.send_message(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG), false, save_to_eeprom);
+                    }
                     MSP.send_message(MSPCodes.MSP_SET_BLACKBOX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BLACKBOX_CONFIG), false, save_to_eeprom);
                 });
             }
             
             populateLoggingRates(loggingRatesSelect);
             populateDevices(deviceSelect);
+            populateDebugModes(debugModeSelect);
 
             deviceSelect.change(function() {
                 if ($(this).val() === "0") {
@@ -248,6 +252,89 @@ TABS.onboard_logging.initialize = function (callback) {
                 
             }
             loggingRatesSelect.val(BLACKBOX.blackboxRateNum + '/' + BLACKBOX.blackboxRateDenom);
+        }
+    }
+
+    function populateDebugModes(debugModeSelect) {
+        var debugModes = [];
+
+        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            $('.blackboxDebugMode').show();
+
+            debugModes = [
+                {text: "NONE"},
+                {text: "CYCLETIME"},
+                {text: "BATTERY"},
+                {text: "GYRO_FILTERED"},
+                {text: "ACCELEROMETER"},
+                {text: "PIDLOOP"},
+                {text: "GYRO_SCALED"},
+                {text: "RC_INTERPOLATION"},
+                {text: "ANGLERATE"},
+                {text: "ESC_SENSOR"},
+                {text: "SCHEDULER"},
+                {text: "STACK"},
+                {text: "ESC_SENSOR_RPM"},
+                {text: "ESC_SENSOR_TMP"},
+                {text: "ALTITUDE"},
+                {text: "FFT"},
+                {text: "FFT_TIME"},
+                {text: "FFT_FREQ"},
+                {text: "RX_FRSKY_SPI"},
+                {text: "RX_SFHSS_SPI"},
+                {text: "GYRO_RAW"},
+                {text: "DUAL_GYRO"},
+                {text: "DUAL_GYRO_RAW"},
+                {text: "DUAL_GYRO_COMBINE"},
+                {text: "DUAL_GYRO_DIFF"},
+                {text: "MAX7456_SIGNAL"},
+                {text: "MAX7456_SPICLOCK"},
+                {text: "SBUS"},
+                {text: "FPORT"},
+                {text: "RANGEFINDER"},
+                {text: "RANGEFINDER_QUALITY"},
+                {text: "LIDAR_TF"},
+                {text: "ADC_INTERNAL"},
+                {text: "RUNAWAY_TAKEOFF"},
+                {text: "SDIO"},
+                {text: "CURRENT_SENSOR"},
+                {text: "USB"},
+                {text: "SMARTAUDIO"},
+                {text: "RTH"},
+                {text: "ITERM_RELAX"},
+                {text: "ACRO_TRAINER"},
+                {text: "RC_SMOOTHING"},
+                {text: "RX_SIGNAL_LOSS"},
+                {text: "RC_SMOOTHING_RATE"},
+                {text: "ANTI_GRAVITY"},
+                {text: "DYN_LPF"},
+                {text: "RX_SPEKTRUM_SPI"},
+                {text: "DSHOT_RPM_TELEMETRY"},
+                {text: "RPM_FILTER"},
+                {text: "D_MIN"},
+                {text: "AC_CORRECTION"},
+                {text: "AC_ERROR"},
+                {text: "DUAL_GYRO_SCALED"},
+                {text: "DSHOT_RPM_ERRORS"},
+                {text: "CRSF_LINK_STATISTICS_UPLINK"},
+                {text: "CRSF_LINK_STATISTICS_PWR"},
+                {text: "CRSF_LINK_STATISTICS_DOWN"},
+                {text: "BARO"},
+                {text: "GPS_RESCUE_THROTTLE_PID"},
+                {text: "DYN_IDLE"},
+            ];
+
+            for (var i = 0; i < PID_ADVANCED_CONFIG.debugModeCount; i++) {
+                if (i < debugModes.length) {
+                    debugModeSelect.append(new Option(debugModes[i].text, i));
+                } else {
+                    debugModeSelect.append(new Option("UNKNOWN", i));
+                }
+            }
+
+            debugModeSelect.val(PID_ADVANCED_CONFIG.debugMode);
+        } else {
+            $('.blackboxDebugMode').hide();
         }
     }
     

--- a/src/tabs/onboard_logging.html
+++ b/src/tabs/onboard_logging.html
@@ -30,6 +30,11 @@
                         </select>
                         <span i18n="onboardLoggingRateOfLogging"></span>
                     </div>
+                    <div class="line blackboxDebugMode">
+                        <select name="blackboxDebugMode">
+                        </select>
+                        <span i18n="onboardLoggingDebugMode"></span>
+                    </div>
                     <div class="line">
                         <a href="#" class="save-settings regular-button" i18n="blackboxButtonSave"></a>
                     </div>


### PR DESCRIPTION
Fixes #1502
Adds debug mode setting in the blackbox tab. Requires MSP to go with it which will be added.