### PR TITLE
Let pid profile and rate selects grow

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -302,7 +302,7 @@
 }
 
 .tab-pid_tuning .single-field {
-    display: inline-block;
+    display: inline-table;
     margin-bottom: 10px;
     margin-right: 5px;
 }
@@ -556,26 +556,17 @@
     height: 20px;
 }
 
-.tab-pid_tuning .profile {
-    width: 100px;
-}
-
-.tab-pid_tuning .profile select {
-    border: 1px solid var(--subtleAccent);
-    border-radius: 3px;
-    margin-left: 5px;
-    width: calc(100% - 10px);
-}
-
-
+.tab-pid_tuning .profile,
 .tab-pid_tuning .rate_profile {
-    width: 130px;
+    min-width: 130px;
 }
 
+.tab-pid_tuning .profile select,
 .tab-pid_tuning .rate_profile select {
     border: 1px solid var(--subtleAccent);
     border-radius: 3px;
     margin-left: 5px;
+    margin-right: 5px;
     width: calc(100% - 10px);
 }
 


### PR DESCRIPTION
Depending on the translation, the width of the profile rates select title and contents may need to grow. This PR fixes it.

Before:
![image](https://user-images.githubusercontent.com/2673520/68671397-83cc9700-054f-11ea-9f60-2b2227c5c166.png)

Later:
![image](https://user-images.githubusercontent.com/2673520/68671539-d017d700-054f-11ea-8446-6506c8110a08.png)
