### PR TITLE
Fix iterm cutoff showing when iterm relax disabled

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -351,7 +351,6 @@ TABS.pid_tuning.initialize = function (callback) {
 
         if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
             $('.smartfeedforward').hide();
-            $('.itermRelaxCutoff').show();
 
             if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
                 $('.dynamicNotch').show();


### PR DESCRIPTION
Iterm cutoff would show even when iterm relax is disabled. Introduced in #1564