### PR TITLE
Add save/load buttons for the VTX Table

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4784,6 +4784,10 @@
         "message": "<span class=\"message-negative\">Attention:</span> You need to configure and save FIRST the VTX Table at the bottom before you can make use of the $t(vtxSelectedMode.message) fields.",
         "description": "Message to show when the VTX is not supported in the VTX tab"
     },
+    "vtxMessageVerifyTable": {
+        "message": "<span class=\"message-negative\">Attention:</span> The values of the VTX Table have been loaded, but not yet stored on the flight controller. You must verify and modify the values to be sure that they are valid and legal in your country and then press the $t(vtxButtonSave.message) button to store them on the flight controller.",
+        "description": "Message to show when the VTX Table has been loaded from a external source"
+    },
     "vtxFrequencyChannel": {
         "message": "Enter frequency directly",
         "description": "Text of one of the fields of the VTX tab"
@@ -4971,6 +4975,31 @@
     "vtxTableBandsChannelsTableHelp": {
         "message": "This table represents all the frequencies that can be used for your VTX. You can have several bands and for each band you must configure:<br><b>- $t(vtxTableBandTitleName.message):</b> Name that you want to assign to this band, like BOSCAM_A, FATSHARK or RACEBAND.<br><b>- $t(vtxTableBandTitleLetter.message):</b> Short letter that references the band.<br><b>- $t(vtxTableBandTitleFactory.message):</b> This indicates if it is a factory band. If enabled Betaflight sends to the VTX a band and channel number. The VTX will then use its built-in frequency table and the frequencies configured here are only to show the value in the OSD and other places. If it is not enabled, then Betaflight will send to the VTX the real frequency configured here.<br><b>- Frequencies:</b> Frequencies for this band.<br><br>Remember that not all frequencies are legal at your country. You must put a value of <b>zero</b> to each frequency index that you are not allowed to use to disable it.",
         "description": "Help for the table of bands-channels that appears in the VTX tab"
+    },
+
+    "vtxSavedFileOk": {
+        "message": "VTX Config file <span class=\"message-positive\">saved</span>",
+        "description": "Message in the GUI log when the VTX Config file is saved"
+    },
+    "vtxSavedFileKo": {
+        "message": "<span class=\"message-negative\">Error</span> while saving the VTX Config file",
+        "description": "Message in the GUI log when the VTX Config file is saved"
+    },
+    "vtxLoadFileOk": {
+        "message": "VTX Config file <span class=\"message-positive\">loaded</span>",
+        "description": "Message in the GUI log when the VTX Config file is loaded"
+    },
+    "vtxLoadFileKo": {
+        "message": "<span class=\"message-negative\">Error</span> while loading the VTX Config file",
+        "description": "Message in the GUI log when the VTX Config file is loaded"
+    },
+    "vtxButtonSaveFile": {
+        "message": "Save to file",
+        "description": "Save to file button in the VTX tab"
+    },
+    "vtxButtonLoadFile": {
+        "message": "Load from file",
+        "description": "Load to file button in the VTX tab"
     },
     "vtxButtonSave": {
         "message": "Save",

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2054,8 +2054,12 @@ MspHelper.prototype.crunch = function(code) {
                 buffer.push8(VTXTABLE_BAND.vtxtable_band_name.charCodeAt(i));
             }
 
-            buffer.push8(VTXTABLE_BAND.vtxtable_band_letter.charCodeAt(0))
-                  .push8(VTXTABLE_BAND.vtxtable_band_is_factory_band ? 1 : 0);
+            if (VTXTABLE_BAND.vtxtable_band_letter != '') {
+                buffer.push8(VTXTABLE_BAND.vtxtable_band_letter.charCodeAt(0))
+            } else {
+                buffer.push8(' '.charCodeAt(0));
+            }
+            buffer.push8(VTXTABLE_BAND.vtxtable_band_is_factory_band ? 1 : 0);
 
             buffer.push8(VTXTABLE_BAND.vtxtable_band_frequencies.length);
             for (let i = 0; i < VTXTABLE_BAND.vtxtable_band_frequencies.length; i++) {

--- a/src/tabs/vtx.html
+++ b/src/tabs/vtx.html
@@ -190,6 +190,10 @@
                 <td>
                     <div class="leftWrapper">
 
+                        <div class="note note_spacer vtx_table_save_pending">
+                            <div i18n="vtxMessageVerifyTable"/>
+                        </div>
+
                         <div class="gui_box grey vtx_table_box vtx_table_available">
 
                             <div class="gui_box_titlebar">
@@ -269,6 +273,12 @@
     </div>
 
     <div class="content_toolbar">
+        <div class="btn save_file_btn">
+            <a class="save_file" id="save_file_button" href="#" i18n="vtxButtonSaveFile"></a>
+        </div>
+        <div class="btn load_file_btn">
+            <a class="load_file" id="load_file_button" href="#" i18n="vtxButtonLoadFile"></a>
+        </div>
         <div class="btn save_btn">
             <a class="save" id="save_button" href="#" i18n="vtxButtonSave"></a>
         </div>
@@ -282,7 +292,7 @@
     <div id="tab-vtx-powerlevel-values">
         <table>
             <tr>
-                <td><span class="numberspacer field_powerlevel_value"><input type="number" id="vtx_table_powerlevels" min="0" max="65535"></span></td>
+                <td><span class="numberspacer field_powerlevel_value"><input type="number" id="vtx_table_powerlevels" min="0" max="65535" value="0"></span></td>
             </tr>
         </table>
     </div>
@@ -319,7 +329,7 @@
     <div id="tab-vtx-channels">
         <table>
             <tr>
-                <td><span class="numberspacer field_band_channel "><input class="frequency_input" type="number" id="vtx_table_band_channel" min="0" max="5999"></span></td>
+                <td><span class="numberspacer field_band_channel "><input class="frequency_input" type="number" id="vtx_table_band_channel" min="0" max="5999" value="0"></span></td>
             </tr>
         </table>
     </div>


### PR DESCRIPTION
It adds a load/save button for the VTX Tables in the VTX tab that work with JSON format.

![image](https://user-images.githubusercontent.com/2673520/64105083-d03c6f00-cd75-11e9-8e40-05ce3fc36201.png)

A sample of the file generated is:
```json
{
    "description": "Betaflight VTX Config file",
    "version": "1.0",
    "vtx_table": {
        "bands": 5,
        "channels": 8,
        "bands_list": [
            {
                "number": 1,
                "name": "BOSCAM_A",
                "letter": "A",
                "is_factory_band": true,
                "frequencies": [
                    5865,
                    5845,
                    5825,
                    5805,
                    5785,
                    5765,
                    5745,
                    5725
                ]
            },
            {
                "number": 2,
                "name": "BOSCAM_B",
                "letter": "B",
                "is_factory_band": true,
                "frequencies": [
                    5733,
                    5752,
                    5771,
                    5790,
                    5809,
                    5828,
                    5847,
                    5866
                ]
            },
            {
                "number": 3,
                "name": "BOSCAM_E",
                "letter": "E",
                "is_factory_band": true,
                "frequencies": [
                    5705,
                    5685,
                    5665,
                    0,
                    5885,
                    5905,
                    0,
                    0
                ]
            },
            {
                "number": 4,
                "name": "FATSHARK",
                "letter": "F",
                "is_factory_band": true,
                "frequencies": [
                    5740,
                    5760,
                    5780,
                    5800,
                    5820,
                    5840,
                    5860,
                    5880
                ]
            },
            {
                "number": 5,
                "name": "RACEBAND",
                "letter": "R",
                "is_factory_band": true,
                "frequencies": [
                    5658,
                    5695,
                    5732,
                    5769,
                    5806,
                    5843,
                    5880,
                    5917
                ]
            }
        ],
        "powerlevels": 4,
        "powerlevels_list": [
            {
                "number": 1,
                "value": 0,
                "label": "25 "
            },
            {
                "number": 2,
                "value": 1,
                "label": "200"
            },
            {
                "number": 3,
                "value": 2,
                "label": "600"
            },
            {
                "number": 4,
                "value": 3,
                "label": "1.2"
            }
        ]
    }
}
```

The buttons work as other tabs:
- They save/load the content but only a message in the GUI log appear. Maybe is better to add a modal window with that info? We don't do it at other similar tabs.
- It saves the "live" tab content (not the saved in the firmware one) to the file. I thought this is most intuitive to the user.
- It loads the content to the tab, but it does not save it. Maybe we need to add a GUI message/modal window saying the user to verify/modify/save it.