### PR TITLE
Add dynamic notch settings to UI

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3127,7 +3127,7 @@
         "message": "Dynamic Notch Filter tracks peak motors noise frequency and places one or two notch filters with their center at that frequency."
     },
     "pidTuningDynamicNotchFilterDisabledWarning": {
-        "message": "<strong>Notice:</strong> The dynamic notch filter is disabled. In order to configure and use it, please enable the 'DYNAMIC_FILTER' feature in the 'Other Features' section of the 'Configuration' tab."
+        "message": "<strong>Notice:</strong> The dynamic notch filter is disabled. In order to configure and use it, please enable the 'DYNAMIC_FILTER' feature in the '$t(configurationFeatures.message)' section of the '$t(tabConfiguration.message)' tab."
     },
     "pidTuningDynamicNotchRange": {
         "message": "Dynamic Notch Filter Range"
@@ -3142,7 +3142,7 @@
         "message": "Dynamic Notch Min Hz"
     },
     "pidTuningDynamicNotchRangeHelp": {
-        "message": "The dynamic notch has three frequency ranges in which it can operate: LOW(80-330hz) for lower revving quads like 6+ inches, MEDIUM(140-550hz) for a normal 5 inch quad, HIGH(230-800hz) for very high revving 2.5-3 inch quads. AUTO option selects the range depending on the value of the Dynamic Lowpass Filter's max cutoff frequency."
+        "message": "The dynamic notch has three frequency ranges in which it can operate: LOW(80-330hz) for lower revving quads like 6+ inches, MEDIUM(140-550hz) for a normal 5 inch quad, HIGH(230-800hz) for very high revving 2.5-3 inch quads. AUTO option selects the range depending on the value of the Gyro Dynamic Lowpass 1 Filter's max cutoff frequency."
     },
     "pidTuningDynamicNotchWidthPercentHelp": {
         "message": "This sets the width between two dynamic notch filters. Setting it at 0 will disable the second dynamic notch filter and will reduce filter delay, however it may make motor temperatures higher."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3120,6 +3120,36 @@
     "pidTuningNotchFilterHelp": {
         "message": "The Notch Filter has a Center and a Cutoff. The filter is symmetrical. The Center Frequency is the center of the filter and the Cutoff Frequency is where Notch filter starts. For example with Notch Cutoff of 160 and Notch Center of 260 it means the range is 160-360Hz with most attenuation around center"
     },
+    "pidTuningDynamicNotchFilterGroup": {
+        "message": "Dynamic Notch Filter"
+    },
+    "pidTuningDynamicNotchFilterHelp": {
+        "message": "Dynamic Notch Filter tracks peak motors noise frequency and places one or two notch filters with their center at that frequency."
+    },
+    "pidTuningDynamicNotchRange": {
+        "message": "Dynamic Notch Filter Range"
+    },
+    "pidTuningDynamicNotchWidthPercent": {
+        "message": "Dynamic Notch Width Percent"
+    },
+    "pidTuningDynamicNotchQ": {
+        "message": "Dynamic Notch Q"
+    },
+    "pidTuningDynamicNotchMinHz": {
+        "message": "Dynamic Notch Min Hz"
+    },
+    "pidTuningDynamicNotchRangeHelp": {
+        "message": "The dynamic notch has three frequency ranges in which it can operate: LOW(80-330hz) for lower revving quads like 6+ inches, MEDIUM(140-550hz) for a normal 5 inch quad, HIGH(230-800hz) for very high revving 2.5-3 inch quads. AUTO option selects the range depending on the value of the Dynamic Lowpass Filter's max cutoff frequency."
+    },
+    "pidTuningDynamicNotchWidthPercentHelp": {
+        "message": "This sets the width between two dynamic notch filters. Setting it at 0 will disable the second dynamic notch filter and will reduce filter delay, however it may make motor temperatures higher."
+    },
+    "pidTuningDynamicNotchQHelp": {
+        "message": "Q factor adjust how narrow or wide the dynamic notch filters are. Higher value makes it narrower and more precise and lower value makes it wider and broader. Having a really low value will greatly increase filter delay."
+    },
+    "pidTuningDynamicNotchMinHzHelp": {
+        "message": "Defines the lowest dynamic notch center frequency below which the dynamic notch will not go."
+    },
     "pidTuningLowpassFilterHelp": {
         "message": "The Lowpass Filters can have two variants: static and dynamic. For a determined lowpass filter number only one (static or dynamic) can be enabled at the same time. The static only has a Cutoff that is a value that defines in some way where the filter starts. The dynamic defines a min and max values, that is the range where the Cutoff is placed. This Cutoff moves from min to max at the same time than you move the throttle stick."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3126,6 +3126,9 @@
     "pidTuningDynamicNotchFilterHelp": {
         "message": "Dynamic Notch Filter tracks peak motors noise frequency and places one or two notch filters with their center at that frequency."
     },
+    "pidTuningDynamicNotchFilterDisabledWarning": {
+        "message": "<span class=\"message-negative\">Warning:</span> Dynamic Notch Filter is disabled, please enable it as a feature in the Configuration tab to show related settings."
+    },
     "pidTuningDynamicNotchRange": {
         "message": "Dynamic Notch Filter Range"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3127,7 +3127,7 @@
         "message": "Dynamic Notch Filter tracks peak motors noise frequency and places one or two notch filters with their center at that frequency."
     },
     "pidTuningDynamicNotchFilterDisabledWarning": {
-        "message": "<span class=\"message-negative\">Warning:</span> Dynamic Notch Filter is disabled, please enable it as a feature in the Configuration tab to show related settings."
+        "message": "<strong>Notice:</strong> The dynamic notch filter is disabled. In order to configure and use it, please enable the 'DYNAMIC_FILTER' feature in the 'Other Features' section of the 'Configuration' tab."
     },
     "pidTuningDynamicNotchRange": {
         "message": "Dynamic Notch Filter Range"

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -366,7 +366,13 @@
     border-radius: 0px;
 }
 
+.tab-pid_tuning .subtab-filter table input {
+    width: 77px;
+    float: right;
+}
+
 .tab-pid_tuning table select {
+    width: 77px;
     text-align-last: right;
 }
 
@@ -539,6 +545,10 @@
 
 .tab-pid_tuning .helpicon {
     margin-top: 1px;
+}
+
+.tab-pid_tuning .subtab-filter .newFilter .helpicon {
+    margin-right: 2px;
 }
 
 .tab-pid_tuning .number .helpicon {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -377,6 +377,10 @@ var FC = {
             dterm_notch_hz:             0,
             dterm_notch_cutoff:         0,
             yaw_lowpass_hz:             0,
+            dyn_notch_range:            0,
+            dyn_notch_width_percent:    0,
+            dyn_notch_q:                0,
+            dyn_notch_min_hz:           0,
         };
 
         ADVANCED_TUNING = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -987,6 +987,12 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             FILTER_CONFIG.gyro_lowpass_dyn_max_hz = data.readU16();
                             FILTER_CONFIG.dterm_lowpass_dyn_min_hz = data.readU16();
                             FILTER_CONFIG.dterm_lowpass_dyn_max_hz = data.readU16();
+                            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                                FILTER_CONFIG.dyn_notch_range = data.readU8();
+                                FILTER_CONFIG.dyn_notch_width_percent = data.readU8();
+                                FILTER_CONFIG.dyn_notch_q = data.readU16();
+                                FILTER_CONFIG.dyn_notch_min_hz = data.readU16();
+                            }
                         }
                     }
                 }
