### PR TITLE
Work with gyro native sampling

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1358,6 +1358,18 @@
     "configurationCalculatedCyclesSec": {
         "message": "Cycles/Sec [Hz]"
     },
+    "configurationSpeedGyroNoGyro": {
+        "message": "No gyro",
+        "description": "When no gyro is configured this appears in place of the speed of the gyro in kHz"
+    },
+    "configurationSpeedPidNoGyro": {
+        "message": "Gyro / {{value}}",
+        "description": "When no gyro is configured this appears in place of the speed of the PID in kHz. Try to keep it short."
+    },
+    "configurationKHzUnitLabel": {
+        "message": "{{value}} kHz",
+        "description": "Value for some options that show the speed of gyro, pid, etc. in kHz"
+    },
     "configurationLoopTimeHelp": {
         "message": "<strong>Note:</strong> Make sure your FC is able to operate at these speeds! Check CPU and cycletime stability. Changing this may require PID re-tuning. TIP: Disable Accelerometer and other sensors to gain more performance."
     },

--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -432,8 +432,16 @@
     width: 100%;
 }
 
-.tab-configuration .gyroSyncDenom, .tab-configuration .pidProcessDenom {
+.tab-configuration .gyroSyncDenom, .tab-configuration .pidProcessDenom, .tab-configuration .gyroFrequency {
     width:90px;
+}
+
+.tab-configuration .gyroFrequency {
+    border: none;
+    background-color: var(--alternativeBackground);
+    padding-left: 6px;
+    margin-right: 10px;
+    font-weight: bold;
 }
 
 .tab-configuration ._3dSettings {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -104,6 +104,7 @@ var FC = {
             signature:                        [],
             mcuTypeId:                        255,
             configurationState:               0,
+            sampleRateHz:                     0,
         };
 
         BF_CONFIG = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -800,6 +800,11 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
                     if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
                         CONFIG.configurationState = data.readU8();
+
+                        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                            CONFIG.sampleRateHz = data.readU16();
+                        }
+
                     }
                 } else {
                     CONFIG.mcuTypeId = 255;

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -192,15 +192,21 @@ TABS.onboard_logging.initialize = function (callback) {
     function populateLoggingRates(loggingRatesSelect) {
 
         // Offer a reasonable choice of logging rates (if people want weird steps they can use CLI)
-        var loggingRates = [];
-        var pidRateBase = 8000;
+        let loggingRates = [];
 
-        if (semver.gte(CONFIG.apiVersion, "1.25.0") && semver.lt(CONFIG.apiVersion, "1.41.0") && PID_ADVANCED_CONFIG.gyroUse32kHz !== 0) {
-            pidRateBase = 32000;
+        let pidRate;
+        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            pidRate = CONFIG.sampleRateHz / PID_ADVANCED_CONFIG.pid_process_denom;
+
+        } else {
+
+            let pidRateBase = 8000;
+
+            if (semver.gte(CONFIG.apiVersion, "1.25.0") && semver.lt(CONFIG.apiVersion, "1.41.0") && PID_ADVANCED_CONFIG.gyroUse32kHz !== 0) {
+                pidRateBase = 32000;
+            }
+            pidRate = pidRateBase / PID_ADVANCED_CONFIG.gyro_sync_denom / PID_ADVANCED_CONFIG.pid_process_denom;
         }
-
-        var pidRate = pidRateBase / PID_ADVANCED_CONFIG.gyro_sync_denom /
-        PID_ADVANCED_CONFIG.pid_process_denom;
 
         if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
             loggingRates = [

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -60,6 +60,7 @@
                                     <div class="helpicon cf_tip" i18n_title="configurationGyroUse32kHzHelp"></div>
                                 </div>
                                 <div class="select">
+                                        <input type="text" class="gyroFrequency" readonly />
                                         <select class="gyroSyncDenom">
                                             <!-- list generated here -->
                                         </select>


### PR DESCRIPTION
To go with https://github.com/betaflight/betaflight/pull/9444

Removes the selection of the gyro by a read only text and adjusts the PID speed selection to the new values.

![image](https://user-images.githubusercontent.com/2673520/73737579-2ce7ef80-4743-11ea-932d-b912c45a7017.png)

The original code was unnecessarily complicated, so I have reordered and cleaned it a little too, so the review can be a little more complicated.

I've done some regression tests but I don't have a large variety of FC, so any test will be welcome.