### PR TITLE
Rpm filters defaults

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1468,6 +1468,14 @@
     "configurationButtonSave": {
         "message": "Save and Reboot"
     },
+    "dialogDynFiltersChangeTitle": {
+        "message": "Dynamic Notch values change"
+    },
+    "dialogDynFiltersChangeNote": {
+        "message": "<span class=\"message-negative\"><b>WARNING: Some dynamic notch values have been changed to default values</b></span> because the RPM filtering has been activated/deactivated.<br> Please, check before flying"
+    },
+    "dialogDynFiltersConfirm": {
+        "message": "OK",
 
     "portsIdentifier": {
         "message": "Identifier"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1472,11 +1472,11 @@
         "message": "Dynamic Notch values change"
     },
     "dialogDynFiltersChangeNote": {
-        "message": "<span class=\"message-negative\"><b>WARNING: Some dynamic notch values have been changed to default values</b></span> because the RPM filtering has been activated/deactivated.<br> Please, check before flying"
+        "message": "<span class=\"message-negative\"><b>WARNING: Some dynamic notch values have been changed to default values</b></span> because the RPM filtering has been activated/deactivated.<br> Please, check before flying."
     },
     "dialogDynFiltersConfirm": {
-        "message": "OK",
-
+        "message": "OK"
+    },
     "portsIdentifier": {
         "message": "Identifier"
     },

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -579,6 +579,10 @@ var FC = {
             dterm_notch_cutoff:             160,
             dterm_notch_hz:                 260,
             yaw_lowpass_hz:                 100,
+            dyn_notch_q:                    120,
+            dyn_notch_width_percent:          8,
+            dyn_notch_q_rpm:                250, // default with rpm filtering
+            dyn_notch_width_percent_rpm:      0,
         };
 
         DEFAULT_PIDS = [

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -760,3 +760,15 @@ function showErrorDialog(message) {
 
     dialog.showModal();
 }
+
+function showDialogDynFiltersChange() {
+    const dialogDynFiltersChange = $('.dialogDynFiltersChange')[0];
+
+    if (!dialogDynFiltersChange.hasAttribute('open')) {
+        dialogDynFiltersChange.showModal();
+
+        $('.dialogDynFiltersChange-confirmbtn').click(function() {
+            dialogDynFiltersChange.close();
+        });
+    }
+}

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -541,15 +541,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 }
 
                 if (FILTER_CONFIG.dyn_notch_width_percent !== self.previousFilterDynWidth) {
-                    const dialogDynFiltersChange = $('.dialogDynFiltersChange')[0];
-
-                    if (!dialogDynFiltersChange.hasAttribute('open')) {
-                        dialogDynFiltersChange.showModal();
-
-                        $('.dialogDynFiltersChange-confirmbtn').click(function() {
-                            dialogDynFiltersChange.close();
-                        });
-                    }
+                    showDialogDynFiltersChange();
                 }
             });
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -359,6 +359,9 @@ TABS.pid_tuning.initialize = function (callback) {
         }
 
         if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            const dynamicNotchWidthPercent_e = $('.pid_filter input[name="dynamicNotchWidthPercent"]');
+            const dynamicNotchQ_e = $('.pid_filter input[name="dynamicNotchQ"]');
+
             $('.smartfeedforward').hide();
 
             if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
@@ -368,8 +371,8 @@ TABS.pid_tuning.initialize = function (callback) {
             }
             $('.dynamicNotchRange').toggle(semver.lt(CONFIG.apiVersion, API_VERSION_1_43));
             $('.pid_filter select[name="dynamicNotchRange"]').val(FILTER_CONFIG.dyn_notch_range);
-            $('.pid_filter input[name="dynamicNotchWidthPercent"]').val(FILTER_CONFIG.dyn_notch_width_percent);
-            $('.pid_filter input[name="dynamicNotchQ"]').val(FILTER_CONFIG.dyn_notch_q);
+            dynamicNotchWidthPercent_e.val(FILTER_CONFIG.dyn_notch_width_percent);
+            dynamicNotchQ_e.val(FILTER_CONFIG.dyn_notch_q);
             $('.pid_filter input[name="dynamicNotchMinHz"]').val(FILTER_CONFIG.dyn_notch_min_hz);
             if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 $('.pid_filter input[name="dynamicNotchMinHz"]').attr("max","250");
@@ -394,7 +397,33 @@ TABS.pid_tuning.initialize = function (callback) {
                 if (harmonics == 0) {
                     $('.pid_filter input[name="rpmFilterHarmonics"]').val(FILTER_DEFAULT.gyro_rpm_notch_harmonics);
                 }
+
+                if (checked !== (FILTER_CONFIG.gyro_rpm_notch_harmonics !== 0)) { // if rpmFilterEnabled is not the same value as saved in the fc
+                    if (checked) {
+                        dynamicNotchWidthPercent_e.val(FILTER_DEFAULT.dyn_notch_width_percent_rpm);
+                        dynamicNotchQ_e.val(FILTER_DEFAULT.dyn_notch_q_rpm);
+                    } else {
+                        dynamicNotchWidthPercent_e.val(FILTER_DEFAULT.dyn_notch_width_percent);
+                        dynamicNotchQ_e.val(FILTER_DEFAULT.dyn_notch_q);
+                    }
+
+                    const dialogDynFiltersChange = $('.dialogDynFiltersChange')[0];
+
+                    if (!dialogDynFiltersChange.hasAttribute('open')) {
+                        dialogDynFiltersChange.showModal();
+
+                        $('.dialogDynFiltersChange-confirmbtn').click(function() {
+                            dialogDynFiltersChange.close();
+                        });
+                    }
+
+                } else { // same value, return saved values
+                    dynamicNotchWidthPercent_e.val(FILTER_CONFIG.dyn_notch_width_percent);
+                    dynamicNotchQ_e.val(FILTER_CONFIG.dyn_notch_q);
+                }
+
             }).prop('checked', FILTER_CONFIG.gyro_rpm_notch_harmonics != 0).change();
