### PR TITLE
i18next uses `:` to denote a namespace for messages. Get rid of warnings.

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -105,7 +105,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                     show_loaded_hex(summary)
 
                 } else {
-                    self.flashingMessage('firmwareFlasherHexCorrupted', self.FLASH_MESSAGE_TYPES.INVALID);
+                    self.flashingMessage(i18n.getMessage('firmwareFlasherHexCorrupted'), self.FLASH_MESSAGE_TYPES.INVALID);
                 }
             });
         }
@@ -515,7 +515,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                 TABS.firmware_flasher.bareBoard = undefined;
                 console.log('board changed to', target);
 
-                self.flashingMessage('firmwareFlasherLoadFirmwareFile', self.FLASH_MESSAGE_TYPES.NEUTRAL)
+                self.flashingMessage(i18n.getMessage('firmwareFlasherLoadFirmwareFile'), self.FLASH_MESSAGE_TYPES.NEUTRAL)
                     .flashProgress(0);
 
                 $('div.git_info').slideUp();
@@ -683,7 +683,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
                                             flashingMessageLocal();
                                         } else {
-                                            self.flashingMessage('firmwareFlasherHexCorrupted', self.FLASH_MESSAGE_TYPES.INVALID);
+                                            self.flashingMessage(i18n.getMessage('firmwareFlasherHexCorrupted'), self.FLASH_MESSAGE_TYPES.INVALID);
                                         }
                                     });
                                 } else {
@@ -694,7 +694,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                                         self.isConfigLocal = true;
                                         flashingMessageLocal();
                                     } catch(err) {
-                                        self.flashingMessage('firmwareFlasherConfigCorrupted', self.FLASH_MESSAGE_TYPES.INVALID);
+                                        self.flashingMessage(i18n.getMessage('firmwareFlasherConfigCorrupted'), self.FLASH_MESSAGE_TYPES.INVALID);
                                         GUI.log(i18n.getMessage('firmwareFlasherConfigCorruptedLogMessage'));
                                     }
                                 }
@@ -1009,6 +1009,8 @@ TABS.firmware_flasher.initialize = function (callback) {
 
         });
 
+        self.flashingMessage(i18n.getMessage('firmwareFlasherLoadFirmwareFile'), self.FLASH_MESSAGE_TYPES.NEUTRAL);
+
         $(document).keypress(function (e) {
             if (e.which == 13) { // enter
                 // Trigger regular Flashing sequence
@@ -1082,13 +1084,7 @@ TABS.firmware_flasher.flashingMessage = function(message, type) {
             break;
     }
     if (message != null) {
-        if (i18next.exists(message)) {
-            progressLabel_e.attr('i18n',message).removeClass('i18n-replaced');
-            i18n.localizePage();
-        } else {
-            progressLabel_e.removeAttr('i18n');
-            progressLabel_e.html(message);
-        }
+        progressLabel_e.html(message);
     }
 
     return self;

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -136,7 +136,7 @@
     <div class="content_toolbar">
         <div class="info"><a name="progressbar"></a>
             <progress class="progress" value="0" min="0" max="100"></progress>
-            <span class="progressLabel" i18n="firmwareFlasherLoadFirmwareFile"></span>
+            <span class="progressLabel"></span>
         </div>
         <div class="btn">
             <a class="flash_firmware disabled" href="#progressbar" i18n="firmwareFlasherFlashFirmware"></a>


### PR DESCRIPTION
The firmware flashing tab has a `flashingMessage` function that is used to update the bar at the bottom, it can either be passed a message key, or a properly formatted string.

`Loaded Local Firmware: (473178 bytes)` was getting looked up as a key, which generates the following warning

i18next.min.js:1 i18next::translator: key " (473178 bytes)" for namespace "Loaded Local Firmware" for languages "en" won't get resolved as namespace was not yet loaded This means something IS WRONG in your application setup. You access the t function before i18next.init / i18next.loadNamespace / i18next.changeLanguage was done. Wait for the callback or Promise to resolve before accessing it!!!

Proposed fix is to just look at the message for a `:` and excluding those before asking the localization system if its a key.