### PR TITLE
Fix sliders marker

### DIFF
--- a/src/css/tabs/adjustments.css
+++ b/src/css/tabs/adjustments.css
@@ -94,6 +94,7 @@
     width: 6px;
     margin-left: -3px;
     border-radius: 3px;
+    z-index: 1000;
 }
 
 .tab-adjustments .adjustment .functionSelection {

--- a/src/css/tabs/auxiliary.css
+++ b/src/css/tabs/auxiliary.css
@@ -180,6 +180,7 @@
     height: 13px;
     width: 6px;
     margin-left: -3px;
+    z-index: 1000;
 }
 
 .tab-auxiliary .range .channel-slider {


### PR DESCRIPTION
Fix sliders markers on adjustments and auxiliary pages.

![sliders_marker](https://user-images.githubusercontent.com/3103909/67335475-6b5af500-f52c-11e9-8884-5afc51bdc9f4.png)
