### PR TITLE
Update MacOS instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Download the installer from [Releases.](https://github.com/betaflight/betaflight
 
 #### Note for MacOS X users
 
-Changes to the security model used in the latest versions of MacOS X 10.14 (Mojave) and 10.15 (Catalina) mean that the operating system will show an error message ('"Betaflight Configurator.app" is damaged and can’t be opened. You should move it to the Trash.') when trying to install the application. To work around this, run the following command in a terminal before installing: `sudo xattr -rd com.apple.quarantine /Applications/Betaflight\ Configurator.app`.
+Changes to the security model used in the latest versions of MacOS X 10.14 (Mojave) and 10.15 (Catalina) mean that the operating system will show an error message ('"Betaflight Configurator.app" is damaged and can’t be opened. You should move it to the Trash.') when trying to install the application. To work around this, run the following command in a terminal after installing: `sudo xattr -rd com.apple.quarantine /Applications/Betaflight\ Configurator.app`.
 
 
 ### Via Chrome Web Store (for ChromeOS)


### PR DESCRIPTION
Trying to run the command before installing results in 

```
sudo xattr -rd com.apple.quarantine /Applications/Betaflight\ Configurator.app
Password:
xattr: No such file: /Applications/Betaflight Configurator.app
```