### PR TITLE
Fix D values when Dmin disabled and autoadjust, coordination with new Dmin values

### DIFF
--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -49,7 +49,7 @@ TuningSliders.setDMinFeatureEnabled = function(dMinFeatureEnabled) {
     if (this.dMinFeatureEnabled) {
         this.defaultPDRatio = this.PID_DEFAULT[0] / this.PID_DEFAULT[2];
     } else {
-        this.defaultPDRatio = this.PID_DEFAULT[0] / this.PID_DEFAULT[3];
+        this.defaultPDRatio = this.PID_DEFAULT[0] / (this.PID_DEFAULT[2] * 0.85);
     }
 };
 
@@ -88,7 +88,7 @@ TuningSliders.initPidSlidersPosition = function() {
     if (this.dMinFeatureEnabled) {
         this.PDGainSliderValue = Math.round(ADVANCED_TUNING.dMinRoll / this.MasterSliderValue / this.PID_DEFAULT[3] * 10) / 10;
     } else {
-        this.PDGainSliderValue = Math.round(PIDs[0][2] / this.MasterSliderValue / this.PID_DEFAULT[3] * 10) / 10;
+        this.PDGainSliderValue = Math.round(PIDs[0][2] / this.MasterSliderValue / (this.PID_DEFAULT[2] * 0.85) * 10) / 10;
     }
     this.ResponseSliderValue = Math.round(ADVANCED_TUNING.feedforwardRoll / this.MasterSliderValue / this.PID_DEFAULT[4] * 10) / 10;
 
@@ -258,8 +258,8 @@ TuningSliders.calculateNewPids = function() {
     } else {
         ADVANCED_TUNING.dMinRoll = 0;
         ADVANCED_TUNING.dMinPitch = 0;
-        PIDs[0][2] = Math.round(this.PID_DEFAULT[3] * this.PDGainSliderValue);
-        PIDs[1][2] = Math.round(this.PID_DEFAULT[8] * this.PDGainSliderValue);
+        PIDs[0][2] = Math.round((this.PID_DEFAULT[2] * 0.85) * this.PDGainSliderValue);
+        PIDs[1][2] = Math.round((this.PID_DEFAULT[7] * 0.85) * this.PDGainSliderValue);
     }
     PIDs[2][0] = Math.round(this.PID_DEFAULT[10] * this.PDGainSliderValue);
 

--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -26,6 +26,10 @@ var TuningSliders = {
 
 TuningSliders.initialize = function() {
     this.PID_DEFAULT = FC.getPidDefaults();
+    if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        this.PID_DEFAULT[3] = 23;
+        this.PID_DEFAULT[8] = 25;
+    }
     this.FILTER_DEFAULT = FC.getFilterDefaults();
 
     this.setDMinFeatureEnabled($('#dMinSwitch').is(':checked'));

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -690,15 +690,8 @@ var FC = {
     },
 
     getPidDefaults: function() {
-        // if defaults change they should go here
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
-            DEFAULT_PIDS = [
-                42, 85, 35, 23, 90,
-                46, 90, 38, 25, 95,
-                30, 90,  0,  0, 90,
-            ];
-        }
         var versionPidDefaults = DEFAULT_PIDS;
+        // if defaults change they should go here
         return versionPidDefaults;
     },
 };

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -690,8 +690,15 @@ var FC = {
     },
 
     getPidDefaults: function() {
-        var versionPidDefaults = DEFAULT_PIDS;
         // if defaults change they should go here
+        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            DEFAULT_PIDS = [
+                42, 85, 35, 23, 90,
+                46, 90, 38, 25, 95,
+                30, 90,  0,  0, 90,
+            ];
+        }
+        var versionPidDefaults = DEFAULT_PIDS;
         return versionPidDefaults;
     },
 };

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -479,6 +479,11 @@ TABS.pid_tuning.initialize = function (callback) {
                         $('.pid_tuning input[name="dMinRoll"]').val(Math.min(Math.round($('.pid_tuning .ROLL input[name="d"]').val() * 0.57), 100));
                         $('.pid_tuning input[name="dMinPitch"]').val(Math.min(Math.round($('.pid_tuning .PITCH input[name="d"]').val() * 0.57), 100));
                         $('.pid_tuning input[name="dMinYaw"]').val(Math.min(Math.round($('.pid_tuning .YAW input[name="d"]').val() * 0.57), 100));
+                        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                            $('.pid_tuning input[name="dMinRoll"]').val(Math.min(Math.round($('.pid_tuning .ROLL input[name="d"]').val() * 0.65), 100));
+                            $('.pid_tuning input[name="dMinPitch"]').val(Math.min(Math.round($('.pid_tuning .PITCH input[name="d"]').val() * 0.65), 100));
+                            $('.pid_tuning input[name="dMinYaw"]').val(Math.min(Math.round($('.pid_tuning .YAW input[name="d"]').val() * 0.65), 100));
+                        }
                     } else {
                         $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
                         $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);


### PR DESCRIPTION
There is a bug since Sliders implementation that breaks D values when Dmin is disabled. up to now has used the constant values of Dmin (20-22). I have change it to works against D values again,and aplies math to calculate necessary values when Dmin changed. For the moment this D autocalculation only works with Sliders enabled and availables.