### PR TITLE
FIx memory leak on model rendering

### DIFF
--- a/src/js/model.js
+++ b/src/js/model.js
@@ -144,3 +144,8 @@ Model.prototype.resize = function () {
 
     this.render();
 };
+
+Model.prototype.dispose = function () {
+    this.renderer.forceContextLoss();
+    this.renderer.dispose();
+};

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1729,6 +1729,7 @@ TABS.pid_tuning.cleanup = function (callback) {
 
     if (self.model) {
         $(window).off('resize', $.proxy(self.model.resize, self.model));
+        self.model.dispose();
     }
 
     $(window).off('resize', $.proxy(this.updateRatesLabels, this));

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -605,6 +605,7 @@ TABS.receiver.cleanup = function (callback) {
     $(window).off('resize', this.resize);
     if (this.model) {
         $(window).off('resize', $.proxy(this.model.resize, this.model));
+        this.model.dispose();
     }
 
     this.keepRendering = false;

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -341,6 +341,7 @@ TABS.setup.renderModel = function () {
 TABS.setup.cleanup = function (callback) {
     if (this.model) {
         $(window).off('resize', $.proxy(this.model.resize, this.model));
+        this.model.dispose();
     }
 
     if (callback) callback();


### PR DESCRIPTION
Some users were reporting on Slack that configurator uses more and more memory and eventually causes it to slow down and they need to restart it. Looking into it I found out that models on setup, pid tuning and receiver tabs were the cause.
To test this out try refreshing the pid tuning tab or just opening any of those tabs many times. If someone is messing around or setting up multiple quads without restarting it grows significantly.
This seems to fix it to a certain point, but I think this whole thing should be looked into more in future.