### PR TITLE
FF Interpolate Options

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1761,6 +1761,33 @@
     "pidTuningDtermSetpointTransitionWarning": {
         "message": "<span class=\"message-negative\"><strong>$t(warningTitle.message):<\/strong> The use of a D Setpoint transition greater than 0 and less than 0.1 is highly discouraged. Doing so may lead instability and reduced stick responsiveness as the sticks cross the centre point.<\/span>"
     },
+    "pidTuningFfInterpolateSp": {
+        "message": "FF Interpolate"
+    },
+    "pidTuningFfInterpolateSpHelp": {
+        "message": "The following options fine-tune feed forward from race/aggressive to smooth/HD.<br><br> Mode: set to NO_AVG for race, AVG_2 for race/fast freestyle, AVG_3 for HD recording, AVG_4 for HD cinematic smoothness.<br><br> Smoothness: limits the amount of change that any one incoming radio step can make, increase for smoother FF signal, decrease for more aggressive FF responses.<br><br> Boost: helps overcome motor lag with quick stick inputs, can increase jitter. Try 10 for HD, 20 for racers. Up to 30 may be useful for low authority quads but can cause micro overshoot or jitter."
+    },
+    "pidTuningFfInterpolate": {
+        "message": "Mode"
+    },
+    "pidTuningFfInterpolateSpOptionNoAverage": {
+        "message": "No AVG"
+    },
+    "pidTuningFfInterpolateSpOptionAverage2": {
+        "message": "AVG 2"
+    },
+    "pidTuningFfInterpolateSpOptionAverage3": {
+        "message": "AVG 3"
+    },
+    "pidTuningFfInterpolateSpOptionAverage4": {
+        "message": "AVG 4"
+    },
+    "pidTuningFfSmoothFactor": {
+        "message": "Smoothness"
+    },
+    "pidTuningFfBoost": {
+        "message": "Boost"
+    },
     "pidTuningProportional": {
         "message": "Proportional"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1765,22 +1765,22 @@
         "message": "FF Interpolate"
     },
     "pidTuningFfInterpolateSpHelp": {
-        "message": "The following options fine-tune feed forward from race/aggressive to smooth/HD.<br><br> Mode: set to NO_AVG for race, AVG_2 for race/fast freestyle, AVG_3 for HD recording, AVG_4 for HD cinematic smoothness.<br><br> Smoothness: limits the amount of change that any one incoming radio step can make, increase for smoother FF signal, decrease for more aggressive FF responses.<br><br> Boost: helps overcome motor lag with quick stick inputs, can increase jitter. Try 10 for HD, 20 for racers. Up to 30 may be useful for low authority quads but can cause micro overshoot or jitter."
+        "message": "The following options fine-tune feed forward from race/aggressive to smooth/HD.<br><br> Mode: set to NoAverage for race, Average 2 for race/fast freestyle, Average 3 for HD recording, Average 4 for HD cinematic smoothness.<br><br> Smoothness: limits the amount of change that any one incoming radio step can make, increase for smoother FF signal, decrease for more aggressive FF responses.<br><br> Boost: helps overcome motor lag with quick stick inputs, can increase jitter. Try 10 for HD, 20 for racers. Up to 30 may be useful for low authority quads but can cause micro overshoot or jitter."
     },
     "pidTuningFfInterpolate": {
         "message": "Mode"
     },
     "pidTuningFfInterpolateSpOptionNoAverage": {
-        "message": "No AVG"
+        "message": "NoAverage"
     },
     "pidTuningFfInterpolateSpOptionAverage2": {
-        "message": "AVG 2"
+        "message": "Average 2"
     },
     "pidTuningFfInterpolateSpOptionAverage3": {
-        "message": "AVG 3"
+        "message": "Average 3"
     },
     "pidTuningFfInterpolateSpOptionAverage4": {
-        "message": "AVG 4"
+        "message": "Average 4"
     },
     "pidTuningFfSmoothFactor": {
         "message": "Smoothness"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -458,6 +458,9 @@ var FC = {
             motorOutputLimit:           0,
             autoProfileCellCount:       0,
             idleMinRpm:                 0,
+            ff_interpolate_sp:          0,
+            ff_smooth_factor:           0,
+            ff_boost:                   0,
         };
         ADVANCED_TUNING_ACTIVE = { ...ADVANCED_TUNING };
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1152,6 +1152,12 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                                 ADVANCED_TUNING.motorOutputLimit = data.readU8();
                                                 ADVANCED_TUNING.autoProfileCellCount = data.read8();
                                                 ADVANCED_TUNING.idleMinRpm = data.readU8();
+
+                                                if(semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
+                                                    ADVANCED_TUNING.ff_interpolate_sp = data.readU8();
+                                                    ADVANCED_TUNING.ff_smooth_factor = data.readU8();
+                                                    ADVANCED_TUNING.ff_boost = data.readU8();
+                                                }
                                             }
                                         }
                                     }
