### PR TITLE
[OSD] Correctly detect devices compatible with MAX7456 fonts and add support for FrSky OSD

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1550,6 +1550,9 @@
     "portsFunction_RUNCAM_DEVICE_CONTROL": {
         "message": "Camera (RunCam Protocol)"
     },
+    "portsFunction_FRSKY_OSD": {
+        "message": "OSD (FrSky Protocol)"
+    },
     "pidTuningProfileOption": {
         "message": "Profile $1"
     },

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -24,7 +24,8 @@ function MspHelper () {
     'TELEMETRY_IBUS': 12,
     'IRC_TRAMP': 13,
     'RUNCAM_DEVICE_CONTROL': 14, // support communitate with RunCam Device
-    'LIDAR_TF': 15
+    'LIDAR_TF': 15,
+    'FRSKY_OSD': 16,
   };
 
     self.REBOOT_TYPES = {

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1881,8 +1881,10 @@ OSD.msp = {
 
         d.state = {};
         d.state.haveSomeOsd = (d.flags != 0)
-        d.state.haveMax7456Video = bit_check(d.flags, 4) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
-        d.state.isMax7456Detected = bit_check(d.flags, 5) || (d.state.haveMax7456Video && semver.lt(CONFIG.apiVersion, API_VERSION_1_43));
+        d.state.haveMax7456Configured = bit_check(d.flags, 4) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
+        d.state.haveFrSkyOSDConfigured = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) && bit_check(d.flags, 3);
+        d.state.haveMax7456FontDeviceConfigured = d.state.haveMax7456Configured || d.state.haveFrSkyOSDConfigured;
+        d.state.isMax7456FontDeviceDetected = bit_check(d.flags, 5) || (d.state.haveMax7456FontDeviceConfigured && semver.lt(CONFIG.apiVersion, API_VERSION_1_43));
         d.state.haveOsdFeature = bit_check(d.flags, 0) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
         d.state.isOsdSlave = bit_check(d.flags, 1) && semver.gte(CONFIG.apiVersion, "1.34.0");
 
@@ -2258,7 +2260,7 @@ TABS.osd.initialize = function (callback) {
 
                     OSD.msp.decode(info);
 
-                    if (!OSD.data.state.haveMax7456Video || !OSD.data.state.isMax7456Detected) {
+                    if (OSD.data.state.haveMax7456FontDeviceConfigured && !OSD.data.state.isMax7456FontDeviceDetected) {
                         $('.noOsdChipDetect').show();
                     }
 
@@ -2495,12 +2497,12 @@ TABS.osd.initialize = function (callback) {
                         }
                     }
 
-                    if (!OSD.data.state.haveMax7456Video) {
+                    if (!OSD.data.state.haveMax7456Configured) {
                         $('.requires-max7456').hide();
                     }
 
-                    if (!OSD.data.state.haveMax7456Video || !OSD.data.state.isMax7456Detected) {
-                        $('.requires-detected-max7456').addClass('disabled');
+                    if (!OSD.data.state.isMax7456FontDeviceDetected || !OSD.data.state.haveMax7456FontDeviceConfigured) {
+                        $('.requires-max7456-font-device-detected').addClass('disabled');
                     }
 
                     if (!OSD.data.state.haveOsdFeature) {

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -53,6 +53,10 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         functionRules.push({ name: 'LIDAR_TF', groups: ['peripherals'], maxPorts: 1 });
     }
 
+    if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+        functionRules.push({ name: 'FRSKY_OSD', groups: ['peripherals'], maxPorts: 1 });
+    }
+
     for (var i = 0; i < functionRules.length; i++) {
         functionRules[i].displayName = i18n.getMessage('portsFunction_' + functionRules[i].name);
     }

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -202,7 +202,7 @@
                         <a class="active save" href="#" i18n="osdSetupSave"></a>
                     </div>
                     <div class="btn">
-                        <a class="fonts requires-detected-max7456" id="fontmanager" href="#" i18n="osdSetupFontManager"></a>
+                        <a class="requires-max7456-font-device-detected fonts" id="fontmanager" href="#" i18n="osdSetupFontManager"></a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Use the flags added in https://github.com/betaflight/betaflight/pull/9333
to detect wether the font manager dialog should be shown. This
fixes the bug that was preventing the Font Manager dialog to be shown
when FrSky OSD was in use.