### PR TITLE
Replace legacy firmware reboot sequence with MSP based sequence.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -217,6 +217,12 @@
     "deviceRebooting": {
         "message": "Device - <span class=\"message-negative\">Rebooting</span>"
     },
+    "deviceRebooting_flashBootloader": {
+        "message": "Device - <span class=\"message-negative\">Rebooting to FLASH BOOTLOADER</span>"
+    },
+    "deviceRebooting_romBootloader": {
+        "message": "Device - <span class=\"message-negative\">Rebooting to ROM BOOTLOADER</span>"
+    },
     "deviceReady": {
         "message": "Device - <span class=\"message-positive\">Ready</span>"
     },
@@ -369,6 +375,12 @@
     },
     "stm32UsbDfuNotFound": {
         "message": "USB DFU not found"
+    },
+    "stm32RebootingToBootloader": {
+        "message": "Initiating reboot to bootloader ..."
+    },
+    "stm32RebootingToBootloaderFailed": {
+        "message": "Rebooting device to bootloader: FAILED"
     },
     "stm32TimedOut": {
         "message": "STM32 - timed out, programming: FAILED"

--- a/src/js/msp/MSPConnector.js
+++ b/src/js/msp/MSPConnector.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var MSPConnectorImpl = function () {
+    this.baud = undefined;
+    this.port = undefined;
+    this.onConnectCallback = undefined;
+    this.onTimeoutCallback = undefined;
+    this.onDisconnectCallback = undefined;
+};
+
+MSPConnectorImpl.prototype.connect = function (port, baud, onConnectCallback, onTimeoutCallback, onFailureCallback) {
+
+    var self = this;
+    self.port = port;
+    self.baud = baud;
+    self.onConnectCallback = onConnectCallback;
+    self.onTimeoutCallback = onTimeoutCallback;
+    self.onFailureCallback = onFailureCallback;
+
+    serial.connect(self.port, {bitrate: self.baud}, function (openInfo) {
+        if (openInfo) {
+            var disconnectAndCleanup = function() {
+                serial.disconnect(function(result) {
+                    console.log('Disconnected');
+                    
+                    MSP.clearListeners();
+                    
+                    self.onTimeoutCallback();
+                });
+                
+                MSP.disconnect_cleanup();
+            };
+            
+            FC.resetState();
+            
+            // disconnect after 10 seconds with error if we don't get IDENT data
+            GUI.timeout_add('msp_connector', function () {
+                if (!CONFIGURATOR.connectionValid) {
+                    GUI.log(i18n.getMessage('noConfigurationReceived'));
+                    
+                    disconnectAndCleanup();
+                }
+            }, 10000);
+
+            serial.onReceive.addListener(read_serial);
+            
+            MSP.listen(update_packet_error);
+            mspHelper = new MspHelper();
+            MSP.listen(mspHelper.process_data.bind(mspHelper));
+            
+            MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
+                CONFIGURATOR.connectionValid = true;
+
+                GUI.timeout_remove('msp_connector');
+                console.log('Connected');
+
+                self.onConnectCallback();
+            });
+        } else {
+            GUI.log(i18n.getMessage('serialPortOpenFail'));
+            self.onFailureCallback();
+        }
+    });
+};
+
+MSPConnectorImpl.prototype.disconnect = function(onDisconnectCallback) {
+    self.onDisconnectCallback = onDisconnectCallback;
+    
+    serial.disconnect(function (result) {
+        MSP.clearListeners();
+        console.log('Disconnected');
+        
+        self.onDisconnectCallback(result);
+    });
+    
+    MSP.disconnect_cleanup();
+};
+

--- a/src/main.html
+++ b/src/main.html
@@ -125,6 +125,7 @@
     <script type="text/javascript" src="./js/model.js"></script>
     <script type="text/javascript" src="./js/serial_backend.js"></script>
     <script type="text/javascript" src="./js/msp/MSPCodes.js"></script>
+    <script type="text/javascript" src="./js/msp/MSPConnector.js"></script>
     <script type="text/javascript" src="./js/msp.js"></script>
     <script type="text/javascript" src="./js/msp/MSPHelper.js"></script>
     <script type="text/javascript" src="./js/backup_restore.js"></script>


### PR DESCRIPTION
This allows two things:
1. good user experience when flashing devices that use FLASH bootloaders.  previously users would have to use `bl flash` or enter flash bootloader manually.
2. arbitrary setting of cli reboot character without breaking ability to reboot flash via configurator.

Tested on SPRacingH7EXTREME and another VCP based target.