### PR TITLE
Fix superexpoRates typo on pidtuning tab

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -994,7 +994,7 @@ TABS.pid_tuning.initialize = function (callback) {
         FEATURE_CONFIG.features.generateElements($('.tab-pid_tuning .features'));
 
         if (semver.lt(CONFIG.apiVersion, "1.16.0") || semver.gte(CONFIG.apiVersion, "1.20.0")) {
-            $('.tab-pid_tuning .pidTuningSuperexpoRate').hide();
+            $('.tab-pid_tuning .pidTuningSuperexpoRates').hide();
         }
 
         if (semver.lt(CONFIG.apiVersion, "1.39.0")) {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/43983086/83753478-a8629a80-a66a-11ea-8438-689b6a420edb.png)
