### PR TITLE
High rates warning message to prevent desyncs

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1746,6 +1746,9 @@
         "message": "Is an additional pushing term (spring) based on stick input. FF helps the P-term push the craft for commanded stick moves.<br><br>The P-term pushes based on the difference between the commanded Setpoint (deg/sec) and the gyro reading of current rotational rate (deg/sec). FF pushes based on the commanded change of the sticks alone.<br><br>Higher values (gains) will result in a more sharp machine response to stick input.<br>Too high of values may result in some overshoot, increased motor heat, and motor saturation (where motors can not keep up with the desired rate of change).<br>Lower or zero (0) values will result in a slower and smoother response to stick inputs.",
         "description": "Feedforward Term helpicon message on PID table titlebar"
     },
+    "pidTuningMaxRateWarning": {
+        "message": "<span class=\"message-negative\"><b>Warning:</b></span> very high rates can result in desyncs from rapid decelerations."
+    },
     "pidTuningRcRate": {
         "message": "RC Rate"
     },

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2100,6 +2100,11 @@ TABS.pid_tuning.updateRatesLabels = function() {
                 {value: parseInt(maxAngularVelPitch), balloon: function() {drawBalloonLabel(stickContext, maxAngularVelPitch, curveWidth, rateScale * (maxAngularVel - parseInt(maxAngularVelPitch)), 'right', BALLOON_COLORS.pitch, balloonsDirty);}},
                 {value: parseInt(maxAngularVelYaw), balloon: function() {drawBalloonLabel(stickContext, maxAngularVelYaw,   curveWidth, rateScale * (maxAngularVel - parseInt(maxAngularVelYaw)),   'right', BALLOON_COLORS.yaw, balloonsDirty);}}
             ];
+            // show warning message if any axis angular velocity exceeds 1800d/s
+            const MAX_RATE_WARNING = 1800;
+            const warningRates = (parseInt(maxAngularVelRoll) > MAX_RATE_WARNING || parseInt(maxAngularVelPitch) > MAX_RATE_WARNING || parseInt(maxAngularVelYaw) > MAX_RATE_WARNING);
+            $('.maxRateWarning').toggle(warningRates);
+
             // and sort them in descending order so the largest value is at the top always
             balloons.sort(function(a,b) {return (b.value - a.value)});
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2102,7 +2102,8 @@ TABS.pid_tuning.updateRatesLabels = function() {
             ];
             // show warning message if any axis angular velocity exceeds 1800d/s
             const MAX_RATE_WARNING = 1800;
-            const warningRates = (parseInt(maxAngularVelRoll) > MAX_RATE_WARNING || parseInt(maxAngularVelPitch) > MAX_RATE_WARNING || parseInt(maxAngularVelYaw) > MAX_RATE_WARNING);
+            const warningRates = (parseInt(maxAngularVelRoll) > MAX_RATE_WARNING || parseInt(maxAngularVelPitch) > MAX_RATE_WARNING
+                || parseInt(maxAngularVelYaw) > MAX_RATE_WARNING);
             $('.maxRateWarning').toggle(warningRates);
 
             // and sort them in descending order so the largest value is at the top always

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -608,6 +608,9 @@
             <div class="subtab-rates" style="display: none;">
                 <div class="clear-both"></div>
                 <div class="cf_column">
+                    <div class="note maxRateWarning">
+                        <p i18n="pidTuningMaxRateWarning"></p>
+                    </div>
                     <div class="gui_box grey rateSetup">
                         <table id="rateSetup" class="pid_tuning">
                             <tr class="pid_titlebar">


### PR DESCRIPTION
Added warning message  when the user exceeds 1800d/s in some Axi. What do you think about this? Is it a maximum correct value to avoid desync problems?what about this warning message? Thanks in advance.
![ratewarning](https://user-images.githubusercontent.com/43983086/75028494-a51f1680-54a0-11ea-8a3f-591d5990e455.jpg)
