### PR TITLE
Reorder and make more consistent the Motor/ESC Configuration box

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1019,7 +1019,7 @@
         "message": "SPI RX support"
     },
     "featureESC_SENSOR": {
-        "message": "Use KISS/BLHeli_32 ESC telemetry as sensor"
+        "message": "Use KISS/BLHeli_32 ESC telemetry <b>over a separate wire</b>"
     },
     "featureCHANNEL_FORWARDING": {
         "message": "Forward aux channels to servo outputs"

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -2,7 +2,6 @@
 
 TABS.configuration = {
     DSHOT_PROTOCOL_MIN_VALUE: 5,
-    PROSHOT_PROTOCOL_VALUE: 0,
     SHOW_OLD_BATTERY_CONFIG: false,
     analyticsChanges: {},
 };
@@ -418,7 +417,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
             if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
                 escprotocols.push('PROSHOT1000');
-                self.PROSHOT_PROTOCOL_VALUE = escprotocols.length - 1; 
             }
         }
 
@@ -453,31 +451,21 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             self.analyticsChanges['EscProtocol'] = newValue;
 
             //hide not used setting for DSHOT protocol
-            if (escProtocolValue >= self.DSHOT_PROTOCOL_MIN_VALUE) {
-                $('div.minthrottle').hide();
-                $('div.maxthrottle').hide();
-                $('div.mincommand').hide();
-                $('div.checkboxPwm').hide();
-                $('div.unsyncedpwmfreq').hide();
+            let digitalProtocol = (escProtocolValue >= self.DSHOT_PROTOCOL_MIN_VALUE);
 
-                $('div.digitalIdlePercent').show();
+            $('div.minthrottle').toggle(!digitalProtocol);
+            $('div.maxthrottle').toggle(!digitalProtocol);
+            $('div.mincommand').toggle(!digitalProtocol);
+            $('div.checkboxPwm').toggle(!digitalProtocol);
+            $('div.unsyncedpwmfreq').toggle(!digitalProtocol);
 
-                $('div.checkboxDshotBidir').toggle(semver.gte(CONFIG.apiVersion, "1.42.0") && escProtocolValue < self.PROSHOT_PROTOCOL_VALUE);
-                $('div.motorPoles').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
+            $('div.digitalIdlePercent').toggle(digitalProtocol);
 
-            } else {
-                $('div.minthrottle').show();
-                $('div.maxthrottle').show();
-                $('div.mincommand').show();
-                $('div.checkboxPwm').show();
-                //trigger change unsyncedPWMSwitch to show/hide Motor PWM freq input
-                $("input[id='unsyncedPWMSwitch']").change();
+            $('div.checkboxDshotBidir').toggle(semver.gte(CONFIG.apiVersion, "1.42.0") && digitalProtocol);
+            $('div.motorPoles').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
 
-                $('div.digitalIdlePercent').hide();
-
-                $('div.checkboxDshotBidir').hide();
-                $('div.motorPoles').hide();
-            }
+            //trigger change unsyncedPWMSwitch to show/hide Motor PWM freq input
+            $("input[id='unsyncedPWMSwitch']").change();
 
         }).change();
 

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -141,7 +141,7 @@
                                     </label>
                                 </div>
                                 <div class="number checkboxPwm">
-                                    <div style="float: left; height: 20px; margin-right: 5px; margin-left: 3px;">
+                                    <div style="float: left; height: 20px; margin-right: 14px; margin-left: 3px;">
                                         <input type="checkbox" id="unsyncedPWMSwitch" class="toggle" />
                                     </div>
                                     <span class="freelabel" i18n="configurationunsyndePwm"></span>
@@ -154,22 +154,9 @@
                                         <span i18n="configurationUnsyncedPWMFreq"></span>
                                     </label>
                                 </div>
-                                <div class="number checkboxDshotBidir">
-                                    <div style="float: left; height: 20px; margin-right: 5px; margin-left: 3px;">
-                                        <input type="checkbox" id="dshotBidir" class="toggle" />
-                                    </div>
-                                    <span class="freelabel" i18n="configurationDshotBidir" />
-                                    <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp" />
-                                </div>
-                                <table cellpadding="0" cellspacing="0" style="margin-bottom:10px;">
-                                    <tbody class="features esc">
-                                        <!-- table generated here -->
-                                    </tbody>
-                                </table>
-                                <!--   -->
                                 <div class="disarm">
                                     <div class="checkbox">
-                                        <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
+                                        <div style="float: left; height: 20px; margin-right: 14px; margin-left: 3px;">
                                             <input type="checkbox" id="disarmkillswitch" class="toggle" />
                                         </div>
                                         <span class="freelabel" i18n="configurationDisarmKillSwitch"></span>
@@ -184,14 +171,18 @@
                                         </label>
                                     </div>
                                 </div>
+                                <table cellpadding="0" cellspacing="0" style="margin-bottom: 5px;">
+                                    <tbody class="features esc">
+                                        <!-- table generated here -->
+                                    </tbody>
+                                </table>
                                 <!--   -->
-                                <div class="number digitalIdlePercent">
-                                    <label>
-                                        <div class="numberspacer">
-                                            <input type="number" name="digitalIdlePercent" min="0.00" max="20.00" step="0.01"/>
-                                        </div>
-                                        <span i18n="configurationDigitalIdlePercent"></span>
-                                    </label>
+                                <div class="number checkboxDshotBidir">
+                                    <div style="float: left; height: 20px; margin-right: 14px; margin-left: 3px;">
+                                        <input type="checkbox" id="dshotBidir" class="toggle" />
+                                    </div>
+                                    <span class="freelabel" i18n="configurationDshotBidir" />
+                                    <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp" />
                                     <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
                                 <div class="number motorPoles">
@@ -202,6 +193,15 @@
                                         <span i18n="configurationMotorPolesLong"></span>
                                     </label>
                                     <div class="helpicon cf_tip" i18n_title="configurationMotorPolesHelp"></div>
+                                </div>
+                                <div class="number digitalIdlePercent">
+                                    <label>
+                                        <div class="numberspacer">
+                                            <input type="number" name="digitalIdlePercent" min="0.00" max="20.00" step="0.01"/>
+                                        </div>
+                                        <span i18n="configurationDigitalIdlePercent"></span>
+                                    </label>
+                                    <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
                                 <div class="number minthrottle">
                                     <label>


### PR DESCRIPTION
This moves and reorders some of the elements of the Motor/ESC configuration Box.

![image](https://user-images.githubusercontent.com/2673520/64485345-dae87f80-d21f-11e9-9293-ef0c7ffa4b44.png)

The Configuration tab needs a complete refactor to make it more consistent and move styles to CSS, don't let Features auto generate it's code, etc. but until that, this let's something usable for version 10.6.