### PR TITLE
vtx tab fix for device without vtx tables

### DIFF
--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -469,7 +469,7 @@ TABS.vtx.initialize = function (callback) {
                 }
             } else {
                 for (let i = 1; i <= TABS.vtx.MAX_BAND_CHANNELS_VALUES; i++) {
-                    selectBand.append(new Option(i18n.getMessage('vtxChannel_X', {channelName: i}), i));
+                    selectChannel.append(new Option(i18n.getMessage('vtxChannel_X', {channelName: i}), i));
                 }
             }
         }


### PR DESCRIPTION
Fixes #2086 in vtx page if connected device doesn't support tables.
