### PR TITLE
Fix options menu not opening

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -537,7 +537,7 @@ function startProcess() {
                 analytics.setDimension(analytics.DIMENSIONS.CONFIGURATOR_EXPERT_MODE, checked ? 'On' : 'Off');
             });
 
-            if (FEATURE_CONFIG) {
+            if (FEATURE_CONFIG && FEATURE_CONFIG.features !== 0) {
                 updateTabList(FEATURE_CONFIG.features);
             }
         }).change();


### PR DESCRIPTION
To reproduce the bug:
1. Without FC plugged in click Connect
2. Abort the connecting process by clicking again on Connecting button
3. Try to open settings menu

It was because of `FEATURE_CONFIG` not being properly initialized if the connection attempt was unsuccessful and `FEATURE_CONFIG.isEnabled` being called then when opening options menu.