### PR TITLE
fix a deprecation in jQuery 3.0 (Firmware flasher tab)

### DIFF
--- a/src/js/jenkins_loader.js
+++ b/src/js/jenkins_loader.js
@@ -52,9 +52,10 @@ JenkinsLoader.prototype.loadJobs = function (viewName, callback) {
                 chrome.storage.local.set(object);
 
                 wrappedCallback(jobs);
-            }).error(xhr => {
+            }).fail(xhr => {
                 GUI.log(i18n.getMessage('buildServerLoadFailed', ['jobs', `HTTP ${xhr.status}`]));
-            }).fail(cachedCallback);
+                cachedCallback();
+            });
         } else {
             cachedCallback();
         }


### PR DESCRIPTION
Right now anyone clicking on the Firmware flasher tab gets a nasty looking error in the javascript console, starting with:
`Error in response to storage.get: TypeError: $.get(...).error is not a function`

https://api.jquery.com/jQuery.ajax/#jqXHR
jqXHR.error() callback removed.