### PR TITLE
Work around false error when claiming interface to fix firmware flashing on MacOS

### DIFF
--- a/src/js/protocols/stm32usbdfu.js
+++ b/src/js/protocols/stm32usbdfu.js
@@ -156,7 +156,10 @@ STM32DFU_protocol.prototype.claimInterface = function (interfaceNumber) {
     var self = this;
 
     chrome.usb.claimInterface(this.handle, interfaceNumber, function claimed() {
-        if(self.checkChromeError()) {
+        // Don't perform the error check on MacOS at this time as there seems to be a bug
+        // where it always reports the Chrome error "Error claiming interface." even though
+        // the interface is in fact successfully claimed.
+        if (self.checkChromeError() && (GUI.operating_system !== "MacOS")) {
             console.log('Failed to claim USB device!');
             self.cleanup();
         }


### PR DESCRIPTION
Fixes #1892 

The error check after attempting to claim the USB interface was falsely indicating failure on MacOS even though it was working properly. Tried all available versions of NW.js (including beta) and none resolve the problem. The problem only seems to affect MacOS.

The error check after claiming the interface is suppressed for MacOS to work around the problem. Risk is low because even if the climing of the interface failed the worst that could happen is flash fails anyway.

Hopefully there will be some future version of NW.js that resolves the problem and we can remove this workaround later (tested through 0.45.0-beta1 so far).
