### PR TITLE
Add RPM filter configuration

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1189,6 +1189,18 @@
     "configurationDigitalIdlePercentHelp": {
         "message": "This is the 'idle' value in percent of maximum throttle that is sent to the ESCs when the craft is armed and the trottle stick is at minimum position. Increase the percent value to gain more idle speed."
     },
+    "configurationMotorPoles": {
+        "message": "Motor poles",
+        "description": "One of the fields of the ESC/Motor configuration"
+    },
+    "configurationMotorPolesLong": {
+        "message": "$t(configurationMotorPoles.message) (number of magnets on the motor bell)",
+        "description": "One of the fields of the ESC/Motor configuration"
+    },
+    "configurationMotorPolesHelp": {
+        "message": "This setting is used for some features like the RPM Filter.<br><br>Represents the number of magnets that are on the bell of the motor. <b>Do NOT count the stators</b> where the windings are located. Typical 5\" motors have 14 magnets, smaller ones like 3\" or less usually have 12 magnets.",
+        "description": "Help text for the Motor poles field of the ESC/Motor configuration"
+    },
     "configurationThrottleMinimum": {
         "message": "Minimum Throttle (Lowest ESC value when armed)"
     },
@@ -3286,6 +3298,9 @@
     "pidTuningGyroLowpass2Type": {
         "message": "Gyro Lowpass 2 Filter Type"
     },
+    "pidTuningLowpassFilterHelp": {
+        "message": "The Lowpass Filters can have two variants: static and dynamic. For a determined lowpass filter number only one (static or dynamic) can be enabled at the same time. The static only has a Cutoff that is a value that defines in some way where the filter starts. The dynamic defines a min and max values, that is the range where the Cutoff is placed. This Cutoff moves from min to max at the same time than you move the throttle stick."
+    },
     "pidTuningGyroNotchFiltersGroup": {
         "message": "Gyro Notch Filters"
     },
@@ -3337,8 +3352,29 @@
     "pidTuningDynamicNotchMinHzHelp": {
         "message": "Defines the lowest dynamic notch center frequency below which the dynamic notch will not go."
     },
