### PR TITLE
Improve PID Tuning tab style and layout

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1452,7 +1452,7 @@
     },
     "pidTuningAntiGravityMode": {
         "message": "Mode",
-        "description": "One of the modes of anti gravity"
+        "description": "Anti Gravity mode selection parameter"
     },
     "pidTuningAntiGravityModeOptionSmooth": {
         "message": "Smooth",
@@ -1486,7 +1486,7 @@
        "description": "Advance of the D Min feature"
     },
     "pidTuningDMinHelp": {
-        "message": "Gain adjusts how fast D min gets up to its maximum value and is based on gyro to determine sharp moves and propwash events. Advance makes D min go up earlier by using setpoint instead of gyro to determine sharp moves.",
+        "message": "D Min provides a way to have a lower level of D in normal flight and a higher level for quick maneuvers that might cause overshoot, like flips and rolls. It also brings D up during prop wash. Gain adjusts how fast D gets up to its maximum value and is based on gyro to determine sharp moves and propwash events. Advance makes D go up earlier by using setpoint instead of gyro to determine sharp moves.",
         "description": "D Min feature helpicon message"
     },
     "pidTuningPidSettings": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1478,7 +1478,7 @@
         "description": "Table header of the D Min feature in the PIDs tab" 
     },
     "pidTuningDMinDisabledNote": {
-        "message": "<strong>Note:</strong> D Min feature is disabled and its paramaters are hidden. To use D Min please enable it in $t(pidTuningPidSettings.message)."
+        "message": "<strong>Note:</strong> D Min feature is disabled and its parameters are hidden. To use D Min please enable it in $t(pidTuningPidSettings.message)."
     },
     "pidTuningDMinGain": {
        "message": "Gain",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1475,7 +1475,10 @@
     },
     "pidTuningDMin": {
         "message": "D Min",
-       "description": "Table header of the D Min feature in the PIDs tab" 
+        "description": "Table header of the D Min feature in the PIDs tab" 
+    },
+    "pidTuningDMinDisabledNote": {
+        "message": "<strong>Note:</strong> D Min feature is disabled and its paramaters are hidden. To use D Min please enable it in $t(pidTuningPidSettings.message)."
     },
     "pidTuningDMinGain": {
        "message": "Gain",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1429,7 +1429,10 @@
         "message": "<span class=\"message-negative\">Changing PID controller disabled - you can change it via the CLI.</span>  You have firmware with API version <span class=\"message-negative\">$1</span>, but this functionality requires <span class=\"message-positive\">$2</span>."
     },
     "pidTuningSubTabPid": {
-        "message": "PID Settings"
+        "message": "PID Profile Settings"
+    },
+    "pidTuningSubTabRates": {
+        "message": "Rateprofile Settings"
     },
     "pidTuningSubTabFilter": {
         "message": "Filter Settings"
@@ -1444,8 +1447,12 @@
         "message": "Profile independent PID Controller Settings"
     },
 
+    "pidTuningAntiGravity": {
+        "message": "Anti Gravity"
+    },
     "pidTuningAntiGravityMode": {
-        "message": "Anti Gravity Mode"
+        "message": "Mode",
+        "description": "One of the modes of anti gravity"
     },
     "pidTuningAntiGravityModeOptionSmooth": {
         "message": "Smooth",
@@ -1456,30 +1463,19 @@
         "description": "One of the modes of anti gravity"
     },
     "pidTuningAntiGravityGain": {
-        "message": "Anti Gravity Gain"
+        "message": "Gain",
+        "description": "Anti Gravity Gain Parameter"
     },
     "pidTuningAntiGravityThres": {
-        "message": "Anti Gravity Threshold"
+        "message": "Threshold",
+        "description": "Anti Gravity Threshold Parameter"
     },
-    "pidTuningDMinHelp": {
-        "message": "D Min provides a way to have a lower level of D in normal flight and a higher level for quick manoeuvres that might cause overshoot, like flips and rolls. It also brings D up during prop wash. The craft will have a dynamic D Term varying from D Min (under normal flight) to the standard D (under fast roll and flips). A value of zero will disable the feature. The Gain determines how strongly D is boosted during quick stick inputs. The Advance speeds up of onset of the boost effect. This can be helpful if you have overshoot with very high rate flips on very responsive quads.",
-        "description": "Help message for D Min feature"
+    "pidTuningAntiGravityHelp": {
+        "message": "Anti Gravity boosts the I term when fast throttle changes are detected. Higher gain values provide stability and better attitude hold when you pump the throttle."
     },
     "pidTuningDMin": {
         "message": "D Min",
        "description": "Table header of the D Min feature in the PIDs tab" 
-    },
-    "pidTuningDMinRoll": {
-       "message": "Roll",
-       "description": "Axis to apply D Min feature" 
-    },
-    "pidTuningDMinPitch": {
-       "message": "Pitch",
-       "description": "Axis to apply D Min feature"
-    },
-    "pidTuningDMinYaw": {
-       "message": "Yaw",
-       "description": "Axis to apply D Min feature"
     },
     "pidTuningDMinGain": {
        "message": "Gain",
@@ -1487,9 +1483,12 @@
     },
     "pidTuningDMinAdvance": {
        "message": "Advance",
-       "description": "Advane of the D Min feature"
+       "description": "Advance of the D Min feature"
     },
-
+    "pidTuningDMinHelp": {
+        "message": "Gain adjusts how fast D min gets up to its maximum value and is based on gyro to determine sharp moves and propwash events. Advance makes D min go up earlier by using setpoint instead of gyro to determine sharp moves.",
+        "description": "D Min feature helpicon message"
+    },
     "pidTuningPidSettings": {
         "message": "PID Controller Settings"
     },
@@ -1631,6 +1630,9 @@
     "pidTuningRatesPreview": {
         "message": "Rates Preview"
     },
+    "pidTuningRatesTuningHelp": {
+        "message": "<b>Rates and Expo</b>: Determine your stick feel based on these parameters. Use the graph and live 3D model to find your favourite rate setting."
+    },
     "pidTuningRcExpo": {
         "message": "RC Expo"
     },
@@ -1639,6 +1641,9 @@
     },
     "pidTuningTPABreakPoint": {
         "message": "TPA Breakpoint"
+    },
+    "pidTuningThrottleCurvePreview": {
+        "message": "Throttle Curve Preview"
     },
     "pidTuningThrottleLimitType": {
         "message": "Throttle Limit"
@@ -3226,7 +3231,8 @@
         "message": "Limits the accumulation of I Term when fast movements happen. This helps specially to reduce the bounceback at the end of rolls and other fast movements. You can choose the axes in which this is active, and if the fast movement is detectd using the Gyro or the Setpoint (stick)."
     },
     "pidTuningItermRelaxAxes": {
-        "message": "Axes:"
+        "message": "Axes",
+        "description": "Iterm Relax Axes selection"
     },
     "pidTuningItermRelaxAxesOptionRP": {
         "message": "RP"
@@ -3241,7 +3247,8 @@
         "message": "RPY (increment only)"
     },
     "pidTuningItermRelaxType": {
-        "message": "Type:"
+        "message": "Type",
+        "description": "Iterm Relax Type selection"
     },
     "pidTuningItermRelaxTypeOptionGyro": {
         "message": "Gyro"
@@ -3250,7 +3257,8 @@
         "message": "Setpoint"
     },
     "pidTuningItermRelaxCutoff": {
-        "message": "Cutoff:"
+        "message": "Cutoff",
+        "description": "Cutoff value of the I Term Relax"
     },
     "pidTuningAbsoluteControlGain": {
         "message": "Absolute Control"
@@ -4819,6 +4827,13 @@
     "pidTuningRateProfileTip": {
         "message": "Up to 3 different rateprofiles per profile can be stored on the flight controller. The rateprofiles include the settings for 'RC Rate', 'Rate', 'RC Expo', 'Throttle', and 'TPA'. Switching between rateprofiles is possible in-flight, by setting up a 3 position switch for 'Rate Profile Selection' on the 'Adjustments' tab."
     },
+    "pidTuningRateSetup": {
+        "message": "Basic/Acro Rates"
+    },
+    "pidTuningRateSetupHelp": {
+        "message": "Adjust these values to set your rates. Use RC Rate to increase maximum rate overall, use Super Rate to have higher rates at the end of the stick travel, use RC Expo to make the middle stick feel smooth.",
+        "description": "Rate table helpicon message"
+    },
     "pidTuningDelta": {
         "message": "Derivative Method"
     },
@@ -4838,10 +4853,13 @@
         "message": "<b>Gyro Soft Filter:</b> Lowpass filter for gyro. Use lower value for more filtering.<br><b>D Term Filter:</b> Lowpass filter for Dterm. Can affect D tuning. Use lower value for more filtering. <br><b>Yaw Filter:</b> Filters yaw output. It can help on setups with noisy yaw axis."
     },
     "pidTuningPidTuningTip": {
-        "message": "<b>Proportional:</b> You will notice a very strong resistant force to any attempts to move the MultiRotor<br><b>Integral:</b> Increase the ability to hold overall initial position and reduce drift, but also increase the delay in returning to initial position.<br><b>Derivative:</b> Improves the speed at which deviations are recovered, but increases noise<br><b>Rates and Expo</b>: Determine your stick feel based on these parameters. Use the graph and live 3D model to find your favourite rate setting"
+        "message": "<b>Proportional:</b> You will notice a very strong resistant force to any attempts to move the MultiRotor<br><b>Integral:</b> Increase the ability to hold overall initial position and reduce drift, but also increase the delay in returning to initial position.<br><b>Derivative:</b> Improves the speed at which deviations are recovered, but increases noise."
     },
     "pidTuningPidTuningTipFeedforward": {
-        "message": "<b>Proportional:</b> You will notice a very strong resistant force to any attempts to move the MultiRotor<br><b>Integral:</b> Increase the ability to hold overall initial position and reduce drift, but also increase the delay in returning to initial position.<br><b>Derivative:</b> Improves the speed at which deviations are recovered, but increases noise<br><b>Feedforward:</b> Usually the PID controller reacts to the error. The Feedforward anticipates the error based on the stick input, giving responsiveness to the quad.<br><b>Rates and Expo</b>: Determine your stick feel based on these parameters. Use the graph and live 3D model to find your favourite rate setting"
+        "message": "<b>Proportional:</b> You will notice a very strong resistant force to any attempts to move the MultiRotor<br><b>Integral:</b> Increase the ability to hold overall initial position and reduce drift, but also increase the delay in returning to initial position.<br><b>Derivative:</b> Improves the speed at which deviations are recovered, but increases noise<br><b>Feedforward:</b> Usually the PID controller reacts to the error. The Feedforward anticipates the error based on the stick input, giving responsiveness to the quad."
+    },
+    "pidTuningPidTuningTipDMin": {
+        "message": "<b>Proportional:</b> You will notice a very strong resistant force to any attempts to move the MultiRotor<br><b>Integral:</b> Increase the ability to hold overall initial position and reduce drift, but also increase the delay in returning to initial position.<br><b>Derivative:</b> Improves the speed at which deviations are recovered, but increases noise<br><b>Feedforward:</b> Usually the PID controller reacts to the error. The Feedforward anticipates the error based on the stick input, giving responsiveness to the quad.<br><b>D Min:</b> D Min provides a way to have a lower level of D in normal flight and a higher level for quick maneuvers that might cause overshoot, like flips and rolls. It also brings D up during prop wash. A value of zero will disable the feature."
     },
     "pidTuningRatesTip": {
         "message": "Play with the rates and see how those affect the stick curve"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1673,7 +1673,7 @@
         "message": "Frequency"
     },
     "pidTuningRatesCurve": {
-        "message": "Rates"
+        "message": "Rates Preview"
     },
     "throttle": {
         "message": "Throttle"

--- a/src/css/tabs-dark/pid_tuning-dark.css
+++ b/src/css/tabs-dark/pid_tuning-dark.css
@@ -40,10 +40,6 @@
     color: white;
 }
 
