### PR TITLE
Add project version to the Sonar file

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,1 @@
+sonar.projectVersion=10.7.0


### PR DESCRIPTION
I'm not too sure if this is supported by the autoscan feature, this PR is to test it.

If it works, for discussion, I think is good to tag the versions of the code, to have the history of the code quality at least by versions. Sonar will remove not final version analysis after some time.

The only problem is that we will need to remember to modify this manually for each version :(