### PR TITLE
Add a way to avoid trying to add a custom icon when building nw.js

### DIFF
--- a/assets/windows/installer.nsi
+++ b/assets/windows/installer.nsi
@@ -152,9 +152,9 @@ Section
 
     # create shortcuts in the start menu and on the desktop
     CreateDirectory "$SMPROGRAMS\${GROUP_NAME}\${FOLDER_NAME}"    
-    CreateShortCut "$SMPROGRAMS\${GROUP_NAME}\${FOLDER_NAME}\${APP_NAME}.lnk" "$INSTDIR\${FILE_NAME_EXECUTABLE}"
+    CreateShortCut "$SMPROGRAMS\${GROUP_NAME}\${FOLDER_NAME}\${APP_NAME}.lnk" "$INSTDIR\${FILE_NAME_EXECUTABLE}" "" "$INSTDIR\images\bf_icon.ico" "0" "" "" ""
     CreateShortCut "$SMPROGRAMS\${GROUP_NAME}\${FOLDER_NAME}\Uninstall ${APP_NAME}.lnk" "$INSTDIR\${FILE_NAME_UNINSTALLER}"
-    CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${FILE_NAME_EXECUTABLE}"
+    CreateShortCut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\${FILE_NAME_EXECUTABLE}" "" "$INSTDIR\images\bf_icon.ico" "0" "" "" ""
 
     # include in add/remove programs
     WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -106,10 +106,13 @@ function getInputPlatforms() {
     for (var i = 3; i < process.argv.length; i++) {
         var arg = process.argv[i].match(regEx)[1];
         if (supportedPlatforms.indexOf(arg) > -1) {
-             platforms.push(arg);
+            platforms.push(arg);
+        } else if (arg == 'nowinicon') {
+            console.log('ignoring winIco')
+            delete nwBuilderOptions['winIco'];
         } else {
-             console.log('Unknown platform: ' + arg);
-             process.exit();
+            console.log('Unknown platform: ' + arg);
+            process.exit();
         }
     }
 


### PR DESCRIPTION
Example use:
yarn run gulp release --win64 --nowinicon


Since [nsis](https://www.npmjs.com/package/makensis) is available natively on linux and macOS, this makes it possible to generate a windows release from those platforms

`src/images/bf_icon.ico` is shipped, using that as the icon for the shortcuts.

This probably should get documented somewhere as well. Since we're not shipping the SDK version of nw.js end users shouldn't see the NW.js icon.