### PR TITLE
Fix problems introduced in #1851

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -819,8 +819,8 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP_CF_SERIAL_CONFIG:
+                SERIAL_CONFIG.ports = [];
                 if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
-                    SERIAL_CONFIG.ports = [];
                     const serialPortCount = (data.byteLength - (4 * 4)) / 2;
                     for (let i = 0; i < serialPortCount; i++) {
                         const serialPort = {
@@ -834,7 +834,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     SERIAL_CONFIG.gpsBaudRate = data.readU32();
                     SERIAL_CONFIG.gpsPassthroughBaudRate = data.readU32();
                 } else {
-                    SERIAL_CONFIG.ports = [];
                     const bytesPerPort = 1 + 2 + (1 * 4);
 
                     const serialPortCount = data.byteLength / bytesPerPort;
@@ -854,6 +853,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP2_COMMON_SERIAL_CONFIG:
+                SERIAL_CONFIG.ports = [];
                 const count = data.readU8();
                 const portConfigSize = data.remaining() / count;
                 for (let ii = 0; ii < count; ii++) {
@@ -1878,7 +1878,6 @@ MspHelper.prototype.crunch = function(code) {
                     const functionMask = self.serialPortFunctionsToMask(serialPort.functions);
                     buffer.push16(functionMask)
                         .push8(self.BAUD_RATES.indexOf(serialPort.msp_baudrate))
-                        .push8(self.BAUD_RATES.indexOf(serialPort.msp_baudrate))
                         .push8(self.BAUD_RATES.indexOf(serialPort.gps_baudrate))
                         .push8(self.BAUD_RATES.indexOf(serialPort.telemetry_baudrate))
                         .push8(self.BAUD_RATES.indexOf(serialPort.blackbox_baudrate));
@@ -1896,7 +1895,6 @@ MspHelper.prototype.crunch = function(code) {
 
                 const functionMask = self.serialPortFunctionsToMask(serialPort.functions);
                 buffer.push32(functionMask)
-                    .push8(self.BAUD_RATES.indexOf(serialPort.msp_baudrate))
                     .push8(self.BAUD_RATES.indexOf(serialPort.msp_baudrate))
                     .push8(self.BAUD_RATES.indexOf(serialPort.gps_baudrate))
                     .push8(self.BAUD_RATES.indexOf(serialPort.telemetry_baudrate))


### PR DESCRIPTION
- Clear the in-memory ports array when reading MSP2_COMMON_SERIAL_CONFIG,
like MSP_CF_SERIAL_CONFIG does. Take the opportunity to move the
`SERIAL_CONFIG.ports = [];` statement to the very first line of both
handler blocks, so it's more evident.
- Remove accidentally duplicated line in the payload serializer
for MSP_SET_CF_SERIAL_CONFIG, which then I copied and pasted to
MSP2_COMMON_SET_SERIAL_CONFIG. This was sending the msp_baudrate
twice, causing all baudrates after it to be misinterpreted.

Fixes #1864