### PR TITLE
Small bug fixes

### DIFF
--- a/src/js/ConfigStorage.js
+++ b/src/js/ConfigStorage.js
@@ -42,7 +42,9 @@ var ConfigStorage = {
       } else {
         //console.log('Abstraction.set',input);
         Object.keys(input).forEach(function (element) {
-            window.localStorage.setItem(element, JSON.stringify(input));
+            var tmpObj = {};
+            tmpObj[element] = input[element];
+            window.localStorage.setItem(element, JSON.stringify(tmpObj));
         });
       }
     }

--- a/src/js/FirmwareCache.js
+++ b/src/js/FirmwareCache.js
@@ -112,6 +112,9 @@ let FirmwareCache = (function () {
      * @returns {boolean}
      */
     function has(release) {
+        if (!release) {
+            return false;
+        }
         if (!journalLoaded) {
             console.warn("Cache not yet loaded");
             return false;

--- a/src/js/jenkins_loader.js
+++ b/src/js/jenkins_loader.js
@@ -104,9 +104,10 @@ JenkinsLoader.prototype.loadBuilds = function (jobName, callback) {
                 chrome.storage.local.set(object);
 
                 self._parseBuilds(jobUrl, jobName, builds, callback);
-            }).error(xhr => {
+            }).fail(xhr => {
                 GUI.log(i18n.getMessage('buildServerLoadFailed', [jobName, `HTTP ${xhr.status}`]));
-            }).fail(cachedCallback);
+                cachedCallback();
+            });
         } else {
             cachedCallback();
         }


### PR DESCRIPTION
Cleaning up some errors in the javascript console before I start adding new ones.

src/js/ConfigStorage.js: forgot to test writing multiple keys at once, can now write multiple keys at once.
src/js/FirmwareCache.js: avoid throwing an error if someone comes asking for an undefined firmware
src/js/jenkins_loader.js: same .error deprecation as #1568

- [ ] `src/js/port_handler.js` should use ConfigStorage