### PR TITLE
Add warning if Smartaudio port assigned and VTX table not set up

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1373,6 +1373,9 @@
     "portsHelp": {
         "message": "<strong>Note:</strong> not all combinations are valid.  When the flight controller firmware detects this the serial port configuration will be reset."
     },
+    "portsVtxTableNotSet": {
+        "message": "<span class=\"message-negative\">WARNING:</span> The VTX table has not been set up correctly and without it VTX control will not be possible. Please set up the VTX table in $t(tabVtx.message) tab."
+    },
     "portsMSPHelp": {
         "message": "<strong>Note:</strong> Do <span class=\"message-negative\">NOT</span> disable MSP on the first serial port unless you know what you are doing.  You may have to reflash and erase your configuration if you do."
     },

--- a/src/tabs/ports.html
+++ b/src/tabs/ports.html
@@ -11,6 +11,11 @@
                     <p i18n="portsMSPHelp"></p>
                 </div>
             </div>
+            <div class="note vtxTableNotSet spacebottom">
+                <div class="note_spacer">
+                    <p i18n="portsVtxTableNotSet"></p>
+                </div>
+            </div>
             <table class="ports spacebottom">
                 <thead>
                     <tr>


### PR DESCRIPTION
Shows a warning note if you assign a port for Smartaudio or Tramp and the vtx table is not set up.
@mikeller Should this be enough to ''fix'' betaflight/betaflight#8805 in your opinion? I don't like the idea to enable configuration of vtx table if port isn't assigned for now. We could do that if the firmware bug isn't resolved by the time of release as a workaround. This warning will be relevant even when the bug is fixed as you said.
With the warning displayed users will not forget to set up the vtx table and that should avoid the bug but only if the VTX is not powered.