### PR TITLE
Further work: consider versions for unified targets

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2582,9 +2582,6 @@
     "firmwareFlasherReleaseDate": {
         "message": "Date:"
     },
-    "firmwareFlasherReleaseStatus": {
-        "message": "State:"
-    },
     "firmwareFlasherReleaseTarget": {
         "message": "Target:"
     },
@@ -2615,6 +2612,9 @@
     },
     "firmwareFlasherLoadFirmwareFile": {
         "message": "Please load firmware file"
+    },
+    "firmwareFlasherLoadedConfig": {
+        "message": "Loaded target, please load firmware file"
     },
     "firmwareFlasherNoReboot": {
         "message": "No reboot sequence"

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -93,7 +93,6 @@
                     href="#" target="_blank"></a><br /> <strong i18n="firmwareFlasherReleaseFile"></strong> <a
                     i18n_title="firmwareFlasherReleaseFileUrl" class="file" href="#" target="_blank"></a><br /> <strong
                     i18n="firmwareFlasherReleaseDate"></strong> <span class="date"></span><br /> <strong
-                    i18n="firmwareFlasherReleaseStatus"></strong> <span class="status"></span><br /> <strong
                     i18n="firmwareFlasherReleaseNotes"></strong>
                 <div class=notes></div>
             </div>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/190571/64420293-ca83a980-d053-11e9-86f7-85d66b0ad7d8.png)

Right under release info, do we want to change the target? At the very least I'd like to keep the binary showing STM32F405....

Also `State:` is blank on both Dev and Release builds. I'm curious as to what goes there.

Todo
- [x] `if (bareBoard == target)` condition needs test
- [x] stop board from changing to 0
- [X] ~~add a button to throw out locally loaded config~~
- [ ] fail to flash if loaded (locally or not) config can't be used.