### PR TITLE
Fix VTX when PowerLevel tag is empty

### DIFF
--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -254,7 +254,7 @@ TABS.vtx.initialize = function (callback) {
             if (VTX_CONFIG.vtx_table_available) {
                 let powerLevel = TABS.vtx.VTXTABLE_POWERLEVEL_LIST[VTX_CONFIG.vtx_power - 1].vtxtable_powerlevel_label;
                 if (powerLevel.trim() === '') {
-                    powerLevel = i;
+                    powerLevel = VTX_CONFIG.vtx_power;
                 }
                 $("#vtx_power_description").text(powerLevel);
             } else {


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1838

This happens when there is no tag to show in the right panel about the current powerlevel selected.
The problem was some old code I suppose from an earlier version...

When the tag is not defined, now it will show the index of the powerlevel. I don't know if this is ok or is better to show the value in place of the label.