### PR TITLE
Add SonarCloud badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Betaflight](http://static.rcgroups.net/forums/attachments/6/1/0/3/7/6/a9088900-228-bf_logo.jpg)
 
-[![Crowdin](https://d322cqt584bo4o.cloudfront.net/betaflight-configurator/localized.svg)](https://crowdin.com/project/betaflight-configurator)
+[![Crowdin](https://d322cqt584bo4o.cloudfront.net/betaflight-configurator/localized.svg)](https://crowdin.com/project/betaflight-configurator) [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=betaflight_betaflight-configurator&metric=alert_status)](https://sonarcloud.io/dashboard?id=betaflight_betaflight-configurator)
 
 Betaflight Configurator is a crossplatform configuration tool for the Betaflight flight control system.
 


### PR DESCRIPTION
Adds a badge with the SonarCloud info analysis. Result:
![image](https://user-images.githubusercontent.com/2673520/68082325-77439280-fe1b-11e9-93cf-a12bed43490a.png)

We have three badges to select, or different metrics to show:
![image](https://user-images.githubusercontent.com/2673520/68082331-a2c67d00-fe1b-11e9-88d2-2a3656bac88c.png)

I think the default one is good enough but can be discussed in this PR.