### PR TITLE
Yaw Response slider to work like pitch and roll

### DIFF
--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -269,7 +269,7 @@ TuningSliders.calculateNewPids = function() {
     // ff
     ADVANCED_TUNING.feedforwardRoll = Math.round(this.PID_DEFAULT[4] * this.ResponseSliderValue);
     ADVANCED_TUNING.feedforwardPitch = Math.round(this.PID_DEFAULT[9] * this.ResponseSliderValue);
-    ADVANCED_TUNING.feedforwardYaw = Math.round(this.PID_DEFAULT[14] * ((this.ResponseSliderValue - 1) / 3 + 1));
+    ADVANCED_TUNING.feedforwardYaw = Math.round(this.PID_DEFAULT[14] * this.ResponseSliderValue);
 
     // master slider part
     // these are not calculated anywhere other than master slider multiplier therefore set at default before every calculation


### PR DESCRIPTION
This is a small change to the Yaw response slider to make it work better.

The original (4.1) implementation of the yaw response slider reduced its range compared to the other response sliders.

For example, the default FF for both Roll and Yaw is 90.  If we move the current Response slider hard right, in expert mode, FF on Roll becomes 180, but FF on yaw only 120.  If we move it hard left, FF on Roll becomes 45, but on Yaw stays quite high at 78.

I think this was originally done out of a feeling that yaw FF should not change so much as the others.  This doesn't seem to be necessary, and in fact seems to generate numbers that don't match the others very well.

Yaw often requires quite high FF, and certainly if someone wanted high FF on Pitch and Roll, usually about the same high number works well on Yaw.  

Likewise if someone cut FF hard, eg for HD use, they would also want to cut yaw FF as much, otherwise yaw may remain 'jumpy'.