### PR TITLE
Added support for Unified Target configurations with manufacturer_id in the name.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2631,8 +2631,11 @@
     "firmwareFlasherReleaseSummaryHead": {
         "message": "Release info"
     },
-    "firmwareFlasherReleaseName": {
-        "message": "Name/Version:"
+    "firmwareFlasherReleaseManufacturer": {
+        "message": "Manufacturer:"
+    },
+    "firmwareFlasherReleaseVersion": {
+        "message": "Version:"
     },
     "firmwareFlasherReleaseVersionUrl": {
         "message": "Visit release page."

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -88,12 +88,24 @@
                     i18n="firmwareFlasherReleaseSummaryHead"></div>
             </div>
             <div class="spacer" style="margin-bottom: 10px;">
-                <strong i18n="firmwareFlasherReleaseTarget"></strong> <span class="target"></span><br /> <strong
-                    i18n="firmwareFlasherReleaseName"></strong> <a i18n_title="firmwareFlasherReleaseVersionUrl" class="name"
-                    href="#" target="_blank"></a><br /> <strong i18n="firmwareFlasherReleaseFile"></strong> <a
-                    i18n_title="firmwareFlasherReleaseFileUrl" class="file" href="#" target="_blank"></a><br /> <strong
-                    i18n="firmwareFlasherReleaseDate"></strong> <span class="date"></span><br /> <strong
-                    i18n="firmwareFlasherReleaseNotes"></strong>
+                <strong i18n="firmwareFlasherReleaseTarget"></strong>
+                <span class="target"></span>
+                <br />
+                <div id="manufacturerInfo">
+                    <strong i18n="firmwareFlasherReleaseManufacturer"></strong>
+                    <span id="manufacturer"></span>
+                    <br />
+                </div>
+                <strong i18n="firmwareFlasherReleaseVersion"></strong>
+                <a i18n_title="firmwareFlasherReleaseVersionUrl" class="name" href="#" target="_blank"></a>
+                <br />
+                <strong i18n="firmwareFlasherReleaseFile"></strong>
+                <a i18n_title="firmwareFlasherReleaseFileUrl" class="file" href="#" target="_blank"></a>
+                <br />
+                <strong i18n="firmwareFlasherReleaseDate"></strong>
+                <span class="date"></span>
+                <br />
+                <strong i18n="firmwareFlasherReleaseNotes"></strong>
                 <div class=notes></div>
             </div>
         </div>


### PR DESCRIPTION
This adds support for loading / processing Unified Target configurations with the following naming schema: `<manufacturer id>-<board name>.config`
This is a prerequisite to allowing manufacturers to manage their own targets, as there would be the potential for naming clashes in the Unified Target configuration files otherwise.
Additionally, the manufacturer id is displayed in the target information page.

![image](https://user-images.githubusercontent.com/4742747/65692954-9d14a380-e0c7-11e9-8ea7-d383d6b7eeb2.png)
