### PR TITLE
Added debug-release build for installers with debug console, changed Azure jobs to build them.

### DIFF
--- a/assets/windows/installer.nsi
+++ b/assets/windows/installer.nsi
@@ -7,9 +7,10 @@
 # ${VERSION} - Version to generate (x.y.z)
 # ${PLATFORM} - Platform to generate (win32 or win64)
 # ${DEST_FOLDER} - Destination folder for the installer files
+# ${SOURCE_FOLDER} - Source folder for the application files
 
 # Some definitions
-!define SOURCE_FILES          "..\..\apps\betaflight-configurator\${PLATFORM}\*"
+!define SOURCE_FILES          "..\..\${SOURCE_FOLDER}\betaflight-configurator\${PLATFORM}\*"
 !define APP_NAME              "Betaflight Configurator"
 !define COMPANY_NAME          "The Betaflight open source project."
 !define GROUP_NAME            "Betaflight"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -42,8 +42,8 @@ stages:
         testResultsFiles: '**/test_results.xml'
         testRunTitle: 'Windows'
         buildPlatform: 'Win32'
-    - script: yarn release --win32
-      displayName: 'Run yarn release for win32'
+    - script: yarn debug-release --win32
+      displayName: 'Run yarn debug release for win32'
     - powershell: Set-Content -Path '$(System.DefaultWorkingDirectory)/release/log.txt' -Value $env:BUILD_SOURCEVERSIONMESSAGE
     - task: PublishPipelineArtifact@1
       displayName: 'Publish Windows release'
@@ -64,8 +64,8 @@ stages:
       displayName: 'Install Gulp'
     - script: yarn install
       displayName: 'Run yarn install'
-    - script: yarn gulp release --osx64
-      displayName: 'Run yarn release for OSX64'
+    - script: yarn gulp debug-release --osx64
+      displayName: 'Run yarn debug release for OSX64'
     - task: PublishPipelineArtifact@1
       displayName: 'Publish MacOS release'
       inputs: 
@@ -83,8 +83,8 @@ stages:
       displayName: 'Install Node.js 10.16.3'
     - script: yarn install
       displayName: 'Run yarn install'
-    - script: yarn release --linux64
-      displayName: 'Run yarn release for linux64'
+    - script: yarn debug-release --linux64
+      displayName: 'Run yarn debug release for linux64'
     - script: cd $(System.DefaultWorkingDirectory)/release; find -mindepth 1 -maxdepth 1 -type d -exec rm -r {} \;
       displayName: 'Clean release folders'
     - task: PublishPipelineArtifact@1


### PR DESCRIPTION
This adds a `debug-release` target that builds the installers with the 'sdk' flavour of NW.js that contains the debug console.

It also switches the Azure builds to build and publish this debug release. This will make it easier in the future to ask testers to get / post debug console logs.

Tested on linux and Windows. @etracer65 can you test on OSX please?