### PR TITLE
Added dialog to offer resetting to custom defaults.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -56,6 +56,9 @@
     "close": {
         "message": "Close"
     },
+    "cancel": {
+        "message": "Cancel"
+    },
     "autoConnectEnabled": {
         "message": "Auto-Connect: Enabled - Configurator automatically tries to connect when new port is detected"
     },
@@ -466,6 +469,12 @@
     },
     "firmwareUpgradeRequired": {
         "message": "The firmware on this device needs upgrading to a newer version. Use CLI for backup before flashing. CLI backup/restore procedure is in the documention.<br />Alternatively download and use an old version of the configurator if you are not ready to upgrade."
+    },
+    "resetToCustomDefaultsDialog": {
+        "message": "There are custom defaults for this board available. Normally, a board will not work properly unless custom defaults are applied.<br />Do you want to apply the custom defaults for this board?"
+    },
+    "resetToCustomDefaultsAccept": {
+        "message": "Apply Custom Defaults"
     },
 
     "infoVersions": {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -2113,3 +2113,8 @@ input {
     height: 9px;
     border:1px solid var(--accent);
 }
+
+#dialogResetToCustomDefaults-content {
+    margin-top: 10px;
+    margin-bottom: 10px;
+}

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -95,12 +95,13 @@ var FC = {
             runawayTakeoffPreventionDisabled: false,
             boardIdentifier:                  "",
             boardVersion:                     0,
-            commCapabilities:                 0,
+            targetCapabilities:               0,
             targetName:                       "",
             boardName:                        "",
             manufacturerId:                   "",
             signature:                        [],
             mcuTypeId:                        255,
+            configurationState:               0,
         };
 
         BF_CONFIG = {
@@ -607,15 +608,25 @@ var FC = {
         return FC.MCU_TYPES[CONFIG.mcuTypeId];
     },
 
-    COMM_CAPABILITIES_FLAGS: {
-        HAS_VCP: 0x01,
-        HAS_SOFTSERIAL: 0x02,
+    CONFIGURATION_STATES: {
+        DEFAULTS_BARE: 0,
+        DEFAULTS_CUSTOM: 1,
+        CONFIGURED: 2,
+    },
+
+    TARGET_CAPABILITIES_FLAGS: {
+        HAS_VCP: 0,
+        HAS_SOFTSERIAL: 1,
+        IS_UNIFIED: 2,
+        HAS_FLASH_BOOTLOADER: 3,
+        SUPPORTS_CUSTOM_DEFAULTS: 4,
+        HAS_CUSTOM_DEFAULTS: 5,
     },
 
     boardHasVcp: function () {
         var hasVcp = false;
         if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-            hasVcp = (CONFIG.commCapabilities & FC.COMM_CAPABILITIES_FLAGS.HAS_VCP) !== 0;
+            hasVcp = bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_VCP);
         } else {
             hasVcp = BOARD.find_board_definition(CONFIG.boardIdentifier).vcp;
         }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -34,6 +34,11 @@ function MspHelper () {
         MSC_UTC: 3
     };
 
+    self.RESET_TYPES = {
+        BASE_DEFAULTS: 0,
+        CUSTOM_DEFAULTS: 1,
+    };
+
     self.SIGNATURE_LENGTH = 32;
 
     self.mspMultipleCache = [];
@@ -751,14 +756,14 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
                 CONFIG.targetName = "";
                 if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                    CONFIG.commCapabilities = data.readU8();
+                    CONFIG.targetCapabilities = data.readU8();
 
                     let length = data.readU8();
                     for (let i = 0; i < length; i++) {
                         CONFIG.targetName += String.fromCharCode(data.readU8());
                     }
                 } else {
-                    CONFIG.commCapabilities = 0;
+                    CONFIG.targetCapabilities = 0;
                 }
 
                 CONFIG.boardName = "";
@@ -782,6 +787,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
                 if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
                     CONFIG.mcuTypeId = data.readU8();
+
+                    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                        CONFIG.configurationState = data.readU8();
+                    }
                 } else {
                     CONFIG.mcuTypeId = 255;
                 }

