### PR TITLE
Hide Esc Sensor for non digital protocols

### DIFF
--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -59,7 +59,7 @@
 }
 
 .tab-configuration .featuresMultiple {
-    border-spacing: 0px;
+    border-collapse: collapse;
     margin-bottom: 5px;
     margin-top: -5px;
     padding: 0px;

--- a/src/css/tabs/configuration.css
+++ b/src/css/tabs/configuration.css
@@ -58,6 +58,13 @@
     font-weight: bold;
 }
 
+.tab-configuration .featuresMultiple {
+    border-spacing: 0px;
+    margin-bottom: 5px;
+    margin-top: -5px;
+    padding: 0px;
+}
+
 .tab-configuration dl.features dt {
     float: left;
     width: 10px;

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -78,7 +78,7 @@ var Features = function (config) {
         if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
             features.push(
                 {bit: 25, group: 'rxMode', mode: 'select', name: 'RX_SPI'},
-                {bit: 27, group: 'esc', name: 'ESC_SENSOR'}
+                {bit: 27, group: 'escSensor', name: 'ESC_SENSOR'}
             );
         }
 

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -544,6 +544,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('div.unsyncedpwmfreq').toggle(!digitalProtocol);
 
             $('div.digitalIdlePercent').toggle(digitalProtocol);
+            $('.escSensor').toggle(digitalProtocol);
 
             $('div.checkboxDshotBidir').toggle(semver.gte(CONFIG.apiVersion, "1.42.0") && digitalProtocol);
             $('div.motorPoles').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -456,7 +456,7 @@
                                 <div class="note">
                                     <p i18n="configurationOtherFeaturesHelp"></p>
                                 </div>
-                                <table cellpadding="0" cellspacing="0">
+                                <table class="featuresMultiple">
                                     <thead>
                                         <tr>
                                             <th i18n="configurationFeatureEnabled"></th>

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -173,8 +173,13 @@
                                         </label>
                                     </div>
                                 </div>
-                                <table cellpadding="0" cellspacing="0" style="margin-bottom: 5px;">
+                                <table class="featuresMultiple">
                                     <tbody class="features esc">
+                                        <!-- table generated here -->
+                                    </tbody>
+                                </table>
+                                <table class="featuresMultiple">
+                                    <tbody class="features escSensor">
                                         <!-- table generated here -->
                                     </tbody>
                                 </table>

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -523,7 +523,7 @@
                                 <div class="spacer_box_title" i18n="configurationGPS"></div>
                             </div>
                             <div class="spacer_box">
-                                <table cellpadding="0" cellspacing="0">
+                                <table class="featuresMultiple">
                                     <thead>
                                         <tr>
                                             <th i18n="configurationFeatureEnabled"></th>


### PR DESCRIPTION
`ESC_SENSOR` only works with digital protocols, so it should only be shown for these.