### PR TITLE
Renamed Derivative to DMax when using Dmin

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1751,6 +1751,9 @@
     "pidTuningDerivative": {
         "message": "Derivative"
     },
+    "pidTuningDMax": {
+        "message": "D Max"
+    },
     "pidTuningDerivativeHelp": {
         "message": "Controls the strength of dampening to ANY motion on the craft.  For stick moves, the D-term dampens the command. For an outside influence (prop wash OR wind gust) the D-term dampens the influence.<br><br>Higher gains provide more dampening and reduce overshoot by P-term and FF.<br>However, the D-term is VERY sensitive to gyro high frequency vibrations (noise | magnifies by 10x to 100x).<br><br>High frequency noise can cause motor heat and burn out motors if D-gains are too high or the gyro noise is not filtered well (see Filters tab).<br><br>Think of the D-term as the shock absorber on your car, but with the negative inherent property of magnifying high frequency gyro noise.",
         "description": "Derivative Term helpicon message on PID table titlebar"

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -493,6 +493,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     $('.dminGroup .suboption').show();
                     $('#pid_main tr :nth-child(5)').show();
                     $('#pid_main .pid_titlebar2 th').attr('colspan', 6);
+                    $('.derivativeText').text(i18n.getMessage("pidTuningDMax"));
                 } else {
                     $('.pid_tuning input[name="dMinRoll"]').val(0);
                     $('.pid_tuning input[name="dMinPitch"]').val(0);
@@ -501,6 +502,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     $('.dminGroup .suboption').hide();
                     $('#pid_main tr :nth-child(5)').hide();
                     $('#pid_main .pid_titlebar2 th').attr('colspan', 5);
+                    $('.derivativeText').text(i18n.getMessage("pidTuningDerivative"));
                 }
             });
             dMinSwitch.change();

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -87,7 +87,7 @@
                                 </th>
                                 <th class="derivative">
                                     <div class="name-helpicon-flex">
-                                        <div i18n="pidTuningDerivative"></div>
+                                        <div class="derivativeText" i18n="pidTuningDerivative"></div>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningDerivativeHelp"></div>
                                     </div>
                                 </th>


### PR DESCRIPTION
As @ctzsnooze requested, renamed `Derivative` to `D Max`  when using D-Min feature.

![DMax](https://user-images.githubusercontent.com/43983086/78764301-a3dd7680-7986-11ea-9013-6403a6b56b66.jpg)
