### PR TITLE
Improving Osd chip status faults warnings

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4151,6 +4151,9 @@
     "osdSetupTitle": {
         "message": "OSD"
     },
+    "osdSetupNoOsdChipConfigWarning": {
+        "message": "<span class=\"message-negative\"><b>WARNING:</b></span> No OSD chip is configured. Please, make sure you have <strong>osd_displayport_device</strong> set to <strong>AUTO</strong> mode or the correct value for your board using $t(tabCLI.message) tab."
+    },
     "osdSetupNoOsdChipDetectWarning": {
         "message": "<span class=\"message-negative\"><b>WARNING:</b></span> No OSD chip was detected. Some flight controllers will not properly power the OSD chip unless connected to battery power. Please connect the battery before connecting the USB (PROPS REMOVED!)."
     },

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2260,6 +2260,10 @@ TABS.osd.initialize = function (callback) {
 
                     OSD.msp.decode(info);
 
+                    if (!OSD.data.state.haveMax7456FontDeviceConfigured) {
+                        $('.noOsdChipConfig').show();
+                    }
+
                     if (OSD.data.state.haveMax7456FontDeviceConfigured && !OSD.data.state.isMax7456FontDeviceDetected) {
                         $('.noOsdChipDetect').show();
                     }

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -6,6 +6,9 @@
             <div class="cf_doc_version_bt">
                 <a id="button-documentation" href="" target="_blank"></a>
             </div>
+            <div class="noOsdChipConfig hide">
+                <p class="note" i18n="osdSetupNoOsdChipConfigWarning"></p>
+            </div>
             <div class="noOsdChipDetect hide">
                 <p class="note" i18n="osdSetupNoOsdChipDetectWarning"></p>
             </div>


### PR DESCRIPTION
"No osd chip detected" warning message is breaks after latest FrskyOsd code and doesnt appears any more.
Edited: the correction for this warning in FrskyOsd PR is good, only need to add diferent warning for these no configured cases
This PR fixes https://github.com/betaflight/betaflight/issues/9942