### PR TITLE
Fixed closing of the problems dialog

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -165,6 +165,9 @@ function finishClose(finishedCallback) {
 
     GUI.connected_to = false;
     GUI.allowedTabs = GUI.defaultAllowedTabsWhenDisconnected.slice();
+    // close problems dialog
+    $('#dialogReportProblems-closebtn').click();
+
     // Reset various UI elements
     $('span.i2c-error').text(0);
     $('span.cycle-time').text(0);


### PR DESCRIPTION
Simple fix to close dialogReportProblems window when flight controller is disconected from usb, and also avoid reconection problems.