### PR TITLE
Fix rateprofiles not working after saving

### DIFF
--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -298,7 +298,7 @@ TuningSliders.calculateNewPids = function() {
     PID_names.forEach(function(elementPid, indexPid) {
         let searchRow = $('.pid_tuning .' + elementPid + ' input');
         searchRow.each(function (indexInput) {
-            if (indexPid < 3) {
+            if (indexPid < 3 && indexInput < 3) {
                 $(this).val(PIDs[indexPid][indexInput]);
             }
         });


### PR DESCRIPTION
There was a bug after saving rates causing them not to work after that, this fixes it. Thanks @IllusionFPV for finding this.
https://github.com/betaflight/betaflight-configurator/blob/635e5dbef9d46443a42b6d9f41d5d86a644928ba/src/js/tabs/pid_tuning.js#L615-L626
I found out while looking into this that PIDs parses rate, super rate, rc expo and stores it. Not sure if this is intended, because on loading only PID values get set there. This hasn't caused issues all this time so I guess it is fine as is but should be changed to not include rate settings because they are set in `RC_tuning`. Am I missing something?