### PR TITLE
Update yaw P in configurator to 45

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -701,7 +701,7 @@ var FC = {
             versionPidDefaults = [
                 42, 85, 35, 23, 90,
                 46, 90, 38, 25, 95,
-                30, 90,  0,  0, 90,
+                45, 90,  0,  0, 90,
             ];
         }
         return versionPidDefaults;


### PR DESCRIPTION
Lots of people complained that yaw P was a bit too low by default in 4.1, and we had indeed dropped it from 70 to 30.

I have done a lot of testing and checking with a variety of users, 45 works OK without obvious oscillation on most setups that would otherwise use default PIDs.  Anything much higher tends to result in fine P oscillation, and noise, on yaw.

Matching change in Betaflight: [PR 9705](https://github.com/betaflight/betaflight/pull/9705).

Needs to have Yaw P calculated correctly, see [Config PR 1969](https://github.com/betaflight/betaflight-configurator/pull/1969).