### PR TITLE
Dynamic Idle configurable

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3615,7 +3615,7 @@
         "message": "Dynamic Idle Value [rpm]"
     },
     "pidTuningIdleMinRpmHelp": {
-        "message": "Set this parameter to provide an rpm based floor-value as a safety net against motor desync.<br>A racer might prefer very good response and low rates - therefore a low idle_min_rpm and a high dshot_idle_value may be useful. Freestylers and LOS pilots will appreciate very low thrust at idle and might want to use less dshot_idle_value while using a bit more idle_min_rpm to avoid desyncs at high rates.<br><br>Visit this <a href=\"https://github.com/betaflight/betaflight/wiki/Tuning-Dynamic-Idle\"target=\"_blank\">wiki</a> entrie for more info."
+        "message": "Set this parameter to provide an rpm based floor-value as a safety net against motor desync.<br>A racer might prefer very good response and low rates - therefore a low idle_min_rpm and a high dshot_idle_value may be useful. Freestylers and LOS pilots will appreciate very low thrust at idle and might want to use less dshot_idle_value while using a bit more idle_min_rpm to avoid desyncs at high rates.<br><br>Visit this <a href=\"https://github.com/betaflight/betaflight/wiki/Tuning-Dynamic-Idle\"target=\"_blank\">wiki</a> entry for more info."
     },
     "pidTuningAcroTrainerAngleLimit": {
         "message": "Acro Trainer Angle Limit"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1227,12 +1227,6 @@
     "configurationDigitalIdlePercentHelp": {
         "message": "This is the 'idle' value in percent of maximum throttle that is sent to the ESCs when the craft is armed and the trottle stick is at minimum position. Increase the percent value to gain more idle speed."
     },
-    "configurationIdleMinRpm": {
-        "message": "Dynamic Idle Value [rpm]"
-    },
-    "configurationIdleMinRpmHelp": {
-        "message": "PIDPROFILE Value, visit this <a href=\"https://github.com/betaflight/betaflight/wiki/Tuning-Dynamic-Idle\"target=\"_blank\">page</a> "
-    },
     "configurationMotorPoles": {
         "message": "Motor poles",
         "description": "One of the fields of the ESC/Motor configuration"
@@ -3616,6 +3610,12 @@
     },
     "pidTuningThrottleBoostHelp": {
         "message": "This feature allows throttle to be temporarily boosted on quick stick movements, which increases acceleration torque to the motors, providing a much faster throttle response."
+    },
+    "pidTuningIdleMinRpm": {
+        "message": "Dynamic Idle Value [rpm]"
+    },
+    "pidTuningIdleMinRpmHelp": {
+        "message": "Set this parameter to provide an rpm based floor-value as a safety net against motor desync.<br>A racer might prefer very good response and low rates - therefore a low idle_min_rpm and a high dshot_idle_value may be useful. Freestylers and LOS pilots will appreciate very low thrust at idle and might want to use less dshot_idle_value while using a bit more idle_min_rpm to avoid desyncs at high rates.<br><br>Visit this <a href=\"https://github.com/betaflight/betaflight/wiki/Tuning-Dynamic-Idle\"target=\"_blank\">wiki</a> entrie for more info."
     },
     "pidTuningAcroTrainerAngleLimit": {
         "message": "Acro Trainer Angle Limit"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1227,6 +1227,12 @@
     "configurationDigitalIdlePercentHelp": {
         "message": "This is the 'idle' value in percent of maximum throttle that is sent to the ESCs when the craft is armed and the trottle stick is at minimum position. Increase the percent value to gain more idle speed."
     },
+    "configurationIdleMinRpm": {
+        "message": "Dynamic Idle Value [rpm]"
+    },
+    "configurationIdleMinRpmHelp": {
+        "message": "PIDPROFILE Value, visit this <a href=\"https://github.com/betaflight/betaflight/wiki/Tuning-Dynamic-Idle\"target=\"_blank\">page</a> "
+    },
     "configurationMotorPoles": {
         "message": "Motor poles",
         "description": "One of the fields of the ESC/Motor configuration"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -460,6 +460,7 @@ var FC = {
             integratedYawRelax:         0,
             motorOutputLimit:           0,
             autoProfileCellCount:       0,
+            idleMinRpm:                 0,
         };
         ADVANCED_TUNING_ACTIVE = { ...ADVANCED_TUNING };
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1146,6 +1146,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                             if(semver.gte(CONFIG.apiVersion, "1.43.0")) {
                                                 ADVANCED_TUNING.motorOutputLimit = data.readU8();
                                                 ADVANCED_TUNING.autoProfileCellCount = data.readU8();
+                                                ADVANCED_TUNING.idleMinRpm = data.readU8();
                                             }
                                         }
                                     }
@@ -2079,7 +2080,8 @@ MspHelper.prototype.crunch = function(code) {
 
                                         if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
                                             buffer.push8(ADVANCED_TUNING.motorOutputLimit)
-                                                  .push8(ADVANCED_TUNING.autoProfileCellCount);
+                                                  .push8(ADVANCED_TUNING.autoProfileCellCount)
+                                                  .push8(ADVANCED_TUNING.idleMinRpm);
                                         }
                                     }
                                 }

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -181,18 +181,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     }
 
     function load_rx_config() {
-        var next_callback = load_profile_features;
+        var next_callback = load_html;
         if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
             MSP.send_message(MSPCodes.MSP_RX_CONFIG, false, false, next_callback);
-        } else {
-            next_callback();
-        }
-    }
-	
-    function load_profile_features() {
-        var next_callback = load_html;
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
-            MSP.send_message(MSPCodes.MSP_PID_ADVANCED, false, false, next_callback);
         } else {
             next_callback();
         }
