### PR TITLE
Fix duplicated digital idle help icon

### DIFF
--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -183,7 +183,6 @@
                                     </div>
                                     <span class="freelabel" i18n="configurationDshotBidir" />
                                     <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp" />
-                                    <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
                                 <div class="number motorPoles">
                                     <label>


### PR DESCRIPTION
Fix duplicate help icon, I think that a bad rest of a rebase. My capture in the PR was ok but it seems that I didn't test it after the rebase :(