### PR TITLE
Hide Motor Poles when it is not necessary

### DIFF
--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -516,6 +516,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('input[name="motorPoles"]').val(MOTOR_CONFIG.motor_poles);
         }
 
+        function hideMotorPoles() {
+            let motorPolesVisible = $("input[id='dshotBidir']").is(':checked') || $("input[name='ESC_SENSOR']").is(':checked');
+            $('div.motorPoles').toggle(motorPolesVisible);
+        }
+
         $('#escProtocolTooltip').toggle(semver.lt(CONFIG.apiVersion, "1.42.0"));
         $('#escProtocolTooltipNoDSHOT1200').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
 
@@ -542,12 +547,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             $('div.checkboxDshotBidir').toggle(semver.gte(CONFIG.apiVersion, "1.42.0") && digitalProtocol);
             $('div.motorPoles').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
+            //trigger change dshotBidir and ESC_SENSOR to show/hide Motor Poles tab
+            $("input[id='dshotBidir']").change(hideMotorPoles).change();
+            $("input[name='ESC_SENSOR']").change(hideMotorPoles);
 
             //trigger change unsyncedPWMSwitch to show/hide Motor PWM freq input
             $("input[id='unsyncedPWMSwitch']").change();
 
         }).change();
-
 
         // Gyro and PID update
         var gyroUse32kHz_e = $('input[id="gyroUse32kHz"]');


### PR DESCRIPTION
Hide Motor Poles tab for more cleanning, only shows when Dshot Bidir or ESC_SENSOR are actived. A lot of thanks @McGiverGim for your help for this ;)

![hidemotorpoles](https://user-images.githubusercontent.com/43983086/67637260-e29bda80-f8d8-11e9-9f34-c243d644c2b1.jpg)