### PR TITLE
Fix throttle preview refresh

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -914,28 +914,6 @@ TABS.pid_tuning.initialize = function (callback) {
             self.currentRates.rc_expo_pitch = self.currentRates.rc_expo;
         }
 
-        function activateSubtab(subtabName) {
-            const names = ['pid', 'rates', 'filter'];
-            if (!names.includes(subtabName)) {
-                console.debug('Invalid subtab name: "' + subtabName + '"');
-                return;
-            }
-            for (name of names) {
-                const el = $('.tab-pid_tuning .subtab-' + name);
-                el[name == subtabName ? 'show' : 'hide']();
-            }
-            $('.tab-pid_tuning .tab-container .tab').removeClass('active');
-            $('.tab-pid_tuning .tab-container .' + subtabName).addClass('active');
-            self.activeSubtab = subtabName;
-            if (subtabName == 'rates') {
-                // force drawing of throttle curve once the throttle curve container element is available
-                // deferring drawing like this is needed to acquire the exact pixel size of the canvas
-                redrawThrottleCurve(true);
-            }
-        }
-
-        activateSubtab(self.activeSubtab);
-
         $('.tab-pid_tuning .tab-container .pid').on('click', () => activateSubtab('pid'));
 
         $('.tab-pid_tuning .tab-container .rates').on('click', () => activateSubtab('rates'));
@@ -1142,6 +1120,28 @@ TABS.pid_tuning.initialize = function (callback) {
         populateFilterTypeSelector('dtermLowpassDynType', loadFilterTypeValues());
 
         pid_and_rc_to_form();
+
+        function activateSubtab(subtabName) {
+            const names = ['pid', 'rates', 'filter'];
+            if (!names.includes(subtabName)) {
+                console.debug('Invalid subtab name: "' + subtabName + '"');
+                return;
+            }
+            for (name of names) {
+                const el = $('.tab-pid_tuning .subtab-' + name);
+                el[name == subtabName ? 'show' : 'hide']();
+            }
+            $('.tab-pid_tuning .tab-container .tab').removeClass('active');
+            $('.tab-pid_tuning .tab-container .' + subtabName).addClass('active');
+            self.activeSubtab = subtabName;
+            if (subtabName == 'rates') {
+                // force drawing of throttle curve once the throttle curve container element is available
+                // deferring drawing like this is needed to acquire the exact pixel size of the canvas
+                redrawThrottleCurve(true);
+            }
+        }
+
+        activateSubtab(self.activeSubtab);
 
         var pidController_e = $('select[name="controller"]');
 


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1871

The problem was that the `redrawThrottleCurve` was called before filling it the inputs with the values that is done in the `pid_and_rc_to_form` and are used to draw the curve.

@IvoFPV you have worked a lot with this nightmare of tab ;) I don't understand why the throttle preview is treated different than the rates preview for example, that is at the same subtab. If you have time maybe you can come to a better code for this, but for the moment, this seems to fix the issue.
