### PR TITLE
Add telemetry dshot data info to the motors tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2298,6 +2298,22 @@
     "motorsSensorAccelSelect":{
         "message": "accel"
     },
+    "motorsTelemetryHelp": {
+        "message": "This numbers show the telemetry info received from the ESCs if available. It can show the actual speed of motors (in RPM), the error rate of the telemetry link and the temperature of the ESCs.",
+        "description": "Help text for the telemetry values in the motors tab."
+    },
+    "motorsRPM": {
+        "message": "R: {{motorsRpmValue}}",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Keep the letters as prefix. Shows the RPM of the motor if telemetry is available."
+    },
+    "motorsRPMError": {
+        "message": "E: {{motorsErrorValue}}%",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the error of motor telemetry if available."
+    },
+    "motorsESCTemperature": {
+        "message": "T: {{motorsESCTempValue}}&deg;C",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the ESC temperature if available."
+    },
     "motorsMaster": {
         "message": "Master"
     },

--- a/src/css/tabs/motors.css
+++ b/src/css/tabs/motors.css
@@ -182,12 +182,12 @@
 
 .tab-motors .left.motors {
     float: left;
-    width: calc(50% - 50px);
+    width: calc(60% - 20px);
 }
 
 .tab-motors .right.servos {
     float: right;
-    width: 50%;
+    width: 40%;
 }
 
 .tab-motors .title {
@@ -251,7 +251,12 @@
     bottom: 45px;
     text-align: center;
     font-weight: bold;
+    font-size: 10px;
     color: #474747;
+}
+
+.tab-motors .m-block .label.rpm_info {
+    bottom: 28px;
 }
 
 .tab-motors .m-block .indicator .label {
@@ -274,11 +279,11 @@
 }
 
 .tab-motors .motor_testing {
-    margin-top: 15px;
+    margin-top: 5px;
 }
 
 .tab-motors .motor_testing .left {
-    width: calc(50% - 50px);
+    width: calc(60% - 20px);
 }
 
 .tab-motors .motor_testing .sliders input {
@@ -296,20 +301,36 @@
     margin-top: 5px;
 }
 
