### PR TITLE
Disallow selecting text in MSP Receiver to make dragging more convenient

### DIFF
--- a/src/css/tabs/receiver_msp.css
+++ b/src/css/tabs/receiver_msp.css
@@ -5,6 +5,7 @@ body {
     color: #303030;
     margin: 10px;
     overflow: hidden;
+    user-select: none;
 }
 
 .control-gimbals {


### PR DESCRIPTION
I've noticed it is easy to get the mouse dragging gesture be interpreted as text selection, so this PR adds a CSS rule to disable it.