### PR TITLE
Add support for firmware side sliders

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -61,7 +61,7 @@
     },
     "portOverrideText": {
         "message": "Port:"
-    },    
+    },
     "autoConnect": {
         "message": "Auto-Connect"
     },
@@ -1642,7 +1642,7 @@
     },
     "pidTuningDMin": {
         "message": "D Min",
-        "description": "Table header of the D Min feature in the PIDs tab" 
+        "description": "Table header of the D Min feature in the PIDs tab"
     },
     "pidTuningDMinDisabledNote": {
         "message": "<strong>Note:</strong> D Min feature is disabled and its parameters are hidden. To use D Min please enable it in $t(pidTuningPidSettings.message)."
@@ -2099,7 +2099,7 @@
     "auxiliaryDisabled": {
         "message": "(DISABLED)",
         "descripton": "Text to add to the ARM mode (maybe others in the future) in the MODES TAB when it has been disabled for some external reason"
-    },    
+    },
     "auxiliaryAddRange": {
         "message": "Add Range"
     },
@@ -2828,7 +2828,7 @@
     },
     "dataflashLogsSpace": {
         "message": "Free space for logs"
-    },    
+    },
     "dataflashNote": {
         "message": "Flight logs can be recorded to your flight controller's onboard dataflash chip."
     },
@@ -2883,25 +2883,25 @@
     "dataflashFileWriteFailed": {
         "message": "Failed to write to the file you selected, are the permissions on that folder okay?"
     },
-    
+
     "sdcardStatusNoCard": {
         "message": "No card inserted"
-    },    
+    },
     "sdcardStatusReboot": {
         "message": "Fatal error<br>Reboot to retry"
-    },    
+    },
     "sdcardStatusReady": {
         "message": "Card ready"
-    },    
+    },
     "sdcardStatusStarting": {
         "message": "Card starting..."
-    },    
+    },
     "sdcardStatusFileSystem": {
         "message": "Filesystem starting..."
-    },    
+    },
     "sdcardStatusUnknown": {
         "message": "Unknown state $1"
-    },    
+    },
 
     "firmwareFlasherReleaseSummaryHead": {
         "message": "Release info"
@@ -3008,7 +3008,7 @@
     },
     "firmwareFlasherBaudRate": {
         "message": "Baud Rate"
-    },    
+    },
     "firmwareFlasherShowDevelopmentReleases":{
         "message": "Show unstable releases"
     },
@@ -3594,6 +3594,22 @@
         "message": "Master Multiplier:",
         "description": "Master tuning slider label"
     },
+    "pidTuningRollPitchRatioSlider": {
+        "message": "Roll Pitch Ratio:",
+        "description": "Roll pitch ratio slider label"
+    },
+    "pidTuningRollPitchRatioSliderHelp": {
+        "message": "Roll Pitch Ratio",
+        "description": "This needs a meaningful help text"
+    },
+    "pidTuningIGainSlider": {
+        "message": "I Gain:",
+        "description": "I gain slider label"
+    },
+    "pidTuningIGainSliderHelp": {
+        "message": "I Gain",
+        "description": "This needs a meaningful help text"
+    },
     "pidTuningPDRatioSlider": {
         "message": "PD Balance:",
         "description": "PD balance tuning slider label"
@@ -3601,6 +3617,14 @@
     "pidTuningPDGainSlider": {
         "message": "P and D Gain:",
         "description": "P and D gain tuning slider label"
+    },
+    "pidTuningDMinRatioSlider": {
+        "message": "D Min Ratio:",
+        "description": "D Min ratio slider label"
+    },
+    "pidTuningDMinRatioSliderHelp": {
+        "message": "D Min Ratio",
+        "description": "This needs a meaningful help text"
     },
     "pidTuningResponseSlider": {
         "message": "Stick Response Gain:",
@@ -3735,7 +3759,7 @@
     },
     "pidTuningDTermLowpassFiltersGroup": {
         "message": "D Term Lowpass Filters"
-    },    
+    },
     "pidTuningDTermLowpassType": {
         "message": "D Term Lowpass 1 Filter Type"
     },
@@ -3762,7 +3786,7 @@
     },
     "pidTuningDTermNotchFiltersGroup": {
         "message": "D Term Notch Filters"
-    },    
+    },
     "pidTuningDTermNotchFrequency": {
         "message": "D Term Notch Filter Center Frequency [Hz]"
     },
@@ -3771,7 +3795,7 @@
     },
     "pidTuningYawLospassFiltersGroup": {
         "message": "Yaw Lowpass Filters"
-    },    
+    },
     "pidTuningYawLowpassFrequency": {
         "message": "Yaw Lowpass Cutoff Frequency [Hz]"
     },
@@ -4462,7 +4486,7 @@
     "osdSetupUploadingFontEnd": {
         "message": "Uploaded all {{length}} characters to the OSD"
     },
-    
+
     "osdSetupSave": {
         "message": "Save"
     },
