### PR TITLE
Hide GPS elements if not selected AUTO

### DIFF
--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -582,7 +582,7 @@
                                             <span class="freelabel" i18n="configurationGPSHomeOnce" />
                                             <div class="helpicon cf_tip" i18n_title="configurationGPSHomeOnceHelp"></div>
                                         </div>
-                                        <div class="select line">
+                                        <div class="select line gps_ubx_sbas">
                                             <select class="gps_ubx_sbas">
                                                 <!-- list generated here -->
                                             </select>


### PR DESCRIPTION
It seems some users are having doubts about some parameters when they configure the GPS manually (disabling the AUTO option).

This PR hides the elements that depends on the AUTO switch when not selected, and refactors a little the code. I didn't wanted to refactor it more to try to not introduce new bugs.