### PR TITLE
Change the tooltip attach method

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -345,12 +345,9 @@ GUI_control.prototype.content_ready = function (callback) {
 
     // loading tooltip
     jQuery(document).ready(function($) {
-        $('cf_tip').each(function() { // Grab all ".cf_tip" elements, and for each...
-        log(this); // ...print out "this", which now refers to each ".cf_tip" DOM element
-    });
 
-    $('.cf_tip').each(function() {
-        $(this).jBox('Tooltip', {            
+        new jBox('Tooltip', {
+            attach: '.cf_tip',
             delayOpen: 100,
             delayClose: 100,
             position: {
@@ -358,10 +355,9 @@ GUI_control.prototype.content_ready = function (callback) {
                 y: 'center'
             },
             outside: 'x'
-            });
         });
-    });
 
+    });
 
     if (callback) callback();
 }


### PR DESCRIPTION
Modified the way the tooltip is attached to the `.cf_tip` elements.

Maybe you have faced some known issue while using the Configurator: when you pass over a help icon, the tooltip appears, but sometimes, I think related with a fast movement of the cursor to other tooltip element, the tooltip does not close and it remains in the window. You can change tabs, etc. and the tooltip remains in the window until you close and open again de Configurator.

I have tested all the possible parameters of the JBox libray without luck to fix it.

This change does not fix it at 100%, but it seems to reduce it at least in some cases.

This PR cleans too a old log message that has no sense.