### PR TITLE
Some minor cleanup for hacktoberfest

### DIFF
--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -11,7 +11,6 @@
 }
 
 .tab-configuration table th {
-    padding-left: 3px;
     padding: 3px;
     border-bottom: 1px solid var(--subtleAccent);
 }

--- a/src/css/tabs/receiver_msp.css
+++ b/src/css/tabs/receiver_msp.css
@@ -104,7 +104,7 @@ body {
 a {
     text-decoration: none;
     color: #000;
-    font-weigt: bold;
+    font-weight: bold;
 }
 
 a:hover {

--- a/src/js/jenkins_loader.js
+++ b/src/js/jenkins_loader.js
@@ -1,4 +1,4 @@
- 'use strict;'
+'use strict';
 
 var JenkinsLoader = function (url) {
     this._url = url;
@@ -46,7 +46,7 @@ JenkinsLoader.prototype.loadJobs = function (viewName, callback) {
                 })
 
                 // cache loaded info
-                object = {}
+                let object = {}
                 object[jobsDataTag] = jobs;
                 object[cacheLastUpdateTag] = $.now();
                 chrome.storage.local.set(object);
@@ -98,7 +98,7 @@ JenkinsLoader.prototype.loadBuilds = function (jobName, callback) {
                     }));
 
                 // cache loaded info
-                object = {}
+                let object = {}
                 object[buildsDataTag] = builds;
                 object[cacheLastUpdateTag] = $.now();
                 chrome.storage.local.set(object);

--- a/src/tabs/adjustments.html
+++ b/src/tabs/adjustments.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabAdjustments"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/wiki" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="note">
             <p i18n="adjustmentsHelp"></p>

--- a/src/tabs/auxiliary.html
+++ b/src/tabs/auxiliary.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabAuxiliary">tabAuxiliary</div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="note">
             <p i18n="auxiliaryHelp"></p>

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabConfiguration"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="note note_adjust">
             <p i18n="configurationFeaturesHelp"></p>

--- a/src/tabs/failsafe.html
+++ b/src/tabs/failsafe.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div i18n="tabFailsafe" class="tab_title"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="note">
                 <p i18n="failsafeFeaturesHelpNew"></p>

--- a/src/tabs/gps.html
+++ b/src/tabs/gps.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabGPS">GPS</div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
 
 

--- a/src/tabs/landing.html
+++ b/src/tabs/landing.html
@@ -26,6 +26,7 @@
                     <div class="donate">
                         <a href="https://paypal.me/betaflight"
                             target="_blank" i18n_title="defaultDonate"><img src="./images/btn-donate.png" alt="Paypal"
+                            rel="noopener noreferrer"
                             height="30" /></a>
                         </li>
                     </div>

--- a/src/tabs/led_strip.html
+++ b/src/tabs/led_strip.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabLedStrip"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="note">
             <p i18n="ledStripHelp"></p>

--- a/src/tabs/logging.html
+++ b/src/tabs/logging.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabLogging"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="note">
             <p i18n="loggingNote"></p>

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabMotorTesting">Motors</div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="gui_box grey" style="margin-bottom: 15px;">
             <div class="wrapper modelAndGraph">

--- a/src/tabs/onboard_logging.html
+++ b/src/tabs/onboard_logging.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabOnboardLogging"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="require-blackbox-unsupported note">
             <p i18n="blackboxNotSupported"></p>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabPidTuning"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="cf_column">
             <div class="profile single-field">

--- a/src/tabs/privacy_policy.html
+++ b/src/tabs/privacy_policy.html
@@ -7,7 +7,7 @@
 
 <p>The Betaflight Group ("us", "we", or "our") operates the  website and the Betaflight Configurator application (the "Service").</p>
 
-<p>This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use our Service and the choices you have associated with that data. This Privacy Policy  for The Betaflight Group is powered by <a target="_blank" href="https://www.freeprivacypolicy.com/free-privacy-policy-generator.php">FreePrivacyPolicy.com</a>.</p>
+<p>This page informs you of our policies regarding the collection, use, and disclosure of personal data when you use our Service and the choices you have associated with that data. This Privacy Policy  for The Betaflight Group is powered by <a target="_blank" rel="noopener noreferrer" href="https://www.freeprivacypolicy.com/free-privacy-policy-generator.php">FreePrivacyPolicy.com</a>.</p>
 
 <p>We use your data to provide and improve the Service. By using the Service, you agree to the collection and use of information in accordance with this policy. Unless otherwise defined in this Privacy Policy, terms used in this Privacy Policy have the same meanings as in our Terms and Conditions.</p>
 
@@ -77,7 +77,7 @@
         <li>
         <p><strong>Google Analytics</strong></p>
         <p>Google Analytics is a web analytics service offered by Google that tracks and reports website traffic. Google uses the data collected to track and monitor the use of our Service. This data is shared with other Google services. Google may use the collected data to contextualize and personalize the ads of its own advertising network.</p>
-                        <p>For more information on the privacy practices of Google, please visit the Google Privacy & Terms web page: <a target="_blank" href="https://policies.google.com/privacy?hl=en">https://policies.google.com/privacy?hl=en</a></p>
+                        <p>For more information on the privacy practices of Google, please visit the Google Privacy & Terms web page: <a target="_blank" rel="noopener noreferrer" href="https://policies.google.com/privacy?hl=en">https://policies.google.com/privacy?hl=en</a></p>
     </li>
                             </ul>
 
@@ -101,6 +101,6 @@
 <h2>Contact Us</h2>
 <p>If you have any questions about this Privacy Policy, please contact us:</p>
 <ul>
-    <li>By visiting this page on our website: <a target="_blank" href="https://github.com/betaflight/betaflight-configurator/issues">https://github.com/betaflight/betaflight-configurator/issues</a></li>
+    <li>By visiting this page on our website: <a target="_blank" rel="noopener noreferrer" href="https://github.com/betaflight/betaflight-configurator/issues">https://github.com/betaflight/betaflight-configurator/issues</a></li>
 </ul>
 </div>

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabReceiver"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
         <div class="note">
             <p i18n="receiverHelp"></p>

--- a/src/tabs/sensors.html
+++ b/src/tabs/sensors.html
@@ -2,7 +2,7 @@
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabRawSensorData"></div>
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
 
         <div class="note">

--- a/src/tabs/transponder.html
+++ b/src/tabs/transponder.html
@@ -4,7 +4,7 @@
         <div class="tab_title" i18n="tabTransponder">Transponder</div>
 
         <div class="cf_doc_version_bt">
-            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank"></a>
+            <a id="button-documentation" href="https://github.com/betaflight/betaflight/releases" target="_blank" rel="noopener noreferrer"></a>
         </div>
 
         <div class="require-transponder-unsupported note">


### PR DESCRIPTION
Links that open target="_blank" should also specify rel="noopener noreferrer", not an issue for NWJS, but potentially an issue for other platforms.

jenkins_loader wasn't properly in strict mode.

