### PR TITLE
Add more parameters to GPS Rescue

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3649,10 +3649,31 @@
     "failsafeGpsRescueItemThrottleHover": {
         "message": "Throttle hover"
     },
+    "failsafeGpsRescueItemAscendRate": {
+        "message": "Ascend rate (meters/second)"
+    },
+    "failsafeGpsRescueItemDescendRate": {
+        "message": "Descend rate (meters/second)"
+    },    
     "failsafeGpsRescueItemMinSats": {
         "message": "Minimum satellites"
     },
-    "failsafeGpsRescueItemSanityChecks": {
+    "failsafeGpsRescueItemAllowArmingWithoutFix": {
+        "message": "Allow arming without fix - <span class=\"message-negative\">WARNING: the GPS Rescue will not be available</span>"
+    },
+    "failsafeGpsRescueItemAltitudeMode": { 
+        "message": "Altitude mode"
+    },
+    "failsafeGpsRescueItemAltitudeModeMaxAlt": { 
+        "message": "Maximum altitude"
+    },
+    "failsafeGpsRescueItemAltitudeModeFixedAlt": { 
+        "message": "Fixed altitude"
+    },
+    "failsafeGpsRescueItemAltitudeModeCurrentAlt": { 
+        "message": "Current altitude"
+    },
+    "failsafeGpsRescueItemSanityChecks": { 
         "message": "Sanity checks"
     },
     "failsafeGpsRescueItemSanityChecksOff": {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -140,8 +140,8 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 
 .message-negative {
-    color: var(--error);
-    font-weight: bold;
+    color: var(--error) !important;
+    font-weight: bold !important;
 }
 
 .headerbar {

--- a/src/css/tabs/failsafe.css
+++ b/src/css/tabs/failsafe.css
@@ -41,6 +41,10 @@
     font-weight: normal;
 }
 
+.tab-failsafe .number .switchery {
+    margin-right: 16px;
+}
+
 .tab-failsafe .number input:disabled {
     background-color: #ececec;
 }
@@ -275,12 +279,6 @@
 
 .tab-failsafe table {
     width: 100%;
-}
-
-.tab-failsafe .selectSwitchMode {
-    clear: left;
-    width: 100%;
-    float: left;
 }
 
 .tab-failsafe .switchMode {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -502,6 +502,10 @@ var FC = {
             throttleHover:                  0,
             sanityChecks:                   0,
             minSats:                        0,
+            ascendRate:                     0,
+            descendRate:                    0,
+            allowArmingWithoutFix:          0,
+            altitudeMode:                   0,
         };
 
         RXFAIL_CONFIG = [];

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -435,6 +435,12 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 GPS_RESCUE.throttleHover     = data.readU16();
                 GPS_RESCUE.sanityChecks      = data.readU8();
                 GPS_RESCUE.minSats           = data.readU8();
+                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                    GPS_RESCUE.ascendRate            = data.readU16();
+                    GPS_RESCUE.descendRate           = data.readU16();
+                    GPS_RESCUE.allowArmingWithoutFix = data.readU8();
+                    GPS_RESCUE.altitudeMode          = data.readU8();
+                }
                 break;
             case MSPCodes.MSP_RSSI_CONFIG:
                 RSSI_CONFIG.channel = data.readU8();
@@ -1705,6 +1711,13 @@ MspHelper.prototype.crunch = function(code) {
                   .push16(GPS_RESCUE.throttleHover)
                   .push8(GPS_RESCUE.sanityChecks)
                   .push8(GPS_RESCUE.minSats);
+
+                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                    buffer.push16(GPS_RESCUE.ascendRate)
+                          .push16(GPS_RESCUE.descendRate)
+                          .push8(GPS_RESCUE.allowArmingWithoutFix)
+                          .push8(GPS_RESCUE.altitudeMode);
+                }
             break;
         case MSPCodes.MSP_SET_COMPASS_CONFIG:
             buffer.push16(Math.round(COMPASS_CONFIG.mag_declination * 100));

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -312,6 +312,19 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 $('input[name="gps_rescue_throttle_hover"]').val(GPS_RESCUE.throttleHover);
                 $('input[name="gps_rescue_min_sats"]').val(GPS_RESCUE.minSats);
                 $('select[name="gps_rescue_sanity_checks"]').val(GPS_RESCUE.sanityChecks);
+
+                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                    $('input[name="gps_rescue_ascend_rate"]').val((GPS_RESCUE.ascendRate / 100).toFixed(2));
+                    $('input[name="gps_rescue_descend_rate"]').val((GPS_RESCUE.descendRate / 100).toFixed(2));
+                    $('input[name="gps_rescue_allow_arming_without_fix"]').prop('checked', GPS_RESCUE.allowArmingWithoutFix > 0);
+                    $('select[name="gps_rescue_altitude_mode"]').val(GPS_RESCUE.altitudeMode);
+                } else {
+                    $('input[name="gps_rescue_ascend_rate"]').closest('.number').hide();
+                    $('input[name="gps_rescue_descend_rate"]').closest('.number').hide();
+                    $('input[name="gps_rescue_allow_arming_without_fix"]').closest('.number').hide();
+                    $('select[name="gps_rescue_altitude_mode"]').closest('.number').hide();
+                }
+
             } else {
                 // GPS Rescue Parameters not available
                 $('.pro4 > .proceduresettings').hide();
@@ -364,6 +377,13 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 GPS_RESCUE.throttleHover     = $('input[name="gps_rescue_throttle_hover"]').val();
                 GPS_RESCUE.minSats           = $('input[name="gps_rescue_min_sats"]').val();
                 GPS_RESCUE.sanityChecks      = $('select[name="gps_rescue_sanity_checks"]').val();
+            }
+
+            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                GPS_RESCUE.ascendRate = $('input[name="gps_rescue_ascend_rate"]').val() * 100;
+                GPS_RESCUE.descendRate = $('input[name="gps_rescue_descend_rate"]').val() * 100;
+                GPS_RESCUE.allowArmingWithoutFix = $('input[name="gps_rescue_allow_arming_without_fix"]').prop('checked') ? 1 : 0;
+                GPS_RESCUE.altitudeMode = parseInt($('select[name="gps_rescue_altitude_mode"]').val());
             }
 
             function save_failssafe_config() {

--- a/src/tabs/failsafe.html
+++ b/src/tabs/failsafe.html
@@ -44,7 +44,7 @@
                     <div class="spacer_box_title" i18n="failsafeSwitchTitle"></div>
                 </div>
                 <div class="spacer_box">
-                    <div class="selectSwitchMode">
+                    <div class="number">
                         <label>
                             <select class="switchMode" name="failsafe_switch_mode">
                                 <option value="0" i18n="failsafeSwitchOptionStage1"></option>
@@ -153,11 +153,36 @@
                                 </label>
                             </div>
                             <div class="number">
+                                <label> <input type="number" name="gps_rescue_ascend_rate" min="1.00" max="25.00" step="0.01" /> <span
+                                    i18n="failsafeGpsRescueItemAscendRate"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label> <input type="number" name="gps_rescue_descend_rate" min="1.00" max="5.00" step="0.01" /> <span
+                                    i18n="failsafeGpsRescueItemDescendRate"></span>
+                                </label>
+                            </div>
+                            <div class="number">
                                 <label> <input type="number" name="gps_rescue_min_sats" min="5" max="50" /> <span
                                     i18n="failsafeGpsRescueItemMinSats"></span>
                                 </label>
                             </div>
-                            <div class="selectSwitchMode">
+                            <div class="number">
+                                <label> <input type="checkbox" name="gps_rescue_allow_arming_without_fix" class="toggle" /> <span
+                                    i18n="failsafeGpsRescueItemAllowArmingWithoutFix"></span>
+                                </label>
+                            </div>
+                            <div class="number">
+                                <label>
+                                    <select class="switchMode" name="gps_rescue_altitude_mode">
+                                        <option value="0" i18n="failsafeGpsRescueItemAltitudeModeMaxAlt"></option>
+                                        <option value="1" i18n="failsafeGpsRescueItemAltitudeModeFixedAlt"></option>
+                                        <option value="2" i18n="failsafeGpsRescueItemAltitudeModeCurrentAlt"></option>
+                                    </select>
+                                <span i18n="failsafeGpsRescueItemAltitudeMode"></span>
+                                </label>
+                            </div>
+                            <div class="number">
                                 <label>
                                     <select class="switchMode" name="gps_rescue_sanity_checks">
                                         <option value="0" i18n="failsafeGpsRescueItemSanityChecksOff"></option>


### PR DESCRIPTION
Adds more parameters to the GPS Rescue.

We start having a lot of them, maybe is a good idea to remove some. For example, now that we have the ascend and descent rates, from here https://github.com/betaflight/betaflight/pull/8015 maybe we can we have a good max, min and hover throttle and let them only CLI? Or maybe remove them from firmware if the vertical velocity PID controller is good enough for it. @IllusionFpv are the throttle values necessary or can they be removed from the firmware and let only your code?

![image](https://user-images.githubusercontent.com/2673520/68397869-2530a300-0174-11ea-8bd9-f60eb71a5d59.png)
