### PR TITLE
Fixed closing of the custom defaults dialog

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -156,6 +156,9 @@ function finishClose(finishedCallback) {
 
         connectedTime = undefined;
     }
+    // close reset to custom defaults dialog
+    $('#dialogResetToCustomDefaults-cancelbtn').click();
+
     analytics.resetFlightControllerData();
 
     serial.disconnect(onClosed);


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/1947
It forces closing of the Reset to custom defaults dialog when port is disconected.