### PR TITLE
Add MSP_MULTIPLE_MSP command

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -61,6 +61,7 @@ var COPY_PROFILE;
 var VTX_CONFIG;
 var VTXTABLE_BAND;
 var VTXTABLE_POWERLEVEL;
+var MULTIPLE_MSP;
 var DEFAULT;
 
 var FC = {
@@ -517,6 +518,10 @@ var FC = {
             vtxtable_powerlevel_number:     0,
             vtxtable_powerlevel_value:      0,
             vtxtable_powerlevel_label:      0,
+        };
+
+        MULTIPLE_MSP = {
+            msp_commands:                   [],
         };
 
         DEFAULT = {

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -154,6 +154,8 @@ var MSPCodes = {
     MSP_SET_VTXTABLE_BAND:          227,
     MSP_SET_VTXTABLE_POWERLEVEL:    228,
 
+    MSP_MULTIPLE_MSP:               230,
+
     MSP_MODE_RANGES_EXTRA:          238,
     MSP_SET_ACC_TRIM:               239,
     MSP_ACC_TRIM:                   240,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -35,6 +35,8 @@ function MspHelper () {
     };
 
     self.SIGNATURE_LENGTH = 32;
+
+    self.mspMultipleCache = [];
 }
 
 MspHelper.prototype.reorderPwmProtocols = function (protocol) {
@@ -1452,6 +1454,51 @@ MspHelper.prototype.process_data = function(dataHandler) {
             case MSPCodes.MSP_SET_RTC:
                 console.log('Real time clock set');
                 break;
+
+            case MSPCodes.MSP_MULTIPLE_MSP:
+
+                let hasReturnedSomeCommand = false; // To avoid infinite loops
+
+                while (data.offset < data.byteLength) {
+
+                    hasReturnedSomeCommand = true;
+
+                    let command = self.mspMultipleCache.shift();
+                    let payloadSize = data.readU8();
+
+                    if (payloadSize != 0) {
+
+                        let currentDataHandler = {
+                                code         : command,
+                                dataView     : new DataView(data.buffer, data.offset, payloadSize),
+                                callbacks    : [],
+                        }
+    
+                        self.process_data(currentDataHandler);
+
+                        data.offset += payloadSize;
+                    }
+                }
+
+                if (hasReturnedSomeCommand) {
+                    // Send again MSP messages missing, the buffer in the FC was too small
+                    if (self.mspMultipleCache.length > 0) {
+    
+                        var partialBuffer = [];
+                        for (let i = 0; i < self.mspMultipleCache.length; i++) {
+                            partialBuffer.push8(self.mspMultipleCache[i]);
+                        }
+    
+                        MSP.send_message(MSPCodes.MSP_MULTIPLE_MSP, partialBuffer, false, dataHandler.callbacks);
+                        dataHandler.callbacks = [];
+                    }
+                } else {
+                    console.log("MSP Multiple can't process the command");
+                    self.mspMultipleCache = [];
+                }
+
+                break;
+
             default:
                 console.log('Unknown code detected: ' + code);
         } else {
@@ -1491,6 +1538,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
 MspHelper.prototype.crunch = function(code) {
     var buffer = [];
     var self = this;
+
     switch (code) {
         case MSPCodes.MSP_SET_FEATURE_CONFIG:
             var featureMask = FEATURE_CONFIG.features.getMask();
@@ -2040,6 +2088,18 @@ MspHelper.prototype.crunch = function(code) {
             buffer.push8(VTXTABLE_BAND.vtxtable_band_frequencies.length);
             for (let i = 0; i < VTXTABLE_BAND.vtxtable_band_frequencies.length; i++) {
                 buffer.push16(VTXTABLE_BAND.vtxtable_band_frequencies[i]);
+            }
+
+            break;
+
+        case MSPCodes.MSP_MULTIPLE_MSP:
+
+            while (MULTIPLE_MSP.msp_commands.length > 0) {
+
+                let mspCommand = MULTIPLE_MSP.msp_commands.shift();
+
+                self.mspMultipleCache.push(mspCommand);
+                buffer.push8(mspCommand);
             }
 
             break;


### PR DESCRIPTION
This fixes (at least partially) the request here: https://github.com/betaflight/betaflight-configurator/issues/1596

This PR implements the MSP_MULTIPLE_MSP command, to allow retrieve multiple MSP data in a single MSP call.

This code is EXPERIMENTAL, I have done some testing, and I think it works ok, but the async nature of the javascript and specially the MSP calls don't let me assure that it will work in all cases, specially the MSP cache queue but the worst final result if something goes wrong if someone sends multiple MSP_MULTIPLE_MSP commands will be that the callbacks of all of them will not be called until all the MULTIPLE MSP commands are finished. I will try to fix it later in a future version if I find how to do it.

To use it is the same process as always, as sample:

```javascript
    function get_adjustment_ranges() {

        MULTIPLE_MSP.msp_commands.push(MSPCodes.MSP_ADJUSTMENT_RANGES,
                                       MSPCodes.MSP_BOXIDS,
                                       MSPCodes.MSP_RC);
        MSP.send_message(MSPCodes.MSP_MULTIPLE_MSP, mspHelper.crunch(MSPCodes.MSP_MULTIPLE_MSP), false, load_html);

    }
```
It can be merged without problem, this PR does not break anything of the current code, and it will let developers play with it, but the real use of it is encouraged to be postponed until the release of Configurator 10.6.