### PR TITLE
read version information from... version.json

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -476,7 +476,10 @@ function getHash(cb) {
 
 function writeChangesetId() {
     var versionJson = new stream.Readable;
-    versionJson.push(JSON.stringify({ gitChangesetId: gitChangeSetId }, undefined, 2));
+    versionJson.push(JSON.stringify({
+        gitChangesetId: gitChangeSetId,
+        version: pkg.version
+        }, undefined, 2));
     versionJson.push(null);
     return versionJson
         .pipe(source('version.json'))

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -5,7 +5,7 @@
 function configuration_backup(callback) {
     var activeProfile = null;
 
-    var version = getManifestVersion();
+    var version = CONFIGURATOR.version;
 
     if (version.indexOf(".") === -1) {
         version = version + ".0.0";


### PR DESCRIPTION
Hi, `version.json` helpfully holds the gitChangesetId, I think it should include the version as well

* version is now written to `version.json`, value is the one in `package.json`

* using this version, instead of asking for a manifest via `chrome.runtime.getManifest()`

* eventpage.js still has its own `getManifestVersion()` that it uses.

* skip checking for updates when running as Other.