### PR TITLE
PD Balance Slider now adjusts D, fixes yaw P issue, tooltip update

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3429,7 +3429,7 @@
         "description": "Master gain tuning slider helpicon message"
     },
     "pidTuningPDRatioSliderHelp":{
-        "message": "Lower PD balance will lower overall response but will also reduce a possibility of fast bounceback after a flip or roll.<br><br>Higher PD balance provides faster reponse and better propwash handling. However, if your PD balance is too high you will get oscillations after a flip or roll and extended oscillations during prop wash.",
+        "message": "Relatively high D will dampen stick responsiveness and may make motors hot, but should help control P oscillations and may improve propwash wobble.<br><br>Relatively low D gives quicker stick responsiveness but may weaken propwash handling.",
         "description": "PD balance tuning slider helpicon message"
     },
     "pidTuningPDGainSliderHelp":{
@@ -3437,7 +3437,7 @@
         "description": "P and D gain tuning slider helpicon message"
     },
     "pidTuningResponseSliderHelp":{
-        "message": "Lower values will worsen the stick response and may result in slow bounceback at the end of a flip or roll (I-term windup).<br><br>Higher value will have a better stick response for sharp moves. However, too high of values can cause overshoots and fast bounceback at the end of a flip or roll.",
+        "message": "Lower FF values will worsen the stick response and may result in slow bounceback at the end of a flip or roll (I-term windup).<br><br>Higher FF values will give snappier stick responses in sharp moves. Excessively high FF values can cause overshoots and fast bounceback at the end of a flip or roll.",
         "description": "Stick response gain tuning slider helpicon message"
     },
     "pidTuningGyroLowpassFiltersGroup": {

--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -47,9 +47,9 @@ TuningSliders.initialize = function() {
 TuningSliders.setDMinFeatureEnabled = function(dMinFeatureEnabled) {
     this.dMinFeatureEnabled = dMinFeatureEnabled;
     if (this.dMinFeatureEnabled) {
-        this.defaultPDRatio = this.PID_DEFAULT[0] / this.PID_DEFAULT[2];
+        this.defaultPDRatio = this.PID_DEFAULT[2] / this.PID_DEFAULT[0];
     } else {
-        this.defaultPDRatio = this.PID_DEFAULT[0] / (this.PID_DEFAULT[2] * 0.85);
+        this.defaultPDRatio = this.PID_DEFAULT[2] / (this.PID_DEFAULT[0] * 1.18);
     }
 };
 
@@ -84,11 +84,11 @@ TuningSliders.initPidSlidersPosition = function() {
     // used to estimate PID slider positions based on PIDF values, and set respective slider position
     // provides only an estimation due to limitation of feature without firmware support, to be improved in later versions
     this.MasterSliderValue = Math.round(PIDs[2][1] / this.PID_DEFAULT[11] * 10) / 10;
-    this.PDRatioSliderValue = Math.round(PIDs[0][0] / PIDs[0][2] / this.defaultPDRatio * 10) / 10;
+    this.PDRatioSliderValue = Math.round(PIDs[0][2] / PIDs[0][0] / this.defaultPDRatio * 10) / 10;
     if (this.dMinFeatureEnabled) {
-        this.PDGainSliderValue = Math.round(ADVANCED_TUNING.dMinRoll / this.MasterSliderValue / this.PID_DEFAULT[3] * 10) / 10;
+        this.PDGainSliderValue = Math.round(ADVANCED_TUNING.dMinRoll / this.PDRatioSliderValue / this.MasterSliderValue / this.PID_DEFAULT[3] * 10) / 10;
     } else {
-        this.PDGainSliderValue = Math.round(PIDs[0][2] / this.MasterSliderValue / (this.PID_DEFAULT[2] * 0.85) * 10) / 10;
+        this.PDGainSliderValue = Math.round(PIDs[0][0] / this.MasterSliderValue / (this.PID_DEFAULT[2] * 1.18) * 10) / 10;
     }
     this.ResponseSliderValue = Math.round(ADVANCED_TUNING.feedforwardRoll / this.MasterSliderValue / this.PID_DEFAULT[4] * 10) / 10;
 
@@ -250,22 +250,21 @@ TuningSliders.calculateNewPids = function() {
 
     if (this.dMinFeatureEnabled) {
         //dmin
-        ADVANCED_TUNING.dMinRoll = Math.round(this.PID_DEFAULT[3] * this.PDGainSliderValue);
-        ADVANCED_TUNING.dMinPitch = Math.round(this.PID_DEFAULT[8] * this.PDGainSliderValue);
+        ADVANCED_TUNING.dMinRoll = Math.round(this.PID_DEFAULT[3] * this.PDGainSliderValue * this.PDRatioSliderValue);
+        ADVANCED_TUNING.dMinPitch = Math.round(this.PID_DEFAULT[8] * this.PDGainSliderValue * this.PDRatioSliderValue);
         // dmax
-        PIDs[0][2] = Math.round(this.PID_DEFAULT[2] * this.PDGainSliderValue);
-        PIDs[1][2] = Math.round(this.PID_DEFAULT[7] * this.PDGainSliderValue);
+        PIDs[0][2] = Math.round(this.PID_DEFAULT[2] * this.PDGainSliderValue * this.PDRatioSliderValue);
+        PIDs[1][2] = Math.round(this.PID_DEFAULT[7] * this.PDGainSliderValue * this.PDRatioSliderValue);
     } else {
         ADVANCED_TUNING.dMinRoll = 0;
         ADVANCED_TUNING.dMinPitch = 0;
-        PIDs[0][2] = Math.round((this.PID_DEFAULT[2] * 0.85) * this.PDGainSliderValue);
-        PIDs[1][2] = Math.round((this.PID_DEFAULT[7] * 0.85) * this.PDGainSliderValue);
+        PIDs[0][2] = Math.round((this.PID_DEFAULT[2] * 0.85) * this.PDGainSliderValue * this.PDRatioSliderValue);
+        PIDs[1][2] = Math.round((this.PID_DEFAULT[7] * 0.85) * this.PDGainSliderValue * this.PDRatioSliderValue);
     }
-    PIDs[2][0] = Math.round(this.PID_DEFAULT[10] * this.PDGainSliderValue);
-
     // p
-    PIDs[0][0] = Math.round(PIDs[0][2] * this.defaultPDRatio * this.PDRatioSliderValue);
-    PIDs[1][0] = Math.round(PIDs[1][2] * this.defaultPDRatio * this.PDRatioSliderValue);
+    PIDs[0][0] = Math.round(this.PID_DEFAULT[0] * this.PDGainSliderValue);
+    PIDs[1][0] = Math.round(this.PID_DEFAULT[5] * this.PDGainSliderValue);
+    PIDs[2][0] = Math.round(this.PID_DEFAULT[10] * this.PDGainSliderValue);
     // ff
     ADVANCED_TUNING.feedforwardRoll = Math.round(this.PID_DEFAULT[4] * this.ResponseSliderValue);
     ADVANCED_TUNING.feedforwardPitch = Math.round(this.PID_DEFAULT[9] * this.ResponseSliderValue);


### PR DESCRIPTION
This PR changes the behaviour of the PD Balance slider, so that it changes D, not P.

This is quite a lot easier and more intuitive for the user.  

They can nowmore readily perform the classical tuning method of increasing P then adjusting D to help deal with excessive oscillation, or to tone down D readily for racing.

This PR also addresses an issue/bug affecting yaw P where the PD Balance slider would attenuate P on pitch and roll but not yaw, leading to imbalanced configurations.

The tooltip has also been improved to better reflect the purpose of the slider.