### PR TITLE
Add support for max7456 detected flag

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1798,6 +1798,7 @@ OSD.msp = {
         d.state = {};
         d.state.haveSomeOsd = (d.flags != 0)
         d.state.haveMax7456Video = bit_check(d.flags, 4) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
+        d.state.isMax7456Detected = bit_check(d.flags, 5) || (d.state.haveMax7456Video && semver.lt(CONFIG.apiVersion, "1.43.0"));
         d.state.haveOsdFeature = bit_check(d.flags, 0) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
         d.state.isOsdSlave = bit_check(d.flags, 1) && semver.gte(CONFIG.apiVersion, "1.34.0");
 
@@ -2364,6 +2365,11 @@ TABS.osd.initialize = function (callback) {
 
                     if (!OSD.data.state.haveMax7456Video) {
                         $('.requires-max7456').hide();
+                        $('.requires-detected-max7456').hide();
+                    }
+
+                    if (!OSD.data.state.haveMax7456Video || !OSD.data.state.isMax7456Detected) {
+                        $('.requires-detected-max7456').hide();
                     }
 
                     if (!OSD.data.state.haveOsdFeature) {

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -64,7 +64,7 @@
 
                     </div>
                     <div class="cf_column third_right" style="width: calc(100% - 377px);">
-                        <div class="gui_box osdprofile-selected-container grey requires-max7456">
+                        <div class="gui_box osdprofile-selected-container grey">
                             <div class="gui_box_titlebar cf_tip">
                                 <div class="spacer_box_title" i18n="osdSetupSelectedProfileTitle"></div>
                             </div>
@@ -198,7 +198,7 @@
                     <div class="btn save">
                         <a class="active save" href="#" i18n="osdSetupSave"></a>
                     </div>
-                    <div class="btn requires-max7456">
+                    <div class="btn requires-detected-max7456">
                         <a class="fonts" id="fontmanager" href="#" i18n="osdSetupFontManager"></a>
                     </div>
                 </div>


### PR DESCRIPTION
Hides the font manager if the max7456 is not detected to prevent the firmware wedging. If the device is not detected then it won't be properly configured and attempting to upload the font will cause a hang.

Also fixes the OSD Profile select div hiding to not be based on the target having a max7456.

Related to https://github.com/betaflight/betaflight/pull/9158.
