### PR TITLE
Change magyar (Hungarian) to uppercase

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -28,7 +28,7 @@
             <li>Euskera (Basque)</li>
             <li>Portugu&ecirc;s Brasileiro (Brasilian Portugese)</li>
             <li>polski (Polish)</li>
-            <li>magyar (Hungarian)</li>
+            <li>Magyar (Hungarian)</li>
             <li>&#32321;&#39636;&#20013;&#25991; (Traditional Chinese)</li>
         </ul>
     </li>

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -138,7 +138,7 @@
         "description": "Don't translate!!!"
     },
     "language_hu": {
-        "message": "magyar",
+        "message": "Magyar",
         "description": "Don't translate!!!"
     },
     "language_id": {


### PR DESCRIPTION
As requested by the Hungarian proofreader.