-    "pidTuningLowpassFilterHelp": {
-        "message": "The Lowpass Filters can have two variants: static and dynamic. For a determined lowpass filter number only one (static or dynamic) can be enabled at the same time. The static only has a Cutoff that is a value that defines in some way where the filter starts. The dynamic defines a min and max values, that is the range where the Cutoff is placed. This Cutoff moves from min to max at the same time than you move the throttle stick."
+    "pidTuningRpmFilterGroup": {
+        "message": "Gyro RPM Filter",
+        "description": "Header text for the RPM Filter group"
+    },
+    "pidTuningRpmFilterHelp": {
+        "message": "RPM filtering is a bank of notch filters on gyro which use the RPM telemetry data to remove motor noise with surgical precision.<br><br><b><span class=\"message-positive\">IMPORTANT</span>: The ESC must support the Bidirectional DShot protocol and the value of the $t(configurationMotorPoles.message) in the $t(tabConfiguration.message) tab must be correct for this filter to work.</b>",
+        "description": "Header text for the RPM Filter group"
+    },
+    "pidTuningRpmHarmonics": {
+        "message": "Gyro RPM Filter Harmonics Number",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmHarmonicsHelp": {
+        "message": "Number of harmonics per motor. A value of 3 (recommended for most quads) will generate 3 notch filters, per motor for each axis, totaling 36 notches. One at the base motor frequency and two harmonics at multiples of that base frequency.",
+        "description": "Help text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmMinHz": {
+        "message": "Gyro RPM Filter Min Frequency [Hz]",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmMinHzHelp": {
+        "message": "Minimum frequency that will be used by the RPM Filter.",
+        "description": "Help text for one of the parameters of the RPM Filter"
     },
     "pidTuningFilterSettings": {
         "message": "Profile dependent Filter Settings"
@@ -5156,6 +5192,14 @@
     },
     "configurationUnsyncedPWMFreq": {
         "message": "Motor PWM frequency"
+    },
+    "configurationDshotBidir": {
+        "message": "Bidirectional DShot (requires supported ESC firmware)",
+        "description": "Feature for the ESC/Motor"
+    },
+    "configurationDshotBidirHelp": {
+        "message": "When enabled lets the DSHOT protocol receive information directly from the ESC, needed by the RPM Filter and other features.<br><br>This requires the JESC firmware from jflight.net on BLHELI_S or the latest BLHELI_32 firmware.",
+        "description": "Description of the Bidirectional DShot feature of the ESC/Motor"
     },
     "configurationGyroSyncDenom": {
         "message": "Gyro update frequency"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -409,6 +409,8 @@ var FC = {
             dyn_notch_width_percent:    0,
             dyn_notch_q:                0,
             dyn_notch_min_hz:           0,
+            gyro_rpm_notch_harmonics:   0,
+            gyro_rpm_notch_min_hz:      0,
         };
 
         ADVANCED_TUNING = {
@@ -550,6 +552,7 @@ var FC = {
             gyro_notch_hz:                  400,
             gyro_notch2_cutoff:             100,
             gyro_notch2_hz:                 200,
+            gyro_rpm_notch_harmonics:         3,
             dterm_lowpass_hz:               100,
             dterm_lowpass_dyn_min_hz:       150,
             dterm_lowpass_dyn_max_hz:       250,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1026,6 +1026,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                 FILTER_CONFIG.dyn_notch_width_percent = data.readU8();
                                 FILTER_CONFIG.dyn_notch_q = data.readU16();
                                 FILTER_CONFIG.dyn_notch_min_hz = data.readU16();
+
+                                FILTER_CONFIG.gyro_rpm_notch_harmonics = data.readU8();
+                                FILTER_CONFIG.gyro_rpm_notch_min_hz = data.readU8();
                             }
                         }
                     }
@@ -1675,6 +1678,7 @@ MspHelper.prototype.crunch = function(code) {
                 .push16(MOTOR_CONFIG.mincommand);
             if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
                 buffer.push8(MOTOR_CONFIG.motor_poles);
+                buffer.push8(MOTOR_CONFIG.use_dshot_telemetry ? 1 : 0);
             }
             break;
         case MSPCodes.MSP_SET_GPS_CONFIG:
@@ -1920,7 +1924,9 @@ MspHelper.prototype.crunch = function(code) {
                     buffer.push8(FILTER_CONFIG.dyn_notch_range)
                           .push8(FILTER_CONFIG.dyn_notch_width_percent)
                           .push16(FILTER_CONFIG.dyn_notch_q)
-                          .push16(FILTER_CONFIG.dyn_notch_min_hz);
+                          .push16(FILTER_CONFIG.dyn_notch_min_hz)
+                          .push8(FILTER_CONFIG.gyro_rpm_notch_harmonics)
+                          .push8(FILTER_CONFIG.gyro_rpm_notch_min_hz);
                 }
             }
             break;

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -2,6 +2,7 @@
 
 TABS.configuration = {
     DSHOT_PROTOCOL_MIN_VALUE: 5,
+    PROSHOT_PROTOCOL_VALUE: 0,
     SHOW_OLD_BATTERY_CONFIG: false,
     analyticsChanges: {},
 };
@@ -417,6 +418,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
             if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                 escprotocols.push('PROSHOT1000');
+                self.PROSHOT_PROTOCOL_VALUE = escprotocols.length - 1; 
             }
         }
 
@@ -437,7 +439,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[id="unsyncedPWMSwitch"]').prop('checked', PID_ADVANCED_CONFIG.use_unsyncedPwm !== 0).change();
         $('input[name="unsyncedpwmfreq"]').val(PID_ADVANCED_CONFIG.motor_pwm_rate);
         $('input[name="digitalIdlePercent"]').val(PID_ADVANCED_CONFIG.digitalIdlePercent);
