### PR TITLE
initial go at flashing unified target with a config

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2757,6 +2757,13 @@
     "firmwareFlasherFailedToLoadOnlineFirmware": {
         "message": "Failed to load remote firmware"
     },
+    "firmwareFlasherFailedToLoadUnifiedConfig": {
+        "message": "Failed to load remote config for {{remote_file}}"
+    },
+    "firmwareFlasherLegacyLabel": {
+        "message": "{{target}} (Legacy)",
+        "description": "If we have a Unified target and a old style target available, we are labeling the older one"
+    },
     "firmwareFlasherNoFirmwareSelected": {
         "message": "<b>No firmware selected to load</b>"
     },

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -66,7 +66,7 @@ PortHandler.check = function () {
 
             // auto-select last used port (only during initialization)
             if (!self.initial_ports) {
-                chrome.storage.local.get('last_used_port', function (result) {
+                ConfigStorage.get('last_used_port', function (result) {
                     // if last_used_port was set, we try to select it
                     if (result.last_used_port) {
                         current_ports.forEach(function(port) {


### PR DESCRIPTION
This adds a method to flash firmware and preload a unified target configuration directly from internet resources. 

This builds on #1585  Applying the configuration automatically will be handled later. 
![image](https://user-images.githubusercontent.com/190571/63555488-fd775a80-c4f5-11e9-8b06-72abc88ee5af.png)
In the above screencut MATEKF411 will use flash with the STM32F411 target and have the `MATEKF411.config` attached. selection of `MATEKF411 (Legacy)` will use the MATEKF411 target.

To test this PR look at [this list](https://github.com/betaflight/unified-targets/tree/master/configs) of configuration files, and pick one of them. After flashing take a look at `defaults show` or just punch in `defaults` and see if the board comes back with a working ACC 

`show_development_releases`  `selected_build_type` are left in config.storage.local as there is some execution order issue that results in the builds list being downloaded twice on the tab load. Any change to those would need to be tested on both ChromeAPP and NWJS builds.

Doubling up on lines like this is a giveaway:
`Using cached release information for firmware releases.`
`Using cached release information for firmware releases.`

Todo
- [x] Version and target choice need to show loading when loading.
- [ ] UI Changes. Need to show an indicator if a user loads a .config locally, and have a way to throw it out.
- [ ] investigate why data is being saved to the `options` in the version `<select>` field with jQuery. I might have to eat my words but it seems like a dumb idea. Get:  `.data('summary')` Set: `.data('summary', object)`
- [x] move the URL for unified configs to a better location.
- [ ] localization pass (read through code and add strings where appropriate)
- [ ] Amount of versions to show
- [x] Amount of (Legacy) to show