### PR TITLE
Add rc smoothing auto smoothness to UI, fix refresh button and slowdown

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1527,6 +1527,14 @@
     "receiverRcSmoothingManual": {
         "message": "Manual"
     },
+    "receiverRcSmoothingAutoSmoothness": {
+        "message": "Auto Smoothness",
+        "description": "Auto Smoothness parameter for RC smoothing"
+    },
+    "receiverRcSmoothingAutoSmoothnessHelp": {
+        "message": "Adjusts the Auto smoothing calculation, 10 is the default smoothing to delay ratio. Increasing the number will smooth RC inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs. ",
+        "description": "Auto Smoothness parameter help message"
+    },
     "receiverRcDerivativeTypeSelect": {
         "message": "Derivative Cutoff Type"
     },

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -461,6 +461,8 @@ var FC = {
             rcSmoothingDerivativeCutoff:  0, 
             rcSmoothingInputType:         0,
             rcSmoothingDerivativeType:    0,
+            rcSmoothingAutoSmoothness:    0,
+            usbCdcHidType:                0,
         };
 
         FAILSAFE_CONFIG = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -896,6 +896,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             RX_CONFIG.rcSmoothingDerivativeCutoff = data.readU8();
                             RX_CONFIG.rcSmoothingInputType = data.readU8();
                             RX_CONFIG.rcSmoothingDerivativeType = data.readU8();