-
+        $('input[id="dshotBidir"]').prop('checked', MOTOR_CONFIG.use_dshot_telemetry).change();
+        $('input[name="motorPoles"]').val(MOTOR_CONFIG.motor_poles);
 
         esc_protocol_e.val(PID_ADVANCED_CONFIG.fast_pwm_protocol + 1);
         esc_protocol_e.change(function () {
@@ -458,6 +461,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 $('div.unsyncedpwmfreq').hide();
 
                 $('div.digitalIdlePercent').show();
+
+                $('div.checkboxDshotBidir').toggle(semver.gte(CONFIG.apiVersion, "1.42.0") && escProtocolValue < self.PROSHOT_PROTOCOL_VALUE);
+                $('div.motorPoles').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
+
             } else {
                 $('div.minthrottle').show();
                 $('div.maxthrottle').show();
@@ -467,7 +474,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 $("input[id='unsyncedPWMSwitch']").change();
 
                 $('div.digitalIdlePercent').hide();
+
+                $('div.checkboxDshotBidir').hide();
+                $('div.motorPoles').hide();
             }
+
         }).change();
 
 
@@ -1068,6 +1079,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             MOTOR_CONFIG.minthrottle = parseInt($('input[name="minthrottle"]').val());
             MOTOR_CONFIG.maxthrottle = parseInt($('input[name="maxthrottle"]').val());
             MOTOR_CONFIG.mincommand = parseInt($('input[name="mincommand"]').val());
+            if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                MOTOR_CONFIG.motor_poles = parseInt($('input[name="motorPoles"]').val());
+                MOTOR_CONFIG.use_dshot_telemetry = $('input[id="dshotBidir"]').prop('checked'); 
+            }
 
             if(self.SHOW_OLD_BATTERY_CONFIG) {
                 MISC.vbatmincellvoltage = parseFloat($('input[name="mincellvoltage"]').val());

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -45,6 +45,8 @@ TABS.pid_tuning.initialize = function (callback) {
     }).then(function() {
         return MSP.promise(MSPCodes.MSP_RC_DEADBAND);
     }).then(function() {
+        return MSP.promise(MSPCodes.MSP_MOTOR_CONFIG);
+    }).then(function() {
         MSP.send_message(MSPCodes.MSP_MIXER_CONFIG, false, false, load_html);
     });
 
@@ -351,9 +353,29 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_filter input[name="dynamicNotchQ"]').val(FILTER_CONFIG.dyn_notch_q);
             $('.pid_filter input[name="dynamicNotchMinHz"]').val(FILTER_CONFIG.dyn_notch_min_hz);
 
