### PR TITLE
Fixes clicking on helpicon affects input

### DIFF
--- a/src/js/Beepers.js
+++ b/src/js/Beepers.js
@@ -87,7 +87,7 @@ Beepers.prototype.generateElements = function (template, destination) {
             destination.append(element);
 
             var input_e = $(element).find('input');
-            var label_e = $(element).find('label');
+            var label_e = $(element).find('div');
             var span_e = $(element).find('span');
 
             input_e.attr('id', 'beeper-' + i);
@@ -96,7 +96,6 @@ Beepers.prototype.generateElements = function (template, destination) {
             input_e.prop('checked', bit_check(self._beeperMask, self._beepers[i].bit) == 0);
             input_e.data('bit', self._beepers[i].bit);
 
-            label_e.attr('for', 'beeper-' + i);
             label_e.text(self._beepers[i].name);
 
             span_e.attr('i18n', 'beeper' + self._beepers[i].name);

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -167,11 +167,9 @@ Features.prototype.generateElements = function (featuresElements) {
                     + self._features[i].name
                     + '" title="'
                     + self._features[i].name
-                    + '" type="checkbox"/></td><td><label for="feature-'
-                    + i
-                    + '">'
+                    + '" type="checkbox"/></td><td><div>'
                     + self._features[i].name
-                    + '</label></td><td><span i18n="feature' + self._features[i].name + '"></span>'
+                    + '</div></td><td><span i18n="feature' + self._features[i].name + '"></span>'
                     + feature_tip_html + '</td></tr>');
 
             var feature_e = newElement.find('input.feature');

--- a/src/tabs/auxiliary.html
+++ b/src/tabs/auxiliary.html
@@ -11,7 +11,7 @@
         <div class="toolbox">
             <form>
                 <input type="checkbox" id="switch-toggle-unused" name="switch-toggle-unused" class="toggle"></input>
-                <label for="switch-toggle-unused"><span i18n="auxiliaryToggleUnused" /></label>
+                <span i18n="auxiliaryToggleUnused" />
             </form>
         </div>
 

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -34,9 +34,7 @@
                                     <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                         <input type="checkbox" id="reverseMotorSwitch" class="toggle" />
                                     </div>
-                                    <label for="reverseMotorSwitch">
-                                        <span class="freelabel" i18n="configurationReverseMotorSwitch"></span>
-                                    </label>
+                                    <span class="freelabel" i18n="configurationReverseMotorSwitch"></span>
                                     <div class="helpicon cf_tip" i18n_title="configurationReverseMotorSwitchHelp"></div>
                                 </div>
                             </div>
@@ -58,51 +56,40 @@
                                     <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                         <input type="checkbox" id="gyroUse32kHz" class="toggle" />
                                     </div>
-                                    <label for="gyroUse32kHz"> <span class="freelabel" i18n="configurationGyroUse32kHz"></span>
-                                    </label>
+                                    <span class="freelabel" i18n="configurationGyroUse32kHz"></span>
                                     <div class="helpicon cf_tip" i18n_title="configurationGyroUse32kHzHelp"></div>
                                 </div>
                                 <div class="select">
-                                    <label>
                                         <select class="gyroSyncDenom">
                                             <!-- list generated here -->
                                         </select>
                                         <span i18n="configurationGyroSyncDenom"></span>
-                                    </label>
                                 </div>
                                 <div class="select selectPidProcessDenom">
-                                    <label>
                                         <select class="pidProcessDenom">
                                             <!-- list generated here -->
                                         </select>
                                         <span i18n="configurationPidProcessDenom"></span>
                                         <div class="helpicon cf_tip" i18n_title="configurationPidProcessDenomHelp"></div>
-                                    </label>
                                 </div>
                                 <div class="hardwareSelection">
                                     <div class="select">
                                         <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                             <input type="checkbox" id="accHardwareSwitch" class="toggle" />
                                         </div>
-                                        <label for="accHardwareSwitch"> <span class="freelabel"
-                                            i18n="configurationAccHardware"></span>
-                                        </label>
+                                        <span class="freelabel" i18n="configurationAccHardware"></span>
                                     </div>
                                     <div class="select">
                                         <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                             <input type="checkbox" id="baroHardwareSwitch" class="toggle" />
                                         </div>
-                                        <label for="baroHardwareSwitch"> <span class="freelabel"
-                                            i18n="configurationBaroHardware"></span>
-                                        </label>
+                                        <span class="freelabel" i18n="configurationBaroHardware"></span>
                                     </div>
                                     <div class="select">
                                         <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                             <input type="checkbox" id="magHardwareSwitch" class="toggle" />
                                         </div>
-                                        <label for="magHardwareSwitch"> <span class="freelabel"
-                                            i18n="configurationMagHardware"></span>
-                                        </label>
+                                        <span class="freelabel" i18n="configurationMagHardware"></span>
                                     </div>
                                 </div>
                             </div>
@@ -157,9 +144,7 @@
                                     <div style="float: left; height: 20px; margin-right: 5px; margin-left: 3px;">
                                         <input type="checkbox" id="unsyncedPWMSwitch" class="toggle" />
                                     </div>
-                                    <label for="unsyncedPWMSwitch"> <span class="freelabel"
-                                        i18n="configurationunsyndePwm"></span>
-                                    </label>
+                                    <span class="freelabel" i18n="configurationunsyndePwm"></span>
                                 </div>
                                 <div class="number unsyncedpwmfreq" style="margin-top: 5px; padding-bottom: 10px;">
                                     <label>
@@ -173,9 +158,7 @@
                                     <div style="float: left; height: 20px; margin-right: 5px; margin-left: 3px;">
                                         <input type="checkbox" id="dshotBidir" class="toggle" />
                                     </div>
-                                    <label for="dshotBidir"> 
-                                        <span class="freelabel" i18n="configurationDshotBidir" />
-                                    </label>
+                                    <span class="freelabel" i18n="configurationDshotBidir" />
                                     <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp" />
                                 </div>
                                 <table cellpadding="0" cellspacing="0" style="margin-bottom:10px;">
@@ -189,9 +172,7 @@
                                         <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                             <input type="checkbox" id="disarmkillswitch" class="toggle" />
                                         </div>
-                                        <label for="disarmkillswitch"> <span class="freelabel"
-                                            i18n="configurationDisarmKillSwitch"></span>
-                                        </label>
+                                        <span class="freelabel" i18n="configurationDisarmKillSwitch"></span>
                                         <div class="helpicon cf_tip" i18n_title="configurationDisarmKillSwitchHelp"></div>
                                     </div>
                                     <div class="number disarmdelay" style="display: none; margin-bottom: 5px;">
@@ -570,17 +551,13 @@
                                             <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                                 <input type="checkbox" name="gps_auto_baud" class="toggle" />
                                             </div>
-                                            <label for="gps_auto_baud"> <span class="freelabel"
-                                                i18n="configurationGPSAutoBaud"></span>
-                                            </label>
+                                            <span class="freelabel" i18n="configurationGPSAutoBaud"></span>
                                         </div>
                                         <div class="select gps_auto_config">
                                             <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
                                                 <input type="checkbox" name="gps_auto_config" class="toggle" />
                                             </div>
-                                            <label for="gps_auto_config"> <span class="freelabel"
-                                                i18n="configurationGPSAutoConfig"></span>
-                                            </label>
+                                            <span class="freelabel" i18n="configurationGPSAutoConfig"></span>
                                         </div>
                                         <div class="line">
                                             <select class="gps_ubx_sbas">
@@ -708,8 +685,7 @@
                                     <div class="numberspacer">
                                         <input type="checkbox" name="multiwiicurrentoutput" class="toggle" />
                                     </div>
-                                    <label> <span i18n="configurationBatteryMultiwiiCurrent"></span>
-                                    </label>
+                                    <span i18n="configurationBatteryMultiwiiCurrent"></span>
                                 </div>
                             </div>
                         </div>
@@ -740,9 +716,7 @@
                                                     <div style="float: left; height: 20px; margin-right: 34px;">
                                                         <input class="dshot-beeper toggle" id="dshotBeeperSwitch" type="checkbox" />
                                                     </div>
-                                                    <label for="dshotBeeperSwitch">    
-                                                        <span i18n="configurationUseDshotBeeper"></span>
-                                                    </label>
+                                                    <span i18n="configurationUseDshotBeeper"></span>
                                                 </div>
                                             </td>
                                         </tr>
@@ -755,9 +729,7 @@
                                                             <!-- list generated here --> 
                                                         </select>
                                                     </div>
-                                                    <label for="dshotBeeperBeaconTone">
-                                                        <span i18n="configurationDshotBeaconTone"></span>
-                                                    </label>
+                                                    <span i18n="configurationDshotBeaconTone"></span>
                                                 </div>
                                             </td>
                                         </tr>
@@ -792,7 +764,7 @@
                                                 <input class="condition toggle" id="" name="" title="" type="checkbox" />
                                             </td>
                                             <td>
-                                                <label for=""></label>
+                                                <div></div>
                                             </td>
                                             <td>
                                                 <span></span>

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -36,8 +36,8 @@
                                     </div>
                                     <label for="reverseMotorSwitch">
                                         <span class="freelabel" i18n="configurationReverseMotorSwitch"></span>
-                                        <div class="helpicon cf_tip" i18n_title="configurationReverseMotorSwitchHelp"></div>
                                     </label>
+                                    <div class="helpicon cf_tip" i18n_title="configurationReverseMotorSwitchHelp"></div>
                                 </div>
                             </div>
 
@@ -175,8 +175,8 @@
                                     </div>
                                     <label for="dshotBidir"> 
                                         <span class="freelabel" i18n="configurationDshotBidir" />
-                                        <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp" />
                                     </label>
+                                    <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp" />
                                 </div>
                                 <table cellpadding="0" cellspacing="0" style="margin-bottom:10px;">
                                     <tbody class="features esc">
@@ -191,8 +191,8 @@
                                         </div>
                                         <label for="disarmkillswitch"> <span class="freelabel"
                                             i18n="configurationDisarmKillSwitch"></span>
-                                            <div class="helpicon cf_tip" i18n_title="configurationDisarmKillSwitchHelp"></div>
                                         </label>
+                                        <div class="helpicon cf_tip" i18n_title="configurationDisarmKillSwitchHelp"></div>
                                     </div>
                                     <div class="number disarmdelay" style="display: none; margin-bottom: 5px;">
                                         <label>
@@ -210,8 +210,8 @@
                                             <input type="number" name="digitalIdlePercent" min="0.00" max="20.00" step="0.01"/>
                                         </div>
                                         <span i18n="configurationDigitalIdlePercent"></span>
-                                        <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                     </label>
+                                    <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
                                 <div class="number motorPoles">
                                     <label>
@@ -219,8 +219,8 @@
                                             <input type="number" name="motorPoles" min="4" max="255" step="1"/>
                                         </div>
                                         <span i18n="configurationMotorPolesLong"></span>
-                                        <div class="helpicon cf_tip" i18n_title="configurationMotorPolesHelp"></div>
                                     </label>
+                                    <div class="helpicon cf_tip" i18n_title="configurationMotorPolesHelp"></div>
                                 </div>
                                 <div class="number minthrottle">
                                     <label>

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -181,8 +181,8 @@
                     </div>
                     <div class="notice">
                         <p i18n="motorsNotice"></p>
-                        <label><input id="motorsEnableTestMode" type="checkbox" class="togglesmall"/><span
-                            class="motorsEnableTestMode" i18n="motorsEnableControl"></span></label>
+                        <input id="motorsEnableTestMode" type="checkbox" class="togglesmall"/>
+                        <span class="motorsEnableTestMode" i18n="motorsEnableControl"></span>
                     </div>
                     <div class="cler-both"></div>
                 </div>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -480,36 +480,24 @@
                             <tr class="itermrotation">
                                 <td><input type="checkbox" id="itermrotation" class="toggle" /></td>
                                 <td colspan="2">
-                                    <div>
-                                        <label for="itermrotation">
-                                            <span i18n="pidTuningItermRotation"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningItermRotationHelp"></div>
-                                    </div>
+                                    <span i18n="pidTuningItermRotation"></span>
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningItermRotationHelp"></div>
                                 </td>
                             </tr>
 
                             <tr>
                                 <td><input type="checkbox" id="vbatpidcompensation" class="toggle" /></td>
                                 <td colspan="2">
-                                    <div>
-                                        <label for="vbatpidcompensation">
-                                            <span i18n="pidTuningVbatPidCompensation"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningVbatPidCompensationHelp"></div>
-                                    </div>
+                                    <span i18n="pidTuningVbatPidCompensation"></span>
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningVbatPidCompensationHelp"></div>
                                 </td>
                             </tr>
 
                             <tr class="smartfeedforward">
                                 <td><input type="checkbox" id="smartfeedforward" class="toggle" /></td>
                                 <td colspan="2">
-                                    <div>
-                                        <label for="smartfeedforward">
-                                            <span i18n="pidTuningSmartFeedforward"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningSmartFeedforwardHelp"></div>
-                                    </div>
+                                    <span i18n="pidTuningSmartFeedforward"></span>
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningSmartFeedforwardHelp"></div>
                                 </td>
                             </tr>
 
@@ -517,11 +505,7 @@
                                 <td><input type="checkbox" id="useIntegratedYaw" class="toggle" /></td>
                                 <td colspan="2">
                                     <div class="helpicon cf_tip" i18n_title="pidTuningIntegratedYawHelp"></div>
-                                    <span>
-                                        <label for="useIntegratedYaw">
-                                            <span i18n="pidTuningIntegratedYaw" />
-                                        </label>
-                                    </span>
+                                    <span i18n="pidTuningIntegratedYaw" />
                                     <span class="spacer_left" id="pidTuningIntegratedYawCaution" i18n="pidTuningIntegratedYawCaution" />
                                 </td>
                             </tr>
@@ -530,11 +514,7 @@
                                 <td><input type="checkbox" id="itermrelax" class="toggle" /></td>
                                 <td colspan="2">
                                     <div class="helpicon cf_tip" i18n_title="pidTuningItermRelaxHelp"></div>
-                                    <span>
-                                        <label for="itermrelax">
-                                            <span i18n="pidTuningItermRelax" />
-                                        </label>
-                                    </span>
+                                    <span i18n="pidTuningItermRelax" />
 
                                     <span class="suboption">
                                         <select id="itermrelaxAxes">
@@ -571,11 +551,7 @@
                                 <td><input type="checkbox" id="dMinSwitch" class="toggle" /></td>
                                 <td colspan="3">
                                     <div class="helpicon cf_tip" i18n_title="pidTuningDMinFeatureHelp"></div>
-                                    <span>
-                                        <label for="dminGroup">
-                                            <span i18n="pidTuningDMin" />
-                                        </label>
-                                    </span>
+                                    <span i18n="pidTuningDMin" />
 
                                     <span class="suboption">
                                         <input type="number" name="dMinGain" step="1" min="0" max="100" />
@@ -597,12 +573,8 @@
                                     <td><input type="checkbox" id="antiGravitySwitch" class="toggle" /></td>
                                     <td colspan="3">
                                         <div class="helpicon cf_tip" i18n_title="pidTuningAntiGravityHelp"></div>
-                                        <span>
-                                            <label for="antiGravity">
-                                                <span i18n="pidTuningAntiGravity" />
-                                            </label>
-                                        </span>
-    
+                                        <span i18n="pidTuningAntiGravity" />
+
                                         <span class="suboption antiGravityMode">
                                             <select id="antiGravityMode">
                                                 <option i18n="pidTuningAntiGravityModeOptionSmooth"     value="0"/>

--- a/src/tabs/vtx.html
+++ b/src/tabs/vtx.html
@@ -85,8 +85,8 @@
                                     </span>
                                     <label for="vtx_power">
                                         <span i18n="vtxPower"/>
-                                        <div class="helpicon cf_tip" i18n_title="vtxPowerHelp"/>
                                     </label>
+                                    <div class="helpicon cf_tip" i18n_title="vtxPowerHelp"/>
                                 </div>
 
                                 <div class="field checkbox vtx_pit_mode">
@@ -95,18 +95,18 @@
                                     </span>
                                     <label for="vtx_pit_mode">
                                         <span class="freelabel" i18n="vtxPitMode" />
-                                        <div class="helpicon cf_tip" i18n_title="vtxPitModeHelp"/>
                                     </label>
+                                    <div class="helpicon cf_tip" i18n_title="vtxPitModeHelp"/>
                                 </div>
 
                                 <div class="field number vtx_pit_mode_frequency">
                                     <span class="numberspacer">
                                         <input class="frequency_input" type="number" id="vtx_pit_mode_frequency" min="0" max="5999">
                                     </span>
-                                    <label>
+                                    <label for="vtx_pit_mode_frequency">
                                         <span i18n="vtxPitModeFrequency"/>
-                                        <div class="helpicon cf_tip" i18n_title="vtxPitModeFrequencyHelp"/>
                                     </label>
+                                    <div class="helpicon cf_tip" i18n_title="vtxPitModeFrequencyHelp"/>
                                 </div>
 
                                 <div class="field select vtx_low_power_disarm">
@@ -119,8 +119,8 @@
                                     </span>
                                     <label for="vtx_low_power_disarm"> 
                                         <span class="freelabel" i18n="vtxLowPowerDisarm" />
-                                        <div class="helpicon cf_tip" i18n_title="vtxLowPowerDisarmHelp"/>
                                     </label>
+                                    <div class="helpicon cf_tip" i18n_title="vtxLowPowerDisarmHelp"/>
                                 </div>
                             </div>
 

--- a/src/tabs/vtx.html
+++ b/src/tabs/vtx.html
@@ -83,9 +83,7 @@
                                             <!-- Power options generated here from the js -->
                                         </select>
                                     </span>
-                                    <label for="vtx_power">
-                                        <span i18n="vtxPower"/>
-                                    </label>
+                                    <span i18n="vtxPower"/>
                                     <div class="helpicon cf_tip" i18n_title="vtxPowerHelp"/>
                                 </div>
 
@@ -93,9 +91,7 @@
                                     <span class="checkboxspacer">
                                         <input type="checkbox" id="vtx_pit_mode" class="toggle" />
                                     </span>
-                                    <label for="vtx_pit_mode">
-                                        <span class="freelabel" i18n="vtxPitMode" />
-                                    </label>
+                                    <span class="freelabel" i18n="vtxPitMode" />
                                     <div class="helpicon cf_tip" i18n_title="vtxPitModeHelp"/>
                                 </div>
 
@@ -103,9 +99,7 @@
                                     <span class="numberspacer">
                                         <input class="frequency_input" type="number" id="vtx_pit_mode_frequency" min="0" max="5999">
                                     </span>
-                                    <label for="vtx_pit_mode_frequency">
-                                        <span i18n="vtxPitModeFrequency"/>
-                                    </label>
+                                    <span i18n="vtxPitModeFrequency"/>
                                     <div class="helpicon cf_tip" i18n_title="vtxPitModeFrequencyHelp"/>
                                 </div>
 
@@ -117,9 +111,7 @@
                                             <option value="2" i18n="vtxLowPowerDisarmOption_2" />
                                         </select>
                                     </span>
-                                    <label for="vtx_low_power_disarm"> 
-                                        <span class="freelabel" i18n="vtxLowPowerDisarm" />
-                                    </label>
+                                    <span class="freelabel" i18n="vtxLowPowerDisarm" />
                                     <div class="helpicon cf_tip" i18n_title="vtxLowPowerDisarmHelp"/>
                                 </div>
                             </div>


### PR DESCRIPTION
Fixes #1635
Clicking on helpicon in configuration and vtx tab would change the switch or select input field associated with that helpicon.
It seems like it was caused by helpicon being inside of a `<label>`