### PR TITLE
Zip files in nwBuilder

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ var nwBuilderOptions = {
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},
     winIco: './src/images/bf_icon.ico',
-    zip: false
+    zip: true
 };
 
 var nwArmVersion = '0.27.6';


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1750

The installer is taking a lot of time under Windows. Usually about 5 minutes but there are reports about 15 minutes.

This time is produced by the uninstaller registering all the files to be safe when removing the app. This with the antivirus working makes it slow.

A solution is to pack the files in the nwBuilder: this makes the program a little slower when starting but a lot faster when installing.

Another solution can be change the uninstalling system, but I don't know if we can find a good replacement for the actual. 

Now we have a lot of time until the next release to test this change.