@@ -1746,6 +1752,12 @@ MspHelper.prototype.crunch = function(code) {
                           .push16(FILTER_CONFIG.gyro_lowpass_dyn_max_hz)
                           .push16(FILTER_CONFIG.dterm_lowpass_dyn_min_hz)
                           .push16(FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
+                }
+                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                    buffer.push8(FILTER_CONFIG.dyn_notch_range)
+                          .push8(FILTER_CONFIG.dyn_notch_width_percent)
+                          .push16(FILTER_CONFIG.dyn_notch_q)
+                          .push16(FILTER_CONFIG.dyn_notch_min_hz);
                 }
             }
             break;

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1819,9 +1819,15 @@ TABS.pid_tuning.updateFilterWarning = function() {
     var dtermDynamicLowpassEnabled = $('input[id="dtermLowpassDynEnabled"]').is(':checked');
     var dtermLowpass1Enabled = $('input[id="dtermLowpassEnabled"]').is(':checked');
     var warning_e = $('#pid-tuning .filterWarning');
+    var warningDynamicNotch_e = $('#pid-tuning .dynamicNotchWarning');
     if (!(gyroDynamicLowpassEnabled || gyroLowpass1Enabled) || !(dtermDynamicLowpassEnabled || dtermLowpass1Enabled)) {
         warning_e.show();
     } else {
         warning_e.hide();
+    }
+    if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
+        warningDynamicNotch_e.hide();
+    } else {
+        warningDynamicNotch_e.show();
     }
 }

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -352,8 +352,20 @@ TABS.pid_tuning.initialize = function (callback) {
         if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
             $('.smartfeedforward').hide();
             $('.itermRelaxCutoff').show();
+
+            if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
+                $('.dynamicNotch').show();
+            } else {
+                $('.dynamicNotch').hide();
+            }
+
+            $('.pid_filter select[name="dynamicNotchRange"]').val(FILTER_CONFIG.dyn_notch_range);
+            $('.pid_filter input[name="dynamicNotchWidthPercent"]').val(FILTER_CONFIG.dyn_notch_width_percent);
+            $('.pid_filter input[name="dynamicNotchQ"]').val(FILTER_CONFIG.dyn_notch_q);
+            $('.pid_filter input[name="dynamicNotchMinHz"]').val(FILTER_CONFIG.dyn_notch_min_hz);
         } else {
             $('.itermRelaxCutoff').hide();
+            $('.dynamicNotch').hide();
         }
 
         $('input[id="useIntegratedYaw"]').change(function() {
@@ -685,6 +697,12 @@ TABS.pid_tuning.initialize = function (callback) {
             ADVANCED_TUNING.useIntegratedYaw = $('input[id="useIntegratedYaw"]').is(':checked') ? 1 : 0;
         }
 
+        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            FILTER_CONFIG.dyn_notch_range = parseInt($('.pid_filter select[name="dynamicNotchRange"]').val());
+            FILTER_CONFIG.dyn_notch_width_percent = parseInt($('.pid_filter input[name="dynamicNotchWidthPercent"]').val());
+            FILTER_CONFIG.dyn_notch_q = parseInt($('.pid_filter input[name="dynamicNotchQ"]').val());
+            FILTER_CONFIG.dyn_notch_min_hz = parseInt($('.pid_filter input[name="dynamicNotchMinHz"]').val());
+        }
     }
 
     function showAllPids() {
@@ -1067,6 +1085,22 @@ TABS.pid_tuning.initialize = function (callback) {
             selectDtermValues.forEach(function(value, key) {
                 dtermFilterSelect.append('<option value="' + key + '">' + value + '</option>');
             });
+        }
+        // Added in API 1.42.0
+        function loadDynamicNotchRangeValues() {
+            var dynamicNotchRangeValues = [
+                "HIGH", "MEDIUM", "LOW", "AUTO",
+            ];
+            return dynamicNotchRangeValues;
+        }
+        function populateDynamicNotchRangeSelect(selectDynamicNotchRangeValues) {
+            var dynamicNotchRangeSelect = $('select[name="dynamicNotchRange"]');
+            selectDynamicNotchRangeValues.forEach(function(value, key) {
+                dynamicNotchRangeSelect.append('<option value="' + key + '">' + value + '</option>');
+            });
+        }
+        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            populateDynamicNotchRangeSelect(loadDynamicNotchRangeValues());
         }
 
         populateFilterTypeSelector('gyroLowpassType', loadFilterTypeValues());

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1825,9 +1825,13 @@ TABS.pid_tuning.updateFilterWarning = function() {
     } else {
         warning_e.hide();
     }
