### PR TITLE
fix alignment of vtx tab icon and transponder tab icon also fix wrong vtx icon on active osd tab

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -860,6 +860,7 @@ li.active .ic_flasher {
 
 .ic_transponder {
     background-image: url(../images/icons/cf_icon_transponder_grey.svg);
+    background-position-y: 2px;
 }
 
 .ic_transponder:hover {
@@ -883,7 +884,7 @@ li.active .ic_transponder {
     background-image: url(../images/icons/cf_icon_vtx_grey.svg);
 }
 
-.ic_vtx:hover, li.active .ic_osd {
+.ic_vtx:hover, li.active .ic_vtx {
     background-image: url(../images/icons/cf_icon_vtx_white.svg);
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -881,7 +881,6 @@ li.active .ic_transponder {
 
 .ic_vtx {
     background-image: url(../images/icons/cf_icon_vtx_grey.svg);
-    background-position-y: 4px;
 }
 
 .ic_vtx:hover, li.active .ic_osd {


### PR DESCRIPTION
- changed icon alignment of vtx tab icon and transponder tab icon
- changed wrong vtx icon on active osd tab

before:
![before](https://user-images.githubusercontent.com/29702171/65889135-008d2280-e3a1-11e9-889a-feba01190c5f.jpg)

after:
![after](https://user-images.githubusercontent.com/29702171/65889147-06830380-e3a1-11e9-91bc-5e456e7f3378.jpg)

