### PR TITLE
Rename Efficiency to 'Battery efficiency'

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4712,11 +4712,11 @@
         "message": "Adds an adjustable outline element designed to represent the field of view of the pilot's HD camera for visual framing.<br><br>You can adjust the width and height in CLI with 'osd_camera_frame_width' and 'osd_camera_frame_height'"
     },    
     "osdTextElementEfficiency": {
-        "message": "Efficiency",
+        "message": "Battery efficiency",
         "description": "One of the elements of the OSD"
     },
     "osdDescElementEfficiency": {
-        "message": "Shows current energy consumption in mAh/distance"
+        "message": "Instantaneous battery consumption in mAh/distance.  (Requires valid GPS fix)"
     },
     
     "osdTextElementUnknown": {


### PR DESCRIPTION
Re: https://github.com/betaflight/betaflight-configurator/pull/1922#issuecomment-601427242

Rename `Efficiency` to `Battery efficiency` so it lives next to related elements.  Also tweaked the description for consistency.

![image](https://user-images.githubusercontent.com/6344319/77127053-69785d80-6a08-11ea-8070-7b9b6884e133.png)
