### PR TITLE
Add visual indicator on ARM mode when arming is disabled by the firmware

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1880,6 +1880,10 @@
     "auxiliaryMax": {
         "message": "Max"
     },
+    "auxiliaryDisabled": {
+        "message": "(DISABLED)",
+        "descripton": "Text to add to the ARM mode (maybe others in the future) in the MODES TAB when it has been disabled for some external reason"
+    },    
     "auxiliaryAddRange": {
         "message": "Add Range"
     },

--- a/src/css/tabs/auxiliary.css
+++ b/src/css/tabs/auxiliary.css
@@ -40,6 +40,14 @@
     background: #828885;
 }
 
+.tab-auxiliary .mode.disabled .info {
+    background: var(--error);
+    color: var(--quietText);}
+
+.tab-auxiliary .mode.disabled:nth-child(odd) .info {
+    background: var(--error);
+}
+
 #tab-auxiliary-templates {
     display: none;
 }

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -429,14 +429,46 @@ TABS.auxiliary.initialize = function (callback) {
                 let modeElement = $('#mode-' + i);
                 if (modeElement.find(' .range').length == 0 && modeElement.find(' .link').length == 0) {
                     // if the mode is unused, skip it
-                    modeElement.removeClass('off').removeClass('on');
+                    modeElement.removeClass('off').removeClass('on').removeClass('disabled');
                     continue;
                 }
                 
                 if (bit_check(CONFIG.mode, i)) {
-                    $('.mode .name').eq(i).data('modeElement').addClass('on').removeClass('off');
+                    $('.mode .name').eq(i).data('modeElement').addClass('on').removeClass('off').removeClass('disabled');
+
+                    // ARM mode is a special case
+                    if (i == 0) {
+                        $('.mode .name').eq(i).html(AUX_CONFIG[i]);
+                    }
                 } else {
-                    $('.mode .name').eq(i).data('modeElement').removeClass('on').addClass('off');
+
+                    //ARM mode is a special case
+                    if (i == 0) {
+                        var armSwitchActive = false;
+                        
+                        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                            if (CONFIG.armingDisableCount > 0) {
+                                // check the highest bit of the armingDisableFlags. This will be the ARMING_DISABLED_ARMSWITCH flag.
+                                var armSwitchMask = 1 << (CONFIG.armingDisableCount - 1);
+                                if ((CONFIG.armingDisableFlags & armSwitchMask) > 0) {
+                                    armSwitchActive = true;
+                                }
+                            }
+                        }
+
+                        // If the ARMING_DISABLED_ARMSWITCH flag is set then that means that arming is disabled
+                        // and the arm switch is in a valid arming range. Highlight the mode in red to indicate
+                        // that arming is disabled.
+                        if (armSwitchActive) {
+                            $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('off').addClass('disabled');
+                            $('.mode .name').eq(i).html(AUX_CONFIG[i] + '<br>' + i18n.getMessage('auxiliaryDisabled'));
+                        } else {
+                            $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('disabled').addClass('off');
+                            $('.mode .name').eq(i).html(AUX_CONFIG[i]);
+                        }
+                    } else {
+                        $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('disabled').addClass('off');
+                    }
                 }
                 hasUsedMode = true;
             }


### PR DESCRIPTION
The most frequent support question we have is "why won't my quad arm?" The majority of these are in the context of the person looking at the Modes tab and seeing the channel indicator in the selected region but questioning why the mode doesn't "light up". They don't understand that this is a refusal to arm by the firmware and instead think there's something wrong with their mode setting because the entry should "light up" like the other modes.

So this change causes the ARM mode to "light up" **in red** whenever the arm switch is in a position that would arm except for being blocked by an arming disabled flag. Additionally the mode name changes from "ARM" to "ARM (DISABLED)". If arming is enabled (safety switch checked and no other item preventing) then the mode will "light up" normally like other modes.

Looks like this:

![Screen Shot 2019-09-03 at 1 58 14 PM](https://user-images.githubusercontent.com/17088539/64196958-eec46800-ce52-11e9-97da-2a38d44b6254.png)

So the user gets a visual indication that "something is happening" and hopefully the combination of "DISABLED" and the red (meaning problem) color will help them towards understanding they need to fix something.

As a follow-on I'd like to add the arming disabled reasons as currently presented on the Setup tab to the top of the modes tab as well. The idea being to reinforce that arming was disabled, and here are the reasons why. However that will take more work to abstract he code from the Setup tab for reuse in both and thus should be a separate PR.

Hopefully these changes will make some improvements to reduce the most frequently asked support question.

Thanks to @McGiverGim for the help with some of the CSS and the mode name update code.