-.tab-pid_tuning .throttle_curve {
-    border: 1px solid #9c9c9c;
-}
-
 .tab-pid_tuning .throttle table th {
     border-right: 1px solid #9c9c9c;
 }
@@ -64,14 +60,6 @@
     border: 1px solid #9c9c9c;
     background-color: #3a3a3a;
     color: white;
-}
-
-.tab-pid_tuning .rc_curve th {
-    border-bottom: 1px solid #00000000;
-}
-
-.tab-pid_tuning .rate_curve {
-    border: 1px solid #9c9c9c;
 }
 
 .tab-pid_tuning table, .tab-pid_tuning table td {
@@ -210,20 +198,8 @@
     border: 1px solid #9c9c9c;
 }
 
-.tab-pid_tuning .rates_preview {
-    border: 1px solid #9c9c9c;
-}
-
 .tab-pid_tuning .pidTuning tr {
     border-bottom: 1px solid #9c9c9c;
-}
-
-.tab-pid_tuning .rc_curve .cf tr  {
-    border-bottom: 1px solid #9c9c9c;
-}
-
-.tab-pid_tuning .rc_curve_bg {
-    background: #393b3a;
 }
 
 .tabarea {

--- a/src/css/tabs-dark/pid_tuning-dark.css
+++ b/src/css/tabs-dark/pid_tuning-dark.css
@@ -19,7 +19,7 @@
 }
 
 .tab-pid_tuning .cf tr {
-    background-color: #393b3a;
+    background-color: #414443;
 }
 
 .tab-pid_tuning .cf th {
@@ -49,17 +49,15 @@
 }
 
 .tab-pid_tuning .throttle table td {
-    background: #414443;
     border-right: 1px solid #9c9c9c;
 }
 
 .tab-pid_tuning .throttle table td {
-    background: #414443;
     border-right: 1px solid #9c9c9c;
 }
 
 .tab-pid_tuning .throttle table tr:nth-child(odd) {
-    background-color: #393b3a;
+    background-color: #414443;
 }
 
 .tab-pid_tuning .throttle table input {
@@ -104,12 +102,13 @@
 }
 
 .tab-pid_tuning table input,.inputBackground {
-    border: 0px solid #9c9c9c;
+    border: 1px solid #9c9c9c;
     background-color: #3a3a3a;
     color: white;
 }
 
 .tab-pid_tuning table select {
+    border: 1px solid #9c9c9c;
     text-align-last: right;
     background-color: #3a3a3a;
     color: white;
@@ -161,8 +160,8 @@
 
 
 .pid_mode {
-    background-color: #1f1f1f;
-    border-bottom: 1px solid #1f1f1f;
+    background-color: #3c3c3c;
+    border-bottom: 1px solid #3c3c3c;
     color: white;
 }
 
@@ -244,4 +243,16 @@
 
 .tab-pid_tuning dialog select {
     border: 1px solid #9c9c9c;
+}
+
+.tab-pid_tuning input:disabled,
+.tab-pid_tuning .cf input:disabled,
+.tab-pid_tuning select:disabled,
+.tab-pid_tuning .cf select:disabled {
+    color: rgb(105, 105, 105);
+    background-color: #2d2d2d;
+}
+
+.tab-pid_tuning table.compensation tr {
+    border-bottom: 1px solid #6b6b6b;
 }

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -47,8 +47,6 @@
 .tab-pid_tuning .throttle_curve {
     float: right;
     width: 100%;
-    border: 1px solid silver;
-    border-radius: 3px;
     background-image: var(--paper);
     background-size: 200%;
     background-position: center;
@@ -60,34 +58,10 @@
     margin-right: 10px;
 }
 
-.tab-pid_tuning .rc_curve {
-    float: right;
-}
-
-.tab-pid_tuning .rc_curve th {
-    background-color: var(--quietHeader);
-    padding: 4px;
-    border-left: 0px solid #ccc;
-    border-bottom: 1px solid #ccc;
-    font-weight: bold;
-    color: var(--quietText);
-    text-align: left;
-}
-
-.tab-pid_tuning .rc_curve th:first-child {
-    border-top-left-radius: 3px;
-}
-
-.tab-pid_tuning .rc_curve th:last-child {
-    border-top-right-radius: 3px;
-}
-
 .tab-pid_tuning .rate_curve {
     height: 100%;
-    min-height: 230px;
+    min-height: 234px;
     min-width: 200px;
-    border: 1px solid silver;
-    border-radius: 3px;
     background-image: var(--paper);
     background-size: 200%;
     background-position: center;
@@ -427,7 +401,7 @@
 }
 
 .tab-pid_tuning .cf .throttleCurvePreview {
-    padding: 0 0 0 2px;
+    padding: 0px;
 }
 
 .pid_roll {
@@ -655,9 +629,6 @@
     background-image: var(--paper);
     background-size: 100%;
     background-position: center;
-    border: 1px solid silver;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
 }
 
 .tab-pid_tuning .pidTuning td {
@@ -693,23 +664,13 @@
     border-bottom-right-radius: 0px;
 }
 
-.tab-pid_tuning .rc_curve .cf tr  {
-    border-bottom: 1px solid silver;
-}
-
 .tab-pid_tuning .rc_curve .cf tr td {
-    border: none;
-    border-bottom-right-radius: 0px;
-    border-bottom-left-radius: 0px;
     padding: 0px;
 }
 
 .tab-pid_tuning .rc_curve_bg {
     float: left;
-    background: #ddd;
-    border-bottom-left-radius: 5px;
-    border-bottom-right-radius: 5px;
-    }
+}
 
 .tab-pid_tuning .new_rates_last-child {
     border-bottom: none;

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -1,21 +1,3 @@
-.tab-pid_tuning .tpa th {
-    background-color: #828885;
-    padding: 4px;
-    border-bottom: 1px solid #ccc;
-    font-weight: bold;
-    color: white;
-    text-align: left;
-}
-
-.tab-pid_tuning .throttle_limit th {
-    background-color: #828885;
-    padding: 4px;
-    border-bottom: 1px solid #ccc;
-    font-weight: bold;
-    color: white;
-    text-align: left;
-}
-
 .tab-pid_tuning .cf tr {
     background-color: #DEDEDE;
 }
@@ -24,10 +6,19 @@
     border-right: solid 1px silver;
     height: 19px;
     font-weight: normal;
+    padding: 4px;
+    color:white;
+    text-align: left;
+    background: var(--quietHeader);
+}
+
+.tab-pid_tuning .cf th:first-child {
+    border-top-left-radius: 3px;
 }
 
 .tab-pid_tuning .cf th:last-child {
     border-right: 0px;
+    border-top-right-radius: 3px;
 }
 
 .tab-pid_tuning .cf td:first-child {
@@ -53,126 +44,24 @@
     border: 1px solid silver;
 }
 
-.tab-pid_tuning .curves {
-    float: left;
-    margin-right: 10px;
-}
-
 .tab-pid_tuning .throttle_curve {
     float: right;
-    width: calc(100% - 2px); /* - ( "virtual" margin) */
-    margin: 0 2px 0px 0;
+    width: 100%;
     border: 1px solid silver;
     border-radius: 3px;
     background-image: var(--paper);
     background-size: 200%;
     background-position: center;
+    height: 164px;
 }
 
