### PR TITLE
[OSD] Add support for FrSky OSD

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1504,6 +1504,9 @@
     "portsFunction_RUNCAM_DEVICE_CONTROL": {
         "message": "Camera (RunCam Protocol)"
     },
+    "portsFunction_FRSKY_OSD": {
+        "message": "OSD (FrSky Protocol)"
+    },
     "pidTuningProfileOption": {
         "message": "Profile $1"
     },

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -24,7 +24,8 @@ function MspHelper () {
     'TELEMETRY_IBUS': 12,
     'IRC_TRAMP': 13,
     'RUNCAM_DEVICE_CONTROL': 14, // support communitate with RunCam Device
-    'LIDAR_TF': 15
+    'LIDAR_TF': 15,
+    'FRSKY_OSD': 16,
   };
 
     self.REBOOT_TYPES = {

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -53,6 +53,10 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         functionRules.push({ name: 'LIDAR_TF', groups: ['peripherals'], maxPorts: 1 });
     }
 
+    if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        functionRules.push({ name: 'FRSKY_OSD', groups: ['peripherals'], maxPorts: 1 });
+    }
+
     for (var i = 0; i < functionRules.length; i++) {
         functionRules[i].displayName = i18n.getMessage('portsFunction_' + functionRules[i].name);
     }


### PR DESCRIPTION
Add peripheral bit definitions to check the port function mask.
Depends on #1851
Depends on #1852