### PR TITLE
clean up gulpfile.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -230,8 +230,6 @@ function dist_src() {
     var distSources = [
         './src/**/*',
         '!./src/css/dropdown-lists/LICENSE',
-        '!./src/css/font-awesome/css/font-awesome.css',
-        '!./src/css/opensans_webfontkit/*.{txt,html}',
         '!./src/support/**'
     ];
     var packageJson = new stream.Readable;

--- a/src/css/opensans_webfontkit/generator_config.txt
+++ b/src/css/opensans_webfontkit/generator_config.txt
@@ -1,5 +1,0 @@
-# Font Squirrel Font-face Generator Configuration File
-# Upload this file to the generator to recreate the settings
-# you used to create these fonts.
-
-{"mode":"optimal","formats":["ttf","woff","woff2","eotz"],"tt_instructor":"default","fix_vertical_metrics":"Y","fix_gasp":"xy","add_spaces":"Y","add_hyphens":"Y","fallback":"none","fallback_custom":"100","options_subset":"basic","subset_custom":"","subset_custom_range":"","subset_ot_features_list":"","css_stylesheet":"stylesheet.css","filename_suffix":"-webfont","emsquare":"2048","spacing_adjustment":"0"}


### PR DESCRIPTION
I forgot to remove a line from `gulpfile.js` in #1784, doing that.

I'm throwing out the generator config as I can't find a place to use it. which means another line can be removed from `gulpfile.js`

