### PR TITLE
Add OSD Camera Frame element

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4642,6 +4642,20 @@
     "osdDescElementRssiDbmValue": {
         "message": "Value in dBm of the RSSI signal if available"
     },
+    "osdTextElementRcChannels": {
+        "message": "RC Channels",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRcChannels": {
+        "message": "Display at most 4 channels values. The channels must be specified with the CLI variable 'osd_rcchannels'"
+    },    
+    "osdTextElementCameraFrame": {
+        "message": "Camera frame",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCameraFrame": {
+        "message": "Adds an adjustable outline element designed to represent the field of view of the pilot's HD camera for visual framing.<br><br>You can adjust the width and height in CLI with 'osd_camera_frame_width' and 'osd_camera_frame_height'"
+    },    
     
     "osdTextElementUnknown": {
         "message": "Unknown $1",
@@ -4833,13 +4847,6 @@
     "osdDescStatMinRssiDbm": {
         "message": "Minimum RSSI dBm value"
     },
-    "osdTextElementRcChannels": {
-        "message": "RC Channels",
-        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
-    },
-    "osdDescElementRcChannels": {
-        "message": "Display at most 4 channels values. The channels must be specified with the CLI variable 'osd_rcchannels'"
-    },    
     "osdTextStatUnknown": {
         "message": "Unknown $1",
         "description": "One of the statistics that can be shown at the end of the flight in the OSD"


### PR DESCRIPTION
Adds the OSD Camera frame element that was added here: https://github.com/betaflight/betaflight/pull/9261

![image](https://user-images.githubusercontent.com/2673520/74227487-d89ebb80-4cbe-11ea-88d1-a6bc00b382b8.png)

Sorry @etracer65 I know you wanted to resize it inside the Configurator, but is too much work at this moment and I don't have time!!! :)