### PR TITLE
Added version information to Unified Targets when they are flashed.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2704,7 +2704,7 @@
         "message": "Release info"
     },
     "firmwareFlasherReleaseManufacturer": {
-        "message": "Manufacturer:"
+        "message": "Manufacturer ID:"
     },
     "firmwareFlasherReleaseVersion": {
         "message": "Version:"
@@ -2724,8 +2724,14 @@
     "firmwareFlasherReleaseFile": {
         "message": "Binary:"
     },
-    "firmwareFlasherReleaseStatusReleaseCandidate": {
-        "message": "<span class=\"message-negative\">IMPORTANT: This firmware release is currently marked as a release candidate.  Please report any issues immediately.</span>"
+    "firmwareFlasherUnifiedTargetName": {
+        "message": "Unified Target:"
+    },
+    "firmwareFlasherUnifiedTargetFileUrl": {
+        "message": "Show config."
+    },
+    "firmwareFlasherUnifiedTargetDate": {
+        "message": "Date:"
     },
     "firmwareFlasherReleaseFileUrl": {
         "message": "Download manually."

--- a/src/js/GitHubApi.js
+++ b/src/js/GitHubApi.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const GitHubApi = function ()
+{
+    const self = this;
+
+    self.GITHUB_API_URL = "https://api.github.com/";
+};
+
+GitHubApi.prototype.getFileLastCommitInfo = function (project, branch, filename, callback)
+{
+    const self = this;
+
+    $.getJSON(`${self.GITHUB_API_URL}repos/${encodeURI(project)}/commits?sha=${encodeURIComponent(branch)}&path=${encodeURIComponent(filename)}`, function (commits) {
+        const result = {};
+        try {
+            result.commitHash = commits[0].sha.substring(0, 8);
+            result.date = commits[0].commit.author.date;
+        } catch (exception) {
+            console.log(`Error while parsing commit: ${exception}`);
+        }
+
+        console.log(`Found commit info for file ${filename}:`, result);
+
+        callback(result);
+    });
+};

--- a/src/js/release_checker.js
+++ b/src/js/release_checker.js
@@ -7,8 +7,6 @@ var ReleaseChecker = function (releaseName, releaseUrl) {
     self._releaseDataTag = `${self._releaseName}ReleaseData`;
     self._releaseLastUpdateTag = `${self._releaseName}ReleaseLastUpdate`
     self._releaseUrl = releaseUrl;
-    
-
 }
 
 ReleaseChecker.prototype.loadReleaseData = function (processFunction) {

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1970,11 +1970,11 @@ OSD.msp = {
             }
             for (var i = 0; i < warningCount; i++) {
 
+                const enabled = (warningFlags & (1 << i)) !== 0;
+
                 // Known warning field
                 if (i < OSD.constants.WARNINGS.length) {
-                    d.warnings.push($.extend(OSD.constants.WARNINGS[i], {
-                        enabled: (warningFlags & (1 << i)) !== 0,
-                    }));
+                    d.warnings.push($.extend(OSD.constants.WARNINGS[i], { enabled: enabled }));
 
                 // Push Unknown Warning field
                 } else {
@@ -1983,7 +1983,7 @@ OSD.msp = {
                         name: 'UNKNOWN',
                         text: ['osdWarningTextUnknown', warningNumber],
                         desc: 'osdWarningUnknown',
-                        enabled: (warningFlags & (1 << i)) !== 0,
+                        enabled: enabled,
                     });
 
                 }
@@ -2168,8 +2168,6 @@ TABS.osd = {
 };
 
 TABS.osd.initialize = function (callback) {
-    var self = this;
-
     if (GUI.active_tab != 'osd') {
         GUI.active_tab = 'osd';
     }

--- a/src/main.html
+++ b/src/main.html
@@ -93,6 +93,7 @@
     <script type="text/javascript" src="./js/release_checker.js"></script>
     <script type="text/javascript" src="./js/jenkins_loader.js"></script>
     <script type="text/javascript" src="./js/Analytics.js"></script>
+    <script type="text/javascript" src="./js/GitHubApi.js"></script>
     <script type="text/javascript" src="./js/main.js"></script>
     <script type="text/javascript" src="./js/Clipboard.js"></script>
     <script type="text/javascript" src="./js/tabs/static_tab.js"></script>

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -88,23 +88,33 @@
                     i18n="firmwareFlasherReleaseSummaryHead"></div>
             </div>
             <div class="spacer" style="margin-bottom: 10px;">
-                <strong i18n="firmwareFlasherReleaseTarget"></strong>
-                <span class="target"></span>
-                <br />
-                <div id="manufacturerInfo">
-                    <strong i18n="firmwareFlasherReleaseManufacturer"></strong>
-                    <span id="manufacturer"></span>
+                <div class="margin-bottom">
+                    <strong i18n="firmwareFlasherReleaseTarget"></strong>
+                    <span class="target"></span>
+                    <br />
+                    <div id="manufacturerInfo">
+                        <strong i18n="firmwareFlasherReleaseManufacturer"></strong>
+                        <span id="manufacturer"></span>
+                        <br />
+                    </div>
+                    <strong i18n="firmwareFlasherReleaseVersion"></strong>
+                    <a i18n_title="firmwareFlasherReleaseVersionUrl" class="name" href="#" target="_blank"></a>
+                    <br />
+                    <strong i18n="firmwareFlasherReleaseFile"></strong>
+                    <a i18n_title="firmwareFlasherReleaseFileUrl" class="file" href="#" target="_blank"></a>
+                    <br />
+                    <strong i18n="firmwareFlasherReleaseDate"></strong>
+                    <span class="date"></span>
                     <br />
                 </div>
-                <strong i18n="firmwareFlasherReleaseVersion"></strong>
-                <a i18n_title="firmwareFlasherReleaseVersionUrl" class="name" href="#" target="_blank"></a>
-                <br />
-                <strong i18n="firmwareFlasherReleaseFile"></strong>
-                <a i18n_title="firmwareFlasherReleaseFileUrl" class="file" href="#" target="_blank"></a>
-                <br />
-                <strong i18n="firmwareFlasherReleaseDate"></strong>
-                <span class="date"></span>
-                <br />
+                <div class="margin-bottom" id="unifiedTargetInfo">
+                    <strong i18n="firmwareFlasherUnifiedTargetName"></strong>
+                    <a i18n_title="firmwareFlasherUnifiedTargetFileUrl" id="unifiedTargetFile" href="#" target="_blank"></a>
+                    <br />
+                    <strong i18n="firmwareFlasherUnifiedTargetDate"></strong>
+                    <span id="unifiedTargetDate"></span>
+                    <br />
+                </div>
                 <strong i18n="firmwareFlasherReleaseNotes"></strong>
                 <div class=notes></div>
             </div>


### PR DESCRIPTION
This will allow bug reports for Unified Targets to be pinpointed to a particular version / release date of the Unified Target configuration.

![image](https://user-images.githubusercontent.com/4742747/77826255-2a1ddf80-7173-11ea-99a1-ac72b78bc3d8.png)

The plan is to add parsing for these fields to the firmware, so that this information will also be shown in a `diff`:

```
# defaults show
# Betaflight / STM32F405 (S405) 4.1.0 Aug 13 2019 / 22:54:29 (52173c798) MSP API: 1.42
# config: manufacturer_id: SPBE, board_name: SPEEDYBEEF4, version: 6fac4231, date: 2019-10-18T22:07:46Z

board_name SPEEDYBEEF4
manufacturer_id SPBE

# resources
resource BEEPER 1 C13
[...]
```