### PR TITLE
Auto adjust sensor texts size in header

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -419,6 +419,11 @@ input[type="number"]::-webkit-inner-spin-button {
     color: #818181;
 }
 
+#sensor-status div {
+    white-space: nowrap;
+    overflow: hidden;    
+}
+
 .gyroicon {
     background-image: url(../images/icons/sensor_gyro_off.png);
     background-size: 43px;


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/2065

The elements of the Configurator not always adjust to the size of translations. This is specially a problem in very short strings, like the sensors header. This tries to fix that making it resize using a SVG. This is the result:

![image](https://user-images.githubusercontent.com/2673520/84787343-2a00e380-afee-11ea-8ad5-de5f89d7a94b.png)

![image](https://user-images.githubusercontent.com/2673520/84787304-1d7c8b00-afee-11ea-84ec-3f1d506fa66a.png)
