### PR TITLE
Tuning sliders redesign

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -758,10 +758,9 @@
 
 .tab-pid_tuning .tuningSlider::-webkit-slider-runnable-track {
     -webkit-appearance: none;
-    background: rgba(0,255,0);
     border: solid 1px silver;
     border-radius: 4px;
-    background: linear-gradient(90deg, rgb(167, 255, 204) 0%, rgb(187, 252, 255) 50%, rgb(255, 90, 23) 100%);
+    background: linear-gradient(90deg, rgb(197, 197, 197) 0%, rgb(241, 241, 241) 50%, rgb(255, 84, 14) 100%);
     height: 15px;
 }
 
@@ -775,6 +774,7 @@
     cursor: pointer;
     position: relative;
     bottom: 5px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.4);
 }
 
 .tab-pid_tuning .sliderLabels tr {


### PR DESCRIPTION
As voted on Slack. More prefer this gray-red gradient. Looks better in my opinion because it is not that eye cathing and colorful, standing out too much, especially in dark mode, and still keeps the red part to warn users they are pushing it. Also, added some shadow for the slider thumb.