### PR TITLE
remove version check for node.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,9 +36,6 @@
   },
   "author": "The Betaflight open source project.",
   "license": "GPL-3.0",
-  "engines": {
-    "node": "10.x"
-  },
   "dependencies": {
     "bluebird": "^3.5.5",
     "i18next": "^17.0.11",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
   },
   "author": "The Betaflight open source project.",
   "license": "GPL-3.0",
+  "engines": {
+    "node": ">=10.x"
+  },
   "dependencies": {
     "bluebird": "^3.5.5",
     "i18next": "^17.0.11",


### PR DESCRIPTION
... or it must be increased with each new version. node v12 has already been released.
imho we remove this, it is also not checked in blackbox-log-viewer 