### PR TITLE
get rid of superfluous notification

### DIFF
--- a/src/js/eventPage.js
+++ b/src/js/eventPage.js
@@ -82,49 +82,6 @@ function startApplication() {
 
 chrome.app.runtime.onLaunched.addListener(startApplication);
 
-chrome.runtime.onInstalled.addListener(function (details) {
-    if (details.reason == 'update') {
-        var previousVersionArr = details.previousVersion.split('.'),
-            currentVersionArr = getManifestVersion().split('.');
-
-        // only fire up notification sequence when one of the major version numbers changed
-        if (currentVersionArr[0] > previousVersionArr[0] || currentVersionArr[1] > previousVersionArr[1]) {
-            var manifest = chrome.runtime.getManifest();
-            var options = {
-                priority: 0,
-                type: 'basic',
-                title: manifest.name,
-                message: chrome.i18n.getMessage('notifications_app_just_updated_to_version', [getManifestVersion(manifest)]),
-                iconUrl: '/images/icon_128.png',
-                buttons: [{'title': chrome.i18n.getMessage('notifications_click_here_to_start_app')}]
-            };
-
-            chrome.notifications.create('baseflight_update', options, function (notificationId) {
-                // empty
-            });
-        }
-    }
-});
-
-chrome.notifications.onButtonClicked.addListener(function (notificationId, buttonIndex) {
-    if (notificationId == 'baseflight_update') {
-        startApplication();
-    }
-});
-
-function getManifestVersion(manifest) {
-    if (!manifest) {
-        manifest = chrome.runtime.getManifest();
-    }
-
-    var version = manifest.version_name;
-    if (!version) {
-        version = manifest.version;
-    }
-
-    return version;
-}
-
 function getChromeVersion () {     
     var raw = navigator.userAgent.match(/Chrom(e|ium)\/([0-9]+)\./);
 


### PR DESCRIPTION
With idea of proofreading english via the translation site, this is kind of the only thing that could run into trouble. 

To get this notification to show, a user would have to be running the configurator from the "Chrome Web Store" on a Chromebook. I feel that its not worth maintaining.