### PR TITLE
Fix esc protocol tooltip for removed dshot1200

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5219,6 +5219,9 @@
     "configurationEscProtocolHelp": {
         "message": "Select your motor protocol. <br>Make sure to verify the protocol is supported by your ESC, this information should be on the makers website. <br> <b>Be carefull using DSHOT900 and DSHOT1200 as not many ESC's support it!</b>"
     },
+    "configurationEscProtocolHelpNoDSHOT1200": {
+        "message": "Select your motor protocol. <br>Make sure to verify the protocol is supported by your ESC, this information should be on the makers website."
+    },
     "configurationunsyndePwm": {
         "message": "Motor PWM speed Separated from PID speed"
     },

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -516,6 +516,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('input[name="motorPoles"]').val(MOTOR_CONFIG.motor_poles);
         }
 
+        $('#escProtocolTooltip').toggle(semver.lt(CONFIG.apiVersion, "1.42.0"));
+        $('#escProtocolTooltipNoDSHOT1200').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
+
         esc_protocol_e.val(PID_ADVANCED_CONFIG.fast_pwm_protocol + 1);
         esc_protocol_e.change(function () {
             var escProtocolValue = parseInt($(this).val()) - 1;

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -137,7 +137,8 @@
                                             <!-- list generated here -->
                                         </select>
                                         <span i18n="configurationEscProtocol"></span>
-                                        <div class="helpicon cf_tip" i18n_title="configurationEscProtocolHelp"></div>
+                                        <div id="escProtocolTooltip" class="helpicon cf_tip" i18n_title="configurationEscProtocolHelp"></div>
+                                        <div id="escProtocolTooltipNoDSHOT1200" class="helpicon cf_tip" i18n_title="configurationEscProtocolHelpNoDSHOT1200"></div>
                                     </label>
                                 </div>
                                 <div class="number checkboxPwm">


### PR DESCRIPTION
Fixes #1688
Dshot1200 is not available for 4.1 therefore it is removed from the tooltip.