### PR TITLE
Updated maximun no battery voltage

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -621,7 +621,7 @@ function update_live_status() {
        var max = BATTERY_CONFIG.vbatmaxcellvoltage * nbCells;
        var warn = BATTERY_CONFIG.vbatwarningcellvoltage * nbCells;
 
-       const NO_BATTERY_VOLTAGE_MAXIMUM = 0.5; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions  
+       const NO_BATTERY_VOLTAGE_MAXIMUM = 1; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions  
 
        if (ANALOG.voltage < min && ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM) {
            $(".battery-status").addClass('state-empty').removeClass('state-ok').removeClass('state-warning');

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -621,7 +621,7 @@ function update_live_status() {
        var max = BATTERY_CONFIG.vbatmaxcellvoltage * nbCells;
        var warn = BATTERY_CONFIG.vbatwarningcellvoltage * nbCells;
 
-       const NO_BATTERY_VOLTAGE_MAXIMUM = 1; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions  
+       const NO_BATTERY_VOLTAGE_MAXIMUM = 1.5; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions  
 
        if (ANALOG.voltage < min && ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM) {
            $(".battery-status").addClass('state-empty').removeClass('state-ok').removeClass('state-warning');

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -621,7 +621,7 @@ function update_live_status() {
        var max = BATTERY_CONFIG.vbatmaxcellvoltage * nbCells;
        var warn = BATTERY_CONFIG.vbatwarningcellvoltage * nbCells;
 
-       const NO_BATTERY_VOLTAGE_MAXIMUM = 1.5; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions  
+       const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions  
 
        if (ANALOG.voltage < min && ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM) {
            $(".battery-status").addClass('state-empty').removeClass('state-ok').removeClass('state-warning');


### PR DESCRIPTION
Some boards consume more than 0.5v connected to Usb, increase the maximum voltage without battery to 1V.
![usb problem](https://user-images.githubusercontent.com/43983086/68068749-bb219380-fd58-11e9-897b-dd8f8357d5ca.jpg)