-.tab-pid_tuning .throttle {
-    float: right;
-    width: 45%;
-}
-
-.tab-pid_tuning .throttle table {
-    border-collapse: collapse;
-    width: calc(100% - 2px);
-}
-
-.tab-pid_tuning .throttle table, .tab-pid_tuning .throttle table th, .tab-pid_tuning .throttle table td {
-    padding: 4px;
-    text-align: left;
-    padding-left: 6px;
-}
-
-.tab-pid_tuning .throttle table th {
-    background: var(--quietHeader);
-    color: var(--quietText);
-    border-right: 1px solid silver;
-    font-weight: normal;
-}
-
-.tab-pid_tuning .throttle table th:first-child {
-    border-top-left-radius: 3px;
-}
-
-.tab-pid_tuning .throttle table th:last-child {
-    border-top-right-radius: 3px;
-    border-right: 0px;
-}
-
-.tab-pid_tuning .throttle table td {
-    background: #DEDEDE;
-    border-right: 1px solid silver;
-    padding: 1px;
-}
-
-.tab-pid_tuning .throttle table td:first-child {
-    border-bottom-left-radius: 3px;
-}
-
-.tab-pid_tuning .throttle table td:last-child {
-    border-bottom-right-radius: 3px;
-    border-right: 0px;
-}
-
-.tab-pid_tuning .throttle {
-    float: right;
-    width: 45%;
-}
-
-.tab-pid_tuning .throttle table {
-    border-collapse: collapse;
-    width: calc(100% - 2px);
-}
-
-.tab-pid_tuning .throttle table, .tab-pid_tuning .throttle table th, .tab-pid_tuning .throttle table td {
-    padding: 4px;
-    text-align: left;
-    padding-left: 6px;
-}
-
-.tab-pid_tuning .throttle table tr:nth-child(odd) {
-    background-color: #ececec;
-}
-
-.tab-pid_tuning .throttle table input {
-    width: calc(100% - 8px);
-    border: 1px solid silver;
-    border-radius: 3px;
-    height: 20px;
-    margin: 3px;
-    line-height: 20px;
-    text-align: right;
-}
-
-.tab-pid_tuning .tpa th:nth-child(2) {
-    border-top-left-radius: 3px;
-}
-
-.tab-pid_tuning .tpa th:first-child {
-    border-top-left-radius: 3px;
-}
-
-.tab-pid_tuning .tpa th:last-child {
-    border-top-right-radius: 3px;
-}
-
-.tab-pid_tuning .throttle_limit th:nth-child(2) {
-    border-top-left-radius: 3px;
-}
-
-.tab-pid_tuning .throttle_limit th:first-child {
-    border-top-left-radius: 3px;
-}
-
-.tab-pid_tuning .throttle_limit th:last-child {
-    border-top-right-radius: 3px;
+.tab-pid_tuning .curves {
+    float: left;
+    margin-right: 10px;
 }
 
 .tab-pid_tuning .rc_curve {
     float: right;
-    width: calc(100% - 2px); /* - ( "virtual" margin) */
 }
 
 .tab-pid_tuning .rc_curve th {
@@ -194,9 +83,8 @@
 }
 
 .tab-pid_tuning .rate_curve {
-    margin: 0 4px 0px 0;
     height: 100%;
-    min-height: 250px;
+    min-height: 230px;
     min-width: 200px;
     border: 1px solid silver;
     border-radius: 3px;
@@ -218,7 +106,12 @@
 }
 
 .tab-pid_tuning .gui_box {
-    margin-bottom: 0px;
+    margin-bottom: 5px;
+    display: table;
+}
+
+.tab-pid_tuning .subtab-filter .gui_box {
+    float: none;
 }
 
 .tab-pid_tuning table .inputBackground {
@@ -247,10 +140,12 @@
 
 .tab-pid_tuning .pid_titlebar th:first-child {
     text-align: left;
+    border-top-left-radius: 3px;
 }
 
 .tab-pid_tuning .pid_titlebar th:last-child {
     border-right: none;
+    border-top-right-radius: 3px;
 }
 
 .tab-pid_tuning table tr td:first-child {
@@ -279,40 +174,57 @@
 }
 
 .tab-pid_tuning table.compensation tr {
-    height: 25px;
+    height: 30px;
+    border-bottom: 1px solid #ccc;
+}
+
+.tab-pid_tuning table.compensation tr:last-child {
+    border-bottom: none;
 }
 
 .tab-pid_tuning table.compensation td {
-    width: 60%;
     padding-left: 5px;
     padding-right: 5px;
 }
 
 .tab-pid_tuning table.compensation td:first-child {
-    width: 10%;
-    text-align: right;
+    width: 65px;
+    text-align: center;
+    vertical-align: top;
+    padding-top: 4px;
 }
 
 .tab-pid_tuning table.compensation td:last-child {
-    width: 30%;
+    width: 100%;
+}
+
+.tab-pid_tuning table.compensation .helpicon {
+    margin-top: 3px
 }
 
 .tab-pid_tuning table.compensation .suboption {
-    margin-left: 4%;
-    white-space: nowrap;
+    margin-left: 2%;
+    display: flex;
+    flex-flow: row wrap-reverse;
+    align-items: center;
+    padding-bottom: 2px;
 }
 
-.tab-pid_tuning table.compensation .suboption select{
-    text-align-last: left;
+.tab-pid_tuning table.compensation .suboption select {
+    width: 80px;
+    text-align-last: right;
     font-size: 1.1em;
     color: darkslategrey;
-    padding-left: 5px;
+    box-sizing: border-box;
 }
 
-.tab-pid_tuning table.compensation .suboption input{
-    display: inline-block;
-    width: 45px;
-    padding-left: 5px;
+.tab-pid_tuning table.compensation .suboption input {
+    width: 80px;
+    box-sizing: border-box;
+}
+
+.tab-pid_tuning table.compensation .suboption label {
+    margin-left: 5px;
 }
 
 .tab-pid_tuning .pidTuningFeatures td {
@@ -362,18 +274,21 @@
     height: 20px;
     line-height: 20px;
     text-align: right;
-    border: 0px solid #ccc;
-    border-radius: 0px;
+    border: 1px solid #ccc;
+    border-radius: 3px;
 }
 
-.tab-pid_tuning .subtab-filter table input {
+.tab-pid_tuning .subtab-filter table input,
+.tab-pid_tuning .subtab-filter table select {
     width: 77px;
     float: right;
+    box-sizing: border-box;
 }
 
 .tab-pid_tuning table select {
-    width: 77px;
     text-align-last: right;
+    border-radius: 3px;
+    border: 1px solid #ccc;
 }
 
 .tab-pid_tuning .tab_container {
@@ -393,12 +308,10 @@
 
 .tab-pid_tuning .tab_container td:first-child {
     border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
 }
 
 .tab-pid_tuning .tab_container td:last-child {
     border-top-right-radius: 5px;
-    border-top-left-radius: 5px;
     background-color: #2e2e2e;
 }
 
@@ -441,17 +354,7 @@
 }
 
 .tab-pid_tuning .new_rates {
-    text-align: left;
-}
-
-.tab-pid_tuning .tpa {
-    float: right;
-    width: calc(100% - 2px); /* - ( "virtual" margin) */
-}
-
-.tab-pid_tuning .throttle_limit {
-    float: right;
-    width: calc(100% - 2px); /* - ( "virtual" margin) */
+    text-align: center;
 }
 
 .tab-pid_tuning .top-buttons {
@@ -507,12 +410,24 @@
     float: left;
 }
 
+.tab-pid_tuning .pid_mode .helpicon {
+    margin-top: 0px;
+}
+
 .tab-pid_tuning .pid_titlebar {
     color: #fff;
     background-color: var(--quietHeader);
     border-top-left-radius: 3px;
     border-top-right-radius: 3px;
     height: 20px;
+}
+
+.tab-pid_tuning .pid_titlebar.needed_by_LEVEL {
+    border-radius: 0px;
+}
+
+.tab-pid_tuning .cf .throttleCurvePreview {
+    padding: 0 0 0 2px;
 }
 
 .pid_roll {
@@ -562,7 +477,7 @@
 }
 
 .tab-pid_tuning .spacer_left {
-    padding-left: 15px;
+    padding-left: 0px;
     float: right;
     width: calc(100% - 20px)
 }
@@ -637,10 +552,6 @@
     padding-left: 0px;
 }
 
-.tab-pid_tuning .tpa-breakpoint {
-    border-top-left-radius: 0px;
-}
-
 .tab-pid_tuning .roll {
     border-bottom-left-radius: 3px;
 }
@@ -661,7 +572,7 @@
 }
 
 .tab-pid_tuning .topspacer {
-    margin-top:15px;
+    margin-top: 5px;
 }
 
 .tab-pid_tuning .bottomarea {
@@ -675,6 +586,7 @@
     padding-top: 5px;
     padding-bottom: 5px;
     background-color: #f9f9f9;
+    height: 20px;
 }
 
 .tab-pid_tuning .profile {
@@ -731,7 +643,7 @@
 .tab-pid_tuning .rates_preview_cell {
     position: relative;
     width: 100%;
-    height: 320px;
+    height: 362px;
 }
 
 .tab-pid_tuning .rates_preview {
@@ -744,7 +656,6 @@
     background-size: 100%;
     background-position: center;
     border: 1px solid silver;
-    margin-top: -1px;
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
 }
@@ -770,7 +681,7 @@
 }
 
 .tab-pid_tuning .pidTuning td {
-width: 40%;
+    width: 40%;
 }
 
 .tab-pid_tuning .new_rates td:first-child {
@@ -790,7 +701,7 @@ width: 40%;
     border: none;
     border-bottom-right-radius: 0px;
     border-bottom-left-radius: 0px;
-    padding-bottom: 3px;
+    padding: 0px;
 }
 
 .tab-pid_tuning .rc_curve_bg {
@@ -905,4 +816,36 @@ width: 40%;
     border: 1px solid silver;
     margin-left: 5px;
     width: 120px;
+}
+
+.tab-pid_tuning .subtab-rates {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: flex-start;
+    justify-content: center;
+}
+
+.tab-pid_tuning .subtab-rates .cf_column {
+    min-width: 380px;
+    flex: 1;
+}
+
+.tab-pid_tuning .subtab-pid {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: flex-start;
+    justify-content: center;
+}
+
+.tab-pid_tuning .subtab-pid .cf_column {
+    min-width: 500px;
+    flex: 1;
+}
+
+.tab-pid_tuning table.filterTable {
+    table-layout: auto;
+}
+
+.tab-pid_tuning table.filterTable td:first-child {
+    width: 25%;
 }

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -803,6 +803,10 @@
     flex: 1;
 }
 
+.tab-pid_tuning .subtab-pid .note {
+    flex: 0 0 100%;
+}
+
 .tab-pid_tuning table.filterTable {
     table-layout: auto;
 }

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -799,7 +799,7 @@
 }
 
 .tab-pid_tuning .subtab-pid .cf_column {
-    min-width: 500px;
+    min-width: 470px;
     flex: 1;
 }
 
@@ -813,4 +813,18 @@
 
 .tab-pid_tuning table.filterTable td:first-child {
     width: 25%;
+}
+
+@media only screen and (max-width: 1205px) {
+
+.tab-pid_tuning .subtab-pid .spacer_left {
+    width: 100%;
+}
+}
+
+@media only screen and (max-width: 1405px) {
+    
+.tab-pid_tuning .subtab-rates .ratePreview.spacer_left {
+    width: 100%;
+}
 }

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1429,20 +1429,6 @@ TABS.pid_tuning.initialize = function (callback) {
             });
         }
 
