### PR TITLE
Hide Accel Features when it is disabled

### DIFF
--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -1108,9 +1108,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             if(semver.gte(CONFIG.apiVersion, "1.37.0")) {
               var checked = $(this).is(':checked');
               if (checked) {
-                $('._smallAngle').show()
+                $('.accelDisabled').show()
               } else {
-                $('._smallAngle').hide()
+                $('.accelDisabled').hide()
               }
             }
         });

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -1107,11 +1107,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[id="accHardwareSwitch"]').change(function() {
             if(semver.gte(CONFIG.apiVersion, "1.37.0")) {
               var checked = $(this).is(':checked');
-              if (checked) {
-                $('.accelDisabled').show()
-              } else {
-                $('.accelDisabled').hide()
-              }
+              $('.accelNeeded').toggle(checked);
             }
         });
 

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -331,7 +331,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="gui_box grey">
+                        <div class="gui_box grey accelDisabled">
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationAccelTrims"></div>
                             </div>
@@ -348,7 +348,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="gui_box grey">
+                        <div class="gui_box grey accelDisabled">
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationArming"></div>
                                 <div class="helpicon cf_tip" i18n_title="configurationArmingHelp"></div>

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -331,7 +331,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="gui_box grey accelDisabled">
+                        <div class="gui_box grey accelNeeded">
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationAccelTrims"></div>
                             </div>
@@ -348,7 +348,7 @@
                                 </div>
                             </div>
                         </div>
-                        <div class="gui_box grey accelDisabled">
+                        <div class="gui_box grey accelNeeded">
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationArming"></div>
                                 <div class="helpicon cf_tip" i18n_title="configurationArmingHelp"></div>


### PR DESCRIPTION
Before only hides `Maximum ARM Angle [degrees]`, now hides completly `Arming` box and `Accelerometer Trim` box, when accelerometer is disabled.