@@ -2086,6 +2092,12 @@ MspHelper.prototype.crunch = function(code) {
                                             buffer.push8(ADVANCED_TUNING.motorOutputLimit)
                                                   .push8(ADVANCED_TUNING.autoProfileCellCount)
                                                   .push8(ADVANCED_TUNING.idleMinRpm);
+
+                                            if(semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
+                                                buffer.push8(ADVANCED_TUNING.ff_interpolate_sp)
+                                                      .push8(ADVANCED_TUNING.ff_smooth_factor)
+                                                      .push8(ADVANCED_TUNING.ff_boost);
+                                            }
                                         }
                                     }
                                 }

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -395,8 +395,6 @@ TABS.pid_tuning.initialize = function (callback) {
                     $('.pid_filter input[name="rpmFilterHarmonics"]').val(FILTER_DEFAULT.gyro_rpm_notch_harmonics);
                 }
             }).prop('checked', FILTER_CONFIG.gyro_rpm_notch_harmonics != 0).change();
-
-
         } else {
             $('.itermRelaxCutoff').hide();
             $('.dynamicNotch').hide();
@@ -436,6 +434,25 @@ TABS.pid_tuning.initialize = function (callback) {
             self.currentRatesType = null;
             self.previousRatesType = null;
             $('.rates_type').hide();
+        }
+
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
+            // FF Interpolate
+            const ffInterpolateCheck = $('input[id="ffInterpolateSp"]');
+
+            ffInterpolateCheck.prop('checked', ADVANCED_TUNING.ff_interpolate_sp !== 0);
+            $('select[id="ffInterpolate"]').val(ADVANCED_TUNING.ff_interpolate_sp > 0 ? ADVANCED_TUNING.ff_interpolate_sp : 2);
+            $('input[name="ffSmoothFactor"]').val(ADVANCED_TUNING.ff_smooth_factor);
+            $('input[name="ffBoost"]').val(ADVANCED_TUNING.ff_boost);
+
+            ffInterpolateCheck.change(function() {
+                const checked = $(this).is(':checked');
+                $('.ffInterpolateSp .suboption').toggle(checked);
+            });
+            ffInterpolateCheck.change();
+
+        } else {
+            $('.ffInterpolateSp').hide();
         }
 
         $('input[id="useIntegratedYaw"]').change(function() {
@@ -898,7 +915,11 @@ TABS.pid_tuning.initialize = function (callback) {
 
             RC_tuning.rates_type = selectedRatesType;
         }
+
         if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
+            ADVANCED_TUNING.ff_interpolate_sp = $('input[id="ffInterpolateSp"]').is(':checked') ? $('select[id="ffInterpolate"]').val() : 0;
+            ADVANCED_TUNING.ff_smooth_factor = parseInt($('input[name="ffSmoothFactor"]').val());
+            ADVANCED_TUNING.ff_boost = parseInt($('input[name="ffBoost"]').val());
             FILTER_CONFIG.dyn_lpf_curve_expo = parseInt($('.pid_filter input[name="dtermLowpassDynExpo"]').val());
         }
     }

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -474,6 +474,40 @@
                                     </div>
                                 </td>
                             </tr>
+							
+                            <tr class="ffInterpolateSp">
+                                <td><input type="checkbox" id="ffInterpolateSp" class="toggle" /></td>
+                                <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningFfInterpolateSpHelp"></div>
+                                    <span i18n="pidTuningFfInterpolateSp" />
+
+                                    <span class="ffInterpolate suboption">
+                                        <select id="ffInterpolate">
+                                            <option i18n="pidTuningFfInterpolateSpOptionNoAverage"     value="1">
+                                            <option i18n="pidTuningFfInterpolateSpOptionAverage2"      value="2"/>
+                                            <option i18n="pidTuningFfInterpolateSpOptionAverage3"      value="3"/>
+                                            <option i18n="pidTuningFfInterpolateSpOptionAverage4"      value="4"/>
+                                        </select>
+                                        <label for="ffInterpolate">
+                                            <span i18n="pidTuningFfInterpolate" />
+                                        </label>
+                                    </span>
+
+                                    <span class="ffSmoothFactor suboption">
+                                        <input type="number" name="ffSmoothFactor" step="1" min="0" max="75" />
+                                        <label for="ffSmoothFactor">
+                                            <span i18n="pidTuningFfSmoothFactor" />
+                                        </label>
+                                    </span>
+
+                                    <span class="ffBoost suboption">
+                                        <input type="number" name="ffBoost" step="1" min="0" max="50" />
+                                        <label for="ffBoost">
+                                            <span i18n="pidTuningFfBoost" />
+                                        </label>
+                                    </span>
+                                </td>
+                            </tr>
 
                             <tr class="acroTrainerAngleLimit">
                                 <td><input type="number" name="acroTrainerAngleLimit-number" step="1" min="10" max="80"/></td>


### PR DESCRIPTION
I have added the most important options of `FF Interpolate` to complement the improvements added by @ctzsnooze , a review of the help button is still necessary. It work with https://github.com/betaflight/betaflight/pull/9465 Here a example:
![FFInterpolate](https://user-images.githubusercontent.com/43983086/74146658-e17d8780-4c01-11ea-9f22-b183a9c7626f.jpg)
