### PR TITLE
Fixed closing development firmware warning

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -170,6 +170,9 @@ PortHandler.check_usb_devices = function (callback) {
         if (!$('option:selected', portPickerElement).data().isDFU) {
             portPickerElement.trigger('change');
         }
+        if ($('option:selected', portPickerElement).data().isManual) {
+            $('#dialogUnstableFirmwareAcknoledgement')[0].close();
+        }
     });
 };
 


### PR DESCRIPTION
Added check in port handler to force closing development firmware warning dialog when port is disconected