### PR TITLE
Fix lua powerTable

### DIFF
--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -588,7 +588,7 @@ TABS.vtx.initialize = function (callback) {
                 writer.onwriteend = function() {
                     dump_html_to_msp();
                     const vtxConfig = createVtxConfigInfo();
-                    const text = creatLuaTables(vtxConfig);
+                    const text = createLuaTables(vtxConfig);
                     const data = new Blob([text], { type: "application/text" });
 
                     // we get here at the end of the truncate method, change to the new end
@@ -935,7 +935,7 @@ TABS.vtx.initialize = function (callback) {
         return vtxConfig;
     }
 
-    function creatLuaTables(vtxConfig) {
+    function createLuaTables(vtxConfig) {
 
         let bandsString = "bandTable = { [0]=\"U\"";
         let frequenciesString = "frequencyTable = {\n";
@@ -957,7 +957,7 @@ TABS.vtx.initialize = function (callback) {
         const powerList = vtxConfig.vtx_table.powerlevels_list;
         let powersString = "powerTable = { ";
         for (let index = 0, len = powerList.length; index < len; ++index) {
-            powersString += `[${(index + 1)}]=${powerList[index].label}, `;
+            powersString += `[${(index + 1)}]="${powerList[index].label}", `;
         }
         powersString += "},\n";
 


### PR DESCRIPTION
The entries in this table should be strings. Added "".

As long as the user only uses numbers for the power labels everything is fine and the betaflight lua scripts will accept them. But if we put in words like for example "MIN", "MAX" it will crash.
The table will look like this
```powerTable = { [1]=MIN, [2]=MAX, }```
when it should look like this
```powerTable = { [1]="MIN", [2]="MAX", }```