### PR TITLE
Fix tooltip not closing properly

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -348,6 +348,9 @@ GUI_control.prototype.content_ready = function (callback) {
 
         new jBox('Tooltip', {
             attach: '.cf_tip',
+            trigger: 'mouseenter',
+            closeOnMouseleave: true,
+            closeOnClick: 'body',
             delayOpen: 100,
             delayClose: 100,
             position: {


### PR DESCRIPTION
Fixes #1664, further improves on #1604
Tooltips sometimes wouldn't close properly and would move to upper left corner and stay there when you switched from a tab tooltip was created on. Now it gets closed whenever you click outside of it. This also makes it `closeOnMouseLeave` so it reduces the possibility of it getting stuck when moving the mouse fast around where there are many tooltips of this kind.
![image](https://user-images.githubusercontent.com/50072760/64978366-9c089880-d8b5-11e9-9d72-3eccb87de1de.png)
