### PR TITLE
Fix font manager select box border radius

### DIFF
--- a/src/css/tabs-dark/osd-dark.css
+++ b/src/css/tabs-dark/osd-dark.css
@@ -1,12 +1,5 @@
-.fontpresets {
-  background-color: #3c3c3c;
-  color: white;
-}
-
-/* Above two items are related to jbox, and serve as a reminder to look in src/css/tabs/osd.css */
-
-.tab-osd .display-layout input.position{
-  border-bottom: 1px solid red;
+.tab-osd .display-layout input.position {
+    border-bottom: 1px solid red;
 }
 
 .tab-osd .preview {
@@ -14,27 +7,8 @@
     background-size: cover;
 }
 
-.tab-osd .preview .gui_box_titlebar select {
-    background-color: #3a3a3a;
-    color: white;
-}
-
-.tab-osd .switchable-field.mouseover {
-  background: #3a3a3a;
-}
-
-.tab-osd .timer-option {
-  margin-bottom: 2px;
-}
-
-.tab-osd input,
-.tab-osd select {
-  background-color: #3a3a3a;
-  color: white;
-}
-
 /* these two items replace the look of the checkboxes in only CSS */
-.tab-osd input[type='checkbox']:after{
+.tab-osd input[type='checkbox']:after {
     line-height: 1.5em;
     content: '';
     display: inline-block;

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -384,7 +384,10 @@ button {
 }
 
 .fontpresets {
+  background: var(--boxBackground);
+  color: var(--defaultText);
   border: 1px solid var(--subtleAccent);
+  border-radius: 3px;
 }
 
 .tab-osd .switchable-field {
@@ -394,7 +397,7 @@ button {
 }
 
 .tab-osd .switchable-field.mouseover {
-  background: #fff;
+  background: var(--boxBackground);
   border: 1px solid var(--subtleAccent);
   font-weight: 800;
 }
@@ -445,6 +448,8 @@ button {
 
 .tab-osd input,
 .tab-osd select {
+  background: var(--boxBackground);
+  color: var(--defaultText);
   border: 1px solid var(--subtleAccent);
   border-radius: 3px;
 }


### PR DESCRIPTION
Added the missing select box border radius in the font manager. While doing that converted some things to use vars for dark mode and cleaned up `osd-dark.css` file. Looks have not been changed aside from that border radius change.