+
         } else {
             $('.itermRelaxCutoff').hide();
             $('.dynamicNotch').hide();

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -407,15 +407,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         dynamicNotchQ_e.val(FILTER_DEFAULT.dyn_notch_q);
                     }
 
-                    const dialogDynFiltersChange = $('.dialogDynFiltersChange')[0];
-
-                    if (!dialogDynFiltersChange.hasAttribute('open')) {
-                        dialogDynFiltersChange.showModal();
-
-                        $('.dialogDynFiltersChange-confirmbtn').click(function() {
-                            dialogDynFiltersChange.close();
-                        });
-                    }
+                    showDialogDynFiltersChange();
 
                 } else { // same value, return saved values
                     dynamicNotchWidthPercent_e.val(FILTER_CONFIG.dyn_notch_width_percent);

--- a/src/main.html
+++ b/src/main.html
@@ -413,6 +413,17 @@
         </div>
     </dialog>
 
+    <dialog class="dialogDynFiltersChange">
+        <h3 i18n="dialogDynFiltersChangeTitle"></h3>
+        <div class="content">
+            <div i18n="dialogDynFiltersChangeNote" style="margin-top: 10px"></div>
+
+        </div>
+        <div class="buttons">
+            <a href="#" class="dialogDynFiltersChange-confirmbtn regular-button" i18n="dialogDynFiltersConfirm"></a>
+        </div>
+    </dialog>
+
     <ul class="hidden"> <!-- Sonar says so -->
         <li id="dialogReportProblems-listItemTemplate" class="dialogReportProblems-listItem"></li>
     </ul>

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -774,4 +774,15 @@
             </div>
         </div>
     </div>
+
+    <dialog class="dialogDynFiltersChange">
+        <h3 i18n="dialogDynFiltersChangeTitle"></h3>
+        <div class="content">
+            <div i18n="dialogDynFiltersChangeNote" style="margin-top: 10px"></div>
+
+        </div>
+        <div class="buttons">
+            <a href="#" class="dialogDynFiltersChange-confirmbtn regular-button" i18n="dialogDynFiltersConfirm"></a>
+        </div>
+    </dialog>
 </div>

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -774,15 +774,4 @@
             </div>
         </div>
     </div>
-
-    <dialog class="dialogDynFiltersChange">
-        <h3 i18n="dialogDynFiltersChangeTitle"></h3>
-        <div class="content">
-            <div i18n="dialogDynFiltersChangeNote" style="margin-top: 10px"></div>
-
-        </div>
-        <div class="buttons">
-            <a href="#" class="dialogDynFiltersChange-confirmbtn regular-button" i18n="dialogDynFiltersConfirm"></a>
-        </div>
-    </dialog>
 </div>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1590,7 +1590,7 @@
             <a href="#" class="dialogCopyProfile-cancelbtn regular-button" i18n="dialogCopyProfileClose"></a>
         </div>
     </dialog>
-    
+
     <dialog class="dialogRatesType">
         <h3 i18n="dialogRatesTypeTitle"></h3>
         <div class="content">
@@ -1600,6 +1600,17 @@
         <div class="buttons">
             <a href="#" class="dialogRatesType-confirmbtn regular-button" i18n="dialogRatesTypeConfirm"></a>
             <a href="#" class="dialogRatesType-cancelbtn regular-button" i18n="cancel"></a>
+        </div>
+    </dialog>
+
+    <dialog class="dialogDynFiltersChange">
+        <h3 i18n="dialogDynFiltersChangeTitle"></h3>
+        <div class="content">
+            <div i18n="dialogDynFiltersChangeNote" style="margin-top: 10px"></div>
+
+        </div>
+        <div class="buttons">
+            <a href="#" class="dialogDynFiltersChange-confirmbtn regular-button" i18n="dialogDynFiltersConfirm"></a>
         </div>
     </dialog>
 </div>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1602,15 +1602,4 @@
             <a href="#" class="dialogRatesType-cancelbtn regular-button" i18n="cancel"></a>
         </div>
     </dialog>
-
-    <dialog class="dialogDynFiltersChange">
-        <h3 i18n="dialogDynFiltersChangeTitle"></h3>
-        <div class="content">
-            <div i18n="dialogDynFiltersChangeNote" style="margin-top: 10px"></div>
-
-        </div>
-        <div class="buttons">
-            <a href="#" class="dialogDynFiltersChange-confirmbtn regular-button" i18n="dialogDynFiltersConfirm"></a>
-        </div>
-    </dialog>
 </div>


### PR DESCRIPTION
Change the dynamic notch q and width to different defaults when enabling/disabling the rpm filtering based on bidirectional dshot.
The default values are only applied if the rpm state change from the saved one, and shows a little warning, otherwise the saved values are retained.
