### PR TITLE
Fix filter subtab line and helpicon spacing

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -437,6 +437,7 @@
 
 .tab-pid_tuning .subtab-filter .newFilter .helpicon {
     margin-right: 2px;
+    margin-top: 2px;
 }
 
 .tab-pid_tuning .number .helpicon {

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1101,7 +1101,7 @@
                             </tr>
 
                             <tr>
-                                <th colspan="2">
+                                <th class="rpmFilter" colspan="2">
                                     <div class="pid_mode rpmFilter">
                                         <div i18n="pidTuningRpmFilterGroup" />
                                         <div class="helpicon cf_tip" i18n_title="pidTuningRpmFilterHelp" />
@@ -1139,7 +1139,7 @@
                             </tr>
 
                             <tr>
-                                <th colspan="2">
+                                <th class="dynamicNotch" colspan="2">
                                     <div class="pid_mode dynamicNotch">
                                         <div i18n="pidTuningDynamicNotchFilterGroup" />
                                         <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchFilterHelp" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/50072760/64487365-cadd9980-d239-11e9-9d41-89ab2683077b.png)
Removes the space when rpm filter or dyn notch are disabled, also fixes helpicons to be in the middle of the row.