### PR TITLE
Change "OpenLog" to "OpenLager"

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2542,7 +2542,7 @@
     },
 
     "serialLoggingSupportedNote": {
-        "message": "You can log to an external logging device (such as an OpenLog or compatible clone) by using a serial port. Configure the port on the Ports tab."
+        "message": "You can log to an external logging device (such as an OpenLager) by using a serial port. Configure the port on the Ports tab."
     },
     "sdcardNote": {
         "message": "Flight logs can be recorded to your flight controller's onboard SD card slot."


### PR DESCRIPTION
OpenLog became not suitable for serial port logging as of 4.0.x.

betaflight/betaflight#9043