### PR TITLE
Fix Azure-Pipelines.yml to do a build and release on check in of master branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,95 +10,102 @@
 # - File content to variable: https://marketplace.visualstudio.com/items?itemName=maikvandergaag.maikvandergaag-file-to-variable
 
 trigger:
-# TODO: change to master once pull request merged
-- azure-pipelines
+- master
 
-jobs:
-- job: 'Windows'
+stages:
+- stage: Build
+  jobs:
 
-  pool:
-    vmImage: 'vs2017-win2016'
+  - job: 'Windows'
+    pool:
+      vmImage: 'vs2017-win2016'
 
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '8.11.2'    
-    displayName: 'Install Node.js'
+    steps:
+    - task: UseNode@1
+      inputs:
+        version: '10.16.3'
+      displayName: 'Install Node.js 10.16.3'
+    - script: yarn install
+      displayName: 'Run yarn install'
+    - script: gulp release --win32 --win64
+      displayName: 'Run gulp release'
+    - powershell: Set-Content -Path '$(System.DefaultWorkingDirectory)/release/log.txt' -Value $env:BUILD_SOURCEVERSIONMESSAGE
 
-  - script: npm install -g npm@6.0.1
-    displayName: 'Install NPM'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Windows release'
+      inputs:
+        targetPath: '$(System.DefaultWorkingDirectory)/release'
+        artifact: 'betaflight-configurator-windows'
 
-  - script: npm install -g gulp
-    displayName: 'Install Gulp'
 
-  - script: npm install
-    displayName: 'Run npm install'
+  - job: 'MacOS'
+    pool:
+      vmImage: 'macos-10.13'
 
-  - script: gulp release --win32
-    displayName: 'Run gulp release'
+    steps:
+    - task: UseNode@1
+      inputs:
+        version: '10.16.3'
+      displayName: 'Install Node.js 10.16.3'
+    - script: npm install -g gulp
+      displayName: 'Install Gulp'
+    - script: yarn install
+      displayName: 'Run yarn install'
+    - script: gulp release --osx64
+      displayName: 'Run gulp release'
 
-  - powershell: Set-Content -Path '$(System.DefaultWorkingDirectory)/release/log.txt' -Value $env:BUILD_SOURCEVERSIONMESSAGE
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish MacOS release'
+      inputs: 
+          artifactName: betaflight-configurator-macos
+          targetPath: '$(System.DefaultWorkingDirectory)/release'
 
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Windows release'
-    inputs: 
-      artifactName: betaflight-configurator-windows
-      targetPath: '$(System.DefaultWorkingDirectory)/release'
 
-- job: 'Linux'
+  - job: 'Linux'
+    pool:
+      vmImage: 'ubuntu-16.04'
 
-  pool:
-    vmImage: 'ubuntu-16.04'
+    steps:
+    - task: UseNode@1
+      inputs:
+        version: '10.16.3'
+      displayName: 'Install Node.js 10.16.3'
+    - script: yarn install
+      displayName: 'Run yarn install'
+    - script: gulp release --linux32 --linux64
+      displayName: 'Run gulp release'
+    - script: cd $(System.DefaultWorkingDirectory)/release; find -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
+      displayName: 'Clean release folders'
 
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '8.11.2'    
-    displayName: 'Install Node.js'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Linux release'
+      inputs: 
+        artifactName: betaflight-configurator-linux
+        targetPath: '$(System.DefaultWorkingDirectory)/release'
 
-  - script: npm install -g npm@6.0.1
-    displayName: 'Install NPM'
 
-  - script: npm install -g gulp
-    displayName: 'Install Gulp'
+- stage: Release
+  jobs:
+  - job: Release
 
-  - script: npm install
-    displayName: 'Run npm install'
+    steps:
+    - task: DownloadPipelineArtifact@2
+      inputs:
+        buildType: 'current'
+        targetPath: '$(Pipeline.Workspace)'
 
