### PR TITLE
Fix PID tuning tab active subtab

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -19,6 +19,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
     if (GUI.active_tab !== 'pid_tuning') {
         GUI.active_tab = 'pid_tuning';
+        self.activeSubtab = 'pid';
     }
 
     // Update filtering defaults based on API version


### PR DESCRIPTION
Introduced in #1610
After selecting the filter or rates subtab, then leaving the PID tuning tab and going back to it, it shows the last selected subtab.
I think it is better to always show PID subtab when you first load the PID tuning tab.