### PR TITLE
missing tooltip added

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -967,12 +967,12 @@
         "message": "The accelerometer has not been calibrated and features are enabled that rely on it. Calibrate the accelerometer.",
         "description": "Message that pops up to describe the NO_ACC_CAL arming disable flag"
     },
-    "initialSetupArmingDisableFlagsTooltipARM_SWITCH": {
-        "message": "One of the others disarm flags is active when arming",
-        "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"
-    },
     "initialSetupArmingDisableFlagsTooltipMOTOR_PROTO": {
         "message": "There is no motor output protocol selected",
+        "description": "Message that pops up to describe the MOTOR_PROTO arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipARM_SWITCH": {
+        "message": "One of the others disarm flags is active when arming",
         "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"
     },
     "initialSetupGPSHead": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -971,6 +971,10 @@
         "message": "One of the others disarm flags is active when arming",
         "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"
     },
+    "initialSetupArmingDisableFlagsTooltipMOTOR_PROTO": {
+        "message": "There is no motor output protocol selected",
+        "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"
+    },
     "initialSetupGPSHead": {
         "message": "GPS"
     },


### PR DESCRIPTION
fixed the missing tooltip for Arming disable flag `MOTOR_PROTO`

![no_tooltip](https://user-images.githubusercontent.com/29702171/80604326-dfbda600-8a31-11ea-99d0-3b2624204f3d.jpg)