-  - script: gulp release --linux32 --linux64
-    displayName: 'run gulp release'
-
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish Linux release'
-    inputs: 
-      artifactName: betaflight-configurator-linux
-      targetPath: '$(System.DefaultWorkingDirectory)/release'
-
-- job: 'MacOS'
-
-  pool:
-    vmImage: 'macos-10.13'
-
-  steps:
-  - task: NodeTool@0
-    inputs:
-      versionSpec: '8.11.2'    
-    displayName: 'Install Node.js'
-
-  - script: npm install -g npm@6.0.1
-    displayName: 'Install NPM'
-
-  - script: npm install -g gulp
-    displayName: 'Install Gulp'
-
-  - script: npm install
-    displayName: 'Run rpm install'
-
-  - script: gulp release --osx64
-    displayName: 'Run gulp release'
-
-  - task: PublishPipelineArtifact@0
-    displayName: 'Publish MacOS release'
-    inputs: 
-      artifactName: betaflight-configurator-macos
-      targetPath: '$(System.DefaultWorkingDirectory)/release'
+    - task: GitHubRelease@1
+      inputs:
+        gitHubConnection: 'Betaflight GitHub'
+        repositoryName: '$(Build.Repository.Name)'
+        action: 'create'
+        target: '$(Build.SourceVersion)'
+        tagSource: userSpecifiedTag
+        tag: '$(Build.BuildNumber) '
+        isPreRelease: true
+        changeLogCompareToRelease: lastNonDraftRelease
+        changeLogType: 'commitBased'
+        assets: |
+          $(Pipeline.Workspace)/betaflight-configurator-windows/**
+          $(Pipeline.Workspace)/betaflight-configurator-macos/**
+          $(Pipeline.Workspace)/betaflight-configurator-linux/**

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,12 +2,14 @@
 #
 # After building, artifacts are released to a seperate repository.
 #
-# Requires Azure Pipelines added to Github repositories:
-# https://azure.microsoft.com/services/devops/pipelines/
+# Azure Pipelines requires the following extensions to be installed:
+# - GitHub Tool: https://marketplace.visualstudio.com/items?itemName=marcelo-formentao.github-tools
 #
-# Azure Pipelines requires tasks to be installed:
-# - Github Release: https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/utility/github-release
-# - File content to variable: https://marketplace.visualstudio.com/items?itemName=maikvandergaag.maikvandergaag-file-to-variable
+# You'll also need to setup the follwing pipeline variables: 
+#     "releaseNotes" - This is used to add the release notes in the windows job in the build stage so they can be published as part of the github release in the release stage
+#     "endpoint" - The name of the github endpoint link setup in AzDo - setup when linking AzDo and GitHub
+#     "owner" - The owner of the repository to release to e.g. betaflight
+#     "repoName" - The name of the repository to release to e.g. betaflight-configurator-nightly
 
 trigger:
 - master
@@ -28,7 +30,7 @@ stages:
     - script: yarn install
       displayName: 'Run yarn install'
     - script: yarn gulp release --win32 --win64
-      displayName: 'Run yarn gulp release'
+      displayName: 'Run gulp release'
     - powershell: Set-Content -Path '$(System.DefaultWorkingDirectory)/release/log.txt' -Value $env:BUILD_SOURCEVERSIONMESSAGE
 
     - task: PublishPipelineArtifact@1
@@ -36,7 +38,6 @@ stages:
       inputs:
         targetPath: '$(System.DefaultWorkingDirectory)/release'
         artifact: 'betaflight-configurator-windows'
-
 
   - job: 'MacOS'
     pool:
@@ -52,14 +53,13 @@ stages:
     - script: yarn install
       displayName: 'Run yarn install'
     - script: yarn gulp release --osx64
-      displayName: 'Run yarn gulp release'
+      displayName: 'Run gulp release'
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish MacOS release'
       inputs: 
           artifactName: betaflight-configurator-macos
           targetPath: '$(System.DefaultWorkingDirectory)/release'
-
 
   - job: 'Linux'
     pool:
@@ -73,7 +73,7 @@ stages:
     - script: yarn install
       displayName: 'Run yarn install'
     - script: yarn gulp release --linux32 --linux64
-      displayName: 'Run yarn gulp release'
+      displayName: 'Run gulp release'
     - script: cd $(System.DefaultWorkingDirectory)/release; find -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
       displayName: 'Clean release folders'
 
@@ -93,19 +93,24 @@ stages:
       inputs:
         buildType: 'current'
         targetPath: '$(Pipeline.Workspace)'
+    - powershell: Write-Output ("##vso[task.setvariable variable=releaseNotes;]$(gc $(Pipeline.Workspace)/betaflight-configurator-windows/log.txt)")
 
-    - task: GitHubRelease@1
+    - task: GitHubReleasePublish@1
       inputs:
-        gitHubConnection: 'Betaflight GitHub'
-        repositoryName: '$(Build.Repository.Name)'
-        action: 'create'
-        target: '$(Build.SourceVersion)'
-        tagSource: userSpecifiedTag
-        tag: '$(Build.BuildNumber) '
-        isPreRelease: true
-        changeLogCompareToRelease: lastNonDraftRelease
-        changeLogType: 'commitBased'
-        assets: |
+        githubEndpoint: '$(endpoint)'
+        manuallySetRepository: true
+        githubOwner: '$(owner)'
+        githubRepositoryName: '$(repoName)'
+        githubReleaseNotes: '$(releaseNotes)'
+        githubReleaseDraft: false
+        githubReleasePrerelease: false
+        githubIgnoreAssets: false
+        githubReleaseAsset: |
           $(Pipeline.Workspace)/betaflight-configurator-windows/**
           $(Pipeline.Workspace)/betaflight-configurator-macos/**
           $(Pipeline.Workspace)/betaflight-configurator-linux/**
+        githubReuseRelease: true
+        githubReuseDraftOnly: true
+        githubSkipDuplicatedAssets: false
+        githubEditRelease: false
+        githubDeleteEmptyTag: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ stages:
     - script: yarn install
       displayName: 'Run yarn install'
     - script: yarn gulp release --linux32 --linux64
-      displayName: 'Run gulp release'
+      displayName: 'Run yarn gulp release'
     - script: cd $(System.DefaultWorkingDirectory)/release; find -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
       displayName: 'Clean release folders'
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,7 +29,7 @@ stages:
       displayName: 'Install Node.js 10.16.3'
     - script: yarn install
       displayName: 'Run yarn install'
-    - script: yarn gulp release --win32 --win64
+    - script: yarn release --win32 --win64
       displayName: 'Run gulp release'
     - powershell: Set-Content -Path '$(System.DefaultWorkingDirectory)/release/log.txt' -Value $env:BUILD_SOURCEVERSIONMESSAGE
 
@@ -53,7 +53,7 @@ stages:
     - script: yarn install
       displayName: 'Run yarn install'
     - script: yarn gulp release --osx64
-      displayName: 'Run gulp release'
+      displayName: 'Run release'
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish MacOS release'
@@ -72,7 +72,7 @@ stages:
       displayName: 'Install Node.js 10.16.3'
     - script: yarn install
       displayName: 'Run yarn install'
-    - script: yarn gulp release --linux32 --linux64
+    - script: yarn release --linux32 --linux64
       displayName: 'Run gulp release'
     - script: cd $(System.DefaultWorkingDirectory)/release; find -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
       displayName: 'Clean release folders'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -27,8 +27,8 @@ stages:
       displayName: 'Install Node.js 10.16.3'
     - script: yarn install
       displayName: 'Run yarn install'
-    - script: gulp release --win32 --win64
-      displayName: 'Run gulp release'
+    - script: yarn gulp release --win32 --win64
+      displayName: 'Run yarn gulp release'
     - powershell: Set-Content -Path '$(System.DefaultWorkingDirectory)/release/log.txt' -Value $env:BUILD_SOURCEVERSIONMESSAGE
 
     - task: PublishPipelineArtifact@1
@@ -51,8 +51,8 @@ stages:
       displayName: 'Install Gulp'
     - script: yarn install
       displayName: 'Run yarn install'
-    - script: gulp release --osx64
-      displayName: 'Run gulp release'
+    - script: yarn gulp release --osx64
+      displayName: 'Run yarn gulp release'
 
     - task: PublishPipelineArtifact@1
       displayName: 'Publish MacOS release'
@@ -72,7 +72,7 @@ stages:
       displayName: 'Install Node.js 10.16.3'
     - script: yarn install
       displayName: 'Run yarn install'
-    - script: gulp release --linux32 --linux64
+    - script: yarn gulp release --linux32 --linux64
       displayName: 'Run gulp release'
     - script: cd $(System.DefaultWorkingDirectory)/release; find -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
       displayName: 'Clean release folders'


### PR DESCRIPTION
Will build all flavours of the configurator upon a check-in to master branch, and create a github release within the same repo after the build has completed successfully. This will require some setup in Azure DevOps but should allow "nightly" builds for all OSes.