-        $(window).resize(function() {
-            let width = $(this).width();
-            if (width <= 1265) {
-                $('.pidControllerAdvancedSettings').removeClass('spacer_left');
-            } else if (width >= 1283) {
-                $('.pidControllerAdvancedSettings').addClass('spacer_left');
-            }
-            if (width <= 1405) {
-                $('.ratePreview').removeClass('spacer_left');
-            } else if (width >= 1423) {
-                $('.ratePreview').addClass('spacer_left');
-            }
-        });
-
         // update == save.
         $('a.update').click(function () {
             form_to_pid_and_rc();

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -332,6 +332,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.dtermLowpass2TypeGroup').hide();
 
             $('.dminGroup').hide();
+            $('.dMinDisabledNote').hide();
             //dmin column
             $('#pid_main tr :nth-child(5)').hide();
 
@@ -399,6 +400,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
                     $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
                     $('.pid_tuning input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
+                    $('.dMinDisabledNote').hide();
                     $('.dminGroup .suboption').show();
                     $('#pid_main tr :nth-child(5)').show();
                     $('#pid_main .pid_titlebar2 th').attr('colspan', 6);
@@ -409,6 +411,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     $('.pid_tuning input[name="dMinPitch"]').val(0);
                     $('.pid_tuning input[name="dMinYaw"]').val(0);
                     $('.dminGroup .suboption').hide();
+                    $('.dMinDisabledNote').show();
                     $('#pid_main tr :nth-child(5)').hide();
                     $('#pid_main .pid_titlebar2 th').attr('colspan', 5);
                     $('.helpicon[i18n_title="pidTuningPidTuningTipFeedforward"]').show();
@@ -1419,6 +1422,20 @@ TABS.pid_tuning.initialize = function (callback) {
                 self.updatePidControllerParameters();
             });
         }
+
+        $(window).resize(function() {
+            let width = $(this).width();
+            if (width <= 1265) {
+                $('.pidControllerAdvancedSettings').removeClass('spacer_left');
+            } else if (width >= 1283) {
+                $('.pidControllerAdvancedSettings').addClass('spacer_left');
+            }
+            if (width <= 1405) {
+                $('.ratePreview').removeClass('spacer_left');
+            } else if (width >= 1423) {
+                $('.ratePreview').addClass('spacer_left');
+            }
+        });
 
         // update == save.
         $('a.update').click(function () {

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -397,9 +397,15 @@ TABS.pid_tuning.initialize = function (callback) {
             dMinSwitch.change(function() {
                 var checked = $(this).is(':checked');
                 if (checked) {
-                    $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
-                    $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
-                    $('.pid_tuning input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
+                    if (ADVANCED_TUNING.dMinRoll == 0 && ADVANCED_TUNING.dMinPitch == 0 && ADVANCED_TUNING.dMinYaw == 0) {
+                        $('.pid_tuning input[name="dMinRoll"]').val(Math.round(PIDs[0][2] * 0.57));
+                        $('.pid_tuning input[name="dMinPitch"]').val(Math.round(PIDs[1][2] * 0.57));
+                        $('.pid_tuning input[name="dMinYaw"]').val(Math.round(PIDs[2][2] * 0.57));
+                    } else {
+                        $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
+                        $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
+                        $('.pid_tuning input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
+                    }
                     $('.dMinDisabledNote').hide();
                     $('.dminGroup .suboption').show();
                     $('#pid_main tr :nth-child(5)').show();

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -125,21 +125,15 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_filter input[name="dTermNotchCutoff"]').val(FILTER_CONFIG.dterm_notch_cutoff);
 
             var dtermSetpointTransitionNumberElement = $('input[name="dtermSetpointTransition-number"]');
-            var dtermSetpointTransitionRangeElement = $('input[name="dtermSetpointTransition-range"]');
             if (semver.gte(CONFIG.apiVersion, "1.38.0")) {
                 dtermSetpointTransitionNumberElement.attr('min', 0.00);
-                dtermSetpointTransitionRangeElement.attr('min', 0.00);
             } else {
                 dtermSetpointTransitionNumberElement.attr('min', 0.01);
-                dtermSetpointTransitionRangeElement.attr('min', 0.01);
             }
 
             dtermSetpointTransitionNumberElement.val(ADVANCED_TUNING.dtermSetpointTransition / 100);
-            dtermSetpointTransitionRangeElement.val(ADVANCED_TUNING.dtermSetpointTransition / 100);
 
             $('input[name="dtermSetpoint-number"]').val(ADVANCED_TUNING.dtermSetpointWeight / 100);
-            $('input[name="dtermSetpoint-range"]').val(ADVANCED_TUNING.dtermSetpointWeight / 100)
-                                                  .trigger('input'); // trigger adjustRangeElement()
         } else {
             $('.pid_filter .newFilter').hide();
         }
@@ -162,6 +156,34 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_filter select[name="dtermLowpassType"]').val(FILTER_CONFIG.dterm_lowpass_type);
             $('.antigravity input[name="itermThrottleThreshold"]').val(ADVANCED_TUNING.itermThrottleThreshold);
             $('.antigravity input[name="itermAcceleratorGain"]').val(ADVANCED_TUNING.itermAcceleratorGain / 1000);
+
+            if (FEATURE_CONFIG.features.isEnabled('ANTI_GRAVITY')) {
+                $('.antigravity').show();
+            } else {
+                $('.antigravity').hide();
+            }
+            var antiGravitySwitch = $('#antiGravitySwitch');
+            antiGravitySwitch.prop('checked', ADVANCED_TUNING.itermAcceleratorGain !== 1000);
+            antiGravitySwitch.change(function() {
+                var checked = $(this).is(':checked');
+                if (checked) {
+                    $('.antigravity input[name="itermAcceleratorGain"]').val(Math.max(ADVANCED_TUNING.itermAcceleratorGain / 1000, 1.1));
+                    $('.antigravity .suboption').show();
+                    if (ADVANCED_TUNING.antiGravityMode == 0) {
+                        $('.antigravity .antiGravityThres').hide();
+                    }
+                    if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+                        $('.antigravity .antiGravityMode').show();
+                    } else {
+                        $('.antigravity .antiGravityMode').hide();
+                    }
+                } else {
+                    $('.antigravity select[id="antiGravityMode"]').val(0);
+                    $('.antigravity input[name="itermAcceleratorGain"]').val(1);
+                    $('.antigravity .suboption').hide();
+                }
+            });
+            antiGravitySwitch.change();
         } else {
             $('.dtermLowpassType').hide();
             $('.antigravity').hide();
@@ -182,11 +204,13 @@ TABS.pid_tuning.initialize = function (callback) {
             // We load it again because the limits are now bigger than in 1.16.0
             $('.pid_filter input[name="gyroLowpassFrequency"]').attr("max","16000");
             $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
-
+            //removes 5th column which is Feedforward
+            $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
         } else {
             $('.gyroLowpass2').hide();
             $('.gyroLowpass2Type').hide();
             $('.dtermLowpass2').hide();
+            $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
@@ -210,6 +234,11 @@ TABS.pid_tuning.initialize = function (callback) {
 
                 if (checked) {
                     $('.itermrelax .suboption').show();
+                    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                        $('.itermRelaxCutoff').show();
+                    } else {
+                        $('.itermRelaxCutoff').hide();
+                    }
                 } else {
                     $('.itermrelax .suboption').hide();
                 }
@@ -218,41 +247,14 @@ TABS.pid_tuning.initialize = function (callback) {
 
             // Absolute Control
             var absoluteControlGainNumberElement = $('input[name="absoluteControlGain-number"]');
-            var absoluteControlGainRangeElement = $('input[name="absoluteControlGain-range"]');
-			
-            //Use 'input' event for coupled controls to allow synchronized update
-            absoluteControlGainNumberElement.on('input', function () {
-                absoluteControlGainRangeElement.val($(this).val());
-            });
-            absoluteControlGainRangeElement.on('input', function () {
-                absoluteControlGainNumberElement.val($(this).val());
-            });
             absoluteControlGainNumberElement.val(ADVANCED_TUNING.absoluteControlGain).trigger('input');
 
             // Throttle Boost
             var throttleBoostNumberElement = $('input[name="throttleBoost-number"]');
-            var throttleBoostRangeElement = $('input[name="throttleBoost-range"]');
-			
-            //Use 'input' event for coupled controls to allow synchronized update
-            throttleBoostNumberElement.on('input', function () {
-                throttleBoostRangeElement.val($(this).val());
-            });
-            throttleBoostRangeElement.on('input', function () {
-                throttleBoostNumberElement.val($(this).val());
-            });
             throttleBoostNumberElement.val(ADVANCED_TUNING.throttleBoost).trigger('input');
 
             // Acro Trainer
             var acroTrainerAngleLimitNumberElement = $('input[name="acroTrainerAngleLimit-number"]');
-            var acroTrainerAngleLimitRangeElement = $('input[name="acroTrainerAngleLimit-range"]');
-			
-            //Use 'input' event for coupled controls to allow synchronized update
-            acroTrainerAngleLimitNumberElement.on('input', function () {
-                acroTrainerAngleLimitRangeElement.val($(this).val());
-            });
-            acroTrainerAngleLimitRangeElement.on('input', function () {
-                acroTrainerAngleLimitNumberElement.val($(this).val());
-            });
             acroTrainerAngleLimitNumberElement.val(ADVANCED_TUNING.acroTrainerAngleLimit).trigger('input');
 
             // Yaw D
@@ -262,20 +264,10 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_tuning .ROLL input[name="f"]').val(ADVANCED_TUNING.feedforwardRoll);
             $('.pid_tuning .PITCH input[name="f"]').val(ADVANCED_TUNING.feedforwardPitch);
             $('.pid_tuning .YAW input[name="f"]').val(ADVANCED_TUNING.feedforwardYaw);
+            $('#pid_main .pid_titlebar2 th').attr('colspan', 5);
 
             var feedforwardTransitionNumberElement = $('input[name="feedforwardTransition-number"]');
-            var feedforwardTransitionRangeElement = $('input[name="feedforwardTransition-range"]');
-
             feedforwardTransitionNumberElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
-            feedforwardTransitionRangeElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
-			
-            //Use 'input' event for coupled controls to allow synchronized update
-            feedforwardTransitionNumberElement.on('input', function () {
-                feedforwardTransitionRangeElement.val($(this).val());
-            });
-            feedforwardTransitionRangeElement.on('input', function () {
-                feedforwardTransitionNumberElement.val($(this).val());
-            });
 
             $('.helpicon[i18n_title="pidTuningPidTuningTip"]').hide();
 
@@ -284,13 +276,11 @@ TABS.pid_tuning.initialize = function (callback) {
             antiGravityModeSelect.change(function () {
                 var antiGravityModeValue = $('.antigravity select[id="antiGravityMode"]').val();
 
-                // Smooth
+                // Smooth removes threshold
                 if (antiGravityModeValue == 0) {
-                    $('.antigravity  table th:nth-child(3)').hide();
-                    $('.antigravity  table td:nth-child(3)').hide();
+                    $('.antiGravityThres').hide();
                 } else {
-                    $('.antigravity  table th:nth-child(3)').show();
-                    $('.antigravity  table td:nth-child(3)').show();
+                    $('.antiGravityThres').show();
                 }
             });
 
@@ -307,14 +297,10 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_tuning .YAW input[name="d"]').hide();
 
             // Feedforward column
-            $('#pid_main tr :nth-child(5)').hide();
-            $('#pid_main .pid_titlebar2 th').attr("colspan", 8);
+            $('#pid_main tr :nth-child(6)').hide();
             $('.helpicon[i18n_title="pidTuningPidTuningTipFeedforward"]').hide();
 
             $('#pid-tuning .feedforwardTransition').hide();
-
-            $('.antigravity  table th:first-child').hide();
-            $('.antigravity  table td:first-child').hide();
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
@@ -329,14 +315,15 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_filter input[name="dtermLowpassDynMaxFrequency"]').val(FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
             $('.pid_filter select[name="dtermLowpassDynType"]').val(FILTER_CONFIG.dterm_lowpass_type);
 
-            $('.dminGroup input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
-            $('.dminGroup input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
-            $('.dminGroup input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
+            $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
+            $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
+            $('.pid_tuning input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
             $('.dminGroup input[name="dMinGain"]').val(ADVANCED_TUNING.dMinGain);
             $('.dminGroup input[name="dMinAdvance"]').val(ADVANCED_TUNING.dMinAdvance);
 
             $('input[id="useIntegratedYaw"]').prop('checked', ADVANCED_TUNING.useIntegratedYaw !== 0);
-
+            //dmin column
+            $('#pid_main .pid_titlebar2 th').attr('colspan', 6);
         } else {
             $('.throttle_limit').hide();
 
@@ -345,27 +332,30 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.dtermLowpass2TypeGroup').hide();
 
             $('.dminGroup').hide();
+            //dmin column
+            $('#pid_main tr :nth-child(5)').hide();
 
             $('.integratedYaw').hide();
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
             $('.smartfeedforward').hide();
-            $('.itermRelaxCutoff').show();
 
             if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
                 $('.dynamicNotch').show();
             } else {
                 $('.dynamicNotch').hide();
             }
-
             $('.pid_filter select[name="dynamicNotchRange"]').val(FILTER_CONFIG.dyn_notch_range);
             $('.pid_filter input[name="dynamicNotchWidthPercent"]').val(FILTER_CONFIG.dyn_notch_width_percent);
             $('.pid_filter input[name="dynamicNotchQ"]').val(FILTER_CONFIG.dyn_notch_q);
             $('.pid_filter input[name="dynamicNotchMinHz"]').val(FILTER_CONFIG.dyn_notch_min_hz);
+
+            $('.helpicon[i18n_title="pidTuningPidTuningTipFeedforward"]').hide();
         } else {
             $('.itermRelaxCutoff').hide();
             $('.dynamicNotch').hide();
+            $('.helpicon[i18n_title="pidTuningPidTuningTipDMin"]').hide();
         }
 
         $('input[id="useIntegratedYaw"]').change(function() {
@@ -386,19 +376,47 @@ TABS.pid_tuning.initialize = function (callback) {
         }
 
         $('.pid_tuning .ROLL input[name="d"]').change(function() {
-            var dMinElement= $('.dminGroup input[name="dMinRoll"]');
+            var dMinElement= $('.pid_tuning input[name="dMinRoll"]');
             adjustDMin($(this), dMinElement);
         }).change();
 
         $('.pid_tuning .PITCH input[name="d"]').change(function() {
-            var dMinElement= $('.dminGroup input[name="dMinPitch"]');
+            var dMinElement= $('.pid_tuning input[name="dMinPitch"]');
             adjustDMin($(this), dMinElement);
         }).change();
 
         $('.pid_tuning .YAW input[name="d"]').change(function() {
-            var dMinElement= $('.dminGroup input[name="dMinYaw"]');
+            var dMinElement= $('.pid_tuning input[name="dMinYaw"]');
             adjustDMin($(this), dMinElement);
         }).change();
+
+        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            var dMinSwitch = $('#dMinSwitch');
+            dMinSwitch.prop('checked', ADVANCED_TUNING.dMinRoll > 0 || ADVANCED_TUNING.dMinPitch > 0 || ADVANCED_TUNING.dMinYaw > 0);
+            dMinSwitch.change(function() {
+                var checked = $(this).is(':checked');
+                if (checked) {
+                    $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
+                    $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
+                    $('.pid_tuning input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
+                    $('.dminGroup .suboption').show();
+                    $('#pid_main tr :nth-child(5)').show();
+                    $('#pid_main .pid_titlebar2 th').attr('colspan', 6);
+                    $('.helpicon[i18n_title="pidTuningPidTuningTipFeedforward"]').hide();
+                    $('.helpicon[i18n_title="pidTuningPidTuningTipDMin"]').show();
+                } else {
+                    $('.pid_tuning input[name="dMinRoll"]').val(0);
+                    $('.pid_tuning input[name="dMinPitch"]').val(0);
+                    $('.pid_tuning input[name="dMinYaw"]').val(0);
+                    $('.dminGroup .suboption').hide();
+                    $('#pid_main tr :nth-child(5)').hide();
+                    $('#pid_main .pid_titlebar2 th').attr('colspan', 5);
+                    $('.helpicon[i18n_title="pidTuningPidTuningTipFeedforward"]').show();
+                    $('.helpicon[i18n_title="pidTuningPidTuningTipDMin"]').hide();
+                }
+            });
+            dMinSwitch.change();
+        }
 
         $('input[id="gyroNotch1Enabled"]').change(function() {
             var checked = $(this).is(':checked');
@@ -653,7 +671,7 @@ TABS.pid_tuning.initialize = function (callback) {
             ADVANCED_TUNING.smartFeedforward = $('input[id="smartfeedforward"]').is(':checked') ? 1 : 0;
 
             ADVANCED_TUNING.itermRelax = $('input[id="itermrelax"]').is(':checked') ? $('select[id="itermrelaxAxes"]').val() : 0;
-            ADVANCED_TUNING.itermRelaxType = $('input[id="itermrelax"]').is(':checked') ? $('select[id="itermrelaxType"]').val() : 0;
+            ADVANCED_TUNING.itermRelaxType = $('select[id="itermrelaxType"]').val();
             ADVANCED_TUNING.itermRelaxCutoff = parseInt($('input[name="itermRelaxCutoff"]').val());
 
             ADVANCED_TUNING.absoluteControlGain = $('input[name="absoluteControlGain-number"]').val();
@@ -688,9 +706,9 @@ TABS.pid_tuning.initialize = function (callback) {
                 FILTER_CONFIG.dterm_lowpass_type = $('.pid_filter select[name="dtermLowpassDynType"]').val();
             }
 
-            ADVANCED_TUNING.dMinRoll = parseInt($('.dminGroup input[name="dMinRoll"]').val());
-            ADVANCED_TUNING.dMinPitch = parseInt($('.dminGroup input[name="dMinPitch"]').val());
-            ADVANCED_TUNING.dMinYaw = parseInt($('.dminGroup input[name="dMinYaw"]').val());
+            ADVANCED_TUNING.dMinRoll = parseInt($('.pid_tuning input[name="dMinRoll"]').val());
+            ADVANCED_TUNING.dMinPitch = parseInt($('.pid_tuning input[name="dMinPitch"]').val());
+            ADVANCED_TUNING.dMinYaw = parseInt($('.pid_tuning input[name="dMinYaw"]').val());
             ADVANCED_TUNING.dMinGain = parseInt($('.dminGroup input[name="dMinGain"]').val());
             ADVANCED_TUNING.dMinAdvance = parseInt($('.dminGroup input[name="dMinAdvance"]').val());
 
@@ -817,7 +835,6 @@ TABS.pid_tuning.initialize = function (callback) {
 
         if (semver.lt(CONFIG.apiVersion, "1.39.0")) {
             $('input[name="dtermSetpoint-number"]').attr('max', self.SETPOINT_WEIGHT_RANGE_LEGACY);
-            $('input[name="dtermSetpoint-range"]').attr('max', self.SETPOINT_WEIGHT_RANGE_LEGACY);
         }
 
         // translate to user-selected language
@@ -867,6 +884,16 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('.tab-pid_tuning .tab_container .pid').on('click', function () {
             $('.tab-pid_tuning .subtab-pid').show();
+            $('.tab-pid_tuning .subtab-rates').hide();
+            $('.tab-pid_tuning .subtab-filter').hide();
+
+            $('.tab-pid_tuning .tab_container td').removeClass('active');
+            $(this).addClass('active');
+        });
+
+        $('.tab-pid_tuning .tab_container .rates').on('click', function () {
+            $('.tab-pid_tuning .subtab-rates').show();
+            $('.tab-pid_tuning .subtab-pid').hide();
             $('.tab-pid_tuning .subtab-filter').hide();
 
             $('.tab-pid_tuning .tab_container td').removeClass('active');
@@ -876,6 +903,7 @@ TABS.pid_tuning.initialize = function (callback) {
         $('.tab-pid_tuning .tab_container .filter').on('click', function () {
             $('.tab-pid_tuning .subtab-filter').show();
             $('.tab-pid_tuning .subtab-pid').hide();
+            $('.tab-pid_tuning .subtab-rates').hide();
 
             $('.tab-pid_tuning .tab_container td').removeClass('active');
             $(this).addClass('active');
@@ -999,7 +1027,6 @@ TABS.pid_tuning.initialize = function (callback) {
             });
 
             var dtermTransitionNumberElement = $('input[name="dtermSetpointTransition-number"]');
-            var dtermTransitionRangeElement = $('input[name="dtermSetpointTransition-range"]');
             var dtermTransitionWarningElement = $('#pid-tuning .dtermSetpointTransitionWarning');
 
             function checkUpdateDtermTransitionWarning(value) {
@@ -1014,36 +1041,8 @@ TABS.pid_tuning.initialize = function (callback) {
             //Use 'input' event for coupled controls to allow synchronized update
             dtermTransitionNumberElement.on('input', function () {
                 checkUpdateDtermTransitionWarning($(this).val());
-                dtermTransitionRangeElement.val($(this).val());
-            });
-            dtermTransitionRangeElement.on('input', function () {
-                checkUpdateDtermTransitionWarning($(this).val());
-                dtermTransitionNumberElement.val($(this).val());
             });
 
-            var dtermNumberElement = $('input[name="dtermSetpoint-number"]');
-            var dtermRangeElement = $('input[name="dtermSetpoint-range"]');
-
-            function adjustRangeElement(value) {
-                var range = dtermRangeElement.attr('max');
-                if (value >= self.SETPOINT_WEIGHT_RANGE_LOW && range <= self.SETPOINT_WEIGHT_RANGE_LOW) {
-                    dtermRangeElement.attr('max', self.SETPOINT_WEIGHT_RANGE_HIGH);
-                } else if (value < self.SETPOINT_WEIGHT_RANGE_LOW && range > self.SETPOINT_WEIGHT_RANGE_LOW) {
-                    dtermRangeElement.attr('max', self.SETPOINT_WEIGHT_RANGE_LOW);
-                }
-            }
-			
-            //Use 'input' event for coupled controls to allow synchronized update
-            dtermNumberElement.on('input', function () {
-                var value = $(this).val();
-                adjustRangeElement(value);
-                dtermRangeElement.val(value);
-            });
-            dtermRangeElement.on('input', function () {
-                var value = $(this).val();
-                adjustRangeElement(value);
-                dtermNumberElement.val(value);
-            });
         } else {
             $('.tab-pid_tuning .rate_profile').hide();
 
@@ -1477,6 +1476,9 @@ TABS.pid_tuning.getRecieverData = function () {
 TABS.pid_tuning.initRatesPreview = function () {
     this.keepRendering = true;
     this.model = new Model($('.rates_preview'), $('.rates_preview canvas'));
+
+    $('.tab-pid_tuning .tab_container .rates').on('click', $.proxy(this.model.resize, this.model));
+    $('.tab-pid_tuning .tab_container .rates').on('click', $.proxy(this.updateRatesLabels, this));
 
     $(window).on('resize', $.proxy(this.model.resize, this.model));
     $(window).on('resize', $.proxy(this.updateRatesLabels, this));

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -68,6 +68,11 @@
             <div class="subtab-pid">
                 <div class="clear-both"></div>
                 <div class="cf_column">
+                    <div class="note dMinDisabledNote">
+                        <div class="note_spacer">
+                            <p i18n="pidTuningDMinDisabledNote"></p>
+                        </div>
+                    </div>
                     <div class="gui_box grey">
                         <table id="pid_main" class="pid_tuning">
                             <tr class="pid_titlebar">
@@ -411,7 +416,7 @@
                                             <span i18n="pidTuningIntegratedYaw" />
                                         </label>
                                     </span>
-                                    <span class="suboption" id="pidTuningIntegratedYawCaution" i18n="pidTuningIntegratedYawCaution" />
+                                    <span class="spacer_left" id="pidTuningIntegratedYawCaution" i18n="pidTuningIntegratedYawCaution" />
                                 </td>
                             </tr>
 
@@ -706,7 +711,7 @@
                 </div>
 
                 <div class="cf_column">
-                    <div class="gui_box grey spacer_left">
+                    <div class="gui_box ratePreview grey spacer_left">
                         <table class="pid_titlebar">
                             <thead>
                                 <tr>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -6,7 +6,7 @@
         </div>
         <div class="cf_column">
             <div class="profile single-field">
-                <div class="helpicon cf_tip" i18n_title="pidTuningProfileTip" style="margin-top: 5px;"></div>
+                <div class="helpicon cf_tip topspacer" i18n_title="pidTuningProfileTip"></div>
                 <div class="head" i18n="pidTuningProfile"></div>
                 <div class="bottomarea">
                     <select name="profile">
@@ -15,7 +15,7 @@
                 </div>
             </div>
             <div class="rate_profile single-field">
-                <div class="helpicon cf_tip" i18n_title="pidTuningRateProfileTip" style="margin-top: 5px;"></div>
+                <div class="helpicon cf_tip topspacer" i18n_title="pidTuningRateProfileTip"></div>
                 <div class="head" i18n="pidTuningRateProfile"></div>
                 <div class="bottomarea">
                     <select name="rate_profile">
@@ -24,7 +24,7 @@
                 </div>
             </div>
             <div class="controller single-field">
-                <div class="helpicon cf_tip" i18n_title="pidTuningPidControllerTip" style="margin-top: 5px;"></div>
+                <div class="helpicon cf_tip topspacer" i18n_title="pidTuningPidControllerTip"></div>
                 <div class="head" i18n="pidTuningControllerHead"></div>
                 <div class="bottomarea">
                     <select name="controller">
@@ -53,6 +53,9 @@
                     <td class="pid active">
                         <a href="#" i18n="pidTuningSubTabPid" />
                     </td>
+                    <td class="rates">
+                        <a href="#" i18n="pidTuningSubTabRates" />
+                    </td>
                     <td class="filter">
                         <a href="#" i18n="pidTuningSubTabFilter" />
                     </td>
@@ -64,26 +67,24 @@
         <form name="pid-tuning" id="pid-tuning">
             <div class="subtab-pid">
                 <div class="clear-both"></div>
-                <div class="cf_column twothird">
-                    <div class="gui_box grey topspacer" style="margin-top: 0px;">
+                <div class="cf_column">
+                    <div class="gui_box grey">
                         <table id="pid_main" class="pid_tuning">
                             <tr class="pid_titlebar">
                                 <th class="name"></th>
                                 <th class="proportional" i18n="pidTuningProportional"></th>
                                 <th class="integral" i18n="pidTuningIntegral"></th>
                                 <th class="derivative" i18n="pidTuningDerivative"></th>
+                                <th class="dmin" i18n="pidTuningDMin"></th>
                                 <th class="feedforward" i18n="pidTuningFeedforward"></th>
-                                <th class="rc_rate" i18n="pidTuningRcRate"></th>
-                                <th class="rate" i18n="pidTuningRate"></th>
-                                <th class="new_rates maxVel" i18n="pidTuningMaxVel"></th>
-                                <th class="rc_expo" i18n="pidTuningRcExpo"></th>
                             </tr>
                             <tr class="pid_titlebar2">
-                                <th colspan="9">
+                                <th colspan="6">
                                     <div class="pid_mode">
                                         <div i18n="pidTuningBasic" style="float:left;"></div>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningPidTuningTip"></div>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningPidTuningTipFeedforward"></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningPidTuningTipDMin"></div>
                                     </div>
                                 </th>
                             </tr>
@@ -93,18 +94,9 @@
                                 <td class="pid_data"><input type="number" name="p" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="i" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="dMinRoll" step="1" min="0" max="100" /></td>
                                 <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
-                                <td rowspan="2" class="inputBackground">
-                                    <input type="number" name="rc_rate" step="0.01" min="0.01" max="2.55" />
-                                    <div class="bracket"></div>
-                                </td>
-                                <td class="roll_rate"><input type="number" name="roll_rate" step="0.01" min="0" max="1.00" /></td>
-                                <td class="roll_pitch_rate" rowspan="2"><input type="number" name="roll_pitch_rate" step="0.01" min="0" max="1.00" /></td>
-                                <td class="new_rates maxAngularVelRoll"></td>
-                                <td rowspan="2" class="inputBackground">
-                                    <input type="number" name="rc_expo" step="0.01" min="0" max="1" />
-                                    <div class="bracket"></div>
-                                </td>
+
                             </tr>
                             <tr class="PITCH">
                                 <!-- 1 -->
@@ -112,11 +104,8 @@
                                 <td class="pid_data"><input type="number" name="p" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="i" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="dMinPitch" step="1" min="0" max="100" /></td>
                                 <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
-                                <td><input type="number" name="rc_rate_pitch" step="0.01" min="0.01" max="2.55" /></td>
-                                <td class="pitch_rate"><input type="number" name="pitch_rate" step="0.01" min="0" max="1.00" /></td>
-                                <td class="new_rates maxAngularVelPitch"></td>
-                                <td><input type="number" name="rc_pitch_expo" step="0.01" min="0" max="1" /></td>
                             </tr>
                             <tr class="YAW">
                                 <!-- 2 -->
@@ -124,11 +113,8 @@
                                 <td class="pid_data"><input type="number" name="p" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="i" step="1" min="0" max="200" /></td>
                                 <td class="pid_data"><input type="number" name="d" step="1" min="0" max="200" /></td>
+                                <td class="pid_data"><input type="number" name="dMinYaw" step="1" min="0" max="100" /></td>
                                 <td class="pid_data"><input type="number" name="f" step="1" min="0" max="2000" /></td>
-                                <td rowspan="1"><input type="number" name="rc_rate_yaw" step="0.01" min="0.01" max="2.55" /></td>
-                                <td><input type="number" name="yaw_rate" step="0.01" min="0" max="2.55" /></td>
-                                <td class="new_rates maxAngularVelYaw"></td>
-                                <td><input type="number" name="rc_yaw_expo" step="0.01" min="0" max="1" /></td>
                             </tr>
                             <tr class="YAW_JUMP_PREVENTION">
                                 <td colspan="3">
@@ -142,6 +128,8 @@
                             </tr>
                         </table>
                     </div>
+
+                    <!-- BARO, MAG, GPS -->
                     <div id="pid_baro_mag_gps" class="pid_optional needed_by_ALT needed_by_VEL needed_by_MAG needed_by_Pos needed_by_PosR needed_by_NavR gui_box grey topspacer pid_tuning">
                         <table class="pid_titlebar needed_by_ALT needed_by_VEL needed_by_MAG">
                             <tr class="needed_by_ALT needed_by_VEL needed_by_MAG">
@@ -263,48 +251,11 @@
                             </tr>
                         </table>
                     </div>
+                </div>
 
-                    <div class="dminGroup topspacer tpa">
-                        <table class="cf">
-                            <thead>
-                                <tr>
-                                    <th colspan="5">
-                                        <span i18n="pidTuningDMin" />
-                                        <span class="helpicon cf_tip" i18n_title="pidTuningDMinHelp" />
-                                    </th>
-                                </tr>
-
-                                <tr>
-                                    <th i18n="pidTuningDMinRoll" />
-                                    <th i18n="pidTuningDMinPitch" />
-                                    <th i18n="pidTuningDMinYaw" />
-                                    <th i18n="pidTuningDMinGain" />
-                                    <th i18n="pidTuningDMinAdvance" />
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td>
-                                        <input type="number" name="dMinRoll" step="1" min="0" max="100" />
-                                    </td>
-                                    <td>
-                                        <input type="number" name="dMinPitch" step="1" min="0" max="100" />
-                                    </td>
-                                    <td>
-                                        <input type="number" name="dMinYaw" step="1" min="0" max="100" />
-                                    </td>
-                                    <td>
-                                        <input type="number" name="dMinGain" step="1" min="0" max="100" />
-                                    </td>
-                                    <td>
-                                        <input type="number" name="dMinAdvance" step="1" min="0" max="200" />
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-
-                    <div class="gui_box grey topspacer pidTuningFeatures">
+                <div class="cf_column">
+                    <!-- Pid controller advanced settings -->
+                    <div class="gui_box grey pidTuningFeatures spacer_left">
                         <table class="pid_titlebar new_rates">
                             <tr>
                                 <th i18n="pidTuningNonProfilePidSettings"></th>
@@ -316,7 +267,7 @@
                             </tbody>
                         </table>
                     </div>
-                    <div class="gui_box grey topspacer">
+                    <div class="gui_box grey pidControllerAdvancedSettings spacer_left">
                         <table class="pid_titlebar new_rates">
                             <tr>
                                 <th i18n="pidTuningPidSettings"></th>
@@ -333,19 +284,18 @@
                                 <td>
                                     <div>
                                         <label for="delta-select">
-                                        <span i18n="pidTuningDelta"></span>
+                                            <span i18n="pidTuningDelta"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningDeltaTip"></div>
                                     </div>
                                 </td>
                             </tr>
-                            <tr class="dtermSetpoint" style="height:30px;">
+                            <tr class="dtermSetpoint">
                                 <td><input type="number" name="dtermSetpoint-number" step="0.01" min="0.00" max="20"/></td>
-                                <td class="slider"><input type="range" name="dtermSetpoint-range" step="0.01" min="0.00" max="20"/></td>
                                 <td>
                                     <div>
                                         <label>
-                                        <span i18n="pidTuningDtermSetpoint"></span>
+                                            <span i18n="pidTuningDtermSetpoint"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningDtermSetpointHelp"></div>
                                     </div>
@@ -353,15 +303,14 @@
                             </tr>
                             <tr class="dtermSetpointTransition">
                                 <td><input type="number" name="dtermSetpointTransition-number" step="0.01" min="0.01" max="1.00"/></td>
-                                <td class="slider"><input type="range" name="dtermSetpointTransition-range" step="0.01" min="0.01" max="1.00"/></td>
-                                 <td colspan="1">
+                                <td colspan="1">
                                     <div>
                                         <label>
-                                        <span i18n="pidTuningDtermSetpointTransition"></span>
+                                            <span i18n="pidTuningDtermSetpointTransition"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningDtermSetpointTransitionHelp"></div>
                                     </div>
-                                 </td>
+                                </td>
                             </tr>
                             <tr class="dtermSetpointTransitionWarning">
                                 <td colspan="3">
@@ -369,13 +318,12 @@
                                 </td>
                             </tr>
 
-                            <tr class="feedforwardTransition" style="height:30px;">
+                            <tr class="feedforwardTransition">
                                 <td><input type="number" name="feedforwardTransition-number" step="0.01" min="0.00" max="1.00"/></td>
-                                <td class="slider"><input type="range" name="feedforwardTransition-range" step="0.01" min="0.00" max="1.00"/></td>
                                 <td colspan="1">
                                     <div>
                                         <label>
-                                        <span i18n="pidTuningFeedforwardTransition"></span>
+                                            <span i18n="pidTuningFeedforwardTransition"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningFeedforwardTransitionHelp"></div>
                                     </div>
@@ -384,41 +332,38 @@
 
                             <tr class="acroTrainerAngleLimit">
                                 <td><input type="number" name="acroTrainerAngleLimit-number" step="1" min="10" max="80"/></td>
-                                <td class="slider"><input type="range" name="acroTrainerAngleLimit-range" step="1" min="10" max="80"/></td>
-                                 <td colspan="1">
+                                <td colspan="1">
                                     <div>
                                         <label>
-                                        <span i18n="pidTuningAcroTrainerAngleLimit"></span>
+                                            <span i18n="pidTuningAcroTrainerAngleLimit"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningAcroTrainerAngleLimitHelp"></div>
                                     </div>
-                                 </td>
+                                </td>
                             </tr>
 
                             <tr class="throttleBoost">
                                 <td><input type="number" name="throttleBoost-number" step="1" min="0" max="100"/></td>
-                                <td class="slider"><input type="range" name="throttleBoost-range" step="1" min="0" max="100"/></td>
-                                 <td colspan="1">
+                                <td colspan="1">
                                     <div>
                                         <label>
-                                        <span i18n="pidTuningThrottleBoost"></span>
+                                            <span i18n="pidTuningThrottleBoost"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningThrottleBoostHelp"></div>
                                     </div>
-                                 </td>
+                                </td>
                             </tr>
 
                             <tr class="absoluteControlGain">
                                 <td><input type="number" name="absoluteControlGain-number" step="1" min="0" max="20"/></td>
-                                <td class="slider"><input type="range" name="absoluteControlGain-range" step="1" min="0" max="20"/></td>
-                                 <td colspan="1">
+                                <td colspan="1">
                                     <div>
                                         <label>
-                                        <span i18n="pidTuningAbsoluteControlGain"></span>
+                                            <span i18n="pidTuningAbsoluteControlGain"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningAbsoluteControlGainHelp"></div>
                                     </div>
-                                 </td>
+                                </td>
                             </tr>
 
                             <tr class="itermrotation">
@@ -426,7 +371,7 @@
                                 <td colspan="2">
                                     <div>
                                         <label for="itermrotation">
-                                        <span i18n="pidTuningItermRotation"></span>
+                                            <span i18n="pidTuningItermRotation"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningItermRotationHelp"></div>
                                     </div>
@@ -438,7 +383,7 @@
                                 <td colspan="2">
                                     <div>
                                         <label for="vbatpidcompensation">
-                                        <span i18n="pidTuningVbatPidCompensation"></span>
+                                            <span i18n="pidTuningVbatPidCompensation"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningVbatPidCompensationHelp"></div>
                                     </div>
@@ -450,16 +395,30 @@
                                 <td colspan="2">
                                     <div>
                                         <label for="smartfeedforward">
-                                        <span i18n="pidTuningSmartFeedforward"></span>
+                                            <span i18n="pidTuningSmartFeedforward"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningSmartFeedforwardHelp"></div>
                                     </div>
                                 </td>
                             </tr>
 
+                            <tr class="integratedYaw">
+                                <td><input type="checkbox" id="useIntegratedYaw" class="toggle" /></td>
+                                <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningIntegratedYawHelp"></div>
+                                    <span>
+                                        <label for="useIntegratedYaw">
+                                            <span i18n="pidTuningIntegratedYaw" />
+                                        </label>
+                                    </span>
+                                    <span class="suboption" id="pidTuningIntegratedYawCaution" i18n="pidTuningIntegratedYawCaution" />
+                                </td>
+                            </tr>
+
                             <tr class="itermrelax">
                                 <td><input type="checkbox" id="itermrelax" class="toggle" /></td>
                                 <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningItermRelaxHelp"></div>
                                     <span>
                                         <label for="itermrelax">
                                             <span i18n="pidTuningItermRelax" />
@@ -467,107 +426,170 @@
                                     </span>
 
                                     <span class="suboption">
-                                        <label for="itermrelaxAxes">
-                                            <span i18n="pidTuningItermRelaxAxes" />
-                                        </label>
                                         <select id="itermrelaxAxes">
                                             <option i18n="pidTuningItermRelaxAxesOptionRP"     value="1">
                                             <option i18n="pidTuningItermRelaxAxesOptionRPY"    value="2"/>
                                             <option i18n="pidTuningItermRelaxAxesOptionRPInc"  value="3"/>
                                             <option i18n="pidTuningItermRelaxAxesOptionRPYInc" value="4"/>
                                         </select>
+                                        <label for="itermrelaxAxes">
+                                            <span i18n="pidTuningItermRelaxAxes" />
+                                        </label>
                                     </span>
 
                                     <span class="suboption">
-                                        <label for="itermrelaxType">
-                                            <span i18n="pidTuningItermRelaxType" />
-                                        </label>
                                         <select id="itermrelaxType">
                                             <option i18n="pidTuningItermRelaxTypeOptionGyro"     value="0"/> 
                                             <option i18n="pidTuningItermRelaxTypeOptionSetpoint" value="1"/>
                                         </select>
+                                        <label for="itermrelaxType">
+                                            <span i18n="pidTuningItermRelaxType" />
+                                        </label>
                                     </span>
 
                                     <span class="itermRelaxCutoff suboption">
+                                        <input type="number" name="itermRelaxCutoff" step="1" min="1" max="100" />
                                         <label for="itermRelaxCutoff">
                                             <span i18n="pidTuningItermRelaxCutoff" />
                                         </label>
-                                        <input type="number" name="itermRelaxCutoff" step="1" min="1" max="100" />
                                     </span>
-
-                                    <div class="helpicon cf_tip" i18n_title="pidTuningItermRelaxHelp"></div>
                                 </td>
                             </tr>
 
-                            <tr class="integratedYaw">
-                                <td><input type="checkbox" id="useIntegratedYaw" class="toggle" /></td>
-                                <td colspan="2">
-
+                            <tr class="dminGroup">
+                                <td><input type="checkbox" id="dMinSwitch" class="toggle" /></td>
+                                <td colspan="3">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningDMinHelp"></div>
                                     <span>
-                                        <label for="useIntegratedYaw">
-                                            <span i18n="pidTuningIntegratedYaw" />
+                                        <label for="dminGroup">
+                                            <span i18n="pidTuningDMin" />
                                         </label>
                                     </span>
 
-                                    <span class="suboption" id="pidTuningIntegratedYawCaution" i18n="pidTuningIntegratedYawCaution" />
+                                    <span class="suboption">
+                                        <input type="number" name="dMinGain" step="1" min="0" max="100" />
+                                        <label for="dMinGain">
+                                            <span i18n="pidTuningDMinGain" />
+                                        </label>
+                                    </span>
 
-                                    <div class="helpicon cf_tip" i18n_title="pidTuningIntegratedYawHelp"></div>
-
+                                    <span class="suboption">
+                                        <input type="number" name="dMinAdvance" step="1" min="0" max="200" />
+                                        <label for="dMinAdvance">
+                                            <span i18n="pidTuningDMinAdvance" />
+                                        </label>
+                                    </span>
                                 </td>
                             </tr>
 
-                        </table>
-                    </div>
+                            <tr class="antigravity">
+                                    <td><input type="checkbox" id="antiGravitySwitch" class="toggle" /></td>
+                                    <td colspan="3">
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningAntiGravityHelp"></div>
+                                        <span>
+                                            <label for="antiGravity">
+                                                <span i18n="pidTuningAntiGravity" />
+                                            </label>
+                                        </span>
+    
+                                        <span class="suboption antiGravityMode">
+                                            <select id="antiGravityMode">
+                                                <option i18n="pidTuningAntiGravityModeOptionSmooth"     value="0"/>
+                                                <option i18n="pidTuningAntiGravityModeOptionStep"       value="1"/>
+                                            </select>
+                                            <label for="antiGravityMode">
+                                                <span i18n="pidTuningAntiGravityMode" />
+                                            </label>
+                                        </span>
+    
+                                        <span class="suboption">
+                                            <input type="number" name="itermAcceleratorGain" step="0.1" min="1.1" max="30" />
+                                            <label for="antiGravityGain">
+                                                <span i18n="pidTuningAntiGravityGain" />
+                                            </label>
+                                        </span>
 
-                    <div class="antigravity topspacer tpa">
-                        <table class="cf">
-                            <thead>
-                                <tr>
-                                    <th i18n="pidTuningAntiGravityMode"></th>
-                                    <th i18n="pidTuningAntiGravityGain"></th>
-                                    <th i18n="pidTuningAntiGravityThres"></th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr style="height: 35px;">
-                                    <td>
-                                        <select id="antiGravityMode">
-                                            <option i18n="pidTuningAntiGravityModeOptionSmooth" value="0">
-                                            <option i18n="pidTuningAntiGravityModeOptionStep"   value="1">
-                                        </select>
-                                    </td>
-                                    <td>
-                                        <input type="number" name="itermAcceleratorGain" step="0.1" min="1" max="30" />
-                                    </td>
-                                    <td>
-                                        <input type="number" name="itermThrottleThreshold" step="10" min="20" max="1000" />
+                                        <span class="suboption antiGravityThres">
+                                            <input type="number" name="itermThrottleThreshold" step="10" min="20" max="1000" />
+                                            <label for="antiGravityThres">
+                                                <span i18n="pidTuningAntiGravityThres" />
+                                            </label>
+                                        </span>
                                     </td>
                                 </tr>
-                            </tbody>
-                        </table>
-                    </div>
-
-                    <div class="gui_box grey topspacer">
-                        <table class="pid_titlebar">
-                            <thead>
-                                <tr>
-                                    <th i18n="pidTuningRatesPreview"></th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr>
-                                    <td class="rates_preview_cell">
-                                        <div class="rates_preview">
-                                            <canvas id="canvas"></canvas>
-                                        </div>
-                                    </td>
-                                </tr>
-                            </tbody>
                         </table>
                     </div>
                 </div>
-                <div class="cf_column third_right">
-                    <div class="spacer_left rc_curve">
+            </div>
+
+            <!-- RATES SUBTAB -->
+            <div class="subtab-rates" style="display: none;">
+                <div class="clear-both"></div>
+                <div class="cf_column">
+                    <div class="gui_box grey rateSetup">
+                        <table id="rateSetup" class="pid_tuning">
+                            <tr class="pid_titlebar">
+                                <th class="name"></th>
+                                <th class="rc_rate" i18n="pidTuningRcRate"></th>
+                                <th class="rate" i18n="pidTuningRate"></th>
+                                <th class="rc_expo" i18n="pidTuningRcExpo"></th>
+                                <th class="new_rates maxVel" i18n="pidTuningMaxVel"></th>
+                            </tr>
+                            <tr class="pid_titlebar2">
+                                <th colspan="5">
+                                    <div class="pid_mode">
+                                        <div i18n="pidTuningRateSetup" style="float:left;"></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRatesTuningHelp"></div>
+                                    </div>
+                                </th>
+                            </tr>
+                            <tr class="ROLL">
+                                <td class="pid_roll"></td>
+                                <td class="rc_rate">
+                                    <input type="number" name="rc_rate" step="0.01" min="0.01" max="2.55" />
+                                </td>
+                                <td class="roll_rate">
+                                    <input type="number" name="roll_rate" step="0.01" min="0" max="1.00" />
+                                </td>
+                                <td class="roll_pitch_rate" rowspan="2">
+                                    <input type="number" name="roll_pitch_rate" step="0.01" min="0" max="1.00" />
+                                </td>
+                                <td rowspan="2" class="inputBackground">
+                                    <input type="number" name="rc_expo" step="0.01" min="0" max="1" />
+                                    <div class="bracket"></div>
+                                </td>
+                                <td class="new_rates maxAngularVelRoll"></td>
+                            </tr>
+                            <tr class="PITCH">
+                                <td class="pid_pitch"></td>
+                                <td>
+                                    <input type="number" name="rc_rate_pitch" step="0.01" min="0.01" max="2.55" />
+                                </td>
+                                <td class="pitch_rate">
+                                    <input type="number" name="pitch_rate" step="0.01" min="0" max="1.00" />
+                                </td>
+                                <td>
+                                    <input type="number" name="rc_pitch_expo" step="0.01" min="0" max="1" />
+                                </td>
+                                <td class="new_rates maxAngularVelPitch"></td>
+                            </tr>
+                            <tr class="YAW">
+                                <td class="pid_yaw"></td>
+                                <td rowspan="1">
+                                    <input type="number" name="rc_rate_yaw" step="0.01" min="0.01" max="2.55" />
+                                </td>
+                                <td>
+                                    <input type="number" name="yaw_rate" step="0.01" min="0" max="2.55" />
+                                </td>
+                                <td>
+                                    <input type="number" name="rc_yaw_expo" step="0.01" min="0" max="1" />
+                                </td>
+                                <td class="new_rates maxAngularVelYaw"></td>
+                            </tr>
+                        </table>
+                    </div>
+
+                    <div class="gui_box rc_curve">
                         <div class="rc_curve_bg">
                             <table class="cf rc_curve">
                                 <thead>
@@ -583,11 +605,9 @@
                                 <tbody>
                                     <tr>
                                         <td colspan="2">
-                                            <div class="spacer" style="margin-top: 10px; margin-bottom: 8px;">
-                                                <div class="rate_curve" style="position:relative;" >
-                                                    <canvas id="rate_curve_layer0" height="120px" style="position:absolute; top: 0; left: 0; z-index: 0; height:100%; width:100%;"></canvas>
-                                                    <canvas id="rate_curve_layer1" height="120px" style="position:absolute; top: 0; left: 0; z-index: 1; height:100%; width:100%;"></canvas>
-                                                </div>
+                                            <div class="rate_curve" style="position:relative;" >
+                                                <canvas id="rate_curve_layer0" height="120px" style="position:absolute; top: 0; left: 0; z-index: 0; height:100%; width:100%;"></canvas>
+                                                <canvas id="rate_curve_layer1" height="120px" style="position:absolute; top: 0; left: 0; z-index: 1; height:100%; width:100%;"></canvas>
                                             </div>
                                         </td>
                                     </tr>
@@ -595,41 +615,10 @@
                             </table>
                         </div>
                     </div>
-                    <div class="spacer_left topspacer throttle">
-                        <table class="cf">
-                            <thead>
-                                <tr>
-                                    <th i18n="receiverThrottleMid"></th>
-                                    <th i18n="receiverThrottleExpo"></th>
-                                </tr>
-                            </thead>
-                            <tbody>
-                                <tr style="height: 35px;">
-                                    <td><input type="number" name="mid" step="0.01" min="0" max="1" /></td>
-                                    <td><input type="number" name="expo" step="0.01" min="0" max="1" /></td>
-                                </tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <div class="spacer_left topspacer throttle">
-                        <table class="cf">
-                            <thead>
-                                <tr>
-                                    <th colspan="2" i18n="throttle"></th>
-                                </tr>
-                            </thead>
-                            <tr>
-                                <td colspan="2">
-                                    <div class="spacer" style="margin-top: 10px; margin-bottom: 10px;">
-                                        <div class="throttle_curve">
-                                            <canvas height="120px" style="width: 100%; height: 100%"></canvas>
-                                        </div>
-                                    </div>
-                                </td>
-                            </tr>
-                        </table>
-                    </div>
-                    <div class="spacer_left topspacer tpa">
+                </div>
+
+                <div class="cf_column">
+                    <div class="gui_box tpa spacer_left">
                         <table class="cf">
                             <thead>
                                 <tr>
@@ -638,7 +627,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr style="height: 35px;">
+                                <tr>
                                     <td class="leftzero"><input type="number" name="tpa" step="0.01" min="0"
                                         max="1.00" /></td>
                                     <td class="tpa-breakpoint"><input type="number" name="tpa-breakpoint" step="10" min="1000" max="2000" /></td>
@@ -646,7 +635,8 @@
                             </tbody>
                         </table>
                     </div>
-                    <div class="spacer_left topspacer throttle_limit">
+
+                    <div class="gui_box throttle_limit spacer_left">
                         <table class="cf">
                             <thead>
                                 <tr>
@@ -665,7 +655,7 @@
                                 </tr>
                             </thead>
                             <tbody>
-                                <tr style="height: 35px;">
+                                <tr>
                                     <td>
                                         <select id="throttleLimitType">
                                             <option i18n="pidTuningThrottleLimitTypeOff" value="0">
@@ -679,19 +669,73 @@
                             </tbody>
                         </table>
                     </div>
+
+                    <div class="gui_box throttle spacer_left">
+                        <table class="cf">
+                            <thead>
+                                <tr>
+                                    <th i18n="receiverThrottleMid"></th>
+                                    <th i18n="receiverThrottleExpo"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td><input type="number" name="mid" step="0.01" min="0" max="1" /></td>
+                                    <td><input type="number" name="expo" step="0.01" min="0" max="1" /></td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+
+                    <div class="gui_box throttle spacer_left">
+                        <table class="cf">
+                            <thead>
+                                <tr>
+                                    <th i18n="pidTuningThrottleCurvePreview" colspan="2"></th>
+                                </tr>
+                            </thead>
+                            <tr>
+                                <td colspan="2" class="throttleCurvePreview">
+                                    <div class="throttle_curve">
+                                        <canvas height="164px" style="width: 100%; height: 100%"></canvas>
+                                    </div>
+                                </td>
+                            </tr>
+                        </table>
+                    </div>
+                </div>
+
+                <div class="cf_column">
+                    <div class="gui_box grey spacer_left">
+                        <table class="pid_titlebar">
+                            <thead>
+                                <tr>
+                                    <th i18n="pidTuningRatesPreview"></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr>
+                                    <td class="rates_preview_cell">
+                                        <div class="rates_preview">
+                                            <canvas id="canvas"></canvas>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
                 </div>
             </div>
 
             <!-- FILTER SUBTAB -->
-
             <div class="subtab-filter" style="display: none;">
                 <div class="clear-both"></div>
-                <div class="note topspacer" style="margin-top: 0px;">
+                <div class="note">
                     <div class="note_spacer">
                         <p i18n="tuningHelp"></p>
                     </div>
                 </div>
-                <div class="note topspacer filterWarning" style="margin-top: 0px;">
+                <div class="note filterWarning">
                     <div class="note_spacer">
                         <p i18n="filterWarning"></p>
                     </div>
@@ -710,7 +754,7 @@
                             </tr>
                         </table>
 
-                        <table>
+                        <table class="filterTable">
                             <tr>
                                 <th colspan="2">
                                     <div class="pid_mode">
@@ -724,7 +768,7 @@
                                 <td>
                                     <span class="groupSwitchValue">
                                         <span class="inputSwitch"><input type="checkbox" id="gyroLowpassDynEnabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" name="gyroLowpassDynMinFrequency" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue"><input type="number" name="gyroLowpassDynMinFrequency" step="1" min="1" max="1000"/></span>
                                     </span>
                                 </td>
                                 <td>
@@ -738,7 +782,7 @@
 
                             <tr class="gyroLowpassDyn">
                                 <td>
-                                    <span class="inputValue"><input type="number" name="gyroLowpassDynMaxFrequency" step="1" min="1" max="16000"/></span>
+                                    <span class="inputValue"><input type="number" name="gyroLowpassDynMaxFrequency" step="1" min="1" max="1000"/></span>
                                 </td>
                                 <td>
                                     <div>
@@ -965,8 +1009,7 @@
                             </tr>
                         </table>
 
-                        <table>
-
+                        <table class="filterTable">
                             <tr>
                                 <th colspan="2">
                                     <div class="pid_mode">
@@ -982,7 +1025,7 @@
                                 <td>
                                     <span class="groupSwitchValue">
                                         <span class="inputSwitch"><input type="checkbox" id="dtermLowpassDynEnabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpassDynMinFrequency" step="1" min="1" max="16000"/></span>
+                                        <span class="inputValue"><input type="number" name="dtermLowpassDynMinFrequency" step="1" min="1" max="1000"/></span>
                                     </span>
                                 </td>
                                 <td>
@@ -996,7 +1039,7 @@
 
                             <tr class="dtermLowpassDyn">
                                 <td>
-                                    <span class="inputValue"><input type="number" name="dtermLowpassDynMaxFrequency" step="1" min="1" max="16000"/></span>
+                                    <span class="inputValue"><input type="number" name="dtermLowpassDynMaxFrequency" step="1" min="1" max="1000"/></span>
                                 </td>
                                 <td>
                                     <div>
@@ -1184,5 +1227,4 @@
             <a href="#" class="dialogCopyProfile-cancelbtn regular-button" i18n="dialogCopyProfileClose"></a> 
         </div>
     </dialog>
-
 </div>


### PR DESCRIPTION
The layout of the PID Tuning tab was changed to make it more organized. There is a 'Rateprofile Settings' subtab which now separated PID Profile and Rateprofile settings. Overall looks have been made more consistent, like table coloring, borders, separation, etc.

UPDATE: Sliders have been removed from the PR.