### PR TITLE
Fix Motor Limit Tooltip Examples

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3333,7 +3333,7 @@
         "message": "Attenuation %"
     },
     "pidTuningMotorLimitHelp": {
-        "message": "Attenuates motor commands by the set percentage. Reduces ESC current and motor heat when using higher cell count batteries, e.g. to get a performance similar to a 4S battery on a 6S build, try 66%; for a 3S performance on a 4S build, try 75%."
+        "message": "Attenuates motor commands by the set percentage. Reduces ESC current and motor heat when using higher cell count batteries, e.g. to get a performance similar to a 4S battery from a 6S battery, try 66%; for a 3S performance on a 4S battery, try 75%.<br>Always make sure that all of your components can support the voltage of the battery you are using."
     },
     "pidTuningCellCount": {
         "message": "Cell Count"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3333,7 +3333,7 @@
         "message": "Attenuation %"
     },
     "pidTuningMotorLimitHelp": {
-        "message": "Attenuates motor commands by the set percentage. Reduces ESC current and motor heat when using higher cell count batteries, e.g. for similar performance from a 6S battery on a 4S build, try 66%; for a 4S battery on a 3S build, try 75%."
+        "message": "Attenuates motor commands by the set percentage. Reduces ESC current and motor heat when using higher cell count batteries, e.g. to get a performance similar to a 4S battery on a 6S build, try 66%; for a 3S performance on a 4S build, try 75%."
     },
     "pidTuningCellCount": {
         "message": "Cell Count"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3333,7 +3333,7 @@
         "message": "Attenuation %"
     },
     "pidTuningMotorLimitHelp": {
-        "message": "Attenuates motor commands by the set percentage. Reduces ESC current and motor heat when using higher cell count batteries, e.g. to get a performance similar to a 4S battery from a 6S battery, try 66%; for a 3S performance on a 4S battery, try 75%.<br>Always make sure that all of your components can support the voltage of the battery you are using."
+        "message": "Attenuates motor commands by the set percentage. Reduces ESC current and motor heat when using higher cell count batteries, e.g. When using a 6S battery on a craft that has motors, props and tuning designed for 4S, try setting the value at 66%; when using a 4S battery on a craft intended for 3S, try 75%.<br>Always make sure that all of your components can support the voltage of the battery you are using."
     },
     "pidTuningCellCount": {
         "message": "Cell Count"


### PR DESCRIPTION
Battery types were inverted on the example for the Motor Limit feature tooltip