### PR TITLE
Fixed Anti Gravity Gain value

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -181,9 +181,13 @@ TABS.pid_tuning.initialize = function (callback) {
             antiGravitySwitch.change(function() {
                 var checked = $(this).is(':checked');
                 if (checked) {
-                    const MAX_ACCELERATOR_GAIN = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) ? 3.5 : 1.1;
-                    const itermAcceleratorGain = Math.max(ADVANCED_TUNING.itermAcceleratorGain / 1000, MAX_ACCELERATOR_GAIN);
-                    $('.antigravity input[name="itermAcceleratorGain"]').val(itermAcceleratorGain);
+                    if (ADVANCED_TUNING.itermAcceleratorGain === 1000) {
+                        const DEFAULT_ACCELERATOR_GAIN = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) ? 3.5 : 1.1;
+                        $('.antigravity input[name="itermAcceleratorGain"]').val(DEFAULT_ACCELERATOR_GAIN);
+                    } else {
+                        const itermAcceleratorGain = (ADVANCED_TUNING.itermAcceleratorGain / 1000);
+                        $('.antigravity input[name="itermAcceleratorGain"]').val(itermAcceleratorGain);
+                    }
                     $('.antigravity .suboption').show();
                     if (ADVANCED_TUNING.antiGravityMode == 0) {
                         $('.antigravity .antiGravityThres').hide();


### PR DESCRIPTION
Fixes #2007 
Kudos to @selimmch for finding it
This is a bug in the code presented since this feature was added, also before, if you unchek antigravity without saving,you lost you configured value. Now we can note this bug when we aplies new 3.5 default value recently, before, we had 1.1,the limit to enable disable this feature.