@@ -5618,7 +5642,7 @@
     "vtxLoadClipboardOk": {
         "message": "VTX Config info <span class=\"message-positive\">loaded</span> from clipboard",
         "description": "Message in the GUI log when the VTX Config file is pasted from clipboard"
-    },    
+    },
     "vtxLoadClipboardKo": {
         "message": "<span class=\"message-negative\">Error</span> while loading the VTX Config info from clipboard. Maybe the contents are not correct",
         "description": "Message in the GUI log when the VTX Config file is pasted from clipboard"

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -734,7 +734,7 @@
     height: 15px;
 }
 
-.tab-pid_tuning .nonExpertModeSliders.tuningSlider::-webkit-slider-runnable-track {
+.tab-pid_tuning .nonExpertModeSliders .tuningSlider::-webkit-slider-runnable-track {
     background: linear-gradient(90deg, rgb(197, 197, 197) -50%, rgb(241, 241, 241) 50%, rgb(255, 84, 14) 150%);
     background-size: 55%;
     background-position: 44%;

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -148,6 +148,7 @@ const FC = {
     SERVO_DATA: null,
     SERVO_RULES: null,
     TRANSPONDER: null,
+    TUNING_SLIDERS: null,
     VOLTAGE_METERS: null,
     VOLTAGE_METER_CONFIGS: null,
     VTXTABLE_BAND: null,
@@ -648,6 +649,21 @@ const FC = {
         ];
 
         this.VTX_DEVICE_STATUS = null;
+
+        this.TUNING_SLIDERS = {
+            slider_pids_mode:                   0,
+            slider_master_multiplier:           0,
+            slider_roll_pitch_ratio:            0,
+            slider_i_gain:                      0,
+            slider_pd_ratio:                    0,
+            slider_pd_gain:                     0,
+            slider_dmin_ratio:                  0,
+            slider_ff_gain:                     0,
+            slider_dterm_filter:                0,
+            slider_dterm_filter_multiplier:     0,
+            slider_gyro_filter:                 0,
+            slider_gyro_filter_multiplier:      0,
+        };
     },
 
     getSerialRxTypes: () => {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -502,6 +502,8 @@ function startProcess() {
             if (FC.FEATURE_CONFIG && FC.FEATURE_CONFIG.features !== 0) {
                 updateTabList(FC.FEATURE_CONFIG.features);
             }
+
+            TuningSliders.setExpertMode(checked);
         }).change();
     });
 

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -117,6 +117,9 @@ const MSPCodes = {
 
     MSP_MOTOR_TELEMETRY:            139,
 
+    MSP_TUNING_SLIDERS:             140,
+    MSP_SET_TUNING_SLIDERS:         141,
+
     MSP_STATUS_EX:                  150,
 
     MSP_UID:                        160,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1475,6 +1475,26 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
                 break;
 
+            case MSPCodes.MSP_SET_TUNING_SLIDERS:
+                console.log("Tuning Sliders data sent");
+                break;
+
+            case MSPCodes.MSP_TUNING_SLIDERS:
+                FC.TUNING_SLIDERS.slider_pids_mode = data.readU8();
+                FC.TUNING_SLIDERS.slider_master_multiplier = data.readU8();
+                FC.TUNING_SLIDERS.slider_roll_pitch_ratio = data.readU8();
+                FC.TUNING_SLIDERS.slider_i_gain = data.readU8();
+                FC.TUNING_SLIDERS.slider_pd_ratio = data.readU8();
+                FC.TUNING_SLIDERS.slider_pd_gain = data.readU8();
+                FC.TUNING_SLIDERS.slider_dmin_ratio = data.readU8();
+                FC.TUNING_SLIDERS.slider_ff_gain = data.readU8();
+                FC.TUNING_SLIDERS.slider_dterm_filter = data.readU8();
+                FC.TUNING_SLIDERS.slider_dterm_filter_multiplier = data.readU8();
+                FC.TUNING_SLIDERS.slider_gyro_filter = data.readU8();
+                FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = data.readU8();
+
+                break;
+
             case MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL:
                 console.log("VTX powerlevel sent");
                 break;
@@ -2272,6 +2292,22 @@ MspHelper.prototype.crunch = function(code) {
 
         case MSPCodes.MSP2_SEND_DSHOT_COMMAND:
             buffer.push8(1);
+            break;
+
+        case MSPCodes.MSP_SET_TUNING_SLIDERS:
+            buffer.push8(FC.TUNING_SLIDERS.slider_pids_mode)
+                  .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
+                  .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
+                  .push8(FC.TUNING_SLIDERS.slider_i_gain)
+                  .push8(FC.TUNING_SLIDERS.slider_pd_ratio)
+                  .push8(FC.TUNING_SLIDERS.slider_pd_gain)
+                  .push8(FC.TUNING_SLIDERS.slider_dmin_ratio)
+                  .push8(FC.TUNING_SLIDERS.slider_ff_gain)
+                  .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
+                  .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
+                  .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
+                  .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier);
+
             break;
 
         default:

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -169,10 +169,16 @@
                     </div>
 
                     <!-- TUNING SLIDERS-->
-                    <div class="gui_box grey topspacer tuningPIDSliders">
+                    <div id="slidersPidsBox" class="gui_box grey topspacer tuningPIDSliders">
                         <table class="pid_titlebar">
                             <tr>
-                                <th scope="col" class="sm-min"></th>
+                                <th scope="col" class="sm-min">
+                                    <select id="sliderPidsModeSelect">
+                                        <option value="0">OFF</option>
+                                        <option value="1">RP</option>
+                                        <option value="2">RPY</option>
+                                    <select>
+                                </th>
                                 <th></th>
                                 <th i18n="pidTuningSliderLow"></th>
                                 <th i18n="pidTuningSliderDefault"></th>
@@ -193,10 +199,10 @@
                                     <span i18n="pidTuningMasterSlider"></span>
                                 </td>
                                 <td>
-                                    <output type="number" name="tuningMasterSlider-number"></output>
+                                    <output type="number" name="sliderMasterMultiplier-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="tuningMasterSlider" />
+                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderMasterMultiplier" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningMasterSliderHelp"></div>
@@ -209,13 +215,41 @@
                             </tr>
                             <tr>
                                 <td class="sm-min">
-                                    <span i18n="pidTuningPDRatioSlider"></span>
+                                    <span i18n="pidTuningRollPitchRatioSlider"/>
                                 </td>
                                 <td>
-                                    <output type="number" name="tuningPDRatioSlider-number"></output>
+                                    <output type="number" name="sliderRollPitchRatio-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="tuningPDRatioSlider" />
+                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderRollPitchRatio" />
+                                </td>
+                                <td>
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningRollPitchRatioSliderHelp"></div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <span i18n="pidTuningIGainSlider"/>
+                                </td>
+                                <td>
+                                    <output type="number" name="sliderIGain-number"></output>
+                                </td>
+                                <td colspan="3">
+                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderIGain" />
+                                </td>
+                                <td>
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningIGainSliderHelp"></div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <span i18n="pidTuningPDRatioSlider"/>
+                                </td>
+                                <td>
+                                    <output type="number" name="sliderPDRatio-number"></output>
+                                </td>
+                                <td colspan="3">
+                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderPDRatio" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningPDRatioSliderHelp"></div>
@@ -231,10 +265,10 @@
                                     <span i18n="pidTuningPDGainSlider"></span>
                                 </td>
                                 <td>
-                                    <output type="number" name="tuningPDGainSlider-number"></output>
+                                    <output type="number" name="sliderPDGain-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="tuningPDGainSlider" />
+                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderPDGain" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningPDGainSliderHelp"></div>
@@ -247,13 +281,27 @@
                             </tr>
                             <tr>
                                 <td class="sm-min">
-                                    <span i18n="pidTuningResponseSlider"></span>
+                                    <span i18n="pidTuningDMinRatioSlider"/>
                                 </td>
                                 <td>
-                                    <output type="number" name="tuningResponseSlider-number"></output>
+                                    <output type="number" name="sliderDMinRatio-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="tuningResponseSlider" />
+                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderDMinRatio" />
+                                </td>
+                                <td>
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningDMinRatioSliderHelp"></div>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td>
+                                    <span i18n="pidTuningResponseSlider"/>
+                                </td>
+                                <td>
+                                    <output type="number" name="sliderFFGain-number"></output>
+                                </td>
+                                <td colspan="3">
+                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderFFGain" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningResponseSliderHelp"></div>
@@ -1016,7 +1064,7 @@
                 </div>
 
                 <!-- Filter Slider -->
-                <div class="gui_box grey topspacer tuningFilterSliders">
+                <div id="slidersFilterBox"class="gui_box grey topspacer tuningFilterSliders">
                     <table class="pid_titlebar">
                         <tr>
                             <th scope="col" class="sm-min"></th>
@@ -1040,10 +1088,10 @@
                                 <span i18n="pidTuningGyroFilterSlider"></span>
                             </td>
                             <td>
-                                <output type="number" name="tuningGyroFilterSlider-number"></output>
+                                <output type="number" name="sliderGyroFilterMultiplier-number"></output>
                             </td>
                             <td colspan="3">
-                                <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="tuningGyroFilterSlider" />
+                                <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderGyroFilterMultiplier" />
                             </td>
                             <td>
                                 <div class="helpicon cf_tip" i18n_title="pidTuningGyroFilterSliderHelp"></div>
@@ -1059,10 +1107,10 @@
                                 <span i18n="pidTuningDTermFilterSlider"></span>
                             </td>
                             <td>
-                                <output type="number" name="tuningDTermFilterSlider-number"></output>
+                                <output type="number" name="sliderDTermFilterMultiplier-number"></output>
                             </td>
                             <td colspan="3">
-                                <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="tuningDTermFilterSlider" />
+                                <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderDTermFilterMultiplier" />
                             </td>
                             <td>
                                 <div class="helpicon cf_tip" i18n_title="pidTuningDTermFilterSliderHelp"></div>


### PR DESCRIPTION
To go with betaflight/betaflight#9119.  For now just for testing the calculation.
Todo:
- [ ] Finalize basic support for firmware sliders
- [ ] Backwards compatibility for 4.1 configurator only based calculation
- [ ] GUI change for expert mode sliders