+            $('.rpmFilter').toggle(MOTOR_CONFIG.use_dshot_telemetry);
+
+            $('.pid_filter input[name="rpmFilterHarmonics"]').val(FILTER_CONFIG.gyro_rpm_notch_harmonics);
+            $('.pid_filter input[name="rpmFilterMinHz"]').val(FILTER_CONFIG.gyro_rpm_notch_min_hz);
+
+            $('.pid_filter #rpmFilterEnabled').change(function() {
+
+                let harmonics = $('.pid_filter input[name="rpmFilterHarmonics"]').val();
+                let checked = $(this).is(':checked') && harmonics != 0;
+
+                $('.pid_filter input[name="rpmFilterHarmonics"]').attr('disabled', !checked);
+                $('.pid_filter input[name="rpmFilterMinHz"]').attr('disabled', !checked);
+
+                if (harmonics == 0) {
+                    $('.pid_filter input[name="rpmFilterHarmonics"]').val(FILTER_DEFAULT.gyro_rpm_notch_harmonics);
+                }
+            }).prop('checked', FILTER_CONFIG.gyro_rpm_notch_harmonics != 0).change();
+
+
         } else {
             $('.itermRelaxCutoff').hide();
             $('.dynamicNotch').hide();
+            $('.rpmFilter').hide();
         }
 
         $('input[id="useIntegratedYaw"]').change(function() {
@@ -723,6 +745,10 @@ TABS.pid_tuning.initialize = function (callback) {
             FILTER_CONFIG.dyn_notch_width_percent = parseInt($('.pid_filter input[name="dynamicNotchWidthPercent"]').val());
             FILTER_CONFIG.dyn_notch_q = parseInt($('.pid_filter input[name="dynamicNotchQ"]').val());
             FILTER_CONFIG.dyn_notch_min_hz = parseInt($('.pid_filter input[name="dynamicNotchMinHz"]').val());
+
+            let rpmFilterEnabled = $('.pid_filter #rpmFilterEnabled').is(':checked');
+            FILTER_CONFIG.gyro_rpm_notch_harmonics = rpmFilterEnabled ? parseInt($('.pid_filter input[name="rpmFilterHarmonics"]').val()) : 0;
+            FILTER_CONFIG.gyro_rpm_notch_min_hz = parseInt($('.pid_filter input[name="rpmFilterMinHz"]').val());
         }
     }
 

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -169,6 +169,15 @@
                                         <span i18n="configurationUnsyncedPWMFreq"></span>
                                     </label>
                                 </div>
+                                <div class="number checkboxDshotBidir">
+                                    <div style="float: left; height: 20px; margin-right: 5px; margin-left: 3px;">
+                                        <input type="checkbox" id="dshotBidir" class="toggle" />
+                                    </div>
+                                    <label for="dshotBidir"> 
+                                        <span class="freelabel" i18n="configurationDshotBidir" />
+                                        <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp" />
+                                    </label>
+                                </div>
                                 <table cellpadding="0" cellspacing="0" style="margin-bottom:10px;">
                                     <tbody class="features esc">
                                         <!-- table generated here -->
@@ -202,6 +211,15 @@
                                         </div>
                                         <span i18n="configurationDigitalIdlePercent"></span>
                                         <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
+                                    </label>
+                                </div>
+                                <div class="number motorPoles">
+                                    <label>
+                                        <div class="numberspacer">
+                                            <input type="number" name="motorPoles" min="4" max="255" step="1"/>
+                                        </div>
+                                        <span i18n="configurationMotorPolesLong"></span>
+                                        <div class="helpicon cf_tip" i18n_title="configurationMotorPolesHelp"></div>
                                     </label>
                                 </div>
                                 <div class="number minthrottle">

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1099,7 +1099,45 @@
                                     </div>
                                 </td>
                             </tr>
-                            
+
+                            <tr>
+                                <th colspan="2">
+                                    <div class="pid_mode rpmFilter">
+                                        <div i18n="pidTuningRpmFilterGroup" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmFilterHelp" />
+                                    </div>
+                                </th>
+                            </tr>
+                            <tr class="newFilter rpmFilter">
+                                <td>
+                                    <span class="groupSwitchValue">
+                                        <span class="inputSwitch"><input type="checkbox" id="rpmFilterEnabled" class="toggle" /></span>
+                                        <span class="inputValue"><input type="number" class="nonProfile" name="rpmFilterHarmonics" step="1" min="1" max="3"/></span>
+                                    </span>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningRpmHarmonics"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmHarmonicsHelp" />
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr class="newFilter rpmFilter">
+                                <td>
+                                    <input type="number" name="rpmFilterMinHz" step="1" min="50" max="200"/>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningRpmMinHz"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmMinHzHelp" />
+                                    </div>
+                                </td>
+                            </tr>
+
                             <tr>
                                 <th colspan="2">
                                     <div class="pid_mode dynamicNotch">
@@ -1162,6 +1200,7 @@
                                     </div>
                                 </td>
                             </tr>
+
                         </table>
                     </div>
                     <div class="gui_box grey topspacer pid_filter two_columns_second">


### PR DESCRIPTION
To go with https://github.com/betaflight/betaflight/pull/8817

Adds configuration for the:
- Bidirectional DShot
- Motor poles
- RPM Filter (harmonics and min hz)

![image](https://user-images.githubusercontent.com/2673520/64282521-e7d24e00-cf55-11e9-8057-027c73a6471e.png)
![image](https://user-images.githubusercontent.com/2673520/64282701-47c8f480-cf56-11e9-90f7-22612458dad3.png)

Don't merge by the moment, the save action in the PIDs tab is giving some strange MSP error that I'm not sure if it is culprit of this code or is another kind of bug.

Fixes #1631.