### PR TITLE
Change self-closing <div>, <span> and <p> tags

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2332,7 +2332,7 @@ TABS.osd.initialize = function (callback) {
                             $('.timers-container').show();
                             var $timers = $('#timer-fields').empty();
                             for (let tim of OSD.data.timers) {
-                                var $timerConfig = $('<div class="switchable-field field-' + tim.index + '"/>');
+                                var $timerConfig = $('<div class="switchable-field field-' + tim.index + '"></div>');
                                 var timerTable = $('<table />');
                                 $timerConfig.append(timerTable);
                                 var timerTableRow = $('<tr />');
@@ -2414,7 +2414,7 @@ TABS.osd.initialize = function (callback) {
                             for (let field of OSD.data.stat_items) {
                                 if (!field.name) { continue; }
 
-                                var $field = $('<div class="switchable-field field-' + field.index + '"/>');
+                                var $field = $('<div class="switchable-field field-' + field.index + '"></div>');
                                 var desc = null;
                                 if (field.desc && field.desc.length) {
                                     desc = i18n.getMessage(field.desc);
@@ -2457,7 +2457,7 @@ TABS.osd.initialize = function (callback) {
                             for (let field of OSD.data.warnings) {
                                 if (!field.name) { continue; }
 
-                                var $field = $('<div class="switchable-field field-' + field.index + '"/>');
+                                var $field = $('<div class="switchable-field field-' + field.index + '"></div>');
                                 var desc = null;
                                 if (field.desc && field.desc.length) {
                                     desc = i18n.getMessage(field.desc);
@@ -2573,7 +2573,7 @@ TABS.osd.initialize = function (callback) {
 
                         if (field.isVisible[OSD.getCurrentPreviewProfile()]) { enabledCount++; }
 
-                        var $field = $('<div class="switchable-field field-' + field.index + '"/>');
+                        var $field = $('<div class="switchable-field field-' + field.index + '"></div>');
                         var desc = null;
                         if (field.desc && field.desc.length) {
                             desc = i18n.getMessage(field.desc);
@@ -2731,7 +2731,7 @@ TABS.osd.initialize = function (callback) {
 
                     // render
                     var $preview = $('.display-layout .preview').empty();
-                    var $row = $('<div class="row"/>');
+                    var $row = $('<div class="row"></div>');
                     for (var i = 0; i < OSD.data.display_size.total;) {
                         var charCode = OSD.data.preview[i];
                         if (typeof charCode === 'object') {
@@ -2764,7 +2764,7 @@ TABS.osd.initialize = function (callback) {
                         $row.append($img);
                         if (++i % OSD.data.display_size.x == 0) {
                             $preview.append($row);
-                            $row = $('<div class="row"/>');
+                            $row = $('<div class="row"></div>');
                         }
                     }
 

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -247,7 +247,7 @@ TABS.setup.initialize = function (callback) {
             disarmFlagElements = disarmFlagElements.concat(['ARM_SWITCH']);
 
             // Arming allowed flag
-            arming_disable_flags_e.append('<span id="initialSetupArmingAllowed" i18n="initialSetupArmingAllowed" style="display: none;"/>');
+            arming_disable_flags_e.append('<span id="initialSetupArmingAllowed" i18n="initialSetupArmingAllowed" style="display: none;"></span>');
 
             // Arming disabled flags
             for (var i = 0; i < CONFIG.armingDisableCount; i++) {

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -133,7 +133,7 @@
                             </div>
                             <div class="spacer_box">
                                 <div id="escProtocolDisabled" class="note">
-                                    <p i18n="configurationEscProtocolDisabled"/>
+                                    <p i18n="configurationEscProtocolDisabled"></p>
                                 </div>
                                 <div class="selectProtocol">
                                     <label>
@@ -191,8 +191,8 @@
                                     <div style="float: left; height: 20px; margin-right: 14px; margin-left: 3px;">
                                         <input type="checkbox" id="dshotBidir" class="toggle" />
                                     </div>
-                                    <span class="freelabel" i18n="configurationDshotBidir" />
-                                    <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp" />
+                                    <span class="freelabel" i18n="configurationDshotBidir"></span>
+                                    <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp"></div>
                                 </div>
                                 <div class="number motorPoles">
                                     <label>
@@ -305,7 +305,7 @@
                                         </label>
                                     </div>
                                     <div class="gyro_alignment_inputs gyro_alignment_inputs_notfound">
-                                        <span class="message-negative" i18n="configurationSensorGyroToUseNotFound"/>
+                                        <span class="message-negative" i18n="configurationSensorGyroToUseNotFound"></span>
                                     </div>
                                 </div>
                                 <div class="sensor_align_content">
@@ -572,14 +572,14 @@
                                             <div>
                                                 <input type="checkbox" name="gps_ublox_galileo" class="toggle" />
                                             </div>
-                                            <span class="freelabel" i18n="configurationGPSGalileo" />
+                                            <span class="freelabel" i18n="configurationGPSGalileo"></span>
                                             <div class="helpicon cf_tip" i18n_title="configurationGPSGalileoHelp"></div>
                                         </div>
                                         <div class="select gps_home_once">
                                             <div>
                                                 <input type="checkbox" name="gps_home_once" class="toggle" />
                                             </div>
-                                            <span class="freelabel" i18n="configurationGPSHomeOnce" />
+                                            <span class="freelabel" i18n="configurationGPSHomeOnce"></span>
                                             <div class="helpicon cf_tip" i18n_title="configurationGPSHomeOnceHelp"></div>
                                         </div>
                                         <div class="select line gps_ubx_sbas">

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -26,7 +26,7 @@
                         <td><select name="board">
                                 <option value="0" i18n="firmwareFlasherOptionLoading">Loading ...</option>
                         </select></td>
-                        <td><span class="description" i18n="firmwareFlasherOnlineSelectBoardDescription"></span><div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherOnlineSelectBoardHint"/></td>
+                        <td><span class="description" i18n="firmwareFlasherOnlineSelectBoardDescription"></span><div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherOnlineSelectBoardHint"></div></td>
                     </tr>
                     <tr>
                         <td><select name="firmware_version">

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -182,7 +182,7 @@
                         <table class="sliderLabels">
                             <tr>
                                 <td>
-                                    <span i18n="pidTuningMasterSlider"/>
+                                    <span i18n="pidTuningMasterSlider"></span>
                                 </td>
                                 <td>
                                     <output type="number" name="tuningMasterSlider-number"></output>
@@ -196,7 +196,7 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <span i18n="pidTuningPDRatioSlider"/>
+                                    <span i18n="pidTuningPDRatioSlider"></span>
                                 </td>
                                 <td>
                                     <output type="number" name="tuningPDRatioSlider-number"></output>
@@ -210,7 +210,7 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <span i18n="pidTuningPDGainSlider"/>
+                                    <span i18n="pidTuningPDGainSlider"></span>
                                 </td>
                                 <td>
                                     <output type="number" name="tuningPDGainSlider-number"></output>
@@ -224,7 +224,7 @@
                             </tr>
                             <tr>
                                 <td>
-                                    <span i18n="pidTuningResponseSlider"/>
+                                    <span i18n="pidTuningResponseSlider"></span>
                                 </td>
                                 <td>
                                     <output type="number" name="tuningResponseSlider-number"></output>
@@ -479,7 +479,7 @@
                                 <td><input type="checkbox" id="ffInterpolateSp" class="toggle" /></td>
                                 <td colspan="2">
                                     <div class="helpicon cf_tip" i18n_title="pidTuningFfInterpolateSpHelp"></div>
-                                    <span i18n="pidTuningFfInterpolateSp" />
+                                    <span i18n="pidTuningFfInterpolateSp"></span>
 
                                     <span class="ffInterpolate suboption">
                                         <select id="ffInterpolate">
@@ -489,21 +489,21 @@
                                             <option i18n="pidTuningFfInterpolateSpOptionAverage4"      value="4"/>
                                         </select>
                                         <label for="ffInterpolate">
-                                            <span i18n="pidTuningFfInterpolate" />
+                                            <span i18n="pidTuningFfInterpolate"></span>
                                         </label>
                                     </span>
 
                                     <span class="ffSmoothFactor suboption">
                                         <input type="number" name="ffSmoothFactor" step="1" min="0" max="75" />
                                         <label for="ffSmoothFactor">
-                                            <span i18n="pidTuningFfSmoothFactor" />
+                                            <span i18n="pidTuningFfSmoothFactor"></span>
                                         </label>
                                     </span>
 
                                     <span class="ffBoost suboption">
                                         <input type="number" name="ffBoost" step="1" min="0" max="50" />
                                         <label for="ffBoost">
-                                            <span i18n="pidTuningFfBoost" />
+                                            <span i18n="pidTuningFfBoost"></span>
                                         </label>
                                     </span>
                                 </td>
@@ -585,8 +585,8 @@
                                 <td><input type="checkbox" id="useIntegratedYaw" class="toggle" /></td>
                                 <td colspan="2">
                                     <div class="helpicon cf_tip" i18n_title="pidTuningIntegratedYawHelp"></div>
-                                    <span i18n="pidTuningIntegratedYaw" />
-                                    <span class="spacer_left" id="pidTuningIntegratedYawCaution" i18n="pidTuningIntegratedYawCaution" />
+                                    <span i18n="pidTuningIntegratedYaw"></span>
+                                    <span class="spacer_left" id="pidTuningIntegratedYawCaution" i18n="pidTuningIntegratedYawCaution"></span>
                                 </td>
                             </tr>
 
@@ -594,7 +594,7 @@
                                 <td><input type="checkbox" id="itermrelax" class="toggle" /></td>
                                 <td colspan="2">
                                     <div class="helpicon cf_tip" i18n_title="pidTuningItermRelaxHelp"></div>
-                                    <span i18n="pidTuningItermRelax" />
+                                    <span i18n="pidTuningItermRelax"></span>
 
                                     <span class="suboption">
                                         <select id="itermrelaxAxes">
@@ -604,7 +604,7 @@
                                             <option i18n="pidTuningItermRelaxAxesOptionRPYInc" value="4"/>
                                         </select>
                                         <label for="itermrelaxAxes">
-                                            <span i18n="pidTuningItermRelaxAxes" />
+                                            <span i18n="pidTuningItermRelaxAxes"></span>
                                         </label>
                                     </span>
 
@@ -614,7 +614,7 @@
                                             <option i18n="pidTuningItermRelaxTypeOptionSetpoint" value="1"/>
                                         </select>
                                         <label for="itermrelaxType">
-                                            <span i18n="pidTuningItermRelaxType" />
+                                            <span i18n="pidTuningItermRelaxType"></span>
                                         </label>
                                     </span>
 
@@ -622,7 +622,7 @@
                                     <span class="itermRelaxCutoff suboption">
                                         <input type="number" name="itermRelaxCutoff" step="1" min="1" max="100" />
                                         <label for="itermRelaxCutoff">
-                                            <span i18n="pidTuningItermRelaxCutoff" />
+                                            <span i18n="pidTuningItermRelaxCutoff"></span>
                                         </label>
                                     </span>
                                 </td>
@@ -632,19 +632,19 @@
                                 <td><input type="checkbox" id="dMinSwitch" class="toggle" /></td>
                                 <td colspan="3">
                                     <div class="helpicon cf_tip" i18n_title="pidTuningDMinFeatureHelp"></div>
-                                    <span i18n="pidTuningDMin" />
+                                    <span i18n="pidTuningDMin"></span>
 
                                     <span class="suboption">
                                         <input type="number" name="dMinGain" step="1" min="0" max="100" />
                                         <label for="dMinGain">
-                                            <span i18n="pidTuningDMinGain" />
+                                            <span i18n="pidTuningDMinGain"></span>
                                         </label>
                                     </span>
 
                                     <span class="suboption">
                                         <input type="number" name="dMinAdvance" step="1" min="0" max="200" />
                                         <label for="dMinAdvance">
-                                            <span i18n="pidTuningDMinAdvance" />
+                                            <span i18n="pidTuningDMinAdvance"></span>
                                         </label>
                                     </span>
                                 </td>
@@ -654,7 +654,7 @@
                                 <td><input type="checkbox" id="antiGravitySwitch" class="toggle" /></td>
                                 <td colspan="3">
                                     <div class="helpicon cf_tip" i18n_title="pidTuningAntiGravityHelp"></div>
-                                    <span i18n="pidTuningAntiGravity" />
+                                    <span i18n="pidTuningAntiGravity"></span>
                                     <span class="suboption">
                                         <table>
                                             <tbody class="features antiGravity">
@@ -669,21 +669,21 @@
                                             <option i18n="pidTuningAntiGravityModeOptionStep"       value="1"/>
                                         </select>
                                         <label for="antiGravityMode">
-                                            <span i18n="pidTuningAntiGravityMode" />
+                                            <span i18n="pidTuningAntiGravityMode"></span>
                                         </label>
                                     </span>
 
                                     <span class="suboption">
                                         <input type="number" name="itermAcceleratorGain" step="0.1" min="1.1" max="30" />
                                         <label for="antiGravityGain">
-                                            <span i18n="pidTuningAntiGravityGain" />
+                                            <span i18n="pidTuningAntiGravityGain"></span>
                                         </label>
                                     </span>
 
                                     <span class="suboption antiGravityThres">
                                         <input type="number" name="itermThrottleThreshold" step="10" min="20" max="1000" />
                                         <label for="antiGravityThres">
-                                            <span i18n="pidTuningAntiGravityThres" />
+                                            <span i18n="pidTuningAntiGravityThres"></span>
                                         </label>
                                     </span>
                                 </td>
@@ -979,7 +979,7 @@
                     <table class="sliderLabels">
                         <tr>
                             <td>
-                                <span i18n="pidTuningGyroFilterSlider"/>
+                                <span i18n="pidTuningGyroFilterSlider"></span>
                             </td>
                             <td>
                                 <output type="number" name="tuningGyroFilterSlider-number"></output>
@@ -993,7 +993,7 @@
                         </tr>
                         <tr>
                             <td>
-                                <span i18n="pidTuningDTermFilterSlider"/>
+                                <span i18n="pidTuningDTermFilterSlider"></span>
                             </td>
                             <td>
                                 <output type="number" name="tuningDTermFilterSlider-number"></output>
@@ -1020,8 +1020,8 @@
                             <tr>
                                 <th colspan="2">
                                     <div class="pid_mode">
-                                        <div i18n="pidTuningGyroLowpassFiltersGroup" />
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningLowpassFilterHelp" />
+                                        <div i18n="pidTuningGyroLowpassFiltersGroup" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningLowpassFilterHelp" ></div>
                                     </div>
                                 </th>
                             </tr>
@@ -1136,8 +1136,8 @@
                             <tr>
                                 <th colspan="2">
                                     <div class="pid_mode">
-                                        <div i18n="pidTuningGyroNotchFiltersGroup" />
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" />
+                                        <div i18n="pidTuningGyroNotchFiltersGroup" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" ></div>
                                     </div>
                                 </th>
                             </tr>
@@ -1203,8 +1203,8 @@
                             <tr>
                                 <th class="rpmFilter" colspan="2">
                                     <div class="pid_mode rpmFilter">
-                                        <div i18n="pidTuningRpmFilterGroup" />
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmFilterHelp" />
+                                        <div i18n="pidTuningRpmFilterGroup" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmFilterHelp" ></div>
                                     </div>
                                 </th>
                             </tr>
@@ -1220,7 +1220,7 @@
                                         <label>
                                             <span i18n="pidTuningRpmHarmonics"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmHarmonicsHelp" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmHarmonicsHelp" ></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1233,7 +1233,7 @@
                                         <label>
                                             <span i18n="pidTuningRpmMinHz"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmMinHzHelp" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmMinHzHelp" ></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1241,8 +1241,8 @@
                             <tr>
                                 <th class="dynamicNotch" colspan="2">
                                     <div class="pid_mode dynamicNotch">
-                                        <div i18n="pidTuningDynamicNotchFilterGroup" />
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchFilterHelp" />
+                                        <div i18n="pidTuningDynamicNotchFilterGroup" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchFilterHelp" ></div>
                                     </div>
                                 </th>
                             </tr>
@@ -1257,7 +1257,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchRange"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchRangeHelp" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchRangeHelp" ></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1270,7 +1270,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchWidthPercent"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchWidthPercentHelp" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchWidthPercentHelp" ></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1283,7 +1283,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchQ"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchQHelp" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchQHelp" ></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1296,7 +1296,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchMinHz"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMinHzHelp" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMinHzHelp" ></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1309,7 +1309,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchMaxHz"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMaxHzHelp" />
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMaxHzHelp" ></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1327,8 +1327,8 @@
                             <tr>
                                 <th colspan="2">
                                     <div class="pid_mode">
-                                        <div i18n="pidTuningDTermLowpassFiltersGroup" />
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningLowpassFilterHelp" />
+                                        <div i18n="pidTuningDTermLowpassFiltersGroup" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningLowpassFilterHelp" ></div>
                                     </div>
 
                                     </div>
@@ -1460,8 +1460,8 @@
                             <tr>
                                 <th colspan="2">
                                     <div class="pid_mode">
-                                        <div  i18n="pidTuningDTermNotchFiltersGroup" />
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" />
+                                        <div  i18n="pidTuningDTermNotchFiltersGroup" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" ></div>
                                     </div>
 
                                 </th>
@@ -1498,7 +1498,7 @@
 
                             <tr>
                                 <th colspan="2">
-                                    <div class="pid_mode" i18n="pidTuningYawLospassFiltersGroup" />
+                                    <div class="pid_mode" i18n="pidTuningYawLospassFiltersGroup" ></div>
                                 </th>
                             </tr>
 

--- a/src/tabs/vtx.html
+++ b/src/tabs/vtx.html
@@ -2,26 +2,26 @@
     <div class="content_wrapper">
         <!-- should be the first DIV on each tab -->
         <div class="cf_column">
-            <div class="tab_title" i18n="tabVtx"/>
+            <div class="tab_title" i18n="tabVtx"></div>
             <div class="cf_doc_version_bt">
                 <a id="button-documentation" href="" target="_blank"></a>
             </div>
         </div>
 
         <div class="note vtx_supported">
-            <p i18n="vtxHelp"/>
+            <p i18n="vtxHelp"></p>
         </div>
 
         <div class="note vtx_not_supported">
-            <div i18n="vtxMessageNotSupported"/>
+            <div i18n="vtxMessageNotSupported"></div>
         </div>
 
         <div class="note vtx_table_not_configured">
-            <div i18n="vtxMessageTableNotConfigured"/>
+            <div i18n="vtxMessageTableNotConfigured"></div>
         </div>
 
         <div class="note vtx_table_factory_bands_not_supported">
-            <div i18n="vtxMessageFactoryBandsNotSupported"/>
+            <div i18n="vtxMessageFactoryBandsNotSupported"></div>
         </div>
 
 


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/2077 at least partially

This replaces self-closing `<div>`, `<span>` and `<p>` tags.

This has been done using regular expressions, and maybe there are other tags that need this solution, but until we found them all seems to be working now.