### PR TITLE
The PID slider heatmap now works with the dark theme

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2134,7 +2134,7 @@ TABS.pid_tuning.updateFilterWarning = function() {
 TABS.pid_tuning.updatePIDColors = function(clear = false) {
     const setTuningElementColor = function(element, mspValue, currentValue) {
         if (clear) {
-            element.css({ "background-color": "white" });
+            element.css({ "background-color": "transparent" });
             return;
         }
 

--- a/src/js/utils/css.js
+++ b/src/js/utils/css.js
@@ -8,15 +8,15 @@ const CSSUtil = function () {};
 
 CSSUtil.prototype.colorTables = {
   redWhiteGreen: [
-    { percentage: -1, color: { r: 0xff, g: 0x00, b: 0x00 } },
-    { percentage: 0, color: { r: 0xff, g: 0xff, b: 0xff } },
-    { percentage: 1, color: { r: 0x00, g: 0xff, b: 0x00 } }
+    { percentage: -1, color: { r: 0xff, g: 0x00, b: 0x00, a: 1.0 } },
+    { percentage: 0, color: { r: 0xff, g: 0xff, b: 0xff, a: 1.0 } },
+    { percentage: 1, color: { r: 0x00, g: 0xff, b: 0x00, a: 1.0 } }
   ],
   pidSlider: [
-    { percentage: -1, color: { r: 0xc5, g: 0xc5, b: 0xc5 } },
-    { percentage: 0, color: { r: 0xff, g: 0xff, b: 0xff } },
-    { percentage: 1, color: { r: 0xff, g: 0x54, b: 0x0e } }
-  ],
+    { percentage: -1, color: { r: 0xc5, g: 0xc5, b: 0xc5, a: 1.0 } },
+    { percentage: 0, color: { r: 0xff, g: 0xff, b: 0xff, a: 0.0 } },
+    { percentage: 1, color: { r: 0xff, g: 0x54, b: 0x0e, a: 1.0 } }
+  ]
 };
 
 // Stack Overflow: https://stackoverflow.com/a/7128796/4107016
@@ -40,9 +40,10 @@ CSSUtil.prototype.getColorForPercentage = function(percentage, colorTable = null
     const color = {
         r: Math.floor(lower.color.r * percentageLower + upper.color.r * percentageUpper),
         g: Math.floor(lower.color.g * percentageLower + upper.color.g * percentageUpper),
-        b: Math.floor(lower.color.b * percentageLower + upper.color.b * percentageUpper)
+        b: Math.floor(lower.color.b * percentageLower + upper.color.b * percentageUpper),
+        a: lower.color.a * percentageLower + upper.color.a * percentageUpper
     };
-    return "rgb(" + [color.r, color.g, color.b].join(",") + ")";
+    return "rgba(" + [color.r, color.g, color.b, color.a].join(",") + ")";
 };
 
 const cssUtil = new CSSUtil();


### PR DESCRIPTION
Change to the feature added in PR #1839.

Transparent is now used as the default colour, allowing the PID slider heatmap to work when the dark theme is enabled.

![Betaflight Configurator - PID Change Heatmap - Dark](https://user-images.githubusercontent.com/1834655/71388488-814e6a00-25f0-11ea-8df7-3106f6c161dc.gif)
