### PR TITLE
Fixed auto_profile_cellcount negative value reads

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1147,7 +1147,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
                                             if(semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
                                                 ADVANCED_TUNING.motorOutputLimit = data.readU8();
-                                                ADVANCED_TUNING.autoProfileCellCount = data.readU8();
+                                                ADVANCED_TUNING.autoProfileCellCount = data.read8();
                                                 ADVANCED_TUNING.idleMinRpm = data.readU8();
                                             }
                                         }


### PR DESCRIPTION
Fixed wrong negative value reads of `auto_profile_cellcount` caused by wrong data type on MspHelper.