### PR TITLE
Exclude PRs and fix build name for nightlies

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,8 +11,13 @@
 #     "owner" - The owner of the repository to release to e.g. betaflight
 #     "repoName" - The name of the repository to release to e.g. betaflight-configurator-nightly
 
+name: $(Date:yyyyMMdd).$(BuildID)
 trigger:
-- master
+  batch: true
+  branches:
+    include:
+    - master
+pr: none
 
 stages:
 - stage: Build


### PR DESCRIPTION
This should exclude PRs from the build, and fix the build name to be {date}.{absolute build number}, as well as batching up commits if there is already a build in progress.