### PR TITLE
Added warning when connecting to firmware newer than configurator.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -236,7 +236,10 @@
         "message": "Show update notifications for unstable versions of the configurator"
     },
     "configuratorUpdateNotice": {
-        "message": "You are using an outdated version of the <b>Betaflight Configurator</b>.<br>Version <b>$1</b> is available online, please visit <a href=\"$2\" target=\"_blank\">the release page</a> to download and install the latest version with fixes and improvements.<br>Please close the configurator window before updating."
+        "message": "You are using an outdated version of the <b>Betaflight Configurator</b>.<br>$t(configuratorUpdateHelp.message)"
+    },
+    "configuratorUpdateHelp": {
+        "message": "Using a newer version of the firmware with an outdated version of Configurator means that changing some settings will result in a <strong>corrupted firmware configuration and a non-working craft</strong>. Furthermore, some features of the firmware will only be configurable in CLI.<br><strong>Betaflight Configurator version <b>$1</b> is available for download online</strong>, please visit <a href=\"$2\" target=\"_blank\" rel=\"noopener noreferrer\">this page</a> to download and install the latest version with fixes and improvements.<br>Please close the configurator window before updating."
     },
     "configuratorUpdateWebsite": {
         "message": "Go to Release Website"
@@ -506,11 +509,14 @@
     "reportProblemsDialogFooter": {
         "message": "Please <strong>fix these problems before attempting to fly your craft</strong>."
     },
-    "reportProblemsDialogACC_NEEDS_CALIBRATION": {
-        "message": "<strong>the accelerometer is enabled but it is not calibrated</strong>. If you plan to use the accelerometer, please follow the instructions for '$t(initialSetupButtonCalibrateAccel.message)' on the '$t(tabSetup.message)' tab. If any function that requires the accelerometer (auto level modes, GPS rescue, ...) is enabled, arming of the craft will be disabled until the accelerometer has been calibrated. If you are not planning on using the accelerometer it is recommended that you disable it in '$t(configurationSystem.message)' on the '$t(tabConfiguration.message)' tab."
+    "reportProblemsDialogAPI_VERSION_MAX_SUPPORTED": {
+        "message": "<strong>the version of configurator that you are using ($3) is older than the firmware you are using ($4)</strong>.<br>$t(configuratorUpdateHelp.message)"
     },
     "reportProblemsDialogMOTOR_PROTOCOL_DISABLED": {
-        "message": "<strong>there is no motor output protocol selected</strong>. Please select a motor output protocol appropriate for your ESCs in '$t(configurationEscFeatures.message)' on the '$t(tabConfiguration.message)' tab. $t(escProtocolDisabledMessage.message)"
+        "message": "<strong>there is no motor output protocol selected</strong>.<br>Please select a motor output protocol appropriate for your ESCs in '$t(configurationEscFeatures.message)' on the '$t(tabConfiguration.message)' tab.<br>$t(escProtocolDisabledMessage.message)"
+    },
+    "reportProblemsDialogACC_NEEDS_CALIBRATION": {
+        "message": "<strong>the accelerometer is enabled but it is not calibrated</strong>.<br>If you plan to use the accelerometer, please follow the instructions for '$t(initialSetupButtonCalibrateAccel.message)' on the '$t(tabSetup.message)' tab. If any function that requires the accelerometer (auto level modes, GPS rescue, ...) is enabled, arming of the craft will be disabled until the accelerometer has been calibrated.<br>If you are not planning on using the accelerometer it is recommended that you disable it in '$t(configurationSystem.message)' on the '$t(tabConfiguration.message)' tab."
     },
 
     "infoVersions": {
@@ -645,16 +651,16 @@
         "message": "Hardware"
     },
     "defaultWelcomeText": {
-        "message": "The application supports all hardware that can run Betaflight. Check flash tab for full list of hardware.<br /><br /> <a href=\"https://github.com/betaflight/blackbox-log-viewer/releases\" target=\"_blank\">Download Betaflight Blackbox Log Viewer</a><br /><br />The firmware source code can be downloaded from <a href=\"https://github.com/betaflight/betaflight\" target=\"_blank\">here</a><br /><br />The latest <b>STM USB VCP Drivers</b> can be downloaded from <a href=\"http://www.st.com/web/en/catalog/tools/PF257938\" target=\"_blank\">here</a><br />For legacy hardware using a CP210x USB to serial chip:<br />The latest <b>CP210x Drivers</b> can be downloaded from <a href=\"https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers\" target=\"_blank\">here</a><br />The latest <b>Zadig</b> for Windows USB driver installation can be downloaded from <a href=\"http://zadig.akeo.ie/\" target=\"_blank\">here</a><br />"
+        "message": "The application supports all hardware that can run Betaflight. Check flash tab for full list of hardware.<br /><br /> <a href=\"https://github.com/betaflight/blackbox-log-viewer/releases\" target=\"_blank\" rel=\"noopener noreferrer\">Download Betaflight Blackbox Log Viewer</a><br /><br />The firmware source code can be downloaded from <a href=\"https://github.com/betaflight/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">here</a><br /><br />The latest <b>STM USB VCP Drivers</b> can be downloaded from <a href=\"http://www.st.com/web/en/catalog/tools/PF257938\" target=\"_blank\" rel=\"noopener noreferrer\">here</a><br />For legacy hardware using a CP210x USB to serial chip:<br />The latest <b>CP210x Drivers</b> can be downloaded from <a href=\"https://www.silabs.com/products/development-tools/software/usb-to-uart-bridge-vcp-drivers\" target=\"_blank\" rel=\"noopener noreferrer\">here</a><br />The latest <b>Zadig</b> for Windows USB driver installation can be downloaded from <a href=\"http://zadig.akeo.ie/\" target=\"_blank\" rel=\"noopener noreferrer\">here</a><br />"
     },
     "defaultContributingHead": {
         "message": "Contributing"
     },
     "defaultContributingText": {
-        "message": "If you would like to help make Betaflight even better you can help in many ways, including:<br /><ul><li>Answering other users questions on the forums and IRC.</li><li>Contributing code to the firmware and configurator - new features, fixes, improvements</li><li>Testing <a href=\"https://github.com/Betaflight/betaflight/pulls\" target=\"_blank\">new features/fixes</a> and providing feedback.</li><li>Helping out with <a href=\"https://github.com/betaflight/betaflight/issues\" target=\"_blank\">issues and commenting on feature requests</a>.</li><li>Collaborate by <a href=\"https://crowdin.com/project/betaflight-configurator\" target=\"_blank\">translating the configurator application</a> into your language.</li></ul>"
+        "message": "If you would like to help make Betaflight even better you can help in many ways, including:<br /><ul><li>Answering other users questions on the forums and IRC.</li><li>Contributing code to the firmware and configurator - new features, fixes, improvements</li><li>Testing <a href=\"https://github.com/Betaflight/betaflight/pulls\" target=\"_blank\" rel=\"noopener noreferrer\">new features/fixes</a> and providing feedback.</li><li>Helping out with <a href=\"https://github.com/betaflight/betaflight/issues\" target=\"_blank\" rel=\"noopener noreferrer\">issues and commenting on feature requests</a>.</li><li>Collaborate by <a href=\"https://crowdin.com/project/betaflight-configurator\" target=\"_blank\" rel=\"noopener noreferrer\">translating the configurator application</a> into your language.</li></ul>"
     },
     "defaultFacebookText": {
-        "message": "We also have a <a href=\"https://www.facebook.com/groups/betaflightgroup/\" target=\"_blank\">Facebook Group</a>.<br />Join us to get a place to talk about Betaflight, ask configuration questions, or just hang out with fellow pilots."
+        "message": "We also have a <a href=\"https://www.facebook.com/groups/betaflightgroup/\" target=\"_blank\" rel=\"noopener noreferrer\">Facebook Group</a>.<br />Join us to get a place to talk about Betaflight, ask configuration questions, or just hang out with fellow pilots."
     },
     "defaultChangelogHead": {
         "message": "Configurator - Changelog"
@@ -672,7 +678,7 @@
         "message": "<p>If you want to contribute financially on an ongoing basis, you should consider becoming a patron for us on $t(patreonLink.message).</p>"
     },
     "patreonLink": {
-        "message": "<a href=\"https://www.patreon.com/betaflight\" target=\"_blank\">Patreon</a>",
+        "message": "<a href=\"https://www.patreon.com/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">Patreon</a>",
         "description": "Patreon is name, and should not require translation"
     },
     "defaultDonate": {
@@ -688,10 +694,10 @@
         "message": "Betaflight documentation is available in release notes and wiki.<br /><br />"
     },
     "defaultDocumentation1": {
-        "message": "The Betaflight wiki is a great resource for information, it can be found <a href=\"https://github.com/betaflight/betaflight/wiki\" target=\"_blank\">here</a>."
+        "message": "The Betaflight wiki is a great resource for information, it can be found <a href=\"https://github.com/betaflight/betaflight/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">here</a>."
     },
     "defaultDocumentation2": {
-        "message": "The release notes for the firmware can be read at GitHub releases page, <a href=\"https://github.com/Betaflight/Betaflight/releases\" target=\"_blank\">here</a>."
+        "message": "The release notes for the firmware can be read at GitHub releases page, <a href=\"https://github.com/Betaflight/Betaflight/releases\" target=\"_blank\" rel=\"noopener noreferrer\">here</a>."
     },
     "defaultSupportHead": {
         "message": "Support"
@@ -706,19 +712,19 @@
         "message": "For support please search the forums and wiki first or contact your vendor.<br /><br />"
     },
     "defaultSupport1": {
-        "message": "<a href=\"http://www.rcgroups.com/forums/showthread.php?t=2464844&page=1\" target=\"_blank\">RC Groups thread</a>"
+        "message": "<a href=\"http://www.rcgroups.com/forums/showthread.php?t=2464844&page=1\" target=\"_blank\" rel=\"noopener noreferrer\">RC Groups thread</a>"
     },
     "defaultSupport2": {
-        "message": "<a href=\"http://betaflight.info\" target=\"_blank\">Betaflight Wiki</a>"
+        "message": "<a href=\"http://betaflight.info\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight Wiki</a>"
     },
     "defaultSupport3": {
-        "message": "<a href=\"https://www.youtube.com/playlist?list=PLwoDb7WF6c8kdK6yHr7vhsU9iRTr5HxP4\" target=\"_blank\">Joshua Bardwell Betaflight Videos</a>"
+        "message": "<a href=\"https://www.youtube.com/playlist?list=PLwoDb7WF6c8kdK6yHr7vhsU9iRTr5HxP4\" target=\"_blank\" rel=\"noopener noreferrer\">Joshua Bardwell Betaflight Videos</a>"
     },
     "defaultSupport4": {
-        "message": "<a href=\"https://github.com/Betaflight\" target=\"_blank\">GitHub</a>"
+        "message": "<a href=\"https://github.com/Betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub</a>"
     },
     "defaultSupport5": {
-        "message": "<a href=\"https://slack.betaflight.com\" target=\"_blank\">Betaflight devs on slack</a>"
+        "message": "<a href=\"https://slack.betaflight.com\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight devs on slack</a>"
     },
 
     "initialSetupBackupAndRestoreApiVersion": {
@@ -2243,16 +2249,16 @@
         "message": "Hexadecimal digits only, 0-9, A-F"
     },
     "transponderHelp1": {
-        "message": "Configure your transponder code here.  Note: Only valid codes will be recognised by race timing systems.  Valid transponder codes can be obtained from <a href=\"http://seriouslypro.com/transponder-codes\" target=\"_blank\">Seriously Pro</a>."
+        "message": "Configure your transponder code here.  Note: Only valid codes will be recognised by race timing systems.  Valid transponder codes can be obtained from <a href=\"http://seriouslypro.com/transponder-codes\" target=\"_blank\" rel=\"noopener noreferrer\">Seriously Pro</a>."
     },
     "transponderHelp2": {
-        "message": "For more information please visit <a href=\"http://www.arcitimer.com/\" title=\"aRCiTimer\" target=\"_blank\">aRCiTimer site</a>"
+        "message": "For more information please visit <a href=\"http://www.arcitimer.com/\" title=\"aRCiTimer\" target=\"_blank\" rel=\"noopener noreferrer\">aRCiTimer site</a>"
     },
     "transponderDataHelp3": {
         "message": "Choose ERLT ID 0-63"
     },
     "transponderHelp3": {
-        "message": "For more information please visit <a href=\"https://github.com/polyvision/EasyRaceLapTimer\" title=\"aRCiTimer\" target=\"_blank\">EasyRaceLapTimer site</a>"
+        "message": "For more information please visit <a href=\"https://github.com/polyvision/EasyRaceLapTimer\" title=\"aRCiTimer\" target=\"_blank\" rel=\"noopener noreferrer\">EasyRaceLapTimer site</a>"
     },
     "transponderButtonSave": {
         "message": "Save"
@@ -2894,7 +2900,7 @@
         "message": "<strong>Recovery / Lost communication</strong>"
     },
     "firmwareFlasherRecoveryText": {
-        "message": "If you have lost communication with your board follow these steps to restore communication: <ul><li>Power off</li><li>Enable 'No reboot sequence', enable 'Full chip erase'.</li><li>Jumper the BOOT pins or hold BOOT button.</li><li>Power on (activity LED will NOT flash if done correctly).</li><li>Install all STM32 drivers and Zadig if required (see <a href=\"https://github.com/betaflight/betaflight/wiki/Installing-Betaflight\"target=\"_blank\">USB Flashing</a> section of Betaflight manual).</li><li>Close configurator, Close all running chrome instances, Close all Chrome apps, Restart Configurator.</li><li>Release BOOT button if your FC has one.</li><li>Flash with correct firmware (using manual baud rate if specified in your FC's manual).</li><li>Power off.</li><li>Remove BOOT jumper.</li><li>Power on (activity LED should flash).</li><li>Connect normally.</li></ul>"
+        "message": "If you have lost communication with your board follow these steps to restore communication: <ul><li>Power off</li><li>Enable 'No reboot sequence', enable 'Full chip erase'.</li><li>Jumper the BOOT pins or hold BOOT button.</li><li>Power on (activity LED will NOT flash if done correctly).</li><li>Install all STM32 drivers and Zadig if required (see <a href=\"https://github.com/betaflight/betaflight/wiki/Installing-Betaflight\"target=\"_blank\" rel=\"noopener noreferrer\">USB Flashing</a> section of Betaflight manual).</li><li>Close configurator, Close all running chrome instances, Close all Chrome apps, Restart Configurator.</li><li>Release BOOT button if your FC has one.</li><li>Flash with correct firmware (using manual baud rate if specified in your FC's manual).</li><li>Power off.</li><li>Remove BOOT jumper.</li><li>Power on (activity LED should flash).</li><li>Connect normally.</li></ul>"
     },
     "firmwareFlasherButtonLeave": {
         "message": "Leave Firmware Flasher"
@@ -3657,7 +3663,7 @@
         "message": "Dynamic Idle Value [rpm]"
     },
     "pidTuningIdleMinRpmHelp": {
-        "message": "Set this parameter to provide an rpm based floor-value as a safety net against motor desync.<br>A racer might prefer very good response and low rates - therefore a low Dynamic Idle[rpm] and a high Dshot Idle value may be useful. Freestylers and LOS pilots will appreciate very low thrust at idle and might want to use less Dshot Idle value while using a bit more Dynamic Idle[rpm] to avoid desyncs at high rates. Note that the Dynamic Idle[rpm] value always must be less than Dshot Idle value.<br><br>Visit this <a href=\"https://github.com/betaflight/betaflight/wiki/Tuning-Dynamic-Idle\"target=\"_blank\">wiki</a> entry for more info."
+        "message": "Set this parameter to provide an rpm based floor-value as a safety net against motor desync.<br>A racer might prefer very good response and low rates - therefore a low Dynamic Idle[rpm] and a high Dshot Idle value may be useful. Freestylers and LOS pilots will appreciate very low thrust at idle and might want to use less Dshot Idle value while using a bit more Dynamic Idle[rpm] to avoid desyncs at high rates. Note that the Dynamic Idle[rpm] value always must be less than Dshot Idle value.<br><br>Visit this <a href=\"https://github.com/betaflight/betaflight/wiki/Tuning-Dynamic-Idle\"target=\"_blank\" rel=\"noopener noreferrer\">wiki</a> entry for more info."
     },
     "pidTuningAcroTrainerAngleLimit": {
         "message": "Acro Trainer Angle Limit"
@@ -3669,7 +3675,7 @@
         "message": "Integrated Yaw"
     },
     "pidTuningIntegratedYawCaution": {
-        "message": "<span class=\"message-negative\">CAUTION</span>: if you enable this feature, you must adjust the YAW PID accordingly. More info <a href=\"https://github.com/betaflight/betaflight/wiki/Integrated-Yaw\" target=\"_blank\">here</a>"
+        "message": "<span class=\"message-negative\">CAUTION</span>: if you enable this feature, you must adjust the YAW PID accordingly. More info <a href=\"https://github.com/betaflight/betaflight/wiki/Integrated-Yaw\" target=\"_blank\" rel=\"noopener noreferrer\">here</a>"
     },
     "pidTuningIntegratedYawHelp": {
         "message": "Integrated Yaw is a feature which corrects a fundamental issue with quad control: while the pitch and roll axis are controlled by the thrust differentials the props generate yaw is different. Integrated Yaw fixes this by integrating the output of the yaw pid before applying them to the mixer. This normalizes the way the pids work. You can now tune as any other axis. It requires use of absolute control since no I is needed with Integrated Yaw."
@@ -4113,7 +4119,7 @@
         "message": "Your flight controller isn't responding to OSD commands. This probably means that it does not have an integrated BetaFlight OSD."
     },
     "osdSetupUnsupportedNote2": {
-        "message": "Note that some flight controllers have an onboard <a href=\"https://www.youtube.com/watch?v=ikKH_6SQ-Tk\" target=\"_blank\">MinimOSD</a> that can be flashed and configured with <a href=\"https://github.com/ShikOfTheRa/scarab-osd/releases/latest\" target='_blank'>scarab-osd</a>, however the MinimOSD cannot be configured through this interface."
+        "message": "Note that some flight controllers have an onboard <a href=\"https://www.youtube.com/watch?v=ikKH_6SQ-Tk\" target=\"_blank\" rel=\"noopener noreferrer\">MinimOSD</a> that can be flashed and configured with <a href=\"https://github.com/ShikOfTheRa/scarab-osd/releases/latest\" target='_blank'>scarab-osd</a>, however the MinimOSD cannot be configured through this interface."
     },
     "osdSetupProfilesTitle": {
         "message": "OSD Profile number",

--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -5,6 +5,7 @@
     --defaultText: #ffffff;
     --subtleText: #c0c0c0;
     --mutedText: #d6d6d6;
+    --linkText: #ffc549;
     --boxBackground: #3a3a3a;
     --alternativeBackground: #4e4e4e;
     --sideBackground: #404040;
@@ -21,10 +22,6 @@
 
 body {
     color: white;
-}
-
-a {
-    color: #ffc549;
 }
 
 #options-window {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -7,6 +7,7 @@
     --defaultText: #000000;
     --subtleText: #c0c0c0;
     --mutedText: #616161;
+    --linkText: #2e2ebb;
     --boxBackground: #ffffff;
     --alternativeBackground: #f9f9f9;
     --sideBackground: #ffffff;
@@ -41,7 +42,7 @@ body {
 
 a {
     text-decoration: none;
-    color: var(--defaultText);
+    color: var(--linkText);
     font-weight: bold;
 }
 

--- a/src/js/RateCurve.js
+++ b/src/js/RateCurve.js
@@ -157,7 +157,7 @@ RateCurve.prototype.rcCommandRawToDegreesPerSecond = function (rcData, rate, rcR
 
     if (rate !== undefined && rcRate !== undefined && rcExpo !== undefined) {
         let rcCommandf = this.rcCommand(rcData, 1, deadband);
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             rcCommandf = rcCommandf / (500 - deadband);
         } else {
             rcCommandf = rcCommandf / 500;

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -334,7 +334,7 @@ function configuration_restore(callback) {
 
 
                     // validate
-                    if (typeof configuration.generatedBy !== 'undefined' && compareVersions(configuration.generatedBy, CONFIGURATOR.backupFileMinVersionAccepted)) {
+                    if (typeof configuration.generatedBy !== 'undefined' && compareVersions(configuration.generatedBy, CONFIGURATOR.BACKUP_FILE_VERSION_MIN_SUPPORTED)) {
                         if (!compareVersions(configuration.generatedBy, "1.14.0") && !migrate(configuration)) {
                             GUI.log(i18n.getMessage('backupFileUnmigratable'));
                             return;

--- a/src/js/data_storage.js
+++ b/src/js/data_storage.js
@@ -1,15 +1,21 @@
 'use strict';
 
+const API_VERSION_1_43 = '1.43.0';
+
 var CONFIGURATOR = {
     // all versions are specified and compared using semantic versioning http://semver.org/
-    'apiVersionAccepted': '1.2.1',
-    'backupRestoreMinApiVersionAccepted': '1.5.0',
-    'pidControllerChangeMinApiVersion': '1.5.0',
-    'backupFileMinVersionAccepted': '0.55.0', // chrome.runtime.getManifest().version is stored as string, so does this one
-    
-    'connectionValid': false,
-    'connectionValidCliOnly': false,
-    'cliActive': false,
-    'cliValid': false,
-    'gitChangesetId': 'unknown'
+    API_VERSION_ACCEPTED: '1.2.1',
+    API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE: '1.5.0',
+    API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE: '1.5.0',
+    BACKUP_FILE_VERSION_MIN_SUPPORTED: '0.55.0', // chrome.runtime.getManifest().version is stored as string, so does this one
+    API_VERSION_MAX_SUPPORTED: API_VERSION_1_43,
+
+    connectionValid: false,
+    connectionValidCliOnly: false,
+    cliActive: false,
+    cliValid: false,
+    gitChangesetId: 'unknown',
+    version: '0.0.1',
+    latestVersion: '0.0.1',
+    latestVersionReleaseUrl: 'https://github.com/betaflight/betaflight-configurator/releases',
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -573,12 +573,18 @@ function notifyOutdatedVersion(releaseData) {
             }
         });
 
-        if (versions.length > 0 && semver.lt(CONFIGURATOR.version, versions[0].tag_name)) {
-            GUI.log(i18n.getMessage('configuratorUpdateNotice', [versions[0].tag_name, versions[0].html_url]));
+        if (versions.length > 0) {
+            CONFIGURATOR.latestVersion = versions[0].tag_name;
+            CONFIGURATOR.latestVersionReleaseUrl = versions[0].html_url;
+        }
+
+        if (semver.lt(CONFIGURATOR.version, CONFIGURATOR.latestVersion)) {
+            const message = i18n.getMessage('configuratorUpdateNotice', [CONFIGURATOR.latestVersion, CONFIGURATOR.latestVersionReleaseUrl]);
+            GUI.log(message);
 
             const dialog = $('.dialogConfiguratorUpdate')[0];
 
-            $('.dialogConfiguratorUpdate-content').html(i18n.getMessage('configuratorUpdateNotice', [versions[0].tag_name, versions[0].html_url]));
+            $('.dialogConfiguratorUpdate-content').html(message);
 
             $('.dialogConfiguratorUpdate-closebtn').click(function() {
                 dialog.close();
@@ -587,7 +593,7 @@ function notifyOutdatedVersion(releaseData) {
             $('.dialogConfiguratorUpdate-websitebtn').click(function() {
                 dialog.close();
 
-                window.open(versions[0].html_url, '_blank');
+                window.open(CONFIGURATOR.latestVersionReleaseUrl, '_blank');
             });
 
             dialog.showModal();

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -357,7 +357,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     RC_tuning.pitch_rate_limit = data.readU16();
                     RC_tuning.yaw_rate_limit = data.readU16();
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                     RC_tuning.rates_type = data.readU8();
                 }
                 break;
@@ -428,7 +428,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     GPS_CONFIG.auto_config = data.readU8();
                     GPS_CONFIG.auto_baud = data.readU8();
 
-                    if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                    if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                         GPS_CONFIG.home_point_once = data.readU8();
                         GPS_CONFIG.ublox_use_galileo = data.readU8();
                     }
@@ -444,7 +444,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 GPS_RESCUE.throttleHover     = data.readU16();
                 GPS_RESCUE.sanityChecks      = data.readU8();
                 GPS_RESCUE.minSats           = data.readU8();
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                     GPS_RESCUE.ascendRate            = data.readU16();
                     GPS_RESCUE.descendRate           = data.readU16();
                     GPS_RESCUE.allowArmingWithoutFix = data.readU8();
@@ -809,7 +809,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     CONFIG.configurationState = data.readU8();
                 }
 
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                     CONFIG.sampleRateHz = data.readU16();
                     CONFIG.configurationProblems = data.readU32();
                 } else {
@@ -1085,7 +1085,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                 FILTER_CONFIG.gyro_rpm_notch_harmonics = data.readU8();
                                 FILTER_CONFIG.gyro_rpm_notch_min_hz = data.readU8();
                             }
-                            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                                 FILTER_CONFIG.dyn_notch_max_hz = data.readU16();
                             }
                         }
@@ -1150,7 +1150,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                         if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
                                             ADVANCED_TUNING.itermRelaxCutoff = data.readU8();
 
-                                            if(semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                                            if(semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                                                 ADVANCED_TUNING.motorOutputLimit = data.readU8();
                                                 ADVANCED_TUNING.autoProfileCellCount = data.readU8();
                                                 ADVANCED_TUNING.idleMinRpm = data.readU8();
@@ -1696,7 +1696,7 @@ MspHelper.prototype.crunch = function(code) {
                 buffer.push16(RC_tuning.pitch_rate_limit);
                 buffer.push16(RC_tuning.yaw_rate_limit);
             }
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 buffer.push8(RC_tuning.rates_type);
             }
             break;
@@ -1757,7 +1757,7 @@ MspHelper.prototype.crunch = function(code) {
                 buffer.push8(GPS_CONFIG.auto_config)
                     .push8(GPS_CONFIG.auto_baud);
 
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                     buffer.push8(GPS_CONFIG.home_point_once)
                           .push8(GPS_CONFIG.ublox_use_galileo);
                 }
@@ -1774,7 +1774,7 @@ MspHelper.prototype.crunch = function(code) {
                   .push8(GPS_RESCUE.sanityChecks)
                   .push8(GPS_RESCUE.minSats);
 
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                     buffer.push16(GPS_RESCUE.ascendRate)
                           .push16(GPS_RESCUE.descendRate)
                           .push8(GPS_RESCUE.allowArmingWithoutFix)
@@ -2026,7 +2026,7 @@ MspHelper.prototype.crunch = function(code) {
                           .push8(FILTER_CONFIG.gyro_rpm_notch_harmonics)
                           .push8(FILTER_CONFIG.gyro_rpm_notch_min_hz);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                     buffer.push16(FILTER_CONFIG.dyn_notch_max_hz);
                 }
             }
@@ -2088,7 +2088,7 @@ MspHelper.prototype.crunch = function(code) {
                                     if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
                                         buffer.push8(ADVANCED_TUNING.itermRelaxCutoff);
 
-                                        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                                        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                                             buffer.push8(ADVANCED_TUNING.motorOutputLimit)
                                                   .push8(ADVANCED_TUNING.autoProfileCellCount)
                                                   .push8(ADVANCED_TUNING.idleMinRpm);
@@ -2765,12 +2765,12 @@ MspHelper.prototype.setArmingEnabled = function(doEnable, disableRunawayTakeoffP
 }
 
 MspHelper.prototype.loadSerialConfig = function(callback) {
-    const mspCode = semver.gte(CONFIG.apiVersion, "1.43.0") ? MSPCodes.MSP2_COMMON_SERIAL_CONFIG : MSPCodes.MSP_CF_SERIAL_CONFIG;
+    const mspCode = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) ? MSPCodes.MSP2_COMMON_SERIAL_CONFIG : MSPCodes.MSP_CF_SERIAL_CONFIG;
     MSP.send_message(mspCode, false, false, callback);
 };
 
 MspHelper.prototype.sendSerialConfig = function(callback) {
-    const mspCode = semver.gte(CONFIG.apiVersion, "1.43.0") ? MSPCodes.MSP2_COMMON_SET_SERIAL_CONFIG : MSPCodes.MSP_SET_CF_SERIAL_CONFIG;
+    const mspCode = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) ? MSPCodes.MSP2_COMMON_SET_SERIAL_CONFIG : MSPCodes.MSP_SET_CF_SERIAL_CONFIG;
     MSP.send_message(mspCode, mspHelper.crunch(mspCode), false, callback);
 };
 

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -641,7 +641,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
              $('div.gyroUse32kHz').hide();
 
-             if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+             if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                  updateGyroDenomReadOnly(CONFIG.sampleRateHz);
              } else {
                  updateGyroDenom(8);
@@ -656,7 +656,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             const originalPidDenom = pidSelectElement.val();
 
             let pidBaseFreq;
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 pidBaseFreq = CONFIG.sampleRateHz / 1000;
             } else {
                 pidBaseFreq = 8;
@@ -733,7 +733,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             i18n.getMessage('gpsSbasJapaneseMSAS'),
             i18n.getMessage('gpsSbasIndianGAGAN'),
         ];
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             gpsSbas.push(i18n.getMessage('gpsSbasNone'));
         }
 
@@ -747,7 +747,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         gps_protocol_e.change(function () {
             GPS_CONFIG.provider = parseInt($(this).val());
 
-            const enableGalileoVisible = semver.gte(CONFIG.apiVersion, "1.43.0") && GPS_CONFIG.provider === gpsProtocols.indexOf('UBLOX');
+            const enableGalileoVisible = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) && GPS_CONFIG.provider === gpsProtocols.indexOf('UBLOX');
             gps_ublox_galileo_e.toggle(enableGalileoVisible);
         });
         gps_protocol_e.val(GPS_CONFIG.provider).change();
@@ -756,7 +756,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             GPS_CONFIG.ublox_use_galileo = $(this).is(':checked') ? 1 : 0;
         }).prop('checked', GPS_CONFIG.ublox_use_galileo > 0).change();
 
-        $('.gps_home_once').toggle(semver.gte(CONFIG.apiVersion, "1.43.0"));
+        $('.gps_home_once').toggle(semver.gte(CONFIG.apiVersion, API_VERSION_1_43));
         $('input[name="gps_home_once"]').change(function() {
             GPS_CONFIG.home_point_once = $(this).is(':checked') ? 1 : 0;
         }).prop('checked', GPS_CONFIG.home_point_once > 0).change();
@@ -889,7 +889,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 );
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 spiRxTypes.push(
                     'REDPINE',
                 );

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -313,7 +313,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 $('input[name="gps_rescue_min_sats"]').val(GPS_RESCUE.minSats);
                 $('select[name="gps_rescue_sanity_checks"]').val(GPS_RESCUE.sanityChecks);
 
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                     $('input[name="gps_rescue_ascend_rate"]').val((GPS_RESCUE.ascendRate / 100).toFixed(2));
                     $('input[name="gps_rescue_descend_rate"]').val((GPS_RESCUE.descendRate / 100).toFixed(2));
                     $('input[name="gps_rescue_allow_arming_without_fix"]').prop('checked', GPS_RESCUE.allowArmingWithoutFix > 0);
@@ -379,7 +379,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 GPS_RESCUE.sanityChecks      = $('select[name="gps_rescue_sanity_checks"]').val();
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 GPS_RESCUE.ascendRate = $('input[name="gps_rescue_ascend_rate"]').val() * 100;
                 GPS_RESCUE.descendRate = $('input[name="gps_rescue_descend_rate"]').val() * 100;
                 GPS_RESCUE.allowArmingWithoutFix = $('input[name="gps_rescue_allow_arming_without_fix"]').prop('checked') ? 1 : 0;

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -195,7 +195,7 @@ TABS.onboard_logging.initialize = function (callback) {
         let loggingRates = [];
 
         let pidRate;
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             pidRate = CONFIG.sampleRateHz / PID_ADVANCED_CONFIG.pid_process_denom;
 
         } else {

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1536,7 +1536,7 @@ OSD.chooseFields = function () {
                                                     F.OSD_PROFILE_NAME,
                                                     F.RSSI_DBM_VALUE,
                                                 ]);
-                                                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                                                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                                                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                                         F.RC_CHANNELS,
                                                         F.CAMERA_FRAME,
@@ -1686,7 +1686,7 @@ OSD.chooseFields = function () {
             F.RSSI_DBM,
         ]);
     }