-    if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
-        warningDynamicNotch_e.hide();
+    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
+            warningDynamicNotch_e.hide();
+        } else {
+            warningDynamicNotch_e.show();
+        }
     } else {
-        warningDynamicNotch_e.show();
+        warningDynamicNotch_e.hide();
     }
 }

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -888,6 +888,69 @@
                                     </div>
                                 </td>
                             </tr>
+                            
+                            <tr>
+                                <th colspan="2">
+                                    <div class="pid_mode dynamicNotch">
+                                        <div i18n="pidTuningDynamicNotchFilterGroup" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchFilterHelp" />
+                                    </div>
+                                </th>
+                            </tr>
+                            <tr class="newFilter dynamicNotch">
+                                <td>
+                                    <select name="dynamicNotchRange">
+                                        <!--  Populated on execution -->
+                                    </select>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningDynamicNotchRange"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchRangeHelp" />
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr class="newFilter dynamicNotch">
+                                <td>
+                                    <input type="number" name="dynamicNotchWidthPercent" step="1" min="0" max="20"/>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningDynamicNotchWidthPercent"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchWidthPercentHelp" />
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr class="newFilter dynamicNotch">
+                                <td>
+                                    <input type="number" name="dynamicNotchQ" step="1" min="1" max="1000"/>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningDynamicNotchQ"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchQHelp" />
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr class="newFilter dynamicNotch">
+                                <td>
+                                    <input type="number" name="dynamicNotchMinHz" step="1" min="60" max="1000"/>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningDynamicNotchMinHz"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMinHzHelp" />
+                                    </div>
+                                </td>
+                            </tr>
                         </table>
                     </div>
                     <div class="gui_box grey topspacer pid_filter two_columns_second">

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -696,6 +696,11 @@
                         <p i18n="filterWarning"></p>
                     </div>
                 </div>
+                <div class="note dynamicNotchWarning">
+                    <div class="note_spacer">
+                        <p i18n="pidTuningDynamicNotchFilterDisabledWarning"></p>
+                    </div>
+                </div>
 
                 <div class="cf_column two_columns">
                     <div class="gui_box grey topspacer pid_filter two_columns_first">


### PR DESCRIPTION
Adds dynamic notch settings to the configurator PID tuning filters tab below gyro notch filters. Requires MSP which will go with this PR.