@@ -525,14 +516,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('input[name="motorPoles"]').val(MOTOR_CONFIG.motor_poles);
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
-            $('input[name="idleMinRpm"]').val(ADVANCED_TUNING.idleMinRpm);
-        }
-
         function hideRpmFeatures() {
             let rpmFeaturesVisible = $("input[id='dshotBidir']").is(':checked') || $("input[name='ESC_SENSOR']").is(':checked');
             $('div.motorPoles').toggle(rpmFeaturesVisible);
-            $('div.idleMinRpm').toggle(rpmFeaturesVisible);
         }
 
         $('#escProtocolTooltip').toggle(semver.lt(CONFIG.apiVersion, "1.42.0"));
@@ -562,7 +548,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             $('div.checkboxDshotBidir').toggle(semver.gte(CONFIG.apiVersion, "1.42.0") && digitalProtocol);
             $('div.motorPoles').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
-            $('div.idleMinRpm').toggle(semver.gte(CONFIG.apiVersion, "1.43.0"));
             //trigger change dshotBidir and ESC_SENSOR to show/hide Motor Poles tab
             $("input[id='dshotBidir']").change(hideRpmFeatures).change();
             $("input[name='ESC_SENSOR']").change(hideRpmFeatures);
@@ -1182,9 +1167,6 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
                 MOTOR_CONFIG.motor_poles = parseInt($('input[name="motorPoles"]').val());
             }
-            if(semver.gte(CONFIG.apiVersion, "1.43.0")) {
-                ADVANCED_TUNING.idleMinRpm = parseInt($('input[name="idleMinRpm"]').val());
-            }
 
             if(self.SHOW_OLD_BATTERY_CONFIG) {
                 MISC.vbatmincellvoltage = parseFloat($('input[name="mincellvoltage"]').val());
@@ -1361,18 +1343,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function save_rx_config() {
-                var next_callback = save_profile_features;
+                var next_callback = save_to_eeprom;
                 if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG), false, next_callback);
-                } else {
-                    next_callback();
-                }
-            }
-			
-            function save_profile_features() {
-                var next_callback = save_to_eeprom;
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
-                    MSP.send_message(MSPCodes.MSP_SET_PID_ADVANCED, mspHelper.crunch(MSPCodes.MSP_SET_PID_ADVANCED), false, next_callback);
                 } else {
                     next_callback();
                 }

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -181,9 +181,18 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
     }
 
     function load_rx_config() {
-        var next_callback = load_html;
+        var next_callback = load_profile_features;
         if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
             MSP.send_message(MSPCodes.MSP_RX_CONFIG, false, false, next_callback);
+        } else {
+            next_callback();
+        }
+    }
+	
+    function load_profile_features() {
+        var next_callback = load_html;
+        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            MSP.send_message(MSPCodes.MSP_PID_ADVANCED, false, false, next_callback);
         } else {
             next_callback();
         }
@@ -516,9 +525,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('input[name="motorPoles"]').val(MOTOR_CONFIG.motor_poles);
         }
 
-        function hideMotorPoles() {
-            let motorPolesVisible = $("input[id='dshotBidir']").is(':checked') || $("input[name='ESC_SENSOR']").is(':checked');
-            $('div.motorPoles').toggle(motorPolesVisible);
+        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            $('input[name="idleMinRpm"]').val(ADVANCED_TUNING.idleMinRpm);
+        }
+
+        function hideRpmFeatures() {
+            let rpmFeaturesVisible = $("input[id='dshotBidir']").is(':checked') || $("input[name='ESC_SENSOR']").is(':checked');
+            $('div.motorPoles').toggle(rpmFeaturesVisible);
+            $('div.idleMinRpm').toggle(rpmFeaturesVisible);
         }
 
         $('#escProtocolTooltip').toggle(semver.lt(CONFIG.apiVersion, "1.42.0"));
@@ -548,9 +562,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             $('div.checkboxDshotBidir').toggle(semver.gte(CONFIG.apiVersion, "1.42.0") && digitalProtocol);
             $('div.motorPoles').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
+            $('div.idleMinRpm').toggle(semver.gte(CONFIG.apiVersion, "1.43.0"));
             //trigger change dshotBidir and ESC_SENSOR to show/hide Motor Poles tab
