### PR TITLE
Show warning on connect when ACC is not calibrated.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -497,6 +497,15 @@
     "resetToCustomDefaultsAccept": {
         "message": "Apply Custom Defaults"
     },
+    "reportProblemsDialogHeader": {
+        "message": "The following <strong>problems with your configuration</strong> were detected:"
+    },
+    "reportProblemsDialogFooter": {
+        "message": "Please <strong>fix these problems before attempting to fly your craft</strong>."
+    },
+    "reportProblemsDialogAccCalibrationNeeded": {
+        "message": "<strong>the accelerometer is enabled but it is not calibrated</strong>. If you plan to use the accelerometer, please follow the instructions for '$t(initialSetupButtonCalibrateAccel.message)' on the '$t(tabSetup.message)' tab. If any function that requires the accelerometer (auto level modes, GPS rescue, ...) is enabled, arming of the craft will be disabled until the accelerometer has been calibrated. If you are not planning on using the accelerometer it is recommended that you disable it in '$t(configurationSystem.message)' on the '$t(tabConfiguration.message)' tab."
+    },
 
     "infoVersions": {
         "message" : "Running - OS: <strong>{{operatingSystem}}</strong>, Chrome: <strong>{{chromeVersion}}</strong>, Configurator: <strong>{{configuratorVersion}}</strong>",

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -2157,6 +2157,22 @@ input {
     margin-bottom: 10px;
 }
 
+#dialogReportProblems-header {
+    margin-top: 10px;
+    margin-bottom: 5px;
+}
+
+.dialogReportProblems-listItem {
+    list-style: initial;
+    list-style-type: circle;
+    margin-left: 20px;
+    margin-bottom: 5px;
+}
+
+#dialogReportProblems-footer {
+    margin-bottom: 10px;
+}
+
 /*
    noUi slider stylings
 */

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -635,6 +635,7 @@ var FC = {
         SUPPORTS_CUSTOM_DEFAULTS: 4,
         HAS_CUSTOM_DEFAULTS: 5,
         SUPPORTS_RX_BIND: 6,
+        ACC_NEEDS_CALIBRATION: 7,
     },
 
     boardHasVcp: function () {

--- a/src/main.html
+++ b/src/main.html
@@ -359,7 +359,7 @@
     <dialog id="dialogResetToCustomDefaults">
         <h3 i18n="noticeTitle"></h3>
         <div class="content">
-            <div id="dialogResetToCustomDefaults-content"></div>
+            <div id="dialogResetToCustomDefaults-content" i18n="resetToCustomDefaultsDialog"></div>
         </div>
         <div>
             <span class="buttons">
@@ -370,6 +370,26 @@
             </span>
         </div>
     </dialog>
+
+    <dialog id="dialogReportProblems">
+        <h3 i18n="warningTitle"></h3>
+        <div class="content">
+            <div id="dialogReportProblems-header" i18n="reportProblemsDialogHeader"></div>
+            <ul id="dialogReportProblems-list">
+                <!-- List elements added dynamically -->
+            </ul>
+            <div id="dialogReportProblems-footer" i18n="reportProblemsDialogFooter"></div>
+        </div>
+        <div>
+            <span class="buttons">
+                <a href="#" id="dialogReportProblems-closebtn" class="regular-button" i18n="close"></a>
+            </span>
+        </div>
+    </dialog>
+
+    <ul> <!-- Sonar says so -->
+        <li class="dialogReportProblems-listItem"></li>
+    </ul>
 
     <dialog class="dialogError">
         <h3 i18n="errorTitle"></h3>


### PR DESCRIPTION
Presents a warning to the user when connecting if ACC is enabled and not calibrated:

![image](https://user-images.githubusercontent.com/4742747/75622253-46297200-5c03-11ea-8aca-03b2f4738650.png)

I think this is a better alternative to betaflight/betaflight#9458, as it points the user to the instructions for a correct calibration.

The list of warnings is built dynamically, so that other problems, like insufficient filtering, can be added and displayed as well.