-.tab-motors .motor_testing .values li:first-child {
+.tab-motors .motor_testing .telemetry {
+    display: flow-root;
+    margin-bottom: 5px;
+}
+
+.tab-motors .motor_testing .telemetry .warning {
+    color: var(--error);
+}
+
+.tab-motors .motor_testing .values li:first-child,
+.tab-motors .motor_testing .telemetry li:first-child {
     margin-left: 0px;
 }
 
-.tab-motors .motor_testing .values li {
+.tab-motors .motor_testing .values li,
+.tab-motors .motor_testing .telemetry li {
     float: left;
     width: calc((100% / 9) - 10px);
     margin-left: 10px;
     text-align: center;
+    font-size: 10px;
+}
+
+.tab-motors .motor_testing .telemetry li {
+    white-space: pre;
 }
 
 .tab-motors .motor_testing .notice {
     float: right;
-    width: calc(50% - 24px);
+    width: calc(40% - 24px);
     padding: 5px;
     border: 2px solid #ccc;
     border-radius: 3px;

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -26,6 +26,7 @@ var SERVO_RULES;
 var SERIAL_CONFIG;
 var SENSOR_DATA;
 var MOTOR_DATA;
+var MOTOR_TELEMETRY_DATA;
 var SERVO_DATA;
 var GPS_DATA;
 var ANALOG;
@@ -210,6 +211,15 @@ var FC = {
         MOTOR_DATA =                    new Array(8);
         SERVO_DATA =                    new Array(8);
 
+        MOTOR_TELEMETRY_DATA = {
+            rpm:                        [0, 0, 0, 0, 0, 0, 0, 0],
+            invalidPercent:             [0, 0, 0, 0, 0, 0, 0, 0],
+            temperature:                [0, 0, 0, 0, 0, 0, 0, 0],
+            voltage:                    [0, 0, 0, 0, 0, 0, 0, 0],
+            current:                    [0, 0, 0, 0, 0, 0, 0, 0],
+            consumption:                [0, 0, 0, 0, 0, 0, 0, 0],
+        };
+
         GPS_DATA = {
             fix:                        0,
             numSat:                     0,
@@ -277,6 +287,10 @@ var FC = {
             minthrottle:                0,
             maxthrottle:                0,
             mincommand:                 0,
+            motor_count:                0,
+            motor_poles:                0,
+            use_dshot_telemetry:        false,
+            use_esc_sensor:             false,
         };
 
         GPS_CONFIG = {

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -115,6 +115,8 @@ var MSPCodes = {
     MSP_VTXTABLE_BAND:              137,
     MSP_VTXTABLE_POWERLEVEL:        138,
 
+    MSP_MOTOR_TELEMETRY:            139,
+
     MSP_STATUS_EX:                  150,
 
     MSP_UID:                        160,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -142,6 +142,17 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     MOTOR_DATA[i] = data.readU16();
                 }
                 break;
+            case MSPCodes.MSP_MOTOR_TELEMETRY:
+                var telemMotorCount = data.readU8();
+                for (let i = 0; i < telemMotorCount; i++) {
+                    MOTOR_TELEMETRY_DATA.rpm[i] = data.readU32();   // RPM
+                    MOTOR_TELEMETRY_DATA.invalidPercent[i] = data.readU16();   // 10000 = 100.00%
+                    MOTOR_TELEMETRY_DATA.temperature[i] = data.readU8();       // degrees celsius
+                    MOTOR_TELEMETRY_DATA.voltage[i] = data.readU16();          // 0.01V per unit
+                    MOTOR_TELEMETRY_DATA.current[i] = data.readU16();          // 0.01A per unit
+                    MOTOR_TELEMETRY_DATA.consumption[i] = data.readU16();      // mAh
+                }
+                break;
             case MSPCodes.MSP_RC:
                 RC.active_channels = data.byteLength / 2;
                 for (var i = 0; i < RC.active_channels; i++) {
@@ -392,6 +403,12 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 MOTOR_CONFIG.minthrottle = data.readU16(); // 0-2000
                 MOTOR_CONFIG.maxthrottle = data.readU16(); // 0-2000
                 MOTOR_CONFIG.mincommand = data.readU16(); // 0-2000
+                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                    MOTOR_CONFIG.motor_count = data.readU8();
+                    MOTOR_CONFIG.motor_poles = data.readU8();
+                    MOTOR_CONFIG.use_dshot_telemetry = data.readU8() != 0;
+                    MOTOR_CONFIG.use_esc_sensor = data.readU8() != 0;
+                }
                 break;
             case MSPCodes.MSP_COMPASS_CONFIG:
                 COMPASS_CONFIG.mag_declination = data.read16() / 100; // -18000-18000
@@ -1604,7 +1621,10 @@ MspHelper.prototype.crunch = function(code) {
             buffer.push16(MOTOR_CONFIG.minthrottle)
                 .push16(MOTOR_CONFIG.maxthrottle)
                 .push16(MOTOR_CONFIG.mincommand);
-                break;
+            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                buffer.push8(MOTOR_CONFIG.motor_poles);
+            }
+            break;
         case MSPCodes.MSP_SET_GPS_CONFIG:
             buffer.push8(GPS_CONFIG.provider)
                 .push8(GPS_CONFIG.ublox_sbas);

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -141,6 +141,19 @@
                 <div class="clear-both"></div>
                 <div class="motor_testing">
                     <div class="left">
+                        <div class="telemetry">
+                            <ul>
+                                <li><span class="motor-0 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
+                                <li><span class="motor-1 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
+                                <li><span class="motor-2 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
+                                <li><span class="motor-3 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
+                                <li><span class="motor-4 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
+                                <li><span class="motor-5 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
+                                <li><span class="motor-6 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
+                                <li><span class="motor-7 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
+                                <li>&nbsp;</li>
+                            </ul>
+                        </div>
                         <div class="sliders">
                             <input type="range" min="1000" max="2000" value="1000" disabled="disabled"/>
                             <input type="range" min="1000" max="2000" value="1000" disabled="disabled"/>


### PR DESCRIPTION
To go with https://github.com/betaflight/betaflight/pull/8745

This adds telemetry data to the motors tab. The problem with this tab is that there is very few space left for this kind of things, so after some tests and after discussing it, @etracer65 and me arrived to the conclusion that the best place is under each motor element.

![image](https://user-images.githubusercontent.com/2673520/63752506-a8e72d00-c8b1-11e9-9e08-a9d9032091f2.png)

The space is adjusted to the maximum, when the window is at its minimum size:

![image](https://user-images.githubusercontent.com/2673520/63752422-7fc69c80-c8b1-11e9-89ad-a6ec3e05bfd1.png)

Now it shows the RPM, DShot error rate and temperature of the ESCs. The PR in the firmware part contains too the voltage, current and mAh of consumption but maybe is too much data if we add all of them.