-            $("input[id='dshotBidir']").change(hideMotorPoles).change();
-            $("input[name='ESC_SENSOR']").change(hideMotorPoles);
+            $("input[id='dshotBidir']").change(hideRpmFeatures).change();
+            $("input[name='ESC_SENSOR']").change(hideRpmFeatures);
 
             //trigger change unsyncedPWMSwitch to show/hide Motor PWM freq input
             $("input[id='unsyncedPWMSwitch']").change();
@@ -1167,6 +1182,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
                 MOTOR_CONFIG.motor_poles = parseInt($('input[name="motorPoles"]').val());
             }
+            if(semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                ADVANCED_TUNING.idleMinRpm = parseInt($('input[name="idleMinRpm"]').val());
+            }
 
             if(self.SHOW_OLD_BATTERY_CONFIG) {
                 MISC.vbatmincellvoltage = parseFloat($('input[name="mincellvoltage"]').val());
@@ -1343,9 +1361,18 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function save_rx_config() {
-                var next_callback = save_to_eeprom;
+                var next_callback = save_profile_features;
                 if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG), false, next_callback);
+                } else {
+                    next_callback();
+                }
+            }
+			
+            function save_profile_features() {
+                var next_callback = save_to_eeprom;
+                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                    MSP.send_message(MSPCodes.MSP_SET_PID_ADVANCED, mspHelper.crunch(MSPCodes.MSP_SET_PID_ADVANCED), false, next_callback);
                 } else {
                     next_callback();
                 }

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -393,8 +393,10 @@ TABS.pid_tuning.initialize = function (callback) {
         if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
             $('.pid_tuning input[name="motorLimit"]').val(ADVANCED_TUNING.motorOutputLimit);
             $('.pid_tuning input[name="cellCount"]').val(ADVANCED_TUNING.autoProfileCellCount);
+            $('input[name="idleMinRpm-number"]').val(ADVANCED_TUNING.idleMinRpm);
         } else {
             $('.motorOutputLimit').hide();
+            $('.idleMinRpm').hide();
         }
 
         $('input[id="useIntegratedYaw"]').change(function() {
@@ -776,6 +778,7 @@ TABS.pid_tuning.initialize = function (callback) {
             FILTER_CONFIG.dyn_notch_max_hz = parseInt($('.pid_filter input[name="dynamicNotchMaxHz"]').val());
             ADVANCED_TUNING.motorOutputLimit = parseInt($('.pid_tuning input[name="motorLimit"]').val());
             ADVANCED_TUNING.autoProfileCellCount = parseInt($('.pid_tuning input[name="cellCount"]').val());
+            ADVANCED_TUNING.idleMinRpm = parseInt($('input[name="idleMinRpm-number"]').val());
         }
     }
 

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -209,6 +209,15 @@
                                     </label>
                                     <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
+                                <div class="number idleMinRpm">
+                                    <label>
+                                        <div class="numberspacer">
+                                            <input type="number" name="idleMinRpm" min="0" max="100" step="1"/>
+                                        </div>
+                                        <span i18n="configurationIdleMinRpm"></span>
+                                    </label>
+                                    <div class="helpicon cf_tip" i18n_title="configurationIdleMinRpmHelp"></div>
+                                </div>
                                 <div class="number minthrottle">
                                     <label>
                                         <div class="numberspacer">

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -209,15 +209,6 @@
                                     </label>
                                     <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
-                                <div class="number idleMinRpm">
-                                    <label>
-                                        <div class="numberspacer">
-                                            <input type="number" name="idleMinRpm" min="0" max="100" step="1"/>
-                                        </div>
-                                        <span i18n="configurationIdleMinRpm"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" i18n_title="configurationIdleMinRpmHelp"></div>
-                                </div>
                                 <div class="number minthrottle">
                                     <label>
                                         <div class="numberspacer">

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -499,6 +499,18 @@
                                 </td>
                             </tr>
 
+                            <tr class="idleMinRpm">
+                                <td><input type="number" name="idleMinRpm-number" step="1" min="0" max="100"/></td>
+                                <td colspan="1">
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningIdleMinRpm"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningIdleMinRpmHelp"></div>
+                                    </div>
+                                </td>
+                            </tr>
+
                             <tr class="absoluteControlGain">
                                 <td><input type="number" name="absoluteControlGain-number" step="1" min="0" max="20"/></td>
                                 <td colspan="1">


### PR DESCRIPTION
I am seeing a great effort in joelucid to improve the explanation in the wiki and social networks of how this feature works and I think it now looks better. Adding Dynamic Idle feature configurable parametre. It is a feature that depends on the pidprofile so I have linked this tab with `MSP_PID_ADVANCED`. My first idea is to show in some way that this feature belongs to the pid profile, happy to hear ideas. Also modify the function of hiding values that depend on rpm and unify it. The tooltip needs updating by @joelucid suggestions.
![DynamicIdle](https://user-images.githubusercontent.com/43983086/75866461-5a3cc180-5e05-11ea-9c54-d41878afd2d1.jpg)