--- a/src/js/protocols/stm32.js
+++ b/src/js/protocols/stm32.js
@@ -153,7 +153,7 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
 
                 MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, function () {
                     var rebootMode = 0; // FIRMWARE
-                    if (bit_check(CONFIG.commCapabilities, 3)) {
+                    if (bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_FLASH_BOOTLOADER)) {
                         // Board has flash bootloader
                         GUI.log(i18n.getMessage('deviceRebooting_flashBootloader'));
                         console.log('flash bootloader detected');

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -258,6 +258,29 @@ function onOpen(openInfo) {
                                     updateStatusBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier, FC.getHardwareName());
                                     updateTopBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier, FC.getHardwareName());
 
+                                    if (bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.SUPPORTS_CUSTOM_DEFAULTS) && bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_CUSTOM_DEFAULTS) && CONFIG.configurationState === FC.CONFIGURATION_STATES.DEFAULTS_BARE) {
+                                        var dialog = $('#dialogResetToCustomDefaults')[0];
+
+                                        $('#dialogResetToCustomDefaults-content').html(i18n.getMessage('resetToCustomDefaultsDialog'));
+
+                                        $('#dialogResetToCustomDefaults-acceptbtn').click(function() {
+                                            analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'AcceptResetToCustomDefaults');
+
+                                            var buffer = [];
+                                            buffer.push(mspHelper.RESET_TYPES.CUSTOM_DEFAULTS);
+                                            MSP.send_message(MSPCodes.MSP_RESET_CONF, buffer, false);
+
+                                            dialog.close();
+                                        });
+
+                                        $('#dialogResetToCustomDefaults-cancelbtn').click(function() {
+                                            analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'CancelResetToCustomDefaults');
+
+                                            dialog.close();
+                                        });
+
+                                        dialog.showModal();
+                                    }
                                     MSP.send_message(MSPCodes.MSP_UID, false, false, function () {
                                         var uniqueDeviceIdentifier = CONFIG.uid[0].toString(16) + CONFIG.uid[1].toString(16) + CONFIG.uid[2].toString(16);
 
@@ -281,7 +304,7 @@ function onOpen(openInfo) {
                             });
                         });
                     } else {
-                        analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'ConnectionRefused');
+                        analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'ConnectionRefusedFirmwareType');
 
                         var dialog = $('.dialogConnectWarning')[0];
 
@@ -297,7 +320,7 @@ function onOpen(openInfo) {
                     }
                 });
             } else {
-                analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'ConnectionRefused');
+                analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'ConnectionRefusedFirmwareVersion');
 
                 var dialog = $('.dialogConnectWarning')[0];
 

--- a/src/main.html
+++ b/src/main.html
@@ -402,6 +402,21 @@
         </div>
     </dialog>
 
+    <dialog id="dialogResetToCustomDefaults">
+        <h3 i18n="noticeTitle"></h3>
+        <div class="content">
+            <div id="dialogResetToCustomDefaults-content"></div>
+        </div>
+        <div>
+            <span class="buttons">
+                <a href="#" id="dialogResetToCustomDefaults-acceptbtn" class="regular-button" i18n="resetToCustomDefaultsAccept"></a>
+            </span>
+            <span class="buttons">
+                <a href="#" id="dialogResetToCustomDefaults-cancelbtn" class="regular-button" i18n="cancel"></a>
+            </span>
+        </div>
+    </dialog>
+
     <dialog class="dialogError">
         <h3 i18n="errorTitle"></h3>
         <div class="content">


### PR DESCRIPTION
When a connection is established to a board that has custom defaults but is currently reset to the target defaults, this asks the user if they want to reset the board to the custom defaults:

![image](https://user-images.githubusercontent.com/4742747/64789773-180a9400-d5c9-11e9-9512-8ec11a202417.png)

The motivation for this is that we are going to hand over control over Unified Target configurations done as custom defaults to target maintainers, thus increasing the risk of untested / broken custom defaults being released. Having the firmware automatically resetting the board to custom defaults after flashing essentially leads to a wedged board if the defaults are bad. This gives the user the option to re-flash or diagnose the problem without having to fix a wedged board first.

At a later stage, once we have a robust process for checking the validity of Unified Target configurations in place, we can consider switching to automatically resetting to custom defaults, and ditch this dialog.