### PR TITLE
Better representation of battery low

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1827,7 +1827,7 @@ dialog {
     color: white;
     font-size: 10px;
     margin-top: 20px;
-    width: 90px;
+    min-width: 90px;
     float: right;
     margin-right: 10px;
     line-height: 12px;
@@ -1851,8 +1851,7 @@ dialog {
     margin-top: 10px;
     margin-left: 14px;
     height: 10px;
-    width: 30px;
-    /* width: 30px; */
+    width: 31px;
 }
 
 
@@ -1867,6 +1866,7 @@ dialog {
     text-align: left;
     color: silver;
     margin-left: -8px;
+    padding-right: 4px
 }
 
 .quad-status-contents progress::-webkit-progress-bar {
@@ -1880,12 +1880,26 @@ dialog {
 
 .battery-status {
     height: 11px;
-    position: relative;
-    box-shadow: inset 0 0 5px rgba(0, 0, 0, 0.20);
-    border-radius: 0px;
-    background-color: var(--accent);
-    /* border-radius: 4px; */
-    margin-top: 0px;
+}
+
+.battery-status.state-ok {
+   background-color: #59AA29;
+}
+.battery-status.state-warning {
+    background-color: var(--error);
+}
+
+.battery-status.state-empty {
+    animation: error-blinker 1s linear infinite;
+}
+
+@keyframes error-blinker {
+  0% {
+    background-color: none;
+  }
+  50% {
+    background-color: var(--error);
+  }
 }
 
 .battery-icon {
@@ -1901,14 +1915,13 @@ dialog {
     background-repeat: no-repeat;
 }
 
+
 .armedicon,
 .failsafeicon,
 .linkicon {
-    float: left;
     margin-left: 8px;
-    margin-right: 2px;
+    margin-right: 8px;
     margin-top: 6px;
-    display: block;
     height: 18px;
     width: 18px;
     opacity: 0.8;
@@ -1929,6 +1942,8 @@ dialog {
 }
 
 .bottomStatusIcons {
+    display: flex;
+    justify-content: space-between;
     background-color: #272727;
     height: 31px;
     margin-top: 2px;

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -646,37 +646,50 @@ function update_live_status() {
                            });
        }
     }
+
     if (ANALOG != undefined) {
-    var nbCells = Math.floor(ANALOG.voltage / BATTERY_CONFIG.vbatmaxcellvoltage) + 1;
-    if (ANALOG.voltage == 0)
-           nbCells = 1;
+        var nbCells = Math.floor(ANALOG.voltage / BATTERY_CONFIG.vbatmaxcellvoltage) + 1;
+
+        if (ANALOG.voltage == 0) {
+               nbCells = 1;
+        }
 
        var min = BATTERY_CONFIG.vbatmincellvoltage * nbCells;
        var max = BATTERY_CONFIG.vbatmaxcellvoltage * nbCells;
        var warn = BATTERY_CONFIG.vbatwarningcellvoltage * nbCells;
 
-       $(".battery-status").css({
-          width: ((ANALOG.voltage - min) / (max - min) * 100) + "%",
-          display: 'inline-block'
-       });
+       const NO_BATTERY_VOLTAGE_MAXIMUM = 0.5; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions  
 
-       if (active) {
-           $(".linkicon").css({
-               'background-image': 'url(images/icons/cf_icon_link_active.svg)'
+       if (ANALOG.voltage < min && ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM) {
+           $(".battery-status").addClass('state-empty').removeClass('state-ok').removeClass('state-warning');
+           $(".battery-status").css({
+               width: "100%",
            });
        } else {
-           $(".linkicon").css({
-               'background-image': 'url(images/icons/cf_icon_link_grey.svg)'
+           $(".battery-status").css({
+               width: ((ANALOG.voltage - min) / (max - min) * 100) + "%",
            });
-       }
 
-       if (ANALOG.voltage < warn) {
-           $(".battery-status").css('background-color', '#D42133');
-       } else  {
-           $(".battery-status").css('background-color', '#59AA29');
+           if (ANALOG.voltage < warn) {
+               $(".battery-status").addClass('state-warning').removeClass('state-empty').removeClass('state-ok');
+           } else  {
+               $(".battery-status").addClass('state-ok').removeClass('state-warning').removeClass('state-empty');
+           }
        }
+       
+       let cellsText = (ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM)? nbCells + 'S' : 'USB';
+       $(".battery-legend").text(ANALOG.voltage.toFixed(2) + "V (" + cellsText + ")");
 
-       $(".battery-legend").text(ANALOG.voltage + " V");
+    }
+
+    if (active) {
+        $(".linkicon").css({
+            'background-image': 'url(images/icons/cf_icon_link_active.svg)'
+        });
+    } else {
+        $(".linkicon").css({
+            'background-image': 'url(images/icons/cf_icon_link_grey.svg)'
+        });
     }
 
     statuswrapper.show();


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1673

This adds several enhancements to the battery icon at the top...
- Refactor and cleaning of the code.
- It adds a text with the number of cells detected, or USB if the voltage is under 0.5V. This is not the best approach, the FC can send the state but it is not available for all versions. So this can be discussed here.
![image](https://user-images.githubusercontent.com/2673520/65422144-f2219280-de05-11e9-9b2a-15f082e8d09b.png)
![image](https://user-images.githubusercontent.com/2673520/65422377-8be93f80-de06-11e9-9c9e-4c101427efc7.png)
- Adds a blinking red battery if the voltage is under the minimum (sorry, I didn't make a gif):
![image](https://user-images.githubusercontent.com/2673520/65422338-7542e880-de06-11e9-9f20-13a2c4b4d09d.png)
