### PR TITLE
Add calcultated KV info to the motors tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2396,7 +2396,7 @@
         "message": "accel"
     },
     "motorsTelemetryHelp": {
-        "message": "This numbers show the telemetry info received from the ESCs if available. It can show the actual speed of motors (in RPM), the error rate of the telemetry link and the temperature of the ESCs.",
+        "message": "This numbers show the telemetry info received from the ESCs if available. It can show the actual speed of motors (in RPM), the error rate of the telemetry link, the temperature of the ESCs and the calculated KV of each motor.",
         "description": "Help text for the telemetry values in the motors tab."
     },
     "motorsRPM": {
@@ -2406,10 +2406,14 @@
     "motorsRPMError": {
         "message": "E: {{motorsErrorValue}}%",
         "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the error of motor telemetry if available."
-    },
+    },    
     "motorsESCTemperature": {
         "message": "T: {{motorsESCTempValue}}&deg;C",
         "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the ESC temperature if available."
+    },
+    "motorsKV": {
+        "message": "K: {{motorsKvValue}}",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the KV of motor telemetry if available."
     },
     "motorsMaster": {
         "message": "Master"


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1785

![image](https://user-images.githubusercontent.com/2673520/68668812-567cea80-0549-11ea-8749-9a7850cb8096.png)

TO DISCUSS: I think is not finished, I'm not too sure how to calculate de KV when the ESC SENSOR is disabled.
At this moment I have used the ANALOG.voltage directly, but there are suggestions to use the voltage based on the throttle. What are the opinions here?