### PR TITLE
Fix vtx table inputs not always responsive

### DIFF
--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -234,7 +234,7 @@ TABS.vtx.initialize = function (callback) {
             }
         }
 
-        $("#vtx_table_powerlevels").change(showHidePowerlevels).change();
+        $("#vtx_table_powerlevels").on('input', showHidePowerlevels).trigger('input');
 
         function showHideBands() {
             let bandsValue = $(this).val();
@@ -244,7 +244,7 @@ TABS.vtx.initialize = function (callback) {
             }
         }
 
-        $("#vtx_table_bands").change(showHideBands).change();
+        $("#vtx_table_bands").on('input', showHideBands).trigger('input');
 
         function showHideBandChannels() {
             let channelsValue = $(this).val();
@@ -254,7 +254,7 @@ TABS.vtx.initialize = function (callback) {
             }
         }
 
-        $("#vtx_table_channels").change(showHideBandChannels).change();
+        $("#vtx_table_channels").on('input', showHideBandChannels).trigger('input');
 
         /*** Helper functions */
 


### PR DESCRIPTION
In the vtx table band, channel and power inputs seem to only make changes after some time if you click fast a few times. This should fix this so it updates on each click. @McGiverGim 
![BetaflightConfigurator2019-09-04](https://user-images.githubusercontent.com/50072760/64243052-f6dddf80-cf06-11e9-8ec1-47f8442c053f.gif)