### PR TITLE
Iterm Relax Cutoff Update

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3542,7 +3542,7 @@
         "message": "I Term Relax"
     },
     "pidTuningItermRelaxHelp": {
-        "message": "Limits the accumulation of I Term when fast movements happen. This helps specially to reduce the bounceback at the end of rolls and other fast movements. You can choose the axes in which this is active, and if the fast movement is detectd using the Gyro or the Setpoint (stick)."
+        "message": "Limits the accumulation of I Term when fast movements happen. This helps specially to reduce the bounceback at the end of rolls and other fast movements. You can choose the axes in which this is active, and if the fast movement is detectd using the Gyro or the Setpoint (stick). <br><br>Cutoff: lower values suppress bounce-back after flips in low authority quads, high values increase high-rate turn precision for racing.<br>Set to 30-40 for racing, 20 for responsive freestyle builds, 10 for heavier freestyle quads, 3-5 for X-class."
     },
     "pidTuningItermRelaxAxes": {
         "message": "Axes",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3542,7 +3542,7 @@
         "message": "I Term Relax"
     },
     "pidTuningItermRelaxHelp": {
-        "message": "Limits the accumulation of I Term when fast movements happen. This helps specially to reduce the bounceback at the end of rolls and other fast movements. You can choose the axes in which this is active, and if the fast movement is detectd using the Gyro or the Setpoint (stick). <br><br>Cutoff: lower values suppress bounce-back after flips in low authority quads, high values increase high-rate turn precision for racing.<br>Set to 30-40 for racing, 20 for responsive freestyle builds, 10 for heavier freestyle quads, 3-5 for X-class."
+        "message": "Limits the accumulation of I Term when fast movements happen. This helps specially to reduce the bounceback at the end of rolls and other fast movements. You can choose the axes in which this is active, and if the fast movement is detectd using the Gyro or the Setpoint (stick)."
     },
     "pidTuningItermRelaxAxes": {
         "message": "Axes",
@@ -3573,6 +3573,9 @@
     "pidTuningItermRelaxCutoff": {
         "message": "Cutoff",
         "description": "Cutoff value of the I Term Relax"
+    },
+    "pidTuningItermRelaxCutoffHelp": {
+        "message": "Lower values suppress bounce-back after flips in low authority quads, high values increase high-rate turn precision for racing.<br>Set to 30-40 for racing, 20 for responsive freestyle builds, 10 for heavier freestyle quads, 3-5 for X-class."
     },
     "pidTuningAbsoluteControlGain": {
         "message": "Absolute Control"

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -234,6 +234,10 @@ TABS.pid_tuning.initialize = function (callback) {
             $('select[id="itermrelaxType"]').val(ADVANCED_TUNING.itermRelaxType);
             $('input[name="itermRelaxCutoff"]').val(ADVANCED_TUNING.itermRelaxCutoff);
 
+            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                $('.itermrelax input[name="itermRelaxCutoff"]').attr("max","50");
+            }
+
             itermRelaxCheck.change(function() {
                 var checked = $(this).is(':checked');
 

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -537,6 +537,7 @@
                                         </label>
                                     </span>
 
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningItermRelaxCutoffHelp"></div>
                                     <span class="itermRelaxCutoff suboption">
                                         <input type="number" name="itermRelaxCutoff" step="1" min="1" max="100" />
                                         <label for="itermRelaxCutoff">


### PR DESCRIPTION
This PR goes with the latest changes in https://github.com/betaflight/betaflight/pull/9482  updated Max cutoff to 50.
Also updated tooltip to add `Cutoff` tips, I would like to add a helpicon for Cutoff but I can't find the way to add it at the end inside the flex