### PR TITLE
Disabled "Exit DFU Button" when no needed

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -166,6 +166,10 @@ PortHandler.check_usb_devices = function (callback) {
         }
 
         if(callback) callback(self.dfu_available);
+
+        if (!$('option:selected', portPickerElement).data().isDFU) {
+            portPickerElement.trigger('change');
+        }
     });
 };
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -981,7 +981,7 @@ TABS.firmware_flasher.initialize = function (callback) {
 
         portPickerElement.change(function () {
             if ($('option:selected', this).data().isDFU) {
-               exitDfuElement.removeClass('disabled');
+                exitDfuElement.removeClass('disabled');
             } else {
                 exitDfuElement.addClass('disabled');
             }
@@ -1054,6 +1054,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         }
 
         function startFlashing() {
+            exitDfuElement.addClass('disabled');
             if (!GUI.connect_lock) { // button disabled while flashing is in progress
                 if (self.parsed_hex) {
                     try {


### PR DESCRIPTION
I have disabled `Exit DFU Button` when firmware is flashing to prevent any dfu exit. Also disabled button after use it to exit dfu mode.

![exitdfubutton](https://user-images.githubusercontent.com/43983086/77251599-8357b180-6c4f-11ea-9605-d5b8354dc59c.jpg)
