### PR TITLE
Fixed structure of VTX tab Introduction string

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4909,7 +4909,7 @@
         "description": "Help for the number of power levels field of the VTX Table element in the VTX tab"
     },
     "vtxTablePowerLevelsTableHelp": {
-        "message": "This table represents the different values of power that can be used for the VTX. They are divided into two: <br><b>- $t(vtxTablePowerLevelsValue.message):</b> each power level requires a value that is defined by the hardware manufacturer. Ask your manufacturer for the correct value or consult the Betaflight wiki of VTX Tables to grab some samples. <br><b>- $t(vtxTablePowerLevelsLabel.message):</b> you can put here the label you want for each power level value. It can be numbers (25, 200, 600, 1.2), letters (OFF, MIN, MAX) or a mix of them. <br><br>You must configure <b>only</b> the power levels that are legal at your contry.",
+        "message": "This table represents the different values of power that can be used for the VTX. They are divided into two: <br><b>- $t(vtxTablePowerLevelsValue.message):</b> each power level requires a value that is defined by the hardware manufacturer. Ask your manufacturer for the correct value or consult the Betaflight wiki of VTX Tables to grab some samples. <br><b>- $t(vtxTablePowerLevelsLabel.message):</b> you can put here the label you want for each power level value. It can be numbers (25, 200, 600, 1.2), letters (OFF, MIN, MAX) or a mix of them. <br><br>You must configure <b>only</b> the power levels that are legal at your country.",
         "description": "Help for the table of power levels (value-label) that appears in the VTX tab"
     },
     "vtxTablePowerLevelsValue": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4749,7 +4749,7 @@
     },
 
     "vtxHelp": {
-        "message": "You can configure here the values for your Video Trasmitter (VTX). You can consult and configure the values of the transmission including the VTX Tables if the flight controller and the VTX support it",
+        "message": "Here you can configure the values for your Video Transmitter (VTX). You can view and change the transmission values, including the VTX Tables, if the flight controller and VTX support it",
         "description": "Introduction message in the VTX tab"
     },
     "vtxMessageNotSupported": {


### PR DESCRIPTION
From:
You can configure here the values for your Video *Trasmitter* (VTX). You can consult and configure the values of the transmission including the VTX Tables if the flight controller and the VTX support it

To:
Here you can configure the values for your Video Transmitter (VTX). You can view and change the transmission values, including the VTX Tables, if the flight controller and VTX support it