### PR TITLE
Fix dark mode on ports tab select boxes

### DIFF
--- a/src/css/tabs-dark/ports-dark.css
+++ b/src/css/tabs-dark/ports-dark.css
@@ -1,12 +1,3 @@
-.tab-ports select {
-    border: 1px solid #00000000;
-}
-
-.tab-ports .ports select {
-    background-color: #3a3a3a;
-    color: white;
-}
-
 .tab-ports table td:first-child {
     border-left: none;
 }

--- a/src/css/tabs/ports.css
+++ b/src/css/tabs/ports.css
@@ -54,6 +54,8 @@
     border: 1px solid var(--subtleAccent);
     border-radius: 3px;
     margin-right: 3px;
+    background: var(--boxBackground);
+    color: var(--defaultText);
 }
 
 .tab-ports .require-support {


### PR DESCRIPTION
Borders were probably removed to make it look cleaner, but to me it doesn't look good and is not consistent with other tabs.
Before
![image](https://user-images.githubusercontent.com/50072760/65166286-b458ee80-da40-11e9-9581-1f7b47ffdb8b.png)

After
![image](https://user-images.githubusercontent.com/50072760/65166241-a30fe200-da40-11e9-87c7-cc982dbb0bec.png)