+                            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                                RX_CONFIG.usbCdcHidType = data.readU8();
+                                RX_CONFIG.rcSmoothingAutoSmoothness = data.readU8();
+                            }
                         }
                     } else {
                         RX_CONFIG.rxSpiProtocol = 0;
@@ -1687,6 +1691,10 @@ MspHelper.prototype.crunch = function(code) {
                             .push8(RX_CONFIG.rcSmoothingDerivativeCutoff)
                             .push8(RX_CONFIG.rcSmoothingInputType)
                             .push8(RX_CONFIG.rcSmoothingDerivativeType);
+                        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                            buffer.push8(RX_CONFIG.usbCdcHidType)
+                                .push8(RX_CONFIG.rcSmoothingAutoSmoothness);
+                        }
                     }
                 }
             }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1693,7 +1693,7 @@ MspHelper.prototype.crunch = function(code) {
                             .push8(RX_CONFIG.rcSmoothingDerivativeType);
                         if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
                             buffer.push8(RX_CONFIG.usbCdcHidType)
-                                .push8(RX_CONFIG.rcSmoothingAutoSmoothness);
+                                  .push8(RX_CONFIG.rcSmoothingAutoSmoothness);
                         }
                     }
                 }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -647,12 +647,12 @@ function updateInterpolationView() {
     $('.tab-receiver .rcSmoothing-derivative-manual').show();
     $('.tab-receiver .rcSmoothing-input-manual').show();
     if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-        if (parseInt(RX_CONFIG.rcSmoothingDerivativeCutoff) === 0 || parseInt(RX_CONFIG.rcSmoothingInputCutoff) === 0) {
+        if (RX_CONFIG.rcSmoothingDerivativeCutoff == 0 || RX_CONFIG.rcSmoothingInputCutoff == 0) {
             $('.tab-receiver .rcSmoothing-auto-smoothness').show();
         }
     }
 
-    if (parseInt(RX_CONFIG.rcSmoothingType) === 0) {
+    if (RX_CONFIG.rcSmoothingType == 0) {
         $('.tab-receiver .rcInterpolation').show();
         $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
         $('.tab-receiver .rcSmoothing-input-cutoff').hide();
@@ -662,10 +662,10 @@ function updateInterpolationView() {
         $('.tab-receiver .rcSmoothing-input-manual').hide();
         $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
     }
-    if (parseInt(RX_CONFIG.rcSmoothingDerivativeCutoff) === 0) {
+    if (RX_CONFIG.rcSmoothingDerivativeCutoff == 0) {
         $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
     }
-    if (parseInt(RX_CONFIG.rcSmoothingInputCutoff) === 0) {
+    if (RX_CONFIG.rcSmoothingInputCutoff == 0) {
         $('.tab-receiver .rcSmoothing-input-cutoff').hide();
     }
 }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -233,7 +233,9 @@ TABS.receiver.initialize = function (callback) {
 
         // UI Hooks
         $('a.refresh').click(function () {
-	    // Todo: refresh data here
+            tab.refresh(function () {
+                GUI.log(i18n.getMessage('receiverDataRefreshed'));
+            });
         });
 
         $('a.update').click(function () {
@@ -333,7 +335,7 @@ TABS.receiver.initialize = function (callback) {
 
             var rcSmoothingnNumberElement = $('input[name="rcSmoothingInputHz-number"]');
             var rcSmoothingnDerivativeNumberElement = $('input[name="rcSmoothingDerivativeCutoff-number"]');
-            
+
             $('.tab-receiver .rcSmoothing-input-cutoff').show();
             $('select[name="rcSmoothing-input-manual-select"]').val("1");
             $('.tab-receiver .rc-smoothing-input-blank').hide();
@@ -371,7 +373,7 @@ TABS.receiver.initialize = function (callback) {
                     rcSmoothingnDerivativeNumberElement.val(RX_CONFIG.rcSmoothingDerivativeCutoff);
                 }
             });
-            
+
             rcSmoothingnNumberElement.change(function () {
                 RX_CONFIG.rcSmoothingInputCutoff = $(this).val();
             });
@@ -397,6 +399,25 @@ TABS.receiver.initialize = function (callback) {
             });
             rc_smoothing_input_type.val(RX_CONFIG.rcSmoothingInputType);
 
+            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                $('select[name="rcSmoothing-input-manual-select"], select[name="rcSmoothing-input-derivative-select"]').change(function() {
+                    if ($('select[name="rcSmoothing-input-manual-select"]').val() == 0 || $('select[name="rcSmoothing-input-derivative-select"]').val() == 0) {
+                        $('.tab-receiver .rcSmoothing-auto-smoothness').show();
+                    } else {
+                        $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
+                    }
+                });
+                $('select[name="rcSmoothing-input-manual-select"]').change();
+
+                var rc_smoothing_auto_smoothness = $('input[name="rcSmoothingAutoSmoothness-number"]');
+                rc_smoothing_auto_smoothness.change(function() {
+                    RX_CONFIG.rcSmoothingAutoSmoothness = $(this).val();
+                });
+                rc_smoothing_auto_smoothness.val(RX_CONFIG.rcSmoothingAutoSmoothness);
+            } else {
+                $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
+            }
+
             updateInterpolationView();
         } else {
             $('.tab-receiver .rcInterpolation').show();
@@ -407,6 +428,7 @@ TABS.receiver.initialize = function (callback) {
             $('.tab-receiver .rcSmoothing-derivative-manual').hide();
             $('.tab-receiver .rcSmoothing-input-manual').hide();
             $('.tab-receiver .rc-smoothing-type').hide();
+            $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
         }
 
         // Only show the MSP control sticks if the MSP Rx feature is enabled
@@ -455,7 +477,7 @@ TABS.receiver.initialize = function (callback) {
                 }
 
                 // Remove old data from array
-                while (RX_plot_data.length > 300) {
+                while (RX_plot_data[0].length > 300) {
                     for (var i = 0; i < RX_plot_data.length; i++) {
                         RX_plot_data[i].shift();
                     }
@@ -594,6 +616,18 @@ TABS.receiver.cleanup = function (callback) {
     if (callback) callback();
 };
 
+TABS.receiver.refresh = function (callback) {
+    var self = this;
+
+    GUI.tab_switch_cleanup(function () {
+        self.initialize();
+
+        if (callback) {
+            callback();
+        }
+    });
+};
+
 TABS.receiver.updateRcInterpolationParameters = function () {
     if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
         if ($('select[name="rcInterpolation-select"]').val() === '3') {
@@ -612,6 +646,11 @@ function updateInterpolationView() {
     $('.tab-receiver .rcSmoothing-input-type').show();
     $('.tab-receiver .rcSmoothing-derivative-manual').show();
     $('.tab-receiver .rcSmoothing-input-manual').show();
+    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (parseInt(RX_CONFIG.rcSmoothingDerivativeCutoff) === 0 || parseInt(RX_CONFIG.rcSmoothingInputCutoff) === 0) {
+            $('.tab-receiver .rcSmoothing-auto-smoothness').show();
+        }
+    }
 
     if (parseInt(RX_CONFIG.rcSmoothingType) === 0) {
         $('.tab-receiver .rcInterpolation').show();
@@ -621,6 +660,7 @@ function updateInterpolationView() {
         $('.tab-receiver .rcSmoothing-input-type').hide();
         $('.tab-receiver .rcSmoothing-derivative-manual').hide();
         $('.tab-receiver .rcSmoothing-input-manual').hide();
+        $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
     }
     if (parseInt(RX_CONFIG.rcSmoothingDerivativeCutoff) === 0) {
         $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -213,6 +213,21 @@
                             <div class="helpicon cf_tip" i18n_title="rcSmoothingDerivativeTypeHelp" style="margin-top:0px;"></div>
                         </td>
                     </tr>
+                    <tr class="rcSmoothing-auto-smoothness">
+                        <td>
+                            <input type="number" name="rcSmoothingAutoSmoothness-number" step="1" min="0" max="50">
+                        </td>
+                        <td>
+                            <div>
+                                <label>
+                                    <span i18n="receiverRcSmoothingAutoSmoothness"></span>
+                                </label>
+                            </div>
+                        </td>
+                        <td>
+                            <div class="helpicon cf_tip" i18n_title="receiverRcSmoothingAutoSmoothnessHelp" style="margin-top:0px;"></div>
+                        </td>
+                    </tr>
                     <tr class="rcInterpolation">
                         <td>
                             <select name="rcInterpolation-select">


### PR DESCRIPTION
Adds rc_smoothing_auto_smoothness to Receiver tab. Also, there was an issue that was introduced in #55. Refresh button didn't do anything all this time. 
Fixed the slowdown caused by channel graph data on the bottom. Excess data was not being removed from the array.
To go with betaflight/betaflight#8754