### PR TITLE
CliAutocomplete for diff #1630

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -521,4 +521,43 @@ CliAutoComplete._initTextcomplete = function() {
             }),
         ]);
     }
+
+
+    // diff command
+    var diffArgs1 = ["master", "profile", "rates", "all"];
+    var diffArgs2 = [];
+
+    if (semver.lt(CONFIG.flightControllerVersion, "3.4.0")) {
+        diffArgs2.push("showdefaults");
+    } else {
+        // above 3.4.0
+        diffArgs2.push("defaults");
+        if (semver.gte(CONFIG.flightControllerVersion, "4.0.0")) {
+            diffArgs1.push("hardware");
+            diffArgs2.push("bare");
+        }
+    }
+
+    diffArgs1.sort();
+    diffArgs2.sort();
+
+    $textarea.textcomplete('register', [
+        strategy({ // "diff arg1"
+            match: /^(\s*diff\s+)(\w*)$/i,
+            search:  function(term, callback, match) {
+                sendOnEnter = true;
+                searcher(term, callback, diffArgs1, 1, true);
+            },
+            template: highlighterPrefix
+        }),
+
+        strategy({ // "diff arg1 arg2"
+            match: /^(\s*diff\s+\w+\s+)(\w*)$/i,
+            search:  function(term, callback, match) {
+                sendOnEnter = true;
+                searcher(term, callback, diffArgs2, 1, true);
+            },
+            template: highlighterPrefix
+        })
+    ]);
 };


### PR DESCRIPTION
#1630

I haven't considered making autocomplete based on the _help strings_ of the commands themselves. It seems to me that they do not follow 100% strict rules for describing the syntax, thus it might be tricky to parse them and make autocomplete logic from them. Furthermore, it was the case that there were slimmed down versions of the firmware that did not include the help strings but only the names of commands. Maybe this won't be an issue from now on as F3 has been dropped out.

Here I present a variant that has the syntax into the code itself (like all already implemented autcompletes) and refines it based on FC version. Of course this has the downside that when changes are made to the command they will have to be reflected in the the configurator CLI code.

If some strict grammar rules are applied to the help strings then it might be practical to automatically generate autocomplete rules for most other commands.

One cosmetic thing to consider about this PR: as it is known, selecting an entry from the autocomplete list can be achieved either by `Tab` or `Enter`. I have made different cases for different commands on whether `Enter` should autocomplete and wait for further input or should autocomplete and dispatch the command (`Tab` always autocompletes and waits). If the the next argument is mandatory there's no point sending the incomplete command on `Enter`. Instead `Enter` should behave like `Tab`.
With the `diff` command the second argument (`bare`, `defaults`) is optional, so it has to be decided if `Enter` on the _first_ argument should autocomplete and wait, or send the command straight out.

In the current implementation, pressing `Enter` on the first argument will send the command. If we want to add second argument we should atucomplete with `Tab` to avoid sending the command immediately.
Can you provide your opinions if this would be the desired behavior or `Enter` on first arg should behave as `Tab`?