-    if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+    if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
             F.OVER_CAP,
         ]);
@@ -1819,7 +1819,7 @@ OSD.msp = {
                     result.push8(OSD.data.parameters.overlayRadioMode);
                 }
 
-                if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                     result.push8(OSD.data.parameters.cameraFrameWidth);
                     result.push8(OSD.data.parameters.cameraFrameHeight);
                 }
@@ -1882,7 +1882,7 @@ OSD.msp = {
         d.state = {};
         d.state.haveSomeOsd = (d.flags != 0)
         d.state.haveMax7456Video = bit_check(d.flags, 4) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
-        d.state.isMax7456Detected = bit_check(d.flags, 5) || (d.state.haveMax7456Video && semver.lt(CONFIG.apiVersion, "1.43.0"));
+        d.state.isMax7456Detected = bit_check(d.flags, 5) || (d.state.haveMax7456Video && semver.lt(CONFIG.apiVersion, API_VERSION_1_43));
         d.state.haveOsdFeature = bit_check(d.flags, 0) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
         d.state.isOsdSlave = bit_check(d.flags, 1) && semver.gte(CONFIG.apiVersion, "1.34.0");
 
@@ -2004,7 +2004,7 @@ OSD.msp = {
         }
 
         // Camera frame size
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             d.parameters.cameraFrameWidth = view.readU8();
             d.parameters.cameraFrameHeight = view.readU8();
         }

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -37,7 +37,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
     // requesting MSP_STATUS manually because it contains CONFIG.profile
     MSP.promise(MSPCodes.MSP_STATUS).then(function() {
-        if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.pidControllerChangeMinApiVersion)) {
+        if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE)) {
             return MSP.promise(MSPCodes.MSP_PID_CONTROLLER);
         }
     }).then(function() {
@@ -181,7 +181,7 @@ TABS.pid_tuning.initialize = function (callback) {
             antiGravitySwitch.change(function() {
                 var checked = $(this).is(':checked');
                 if (checked) {
-                    const MAX_ACCELERATOR_GAIN = semver.gte(CONFIG.apiVersion, "1.43.0") ? 3.5 : 1.1;
+                    const MAX_ACCELERATOR_GAIN = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) ? 3.5 : 1.1;
                     const itermAcceleratorGain = Math.max(ADVANCED_TUNING.itermAcceleratorGain / 1000, MAX_ACCELERATOR_GAIN);
                     $('.antigravity input[name="itermAcceleratorGain"]').val(itermAcceleratorGain);
                     $('.antigravity .suboption').show();
@@ -245,7 +245,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('select[id="itermrelaxType"]').val(ADVANCED_TUNING.itermRelaxType);
             $('input[name="itermRelaxCutoff"]').val(ADVANCED_TUNING.itermRelaxCutoff);
 
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 $('.itermrelax input[name="itermRelaxCutoff"]').attr("max","50");
             }
 
@@ -364,12 +364,12 @@ TABS.pid_tuning.initialize = function (callback) {
             } else {
                 $('.dynamicNotch').hide();
             }
-            $('.dynamicNotchRange').toggle(semver.lt(CONFIG.apiVersion, "1.43.0"));
+            $('.dynamicNotchRange').toggle(semver.lt(CONFIG.apiVersion, API_VERSION_1_43));
             $('.pid_filter select[name="dynamicNotchRange"]').val(FILTER_CONFIG.dyn_notch_range);
             $('.pid_filter input[name="dynamicNotchWidthPercent"]').val(FILTER_CONFIG.dyn_notch_width_percent);
             $('.pid_filter input[name="dynamicNotchQ"]').val(FILTER_CONFIG.dyn_notch_q);
             $('.pid_filter input[name="dynamicNotchMinHz"]').val(FILTER_CONFIG.dyn_notch_min_hz);
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 $('.pid_filter input[name="dynamicNotchMinHz"]').attr("max","250");
                 $('.pid_filter input[name="dynamicNotchMaxHz"]').val(FILTER_CONFIG.dyn_notch_max_hz);
             } else {
@@ -401,7 +401,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.rpmFilter').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             $('.pid_tuning input[name="motorLimit"]').val(ADVANCED_TUNING.motorOutputLimit);
             $('.pid_tuning input[name="cellCount"]').val(ADVANCED_TUNING.autoProfileCellCount);
             $('input[name="idleMinRpm-number"]').val(ADVANCED_TUNING.idleMinRpm);
@@ -410,7 +410,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.idleMinRpm').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             const ratesTypeListElement = $('select[id="ratesType"]'); // generates list
             const ratesList = [
                 {name: "Betaflight"},
@@ -714,7 +714,7 @@ TABS.pid_tuning.initialize = function (callback) {
         RC_tuning.rcPitchRate = parseFloat(rc_rate_pitch_e.val());
         RC_tuning.RC_PITCH_EXPO = parseFloat(rc_pitch_expo_e.val());
 
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             switch(self.currentRatesType) {
                 case self.RATES_TYPE.RACEFLIGHT:
                     RC_tuning.pitch_rate = parseFloat(pitch_rate_e.val()) / 100;
@@ -875,7 +875,7 @@ TABS.pid_tuning.initialize = function (callback) {
             FILTER_CONFIG.gyro_rpm_notch_min_hz = parseInt($('.pid_filter input[name="rpmFilterMinHz"]').val());
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             FILTER_CONFIG.dyn_notch_max_hz = parseInt($('.pid_filter input[name="dynamicNotchMaxHz"]').val());
             ADVANCED_TUNING.motorOutputLimit = parseInt($('.pid_tuning input[name="motorLimit"]').val());
             ADVANCED_TUNING.autoProfileCellCount = parseInt($('.pid_tuning input[name="cellCount"]').val());
@@ -1051,7 +1051,7 @@ TABS.pid_tuning.initialize = function (callback) {
             self.currentRates.rc_expo_pitch = self.currentRates.rc_expo;
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             switch(RC_tuning.rates_type) {
                 case self.RATES_TYPE.RACEFLIGHT:
                     self.currentRates.roll_rate *= 100;
@@ -1351,12 +1351,12 @@ TABS.pid_tuning.initialize = function (callback) {
                 pidController_e.append('<option value="' + (i) + '">' + pidControllerList[i].name + '</option>');
             }
 
-            if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.pidControllerChangeMinApiVersion)) {
+            if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE)) {
                 pidController_e.val(PID.controller);
 
                 self.updatePidControllerParameters();
             } else {
-                GUI.log(i18n.getMessage('pidTuningUpgradeFirmwareToChangePidController', [CONFIG.apiVersion, CONFIGURATOR.pidControllerChangeMinApiVersion]));
+                GUI.log(i18n.getMessage('pidTuningUpgradeFirmwareToChangePidController', [CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE]));
 
                 pidController_e.empty();
                 pidController_e.append('<option value="">Unknown</option>');
@@ -1449,7 +1449,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         self.currentRates.rc_pitch_expo = targetValue;
                     }
 
-                    if (targetElement.attr('id') === 'ratesType' && semver.gte(CONFIG.apiVersion, "1.43.0")) {
+                    if (targetElement.attr('id') === 'ratesType' && semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                         self.changeRatesType(targetValue);
 
                         updateNeeded = true;
@@ -1889,7 +1889,7 @@ TABS.pid_tuning.initialize = function (callback) {
             Promise.resolve(true)
             .then(function () {
                 var promise;
-                if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.pidControllerChangeMinApiVersion) && semver.lt(CONFIG.apiVersion, "1.31.0")) {
+                if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE) && semver.lt(CONFIG.apiVersion, "1.31.0")) {
                     PID.controller = pidController_e.val();
                     promise = MSP.promise(MSPCodes.MSP_SET_PID_CONTROLLER, mspHelper.crunch(MSPCodes.MSP_SET_PID_CONTROLLER));
                 }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -326,7 +326,7 @@ TABS.receiver.initialize = function (callback) {
         });
 
         let showBindButton = false;
-        if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
             showBindButton = bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.SUPPORTS_RX_BIND);
 
             $("a.bind").click(function() {
@@ -396,7 +396,7 @@ TABS.receiver.initialize = function (callback) {
             rcSmoothingnDerivativeNumberElement.val(RX_CONFIG.rcSmoothingDerivativeCutoff);
             var rc_smoothing_derivative_type = $('select[name="rcSmoothingDerivativeType-select"]');
 
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 rc_smoothing_derivative_type.append($(`<option value="3">${i18n.getMessage("receiverRcSmoothingDerivativeTypeAuto")}</option>`));
             }
 

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -29,11 +29,11 @@ TABS.setup.initialize = function (callback) {
         // translate to user-selected language
         i18n.localizePage();
 
-        if (semver.lt(CONFIG.apiVersion, CONFIGURATOR.backupRestoreMinApiVersionAccepted)) {
+        if (semver.lt(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE)) {
             $('#content .backup').addClass('disabled');
             $('#content .restore').addClass('disabled');
 
-            GUI.log(i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [CONFIG.apiVersion, CONFIGURATOR.backupRestoreMinApiVersionAccepted]));
+            GUI.log(i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE]));
         }
 
         // initialize 3D Model
@@ -239,7 +239,7 @@ TABS.setup.initialize = function (callback) {
                 disarmFlagElements = disarmFlagElements.concat(['REBOOT_REQD',
                                                                 'DSHOT_BBANG']);
             }
-            if (semver.gte(CONFIG.apiVersion, "1.43.0")) {
+            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                 disarmFlagElements = disarmFlagElements.concat(['NO_ACC_CAL', 'MOTOR_PROTO']);
             }
 


### PR DESCRIPTION
Adds a warning when connecting to firmware that is newer than the version released at the same time as the configurator version:

![image](https://user-images.githubusercontent.com/4742747/79035726-5d517b80-7c15-11ea-8394-2f2aaf0d2063.png)
(version numbers simulated)

The warning on configurator startup was also spiffed up:

![image](https://user-images.githubusercontent.com/4742747/79035601-478f8680-7c14-11ea-95a1-ac5028ef702d.png)

The colour of hyperlinks was changed to a saturated blue as well, as they are currently styled identically to `<strong>` text and impossible to recognise.
