### PR TITLE
Improving osd chip detection warnings

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4070,6 +4070,9 @@
     "osdSetupTitle": {
         "message": "OSD"
     },
+    "osdSetupNoOsdChipDetectWarning": {
+        "message": "<span class=\"message-negative\"><b>WARNING:</b></span> No OSD chip was detected. Some flight controllers will not properly power the OSD chip unless connected to battery power. Please connect the battery before connecting the USB (PROPS REMOVED!)."
+    },
     "osdSetupPreviewHelp": {
         "message": "<strong>Note:</strong> OSD preview may not show the actual font that is installed on the flight controller. The layout of individual elements may look different when older versions of the firmware are used - please check the look through your goggles before flying."
     },

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -1382,6 +1382,7 @@ dialog {
     display: block;
     transition: all ease 0.2s;
     text-decoration:none;
+    cursor: pointer;
 }
 
 .default_btn a.disabled {

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2244,6 +2244,10 @@ TABS.osd.initialize = function (callback) {
 
                     OSD.msp.decode(info);
 
+                    if (!OSD.data.state.haveMax7456Video || !OSD.data.state.isMax7456Detected) {
+                        $('.noOsdChipDetect').show();
+                    }
+
                     if (OSD.data.state.haveSomeOsd == 0) {
                         $('.unsupported').fadeIn();
                         return;
@@ -2466,11 +2470,10 @@ TABS.osd.initialize = function (callback) {
 
                     if (!OSD.data.state.haveMax7456Video) {
                         $('.requires-max7456').hide();
-                        $('.requires-detected-max7456').hide();
                     }
 
                     if (!OSD.data.state.haveMax7456Video || !OSD.data.state.isMax7456Detected) {
-                        $('.requires-detected-max7456').hide();
+                        $('.requires-detected-max7456').addClass('disabled');
                     }
 
                     if (!OSD.data.state.haveOsdFeature) {

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -6,6 +6,9 @@
             <div class="cf_doc_version_bt">
                 <a id="button-documentation" href="" target="_blank"></a>
             </div>
+            <div class="noOsdChipDetect hide">
+                <p class="note" i18n="osdSetupNoOsdChipDetectWarning"></p>
+            </div>
             <div class="unsupported hide">
                 <p class="note" i18n="osdSetupUnsupportedNote1"></p>
                 <p class="note" i18n="osdSetupUnsupportedNote2"></p>
@@ -198,8 +201,8 @@
                     <div class="btn save">
                         <a class="active save" href="#" i18n="osdSetupSave"></a>
                     </div>
-                    <div class="btn requires-detected-max7456">
-                        <a class="fonts" id="fontmanager" href="#" i18n="osdSetupFontManager"></a>
+                    <div class="btn">
+                        <a class="fonts requires-detected-max7456" id="fontmanager" href="#" i18n="osdSetupFontManager"></a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Added warning note when no osd chip detected, trying to avoid these issues https://github.com/betaflight/betaflight-configurator/issues/1925 https://github.com/betaflight/betaflight-configurator/issues/1816, modified `Font Manager` button to not hidden only disable. Also fixed pointer on Font Manager tools buttons.

![fontmanager](https://user-images.githubusercontent.com/43983086/77176211-0a781e80-6ac4-11ea-9b45-ea9299f801d1.jpg)


