### PR TITLE
Add an VTX tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6,6 +6,14 @@
         "message": "Betaflight Configurator",
         "description": "Title of the application window, usually not translated"
     },
+    "yes": {
+        "message": "Yes",
+        "description": "General Yes message to be used across the application"
+    },
+    "no": {
+        "message": "No",
+        "description": "General No message to be used across the application"
+    },
     "error": {
         "message": "Error: {{errorMessage}}"
     },
@@ -279,6 +287,9 @@
     },
     "tabOsd": {
         "message": "OSD"
+    },
+    "tabVtx": {
+        "message": "Video Transmitter"
     },
     "tabPower": {
         "message": "Power & Battery"
@@ -3807,12 +3818,6 @@
     "osdSetupCameraConnected": {
         "message": "Camera Connected"
     },
-    "osdSetupCameraConnectedValueYes": {
-        "message": "Yes"
-    },
-    "osdSetupCameraConnectedValueNo": {
-        "message": "No"
-    },
 
     "osdSetupResetText": {
         "message": "Reset OSD to default"
@@ -4685,6 +4690,215 @@
     },
     "osdButtonSaved": {
         "message": "Saved"
+    },
+
+    "vtxHelp": {
+        "message": "You can configure here the values for your Video Trasmitter (VTX). You can consult and configure the values of the transmission including the VTX Tables if the flight controller and the VTX support it",
+        "description": "Introduction message in the VTX tab"
+    },
+    "vtxMessageNotSupported": {
+        "message": "<span class=\"message-negative\">Attention:</span> Your VTX is not configured or not supported. So you can't modify the VTX values from here. This will only be possible if the flight controller is attached to the VTX using some protocol like Tramp or SmartAudio and is correctly configured in the $t(tabPorts.message) tab if needed.",
+        "description": "Message to show when the VTX is not supported in the VTX tab"
+    },
+    "vtxMessageTableNotConfigured": {
+        "message": "<span class=\"message-negative\">Attention:</span> You need to configure and save FIRST the VTX Table at the bottom before you can make use of the $t(vtxSelectedMode.message) fields.",
+        "description": "Message to show when the VTX is not supported in the VTX tab"
+    },
+    "vtxFrequencyChannel": {
+        "message": "Enter frequency directly",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxFrequencyChannelHelp": {
+        "message": "If you enable this, the Configurator will let you select a frequency in place of the habitual band/channel. For this to work your VTX must support this feature.",
+        "description": "Help text for the frequency or channel select field of the VTX tab"
+    },
+    "vtxSelectedMode": {
+        "message": "Selected Mode",
+        "description": "Title for the actual mode header of the VTX"
+    },
+    "vtxActualState": {
+        "message": "Current Values",
+        "description": "Title for the actual values header of the VTX"
+    },
+    "vtxType": {
+        "message": "VTX Type",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxType_0": {
+        "message": "Unsupported",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_1": {
+        "message": "RTC607",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_3": {
+        "message": "SmartAudio",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_4": {
+        "message": "Tramp",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_255": {
+        "message": "Unknown",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxBand": {
+        "message": "Band",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxBandHelp": {
+        "message": "You can select here the band for your VTX",
+        "description": "Help text for the band field of the VTX tab"
+    },
+    "vtxBand_0": {
+        "message": "None",
+        "description": "Text of one of the options for the band field of the VTX tab"
+    },
+    "vtxBand_X": {
+        "message": "Band {{bandName}}",
+        "description": "Text of one of the options for the band field of the VTX tab"
+    },
+    "vtxChannel_0": {
+        "message": "None",
+        "description": "Text of one of the options for the channel field of the VTX tab"
+    },
+    "vtxChannel_X": {
+        "message": "Channel {{channelName}}",
+        "description": "Text of one of the options for the channel field of the VTX tab"
+    },
+    "vtxPower_0": {
+        "message": "None",
+        "description": "Text of one of the options for the power field of the VTX tab"
+    },
+    "vtxPower_X": {
+        "message": "Level {{powerLevel}}",
+        "description": "Text of one of the options for the power field of the VTX tab"
+    },
+    "vtxChannel": {
+        "message": "Channel",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxChannelHelp": {
+        "message": "You can select here the channel for your VTX",
+        "description": "Help text for the channel field of the VTX tab"
+    },
+    "vtxFrequency": {
+        "message": "Frequency",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxFrequencyHelp": {
+        "message": "You can select here the frequency for your VTX if it is supported",
+        "description": "Help text for the frequency field of the VTX tab"
+    },
+    "vtxDeviceReady": {
+        "message": "Device ready",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPower": {
+        "message": "Power",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPowerHelp": {
+        "message": "This is the power selected for the VTX. It can be modified if the $t(vtxPitMode.message) or the $t(vtxLowPowerDisarm.message) is enabled",
+        "description": "Help text for the power field of the VTX tab"
+    },
+    "vtxPitMode": {
+        "message": "Pit Mode",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPitModeHelp": {
+        "message": "When enabled, the VTX enters in a very low power mode to let the quad be on at the bench without disturbing other pilots. Usually the range of this mode is less than 5m.<br><br>NOTE: Some protocols, like SmartAudio, can't enable Pit Mode via software after power-up.'",
+        "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxPitModeFrequency": {
+        "message": "Pit Mode frequency",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPitModeFrequencyHelp": {
+        "message": "Frequency at which the Pit Mode changes when enabled.",
+        "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxLowPowerDisarm": {
+        "message": "Low Power Disarm",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxLowPowerDisarmHelp": {
+        "message": "When enabled, the VTX uses the lowest available power when disarmed (except if a failsafe has occurred).",
+        "description": "Help text for the low power disarm field of the VTX tab"
+    },
+    "vtxLowPowerDisarmOption_0": {
+        "message": "Off",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxLowPowerDisarmOption_1": {
+        "message": "On",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxLowPowerDisarmOption_2": {
+        "message": "On until first arm",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxTable": {
+        "message": "VTX Table",
+        "description": "Text of the header of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevels": {
+        "message": "Number of power levels",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsHelp": {
+        "message": "This defines the number of power levels supported by your VTX",
+        "description": "Help for the number of power levels field of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsTableHelp": {
+        "message": "This table represents the different values of power that can be used for the VTX. They are divided into two: <br><b>- $t(vtxTablePowerLevelsValue.message):</b> each power level requires a value that is defined by the hardware manufacturer. Ask your manufacturer for the correct value or consult the Betaflight wiki of VTX Tables to grab some samples. <br><b>- $t(vtxTablePowerLevelsLabel.message):</b> you can put here the label you want for each power level value. It can be numbers (25, 200, 600, 1.2), letters (OFF, MIN, MAX) or a mix of them. <br><br>You must configure <b>only</b> the power levels that are legal at your contry.",
+        "description": "Help for the table of power levels (value-label) that appears in the VTX tab"
+    },
+    "vtxTablePowerLevelsValue": {
+        "message": "Value",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsLabel": {
+        "message": "Label",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBands": {
+        "message": "Number of bands",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableChannels": {
+        "message": "Number of channels by band",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsChannelsHelp": {
+        "message": "This defines the number of bands and the number of channels by band that you that you want for your VTX.",
+        "description": "Help for the number of bands and channels field of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleName": {
+        "message": "Name",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleLetter": {
+        "message": "Letter",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleFactory": {
+        "message": "Factory",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsChannelsTableHelp": {
+        "message": "This table represents all the frequencies that can be used for your VTX. You can have several bands and for each band you must configure:<br><b>- $t(vtxTableBandTitleName.message):</b> Name that you want to assign to this band, like BOSCAM_A, FATSHARK or RACEBAND.<br><b>- $t(vtxTableBandTitleLetter.message):</b> Short letter that references the band.<br><b>- $t(vtxTableBandTitleFactory.message):</b> This indicates if it is a factory band. If enabled Betaflight sends to the VTX a band and channel number. The VTX will then use its built-in frequency table and the frequencies configured here are only to show the value in the OSD and other places. If it is not enabled, then Betaflight will send to the VTX the real frequency configured here.<br><b>- Frequencies:</b> Frequencies for this band.<br><br>Remember that not all frequencies are legal at your country. You must put a value of <b>zero</b> to each frequency index that you are not allowed to use to disable it.",
+        "description": "Help for the table of bands-channels that appears in the VTX tab"
+    },
+    "vtxButtonSave": {
+        "message": "Save",
+        "description": "Save button in the VTX tab"
+    },
+    "vtxButtonSaved": {
+        "message": "Saved",
+        "description": "Saved action button in the VTX tab"
     },
 
     "mainHelpArmed": {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -876,6 +876,15 @@ li.active .ic_transponder {
     background-image: url(../images/icons/icon_osd_white.svg);
 }
 
+.ic_vtx {
+    background-image: url(../images/icons/cf_icon_vtx_grey.svg);
+    background-position-y: 4px;
+}
+
+.ic_vtx:hover, li.active .ic_osd {
+    background-image: url(../images/icons/cf_icon_vtx_white.svg);
+}
+
 .ic_power {
     background-image: url(../images/icons/cf_icon_power_grey.svg);
     background-position-y: 9px;
@@ -1481,9 +1490,12 @@ dialog {
 
 .cf_table td {
     border: 0px;
-    border-bottom: solid 1px var(--subtleAccent);
     padding-top: 2px;
     padding-bottom: 5px;
+}
+
+.cf_table tr:not(:last-child) td {
+    border-bottom: solid 1px var(--subtleAccent);
     border-style: dotted;
 }
 

--- a/src/css/tabs/vtx.css
+++ b/src/css/tabs/vtx.css
@@ -1,0 +1,125 @@
+.tab-vtx {
+    height: 100%;
+}
+
+.tab-vtx .require-support {
+    display: none;
+}
+
+.tab-vtx.supported .require-support {
+    display: block;
+}
+
+.tab-vtx .require-upgrade {
+    display: block;
+}
+
+.tab-vtx.supported .require-upgrade {
+    display: none;
+}
+
+.tab-vtx .leftWrapper {
+    float: left;
+    width:calc(60% - 20px)
+}
+
+.tab-vtx .rightWrapper {
+    float: left;
+    width: calc(30% - 0px);
+    max-width: 300px;
+    margin: 0 0 10px 20px;
+}
+
+.tab-vtx input , .tab-vtx select {
+    border: 1px solid var(--subtleAccent);
+    border-radius: 3px;
+    max-width: 100px;
+
+}
+
+.tab-vtx .number input {
+    width: 55px;
+    padding-left: 3px;
+    height: 20px;
+    line-height: 20px;
+    text-align: left;
+    border-radius: 3px;
+    margin-right: 11px;
+    font-size: 12px;
+    font-weight: normal;
+}
+
+.tab-vtx .gui_box span {
+    font-style: normal;
+    font-family: 'open_sansregular', Arial;
+    line-height: 19px;
+    color: var(--mutedtext);
+    font-size: 11px;
+}
+
+.tab-vtx .spacer_box .field {
+    margin-bottom: 5px;
+    clear: left;
+    padding-bottom: 5px;
+    width: 100%;
+    float: left;
+}
+
+.tab-vtx .spacer_box .field:not(:last-child) {
+    border-bottom: 1px solid var(--subtleAccent);
+}
+
+.tab-vtx .select_mode .field > span {
+    margin-right: 10px;
+    display: inline-block;
+    min-width: 100px;
+}
+
+.tab-vtx input.one_digit_input {
+    width: 28px;
+}
+
+.tab-vtx input.frequency_input {
+    width: 48px;
+}
+
+.tab-vtx .vtx_table_box {
+    min-width: 750px
+}
+
+.tab-vtx .table_vtx_bands tr:first-child td, .tab-vtx .table_vtx_powerlevels tr:first-child td {
+    text-align: center;
+}
+
+
+.tab-vtx .table_vtx_bands td, .tab-vtx .table_vtx_powerlevels td {
+    padding: 0px 1px;
+    text-align: center;
+}
+
+.tab-vtx .table_vtx_bands input, .tab-vtx .table_vtx_powerlevels input {
+    display: block;
+    margin: 0 auto;
+}
+
+.tab-vtx .field_powerlevel_value input, .tab-vtx .field_powerlevel_label input {
+    width: 53px;
+
+}
+
+.tab-vtx .field_band_name input {
+    width: 71px;
+
+}
+
+.tab-vtx .field_band_letter input {
+    width: 13px;
+}
+
+.tab-vtx .vtx_table_bands_table span table, .tab-vtx .vtx_table_powerlevels_table span table {
+    float: left;
+}
+
+#tab-vtx-templates {
+    display: none;
+}

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -58,6 +58,9 @@ var FILTER_CONFIG;
 var ADVANCED_TUNING;
 var SENSOR_CONFIG;
 var COPY_PROFILE;
+var VTX_CONFIG;
+var VTXTABLE_BAND;
+var VTXTABLE_POWERLEVEL;
 var DEFAULT;
 
 var FC = {
@@ -469,6 +472,37 @@ var FC = {
         };
 
         RXFAIL_CONFIG = [];
+
+        VTX_CONFIG = {
+            vtx_type:                       0,
+            vtx_band:                       0,
+            vtx_channel:                    0,
+            vtx_power:                      0,
+            vtx_pit_mode:                   false,
+            vtx_frequency:                  0,
+            vtx_device_ready:               false,
+            vtx_low_power_disarm:           0,
+            vtx_pit_mode_frequency:         0,
+            vtx_table_available:            false,
+            vtx_table_bands:                0,
+            vtx_table_channels:             0,
+            vtx_table_powerlevels:          0,
+            vtx_table_clear:                false,
+        };
+
+        VTXTABLE_BAND = {
+            vtxtable_band_number:           0,
+            vtxtable_band_name:             '',
+            vtxtable_band_letter:           '',
+            vtxtable_band_is_factory_band:  false,
+            vtxtable_band_frequencies:      [],
+        };
+
+        VTXTABLE_POWERLEVEL = {
+            vtxtable_powerlevel_number:     0,
+            vtxtable_powerlevel_value:      0,
+            vtxtable_powerlevel_label:      0,
+        };
 
         DEFAULT = {
             gyro_lowpass_hz:                100,

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -42,6 +42,7 @@ var GUI_control = function () {
         'receiver',
         'sensors',
         'servos',
+        'vtx',
     ];
     this.defaultAllowedOSDTabsWhenConnected = [
         'setup_osd',

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -236,6 +236,9 @@ function startProcess() {
                     case 'osd':
                         TABS.osd.initialize(content_ready);
                         break;
+                    case 'vtx':
+                        TABS.vtx.initialize(content_ready);
+                        break;
                     case 'power':
                         TABS.power.initialize(content_ready);
                         break;
@@ -620,46 +623,31 @@ function isExpertModeEnabled() {
 }
 
 function updateTabList(features) {
+
+    if (isExpertModeEnabled()) {
+        $('#tabs ul.mode-connected li.tab_failsafe').show();
+        $('#tabs ul.mode-connected li.tab_adjustments').show();
+        $('#tabs ul.mode-connected li.tab_servos').show();
+        $('#tabs ul.mode-connected li.tab_sensors').show();
+        $('#tabs ul.mode-connected li.tab_logging').show();
+    } else {
+        $('#tabs ul.mode-connected li.tab_failsafe').hide();
+        $('#tabs ul.mode-connected li.tab_adjustments').hide();
+        $('#tabs ul.mode-connected li.tab_servos').hide();
+        $('#tabs ul.mode-connected li.tab_sensors').hide();
+        $('#tabs ul.mode-connected li.tab_logging').hide();
+    }
+
     if (features.isEnabled('GPS') && isExpertModeEnabled()) {
         $('#tabs ul.mode-connected li.tab_gps').show();
     } else {
         $('#tabs ul.mode-connected li.tab_gps').hide();
     }
 
-    if (isExpertModeEnabled()) {
-        $('#tabs ul.mode-connected li.tab_failsafe').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_failsafe').hide();
-    }
-
-    if (isExpertModeEnabled()) {
-        $('#tabs ul.mode-connected li.tab_adjustments').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_adjustments').hide();
-    }
-
-    if (isExpertModeEnabled()) {
-        $('#tabs ul.mode-connected li.tab_servos').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_servos').hide();
-    }
-
     if (features.isEnabled('LED_STRIP')) {
         $('#tabs ul.mode-connected li.tab_led_strip').show();
     } else {
         $('#tabs ul.mode-connected li.tab_led_strip').hide();
-    }
-
-    if (isExpertModeEnabled()) {
-        $('#tabs ul.mode-connected li.tab_sensors').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_sensors').hide();
-    }
-
-    if (isExpertModeEnabled()) {
-        $('#tabs ul.mode-connected li.tab_logging').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_logging').hide();
     }
 
     if (features.isEnabled('TRANSPONDER')) {
@@ -679,6 +667,13 @@ function updateTabList(features) {
     } else {
         $('#tabs ul.mode-connected li.tab_power').hide();
     }
+
+    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        $('#tabs ul.mode-connected li.tab_vtx').show();
+    } else {
+        $('#tabs ul.mode-connected li.tab_vtx').hide();
+    }
+
 }
 
 function zeroPad(value, width) {

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -112,6 +112,9 @@ var MSPCodes = {
     MSP_COMPASS_CONFIG:             133,
     MSP_GPS_RESCUE:                 135,
 
+    MSP_VTXTABLE_BAND:              137,
+    MSP_VTXTABLE_POWERLEVEL:        138,
+
     MSP_STATUS_EX:                  150,
 
     MSP_UID:                        160,
@@ -147,6 +150,9 @@ var MSPCodes = {
     MSP_SET_GPS_CONFIG:             223,
     MSP_SET_COMPASS_CONFIG:         224,
     MSP_SET_GPS_RESCUE:             225,
+
+    MSP_SET_VTXTABLE_BAND:          227,
+    MSP_SET_VTXTABLE_POWERLEVEL:    228,
 
     MSP_MODE_RANGES_EXTRA:          238,
     MSP_SET_ACC_TRIM:               239,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1282,9 +1282,78 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     TRANSPONDER.data.push(data.readU8());
                 }
                 break;
+
             case MSPCodes.MSP_SET_TRANSPONDER_CONFIG:
                 console.log("Transponder config saved");
                 break;
+
+            case MSPCodes.MSP_VTX_CONFIG:
+
+                VTX_CONFIG.vtx_type = data.readU8();
+                VTX_CONFIG.vtx_band = data.readU8();
+                VTX_CONFIG.vtx_channel = data.readU8();
+                VTX_CONFIG.vtx_power = data.readU8();
+                VTX_CONFIG.vtx_pit_mode = data.readU8() != 0;
+                VTX_CONFIG.vtx_frequency = data.readU16();
+                VTX_CONFIG.vtx_device_ready = data.readU8() != 0;
+                VTX_CONFIG.vtx_low_power_disarm = data.readU8();
+
+                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                    VTX_CONFIG.vtx_pit_mode_frequency = data.readU16();
+                    VTX_CONFIG.vtx_table_available = data.readU8() != 0;
+                    VTX_CONFIG.vtx_table_bands = data.readU8();
+                    VTX_CONFIG.vtx_table_channels = data.readU8();
+                    VTX_CONFIG.vtx_table_powerlevels = data.readU8();
+                    VTX_CONFIG.vtx_table_clear = false;
+                }
+                break;
+
+            case MSPCodes.MSP_SET_VTX_CONFIG:
+                console.log("VTX config sent");
+                break;
+
+            case MSPCodes.MSP_VTXTABLE_BAND:
+
+                VTXTABLE_BAND.vtxtable_band_number = data.readU8();
+
+                let bandNameLength = data.readU8();
+                VTXTABLE_BAND.vtxtable_band_name = '';
+                for (let i = 0; i < bandNameLength; i++) {
+                    VTXTABLE_BAND.vtxtable_band_name += String.fromCharCode(data.readU8());
+                }
+
+                VTXTABLE_BAND.vtxtable_band_letter = String.fromCharCode(data.readU8());
+                VTXTABLE_BAND.vtxtable_band_is_factory_band = data.readU8() != 0;
+
+                let bandFrequenciesLength = data.readU8();
+                VTXTABLE_BAND.vtxtable_band_frequencies = [];
+                for (let i = 0; i < bandFrequenciesLength; i++) {
+                    VTXTABLE_BAND.vtxtable_band_frequencies.push(data.readU16());
+                }
+
+                break;
+
+            case MSPCodes.MSP_SET_VTXTABLE_BAND:
+                console.log("VTX band sent");
+                break;
+
+            case MSPCodes.MSP_VTXTABLE_POWERLEVEL:
+
+                VTXTABLE_POWERLEVEL.vtxtable_powerlevel_number = data.readU8();
+                VTXTABLE_POWERLEVEL.vtxtable_powerlevel_value = data.readU16();
+
+                let powerLabelLength = data.readU8();
+                VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label = '';
+                for (let i = 0; i < powerLabelLength; i++) {
+                    VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label += String.fromCharCode(data.readU8());
+                }
+
+                break;
+
+            case MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL:
+                console.log("VTX powerlevel sent");
+                break;
+
             case MSPCodes.MSP_SET_MODE_RANGE:
                 console.log('Mode range saved');
                 break;
@@ -1339,10 +1408,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             case MSPCodes.MSP_OSD_CHAR_WRITE:
                 console.log('OSD char uploaded');
-                break;
-            case MSPCodes.MSP_VTX_CONFIG:
-                break;
-            case MSPCodes.MSP_SET_VTX_CONFIG:
                 break;
             case MSPCodes.MSP_SET_NAME:
                 console.log('Name set');
@@ -1885,6 +1950,58 @@ MspHelper.prototype.crunch = function(code) {
             }
 
             break;
+
+        case MSPCodes.MSP_SET_VTX_CONFIG:
+
+            buffer.push16(VTX_CONFIG.vtx_frequency)
+                  .push8(VTX_CONFIG.vtx_power)
+                  .push8(VTX_CONFIG.vtx_pit_mode ? 1 : 0)
+                  .push8(VTX_CONFIG.vtx_low_power_disarm);
+
+            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                buffer.push16(VTX_CONFIG.vtx_pit_mode_frequency)
+                      .push8(VTX_CONFIG.vtx_band)
+                      .push8(VTX_CONFIG.vtx_channel)
+                      .push16(VTX_CONFIG.vtx_frequency)
+                      .push8(VTX_CONFIG.vtx_table_bands)
+                      .push8(VTX_CONFIG.vtx_table_channels)
+                      .push8(VTX_CONFIG.vtx_table_powerlevels)
+                      .push8(VTX_CONFIG.vtx_table_clear ? 1 : 0);
+            }
+
+            break;
+
+        case MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL:
+
+            buffer.push8(VTXTABLE_POWERLEVEL.vtxtable_powerlevel_number)
+                  .push16(VTXTABLE_POWERLEVEL.vtxtable_powerlevel_value);
+
+            buffer.push8(VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.length);
+            for (let i = 0; i < VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.length; i++) {
+                buffer.push8(VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.charCodeAt(i));
+            }
+
+            break;
+
+        case MSPCodes.MSP_SET_VTXTABLE_BAND:
+
+            buffer.push8(VTXTABLE_BAND.vtxtable_band_number);
+
+            buffer.push8(VTXTABLE_BAND.vtxtable_band_name.length);
+            for (let i = 0; i < VTXTABLE_BAND.vtxtable_band_name.length; i++) {
+                buffer.push8(VTXTABLE_BAND.vtxtable_band_name.charCodeAt(i));
+            }
+
+            buffer.push8(VTXTABLE_BAND.vtxtable_band_letter.charCodeAt(0))
+                  .push8(VTXTABLE_BAND.vtxtable_band_is_factory_band ? 1 : 0);
+
+            buffer.push8(VTXTABLE_BAND.vtxtable_band_frequencies.length);
+            for (let i = 0; i < VTXTABLE_BAND.vtxtable_band_frequencies.length; i++) {
+                buffer.push16(VTXTABLE_BAND.vtxtable_band_frequencies[i]);
+            }
+
+            break;
+
         default:
             return false;
     }

--- a/src/js/tabs/setup_osd.js
+++ b/src/js/tabs/setup_osd.js
@@ -55,7 +55,7 @@ TABS.setup_osd.initialize = function (callback) {
                 element.text(osdVideoMode);
                 
                 element = $('.camera-connected');
-                element.text(OSD_VIDEO_STATE.camera_connected ? i18n.getMessage('osdSetupCameraConnectedValueYes') : i18n.getMessage('osdSetupCameraConnectedValueNo'));
+                element.text(OSD_VIDEO_STATE.camera_connected ? i18n.getMessage('yes') : i18n.getMessage('No'));
             });
             */
         }

--- a/src/main.html
+++ b/src/main.html
@@ -29,6 +29,7 @@
     <link type="text/css" rel="stylesheet" href="./css/tabs/auxiliary.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./css/tabs/failsafe.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./css/tabs/osd.css" media="all"/>
+    <link type="text/css" rel="stylesheet" href="./css/tabs/vtx.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./css/tabs/power.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./css/tabs/transponder.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./css/tabs/privacy_policy.css" media="all"/>
@@ -163,6 +164,7 @@
     <script type="text/javascript" src="./js/tabs/failsafe.js"></script>
     <script type="text/javascript" src="./js/LogoManager.js"></script>
     <script type="text/javascript" src="./js/tabs/osd.js"></script>
+    <script type="text/javascript" src="./js/tabs/vtx.js"></script>
     <script type="text/javascript" src="./js/tabs/power.js"></script>
     <script type="text/javascript" src="./js/tabs/transponder.js"></script>
     <script type="text/javascript" src="./node_modules/jquery-textcomplete/dist/jquery.textcomplete.min.js"></script>
@@ -322,6 +324,7 @@
                 <li class="tab_motors"><a href="#" i18n="tabMotorTesting" class="tabicon ic_motor" i18n_title="tabMotorTesting"></a>
                 </li>
                 <li class="tab_osd"><a href="#" i18n="tabOsd" class="tabicon ic_osd" i18n_title="tabOsd"></a></li>
+                <li class="tab_vtx"><a href="#" i18n="tabVtx" class="tabicon ic_vtx" i18n_title="tabVtx"></a></li>
                 <li class="tab_transponder"><a href="#" i18n="tabTransponder" class="tabicon ic_transponder"
                                                i18n_title="tabTransponder"></a></li>
                 <li class="tab_led_strip"><a href="#" i18n="tabLedStrip" class="tabicon ic_led" i18n_title="tabLedStrip"></a>

--- a/src/tabs/vtx.html
+++ b/src/tabs/vtx.html
@@ -1,0 +1,329 @@
+<div class="tab-vtx toolbar_fixed_bottom">
+    <div class="content_wrapper">
+        <!-- should be the first DIV on each tab -->
+        <div class="cf_column spacerbottom">
+            <div class="tab_title" i18n="tabVtx"/>
+            <div class="cf_doc_version_bt">
+                <a id="button-documentation" href="" target="_blank"></a>
+            </div>
+        </div>
+
+        <div class="note spacebottom note_spacer">
+            <p i18n="vtxHelp"/>
+        </div>
+
+        <div class="note note_spacer vtx_not_supported">
+            <div i18n="vtxMessageNotSupported"/>
+        </div>
+
+        <div class="note note_spacer vtx_table_not_configured">
+            <div i18n="vtxMessageTableNotConfigured"/>
+        </div>
+
+        <table style="width:100%">
+            <tr>
+                <td>
+                    <div class="leftWrapper">
+
+                        <div class="gui_box grey select_mode vtx_supported">
+
+                            <div class="gui_box_titlebar">
+                                <div class="spacer_box_title" i18n="vtxSelectedMode"/>
+                            </div>
+
+                            <div class="spacer_box">
+
+                                <div class="field checkbox vtx_frequency_channel">
+                                    <span class="checkboxspacer">
+                                        <input type="checkbox" id="vtx_frequency_channel" class="toggle" />
+                                    </span>
+                                    <label>
+                                        <span class="freelabel" i18n="vtxFrequencyChannel" />
+                                        <div class="helpicon cf_tip" i18n_title="vtxFrequencyChannelHelp"/>
+                                    </label>
+                                </div>
+
+                                <div class="field number vtx_band">
+                                    <span class="numberspacer">
+                                        <select id="vtx_band">
+                                            <!-- Band options generated here from the js -->
+                                        </select>
+                                    </span>
+                                    <label>
+                                        <span i18n="vtxBand"/>
+                                        <div class="helpicon cf_tip" i18n_title="vtxBandHelp"/>
+                                    </label>
+                                </div>
+
+                                <div class="field number vtx_channel">
+                                    <span class="numberspacer">
+                                        <select id="vtx_channel">
+                                            <!-- Channel options generated here from the js -->
+                                        </select>
+                                    </span>
+                                    <label>
+                                        <span i18n="vtxChannel"/>
+                                        <div class="helpicon cf_tip" i18n_title="vtxChannelHelp"/>
+                                    </label>
+                                </div>
+
+                                <div class="field number vtx_frequency">
+                                    <span class="numberspacer">
+                                        <input class="frequency_input" type="number" id="vtx_frequency" min="64" max="5999">
+                                    </span>
+                                    <label>
+                                        <span i18n="vtxFrequency"/>
+                                        <div class="helpicon cf_tip" i18n_title="vtxFrequencyHelp"/>
+                                    </label>
+                                </div>
+
+                                <div class="field number vtx_power">
+                                    <span class="numberspacer">
+                                        <select id="vtx_power">
+                                            <!-- Power options generated here from the js -->
+                                        </select>
+                                    </span>
+                                    <label for="vtx_power">
+                                        <span i18n="vtxPower"/>
+                                        <div class="helpicon cf_tip" i18n_title="vtxPowerHelp"/>
+                                    </label>
+                                </div>
+
+                                <div class="field checkbox vtx_pit_mode">
+                                    <span class="checkboxspacer">
+                                        <input type="checkbox" id="vtx_pit_mode" class="toggle" />
+                                    </span>
+                                    <label for="vtx_pit_mode">
+                                        <span class="freelabel" i18n="vtxPitMode" />
+                                        <div class="helpicon cf_tip" i18n_title="vtxPitModeHelp"/>
+                                    </label>
+                                </div>
+
+                                <div class="field number vtx_pit_mode_frequency">
+                                    <span class="numberspacer">
+                                        <input class="frequency_input" type="number" id="vtx_pit_mode_frequency" min="0" max="5999">
+                                    </span>
+                                    <label>
+                                        <span i18n="vtxPitModeFrequency"/>
+                                        <div class="helpicon cf_tip" i18n_title="vtxPitModeFrequencyHelp"/>
+                                    </label>
+                                </div>
+
+                                <div class="field select vtx_low_power_disarm">
+                                    <span class="selectspacer">
+                                        <select id="vtx_low_power_disarm">
+                                            <option value="0" i18n="vtxLowPowerDisarmOption_0" />
+                                            <option value="1" i18n="vtxLowPowerDisarmOption_1" />
+                                            <option value="2" i18n="vtxLowPowerDisarmOption_2" />
+                                        </select>
+                                    </span>
+                                    <label for="vtx_low_power_disarm"> 
+                                        <span class="freelabel" i18n="vtxLowPowerDisarm" />
+                                        <div class="helpicon cf_tip" i18n_title="vtxLowPowerDisarmHelp"/>
+                                    </label>
+                                </div>
+                            </div>
+
+                        </div>
+
+
+                    </div>
+                    <div class="rightWrapper">
+
+                        <div class="gui_box grey vtx_supported">
+
+                            <div class="gui_box_titlebar">
+                                <div class="spacer_box_title" i18n="vtxActualState"></div>
+                            </div>
+
+                            <div class="spacer_box">
+
+                            <table class="cf_table">
+	                            <tbody>
+	                                <tr class="description vtx_type">
+	                                    <td class="description_text" i18n="vtxType" />
+	                                    <td class="description_value" id="vtx_type_description"/>
+	                                </tr>
+                                    <tr class="description vtx_device_ready">
+                                        <td class="description_text" i18n="vtxDeviceReady" />
+                                        <td class="description_value" id="vtx_device_ready_description"/>
+                                    </tr>
+                                    <tr class="description vtx_band">
+                                        <td class="description_text" i18n="vtxBand" />
+                                        <td class="description_value" id="vtx_band_description"/>
+                                    </tr>
+                                    <tr class="description vtx_channel">
+                                        <td class="description_text" i18n="vtxChannel" />
+                                        <td class="description_value" id="vtx_channel_description"/>
+                                    </tr>
+	                                <tr class="description vtx_frequency">
+                                        <td class="description_text" i18n="vtxFrequency" />
+                                        <td class="description_value" id="vtx_frequency_description"/>
+                                    </tr>
+                                    <tr class="description vtx_power">
+                                        <td class="description_text" i18n="vtxPower" />
+                                        <td class="description_value" id="vtx_power_description"/>
+                                    </tr>
+                                    <tr class="description pit_mode">
+                                        <td class="description_text" i18n="vtxPitMode" />
+                                        <td class="description_value" id="vtx_pit_mode_description"/>
+                                    </tr>
+                                    <tr class="description vtx_pit_mode">
+                                        <td class="description_text" i18n="vtxPitModeFrequency" />
+                                        <td class="description_value" id="vtx_pit_mode_frequency_description"/>
+                                    </tr>
+                                    <tr class="description vtx_low_power_disarm">
+                                        <td class="description_text" i18n="vtxLowPowerDisarm" />
+                                        <td class="description_value" id="vtx_low_power_disarm_description"/>
+                                    </tr>
+
+	                            </tbody>
+	                        </table>
+
+                            </div>
+                        </div>
+                    </div>
+                </td>
+            </tr>
+
+            <tr>
+                <td>
+                    <div class="leftWrapper">
+
+                        <div class="gui_box grey vtx_table_box vtx_table_available">
+
+                            <div class="gui_box_titlebar">
+                                <div class="spacer_box_title" i18n="vtxTable"></div>
+                            </div>
+
+                            <div class="spacer_box">
+
+                                <div class="field number vtx_table_bands_channels">
+                                    <span class="numberspacer">
+                                        <input class="one_digit_input" type="number" id="vtx_table_bands" min="0" max="8">
+                                    </span>
+                                    <label>
+                                        <span i18n="vtxTableBands"/>
+                                    </label>
+                                    <span class="numberspacer">
+                                        <input class="one_digit_input" type="number" id="vtx_table_channels" min="0" max="8">
+                                    </span>
+                                    <label>
+                                        <span i18n="vtxTableChannels"/>
+                                    </label>
+                                    <div class="helpicon cf_tip" i18n_title="vtxTableBandsChannelsHelp"/>
+                                </div>
+
+                                <div class="field number table vtx_table_bands_table">
+                                    <span>
+	                                    <table class="table_vtx_bands">
+	                                        <tbody>
+	                                            <!--  Bands generated here from the templates at the bottom -->
+	                                        </tbody>
+	                                    </table>
+                                    </span>
+                                    <span>
+                                        <div class="helpicon cf_tip" i18n_title="vtxTableBandsChannelsTableHelp"/>
+                                    </span>
+                                </div>
+
+                                <div class="field number vtx_table_powerlevels">
+                                    <span class="numberspacer">
+                                        <input class="one_digit_input" type="number" id="vtx_table_powerlevels" min="0" max="8">
+                                    </span>
+                                    <label>
+                                        <span i18n="vtxTablePowerLevels"/>
+                                        <div class="helpicon cf_tip" i18n_title="vtxTablePowerLevelsHelp"/>
+                                    </label>
+                                </div>
+
+                                <div class="field number table vtx_table_powerlevels_table">
+                                    <span>
+                                        <table class="table_vtx_powerlevels">
+                                            <tbody>
+                                                <tr class="vtx_table_powerlevels_title">
+                                                    <!--  Title values generated here dinamically -->
+                                                </tr>
+                                                <tr class="vtx_table_powerlevels_values">
+                                                    <!--  Powerlevels values generated here from the templates at the bottom -->
+                                                </tr>
+                                                <tr class="vtx_table_powerlevels_labels">
+                                                    <!--  Powerlevels labels generated here from the templates at the bottom -->
+                                                </tr>
+                                            </tbody>
+                                        </table>
+                                    </span>
+                                    <span>
+                                        <div class="helpicon cf_tip" i18n_title="vtxTablePowerLevelsTableHelp"/>
+                                    </span>
+                                </div>
+
+                            </div>
+                        </div>
+
+                    </div>
+                </td>
+            </tr>
+        </table>
+
+    </div>
+
+    <div class="content_toolbar">
+        <div class="btn save_btn">
+            <a class="save" id="save_button" href="#" i18n="vtxButtonSave"></a>
+        </div>
+        
+    </div>
+
+</div> 
+
+<div id="tab-vtx-templates">
+
+    <div id="tab-vtx-powerlevel-values">
+        <table>
+            <tr>
+                <td><span class="numberspacer field_powerlevel_value"><input type="number" id="vtx_table_powerlevels" min="0" max="65535"></span></td>
+            </tr>
+        </table>
+    </div>
+
+    <div id="tab-vtx-powerlevel-labels">
+        <table>
+            <tr>
+                <td><span class="textspacer field_powerlevel_label"><input class="uppercase" type="text" id="vtx_table_powerlabels" maxlength="3" size="1"></span></td>
+            </tr>
+        </table>
+    </div>
+
+    <div id="tab-vtx-bands-title">
+        <table>
+            <tr class="vtx_table_band_values_title">
+                <td><span i18n="vtxTableBandTitleName"/></td>
+                <td><span i18n="vtxTableBandTitleLetter"/></td>
+                <td><span i18n="vtxTableBandTitleFactory"/></td>
+            </tr>
+        </table>
+    </div>
+
+    <div id="tab-vtx-bands">
+        <table>
+            <tr class="vtx_table_band_values">
+                <td><span class="textspacer field_band_name"><input class="uppercase" type="text" id="vtx_table_band_name" maxlength="8" size="8" /></span></td>
+                <td><span class="textspacer field_band_letter"><input class="uppercase" type="text" id="vtx_table_band_letter" maxlength="1" size="1" /></span></td>
+                <td><span class="checkboxspacer"><input id="vtx_table_band_factory" type="checkbox" class="togglesmall" /></span></td>
+                <!--  Channels generated here from the templates at the bottom -->
+            </tr>
+        </table>
+    </div>
+
+    <div id="tab-vtx-channels">
+        <table>
+            <tr>
+                <td><span class="numberspacer field_band_channel "><input class="frequency_input" type="number" id="vtx_table_band_channel" min="0" max="5999"></span></td>
+            </tr>
+        </table>
+    </div>
+
+
+
+</div>


### PR DESCRIPTION
Adds an VTX tab to control the VTX and populate the VTX Table. To go with: https://github.com/betaflight/betaflight/pull/8693

This PR is not finished, it needs some refactor and some little changes, but is at 99% almost done. It has been opened to discuss some things:
1. Now, the tab only appears for Betaflight 4.1, but the code to make it work in Betaflight 4.0 (or earlier) is almost there if we want to give support because the VTX Table is conditional at compilation so I needed to take it into account.
2. The tab is divided into two, the upper part can be used in older Betafligth versions but it can be used too in 4.1 when there is no vtx table support.
3. In the upper right there is a box with general info that is valid always.
4. Flag vtxtype unknown, vtxtype not supported. We want to show the tab only with the general info and with a message that VTX not valid? Or we prefer to hide the tab?
5. Flag vtxtables not supported. We want to show the tab only with the upper part giving some functionality or hide the tab?

![image](https://user-images.githubusercontent.com/2673520/62782991-b2078a00-babb-11e9-8295-f4804c9e6234.png)
