### PR TITLE
Fix OSD tab save button behavior

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2799,11 +2799,11 @@ TABS.osd.initialize = function (callback) {
         $('a.save').click(function () {
             MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
             GUI.log(i18n.getMessage('osdSettingsSaved'));
-            var oldText = $(this).text();
+            const oldText = $(this).html();
             $(this).html(i18n.getMessage('osdButtonSaved'));
-            setTimeout(function () {
+            setTimeout(() => {
                 $(this).html(oldText);
-            }, 2000);
+            }, 1500);
 
             Object.keys(self.analyticsChanges).forEach(function (change) {
                 const value = self.analyticsChanges[change];


### PR DESCRIPTION
Original label on the save button in OSD tab wasn't restored after the timeout due to `this` has referenced the wrong element. Also set the same timeout millis as [on the CLI tab](https://github.com/betaflight/betaflight-configurator/blob/master/src/js/tabs/cli.js#L58) copy button (now both timeouts are 1500 millis).