### PR TITLE
Move FC global vars inside FC object

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -12,7 +12,7 @@ var CliAutoComplete = {
 };
 
 CliAutoComplete.isEnabled = function() {
-    return this.isBuilding() || (this.configEnabled && CONFIG.flightControllerIdentifier == "BTFL" && this.builder.state != 'fail');
+    return this.isBuilding() || (this.configEnabled && FC.CONFIG.flightControllerIdentifier == "BTFL" && this.builder.state != 'fail');
 };
 
 CliAutoComplete.isBuilding = function() {
@@ -397,7 +397,7 @@ CliAutoComplete._initTextcomplete = function() {
             search:  function(term, callback, match) {
                 sendOnEnter = false;
                 var arr = cache.resources;
-                if (semver.gte(CONFIG.flightControllerVersion, "4.0.0")) {
+                if (semver.gte(FC.CONFIG.flightControllerVersion, "4.0.0")) {
                     arr = ['show'].concat(arr);
                 } else {
                     arr = ['list'].concat(arr);
@@ -509,7 +509,7 @@ CliAutoComplete._initTextcomplete = function() {
         })
     ]);
 
-    if (semver.gte(CONFIG.flightControllerVersion, "4.0.0")) {
+    if (semver.gte(FC.CONFIG.flightControllerVersion, "4.0.0")) {
         $textarea.textcomplete('register', [
             strategy({ // "resource show all", from BF 4.0.0 onwards
                 match: /^(\s*resource\s+show\s+)(\w*)$/i,
@@ -527,12 +527,12 @@ CliAutoComplete._initTextcomplete = function() {
     var diffArgs1 = ["master", "profile", "rates", "all"];
     var diffArgs2 = [];
 
-    if (semver.lt(CONFIG.flightControllerVersion, "3.4.0")) {
+    if (semver.lt(FC.CONFIG.flightControllerVersion, "3.4.0")) {
         diffArgs2.push("showdefaults");
     } else {
         // above 3.4.0
         diffArgs2.push("defaults");
-        if (semver.gte(CONFIG.flightControllerVersion, "4.0.0")) {
+        if (semver.gte(FC.CONFIG.flightControllerVersion, "4.0.0")) {
             diffArgs1.push("hardware");
             diffArgs2.push("bare");
         }

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -33,27 +33,27 @@ var Features = function (config) {
         );
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.15.0") && !semver.gte(CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.15.0") && !semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
         features.push(
             {bit: 8, group: 'rxFailsafe', name: 'FAILSAFE', haveTip: true}
         );
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
         features.push(
             {bit: 21, group: 'other', name: 'TRANSPONDER', haveTip: true}
         );
     }
 
     if (config.flightControllerVersion !== '') {
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
             features.push(
                 {bit: 22, group: 'other', name: 'AIRMODE'}
             );
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-            if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
                 features.push(
                     {bit: 23, group: 'superexpoRates', name: 'SUPEREXPO_RATES'}
                 );
@@ -64,32 +64,32 @@ var Features = function (config) {
             }
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             features.push(
                 {bit: 18, group: 'other', name: 'OSD'}
             );
-            if (!semver.gte(CONFIG.apiVersion, "1.35.0")) {
+            if (!semver.gte(FC.CONFIG.apiVersion, "1.35.0")) {
               features.push(
                 {bit: 24, group: 'other', name: 'VTX'}
               )
             }
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
             features.push(
                 {bit: 25, group: 'rxMode', mode: 'select', name: 'RX_SPI'},
                 {bit: 27, group: 'escSensor', name: 'ESC_SENSOR'}
             );
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
             features.push(
                 {bit: 28, group: 'antiGravity', name: 'ANTI_GRAVITY', haveTip: true, hideName: true},
                 {bit: 29, group: 'other', name: 'DYNAMIC_FILTER'}
             );
         }
 
-        if (!semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (!semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
             features.push(
                 {bit: 1, group: 'batteryVoltage', name: 'VBAT'},
                 {bit: 11, group: 'batteryCurrent', name: 'CURRENT_METER'}

--- a/src/js/RateCurve.js
+++ b/src/js/RateCurve.js
@@ -88,7 +88,7 @@ var RateCurve = function (useLegacyCurve) {
         var expoPower;
         var rcRateConstant;
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             expoPower = 3;
             rcRateConstant = 200;
         } else {
@@ -157,7 +157,7 @@ RateCurve.prototype.rcCommandRawToDegreesPerSecond = function (rcData, rate, rcR
 
     if (rate !== undefined && rcRate !== undefined && rcExpo !== undefined) {
         let rcCommandf = this.rcCommand(rcData, 1, deadband);
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
             rcCommandf = rcCommandf / (500 - deadband);
         } else {
             rcCommandf = rcCommandf / 500;

--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -85,14 +85,14 @@ TuningSliders.downscaleSliderValue = function(value) {
 TuningSliders.initPidSlidersPosition = function() {
     // used to estimate PID slider positions based on PIDF values, and set respective slider position
     // provides only an estimation due to limitation of feature without firmware support, to be improved in later versions
-    this.MasterSliderValue = Math.round(PIDs[2][1] / this.PID_DEFAULT[11] * 10) / 10;
-    this.PDRatioSliderValue = Math.round(PIDs[0][2] / PIDs[0][0] / this.defaultPDRatio * 10) / 10;
+    this.MasterSliderValue = Math.round(FC.PIDS[2][1] / this.PID_DEFAULT[11] * 10) / 10;
+    this.PDRatioSliderValue = Math.round(FC.PIDS[0][2] / FC.PIDS[0][0] / this.defaultPDRatio * 10) / 10;
     if (this.dMinFeatureEnabled) {
-        this.PDGainSliderValue = Math.round(ADVANCED_TUNING.dMinRoll / this.PDRatioSliderValue / this.MasterSliderValue / this.PID_DEFAULT[3] * 10) / 10;
+        this.PDGainSliderValue = Math.round(FC.ADVANCED_TUNING.dMinRoll / this.PDRatioSliderValue / this.MasterSliderValue / this.PID_DEFAULT[3] * 10) / 10;
     } else {
-        this.PDGainSliderValue = Math.round(PIDs[0][0] / this.MasterSliderValue / (this.PID_DEFAULT[2] * (1 / D_MIN_RATIO)) * 10) / 10;
+        this.PDGainSliderValue = Math.round(FC.PIDS[0][0] / this.MasterSliderValue / (this.PID_DEFAULT[2] * (1 / D_MIN_RATIO)) * 10) / 10;
     }
-    this.ResponseSliderValue = Math.round(ADVANCED_TUNING.feedforwardRoll / this.MasterSliderValue / this.PID_DEFAULT[4] * 10) / 10;
+    this.ResponseSliderValue = Math.round(FC.ADVANCED_TUNING.feedforwardRoll / this.MasterSliderValue / this.PID_DEFAULT[4] * 10) / 10;
 
     $('output[name="tuningMasterSlider-number"]').val(this.MasterSliderValue);
     $('output[name="tuningPDRatioSlider-number"]').val(this.PDRatioSliderValue);
@@ -106,14 +106,14 @@ TuningSliders.initPidSlidersPosition = function() {
 };
 
 TuningSliders.initGyroFilterSliderPosition = function() {
-    this.gyroFilterSliderValue = Math.round((FILTER_CONFIG.gyro_lowpass_dyn_min_hz + FILTER_CONFIG.gyro_lowpass_dyn_max_hz + FILTER_CONFIG.gyro_lowpass2_hz) / 
+    this.gyroFilterSliderValue = Math.round((FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz + FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz + FC.FILTER_CONFIG.gyro_lowpass2_hz) / 
                                 (this.FILTER_DEFAULT.gyro_lowpass_dyn_min_hz + this.FILTER_DEFAULT.gyro_lowpass_dyn_max_hz + this.FILTER_DEFAULT.gyro_lowpass2_hz) * 100) / 100;
     $('output[name="tuningGyroFilterSlider-number"]').val(this.gyroFilterSliderValue);
     $('#tuningGyroFilterSlider').val(this.downscaleSliderValue(this.gyroFilterSliderValue));
 };
 
 TuningSliders.initDTermFilterSliderPosition = function() {
-    this.dtermFilterSliderValue = Math.round((FILTER_CONFIG.dterm_lowpass_dyn_min_hz + FILTER_CONFIG.dterm_lowpass_dyn_max_hz + FILTER_CONFIG.dterm_lowpass2_hz) / 
+    this.dtermFilterSliderValue = Math.round((FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz + FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz + FC.FILTER_CONFIG.dterm_lowpass2_hz) / 
                                 (this.FILTER_DEFAULT.dterm_lowpass_dyn_min_hz + this.FILTER_DEFAULT.dterm_lowpass_dyn_max_hz + this.FILTER_DEFAULT.dterm_lowpass2_hz) * 100) / 100;
     $('output[name="tuningDTermFilterSlider-number"]').val(this.dtermFilterSliderValue);
     $('#tuningDTermFilterSlider').val(this.downscaleSliderValue(this.dtermFilterSliderValue));
@@ -162,7 +162,7 @@ TuningSliders.updatePidSlidersDisplay = function() {
 
     this.pidSlidersUnavailable = false;
     let currentPIDs = [];
-    PID_names.forEach(function(elementPid, indexPid) {
+    FC.PID_NAMES.forEach(function(elementPid, indexPid) {
         let searchRow = $('.pid_tuning .' + elementPid + ' input');
         searchRow.each(function (indexInput) {
             if (indexPid < 3 && indexInput < 5) {
@@ -171,7 +171,7 @@ TuningSliders.updatePidSlidersDisplay = function() {
         });
     });
     this.calculateNewPids();
-    PID_names.forEach(function(elementPid, indexPid) {
+    FC.PID_NAMES.forEach(function(elementPid, indexPid) {
         let searchRow = $('.pid_tuning .' + elementPid + ' input');
         searchRow.each(function (indexInput) {
             if (indexPid < 3 && indexInput < 5) {
@@ -196,8 +196,8 @@ TuningSliders.updatePidSlidersDisplay = function() {
     $('.tuningPIDSliders').toggle(!this.pidSlidersUnavailable);
     $('.subtab-pid .slidersDisabled').toggle(this.pidSlidersUnavailable);
     $('.subtab-pid .nonExpertModeSlidersNote').toggle(!this.pidSlidersUnavailable && !this.expertMode);
-    $('.subtab-pid .slidersWarning').toggle((PIDs[1][0] > WARNING_P_GAIN || PIDs[1][1] > WARNING_I_GAIN || PIDs[1][2] > WARNING_DMAX_GAIN ||
-                                                ADVANCED_TUNING.dMinPitch > WARNING_DMIN_GAIN) && !this.pidSlidersUnavailable);
+    $('.subtab-pid .slidersWarning').toggle((FC.PIDS[1][0] > WARNING_P_GAIN || FC.PIDS[1][1] > WARNING_I_GAIN || FC.PIDS[1][2] > WARNING_DMAX_GAIN ||
+                                                FC.ADVANCED_TUNING.dMinPitch > WARNING_DMIN_GAIN) && !this.pidSlidersUnavailable);
 };
 
 TuningSliders.updateFilterSlidersDisplay = function() {
@@ -252,48 +252,48 @@ TuningSliders.calculateNewPids = function() {
 
     if (this.dMinFeatureEnabled) {
         //dmin
-        ADVANCED_TUNING.dMinRoll = Math.round(this.PID_DEFAULT[3] * this.PDGainSliderValue * this.PDRatioSliderValue);
-        ADVANCED_TUNING.dMinPitch = Math.round(this.PID_DEFAULT[8] * this.PDGainSliderValue * this.PDRatioSliderValue);
+        FC.ADVANCED_TUNING.dMinRoll = Math.round(this.PID_DEFAULT[3] * this.PDGainSliderValue * this.PDRatioSliderValue);
+        FC.ADVANCED_TUNING.dMinPitch = Math.round(this.PID_DEFAULT[8] * this.PDGainSliderValue * this.PDRatioSliderValue);
         // dmax
-        PIDs[0][2] = Math.round(this.PID_DEFAULT[2] * this.PDGainSliderValue * this.PDRatioSliderValue);
-        PIDs[1][2] = Math.round(this.PID_DEFAULT[7] * this.PDGainSliderValue * this.PDRatioSliderValue);
+        FC.PIDS[0][2] = Math.round(this.PID_DEFAULT[2] * this.PDGainSliderValue * this.PDRatioSliderValue);
+        FC.PIDS[1][2] = Math.round(this.PID_DEFAULT[7] * this.PDGainSliderValue * this.PDRatioSliderValue);
     } else {
-        ADVANCED_TUNING.dMinRoll = 0;
-        ADVANCED_TUNING.dMinPitch = 0;
-        PIDs[0][2] = Math.round((this.PID_DEFAULT[2] * D_MIN_RATIO) * this.PDGainSliderValue * this.PDRatioSliderValue);
-        PIDs[1][2] = Math.round((this.PID_DEFAULT[7] * D_MIN_RATIO) * this.PDGainSliderValue * this.PDRatioSliderValue);
+        FC.ADVANCED_TUNING.dMinRoll = 0;
+        FC.ADVANCED_TUNING.dMinPitch = 0;
+        FC.PIDS[0][2] = Math.round((this.PID_DEFAULT[2] * D_MIN_RATIO) * this.PDGainSliderValue * this.PDRatioSliderValue);
+        FC.PIDS[1][2] = Math.round((this.PID_DEFAULT[7] * D_MIN_RATIO) * this.PDGainSliderValue * this.PDRatioSliderValue);
     }
     // p
-    PIDs[0][0] = Math.round(this.PID_DEFAULT[0] * this.PDGainSliderValue);
-    PIDs[1][0] = Math.round(this.PID_DEFAULT[5] * this.PDGainSliderValue);
-    PIDs[2][0] = Math.round(this.PID_DEFAULT[10] * this.PDGainSliderValue);
+    FC.PIDS[0][0] = Math.round(this.PID_DEFAULT[0] * this.PDGainSliderValue);
+    FC.PIDS[1][0] = Math.round(this.PID_DEFAULT[5] * this.PDGainSliderValue);
+    FC.PIDS[2][0] = Math.round(this.PID_DEFAULT[10] * this.PDGainSliderValue);
     // ff
-    ADVANCED_TUNING.feedforwardRoll = Math.round(this.PID_DEFAULT[4] * this.ResponseSliderValue);
-    ADVANCED_TUNING.feedforwardPitch = Math.round(this.PID_DEFAULT[9] * this.ResponseSliderValue);
-    ADVANCED_TUNING.feedforwardYaw = Math.round(this.PID_DEFAULT[14] * this.ResponseSliderValue);
+    FC.ADVANCED_TUNING.feedforwardRoll = Math.round(this.PID_DEFAULT[4] * this.ResponseSliderValue);
+    FC.ADVANCED_TUNING.feedforwardPitch = Math.round(this.PID_DEFAULT[9] * this.ResponseSliderValue);
+    FC.ADVANCED_TUNING.feedforwardYaw = Math.round(this.PID_DEFAULT[14] * this.ResponseSliderValue);
 
     // master slider part
     // these are not calculated anywhere other than master slider multiplier therefore set at default before every calculation
-    PIDs[0][1] = this.PID_DEFAULT[1];
-    PIDs[1][1] = this.PID_DEFAULT[6];
-    PIDs[2][1] = this.PID_DEFAULT[11];
+    FC.PIDS[0][1] = this.PID_DEFAULT[1];
+    FC.PIDS[1][1] = this.PID_DEFAULT[6];
+    FC.PIDS[2][1] = this.PID_DEFAULT[11];
     // yaw d, dmin
-    PIDs[2][2] = this.PID_DEFAULT[12];
-    ADVANCED_TUNING.dMinYaw = this.PID_DEFAULT[13];
+    FC.PIDS[2][2] = this.PID_DEFAULT[12];
+    FC.ADVANCED_TUNING.dMinYaw = this.PID_DEFAULT[13];
 
     //master slider multiplication, max value 200 for main PID values
     for (let i = 0; i < 3; i++) {
         for (let j = 0; j < 3; j++) {
-            PIDs[j][i] = Math.min(Math.round(PIDs[j][i] * this.MasterSliderValue), MAX_PID_GAIN);
+            FC.PIDS[j][i] = Math.min(Math.round(FC.PIDS[j][i] * this.MasterSliderValue), MAX_PID_GAIN);
         }
     }
-    ADVANCED_TUNING.feedforwardRoll = Math.min(Math.round(ADVANCED_TUNING.feedforwardRoll * this.MasterSliderValue), MAX_FF_GAIN);
-    ADVANCED_TUNING.feedforwardPitch = Math.min(Math.round(ADVANCED_TUNING.feedforwardPitch * this.MasterSliderValue), MAX_FF_GAIN);
-    ADVANCED_TUNING.feedforwardYaw = Math.min(Math.round(ADVANCED_TUNING.feedforwardYaw * this.MasterSliderValue), MAX_FF_GAIN);
+    FC.ADVANCED_TUNING.feedforwardRoll = Math.min(Math.round(FC.ADVANCED_TUNING.feedforwardRoll * this.MasterSliderValue), MAX_FF_GAIN);
+    FC.ADVANCED_TUNING.feedforwardPitch = Math.min(Math.round(FC.ADVANCED_TUNING.feedforwardPitch * this.MasterSliderValue), MAX_FF_GAIN);
+    FC.ADVANCED_TUNING.feedforwardYaw = Math.min(Math.round(FC.ADVANCED_TUNING.feedforwardYaw * this.MasterSliderValue), MAX_FF_GAIN);
     if (this.dMinFeatureEnabled) {
-        ADVANCED_TUNING.dMinRoll = Math.min(Math.round(ADVANCED_TUNING.dMinRoll * this.MasterSliderValue), MAX_DMIN_GAIN);
-        ADVANCED_TUNING.dMinPitch = Math.min(Math.round(ADVANCED_TUNING.dMinPitch * this.MasterSliderValue), MAX_DMIN_GAIN);
-        ADVANCED_TUNING.dMinYaw = Math.min(Math.round(ADVANCED_TUNING.dMinYaw * this.MasterSliderValue), MAX_DMIN_GAIN);
+        FC.ADVANCED_TUNING.dMinRoll = Math.min(Math.round(FC.ADVANCED_TUNING.dMinRoll * this.MasterSliderValue), MAX_DMIN_GAIN);
+        FC.ADVANCED_TUNING.dMinPitch = Math.min(Math.round(FC.ADVANCED_TUNING.dMinPitch * this.MasterSliderValue), MAX_DMIN_GAIN);
+        FC.ADVANCED_TUNING.dMinYaw = Math.min(Math.round(FC.ADVANCED_TUNING.dMinYaw * this.MasterSliderValue), MAX_DMIN_GAIN);
     }
 
     $('output[name="tuningMasterSlider-number"]').val(this.MasterSliderValue);
@@ -302,52 +302,52 @@ TuningSliders.calculateNewPids = function() {
     $('output[name="tuningResponseSlider-number"]').val(this.ResponseSliderValue);
 
     // updates values in forms
-    PID_names.forEach(function(elementPid, indexPid) {
+    FC.PID_NAMES.forEach(function(elementPid, indexPid) {
         let searchRow = $('.pid_tuning .' + elementPid + ' input');
         searchRow.each(function (indexInput) {
             if (indexPid < 3 && indexInput < 3) {
-                $(this).val(PIDs[indexPid][indexInput]);
+                $(this).val(FC.PIDS[indexPid][indexInput]);
             }
         });
     });
-    $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
-    $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
-    $('.pid_tuning input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
-    $('.pid_tuning .ROLL input[name="f"]').val(ADVANCED_TUNING.feedforwardRoll);
-    $('.pid_tuning .PITCH input[name="f"]').val(ADVANCED_TUNING.feedforwardPitch);
-    $('.pid_tuning .YAW input[name="f"]').val(ADVANCED_TUNING.feedforwardYaw);
+    $('.pid_tuning input[name="dMinRoll"]').val(FC.ADVANCED_TUNING.dMinRoll);
+    $('.pid_tuning input[name="dMinPitch"]').val(FC.ADVANCED_TUNING.dMinPitch);
+    $('.pid_tuning input[name="dMinYaw"]').val(FC.ADVANCED_TUNING.dMinYaw);
+    $('.pid_tuning .ROLL input[name="f"]').val(FC.ADVANCED_TUNING.feedforwardRoll);
+    $('.pid_tuning .PITCH input[name="f"]').val(FC.ADVANCED_TUNING.feedforwardPitch);
+    $('.pid_tuning .YAW input[name="f"]').val(FC.ADVANCED_TUNING.feedforwardYaw);
 
     TABS.pid_tuning.updatePIDColors();
 };
 
 TuningSliders.calculateNewGyroFilters = function() {
     // calculate, set and display new values in forms based on slider position
-    FILTER_CONFIG.gyro_lowpass_dyn_min_hz = Math.round(this.FILTER_DEFAULT.gyro_lowpass_dyn_min_hz * this.gyroFilterSliderValue);
-    FILTER_CONFIG.gyro_lowpass_dyn_max_hz = Math.round(this.FILTER_DEFAULT.gyro_lowpass_dyn_max_hz * this.gyroFilterSliderValue);
-    FILTER_CONFIG.gyro_lowpass2_hz = Math.round(this.FILTER_DEFAULT.gyro_lowpass2_hz * this.gyroFilterSliderValue);
-    FILTER_CONFIG.gyro_lowpass_type = this.FILTER_DEFAULT.gyro_lowpass_type;
-    FILTER_CONFIG.gyro_lowpass2_type = this.FILTER_DEFAULT.gyro_lowpass2_type;
+    FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz = Math.round(this.FILTER_DEFAULT.gyro_lowpass_dyn_min_hz * this.gyroFilterSliderValue);
+    FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = Math.round(this.FILTER_DEFAULT.gyro_lowpass_dyn_max_hz * this.gyroFilterSliderValue);
+    FC.FILTER_CONFIG.gyro_lowpass2_hz = Math.round(this.FILTER_DEFAULT.gyro_lowpass2_hz * this.gyroFilterSliderValue);
+    FC.FILTER_CONFIG.gyro_lowpass_type = this.FILTER_DEFAULT.gyro_lowpass_type;
+    FC.FILTER_CONFIG.gyro_lowpass2_type = this.FILTER_DEFAULT.gyro_lowpass2_type;
 
-    $('.pid_filter input[name="gyroLowpassDynMinFrequency"]').val(FILTER_CONFIG.gyro_lowpass_dyn_min_hz);
-    $('.pid_filter input[name="gyroLowpassDynMaxFrequency"]').val(FILTER_CONFIG.gyro_lowpass_dyn_max_hz);
-    $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FILTER_CONFIG.gyro_lowpass2_hz);
-    $('.pid_filter select[name="gyroLowpassDynType').val(FILTER_CONFIG.gyro_lowpass_type);
-    $('.pid_filter select[name="gyroLowpass2Type').val(FILTER_CONFIG.gyro_lowpass2_type);
+    $('.pid_filter input[name="gyroLowpassDynMinFrequency"]').val(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz);
+    $('.pid_filter input[name="gyroLowpassDynMaxFrequency"]').val(FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz);
+    $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FC.FILTER_CONFIG.gyro_lowpass2_hz);
+    $('.pid_filter select[name="gyroLowpassDynType').val(FC.FILTER_CONFIG.gyro_lowpass_type);
+    $('.pid_filter select[name="gyroLowpass2Type').val(FC.FILTER_CONFIG.gyro_lowpass2_type);
     $('output[name="tuningGyroFilterSlider-number"]').val(this.gyroFilterSliderValue);
 };
 
 TuningSliders.calculateNewDTermFilters = function() {
     // calculate, set and display new values in forms based on slider position
-    FILTER_CONFIG.dterm_lowpass_dyn_min_hz = Math.round(this.FILTER_DEFAULT.dterm_lowpass_dyn_min_hz * this.dtermFilterSliderValue);
-    FILTER_CONFIG.dterm_lowpass_dyn_max_hz = Math.round(this.FILTER_DEFAULT.dterm_lowpass_dyn_max_hz * this.dtermFilterSliderValue);
-    FILTER_CONFIG.dterm_lowpass2_hz = Math.round(this.FILTER_DEFAULT.dterm_lowpass2_hz * this.dtermFilterSliderValue);
-    FILTER_CONFIG.dterm_lowpass_type = this.FILTER_DEFAULT.dterm_lowpass_type;
-    FILTER_CONFIG.dterm_lowpass2_type = this.FILTER_DEFAULT.dterm_lowpass2_type;
+    FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz = Math.round(this.FILTER_DEFAULT.dterm_lowpass_dyn_min_hz * this.dtermFilterSliderValue);
+    FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = Math.round(this.FILTER_DEFAULT.dterm_lowpass_dyn_max_hz * this.dtermFilterSliderValue);
+    FC.FILTER_CONFIG.dterm_lowpass2_hz = Math.round(this.FILTER_DEFAULT.dterm_lowpass2_hz * this.dtermFilterSliderValue);
+    FC.FILTER_CONFIG.dterm_lowpass_type = this.FILTER_DEFAULT.dterm_lowpass_type;
+    FC.FILTER_CONFIG.dterm_lowpass2_type = this.FILTER_DEFAULT.dterm_lowpass2_type;
 
-    $('.pid_filter input[name="dtermLowpassDynMinFrequency"]').val(FILTER_CONFIG.dterm_lowpass_dyn_min_hz);
-    $('.pid_filter input[name="dtermLowpassDynMaxFrequency"]').val(FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
-    $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FILTER_CONFIG.dterm_lowpass2_hz);
-    $('.pid_filter select[name="dtermLowpassDynType').val(FILTER_CONFIG.dterm_lowpass_type);
-    $('.pid_filter select[name="dtermLowpass2Type').val(FILTER_CONFIG.dterm_lowpass2_type);
+    $('.pid_filter input[name="dtermLowpassDynMinFrequency"]').val(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz);
+    $('.pid_filter input[name="dtermLowpassDynMaxFrequency"]').val(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
+    $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FC.FILTER_CONFIG.dterm_lowpass2_hz);
+    $('.pid_filter select[name="dtermLowpassDynType').val(FC.FILTER_CONFIG.dterm_lowpass_type);
+    $('.pid_filter select[name="dtermLowpass2Type').val(FC.FILTER_CONFIG.dterm_lowpass2_type);
     $('output[name="tuningDTermFilterSlider-number"]').val(this.dtermFilterSliderValue);
 };

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -13,7 +13,7 @@ function configuration_backup(callback) {
 
     var configuration = {
         'generatedBy': version,
-        'apiVersion': CONFIG.apiVersion,
+        'apiVersion': FC.CONFIG.apiVersion,
         'profiles': [],
     };
 
@@ -28,10 +28,10 @@ function configuration_backup(callback) {
     ];
 
     function update_profile_specific_data_list() {
-        if (semver.gt(CONFIG.apiVersion, "1.12.0")) {
+        if (semver.gt(FC.CONFIG.apiVersion, "1.12.0")) {
             profileSpecificData.push(MSPCodes.MSP_SERVO_MIX_RULES);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
             profileSpecificData.push(MSPCodes.MSP_RC_DEADBAND);
         }
     }
@@ -39,7 +39,7 @@ function configuration_backup(callback) {
     update_profile_specific_data_list();
 
     MSP.send_message(MSPCodes.MSP_STATUS, false, false, function () {
-        activeProfile = CONFIG.profile;
+        activeProfile = FC.CONFIG.profile;
         select_profile();
     });
 
@@ -56,7 +56,7 @@ function configuration_backup(callback) {
             codeKey = 0;
 
         function fetch_specific_data_item() {
-            if (fetchingProfile < CONFIG.numProfiles) {
+            if (fetchingProfile < FC.CONFIG.numProfiles) {
                 MSP.send_message(profileSpecificData[codeKey], false, false, function () {
                     codeKey++;
 
@@ -64,18 +64,18 @@ function configuration_backup(callback) {
                         fetch_specific_data_item();
                     } else {
                         configuration.profiles.push({
-                            'PID': jQuery.extend(true, {}, PID),
-                            'PIDs': jQuery.extend(true, [], PIDs),
-                            'RC': jQuery.extend(true, {}, RC_tuning),
-                            'AccTrim': jQuery.extend(true, [], CONFIG.accelerometerTrims),
-                            'ServoConfig': jQuery.extend(true, [], SERVO_CONFIG),
-                            'ServoRules': jQuery.extend(true, [], SERVO_RULES),
-                            'ModeRanges': jQuery.extend(true, [], MODE_RANGES),
-                            'AdjustmentRanges': jQuery.extend(true, [], ADJUSTMENT_RANGES)
+                            'PID': jQuery.extend(true, {}, FC.PID),
+                            'PIDs': jQuery.extend(true, [], FC.PIDS),
+                            'RC': jQuery.extend(true, {}, FC.RC_TUNING),
+                            'AccTrim': jQuery.extend(true, [], FC.CONFIG.accelerometerTrims),
+                            'ServoConfig': jQuery.extend(true, [], FC.SERVO_CONFIG),
+                            'ServoRules': jQuery.extend(true, [], FC.SERVO_RULES),
+                            'ModeRanges': jQuery.extend(true, [], FC.MODE_RANGES),
+                            'AdjustmentRanges': jQuery.extend(true, [], FC.ADJUSTMENT_RANGES)
                         });
 
-                        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                            configuration.profiles[fetchingProfile].RCdeadband = jQuery.extend(true, {}, RC_DEADBAND_CONFIG);
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
+                            configuration.profiles[fetchingProfile].RCdeadband = jQuery.extend(true, {}, FC.RC_DEADBAND_CONFIG);
                         }
                         codeKey = 0;
                         fetchingProfile++;
@@ -100,29 +100,29 @@ function configuration_backup(callback) {
     ];
 
     function update_unique_data_list() {
-        if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
             uniqueData.push(MSPCodes.MSP_LOOP_TIME);
             uniqueData.push(MSPCodes.MSP_ARMING_CONFIG);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.14.0")) {
             uniqueData.push(MSPCodes.MSP_MOTOR_3D_CONFIG);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
             uniqueData.push(MSPCodes.MSP_SENSOR_ALIGNMENT);
             uniqueData.push(MSPCodes.MSP_RX_CONFIG);
             uniqueData.push(MSPCodes.MSP_FAILSAFE_CONFIG);
             uniqueData.push(MSPCodes.MSP_RXFAIL_CONFIG);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.19.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.19.0")) {
             uniqueData.push(MSPCodes.MSP_LED_STRIP_MODECOLOR);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
             uniqueData.push(MSPCodes.MSP_MOTOR_CONFIG);
             uniqueData.push(MSPCodes.MSP_RSSI_CONFIG);
             uniqueData.push(MSPCodes.MSP_GPS_CONFIG);
             uniqueData.push(MSPCodes.MSP_FEATURE_CONFIG);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
             uniqueData.push(MSPCodes.MSP_MODE_RANGES_EXTRA);
         }
     }
@@ -139,44 +139,44 @@ function configuration_backup(callback) {
                     fetch_unique_data_item();
                 });
             } else {
-                configuration.RCMAP = jQuery.extend(true, [], RC_MAP);
-                configuration.SERIAL_CONFIG = jQuery.extend(true, {}, SERIAL_CONFIG);
-                configuration.LED_STRIP = jQuery.extend(true, [], LED_STRIP);
-                configuration.LED_COLORS = jQuery.extend(true, [], LED_COLORS);
-                configuration.BOARD_ALIGNMENT_CONFIG = jQuery.extend(true, {}, BOARD_ALIGNMENT_CONFIG);
-                configuration.CRAFT_NAME = CONFIG.name;
-                configuration.DISPLAY_NAME = CONFIG.displayName;
-                configuration.MIXER_CONFIG = jQuery.extend(true, {}, MIXER_CONFIG);
-                configuration.SENSOR_CONFIG = jQuery.extend(true, {}, SENSOR_CONFIG);
-                configuration.PID_ADVANCED_CONFIG = jQuery.extend(true, {}, PID_ADVANCED_CONFIG);
+                configuration.RCMAP = jQuery.extend(true, [], FC.RC_MAP);
+                configuration.SERIAL_CONFIG = jQuery.extend(true, {}, FC.SERIAL_CONFIG);
+                configuration.LED_STRIP = jQuery.extend(true, [], FC.LED_STRIP);
+                configuration.LED_COLORS = jQuery.extend(true, [], FC.LED_COLORS);
+                configuration.BOARD_ALIGNMENT_CONFIG = jQuery.extend(true, {}, FC.BOARD_ALIGNMENT_CONFIG);
+                configuration.CRAFT_NAME = FC.CONFIG.name;
+                configuration.DISPLAY_NAME = FC.CONFIG.displayName;
+                configuration.MIXER_CONFIG = jQuery.extend(true, {}, FC.MIXER_CONFIG);
+                configuration.SENSOR_CONFIG = jQuery.extend(true, {}, FC.SENSOR_CONFIG);
+                configuration.PID_ADVANCED_CONFIG = jQuery.extend(true, {}, FC.PID_ADVANCED_CONFIG);
 
-                if (semver.gte(CONFIG.apiVersion, "1.19.0")) {
-                    configuration.LED_MODE_COLORS = jQuery.extend(true, [], LED_MODE_COLORS);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.19.0")) {
+                    configuration.LED_MODE_COLORS = jQuery.extend(true, [], FC.LED_MODE_COLORS);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
-                    configuration.FC_CONFIG = jQuery.extend(true, {}, FC_CONFIG);
-                    configuration.ARMING_CONFIG = jQuery.extend(true, {}, ARMING_CONFIG);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
+                    configuration.FC_CONFIG = jQuery.extend(true, {}, FC.FC_CONFIG);
+                    configuration.ARMING_CONFIG = jQuery.extend(true, {}, FC.ARMING_CONFIG);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
-                    configuration.MOTOR_3D_CONFIG = jQuery.extend(true, {}, MOTOR_3D_CONFIG);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.14.0")) {
+                    configuration.MOTOR_3D_CONFIG = jQuery.extend(true, {}, FC.MOTOR_3D_CONFIG);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                    configuration.SENSOR_ALIGNMENT = jQuery.extend(true, {}, SENSOR_ALIGNMENT);
-                    configuration.RX_CONFIG = jQuery.extend(true, {}, RX_CONFIG);
-                    configuration.FAILSAFE_CONFIG = jQuery.extend(true, {}, FAILSAFE_CONFIG);
-                    configuration.RXFAIL_CONFIG = jQuery.extend(true, [], RXFAIL_CONFIG);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
+                    configuration.SENSOR_ALIGNMENT = jQuery.extend(true, {}, FC.SENSOR_ALIGNMENT);
+                    configuration.RX_CONFIG = jQuery.extend(true, {}, FC.RX_CONFIG);
+                    configuration.FAILSAFE_CONFIG = jQuery.extend(true, {}, FC.FAILSAFE_CONFIG);
+                    configuration.RXFAIL_CONFIG = jQuery.extend(true, [], FC.RXFAIL_CONFIG);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
-                    configuration.RSSI_CONFIG = jQuery.extend(true, {}, RSSI_CONFIG);
-                    configuration.FEATURE_CONFIG = jQuery.extend(true, {}, FEATURE_CONFIG);
-                    configuration.MOTOR_CONFIG = jQuery.extend(true, {}, MOTOR_CONFIG);
-                    configuration.GPS_CONFIG = jQuery.extend(true, {}, GPS_CONFIG);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+                    configuration.RSSI_CONFIG = jQuery.extend(true, {}, FC.RSSI_CONFIG);
+                    configuration.FEATURE_CONFIG = jQuery.extend(true, {}, FC.FEATURE_CONFIG);
+                    configuration.MOTOR_CONFIG = jQuery.extend(true, {}, FC.MOTOR_CONFIG);
+                    configuration.GPS_CONFIG = jQuery.extend(true, {}, FC.GPS_CONFIG);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                    configuration.BEEPER_CONFIG = jQuery.extend(true, {}, BEEPER_CONFIG);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                    configuration.BEEPER_CONFIG = jQuery.extend(true, {}, FC.BEEPER_CONFIG);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    configuration.MODE_RANGES_EXTRA = jQuery.extend(true, [], MODE_RANGES_EXTRA);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    configuration.MODE_RANGES_EXTRA = jQuery.extend(true, [], FC.MODE_RANGES_EXTRA);
                 }
 
                 save();
@@ -339,7 +339,7 @@ function configuration_restore(callback) {
                             return;
                         }
                         if (configuration.FEATURE_CONFIG.features._featureMask) {
-                            var features = new Features(CONFIG);
+                            var features = new Features(FC.CONFIG);
                             features.setMask(configuration.FEATURE_CONFIG.features._featureMask);
                             configuration.FEATURE_CONFIG.features = features;
                         }
@@ -421,8 +421,8 @@ function configuration_restore(callback) {
                 configuration.LED_STRIP = fixed_led_strip;
             }
 
-            for (var profileIndex = 0; profileIndex < 3; profileIndex++) {
-                var RC = configuration.profiles[profileIndex].RC;
+            for (let profileIndex = 0; profileIndex < 3; profileIndex++) {
+                const RC = configuration.profiles[profileIndex].RC;
                 // TPA breakpoint was added
                 if (!RC.dynamic_THR_breakpoint) {
                     RC.dynamic_THR_breakpoint = 1500; // firmware default
@@ -555,7 +555,7 @@ function configuration_restore(callback) {
             appliedMigrationsCount++;
         }
 
-        if (semver.lt(configuration.apiVersion, '1.14.0') && semver.gte(CONFIG.apiVersion, "1.14.0")) {
+        if (semver.lt(configuration.apiVersion, '1.14.0') && semver.gte(FC.CONFIG.apiVersion, "1.14.0")) {
             // api 1.14 removed old pid controllers
             for (var profileIndex = 0; profileIndex < configuration.profiles.length; profileIndex++) {
                 var newPidControllerIndex = configuration.profiles[profileIndex].PID.controller;
@@ -659,8 +659,8 @@ function configuration_restore(callback) {
 
         if (compareVersions(migratedVersion, '1.2.0')) {
             // old version of the configurator incorrectly had a 'disabled' option for GPS SBAS mode.
-            if (GPS_CONFIG.ublox_sbas < 0) {
-                GPS_CONFIG.ublox_sbas = 0;
+            if (FC.GPS_CONFIG.ublox_sbas < 0) {
+                FC.GPS_CONFIG.ublox_sbas = 0;
             }
             migratedVersion = '1.2.0';
 
@@ -693,7 +693,7 @@ function configuration_restore(callback) {
     function configuration_upload(configuration, callback) {
         function upload() {
             var activeProfile = null;
-            var numProfiles = CONFIG.numProfiles;
+            var numProfiles = FC.CONFIG.numProfiles;
             if (configuration.profiles.length < numProfiles) {
                 numProfiles = configuration.profiles.length;
             }
@@ -705,12 +705,12 @@ function configuration_restore(callback) {
                 MSPCodes.MSP_SET_ACC_TRIM
             ];
 
-            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
                 profileSpecificData.push(MSPCodes.MSP_SET_RC_DEADBAND);
             }
 
             MSP.send_message(MSPCodes.MSP_STATUS, false, false, function () {
-                activeProfile = CONFIG.profile;
+                activeProfile = FC.CONFIG.profile;
                 select_profile();
             });
 
@@ -727,15 +727,15 @@ function configuration_restore(callback) {
                     codeKey = 0;
 
                 function load_objects(profile) {
-                    PID = configuration.profiles[profile].PID;
-                    PIDs = configuration.profiles[profile].PIDs;
-                    RC_tuning = configuration.profiles[profile].RC;
-                    CONFIG.accelerometerTrims = configuration.profiles[profile].AccTrim;
-                    SERVO_CONFIG = configuration.profiles[profile].ServoConfig;
-                    SERVO_RULES = configuration.profiles[profile].ServoRules;
-                    MODE_RANGES = configuration.profiles[profile].ModeRanges;
-                    ADJUSTMENT_RANGES = configuration.profiles[profile].AdjustmentRanges;
-                    RC_DEADBAND_CONFIG = configuration.profiles[profile].RCdeadband;
+                    FC.PID = configuration.profiles[profile].PID;
+                    FC.PIDS = configuration.profiles[profile].PIDs;
+                    FC.RC_TUNING = configuration.profiles[profile].RC;
+                    FC.CONFIG.accelerometerTrims = configuration.profiles[profile].AccTrim;
+                    FC.SERVO_CONFIG = configuration.profiles[profile].ServoConfig;
+                    FC.SERVO_RULES = configuration.profiles[profile].ServoRules;
+                    FC.MODE_RANGES = configuration.profiles[profile].ModeRanges;
+                    FC.ADJUSTMENT_RANGES = configuration.profiles[profile].AdjustmentRanges;
+                    FC.RC_DEADBAND_CONFIG = configuration.profiles[profile].RCdeadband;
                 }
 
                 function upload_using_specific_commands() {
@@ -768,20 +768,20 @@ function configuration_restore(callback) {
                 }
 
                 function upload_mode_ranges() {
-                    if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                         if (configuration.MODE_RANGES_EXTRA == undefined) {
-                            MODE_RANGES_EXTRA = [];
+                            FC.MODE_RANGES_EXTRA = [];
 
-                            for (var modeIndex = 0; modeIndex < MODE_RANGES.length; modeIndex++) {
+                            for (var modeIndex = 0; modeIndex < FC.MODE_RANGES.length; modeIndex++) {
                                 var defaultModeRangeExtra = {
-                                    modeId:     MODE_RANGES[modeIndex].modeId,
+                                    modeId:     FC.MODE_RANGES[modeIndex].modeId,
                                     modeLogic:  0,
                                     linkedTo:   0
                                 };
-                                MODE_RANGES_EXTRA.push(defaultModeRangeExtra);
+                                FC.MODE_RANGES_EXTRA.push(defaultModeRangeExtra);
                             }
                         } else {
-                            MODE_RANGES_EXTRA = configuration.MODE_RANGES_EXTRA;
+                            FC.MODE_RANGES_EXTRA = configuration.MODE_RANGES_EXTRA;
                         }
                     }
 
@@ -812,19 +812,19 @@ function configuration_restore(callback) {
                     uniqueData.push(MSPCodes.MSP_SET_BOARD_ALIGNMENT_CONFIG);
                     uniqueData.push(MSPCodes.MSP_SET_ADVANCED_CONFIG);
 
-                    if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
                         uniqueData.push(MSPCodes.MSP_SET_LOOP_TIME);
                         uniqueData.push(MSPCodes.MSP_SET_ARMING_CONFIG);
                     }
-                    if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.14.0")) {
                         uniqueData.push(MSPCodes.MSP_SET_MOTOR_3D_CONFIG);
                     }
-                    if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
                         uniqueData.push(MSPCodes.MSP_SET_SENSOR_ALIGNMENT);
                         uniqueData.push(MSPCodes.MSP_SET_RX_CONFIG);
                         uniqueData.push(MSPCodes.MSP_SET_FAILSAFE_CONFIG);
                     }
-                    if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
                         uniqueData.push(MSPCodes.MSP_SET_FEATURE_CONFIG);
                         uniqueData.push(MSPCodes.MSP_SET_MOTOR_CONFIG);
                         uniqueData.push(MSPCodes.MSP_SET_GPS_CONFIG);
@@ -833,35 +833,35 @@ function configuration_restore(callback) {
                 }
 
                 function load_objects() {
-                    MISC = configuration.MISC;
-                    RC_MAP = configuration.RCMAP;
-                    SERIAL_CONFIG = configuration.SERIAL_CONFIG;
-                    LED_STRIP = configuration.LED_STRIP;
-                    LED_COLORS = configuration.LED_COLORS;
-                    LED_MODE_COLORS = configuration.LED_MODE_COLORS;
-                    ARMING_CONFIG = configuration.ARMING_CONFIG;
-                    FC_CONFIG = configuration.FC_CONFIG;
-                    MOTOR_3D_CONFIG = configuration.MOTOR_3D_CONFIG;
-                    SENSOR_ALIGNMENT = configuration.SENSOR_ALIGNMENT;
-                    RX_CONFIG = configuration.RX_CONFIG;
-                    FAILSAFE_CONFIG = configuration.FAILSAFE_CONFIG;
-                    RXFAIL_CONFIG = configuration.RXFAIL_CONFIG;
-                    FEATURE_CONFIG = configuration.FEATURE_CONFIG;
-                    MOTOR_CONFIG = configuration.MOTOR_CONFIG;
-                    GPS_CONFIG = configuration.GPS_CONFIG;
-                    RSSI_CONFIG = configuration.RSSI_CONFIG;
-                    BOARD_ALIGNMENT_CONFIG = configuration.BOARD_ALIGNMENT_CONFIG;
-                    CONFIG.name = configuration.CRAFT_NAME;
-                    CONFIG.displayName = configuration.DISPLAY_NAME;
-                    MIXER_CONFIG = configuration.MIXER_CONFIG;
-                    SENSOR_CONFIG = configuration.SENSOR_CONFIG;
-                    PID_ADVANCED_CONFIG = configuration.PID_ADVANCED_CONFIG;
+                    FC.MISC = configuration.MISC;
+                    FC.RC_MAP = configuration.RCMAP;
+                    FC.SERIAL_CONFIG = configuration.SERIAL_CONFIG;
+                    FC.LED_STRIP = configuration.LED_STRIP;
+                    FC.LED_COLORS = configuration.LED_COLORS;
+                    FC.LED_MODE_COLORS = configuration.LED_MODE_COLORS;
+                    FC.ARMING_CONFIG = configuration.ARMING_CONFIG;
+                    FC.FC_CONFIG = configuration.FC_CONFIG;
+                    FC.MOTOR_3D_CONFIG = configuration.MOTOR_3D_CONFIG;
+                    FC.SENSOR_ALIGNMENT = configuration.SENSOR_ALIGNMENT;
+                    FC.RX_CONFIG = configuration.RX_CONFIG;
+                    FC.FAILSAFE_CONFIG = configuration.FAILSAFE_CONFIG;
+                    FC.RXFAIL_CONFIG = configuration.RXFAIL_CONFIG;
+                    FC.FEATURE_CONFIG = configuration.FEATURE_CONFIG;
+                    FC.MOTOR_CONFIG = configuration.MOTOR_CONFIG;
+                    FC.GPS_CONFIG = configuration.GPS_CONFIG;
+                    FC.RSSI_CONFIG = configuration.RSSI_CONFIG;
+                    FC.BOARD_ALIGNMENT_CONFIG = configuration.BOARD_ALIGNMENT_CONFIG;
+                    FC.CONFIG.name = configuration.CRAFT_NAME;
+                    FC.CONFIG.displayName = configuration.DISPLAY_NAME;
+                    FC.MIXER_CONFIG = configuration.MIXER_CONFIG;
+                    FC.SENSOR_CONFIG = configuration.SENSOR_CONFIG;
+                    FC.PID_ADVANCED_CONFIG = configuration.PID_ADVANCED_CONFIG;
 
-                    BEEPER_CONFIG.beepers = new Beepers(CONFIG);
-                    BEEPER_CONFIG.beepers.setMask(configuration.BEEPER_CONFIG.beepers._beeperMask);
-                    BEEPER_CONFIG.dshotBeaconTone = configuration.BEEPER_CONFIG.dshotBeaconTone;
-                    BEEPER_CONFIG.dshotBeaconConditions = new Beepers(CONFIG, [ "RX_LOST", "RX_SET" ]);
-                    BEEPER_CONFIG.dshotBeaconConditions.setMask(configuration.BEEPER_CONFIG.dshotBeaconConditions._beeperMask);
+                    FC.BEEPER_CONFIG.beepers = new Beepers(FC.CONFIG);
+                    FC.BEEPER_CONFIG.beepers.setMask(configuration.BEEPER_CONFIG.beepers._beeperMask);
+                    FC.BEEPER_CONFIG.dshotBeaconTone = configuration.BEEPER_CONFIG.dshotBeaconTone;
+                    FC.BEEPER_CONFIG.dshotBeaconConditions = new Beepers(FC.CONFIG, [ "RX_LOST", "RX_SET" ]);
+                    FC.BEEPER_CONFIG.dshotBeaconConditions.setMask(configuration.BEEPER_CONFIG.dshotBeaconConditions._beeperMask);
                 }
 
                 function send_unique_data_item() {
@@ -892,14 +892,14 @@ function configuration_restore(callback) {
             }
 
             function send_led_strip_mode_colors() {
-                if (semver.gte(CONFIG.apiVersion, "1.19.0"))
+                if (semver.gte(FC.CONFIG.apiVersion, "1.19.0"))
                     mspHelper.sendLedStripModeColors(send_rxfail_config);
                 else
                     send_rxfail_config();
             }
 
             function send_rxfail_config() {
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
                     mspHelper.sendRxFailConfig(save_to_eeprom);
                 } else {
                     save_to_eeprom();

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -1,75 +1,77 @@
 'use strict';
 
-// define all the global variables that are uses to hold FC state
-var CONFIG;
-var BF_CONFIG;          // Remove when we officialy retire BF 3.1
-var FEATURE_CONFIG;
-var BEEPER_CONFIG;
-var MIXER_CONFIG;
-var BOARD_ALIGNMENT_CONFIG;
-var LED_STRIP;
-var LED_COLORS;
-var LED_MODE_COLORS;
-var PID;
-var PID_names;
-var PIDS_ACTIVE;
-var PIDs;
-var RC_MAP;
-var RC;
-var RC_tuning;
-var AUX_CONFIG;
-var AUX_CONFIG_IDS;
-var MODE_RANGES;
-var MODE_RANGES_EXTRA;
-var ADJUSTMENT_RANGES;
-var SERVO_CONFIG;
-var SERVO_RULES;
-var SERIAL_CONFIG;
-var SENSOR_DATA;
-var MOTOR_DATA;
-var MOTOR_TELEMETRY_DATA;
-var SERVO_DATA;
-var GPS_DATA;
-var ANALOG;
-var VOLTAGE_METERS;
-var VOLTAGE_METER_CONFIGS;
-var CURRENT_METERS;
-var CURRENT_METER_CONFIGS;
-var BATTERY_STATE;
-var BATTERY_CONFIG;
-var ARMING_CONFIG;
-var FC_CONFIG;
-var MISC; // DEPRECATED
-var MOTOR_CONFIG;
-var GPS_CONFIG;
-var RSSI_CONFIG;
-var MOTOR_3D_CONFIG;
-var DATAFLASH;
-var SDCARD;
-var BLACKBOX;
-var TRANSPONDER;
-var RC_DEADBAND_CONFIG;
-var SENSOR_ALIGNMENT;
-var RX_CONFIG;
-var FAILSAFE_CONFIG;
-var GPS_RESCUE;
-var RXFAIL_CONFIG;
-var PID_ADVANCED_CONFIG;
-var FILTER_CONFIG;
-var ADVANCED_TUNING_ACTIVE;
-var ADVANCED_TUNING;
-var SENSOR_CONFIG;
-var COPY_PROFILE;
-var VTX_CONFIG;
-var VTXTABLE_BAND;
-var VTXTABLE_POWERLEVEL;
-var MULTIPLE_MSP;
-var DEFAULT;
-var DEFAULT_PIDS;
+const FC = {
 
-var FC = {
-    resetState: function () {
-        CONFIG = {
+    // define all the global variables that are uses to hold FC state
+    // the default state must be defined inside the resetState() method
+    ADJUSTMENT_RANGES: null,
+    ADVANCED_TUNING: null,
+    ADVANCED_TUNING_ACTIVE: null,
+    ANALOG: null,
+    ARMING_CONFIG: null,
+    AUX_CONFIG: null,
+    AUX_CONFIG_IDS: null,
+    BATTERY_CONFIG: null,
+    BATTERY_STATE: null,
+    BEEPER_CONFIG: null,
+    BF_CONFIG: null,          // Remove when we officialy retire BF 3.1
+    BLACKBOX: null,
+    BOARD_ALIGNMENT_CONFIG: null,
+    CONFIG: null,
+    COPY_PROFILE: null,
+    CURRENT_METERS: null,
+    CURRENT_METER_CONFIGS: null,
+    DATAFLASH: null,
+    DEFAULT: null,
+    DEFAULT_PIDS: null,
+    FAILSAFE_CONFIG: null,
+    FC_CONFIG: null,
+    FEATURE_CONFIG: null,
+    FILTER_CONFIG: null,
+    GPS_CONFIG: null,
+    GPS_DATA: null,
+    GPS_RESCUE: null,
+    LED_COLORS: null,
+    LED_MODE_COLORS: null,
+    LED_STRIP: null,
+    MISC: null, // DEPRECATED
+    MIXER_CONFIG: null,
+    MODE_RANGES: null,
+    MODE_RANGES_EXTRA: null,
+    MOTOR_3D_CONFIG: null,
+    MOTOR_CONFIG: null,
+    MOTOR_DATA: null,
+    MOTOR_TELEMETRY_DATA: null,
+    MULTIPLE_MSP: null,
+    PID: null,
+    PIDS_ACTIVE: null,
+    PID_ADVANCED_CONFIG: null,
+    PID_NAMES: null,
+    PIDS: null,
+    RC: null,
+    RC_DEADBAND_CONFIG: null,
+    RC_MAP: null,
+    RC_TUNING: null,
+    RSSI_CONFIG: null,
+    RXFAIL_CONFIG: null,
+    RX_CONFIG: null,
+    SDCARD: null,
+    SENSOR_ALIGNMENT: null,
+    SENSOR_CONFIG: null,
+    SENSOR_DATA: null,
+    SERIAL_CONFIG: null,
+    SERVO_CONFIG: null,
+    SERVO_DATA: null,
+    SERVO_RULES: null,
+    TRANSPONDER: null,
+    VOLTAGE_METERS: null,
+    VOLTAGE_METER_CONFIGS: null,
+    VTXTABLE_BAND: null,
+    VTXTABLE_POWERLEVEL: null,
+    VTX_CONFIG: null,
+
+    resetState () {
+        this.CONFIG = {
             apiVersion:                       "0.0.0",
             flightControllerIdentifier:       '',
             flightControllerVersion:          '',
@@ -107,66 +109,66 @@ var FC = {
             configurationProblems:            0,
         };
 
-        BF_CONFIG = {
+        this.BF_CONFIG = {
             currentscale:               0,
             currentoffset:              0,
             currentmetertype:           0,
             batterycapacity:            0,
         };
 
-        COPY_PROFILE = {
+        this.COPY_PROFILE = {
             type:                       0,
             dstProfile:                 0,
             srcProfile:                 0,
         };
-        
-        FEATURE_CONFIG = {
+
+        this.FEATURE_CONFIG = {
             features:                   0,
         };
 
-        BEEPER_CONFIG = {
+        this.BEEPER_CONFIG = {
             beepers:                    0,
             dshotBeaconTone:            0,
             dshotBeaconConditions:      0,
         };
-        
-        MIXER_CONFIG = {
+
+        this.MIXER_CONFIG = {
             mixer:                      0,
             reverseMotorDir:            0,
-        }; 
+        };
 
-        BOARD_ALIGNMENT_CONFIG = {
+        this.BOARD_ALIGNMENT_CONFIG = {
             roll:                       0,
             pitch:                      0,
             yaw:                        0,
         };
 
-        LED_STRIP =                     [];
-        LED_COLORS =                    [];
-        LED_MODE_COLORS =               [];
+        this.LED_STRIP =                [];
+        this.LED_COLORS =               [];
+        this.LED_MODE_COLORS =          [];
 
-        PID = {
-            controller:                 0
+        this.PID = {
+            controller:                 0,
         };
 
-        PID_names =                     [];
-        PIDS_ACTIVE = new Array(10);
-        PIDs = new Array(10);
-        for (var i = 0; i < 10; i++) {
-            PIDS_ACTIVE[i] = new Array(3);
-            PIDs[i] = new Array(3);
+        this.PID_NAMES =                [];
+        this.PIDS_ACTIVE = Array.from({length: 10});
+        this.PIDS = Array.from({length: 10});
+        for (let i = 0; i < 10; i++) {
+            this.PIDS_ACTIVE[i] = Array.from({length: 3});
+            this.PIDS[i] = Array.from({length: 3});
         }
 
-        RC_MAP = [];
+        this.RC_MAP = [];
 
         // defaults
         // roll, pitch, yaw, throttle, aux 1, ... aux n
-        RC = {
+        this.RC = {
             active_channels:            0,
-            channels:                   new Array(32),
+            channels:                   Array.from({length: 32}),
         };
 
-        RC_tuning = {
+        this.RC_TUNING = {
             RC_RATE:                    0,
             RC_EXPO:                    0,
             roll_pitch_rate:            0, // pre 1.7 api only
@@ -186,17 +188,17 @@ var FC = {
             yaw_rate_limit:             1998,
         };
 
-        AUX_CONFIG =                    [];
-        AUX_CONFIG_IDS =                [];
+        this.AUX_CONFIG =               [];
+        this.AUX_CONFIG_IDS =           [];
 
-        MODE_RANGES =                   [];
-        MODE_RANGES_EXTRA =             [];
-        ADJUSTMENT_RANGES =             [];
+        this.MODE_RANGES =              [];
+        this.MODE_RANGES_EXTRA =        [];
+        this.ADJUSTMENT_RANGES =        [];
 
-        SERVO_CONFIG =                  [];
-        SERVO_RULES =                   [];
+        this.SERVO_CONFIG =             [];
+        this.SERVO_RULES =              [];
 
-        SERIAL_CONFIG = {
+        this.SERIAL_CONFIG = {
             ports:                      [],
 
             // pre 1.6 settings
@@ -206,7 +208,7 @@ var FC = {
             cliBaudRate:                0,
         };
 
-        SENSOR_DATA = {
+        this.SENSOR_DATA = {
             gyroscope:                  [0, 0, 0],
             accelerometer:              [0, 0, 0],
             magnetometer:               [0, 0, 0],
@@ -216,10 +218,10 @@ var FC = {
             debug:                      [0, 0, 0, 0],
         };
 
-        MOTOR_DATA =                    new Array(8);
-        SERVO_DATA =                    new Array(8);
+        this.MOTOR_DATA =               Array.from({length: 8});
+        this.SERVO_DATA =               Array.from({length: 8});
 
-        MOTOR_TELEMETRY_DATA = {
+        this.MOTOR_TELEMETRY_DATA = {
             rpm:                        [0, 0, 0, 0, 0, 0, 0, 0],
             invalidPercent:             [0, 0, 0, 0, 0, 0, 0, 0],
             temperature:                [0, 0, 0, 0, 0, 0, 0, 0],
@@ -228,7 +230,7 @@ var FC = {
             consumption:                [0, 0, 0, 0, 0, 0, 0, 0],
         };
 
-        GPS_DATA = {
+        this.GPS_DATA = {
             fix:                        0,
             numSat:                     0,
             lat:                        0,
@@ -243,24 +245,24 @@ var FC = {
             chn:                        [],
             svid:                       [],
             quality:                    [],
-            cno:                        []
+            cno:                        [],
         };
 
-        ANALOG = {
+        this.ANALOG = {
             voltage:                    0,
             mAhdrawn:                   0,
             rssi:                       0,
             amperage:                   0,
-            last_received_timestamp:    Date.now() // FIXME this code lies, it's never been received at this point
+            last_received_timestamp:    Date.now(), // FIXME this code lies, it's never been received at this point
         };
 
-        VOLTAGE_METERS =                [];
-        VOLTAGE_METER_CONFIGS =         [];
-        CURRENT_METERS =                [];
-        CURRENT_METER_CONFIGS =         [];
+        this.VOLTAGE_METERS =           [];
+        this.VOLTAGE_METER_CONFIGS =    [];
+        this.CURRENT_METERS =           [];
+        this.CURRENT_METER_CONFIGS =    [];
 
-        BATTERY_STATE = {};
-        BATTERY_CONFIG = {
+        this.BATTERY_STATE = {};
+        this.BATTERY_CONFIG = {
             vbatmincellvoltage:         0,
             vbatmaxcellvoltage:         0,
             vbatwarningcellvoltage:     0,
@@ -269,17 +271,17 @@ var FC = {
             currentMeterSource:         0,
         };
 
-        ARMING_CONFIG = {
+        this.ARMING_CONFIG = {
             auto_disarm_delay:          0,
             disarm_kill_switch:         0,
             small_angle:                0,
         };
 
-        FC_CONFIG = {
-            loopTime:                   0
+        this.FC_CONFIG = {
+            loopTime:                   0,
         };
 
-        MISC = {
+        this.MISC = {
             // DEPRECATED = only used to store values that are written back to the fc as-is, do NOT use for any other purpose
             failsafe_throttle:          0,
             gps_baudrate:               0,
@@ -291,7 +293,7 @@ var FC = {
             vbatwarningcellvoltage:     0,
             batterymetertype:           1, // 1=ADC, 2=ESC
         };
-        MOTOR_CONFIG = {
+        this.MOTOR_CONFIG = {
             minthrottle:                0,
             maxthrottle:                0,
             mincommand:                 0,
@@ -301,7 +303,7 @@ var FC = {
             use_esc_sensor:             false,
         };
 
-        GPS_CONFIG = {
+        this.GPS_CONFIG = {
             provider:                   0,
             ublox_sbas:                 0,
             auto_config:                0,
@@ -310,25 +312,25 @@ var FC = {
             ublox_use_galileo:          0,
         };
 
-        RSSI_CONFIG = {
+        this.RSSI_CONFIG = {
             channel:                    0,
         };
 
-        MOTOR_3D_CONFIG = {
+        this.MOTOR_3D_CONFIG = {
             deadband3d_low:             0,
             deadband3d_high:            0,
             neutral:                    0,
         };
 
-        DATAFLASH = {
+        this.DATAFLASH = {
             ready:                      false,
             supported:                  false,
             sectors:                    0,
             totalSize:                  0,
-            usedSize:                   0
+            usedSize:                   0,
         };
 
-        SDCARD = {
+        this.SDCARD = {
             supported:                  false,
             state:                      0,
             filesystemLastError:        0,
@@ -336,7 +338,7 @@ var FC = {
             totalSizeKB:                0,
         };
 
-        BLACKBOX = {
+        this.BLACKBOX = {
             supported:                  false,
             blackboxDevice:             0,
             blackboxRateNum:            1,
@@ -345,21 +347,21 @@ var FC = {
             blackboxSampleRate:         0,
         };
 
-        TRANSPONDER = {
+        this.TRANSPONDER = {
             supported:                  false,
             data:                       [],
             provider:                   0,
             providers:                  [],
         };
 
-        RC_DEADBAND_CONFIG = {
+        this.RC_DEADBAND_CONFIG = {
             deadband:                   0,
             yaw_deadband:               0,
             alt_hold_deadband:          0,
             deadband3d_throttle:        0,
         };
 
-        SENSOR_ALIGNMENT = {
+        this.SENSOR_ALIGNMENT = {
             align_gyro:                 0,
             align_acc:                  0,
             align_mag:                  0,
@@ -369,7 +371,7 @@ var FC = {
             gyro_2_align:               0,
         };
 
-        PID_ADVANCED_CONFIG = {
+        this.PID_ADVANCED_CONFIG = {
             gyro_sync_denom:            0,
             pid_process_denom:          0,
             use_unsyncedPwm:            0,
@@ -387,7 +389,7 @@ var FC = {
             debugModeCount:             0,
         };
 
-        FILTER_CONFIG = {
+        this.FILTER_CONFIG = {
             gyro_hardware_lpf:          0,
             gyro_32khz_hardware_lpf:    0,
             gyro_lowpass_hz:            0,
@@ -419,7 +421,7 @@ var FC = {
             gyro_rpm_notch_min_hz:      0,
         };
 
-        ADVANCED_TUNING = {
+        this.ADVANCED_TUNING = {
             rollPitchItermIgnoreRate:   0,
             yawItermIgnoreRate:         0,
             yaw_p_limit:                0,
@@ -464,15 +466,15 @@ var FC = {
             ff_boost:                   0,
             vbat_sag_compensation:      0,
         };
-        ADVANCED_TUNING_ACTIVE = { ...ADVANCED_TUNING };
+        this.ADVANCED_TUNING_ACTIVE = { ...this.ADVANCED_TUNING };
 
-        SENSOR_CONFIG = {
+        this.SENSOR_CONFIG = {
             acc_hardware:               0,
             baro_hardware:              0,
             mag_hardware:               0,
         };
 
-        RX_CONFIG = {
+        this.RX_CONFIG = {
             serialrx_provider:            0,
             stick_max:                    0,
             stick_center:                 0,
@@ -490,14 +492,14 @@ var FC = {
             fpvCamAngleDegrees:           0,
             rcSmoothingType:              0,
             rcSmoothingInputCutoff:       0,
-            rcSmoothingDerivativeCutoff:  0, 
+            rcSmoothingDerivativeCutoff:  0,
             rcSmoothingInputType:         0,
             rcSmoothingDerivativeType:    0,
             rcSmoothingAutoSmoothness:    0,
             usbCdcHidType:                0,
         };
 
-        FAILSAFE_CONFIG = {
+        this.FAILSAFE_CONFIG = {
             failsafe_delay:                 0,
             failsafe_off_delay:             0,
             failsafe_throttle:              0,
@@ -506,7 +508,7 @@ var FC = {
             failsafe_procedure:             0,
         };
 
-        GPS_RESCUE = {
+        this.GPS_RESCUE = {
             angle:                          0,
             initialAltitudeM:               0,
             descentDistanceM:               0,
@@ -522,9 +524,9 @@ var FC = {
             altitudeMode:                   0,
         };
 
-        RXFAIL_CONFIG = [];
+        this.RXFAIL_CONFIG = [];
 
-        VTX_CONFIG = {
+        this.VTX_CONFIG = {
             vtx_type:                       0,
             vtx_band:                       0,
             vtx_channel:                    0,
@@ -541,7 +543,7 @@ var FC = {
             vtx_table_clear:                false,
         };
 
-        VTXTABLE_BAND = {
+        this.VTXTABLE_BAND = {
             vtxtable_band_number:           0,
             vtxtable_band_name:             '',
             vtxtable_band_letter:           '',
@@ -549,23 +551,23 @@ var FC = {
             vtxtable_band_frequencies:      [],
         };
 
-        VTXTABLE_POWERLEVEL = {
+        this.VTXTABLE_POWERLEVEL = {
             vtxtable_powerlevel_number:     0,
             vtxtable_powerlevel_value:      0,
             vtxtable_powerlevel_label:      0,
         };
 
-        MULTIPLE_MSP = {
+        this.MULTIPLE_MSP = {
             msp_commands:                   [],
         };
 
-        DEFAULT = {
+        this.DEFAULT = {
             gyro_lowpass_hz:                100,
             gyro_lowpass_dyn_min_hz:        150,
             gyro_lowpass_dyn_max_hz:        450,
-            gyro_lowpass_type:              FC.FILTER_TYPE_FLAGS.PT1,
+            gyro_lowpass_type:              this.FILTER_TYPE_FLAGS.PT1,
             gyro_lowpass2_hz:               300,
-            gyro_lowpass2_type:             FC.FILTER_TYPE_FLAGS.PT1,
+            gyro_lowpass2_type:             this.FILTER_TYPE_FLAGS.PT1,
             gyro_notch_cutoff:              300,
             gyro_notch_hz:                  400,
             gyro_notch2_cutoff:             100,
@@ -575,9 +577,9 @@ var FC = {
             dterm_lowpass_dyn_min_hz:       150,
             dterm_lowpass_dyn_max_hz:       250,
             dyn_lpf_curve_expo:             5,
-            dterm_lowpass_type:             FC.FILTER_TYPE_FLAGS.PT1,
+            dterm_lowpass_type:             this.FILTER_TYPE_FLAGS.PT1,
             dterm_lowpass2_hz:              150,
-            dterm_lowpass2_type:            FC.FILTER_TYPE_FLAGS.BIQUAD,
+            dterm_lowpass2_type:            this.FILTER_TYPE_FLAGS.BIQUAD,
             dterm_notch_cutoff:             160,
             dterm_notch_hz:                 260,
             yaw_lowpass_hz:                 100,
@@ -587,27 +589,27 @@ var FC = {
             dyn_notch_width_percent_rpm:      0,
         };
 
-        DEFAULT_PIDS = [
+        this.DEFAULT_PIDS = [
             42, 85, 35, 20, 90,
             46, 90, 38, 22, 95,
             30, 90,  0,  0, 90,
         ];
     },
 
-    getHardwareName: function () {
+    getHardwareName() {
         let name;
-        if (CONFIG.targetName) {
-            name = CONFIG.targetName;
+        if (this.CONFIG.targetName) {
+            name = this.CONFIG.targetName;
         } else {
-            name = CONFIG.boardIdentifier;
+            name = this.CONFIG.boardIdentifier;
         }
 
-        if (CONFIG.boardName && CONFIG.boardName !== name) {
-            name = CONFIG.boardName + "(" + name + ")";
+        if (this.CONFIG.boardName && this.CONFIG.boardName !== name) {
+            name = `${this.CONFIG.boardName}(${name})`;
         }
 
-        if (CONFIG.manufacturerId) {
-            name = CONFIG.manufacturerId + "/" + name;
+        if (this.CONFIG.manufacturerId) {
+            name = `${this.CONFIG.manufacturerId}/${name}`;
         }
 
         return name;
@@ -627,8 +629,8 @@ var FC = {
         255: "Unknown MCU",
     },
 
-    getMcuType: function () {
-        return FC.MCU_TYPES[CONFIG.mcuTypeId];
+    getMcuType() {
+        return this.MCU_TYPES[this.CONFIG.mcuTypeId];
     },
 
     CONFIGURATION_STATES: {
@@ -652,12 +654,12 @@ var FC = {
         MOTOR_PROTOCOL_DISABLED: 1,
     },
 
-    boardHasVcp: function () {
-        var hasVcp = false;
-        if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-            hasVcp = bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_VCP);
+    boardHasVcp() {
+        let hasVcp = false;
+        if (semver.gte(this.CONFIG.apiVersion, "1.37.0")) {
+            hasVcp = bit_check(this.CONFIG.targetCapabilities, this.TARGET_CAPABILITIES_FLAGS.HAS_VCP);
         } else {
-            hasVcp = BOARD.find_board_definition(CONFIG.boardIdentifier).vcp;
+            hasVcp = BOARD.find_board_definition(this.CONFIG.boardIdentifier).vcp;
         }
 
         return hasVcp;
@@ -668,42 +670,42 @@ var FC = {
         BIQUAD: 1,
     },
 
-    getFilterDefaults: function() {
-        var versionFilterDefaults = DEFAULT;
+    getFilterDefaults() {
+        const versionFilterDefaults = this.DEFAULT;
 
-        if (semver.eq(CONFIG.apiVersion, "1.40.0")) {
+        if (semver.eq(this.CONFIG.apiVersion, "1.40.0")) {
             versionFilterDefaults.dterm_lowpass2_hz = 200;
-        } else if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+        } else if (semver.gte(this.CONFIG.apiVersion, "1.41.0")) {
             versionFilterDefaults.gyro_lowpass_hz = 150;
-            versionFilterDefaults.gyro_lowpass_type = FC.FILTER_TYPE_FLAGS.BIQUAD;
+            versionFilterDefaults.gyro_lowpass_type = this.FILTER_TYPE_FLAGS.BIQUAD;
             versionFilterDefaults.gyro_lowpass2_hz = 0;
-            versionFilterDefaults.gyro_lowpass2_type = FC.FILTER_TYPE_FLAGS.BIQUAD;
+            versionFilterDefaults.gyro_lowpass2_type = this.FILTER_TYPE_FLAGS.BIQUAD;
             versionFilterDefaults.dterm_lowpass_hz = 150;
-            versionFilterDefaults.dterm_lowpass_type = FC.FILTER_TYPE_FLAGS.BIQUAD;
+            versionFilterDefaults.dterm_lowpass_type = this.FILTER_TYPE_FLAGS.BIQUAD;
             versionFilterDefaults.dterm_lowpass2_hz = 150;
-            versionFilterDefaults.dterm_lowpass2_type = FC.FILTER_TYPE_FLAGS.BIQUAD;
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            versionFilterDefaults.dterm_lowpass2_type = this.FILTER_TYPE_FLAGS.BIQUAD;
+            if (semver.gte(this.CONFIG.apiVersion, "1.42.0")) {
                 versionFilterDefaults.gyro_lowpass_hz = 200;
                 versionFilterDefaults.gyro_lowpass_dyn_min_hz = 200;
                 versionFilterDefaults.gyro_lowpass_dyn_max_hz = 500;
-                versionFilterDefaults.gyro_lowpass_type = FC.FILTER_TYPE_FLAGS.PT1;
+                versionFilterDefaults.gyro_lowpass_type = this.FILTER_TYPE_FLAGS.PT1;
                 versionFilterDefaults.gyro_lowpass2_hz = 250;
-                versionFilterDefaults.gyro_lowpass2_type = FC.FILTER_TYPE_FLAGS.PT1;
+                versionFilterDefaults.gyro_lowpass2_type = this.FILTER_TYPE_FLAGS.PT1;
                 versionFilterDefaults.dterm_lowpass_hz = 150;
                 versionFilterDefaults.dterm_lowpass_dyn_min_hz = 70;
                 versionFilterDefaults.dterm_lowpass_dyn_max_hz = 170;
-                versionFilterDefaults.dterm_lowpass_type = FC.FILTER_TYPE_FLAGS.PT1;
+                versionFilterDefaults.dterm_lowpass_type = this.FILTER_TYPE_FLAGS.PT1;
                 versionFilterDefaults.dterm_lowpass2_hz = 150;
-                versionFilterDefaults.dterm_lowpass2_type = FC.FILTER_TYPE_FLAGS.PT1;
+                versionFilterDefaults.dterm_lowpass2_type = this.FILTER_TYPE_FLAGS.PT1;
             }
-        } 
+        }
         return versionFilterDefaults;
     },
 
-    getPidDefaults: function() {
-        var versionPidDefaults = DEFAULT_PIDS;
+    getPidDefaults() {
+        let versionPidDefaults = this.DEFAULT_PIDS;
         // if defaults change they should go here
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+        if (semver.gte(this.CONFIG.apiVersion, API_VERSION_1_43)) {
             versionPidDefaults = [
                 42, 85, 35, 23, 90,
                 46, 90, 38, 25, 95,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -126,8 +126,8 @@ function closeSerial() {
             checksum = bufView[3] ^ bufView[4];
 
             for (let i = 0; i < 16; i += 2) {
-                bufView[i + 5] = MOTOR_CONFIG.mincommand & 0x00FF;
-                bufView[i + 6] = MOTOR_CONFIG.mincommand >> 8;
+                bufView[i + 5] = FC.MOTOR_CONFIG.mincommand & 0x00FF;
+                bufView[i + 6] = FC.MOTOR_CONFIG.mincommand >> 8;
 
                 checksum ^= bufView[i + 5];
                 checksum ^= bufView[i + 6];
@@ -483,8 +483,8 @@ function startProcess() {
                 analyticsService.setDimension(analyticsService.DIMENSIONS.CONFIGURATOR_EXPERT_MODE, checked ? 'On' : 'Off');
             });
 
-            if (FEATURE_CONFIG && FEATURE_CONFIG.features !== 0) {
-                updateTabList(FEATURE_CONFIG.features);
+            if (FC.FEATURE_CONFIG && FC.FEATURE_CONFIG.features !== 0) {
+                updateTabList(FC.FEATURE_CONFIG.features);
             }
         }).change();
     });
@@ -648,13 +648,13 @@ function updateTabList(features) {
         $('#tabs ul.mode-connected li.tab_osd').hide();
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
         $('#tabs ul.mode-connected li.tab_power').show();
     } else {
         $('#tabs ul.mode-connected li.tab_power').hide();
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
         $('#tabs ul.mode-connected li.tab_vtx').show();
     } else {
         $('#tabs ul.mode-connected li.tab_vtx').hide();
@@ -677,12 +677,12 @@ function generateFilename(prefix, suffix) {
     const date = new Date();
     let filename = prefix;
 
-    if (CONFIG) {
-        if (CONFIG.flightControllerIdentifier) {
-            filename = `${CONFIG.flightControllerIdentifier}_${filename}`;
+    if (FC.CONFIG) {
+        if (FC.CONFIG.flightControllerIdentifier) {
+            filename = `${FC.CONFIG.flightControllerIdentifier}_${filename}`;
         }
-        if(CONFIG.name && CONFIG.name.trim() !== '') {
-            filename = `${filename}_${CONFIG.name.trim().replace(' ', '_')}`;
+        if(FC.CONFIG.name && FC.CONFIG.name.trim() !== '') {
+            filename = `${filename}_${FC.CONFIG.name.trim().replace(' ', '_')}`;
         }
     }
 

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -47,7 +47,7 @@ var Model = function (wrapper, canvas) {
     this.renderer.setSize(this.wrapper.width() * 2, this.wrapper.height() * 2);
 
     // load the model including materials
-    var model_file = useWebGLRenderer ? mixerList[MIXER_CONFIG.mixer - 1].model : 'fallback';
+    var model_file = useWebGLRenderer ? mixerList[FC.MIXER_CONFIG.mixer - 1].model : 'fallback';
 
     // Temporary workaround for 'custom' model until akfreak's custom model is merged.
     if (model_file == 'custom') { model_file = 'fallback'; }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -47,7 +47,7 @@ function MspHelper () {
 
 MspHelper.prototype.reorderPwmProtocols = function (protocol) {
     var result = protocol;
-    if (semver.lt(CONFIG.apiVersion, "1.26.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, "1.26.0")) {
         switch (protocol) {
             case 5:
                 result = 7;
@@ -74,30 +74,30 @@ MspHelper.prototype.process_data = function(dataHandler) {
     if (!crcError) {
         if (!dataHandler.unsupported) switch (code) {
             case MSPCodes.MSP_STATUS:
-                CONFIG.cycleTime = data.readU16();
-                CONFIG.i2cError = data.readU16();
-                CONFIG.activeSensors = data.readU16();
-                CONFIG.mode = data.readU32();
-                CONFIG.profile = data.readU8();
+                FC.CONFIG.cycleTime = data.readU16();
+                FC.CONFIG.i2cError = data.readU16();
+                FC.CONFIG.activeSensors = data.readU16();
+                FC.CONFIG.mode = data.readU32();
+                FC.CONFIG.profile = data.readU8();
 
                 TABS.pid_tuning.checkUpdateProfile(false);
 
-                sensor_status(CONFIG.activeSensors);
-                $('span.i2c-error').text(CONFIG.i2cError);
-                $('span.cycle-time').text(CONFIG.cycleTime);
+                sensor_status(FC.CONFIG.activeSensors);
+                $('span.i2c-error').text(FC.CONFIG.i2cError);
+                $('span.cycle-time').text(FC.CONFIG.cycleTime);
                 break;
             case MSPCodes.MSP_STATUS_EX:
-                CONFIG.cycleTime = data.readU16();
-                CONFIG.i2cError = data.readU16();
-                CONFIG.activeSensors = data.readU16();
-                CONFIG.mode = data.readU32();
-                CONFIG.profile = data.readU8();
-                CONFIG.cpuload = data.readU16();
-                if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-                    CONFIG.numProfiles = data.readU8();
-                    CONFIG.rateProfile = data.readU8();
+                FC.CONFIG.cycleTime = data.readU16();
+                FC.CONFIG.i2cError = data.readU16();
+                FC.CONFIG.activeSensors = data.readU16();
+                FC.CONFIG.mode = data.readU32();
+                FC.CONFIG.profile = data.readU8();
+                FC.CONFIG.cpuload = data.readU16();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
+                    FC.CONFIG.numProfiles = data.readU8();
+                    FC.CONFIG.rateProfile = data.readU8();
 
-                    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
                       // Read flight mode flags
                       var byteCount = data.readU8();
                       for (let i = 0; i < byteCount; i++) {
@@ -105,114 +105,114 @@ MspHelper.prototype.process_data = function(dataHandler) {
                       }
 
                       // Read arming disable flags
-                      CONFIG.armingDisableCount = data.readU8(); // Flag count
-                      CONFIG.armingDisableFlags = data.readU32();
+                      FC.CONFIG.armingDisableCount = data.readU8(); // Flag count
+                      FC.CONFIG.armingDisableFlags = data.readU32();
                     }
 
                     TABS.pid_tuning.checkUpdateProfile(true);
                 }
 
-                sensor_status(CONFIG.activeSensors);
-                $('span.i2c-error').text(CONFIG.i2cError);
-                $('span.cycle-time').text(CONFIG.cycleTime);
-                $('span.cpu-load').text(i18n.getMessage('statusbar_cpu_load', [CONFIG.cpuload]));
+                sensor_status(FC.CONFIG.activeSensors);
+                $('span.i2c-error').text(FC.CONFIG.i2cError);
+                $('span.cycle-time').text(FC.CONFIG.cycleTime);
+                $('span.cpu-load').text(i18n.getMessage('statusbar_cpu_load', [FC.CONFIG.cpuload]));
                 break;
 
             case MSPCodes.MSP_RAW_IMU:
                 // 512 for mpu6050, 256 for mma
                 // currently we are unable to differentiate between the sensor types, so we are goign with 512
-                SENSOR_DATA.accelerometer[0] = data.read16() / 512;
-                SENSOR_DATA.accelerometer[1] = data.read16() / 512;
-                SENSOR_DATA.accelerometer[2] = data.read16() / 512;
+                FC.SENSOR_DATA.accelerometer[0] = data.read16() / 512;
+                FC.SENSOR_DATA.accelerometer[1] = data.read16() / 512;
+                FC.SENSOR_DATA.accelerometer[2] = data.read16() / 512;
 
                 // properly scaled
-                SENSOR_DATA.gyroscope[0] = data.read16() * (4 / 16.4);
-                SENSOR_DATA.gyroscope[1] = data.read16() * (4 / 16.4);
-                SENSOR_DATA.gyroscope[2] = data.read16() * (4 / 16.4);
+                FC.SENSOR_DATA.gyroscope[0] = data.read16() * (4 / 16.4);
+                FC.SENSOR_DATA.gyroscope[1] = data.read16() * (4 / 16.4);
+                FC.SENSOR_DATA.gyroscope[2] = data.read16() * (4 / 16.4);
 
                 // no clue about scaling factor
-                SENSOR_DATA.magnetometer[0] = data.read16() / 1090;
-                SENSOR_DATA.magnetometer[1] = data.read16() / 1090;
-                SENSOR_DATA.magnetometer[2] = data.read16() / 1090;
+                FC.SENSOR_DATA.magnetometer[0] = data.read16() / 1090;
+                FC.SENSOR_DATA.magnetometer[1] = data.read16() / 1090;
+                FC.SENSOR_DATA.magnetometer[2] = data.read16() / 1090;
                 break;
             case MSPCodes.MSP_SERVO:
                 var servoCount = data.byteLength / 2;
                 for (let i = 0; i < servoCount; i++) {
-                    SERVO_DATA[i] = data.readU16();
+                    FC.SERVO_DATA[i] = data.readU16();
                 }
                 break;
             case MSPCodes.MSP_MOTOR:
                 var motorCount = data.byteLength / 2;
                 for (let i = 0; i < motorCount; i++) {
-                    MOTOR_DATA[i] = data.readU16();
+                    FC.MOTOR_DATA[i] = data.readU16();
                 }
                 break;
             case MSPCodes.MSP_MOTOR_TELEMETRY:
                 var telemMotorCount = data.readU8();
                 for (let i = 0; i < telemMotorCount; i++) {
-                    MOTOR_TELEMETRY_DATA.rpm[i] = data.readU32();   // RPM
-                    MOTOR_TELEMETRY_DATA.invalidPercent[i] = data.readU16();   // 10000 = 100.00%
-                    MOTOR_TELEMETRY_DATA.temperature[i] = data.readU8();       // degrees celsius
-                    MOTOR_TELEMETRY_DATA.voltage[i] = data.readU16();          // 0.01V per unit
-                    MOTOR_TELEMETRY_DATA.current[i] = data.readU16();          // 0.01A per unit
-                    MOTOR_TELEMETRY_DATA.consumption[i] = data.readU16();      // mAh
+                    FC.MOTOR_TELEMETRY_DATA.rpm[i] = data.readU32();   // RPM
+                    FC.MOTOR_TELEMETRY_DATA.invalidPercent[i] = data.readU16();   // 10000 = 100.00%
+                    FC.MOTOR_TELEMETRY_DATA.temperature[i] = data.readU8();       // degrees celsius
+                    FC.MOTOR_TELEMETRY_DATA.voltage[i] = data.readU16();          // 0.01V per unit
+                    FC.MOTOR_TELEMETRY_DATA.current[i] = data.readU16();          // 0.01A per unit
+                    FC.MOTOR_TELEMETRY_DATA.consumption[i] = data.readU16();      // mAh
                 }
                 break;
             case MSPCodes.MSP_RC:
-                RC.active_channels = data.byteLength / 2;
-                for (let i = 0; i < RC.active_channels; i++) {
-                    RC.channels[i] = data.readU16();
+                FC.RC.active_channels = data.byteLength / 2;
+                for (let i = 0; i < FC.RC.active_channels; i++) {
+                    FC.RC.channels[i] = data.readU16();
                 }
                 break;
             case MSPCodes.MSP_RAW_GPS:
-                GPS_DATA.fix = data.readU8();
-                GPS_DATA.numSat = data.readU8();
-                GPS_DATA.lat = data.read32();
-                GPS_DATA.lon = data.read32();
-                GPS_DATA.alt = data.readU16();
-                GPS_DATA.speed = data.readU16();
-                GPS_DATA.ground_course = data.readU16();
+                FC.GPS_DATA.fix = data.readU8();
+                FC.GPS_DATA.numSat = data.readU8();
+                FC.GPS_DATA.lat = data.read32();
+                FC.GPS_DATA.lon = data.read32();
+                FC.GPS_DATA.alt = data.readU16();
+                FC.GPS_DATA.speed = data.readU16();
+                FC.GPS_DATA.ground_course = data.readU16();
                 break;
             case MSPCodes.MSP_COMP_GPS:
-                GPS_DATA.distanceToHome = data.readU16();
-                GPS_DATA.directionToHome = data.readU16();
-                GPS_DATA.update = data.readU8();
+                FC.GPS_DATA.distanceToHome = data.readU16();
+                FC.GPS_DATA.directionToHome = data.readU16();
+                FC.GPS_DATA.update = data.readU8();
                 break;
             case MSPCodes.MSP_ATTITUDE:
-                SENSOR_DATA.kinematics[0] = data.read16() / 10.0; // x
-                SENSOR_DATA.kinematics[1] = data.read16() / 10.0; // y
-                SENSOR_DATA.kinematics[2] = data.read16(); // z
+                FC.SENSOR_DATA.kinematics[0] = data.read16() / 10.0; // x
+                FC.SENSOR_DATA.kinematics[1] = data.read16() / 10.0; // y
+                FC.SENSOR_DATA.kinematics[2] = data.read16(); // z
                 break;
             case MSPCodes.MSP_ALTITUDE:
-                SENSOR_DATA.altitude = parseFloat((data.read32() / 100.0).toFixed(2)); // correct scale factor
+                FC.SENSOR_DATA.altitude = parseFloat((data.read32() / 100.0).toFixed(2)); // correct scale factor
                 break;
             case MSPCodes.MSP_SONAR:
-                SENSOR_DATA.sonar = data.read32();
+                FC.SENSOR_DATA.sonar = data.read32();
                 break;
             case MSPCodes.MSP_ANALOG:
-                ANALOG.voltage = data.readU8() / 10.0;
-                ANALOG.mAhdrawn = data.readU16();
-                ANALOG.rssi = data.readU16(); // 0-1023
-                ANALOG.amperage = data.read16() / 100; // A
-                ANALOG.last_received_timestamp = Date.now();
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    ANALOG.voltage = data.readU16() / 100;
+                FC.ANALOG.voltage = data.readU8() / 10.0;
+                FC.ANALOG.mAhdrawn = data.readU16();
+                FC.ANALOG.rssi = data.readU16(); // 0-1023
+                FC.ANALOG.amperage = data.read16() / 100; // A
+                FC.ANALOG.last_received_timestamp = Date.now();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    FC.ANALOG.voltage = data.readU16() / 100;
                 }
                 break;
             case MSPCodes.MSP_VOLTAGE_METERS:
-                VOLTAGE_METERS = [];
+                FC.VOLTAGE_METERS = [];
                 var voltageMeterLength = 2;
                 for (let i = 0; i < (data.byteLength / voltageMeterLength); i++) {
                     var voltageMeter = {};
                     voltageMeter.id = data.readU8();
                     voltageMeter.voltage = data.readU8() / 10.0;
 
-                    VOLTAGE_METERS.push(voltageMeter)
+                    FC.VOLTAGE_METERS.push(voltageMeter)
                 }
                 break;
             case MSPCodes.MSP_CURRENT_METERS:
 
-                CURRENT_METERS = [];
+                FC.CURRENT_METERS = [];
                 var currentMeterLength = 5;
                 for (let i = 0; i < (data.byteLength / currentMeterLength); i++) {
                     var currentMeter = {};
@@ -220,33 +220,33 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     currentMeter.mAhDrawn = data.readU16(); // mAh
                     currentMeter.amperage = data.readU16() / 1000; // A
 
-                    CURRENT_METERS.push(currentMeter);
+                    FC.CURRENT_METERS.push(currentMeter);
                 }
                 break;
             case MSPCodes.MSP_BATTERY_STATE:
-                BATTERY_STATE.cellCount = data.readU8();
-                BATTERY_STATE.capacity = data.readU16(); // mAh
+                FC.BATTERY_STATE.cellCount = data.readU8();
+                FC.BATTERY_STATE.capacity = data.readU16(); // mAh
 
-                BATTERY_STATE.voltage = data.readU8() / 10.0; // V
-                BATTERY_STATE.mAhDrawn = data.readU16(); // mAh
-                BATTERY_STATE.amperage = data.readU16() / 100; // A
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    BATTERY_STATE.batteryState = data.readU8();
-                    BATTERY_STATE.voltage = data.readU16() / 100;
+                FC.BATTERY_STATE.voltage = data.readU8() / 10.0; // V
+                FC.BATTERY_STATE.mAhDrawn = data.readU16(); // mAh
+                FC.BATTERY_STATE.amperage = data.readU16() / 100; // A
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    FC.BATTERY_STATE.batteryState = data.readU8();
+                    FC.BATTERY_STATE.voltage = data.readU16() / 100;
                 }
                 break;
 
             case MSPCodes.MSP_VOLTAGE_METER_CONFIG:
-                if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
-                    MISC.vbatscale = data.readU8(); // 10-200
-                    MISC.vbatmincellvoltage = data.readU8() / 10; // 10-50
-                    MISC.vbatmaxcellvoltage = data.readU8() / 10; // 10-50
-                    MISC.vbatwarningcellvoltage = data.readU8() / 10; // 10-50
-                    if (semver.gte(CONFIG.apiVersion, "1.23.0")) {
-                        MISC.batterymetertype = data.readU8();
+                if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+                    FC.MISC.vbatscale = data.readU8(); // 10-200
+                    FC.MISC.vbatmincellvoltage = data.readU8() / 10; // 10-50
+                    FC.MISC.vbatmaxcellvoltage = data.readU8() / 10; // 10-50
+                    FC.MISC.vbatwarningcellvoltage = data.readU8() / 10; // 10-50
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.23.0")) {
+                        FC.MISC.batterymetertype = data.readU8();
                     }
                 } else {
-                    VOLTAGE_METER_CONFIGS = [];
+                    FC.VOLTAGE_METER_CONFIGS = [];
                     var voltage_meter_count = data.readU8();
 
                     for (let i = 0; i < voltage_meter_count; i++) {
@@ -263,20 +263,20 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             voltageMeterConfig.vbatresdivval = data.readU8();
                             voltageMeterConfig.vbatresdivmultiplier = data.readU8();
 
-                            VOLTAGE_METER_CONFIGS.push(voltageMeterConfig);
+                            FC.VOLTAGE_METER_CONFIGS.push(voltageMeterConfig);
                         }
                     }
                 }
                 break;
             case MSPCodes.MSP_CURRENT_METER_CONFIG:
-                if (semver.lt(CONFIG.apiVersion, "1.36.0"))  {
-                    BF_CONFIG.currentscale = data.read16();
-                    BF_CONFIG.currentoffset = data.read16();
-                    BF_CONFIG.currentmetertype = data.readU8();
-                    BF_CONFIG.batterycapacity = data.readU16();
+                if (semver.lt(FC.CONFIG.apiVersion, "1.36.0"))  {
+                    FC.BF_CONFIG.currentscale = data.read16();
+                    FC.BF_CONFIG.currentoffset = data.read16();
+                    FC.BF_CONFIG.currentmetertype = data.readU8();
+                    FC.BF_CONFIG.batterycapacity = data.readU16();
                 } else {
                     var offset = 0;
-                    CURRENT_METER_CONFIGS = [];
+                    FC.CURRENT_METER_CONFIGS = [];
                     var current_meter_count = data.readU8();
                     for (let i = 0; i < current_meter_count; i++) {
                         var currentMeterConfig = {};
@@ -292,74 +292,74 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             currentMeterConfig.scale = data.read16();
                             currentMeterConfig.offset = data.read16();
 
-                            CURRENT_METER_CONFIGS.push(currentMeterConfig);
+                            FC.CURRENT_METER_CONFIGS.push(currentMeterConfig);
                         }
                     }
                 }
                 break;
 
             case MSPCodes.MSP_BATTERY_CONFIG:
-                BATTERY_CONFIG.vbatmincellvoltage = data.readU8() / 10; // 10-50
-                BATTERY_CONFIG.vbatmaxcellvoltage = data.readU8() / 10; // 10-50
-                BATTERY_CONFIG.vbatwarningcellvoltage = data.readU8() / 10; // 10-50
-                BATTERY_CONFIG.capacity = data.readU16();
-                BATTERY_CONFIG.voltageMeterSource = data.readU8();
-                BATTERY_CONFIG.currentMeterSource = data.readU8();
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    BATTERY_CONFIG.vbatmincellvoltage = data.readU16() / 100;
-                    BATTERY_CONFIG.vbatmaxcellvoltage = data.readU16() / 100;
-                    BATTERY_CONFIG.vbatwarningcellvoltage = data.readU16() / 100;
+                FC.BATTERY_CONFIG.vbatmincellvoltage = data.readU8() / 10; // 10-50
+                FC.BATTERY_CONFIG.vbatmaxcellvoltage = data.readU8() / 10; // 10-50
+                FC.BATTERY_CONFIG.vbatwarningcellvoltage = data.readU8() / 10; // 10-50
+                FC.BATTERY_CONFIG.capacity = data.readU16();
+                FC.BATTERY_CONFIG.voltageMeterSource = data.readU8();
+                FC.BATTERY_CONFIG.currentMeterSource = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    FC.BATTERY_CONFIG.vbatmincellvoltage = data.readU16() / 100;
+                    FC.BATTERY_CONFIG.vbatmaxcellvoltage = data.readU16() / 100;
+                    FC.BATTERY_CONFIG.vbatwarningcellvoltage = data.readU16() / 100;
                 }
                 break;
             case MSPCodes.MSP_RC_TUNING:
-                RC_tuning.RC_RATE = parseFloat((data.readU8() / 100).toFixed(2));
-                RC_tuning.RC_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
-                if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
-                    RC_tuning.roll_pitch_rate = parseFloat((data.readU8() / 100).toFixed(2));
-                    RC_tuning.pitch_rate = 0;
-                    RC_tuning.roll_rate = 0;
+                FC.RC_TUNING.RC_RATE = parseFloat((data.readU8() / 100).toFixed(2));
+                FC.RC_TUNING.RC_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
+                if (semver.lt(FC.CONFIG.apiVersion, "1.7.0")) {
+                    FC.RC_TUNING.roll_pitch_rate = parseFloat((data.readU8() / 100).toFixed(2));
+                    FC.RC_TUNING.pitch_rate = 0;
+                    FC.RC_TUNING.roll_rate = 0;
                 } else {
-                    RC_tuning.roll_pitch_rate = 0;
-                    RC_tuning.roll_rate = parseFloat((data.readU8() / 100).toFixed(2));
-                    RC_tuning.pitch_rate = parseFloat((data.readU8() / 100).toFixed(2));
+                    FC.RC_TUNING.roll_pitch_rate = 0;
+                    FC.RC_TUNING.roll_rate = parseFloat((data.readU8() / 100).toFixed(2));
+                    FC.RC_TUNING.pitch_rate = parseFloat((data.readU8() / 100).toFixed(2));
                 }
-                RC_tuning.yaw_rate = parseFloat((data.readU8() / 100).toFixed(2));
-                RC_tuning.dynamic_THR_PID = parseFloat((data.readU8() / 100).toFixed(2));
-                RC_tuning.throttle_MID = parseFloat((data.readU8() / 100).toFixed(2));
-                RC_tuning.throttle_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
-                if (semver.gte(CONFIG.apiVersion, "1.7.0")) {
-                    RC_tuning.dynamic_THR_breakpoint = data.readU16();
+                FC.RC_TUNING.yaw_rate = parseFloat((data.readU8() / 100).toFixed(2));
+                FC.RC_TUNING.dynamic_THR_PID = parseFloat((data.readU8() / 100).toFixed(2));
+                FC.RC_TUNING.throttle_MID = parseFloat((data.readU8() / 100).toFixed(2));
+                FC.RC_TUNING.throttle_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
+                if (semver.gte(FC.CONFIG.apiVersion, "1.7.0")) {
+                    FC.RC_TUNING.dynamic_THR_breakpoint = data.readU16();
                 } else {
-                    RC_tuning.dynamic_THR_breakpoint = 0;
+                    FC.RC_TUNING.dynamic_THR_breakpoint = 0;
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
-                    RC_tuning.RC_YAW_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
-                    if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-                        RC_tuning.rcYawRate = parseFloat((data.readU8() / 100).toFixed(2));
+                if (semver.gte(FC.CONFIG.apiVersion, "1.10.0")) {
+                    FC.RC_TUNING.RC_YAW_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
+                        FC.RC_TUNING.rcYawRate = parseFloat((data.readU8() / 100).toFixed(2));
                     } else {
-                        RC_tuning.rcYawRate = 0;
+                        FC.RC_TUNING.rcYawRate = 0;
                     }
                 } else {
-                    RC_tuning.RC_YAW_EXPO = 0;
+                    FC.RC_TUNING.RC_YAW_EXPO = 0;
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                    RC_tuning.rcPitchRate = parseFloat((data.readU8() / 100).toFixed(2));
-                    RC_tuning.RC_PITCH_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
+                if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                    FC.RC_TUNING.rcPitchRate = parseFloat((data.readU8() / 100).toFixed(2));
+                    FC.RC_TUNING.RC_PITCH_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
                 } else {
-                    RC_tuning.rcPitchRate = 0;
-                    RC_tuning.RC_PITCH_EXPO = 0;
+                    FC.RC_TUNING.rcPitchRate = 0;
+                    FC.RC_TUNING.RC_PITCH_EXPO = 0;
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    RC_tuning.throttleLimitType = data.readU8();
-                    RC_tuning.throttleLimitPercent = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    FC.RC_TUNING.throttleLimitType = data.readU8();
+                    FC.RC_TUNING.throttleLimitPercent = data.readU8();
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                    RC_tuning.roll_rate_limit = data.readU16();
-                    RC_tuning.pitch_rate_limit = data.readU16();
-                    RC_tuning.yaw_rate_limit = data.readU16();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                    FC.RC_TUNING.roll_rate_limit = data.readU16();
+                    FC.RC_TUNING.pitch_rate_limit = data.readU16();
+                    FC.RC_TUNING.yaw_rate_limit = data.readU16();
                 }
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                    RC_tuning.rates_type = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                    FC.RC_TUNING.rates_type = data.readU8();
                 }
                 break;
             case MSPCodes.MSP_PID:
@@ -367,104 +367,104 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 for (let i = 0, needle = 0; i < (data.byteLength / 3); i++, needle += 3) {
                     // main for loop selecting the pid section
                     for (var j = 0; j < 3; j++) {
-                        PIDS_ACTIVE[i][j] = data.readU8();
-                        PIDs[i][j] = PIDS_ACTIVE[i][j];
+                        FC.PIDS_ACTIVE[i][j] = data.readU8();
+                        FC.PIDS[i][j] = FC.PIDS_ACTIVE[i][j];
                     }
                 }
                 break;
 
             case MSPCodes.MSP_ARMING_CONFIG:
-                if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
-                    ARMING_CONFIG.auto_disarm_delay = data.readU8();
-                    ARMING_CONFIG.disarm_kill_switch = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
+                    FC.ARMING_CONFIG.auto_disarm_delay = data.readU8();
+                    FC.ARMING_CONFIG.disarm_kill_switch = data.readU8();
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                    ARMING_CONFIG.small_angle = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                    FC.ARMING_CONFIG.small_angle = data.readU8();
                 }
                 break;
             case MSPCodes.MSP_LOOP_TIME:
-                if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
-                    FC_CONFIG.loopTime = data.readU16();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
+                    FC.FC_CONFIG.loopTime = data.readU16();
                 }
                 break;
             case MSPCodes.MSP_MISC: // 22 bytes
-                RX_CONFIG.midrc = data.readU16();
-                MOTOR_CONFIG.minthrottle = data.readU16(); // 0-2000
-                MOTOR_CONFIG.maxthrottle = data.readU16(); // 0-2000
-                MOTOR_CONFIG.mincommand = data.readU16(); // 0-2000
-                MISC.failsafe_throttle = data.readU16(); // 1000-2000
-                GPS_CONFIG.provider = data.readU8();
-                MISC.gps_baudrate = data.readU8();
-                GPS_CONFIG.ublox_sbas = data.readU8();
-                MISC.multiwiicurrentoutput = data.readU8();
-                RSSI_CONFIG.channel = data.readU8();
-                MISC.placeholder2 = data.readU8();
+                FC.RX_CONFIG.midrc = data.readU16();
+                FC.MOTOR_CONFIG.minthrottle = data.readU16(); // 0-2000
+                FC.MOTOR_CONFIG.maxthrottle = data.readU16(); // 0-2000
+                FC.MOTOR_CONFIG.mincommand = data.readU16(); // 0-2000
+                FC.MISC.failsafe_throttle = data.readU16(); // 1000-2000
+                FC.GPS_CONFIG.provider = data.readU8();
+                FC.MISC.gps_baudrate = data.readU8();
+                FC.GPS_CONFIG.ublox_sbas = data.readU8();
+                FC.MISC.multiwiicurrentoutput = data.readU8();
+                FC.RSSI_CONFIG.channel = data.readU8();
+                FC.MISC.placeholder2 = data.readU8();
                 data.read16(); // was mag_declination
-                MISC.vbatscale = data.readU8(); // was MISC.vbatscale - 10-200
-                MISC.vbatmincellvoltage = data.readU8() / 10; // 10-50
-                MISC.vbatmaxcellvoltage = data.readU8() / 10; // 10-50
-                MISC.vbatwarningcellvoltage = data.readU8() / 10; // 10-50
+                FC.MISC.vbatscale = data.readU8(); // was FC.MISC.vbatscale - 10-200
+                FC.MISC.vbatmincellvoltage = data.readU8() / 10; // 10-50
+                FC.MISC.vbatmaxcellvoltage = data.readU8() / 10; // 10-50
+                FC.MISC.vbatwarningcellvoltage = data.readU8() / 10; // 10-50
                 break;
             case MSPCodes.MSP_MOTOR_CONFIG:
-                MOTOR_CONFIG.minthrottle = data.readU16(); // 0-2000
-                MOTOR_CONFIG.maxthrottle = data.readU16(); // 0-2000
-                MOTOR_CONFIG.mincommand = data.readU16(); // 0-2000
-                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                    MOTOR_CONFIG.motor_count = data.readU8();
-                    MOTOR_CONFIG.motor_poles = data.readU8();
-                    MOTOR_CONFIG.use_dshot_telemetry = data.readU8() != 0;
-                    MOTOR_CONFIG.use_esc_sensor = data.readU8() != 0;
+                FC.MOTOR_CONFIG.minthrottle = data.readU16(); // 0-2000
+                FC.MOTOR_CONFIG.maxthrottle = data.readU16(); // 0-2000
+                FC.MOTOR_CONFIG.mincommand = data.readU16(); // 0-2000
+                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                    FC.MOTOR_CONFIG.motor_count = data.readU8();
+                    FC.MOTOR_CONFIG.motor_poles = data.readU8();
+                    FC.MOTOR_CONFIG.use_dshot_telemetry = data.readU8() != 0;
+                    FC.MOTOR_CONFIG.use_esc_sensor = data.readU8() != 0;
                 }
                 break;
             case MSPCodes.MSP_GPS_CONFIG:
-                GPS_CONFIG.provider = data.readU8();
-                GPS_CONFIG.ublox_sbas = data.readU8();
-                if (semver.gte(CONFIG.apiVersion, "1.34.0")) {
-                    GPS_CONFIG.auto_config = data.readU8();
-                    GPS_CONFIG.auto_baud = data.readU8();
+                FC.GPS_CONFIG.provider = data.readU8();
+                FC.GPS_CONFIG.ublox_sbas = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
+                    FC.GPS_CONFIG.auto_config = data.readU8();
+                    FC.GPS_CONFIG.auto_baud = data.readU8();
 
-                    if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                        GPS_CONFIG.home_point_once = data.readU8();
-                        GPS_CONFIG.ublox_use_galileo = data.readU8();
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                        FC.GPS_CONFIG.home_point_once = data.readU8();
+                        FC.GPS_CONFIG.ublox_use_galileo = data.readU8();
                     }
                 }
                 break;
             case MSPCodes.MSP_GPS_RESCUE:
-                GPS_RESCUE.angle             = data.readU16();
-                GPS_RESCUE.initialAltitudeM  = data.readU16();
-                GPS_RESCUE.descentDistanceM  = data.readU16();
-                GPS_RESCUE.rescueGroundspeed = data.readU16();
-                GPS_RESCUE.throttleMin       = data.readU16();
-                GPS_RESCUE.throttleMax       = data.readU16();
-                GPS_RESCUE.throttleHover     = data.readU16();
-                GPS_RESCUE.sanityChecks      = data.readU8();
-                GPS_RESCUE.minSats           = data.readU8();
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                    GPS_RESCUE.ascendRate            = data.readU16();
-                    GPS_RESCUE.descendRate           = data.readU16();
-                    GPS_RESCUE.allowArmingWithoutFix = data.readU8();
-                    GPS_RESCUE.altitudeMode          = data.readU8();
+                FC.GPS_RESCUE.angle             = data.readU16();
+                FC.GPS_RESCUE.initialAltitudeM  = data.readU16();
+                FC.GPS_RESCUE.descentDistanceM  = data.readU16();
+                FC.GPS_RESCUE.rescueGroundspeed = data.readU16();
+                FC.GPS_RESCUE.throttleMin       = data.readU16();
+                FC.GPS_RESCUE.throttleMax       = data.readU16();
+                FC.GPS_RESCUE.throttleHover     = data.readU16();
+                FC.GPS_RESCUE.sanityChecks      = data.readU8();
+                FC.GPS_RESCUE.minSats           = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                    FC.GPS_RESCUE.ascendRate            = data.readU16();
+                    FC.GPS_RESCUE.descendRate           = data.readU16();
+                    FC.GPS_RESCUE.allowArmingWithoutFix = data.readU8();
+                    FC.GPS_RESCUE.altitudeMode          = data.readU8();
                 }
                 break;
             case MSPCodes.MSP_RSSI_CONFIG:
-                RSSI_CONFIG.channel = data.readU8();
+                FC.RSSI_CONFIG.channel = data.readU8();
                 break;
             case MSPCodes.MSP_MOTOR_3D_CONFIG:
-                MOTOR_3D_CONFIG.deadband3d_low = data.readU16();
-                MOTOR_3D_CONFIG.deadband3d_high = data.readU16();
-                MOTOR_3D_CONFIG.neutral = data.readU16();
-                if (semver.lt(CONFIG.apiVersion, "1.17.0")) {
-                    RC_DEADBAND_CONFIG.deadband3d_throttle = data.readU16();
+                FC.MOTOR_3D_CONFIG.deadband3d_low = data.readU16();
+                FC.MOTOR_3D_CONFIG.deadband3d_high = data.readU16();
+                FC.MOTOR_3D_CONFIG.neutral = data.readU16();
+                if (semver.lt(FC.CONFIG.apiVersion, "1.17.0")) {
+                    FC.RC_DEADBAND_CONFIG.deadband3d_throttle = data.readU16();
                 }
                 break;
             case MSPCodes.MSP_BOXNAMES:
-                AUX_CONFIG = []; // empty the array as new data is coming in
+                FC.AUX_CONFIG = []; // empty the array as new data is coming in
 
                 var buff = [];
                 for (let i = 0; i < data.byteLength; i++) {
                     var char = data.readU8();
                     if (char == 0x3B) { // ; (delimeter char)
-                        AUX_CONFIG.push(String.fromCharCode.apply(null, buff)); // convert bytes into ASCII and save as strings
+                        FC.AUX_CONFIG.push(String.fromCharCode.apply(null, buff)); // convert bytes into ASCII and save as strings
 
                         // empty buffer
                         buff = [];
@@ -474,13 +474,13 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 break;
             case MSPCodes.MSP_PIDNAMES:
-                PID_names = []; // empty the array as new data is coming in
+                FC.PID_NAMES = []; // empty the array as new data is coming in
 
                 var buff = [];
                 for (let i = 0; i < data.byteLength; i++) {
                     var char = data.readU8();
                     if (char == 0x3B) { // ; (delimeter char)
-                        PID_names.push(String.fromCharCode.apply(null, buff)); // convert bytes into ASCII and save as strings
+                        FC.PID_NAMES.push(String.fromCharCode.apply(null, buff)); // convert bytes into ASCII and save as strings
 
                         // empty buffer
                         buff = [];
@@ -490,18 +490,18 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 break;
             case MSPCodes.MSP_BOXIDS:
-                AUX_CONFIG_IDS = []; // empty the array as new data is coming in
+                FC.AUX_CONFIG_IDS = []; // empty the array as new data is coming in
 
                 for (let i = 0; i < data.byteLength; i++) {
-                    AUX_CONFIG_IDS.push(data.readU8());
+                    FC.AUX_CONFIG_IDS.push(data.readU8());
                 }
                 break;
             case MSPCodes.MSP_SERVO_MIX_RULES:
                 break;
 
             case MSPCodes.MSP_SERVO_CONFIGURATIONS:
-                SERVO_CONFIG = []; // empty the array as new data is coming in
-                if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
+                FC.SERVO_CONFIG = []; // empty the array as new data is coming in
+                if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
                     if (data.byteLength % 12 == 0) {
                         for (let i = 0; i < data.byteLength; i += 12) {
                             var arr = {
@@ -513,10 +513,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                 'reversedInputSources':     data.readU32()
                             };
 
-                            SERVO_CONFIG.push(arr);
+                            FC.SERVO_CONFIG.push(arr);
                         }
                     }
-                } else if (semver.gte(CONFIG.apiVersion, "1.12.0")) {
+                } else if (semver.gte(FC.CONFIG.apiVersion, "1.12.0")) {
                     if (data.byteLength % 14 == 0) {
                         for (let i = 0; i < data.byteLength; i += 14) {
                             var arr = {
@@ -530,7 +530,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                 'reversedInputSources':     data.readU32()
                             };
 
-                            SERVO_CONFIG.push(arr);
+                            FC.SERVO_CONFIG.push(arr);
                         }
                     }
                 } else {
@@ -547,37 +547,37 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                 'reversedInputSources':     0
                             };
 
-                            SERVO_CONFIG.push(arr);
+                            FC.SERVO_CONFIG.push(arr);
                         }
                     }
 
-                    if (semver.eq(CONFIG.apiVersion, '1.10.0')) {
+                    if (semver.eq(FC.CONFIG.apiVersion, '1.10.0')) {
                         // drop two unused servo configurations due to MSP rx buffer to small)
-                        while (SERVO_CONFIG.length > 8) {
-                            SERVO_CONFIG.pop();
+                        while (FC.SERVO_CONFIG.length > 8) {
+                            FC.SERVO_CONFIG.pop();
                         }
                     }
                 }
                 break;
             case MSPCodes.MSP_RC_DEADBAND:
-                RC_DEADBAND_CONFIG.deadband = data.readU8();
-                RC_DEADBAND_CONFIG.yaw_deadband = data.readU8();
-                RC_DEADBAND_CONFIG.alt_hold_deadband = data.readU8();
+                FC.RC_DEADBAND_CONFIG.deadband = data.readU8();
+                FC.RC_DEADBAND_CONFIG.yaw_deadband = data.readU8();
+                FC.RC_DEADBAND_CONFIG.alt_hold_deadband = data.readU8();
 
-                if (semver.gte(CONFIG.apiVersion, "1.17.0")) {
-                    RC_DEADBAND_CONFIG.deadband3d_throttle = data.readU16();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.17.0")) {
+                    FC.RC_DEADBAND_CONFIG.deadband3d_throttle = data.readU16();
                 }
                 break;
             case MSPCodes.MSP_SENSOR_ALIGNMENT:
-                SENSOR_ALIGNMENT.align_gyro = data.readU8();
-                SENSOR_ALIGNMENT.align_acc = data.readU8();
-                SENSOR_ALIGNMENT.align_mag = data.readU8();
+                FC.SENSOR_ALIGNMENT.align_gyro = data.readU8();
+                FC.SENSOR_ALIGNMENT.align_acc = data.readU8();
+                FC.SENSOR_ALIGNMENT.align_mag = data.readU8();
 
-                if (semver.gte(CONFIG.apiVersion, '1.41.0')) {
-                    SENSOR_ALIGNMENT.gyro_detection_flags = data.readU8();
-                    SENSOR_ALIGNMENT.gyro_to_use = data.readU8();
-                    SENSOR_ALIGNMENT.gyro_1_align = data.readU8();
-                    SENSOR_ALIGNMENT.gyro_2_align = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, '1.41.0')) {
+                    FC.SENSOR_ALIGNMENT.gyro_detection_flags = data.readU8();
+                    FC.SENSOR_ALIGNMENT.gyro_to_use = data.readU8();
+                    FC.SENSOR_ALIGNMENT.gyro_1_align = data.readU8();
+                    FC.SENSOR_ALIGNMENT.gyro_2_align = data.readU8();
                 }
                 break;
             case MSPCodes.MSP_DISPLAYPORT:
@@ -586,7 +586,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             case MSPCodes.MSP_SET_PID:
                 console.log('PID settings saved');
-                PIDS_ACTIVE = PIDs.map(array => array.slice());
+                FC.PIDS_ACTIVE = FC.PIDS.map(array => array.slice());
                 break;
             case MSPCodes.MSP_SET_RC_TUNING:
                 console.log('RC Tuning saved');
@@ -631,19 +631,19 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log('Voltage config saved');
             case MSPCodes.MSP_DEBUG:
                 for (let i = 0; i < 4; i++)
-                    SENSOR_DATA.debug[i] = data.read16();
+                    FC.SENSOR_DATA.debug[i] = data.read16();
                 break;
             case MSPCodes.MSP_SET_MOTOR:
                 console.log('Motor Speeds Updated');
                 break;
             case MSPCodes.MSP_UID:
-                CONFIG.uid[0] = data.readU32();
-                CONFIG.uid[1] = data.readU32();
-                CONFIG.uid[2] = data.readU32();
+                FC.CONFIG.uid[0] = data.readU32();
+                FC.CONFIG.uid[1] = data.readU32();
+                FC.CONFIG.uid[2] = data.readU32();
                 break;
             case MSPCodes.MSP_ACC_TRIM:
-                CONFIG.accelerometerTrims[0] = data.read16(); // pitch
-                CONFIG.accelerometerTrims[1] = data.read16(); // roll
+                FC.CONFIG.accelerometerTrims[0] = data.read16(); // pitch
+                FC.CONFIG.accelerometerTrims[1] = data.read16(); // roll
                 break;
             case MSPCodes.MSP_SET_ACC_TRIM:
                 console.log('Accelerometer trimms saved.');
@@ -653,19 +653,19 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     var numCh = data.readU8();
 
                     for (let i = 0; i < numCh; i++) {
-                        GPS_DATA.chn[i] = data.readU8();
-                        GPS_DATA.svid[i] = data.readU8();
-                        GPS_DATA.quality[i] = data.readU8();
-                        GPS_DATA.cno[i] = data.readU8();
+                        FC.GPS_DATA.chn[i] = data.readU8();
+                        FC.GPS_DATA.svid[i] = data.readU8();
+                        FC.GPS_DATA.quality[i] = data.readU8();
+                        FC.GPS_DATA.cno[i] = data.readU8();
                     }
                 }
                 break;
 
             case MSPCodes.MSP_RX_MAP:
-                RC_MAP = []; // empty the array as new data is coming in
+                FC.RC_MAP = []; // empty the array as new data is coming in
 
                 for (let i = 0; i < data.byteLength; i++) {
-                    RC_MAP.push(data.readU8());
+                    FC.RC_MAP.push(data.readU8());
                 }
                 break;
             case MSPCodes.MSP_SET_RX_MAP:
@@ -673,36 +673,36 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP_MIXER_CONFIG:
-                MIXER_CONFIG.mixer = data.readU8();
-                if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                    MIXER_CONFIG.reverseMotorDir = data.readU8();
+                FC.MIXER_CONFIG.mixer = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                    FC.MIXER_CONFIG.reverseMotorDir = data.readU8();
                 }
                 break;
 
             case MSPCodes.MSP_FEATURE_CONFIG:
-                FEATURE_CONFIG.features.setMask(data.readU32());
+                FC.FEATURE_CONFIG.features.setMask(data.readU32());
 
-                updateTabList(FEATURE_CONFIG.features);
+                updateTabList(FC.FEATURE_CONFIG.features);
                 break;
 
             case MSPCodes.MSP_BEEPER_CONFIG:
-                BEEPER_CONFIG.beepers.setMask(data.readU32());
-                if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                    BEEPER_CONFIG.dshotBeaconTone = data.readU8();
+                FC.BEEPER_CONFIG.beepers.setMask(data.readU32());
+                if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                    FC.BEEPER_CONFIG.dshotBeaconTone = data.readU8();
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-                    BEEPER_CONFIG.dshotBeaconConditions.setMask(data.readU32());
+                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                    FC.BEEPER_CONFIG.dshotBeaconConditions.setMask(data.readU32());
                 }
                 break;
 
             case MSPCodes.MSP_BOARD_ALIGNMENT_CONFIG:
-                BOARD_ALIGNMENT_CONFIG.roll = data.read16(); // -180 - 360
-                BOARD_ALIGNMENT_CONFIG.pitch = data.read16(); // -180 - 360
-                BOARD_ALIGNMENT_CONFIG.yaw = data.read16(); // -180 - 360
+                FC.BOARD_ALIGNMENT_CONFIG.roll = data.read16(); // -180 - 360
+                FC.BOARD_ALIGNMENT_CONFIG.pitch = data.read16(); // -180 - 360
+                FC.BOARD_ALIGNMENT_CONFIG.yaw = data.read16(); // -180 - 360
                 break;
 
             case MSPCodes.MSP_SET_REBOOT:
-                if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
                     var rebootType = data.read8();
                     if ((rebootType === self.REBOOT_TYPES.MSC) || (rebootType === self.REBOOT_TYPES.MSC_UTC)) {
                         if (data.read8() === 0) {
@@ -717,8 +717,8 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP_API_VERSION:
-                CONFIG.mspProtocolVersion = data.readU8();
-                CONFIG.apiVersion = data.readU8() + '.' + data.readU8() + '.0';
+                FC.CONFIG.mspProtocolVersion = data.readU8();
+                FC.CONFIG.apiVersion = data.readU8() + '.' + data.readU8() + '.0';
                 break;
 
             case MSPCodes.MSP_FC_VARIANT:
@@ -726,11 +726,11 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 for (let i = 0; i < 4; i++) {
                     identifier += String.fromCharCode(data.readU8());
                 }
-                CONFIG.flightControllerIdentifier = identifier;
+                FC.CONFIG.flightControllerIdentifier = identifier;
                 break;
 
             case MSPCodes.MSP_FC_VERSION:
-                CONFIG.flightControllerVersion = data.readU8() + '.' + data.readU8() + '.' + data.readU8();
+                FC.CONFIG.flightControllerVersion = data.readU8() + '.' + data.readU8() + '.' + data.readU8();
                 break;
 
             case MSPCodes.MSP_BUILD_INFO:
@@ -745,7 +745,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 for (let i = 0; i < timeLength; i++) {
                     buff.push(data.readU8());
                 }
-                CONFIG.buildInfo = String.fromCharCode.apply(null, buff);
+                FC.CONFIG.buildInfo = String.fromCharCode.apply(null, buff);
                 break;
 
             case MSPCodes.MSP_BOARD_INFO:
@@ -753,71 +753,71 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 for (let i = 0; i < 4; i++) {
                     identifier += String.fromCharCode(data.readU8());
                 }
-                CONFIG.boardIdentifier = identifier;
-                CONFIG.boardVersion = data.readU16();
+                FC.CONFIG.boardIdentifier = identifier;
+                FC.CONFIG.boardVersion = data.readU16();
 
-                if (semver.gte(CONFIG.apiVersion, "1.35.0")) {
-                    CONFIG.boardType = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.35.0")) {
+                    FC.CONFIG.boardType = data.readU8();
                 } else {
-                    CONFIG.boardType = 0;
+                    FC.CONFIG.boardType = 0;
                 }
 
-                if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                    CONFIG.targetCapabilities = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                    FC.CONFIG.targetCapabilities = data.readU8();
 
                     let length = data.readU8();
                     for (let i = 0; i < length; i++) {
-                        CONFIG.targetName += String.fromCharCode(data.readU8());
+                        FC.CONFIG.targetName += String.fromCharCode(data.readU8());
                     }
                 } else {
-                    CONFIG.targetCapabilities = 0;
-                    CONFIG.targetName = "";
+                    FC.CONFIG.targetCapabilities = 0;
+                    FC.CONFIG.targetName = "";
                 }
 
-                if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
                     let length = data.readU8();
                     for (let i = 0; i < length; i++) {
-                        CONFIG.boardName += String.fromCharCode(data.readU8());
+                        FC.CONFIG.boardName += String.fromCharCode(data.readU8());
                     }
 
                     length = data.readU8();
                     for (let i = 0; i < length; i++) {
-                        CONFIG.manufacturerId += String.fromCharCode(data.readU8());
+                        FC.CONFIG.manufacturerId += String.fromCharCode(data.readU8());
                     }
 
                     for (let i = 0; i < self.SIGNATURE_LENGTH; i++) {
-                        CONFIG.signature.push(data.readU8());
+                        FC.CONFIG.signature.push(data.readU8());
                     }
                 } else {
-                    CONFIG.boardName = "";
-                    CONFIG.manufacturerId = "";
-                    CONFIG.signature = [];
+                    FC.CONFIG.boardName = "";
+                    FC.CONFIG.manufacturerId = "";
+                    FC.CONFIG.signature = [];
                 }
 
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    CONFIG.mcuTypeId = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    FC.CONFIG.mcuTypeId = data.readU8();
                 } else {
-                    CONFIG.mcuTypeId = 255;
+                    FC.CONFIG.mcuTypeId = 255;
                 }
 
-                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                    CONFIG.configurationState = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                    FC.CONFIG.configurationState = data.readU8();
                 }
 
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                    CONFIG.sampleRateHz = data.readU16();
-                    CONFIG.configurationProblems = data.readU32();
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                    FC.CONFIG.sampleRateHz = data.readU16();
+                    FC.CONFIG.configurationProblems = data.readU32();
                 } else {
-                    CONFIG.configurationProblems = 0;
+                    FC.CONFIG.configurationProblems = 0;
                 }
 
                 break;
 
             case MSPCodes.MSP_NAME:
-                CONFIG.name = '';
+                FC.CONFIG.name = '';
                 var char;
                 while ((char = data.readU8()) !== null) {
-                    CONFIG.name += String.fromCharCode(char);
+                    FC.CONFIG.name += String.fromCharCode(char);
                 }
                 break;
 
@@ -826,20 +826,20 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP_CF_SERIAL_CONFIG:
-                SERIAL_CONFIG.ports = [];
-                if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+                FC.SERIAL_CONFIG.ports = [];
+                if (semver.lt(FC.CONFIG.apiVersion, "1.6.0")) {
                     const serialPortCount = (data.byteLength - (4 * 4)) / 2;
                     for (let i = 0; i < serialPortCount; i++) {
                         const serialPort = {
                             identifier: data.readU8(),
                             scenario: data.readU8()
                         }
-                        SERIAL_CONFIG.ports.push(serialPort);
+                        FC.SERIAL_CONFIG.ports.push(serialPort);
                     }
-                    SERIAL_CONFIG.mspBaudRate = data.readU32();
-                    SERIAL_CONFIG.cliBaudRate = data.readU32();
-                    SERIAL_CONFIG.gpsBaudRate = data.readU32();
-                    SERIAL_CONFIG.gpsPassthroughBaudRate = data.readU32();
+                    FC.SERIAL_CONFIG.mspBaudRate = data.readU32();
+                    FC.SERIAL_CONFIG.cliBaudRate = data.readU32();
+                    FC.SERIAL_CONFIG.gpsBaudRate = data.readU32();
+                    FC.SERIAL_CONFIG.gpsPassthroughBaudRate = data.readU32();
                 } else {
                     const bytesPerPort = 1 + 2 + (1 * 4);
 
@@ -854,13 +854,13 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             blackbox_baudrate: self.BAUD_RATES[data.readU8()]
                         }
 
-                        SERIAL_CONFIG.ports.push(serialPort);
+                        FC.SERIAL_CONFIG.ports.push(serialPort);
                     }
                 }
                 break;
 
             case MSPCodes.MSP2_COMMON_SERIAL_CONFIG:
-                SERIAL_CONFIG.ports = [];
+                FC.SERIAL_CONFIG.ports = [];
                 const count = data.readU8();
                 const portConfigSize = data.remaining() / count;
                 for (let ii = 0; ii < count; ii++) {
@@ -873,7 +873,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         telemetry_baudrate: self.BAUD_RATES[data.readU8()],
                         blackbox_baudrate: self.BAUD_RATES[data.readU8()],
                     };
-                    SERIAL_CONFIG.ports.push(serialPort);
+                    FC.SERIAL_CONFIG.ports.push(serialPort);
                     while(start - data.remaining() < portConfigSize && data.remaining() > 0) {
                         data.readU8();
                     }
@@ -889,7 +889,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP_MODE_RANGES:
-                MODE_RANGES = []; // empty the array as new data is coming in
+                FC.MODE_RANGES = []; // empty the array as new data is coming in
 
                 var modeRangeCount = data.byteLength / 4; // 4 bytes per item.
 
@@ -902,12 +902,12 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             end: 900 + (data.readU8() * 25)
                         }
                     };
-                    MODE_RANGES.push(modeRange);
+                    FC.MODE_RANGES.push(modeRange);
                 }
                 break;
 
             case MSPCodes.MSP_MODE_RANGES_EXTRA:
-                MODE_RANGES_EXTRA = []; // empty the array as new data is coming in
+                FC.MODE_RANGES_EXTRA = []; // empty the array as new data is coming in
 
                 var modeRangeExtraCount = data.readU8();
 
@@ -917,12 +917,12 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         modeLogic: data.readU8(),
                         linkedTo: data.readU8()
                     };
-                    MODE_RANGES_EXTRA.push(modeRangeExtra);
+                    FC.MODE_RANGES_EXTRA.push(modeRangeExtra);
                 }
                 break;
 
             case MSPCodes.MSP_ADJUSTMENT_RANGES:
-                ADJUSTMENT_RANGES = []; // empty the array as new data is coming in
+                FC.ADJUSTMENT_RANGES = []; // empty the array as new data is coming in
 
                 var adjustmentRangeCount = data.byteLength / 6; // 6 bytes per item.
 
@@ -937,67 +937,67 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         adjustmentFunction: data.readU8(),
                         auxSwitchChannelIndex: data.readU8()
                     };
-                    ADJUSTMENT_RANGES.push(adjustmentRange);
+                    FC.ADJUSTMENT_RANGES.push(adjustmentRange);
                 }
                 break;
 
             case MSPCodes.MSP_RX_CONFIG:
-                RX_CONFIG.serialrx_provider = data.readU8();
-                RX_CONFIG.stick_max = data.readU16();
-                RX_CONFIG.stick_center = data.readU16();
-                RX_CONFIG.stick_min = data.readU16();
-                RX_CONFIG.spektrum_sat_bind = data.readU8();
-                RX_CONFIG.rx_min_usec = data.readU16();
-                RX_CONFIG.rx_max_usec = data.readU16();
-                if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                    RX_CONFIG.rcInterpolation = data.readU8();
-                    RX_CONFIG.rcInterpolationInterval = data.readU8();
-                    RX_CONFIG.airModeActivateThreshold = data.readU16();
-                    if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
-                        RX_CONFIG.rxSpiProtocol = data.readU8();
-                        RX_CONFIG.rxSpiId = data.readU32();
-                        RX_CONFIG.rxSpiRfChannelCount = data.readU8();
-                        RX_CONFIG.fpvCamAngleDegrees = data.readU8();
-                        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-                            RX_CONFIG.rcInterpolationChannels = data.readU8();
-                            RX_CONFIG.rcSmoothingType = data.readU8();
-                            RX_CONFIG.rcSmoothingInputCutoff = data.readU8();
-                            RX_CONFIG.rcSmoothingDerivativeCutoff = data.readU8();
-                            RX_CONFIG.rcSmoothingInputType = data.readU8();
-                            RX_CONFIG.rcSmoothingDerivativeType = data.readU8();
-                            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                                RX_CONFIG.usbCdcHidType = data.readU8();
-                                RX_CONFIG.rcSmoothingAutoSmoothness = data.readU8();
+                FC.RX_CONFIG.serialrx_provider = data.readU8();
+                FC.RX_CONFIG.stick_max = data.readU16();
+                FC.RX_CONFIG.stick_center = data.readU16();
+                FC.RX_CONFIG.stick_min = data.readU16();
+                FC.RX_CONFIG.spektrum_sat_bind = data.readU8();
+                FC.RX_CONFIG.rx_min_usec = data.readU16();
+                FC.RX_CONFIG.rx_max_usec = data.readU16();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+                    FC.RX_CONFIG.rcInterpolation = data.readU8();
+                    FC.RX_CONFIG.rcInterpolationInterval = data.readU8();
+                    FC.RX_CONFIG.airModeActivateThreshold = data.readU16();
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+                        FC.RX_CONFIG.rxSpiProtocol = data.readU8();
+                        FC.RX_CONFIG.rxSpiId = data.readU32();
+                        FC.RX_CONFIG.rxSpiRfChannelCount = data.readU8();
+                        FC.RX_CONFIG.fpvCamAngleDegrees = data.readU8();
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                            FC.RX_CONFIG.rcInterpolationChannels = data.readU8();
+                            FC.RX_CONFIG.rcSmoothingType = data.readU8();
+                            FC.RX_CONFIG.rcSmoothingInputCutoff = data.readU8();
+                            FC.RX_CONFIG.rcSmoothingDerivativeCutoff = data.readU8();
+                            FC.RX_CONFIG.rcSmoothingInputType = data.readU8();
+                            FC.RX_CONFIG.rcSmoothingDerivativeType = data.readU8();
+                            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                                FC.RX_CONFIG.usbCdcHidType = data.readU8();
+                                FC.RX_CONFIG.rcSmoothingAutoSmoothness = data.readU8();
                             }
                         }
                     } else {
-                        RX_CONFIG.rxSpiProtocol = 0;
-                        RX_CONFIG.rxSpiId = 0;
-                        RX_CONFIG.rxSpiRfChannelCount = 0;
-                        RX_CONFIG.fpvCamAngleDegrees = 0;
+                        FC.RX_CONFIG.rxSpiProtocol = 0;
+                        FC.RX_CONFIG.rxSpiId = 0;
+                        FC.RX_CONFIG.rxSpiRfChannelCount = 0;
+                        FC.RX_CONFIG.fpvCamAngleDegrees = 0;
                     }
                 } else {
-                    RX_CONFIG.rcInterpolation = 0;
-                    RX_CONFIG.rcInterpolationInterval = 0;
-                    RX_CONFIG.airModeActivateThreshold = 0;
+                    FC.RX_CONFIG.rcInterpolation = 0;
+                    FC.RX_CONFIG.rcInterpolationInterval = 0;
+                    FC.RX_CONFIG.airModeActivateThreshold = 0;
                 }
 
                 
                 break;
 
             case MSPCodes.MSP_FAILSAFE_CONFIG:
-                FAILSAFE_CONFIG.failsafe_delay = data.readU8();
-                FAILSAFE_CONFIG.failsafe_off_delay = data.readU8();
-                FAILSAFE_CONFIG.failsafe_throttle = data.readU16();
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                    FAILSAFE_CONFIG.failsafe_switch_mode = data.readU8();
-                    FAILSAFE_CONFIG.failsafe_throttle_low_delay = data.readU16();
-                    FAILSAFE_CONFIG.failsafe_procedure = data.readU8();
+                FC.FAILSAFE_CONFIG.failsafe_delay = data.readU8();
+                FC.FAILSAFE_CONFIG.failsafe_off_delay = data.readU8();
+                FC.FAILSAFE_CONFIG.failsafe_throttle = data.readU16();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
+                    FC.FAILSAFE_CONFIG.failsafe_switch_mode = data.readU8();
+                    FC.FAILSAFE_CONFIG.failsafe_throttle_low_delay = data.readU16();
+                    FC.FAILSAFE_CONFIG.failsafe_procedure = data.readU8();
                 }
                 break;
 
             case MSPCodes.MSP_RXFAIL_CONFIG:
-                RXFAIL_CONFIG = []; // empty the array as new data is coming in
+                FC.RXFAIL_CONFIG = []; // empty the array as new data is coming in
 
                 var channelCount = data.byteLength / 3;
                 for (let i = 0; i < channelCount; i++) {
@@ -1005,86 +1005,86 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         mode:  data.readU8(),
                         value: data.readU16()
                     };
-                    RXFAIL_CONFIG.push(rxfailChannel);
+                    FC.RXFAIL_CONFIG.push(rxfailChannel);
                 }
                 break;
 
             case MSPCodes.MSP_ADVANCED_CONFIG:
-                PID_ADVANCED_CONFIG.gyro_sync_denom = data.readU8();
-                PID_ADVANCED_CONFIG.pid_process_denom = data.readU8();
-                PID_ADVANCED_CONFIG.use_unsyncedPwm = data.readU8();
-                PID_ADVANCED_CONFIG.fast_pwm_protocol = self.reorderPwmProtocols(data.readU8());
-                PID_ADVANCED_CONFIG.motor_pwm_rate = data.readU16();
-                if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
-                    PID_ADVANCED_CONFIG.digitalIdlePercent = data.readU16() / 100;
+                FC.PID_ADVANCED_CONFIG.gyro_sync_denom = data.readU8();
+                FC.PID_ADVANCED_CONFIG.pid_process_denom = data.readU8();
+                FC.PID_ADVANCED_CONFIG.use_unsyncedPwm = data.readU8();
+                FC.PID_ADVANCED_CONFIG.fast_pwm_protocol = self.reorderPwmProtocols(data.readU8());
+                FC.PID_ADVANCED_CONFIG.motor_pwm_rate = data.readU16();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.24.0")) {
+                    FC.PID_ADVANCED_CONFIG.digitalIdlePercent = data.readU16() / 100;
 
-                    if (semver.gte(CONFIG.apiVersion, "1.25.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.25.0")) {
                         let gyroUse32kHz = data.readU8();
-                        if (semver.lt(CONFIG.apiVersion, "1.41.0")) {
-                            PID_ADVANCED_CONFIG.gyroUse32kHz = gyroUse32kHz;
+                        if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                            FC.PID_ADVANCED_CONFIG.gyroUse32kHz = gyroUse32kHz;
                         } 
-                        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                            PID_ADVANCED_CONFIG.motorPwmInversion = data.readU8();
-                            SENSOR_ALIGNMENT.gyro_to_use = data.readU8(); // We don't want to double up on storing this state
-                            PID_ADVANCED_CONFIG.gyroHighFsr = data.readU8();
-                            PID_ADVANCED_CONFIG.gyroMovementCalibThreshold = data.readU8();
-                            PID_ADVANCED_CONFIG.gyroCalibDuration = data.readU16();
-                            PID_ADVANCED_CONFIG.gyroOffsetYaw = data.readU16();
-                            PID_ADVANCED_CONFIG.gyroCheckOverflow = data.readU8();
-                            PID_ADVANCED_CONFIG.debugMode = data.readU8();
-                            PID_ADVANCED_CONFIG.debugModeCount = data.readU8();
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                            FC.PID_ADVANCED_CONFIG.motorPwmInversion = data.readU8();
+                            FC.SENSOR_ALIGNMENT.gyro_to_use = data.readU8(); // We don't want to double up on storing this state
+                            FC.PID_ADVANCED_CONFIG.gyroHighFsr = data.readU8();
+                            FC.PID_ADVANCED_CONFIG.gyroMovementCalibThreshold = data.readU8();
+                            FC.PID_ADVANCED_CONFIG.gyroCalibDuration = data.readU16();
+                            FC.PID_ADVANCED_CONFIG.gyroOffsetYaw = data.readU16();
+                            FC.PID_ADVANCED_CONFIG.gyroCheckOverflow = data.readU8();
+                            FC.PID_ADVANCED_CONFIG.debugMode = data.readU8();
+                            FC.PID_ADVANCED_CONFIG.debugModeCount = data.readU8();
                         }
                     }
                 }
                 break;
             case MSPCodes.MSP_FILTER_CONFIG:
-                FILTER_CONFIG.gyro_lowpass_hz = data.readU8();
-                FILTER_CONFIG.dterm_lowpass_hz = data.readU16();
-                FILTER_CONFIG.yaw_lowpass_hz = data.readU16();
-                if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                    FILTER_CONFIG.gyro_notch_hz = data.readU16();
-                    FILTER_CONFIG.gyro_notch_cutoff = data.readU16();
-                    FILTER_CONFIG.dterm_notch_hz = data.readU16();
-                    FILTER_CONFIG.dterm_notch_cutoff = data.readU16();
-                    if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-                        FILTER_CONFIG.gyro_notch2_hz = data.readU16();
-                        FILTER_CONFIG.gyro_notch2_cutoff = data.readU16();
+                FC.FILTER_CONFIG.gyro_lowpass_hz = data.readU8();
+                FC.FILTER_CONFIG.dterm_lowpass_hz = data.readU16();
+                FC.FILTER_CONFIG.yaw_lowpass_hz = data.readU16();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+                    FC.FILTER_CONFIG.gyro_notch_hz = data.readU16();
+                    FC.FILTER_CONFIG.gyro_notch_cutoff = data.readU16();
+                    FC.FILTER_CONFIG.dterm_notch_hz = data.readU16();
+                    FC.FILTER_CONFIG.dterm_notch_cutoff = data.readU16();
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
+                        FC.FILTER_CONFIG.gyro_notch2_hz = data.readU16();
+                        FC.FILTER_CONFIG.gyro_notch2_cutoff = data.readU16();
                     }
-                    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                        FILTER_CONFIG.dterm_lowpass_type = data.readU8();
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                        FC.FILTER_CONFIG.dterm_lowpass_type = data.readU8();
                     }
-                    if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-                        FILTER_CONFIG.gyro_hardware_lpf = data.readU8();
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                        FC.FILTER_CONFIG.gyro_hardware_lpf = data.readU8();
                         let gyro_32khz_hardware_lpf = data.readU8();
-                        FILTER_CONFIG.gyro_lowpass_hz = data.readU16();
-                        FILTER_CONFIG.gyro_lowpass2_hz = data.readU16();
-                        FILTER_CONFIG.gyro_lowpass_type = data.readU8();
-                        FILTER_CONFIG.gyro_lowpass2_type = data.readU8();
-                        FILTER_CONFIG.dterm_lowpass2_hz = data.readU16();
-                        if (semver.lt(CONFIG.apiVersion, "1.41.0")) {
-                            FILTER_CONFIG.gyro_32khz_hardware_lpf = gyro_32khz_hardware_lpf;
+                        FC.FILTER_CONFIG.gyro_lowpass_hz = data.readU16();
+                        FC.FILTER_CONFIG.gyro_lowpass2_hz = data.readU16();
+                        FC.FILTER_CONFIG.gyro_lowpass_type = data.readU8();
+                        FC.FILTER_CONFIG.gyro_lowpass2_type = data.readU8();
+                        FC.FILTER_CONFIG.dterm_lowpass2_hz = data.readU16();
+                        if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                            FC.FILTER_CONFIG.gyro_32khz_hardware_lpf = gyro_32khz_hardware_lpf;
                         } else {
-                            FILTER_CONFIG.gyro_32khz_hardware_lpf = 0;
+                            FC.FILTER_CONFIG.gyro_32khz_hardware_lpf = 0;
 
-                            FILTER_CONFIG.dterm_lowpass2_type = data.readU8();
-                            FILTER_CONFIG.gyro_lowpass_dyn_min_hz = data.readU16();
-                            FILTER_CONFIG.gyro_lowpass_dyn_max_hz = data.readU16();
-                            FILTER_CONFIG.dterm_lowpass_dyn_min_hz = data.readU16();
-                            FILTER_CONFIG.dterm_lowpass_dyn_max_hz = data.readU16();
-                            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                                FILTER_CONFIG.dyn_notch_range = data.readU8();
-                                FILTER_CONFIG.dyn_notch_width_percent = data.readU8();
-                                FILTER_CONFIG.dyn_notch_q = data.readU16();
-                                FILTER_CONFIG.dyn_notch_min_hz = data.readU16();
+                            FC.FILTER_CONFIG.dterm_lowpass2_type = data.readU8();
+                            FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz = data.readU16();
+                            FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = data.readU16();
+                            FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz = data.readU16();
+                            FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = data.readU16();
+                            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                                FC.FILTER_CONFIG.dyn_notch_range = data.readU8();
+                                FC.FILTER_CONFIG.dyn_notch_width_percent = data.readU8();
+                                FC.FILTER_CONFIG.dyn_notch_q = data.readU16();
+                                FC.FILTER_CONFIG.dyn_notch_min_hz = data.readU16();
 
-                                FILTER_CONFIG.gyro_rpm_notch_harmonics = data.readU8();
-                                FILTER_CONFIG.gyro_rpm_notch_min_hz = data.readU8();
+                                FC.FILTER_CONFIG.gyro_rpm_notch_harmonics = data.readU8();
+                                FC.FILTER_CONFIG.gyro_rpm_notch_min_hz = data.readU8();
                             }
-                            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                                FILTER_CONFIG.dyn_notch_max_hz = data.readU16();
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                                FC.FILTER_CONFIG.dyn_notch_max_hz = data.readU16();
                             }
-                            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-                                FILTER_CONFIG.dyn_lpf_curve_expo = data.readU8();
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                                FC.FILTER_CONFIG.dyn_lpf_curve_expo = data.readU8();
                             }
                         }
                     }
@@ -1092,72 +1092,72 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             case MSPCodes.MSP_SET_PID_ADVANCED:
                 console.log("Advanced PID settings saved");
-                ADVANCED_TUNING_ACTIVE = { ...ADVANCED_TUNING };
+                FC.ADVANCED_TUNING_ACTIVE = { ...FC.ADVANCED_TUNING };
                 break;
             case MSPCodes.MSP_PID_ADVANCED:
-                ADVANCED_TUNING.rollPitchItermIgnoreRate = data.readU16();
-                ADVANCED_TUNING.yawItermIgnoreRate = data.readU16();
-                ADVANCED_TUNING.yaw_p_limit = data.readU16();
-                ADVANCED_TUNING.deltaMethod = data.readU8();
-                ADVANCED_TUNING.vbatPidCompensation = data.readU8();
-                if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                    if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-                        ADVANCED_TUNING.feedforwardTransition = data.readU8();
+                FC.ADVANCED_TUNING.rollPitchItermIgnoreRate = data.readU16();
+                FC.ADVANCED_TUNING.yawItermIgnoreRate = data.readU16();
+                FC.ADVANCED_TUNING.yaw_p_limit = data.readU16();
+                FC.ADVANCED_TUNING.deltaMethod = data.readU8();
+                FC.ADVANCED_TUNING.vbatPidCompensation = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                        FC.ADVANCED_TUNING.feedforwardTransition = data.readU8();
                     } else {
-                        ADVANCED_TUNING.dtermSetpointTransition = data.readU8();
+                        FC.ADVANCED_TUNING.dtermSetpointTransition = data.readU8();
                     }
-                    ADVANCED_TUNING.dtermSetpointWeight = data.readU8();
-                    ADVANCED_TUNING.toleranceBand = data.readU8();
-                    ADVANCED_TUNING.toleranceBandReduction = data.readU8();
-                    ADVANCED_TUNING.itermThrottleGain = data.readU8();
-                    ADVANCED_TUNING.pidMaxVelocity = data.readU16();
-                    ADVANCED_TUNING.pidMaxVelocityYaw = data.readU16();
-                    if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
-                        ADVANCED_TUNING.levelAngleLimit = data.readU8();
-                        ADVANCED_TUNING.levelSensitivity = data.readU8();
+                    FC.ADVANCED_TUNING.dtermSetpointWeight = data.readU8();
+                    FC.ADVANCED_TUNING.toleranceBand = data.readU8();
+                    FC.ADVANCED_TUNING.toleranceBandReduction = data.readU8();
+                    FC.ADVANCED_TUNING.itermThrottleGain = data.readU8();
+                    FC.ADVANCED_TUNING.pidMaxVelocity = data.readU16();
+                    FC.ADVANCED_TUNING.pidMaxVelocityYaw = data.readU16();
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.24.0")) {
+                        FC.ADVANCED_TUNING.levelAngleLimit = data.readU8();
+                        FC.ADVANCED_TUNING.levelSensitivity = data.readU8();
 
-                        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                            ADVANCED_TUNING.itermThrottleThreshold = data.readU16();
-                            ADVANCED_TUNING.itermAcceleratorGain = data.readU16();
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                            FC.ADVANCED_TUNING.itermThrottleThreshold = data.readU16();
+                            FC.ADVANCED_TUNING.itermAcceleratorGain = data.readU16();
 
-                            if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-                                ADVANCED_TUNING.dtermSetpointWeight = data.readU16();
+                            if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                                FC.ADVANCED_TUNING.dtermSetpointWeight = data.readU16();
 
-                                if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-                                    ADVANCED_TUNING.itermRotation = data.readU8();
-                                    ADVANCED_TUNING.smartFeedforward = data.readU8();
-                                    ADVANCED_TUNING.itermRelax = data.readU8();
-                                    ADVANCED_TUNING.itermRelaxType = data.readU8();
-                                    ADVANCED_TUNING.absoluteControlGain = data.readU8();
-                                    ADVANCED_TUNING.throttleBoost = data.readU8();
-                                    ADVANCED_TUNING.acroTrainerAngleLimit = data.readU8();
-                                    ADVANCED_TUNING.feedforwardRoll  = data.readU16();
-                                    ADVANCED_TUNING.feedforwardPitch = data.readU16();
-                                    ADVANCED_TUNING.feedforwardYaw   = data.readU16();
-                                    ADVANCED_TUNING.antiGravityMode  = data.readU8();
+                                if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                                    FC.ADVANCED_TUNING.itermRotation = data.readU8();
+                                    FC.ADVANCED_TUNING.smartFeedforward = data.readU8();
+                                    FC.ADVANCED_TUNING.itermRelax = data.readU8();
+                                    FC.ADVANCED_TUNING.itermRelaxType = data.readU8();
+                                    FC.ADVANCED_TUNING.absoluteControlGain = data.readU8();
+                                    FC.ADVANCED_TUNING.throttleBoost = data.readU8();
+                                    FC.ADVANCED_TUNING.acroTrainerAngleLimit = data.readU8();
+                                    FC.ADVANCED_TUNING.feedforwardRoll  = data.readU16();
+                                    FC.ADVANCED_TUNING.feedforwardPitch = data.readU16();
+                                    FC.ADVANCED_TUNING.feedforwardYaw   = data.readU16();
+                                    FC.ADVANCED_TUNING.antiGravityMode  = data.readU8();
                                     
-                                    if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                                        ADVANCED_TUNING.dMinRoll = data.readU8();
-                                        ADVANCED_TUNING.dMinPitch = data.readU8();
-                                        ADVANCED_TUNING.dMinYaw = data.readU8();
-                                        ADVANCED_TUNING.dMinGain = data.readU8();
-                                        ADVANCED_TUNING.dMinAdvance = data.readU8();
-                                        ADVANCED_TUNING.useIntegratedYaw = data.readU8();
-                                        ADVANCED_TUNING.integratedYawRelax = data.readU8();
+                                    if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                                        FC.ADVANCED_TUNING.dMinRoll = data.readU8();
+                                        FC.ADVANCED_TUNING.dMinPitch = data.readU8();
+                                        FC.ADVANCED_TUNING.dMinYaw = data.readU8();
+                                        FC.ADVANCED_TUNING.dMinGain = data.readU8();
+                                        FC.ADVANCED_TUNING.dMinAdvance = data.readU8();
+                                        FC.ADVANCED_TUNING.useIntegratedYaw = data.readU8();
+                                        FC.ADVANCED_TUNING.integratedYawRelax = data.readU8();
 
-                                        if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                                            ADVANCED_TUNING.itermRelaxCutoff = data.readU8();
+                                        if(semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                                            FC.ADVANCED_TUNING.itermRelaxCutoff = data.readU8();
 
-                                            if(semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                                                ADVANCED_TUNING.motorOutputLimit = data.readU8();
-                                                ADVANCED_TUNING.autoProfileCellCount = data.read8();
-                                                ADVANCED_TUNING.idleMinRpm = data.readU8();
+                                            if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                                                FC.ADVANCED_TUNING.motorOutputLimit = data.readU8();
+                                                FC.ADVANCED_TUNING.autoProfileCellCount = data.read8();
+                                                FC.ADVANCED_TUNING.idleMinRpm = data.readU8();
 
-                                                if(semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-                                                    ADVANCED_TUNING.ff_interpolate_sp = data.readU8();
-                                                    ADVANCED_TUNING.ff_smooth_factor = data.readU8();
-                                                    ADVANCED_TUNING.ff_boost = data.readU8();
-                                                    ADVANCED_TUNING.vbat_sag_compensation = data.readU8();
+                                                if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                                                    FC.ADVANCED_TUNING.ff_interpolate_sp = data.readU8();
+                                                    FC.ADVANCED_TUNING.ff_smooth_factor = data.readU8();
+                                                    FC.ADVANCED_TUNING.ff_boost = data.readU8();
+                                                    FC.ADVANCED_TUNING.vbat_sag_compensation = data.readU8();
                                                 }
                                             }
                                         }
@@ -1167,21 +1167,21 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         }
                     }
                 }
-                ADVANCED_TUNING_ACTIVE = { ...ADVANCED_TUNING };
+                FC.ADVANCED_TUNING_ACTIVE = { ...FC.ADVANCED_TUNING };
                 break;
             case MSPCodes.MSP_SENSOR_CONFIG:
-                SENSOR_CONFIG.acc_hardware = data.readU8();
-                SENSOR_CONFIG.baro_hardware = data.readU8();
-                SENSOR_CONFIG.mag_hardware = data.readU8();
+                FC.SENSOR_CONFIG.acc_hardware = data.readU8();
+                FC.SENSOR_CONFIG.baro_hardware = data.readU8();
+                FC.SENSOR_CONFIG.mag_hardware = data.readU8();
                 break;
 
             case MSPCodes.MSP_LED_STRIP_CONFIG:
-                LED_STRIP = [];
+                FC.LED_STRIP = [];
 
                 var ledDirectionLetters =       ['n', 'e', 's', 'w', 'u', 'd'];      // in LSB bit order
                 var ledFunctionLetters =        ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l']; // in LSB bit order
                 var ledBaseFunctionLetters =    ['c', 'f', 'a', 'l', 's', 'g', 'r']; // in LSB bit
-                if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+                if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
                     var ledOverlayLetters =     ['t', 'o', 'b', 'n', 'i', 'w']; // in LSB bit
                 } else {
                     var ledOverlayLetters =     ['t', 'o', 'b', 'v', 'i', 'w']; // in LSB bit
@@ -1189,10 +1189,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
 
                 var ledCount = data.byteLength / 7; // v1.4.0 and below incorrectly reported 4 bytes per led.
-                if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
                     ledCount = data.byteLength / 4;
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                     // According to betaflight/src/main/msp/msp.c
                     // API 1.41 - add indicator for advanced profile support and the current profile selection
                     // 0 = basic ledstrip available
@@ -1202,7 +1202,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 for (let i = 0; i < ledCount; i++) {
 
-                    if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+                    if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
                         var directionMask = data.readU16();
 
                         var directions = [];
@@ -1229,7 +1229,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             color: data.readU8()
                         };
 
-                        LED_STRIP.push(led);
+                        FC.LED_STRIP.push(led);
                     } else {
                         var mask = data.readU32();
 
@@ -1265,7 +1265,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             parameters: (mask >> 28) & 0xF
                         };
 
-                        LED_STRIP.push(led);
+                        FC.LED_STRIP.push(led);
                     }
                 }
                 break;
@@ -1274,7 +1274,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             case MSPCodes.MSP_LED_COLORS:
 
-                LED_COLORS = [];
+                FC.LED_COLORS = [];
 
                 var colorCount = data.byteLength / 4;
 
@@ -1285,7 +1285,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         s: data.readU8(),
                         v: data.readU8()
                     };
-                    LED_COLORS.push(color);
+                    FC.LED_COLORS.push(color);
                 }
 
                 break;
@@ -1293,9 +1293,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log('Led strip colors saved');
                 break;
             case MSPCodes.MSP_LED_STRIP_MODECOLOR:
-                if (semver.gte(CONFIG.apiVersion, "1.19.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.19.0")) {
 
-                    LED_MODE_COLORS = [];
+                    FC.LED_MODE_COLORS = [];
 
                     var colorCount = data.byteLength / 3;
 
@@ -1306,7 +1306,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             direction: data.readU8(),
                             color: data.readU8()
                         };
-                        LED_MODE_COLORS.push(mode_color);
+                        FC.LED_MODE_COLORS.push(mode_color);
                     }
                 }
                 break;
@@ -1317,18 +1317,18 @@ MspHelper.prototype.process_data = function(dataHandler) {
             case MSPCodes.MSP_DATAFLASH_SUMMARY:
                 if (data.byteLength >= 13) {
                     var flags = data.readU8();
-                    DATAFLASH.ready = (flags & 1) != 0;
-                    DATAFLASH.supported = (flags & 2) != 0;
-                    DATAFLASH.sectors = data.readU32();
-                    DATAFLASH.totalSize = data.readU32();
-                    DATAFLASH.usedSize = data.readU32();
+                    FC.DATAFLASH.ready = (flags & 1) != 0;
+                    FC.DATAFLASH.supported = (flags & 2) != 0;
+                    FC.DATAFLASH.sectors = data.readU32();
+                    FC.DATAFLASH.totalSize = data.readU32();
+                    FC.DATAFLASH.usedSize = data.readU32();
                 } else {
                     // Firmware version too old to support MSP_DATAFLASH_SUMMARY
-                    DATAFLASH.ready = false;
-                    DATAFLASH.supported = false;
-                    DATAFLASH.sectors = 0;
-                    DATAFLASH.totalSize = 0;
-                    DATAFLASH.usedSize = 0;
+                    FC.DATAFLASH.ready = false;
+                    FC.DATAFLASH.supported = false;
+                    FC.DATAFLASH.sectors = 0;
+                    FC.DATAFLASH.totalSize = 0;
+                    FC.DATAFLASH.usedSize = 0;
                 }
                 update_dataflash_global();
                 break;
@@ -1341,22 +1341,22 @@ MspHelper.prototype.process_data = function(dataHandler) {
             case MSPCodes.MSP_SDCARD_SUMMARY:
                 var flags = data.readU8();
 
-                SDCARD.supported = (flags & 0x01) != 0;
-                SDCARD.state = data.readU8();
-                SDCARD.filesystemLastError = data.readU8();
-                SDCARD.freeSizeKB = data.readU32();
-                SDCARD.totalSizeKB = data.readU32();
+                FC.SDCARD.supported = (flags & 0x01) != 0;
+                FC.SDCARD.state = data.readU8();
+                FC.SDCARD.filesystemLastError = data.readU8();
+                FC.SDCARD.freeSizeKB = data.readU32();
+                FC.SDCARD.totalSizeKB = data.readU32();
                 break;
             case MSPCodes.MSP_BLACKBOX_CONFIG:
-                BLACKBOX.supported = (data.readU8() & 1) != 0;
-                BLACKBOX.blackboxDevice = data.readU8();
-                BLACKBOX.blackboxRateNum = data.readU8();
-                BLACKBOX.blackboxRateDenom = data.readU8();
-                if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                    BLACKBOX.blackboxPDenom = data.readU16();
+                FC.BLACKBOX.supported = (data.readU8() & 1) != 0;
+                FC.BLACKBOX.blackboxDevice = data.readU8();
+                FC.BLACKBOX.blackboxRateNum = data.readU8();
+                FC.BLACKBOX.blackboxRateDenom = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                    FC.BLACKBOX.blackboxPDenom = data.readU16();
                 }
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-                    BLACKBOX.blackboxSampleRate = data.readU8();
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                    FC.BLACKBOX.blackboxSampleRate = data.readU8();
                 }
                 break;
             case MSPCodes.MSP_SET_BLACKBOX_CONFIG:
@@ -1364,12 +1364,12 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             case MSPCodes.MSP_TRANSPONDER_CONFIG:
                 var bytesRemaining = data.byteLength;
-                if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
                     var providerCount = data.readU8();
                     bytesRemaining--;
 
-                    TRANSPONDER.supported = providerCount > 0;
-                    TRANSPONDER.providers = [];
+                    FC.TRANSPONDER.supported = providerCount > 0;
+                    FC.TRANSPONDER.providers = [];
 
                     for (let i = 0; i < providerCount; i++) {
                         var provider = {
@@ -1378,25 +1378,25 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         };
                         bytesRemaining -= 2;
 
-                        TRANSPONDER.providers.push(provider);
+                        FC.TRANSPONDER.providers.push(provider);
                     }
-                    TRANSPONDER.provider = data.readU8();
+                    FC.TRANSPONDER.provider = data.readU8();
                     bytesRemaining--;
 
                 } else {
-                    TRANSPONDER.supported = (data.readU8() & 1) != 0;
+                    FC.TRANSPONDER.supported = (data.readU8() & 1) != 0;
                     bytesRemaining--;
 
                     // only ILAP was supported prior to 1.33.0
-                    TRANSPONDER.providers = [{
+                    FC.TRANSPONDER.providers = [{
                         id: 1, // ILAP
                         dataLength: 6
                     }];
-                    TRANSPONDER.provider = TRANSPONDER.providers[0].id;
+                    FC.TRANSPONDER.provider = FC.TRANSPONDER.providers[0].id;
                 }
-                TRANSPONDER.data = [];
+                FC.TRANSPONDER.data = [];
                 for (let i = 0; i < bytesRemaining; i++) {
-                    TRANSPONDER.data.push(data.readU8());
+                    FC.TRANSPONDER.data.push(data.readU8());
                 }
                 break;
 
@@ -1406,22 +1406,22 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP_VTX_CONFIG:
 
-                VTX_CONFIG.vtx_type = data.readU8();
-                VTX_CONFIG.vtx_band = data.readU8();
-                VTX_CONFIG.vtx_channel = data.readU8();
-                VTX_CONFIG.vtx_power = data.readU8();
-                VTX_CONFIG.vtx_pit_mode = data.readU8() != 0;
-                VTX_CONFIG.vtx_frequency = data.readU16();
-                VTX_CONFIG.vtx_device_ready = data.readU8() != 0;
-                VTX_CONFIG.vtx_low_power_disarm = data.readU8();
+                FC.VTX_CONFIG.vtx_type = data.readU8();
+                FC.VTX_CONFIG.vtx_band = data.readU8();
+                FC.VTX_CONFIG.vtx_channel = data.readU8();
+                FC.VTX_CONFIG.vtx_power = data.readU8();
+                FC.VTX_CONFIG.vtx_pit_mode = data.readU8() != 0;
+                FC.VTX_CONFIG.vtx_frequency = data.readU16();
+                FC.VTX_CONFIG.vtx_device_ready = data.readU8() != 0;
+                FC.VTX_CONFIG.vtx_low_power_disarm = data.readU8();
 
-                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                    VTX_CONFIG.vtx_pit_mode_frequency = data.readU16();
-                    VTX_CONFIG.vtx_table_available = data.readU8() != 0;
-                    VTX_CONFIG.vtx_table_bands = data.readU8();
-                    VTX_CONFIG.vtx_table_channels = data.readU8();
-                    VTX_CONFIG.vtx_table_powerlevels = data.readU8();
-                    VTX_CONFIG.vtx_table_clear = false;
+                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                    FC.VTX_CONFIG.vtx_pit_mode_frequency = data.readU16();
+                    FC.VTX_CONFIG.vtx_table_available = data.readU8() != 0;
+                    FC.VTX_CONFIG.vtx_table_bands = data.readU8();
+                    FC.VTX_CONFIG.vtx_table_channels = data.readU8();
+                    FC.VTX_CONFIG.vtx_table_powerlevels = data.readU8();
+                    FC.VTX_CONFIG.vtx_table_clear = false;
                 }
                 break;
 
@@ -1431,21 +1431,21 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP_VTXTABLE_BAND:
 
-                VTXTABLE_BAND.vtxtable_band_number = data.readU8();
+                FC.VTXTABLE_BAND.vtxtable_band_number = data.readU8();
 
                 let bandNameLength = data.readU8();
-                VTXTABLE_BAND.vtxtable_band_name = '';
+                FC.VTXTABLE_BAND.vtxtable_band_name = '';
                 for (let i = 0; i < bandNameLength; i++) {
-                    VTXTABLE_BAND.vtxtable_band_name += String.fromCharCode(data.readU8());
+                    FC.VTXTABLE_BAND.vtxtable_band_name += String.fromCharCode(data.readU8());
                 }
 
-                VTXTABLE_BAND.vtxtable_band_letter = String.fromCharCode(data.readU8());
-                VTXTABLE_BAND.vtxtable_band_is_factory_band = data.readU8() != 0;
+                FC.VTXTABLE_BAND.vtxtable_band_letter = String.fromCharCode(data.readU8());
+                FC.VTXTABLE_BAND.vtxtable_band_is_factory_band = data.readU8() != 0;
 
                 let bandFrequenciesLength = data.readU8();
-                VTXTABLE_BAND.vtxtable_band_frequencies = [];
+                FC.VTXTABLE_BAND.vtxtable_band_frequencies = [];
                 for (let i = 0; i < bandFrequenciesLength; i++) {
-                    VTXTABLE_BAND.vtxtable_band_frequencies.push(data.readU16());
+                    FC.VTXTABLE_BAND.vtxtable_band_frequencies.push(data.readU16());
                 }
 
                 break;
@@ -1456,13 +1456,13 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP_VTXTABLE_POWERLEVEL:
 
-                VTXTABLE_POWERLEVEL.vtxtable_powerlevel_number = data.readU8();
-                VTXTABLE_POWERLEVEL.vtxtable_powerlevel_value = data.readU16();
+                FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_number = data.readU8();
+                FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_value = data.readU16();
 
                 let powerLabelLength = data.readU8();
-                VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label = '';
+                FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label = '';
                 for (let i = 0; i < powerLabelLength; i++) {
-                    VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label += String.fromCharCode(data.readU8());
+                    FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label += String.fromCharCode(data.readU8());
                 }
 
                 break;
@@ -1481,7 +1481,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log('Board alignment saved');
                 break;
             case MSPCodes.MSP_PID_CONTROLLER:
-                PID.controller = data.readU8();
+                FC.PID.controller = data.readU8();
                 break;
             case MSPCodes.MSP_SET_PID_CONTROLLER:
                 console.log('PID controller changed');
@@ -1634,219 +1634,219 @@ MspHelper.prototype.crunch = function(code) {
 
     switch (code) {
         case MSPCodes.MSP_SET_FEATURE_CONFIG:
-            var featureMask = FEATURE_CONFIG.features.getMask();
+            var featureMask = FC.FEATURE_CONFIG.features.getMask();
             buffer.push32(featureMask);
             break;
         case MSPCodes.MSP_SET_BEEPER_CONFIG:
-            var beeperMask = BEEPER_CONFIG.beepers.getMask();
+            var beeperMask = FC.BEEPER_CONFIG.beepers.getMask();
             buffer.push32(beeperMask);
-            if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                buffer.push8(BEEPER_CONFIG.dshotBeaconTone);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                buffer.push8(FC.BEEPER_CONFIG.dshotBeaconTone);
             }
-            if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-                buffer.push32(BEEPER_CONFIG.dshotBeaconConditions.getMask());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                buffer.push32(FC.BEEPER_CONFIG.dshotBeaconConditions.getMask());
             }
             break;
         case MSPCodes.MSP_SET_MIXER_CONFIG:
-            buffer.push8(MIXER_CONFIG.mixer)
-            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                buffer.push8(MIXER_CONFIG.reverseMotorDir);
+            buffer.push8(FC.MIXER_CONFIG.mixer)
+            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                buffer.push8(FC.MIXER_CONFIG.reverseMotorDir);
             }
             break;
         case MSPCodes.MSP_SET_BOARD_ALIGNMENT_CONFIG:
-            buffer.push16(BOARD_ALIGNMENT_CONFIG.roll)
-                .push16(BOARD_ALIGNMENT_CONFIG.pitch)
-                .push16(BOARD_ALIGNMENT_CONFIG.yaw);
+            buffer.push16(FC.BOARD_ALIGNMENT_CONFIG.roll)
+                .push16(FC.BOARD_ALIGNMENT_CONFIG.pitch)
+                .push16(FC.BOARD_ALIGNMENT_CONFIG.yaw);
             break;
         case MSPCodes.MSP_SET_PID_CONTROLLER:
-            buffer.push8(PID.controller);
+            buffer.push8(FC.PID.controller);
             break;
         case MSPCodes.MSP_SET_PID:
-            for (let i = 0; i < PIDs.length; i++) {
+            for (let i = 0; i < FC.PIDS.length; i++) {
                 for (let j = 0; j < 3; j++) {
-                    buffer.push8(parseInt(PIDs[i][j]));
+                    buffer.push8(parseInt(FC.PIDS[i][j]));
                 }
             }
             break;
         case MSPCodes.MSP_SET_RC_TUNING:
-            buffer.push8(Math.round(RC_tuning.RC_RATE * 100))
-                .push8(Math.round(RC_tuning.RC_EXPO * 100));
-            if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
-                buffer.push8(Math.round(RC_tuning.roll_pitch_rate * 100));
+            buffer.push8(Math.round(FC.RC_TUNING.RC_RATE * 100))
+                .push8(Math.round(FC.RC_TUNING.RC_EXPO * 100));
+            if (semver.lt(FC.CONFIG.apiVersion, "1.7.0")) {
+                buffer.push8(Math.round(FC.RC_TUNING.roll_pitch_rate * 100));
             } else {
-                buffer.push8(Math.round(RC_tuning.roll_rate * 100))
-                    .push8(Math.round(RC_tuning.pitch_rate * 100));
+                buffer.push8(Math.round(FC.RC_TUNING.roll_rate * 100))
+                    .push8(Math.round(FC.RC_TUNING.pitch_rate * 100));
             }
-            buffer.push8(Math.round(RC_tuning.yaw_rate * 100))
-                .push8(Math.round(RC_tuning.dynamic_THR_PID * 100))
-                .push8(Math.round(RC_tuning.throttle_MID * 100))
-                .push8(Math.round(RC_tuning.throttle_EXPO * 100));
-            if (semver.gte(CONFIG.apiVersion, "1.7.0")) {
-                buffer.push16(RC_tuning.dynamic_THR_breakpoint);
+            buffer.push8(Math.round(FC.RC_TUNING.yaw_rate * 100))
+                .push8(Math.round(FC.RC_TUNING.dynamic_THR_PID * 100))
+                .push8(Math.round(FC.RC_TUNING.throttle_MID * 100))
+                .push8(Math.round(FC.RC_TUNING.throttle_EXPO * 100));
+            if (semver.gte(FC.CONFIG.apiVersion, "1.7.0")) {
+                buffer.push16(FC.RC_TUNING.dynamic_THR_breakpoint);
             }
-            if (semver.gte(CONFIG.apiVersion, "1.10.0")) {
-                buffer.push8(Math.round(RC_tuning.RC_YAW_EXPO * 100));
-                if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-                    buffer.push8(Math.round(RC_tuning.rcYawRate * 100));
+            if (semver.gte(FC.CONFIG.apiVersion, "1.10.0")) {
+                buffer.push8(Math.round(FC.RC_TUNING.RC_YAW_EXPO * 100));
+                if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
+                    buffer.push8(Math.round(FC.RC_TUNING.rcYawRate * 100));
                 }
             }
-            if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                buffer.push8(Math.round(RC_tuning.rcPitchRate * 100));
-                buffer.push8(Math.round(RC_tuning.RC_PITCH_EXPO * 100));
+            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                buffer.push8(Math.round(FC.RC_TUNING.rcPitchRate * 100));
+                buffer.push8(Math.round(FC.RC_TUNING.RC_PITCH_EXPO * 100));
             }
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                buffer.push8(RC_tuning.throttleLimitType);
-                buffer.push8(RC_tuning.throttleLimitPercent);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                buffer.push8(FC.RC_TUNING.throttleLimitType);
+                buffer.push8(FC.RC_TUNING.throttleLimitPercent);
             }
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                buffer.push16(RC_tuning.roll_rate_limit);
-                buffer.push16(RC_tuning.pitch_rate_limit);
-                buffer.push16(RC_tuning.yaw_rate_limit);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                buffer.push16(FC.RC_TUNING.roll_rate_limit);
+                buffer.push16(FC.RC_TUNING.pitch_rate_limit);
+                buffer.push16(FC.RC_TUNING.yaw_rate_limit);
             }
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                buffer.push8(RC_tuning.rates_type);
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                buffer.push8(FC.RC_TUNING.rates_type);
             }
             break;
         case MSPCodes.MSP_SET_RX_MAP:
-            for (let i = 0; i < RC_MAP.length; i++) {
-                buffer.push8(RC_MAP[i]);
+            for (let i = 0; i < FC.RC_MAP.length; i++) {
+                buffer.push8(FC.RC_MAP[i]);
             }
             break;
         case MSPCodes.MSP_SET_ACC_TRIM:
-            buffer.push16(CONFIG.accelerometerTrims[0])
-                .push16(CONFIG.accelerometerTrims[1]);
+            buffer.push16(FC.CONFIG.accelerometerTrims[0])
+                .push16(FC.CONFIG.accelerometerTrims[1]);
             break;
         case MSPCodes.MSP_SET_ARMING_CONFIG:
-            buffer.push8(ARMING_CONFIG.auto_disarm_delay)
-                .push8(ARMING_CONFIG.disarm_kill_switch);
-            if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                buffer.push8(ARMING_CONFIG.small_angle);
+            buffer.push8(FC.ARMING_CONFIG.auto_disarm_delay)
+                .push8(FC.ARMING_CONFIG.disarm_kill_switch);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                buffer.push8(FC.ARMING_CONFIG.small_angle);
             }
             break;
         case MSPCodes.MSP_SET_LOOP_TIME:
-            buffer.push16(FC_CONFIG.loopTime);
+            buffer.push16(FC.FC_CONFIG.loopTime);
             break;
         case MSPCodes.MSP_SET_MISC:
-            buffer.push16(RX_CONFIG.midrc)
-                .push16(MOTOR_CONFIG.minthrottle)
-                .push16(MOTOR_CONFIG.maxthrottle)
-                .push16(MOTOR_CONFIG.mincommand)
-                .push16(MISC.failsafe_throttle)
-                .push8(GPS_CONFIG.provider)
-                .push8(MISC.gps_baudrate)
-                .push8(GPS_CONFIG.ublox_sbas)
-                .push8(MISC.multiwiicurrentoutput)
-                .push8(RSSI_CONFIG.channel)
-                .push8(MISC.placeholder2)
+            buffer.push16(FC.RX_CONFIG.midrc)
+                .push16(FC.MOTOR_CONFIG.minthrottle)
+                .push16(FC.MOTOR_CONFIG.maxthrottle)
+                .push16(FC.MOTOR_CONFIG.mincommand)
+                .push16(FC.MISC.failsafe_throttle)
+                .push8(FC.GPS_CONFIG.provider)
+                .push8(FC.MISC.gps_baudrate)
+                .push8(FC.GPS_CONFIG.ublox_sbas)
+                .push8(FC.MISC.multiwiicurrentoutput)
+                .push8(FC.RSSI_CONFIG.channel)
+                .push8(FC.MISC.placeholder2)
                 .push16(0) // was mag_declination
-                .push8(MISC.vbatscale)
-                .push8(Math.round(MISC.vbatmincellvoltage * 10))
-                .push8(Math.round(MISC.vbatmaxcellvoltage * 10))
-                .push8(Math.round(MISC.vbatwarningcellvoltage * 10));
+                .push8(FC.MISC.vbatscale)
+                .push8(Math.round(FC.MISC.vbatmincellvoltage * 10))
+                .push8(Math.round(FC.MISC.vbatmaxcellvoltage * 10))
+                .push8(Math.round(FC.MISC.vbatwarningcellvoltage * 10));
             break;
         case MSPCodes.MSP_SET_MOTOR_CONFIG:
-            buffer.push16(MOTOR_CONFIG.minthrottle)
-                .push16(MOTOR_CONFIG.maxthrottle)
-                .push16(MOTOR_CONFIG.mincommand);
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                buffer.push8(MOTOR_CONFIG.motor_poles);
-                buffer.push8(MOTOR_CONFIG.use_dshot_telemetry ? 1 : 0);
+            buffer.push16(FC.MOTOR_CONFIG.minthrottle)
+                .push16(FC.MOTOR_CONFIG.maxthrottle)
+                .push16(FC.MOTOR_CONFIG.mincommand);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                buffer.push8(FC.MOTOR_CONFIG.motor_poles);
+                buffer.push8(FC.MOTOR_CONFIG.use_dshot_telemetry ? 1 : 0);
             }
             break;
         case MSPCodes.MSP_SET_GPS_CONFIG:
-            buffer.push8(GPS_CONFIG.provider)
-                .push8(GPS_CONFIG.ublox_sbas);
-            if (semver.gte(CONFIG.apiVersion, "1.34.0")) {
-                buffer.push8(GPS_CONFIG.auto_config)
-                    .push8(GPS_CONFIG.auto_baud);
+            buffer.push8(FC.GPS_CONFIG.provider)
+                .push8(FC.GPS_CONFIG.ublox_sbas);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
+                buffer.push8(FC.GPS_CONFIG.auto_config)
+                    .push8(FC.GPS_CONFIG.auto_baud);
 
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                    buffer.push8(GPS_CONFIG.home_point_once)
-                          .push8(GPS_CONFIG.ublox_use_galileo);
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                    buffer.push8(FC.GPS_CONFIG.home_point_once)
+                          .push8(FC.GPS_CONFIG.ublox_use_galileo);
                 }
             }
             break;
         case MSPCodes.MSP_SET_GPS_RESCUE:
-            buffer.push16(GPS_RESCUE.angle)
-                  .push16(GPS_RESCUE.initialAltitudeM)
-                  .push16(GPS_RESCUE.descentDistanceM)
-                  .push16(GPS_RESCUE.rescueGroundspeed)
-                  .push16(GPS_RESCUE.throttleMin)
-                  .push16(GPS_RESCUE.throttleMax)
-                  .push16(GPS_RESCUE.throttleHover)
-                  .push8(GPS_RESCUE.sanityChecks)
-                  .push8(GPS_RESCUE.minSats);
+            buffer.push16(FC.GPS_RESCUE.angle)
+                  .push16(FC.GPS_RESCUE.initialAltitudeM)
+                  .push16(FC.GPS_RESCUE.descentDistanceM)
+                  .push16(FC.GPS_RESCUE.rescueGroundspeed)
+                  .push16(FC.GPS_RESCUE.throttleMin)
+                  .push16(FC.GPS_RESCUE.throttleMax)
+                  .push16(FC.GPS_RESCUE.throttleHover)
+                  .push8(FC.GPS_RESCUE.sanityChecks)
+                  .push8(FC.GPS_RESCUE.minSats);
 
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                    buffer.push16(GPS_RESCUE.ascendRate)
-                          .push16(GPS_RESCUE.descendRate)
-                          .push8(GPS_RESCUE.allowArmingWithoutFix)
-                          .push8(GPS_RESCUE.altitudeMode);
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                    buffer.push16(FC.GPS_RESCUE.ascendRate)
+                          .push16(FC.GPS_RESCUE.descendRate)
+                          .push8(FC.GPS_RESCUE.allowArmingWithoutFix)
+                          .push8(FC.GPS_RESCUE.altitudeMode);
                 }
             break;
         case MSPCodes.MSP_SET_RSSI_CONFIG:
-            buffer.push8(RSSI_CONFIG.channel);
+            buffer.push8(FC.RSSI_CONFIG.channel);
             break;
         case MSPCodes.MSP_SET_BATTERY_CONFIG:
-            buffer.push8(Math.round(BATTERY_CONFIG.vbatmincellvoltage * 10))
-                .push8(Math.round(BATTERY_CONFIG.vbatmaxcellvoltage * 10))
-                .push8(Math.round(BATTERY_CONFIG.vbatwarningcellvoltage * 10))
-                .push16(BATTERY_CONFIG.capacity)
-                .push8(BATTERY_CONFIG.voltageMeterSource)
-                .push8(BATTERY_CONFIG.currentMeterSource);
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    buffer.push16(Math.round(BATTERY_CONFIG.vbatmincellvoltage * 100))
-                        .push16(Math.round(BATTERY_CONFIG.vbatmaxcellvoltage * 100))
-                        .push16(Math.round(BATTERY_CONFIG.vbatwarningcellvoltage * 100));
+            buffer.push8(Math.round(FC.BATTERY_CONFIG.vbatmincellvoltage * 10))
+                .push8(Math.round(FC.BATTERY_CONFIG.vbatmaxcellvoltage * 10))
+                .push8(Math.round(FC.BATTERY_CONFIG.vbatwarningcellvoltage * 10))
+                .push16(FC.BATTERY_CONFIG.capacity)
+                .push8(FC.BATTERY_CONFIG.voltageMeterSource)
+                .push8(FC.BATTERY_CONFIG.currentMeterSource);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    buffer.push16(Math.round(FC.BATTERY_CONFIG.vbatmincellvoltage * 100))
+                        .push16(Math.round(FC.BATTERY_CONFIG.vbatmaxcellvoltage * 100))
+                        .push16(Math.round(FC.BATTERY_CONFIG.vbatwarningcellvoltage * 100));
                 }
             break;
         case MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG:
-            if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
-                buffer.push8(MISC.vbatscale)
-                    .push8(Math.round(MISC.vbatmincellvoltage * 10))
-                    .push8(Math.round(MISC.vbatmaxcellvoltage * 10))
-                    .push8(Math.round(MISC.vbatwarningcellvoltage * 10));
-                    if (semver.gte(CONFIG.apiVersion, "1.23.0")) {
-                        buffer.push8(MISC.batterymetertype);
+            if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+                buffer.push8(FC.MISC.vbatscale)
+                    .push8(Math.round(FC.MISC.vbatmincellvoltage * 10))
+                    .push8(Math.round(FC.MISC.vbatmaxcellvoltage * 10))
+                    .push8(Math.round(FC.MISC.vbatwarningcellvoltage * 10));
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.23.0")) {
+                        buffer.push8(FC.MISC.batterymetertype);
                     }
             }
            break;
         case MSPCodes.MSP_SET_CURRENT_METER_CONFIG:
-            if (semver.lt(CONFIG.apiVersion, "1.36.0"))  {
-                buffer.push16(BF_CONFIG.currentscale)
-                    .push16(BF_CONFIG.currentoffset)
-                    .push8(BF_CONFIG.currentmetertype)
-                    .push16(BF_CONFIG.batterycapacity)
+            if (semver.lt(FC.CONFIG.apiVersion, "1.36.0"))  {
+                buffer.push16(FC.BF_CONFIG.currentscale)
+                    .push16(FC.BF_CONFIG.currentoffset)
+                    .push8(FC.BF_CONFIG.currentmetertype)
+                    .push16(FC.BF_CONFIG.batterycapacity)
             }
             break;
 
         case MSPCodes.MSP_SET_RX_CONFIG:
-            buffer.push8(RX_CONFIG.serialrx_provider)
-                .push16(RX_CONFIG.stick_max)
-                .push16(RX_CONFIG.stick_center)
-                .push16(RX_CONFIG.stick_min)
-                .push8(RX_CONFIG.spektrum_sat_bind)
-                .push16(RX_CONFIG.rx_min_usec)
-                .push16(RX_CONFIG.rx_max_usec);
-            if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                buffer.push8(RX_CONFIG.rcInterpolation)
-                    .push8(RX_CONFIG.rcInterpolationInterval)
-                    .push16(RX_CONFIG.airModeActivateThreshold);
-                if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
-                    buffer.push8(RX_CONFIG.rxSpiProtocol)
-                        .push32(RX_CONFIG.rxSpiId)
-                        .push8(RX_CONFIG.rxSpiRfChannelCount)
-                        .push8(RX_CONFIG.fpvCamAngleDegrees);
-                    if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-                        buffer.push8(RX_CONFIG.rcInterpolationChannels)
-                            .push8(RX_CONFIG.rcSmoothingType)
-                            .push8(RX_CONFIG.rcSmoothingInputCutoff)
-                            .push8(RX_CONFIG.rcSmoothingDerivativeCutoff)
-                            .push8(RX_CONFIG.rcSmoothingInputType)
-                            .push8(RX_CONFIG.rcSmoothingDerivativeType);
-                        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                            buffer.push8(RX_CONFIG.usbCdcHidType)
-                                  .push8(RX_CONFIG.rcSmoothingAutoSmoothness);
+            buffer.push8(FC.RX_CONFIG.serialrx_provider)
+                .push16(FC.RX_CONFIG.stick_max)
+                .push16(FC.RX_CONFIG.stick_center)
+                .push16(FC.RX_CONFIG.stick_min)
+                .push8(FC.RX_CONFIG.spektrum_sat_bind)
+                .push16(FC.RX_CONFIG.rx_min_usec)
+                .push16(FC.RX_CONFIG.rx_max_usec);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+                buffer.push8(FC.RX_CONFIG.rcInterpolation)
+                    .push8(FC.RX_CONFIG.rcInterpolationInterval)
+                    .push16(FC.RX_CONFIG.airModeActivateThreshold);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+                    buffer.push8(FC.RX_CONFIG.rxSpiProtocol)
+                        .push32(FC.RX_CONFIG.rxSpiId)
+                        .push8(FC.RX_CONFIG.rxSpiRfChannelCount)
+                        .push8(FC.RX_CONFIG.fpvCamAngleDegrees);
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                        buffer.push8(FC.RX_CONFIG.rcInterpolationChannels)
+                            .push8(FC.RX_CONFIG.rcSmoothingType)
+                            .push8(FC.RX_CONFIG.rcSmoothingInputCutoff)
+                            .push8(FC.RX_CONFIG.rcSmoothingDerivativeCutoff)
+                            .push8(FC.RX_CONFIG.rcSmoothingInputType)
+                            .push8(FC.RX_CONFIG.rcSmoothingDerivativeType);
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                            buffer.push8(FC.RX_CONFIG.usbCdcHidType)
+                                  .push8(FC.RX_CONFIG.rcSmoothingAutoSmoothness);
                         }
                     }
                 }
@@ -1855,28 +1855,28 @@ MspHelper.prototype.crunch = function(code) {
             break;
 
         case MSPCodes.MSP_SET_FAILSAFE_CONFIG:
-            buffer.push8(FAILSAFE_CONFIG.failsafe_delay)
-                .push8(FAILSAFE_CONFIG.failsafe_off_delay)
-                .push16(FAILSAFE_CONFIG.failsafe_throttle);
-            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                buffer.push8(FAILSAFE_CONFIG.failsafe_switch_mode)
-                    .push16(FAILSAFE_CONFIG.failsafe_throttle_low_delay)
-                    .push8(FAILSAFE_CONFIG.failsafe_procedure);
+            buffer.push8(FC.FAILSAFE_CONFIG.failsafe_delay)
+                .push8(FC.FAILSAFE_CONFIG.failsafe_off_delay)
+                .push16(FC.FAILSAFE_CONFIG.failsafe_throttle);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
+                buffer.push8(FC.FAILSAFE_CONFIG.failsafe_switch_mode)
+                    .push16(FC.FAILSAFE_CONFIG.failsafe_throttle_low_delay)
+                    .push8(FC.FAILSAFE_CONFIG.failsafe_procedure);
             }
             break;
 
         case MSPCodes.MSP_SET_TRANSPONDER_CONFIG:
-            if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
-                buffer.push8(TRANSPONDER.provider); //
+            if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+                buffer.push8(FC.TRANSPONDER.provider); //
             }
-            for (let i = 0; i < TRANSPONDER.data.length; i++) {
-                buffer.push8(TRANSPONDER.data[i]);
+            for (let i = 0; i < FC.TRANSPONDER.data.length; i++) {
+                buffer.push8(FC.TRANSPONDER.data[i]);
             }
             break;
 
         case MSPCodes.MSP_SET_CHANNEL_FORWARDING:
-            for (let i = 0; i < SERVO_CONFIG.length; i++) {
-                var out = SERVO_CONFIG[i].indexOfChannelToForward;
+            for (let i = 0; i < FC.SERVO_CONFIG.length; i++) {
+                var out = FC.SERVO_CONFIG[i].indexOfChannelToForward;
                 if (out == undefined) {
                     out = 255; // Cleanflight defines "CHANNEL_FORWARDING_DISABLED" as "(uint8_t)0xFF"
                 }
@@ -1884,18 +1884,18 @@ MspHelper.prototype.crunch = function(code) {
             }
             break;
         case MSPCodes.MSP_SET_CF_SERIAL_CONFIG:
-            if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.6.0")) {
 
-                for (let i = 0; i < SERIAL_CONFIG.ports.length; i++) {
-                    buffer.push8(SERIAL_CONFIG.ports[i].scenario);
+                for (let i = 0; i < FC.SERIAL_CONFIG.ports.length; i++) {
+                    buffer.push8(FC.SERIAL_CONFIG.ports[i].scenario);
                 }
-                buffer.push32(SERIAL_CONFIG.mspBaudRate)
-                    .push32(SERIAL_CONFIG.cliBaudRate)
-                    .push32(SERIAL_CONFIG.gpsBaudRate)
-                    .push32(SERIAL_CONFIG.gpsPassthroughBaudRate);
+                buffer.push32(FC.SERIAL_CONFIG.mspBaudRate)
+                    .push32(FC.SERIAL_CONFIG.cliBaudRate)
+                    .push32(FC.SERIAL_CONFIG.gpsBaudRate)
+                    .push32(FC.SERIAL_CONFIG.gpsPassthroughBaudRate);
             } else {
-                for (let i = 0; i < SERIAL_CONFIG.ports.length; i++) {
-                    const serialPort = SERIAL_CONFIG.ports[i];
+                for (let i = 0; i < FC.SERIAL_CONFIG.ports.length; i++) {
+                    const serialPort = FC.SERIAL_CONFIG.ports[i];
 
                     buffer.push8(serialPort.identifier);
 
@@ -1910,10 +1910,10 @@ MspHelper.prototype.crunch = function(code) {
             break;
 
         case MSPCodes.MSP2_COMMON_SET_SERIAL_CONFIG:
-            buffer.push8(SERIAL_CONFIG.ports.length);
+            buffer.push8(FC.SERIAL_CONFIG.ports.length);
 
-            for (let i = 0; i < SERIAL_CONFIG.ports.length; i++) {
-                const serialPort = SERIAL_CONFIG.ports[i];
+            for (let i = 0; i < FC.SERIAL_CONFIG.ports.length; i++) {
+                const serialPort = FC.SERIAL_CONFIG.ports[i];
 
                 buffer.push8(serialPort.identifier);
 
@@ -1927,180 +1927,180 @@ MspHelper.prototype.crunch = function(code) {
             break;
 
         case MSPCodes.MSP_SET_MOTOR_3D_CONFIG:
-            buffer.push16(MOTOR_3D_CONFIG.deadband3d_low)
-                .push16(MOTOR_3D_CONFIG.deadband3d_high)
-                .push16(MOTOR_3D_CONFIG.neutral);
-            if (semver.lt(CONFIG.apiVersion, "1.17.0")) {
-                buffer.push16(RC_DEADBAND_CONFIG.deadband3d_throttle);
+            buffer.push16(FC.MOTOR_3D_CONFIG.deadband3d_low)
+                .push16(FC.MOTOR_3D_CONFIG.deadband3d_high)
+                .push16(FC.MOTOR_3D_CONFIG.neutral);
+            if (semver.lt(FC.CONFIG.apiVersion, "1.17.0")) {
+                buffer.push16(FC.RC_DEADBAND_CONFIG.deadband3d_throttle);
             }
             break;
 
         case MSPCodes.MSP_SET_RC_DEADBAND:
-            buffer.push8(RC_DEADBAND_CONFIG.deadband)
-                .push8(RC_DEADBAND_CONFIG.yaw_deadband)
-                .push8(RC_DEADBAND_CONFIG.alt_hold_deadband);
-            if (semver.gte(CONFIG.apiVersion, "1.17.0")) {
-                buffer.push16(RC_DEADBAND_CONFIG.deadband3d_throttle);
+            buffer.push8(FC.RC_DEADBAND_CONFIG.deadband)
+                .push8(FC.RC_DEADBAND_CONFIG.yaw_deadband)
+                .push8(FC.RC_DEADBAND_CONFIG.alt_hold_deadband);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.17.0")) {
+                buffer.push16(FC.RC_DEADBAND_CONFIG.deadband3d_throttle);
             }
             break;
 
         case MSPCodes.MSP_SET_SENSOR_ALIGNMENT:
-            buffer.push8(SENSOR_ALIGNMENT.align_gyro)
-                .push8(SENSOR_ALIGNMENT.align_acc)
-                .push8(SENSOR_ALIGNMENT.align_mag);
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                buffer.push8(SENSOR_ALIGNMENT.gyro_to_use)
-                .push8(SENSOR_ALIGNMENT.gyro_1_align)
-                .push8(SENSOR_ALIGNMENT.gyro_2_align);
+            buffer.push8(FC.SENSOR_ALIGNMENT.align_gyro)
+                .push8(FC.SENSOR_ALIGNMENT.align_acc)
+                .push8(FC.SENSOR_ALIGNMENT.align_mag);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                buffer.push8(FC.SENSOR_ALIGNMENT.gyro_to_use)
+                .push8(FC.SENSOR_ALIGNMENT.gyro_1_align)
+                .push8(FC.SENSOR_ALIGNMENT.gyro_2_align);
             }
             break;
         case MSPCodes.MSP_SET_ADVANCED_CONFIG:
-            buffer.push8(PID_ADVANCED_CONFIG.gyro_sync_denom)
-                .push8(PID_ADVANCED_CONFIG.pid_process_denom)
-                .push8(PID_ADVANCED_CONFIG.use_unsyncedPwm)
-                .push8(self.reorderPwmProtocols(PID_ADVANCED_CONFIG.fast_pwm_protocol))
-                .push16(PID_ADVANCED_CONFIG.motor_pwm_rate);
-            if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
-                buffer.push16(PID_ADVANCED_CONFIG.digitalIdlePercent * 100);
+            buffer.push8(FC.PID_ADVANCED_CONFIG.gyro_sync_denom)
+                .push8(FC.PID_ADVANCED_CONFIG.pid_process_denom)
+                .push8(FC.PID_ADVANCED_CONFIG.use_unsyncedPwm)
+                .push8(self.reorderPwmProtocols(FC.PID_ADVANCED_CONFIG.fast_pwm_protocol))
+                .push16(FC.PID_ADVANCED_CONFIG.motor_pwm_rate);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.24.0")) {
+                buffer.push16(FC.PID_ADVANCED_CONFIG.digitalIdlePercent * 100);
 
-                if (semver.gte(CONFIG.apiVersion, "1.25.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.25.0")) {
                     let gyroUse32kHz = 0;
-                    if (semver.lt(CONFIG.apiVersion, "1.41.0")) {
-                        gyroUse32kHz = PID_ADVANCED_CONFIG.gyroUse32kHz;
+                    if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                        gyroUse32kHz = FC.PID_ADVANCED_CONFIG.gyroUse32kHz;
                     }
                     buffer.push8(gyroUse32kHz);
-                    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                        buffer.push8(PID_ADVANCED_CONFIG.motorPwmInversion)
-                              .push8(SENSOR_ALIGNMENT.gyro_to_use) // We don't want to double up on storing this state
-                              .push8(PID_ADVANCED_CONFIG.gyroHighFsr)
-                              .push8(PID_ADVANCED_CONFIG.gyroMovementCalibThreshold)
-                              .push16(PID_ADVANCED_CONFIG.gyroCalibDuration)
-                              .push16(PID_ADVANCED_CONFIG.gyroOffsetYaw)
-                              .push8(PID_ADVANCED_CONFIG.gyroCheckOverflow)
-                              .push8(PID_ADVANCED_CONFIG.debugMode);
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                        buffer.push8(FC.PID_ADVANCED_CONFIG.motorPwmInversion)
+                              .push8(FC.SENSOR_ALIGNMENT.gyro_to_use) // We don't want to double up on storing this state
+                              .push8(FC.PID_ADVANCED_CONFIG.gyroHighFsr)
+                              .push8(FC.PID_ADVANCED_CONFIG.gyroMovementCalibThreshold)
+                              .push16(FC.PID_ADVANCED_CONFIG.gyroCalibDuration)
+                              .push16(FC.PID_ADVANCED_CONFIG.gyroOffsetYaw)
+                              .push8(FC.PID_ADVANCED_CONFIG.gyroCheckOverflow)
+                              .push8(FC.PID_ADVANCED_CONFIG.debugMode);
                     }
                 }
             }
             break;
         case MSPCodes.MSP_SET_FILTER_CONFIG:
-            buffer.push8(FILTER_CONFIG.gyro_lowpass_hz)
-                .push16(FILTER_CONFIG.dterm_lowpass_hz)
-                .push16(FILTER_CONFIG.yaw_lowpass_hz);
-            if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                buffer.push16(FILTER_CONFIG.gyro_notch_hz)
-                    .push16(FILTER_CONFIG.gyro_notch_cutoff)
-                    .push16(FILTER_CONFIG.dterm_notch_hz)
-                    .push16(FILTER_CONFIG.dterm_notch_cutoff);
-                if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-                    buffer.push16(FILTER_CONFIG.gyro_notch2_hz)
-                        .push16(FILTER_CONFIG.gyro_notch2_cutoff)
+            buffer.push8(FC.FILTER_CONFIG.gyro_lowpass_hz)
+                .push16(FC.FILTER_CONFIG.dterm_lowpass_hz)
+                .push16(FC.FILTER_CONFIG.yaw_lowpass_hz);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+                buffer.push16(FC.FILTER_CONFIG.gyro_notch_hz)
+                    .push16(FC.FILTER_CONFIG.gyro_notch_cutoff)
+                    .push16(FC.FILTER_CONFIG.dterm_notch_hz)
+                    .push16(FC.FILTER_CONFIG.dterm_notch_cutoff);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
+                    buffer.push16(FC.FILTER_CONFIG.gyro_notch2_hz)
+                        .push16(FC.FILTER_CONFIG.gyro_notch2_cutoff)
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                    buffer.push8(FILTER_CONFIG.dterm_lowpass_type);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                    buffer.push8(FC.FILTER_CONFIG.dterm_lowpass_type);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
                     let gyro_32khz_hardware_lpf = 0;
-                    if (semver.lt(CONFIG.apiVersion, "1.41.0")) {
-                        gyro_32khz_hardware_lpf = FILTER_CONFIG.gyro_32khz_hardware_lpf;
+                    if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                        gyro_32khz_hardware_lpf = FC.FILTER_CONFIG.gyro_32khz_hardware_lpf;
                     }
-                    buffer.push8(FILTER_CONFIG.gyro_hardware_lpf)
+                    buffer.push8(FC.FILTER_CONFIG.gyro_hardware_lpf)
                           .push8(gyro_32khz_hardware_lpf)
-                          .push16(FILTER_CONFIG.gyro_lowpass_hz)
-                          .push16(FILTER_CONFIG.gyro_lowpass2_hz)
-                          .push8(FILTER_CONFIG.gyro_lowpass_type)
-                          .push8(FILTER_CONFIG.gyro_lowpass2_type)
-                          .push16(FILTER_CONFIG.dterm_lowpass2_hz);
+                          .push16(FC.FILTER_CONFIG.gyro_lowpass_hz)
+                          .push16(FC.FILTER_CONFIG.gyro_lowpass2_hz)
+                          .push8(FC.FILTER_CONFIG.gyro_lowpass_type)
+                          .push8(FC.FILTER_CONFIG.gyro_lowpass2_type)
+                          .push16(FC.FILTER_CONFIG.dterm_lowpass2_hz);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    buffer.push8(FILTER_CONFIG.dterm_lowpass2_type)
-                          .push16(FILTER_CONFIG.gyro_lowpass_dyn_min_hz)
-                          .push16(FILTER_CONFIG.gyro_lowpass_dyn_max_hz)
-                          .push16(FILTER_CONFIG.dterm_lowpass_dyn_min_hz)
-                          .push16(FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    buffer.push8(FC.FILTER_CONFIG.dterm_lowpass2_type)
+                          .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz)
+                          .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz)
+                          .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz)
+                          .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
                 }
-                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                    buffer.push8(FILTER_CONFIG.dyn_notch_range)
-                          .push8(FILTER_CONFIG.dyn_notch_width_percent)
-                          .push16(FILTER_CONFIG.dyn_notch_q)
-                          .push16(FILTER_CONFIG.dyn_notch_min_hz)
-                          .push8(FILTER_CONFIG.gyro_rpm_notch_harmonics)
-                          .push8(FILTER_CONFIG.gyro_rpm_notch_min_hz);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                    buffer.push8(FC.FILTER_CONFIG.dyn_notch_range)
+                          .push8(FC.FILTER_CONFIG.dyn_notch_width_percent)
+                          .push16(FC.FILTER_CONFIG.dyn_notch_q)
+                          .push16(FC.FILTER_CONFIG.dyn_notch_min_hz)
+                          .push8(FC.FILTER_CONFIG.gyro_rpm_notch_harmonics)
+                          .push8(FC.FILTER_CONFIG.gyro_rpm_notch_min_hz);
                 }
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                    buffer.push16(FILTER_CONFIG.dyn_notch_max_hz);
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                    buffer.push16(FC.FILTER_CONFIG.dyn_notch_max_hz);
                 }
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-                    buffer.push8(FILTER_CONFIG.dyn_lpf_curve_expo);
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                    buffer.push8(FC.FILTER_CONFIG.dyn_lpf_curve_expo);
                 }
             }
             break;
         case MSPCodes.MSP_SET_PID_ADVANCED:
-            if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                buffer.push16(ADVANCED_TUNING.rollPitchItermIgnoreRate)
-                    .push16(ADVANCED_TUNING.yawItermIgnoreRate)
-                    .push16(ADVANCED_TUNING.yaw_p_limit)
-                    .push8(ADVANCED_TUNING.deltaMethod)
-                    .push8(ADVANCED_TUNING.vbatPidCompensation);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+                buffer.push16(FC.ADVANCED_TUNING.rollPitchItermIgnoreRate)
+                    .push16(FC.ADVANCED_TUNING.yawItermIgnoreRate)
+                    .push16(FC.ADVANCED_TUNING.yaw_p_limit)
+                    .push8(FC.ADVANCED_TUNING.deltaMethod)
+                    .push8(FC.ADVANCED_TUNING.vbatPidCompensation);
 
-                if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-                    buffer.push8(ADVANCED_TUNING.feedforwardTransition);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                    buffer.push8(FC.ADVANCED_TUNING.feedforwardTransition);
                 } else {
-                    buffer.push8(ADVANCED_TUNING.dtermSetpointTransition);
+                    buffer.push8(FC.ADVANCED_TUNING.dtermSetpointTransition);
                 }
 
-                buffer.push8(Math.min(ADVANCED_TUNING.dtermSetpointWeight, 254))
-                      .push8(ADVANCED_TUNING.toleranceBand)
-                      .push8(ADVANCED_TUNING.toleranceBandReduction)
-                      .push8(ADVANCED_TUNING.itermThrottleGain)
-                      .push16(ADVANCED_TUNING.pidMaxVelocity)
-                      .push16(ADVANCED_TUNING.pidMaxVelocityYaw);
+                buffer.push8(Math.min(FC.ADVANCED_TUNING.dtermSetpointWeight, 254))
+                      .push8(FC.ADVANCED_TUNING.toleranceBand)
+                      .push8(FC.ADVANCED_TUNING.toleranceBandReduction)
+                      .push8(FC.ADVANCED_TUNING.itermThrottleGain)
+                      .push16(FC.ADVANCED_TUNING.pidMaxVelocity)
+                      .push16(FC.ADVANCED_TUNING.pidMaxVelocityYaw);
 
-                if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
-                    buffer.push8(ADVANCED_TUNING.levelAngleLimit)
-                        .push8(ADVANCED_TUNING.levelSensitivity);
+                if (semver.gte(FC.CONFIG.apiVersion, "1.24.0")) {
+                    buffer.push8(FC.ADVANCED_TUNING.levelAngleLimit)
+                        .push8(FC.ADVANCED_TUNING.levelSensitivity);
 
-                    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                        buffer.push16(ADVANCED_TUNING.itermThrottleThreshold)
-                            .push16(ADVANCED_TUNING.itermAcceleratorGain);
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                        buffer.push16(FC.ADVANCED_TUNING.itermThrottleThreshold)
+                            .push16(FC.ADVANCED_TUNING.itermAcceleratorGain);
 
-                        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-                            buffer.push16(ADVANCED_TUNING.dtermSetpointWeight);
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                            buffer.push16(FC.ADVANCED_TUNING.dtermSetpointWeight);
 
-                            if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-                                buffer.push8(ADVANCED_TUNING.itermRotation)
-                                      .push8(ADVANCED_TUNING.smartFeedforward)
-                                      .push8(ADVANCED_TUNING.itermRelax)
-                                      .push8(ADVANCED_TUNING.itermRelaxType)
-                                      .push8(ADVANCED_TUNING.absoluteControlGain)
-                                      .push8(ADVANCED_TUNING.throttleBoost)
-                                      .push8(ADVANCED_TUNING.acroTrainerAngleLimit)
-                                      .push16(ADVANCED_TUNING.feedforwardRoll)
-                                      .push16(ADVANCED_TUNING.feedforwardPitch)
-                                      .push16(ADVANCED_TUNING.feedforwardYaw)
-                                      .push8(ADVANCED_TUNING.antiGravityMode);
+                            if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                                buffer.push8(FC.ADVANCED_TUNING.itermRotation)
+                                      .push8(FC.ADVANCED_TUNING.smartFeedforward)
+                                      .push8(FC.ADVANCED_TUNING.itermRelax)
+                                      .push8(FC.ADVANCED_TUNING.itermRelaxType)
+                                      .push8(FC.ADVANCED_TUNING.absoluteControlGain)
+                                      .push8(FC.ADVANCED_TUNING.throttleBoost)
+                                      .push8(FC.ADVANCED_TUNING.acroTrainerAngleLimit)
+                                      .push16(FC.ADVANCED_TUNING.feedforwardRoll)
+                                      .push16(FC.ADVANCED_TUNING.feedforwardPitch)
+                                      .push16(FC.ADVANCED_TUNING.feedforwardYaw)
+                                      .push8(FC.ADVANCED_TUNING.antiGravityMode);
 
-                                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                                    buffer.push8(ADVANCED_TUNING.dMinRoll)
-                                          .push8(ADVANCED_TUNING.dMinPitch)
-                                          .push8(ADVANCED_TUNING.dMinYaw)
-                                          .push8(ADVANCED_TUNING.dMinGain)
-                                          .push8(ADVANCED_TUNING.dMinAdvance)
-                                          .push8(ADVANCED_TUNING.useIntegratedYaw)
-                                          .push8(ADVANCED_TUNING.integratedYawRelax);
+                                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                                    buffer.push8(FC.ADVANCED_TUNING.dMinRoll)
+                                          .push8(FC.ADVANCED_TUNING.dMinPitch)
+                                          .push8(FC.ADVANCED_TUNING.dMinYaw)
+                                          .push8(FC.ADVANCED_TUNING.dMinGain)
+                                          .push8(FC.ADVANCED_TUNING.dMinAdvance)
+                                          .push8(FC.ADVANCED_TUNING.useIntegratedYaw)
+                                          .push8(FC.ADVANCED_TUNING.integratedYawRelax);
                                           
-                                    if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                                        buffer.push8(ADVANCED_TUNING.itermRelaxCutoff);
+                                    if(semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                                        buffer.push8(FC.ADVANCED_TUNING.itermRelaxCutoff);
 
-                                        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                                            buffer.push8(ADVANCED_TUNING.motorOutputLimit)
-                                                  .push8(ADVANCED_TUNING.autoProfileCellCount)
-                                                  .push8(ADVANCED_TUNING.idleMinRpm);
+                                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                                            buffer.push8(FC.ADVANCED_TUNING.motorOutputLimit)
+                                                  .push8(FC.ADVANCED_TUNING.autoProfileCellCount)
+                                                  .push8(FC.ADVANCED_TUNING.idleMinRpm);
 
-                                            if(semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-                                                buffer.push8(ADVANCED_TUNING.ff_interpolate_sp)
-                                                      .push8(ADVANCED_TUNING.ff_smooth_factor)
-                                                      .push8(ADVANCED_TUNING.ff_boost)
-                                                      .push8(ADVANCED_TUNING.vbat_sag_compensation);
+                                            if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                                                buffer.push8(FC.ADVANCED_TUNING.ff_interpolate_sp)
+                                                      .push8(FC.ADVANCED_TUNING.ff_smooth_factor)
+                                                      .push8(FC.ADVANCED_TUNING.ff_boost)
+                                                      .push8(FC.ADVANCED_TUNING.vbat_sag_compensation);
                                             }
                                         }
                                     }
@@ -2112,53 +2112,53 @@ MspHelper.prototype.crunch = function(code) {
             }
             // only supports 1 version pre bf 3.0
             else {
-                buffer.push16(ADVANCED_TUNING.rollPitchItermIgnoreRate)
-                   .push16(ADVANCED_TUNING.yawItermIgnoreRate)
-                   .push16(ADVANCED_TUNING.yaw_p_limit)
-                   .push8(ADVANCED_TUNING.deltaMethod)
-                   .push8(ADVANCED_TUNING.vbatPidCompensation);
+                buffer.push16(FC.ADVANCED_TUNING.rollPitchItermIgnoreRate)
+                   .push16(FC.ADVANCED_TUNING.yawItermIgnoreRate)
+                   .push16(FC.ADVANCED_TUNING.yaw_p_limit)
+                   .push8(FC.ADVANCED_TUNING.deltaMethod)
+                   .push8(FC.ADVANCED_TUNING.vbatPidCompensation);
             }
             break;
         case MSPCodes.MSP_SET_SENSOR_CONFIG:
-            buffer.push8(SENSOR_CONFIG.acc_hardware)
-                .push8(SENSOR_CONFIG.baro_hardware)
-                .push8(SENSOR_CONFIG.mag_hardware);
+            buffer.push8(FC.SENSOR_CONFIG.acc_hardware)
+                .push8(FC.SENSOR_CONFIG.baro_hardware)
+                .push8(FC.SENSOR_CONFIG.mag_hardware);
             break;
 
         case MSPCodes.MSP_SET_NAME:
             var MSP_BUFFER_SIZE = 64;
-            for (let i = 0; i<CONFIG.name.length && i<MSP_BUFFER_SIZE; i++) {
-                buffer.push8(CONFIG.name.charCodeAt(i));
+            for (let i = 0; i<FC.CONFIG.name.length && i<MSP_BUFFER_SIZE; i++) {
+                buffer.push8(FC.CONFIG.name.charCodeAt(i));
             }
             break;
 
         case MSPCodes.MSP_SET_BLACKBOX_CONFIG:
-            buffer.push8(BLACKBOX.blackboxDevice)
-                .push8(BLACKBOX.blackboxRateNum)
-                .push8(BLACKBOX.blackboxRateDenom);
-            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                buffer.push16(BLACKBOX.blackboxPDenom);
+            buffer.push8(FC.BLACKBOX.blackboxDevice)
+                .push8(FC.BLACKBOX.blackboxRateNum)
+                .push8(FC.BLACKBOX.blackboxRateDenom);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                buffer.push16(FC.BLACKBOX.blackboxPDenom);
             }
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-                buffer.push8(BLACKBOX.blackboxSampleRate);
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                buffer.push8(FC.BLACKBOX.blackboxSampleRate);
             }
             break;
 
         case MSPCodes.MSP_COPY_PROFILE:
-            buffer.push8(COPY_PROFILE.type)
-                .push8(COPY_PROFILE.dstProfile)
-                .push8(COPY_PROFILE.srcProfile);
+            buffer.push8(FC.COPY_PROFILE.type)
+                .push8(FC.COPY_PROFILE.dstProfile)
+                .push8(FC.COPY_PROFILE.srcProfile);
             break;
         case MSPCodes.MSP_ARMING_DISABLE:
             var value;
-            if (CONFIG.armingDisabled) {
+            if (FC.CONFIG.armingDisabled) {
                 value = 1;
             } else {
                 value = 0;
             }
             buffer.push8(value);
 
-            if (CONFIG.runawayTakeoffPreventionDisabled) {
+            if (FC.CONFIG.runawayTakeoffPreventionDisabled) {
                 value = 1;
             } else {
                 value = 0;
@@ -2170,7 +2170,7 @@ MspHelper.prototype.crunch = function(code) {
         case MSPCodes.MSP_SET_RTC:
             var now = new Date();
 
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                 var timestamp = now.getTime();
                 var secs = timestamp / 1000;
                 var millis = timestamp % 1000;
@@ -2189,64 +2189,64 @@ MspHelper.prototype.crunch = function(code) {
 
         case MSPCodes.MSP_SET_VTX_CONFIG:
 
-            buffer.push16(VTX_CONFIG.vtx_frequency)
-                  .push8(VTX_CONFIG.vtx_power)
-                  .push8(VTX_CONFIG.vtx_pit_mode ? 1 : 0)
-                  .push8(VTX_CONFIG.vtx_low_power_disarm);
+            buffer.push16(FC.VTX_CONFIG.vtx_frequency)
+                  .push8(FC.VTX_CONFIG.vtx_power)
+                  .push8(FC.VTX_CONFIG.vtx_pit_mode ? 1 : 0)
+                  .push8(FC.VTX_CONFIG.vtx_low_power_disarm);
 
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                buffer.push16(VTX_CONFIG.vtx_pit_mode_frequency)
-                      .push8(VTX_CONFIG.vtx_band)
-                      .push8(VTX_CONFIG.vtx_channel)
-                      .push16(VTX_CONFIG.vtx_frequency)
-                      .push8(VTX_CONFIG.vtx_table_bands)
-                      .push8(VTX_CONFIG.vtx_table_channels)
-                      .push8(VTX_CONFIG.vtx_table_powerlevels)
-                      .push8(VTX_CONFIG.vtx_table_clear ? 1 : 0);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                buffer.push16(FC.VTX_CONFIG.vtx_pit_mode_frequency)
+                      .push8(FC.VTX_CONFIG.vtx_band)
+                      .push8(FC.VTX_CONFIG.vtx_channel)
+                      .push16(FC.VTX_CONFIG.vtx_frequency)
+                      .push8(FC.VTX_CONFIG.vtx_table_bands)
+                      .push8(FC.VTX_CONFIG.vtx_table_channels)
+                      .push8(FC.VTX_CONFIG.vtx_table_powerlevels)
+                      .push8(FC.VTX_CONFIG.vtx_table_clear ? 1 : 0);
             }
 
             break;
 
         case MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL:
 
-            buffer.push8(VTXTABLE_POWERLEVEL.vtxtable_powerlevel_number)
-                  .push16(VTXTABLE_POWERLEVEL.vtxtable_powerlevel_value);
+            buffer.push8(FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_number)
+                  .push16(FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_value);
 
-            buffer.push8(VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.length);
-            for (let i = 0; i < VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.length; i++) {
-                buffer.push8(VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.charCodeAt(i));
+            buffer.push8(FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.length);
+            for (let i = 0; i < FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.length; i++) {
+                buffer.push8(FC.VTXTABLE_POWERLEVEL.vtxtable_powerlevel_label.charCodeAt(i));
             }
 
             break;
 
         case MSPCodes.MSP_SET_VTXTABLE_BAND:
 
-            buffer.push8(VTXTABLE_BAND.vtxtable_band_number);
+            buffer.push8(FC.VTXTABLE_BAND.vtxtable_band_number);
 
-            buffer.push8(VTXTABLE_BAND.vtxtable_band_name.length);
-            for (let i = 0; i < VTXTABLE_BAND.vtxtable_band_name.length; i++) {
-                buffer.push8(VTXTABLE_BAND.vtxtable_band_name.charCodeAt(i));
+            buffer.push8(FC.VTXTABLE_BAND.vtxtable_band_name.length);
+            for (let i = 0; i < FC.VTXTABLE_BAND.vtxtable_band_name.length; i++) {
+                buffer.push8(FC.VTXTABLE_BAND.vtxtable_band_name.charCodeAt(i));
             }
 
-            if (VTXTABLE_BAND.vtxtable_band_letter != '') {
-                buffer.push8(VTXTABLE_BAND.vtxtable_band_letter.charCodeAt(0))
+            if (FC.VTXTABLE_BAND.vtxtable_band_letter != '') {
+                buffer.push8(FC.VTXTABLE_BAND.vtxtable_band_letter.charCodeAt(0))
             } else {
                 buffer.push8(' '.charCodeAt(0));
             }
-            buffer.push8(VTXTABLE_BAND.vtxtable_band_is_factory_band ? 1 : 0);
+            buffer.push8(FC.VTXTABLE_BAND.vtxtable_band_is_factory_band ? 1 : 0);
 
-            buffer.push8(VTXTABLE_BAND.vtxtable_band_frequencies.length);
-            for (let i = 0; i < VTXTABLE_BAND.vtxtable_band_frequencies.length; i++) {
-                buffer.push16(VTXTABLE_BAND.vtxtable_band_frequencies[i]);
+            buffer.push8(FC.VTXTABLE_BAND.vtxtable_band_frequencies.length);
+            for (let i = 0; i < FC.VTXTABLE_BAND.vtxtable_band_frequencies.length; i++) {
+                buffer.push16(FC.VTXTABLE_BAND.vtxtable_band_frequencies[i]);
             }
 
             break;
 
         case MSPCodes.MSP_MULTIPLE_MSP:
 
-            while (MULTIPLE_MSP.msp_commands.length > 0) {
+            while (FC.MULTIPLE_MSP.msp_commands.length > 0) {
 
-                let mspCommand = MULTIPLE_MSP.msp_commands.shift();
+                let mspCommand = FC.MULTIPLE_MSP.msp_commands.shift();
 
                 self.mspMultipleCache.push(mspCommand);
                 buffer.push8(mspCommand);
@@ -2283,11 +2283,11 @@ MspHelper.prototype.setRawRx = function(channels) {
 MspHelper.prototype.dataflashRead = function(address, blockSize, onDataCallback) {
     var outData = [address & 0xFF, (address >> 8) & 0xFF, (address >> 16) & 0xFF, (address >> 24) & 0xFF];
 
-    if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
         outData = outData.concat([blockSize & 0xFF, (blockSize >> 8) & 0xFF]);
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
         // Allow compression
         outData = outData.concat([1]);
     }
@@ -2299,7 +2299,7 @@ MspHelper.prototype.dataflashRead = function(address, blockSize, onDataCallback)
             var headerSize = 4;
             var dataSize = response.data.buffer.byteLength - headerSize;
             var dataCompressionType = 0;
-            if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
                 headerSize = headerSize + 3;
                 dataSize = response.data.readU16();
                 dataCompressionType = response.data.readU8();
@@ -2340,7 +2340,7 @@ MspHelper.prototype.sendServoConfigurations = function(onCompleteCallback) {
 
     var servoIndex = 0;
 
-    if (SERVO_CONFIG.length == 0) {
+    if (FC.SERVO_CONFIG.length == 0) {
         onCompleteCallback();
     } else {
         nextFunction();
@@ -2351,20 +2351,20 @@ MspHelper.prototype.sendServoConfigurations = function(onCompleteCallback) {
 
         var buffer = [];
 
-        if (semver.lt(CONFIG.apiVersion, "1.12.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.12.0")) {
             // send all in one go
             // 1.9.0 had a bug where the MSP input buffer was too small, limit to 8.
-            for (let i = 0; i < SERVO_CONFIG.length && i < 8; i++) {
-                buffer.push16(SERVO_CONFIG[i].min)
-                    .push16(SERVO_CONFIG[i].max)
-                    .push16(SERVO_CONFIG[i].middle)
-                    .push8(SERVO_CONFIG[i].rate);
+            for (let i = 0; i < FC.SERVO_CONFIG.length && i < 8; i++) {
+                buffer.push16(FC.SERVO_CONFIG[i].min)
+                    .push16(FC.SERVO_CONFIG[i].max)
+                    .push16(FC.SERVO_CONFIG[i].middle)
+                    .push8(FC.SERVO_CONFIG[i].rate);
             }
             nextFunction = send_channel_forwarding;
         } else {
             // send one at a time, with index
 
-            var servoConfiguration = SERVO_CONFIG[servoIndex];
+            var servoConfiguration = FC.SERVO_CONFIG[servoIndex];
 
             buffer.push8(servoIndex)
                 .push16(servoConfiguration.min)
@@ -2372,7 +2372,7 @@ MspHelper.prototype.sendServoConfigurations = function(onCompleteCallback) {
                 .push16(servoConfiguration.middle)
                 .push8(servoConfiguration.rate);
 
-            if (semver.lt(CONFIG.apiVersion, "1.33.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.33.0")) {
                 buffer.push8(servoConfiguration.angleAtMin)
                     .push8(servoConfiguration.angleAtMax);
             }
@@ -2386,7 +2386,7 @@ MspHelper.prototype.sendServoConfigurations = function(onCompleteCallback) {
 
             // prepare for next iteration
             servoIndex++;
-            if (servoIndex == SERVO_CONFIG.length) {
+            if (servoIndex == FC.SERVO_CONFIG.length) {
                 nextFunction = onCompleteCallback;
             }
         }
@@ -2396,8 +2396,8 @@ MspHelper.prototype.sendServoConfigurations = function(onCompleteCallback) {
     function send_channel_forwarding() {
         var buffer = [];
 
-        for (let i = 0; i < SERVO_CONFIG.length; i++) {
-            var out = SERVO_CONFIG[i].indexOfChannelToForward;
+        for (let i = 0; i < FC.SERVO_CONFIG.length; i++) {
+            var out = FC.SERVO_CONFIG[i].indexOfChannelToForward;
             if (out == undefined) {
                 out = 255; // Cleanflight defines "CHANNEL_FORWARDING_DISABLED" as "(uint8_t)0xFF"
             }
@@ -2415,7 +2415,7 @@ MspHelper.prototype.sendModeRanges = function(onCompleteCallback) {
 
     var modeRangeIndex = 0;
 
-    if (MODE_RANGES.length == 0) {
+    if (FC.MODE_RANGES.length == 0) {
         onCompleteCallback();
     } else {
         send_next_mode_range();
@@ -2423,7 +2423,7 @@ MspHelper.prototype.sendModeRanges = function(onCompleteCallback) {
 
     function send_next_mode_range() {
 
-        var modeRange = MODE_RANGES[modeRangeIndex];
+        var modeRange = FC.MODE_RANGES[modeRangeIndex];
 
         var buffer = [];
         buffer.push8(modeRangeIndex)
@@ -2432,8 +2432,8 @@ MspHelper.prototype.sendModeRanges = function(onCompleteCallback) {
             .push8((modeRange.range.start - 900) / 25)
             .push8((modeRange.range.end - 900) / 25);
 
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-            var modeRangeExtra = MODE_RANGES_EXTRA[modeRangeIndex];
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            var modeRangeExtra = FC.MODE_RANGES_EXTRA[modeRangeIndex];
             
             buffer.push8(modeRangeExtra.modeLogic)
                 .push8(modeRangeExtra.linkedTo);
@@ -2441,7 +2441,7 @@ MspHelper.prototype.sendModeRanges = function(onCompleteCallback) {
 
         // prepare for next iteration
         modeRangeIndex++;
-        if (modeRangeIndex == MODE_RANGES.length) {
+        if (modeRangeIndex == FC.MODE_RANGES.length) {
             nextFunction = onCompleteCallback;
         }
         MSP.send_message(MSPCodes.MSP_SET_MODE_RANGE, buffer, false, nextFunction);
@@ -2453,7 +2453,7 @@ MspHelper.prototype.sendAdjustmentRanges = function(onCompleteCallback) {
 
     var adjustmentRangeIndex = 0;
 
-    if (ADJUSTMENT_RANGES.length == 0) {
+    if (FC.ADJUSTMENT_RANGES.length == 0) {
         onCompleteCallback();
     } else {
         send_next_adjustment_range();
@@ -2462,7 +2462,7 @@ MspHelper.prototype.sendAdjustmentRanges = function(onCompleteCallback) {
 
     function send_next_adjustment_range() {
 
-        var adjustmentRange = ADJUSTMENT_RANGES[adjustmentRangeIndex];
+        var adjustmentRange = FC.ADJUSTMENT_RANGES[adjustmentRangeIndex];
 
         var buffer = [];
         buffer.push8(adjustmentRangeIndex)
@@ -2475,7 +2475,7 @@ MspHelper.prototype.sendAdjustmentRanges = function(onCompleteCallback) {
 
         // prepare for next iteration
         adjustmentRangeIndex++;
-        if (adjustmentRangeIndex == ADJUSTMENT_RANGES.length) {
+        if (adjustmentRangeIndex == FC.ADJUSTMENT_RANGES.length) {
             nextFunction = onCompleteCallback;
 
         }
@@ -2489,7 +2489,7 @@ MspHelper.prototype.sendVoltageConfig = function(onCompleteCallback) {
 
     var configIndex = 0;
     
-    if (VOLTAGE_METER_CONFIGS.length == 0) {
+    if (FC.VOLTAGE_METER_CONFIGS.length == 0) {
         onCompleteCallback();
     } else {
         send_next_voltage_config();
@@ -2498,14 +2498,14 @@ MspHelper.prototype.sendVoltageConfig = function(onCompleteCallback) {
     function send_next_voltage_config() {
         var buffer = [];
 
-        buffer.push8(VOLTAGE_METER_CONFIGS[configIndex].id)
-            .push8(VOLTAGE_METER_CONFIGS[configIndex].vbatscale)
-            .push8(VOLTAGE_METER_CONFIGS[configIndex].vbatresdivval)
-            .push8(VOLTAGE_METER_CONFIGS[configIndex].vbatresdivmultiplier);
+        buffer.push8(FC.VOLTAGE_METER_CONFIGS[configIndex].id)
+            .push8(FC.VOLTAGE_METER_CONFIGS[configIndex].vbatscale)
+            .push8(FC.VOLTAGE_METER_CONFIGS[configIndex].vbatresdivval)
+            .push8(FC.VOLTAGE_METER_CONFIGS[configIndex].vbatresdivmultiplier);
 
         // prepare for next iteration
         configIndex++;
-        if (configIndex == VOLTAGE_METER_CONFIGS.length) {
+        if (configIndex == FC.VOLTAGE_METER_CONFIGS.length) {
             nextFunction = onCompleteCallback;
         }
 
@@ -2520,7 +2520,7 @@ MspHelper.prototype.sendCurrentConfig = function(onCompleteCallback) {
 
     var configIndex = 0;
     
-    if (CURRENT_METER_CONFIGS.length == 0) {
+    if (FC.CURRENT_METER_CONFIGS.length == 0) {
         onCompleteCallback();
     } else {
         send_next_current_config();
@@ -2529,13 +2529,13 @@ MspHelper.prototype.sendCurrentConfig = function(onCompleteCallback) {
     function send_next_current_config() {
         var buffer = [];
 
-        buffer.push8(CURRENT_METER_CONFIGS[configIndex].id)
-            .push16(CURRENT_METER_CONFIGS[configIndex].scale)
-            .push16(CURRENT_METER_CONFIGS[configIndex].offset);
+        buffer.push8(FC.CURRENT_METER_CONFIGS[configIndex].id)
+            .push16(FC.CURRENT_METER_CONFIGS[configIndex].scale)
+            .push16(FC.CURRENT_METER_CONFIGS[configIndex].offset);
 
         // prepare for next iteration
         configIndex++;
-        if (configIndex == CURRENT_METER_CONFIGS.length) {
+        if (configIndex == FC.CURRENT_METER_CONFIGS.length) {
             nextFunction = onCompleteCallback;
         }
 
@@ -2550,7 +2550,7 @@ MspHelper.prototype.sendLedStripConfig = function(onCompleteCallback) {
 
     var ledIndex = 0;
 
-    if (LED_STRIP.length == 0) {
+    if (FC.LED_STRIP.length == 0) {
         onCompleteCallback();
     } else {
         send_next_led_strip_config();
@@ -2558,11 +2558,11 @@ MspHelper.prototype.sendLedStripConfig = function(onCompleteCallback) {
 
     function send_next_led_strip_config() {
 
-        var led = LED_STRIP[ledIndex];
+        var led = FC.LED_STRIP[ledIndex];
         var ledDirectionLetters =        ['n', 'e', 's', 'w', 'u', 'd'];      // in LSB bit order
         var ledFunctionLetters =         ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l']; // in LSB bit order
         var ledBaseFunctionLetters =     ['c', 'f', 'a', 'l', 's', 'g', 'r']; // in LSB bit
-        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
             var ledOverlayLetters =      ['t', 'o', 'b', 'w', 'i', 'w']; // in LSB bit
         } else {
             var ledOverlayLetters =      ['t', 'o', 'b', 'v', 'i', 'w']; // in LSB bit
@@ -2572,7 +2572,7 @@ MspHelper.prototype.sendLedStripConfig = function(onCompleteCallback) {
 
         buffer.push(ledIndex);
 
-        if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
             var directionMask = 0;
             for (var directionLetterIndex = 0; directionLetterIndex < led.directions.length; directionLetterIndex++) {
                 var bitIndex = ledDirectionLetters.indexOf(led.directions[directionLetterIndex]);
@@ -2633,7 +2633,7 @@ MspHelper.prototype.sendLedStripConfig = function(onCompleteCallback) {
 
         // prepare for next iteration
         ledIndex++;
-        if (ledIndex == LED_STRIP.length) {
+        if (ledIndex == FC.LED_STRIP.length) {
             nextFunction = onCompleteCallback;
         }
 
@@ -2642,13 +2642,13 @@ MspHelper.prototype.sendLedStripConfig = function(onCompleteCallback) {
 }
 
 MspHelper.prototype.sendLedStripColors = function(onCompleteCallback) {
-    if (LED_COLORS.length == 0) {
+    if (FC.LED_COLORS.length == 0) {
         onCompleteCallback();
     } else {
         var buffer = [];
 
-        for (var colorIndex = 0; colorIndex < LED_COLORS.length; colorIndex++) {
-            var color = LED_COLORS[colorIndex];
+        for (var colorIndex = 0; colorIndex < FC.LED_COLORS.length; colorIndex++) {
+            var color = FC.LED_COLORS[colorIndex];
 
             buffer.push16(color.h)
                 .push8(color.s)
@@ -2663,7 +2663,7 @@ MspHelper.prototype.sendLedStripModeColors = function(onCompleteCallback) {
     var nextFunction = send_next_led_strip_mode_color;
     var index = 0;
 
-    if (LED_MODE_COLORS.length == 0) {
+    if (FC.LED_MODE_COLORS.length == 0) {
         onCompleteCallback();
     } else {
         send_next_led_strip_mode_color();
@@ -2672,7 +2672,7 @@ MspHelper.prototype.sendLedStripModeColors = function(onCompleteCallback) {
     function send_next_led_strip_mode_color() {
         var buffer = [];
 
-        var mode_color = LED_MODE_COLORS[index];
+        var mode_color = FC.LED_MODE_COLORS[index];
 
         buffer.push8(mode_color.mode)
             .push8(mode_color.direction)
@@ -2680,7 +2680,7 @@ MspHelper.prototype.sendLedStripModeColors = function(onCompleteCallback) {
 
         // prepare for next iteration
         index++;
-        if (index == LED_MODE_COLORS.length) {
+        if (index == FC.LED_MODE_COLORS.length) {
             nextFunction = onCompleteCallback;
         }
 
@@ -2723,7 +2723,7 @@ MspHelper.prototype.sendRxFailConfig = function(onCompleteCallback) {
 
     var rxFailIndex = 0;
 
-    if (RXFAIL_CONFIG.length == 0) {
+    if (FC.RXFAIL_CONFIG.length == 0) {
         onCompleteCallback();
     } else {
         send_next_rxfail_config();
@@ -2731,7 +2731,7 @@ MspHelper.prototype.sendRxFailConfig = function(onCompleteCallback) {
 
     function send_next_rxfail_config() {
 
-        var rxFail = RXFAIL_CONFIG[rxFailIndex];
+        var rxFail = FC.RXFAIL_CONFIG[rxFailIndex];
 
         var buffer = [];
         buffer.push8(rxFailIndex)
@@ -2741,7 +2741,7 @@ MspHelper.prototype.sendRxFailConfig = function(onCompleteCallback) {
 
         // prepare for next iteration
         rxFailIndex++;
-        if (rxFailIndex == RXFAIL_CONFIG.length) {
+        if (rxFailIndex == FC.RXFAIL_CONFIG.length) {
             nextFunction = onCompleteCallback;
 
         }
@@ -2750,9 +2750,9 @@ MspHelper.prototype.sendRxFailConfig = function(onCompleteCallback) {
 }
 
 MspHelper.prototype.setArmingEnabled = function(doEnable, disableRunawayTakeoffPrevention, onCompleteCallback) {
-    if (semver.gte(CONFIG.apiVersion, "1.37.0") && (CONFIG.armingDisabled === doEnable || CONFIG.runawayTakeoffPreventionDisabled !== disableRunawayTakeoffPrevention)) {
-        CONFIG.armingDisabled = !doEnable;
-        CONFIG.runawayTakeoffPreventionDisabled = disableRunawayTakeoffPrevention;
+    if (semver.gte(FC.CONFIG.apiVersion, "1.37.0") && (FC.CONFIG.armingDisabled === doEnable || FC.CONFIG.runawayTakeoffPreventionDisabled !== disableRunawayTakeoffPrevention)) {
+        FC.CONFIG.armingDisabled = !doEnable;
+        FC.CONFIG.runawayTakeoffPreventionDisabled = disableRunawayTakeoffPrevention;
 
         MSP.send_message(MSPCodes.MSP_ARMING_DISABLE, mspHelper.crunch(MSPCodes.MSP_ARMING_DISABLE), false, function () {
             if (doEnable) {
@@ -2778,12 +2778,12 @@ MspHelper.prototype.setArmingEnabled = function(doEnable, disableRunawayTakeoffP
 }
 
 MspHelper.prototype.loadSerialConfig = function(callback) {
-    const mspCode = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) ? MSPCodes.MSP2_COMMON_SERIAL_CONFIG : MSPCodes.MSP_CF_SERIAL_CONFIG;
+    const mspCode = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43) ? MSPCodes.MSP2_COMMON_SERIAL_CONFIG : MSPCodes.MSP_CF_SERIAL_CONFIG;
     MSP.send_message(mspCode, false, false, callback);
 };
 
 MspHelper.prototype.sendSerialConfig = function(callback) {
-    const mspCode = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) ? MSPCodes.MSP2_COMMON_SET_SERIAL_CONFIG : MSPCodes.MSP_SET_CF_SERIAL_CONFIG;
+    const mspCode = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43) ? MSPCodes.MSP2_COMMON_SET_SERIAL_CONFIG : MSPCodes.MSP_SET_CF_SERIAL_CONFIG;
     MSP.send_message(mspCode, mspHelper.crunch(mspCode), false, callback);
 };
 

--- a/src/js/peripherals.js
+++ b/src/js/peripherals.js
@@ -2,8 +2,8 @@
 
 // return true if user has choose a special peripheral
 function isPeripheralSelected(peripheralName) {
-    for (var portIndex = 0; portIndex < SERIAL_CONFIG.ports.length; portIndex++) {
-        var serialPort = SERIAL_CONFIG.ports[portIndex];
+    for (var portIndex = 0; portIndex < FC.SERIAL_CONFIG.ports.length; portIndex++) {
+        var serialPort = FC.SERIAL_CONFIG.ports[portIndex];
         if (serialPort.functions.indexOf(peripheralName) >= 0) {
             return true;
         }

--- a/src/js/protocols/stm32.js
+++ b/src/js/protocols/stm32.js
@@ -139,9 +139,9 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
 
         var onConnectHandler = function () {
 
-            GUI.log(i18n.getMessage('apiVersionReceived', [CONFIG.apiVersion]));
+            GUI.log(i18n.getMessage('apiVersionReceived', [FC.CONFIG.apiVersion]));
 
-            if (semver.lt(CONFIG.apiVersion, "1.42.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
 
                 self.msp_connector.disconnect(function (disconnectionResult) {
 
@@ -153,7 +153,7 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
 
                 MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, function () {
                     var rebootMode = 0; // FIRMWARE
-                    if (bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_FLASH_BOOTLOADER)) {
+                    if (bit_check(FC.CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_FLASH_BOOTLOADER)) {
                         // Board has flash bootloader
                         GUI.log(i18n.getMessage('deviceRebooting_flashBootloader'));
                         console.log('flash bootloader detected');

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -122,8 +122,8 @@ var serial = {
                         case 'device_lost':
                         default:
                             console.log("serial disconnecting: " + info.error);
-                            CONFIG.armingDisabled = false;
-                            CONFIG.runawayTakeoffPreventionDisabled = false;
+                            FC.CONFIG.armingDisabled = false;
+                            FC.CONFIG.runawayTakeoffPreventionDisabled = false;
 
                             if (GUI.connected_to || GUI.connecting_to) {
                                 $('a.connect').click();

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -178,7 +178,7 @@ function finishClose(finishedCallback) {
     // Reset various UI elements
     $('span.i2c-error').text(0);
     $('span.cycle-time').text(0);
-    if (semver.gte(CONFIG.apiVersion, "1.20.0"))
+    if (semver.gte(FC.CONFIG.apiVersion, "1.20.0"))
         $('span.cpu-load').text('');
 
     // unlock port select & baud
@@ -247,31 +247,31 @@ function onOpen(openInfo) {
 
         // request configuration data
         MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
-            analytics.setFlightControllerData(analytics.DATA.API_VERSION, CONFIG.apiVersion);
+            analytics.setFlightControllerData(analytics.DATA.API_VERSION, FC.CONFIG.apiVersion);
 
-            GUI.log(i18n.getMessage('apiVersionReceived', [CONFIG.apiVersion]));
+            GUI.log(i18n.getMessage('apiVersionReceived', [FC.CONFIG.apiVersion]));
 
-            if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_ACCEPTED)) {
+            if (semver.gte(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_ACCEPTED)) {
 
                 MSP.send_message(MSPCodes.MSP_FC_VARIANT, false, false, function () {
-                    analytics.setFlightControllerData(analytics.DATA.FIRMWARE_TYPE, CONFIG.flightControllerIdentifier);
-                    if (CONFIG.flightControllerIdentifier === 'BTFL') {
+                    analytics.setFlightControllerData(analytics.DATA.FIRMWARE_TYPE, FC.CONFIG.flightControllerIdentifier);
+                    if (FC.CONFIG.flightControllerIdentifier === 'BTFL') {
                         MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
-                            analytics.setFlightControllerData(analytics.DATA.FIRMWARE_VERSION, CONFIG.flightControllerVersion);
+                            analytics.setFlightControllerData(analytics.DATA.FIRMWARE_VERSION, FC.CONFIG.flightControllerVersion);
 
-                            GUI.log(i18n.getMessage('fcInfoReceived', [CONFIG.flightControllerIdentifier, CONFIG.flightControllerVersion]));
-                            updateStatusBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier);
-                            updateTopBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier);
+                            GUI.log(i18n.getMessage('fcInfoReceived', [FC.CONFIG.flightControllerIdentifier, FC.CONFIG.flightControllerVersion]));
+                            updateStatusBarVersion(FC.CONFIG.flightControllerVersion, FC.CONFIG.flightControllerIdentifier);
+                            updateTopBarVersion(FC.CONFIG.flightControllerVersion, FC.CONFIG.flightControllerIdentifier);
 
                             MSP.send_message(MSPCodes.MSP_BUILD_INFO, false, false, function () {
 
-                                GUI.log(i18n.getMessage('buildInfoReceived', [CONFIG.buildInfo]));
+                                GUI.log(i18n.getMessage('buildInfoReceived', [FC.CONFIG.buildInfo]));
 
                                 MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, processBoardInfo);
                             });
                         });
                     } else {
-                        analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'ConnectionRefusedFirmwareType', CONFIG.flightControllerIdentifier);
+                        analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'ConnectionRefusedFirmwareType', FC.CONFIG.flightControllerIdentifier);
 
                         var dialog = $('.dialogConnectWarning')[0];
 
@@ -287,7 +287,7 @@ function onOpen(openInfo) {
                     }
                 });
             } else {
-                analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'ConnectionRefusedFirmwareVersion', CONFIG.apiVersion);
+                analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'ConnectionRefusedFirmwareVersion', FC.CONFIG.apiVersion);
 
                 var dialog = $('.dialogConnectWarning')[0];
 
@@ -324,17 +324,17 @@ function abortConnect() {
 }
 
 function processBoardInfo() {
-    analytics.setFlightControllerData(analytics.DATA.BOARD_TYPE, CONFIG.boardIdentifier);
-    analytics.setFlightControllerData(analytics.DATA.TARGET_NAME, CONFIG.targetName);
-    analytics.setFlightControllerData(analytics.DATA.BOARD_NAME, CONFIG.boardName);
-    analytics.setFlightControllerData(analytics.DATA.MANUFACTURER_ID, CONFIG.manufacturerId);
+    analytics.setFlightControllerData(analytics.DATA.BOARD_TYPE, FC.CONFIG.boardIdentifier);
+    analytics.setFlightControllerData(analytics.DATA.TARGET_NAME, FC.CONFIG.targetName);
+    analytics.setFlightControllerData(analytics.DATA.BOARD_NAME, FC.CONFIG.boardName);
+    analytics.setFlightControllerData(analytics.DATA.MANUFACTURER_ID, FC.CONFIG.manufacturerId);
     analytics.setFlightControllerData(analytics.DATA.MCU_TYPE, FC.getMcuType());
 
-    GUI.log(i18n.getMessage('boardInfoReceived', [FC.getHardwareName(), CONFIG.boardVersion]));
-    updateStatusBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier, FC.getHardwareName());
-    updateTopBarVersion(CONFIG.flightControllerVersion, CONFIG.flightControllerIdentifier, FC.getHardwareName());
+    GUI.log(i18n.getMessage('boardInfoReceived', [FC.getHardwareName(), FC.CONFIG.boardVersion]));
+    updateStatusBarVersion(FC.CONFIG.flightControllerVersion, FC.CONFIG.flightControllerIdentifier, FC.getHardwareName());
+    updateTopBarVersion(FC.CONFIG.flightControllerVersion, FC.CONFIG.flightControllerIdentifier, FC.getHardwareName());
 
-    if (bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.SUPPORTS_CUSTOM_DEFAULTS) && bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_CUSTOM_DEFAULTS) && CONFIG.configurationState === FC.CONFIGURATION_STATES.DEFAULTS_BARE) {
+    if (bit_check(FC.CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.SUPPORTS_CUSTOM_DEFAULTS) && bit_check(FC.CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_CUSTOM_DEFAULTS) && FC.CONFIG.configurationState === FC.CONFIGURATION_STATES.DEFAULTS_BARE) {
         var dialog = $('#dialogResetToCustomDefaults')[0];
 
         $('#dialogResetToCustomDefaults-acceptbtn').click(function() {
@@ -374,7 +374,7 @@ function checkReportProblems() {
     const problemItemTemplate = $('#dialogReportProblems-listItemTemplate');
 
     function checkReportProblem(problemName, problemDialogList) {
-        if (bit_check(CONFIG.configurationProblems, FC.CONFIGURATION_PROBLEM_FLAGS[problemName])) {
+        if (bit_check(FC.CONFIG.configurationProblems, FC.CONFIGURATION_PROBLEM_FLAGS[problemName])) {
             problemItemTemplate.clone().html(i18n.getMessage(`reportProblemsDialog${problemName}`)).appendTo(problemDialogList);
 
             analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, PROBLEM_ANALYTICS_EVENT, problemName);
@@ -390,19 +390,19 @@ function checkReportProblems() {
         const problemDialogList = $('#dialogReportProblems-list');
         problemDialogList.empty();
 
-        if (semver.gt(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MAX_SUPPORTED)) {
+        if (semver.gt(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MAX_SUPPORTED)) {
             const problemName = 'API_VERSION_MAX_SUPPORTED';
             problemItemTemplate.clone().html(i18n.getMessage(`reportProblemsDialog${problemName}`,
-                [CONFIGURATOR.latestVersion, CONFIGURATOR.latestVersionReleaseUrl, CONFIGURATOR.version, CONFIG.flightControllerVersion])).appendTo(problemDialogList);
+                [CONFIGURATOR.latestVersion, CONFIGURATOR.latestVersionReleaseUrl, CONFIGURATOR.version, FC.CONFIG.flightControllerVersion])).appendTo(problemDialogList);
             needsProblemReportingDialog = true;
 
             analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, PROBLEM_ANALYTICS_EVENT,
-                `${problemName};${CONFIGURATOR.API_VERSION_MAX_SUPPORTED};${CONFIG.apiVersion}`);
+                `${problemName};${CONFIGURATOR.API_VERSION_MAX_SUPPORTED};${FC.CONFIG.apiVersion}`);
         }
 
         needsProblemReportingDialog = checkReportProblem('MOTOR_PROTOCOL_DISABLED', problemDialogList) || needsProblemReportingDialog;
 
-        if (have_sensor(CONFIG.activeSensors, 'acc')) {
+        if (have_sensor(FC.CONFIG.activeSensors, 'acc')) {
             needsProblemReportingDialog = checkReportProblem('ACC_NEEDS_CALIBRATION', problemDialogList) || needsProblemReportingDialog;
         }
 
@@ -422,14 +422,14 @@ function checkReportProblems() {
 
 function processUid() {
     MSP.send_message(MSPCodes.MSP_UID, false, false, function () {
-        var uniqueDeviceIdentifier = CONFIG.uid[0].toString(16) + CONFIG.uid[1].toString(16) + CONFIG.uid[2].toString(16);
+        var uniqueDeviceIdentifier = FC.CONFIG.uid[0].toString(16) + FC.CONFIG.uid[1].toString(16) + FC.CONFIG.uid[2].toString(16);
 
         analytics.setFlightControllerData(analytics.DATA.MCU_ID, objectHash.sha1(uniqueDeviceIdentifier));
         analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'Connected');
         connectionTimestamp = Date.now();
         GUI.log(i18n.getMessage('uniqueDeviceIdReceived', [uniqueDeviceIdentifier]));
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             processName();
         } else {
             setRtc();
@@ -439,15 +439,15 @@ function processUid() {
 
 function processName() {
     MSP.send_message(MSPCodes.MSP_NAME, false, false, function () {
-        GUI.log(i18n.getMessage('craftNameReceived', [CONFIG.name]));
+        GUI.log(i18n.getMessage('craftNameReceived', [FC.CONFIG.name]));
 
-        CONFIG.armingDisabled = false;
+        FC.CONFIG.armingDisabled = false;
         mspHelper.setArmingEnabled(false, false, setRtc);
     });
 }
 
 function setRtc() {
-    if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
         MSP.send_message(MSPCodes.MSP_SET_RTC, mspHelper.crunch(MSPCodes.MSP_SET_RTC), false, finishOpen);
     } else {
         finishOpen();
@@ -457,7 +457,7 @@ function setRtc() {
 function finishOpen() {
     CONFIGURATOR.connectionValid = true;
     GUI.allowedTabs = GUI.defaultAllowedFCTabsWhenConnected.slice();
-    if (semver.lt(CONFIG.apiVersion, "1.4.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, "1.4.0")) {
         GUI.allowedTabs.splice(GUI.allowedTabs.indexOf('led_strip'), 1);
     }
 
@@ -502,7 +502,7 @@ function onConnect() {
             }
         });
 
-        if (CONFIG.boardType == 0) {
+        if (FC.CONFIG.boardType == 0) {
             if (classes.indexOf("osd-required") >= 0) {
                 found = false;
             }
@@ -511,21 +511,21 @@ function onConnect() {
         return found;
     }).show();
 
-    if (CONFIG.flightControllerVersion !== '') {
-        FEATURE_CONFIG.features = new Features(CONFIG);
-        BEEPER_CONFIG.beepers = new Beepers(CONFIG);
-        BEEPER_CONFIG.dshotBeaconConditions = new Beepers(CONFIG, [ "RX_LOST", "RX_SET" ]);
+    if (FC.CONFIG.flightControllerVersion !== '') {
+        FC.FEATURE_CONFIG.features = new Features(FC.CONFIG);
+        FC.BEEPER_CONFIG.beepers = new Beepers(FC.CONFIG);
+        FC.BEEPER_CONFIG.dshotBeaconConditions = new Beepers(FC.CONFIG, [ "RX_LOST", "RX_SET" ]);
 
         $('#tabs ul.mode-connected').show();
 
         MSP.send_message(MSPCodes.MSP_FEATURE_CONFIG, false, false);
-        if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
             MSP.send_message(MSPCodes.MSP_BATTERY_CONFIG, false, false);
         }
         MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
         MSP.send_message(MSPCodes.MSP_DATAFLASH_SUMMARY, false, false);
 
-        if (CONFIG.boardType == 0 || CONFIG.boardType == 2) {
+        if (FC.CONFIG.boardType == 0 || FC.CONFIG.boardType == 2) {
             startLiveDataRefreshTimer();
         }
     }
@@ -606,7 +606,7 @@ function sensor_status(sensors_detected) {
         $('.accicon', e_sensor_status).removeClass('active');
     }
 
-    if ((CONFIG.boardType == 0 || CONFIG.boardType == 2) && have_sensor(sensors_detected, 'gyro')) {
+    if ((FC.CONFIG.boardType == 0 || FC.CONFIG.boardType == 2) && have_sensor(sensors_detected, 'gyro')) {
         $('.gyro', e_sensor_status).addClass('on');
         $('.gyroicon', e_sensor_status).addClass('active');
     } else {
@@ -660,7 +660,7 @@ function have_sensor(sensors_detected, sensor_code) {
         case 'sonar':
             return bit_check(sensors_detected, 4);
         case 'gyro':
-            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
                 return bit_check(sensors_detected, 5);
             } else {
                 return true;
@@ -684,7 +684,7 @@ function update_live_status() {
 
     if (GUI.active_tab != 'cli') {
         MSP.send_message(MSPCodes.MSP_BOXNAMES, false, false);
-        if (semver.gte(CONFIG.apiVersion, "1.32.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.32.0")) {
             MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
         } else {
             MSP.send_message(MSPCodes.MSP_STATUS, false, false);
@@ -692,55 +692,55 @@ function update_live_status() {
         MSP.send_message(MSPCodes.MSP_ANALOG, false, false);
     }
 
-    var active = ((Date.now() - ANALOG.last_received_timestamp) < 300);
+    var active = ((Date.now() - FC.ANALOG.last_received_timestamp) < 300);
 
-    for (var i = 0; i < AUX_CONFIG.length; i++) {
-       if (AUX_CONFIG[i] == 'ARM') {
-               if (bit_check(CONFIG.mode, i))
+    for (var i = 0; i < FC.AUX_CONFIG.length; i++) {
+       if (FC.AUX_CONFIG[i] == 'ARM') {
+               if (bit_check(FC.CONFIG.mode, i))
                        $(".armedicon").addClass('active');
                else
                        $(".armedicon").removeClass('active');
        }
-       if (AUX_CONFIG[i] == 'FAILSAFE') {
-               if (bit_check(CONFIG.mode, i))
+       if (FC.AUX_CONFIG[i] == 'FAILSAFE') {
+               if (bit_check(FC.CONFIG.mode, i))
                        $(".failsafeicon").addClass('active');
                else
                        $(".failsafeicon").removeClass('active');
        }
     }
 
-    if (ANALOG != undefined) {
-        var nbCells = Math.floor(ANALOG.voltage / BATTERY_CONFIG.vbatmaxcellvoltage) + 1;
+    if (FC.ANALOG != undefined) {
+        var nbCells = Math.floor(FC.ANALOG.voltage / FC.BATTERY_CONFIG.vbatmaxcellvoltage) + 1;
 
-        if (ANALOG.voltage == 0) {
+        if (FC.ANALOG.voltage == 0) {
                nbCells = 1;
         }
 
-       var min = BATTERY_CONFIG.vbatmincellvoltage * nbCells;
-       var max = BATTERY_CONFIG.vbatmaxcellvoltage * nbCells;
-       var warn = BATTERY_CONFIG.vbatwarningcellvoltage * nbCells;
+       var min = FC.BATTERY_CONFIG.vbatmincellvoltage * nbCells;
+       var max = FC.BATTERY_CONFIG.vbatmaxcellvoltage * nbCells;
+       var warn = FC.BATTERY_CONFIG.vbatwarningcellvoltage * nbCells;
 
        const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions  
 
-       if (ANALOG.voltage < min && ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM) {
+       if (FC.ANALOG.voltage < min && FC.ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM) {
            $(".battery-status").addClass('state-empty').removeClass('state-ok').removeClass('state-warning');
            $(".battery-status").css({
                width: "100%",
            });
        } else {
            $(".battery-status").css({
-               width: ((ANALOG.voltage - min) / (max - min) * 100) + "%",
+               width: ((FC.ANALOG.voltage - min) / (max - min) * 100) + "%",
            });
 
-           if (ANALOG.voltage < warn) {
+           if (FC.ANALOG.voltage < warn) {
                $(".battery-status").addClass('state-warning').removeClass('state-empty').removeClass('state-ok');
            } else  {
                $(".battery-status").addClass('state-ok').removeClass('state-warning').removeClass('state-empty');
            }
        }
        
-       let cellsText = (ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM)? nbCells + 'S' : 'USB';
-       $(".battery-legend").text(ANALOG.voltage.toFixed(2) + "V (" + cellsText + ")");
+       let cellsText = (FC.ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM)? nbCells + 'S' : 'USB';
+       $(".battery-legend").text(FC.ANALOG.voltage.toFixed(2) + "V (" + cellsText + ")");
 
     }
 
@@ -787,7 +787,7 @@ function update_dataflash_global() {
         return megabytes.toFixed(1) + "MB";
     }
 
-    var supportsDataflash = DATAFLASH.totalSize > 0;
+    var supportsDataflash = FC.DATAFLASH.totalSize > 0;
 
     if (supportsDataflash){
         $(".noflash_global").css({
@@ -799,10 +799,10 @@ function update_dataflash_global() {
         });
 
         $(".dataflash-free_global").css({
-           width: (100-(DATAFLASH.totalSize - DATAFLASH.usedSize) / DATAFLASH.totalSize * 100) + "%",
+           width: (100-(FC.DATAFLASH.totalSize - FC.DATAFLASH.usedSize) / FC.DATAFLASH.totalSize * 100) + "%",
            display: 'block'
         });
-        $(".dataflash-free_global div").text('Dataflash: free ' + formatFilesize(DATAFLASH.totalSize - DATAFLASH.usedSize));
+        $(".dataflash-free_global div").text('Dataflash: free ' + formatFilesize(FC.DATAFLASH.totalSize - FC.DATAFLASH.usedSize));
      } else {
         $(".noflash_global").css({
            display: 'block'

--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -37,7 +37,7 @@ TABS.adjustments.initialize = function (callback) {
         // update selected slot
         //
         
-        if (semver.lt(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
             var adjustmentList = $(newAdjustment).find('.adjustmentSlot .slot');
             adjustmentList.val(adjustmentRange.slotIndex);
         }
@@ -156,16 +156,16 @@ TABS.adjustments.initialize = function (callback) {
 
         self.adjust_template();
 
-        var auxChannelCount = RC.active_channels - 4;
+        var auxChannelCount = FC.RC.active_channels - 4;
 
         var modeTableBodyElement = $('.tab-adjustments .adjustments tbody');
-        for (var adjustmentIndex = 0; adjustmentIndex < ADJUSTMENT_RANGES.length; adjustmentIndex++) {
-            var newAdjustment = addAdjustment(adjustmentIndex, ADJUSTMENT_RANGES[adjustmentIndex], auxChannelCount);
+        for (var adjustmentIndex = 0; adjustmentIndex < FC.ADJUSTMENT_RANGES.length; adjustmentIndex++) {
+            var newAdjustment = addAdjustment(adjustmentIndex, FC.ADJUSTMENT_RANGES[adjustmentIndex], auxChannelCount);
             modeTableBodyElement.append(newAdjustment);
         }
         
 
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             $('.tab-adjustments .adjustmentSlotsHelp').hide();
             $('.tab-adjustments .adjustmentSlotHeader').hide();
             $('.tab-adjustments .adjustmentSlot').hide();
@@ -178,9 +178,9 @@ TABS.adjustments.initialize = function (callback) {
         $('a.save').click(function () {
 
             // update internal data structures based on current UI elements
-            var requiredAdjustmentRangeCount = ADJUSTMENT_RANGES.length;
+            var requiredAdjustmentRangeCount = FC.ADJUSTMENT_RANGES.length;
             
-            ADJUSTMENT_RANGES = [];
+            FC.ADJUSTMENT_RANGES = [];
             
             var defaultAdjustmentRange = {
                 slotIndex: 0,
@@ -199,7 +199,7 @@ TABS.adjustments.initialize = function (callback) {
                 if ($(adjustmentElement).find('.enable').prop("checked")) {
                     var rangeValues = $(this).find('.range .channel-slider').val();
                     var slotIndex = 0;
-                    if (semver.lt(CONFIG.apiVersion, "1.42.0")) {
+                    if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
                         slotIndex = parseInt($(this).find('.adjustmentSlot .slot').val());
                     }
 
@@ -213,14 +213,14 @@ TABS.adjustments.initialize = function (callback) {
                         adjustmentFunction: parseInt($(this).find('.functionSelection .function').val()),
                         auxSwitchChannelIndex: parseInt($(this).find('.functionSwitchChannel .channel').val())
                     };
-                    ADJUSTMENT_RANGES.push(adjustmentRange);
+                    FC.ADJUSTMENT_RANGES.push(adjustmentRange);
                 } else {
-                    ADJUSTMENT_RANGES.push(defaultAdjustmentRange);
+                    FC.ADJUSTMENT_RANGES.push(defaultAdjustmentRange);
                 }
             });
             
-            for (var adjustmentRangeIndex = ADJUSTMENT_RANGES.length; adjustmentRangeIndex < requiredAdjustmentRangeCount; adjustmentRangeIndex++) {
-                ADJUSTMENT_RANGES.push(defaultAdjustmentRange);
+            for (var adjustmentRangeIndex = FC.ADJUSTMENT_RANGES.length; adjustmentRangeIndex < requiredAdjustmentRangeCount; adjustmentRangeIndex++) {
+                FC.ADJUSTMENT_RANGES.push(defaultAdjustmentRange);
             }
             
             //
@@ -260,10 +260,10 @@ TABS.adjustments.initialize = function (callback) {
         }
 
         function update_ui() {
-            var auxChannelCount = RC.active_channels - 4;
+            var auxChannelCount = FC.RC.active_channels - 4;
 
             for (var auxChannelIndex = 0; auxChannelIndex < auxChannelCount; auxChannelIndex++) {
-                update_marker(auxChannelIndex, RC.channels[auxChannelIndex + 4]);
+                update_marker(auxChannelIndex, FC.RC.channels[auxChannelIndex + 4]);
             }           
         }
 
@@ -291,13 +291,13 @@ TABS.adjustments.adjust_template = function () {
     var selectFunction = $('#functionSelectionSelect');
     var elementsNumber;
 
-    if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
         elementsNumber = 31; // OSD Profile Select & LED Profile Select
-    } else if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+    } else if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
         elementsNumber = 29; // PID Audio
-    } else if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+    } else if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
         elementsNumber = 26; // PID Audio
-    } else if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+    } else if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
         elementsNumber = 25; // Horizon Strength
     } else {
         elementsNumber = 24; // Setpoint transition
@@ -308,7 +308,7 @@ TABS.adjustments.adjust_template = function () {
     }
     
     // For 1.40, the D Setpoint has been replaced, so we replace it with the correct values
-    if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
 
         var element22 = selectFunction.find("option[value='22']");
         var element23 = selectFunction.find("option[value='23']");

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -9,7 +9,7 @@ TABS.auxiliary.initialize = function (callback) {
 
     function get_mode_ranges() {
         MSP.send_message(MSPCodes.MSP_MODE_RANGES, false, false, 
-            semver.gte(CONFIG.apiVersion, "1.41.0") ? get_mode_ranges_extra : get_box_ids);
+            semver.gte(FC.CONFIG.apiVersion, "1.41.0") ? get_mode_ranges_extra : get_box_ids);
     }
 
     function get_mode_ranges_extra() {
@@ -42,7 +42,7 @@ TABS.auxiliary.initialize = function (callback) {
         var modeTemplate = $('#tab-auxiliary-templates .mode');
         var newMode = modeTemplate.clone();
         
-        var modeName = AUX_CONFIG[modeIndex];        
+        var modeName = FC.AUX_CONFIG[modeIndex];        
         // Adjust the name of the box if a peripheral is selected
         modeName = adjustBoxNameIfPeripheralWithModeID(modeId, modeName);
 
@@ -57,7 +57,7 @@ TABS.auxiliary.initialize = function (callback) {
         $(newMode).find('a.addLink').data('modeElement', newMode);
 
         // hide link button for ARM
-        if (modeId == 0 || semver.lt(CONFIG.apiVersion, "1.41.0")) {
+        if (modeId == 0 || semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
             $(newMode).find('.addLink').hide();
         }
 
@@ -75,7 +75,7 @@ TABS.auxiliary.initialize = function (callback) {
         logicOption.val(0);
         logicList.append(logicOption);
         
-        if(semver.gte(CONFIG.apiVersion, "1.41.0")){
+        if(semver.gte(FC.CONFIG.apiVersion, "1.41.0")){
             var logicOption = logicOptionTemplate.clone();
             logicOption.text(i18n.getMessage('auxiliaryModeLogicAND'));
             logicOption.val(1);
@@ -122,10 +122,10 @@ TABS.auxiliary.initialize = function (callback) {
         linkOption.val(0);
         linkList.append(linkOption);
 
-        for (var index = 1; index < AUX_CONFIG.length; index++) {
+        for (var index = 1; index < FC.AUX_CONFIG.length; index++) {
             var linkOption = linkOptionTemplate.clone();
-            linkOption.text(AUX_CONFIG[index]);
-            linkOption.val(AUX_CONFIG_IDS[index]);  // set value to mode id
+            linkOption.text(FC.AUX_CONFIG[index]);
+            linkOption.val(FC.AUX_CONFIG_IDS[index]);  // set value to mode id
             linkList.append(linkOption);
         }
 
@@ -249,30 +249,30 @@ TABS.auxiliary.initialize = function (callback) {
     }
 
     function process_html() {
-        var auxChannelCount = RC.active_channels - 4;
+        var auxChannelCount = FC.RC.active_channels - 4;
 
         configureRangeTemplate(auxChannelCount);
         configureLinkTemplate();
 
         const modeTableBodyElement = $('.tab-auxiliary .modes');
-        for (var modeIndex = 0; modeIndex < AUX_CONFIG.length; modeIndex++) {
+        for (var modeIndex = 0; modeIndex < FC.AUX_CONFIG.length; modeIndex++) {
             
-            var modeId = AUX_CONFIG_IDS[modeIndex];
+            var modeId = FC.AUX_CONFIG_IDS[modeIndex];
             var newMode = createMode(modeIndex, modeId);
             modeTableBodyElement.append(newMode);
             
             // generate ranges from the supplied AUX names and MODE_RANGES[_EXTRA] data
             // skip linked modes for now
-            for (var modeRangeIndex = 0; modeRangeIndex < MODE_RANGES.length; modeRangeIndex++) {
-                var modeRange = MODE_RANGES[modeRangeIndex];
+            for (var modeRangeIndex = 0; modeRangeIndex < FC.MODE_RANGES.length; modeRangeIndex++) {
+                var modeRange = FC.MODE_RANGES[modeRangeIndex];
 
                 var modeRangeExtra = {
                     id: modeRange.id,
                     modeLogic: 0,
                     linkedTo: 0
                 };
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                    modeRangeExtra = MODE_RANGES_EXTRA[modeRangeIndex];
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    modeRangeExtra = FC.MODE_RANGES_EXTRA[modeRangeIndex];
                 }
                 
                 if (modeRange.id != modeId || modeRangeExtra.id != modeId) {
@@ -314,10 +314,10 @@ TABS.auxiliary.initialize = function (callback) {
             // update internal data structures based on current UI elements
             
             // we must send this many back to the FC - overwrite all of the old ones to be sure.
-            var requiredModesRangeCount = MODE_RANGES.length;
+            var requiredModesRangeCount = FC.MODE_RANGES.length;
             
-            MODE_RANGES = [];
-            MODE_RANGES_EXTRA = [];
+            FC.MODE_RANGES = [];
+            FC.MODE_RANGES_EXTRA = [];
             
             $('.tab-auxiliary .modes .mode').each(function () {
                 var modeElement = $(this);
@@ -333,14 +333,14 @@ TABS.auxiliary.initialize = function (callback) {
                             end: rangeValues[1]
                         }
                     };
-                    MODE_RANGES.push(modeRange);
+                    FC.MODE_RANGES.push(modeRange);
 
                     var modeRangeExtra = {
                         id: modeId,
                         modeLogic: parseInt($(this).find('.logic').val()),
                         linkedTo: 0
                     };
-                    MODE_RANGES_EXTRA.push(modeRangeExtra);
+                    FC.MODE_RANGES_EXTRA.push(modeRangeExtra);
                 });
 
                 $(modeElement).find('.link').each(function() {
@@ -357,19 +357,19 @@ TABS.auxiliary.initialize = function (callback) {
                                 end: 900
                             }
                         };
-                        MODE_RANGES.push(modeRange);
+                        FC.MODE_RANGES.push(modeRange);
 
                         var modeRangeExtra = {
                             id: modeId,
                             modeLogic: parseInt($(this).find('.logic').val()),
                             linkedTo: linkedToSelection
                         };
-                        MODE_RANGES_EXTRA.push(modeRangeExtra);
+                        FC.MODE_RANGES_EXTRA.push(modeRangeExtra);
                     }
                 });
             });
             
-            for (var modeRangeIndex = MODE_RANGES.length; modeRangeIndex < requiredModesRangeCount; modeRangeIndex++) {
+            for (var modeRangeIndex = FC.MODE_RANGES.length; modeRangeIndex < requiredModesRangeCount; modeRangeIndex++) {
                 var defaultModeRange = {
                     id: 0,
                     auxChannelIndex: 0,
@@ -378,14 +378,14 @@ TABS.auxiliary.initialize = function (callback) {
                         end: 900
                     }
                 };
-                MODE_RANGES.push(defaultModeRange);
+                FC.MODE_RANGES.push(defaultModeRange);
 
                 var defaultModeRangeExtra = {
                     id: 0,
                     modeLogic: 0,
                     linkedTo: 0
                 };
-                MODE_RANGES_EXTRA.push(defaultModeRangeExtra);
+                FC.MODE_RANGES_EXTRA.push(defaultModeRangeExtra);
             }
 
             //
@@ -430,7 +430,7 @@ TABS.auxiliary.initialize = function (callback) {
 
         function update_ui() {
             let hasUsedMode = false;
-            for (let i = 0; i < AUX_CONFIG.length; i++) {
+            for (let i = 0; i < FC.AUX_CONFIG.length; i++) {
                 let modeElement = $('#mode-' + i);
                 if (modeElement.find(' .range').length == 0 && modeElement.find(' .link').length == 0) {
                     // if the mode is unused, skip it
@@ -438,12 +438,12 @@ TABS.auxiliary.initialize = function (callback) {
                     continue;
                 }
                 
-                if (bit_check(CONFIG.mode, i)) {
+                if (bit_check(FC.CONFIG.mode, i)) {
                     $('.mode .name').eq(i).data('modeElement').addClass('on').removeClass('off').removeClass('disabled');
 
                     // ARM mode is a special case
                     if (i == 0) {
-                        $('.mode .name').eq(i).html(AUX_CONFIG[i]);
+                        $('.mode .name').eq(i).html(FC.AUX_CONFIG[i]);
                     }
                 } else {
 
@@ -451,11 +451,11 @@ TABS.auxiliary.initialize = function (callback) {
                     if (i == 0) {
                         var armSwitchActive = false;
                         
-                        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                            if (CONFIG.armingDisableCount > 0) {
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                            if (FC.CONFIG.armingDisableCount > 0) {
                                 // check the highest bit of the armingDisableFlags. This will be the ARMING_DISABLED_ARMSWITCH flag.
-                                var armSwitchMask = 1 << (CONFIG.armingDisableCount - 1);
-                                if ((CONFIG.armingDisableFlags & armSwitchMask) > 0) {
+                                var armSwitchMask = 1 << (FC.CONFIG.armingDisableCount - 1);
+                                if ((FC.CONFIG.armingDisableFlags & armSwitchMask) > 0) {
                                     armSwitchActive = true;
                                 }
                             }
@@ -466,10 +466,10 @@ TABS.auxiliary.initialize = function (callback) {
                         // that arming is disabled.
                         if (armSwitchActive) {
                             $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('off').addClass('disabled');
-                            $('.mode .name').eq(i).html(AUX_CONFIG[i] + '<br>' + i18n.getMessage('auxiliaryDisabled'));
+                            $('.mode .name').eq(i).html(FC.AUX_CONFIG[i] + '<br>' + i18n.getMessage('auxiliaryDisabled'));
                         } else {
                             $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('disabled').addClass('off');
-                            $('.mode .name').eq(i).html(AUX_CONFIG[i]);
+                            $('.mode .name').eq(i).html(FC.AUX_CONFIG[i]);
                         }
                     } else {
                         $('.mode .name').eq(i).data('modeElement').removeClass('on').removeClass('disabled').addClass('off');
@@ -479,19 +479,19 @@ TABS.auxiliary.initialize = function (callback) {
             }
 
             let hideUnused = hideUnusedModes && hasUsedMode;
-            for (let i = 0; i < AUX_CONFIG.length; i++) {
+            for (let i = 0; i < FC.AUX_CONFIG.length; i++) {
                 let modeElement = $('#mode-' + i);
                 if (modeElement.find(' .range').length == 0 && modeElement.find(' .link').length == 0) {
                     modeElement.toggle(!hideUnused);
                 }
             }    
 
-            auto_select_channel(RC.channels, RSSI_CONFIG.channel);
+            auto_select_channel(FC.RC.channels, FC.RSSI_CONFIG.channel);
 
-            var auxChannelCount = RC.active_channels - 4;
+            var auxChannelCount = FC.RC.active_channels - 4;
 
             for (var i = 0; i < (auxChannelCount); i++) {
-                update_marker(i, limit_channel(RC.channels[i + 4]));
+                update_marker(i, limit_channel(FC.RC.channels[i + 4]));
             }
 
         }

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -19,7 +19,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         GUI.configuration_loaded = true;
     }
 
-    if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
         //Show old battery configuration for pre-BF-3.2
         self.SHOW_OLD_BATTERY_CONFIG = true;
     } else {
@@ -32,7 +32,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_beeper_config() {
         var next_callback = load_serial_config;
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
             MSP.send_message(MSPCodes.MSP_BEEPER_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -61,7 +61,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_motor_config() {
         var next_callback = load_gps_config;
-        if(semver.gte(CONFIG.apiVersion, "1.33.0")) {
+        if(semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
             MSP.send_message(MSPCodes.MSP_MOTOR_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -70,7 +70,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_gps_config() {
         var next_callback = load_acc_trim;
-        if(semver.gte(CONFIG.apiVersion, "1.33.0")) {
+        if(semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
             MSP.send_message(MSPCodes.MSP_GPS_CONFIG, false, false, load_acc_trim);
         } else {
             next_callback();
@@ -83,7 +83,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_misc() {
         var next_callback = load_arming_config;
-        if (semver.lt(CONFIG.apiVersion, "1.33.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.33.0")) {
             MSP.send_message(MSPCodes.MSP_MISC, false, false, next_callback);
         } else {
             next_callback();
@@ -92,7 +92,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_arming_config() {
         var next_callback = load_3d;
-        if (semver.gte(CONFIG.apiVersion, "1.8.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
             MSP.send_message(MSPCodes.MSP_ARMING_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -101,7 +101,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_3d() {
         var next_callback = load_rc_deadband;
-        if (semver.gte(CONFIG.apiVersion, "1.14.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.14.0")) {
             MSP.send_message(MSPCodes.MSP_MOTOR_3D_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -110,7 +110,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_rc_deadband() {
         var next_callback = esc_protocol;
-        if (semver.gte(CONFIG.apiVersion, "1.17.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.17.0")) {
             MSP.send_message(MSPCodes.MSP_RC_DEADBAND, false, false, next_callback);
         } else {
             next_callback();
@@ -119,7 +119,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function esc_protocol() {
         var next_callback = sensor_config;
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
             MSP.send_message(MSPCodes.MSP_ADVANCED_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -128,7 +128,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function sensor_config() {
         var next_callback = load_sensor_alignment;
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
             MSP.send_message(MSPCodes.MSP_SENSOR_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -137,7 +137,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_sensor_alignment() {
         var next_callback = load_name;
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
             MSP.send_message(MSPCodes.MSP_SENSOR_ALIGNMENT, false, false, next_callback);
         } else {
             next_callback();
@@ -151,7 +151,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             next_callback = load_battery;
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             MSP.send_message(MSPCodes.MSP_NAME, false, false, next_callback);
         } else {
             next_callback();
@@ -160,7 +160,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_battery() {
         var next_callback = load_current;
-        if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+        if (semver.gte(FC.CONFIG.flightControllerVersion, "3.1.0")) {
             MSP.send_message(MSPCodes.MSP_VOLTAGE_METER_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -169,7 +169,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_current() {
         var next_callback = load_rx_config;
-        if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+        if (semver.gte(FC.CONFIG.flightControllerVersion, "3.1.0")) {
             MSP.send_message(MSPCodes.MSP_CURRENT_METER_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -178,7 +178,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_rx_config() {
         const next_callback = load_filter_config;
-        if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
             MSP.send_message(MSPCodes.MSP_RX_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -187,7 +187,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_filter_config() {
         const next_callback = load_html;
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             MSP.send_message(MSPCodes.MSP_FILTER_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -213,11 +213,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         function refreshMixerPreview() {
-            var mixer = MIXER_CONFIG.mixer
+            var mixer = FC.MIXER_CONFIG.mixer
             var reverse = "";
 
-            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                reverse = MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
+            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                reverse = FC.MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
             }
 
             $('.mixerPreview img').attr('src', './resources/motor_order/' + mixerList[mixer - 1].image + reverse + '.svg');
@@ -227,30 +227,30 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         var reverseMotor_e = $('.reverseMotor');
 
         reverseMotorSwitch_e.change(function() {
-            MIXER_CONFIG.reverseMotorDir = $(this).prop('checked') ? 1 : 0;
+            FC.MIXER_CONFIG.reverseMotorDir = $(this).prop('checked') ? 1 : 0;
             refreshMixerPreview();
         });
-        reverseMotorSwitch_e.prop('checked', MIXER_CONFIG.reverseMotorDir != 0).change();
+        reverseMotorSwitch_e.prop('checked', FC.MIXER_CONFIG.reverseMotorDir != 0).change();
 
         mixer_list_e.change(function () {
             var mixerValue = parseInt($(this).val());
 
             var newValue;
-            if (mixerValue !== MIXER_CONFIG.mixer) {
+            if (mixerValue !== FC.MIXER_CONFIG.mixer) {
                 newValue = $(this).find('option:selected').text();
             }
             self.analyticsChanges['Mixer'] = newValue;
 
-            MIXER_CONFIG.mixer = mixerValue;
+            FC.MIXER_CONFIG.mixer = mixerValue;
             refreshMixerPreview();
         });
 
         // select current mixer configuration
-        mixer_list_e.val(MIXER_CONFIG.mixer).change();
+        mixer_list_e.val(FC.MIXER_CONFIG.mixer).change();
 
         var features_e = $('.tab-configuration .features');
 
-        FEATURE_CONFIG.features.generateElements(features_e);
+        FC.FEATURE_CONFIG.features.generateElements(features_e);
 
         // Dshot Beeper
         var dshotBeeper_e = $('.tab-configuration .dshotbeeper');
@@ -260,7 +260,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         var dshotBeaconCondition_e = $('tbody.dshotBeaconConditions');
         var dshotBeaconSwitch_e = $('tr.dshotBeaconSwitch');
 
-        if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
             for (var i = 1; i <= 5; i++) {
                 dshotBeeperBeaconTone.append('<option value="' + (i) + '">'+ (i) + '</option>');
             }
@@ -270,19 +270,19 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         dshotBeeperBeaconTone.change(function() {
-            BEEPER_CONFIG.dshotBeaconTone = dshotBeeperBeaconTone.val();
+            FC.BEEPER_CONFIG.dshotBeaconTone = dshotBeeperBeaconTone.val();
         });
 
-        dshotBeeperBeaconTone.val(BEEPER_CONFIG.dshotBeaconTone);
+        dshotBeeperBeaconTone.val(FC.BEEPER_CONFIG.dshotBeaconTone);
 
         var template = $('.beepers .beeper-template');
-        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
             dshotBeaconSwitch_e.hide();
-            BEEPER_CONFIG.dshotBeaconConditions.generateElements(template, dshotBeaconCondition_e);
+            FC.BEEPER_CONFIG.dshotBeaconConditions.generateElements(template, dshotBeaconCondition_e);
 
             $('input.condition', dshotBeaconCondition_e).change(function () {
                 var element = $(this);
-                BEEPER_CONFIG.dshotBeaconConditions.updateData(element);
+                FC.BEEPER_CONFIG.dshotBeaconConditions.updateData(element);
             });
         } else {
             dshotBeaconCondition_e.hide();
@@ -299,15 +299,15 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 }
             });
 
-            dshotBeeperSwitch.prop('checked', BEEPER_CONFIG.dshotBeaconTone !== 0).change();
+            dshotBeeperSwitch.prop('checked', FC.BEEPER_CONFIG.dshotBeaconTone !== 0).change();
         }
 
         // Analog Beeper
         var destination = $('.beepers .beeper-configuration');
         var beeper_e = $('.tab-configuration .beepers');
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-            BEEPER_CONFIG.beepers.generateElements(template, destination);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            FC.BEEPER_CONFIG.beepers.generateElements(template, destination);
         } else {
             beeper_e.hide();
             reverseMotor_e.hide();
@@ -327,7 +327,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'CW 270° flip'
         ];
 
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             alignments.push('Custom');
         }
 
@@ -344,7 +344,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         var orientation_gyro_2_align_e = $('select.gyro_2_align');
 
         gyro_align_content_e.hide(); // default value
-        if (semver.lt(CONFIG.apiVersion, "1.15.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.15.0")) {
             $('.tab-configuration .sensoralignment').hide();
         } else {
 
@@ -354,48 +354,48 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 orientation_mag_e.append('<option value="' + (i+1) + '">'+ alignments[i] + '</option>');
             }
 
-            orientation_gyro_e.val(SENSOR_ALIGNMENT.align_gyro);
-            orientation_acc_e.val(SENSOR_ALIGNMENT.align_acc);
-            orientation_mag_e.val(SENSOR_ALIGNMENT.align_mag);
+            orientation_gyro_e.val(FC.SENSOR_ALIGNMENT.align_gyro);
+            orientation_acc_e.val(FC.SENSOR_ALIGNMENT.align_acc);
+            orientation_mag_e.val(FC.SENSOR_ALIGNMENT.align_mag);
 
             orientation_gyro_e.change(function () {
                 let value = parseInt($(this).val());
 
                 let newValue = undefined;
-                if (value !== SENSOR_ALIGNMENT.align_gyro) {
+                if (value !== FC.SENSOR_ALIGNMENT.align_gyro) {
                     newValue = $(this).find('option:selected').text();
                 }
                 self.analyticsChanges['GyroAlignment'] = newValue;
 
-                SENSOR_ALIGNMENT.align_gyro = value;
+                FC.SENSOR_ALIGNMENT.align_gyro = value;
             });
 
             orientation_acc_e.change(function () {
                 let value = parseInt($(this).val());
 
                 let newValue = undefined;
-                if (value !== SENSOR_ALIGNMENT.align_acc) {
+                if (value !== FC.SENSOR_ALIGNMENT.align_acc) {
                     newValue = $(this).find('option:selected').text();
                 }
                 self.analyticsChanges['AccAlignment'] = newValue;
 
-                SENSOR_ALIGNMENT.align_acc = value;
+                FC.SENSOR_ALIGNMENT.align_acc = value;
             });
 
             orientation_mag_e.change(function () {
                 let value = parseInt($(this).val());
 
                 let newValue = undefined;
-                if (value !== SENSOR_ALIGNMENT.align_mag) {
+                if (value !== FC.SENSOR_ALIGNMENT.align_mag) {
                     newValue = $(this).find('option:selected').text();
                 }
                 self.analyticsChanges['MagAlignment'] = newValue;
 
-                SENSOR_ALIGNMENT.align_mag = value;
+                FC.SENSOR_ALIGNMENT.align_mag = value;
             });
 
             // Multi gyro config
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
 
                 gyro_align_content_e.show();
                 legacy_gyro_alignment_e.hide();
@@ -407,9 +407,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                         DETECTED_DUAL_GYROS:  (1 << 7)
                 };
 
-                var detected_gyro_1 = (SENSOR_ALIGNMENT.gyro_detection_flags & GYRO_DETECTION_FLAGS.DETECTED_GYRO_1) != 0;
-                var detected_gyro_2 = (SENSOR_ALIGNMENT.gyro_detection_flags & GYRO_DETECTION_FLAGS.DETECTED_GYRO_2) != 0;
-                var detected_dual_gyros = (SENSOR_ALIGNMENT.gyro_detection_flags & GYRO_DETECTION_FLAGS.DETECTED_DUAL_GYROS) != 0;
+                var detected_gyro_1 = (FC.SENSOR_ALIGNMENT.gyro_detection_flags & GYRO_DETECTION_FLAGS.DETECTED_GYRO_1) != 0;
+                var detected_gyro_2 = (FC.SENSOR_ALIGNMENT.gyro_detection_flags & GYRO_DETECTION_FLAGS.DETECTED_GYRO_2) != 0;
+                var detected_dual_gyros = (FC.SENSOR_ALIGNMENT.gyro_detection_flags & GYRO_DETECTION_FLAGS.DETECTED_DUAL_GYROS) != 0;
 
                 if (detected_gyro_1) {
                     orientation_gyro_to_use_e.append('<option value="0">'+ i18n.getMessage('configurationSensorGyroToUseFirst') + '</option>');
@@ -426,9 +426,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                     orientation_gyro_2_align_e.append('<option value="' + (i+1) + '">'+ alignments[i] + '</option>');
                 }
 
-                orientation_gyro_to_use_e.val(SENSOR_ALIGNMENT.gyro_to_use);
-                orientation_gyro_1_align_e.val(SENSOR_ALIGNMENT.gyro_1_align);
-                orientation_gyro_2_align_e.val(SENSOR_ALIGNMENT.gyro_2_align);
+                orientation_gyro_to_use_e.val(FC.SENSOR_ALIGNMENT.gyro_to_use);
+                orientation_gyro_1_align_e.val(FC.SENSOR_ALIGNMENT.gyro_1_align);
+                orientation_gyro_2_align_e.val(FC.SENSOR_ALIGNMENT.gyro_2_align);
 
                 $('.gyro_alignment_inputs_first').toggle(detected_gyro_1);
                 $('.gyro_alignment_inputs_second').toggle(detected_gyro_2);
@@ -439,24 +439,24 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                     let value = parseInt($(this).val());
 
                     let newValue = undefined;
-                    if (value !== SENSOR_ALIGNMENT.gyro_1_align) {
+                    if (value !== FC.SENSOR_ALIGNMENT.gyro_1_align) {
                         newValue = $(this).find('option:selected').text();
                     }
                     self.analyticsChanges['Gyro1Alignment'] = newValue;
 
-                    SENSOR_ALIGNMENT.gyro_1_align = value;
+                    FC.SENSOR_ALIGNMENT.gyro_1_align = value;
                 });
 
                 orientation_gyro_2_align_e.change(function () {
                     let value = parseInt($(this).val());
 
                     let newValue = undefined;
-                    if (value !== SENSOR_ALIGNMENT.gyro_2_align) {
+                    if (value !== FC.SENSOR_ALIGNMENT.gyro_2_align) {
                         newValue = $(this).find('option:selected').text();
                     }
                     self.analyticsChanges['Gyro2Alignment'] = newValue;
 
-                    SENSOR_ALIGNMENT.gyro_2_align = value;
+                    FC.SENSOR_ALIGNMENT.gyro_2_align = value;
                 });
             }
         }
@@ -469,25 +469,25 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'MULTISHOT'
         ];
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             escProtocols.push('BRUSHED');
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
             escProtocols.push('DSHOT150');
             escProtocols.push('DSHOT300');
             escProtocols.push('DSHOT600');
 
-            if (semver.lt(CONFIG.apiVersion, "1.42.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
                 escProtocols.push('DSHOT1200');
             }
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
             escProtocols.push('PROSHOT1000');
         }
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
             escProtocols.push('DISABLED');
         }
 
@@ -505,51 +505,51 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
         });
 
-        $('input[id="unsyncedPWMSwitch"]').prop('checked', PID_ADVANCED_CONFIG.use_unsyncedPwm !== 0).change();
-        $('input[name="unsyncedpwmfreq"]').val(PID_ADVANCED_CONFIG.motor_pwm_rate);
-        $('input[name="digitalIdlePercent"]').val(PID_ADVANCED_CONFIG.digitalIdlePercent);
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        $('input[id="unsyncedPWMSwitch"]').prop('checked', FC.PID_ADVANCED_CONFIGuse_unsyncedPwm !== 0).change();
+        $('input[name="unsyncedpwmfreq"]').val(FC.PID_ADVANCED_CONFIG.motor_pwm_rate);
+        $('input[name="digitalIdlePercent"]').val(FC.PID_ADVANCED_CONFIG.digitalIdlePercent);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             let dshotBidirectional_e = $('input[id="dshotBidir"]');
-            dshotBidirectional_e.prop('checked', MOTOR_CONFIG.use_dshot_telemetry).change();
+            dshotBidirectional_e.prop('checked', FC.MOTOR_CONFIGuse_dshot_telemetry).change();
 
-            self.previousDshotBidir = MOTOR_CONFIG.use_dshot_telemetry;
-            self.previousFilterDynQ = FILTER_CONFIG.dyn_notch_q;
-            self.previousFilterDynWidth = FILTER_CONFIG.dyn_notch_width_percent;
+            self.previousDshotBidir = FC.MOTOR_CONFIG.use_dshot_telemetry;
+            self.previousFilterDynQ = FC.FILTER_CONFIG.dyn_notch_q;
+            self.previousFilterDynWidth = FC.FILTER_CONFIG.dyn_notch_width_percent;
 
             dshotBidirectional_e.change(function () {
                 let value = $(this).prop('checked');
 
                 var newValue = undefined;
-                if (value !== MOTOR_CONFIG.use_dshot_telemetry) {
+                if (value !== FC.MOTOR_CONFIGuse_dshot_telemetry) {
                     newValue = value ? 'On' : 'Off';
                 }
                 self.analyticsChanges['BidirectionalDshot'] = newValue;
 
-                MOTOR_CONFIG.use_dshot_telemetry = value;
+                FC.MOTOR_CONFIG.use_dshot_telemetry = value;
 
-                FILTER_CONFIG.dyn_notch_width_percent = self.previousFilterDynWidth;
-                FILTER_CONFIG.dyn_notch_q = self.previousFilterDynQ;
+                FC.FILTER_CONFIG.dyn_notch_width_percent = self.previousFilterDynWidth;
+                FC.FILTER_CONFIG.dyn_notch_q = self.previousFilterDynQ;
 
-                if (FILTER_CONFIG.gyro_rpm_notch_harmonics !== 0) { // if rpm filter is active
+                if (FC.FILTER_CONFIG.gyro_rpm_notch_harmonics !== 0) { // if rpm filter is active
                     if (value && !self.previousDshotBidir) {
-                        FILTER_CONFIG.dyn_notch_width_percent = FILTER_DEFAULT.dyn_notch_width_percent_rpm;
-                        FILTER_CONFIG.dyn_notch_q = FILTER_DEFAULT.dyn_notch_q_rpm;
+                        FC.FILTER_CONFIG.dyn_notch_width_percent = FILTER_DEFAULT.dyn_notch_width_percent_rpm;
+                        FC.FILTER_CONFIG.dyn_notch_q = FILTER_DEFAULT.dyn_notch_q_rpm;
                     } else if (!value && self.previousDshotBidir) {
-                        FILTER_CONFIG.dyn_notch_width_percent = FILTER_DEFAULT.dyn_notch_width_percent;
-                        FILTER_CONFIG.dyn_notch_q = FILTER_DEFAULT.dyn_notch_q;
+                        FC.FILTER_CONFIG.dyn_notch_width_percent = FILTER_DEFAULT.dyn_notch_width_percent;
+                        FC.FILTER_CONFIG.dyn_notch_q = FILTER_DEFAULT.dyn_notch_q;
                     }
                 }
 
-                if (FILTER_CONFIG.dyn_notch_width_percent !== self.previousFilterDynWidth) {
+                if (FC.FILTER_CONFIG.dyn_notch_width_percent !== self.previousFilterDynWidth) {
                     showDialogDynFiltersChange();
                 }
             });
 
-            $('input[name="motorPoles"]').val(MOTOR_CONFIG.motor_poles);
+            $('input[name="motorPoles"]').val(FC.MOTOR_CONFIG.motor_poles);
         }
 
-        $('#escProtocolTooltip').toggle(semver.lt(CONFIG.apiVersion, "1.42.0"));
-        $('#escProtocolTooltipNoDSHOT1200').toggle(semver.gte(CONFIG.apiVersion, "1.42.0"));
+        $('#escProtocolTooltip').toggle(semver.lt(FC.CONFIG.apiVersion, "1.42.0"));
+        $('#escProtocolTooltipNoDSHOT1200').toggle(semver.gte(FC.CONFIG.apiVersion, "1.42.0"));
 
         function updateVisibility() {
             // Hide unused settings
@@ -581,8 +581,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('div.digitalIdlePercent').toggle(protocolConfigured && digitalProtocol);
             $('.escSensor').toggle(protocolConfigured && digitalProtocol);
 
-            $('div.checkboxDshotBidir').toggle(protocolConfigured && semver.gte(CONFIG.apiVersion, "1.42.0") && digitalProtocol);
-            $('div.motorPoles').toggle(protocolConfigured && rpmFeaturesVisible && semver.gte(CONFIG.apiVersion, "1.42.0"));
+            $('div.checkboxDshotBidir').toggle(protocolConfigured && semver.gte(FC.CONFIG.apiVersion, "1.42.0") && digitalProtocol);
+            $('div.motorPoles').toggle(protocolConfigured && rpmFeaturesVisible && semver.gte(FC.CONFIG.apiVersion, "1.42.0"));
 
             $('.escMotorStop').toggle(protocolConfigured);
 
@@ -592,12 +592,12 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $("input[id='unsyncedPWMSwitch']").change();
         }
 
-        esc_protocol_e.val(PID_ADVANCED_CONFIG.fast_pwm_protocol + 1);
+        esc_protocol_e.val(FC.PID_ADVANCED_CONFIG.fast_pwm_protocol + 1);
         esc_protocol_e.change(function () {
             const escProtocolValue = parseInt($(this).val()) - 1;
 
             let newValue = undefined;
-            if (escProtocolValue !== PID_ADVANCED_CONFIG.fast_pwm_protocol) {
+            if (escProtocolValue !== FC.PID_ADVANCED_CONFIGfast_pwm_protocol) {
                 newValue = $(this).find('option:selected').text();
             }
             self.analyticsChanges['EscProtocol'] = newValue;
@@ -633,7 +633,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             gyroSelectElement.empty();
 
-            const MAX_DENOM = semver.gte(CONFIG.apiVersion, "1.25.0") ? 32 : 8;
+            const MAX_DENOM = semver.gte(FC.CONFIG.apiVersion, "1.25.0") ? 32 : 8;
             for (let denom = 1; denom <= MAX_DENOM; denom++) {
                 addDenomOption(gyroSelectElement, denom, gyroBaseFreq);
             }
@@ -655,8 +655,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
              gyroTextElement.val(gyroContent);
          };
 
-         if (semver.gte(CONFIG.apiVersion, "1.25.0") && semver.lt(CONFIG.apiVersion, "1.41.0")) {
-             gyroUse32kHzElement.prop('checked', PID_ADVANCED_CONFIG.gyroUse32kHz !== 0);
+         if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+             gyroUse32kHzElement.prop('checked', FC.PID_ADVANCED_CONFIGgyroUse32kHz !== 0);
 
              gyroUse32kHzElement.change(function () {
                  const gyroBaseFreq = ($(this).is(':checked'))? 32 : 8;
@@ -668,14 +668,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
              $('div.gyroUse32kHz').hide();
 
-             if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                 updateGyroDenomReadOnly(CONFIG.sampleRateHz);
+             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                 updateGyroDenomReadOnly(FC.CONFIG.sampleRateHz);
              } else {
                  updateGyroDenom(8);
              }
         }
 
-        gyroSelectElement.val(PID_ADVANCED_CONFIG.gyro_sync_denom);
+        gyroSelectElement.val(FC.PID_ADVANCED_CONFIG.gyro_sync_denom);
 
         $('.systemconfigNote').html(i18n.getMessage('configurationLoopTimeHelp'));
 
@@ -683,11 +683,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             const originalPidDenom = pidSelectElement.val();
 
             let pidBaseFreq;
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                pidBaseFreq = CONFIG.sampleRateHz / 1000;
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                pidBaseFreq = FC.CONFIGsampleRateHz / 1000;
             } else {
                 pidBaseFreq = 8;
-                if (semver.gte(CONFIG.apiVersion, "1.25.0") && semver.lt(CONFIG.apiVersion, "1.41.0") && gyroUse32kHzElement.is(':checked')) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, "1.41.0") && gyroUse32kHzElement.is(':checked')) {
                     pidBaseFreq = 32;
                 }
                 pidBaseFreq = pidBaseFreq / parseInt($(this).val());
@@ -695,7 +695,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             pidSelectElement.empty();
 
-            const MAX_DENOM = semver.gte(CONFIG.apiVersion, "1.24.0") ? 16 : 8;
+            const MAX_DENOM = semver.gte(FC.CONFIG.apiVersion, "1.24.0") ? 16 : 8;
 
             for (let denom = 1; denom <= MAX_DENOM; denom++) {
                 addDenomOption(pidSelectElement, denom, pidBaseFreq);
@@ -704,35 +704,35 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             pidSelectElement.val(originalPidDenom);
         }).change();
 
-        pidSelectElement.val(PID_ADVANCED_CONFIG.pid_process_denom);
+        pidSelectElement.val(FC.PID_ADVANCED_CONFIG.pid_process_denom);
 
-        $('input[id="accHardwareSwitch"]').prop('checked', SENSOR_CONFIG.acc_hardware !== 1);
-        $('input[id="baroHardwareSwitch"]').prop('checked', SENSOR_CONFIG.baro_hardware !== 1);
-        $('input[id="magHardwareSwitch"]').prop('checked', SENSOR_CONFIG.mag_hardware !== 1);
+        $('input[id="accHardwareSwitch"]').prop('checked', FC.SENSOR_CONFIGacc_hardware !== 1);
+        $('input[id="baroHardwareSwitch"]').prop('checked', FC.SENSOR_CONFIGbaro_hardware !== 1);
+        $('input[id="magHardwareSwitch"]').prop('checked', FC.SENSOR_CONFIGmag_hardware !== 1);
 
         // Only show these sections for supported FW
-        if (semver.lt(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.16.0")) {
             $('.selectProtocol').hide();
             $('.checkboxPwm').hide();
             $('.selectPidProcessDenom').hide();
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.16.0")) {
             $('.hardwareSelection').hide();
         }
 
-        $('input[name="craftName"]').val(CONFIG.name);
+        $('input[name="craftName"]').val(FC.CONFIG.name);
 
-        if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
-            $('input[name="fpvCamAngleDegrees"]').val(RX_CONFIG.fpvCamAngleDegrees);
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+            $('input[name="fpvCamAngleDegrees"]').val(FC.RX_CONFIG.fpvCamAngleDegrees);
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                 $('input[name="fpvCamAngleDegrees"]').attr("max", 90);
             }
         } else {
             $('div.fpvCamAngleDegrees').hide();
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
             $('.miscSettings').hide();
         }
 
@@ -741,7 +741,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'NMEA',
             'UBLOX'
         ];
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
             gpsProtocols.push('MSP');
         }
 
@@ -760,7 +760,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             i18n.getMessage('gpsSbasJapaneseMSAS'),
             i18n.getMessage('gpsSbasIndianGAGAN'),
         ];
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
             gpsSbas.push(i18n.getMessage('gpsSbasNone'));
         }
 
@@ -782,29 +782,29 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         gpsProtocolElement.change(function () {
-            GPS_CONFIG.provider = parseInt($(this).val());
+            FC.GPS_CONFIGprovider = parseInt($(this).val());
 
             // Call this to enable or disable auto config elements depending on the protocol
             gpsAutoConfigElement.change();
 
-        }).val(GPS_CONFIG.provider).change();
+        }).val(FC.GPS_CONFIG.provider).change();
 
-        gpsAutoBaudElement.prop('checked', GPS_CONFIG.auto_baud === 1);
+        gpsAutoBaudElement.prop('checked', FC.GPS_CONFIGauto_baud === 1);
 
         gpsAutoConfigElement.change(function () {
             const checked = $(this).is(":checked");
 
-            const ubloxSelected = GPS_CONFIG.provider === gpsProtocols.indexOf('UBLOX');
+            const ubloxSelected = FC.GPS_CONFIGprovider === gpsProtocols.indexOf('UBLOX');
 
-            const enableGalileoVisible = checked && ubloxSelected && semver.gte(CONFIG.apiVersion, API_VERSION_1_43);
+            const enableGalileoVisible = checked && ubloxSelected && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43);
             gpsUbloxGalileoGroup.toggle(enableGalileoVisible);
 
             const enableSbasVisible = checked && ubloxSelected;
             gpsUbloxSbasGroup.toggle(enableSbasVisible);
 
-        }).prop('checked', GPS_CONFIG.auto_config === 1).change();
+        }).prop('checked', FC.GPS_CONFIGauto_config === 1).change();
 
-        if (semver.gte(CONFIG.apiVersion, "1.34.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
             gpsAutoBaudGroup.show();
             gpsAutoConfigGroup.show();
         } else {
@@ -813,31 +813,31 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         gpsUbloxGalileoElement.change(function() {
-            GPS_CONFIG.ublox_use_galileo = $(this).is(':checked') ? 1 : 0;
-        }).prop('checked', GPS_CONFIG.ublox_use_galileo > 0).change();
+            FC.GPS_CONFIGublox_use_galileo = $(this).is(':checked') ? 1 : 0;
+        }).prop('checked', FC.GPS_CONFIGublox_use_galileo > 0).change();
 
         for (let sbasIndex = 0; sbasIndex < gpsSbas.length; sbasIndex++) {
             gpsUbloxSbasElement.append(`<option value="${sbasIndex}">${gpsSbas[sbasIndex]}</option>`);
         }
 
         gpsUbloxSbasElement.change(function () {
-            GPS_CONFIG.ublox_sbas = parseInt($(this).val());
-        }).val(GPS_CONFIG.ublox_sbas);
+            FC.GPS_CONFIGublox_sbas = parseInt($(this).val());
+        }).val(FC.GPS_CONFIG.ublox_sbas);
 
-        $('.gps_home_once').toggle(semver.gte(CONFIG.apiVersion, API_VERSION_1_43));
+        $('.gps_home_once').toggle(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43));
         gpsHomeOnceElement.change(function() {
-            GPS_CONFIG.home_point_once = $(this).is(':checked') ? 1 : 0;
-        }).prop('checked', GPS_CONFIG.home_point_once > 0).change();
+            FC.GPS_CONFIGhome_point_once = $(this).is(':checked') ? 1 : 0;
+        }).prop('checked', FC.GPS_CONFIGhome_point_once > 0).change();
 
         for (let baudRateIndex = 0; baudRateIndex < gpsBaudRates.length; baudRateIndex++) {
             gpsBaudrateElement.append(`<option value="${gpsBaudRates[baudRateIndex]}">${gpsBaudRates[baudRateIndex]}</option>`);
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.6.0")) {
             gpsBaudrateElement.change(function () {
-                SERIAL_CONFIG.gpsBaudRate = parseInt($(this).val());
+                FC.SERIAL_CONFIGgpsBaudRate = parseInt($(this).val());
             });
-            gpsBaudrateElement.val(SERIAL_CONFIG.gpsBaudRate);
+            gpsBaudrateElement.val(FC.SERIAL_CONFIG.gpsBaudRate);
         } else {
             gpsBaudrateElement.prop("disabled", true);
             gpsBaudrateElement.parent().hide();
@@ -854,32 +854,32 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'XBUS_MODE_B_RJ01'
         ];
 
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
             serialRXtypes.push('IBUS');
         }
 
-        if ((CONFIG.flightControllerIdentifier === 'BTFL' && semver.gte(CONFIG.flightControllerVersion, "2.6.0")) ||
-            (CONFIG.flightControllerIdentifier === 'CLFL' && semver.gte(CONFIG.apiVersion, "1.31.0"))) {
+        if ((FC.CONFIG.flightControllerIdentifier === 'BTFL' && semver.gte(FC.CONFIG.flightControllerVersion, "2.6.0")) ||
+            (FC.CONFIG.flightControllerIdentifier === 'CLFL' && semver.gte(FC.CONFIG.apiVersion, "1.31.0"))) {
             serialRXtypes.push('JETIEXBUS');
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.31.0"))  {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0"))  {
             serialRXtypes.push('CRSF');
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.24.0"))  {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.24.0"))  {
             serialRXtypes.push('SPEKTRUM2048/SRXL');
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.35.0"))  {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.35.0"))  {
             serialRXtypes.push('TARGET_CUSTOM');
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.37.0"))  {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0"))  {
             serialRXtypes.push('FrSky FPort');
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.42.0"))  {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0"))  {
             serialRXtypes.push('SPEKTRUM SRXL2');
         }
 
@@ -892,18 +892,18 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             var serialRxValue = parseInt($(this).val());
 
             var newValue;
-            if (serialRxValue !== RX_CONFIG.serialrx_provider) {
+            if (serialRxValue !== FC.RX_CONFIGserialrx_provider) {
                 newValue = $(this).find('option:selected').text();
             }
             self.analyticsChanges['SerialRx'] = newValue;
 
-            RX_CONFIG.serialrx_provider = serialRxValue;
+            FC.RX_CONFIGserialrx_provider = serialRxValue;
         });
 
         // select current serial RX type
-        serialRX_e.val(RX_CONFIG.serialrx_provider);
+        serialRX_e.val(FC.RX_CONFIG.serialrx_provider);
 
-        if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
             var spiRxTypes = [
                 'NRF24_V202_250K',
                 'NRF24_V202_1M',
@@ -916,7 +916,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 'FRSKY_D'
             ];
 
-            if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
                 spiRxTypes.push(
                     'FRSKY_X',
                     'A7105_FLYSKY',
@@ -925,7 +925,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 );
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                 spiRxTypes.push(
                     'SFHSS',
                     'SPEKTRUM',
@@ -933,13 +933,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 );
             }
 
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                 spiRxTypes.push(
                     'REDPINE',
                 );
             }
 
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
                 spiRxTypes.push(
                     'FRSKY_X_V2',
                     'FRSKY_X_LBT_V2'
@@ -955,16 +955,16 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 const value = parseInt($(this).val());
 
                 let newValue = undefined;
-                if (value !== RX_CONFIG.rxSpiProtocol) {
+                if (value !== FC.RX_CONFIGrxSpiProtocol) {
                     newValue = $(this).find('option:selected').text();
                 }
                 self.analyticsChanges['SPIRXProtocol'] = newValue;
 
-                RX_CONFIG.rxSpiProtocol = value;
+                FC.RX_CONFIGrxSpiProtocol = value;
             });
 
             // select current serial RX type
-            spiRx_e.val(RX_CONFIG.rxSpiProtocol);
+            spiRx_e.val(FC.RX_CONFIG.rxSpiProtocol);
             }
 
         // for some odd reason chrome 38+ changes scroll according to the touched select element
@@ -973,41 +973,41 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
 
         // fill board alignment
-        $('input[name="board_align_roll"]').val(BOARD_ALIGNMENT_CONFIG.roll);
-        $('input[name="board_align_pitch"]').val(BOARD_ALIGNMENT_CONFIG.pitch);
-        $('input[name="board_align_yaw"]').val(BOARD_ALIGNMENT_CONFIG.yaw);
+        $('input[name="board_align_roll"]').val(FC.BOARD_ALIGNMENT_CONFIG.roll);
+        $('input[name="board_align_pitch"]').val(FC.BOARD_ALIGNMENT_CONFIG.pitch);
+        $('input[name="board_align_yaw"]').val(FC.BOARD_ALIGNMENT_CONFIG.yaw);
 
         // fill accel trims
-        $('input[name="roll"]').val(CONFIG.accelerometerTrims[1]);
-        $('input[name="pitch"]').val(CONFIG.accelerometerTrims[0]);
+        $('input[name="roll"]').val(FC.CONFIG.accelerometerTrims[1]);
+        $('input[name="pitch"]').val(FC.CONFIG.accelerometerTrims[0]);
 
         //fill motor disarm params and FC loop time
-        if(semver.gte(CONFIG.apiVersion, "1.8.0")) {
-            $('input[name="autodisarmdelay"]').val(ARMING_CONFIG.auto_disarm_delay);
-            $('input[id="disarmkillswitch"]').prop('checked', ARMING_CONFIG.disarm_kill_switch !== 0);
+        if(semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
+            $('input[name="autodisarmdelay"]').val(FC.ARMING_CONFIG.auto_disarm_delay);
+            $('input[id="disarmkillswitch"]').prop('checked', FC.ARMING_CONFIGdisarm_kill_switch !== 0);
             $('div.disarm').show();
 
             $('div.cycles').show();
         }
 
-        if(semver.gte(CONFIG.apiVersion, "1.37.0") || !isExpertModeEnabled()) {
+        if(semver.gte(FC.CONFIG.apiVersion, "1.37.0") || !isExpertModeEnabled()) {
             $('input[id="disarmkillswitch"]').prop('checked', true);
             $('div.disarm').hide();
         }
 
-        $('._smallAngle').toggle(semver.gte(CONFIG.apiVersion, "1.37.0"));
-        if(semver.gte(CONFIG.apiVersion, "1.37.0")) {
-            $('input[id="configurationSmallAngle"]').val(ARMING_CONFIG.small_angle);
+        $('._smallAngle').toggle(semver.gte(FC.CONFIG.apiVersion, "1.37.0"));
+        if(semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            $('input[id="configurationSmallAngle"]').val(FC.ARMING_CONFIG.small_angle);
         }
 
         // fill throttle
-        $('input[name="minthrottle"]').val(MOTOR_CONFIG.minthrottle);
-        $('input[name="maxthrottle"]').val(MOTOR_CONFIG.maxthrottle);
-        $('input[name="mincommand"]').val(MOTOR_CONFIG.mincommand);
+        $('input[name="minthrottle"]').val(FC.MOTOR_CONFIG.minthrottle);
+        $('input[name="maxthrottle"]').val(FC.MOTOR_CONFIG.maxthrottle);
+        $('input[name="mincommand"]').val(FC.MOTOR_CONFIG.mincommand);
 
         // fill battery
         if (self.SHOW_OLD_BATTERY_CONFIG) {
-            if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+            if (semver.gte(FC.CONFIG.flightControllerVersion, "3.1.0")) {
                 var batteryMeterTypes = [
                     'Onboard ADC',
                     'ESC Sensor'
@@ -1019,24 +1019,24 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 }
 
                 batteryMeterType_e.change(function () {
-                    MISC.batterymetertype = parseInt($(this).val());
+                    FC.MISCbatterymetertype = parseInt($(this).val());
                     checkUpdateVbatControls();
                 });
-                batteryMeterType_e.val(MISC.batterymetertype).change();
+                batteryMeterType_e.val(FC.MISC.batterymetertype).change();
             } else {
                 $('div.batterymetertype').hide();
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                 $('input[name="mincellvoltage"]').prop('step','0.01');
                 $('input[name="maxcellvoltage"]').prop('step','0.01');
                 $('input[name="warningcellvoltage"]').prop('step','0.01');
             }
 
-            $('input[name="mincellvoltage"]').val(MISC.vbatmincellvoltage);
-            $('input[name="maxcellvoltage"]').val(MISC.vbatmaxcellvoltage);
-            $('input[name="warningcellvoltage"]').val(MISC.vbatwarningcellvoltage);
-            $('input[name="voltagescale"]').val(MISC.vbatscale);
+            $('input[name="mincellvoltage"]').val(FC.MISC.vbatmincellvoltage);
+            $('input[name="maxcellvoltage"]').val(FC.MISC.vbatmaxcellvoltage);
+            $('input[name="warningcellvoltage"]').val(FC.MISC.vbatwarningcellvoltage);
+            $('input[name="voltagescale"]').val(FC.MISC.vbatscale);
 
             // fill current
             var currentMeterTypes = [
@@ -1045,7 +1045,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 'Virtual'
             ];
 
-            if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+            if (semver.gte(FC.CONFIG.flightControllerVersion, "3.1.0")) {
                 currentMeterTypes.push('ESC Sensor');
             }
 
@@ -1055,26 +1055,26 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             currentMeterType_e.change(function () {
-                BF_CONFIG.currentmetertype = parseInt($(this).val());
+                FC.BF_CONFIGcurrentmetertype = parseInt($(this).val());
                 checkUpdateCurrentControls();
             });
-            currentMeterType_e.val(BF_CONFIG.currentmetertype).change();
+            currentMeterType_e.val(FC.BF_CONFIG.currentmetertype).change();
 
-            $('input[name="currentscale"]').val(BF_CONFIG.currentscale);
-            $('input[name="currentoffset"]').val(BF_CONFIG.currentoffset);
-            $('input[name="multiwiicurrentoutput"]').prop('checked', MISC.multiwiicurrentoutput !== 0);
+            $('input[name="currentscale"]').val(FC.BF_CONFIG.currentscale);
+            $('input[name="currentoffset"]').val(FC.BF_CONFIG.currentoffset);
+            $('input[name="multiwiicurrentoutput"]').prop('checked', FC.MISCmultiwiicurrentoutput !== 0);
         } else {
             $('.oldBatteryConfig').hide();
         }
 
         function checkUpdateVbatControls() {
-            if (FEATURE_CONFIG.features.isEnabled('VBAT')) {
+            if (FC.FEATURE_CONFIG.features.isEnabled('VBAT')) {
                 $('.vbatmonitoring').show();
 
-                if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+                if (semver.gte(FC.CONFIG.flightControllerVersion, "3.1.0")) {
                      $('select.batterymetertype').show();
 
-                    if (MISC.batterymetertype !== 0) {
+                    if (FC.MISC.batterymetertype !== 0) {
                         $('.vbatCalibration').hide();
                      }
                 } else {
@@ -1086,10 +1086,10 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         function checkUpdateCurrentControls() {
-            if (FEATURE_CONFIG.features.isEnabled('CURRENT_METER')) {
+            if (FC.FEATURE_CONFIG.features.isEnabled('CURRENT_METER')) {
                 $('.currentMonitoring').show();
 
-                switch(BF_CONFIG.currentmetertype) {
+                switch(FC.BF_CONFIG.currentmetertype) {
                     case 0:
                         $('.currentCalibration').hide();
                         $('.currentOutput').hide();
@@ -1099,7 +1099,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                         $('.currentCalibration').hide();
                 }
 
-                if (BF_CONFIG.currentmetertype !== 1 && BF_CONFIG.currentmetertype !== 2) {
+                if (FC.BF_CONFIG.currentmetertype !== 1 && FC.BF_CONFIGcurrentmetertype !== 2) {
                     $('.currentCalibration').hide();
                 }
             } else {
@@ -1108,17 +1108,17 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         //fill 3D
-        if (semver.lt(CONFIG.apiVersion, "1.14.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.14.0")) {
             $('.tab-configuration ._3d').hide();
         } else {
-            $('input[name="3ddeadbandlow"]').val(MOTOR_3D_CONFIG.deadband3d_low);
-            $('input[name="3ddeadbandhigh"]').val(MOTOR_3D_CONFIG.deadband3d_high);
-            $('input[name="3dneutral"]').val(MOTOR_3D_CONFIG.neutral);
+            $('input[name="3ddeadbandlow"]').val(FC.MOTOR_3D_CONFIG.deadband3d_low);
+            $('input[name="3ddeadbandhigh"]').val(FC.MOTOR_3D_CONFIG.deadband3d_high);
+            $('input[name="3dneutral"]').val(FC.MOTOR_3D_CONFIG.neutral);
         }
 
         // UI hooks
         function checkShowDisarmDelay() {
-            if (FEATURE_CONFIG.features.isEnabled('MOTOR_STOP')) {
+            if (FC.FEATURE_CONFIG.features.isEnabled('MOTOR_STOP')) {
                 $('div.disarmdelay').show();
             } else {
                 $('div.disarmdelay').hide();
@@ -1126,7 +1126,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         function checkShowSerialRxBox() {
-            if (FEATURE_CONFIG.features.isEnabled('RX_SERIAL')) {
+            if (FC.FEATURE_CONFIG.features.isEnabled('RX_SERIAL')) {
                 $('div.serialRXBox').show();
             } else {
                 $('div.serialRXBox').hide();
@@ -1134,7 +1134,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         function checkShowSpiRxBox() {
-            if (FEATURE_CONFIG.features.isEnabled('RX_SPI')) {
+            if (FC.FEATURE_CONFIG.features.isEnabled('RX_SPI')) {
                 $('div.spiRxBox').show();
             } else {
                 $('div.spiRxBox').hide();
@@ -1142,7 +1142,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         function checkUpdateGpsControls() {
-            if (FEATURE_CONFIG.features.isEnabled('GPS')) {
+            if (FC.FEATURE_CONFIG.features.isEnabled('GPS')) {
                 $('.gpsSettings').show();
             } else {
                 $('.gpsSettings').hide();
@@ -1150,7 +1150,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         function checkUpdate3dControls() {
-            if (FEATURE_CONFIG.features.isEnabled('3D')) {
+            if (FC.FEATURE_CONFIG.features.isEnabled('3D')) {
                 $('._3dSettings').show();
             } else {
                 $('._3dSettings').hide();
@@ -1160,8 +1160,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input.feature', features_e).change(function () {
             var element = $(this);
 
-            FEATURE_CONFIG.features.updateData(element);
-            updateTabList(FEATURE_CONFIG.features);
+            FC.FEATURE_CONFIGfeatures.updateData(element);
+            updateTabList(FC.FEATURE_CONFIG.features);
 
             switch (element.attr('name')) {
                 case 'MOTOR_STOP':
@@ -1193,7 +1193,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         });
 
         $('input[id="accHardwareSwitch"]').change(function() {
-            if(semver.gte(CONFIG.apiVersion, "1.37.0")) {
+            if(semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
               var checked = $(this).is(':checked');
               $('.accelNeeded').toggle(checked);
             }
@@ -1202,8 +1202,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $(features_e).filter('select').change(function () {
             var element = $(this);
 
-            FEATURE_CONFIG.features.updateData(element);
-            updateTabList(FEATURE_CONFIG.features);
+            FC.FEATURE_CONFIGfeatures.updateData(element);
+            updateTabList(FC.FEATURE_CONFIG.features);
 
             switch (element.attr('name')) {
                 case 'rxMode':
@@ -1218,7 +1218,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         $('input.condition', beeper_e).change(function () {
             var element = $(this);
-            BEEPER_CONFIG.beepers.updateData(element);
+            FC.BEEPER_CONFIG.beepers.updateData(element);
         });
 
         checkShowDisarmDelay();
@@ -1234,73 +1234,73 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         $('a.save').click(function () {
             // gather data that doesn't have automatic change event bound
-            BOARD_ALIGNMENT_CONFIG.roll = parseInt($('input[name="board_align_roll"]').val());
-            BOARD_ALIGNMENT_CONFIG.pitch = parseInt($('input[name="board_align_pitch"]').val());
-            BOARD_ALIGNMENT_CONFIG.yaw = parseInt($('input[name="board_align_yaw"]').val());
+            FC.BOARD_ALIGNMENT_CONFIGroll = parseInt($('input[name="board_align_roll"]').val());
+            FC.BOARD_ALIGNMENT_CONFIGpitch = parseInt($('input[name="board_align_pitch"]').val());
+            FC.BOARD_ALIGNMENT_CONFIGyaw = parseInt($('input[name="board_align_yaw"]').val());
 
-            CONFIG.accelerometerTrims[1] = parseInt($('input[name="roll"]').val());
-            CONFIG.accelerometerTrims[0] = parseInt($('input[name="pitch"]').val());
+            FC.CONFIGaccelerometerTrims[1] = parseInt($('input[name="roll"]').val());
+            FC.CONFIGaccelerometerTrims[0] = parseInt($('input[name="pitch"]').val());
 
             // motor disarm
-            if(semver.gte(CONFIG.apiVersion, "1.8.0")) {
-                ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
-                ARMING_CONFIG.disarm_kill_switch = $('input[id="disarmkillswitch"]').is(':checked') ? 1 : 0;
+            if(semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
+                FC.ARMING_CONFIGauto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
+                FC.ARMING_CONFIGdisarm_kill_switch = $('input[id="disarmkillswitch"]').is(':checked') ? 1 : 0;
             }
-            if(semver.gte(CONFIG.apiVersion, "1.37.0")) {
-                ARMING_CONFIG.small_angle = parseInt($('input[id="configurationSmallAngle"]').val());
+            if(semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                FC.ARMING_CONFIGsmall_angle = parseInt($('input[id="configurationSmallAngle"]').val());
             }
 
-            MOTOR_CONFIG.minthrottle = parseInt($('input[name="minthrottle"]').val());
-            MOTOR_CONFIG.maxthrottle = parseInt($('input[name="maxthrottle"]').val());
-            MOTOR_CONFIG.mincommand = parseInt($('input[name="mincommand"]').val());
-            if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                MOTOR_CONFIG.motor_poles = parseInt($('input[name="motorPoles"]').val());
+            FC.MOTOR_CONFIGminthrottle = parseInt($('input[name="minthrottle"]').val());
+            FC.MOTOR_CONFIGmaxthrottle = parseInt($('input[name="maxthrottle"]').val());
+            FC.MOTOR_CONFIGmincommand = parseInt($('input[name="mincommand"]').val());
+            if(semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                FC.MOTOR_CONFIGmotor_poles = parseInt($('input[name="motorPoles"]').val());
             }
 
             if(self.SHOW_OLD_BATTERY_CONFIG) {
-                MISC.vbatmincellvoltage = parseFloat($('input[name="mincellvoltage"]').val());
-                MISC.vbatmaxcellvoltage = parseFloat($('input[name="maxcellvoltage"]').val());
-                MISC.vbatwarningcellvoltage = parseFloat($('input[name="warningcellvoltage"]').val());
-                MISC.vbatscale = parseInt($('input[name="voltagescale"]').val());
+                FC.MISCvbatmincellvoltage = parseFloat($('input[name="mincellvoltage"]').val());
+                FC.MISCvbatmaxcellvoltage = parseFloat($('input[name="maxcellvoltage"]').val());
+                FC.MISCvbatwarningcellvoltage = parseFloat($('input[name="warningcellvoltage"]').val());
+                FC.MISCvbatscale = parseInt($('input[name="voltagescale"]').val());
 
-                BF_CONFIG.currentscale = parseInt($('input[name="currentscale"]').val());
-                BF_CONFIG.currentoffset = parseInt($('input[name="currentoffset"]').val());
-                MISC.multiwiicurrentoutput = $('input[name="multiwiicurrentoutput"]').is(':checked') ? 1 : 0;
+                FC.BF_CONFIGcurrentscale = parseInt($('input[name="currentscale"]').val());
+                FC.BF_CONFIGcurrentoffset = parseInt($('input[name="currentoffset"]').val());
+                FC.MISCmultiwiicurrentoutput = $('input[name="multiwiicurrentoutput"]').is(':checked') ? 1 : 0;
             }
 
-            if(semver.gte(CONFIG.apiVersion, "1.14.0")) {
-                MOTOR_3D_CONFIG.deadband3d_low = parseInt($('input[name="3ddeadbandlow"]').val());
-                MOTOR_3D_CONFIG.deadband3d_high = parseInt($('input[name="3ddeadbandhigh"]').val());
-                MOTOR_3D_CONFIG.neutral = parseInt($('input[name="3dneutral"]').val());
+            if(semver.gte(FC.CONFIG.apiVersion, "1.14.0")) {
+                FC.MOTOR_3D_CONFIGdeadband3d_low = parseInt($('input[name="3ddeadbandlow"]').val());
+                FC.MOTOR_3D_CONFIGdeadband3d_high = parseInt($('input[name="3ddeadbandhigh"]').val());
+                FC.MOTOR_3D_CONFIGneutral = parseInt($('input[name="3dneutral"]').val());
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-                SENSOR_ALIGNMENT.gyro_to_use = parseInt(orientation_gyro_to_use_e.val());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                FC.SENSOR_ALIGNMENT.gyro_to_use = parseInt(orientation_gyro_to_use_e.val());
             }
 
-            PID_ADVANCED_CONFIG.fast_pwm_protocol = parseInt(esc_protocol_e.val()-1);
-            PID_ADVANCED_CONFIG.use_unsyncedPwm = $('input[id="unsyncedPWMSwitch"]').is(':checked') ? 1 : 0;
-            PID_ADVANCED_CONFIG.motor_pwm_rate = parseInt($('input[name="unsyncedpwmfreq"]').val());
-            PID_ADVANCED_CONFIG.gyro_sync_denom = parseInt(gyroSelectElement.val());
+            FC.PID_ADVANCED_CONFIGfast_pwm_protocol = parseInt(esc_protocol_e.val()-1);
+            FC.PID_ADVANCED_CONFIGuse_unsyncedPwm = $('input[id="unsyncedPWMSwitch"]').is(':checked') ? 1 : 0;
+            FC.PID_ADVANCED_CONFIGmotor_pwm_rate = parseInt($('input[name="unsyncedpwmfreq"]').val());
+            FC.PID_ADVANCED_CONFIGgyro_sync_denom = parseInt(gyroSelectElement.val());
 
             const value = parseInt(pidSelectElement.val());
 
-            if (value !== PID_ADVANCED_CONFIG.pid_process_denom) {
+            if (value !== FC.PID_ADVANCED_CONFIGpid_process_denom) {
                 const newFrequency = pidSelectElement.find('option:selected').text();
                 self.analyticsChanges['PIDLoopSettings'] = `denominator: ${value} | frequency: ${newFrequency}`;
             } else {
                 self.analyticsChanges['PIDLoopSettings'] = undefined;
             }
 
-            PID_ADVANCED_CONFIG.pid_process_denom = value;
+            FC.PID_ADVANCED_CONFIGpid_process_denom = value;
 
-            PID_ADVANCED_CONFIG.digitalIdlePercent = parseFloat($('input[name="digitalIdlePercent"]').val());
-            if (semver.gte(CONFIG.apiVersion, "1.25.0") && semver.lt(CONFIG.apiVersion, "1.41.0")) {
-                PID_ADVANCED_CONFIG.gyroUse32kHz = $('input[id="gyroUse32kHz"]').is(':checked') ? 1 : 0;
+            FC.PID_ADVANCED_CONFIGdigitalIdlePercent = parseFloat($('input[name="digitalIdlePercent"]').val());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                FC.PID_ADVANCED_CONFIGgyroUse32kHz = $('input[id="gyroUse32kHz"]').is(':checked') ? 1 : 0;
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
-                RX_CONFIG.fpvCamAngleDegrees = parseInt($('input[name="fpvCamAngleDegrees"]').val());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+                FC.RX_CONFIGfpvCamAngleDegrees = parseInt($('input[name="fpvCamAngleDegrees"]').val());
             }
 
             analytics.sendChangeEvents(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, self.analyticsChanges);
@@ -1318,7 +1318,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_beeper_config() {
                 var next_callback = save_misc;
-                if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_BEEPER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BEEPER_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1327,7 +1327,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_misc() {
                 var next_callback = save_mixer_config;
-                if(semver.lt(CONFIG.apiVersion, "1.33.0")) {
+                if(semver.lt(FC.CONFIG.apiVersion, "1.33.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_MISC, mspHelper.crunch(MSPCodes.MSP_SET_MISC), false, next_callback);
                 } else {
                     next_callback();
@@ -1346,7 +1346,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_motor_config() {
                 var next_callback = save_gps_config;
-                if(semver.gte(CONFIG.apiVersion, "1.33.0")) {
+                if(semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_MOTOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1354,13 +1354,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function save_gps_config() {
-                if (semver.gte(CONFIG.apiVersion, "1.34.0")) {
-                    GPS_CONFIG.auto_baud = $('input[name="gps_auto_baud"]').is(':checked') ? 1 : 0;
-                    GPS_CONFIG.auto_config = $('input[name="gps_auto_config"]').is(':checked') ? 1 : 0;
+                if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
+                    FC.GPS_CONFIGauto_baud = $('input[name="gps_auto_baud"]').is(':checked') ? 1 : 0;
+                    FC.GPS_CONFIGauto_config = $('input[name="gps_auto_config"]').is(':checked') ? 1 : 0;
                 }
 
                 var next_callback = save_motor_3d_config;
-                if(semver.gte(CONFIG.apiVersion, "1.33.0")) {
+                if(semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_GPS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_GPS_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1396,9 +1396,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function save_sensor_config() {
-                SENSOR_CONFIG.acc_hardware = $('input[id="accHardwareSwitch"]').is(':checked') ? 0 : 1;
-                SENSOR_CONFIG.baro_hardware = $('input[id="baroHardwareSwitch"]').is(':checked') ? 0 : 1;
-                SENSOR_CONFIG.mag_hardware = $('input[id="magHardwareSwitch"]').is(':checked') ? 0 : 1;
+                FC.SENSOR_CONFIGacc_hardware = $('input[id="accHardwareSwitch"]').is(':checked') ? 0 : 1;
+                FC.SENSOR_CONFIGbaro_hardware = $('input[id="baroHardwareSwitch"]').is(':checked') ? 0 : 1;
+                FC.SENSOR_CONFIGmag_hardware = $('input[id="magHardwareSwitch"]').is(':checked') ? 0 : 1;
 
                 var next_callback = save_name;
                 MSP.send_message(MSPCodes.MSP_SET_SENSOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_SENSOR_CONFIG), false, next_callback);
@@ -1411,13 +1411,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                     next_callback = save_battery;
                 }
 
-                CONFIG.name = $.trim($('input[name="craftName"]').val());
+                FC.CONFIGname = $.trim($('input[name="craftName"]').val());
                 MSP.send_message(MSPCodes.MSP_SET_NAME, mspHelper.crunch(MSPCodes.MSP_SET_NAME), false, next_callback);
             }
 
             function save_battery() {
                 var next_callback = save_current;
-                if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+                if (semver.gte(FC.CONFIG.flightControllerVersion, "3.1.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1426,7 +1426,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_current() {
                 var next_callback = save_rx_config;
-                if (semver.gte(CONFIG.flightControllerVersion, "3.1.0")) {
+                if (semver.gte(FC.CONFIG.flightControllerVersion, "3.1.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_CURRENT_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_CURRENT_METER_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1435,7 +1435,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_rx_config() {
                 const next_callback = save_filter_config;
-                if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1444,7 +1444,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_filter_config() {
                 const next_callback = save_to_eeprom;
-                if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG), false, next_callback);
                 } else {
                     next_callback();

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -19,7 +19,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
     
     function load_rxfail_config() {
         MSP.send_message(MSPCodes.MSP_RXFAIL_CONFIG, false, false, 
-                semver.gte(CONFIG.apiVersion, "1.41.0") ? load_gps_rescue : get_box_names);
+                semver.gte(FC.CONFIG.apiVersion, "1.41.0") ? load_gps_rescue : get_box_names);
     }
 
     function load_gps_rescue() {
@@ -89,21 +89,21 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             i,
             element;
 
-        for (var channelIndex = 0; channelIndex < RC.active_channels - 4; channelIndex++) {
+        for (var channelIndex = 0; channelIndex < FC.RC.active_channels - 4; channelIndex++) {
             auxAssignment.push("");
         }
 
-        if (typeof RSSI_CONFIG.channel !== 'undefined')  {
-            auxAssignment[RSSI_CONFIG.channel - 5] += "<span class=\"modename\">" + "RSSI" + "</span>";         // Aux channels start at 5 in backend so we have to substract 5
+        if (typeof FC.RSSI_CONFIG.channel !== 'undefined')  {
+            auxAssignment[FC.RSSI_CONFIG.channel - 5] += "<span class=\"modename\">" + "RSSI" + "</span>";         // Aux channels start at 5 in backend so we have to substract 5
         }  
 
-        for (var modeIndex = 0; modeIndex < AUX_CONFIG.length; modeIndex++) {
+        for (var modeIndex = 0; modeIndex < FC.AUX_CONFIG.length; modeIndex++) {
 
-            var modeId = AUX_CONFIG_IDS[modeIndex];
+            var modeId = FC.AUX_CONFIG_IDS[modeIndex];
 
             // scan mode ranges to find assignments
-            for (var modeRangeIndex = 0; modeRangeIndex < MODE_RANGES.length; modeRangeIndex++) {
-                var modeRange = MODE_RANGES[modeRangeIndex];
+            for (var modeRangeIndex = 0; modeRangeIndex < FC.MODE_RANGES.length; modeRangeIndex++) {
+                var modeRange = FC.MODE_RANGES[modeRangeIndex];
 
                 if (modeRange.id != modeId) {
                     continue;
@@ -115,7 +115,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 }
                 
                 // Search for the real name if it belongs to a peripheral
-                var modeName = AUX_CONFIG[modeIndex];                
+                var modeName = FC.AUX_CONFIG[modeIndex];                
                 modeName = adjustBoxNameIfPeripheralWithModeID(modeId, modeName);
 
                 auxAssignment[modeRange.auxChannelIndex] += "<span class=\"modename\">" + modeName + "</span>";                
@@ -133,9 +133,9 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             aux_index = 1,
             aux_assignment_index = 0;
 
-        for (i = 0; i < RXFAIL_CONFIG.length; i++) {
+        for (i = 0; i < FC.RXFAIL_CONFIG.length; i++) {
             if (i < channelNames.length) {
-                if (semver.lt(CONFIG.apiVersion, "1.41.0")) {
+                if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
                     fullChannels_e.append('\
                         <div class="number">\
                             <div class="channelprimary">\
@@ -202,7 +202,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         channelMode.change(function () {
             var currentMode = parseInt($(this).val());
             var i = parseInt($(this).prop("id"));
-            RXFAIL_CONFIG[i].mode = currentMode;
+            FC.RXFAIL_CONFIG[i].mode = currentMode;
             if (currentMode == 2) {
                 channel_value_array[i].prop("disabled", false);
                 channel_value_array[i].show();
@@ -215,7 +215,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         // UI hooks
         channelValue.change(function () {
             var i = parseInt($(this).prop("id"));
-            RXFAIL_CONFIG[i].value = parseInt($(this).val());
+            FC.RXFAIL_CONFIG[i].value = parseInt($(this).val());
         });
 
         // for some odd reason chrome 38+ changes scroll according to the touched select element
@@ -224,19 +224,19 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
 
         // fill stage 1 Valid Pulse Range Settings
-        $('input[name="rx_min_usec"]').val(RX_CONFIG.rx_min_usec);
-        $('input[name="rx_max_usec"]').val(RX_CONFIG.rx_max_usec);
+        $('input[name="rx_min_usec"]').val(FC.RX_CONFIG.rx_min_usec);
+        $('input[name="rx_max_usec"]').val(FC.RX_CONFIG.rx_max_usec);
 
         // fill fallback settings (mode and value) for all channels
-        for (i = 0; i < RXFAIL_CONFIG.length; i++) {
-            channel_value_array[i].val(RXFAIL_CONFIG[i].value);
-            channel_mode_array[i].val(RXFAIL_CONFIG[i].mode);
+        for (i = 0; i < FC.RXFAIL_CONFIG.length; i++) {
+            channel_value_array[i].val(FC.RXFAIL_CONFIG[i].value);
+            channel_mode_array[i].val(FC.RXFAIL_CONFIG[i].mode);
             channel_mode_array[i].change();
         }
 
-        FEATURE_CONFIG.features.generateElements($('.tab-failsafe .featuresNew'));
+        FC.FEATURE_CONFIG.features.generateElements($('.tab-failsafe .featuresNew'));
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
           $('tbody.rxFailsafe').hide();
           toggleStage2(true);
         } else {
@@ -244,13 +244,13 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
           failsafeFeature.change(function () {
               toggleStage2($(this).is(':checked'));
           });
-          toggleStage2(FEATURE_CONFIG.features.isEnabled('FAILSAFE'));
+          toggleStage2(FC.FEATURE_CONFIG.features.isEnabled('FAILSAFE'));
         }
 
-        $('input[name="failsafe_throttle"]').val(FAILSAFE_CONFIG.failsafe_throttle);
-        $('input[name="failsafe_off_delay"]').val(FAILSAFE_CONFIG.failsafe_off_delay);
-        $('input[name="failsafe_throttle_low_delay"]').val(FAILSAFE_CONFIG.failsafe_throttle_low_delay);
-        $('input[name="failsafe_delay"]').val(FAILSAFE_CONFIG.failsafe_delay);
+        $('input[name="failsafe_throttle"]').val(FC.FAILSAFE_CONFIG.failsafe_throttle);
+        $('input[name="failsafe_off_delay"]').val(FC.FAILSAFE_CONFIG.failsafe_off_delay);
+        $('input[name="failsafe_throttle_low_delay"]').val(FC.FAILSAFE_CONFIG.failsafe_throttle_low_delay);
+        $('input[name="failsafe_delay"]').val(FC.FAILSAFE_CONFIG.failsafe_delay);
 
         // set stage 2 failsafe procedure
         $('input[type="radio"].procedure').change(function () {
@@ -264,7 +264,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             element.parent().parent().find(':input').attr('disabled',false);
         });
 
-        switch(FAILSAFE_CONFIG.failsafe_procedure) {
+        switch(FC.FAILSAFE_CONFIG.failsafe_procedure) {
             default:
             case 0:
                 element = $('input[id="land"]') ;
@@ -283,37 +283,37 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 break;
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
             // `failsafe_kill_switch` has been renamed to `failsafe_switch_mode`.
             // It is backwards compatible with `failsafe_kill_switch`
-            $('select[name="failsafe_switch_mode"]').val(FAILSAFE_CONFIG.failsafe_switch_mode);
+            $('select[name="failsafe_switch_mode"]').val(FC.FAILSAFE_CONFIG.failsafe_switch_mode);
             $('div.kill_switch').hide();
         }
         else {
-            $('input[name="failsafe_kill_switch"]').prop('checked', FAILSAFE_CONFIG.failsafe_switch_mode);
+            $('input[name="failsafe_kill_switch"]').prop('checked', FC.FAILSAFE_CONFIG.failsafe_switch_mode);
             $('div.failsafe_switch').hide();
         }
 
         // The GPS Rescue tab is only available for 1.40 or later, and the parameters for 1.41
-        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
 
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                 // Load GPS Rescue parameters
-                $('input[name="gps_rescue_angle"]').val(GPS_RESCUE.angle);
-                $('input[name="gps_rescue_initial_altitude"]').val(GPS_RESCUE.initialAltitudeM);
-                $('input[name="gps_rescue_descent_distance"]').val(GPS_RESCUE.descentDistanceM);
-                $('input[name="gps_rescue_ground_speed"]').val((GPS_RESCUE.rescueGroundspeed / 100).toFixed(2));
-                $('input[name="gps_rescue_throttle_min"]').val(GPS_RESCUE.throttleMin);
-                $('input[name="gps_rescue_throttle_max"]').val(GPS_RESCUE.throttleMax);
-                $('input[name="gps_rescue_throttle_hover"]').val(GPS_RESCUE.throttleHover);
-                $('input[name="gps_rescue_min_sats"]').val(GPS_RESCUE.minSats);
-                $('select[name="gps_rescue_sanity_checks"]').val(GPS_RESCUE.sanityChecks);
+                $('input[name="gps_rescue_angle"]').val(FC.GPS_RESCUE.angle);
+                $('input[name="gps_rescue_initial_altitude"]').val(FC.GPS_RESCUE.initialAltitudeM);
+                $('input[name="gps_rescue_descent_distance"]').val(FC.GPS_RESCUE.descentDistanceM);
+                $('input[name="gps_rescue_ground_speed"]').val((FC.GPS_RESCUE.rescueGroundspeed / 100).toFixed(2));
+                $('input[name="gps_rescue_throttle_min"]').val(FC.GPS_RESCUE.throttleMin);
+                $('input[name="gps_rescue_throttle_max"]').val(FC.GPS_RESCUE.throttleMax);
+                $('input[name="gps_rescue_throttle_hover"]').val(FC.GPS_RESCUE.throttleHover);
+                $('input[name="gps_rescue_min_sats"]').val(FC.GPS_RESCUE.minSats);
+                $('select[name="gps_rescue_sanity_checks"]').val(FC.GPS_RESCUE.sanityChecks);
 
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                    $('input[name="gps_rescue_ascend_rate"]').val((GPS_RESCUE.ascendRate / 100).toFixed(2));
-                    $('input[name="gps_rescue_descend_rate"]').val((GPS_RESCUE.descendRate / 100).toFixed(2));
-                    $('input[name="gps_rescue_allow_arming_without_fix"]').prop('checked', GPS_RESCUE.allowArmingWithoutFix > 0);
-                    $('select[name="gps_rescue_altitude_mode"]').val(GPS_RESCUE.altitudeMode);
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                    $('input[name="gps_rescue_ascend_rate"]').val((FC.GPS_RESCUE.ascendRate / 100).toFixed(2));
+                    $('input[name="gps_rescue_descend_rate"]').val((FC.GPS_RESCUE.descendRate / 100).toFixed(2));
+                    $('input[name="gps_rescue_allow_arming_without_fix"]').prop('checked', FC.GPS_RESCUE.allowArmingWithoutFix > 0);
+                    $('select[name="gps_rescue_altitude_mode"]').val(FC.GPS_RESCUE.altitudeMode);
                 } else {
                     $('input[name="gps_rescue_ascend_rate"]').closest('.number').hide();
                     $('input[name="gps_rescue_descend_rate"]').closest('.number').hide();
@@ -337,49 +337,49 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         $('a.save').click(function () {
             // gather data that doesn't have automatic change event bound
 
-            FEATURE_CONFIG.features.updateData($('input[name="FAILSAFE"]'));
+            FC.FEATURE_CONFIG.features.updateData($('input[name="FAILSAFE"]'));
 
-            RX_CONFIG.rx_min_usec = parseInt($('input[name="rx_min_usec"]').val());
-            RX_CONFIG.rx_max_usec = parseInt($('input[name="rx_max_usec"]').val());
+            FC.RX_CONFIG.rx_min_usec = parseInt($('input[name="rx_min_usec"]').val());
+            FC.RX_CONFIG.rx_max_usec = parseInt($('input[name="rx_max_usec"]').val());
 
-            FAILSAFE_CONFIG.failsafe_throttle = parseInt($('input[name="failsafe_throttle"]').val());
-            FAILSAFE_CONFIG.failsafe_off_delay = parseInt($('input[name="failsafe_off_delay"]').val());
-            FAILSAFE_CONFIG.failsafe_throttle_low_delay = parseInt($('input[name="failsafe_throttle_low_delay"]').val());
-            FAILSAFE_CONFIG.failsafe_delay = parseInt($('input[name="failsafe_delay"]').val());
+            FC.FAILSAFE_CONFIG.failsafe_throttle = parseInt($('input[name="failsafe_throttle"]').val());
+            FC.FAILSAFE_CONFIG.failsafe_off_delay = parseInt($('input[name="failsafe_off_delay"]').val());
+            FC.FAILSAFE_CONFIG.failsafe_throttle_low_delay = parseInt($('input[name="failsafe_throttle_low_delay"]').val());
+            FC.FAILSAFE_CONFIG.failsafe_delay = parseInt($('input[name="failsafe_delay"]').val());
 
             if( $('input[id="land"]').is(':checked')) {
-                FAILSAFE_CONFIG.failsafe_procedure = 0;
+                FC.FAILSAFE_CONFIG.failsafe_procedure = 0;
             } else if( $('input[id="drop"]').is(':checked')) {
-                FAILSAFE_CONFIG.failsafe_procedure = 1;
+                FC.FAILSAFE_CONFIG.failsafe_procedure = 1;
             } else if( $('input[id="gps_rescue"]').is(':checked')) {
-                FAILSAFE_CONFIG.failsafe_procedure = 2;
+                FC.FAILSAFE_CONFIG.failsafe_procedure = 2;
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-                FAILSAFE_CONFIG.failsafe_switch_mode = $('select[name="failsafe_switch_mode"]').val();
+            if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                FC.FAILSAFE_CONFIG.failsafe_switch_mode = $('select[name="failsafe_switch_mode"]').val();
             }
             else {
-                FAILSAFE_CONFIG.failsafe_switch_mode = $('input[name="failsafe_kill_switch"]').is(':checked') ? 1 : 0;
+                FC.FAILSAFE_CONFIG.failsafe_switch_mode = $('input[name="failsafe_kill_switch"]').is(':checked') ? 1 : 0;
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                 // Load GPS Rescue parameters
-                GPS_RESCUE.angle             = $('input[name="gps_rescue_angle"]').val();
-                GPS_RESCUE.initialAltitudeM  = $('input[name="gps_rescue_initial_altitude"]').val();
-                GPS_RESCUE.descentDistanceM  = $('input[name="gps_rescue_descent_distance"]').val();
-                GPS_RESCUE.rescueGroundspeed = $('input[name="gps_rescue_ground_speed"]').val() * 100;
-                GPS_RESCUE.throttleMin       = $('input[name="gps_rescue_throttle_min"]').val();
-                GPS_RESCUE.throttleMax       = $('input[name="gps_rescue_throttle_max"]').val();
-                GPS_RESCUE.throttleHover     = $('input[name="gps_rescue_throttle_hover"]').val();
-                GPS_RESCUE.minSats           = $('input[name="gps_rescue_min_sats"]').val();
-                GPS_RESCUE.sanityChecks      = $('select[name="gps_rescue_sanity_checks"]').val();
+                FC.GPS_RESCUE.angle             = $('input[name="gps_rescue_angle"]').val();
+                FC.GPS_RESCUE.initialAltitudeM  = $('input[name="gps_rescue_initial_altitude"]').val();
+                FC.GPS_RESCUE.descentDistanceM  = $('input[name="gps_rescue_descent_distance"]').val();
+                FC.GPS_RESCUE.rescueGroundspeed = $('input[name="gps_rescue_ground_speed"]').val() * 100;
+                FC.GPS_RESCUE.throttleMin       = $('input[name="gps_rescue_throttle_min"]').val();
+                FC.GPS_RESCUE.throttleMax       = $('input[name="gps_rescue_throttle_max"]').val();
+                FC.GPS_RESCUE.throttleHover     = $('input[name="gps_rescue_throttle_hover"]').val();
+                FC.GPS_RESCUE.minSats           = $('input[name="gps_rescue_min_sats"]').val();
+                FC.GPS_RESCUE.sanityChecks      = $('select[name="gps_rescue_sanity_checks"]').val();
             }
 
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-                GPS_RESCUE.ascendRate = $('input[name="gps_rescue_ascend_rate"]').val() * 100;
-                GPS_RESCUE.descendRate = $('input[name="gps_rescue_descend_rate"]').val() * 100;
-                GPS_RESCUE.allowArmingWithoutFix = $('input[name="gps_rescue_allow_arming_without_fix"]').prop('checked') ? 1 : 0;
-                GPS_RESCUE.altitudeMode = parseInt($('select[name="gps_rescue_altitude_mode"]').val());
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+                FC.GPS_RESCUE.ascendRate = $('input[name="gps_rescue_ascend_rate"]').val() * 100;
+                FC.GPS_RESCUE.descendRate = $('input[name="gps_rescue_descend_rate"]').val() * 100;
+                FC.GPS_RESCUE.allowArmingWithoutFix = $('input[name="gps_rescue_allow_arming_without_fix"]').prop('checked') ? 1 : 0;
+                FC.GPS_RESCUE.altitudeMode = parseInt($('select[name="gps_rescue_altitude_mode"]').val());
             }
 
             function save_failssafe_config() {
@@ -392,7 +392,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
 
             function save_feature_config() {
                 MSP.send_message(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG), false, 
-                        semver.gte(CONFIG.apiVersion, "1.41.0") ? save_gps_rescue : save_to_eeprom);
+                        semver.gte(FC.CONFIG.apiVersion, "1.41.0") ? save_gps_rescue : save_to_eeprom);
             }
 
             function save_gps_rescue() {

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -46,31 +46,31 @@ TABS.gps.initialize = function (callback) {
         var gpsWasFixed = false;
 
         function update_ui() {
-            var lat = GPS_DATA.lat / 10000000;
-            var lon = GPS_DATA.lon / 10000000;
+            var lat = FC.GPS_DATA.lat / 10000000;
+            var lon = FC.GPS_DATA.lon / 10000000;
             var url = 'https://maps.google.com/?q=' + lat + ',' + lon;
-            var alt = GPS_DATA.alt;
-            if (semver.lt(CONFIG.apiVersion, "1.39.0")) {
+            var alt = FC.GPS_DATA.alt;
+            if (semver.lt(FC.CONFIG.apiVersion, "1.39.0")) {
                 alt = alt / 10;
             }
 
-            $('.GPS_info td.fix').html((GPS_DATA.fix) ? i18n.getMessage('gpsFixTrue') : i18n.getMessage('gpsFixFalse'));
+            $('.GPS_info td.fix').html((FC.GPS_DATA.fix) ? i18n.getMessage('gpsFixTrue') : i18n.getMessage('gpsFixFalse'));
             $('.GPS_info td.alt').text(alt + ' m');
             $('.GPS_info td.lat a').prop('href', url).text(lat.toFixed(4) + ' deg');
             $('.GPS_info td.lon a').prop('href', url).text(lon.toFixed(4) + ' deg');
-            $('.GPS_info td.speed').text(GPS_DATA.speed + ' cm/s');
-            $('.GPS_info td.sats').text(GPS_DATA.numSat);
-            $('.GPS_info td.distToHome').text(GPS_DATA.distanceToHome + ' m');
+            $('.GPS_info td.speed').text(FC.GPS_DATA.speed + ' cm/s');
+            $('.GPS_info td.sats').text(FC.GPS_DATA.numSat);
+            $('.GPS_info td.distToHome').text(FC.GPS_DATA.distanceToHome + ' m');
 
             // Update GPS Signal Strengths
             var e_ss_table = $('div.GPS_signal_strength table tr:not(.titles)');
 
-            for (var i = 0; i < GPS_DATA.chn.length; i++) {
+            for (var i = 0; i < FC.GPS_DATA.chn.length; i++) {
                 var row = e_ss_table.eq(i);
 
-                $('td', row).eq(0).text(GPS_DATA.svid[i]);
-                $('td', row).eq(1).text(GPS_DATA.quality[i]);
-                $('td', row).eq(2).find('progress').val(GPS_DATA.cno[i]);
+                $('td', row).eq(0).text(FC.GPS_DATA.svid[i]);
+                $('td', row).eq(1).text(FC.GPS_DATA.quality[i]);
+                $('td', row).eq(2).find('progress').val(FC.GPS_DATA.cno[i]);
             }
             
 
@@ -84,7 +84,7 @@ TABS.gps.initialize = function (callback) {
             if (navigator.onLine) {
                 $('#connect').hide();
 
-                if (GPS_DATA.fix) {
+                if (FC.GPS_DATA.fix) {
                    gpsWasFixed = true;
                    frame.contentWindow.postMessage(message, '*');
                    $('#loadmap').show();
@@ -107,7 +107,7 @@ TABS.gps.initialize = function (callback) {
         // enable data pulling
         GUI.interval_add('gps_pull', function gps_update() {
             // avoid usage of the GPS commands until a GPS sensor is detected for targets that are compiled without GPS support.
-            if (!have_sensor(CONFIG.activeSensors, 'gps')) {
+            if (!have_sensor(FC.CONFIG.activeSensors, 'gps')) {
                 //return;
             }
             

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -11,14 +11,14 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     var selectedColorIndex = null;
     var selectedModeColor = null;
 
-    if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
         TABS.led_strip.functions = ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b'];
         TABS.led_strip.baseFuncs = ['c', 'f', 'a', 'b', 'g', 'r'];
         TABS.led_strip.overlays = ['t', 's', 'i', 'w'];
     } else {
         TABS.led_strip.functions = ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l', 'o', 'n'];
         TABS.led_strip.baseFuncs = ['c', 'f', 'a', 'l', 's', 'g', 'r'];
-        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
             TABS.led_strip.overlays =  ['t', 'o', 'b', 'n', 'i', 'w'];
         } else {
             TABS.led_strip.overlays =  ['t', 'o', 'b', 'v', 'i', 'w'];
@@ -40,7 +40,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function load_led_mode_colors() {
-        if (semver.gte(CONFIG.apiVersion, "1.19.0"))
+        if (semver.gte(FC.CONFIG.apiVersion, "1.19.0"))
             MSP.send_message(MSPCodes.MSP_LED_STRIP_MODECOLOR, false, false, load_html);
         else
             load_html();
@@ -73,9 +73,9 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         var theHTML = [];
         var theHTMLlength = 0;
         for (var i = 0; i < 256; i++) {
-            if (semver.lte(CONFIG.apiVersion, "1.19.0")) {
+            if (semver.lte(FC.CONFIG.apiVersion, "1.19.0")) {
                 theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-s"> </span><span class="overlay-w"> </span><span class="overlay-i"> </span><span class="overlay-color"> </span></div>');
-            } else if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+            } else if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
                 theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-o"> </span><span class="overlay-b"> </span><span class="overlay-n"> </span><span class="overlay-i"> </span><span class="overlay-w"> </span><span class="overlay-color"> </span></div>');
             } else {
                 theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-o"> </span><span class="overlay-b"> </span><span class="overlay-v"> </span><span class="overlay-i"> </span><span class="overlay-w"> </span><span class="overlay-color"> </span></div>');
@@ -88,7 +88,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         });
 
         // Aux channel drop-down
-        if (semver.lte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.lte(FC.CONFIG.apiVersion, "1.20.0")) {
             $('.auxSelect').hide();
             $('.labelSelect').show();
         } else {
@@ -105,7 +105,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             });
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
             $('.vtxOverlay').hide();
             $('.landingBlinkOverlay').show();
         }
@@ -178,7 +178,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         // Mode Color Buttons
         $('.mode_colors').on('click', 'button', function() {
             var that = this;
-            LED_MODE_COLORS.forEach(function(mc) {
+            FC.LED_MODE_COLORS.forEach(function(mc) {
                 if ($(that).is('.mode_color-' + mc.mode + '-' + mc.direction)) {
                     if ($(that).is('.btnOn')) {
                         $(that).removeClass('btnOn');
@@ -320,7 +320,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
                     }
 
                     if (TABS.led_strip.wireMode) {
-                        if ($(this).find('.wire').html() == '' && nextWireNumber < LED_STRIP.length) {
+                        if ($(this).find('.wire').html() == '' && nextWireNumber < FC.LED_STRIP.length) {
                             $(this).find('.wire').html(nextWireNumber);
                         }
                     }
@@ -571,7 +571,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             }
 
             function send_led_strip_mode_colors() {
-                if (semver.gte(CONFIG.apiVersion, "1.19.0"))
+                if (semver.gte(FC.CONFIG.apiVersion, "1.19.0"))
                     mspHelper.sendLedStripModeColors(save_to_eeprom);
                 else
                     save_to_eeprom();
@@ -608,8 +608,8 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
 
     function findLed(x, y) {
-        for (var ledIndex = 0; ledIndex < LED_STRIP.length; ledIndex++) {
-            var led = LED_STRIP[ledIndex];
+        for (var ledIndex = 0; ledIndex < FC.LED_STRIP.length; ledIndex++) {
+            var led = FC.LED_STRIP[ledIndex];
             if (led.x == x && led.y == y) {
                 return { index: ledIndex, led: led };
             }
@@ -619,9 +619,9 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
 
     function updateBulkCmd() {
-        var ledStripLength = LED_STRIP.length;
+        var ledStripLength = FC.LED_STRIP.length;
 
-        LED_STRIP = [];
+        FC.LED_STRIP = [];
 
         $('.gPoint').each(function(){
             if ($(this).is('[class*="function"]')) {
@@ -667,7 +667,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
                         color: colorIndex
                     }
 
-                    LED_STRIP[wireNumber] = led;
+                    FC.LED_STRIP[wireNumber] = led;
                 }
             }
         });
@@ -680,22 +680,22 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         };
 
         for (var i = 0; i < ledStripLength; i++) {
-            if (LED_STRIP[i]) {
+            if (FC.LED_STRIP[i]) {
                 continue;
             }
-            LED_STRIP[i] = defaultLed;
+            FC.LED_STRIP[i] = defaultLed;
         }
 
         var usedWireNumbers = buildUsedWireNumbers();
 
-        var remaining = LED_STRIP.length - usedWireNumbers.length;
+        var remaining = FC.LED_STRIP.length - usedWireNumbers.length;
 
         $('.wires-remaining div').html(remaining);
     }
 
     // refresh mode color buttons
     function setModeBackgroundColor(element) {
-        if (semver.gte(CONFIG.apiVersion, "1.19.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.19.0")) {
             element.find('[class*="mode_color"]').each(function() {
                 var m = 0;
                 var d = 0;
@@ -704,7 +704,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
                 if (match) {
                     m = Number(match[2]);
                     d = Number(match[3]);
-                    $(this).css('background-color', HsvToColor(LED_COLORS[getModeColor(m, d)]));
+                    $(this).css('background-color', HsvToColor(FC.LED_COLORS[getModeColor(m, d)]));
                 }
             });
         }
@@ -717,7 +717,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             var match = element.attr("class").match(/(^|\s)color-([0-9]+)(\s|$)/);
             if (match) {
                 colorIndex = match[2];
-                element.css('background-color', HsvToColor(LED_COLORS[colorIndex]));
+                element.css('background-color', HsvToColor(FC.LED_COLORS[colorIndex]));
             }
         }
     }
@@ -734,7 +734,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function areOverlaysActive(activeFunction) {
-        if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
             switch (activeFunction) {
                 case "function-c":
                 case "function-a":
@@ -762,7 +762,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function areBlinkersActive(activeFunction) {
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             switch (activeFunction) {
                 case "function-c":
                 case "function-a":
@@ -783,7 +783,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
                 break;
             case "function-r":
             case "function-b":
-                if (semver.lt(CONFIG.apiVersion, "1.20.0"))
+                if (semver.lt(FC.CONFIG.apiVersion, "1.20.0"))
                     return false;
             break;
             default:
@@ -793,7 +793,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function isVtxActive(activeFunction) {
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
             switch (activeFunction) {
                 case "function-v":
                 case "function-c":
@@ -814,7 +814,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         $('select.functionSelect').addClass(activeFunction);
 
 
-        if (semver.lte(CONFIG.apiVersion, "1.18.0")) {
+        if (semver.lte(FC.CONFIG.apiVersion, "1.18.0")) {
             // <= 18
             // Hide GPS (Func)
             // Hide RSSI (O/L), Blink (Func)
@@ -856,7 +856,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
 
 
         // set directions visibility
-        if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
             switch (activeFunction) {
                 case "function-r":
                     $('.indicatorOverlay').hide();
@@ -870,10 +870,10 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         }
 
         $('.mode_colors').hide();
-        if (semver.gte(CONFIG.apiVersion, "1.19.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.19.0")) {
             // set mode colors visibility
 
-            if (semver.gte(CONFIG.apiVersion, "1.20.0"))
+            if (semver.gte(FC.CONFIG.apiVersion, "1.20.0"))
                 if (activeFunction == "function-f")
                     $('.mode_colors').show();
 
@@ -944,7 +944,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function unselectOverlays(letter) {
-        if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
             if (letter == 'b' || letter == 'r') {
                 unselectOverlay(letter, 'i');
             }
@@ -992,23 +992,23 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         if ($(className).hasClass('btnOn')) {
             switch (hsvIndex) {
                 case 0:
-                    if (LED_COLORS[selectedColorIndex].h != value) {
-                        LED_COLORS[selectedColorIndex].h = value;
-                        $('.colorDefineSliderValue.Hvalue').text(LED_COLORS[selectedColorIndex].h);
+                    if (FC.LED_COLORS[selectedColorIndex].h != value) {
+                        FC.LED_COLORS[selectedColorIndex].h = value;
+                        $('.colorDefineSliderValue.Hvalue').text(FC.LED_COLORS[selectedColorIndex].h);
                         change = true
                     }
                     break;
                 case 1:
-                    if (LED_COLORS[selectedColorIndex].s != value) {
-                        LED_COLORS[selectedColorIndex].s = value;
-                        $('.colorDefineSliderValue.Svalue').text(LED_COLORS[selectedColorIndex].s);
+                    if (FC.LED_COLORS[selectedColorIndex].s != value) {
+                        FC.LED_COLORS[selectedColorIndex].s = value;
+                        $('.colorDefineSliderValue.Svalue').text(FC.LED_COLORS[selectedColorIndex].s);
                         change = true
                     }
                     break;
                 case 2:
-                    if (LED_COLORS[selectedColorIndex].v != value) {
-                        LED_COLORS[selectedColorIndex].v = value;
-                        $('.colorDefineSliderValue.Vvalue').text(LED_COLORS[selectedColorIndex].v);
+                    if (FC.LED_COLORS[selectedColorIndex].v != value) {
+                        FC.LED_COLORS[selectedColorIndex].v = value;
+                        $('.colorDefineSliderValue.Vvalue').text(FC.LED_COLORS[selectedColorIndex].v);
                         change = true
                     }
                     break;
@@ -1036,7 +1036,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
                     var className = 'color-' + colorIndex;
                     if ($(this).is('.' + className)) {
                         $(this).find('.overlay-color').addClass(className);
-                        $(this).find('.overlay-color').css('background-color', HsvToColor(LED_COLORS[colorIndex]))
+                        $(this).find('.overlay-color').css('background-color', HsvToColor(FC.LED_COLORS[colorIndex]))
                     } else {
                         if ($(this).find('.overlay-color').is('.' + className))
                             $(this).find('.overlay-color').removeClass(className);
@@ -1053,24 +1053,24 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         var sliders = $('div.colorDefineSliders input');
         var change = false;
 
-        if (!LED_COLORS[colorIndex])
+        if (!FC.LED_COLORS[colorIndex])
             return;
 
-        if (LED_COLORS[colorIndex].h != Number(sliders.eq(0).val())) {
-            sliders.eq(0).val(LED_COLORS[colorIndex].h);
-            $('.colorDefineSliderValue.Hvalue').text(LED_COLORS[colorIndex].h);
+        if (FC.LED_COLORS[colorIndex].h != Number(sliders.eq(0).val())) {
+            sliders.eq(0).val(FC.LED_COLORS[colorIndex].h);
+            $('.colorDefineSliderValue.Hvalue').text(FC.LED_COLORS[colorIndex].h);
             change = true;
         }
 
-        if (LED_COLORS[colorIndex].s != Number(sliders.eq(1).val())) {
-            sliders.eq(1).val(LED_COLORS[colorIndex].s);
-            $('.colorDefineSliderValue.Svalue').text(LED_COLORS[colorIndex].s);
+        if (FC.LED_COLORS[colorIndex].s != Number(sliders.eq(1).val())) {
+            sliders.eq(1).val(FC.LED_COLORS[colorIndex].s);
+            $('.colorDefineSliderValue.Svalue').text(FC.LED_COLORS[colorIndex].s);
             change = true;
         }
 
-        if (LED_COLORS[colorIndex].v != Number(sliders.eq(2).val())) {
-            sliders.eq(2).val(LED_COLORS[colorIndex].v);
-            $('.colorDefineSliderValue.Vvalue').text(LED_COLORS[colorIndex].v);
+        if (FC.LED_COLORS[colorIndex].v != Number(sliders.eq(2).val())) {
+            sliders.eq(2).val(FC.LED_COLORS[colorIndex].v);
+            $('.colorDefineSliderValue.Vvalue').text(FC.LED_COLORS[colorIndex].v);
             change = true;
         }
 
@@ -1101,8 +1101,8 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function getModeColor(mode, dir) {
-        for (var i = 0; i < LED_MODE_COLORS.length; i++) {
-            var mc = LED_MODE_COLORS[i];
+        for (var i = 0; i < FC.LED_MODE_COLORS.length; i++) {
+            var mc = FC.LED_MODE_COLORS[i];
             if (mc.mode == mode && mc.direction == dir)
                 return mc.color;
         }
@@ -1110,8 +1110,8 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function setModeColor(mode, dir, color) {
-        for (var i = 0; i < LED_MODE_COLORS.length; i++) {
-            var mc = LED_MODE_COLORS[i];
+        for (var i = 0; i < FC.LED_MODE_COLORS.length; i++) {
+            var mc = FC.LED_MODE_COLORS[i];
             if (mc.mode == mode && mc.direction == dir) {
                 mc.color = color;
                 return 1;

--- a/src/js/tabs/logging.js
+++ b/src/js/tabs/logging.js
@@ -154,17 +154,17 @@ TABS.logging.initialize = function (callback) {
                     head += ',' + 'rssi';
                     break;
                 case 'MSP_RC':
-                    for (var chan = 0; chan < RC.active_channels; chan++) {
+                    for (var chan = 0; chan < FC.RC.active_channels; chan++) {
                         head += ',' + 'RC' + chan;
                     }
                     break;
                 case 'MSP_MOTOR':
-                    for (var motor = 0; motor < MOTOR_DATA.length; motor++) {
+                    for (var motor = 0; motor < FC.MOTOR_DATA.length; motor++) {
                         head += ',' + 'Motor' + motor;
                     }
                     break;
                 case 'MSP_DEBUG':
-                    for (var debug = 0; debug < SENSOR_DATA.debug.length; debug++) {
+                    for (var debug = 0; debug < FC.SENSOR_DATA.debug.length; debug++) {
                         head += ',' + 'Debug' + debug;
                     }
                     break;
@@ -180,43 +180,43 @@ TABS.logging.initialize = function (callback) {
         for (var i = 0; i < requested_properties.length; i++) {
             switch (requested_properties[i]) {
                 case 'MSP_RAW_IMU':
-                    sample += ',' + SENSOR_DATA.gyroscope;
-                    sample += ',' + SENSOR_DATA.accelerometer;
-                    sample += ',' + SENSOR_DATA.magnetometer;
+                    sample += ',' + FC.SENSOR_DATA.gyroscope;
+                    sample += ',' + FC.SENSOR_DATA.accelerometer;
+                    sample += ',' + FC.SENSOR_DATA.magnetometer;
                     break;
                 case 'MSP_ATTITUDE':
-                    sample += ',' + SENSOR_DATA.kinematics[0];
-                    sample += ',' + SENSOR_DATA.kinematics[1];
-                    sample += ',' + SENSOR_DATA.kinematics[2];
+                    sample += ',' + FC.SENSOR_DATA.kinematics[0];
+                    sample += ',' + FC.SENSOR_DATA.kinematics[1];
+                    sample += ',' + FC.SENSOR_DATA.kinematics[2];
                     break;
                 case 'MSP_ALTITUDE':
-                    sample += ',' + SENSOR_DATA.altitude;
+                    sample += ',' + FC.SENSOR_DATA.altitude;
                     break;
                 case 'MSP_RAW_GPS':
-                    sample += ',' + GPS_DATA.fix;
-                    sample += ',' + GPS_DATA.numSat;
-                    sample += ',' + (GPS_DATA.lat / 10000000);
-                    sample += ',' + (GPS_DATA.lon / 10000000);
-                    sample += ',' + GPS_DATA.alt;
-                    sample += ',' + GPS_DATA.speed;
-                    sample += ',' + GPS_DATA.ground_course;
+                    sample += ',' + FC.GPS_DATA.fix;
+                    sample += ',' + FC.GPS_DATA.numSat;
+                    sample += ',' + (FC.GPS_DATA.lat / 10000000);
+                    sample += ',' + (FC.GPS_DATA.lon / 10000000);
+                    sample += ',' + FC.GPS_DATA.alt;
+                    sample += ',' + FC.GPS_DATA.speed;
+                    sample += ',' + FC.GPS_DATA.ground_course;
                     break;
                 case 'MSP_ANALOG':
-                    sample += ',' + ANALOG.voltage;
-                    sample += ',' + ANALOG.amperage;
-                    sample += ',' + ANALOG.mAhdrawn;
-                    sample += ',' + ANALOG.rssi;
+                    sample += ',' + FC.ANALOG.voltage;
+                    sample += ',' + FC.ANALOG.amperage;
+                    sample += ',' + FC.ANALOG.mAhdrawn;
+                    sample += ',' + FC.ANALOG.rssi;
                     break;
                 case 'MSP_RC':
-                    for (var chan = 0; chan < RC.active_channels; chan++) {
-                        sample += ',' + RC.channels[chan];
+                    for (var chan = 0; chan < FC.RC.active_channels; chan++) {
+                        sample += ',' + FC.RC.channels[chan];
                     }
                     break;
                 case 'MSP_MOTOR':
-                    sample += ',' + MOTOR_DATA;
+                    sample += ',' + FC.MOTOR_DATA;
                     break;
                 case 'MSP_DEBUG':
-                    sample += ',' + SENSOR_DATA.debug;
+                    sample += ',' + FC.SENSOR_DATA.debug;
                     break;
             }
         }

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -65,7 +65,7 @@ TABS.motors.initialize = function (callback) {
     }
 
     function load_motor_telemetry_data() {
-        if (MOTOR_CONFIG.use_dshot_telemetry || MOTOR_CONFIG.use_esc_sensor) {
+        if (FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor) {
             MSP.send_message(MSPCodes.MSP_MOTOR_TELEMETRY, false, false, load_mixer_config);
         } else {
             load_mixer_config();
@@ -81,7 +81,7 @@ TABS.motors.initialize = function (callback) {
     }
 
     // Get information from Betaflight
-    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
         // BF 3.2.0+
         MSP.send_message(MSPCodes.MSP_MOTOR_CONFIG, false, false, get_arm_status);
     } else {
@@ -90,13 +90,13 @@ TABS.motors.initialize = function (callback) {
     }
 
     function update_arm_status() {
-        self.armed = bit_check(CONFIG.mode, 0);
+        self.armed = bit_check(FC.CONFIG.mode, 0);
     }
 
     function initSensorData() {
         for (var i = 0; i < 3; i++) {
-            SENSOR_DATA.accelerometer[i] = 0;
-            SENSOR_DATA.gyroscope[i] = 0;
+            FC.SENSOR_DATA.accelerometer[i] = 0;
+            FC.SENSOR_DATA.gyroscope[i] = 0;
         }
     }
 
@@ -217,8 +217,8 @@ TABS.motors.initialize = function (callback) {
     function update_model(mixer) {
         var reverse = "";
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-            reverse = MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            reverse = FC.MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
         }
 
         $('.mixerPreview img').attr('src', './resources/motor_order/' + mixerList[mixer - 1].image + reverse + '.svg');
@@ -230,9 +230,9 @@ TABS.motors.initialize = function (callback) {
 
         update_arm_status();
 
-        self.feature3DEnabled = FEATURE_CONFIG.features.isEnabled('3D');
+        self.feature3DEnabled = FC.FEATURE_CONFIG.features.isEnabled('3D');
 
-        if (PID_ADVANCED_CONFIG.fast_pwm_protocol >= TABS.configuration.DSHOT_PROTOCOL_MIN_VALUE) {
+        if (FC.PID_ADVANCED_CONFIG.fast_pwm_protocol >= TABS.configuration.DSHOT_PROTOCOL_MIN_VALUE) {
             self.escProtocolIsDshot = true;
         } else {
             self.escProtocolIsDshot = false;
@@ -240,16 +240,16 @@ TABS.motors.initialize = function (callback) {
 
         $('#motorsEnableTestMode').prop('checked', false);
 
-        if (semver.lt(CONFIG.apiVersion, "1.42.0") || !(MOTOR_CONFIG.use_dshot_telemetry || MOTOR_CONFIG.use_esc_sensor)) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.42.0") || !(FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor)) {
             $(".motor_testing .telemetry").hide();
         } else {
             // Hide telemetry from unused motors (to hide the tooltip in an empty blank space)
-            for (let i = MOTOR_CONFIG.motor_count; i < MOTOR_DATA.length; i++) {
+            for (let i = FC.MOTOR_CONFIG.motor_count; i < FC.MOTOR_DATA.length; i++) {
                 $(".motor_testing .telemetry .motor-" + i).hide();
             }
         }
 
-        update_model(MIXER_CONFIG.mixer);
+        update_model(FC.MIXER_CONFIG.mixer);
 
         // Always start with default/empty sensor data array, clean slate all
         initSensorData();
@@ -360,16 +360,16 @@ TABS.motors.initialize = function (callback) {
             function update_accel_graph() {
                 if (!accel_offset_established) {
                     for (var i = 0; i < 3; i++) {
-                        accel_offset[i] = SENSOR_DATA.accelerometer[i] * -1;
+                        accel_offset[i] = FC.SENSOR_DATA.accelerometer[i] * -1;
                     }
 
                     accel_offset_established = true;
                 }
 
                 var accel_with_offset = [
-                    accel_offset[0] + SENSOR_DATA.accelerometer[0],
-                    accel_offset[1] + SENSOR_DATA.accelerometer[1],
-                    accel_offset[2] + SENSOR_DATA.accelerometer[2]
+                    accel_offset[0] + FC.SENSOR_DATA.accelerometer[0],
+                    accel_offset[1] + FC.SENSOR_DATA.accelerometer[1],
+                    accel_offset[2] + FC.SENSOR_DATA.accelerometer[2]
                     ];
 
                 updateGraphHelperSize(accel_helpers);
@@ -384,9 +384,9 @@ TABS.motors.initialize = function (callback) {
 
             function update_gyro_graph() {
                 var gyro = [
-                    SENSOR_DATA.gyroscope[0],
-                    SENSOR_DATA.gyroscope[1],
-                    SENSOR_DATA.gyroscope[2]
+                    FC.SENSOR_DATA.gyroscope[0],
+                    FC.SENSOR_DATA.gyroscope[1],
+                    FC.SENSOR_DATA.gyroscope[2]
                     ];
 
                 updateGraphHelperSize(gyro_helpers);
@@ -437,9 +437,9 @@ TABS.motors.initialize = function (callback) {
 
         // Amperage
         function power_data_pull() {
-            motor_voltage_e.text(i18n.getMessage('motorsVoltageValue', [ANALOG.voltage]));
-            motor_mah_drawing_e.text(i18n.getMessage('motorsADrawingValue', [ANALOG.amperage.toFixed(2)]));
-            motor_mah_drawn_e.text(i18n.getMessage('motorsmAhDrawnValue', [ANALOG.mAhdrawn]));
+            motor_voltage_e.text(i18n.getMessage('motorsVoltageValue', [FC.ANALOG.voltage]));
+            motor_mah_drawing_e.text(i18n.getMessage('motorsADrawingValue', [FC.ANALOG.amperage.toFixed(2)]));
+            motor_mah_drawn_e.text(i18n.getMessage('motorsmAhDrawnValue', [FC.ANALOG.mAhdrawn]));
             
         }
         GUI.interval_add('motors_power_data_pull_slow', power_data_pull, 250, true); // 4 fps
@@ -450,7 +450,7 @@ TABS.motors.initialize = function (callback) {
             accel_offset_established = false;
         });
 
-        var number_of_valid_outputs = (MOTOR_DATA.indexOf(0) > -1) ? MOTOR_DATA.indexOf(0) : 8;
+        var number_of_valid_outputs = (FC.MOTOR_DATA.indexOf(0) > -1) ? FC.MOTOR_DATA.indexOf(0) : 8;
         var rangeMin;
         var rangeMax;
         var neutral3d;
@@ -459,11 +459,11 @@ TABS.motors.initialize = function (callback) {
             rangeMax = self.DSHOT_MAX_VALUE;
             neutral3d = self.DSHOT_3D_NEUTRAL;
         } else {
-            rangeMin = MOTOR_CONFIG.mincommand;
-            rangeMax = MOTOR_CONFIG.maxthrottle;
+            rangeMin = FC.MOTOR_CONFIG.mincommand;
+            rangeMax = FC.MOTOR_CONFIG.maxthrottle;
             //Arbitrary sanity checks
             //Note: values may need to be revisited
-            neutral3d = (MOTOR_3D_CONFIG.neutral > 1575 || MOTOR_3D_CONFIG.neutral < 1425) ? 1500 : MOTOR_3D_CONFIG.neutral;
+            neutral3d = (FC.MOTOR_3D_CONFIG.neutral > 1575 || FC.MOTOR_3D_CONFIG.neutral < 1425) ? 1500 : FC.MOTOR_3D_CONFIG.neutral;
         }
 
         var motors_wrapper = $('.motors .bar-wrapper'),
@@ -579,11 +579,11 @@ TABS.motors.initialize = function (callback) {
 
         for (var i = 0; i < number_of_valid_outputs; i++) {
             if (!self.feature3DEnabled) {
-                if (MOTOR_DATA[i] > rangeMin) {
+                if (FC.MOTOR_DATA[i] > rangeMin) {
                     motors_running = true;
                 }
             } else {
-                if ((MOTOR_DATA[i] < MOTOR_3D_CONFIG.deadband3d_low) || (MOTOR_DATA[i] > MOTOR_3D_CONFIG.deadband3d_high)) {
+                if ((FC.MOTOR_DATA[i] < FC.MOTOR_3D_CONFIG.deadband3d_low) || (FC.MOTOR_DATA[i] > FC.MOTOR_3D_CONFIG.deadband3d_high)) {
                     motors_running = true;
                 }
             }
@@ -596,12 +596,12 @@ TABS.motors.initialize = function (callback) {
 
             var sliders = $('div.sliders input:not(.master)');
 
-            var master_value = MOTOR_DATA[0];
-            for (var i = 0; i < MOTOR_DATA.length; i++) {
-                if (MOTOR_DATA[i] > 0) {
-                    sliders.eq(i).val(MOTOR_DATA[i]);
+            var master_value = FC.MOTOR_DATA[0];
+            for (var i = 0; i < FC.MOTOR_DATA.length; i++) {
+                if (FC.MOTOR_DATA[i] > 0) {
+                    sliders.eq(i).val(FC.MOTOR_DATA[i]);
 
-                    if (master_value != MOTOR_DATA[i]) {
+                    if (master_value != FC.MOTOR_DATA[i]) {
                         master_value = false;
                     }
                 }
@@ -629,7 +629,7 @@ TABS.motors.initialize = function (callback) {
         }
 
         function get_motor_telemetry_data() {
-            if (MOTOR_CONFIG.use_dshot_telemetry || MOTOR_CONFIG.use_esc_sensor) {
+            if (FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor) {
                 MSP.send_message(MSPCodes.MSP_MOTOR_TELEMETRY, false, false, get_servo_data);
             } else {
                 get_servo_data();
@@ -646,8 +646,8 @@ TABS.motors.initialize = function (callback) {
             var previousArmState = self.armed;
             var block_height = $('div.m-block:first').height();
 
-            for (var i = 0; i < MOTOR_DATA.length; i++) {
-                var motorValue = MOTOR_DATA[i];
+            for (var i = 0; i < FC.MOTOR_DATA.length; i++) {
+                var motorValue = FC.MOTOR_DATA[i];
                 var barHeight = motorValue - rangeMin,
                 margin_top = block_height - (barHeight * (block_height / full_block_scale)).clamp(0, block_height),
                 height = (barHeight * (block_height / full_block_scale)).clamp(0, block_height),
@@ -660,12 +660,12 @@ TABS.motors.initialize = function (callback) {
                     'background-color' : 'rgba(255,187,0,1.'+ color +')'
                 });
 
-                if (i < MOTOR_CONFIG.motor_count && (MOTOR_CONFIG.use_dshot_telemetry || MOTOR_CONFIG.use_esc_sensor)) {
+                if (i < FC.MOTOR_CONFIG.motor_count && (FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor)) {
 
                     const MAX_INVALID_PERCENT = 100,
                           MAX_VALUE_SIZE = 6;
 
-                    let rpmMotorValue = MOTOR_TELEMETRY_DATA.rpm[i];
+                    let rpmMotorValue = FC.MOTOR_TELEMETRY_DATA.rpm[i];
 
                     // Reduce the size of the value if too big
                     if (rpmMotorValue > 999999) {
@@ -676,9 +676,9 @@ TABS.motors.initialize = function (callback) {
                     let telemetryText = i18n.getMessage('motorsRPM', {motorsRpmValue: rpmMotorValue});
 
                     
-                    if (MOTOR_CONFIG.use_dshot_telemetry) {
+                    if (FC.MOTOR_CONFIG.use_dshot_telemetry) {
 
-                        let invalidPercent = MOTOR_TELEMETRY_DATA.invalidPercent[i];
+                        let invalidPercent = FC.MOTOR_TELEMETRY_DATA.invalidPercent[i];
 
                         let classError = (invalidPercent > MAX_INVALID_PERCENT) ? "warning" : "";
                         invalidPercent = (invalidPercent / 100).toFixed(2).toString().padStart(MAX_VALUE_SIZE);
@@ -688,9 +688,9 @@ TABS.motors.initialize = function (callback) {
                         telemetryText += "</span>";
                     }
 
-                    if (MOTOR_CONFIG.use_esc_sensor) {
+                    if (FC.MOTOR_CONFIG.use_esc_sensor) {
 
-                        let escTemperature = MOTOR_TELEMETRY_DATA.temperature[i];
+                        let escTemperature = FC.MOTOR_TELEMETRY_DATA.temperature[i];
 
                         telemetryText += "<br>";
                         escTemperature = escTemperature.toString().padStart(MAX_VALUE_SIZE);
@@ -704,13 +704,13 @@ TABS.motors.initialize = function (callback) {
             }
 
             // servo indicators are still using old (not flexible block scale), it will be changed in the future accordingly
-            for (var i = 0; i < SERVO_DATA.length; i++) {
-                var data = SERVO_DATA[i] - 1000,
+            for (var i = 0; i < FC.SERVO_DATA.length; i++) {
+                var data = FC.SERVO_DATA[i] - 1000,
                 margin_top = block_height - (data * (block_height / 1000)).clamp(0, block_height),
                 height = (data * (block_height / 1000)).clamp(0, block_height),
                 color = parseInt(data * 0.009);
 
-                $('.servo-' + i + ' .label', servos_wrapper).text(SERVO_DATA[i]);
+                $('.servo-' + i + ' .label', servos_wrapper).text(FC.SERVO_DATA[i]);
                 $('.servo-' + i + ' .indicator', servos_wrapper).css({'margin-top' : margin_top + 'px', 'height' : height + 'px', 'background-color' : 'rgba(255,187,0,1'+ color +')'});
             }
             //keep the following here so at least we get a visual cue of our motor setup

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -61,7 +61,7 @@ TABS.onboard_logging.initialize = function (callback) {
             i18n.localizePage();
 
             var
-                dataflashPresent = DATAFLASH.totalSize > 0,
+                dataflashPresent = FC.DATAFLASH.totalSize > 0,
                 blackboxSupport;
 
             /*
@@ -69,7 +69,7 @@ TABS.onboard_logging.initialize = function (callback) {
              *
              * The best we can do on those targets is check the BLACKBOX feature bit to identify support for Blackbox instead.
              */
-            if ((BLACKBOX.supported || DATAFLASH.supported) && (semver.gte(CONFIG.apiVersion, "1.33.0") || FEATURE_CONFIG.features.isEnabled('BLACKBOX'))) {
+            if ((FC.BLACKBOX.supported || FC.DATAFLASH.supported) && (semver.gte(FC.CONFIG.apiVersion, "1.33.0") || FC.FEATURE_CONFIG.features.isEnabled('BLACKBOX'))) {
                 blackboxSupport = 'yes';
             } else {
                 blackboxSupport = 'no';
@@ -77,10 +77,10 @@ TABS.onboard_logging.initialize = function (callback) {
 
             $(".tab-onboard_logging")
                 .addClass("serial-supported")
-                .toggleClass("dataflash-supported", DATAFLASH.supported)
+                .toggleClass("dataflash-supported", FC.DATAFLASH.supported)
                 .toggleClass("dataflash-present", dataflashPresent)
-                .toggleClass("sdcard-supported", SDCARD.supported)
-                .toggleClass("blackbox-config-supported", BLACKBOX.supported)
+                .toggleClass("sdcard-supported", FC.SDCARD.supported)
+                .toggleClass("blackbox-config-supported", FC.BLACKBOX.supported)
 
                 .toggleClass("blackbox-supported", blackboxSupport === 'yes')
                 .toggleClass("blackbox-maybe-supported", blackboxSupport === 'maybe')
@@ -102,20 +102,20 @@ TABS.onboard_logging.initialize = function (callback) {
             var loggingRatesSelect = $(".blackboxRate select");
             var debugModeSelect = $(".blackboxDebugMode select");
 
-            if (BLACKBOX.supported) {
+            if (FC.BLACKBOX.supported) {
                 $(".tab-onboard_logging a.save-settings").click(function() {
-                    if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-                        BLACKBOX.blackboxSampleRate = parseInt(loggingRatesSelect.val(), 10);
-                    } else if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-                        BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                        FC.BLACKBOX.blackboxSampleRate = parseInt(loggingRatesSelect.val(), 10);
+                    } else if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                        FC.BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);
                     } else {
                         var rate = loggingRatesSelect.val().split('/');
-                        BLACKBOX.blackboxRateNum = parseInt(rate[0], 10);
-                        BLACKBOX.blackboxRateDenom = parseInt(rate[1], 10);
+                        FC.BLACKBOX.blackboxRateNum = parseInt(rate[0], 10);
+                        FC.BLACKBOX.blackboxRateDenom = parseInt(rate[1], 10);
                     }
-                    BLACKBOX.blackboxDevice = parseInt(deviceSelect.val(), 10);
-                    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                        PID_ADVANCED_CONFIG.debugMode = parseInt(debugModeSelect.val());
+                    FC.BLACKBOX.blackboxDevice = parseInt(deviceSelect.val(), 10);
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                        FC.PID_ADVANCED_CONFIG.debugMode = parseInt(debugModeSelect.val());
                         MSP.send_message(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG), false, save_to_eeprom);
                     }
                     MSP.send_message(MSPCodes.MSP_SET_BLACKBOX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BLACKBOX_CONFIG), false, save_to_eeprom);
@@ -134,8 +134,8 @@ TABS.onboard_logging.initialize = function (callback) {
                 }
             }).change();
 
-            if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-                if ((SDCARD.supported && deviceSelect.val() == 2) || (DATAFLASH.supported && deviceSelect.val() == 1)) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                if ((FC.SDCARD.supported && deviceSelect.val() == 2) || (FC.DATAFLASH.supported && deviceSelect.val() == 1)) {
 
                     $(".tab-onboard_logging")
                         .toggleClass("msc-supported", true);
@@ -144,7 +144,7 @@ TABS.onboard_logging.initialize = function (callback) {
                          analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'RebootMsc');
 
                         var buffer = [];
-                        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                             if (GUI.operating_system === "Linux") {
                                 // Reboot into MSC using UTC time offset instead of user timezone
                                 // Linux seems to expect that the FAT file system timestamps are UTC based
@@ -169,26 +169,26 @@ TABS.onboard_logging.initialize = function (callback) {
     function populateDevices(deviceSelect) {
         deviceSelect.empty();
 
-        if (semver.gte(CONFIG.apiVersion, "1.33.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
             deviceSelect.append('<option value="0">' + i18n.getMessage('blackboxLoggingNone') + '</option>');
-            if (DATAFLASH.supported) {
+            if (FC.DATAFLASH.supported) {
                 deviceSelect.append('<option value="1">' + i18n.getMessage('blackboxLoggingFlash') + '</option>');
             }
-            if (SDCARD.supported) {
+            if (FC.SDCARD.supported) {
                 deviceSelect.append('<option value="2">' + i18n.getMessage('blackboxLoggingSdCard') + '</option>');
             }
             deviceSelect.append('<option value="3">' + i18n.getMessage('blackboxLoggingSerial') + '</option>');
         } else {
             deviceSelect.append('<option value="0">' + i18n.getMessage('blackboxLoggingSerial') + '</option>');
-            if (DATAFLASH.ready) {
+            if (FC.DATAFLASH.ready) {
                 deviceSelect.append('<option value="1">' + i18n.getMessage('blackboxLoggingFlash') + '</option>');
             }
-            if (SDCARD.supported) {
+            if (FC.SDCARD.supported) {
                 deviceSelect.append('<option value="2">' + i18n.getMessage('blackboxLoggingSdCard') + '</option>');
             }
         }
 
-        deviceSelect.val(BLACKBOX.blackboxDevice);
+        deviceSelect.val(FC.BLACKBOX.blackboxDevice);
     }
 
     function populateLoggingRates(loggingRatesSelect) {
@@ -197,20 +197,20 @@ TABS.onboard_logging.initialize = function (callback) {
         let loggingRates = [];
 
         let pidRate;
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-            pidRate = CONFIG.sampleRateHz / PID_ADVANCED_CONFIG.pid_process_denom;
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+            pidRate = FC.CONFIG.sampleRateHz / FC.PID_ADVANCED_CONFIG.pid_process_denom;
 
         } else {
 
             let pidRateBase = 8000;
 
-            if (semver.gte(CONFIG.apiVersion, "1.25.0") && semver.lt(CONFIG.apiVersion, "1.41.0") && PID_ADVANCED_CONFIG.gyroUse32kHz !== 0) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, "1.41.0") && FC.PID_ADVANCED_CONFIG.gyroUse32kHz !== 0) {
                 pidRateBase = 32000;
             }
-            pidRate = pidRateBase / PID_ADVANCED_CONFIG.gyro_sync_denom / PID_ADVANCED_CONFIG.pid_process_denom;
+            pidRate = pidRateBase / FC.PID_ADVANCED_CONFIG.gyro_sync_denom / FC.PID_ADVANCED_CONFIG.pid_process_denom;
         }
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
             const sampleRateNum=5;
             for (let i = 0; i < sampleRateNum; i++) {
                 let loggingFrequency = Math.round(pidRate / (2**i));
@@ -221,8 +221,8 @@ TABS.onboard_logging.initialize = function (callback) {
                 }
                 loggingRatesSelect.append(`<option value="${i}">1/${2**i} (${loggingFrequency}${loggingFrequencyUnit})</option>`);
             }
-            loggingRatesSelect.val(BLACKBOX.blackboxSampleRate);
-        } else if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            loggingRatesSelect.val(FC.BLACKBOX.blackboxSampleRate);
+        } else if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
             loggingRates = [
                 {text: "Disabled", hz: 0,     p_denom: 0},
                 {text: "500 Hz",   hz: 500,   p_denom: 16},
@@ -241,7 +241,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 }
             });
 
-            loggingRatesSelect.val(BLACKBOX.blackboxPDenom);
+            loggingRatesSelect.val(FC.BLACKBOX.blackboxPDenom);
         }
         else {
             loggingRates = [
@@ -271,14 +271,14 @@ TABS.onboard_logging.initialize = function (callback) {
                     + loggingRate + loggingRateUnit + ' (' + Math.round(loggingRates[i].num / loggingRates[i].denom * 100) + '%)</option>');
 
             }
-            loggingRatesSelect.val(BLACKBOX.blackboxRateNum + '/' + BLACKBOX.blackboxRateDenom);
+            loggingRatesSelect.val(FC.BLACKBOX.blackboxRateNum + '/' + FC.BLACKBOX.blackboxRateDenom);
         }
     }
 
     function populateDebugModes(debugModeSelect) {
         var debugModes = [];
 
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             $('.blackboxDebugMode').show();
 
             debugModes = [
@@ -344,7 +344,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 {text: "FF_INTERPOLATED"},
             ];
 
-            for (let i = 0; i < PID_ADVANCED_CONFIG.debugModeCount; i++) {
+            for (let i = 0; i < FC.PID_ADVANCED_CONFIG.debugModeCount; i++) {
                 if (i < debugModes.length) {
                     debugModeSelect.append(new Option(debugModes[i].text, i));
                 } else {
@@ -352,7 +352,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 }
             }
 
-            debugModeSelect.val(PID_ADVANCED_CONFIG.debugMode);
+            debugModeSelect.val(FC.PID_ADVANCED_CONFIG.debugMode);
         } else {
             $('.blackboxDebugMode').hide();
         }
@@ -399,23 +399,23 @@ TABS.onboard_logging.initialize = function (callback) {
     }
 
     function update_html() {
-        var dataflashPresent = DATAFLASH.totalSize > 0;
+        var dataflashPresent = FC.DATAFLASH.totalSize > 0;
 
-        update_bar_width($(".tab-onboard_logging .dataflash-used"), DATAFLASH.usedSize, DATAFLASH.totalSize, i18n.getMessage('dataflashUsedSpace'), false);
-        update_bar_width($(".tab-onboard_logging .dataflash-free"), DATAFLASH.totalSize - DATAFLASH.usedSize, DATAFLASH.totalSize, i18n.getMessage('dataflashFreeSpace'), false);
+        update_bar_width($(".tab-onboard_logging .dataflash-used"), FC.DATAFLASH.usedSize, FC.DATAFLASH.totalSize, i18n.getMessage('dataflashUsedSpace'), false);
+        update_bar_width($(".tab-onboard_logging .dataflash-free"), FC.DATAFLASH.totalSize - FC.DATAFLASH.usedSize, FC.DATAFLASH.totalSize, i18n.getMessage('dataflashFreeSpace'), false);
 
-        update_bar_width($(".tab-onboard_logging .sdcard-other"), SDCARD.totalSizeKB - SDCARD.freeSizeKB, SDCARD.totalSizeKB, i18n.getMessage('dataflashUnavSpace'), true);
-        update_bar_width($(".tab-onboard_logging .sdcard-free"), SDCARD.freeSizeKB, SDCARD.totalSizeKB, i18n.getMessage('dataflashLogsSpace'), true);
+        update_bar_width($(".tab-onboard_logging .sdcard-other"), FC.SDCARD.totalSizeKB - FC.SDCARD.freeSizeKB, FC.SDCARD.totalSizeKB, i18n.getMessage('dataflashUnavSpace'), true);
+        update_bar_width($(".tab-onboard_logging .sdcard-free"), FC.SDCARD.freeSizeKB, FC.SDCARD.totalSizeKB, i18n.getMessage('dataflashLogsSpace'), true);
 
-        $(".btn a.erase-flash, .btn a.save-flash").toggleClass("disabled", DATAFLASH.usedSize === 0);
+        $(".btn a.erase-flash, .btn a.save-flash").toggleClass("disabled", FC.DATAFLASH.usedSize === 0);
 
         $(".tab-onboard_logging")
-            .toggleClass("sdcard-error", SDCARD.state === MSP.SDCARD_STATE_FATAL)
-            .toggleClass("sdcard-initializing", SDCARD.state === MSP.SDCARD_STATE_CARD_INIT || SDCARD.state === MSP.SDCARD_STATE_FS_INIT)
-            .toggleClass("sdcard-ready", SDCARD.state === MSP.SDCARD_STATE_READY);
+            .toggleClass("sdcard-error", FC.SDCARD.state === MSP.SDCARD_STATE_FATAL)
+            .toggleClass("sdcard-initializing", FC.SDCARD.state === MSP.SDCARD_STATE_CARD_INIT || FC.SDCARD.state === MSP.SDCARD_STATE_FS_INIT)
+            .toggleClass("sdcard-ready", FC.SDCARD.state === MSP.SDCARD_STATE_READY);
 
-        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-            var mscIsReady = dataflashPresent || (SDCARD.state === MSP.SDCARD_STATE_READY);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+            var mscIsReady = dataflashPresent || (FC.SDCARD.state === MSP.SDCARD_STATE_READY);
             $(".tab-onboard_logging")
                 .toggleClass("msc-not-ready", !mscIsReady);
 
@@ -427,7 +427,7 @@ TABS.onboard_logging.initialize = function (callback) {
         }
 
         var loggingStatus
-        switch (SDCARD.state) {
+        switch (FC.SDCARD.state) {
             case MSP.SDCARD_STATE_NOT_PRESENT:
                 $(".sdcard-status").text(i18n.getMessage('sdcardStatusNoCard'));
                 loggingStatus = 'SdCard: NotPresent';
@@ -449,16 +449,16 @@ TABS.onboard_logging.initialize = function (callback) {
                 loggingStatus = 'SdCard: FsInit';
             break;
             default:
-                $(".sdcard-status").text(i18n.getMessage('sdcardStatusUnknown',[SDCARD.state]));
+                $(".sdcard-status").text(i18n.getMessage('sdcardStatusUnknown',[FC.SDCARD.state]));
         }
 
-        if (dataflashPresent && SDCARD.state === MSP.SDCARD_STATE_NOT_PRESENT) {
+        if (dataflashPresent && FC.SDCARD.state === MSP.SDCARD_STATE_NOT_PRESENT) {
             loggingStatus = 'Dataflash';
-            analytics.setFlightControllerData(analytics.DATA.LOG_SIZE, DATAFLASH.usedSize);
+            analytics.setFlightControllerData(analytics.DATA.LOG_SIZE, FC.DATAFLASH.usedSize);
         }
         analytics.setFlightControllerData(analytics.DATA.LOGGING_STATUS, loggingStatus);
 
-        if (SDCARD.supported && !sdcardTimer) {
+        if (FC.SDCARD.supported && !sdcardTimer) {
             // Poll for changes in SD card status
             sdcardTimer = setTimeout(function() {
                 sdcardTimer = false;
@@ -514,7 +514,7 @@ TABS.onboard_logging.initialize = function (callback) {
     function flash_save_begin() {
         if (GUI.connected_to) {
             if (FC.boardHasVcp()) {
-                if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
                     self.blockSize = self.VCP_BLOCK_SIZE;
                 } else {
                     self.blockSize = self.VCP_BLOCK_SIZE_3_0;
@@ -525,7 +525,7 @@ TABS.onboard_logging.initialize = function (callback) {
 
             // Begin by refreshing the occupied size in case it changed while the tab was open
             flash_update_summary(function() {
-                var maxBytes = DATAFLASH.usedSize;
+                var maxBytes = FC.DATAFLASH.usedSize;
 
                 prepare_file(function(fileWriter) {
                     var nextAddress = 0;
@@ -637,7 +637,7 @@ TABS.onboard_logging.initialize = function (callback) {
     function poll_for_erase_completion() {
         flash_update_summary(function() {
             if (CONFIGURATOR.connectionValid && !eraseCancelled) {
-                if (DATAFLASH.ready) {
+                if (FC.DATAFLASH.ready) {
                     $(".dataflash-confirm-erase")[0].close();
                 } else {
                     setTimeout(poll_for_erase_completion, 500);

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -70,7 +70,7 @@ SYM.loadSymbols = function() {
      * - Symbols used in this versions
      * - That were moved or didn't exist in the font file
      */
-    if (semver.lt(CONFIG.apiVersion, "1.42.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
         SYM.AH_CENTER_LINE = 0x26;
         SYM.AH_CENTER = 0x7E;
         SYM.AH_CENTER_LINE_RIGHT = 0x27;
@@ -347,16 +347,16 @@ OSD.generateTemperaturePreview = function (osd_data, temperature) {
 
 OSD.generateCraftName = function (osd_data) {
     var preview = 'CRAFT_NAME';
-    if (CONFIG.name != '') {
-        preview = CONFIG.name.toUpperCase();
+    if (FC.CONFIG.name != '') {
+        preview = FC.CONFIG.name.toUpperCase();
     }
     return preview;
 }
 
 OSD.generateDisplayName = function(osd_data) {
   var preview = 'DISPLAY_NAME';
-  if (CONFIG.displayName != '')
-      preview = CONFIG.displayName.toUpperCase();
+  if (FC.CONFIG.displayName != '')
+      preview = FC.CONFIG.displayName.toUpperCase();
   return preview;
 }
 
@@ -523,7 +523,7 @@ OSD.loadDisplayFields = function() {
             },
             draw_order: 40,
             positionable: function () {
-                return semver.gte(CONFIG.apiVersion, "1.39.0") ? true : false;
+                return semver.gte(FC.CONFIG.apiVersion, "1.39.0") ? true : false;
             },
             preview: function () {
                 return FONT.symbol(SYM.AH_CENTER_LINE) + FONT.symbol(SYM.AH_CENTER) + FONT.symbol(SYM.AH_CENTER_LINE_RIGHT);
@@ -542,7 +542,7 @@ OSD.loadDisplayFields = function() {
             },
             draw_order: 10,
             positionable: function () {
-                return semver.gte(CONFIG.apiVersion, "1.39.0") ? true : false;
+                return semver.gte(FC.CONFIG.apiVersion, "1.39.0") ? true : false;
             },
             preview: function () {
                 var artificialHorizon = new Array();
@@ -579,7 +579,7 @@ OSD.loadDisplayFields = function() {
             },
             draw_order: 50,
             positionable: function () {
-                return semver.gte(CONFIG.apiVersion, "1.39.0") ? true : false;
+                return semver.gte(FC.CONFIG.apiVersion, "1.39.0") ? true : false;
             },
             preview: function (fieldPosition) {
 
@@ -613,7 +613,7 @@ OSD.loadDisplayFields = function() {
             draw_order: 130,
             positionable: true,
             preview: function () {
-                return semver.gte(CONFIG.apiVersion, "1.36.0") ? ' 42.00' + FONT.symbol(SYM.AMP) : FONT.symbol(SYM.AMP) + '42.0';
+                return semver.gte(FC.CONFIG.apiVersion, "1.36.0") ? ' 42.00' + FONT.symbol(SYM.AMP) : FONT.symbol(SYM.AMP) + '42.0';
             }
         },
         MAH_DRAWN: {
@@ -624,7 +624,7 @@ OSD.loadDisplayFields = function() {
             draw_order: 140,
             positionable: true,
             preview: function () {
-                return semver.gte(CONFIG.apiVersion, "1.36.0") ? ' 690' + FONT.symbol(SYM.MAH) : FONT.symbol(SYM.MAH) + '690';
+                return semver.gte(FC.CONFIG.apiVersion, "1.36.0") ? ' 690' + FONT.symbol(SYM.MAH) : FONT.symbol(SYM.MAH) + '690';
             }
         },
         CRAFT_NAME: {
@@ -754,7 +754,7 @@ OSD.loadDisplayFields = function() {
             draw_order: 200,
             positionable: true,
             preview: function () {
-                return semver.gte(CONFIG.apiVersion, "1.36.0") ? ' 142W' : '142W';
+                return semver.gte(FC.CONFIG.apiVersion, "1.36.0") ? ' 142W' : '142W';
             }
         },
         PID_RATE_PROFILE: {
@@ -1434,7 +1434,7 @@ OSD.searchLimitsElement = function (arrayElements) {
 OSD.chooseFields = function () {
     var F = OSD.ALL_DISPLAY_FIELDS;
     // version 3.0.1
-    if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
         OSD.constants.DISPLAY_FIELDS = [
             F.RSSI_VALUE,
             F.MAIN_BATT_VOLTAGE,
@@ -1443,7 +1443,7 @@ OSD.chooseFields = function () {
             F.HORIZON_SIDEBARS
         ];
 
-        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
             OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                 F.ONTIME,
                 F.FLYTIME
@@ -1466,31 +1466,31 @@ OSD.chooseFields = function () {
             F.GPS_SATS,
             F.ALTITUDE
         ]);
-        if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
             OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                 F.PID_ROLL,
                 F.PID_PITCH,
                 F.PID_YAW,
                 F.POWER
             ]);
-            if (semver.gte(CONFIG.apiVersion, "1.32.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.32.0")) {
                 OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                     F.PID_RATE_PROFILE,
-                    semver.gte(CONFIG.apiVersion, "1.36.0") ? F.WARNINGS : F.BATTERY_WARNING,
+                    semver.gte(FC.CONFIG.apiVersion, "1.36.0") ? F.WARNINGS : F.BATTERY_WARNING,
                     F.AVG_CELL_VOLTAGE
                 ]);
-                if (semver.gte(CONFIG.apiVersion, "1.34.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                         F.GPS_LON,
                         F.GPS_LAT,
                         F.DEBUG
                     ]);
-                    if (semver.gte(CONFIG.apiVersion, "1.35.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.35.0")) {
                         OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                             F.PITCH_ANGLE,
                             F.ROLL_ANGLE
                         ]);
-                        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
                             OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                 F.MAIN_BATT_USAGE,
                                 F.DISARMED,
@@ -1502,22 +1502,22 @@ OSD.chooseFields = function () {
                                 F.ESC_TEMPERATURE,
                                 F.ESC_RPM
                             ]);
-                            if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+                            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
                                 OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                     F.REMAINING_TIME_ESTIMATE,
                                     F.RTC_DATE_TIME,
                                     F.ADJUSTMENT_RANGE,
                                     F.CORE_TEMPERATURE
                                 ]);
-                                if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+                                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
                                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                         F.ANTI_GRAVITY
                                     ]);
-                                    if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+                                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
                                         OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                             F.G_FORCE,
                                         ]);
-                                        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                                        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                                             OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                                 F.MOTOR_DIAG,
                                                 F.LOG_STATUS,
@@ -1529,14 +1529,14 @@ OSD.chooseFields = function () {
                                                 F.DISPLAY_NAME,
                                                 F.ESC_RPM_FREQ
                                             ]);
-                                            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                                            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
                                                 OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                                     F.RATE_PROFILE_NAME,
                                                     F.PID_PROFILE_NAME,
                                                     F.OSD_PROFILE_NAME,
                                                     F.RSSI_DBM_VALUE,
                                                 ]);
-                                                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+                                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                                                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                                         F.RC_CHANNELS,
                                                         F.CAMERA_FRAME,
@@ -1587,7 +1587,7 @@ OSD.chooseFields = function () {
     // that needs to be implemented here as well. Simply appending new stats does not
     // require a completely new section for the version - only reordering.
 
-    if (semver.lt(CONFIG.apiVersion, "1.39.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, "1.39.0")) {
         OSD.constants.STATISTIC_FIELDS = [
             F.MAX_SPEED,
             F.MIN_BATTERY,
@@ -1602,7 +1602,7 @@ OSD.chooseFields = function () {
             F.MAX_DISTANCE,
             F.BLACKBOX_LOG_NUMBER
         ];
-        if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
             OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([
                 F.RTC_DATE_TIME
             ]);
@@ -1624,7 +1624,7 @@ OSD.chooseFields = function () {
             F.BLACKBOX,
             F.BLACKBOX_LOG_NUMBER
         ];
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
             OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([
                 F.MAX_G_FORCE,
                 F.MAX_ESC_TEMP,
@@ -1634,7 +1634,7 @@ OSD.chooseFields = function () {
                 F.MAX_FFT
             ]);
         }
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([
                 F.TOTAL_FLIGHTS,
                 F.TOTAL_FLIGHT_TIME,
@@ -1655,14 +1655,14 @@ OSD.chooseFields = function () {
         F.VISUAL_BEEPER,
         F.CRASH_FLIP_MODE
     ];
-    if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
             F.ESC_FAIL,
             F.CORE_TEMPERATURE,
             F.RC_SMOOTHING_FAILURE
         ]);
     }
-    if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
             F.FAILSAFE,
             F.LAUNCH_CONTROL,
@@ -1676,7 +1676,7 @@ OSD.chooseFields = function () {
         'TOTAL_ARMED_TIME',
         'LAST_ARMED_TIME'
     ];
-    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
         OSD.constants.TIMER_TYPES = OSD.constants.TIMER_TYPES.concat([
             'ON_ARM_TIME'
         ]);
@@ -1686,7 +1686,7 @@ OSD.chooseFields = function () {
             F.RSSI_DBM,
         ]);
     }
-    if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
             F.OVER_CAP,
         ]);
@@ -1744,7 +1744,7 @@ OSD.msp = {
                 var default_position = typeof (c.default_position) === 'function' ? c.default_position() : c.default_position;
 
                 display_item.positionable = positionable;
-                if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
                     // size * y + x
                     display_item.position = positionable ? FONT.constants.SIZES.LINE * ((bits >> 5) & 0x001F) + (bits & 0x001F) : default_position;
 
@@ -1772,7 +1772,7 @@ OSD.msp = {
             position: function (display_item) {
                 var isVisible = display_item.isVisible;
                 var position = display_item.position;
-                if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
 
                     let packed_visible = 0;
                     for (let osd_profile = 0; osd_profile < OSD.getNumberOfProfiles(); osd_profile++) {
@@ -1790,19 +1790,19 @@ OSD.msp = {
     },
     encodeOther: function () {
         var result = [-1, OSD.data.video_system];
-        if (OSD.data.state.haveOsdFeature && semver.gte(CONFIG.apiVersion, "1.21.0")) {
+        if (OSD.data.state.haveOsdFeature && semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
             result.push8(OSD.data.unit_mode);
             // watch out, order matters! match the firmware
             result.push8(OSD.data.alarms.rssi.value);
             result.push16(OSD.data.alarms.cap.value);
-            if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
                 result.push16(OSD.data.alarms.time.value);
             } else {
                 // This value is unused by the firmware with configurable timers
                 result.push16(0);
             }
             result.push16(OSD.data.alarms.alt.value);
-            if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
                 var warningFlags = 0;
                 for (var i = 0; i < OSD.data.warnings.length; i++) {
                     if (OSD.data.warnings[i].enabled) {
@@ -1811,7 +1811,7 @@ OSD.msp = {
                 }
                 console.log(warningFlags);
                 result.push16(warningFlags);
-                if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                     result.push32(warningFlags);
 
                     result.push8(OSD.data.osd_profiles.selected + 1);
@@ -1819,7 +1819,7 @@ OSD.msp = {
                     result.push8(OSD.data.parameters.overlayRadioMode);
                 }
 
-                if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                     result.push8(OSD.data.parameters.cameraFrameWidth);
                     result.push8(OSD.data.parameters.cameraFrameHeight);
                 }
@@ -1858,18 +1858,18 @@ OSD.msp = {
         if (d.flags > 0) {
             if (payload.length > 1) {
                 d.video_system = view.readU8();
-                if (semver.gte(CONFIG.apiVersion, "1.21.0") && bit_check(d.flags, 0)) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.21.0") && bit_check(d.flags, 0)) {
                     d.unit_mode = view.readU8();
                     d.alarms = {};
                     d.alarms['rssi'] = { display_name: i18n.getMessage('osdTimerAlarmOptionRssi'), value: view.readU8() };
                     d.alarms['cap'] = { display_name: i18n.getMessage('osdTimerAlarmOptionCapacity'), value: view.readU16() };
-                    if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+                    if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
                         d.alarms['time'] = { display_name: 'Minutes', value: view.readU16() };
                     } else {
                         // This value was obsoleted by the introduction of configurable timers, and has been reused to encode the number of display elements sent in this command
                         view.readU8();
                         var tmp = view.readU8();
-                        if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
                             displayItemsCountActual = tmp;
                         }
                     }
@@ -1881,12 +1881,12 @@ OSD.msp = {
 
         d.state = {};
         d.state.haveSomeOsd = (d.flags != 0)
-        d.state.haveMax7456Configured = bit_check(d.flags, 4) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
-        d.state.haveFrSkyOSDConfigured = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) && bit_check(d.flags, 3);
+        d.state.haveMax7456Configured = bit_check(d.flags, 4) || (d.flags == 1 && semver.lt(FC.CONFIG.apiVersion, "1.34.0"));
+        d.state.haveFrSkyOSDConfigured = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43) && bit_check(d.flags, 3);
         d.state.haveMax7456FontDeviceConfigured = d.state.haveMax7456Configured || d.state.haveFrSkyOSDConfigured;
-        d.state.isMax7456FontDeviceDetected = bit_check(d.flags, 5) || (d.state.haveMax7456FontDeviceConfigured && semver.lt(CONFIG.apiVersion, API_VERSION_1_43));
-        d.state.haveOsdFeature = bit_check(d.flags, 0) || (d.flags == 1 && semver.lt(CONFIG.apiVersion, "1.34.0"));
-        d.state.isOsdSlave = bit_check(d.flags, 1) && semver.gte(CONFIG.apiVersion, "1.34.0");
+        d.state.isMax7456FontDeviceDetected = bit_check(d.flags, 5) || (d.state.haveMax7456FontDeviceConfigured && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_43));
+        d.state.haveOsdFeature = bit_check(d.flags, 0) || (d.flags == 1 && semver.lt(FC.CONFIG.apiVersion, "1.34.0"));
+        d.state.isOsdSlave = bit_check(d.flags, 1) && semver.gte(FC.CONFIG.apiVersion, "1.34.0");
 
         d.display_items = [];
         d.stat_items = [];
@@ -1902,7 +1902,7 @@ OSD.msp = {
         var items_positions_read = [];
         while (view.offset < view.byteLength && items_positions_read.length < displayItemsCountActual) {
             var v = null;
-            if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
                 v = view.readU16();
             } else {
                 v = view.read16();
@@ -1910,7 +1910,7 @@ OSD.msp = {
             items_positions_read.push(v);
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
             // Parse statistics display enable
             var expectedStatsCount = view.readU8();
             if (expectedStatsCount != OSD.constants.STATISTIC_FIELDS.length) {
@@ -1965,7 +1965,7 @@ OSD.msp = {
             // Parse enabled warnings
             var warningCount = OSD.constants.WARNINGS.length;
             var warningFlags = view.readU16();
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                 warningCount = view.readU8();
                 // the flags were replaced with a 32bit version
                 warningFlags = view.readU32();
@@ -1992,7 +1992,7 @@ OSD.msp = {
             }
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
             // OSD profiles
             d.osd_profiles.number = view.readU8();
             d.osd_profiles.selected = view.readU8() - 1;
@@ -2006,7 +2006,7 @@ OSD.msp = {
         }
 
         // Camera frame size
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
             d.parameters.cameraFrameWidth = view.readU8();
             d.parameters.cameraFrameHeight = view.readU8();
         }
@@ -2153,7 +2153,7 @@ OSD.GUI.preview = {
             }
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
             // unsigned now
         } else {
             if (position > OSD.data.display_size.total / 2) {
@@ -2295,7 +2295,7 @@ TABS.osd.initialize = function (callback) {
                             });
                     });
 
-                    if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
                         // units
                         $('.units-container').show();
                         var $unitMode = $('.units').empty();
@@ -2333,7 +2333,7 @@ TABS.osd.initialize = function (callback) {
                             $alarms.append($input);
                         }
 
-                        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
                             // Timers
                             $('.timers-container').show();
                             var $timers = $('#timer-fields').empty();
@@ -2837,7 +2837,7 @@ TABS.osd.initialize = function (callback) {
         fontPresetsElement.change(function (e) {
             var $font = $('.fontpresets option:selected');
             var fontver = 1;
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
                 fontver = 2;
             }
             $('.font-manager-version-info').text(i18n.getMessage('osdDescribeFontVersion' + fontver));

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -35,9 +35,9 @@ TABS.pid_tuning.initialize = function (callback) {
     // Update filtering defaults based on API version
     var FILTER_DEFAULT = FC.getFilterDefaults();
 
-    // requesting MSP_STATUS manually because it contains CONFIG.profile
+    // requesting MSP_STATUS manually because it contains FC.CONFIG.profile
     MSP.promise(MSPCodes.MSP_STATUS).then(function() {
-        if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE)) {
+        if (semver.gte(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE)) {
             return MSP.promise(MSPCodes.MSP_PID_CONTROLLER);
         }
     }).then(function() {
@@ -45,7 +45,7 @@ TABS.pid_tuning.initialize = function (callback) {
     }).then(function() {
         return MSP.promise(MSPCodes.MSP_PID);
     }).then(function() {
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
           return MSP.promise(MSPCodes.MSP_PID_ADVANCED);
         }
     }).then(function() {
@@ -66,128 +66,128 @@ TABS.pid_tuning.initialize = function (callback) {
 
     function pid_and_rc_to_form() {
         self.setProfile();
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             self.setRateProfile();
         }
 
         // Fill in the data from PIDs array
 
         // For each pid name
-        PID_names.forEach(function(elementPid, indexPid) {
+        FC.PID_NAMES.forEach(function(elementPid, indexPid) {
 
             // Look into the PID table to a row with the name of the pid
             var searchRow = $('.pid_tuning .' + elementPid + ' input');
 
             // Assign each value
             searchRow.each(function (indexInput) {
-                if (PIDs[indexPid][indexInput] !== undefined) {
-                    $(this).val(PIDs[indexPid][indexInput]);
+                if (FC.PIDS[indexPid][indexInput] !== undefined) {
+                    $(this).val(FC.PIDS[indexPid][indexInput]);
                 }
             });
         });
 
         // Fill in data from RC_tuning object
-        $('.pid_tuning input[name="rc_rate"]').val(RC_tuning.RC_RATE.toFixed(2));
-        $('.pid_tuning input[name="roll_pitch_rate"]').val(RC_tuning.roll_pitch_rate.toFixed(2));
-        $('.pid_tuning input[name="roll_rate"]').val(RC_tuning.roll_rate.toFixed(2));
-        $('.pid_tuning input[name="pitch_rate"]').val(RC_tuning.pitch_rate.toFixed(2));
-        $('.pid_tuning input[name="yaw_rate"]').val(RC_tuning.yaw_rate.toFixed(2));
-        $('.pid_tuning input[name="rc_expo"]').val(RC_tuning.RC_EXPO.toFixed(2));
-        $('.pid_tuning input[name="rc_yaw_expo"]').val(RC_tuning.RC_YAW_EXPO.toFixed(2));
+        $('.pid_tuning input[name="rc_rate"]').val(FC.RC_TUNING.RC_RATE.toFixed(2));
+        $('.pid_tuning input[name="roll_pitch_rate"]').val(FC.RC_TUNING.roll_pitch_rate.toFixed(2));
+        $('.pid_tuning input[name="roll_rate"]').val(FC.RC_TUNING.roll_rate.toFixed(2));
+        $('.pid_tuning input[name="pitch_rate"]').val(FC.RC_TUNING.pitch_rate.toFixed(2));
+        $('.pid_tuning input[name="yaw_rate"]').val(FC.RC_TUNING.yaw_rate.toFixed(2));
+        $('.pid_tuning input[name="rc_expo"]').val(FC.RC_TUNING.RC_EXPO.toFixed(2));
+        $('.pid_tuning input[name="rc_yaw_expo"]').val(FC.RC_TUNING.RC_YAW_EXPO.toFixed(2));
 
-        $('.throttle input[name="mid"]').val(RC_tuning.throttle_MID.toFixed(2));
-        $('.throttle input[name="expo"]').val(RC_tuning.throttle_EXPO.toFixed(2));
+        $('.throttle input[name="mid"]').val(FC.RC_TUNING.throttle_MID.toFixed(2));
+        $('.throttle input[name="expo"]').val(FC.RC_TUNING.throttle_EXPO.toFixed(2));
 
-        $('.tpa input[name="tpa"]').val(RC_tuning.dynamic_THR_PID.toFixed(2));
-        $('.tpa input[name="tpa-breakpoint"]').val(RC_tuning.dynamic_THR_breakpoint);
+        $('.tpa input[name="tpa"]').val(FC.RC_TUNING.dynamic_THR_PID.toFixed(2));
+        $('.tpa input[name="tpa-breakpoint"]').val(FC.RC_TUNING.dynamic_THR_breakpoint);
 
-        if (semver.lt(CONFIG.apiVersion, "1.10.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.10.0")) {
             $('.pid_tuning input[name="rc_yaw_expo"]').hide();
             $('.pid_tuning input[name="rc_expo"]').attr("rowspan", "3");
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-            $('input[id="vbatpidcompensation"]').prop('checked', ADVANCED_TUNING.vbatPidCompensation !== 0);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
+            $('input[id="vbatpidcompensation"]').prop('checked', FC.ADVANCED_TUNING.vbatPidCompensation !== 0);
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-            $('#pid-tuning .delta select').val(ADVANCED_TUNING.deltaMethod);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
+            $('#pid-tuning .delta select').val(FC.ADVANCED_TUNING.deltaMethod);
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-            $('.pid_tuning input[name="rc_rate_yaw"]').val(RC_tuning.rcYawRate.toFixed(2));
-            $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
-            $('.pid_filter input[name="dtermLowpassFrequency"]').val(FILTER_CONFIG.dterm_lowpass_hz);
-            $('.pid_filter input[name="yawLowpassFrequency"]').val(FILTER_CONFIG.yaw_lowpass_hz);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
+            $('.pid_tuning input[name="rc_rate_yaw"]').val(FC.RC_TUNING.rcYawRate.toFixed(2));
+            $('.pid_filter input[name="gyroLowpassFrequency"]').val(FC.FILTER_CONFIG.gyro_lowpass_hz);
+            $('.pid_filter input[name="dtermLowpassFrequency"]').val(FC.FILTER_CONFIG.dterm_lowpass_hz);
+            $('.pid_filter input[name="yawLowpassFrequency"]').val(FC.FILTER_CONFIG.yaw_lowpass_hz);
         } else {
             $('.tab-pid_tuning .subtab-filter').hide();
             $('.tab-pid_tuning .tab-container').hide();
             $('.pid_tuning input[name="rc_rate_yaw"]').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")
-            || semver.gte(CONFIG.apiVersion, "1.16.0") && FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES')) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")
+            || semver.gte(FC.CONFIG.apiVersion, "1.16.0") && FC.FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES')) {
             $('#pid-tuning .rate').text(i18n.getMessage("pidTuningSuperRate"));
         } else {
             $('#pid-tuning .rate').text(i18n.getMessage("pidTuningRate"));
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-            $('.pid_filter input[name="gyroNotch1Frequency"]').val(FILTER_CONFIG.gyro_notch_hz);
-            $('.pid_filter input[name="gyroNotch1Cutoff"]').val(FILTER_CONFIG.gyro_notch_cutoff);
-            $('.pid_filter input[name="dTermNotchFrequency"]').val(FILTER_CONFIG.dterm_notch_hz);
-            $('.pid_filter input[name="dTermNotchCutoff"]').val(FILTER_CONFIG.dterm_notch_cutoff);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+            $('.pid_filter input[name="gyroNotch1Frequency"]').val(FC.FILTER_CONFIG.gyro_notch_hz);
+            $('.pid_filter input[name="gyroNotch1Cutoff"]').val(FC.FILTER_CONFIG.gyro_notch_cutoff);
+            $('.pid_filter input[name="dTermNotchFrequency"]').val(FC.FILTER_CONFIG.dterm_notch_hz);
+            $('.pid_filter input[name="dTermNotchCutoff"]').val(FC.FILTER_CONFIG.dterm_notch_cutoff);
 
             var dtermSetpointTransitionNumberElement = $('input[name="dtermSetpointTransition-number"]');
-            if (semver.gte(CONFIG.apiVersion, "1.38.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.38.0")) {
                 dtermSetpointTransitionNumberElement.attr('min', 0.00);
             } else {
                 dtermSetpointTransitionNumberElement.attr('min', 0.01);
             }
 
-            dtermSetpointTransitionNumberElement.val(ADVANCED_TUNING.dtermSetpointTransition / 100);
+            dtermSetpointTransitionNumberElement.val(FC.ADVANCED_TUNING.dtermSetpointTransition / 100);
 
-            $('input[name="dtermSetpoint-number"]').val(ADVANCED_TUNING.dtermSetpointWeight / 100);
+            $('input[name="dtermSetpoint-number"]').val(FC.ADVANCED_TUNING.dtermSetpointWeight / 100);
         } else {
             $('.pid_filter .newFilter').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-            $('.pid_filter input[name="gyroNotch2Frequency"]').val(FILTER_CONFIG.gyro_notch2_hz);
-            $('.pid_filter input[name="gyroNotch2Cutoff"]').val(FILTER_CONFIG.gyro_notch2_cutoff);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
+            $('.pid_filter input[name="gyroNotch2Frequency"]').val(FC.FILTER_CONFIG.gyro_notch2_hz);
+            $('.pid_filter input[name="gyroNotch2Cutoff"]').val(FC.FILTER_CONFIG.gyro_notch2_cutoff);
         } else {
             $('.pid_filter .gyroNotch2').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
-            $('.pid_tuning input[name="angleLimit"]').val(ADVANCED_TUNING.levelAngleLimit);
-            $('.pid_tuning input[name="sensitivity"]').val(ADVANCED_TUNING.levelSensitivity);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.24.0")) {
+            $('.pid_tuning input[name="angleLimit"]').val(FC.ADVANCED_TUNING.levelAngleLimit);
+            $('.pid_tuning input[name="sensitivity"]').val(FC.ADVANCED_TUNING.levelSensitivity);
         } else {
             $('.pid_sensitivity').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-            $('.pid_filter select[name="dtermLowpassType"]').val(FILTER_CONFIG.dterm_lowpass_type);
-            $('.antigravity input[name="itermThrottleThreshold"]').val(ADVANCED_TUNING.itermThrottleThreshold);
-            $('.antigravity input[name="itermAcceleratorGain"]').val(ADVANCED_TUNING.itermAcceleratorGain / 1000);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            $('.pid_filter select[name="dtermLowpassType"]').val(FC.FILTER_CONFIG.dterm_lowpass_type);
+            $('.antigravity input[name="itermThrottleThreshold"]').val(FC.ADVANCED_TUNING.itermThrottleThreshold);
+            $('.antigravity input[name="itermAcceleratorGain"]').val(FC.ADVANCED_TUNING.itermAcceleratorGain / 1000);
 
             var antiGravitySwitch = $('#antiGravitySwitch');
-            antiGravitySwitch.prop('checked', ADVANCED_TUNING.itermAcceleratorGain !== 1000);
+            antiGravitySwitch.prop('checked', FC.ADVANCED_TUNING.itermAcceleratorGain !== 1000);
             antiGravitySwitch.change(function() {
                 var checked = $(this).is(':checked');
                 if (checked) {
-                    if (ADVANCED_TUNING.itermAcceleratorGain === 1000) {
-                        const DEFAULT_ACCELERATOR_GAIN = semver.gte(CONFIG.apiVersion, API_VERSION_1_43) ? 3.5 : 1.1;
+                    if (FC.ADVANCED_TUNING.itermAcceleratorGain === 1000) {
+                        const DEFAULT_ACCELERATOR_GAIN = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43) ? 3.5 : 1.1;
                         $('.antigravity input[name="itermAcceleratorGain"]').val(DEFAULT_ACCELERATOR_GAIN);
                     } else {
-                        const itermAcceleratorGain = (ADVANCED_TUNING.itermAcceleratorGain / 1000);
+                        const itermAcceleratorGain = (FC.ADVANCED_TUNING.itermAcceleratorGain / 1000);
                         $('.antigravity input[name="itermAcceleratorGain"]').val(itermAcceleratorGain);
                     }
                     $('.antigravity .suboption').show();
-                    if (ADVANCED_TUNING.antiGravityMode == 0) {
+                    if (FC.ADVANCED_TUNING.antiGravityMode == 0) {
                         $('.antigravity .antiGravityThres').hide();
                     }
-                    if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
                         $('.antigravity .antiGravityMode').show();
                     } else {
                         $('.antigravity .antiGravityMode').hide();
@@ -204,21 +204,21 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.antigravity').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
-            $('.pid_tuning input[name="rc_rate_pitch"]').val(RC_tuning.rcPitchRate.toFixed(2));
-            $('.pid_tuning input[name="rc_pitch_expo"]').val(RC_tuning.RC_PITCH_EXPO.toFixed(2));
+        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            $('.pid_tuning input[name="rc_rate_pitch"]').val(FC.RC_TUNING.rcPitchRate.toFixed(2));
+            $('.pid_tuning input[name="rc_pitch_expo"]').val(FC.RC_TUNING.RC_PITCH_EXPO.toFixed(2));
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
 
-            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FILTER_CONFIG.gyro_lowpass2_hz);
-            $('.pid_filter select[name="gyroLowpassType"]').val(FILTER_CONFIG.gyro_lowpass_type);
-            $('.pid_filter select[name="gyroLowpass2Type"]').val(FILTER_CONFIG.gyro_lowpass2_type);
-            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FILTER_CONFIG.dterm_lowpass2_hz);
+            $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FC.FILTER_CONFIG.gyro_lowpass2_hz);
+            $('.pid_filter select[name="gyroLowpassType"]').val(FC.FILTER_CONFIG.gyro_lowpass_type);
+            $('.pid_filter select[name="gyroLowpass2Type"]').val(FC.FILTER_CONFIG.gyro_lowpass2_type);
+            $('.pid_filter input[name="dtermLowpass2Frequency"]').val(FC.FILTER_CONFIG.dterm_lowpass2_hz);
 
             // We load it again because the limits are now bigger than in 1.16.0
             $('.pid_filter input[name="gyroLowpassFrequency"]').attr("max","16000");
-            $('.pid_filter input[name="gyroLowpassFrequency"]').val(FILTER_CONFIG.gyro_lowpass_hz);
+            $('.pid_filter input[name="gyroLowpassFrequency"]').val(FC.FILTER_CONFIG.gyro_lowpass_hz);
             //removes 5th column which is Feedforward
             $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
         } else {
@@ -228,23 +228,23 @@ TABS.pid_tuning.initialize = function (callback) {
             $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
 
             // I Term Rotation
-            $('input[id="itermrotation"]').prop('checked', ADVANCED_TUNING.itermRotation !== 0);
+            $('input[id="itermrotation"]').prop('checked', FC.ADVANCED_TUNING.itermRotation !== 0);
 
              // Smart Feed Forward
-            $('input[id="smartfeedforward"]').prop('checked', ADVANCED_TUNING.smartFeedforward !== 0);
+            $('input[id="smartfeedforward"]').prop('checked', FC.ADVANCED_TUNING.smartFeedforward !== 0);
 
             // I Term Relax
             var itermRelaxCheck = $('input[id="itermrelax"]');
 
-            itermRelaxCheck.prop('checked', ADVANCED_TUNING.itermRelax !== 0);
-            $('select[id="itermrelaxAxes"]').val(ADVANCED_TUNING.itermRelax > 0 ? ADVANCED_TUNING.itermRelax : 1);
-            $('select[id="itermrelaxType"]').val(ADVANCED_TUNING.itermRelaxType);
-            $('input[name="itermRelaxCutoff"]').val(ADVANCED_TUNING.itermRelaxCutoff);
+            itermRelaxCheck.prop('checked', FC.ADVANCED_TUNING.itermRelax !== 0);
+            $('select[id="itermrelaxAxes"]').val(FC.ADVANCED_TUNING.itermRelax > 0 ? FC.ADVANCED_TUNING.itermRelax : 1);
+            $('select[id="itermrelaxType"]').val(FC.ADVANCED_TUNING.itermRelaxType);
+            $('input[name="itermRelaxCutoff"]').val(FC.ADVANCED_TUNING.itermRelaxCutoff);
 
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                 $('.itermrelax input[name="itermRelaxCutoff"]').attr("max","50");
             }
 
@@ -253,7 +253,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
                 if (checked) {
                     $('.itermrelax .suboption').show();
-                    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
                         $('.itermRelaxCutoff').show();
                     } else {
                         $('.itermRelaxCutoff').hide();
@@ -266,27 +266,27 @@ TABS.pid_tuning.initialize = function (callback) {
 
             // Absolute Control
             var absoluteControlGainNumberElement = $('input[name="absoluteControlGain-number"]');
-            absoluteControlGainNumberElement.val(ADVANCED_TUNING.absoluteControlGain).trigger('input');
+            absoluteControlGainNumberElement.val(FC.ADVANCED_TUNING.absoluteControlGain).trigger('input');
 
             // Throttle Boost
             var throttleBoostNumberElement = $('input[name="throttleBoost-number"]');
-            throttleBoostNumberElement.val(ADVANCED_TUNING.throttleBoost).trigger('input');
+            throttleBoostNumberElement.val(FC.ADVANCED_TUNING.throttleBoost).trigger('input');
 
             // Acro Trainer
             var acroTrainerAngleLimitNumberElement = $('input[name="acroTrainerAngleLimit-number"]');
-            acroTrainerAngleLimitNumberElement.val(ADVANCED_TUNING.acroTrainerAngleLimit).trigger('input');
+            acroTrainerAngleLimitNumberElement.val(FC.ADVANCED_TUNING.acroTrainerAngleLimit).trigger('input');
 
             // Yaw D
-            $('.pid_tuning .YAW input[name="d"]').val(PIDs[2][2]); // PID Yaw D
+            $('.pid_tuning .YAW input[name="d"]').val(FC.PIDS[2][2]); // PID Yaw D
 
             // Feedforward
-            $('.pid_tuning .ROLL input[name="f"]').val(ADVANCED_TUNING.feedforwardRoll);
-            $('.pid_tuning .PITCH input[name="f"]').val(ADVANCED_TUNING.feedforwardPitch);
-            $('.pid_tuning .YAW input[name="f"]').val(ADVANCED_TUNING.feedforwardYaw);
+            $('.pid_tuning .ROLL input[name="f"]').val(FC.ADVANCED_TUNING.feedforwardRoll);
+            $('.pid_tuning .PITCH input[name="f"]').val(FC.ADVANCED_TUNING.feedforwardPitch);
+            $('.pid_tuning .YAW input[name="f"]').val(FC.ADVANCED_TUNING.feedforwardYaw);
             $('#pid_main .pid_titlebar2 th').attr('colspan', 5);
 
             var feedforwardTransitionNumberElement = $('input[name="feedforwardTransition-number"]');
-            feedforwardTransitionNumberElement.val(ADVANCED_TUNING.feedforwardTransition / 100);
+            feedforwardTransitionNumberElement.val(FC.ADVANCED_TUNING.feedforwardTransition / 100);
 
             // AntiGravity Mode
             var antiGravityModeSelect = $('.antigravity select[id="antiGravityMode"]');
@@ -301,7 +301,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 }
             });
 
-            antiGravityModeSelect.val(ADVANCED_TUNING.antiGravityMode).change();
+            antiGravityModeSelect.val(FC.ADVANCED_TUNING.antiGravityMode).change();
 
         } else {
             $('.itermrotation').hide();
@@ -319,28 +319,28 @@ TABS.pid_tuning.initialize = function (callback) {
             $('#pid-tuning .feedforwardTransition').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-            $('select[id="throttleLimitType"]').val(RC_tuning.throttleLimitType);
-            $('.throttle_limit input[name="throttleLimitPercent"]').val(RC_tuning.throttleLimitPercent);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            $('select[id="throttleLimitType"]').val(FC.RC_TUNING.throttleLimitType);
+            $('.throttle_limit input[name="throttleLimitPercent"]').val(FC.RC_TUNING.throttleLimitPercent);
 
-            $('.pid_filter select[name="dtermLowpass2Type"]').val(FILTER_CONFIG.dterm_lowpass2_type);
-            $('.pid_filter input[name="gyroLowpassDynMinFrequency"]').val(FILTER_CONFIG.gyro_lowpass_dyn_min_hz);
-            $('.pid_filter input[name="gyroLowpassDynMaxFrequency"]').val(FILTER_CONFIG.gyro_lowpass_dyn_max_hz);
-            $('.pid_filter select[name="gyroLowpassDynType"]').val(FILTER_CONFIG.gyro_lowpass_type);
-            $('.pid_filter input[name="dtermLowpassDynMinFrequency"]').val(FILTER_CONFIG.dterm_lowpass_dyn_min_hz);
-            $('.pid_filter input[name="dtermLowpassDynMaxFrequency"]').val(FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
-            $('.pid_filter select[name="dtermLowpassDynType"]').val(FILTER_CONFIG.dterm_lowpass_type);
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-                $('.pid_filter input[name="dtermLowpassDynExpo"]').val(FILTER_CONFIG.dyn_lpf_curve_expo);
+            $('.pid_filter select[name="dtermLowpass2Type"]').val(FC.FILTER_CONFIG.dterm_lowpass2_type);
+            $('.pid_filter input[name="gyroLowpassDynMinFrequency"]').val(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz);
+            $('.pid_filter input[name="gyroLowpassDynMaxFrequency"]').val(FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz);
+            $('.pid_filter select[name="gyroLowpassDynType"]').val(FC.FILTER_CONFIG.gyro_lowpass_type);
+            $('.pid_filter input[name="dtermLowpassDynMinFrequency"]').val(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz);
+            $('.pid_filter input[name="dtermLowpassDynMaxFrequency"]').val(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
+            $('.pid_filter select[name="dtermLowpassDynType"]').val(FC.FILTER_CONFIG.dterm_lowpass_type);
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                $('.pid_filter input[name="dtermLowpassDynExpo"]').val(FC.FILTER_CONFIG.dyn_lpf_curve_expo);
             }
 
-            $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
-            $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
-            $('.pid_tuning input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
-            $('.dminGroup input[name="dMinGain"]').val(ADVANCED_TUNING.dMinGain);
-            $('.dminGroup input[name="dMinAdvance"]').val(ADVANCED_TUNING.dMinAdvance);
+            $('.pid_tuning input[name="dMinRoll"]').val(FC.ADVANCED_TUNING.dMinRoll);
+            $('.pid_tuning input[name="dMinPitch"]').val(FC.ADVANCED_TUNING.dMinPitch);
+            $('.pid_tuning input[name="dMinYaw"]').val(FC.ADVANCED_TUNING.dMinYaw);
+            $('.dminGroup input[name="dMinGain"]').val(FC.ADVANCED_TUNING.dMinGain);
+            $('.dminGroup input[name="dMinAdvance"]').val(FC.ADVANCED_TUNING.dMinAdvance);
 
-            $('input[id="useIntegratedYaw"]').prop('checked', ADVANCED_TUNING.useIntegratedYaw !== 0);
+            $('input[id="useIntegratedYaw"]').prop('checked', FC.ADVANCED_TUNING.useIntegratedYaw !== 0);
             //dmin column
             $('#pid_main .pid_titlebar2 th').attr('colspan', 6);
         } else {
@@ -358,33 +358,33 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.integratedYaw').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             const dynamicNotchWidthPercent_e = $('.pid_filter input[name="dynamicNotchWidthPercent"]');
             const dynamicNotchQ_e = $('.pid_filter input[name="dynamicNotchQ"]');
 
             $('.smartfeedforward').hide();
 
-            if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
+            if (FC.FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
                 $('.dynamicNotch').show();
             } else {
                 $('.dynamicNotch').hide();
             }
-            $('.dynamicNotchRange').toggle(semver.lt(CONFIG.apiVersion, API_VERSION_1_43));
-            $('.pid_filter select[name="dynamicNotchRange"]').val(FILTER_CONFIG.dyn_notch_range);
-            dynamicNotchWidthPercent_e.val(FILTER_CONFIG.dyn_notch_width_percent);
-            dynamicNotchQ_e.val(FILTER_CONFIG.dyn_notch_q);
-            $('.pid_filter input[name="dynamicNotchMinHz"]').val(FILTER_CONFIG.dyn_notch_min_hz);
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+            $('.dynamicNotchRange').toggle(semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_43));
+            $('.pid_filter select[name="dynamicNotchRange"]').val(FC.FILTER_CONFIG.dyn_notch_range);
+            dynamicNotchWidthPercent_e.val(FC.FILTER_CONFIG.dyn_notch_width_percent);
+            dynamicNotchQ_e.val(FC.FILTER_CONFIG.dyn_notch_q);
+            $('.pid_filter input[name="dynamicNotchMinHz"]').val(FC.FILTER_CONFIG.dyn_notch_min_hz);
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                 $('.pid_filter input[name="dynamicNotchMinHz"]').attr("max","250");
-                $('.pid_filter input[name="dynamicNotchMaxHz"]').val(FILTER_CONFIG.dyn_notch_max_hz);
+                $('.pid_filter input[name="dynamicNotchMaxHz"]').val(FC.FILTER_CONFIG.dyn_notch_max_hz);
             } else {
                 $('.dynamicNotchMaxHz').hide();
             }
 
-            $('.rpmFilter').toggle(MOTOR_CONFIG.use_dshot_telemetry);
+            $('.rpmFilter').toggle(FC.MOTOR_CONFIG.use_dshot_telemetry);
 
-            $('.pid_filter input[name="rpmFilterHarmonics"]').val(FILTER_CONFIG.gyro_rpm_notch_harmonics);
-            $('.pid_filter input[name="rpmFilterMinHz"]').val(FILTER_CONFIG.gyro_rpm_notch_min_hz);
+            $('.pid_filter input[name="rpmFilterHarmonics"]').val(FC.FILTER_CONFIG.gyro_rpm_notch_harmonics);
+            $('.pid_filter input[name="rpmFilterMinHz"]').val(FC.FILTER_CONFIG.gyro_rpm_notch_min_hz);
 
             $('.pid_filter #rpmFilterEnabled').change(function() {
 
@@ -398,7 +398,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     $('.pid_filter input[name="rpmFilterHarmonics"]').val(FILTER_DEFAULT.gyro_rpm_notch_harmonics);
                 }
 
-                if (checked !== (FILTER_CONFIG.gyro_rpm_notch_harmonics !== 0)) { // if rpmFilterEnabled is not the same value as saved in the fc
+                if (checked !== (FC.FILTER_CONFIG.gyro_rpm_notch_harmonics !== 0)) { // if rpmFilterEnabled is not the same value as saved in the fc
                     if (checked) {
                         dynamicNotchWidthPercent_e.val(FILTER_DEFAULT.dyn_notch_width_percent_rpm);
                         dynamicNotchQ_e.val(FILTER_DEFAULT.dyn_notch_q_rpm);
@@ -410,11 +410,11 @@ TABS.pid_tuning.initialize = function (callback) {
                     showDialogDynFiltersChange();
 
                 } else { // same value, return saved values
-                    dynamicNotchWidthPercent_e.val(FILTER_CONFIG.dyn_notch_width_percent);
-                    dynamicNotchQ_e.val(FILTER_CONFIG.dyn_notch_q);
+                    dynamicNotchWidthPercent_e.val(FC.FILTER_CONFIG.dyn_notch_width_percent);
+                    dynamicNotchQ_e.val(FC.FILTER_CONFIG.dyn_notch_q);
                 }
 
-            }).prop('checked', FILTER_CONFIG.gyro_rpm_notch_harmonics != 0).change();
+            }).prop('checked', FC.FILTER_CONFIG.gyro_rpm_notch_harmonics != 0).change();
 
         } else {
             $('.itermRelaxCutoff').hide();
@@ -422,16 +422,16 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.rpmFilter').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-            $('.pid_tuning input[name="motorLimit"]').val(ADVANCED_TUNING.motorOutputLimit);
-            $('.pid_tuning input[name="cellCount"]').val(ADVANCED_TUNING.autoProfileCellCount);
-            $('input[name="idleMinRpm-number"]').val(ADVANCED_TUNING.idleMinRpm);
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+            $('.pid_tuning input[name="motorLimit"]').val(FC.ADVANCED_TUNING.motorOutputLimit);
+            $('.pid_tuning input[name="cellCount"]').val(FC.ADVANCED_TUNING.autoProfileCellCount);
+            $('input[name="idleMinRpm-number"]').val(FC.ADVANCED_TUNING.idleMinRpm);
         } else {
             $('.motorOutputLimit').hide();
             $('.idleMinRpm').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
             const ratesTypeListElement = $('select[id="ratesType"]'); // generates list
             const ratesList = [
                 {name: "Betaflight"},
@@ -440,12 +440,12 @@ TABS.pid_tuning.initialize = function (callback) {
                 {name: "Actual"},
                 {name: "QuickRates"},
             ];
-            // add future rates types here with CONFIG.apiVersion check
+            // add future rates types here with FC.CONFIG.apiVersion check
             for (let i = 0; i < ratesList.length; i++) {
                 ratesTypeListElement.append(`<option value="${i}">${ratesList[i].name}</option>`);
             }
 
-            self.currentRatesType = RC_tuning.rates_type;
+            self.currentRatesType = FC.RC_TUNING.rates_type;
             self.previousRatesType = null;
             ratesTypeListElement.val(self.currentRatesType);
 
@@ -457,14 +457,14 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.rates_type').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
             // FF Interpolate
             const ffInterpolateCheck = $('input[id="ffInterpolateSp"]');
 
-            ffInterpolateCheck.prop('checked', ADVANCED_TUNING.ff_interpolate_sp !== 0);
-            $('select[id="ffInterpolate"]').val(ADVANCED_TUNING.ff_interpolate_sp > 0 ? ADVANCED_TUNING.ff_interpolate_sp : 2);
-            $('input[name="ffSmoothFactor"]').val(ADVANCED_TUNING.ff_smooth_factor);
-            $('input[name="ffBoost"]').val(ADVANCED_TUNING.ff_boost);
+            ffInterpolateCheck.prop('checked', FC.ADVANCED_TUNING.ff_interpolate_sp !== 0);
+            $('select[id="ffInterpolate"]').val(FC.ADVANCED_TUNING.ff_interpolate_sp > 0 ? FC.ADVANCED_TUNING.ff_interpolate_sp : 2);
+            $('input[name="ffSmoothFactor"]').val(FC.ADVANCED_TUNING.ff_smooth_factor);
+            $('input[name="ffBoost"]').val(FC.ADVANCED_TUNING.ff_boost);
 
             ffInterpolateCheck.change(function() {
                 const checked = $(this).is(':checked');
@@ -474,8 +474,8 @@ TABS.pid_tuning.initialize = function (callback) {
             // Vbat Sag Compensation
             const vbatSagCompensationCheck = $('input[id="vbatSagCompensation"]');
 
-            vbatSagCompensationCheck.prop('checked', ADVANCED_TUNING.vbat_sag_compensation !== 0);
-            $('input[name="vbatSagValue"]').val(ADVANCED_TUNING.vbat_sag_compensation > 0 ? ADVANCED_TUNING.vbat_sag_compensation : 100);
+            vbatSagCompensationCheck.prop('checked', FC.ADVANCED_TUNING.vbat_sag_compensation !== 0);
+            $('input[name="vbatSagValue"]').val(FC.ADVANCED_TUNING.vbat_sag_compensation > 0 ? FC.ADVANCED_TUNING.vbat_sag_compensation : 100);
 
             vbatSagCompensationCheck.change(function() {
                 const checked = $(this).is(':checked');
@@ -518,9 +518,9 @@ TABS.pid_tuning.initialize = function (callback) {
             adjustDMin($(this), dMinElement);
         }).change();
 
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
             var dMinSwitch = $('#dMinSwitch');
-            dMinSwitch.prop('checked', ADVANCED_TUNING.dMinRoll > 0 || ADVANCED_TUNING.dMinPitch > 0 || ADVANCED_TUNING.dMinYaw > 0);
+            dMinSwitch.prop('checked', FC.ADVANCED_TUNING.dMinRoll > 0 || FC.ADVANCED_TUNING.dMinPitch > 0 || FC.ADVANCED_TUNING.dMinYaw > 0);
             dMinSwitch.change(function() {
                 var checked = $(this).is(':checked');
                 if (checked) {
@@ -529,15 +529,15 @@ TABS.pid_tuning.initialize = function (callback) {
                         $('.pid_tuning input[name="dMinRoll"]').val(Math.min(Math.round($('.pid_tuning .ROLL input[name="d"]').val() * 0.57), 100));
                         $('.pid_tuning input[name="dMinPitch"]').val(Math.min(Math.round($('.pid_tuning .PITCH input[name="d"]').val() * 0.57), 100));
                         $('.pid_tuning input[name="dMinYaw"]').val(Math.min(Math.round($('.pid_tuning .YAW input[name="d"]').val() * 0.57), 100));
-                        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                             $('.pid_tuning input[name="dMinRoll"]').val(Math.min(Math.round($('.pid_tuning .ROLL input[name="d"]').val() * 0.65), 100));
                             $('.pid_tuning input[name="dMinPitch"]').val(Math.min(Math.round($('.pid_tuning .PITCH input[name="d"]').val() * 0.65), 100));
                             $('.pid_tuning input[name="dMinYaw"]').val(Math.min(Math.round($('.pid_tuning .YAW input[name="d"]').val() * 0.65), 100));
                         }
                     } else {
-                        $('.pid_tuning input[name="dMinRoll"]').val(ADVANCED_TUNING.dMinRoll);
-                        $('.pid_tuning input[name="dMinPitch"]').val(ADVANCED_TUNING.dMinPitch);
-                        $('.pid_tuning input[name="dMinYaw"]').val(ADVANCED_TUNING.dMinYaw);
+                        $('.pid_tuning input[name="dMinRoll"]').val(FC.ADVANCED_TUNING.dMinRoll);
+                        $('.pid_tuning input[name="dMinPitch"]').val(FC.ADVANCED_TUNING.dMinPitch);
+                        $('.pid_tuning input[name="dMinYaw"]').val(FC.ADVANCED_TUNING.dMinYaw);
                     }
                     $('.dMinDisabledNote').hide();
                     $('.dminGroup .suboption').show();
@@ -560,7 +560,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('input[id="gyroNotch1Enabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var hz = FILTER_CONFIG.gyro_notch_hz > 0 ? FILTER_CONFIG.gyro_notch_hz : FILTER_DEFAULT.gyro_notch_hz;
+            var hz = FC.FILTER_CONFIG.gyro_notch_hz > 0 ? FC.FILTER_CONFIG.gyro_notch_hz : FILTER_DEFAULT.gyro_notch_hz;
 
             $('.pid_filter input[name="gyroNotch1Frequency"]').val(checked ? hz : 0).attr('disabled', !checked)
                     .attr("min", checked ? 1 : 0).change();
@@ -569,7 +569,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('input[id="gyroNotch2Enabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var hz = FILTER_CONFIG.gyro_notch2_hz > 0 ? FILTER_CONFIG.gyro_notch2_hz : FILTER_DEFAULT.gyro_notch2_hz;
+            var hz = FC.FILTER_CONFIG.gyro_notch2_hz > 0 ? FC.FILTER_CONFIG.gyro_notch2_hz : FILTER_DEFAULT.gyro_notch2_hz;
 
             $('.pid_filter input[name="gyroNotch2Frequency"]').val(checked ? hz : 0).attr('disabled', !checked)
                     .attr("min", checked ? 1 : 0).change();
@@ -578,7 +578,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('input[id="dtermNotchEnabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var hz = FILTER_CONFIG.dterm_notch_hz > 0 ? FILTER_CONFIG.dterm_notch_hz : FILTER_DEFAULT.dterm_notch_hz;
+            var hz = FC.FILTER_CONFIG.dterm_notch_hz > 0 ? FC.FILTER_CONFIG.dterm_notch_hz : FILTER_DEFAULT.dterm_notch_hz;
 
             $('.pid_filter input[name="dTermNotchFrequency"]').val(checked ? hz : 0).attr('disabled', !checked)
                     .attr("min", checked ? 1 : 0).change();
@@ -589,8 +589,8 @@ TABS.pid_tuning.initialize = function (callback) {
             var checked = $(this).is(':checked');
             var disabledByDynamicLowpass = $('input[id="gyroLowpassDynEnabled"]').is(':checked');
 
-            var cutoff = FILTER_CONFIG.gyro_lowpass_hz > 0 ? FILTER_CONFIG.gyro_lowpass_hz : FILTER_DEFAULT.gyro_lowpass_hz;
-            var type = FILTER_CONFIG.gyro_lowpass_hz > 0 ? FILTER_CONFIG.gyro_lowpass_type : FILTER_DEFAULT.gyro_lowpass_type;
+            var cutoff = FC.FILTER_CONFIG.gyro_lowpass_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass_hz : FILTER_DEFAULT.gyro_lowpass_hz;
+            var type = FC.FILTER_CONFIG.gyro_lowpass_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass_type : FILTER_DEFAULT.gyro_lowpass_type;
 
             $('.pid_filter input[name="gyroLowpassFrequency"]').val((checked || disabledByDynamicLowpass) ? cutoff : 0).attr('disabled', !checked);
             $('.pid_filter select[name="gyroLowpassType"]').val(type).attr('disabled', !checked);
@@ -605,9 +605,9 @@ TABS.pid_tuning.initialize = function (callback) {
             var checked = $(this).is(':checked');
             var cutoff_min = FILTER_DEFAULT.gyro_lowpass_dyn_min_hz;
             var type = FILTER_DEFAULT.gyro_lowpass_type;
-            if (FILTER_CONFIG.gyro_lowpass_dyn_min_hz > 0 && FILTER_CONFIG.gyro_lowpass_dyn_min_hz < FILTER_CONFIG.gyro_lowpass_dyn_max_hz) {
-                cutoff_min = FILTER_CONFIG.gyro_lowpass_dyn_min_hz;
-                type = FILTER_CONFIG.gyro_lowpass_type;
+            if (FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz > 0 && FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz < FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz) {
+                cutoff_min = FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz;
+                type = FC.FILTER_CONFIG.gyro_lowpass_type;
             }
 
             $('.pid_filter input[name="gyroLowpassDynMinFrequency"]').val(checked ? cutoff_min : 0).attr('disabled', !checked);
@@ -616,7 +616,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
             if (checked) {
                 $('input[id="gyroLowpassEnabled"]').prop('checked', false).change();
-            } else if (FILTER_CONFIG.gyro_lowpass_hz > 0 && !$('input[id="gyroLowpassEnabled"]').is(':checked')) {
+            } else if (FC.FILTER_CONFIG.gyro_lowpass_hz > 0 && !$('input[id="gyroLowpassEnabled"]').is(':checked')) {
                 $('input[id="gyroLowpassEnabled"]').prop('checked', true).change();
             }
             self.updateFilterWarning();
@@ -624,8 +624,8 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('input[id="gyroLowpass2Enabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var cutoff = FILTER_CONFIG.gyro_lowpass2_hz > 0 ? FILTER_CONFIG.gyro_lowpass2_hz : FILTER_DEFAULT.gyro_lowpass2_hz;
-            var type = FILTER_CONFIG.gyro_lowpass2_hz > 0 ? FILTER_CONFIG.gyro_lowpass2_type : FILTER_DEFAULT.gyro_lowpass2_type;
+            var cutoff = FC.FILTER_CONFIG.gyro_lowpass2_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass2_hz : FILTER_DEFAULT.gyro_lowpass2_hz;
+            var type = FC.FILTER_CONFIG.gyro_lowpass2_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass2_type : FILTER_DEFAULT.gyro_lowpass2_type;
 
             $('.pid_filter input[name="gyroLowpass2Frequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
             $('.pid_filter select[name="gyroLowpass2Type"]').val(type).attr('disabled', !checked);
@@ -635,8 +635,8 @@ TABS.pid_tuning.initialize = function (callback) {
             var checked = $(this).is(':checked');
             var disabledByDynamicLowpass = $('input[id="dtermLowpassDynEnabled"]').is(':checked');
 
-            var cutoff = FILTER_CONFIG.dterm_lowpass_hz > 0 ? FILTER_CONFIG.dterm_lowpass_hz : FILTER_DEFAULT.dterm_lowpass_hz;
-            var type = FILTER_CONFIG.dterm_lowpass_hz > 0 ? FILTER_CONFIG.dterm_lowpass_type : FILTER_DEFAULT.dterm_lowpass_type;
+            var cutoff = FC.FILTER_CONFIG.dterm_lowpass_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass_hz : FILTER_DEFAULT.dterm_lowpass_hz;
+            var type = FC.FILTER_CONFIG.dterm_lowpass_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass_type : FILTER_DEFAULT.dterm_lowpass_type;
 
             $('.pid_filter input[name="dtermLowpassFrequency"]').val((checked || disabledByDynamicLowpass) ? cutoff : 0).attr('disabled', !checked);
             $('.pid_filter select[name="dtermLowpassType"]').val(type).attr('disabled', !checked);
@@ -647,14 +647,14 @@ TABS.pid_tuning.initialize = function (callback) {
             self.updateFilterWarning();
         });
 
-        $('.dynLpfCurveExpo').toggle(semver.gte(CONFIG.apiVersion, API_VERSION_1_44));
+        $('.dynLpfCurveExpo').toggle(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44));
         $('input[id="dtermLowpassDynEnabled"]').change(function() {
             var checked = $(this).is(':checked');
             var cutoff_min = FILTER_DEFAULT.dterm_lowpass_dyn_min_hz;
             var type = FILTER_DEFAULT.dterm_lowpass_type;
-            if (FILTER_CONFIG.dterm_lowpass_dyn_min_hz > 0 && FILTER_CONFIG.dterm_lowpass_dyn_min_hz < FILTER_CONFIG.dterm_lowpass_dyn_max_hz) {
-                cutoff_min = FILTER_CONFIG.dterm_lowpass_dyn_min_hz;
-                type = FILTER_CONFIG.dterm_lowpass_type;
+            if (FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz > 0 && FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz < FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz) {
+                cutoff_min = FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz;
+                type = FC.FILTER_CONFIG.dterm_lowpass_type;
             }
 
             $('.pid_filter input[name="dtermLowpassDynMinFrequency"]').val(checked ? cutoff_min : 0).attr('disabled', !checked);
@@ -663,7 +663,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
             if (checked) {
                 $('input[id="dtermLowpassEnabled"]').prop('checked', false).change();
-            } else if (FILTER_CONFIG.dterm_lowpass_hz > 0 && !$('input[id="dtermLowpassEnabled"]').is(':checked')) {
+            } else if (FC.FILTER_CONFIG.dterm_lowpass_hz > 0 && !$('input[id="dtermLowpassEnabled"]').is(':checked')) {
                 $('input[id="dtermLowpassEnabled"]').prop('checked', true).change();
                 $('.pid_filter input[id="dtermLowpassDynExpoEnabled"]').prop('checked', false).change();
             }
@@ -672,15 +672,15 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('input[id="dtermLowpassDynExpoEnabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var curveExpo = FILTER_CONFIG.dyn_lpf_curve_expo > 0 ? FILTER_CONFIG.dyn_lpf_curve_expo : FILTER_DEFAULT.dyn_lpf_curve_expo;
+            var curveExpo = FC.FILTER_CONFIG.dyn_lpf_curve_expo > 0 ? FC.FILTER_CONFIG.dyn_lpf_curve_expo : FILTER_DEFAULT.dyn_lpf_curve_expo;
 
             $('.pid_filter input[name="dtermLowpassDynExpo"]').val(checked ? curveExpo : 0).attr('disabled', !checked);
         });
 
         $('input[id="dtermLowpass2Enabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var cutoff = FILTER_CONFIG.dterm_lowpass2_hz > 0 ? FILTER_CONFIG.dterm_lowpass2_hz : FILTER_DEFAULT.dterm_lowpass2_hz;
-            var type = FILTER_CONFIG.dterm_lowpass2_hz > 0 ? FILTER_CONFIG.dterm_lowpass2_type : FILTER_DEFAULT.dterm_lowpass2_type;
+            var cutoff = FC.FILTER_CONFIG.dterm_lowpass2_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass2_hz : FILTER_DEFAULT.dterm_lowpass2_hz;
+            var type = FC.FILTER_CONFIG.dterm_lowpass2_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass2_type : FILTER_DEFAULT.dterm_lowpass2_type;
 
             $('.pid_filter input[name="dtermLowpass2Frequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
             $('.pid_filter select[name="dtermLowpass2Type"]').val(type).attr('disabled', !checked);
@@ -688,7 +688,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         $('input[id="yawLowpassEnabled"]').change(function() {
             var checked = $(this).is(':checked');
-            var cutoff = FILTER_CONFIG.yaw_lowpass_hz > 0 ? FILTER_CONFIG.yaw_lowpass_hz : FILTER_DEFAULT.yaw_lowpass_hz;
+            var cutoff = FC.FILTER_CONFIG.yaw_lowpass_hz > 0 ? FC.FILTER_CONFIG.yaw_lowpass_hz : FILTER_DEFAULT.yaw_lowpass_hz;
 
             $('.pid_filter input[name="yawLowpassFrequency"]').val(checked ? cutoff : 0).attr('disabled', !checked);
         });
@@ -719,17 +719,17 @@ TABS.pid_tuning.initialize = function (callback) {
         }).change();
 
         // Initial state of the filters: enabled or disabled
-        $('input[id="gyroNotch1Enabled"]').prop('checked', FILTER_CONFIG.gyro_notch_hz != 0).change();
-        $('input[id="gyroNotch2Enabled"]').prop('checked', FILTER_CONFIG.gyro_notch2_hz != 0).change();
-        $('input[id="dtermNotchEnabled"]').prop('checked', FILTER_CONFIG.dterm_notch_hz != 0).change();
-        $('input[id="gyroLowpassEnabled"]').prop('checked', FILTER_CONFIG.gyro_lowpass_hz != 0).change();
-        $('input[id="gyroLowpassDynEnabled"]').prop('checked', FILTER_CONFIG.gyro_lowpass_dyn_min_hz != 0 && FILTER_CONFIG.gyro_lowpass_dyn_min_hz < FILTER_CONFIG.gyro_lowpass_dyn_max_hz).change();
-        $('input[id="dtermLowpassDynExpoEnabled"]').prop('checked', FILTER_CONFIG.dyn_lpf_curve_expo != 0).change();
-        $('input[id="gyroLowpass2Enabled"]').prop('checked', FILTER_CONFIG.gyro_lowpass2_hz != 0).change();
-        $('input[id="dtermLowpassEnabled"]').prop('checked', FILTER_CONFIG.dterm_lowpass_hz != 0).change();
-        $('input[id="dtermLowpassDynEnabled"]').prop('checked', FILTER_CONFIG.dterm_lowpass_dyn_min_hz != 0 && FILTER_CONFIG.dterm_lowpass_dyn_min_hz < FILTER_CONFIG.dterm_lowpass_dyn_max_hz).change();
-        $('input[id="dtermLowpass2Enabled"]').prop('checked', FILTER_CONFIG.dterm_lowpass2_hz != 0).change();
-        $('input[id="yawLowpassEnabled"]').prop('checked', FILTER_CONFIG.yaw_lowpass_hz != 0).change();
+        $('input[id="gyroNotch1Enabled"]').prop('checked', FC.FILTER_CONFIG.gyro_notch_hz != 0).change();
+        $('input[id="gyroNotch2Enabled"]').prop('checked', FC.FILTER_CONFIG.gyro_notch2_hz != 0).change();
+        $('input[id="dtermNotchEnabled"]').prop('checked', FC.FILTER_CONFIG.dterm_notch_hz != 0).change();
+        $('input[id="gyroLowpassEnabled"]').prop('checked', FC.FILTER_CONFIG.gyro_lowpass_hz != 0).change();
+        $('input[id="gyroLowpassDynEnabled"]').prop('checked', FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz != 0 && FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz < FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz).change();
+        $('input[id="dtermLowpassDynExpoEnabled"]').prop('checked', FC.FILTER_CONFIG.dyn_lpf_curve_expo != 0).change();
+        $('input[id="gyroLowpass2Enabled"]').prop('checked', FC.FILTER_CONFIG.gyro_lowpass2_hz != 0).change();
+        $('input[id="dtermLowpassEnabled"]').prop('checked', FC.FILTER_CONFIG.dterm_lowpass_hz != 0).change();
+        $('input[id="dtermLowpassDynEnabled"]').prop('checked', FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz != 0 && FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz < FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz).change();
+        $('input[id="dtermLowpass2Enabled"]').prop('checked', FC.FILTER_CONFIG.dterm_lowpass2_hz != 0).change();
+        $('input[id="yawLowpassEnabled"]').prop('checked', FC.FILTER_CONFIG.yaw_lowpass_hz != 0).change();
 
         self.updatePIDColors();
     }
@@ -739,7 +739,7 @@ TABS.pid_tuning.initialize = function (callback) {
         // Catch all the changes and stuff the inside PIDs array
 
         // For each pid name
-        PID_names.forEach(function(elementPid, indexPid) {
+        FC.PID_NAMES.forEach(function(elementPid, indexPid) {
 
             // Look into the PID table to a row with the name of the pid
             var searchRow = $('.pid_tuning .' + elementPid + ' input');
@@ -747,7 +747,7 @@ TABS.pid_tuning.initialize = function (callback) {
             // Assign each value
             searchRow.each(function (indexInput) {
                 if ($(this).val()) {
-                    PIDs[indexPid][indexInput] = parseFloat($(this).val());
+                    FC.PIDS[indexPid][indexInput] = parseFloat($(this).val());
                 }
             });
         });
@@ -763,46 +763,46 @@ TABS.pid_tuning.initialize = function (callback) {
         const rc_expo_e = $('.pid_tuning input[name="rc_expo"]');
         const rc_yaw_expo_e = $('.pid_tuning input[name="rc_yaw_expo"]');
 
-        RC_tuning.roll_pitch_rate = parseFloat($('.pid_tuning input[name="roll_pitch_rate"]').val());
-        RC_tuning.RC_RATE = parseFloat(rc_rate_e.val());
-        RC_tuning.roll_rate = parseFloat(roll_rate_e.val());
-        RC_tuning.pitch_rate = parseFloat(pitch_rate_e.val());
-        RC_tuning.yaw_rate = parseFloat(yaw_rate_e.val());
-        RC_tuning.RC_EXPO = parseFloat(rc_expo_e.val());
-        RC_tuning.RC_YAW_EXPO = parseFloat(rc_yaw_expo_e.val());
-        RC_tuning.rcYawRate = parseFloat(rc_rate_yaw_e.val());
-        RC_tuning.rcPitchRate = parseFloat(rc_rate_pitch_e.val());
-        RC_tuning.RC_PITCH_EXPO = parseFloat(rc_pitch_expo_e.val());
+        FC.RC_TUNING.roll_pitch_rate = parseFloat($('.pid_tuning input[name="roll_pitch_rate"]').val());
+        FC.RC_TUNING.RC_RATE = parseFloat(rc_rate_e.val());
+        FC.RC_TUNING.roll_rate = parseFloat(roll_rate_e.val());
+        FC.RC_TUNING.pitch_rate = parseFloat(pitch_rate_e.val());
+        FC.RC_TUNING.yaw_rate = parseFloat(yaw_rate_e.val());
+        FC.RC_TUNING.RC_EXPO = parseFloat(rc_expo_e.val());
+        FC.RC_TUNING.RC_YAW_EXPO = parseFloat(rc_yaw_expo_e.val());
+        FC.RC_TUNING.rcYawRate = parseFloat(rc_rate_yaw_e.val());
+        FC.RC_TUNING.rcPitchRate = parseFloat(rc_rate_pitch_e.val());
+        FC.RC_TUNING.RC_PITCH_EXPO = parseFloat(rc_pitch_expo_e.val());
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
             switch(self.currentRatesType) {
                 case self.RATES_TYPE.RACEFLIGHT:
-                    RC_tuning.pitch_rate = parseFloat(pitch_rate_e.val()) / 100;
-                    RC_tuning.roll_rate = parseFloat(roll_rate_e.val()) / 100;
-                    RC_tuning.yaw_rate = parseFloat(yaw_rate_e.val()) / 100;
-                    RC_tuning.rcPitchRate = parseFloat(rc_rate_pitch_e.val()) / 1000;
-                    RC_tuning.RC_RATE = parseFloat(rc_rate_e.val()) / 1000;
-                    RC_tuning.rcYawRate = parseFloat(rc_rate_yaw_e.val()) / 1000;
-                    RC_tuning.RC_PITCH_EXPO = parseFloat(rc_pitch_expo_e.val()) / 100;
-                    RC_tuning.RC_EXPO = parseFloat(rc_expo_e.val()) / 100;
-                    RC_tuning.RC_YAW_EXPO = parseFloat(rc_yaw_expo_e.val()) / 100;
+                    FC.RC_TUNING.pitch_rate = parseFloat(pitch_rate_e.val()) / 100;
+                    FC.RC_TUNING.roll_rate = parseFloat(roll_rate_e.val()) / 100;
+                    FC.RC_TUNING.yaw_rate = parseFloat(yaw_rate_e.val()) / 100;
+                    FC.RC_TUNING.rcPitchRate = parseFloat(rc_rate_pitch_e.val()) / 1000;
+                    FC.RC_TUNING.RC_RATE = parseFloat(rc_rate_e.val()) / 1000;
+                    FC.RC_TUNING.rcYawRate = parseFloat(rc_rate_yaw_e.val()) / 1000;
+                    FC.RC_TUNING.RC_PITCH_EXPO = parseFloat(rc_pitch_expo_e.val()) / 100;
+                    FC.RC_TUNING.RC_EXPO = parseFloat(rc_expo_e.val()) / 100;
+                    FC.RC_TUNING.RC_YAW_EXPO = parseFloat(rc_yaw_expo_e.val()) / 100;
 
                     break;
 
                 case self.RATES_TYPE.ACTUAL:
-                    RC_tuning.pitch_rate = parseFloat(pitch_rate_e.val()) / 1000;
-                    RC_tuning.roll_rate = parseFloat(roll_rate_e.val()) / 1000;
-                    RC_tuning.yaw_rate = parseFloat(yaw_rate_e.val()) / 1000;
-                    RC_tuning.rcPitchRate = parseFloat(rc_rate_pitch_e.val()) / 1000;
-                    RC_tuning.RC_RATE = parseFloat(rc_rate_e.val()) / 1000;
-                    RC_tuning.rcYawRate = parseFloat(rc_rate_yaw_e.val()) / 1000;
+                    FC.RC_TUNING.pitch_rate = parseFloat(pitch_rate_e.val()) / 1000;
+                    FC.RC_TUNING.roll_rate = parseFloat(roll_rate_e.val()) / 1000;
+                    FC.RC_TUNING.yaw_rate = parseFloat(yaw_rate_e.val()) / 1000;
+                    FC.RC_TUNING.rcPitchRate = parseFloat(rc_rate_pitch_e.val()) / 1000;
+                    FC.RC_TUNING.RC_RATE = parseFloat(rc_rate_e.val()) / 1000;
+                    FC.RC_TUNING.rcYawRate = parseFloat(rc_rate_yaw_e.val()) / 1000;
 
                     break;
 
                 case self.RATES_TYPE.QUICKRATES:
-                    RC_tuning.pitch_rate = parseFloat(pitch_rate_e.val()) / 1000;
-                    RC_tuning.roll_rate = parseFloat(roll_rate_e.val()) / 1000;
-                    RC_tuning.yaw_rate = parseFloat(yaw_rate_e.val()) / 1000;
+                    FC.RC_TUNING.pitch_rate = parseFloat(pitch_rate_e.val()) / 1000;
+                    FC.RC_TUNING.roll_rate = parseFloat(roll_rate_e.val()) / 1000;
+                    FC.RC_TUNING.yaw_rate = parseFloat(yaw_rate_e.val()) / 1000;
 
                     break;
 
@@ -813,146 +813,146 @@ TABS.pid_tuning.initialize = function (callback) {
             }
         }
 
-        RC_tuning.throttle_MID = parseFloat($('.throttle input[name="mid"]').val());
-        RC_tuning.throttle_EXPO = parseFloat($('.throttle input[name="expo"]').val());
+        FC.RC_TUNING.throttle_MID = parseFloat($('.throttle input[name="mid"]').val());
+        FC.RC_TUNING.throttle_EXPO = parseFloat($('.throttle input[name="expo"]').val());
 
-        RC_tuning.dynamic_THR_PID = parseFloat($('.tpa input[name="tpa"]').val());
-        RC_tuning.dynamic_THR_breakpoint = parseInt($('.tpa input[name="tpa-breakpoint"]').val());
-        FILTER_CONFIG.gyro_lowpass_hz = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
-        FILTER_CONFIG.dterm_lowpass_hz = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
-        FILTER_CONFIG.yaw_lowpass_hz = parseInt($('.pid_filter input[name="yawLowpassFrequency"]').val());
+        FC.RC_TUNING.dynamic_THR_PID = parseFloat($('.tpa input[name="tpa"]').val());
+        FC.RC_TUNING.dynamic_THR_breakpoint = parseInt($('.tpa input[name="tpa-breakpoint"]').val());
+        FC.FILTER_CONFIG.gyro_lowpass_hz = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());
+        FC.FILTER_CONFIG.dterm_lowpass_hz = parseInt($('.pid_filter input[name="dtermLowpassFrequency"]').val());
+        FC.FILTER_CONFIG.yaw_lowpass_hz = parseInt($('.pid_filter input[name="yawLowpassFrequency"]').val());
 
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
             const element = $('input[id="vbatpidcompensation"]');
             const value = element.is(':checked') ? 1 : 0;
             let analyticsValue = undefined;
-            if (value !== ADVANCED_TUNING.vbatPidCompensation) {
+            if (value !== FC.ADVANCED_TUNING.vbatPidCompensation) {
                 analyticsValue = element.is(':checked');
             }
             self.analyticsChanges['VbatPidCompensation'] = analyticsValue;
 
-            ADVANCED_TUNING.vbatPidCompensation = value;
+            FC.ADVANCED_TUNING.vbatPidCompensation = value;
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
-            ADVANCED_TUNING.deltaMethod = $('#pid-tuning .delta select').val();
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
+            FC.ADVANCED_TUNING.deltaMethod = $('#pid-tuning .delta select').val();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-            ADVANCED_TUNING.dtermSetpointTransition = parseInt($('input[name="dtermSetpointTransition-number"]').val() * 100);
-            ADVANCED_TUNING.dtermSetpointWeight = parseInt($('input[name="dtermSetpoint-number"]').val() * 100);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+            FC.ADVANCED_TUNING.dtermSetpointTransition = parseInt($('input[name="dtermSetpointTransition-number"]').val() * 100);
+            FC.ADVANCED_TUNING.dtermSetpointWeight = parseInt($('input[name="dtermSetpoint-number"]').val() * 100);
 
-            FILTER_CONFIG.gyro_notch_hz = parseInt($('.pid_filter input[name="gyroNotch1Frequency"]').val());
-            FILTER_CONFIG.gyro_notch_cutoff = parseInt($('.pid_filter input[name="gyroNotch1Cutoff"]').val());
-            FILTER_CONFIG.dterm_notch_hz = parseInt($('.pid_filter input[name="dTermNotchFrequency"]').val());
-            FILTER_CONFIG.dterm_notch_cutoff = parseInt($('.pid_filter input[name="dTermNotchCutoff"]').val());
-            if (semver.gte(CONFIG.apiVersion, "1.21.0")) {
-                FILTER_CONFIG.gyro_notch2_hz = parseInt($('.pid_filter input[name="gyroNotch2Frequency"]').val());
-                FILTER_CONFIG.gyro_notch2_cutoff = parseInt($('.pid_filter input[name="gyroNotch2Cutoff"]').val());
+            FC.FILTER_CONFIG.gyro_notch_hz = parseInt($('.pid_filter input[name="gyroNotch1Frequency"]').val());
+            FC.FILTER_CONFIG.gyro_notch_cutoff = parseInt($('.pid_filter input[name="gyroNotch1Cutoff"]').val());
+            FC.FILTER_CONFIG.dterm_notch_hz = parseInt($('.pid_filter input[name="dTermNotchFrequency"]').val());
+            FC.FILTER_CONFIG.dterm_notch_cutoff = parseInt($('.pid_filter input[name="dTermNotchCutoff"]').val());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.21.0")) {
+                FC.FILTER_CONFIG.gyro_notch2_hz = parseInt($('.pid_filter input[name="gyroNotch2Frequency"]').val());
+                FC.FILTER_CONFIG.gyro_notch2_cutoff = parseInt($('.pid_filter input[name="gyroNotch2Cutoff"]').val());
             }
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.24.0")) {
-            ADVANCED_TUNING.levelAngleLimit = parseInt($('.pid_tuning input[name="angleLimit"]').val());
-            ADVANCED_TUNING.levelSensitivity = parseInt($('.pid_tuning input[name="sensitivity"]').val());
+        if (semver.gte(FC.CONFIG.apiVersion, "1.24.0")) {
+            FC.ADVANCED_TUNING.levelAngleLimit = parseInt($('.pid_tuning input[name="angleLimit"]').val());
+            FC.ADVANCED_TUNING.levelSensitivity = parseInt($('.pid_tuning input[name="sensitivity"]').val());
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
-            FILTER_CONFIG.dterm_lowpass_type = $('.pid_filter select[name="dtermLowpassType"]').val();
-            ADVANCED_TUNING.itermThrottleThreshold = parseInt($('.antigravity input[name="itermThrottleThreshold"]').val());
-            ADVANCED_TUNING.itermAcceleratorGain = parseInt($('.antigravity input[name="itermAcceleratorGain"]').val() * 1000);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            FC.FILTER_CONFIG.dterm_lowpass_type = $('.pid_filter select[name="dtermLowpassType"]').val();
+            FC.ADVANCED_TUNING.itermThrottleThreshold = parseInt($('.antigravity input[name="itermThrottleThreshold"]').val());
+            FC.ADVANCED_TUNING.itermAcceleratorGain = parseInt($('.antigravity input[name="itermAcceleratorGain"]').val() * 1000);
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
-            FILTER_CONFIG.gyro_lowpass2_hz = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
-            FILTER_CONFIG.gyro_lowpass_type = parseInt($('.pid_filter select[name="gyroLowpassType"]').val());
-            FILTER_CONFIG.gyro_lowpass2_type = parseInt($('.pid_filter select[name="gyroLowpass2Type"]').val());
-            FILTER_CONFIG.dterm_lowpass2_hz = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
+        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+            FC.FILTER_CONFIG.gyro_lowpass2_hz = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
+            FC.FILTER_CONFIG.gyro_lowpass_type = parseInt($('.pid_filter select[name="gyroLowpassType"]').val());
+            FC.FILTER_CONFIG.gyro_lowpass2_type = parseInt($('.pid_filter select[name="gyroLowpass2Type"]').val());
+            FC.FILTER_CONFIG.dterm_lowpass2_hz = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
 
-            ADVANCED_TUNING.itermRotation = $('input[id="itermrotation"]').is(':checked') ? 1 : 0;
-            ADVANCED_TUNING.smartFeedforward = $('input[id="smartfeedforward"]').is(':checked') ? 1 : 0;
+            FC.ADVANCED_TUNING.itermRotation = $('input[id="itermrotation"]').is(':checked') ? 1 : 0;
+            FC.ADVANCED_TUNING.smartFeedforward = $('input[id="smartfeedforward"]').is(':checked') ? 1 : 0;
 
-            ADVANCED_TUNING.itermRelax = $('input[id="itermrelax"]').is(':checked') ? $('select[id="itermrelaxAxes"]').val() : 0;
-            ADVANCED_TUNING.itermRelaxType = $('select[id="itermrelaxType"]').val();
-            ADVANCED_TUNING.itermRelaxCutoff = parseInt($('input[name="itermRelaxCutoff"]').val());
+            FC.ADVANCED_TUNING.itermRelax = $('input[id="itermrelax"]').is(':checked') ? $('select[id="itermrelaxAxes"]').val() : 0;
+            FC.ADVANCED_TUNING.itermRelaxType = $('select[id="itermrelaxType"]').val();
+            FC.ADVANCED_TUNING.itermRelaxCutoff = parseInt($('input[name="itermRelaxCutoff"]').val());
 
-            ADVANCED_TUNING.absoluteControlGain = $('input[name="absoluteControlGain-number"]').val();
+            FC.ADVANCED_TUNING.absoluteControlGain = $('input[name="absoluteControlGain-number"]').val();
 
-            ADVANCED_TUNING.throttleBoost = $('input[name="throttleBoost-number"]').val();
+            FC.ADVANCED_TUNING.throttleBoost = $('input[name="throttleBoost-number"]').val();
 
-            ADVANCED_TUNING.acroTrainerAngleLimit = $('input[name="acroTrainerAngleLimit-number"]').val();
+            FC.ADVANCED_TUNING.acroTrainerAngleLimit = $('input[name="acroTrainerAngleLimit-number"]').val();
 
-            ADVANCED_TUNING.feedforwardRoll  = parseInt($('.pid_tuning .ROLL input[name="f"]').val());
-            ADVANCED_TUNING.feedforwardPitch = parseInt($('.pid_tuning .PITCH input[name="f"]').val());
-            ADVANCED_TUNING.feedforwardYaw   = parseInt($('.pid_tuning .YAW input[name="f"]').val());
+            FC.ADVANCED_TUNING.feedforwardRoll  = parseInt($('.pid_tuning .ROLL input[name="f"]').val());
+            FC.ADVANCED_TUNING.feedforwardPitch = parseInt($('.pid_tuning .PITCH input[name="f"]').val());
+            FC.ADVANCED_TUNING.feedforwardYaw   = parseInt($('.pid_tuning .YAW input[name="f"]').val());
 
-            ADVANCED_TUNING.feedforwardTransition = parseInt($('input[name="feedforwardTransition-number"]').val() * 100);
+            FC.ADVANCED_TUNING.feedforwardTransition = parseInt($('input[name="feedforwardTransition-number"]').val() * 100);
 
-            ADVANCED_TUNING.antiGravityMode = $('select[id="antiGravityMode"]').val();
+            FC.ADVANCED_TUNING.antiGravityMode = $('select[id="antiGravityMode"]').val();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
-            RC_tuning.throttleLimitType = $('select[id="throttleLimitType"]').val();
-            RC_tuning.throttleLimitPercent = parseInt($('.throttle_limit input[name="throttleLimitPercent"]').val());
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            FC.RC_TUNING.throttleLimitType = $('select[id="throttleLimitType"]').val();
+            FC.RC_TUNING.throttleLimitPercent = parseInt($('.throttle_limit input[name="throttleLimitPercent"]').val());
 
-            FILTER_CONFIG.dterm_lowpass2_type = $('.pid_filter select[name="dtermLowpass2Type"]').val();
-            FILTER_CONFIG.gyro_lowpass_dyn_min_hz = parseInt($('.pid_filter input[name="gyroLowpassDynMinFrequency"]').val());
-            FILTER_CONFIG.gyro_lowpass_dyn_max_hz = parseInt($('.pid_filter input[name="gyroLowpassDynMaxFrequency"]').val());
-            FILTER_CONFIG.dterm_lowpass_dyn_min_hz = parseInt($('.pid_filter input[name="dtermLowpassDynMinFrequency"]').val());
-            FILTER_CONFIG.dterm_lowpass_dyn_max_hz = parseInt($('.pid_filter input[name="dtermLowpassDynMaxFrequency"]').val());
+            FC.FILTER_CONFIG.dterm_lowpass2_type = $('.pid_filter select[name="dtermLowpass2Type"]').val();
+            FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz = parseInt($('.pid_filter input[name="gyroLowpassDynMinFrequency"]').val());
+            FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = parseInt($('.pid_filter input[name="gyroLowpassDynMaxFrequency"]').val());
+            FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz = parseInt($('.pid_filter input[name="dtermLowpassDynMinFrequency"]').val());
+            FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = parseInt($('.pid_filter input[name="dtermLowpassDynMaxFrequency"]').val());
 
-            if (FILTER_CONFIG.gyro_lowpass_dyn_min_hz > 0 && FILTER_CONFIG.gyro_lowpass_dyn_min_hz < FILTER_CONFIG.gyro_lowpass_dyn_max_hz ) {
-                FILTER_CONFIG.gyro_lowpass_type = $('.pid_filter select[name="gyroLowpassDynType"]').val();
+            if (FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz > 0 && FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz < FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz ) {
+                FC.FILTER_CONFIG.gyro_lowpass_type = $('.pid_filter select[name="gyroLowpassDynType"]').val();
             }
-            if (FILTER_CONFIG.dterm_lowpass_dyn_min_hz > 0 && FILTER_CONFIG.dterm_lowpass_dyn_min_hz < FILTER_CONFIG.dterm_lowpass_dyn_max_hz ) {
-                FILTER_CONFIG.dterm_lowpass_type = $('.pid_filter select[name="dtermLowpassDynType"]').val();
+            if (FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz > 0 && FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz < FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz ) {
+                FC.FILTER_CONFIG.dterm_lowpass_type = $('.pid_filter select[name="dtermLowpassDynType"]').val();
             }
 
-            ADVANCED_TUNING.dMinRoll = parseInt($('.pid_tuning input[name="dMinRoll"]').val());
-            ADVANCED_TUNING.dMinPitch = parseInt($('.pid_tuning input[name="dMinPitch"]').val());
-            ADVANCED_TUNING.dMinYaw = parseInt($('.pid_tuning input[name="dMinYaw"]').val());
-            ADVANCED_TUNING.dMinGain = parseInt($('.dminGroup input[name="dMinGain"]').val());
-            ADVANCED_TUNING.dMinAdvance = parseInt($('.dminGroup input[name="dMinAdvance"]').val());
+            FC.ADVANCED_TUNING.dMinRoll = parseInt($('.pid_tuning input[name="dMinRoll"]').val());
+            FC.ADVANCED_TUNING.dMinPitch = parseInt($('.pid_tuning input[name="dMinPitch"]').val());
+            FC.ADVANCED_TUNING.dMinYaw = parseInt($('.pid_tuning input[name="dMinYaw"]').val());
+            FC.ADVANCED_TUNING.dMinGain = parseInt($('.dminGroup input[name="dMinGain"]').val());
+            FC.ADVANCED_TUNING.dMinAdvance = parseInt($('.dminGroup input[name="dMinAdvance"]').val());
 
-            ADVANCED_TUNING.useIntegratedYaw = $('input[id="useIntegratedYaw"]').is(':checked') ? 1 : 0;
+            FC.ADVANCED_TUNING.useIntegratedYaw = $('input[id="useIntegratedYaw"]').is(':checked') ? 1 : 0;
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-            FILTER_CONFIG.dyn_notch_range = parseInt($('.pid_filter select[name="dynamicNotchRange"]').val());
-            FILTER_CONFIG.dyn_notch_width_percent = parseInt($('.pid_filter input[name="dynamicNotchWidthPercent"]').val());
-            FILTER_CONFIG.dyn_notch_q = parseInt($('.pid_filter input[name="dynamicNotchQ"]').val());
-            FILTER_CONFIG.dyn_notch_min_hz = parseInt($('.pid_filter input[name="dynamicNotchMinHz"]').val());
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            FC.FILTER_CONFIG.dyn_notch_range = parseInt($('.pid_filter select[name="dynamicNotchRange"]').val());
+            FC.FILTER_CONFIG.dyn_notch_width_percent = parseInt($('.pid_filter input[name="dynamicNotchWidthPercent"]').val());
+            FC.FILTER_CONFIG.dyn_notch_q = parseInt($('.pid_filter input[name="dynamicNotchQ"]').val());
+            FC.FILTER_CONFIG.dyn_notch_min_hz = parseInt($('.pid_filter input[name="dynamicNotchMinHz"]').val());
 
             let rpmFilterEnabled = $('.pid_filter #rpmFilterEnabled').is(':checked');
-            FILTER_CONFIG.gyro_rpm_notch_harmonics = rpmFilterEnabled ? parseInt($('.pid_filter input[name="rpmFilterHarmonics"]').val()) : 0;
-            FILTER_CONFIG.gyro_rpm_notch_min_hz = parseInt($('.pid_filter input[name="rpmFilterMinHz"]').val());
+            FC.FILTER_CONFIG.gyro_rpm_notch_harmonics = rpmFilterEnabled ? parseInt($('.pid_filter input[name="rpmFilterHarmonics"]').val()) : 0;
+            FC.FILTER_CONFIG.gyro_rpm_notch_min_hz = parseInt($('.pid_filter input[name="rpmFilterMinHz"]').val());
         }
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-            FILTER_CONFIG.dyn_notch_max_hz = parseInt($('.pid_filter input[name="dynamicNotchMaxHz"]').val());
-            ADVANCED_TUNING.motorOutputLimit = parseInt($('.pid_tuning input[name="motorLimit"]').val());
-            ADVANCED_TUNING.autoProfileCellCount = parseInt($('.pid_tuning input[name="cellCount"]').val());
-            ADVANCED_TUNING.idleMinRpm = parseInt($('input[name="idleMinRpm-number"]').val());
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+            FC.FILTER_CONFIG.dyn_notch_max_hz = parseInt($('.pid_filter input[name="dynamicNotchMaxHz"]').val());
+            FC.ADVANCED_TUNING.motorOutputLimit = parseInt($('.pid_tuning input[name="motorLimit"]').val());
+            FC.ADVANCED_TUNING.autoProfileCellCount = parseInt($('.pid_tuning input[name="cellCount"]').val());
+            FC.ADVANCED_TUNING.idleMinRpm = parseInt($('input[name="idleMinRpm-number"]').val());
 
             const selectedRatesType = $('select[id="ratesType"]').val(); // send analytics for rates type
             let selectedRatesTypeName = undefined;
-            if (selectedRatesType !== RC_tuning.rates_type) {
+            if (selectedRatesType !== FC.RC_TUNING.rates_type) {
                 selectedRatesTypeName = $('select[id="ratesType"]').find('option:selected').text();
             }
             self.analyticsChanges['RatesType'] = selectedRatesTypeName;
 
-            RC_tuning.rates_type = selectedRatesType;
+            FC.RC_TUNING.rates_type = selectedRatesType;
         }
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_44)) {
-            ADVANCED_TUNING.ff_interpolate_sp = $('input[id="ffInterpolateSp"]').is(':checked') ? $('select[id="ffInterpolate"]').val() : 0;
-            ADVANCED_TUNING.ff_smooth_factor = parseInt($('input[name="ffSmoothFactor"]').val());
-            ADVANCED_TUNING.ff_boost = parseInt($('input[name="ffBoost"]').val());
-            FILTER_CONFIG.dyn_lpf_curve_expo = parseInt($('.pid_filter input[name="dtermLowpassDynExpo"]').val());
-            ADVANCED_TUNING.vbat_sag_compensation = $('input[id="vbatSagCompensation"]').is(':checked') ? parseInt($('input[name="vbatSagValue"]').val()) : 0;
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+            FC.ADVANCED_TUNING.ff_interpolate_sp = $('input[id="ffInterpolateSp"]').is(':checked') ? $('select[id="ffInterpolate"]').val() : 0;
+            FC.ADVANCED_TUNING.ff_smooth_factor = parseInt($('input[name="ffSmoothFactor"]').val());
+            FC.ADVANCED_TUNING.ff_boost = parseInt($('input[name="ffBoost"]').val());
+            FC.FILTER_CONFIG.dyn_lpf_curve_expo = parseInt($('.pid_filter input[name="dtermLowpassDynExpo"]').val());
+            FC.ADVANCED_TUNING.vbat_sag_compensation = $('input[id="vbatSagCompensation"]').is(':checked') ? parseInt($('input[name="vbatSagValue"]').val()) : 0;
         }
     }
 
@@ -964,7 +964,7 @@ TABS.pid_tuning.initialize = function (callback) {
         $('.pid_optional').hide(); // Hide general div
 
         // Only show rows supported by the firmware
-        PID_names.forEach(function(elementPid) {
+        FC.PID_NAMES.forEach(function(elementPid) {
             // Show rows for the PID
             $('.pid_tuning .' + elementPid).show();
 
@@ -973,7 +973,7 @@ TABS.pid_tuning.initialize = function (callback) {
         });
 
         // Special case
-        if (semver.lt(CONFIG.apiVersion, "1.24.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.24.0")) {
             $('#pid_sensitivity').hide();
         }
 
@@ -981,7 +981,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
     function hideUnusedPids() {
 
-        if (!have_sensor(CONFIG.activeSensors, 'acc')) {
+        if (!have_sensor(FC.CONFIG.activeSensors, 'acc')) {
             $('#pid_accel').hide();
         }
 
@@ -997,11 +997,11 @@ TABS.pid_tuning.initialize = function (callback) {
 
         var isVisibleBaroMagGps = false;
 
-        isVisibleBaroMagGps |= hideSensorPid($('#pid_baro'), have_sensor(CONFIG.activeSensors, 'baro') || have_sensor(CONFIG.activeSensors, 'sonar'));
+        isVisibleBaroMagGps |= hideSensorPid($('#pid_baro'), have_sensor(FC.CONFIG.activeSensors, 'baro') || have_sensor(FC.CONFIG.activeSensors, 'sonar'));
 
-        isVisibleBaroMagGps |= hideSensorPid($('#pid_mag'), have_sensor(CONFIG.activeSensors, 'mag'));
+        isVisibleBaroMagGps |= hideSensorPid($('#pid_mag'), have_sensor(FC.CONFIG.activeSensors, 'mag'));
 
-        isVisibleBaroMagGps |= hideSensorPid($('#pid_gps'), have_sensor(CONFIG.activeSensors, 'GPS'));
+        isVisibleBaroMagGps |= hideSensorPid($('#pid_gps'), have_sensor(FC.CONFIG.activeSensors, 'GPS'));
 
         if (!isVisibleBaroMagGps) {
             $('#pid_baro_mag_gps').hide();
@@ -1038,7 +1038,7 @@ TABS.pid_tuning.initialize = function (callback) {
     }
 
     var useLegacyCurve = false;
-    if (!semver.gte(CONFIG.apiVersion, "1.16.0")) {
+    if (!semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
         useLegacyCurve = true;
     }
 
@@ -1060,13 +1060,13 @@ TABS.pid_tuning.initialize = function (callback) {
     }
 
     function process_html() {
-        FEATURE_CONFIG.features.generateElements($('.tab-pid_tuning .features'));
+        FC.FEATURE_CONFIG.features.generateElements($('.tab-pid_tuning .features'));
 
-        if (semver.lt(CONFIG.apiVersion, "1.16.0") || semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.16.0") || semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             $('.tab-pid_tuning .pidTuningSuperexpoRates').hide();
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.39.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.39.0")) {
             $('input[name="dtermSetpoint-number"]').attr('max', self.SETPOINT_WEIGHT_RANGE_LEGACY);
         }
 
@@ -1075,48 +1075,48 @@ TABS.pid_tuning.initialize = function (callback) {
 
         // Local cache of current rates
         self.currentRates = {
-            roll_rate:     RC_tuning.roll_rate,
-            pitch_rate:    RC_tuning.pitch_rate,
-            yaw_rate:      RC_tuning.yaw_rate,
-            rc_rate:       RC_tuning.RC_RATE,
-            rc_rate_yaw:   RC_tuning.rcYawRate,
-            rc_expo:       RC_tuning.RC_EXPO,
-            rc_yaw_expo:   RC_tuning.RC_YAW_EXPO,
-            rc_rate_pitch: RC_tuning.rcPitchRate,
-            rc_pitch_expo: RC_tuning.RC_PITCH_EXPO,
-            superexpo:   FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES'),
-            deadband: RC_DEADBAND_CONFIG.deadband,
-            yawDeadband: RC_DEADBAND_CONFIG.yaw_deadband,
-            roll_rate_limit:   RC_tuning.roll_rate_limit,
-            pitch_rate_limit:  RC_tuning.pitch_rate_limit,
-            yaw_rate_limit:    RC_tuning.yaw_rate_limit
+            roll_rate:     FC.RC_TUNING.roll_rate,
+            pitch_rate:    FC.RC_TUNING.pitch_rate,
+            yaw_rate:      FC.RC_TUNING.yaw_rate,
+            rc_rate:       FC.RC_TUNING.RC_RATE,
+            rc_rate_yaw:   FC.RC_TUNING.rcYawRate,
+            rc_expo:       FC.RC_TUNING.RC_EXPO,
+            rc_yaw_expo:   FC.RC_TUNING.RC_YAW_EXPO,
+            rc_rate_pitch: FC.RC_TUNING.rcPitchRate,
+            rc_pitch_expo: FC.RC_TUNING.RC_PITCH_EXPO,
+            superexpo:   FC.FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES'),
+            deadband: FC.RC_DEADBAND_CONFIG.deadband,
+            yawDeadband: FC.RC_DEADBAND_CONFIG.yaw_deadband,
+            roll_rate_limit:   FC.RC_TUNING.roll_rate_limit,
+            pitch_rate_limit:  FC.RC_TUNING.pitch_rate_limit,
+            yaw_rate_limit:    FC.RC_TUNING.yaw_rate_limit
         };
 
-        if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
-            self.currentRates.roll_rate = RC_tuning.roll_pitch_rate;
-            self.currentRates.pitch_rate = RC_tuning.roll_pitch_rate;
+        if (semver.lt(FC.CONFIG.apiVersion, "1.7.0")) {
+            self.currentRates.roll_rate = FC.RC_TUNING.roll_pitch_rate;
+            self.currentRates.pitch_rate = FC.RC_TUNING.roll_pitch_rate;
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.16.0")) {
             self.currentRates.rc_rate_yaw = self.currentRates.rc_rate;
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             self.currentRates.superexpo = true;
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
             $('.pid_tuning input[name="sensitivity"]').hide();
             $('.pid_tuning .levelSensitivityHeader').empty();
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.37.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.37.0")) {
             self.currentRates.rc_rate_pitch = self.currentRates.rc_rate;
             self.currentRates.rc_expo_pitch = self.currentRates.rc_expo;
         }
 
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-            switch(RC_tuning.rates_type) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+            switch(FC.RC_TUNING.rates_type) {
                 case self.RATES_TYPE.RACEFLIGHT:
                     self.currentRates.roll_rate *= 100;
                     self.currentRates.pitch_rate *= 100;
@@ -1162,8 +1162,8 @@ TABS.pid_tuning.initialize = function (callback) {
 
         function loadProfilesList() {
             var numberOfProfiles = 3;
-            if (semver.gte(CONFIG.apiVersion, "1.20.0")
-                 && CONFIG.numProfiles === 2) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")
+                 && FC.CONFIG.numProfiles === 2) {
                     numberOfProfiles = 2;
             }
 
@@ -1176,7 +1176,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         function loadRateProfilesList() {
             var numberOfRateProfiles = 6;
-            if (semver.lt(CONFIG.apiVersion, "1.37.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.37.0")) {
                 numberOfRateProfiles = 3;
             }
 
@@ -1252,14 +1252,14 @@ TABS.pid_tuning.initialize = function (callback) {
                     self.updating = false;
 
                     $('.tab-pid_tuning select[name="profile"]').prop('disabled', 'false');
-                    CONFIG.profile = self.currentProfile;
+                    FC.CONFIG.profile = self.currentProfile;
 
                     GUI.log(i18n.getMessage('pidTuningLoadedProfile', [self.currentProfile + 1]));
                 });
             });
         });
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             $('.tab-pid_tuning select[name="rate_profile"]').change(function () {
                 self.currentRateProfile = parseInt($(this).val());
                 self.updating = true;
@@ -1269,7 +1269,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         self.updating = false;
 
                         $('.tab-pid_tuning select[name="rate_profile"]').prop('disabled', 'false');
-                        CONFIG.rateProfile = self.currentRateProfile;
+                        FC.CONFIG.rateProfile = self.currentRateProfile;
 
                         GUI.log(i18n.getMessage('pidTuningLoadedRateProfile', [self.currentRateProfile + 1]));
                     });
@@ -1300,18 +1300,18 @@ TABS.pid_tuning.initialize = function (callback) {
             $('#pid-tuning .dtermSetpoint').hide();
         }
 
-        if (!semver.gte(CONFIG.apiVersion, "1.16.0")) {
+        if (!semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
             $('#pid-tuning .delta').hide();
             $('.tab-pid_tuning .note').hide();
         }
 
         // Add a name to each row of PIDs if empty
         $('.pid_tuning tr').each(function(){
-            for(i = 0; i < PID_names.length; i++) {
-                if($(this).hasClass(PID_names[i])) {
+            for(i = 0; i < FC.PID_NAMES.length; i++) {
+                if($(this).hasClass(FC.PID_NAMES[i])) {
                     var firstColumn = $(this).find('td:first');
                     if (!firstColumn.text()) {
-                        firstColumn.text(PID_names[i]);
+                        firstColumn.text(FC.PID_NAMES[i]);
                     }
                 }
             }
@@ -1323,7 +1323,7 @@ TABS.pid_tuning.initialize = function (callback) {
             var filterTypeValues = [];
             filterTypeValues.push("PT1");
             filterTypeValues.push("BIQUAD");
-            if (semver.lt(CONFIG.apiVersion, "1.39.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.39.0")) {
                 filterTypeValues.push("FIR");
             }
             return filterTypeValues;
@@ -1348,7 +1348,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 dynamicNotchRangeSelect.append('<option value="' + key + '">' + value + '</option>');
             });
         }
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             populateDynamicNotchRangeSelect(loadDynamicNotchRangeValues());
         }
 
@@ -1385,11 +1385,11 @@ TABS.pid_tuning.initialize = function (callback) {
 
         var pidController_e = $('select[name="controller"]');
 
-        if (semver.lt(CONFIG.apiVersion, "1.31.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.31.0")) {
             var pidControllerList;
 
 
-            if (semver.lt(CONFIG.apiVersion, "1.14.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, "1.14.0")) {
                 pidControllerList = [
                     {name: "MultiWii (Old)"},
                     {name: "MultiWii (rewrite)"},
@@ -1398,7 +1398,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     {name: "MultiWii (2.3 - hybrid)"},
                     {name: "Harakiri"}
                 ]
-            } else if (semver.lt(CONFIG.apiVersion, "1.20.0")) {
+            } else if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
                 pidControllerList = [
                     {name: ""},
                     {name: "Integer"},
@@ -1415,12 +1415,12 @@ TABS.pid_tuning.initialize = function (callback) {
                 pidController_e.append('<option value="' + (i) + '">' + pidControllerList[i].name + '</option>');
             }
 
-            if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE)) {
-                pidController_e.val(PID.controller);
+            if (semver.gte(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE)) {
+                pidController_e.val(FC.PID.controller);
 
                 self.updatePidControllerParameters();
             } else {
-                GUI.log(i18n.getMessage('pidTuningUpgradeFirmwareToChangePidController', [CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE]));
+                GUI.log(i18n.getMessage('pidTuningUpgradeFirmwareToChangePidController', [FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE]));
 
                 pidController_e.empty();
                 pidController_e.append('<option value="">Unknown</option>');
@@ -1433,7 +1433,7 @@ TABS.pid_tuning.initialize = function (callback) {
             self.updatePidControllerParameters();
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.7.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.7.0")) {
             $('.tpa .tpa-breakpoint').hide();
 
             $('.pid_tuning .roll_rate').hide();
@@ -1442,7 +1442,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_tuning .roll_pitch_rate').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
             $('.pid_tuning .bracket').hide();
             $('.pid_tuning input[name=rc_rate]').parent().attr('class', 'pid_data');
             $('.pid_tuning input[name=rc_rate]').parent().attr('rowspan', 1);
@@ -1488,11 +1488,11 @@ TABS.pid_tuning.initialize = function (callback) {
                         updateNeeded = true;
                     }
 
-                    if (targetElement.attr('name') === 'rc_rate' && semver.lt(CONFIG.apiVersion, "1.16.0")) {
+                    if (targetElement.attr('name') === 'rc_rate' && semver.lt(FC.CONFIG.apiVersion, "1.16.0")) {
                         self.currentRates.rc_rate_yaw = targetValue;
                     }
 
-                    if (targetElement.attr('name') === 'roll_pitch_rate' && semver.lt(CONFIG.apiVersion, "1.7.0")) {
+                    if (targetElement.attr('name') === 'roll_pitch_rate' && semver.lt(FC.CONFIG.apiVersion, "1.7.0")) {
                         self.currentRates.roll_rate = targetValue;
                         self.currentRates.pitch_rate = targetValue;
 
@@ -1505,15 +1505,15 @@ TABS.pid_tuning.initialize = function (callback) {
                         updateNeeded = true;
                     }
 
-                    if (targetElement.attr('name') === 'rc_rate' && semver.lt(CONFIG.apiVersion, "1.37.0")) {
+                    if (targetElement.attr('name') === 'rc_rate' && semver.lt(FC.CONFIG.apiVersion, "1.37.0")) {
                         self.currentRates.rc_rate_pitch = targetValue;
                     }
 
-                    if (targetElement.attr('name') === 'rc_expo' && semver.lt(CONFIG.apiVersion, "1.37.0")) {
+                    if (targetElement.attr('name') === 'rc_expo' && semver.lt(FC.CONFIG.apiVersion, "1.37.0")) {
                         self.currentRates.rc_pitch_expo = targetValue;
                     }
 
-                    if (targetElement.attr('id') === 'ratesType' && semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+                    if (targetElement.attr('id') === 'ratesType' && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                         self.changeRatesType(targetValue);
 
                         updateNeeded = true;
@@ -1560,7 +1560,7 @@ TABS.pid_tuning.initialize = function (callback) {
         $('input.feature').on('input change', function () {
             const element = $(this);
 
-            FEATURE_CONFIG.features.updateData(element);
+            FC.FEATURE_CONFIG.features.updateData(element);
 
             updateRates();
         });
@@ -1623,7 +1623,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 midyl = canvasHeight - ((canvasHeight - midy) * 0.5 *(expo + 1)),
                 midyr = (midy / 2) * (expo + 1);
 
-            let thrPercent = (RC.channels[3] - 1000) / 1000,
+            let thrPercent = (FC.RC.channels[3] - 1000) / 1000,
                 thrpos = thrPercent <= mid
                     ? getQuadraticCurvePoint(0, canvasHeight, midxl, midyl, midx, midy, thrPercent * (1.0 / mid))
                     : getQuadraticCurvePoint(midx, midy, midxr, midyr, canvasWidth, 0, (thrPercent - mid) * (1.0 / (1.0 - mid)));
@@ -1681,17 +1681,17 @@ TABS.pid_tuning.initialize = function (callback) {
         var DIALOG_MODE_RATEPROFILE = 1;
         var dialogCopyProfileMode;
 
-        if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
 
             var selectProfile = $('.selectProfile');
             var selectRateProfile = $('.selectRateProfile');
 
             $.each(selectProfileValues, function(key, value) {
-                if (key != CONFIG.profile)
+                if (key != FC.CONFIG.profile)
                     selectProfile.append(new Option(value, key));
             });
             $.each(selectRateProfileValues, function(key, value) {
-                if (key != CONFIG.rateProfile)
+                if (key != FC.CONFIG.rateProfile)
                     selectRateProfile.append(new Option(value, key));
             });
 
@@ -1716,18 +1716,18 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.dialogCopyProfile-confirmbtn').click(function() {
                 switch(dialogCopyProfileMode) {
                     case DIALOG_MODE_PROFILE:
-                        COPY_PROFILE.type = DIALOG_MODE_PROFILE;    // 0 = pid profile
-                        COPY_PROFILE.dstProfile = parseInt(selectProfile.val());
-                        COPY_PROFILE.srcProfile = CONFIG.profile;
+                        FC.COPY_PROFILE.type = DIALOG_MODE_PROFILE;    // 0 = pid profile
+                        FC.COPY_PROFILE.dstProfile = parseInt(selectProfile.val());
+                        FC.COPY_PROFILE.srcProfile = FC.CONFIG.profile;
 
                         MSP.send_message(MSPCodes.MSP_COPY_PROFILE, mspHelper.crunch(MSPCodes.MSP_COPY_PROFILE), false, close_dialog);
 
                         break;
 
                     case DIALOG_MODE_RATEPROFILE:
-                        COPY_PROFILE.type = DIALOG_MODE_RATEPROFILE;    // 1 = rate profile
-                        COPY_PROFILE.dstProfile = parseInt(selectRateProfile.val());
-                        COPY_PROFILE.srcProfile = CONFIG.rateProfile;
+                        FC.COPY_PROFILE.type = DIALOG_MODE_RATEPROFILE;    // 1 = rate profile
+                        FC.COPY_PROFILE.dstProfile = parseInt(selectRateProfile.val());
+                        FC.COPY_PROFILE.srcProfile = FC.CONFIG.rateProfile;
 
                         MSP.send_message(MSPCodes.MSP_COPY_PROFILE, mspHelper.crunch(MSPCodes.MSP_COPY_PROFILE), false, close_dialog);
 
@@ -1747,7 +1747,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.copyrateprofilebtn').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             // filter and tuning sliders
             TuningSliders.initialize();
 
@@ -1768,13 +1768,13 @@ TABS.pid_tuning.initialize = function (callback) {
                 // switch dmin and dmax values on dmin on/off if sliders available
                 if (!TuningSliders.pidSlidersUnavailable) {
                     if (TuningSliders.dMinFeatureEnabled) {
-                        ADVANCED_TUNING.dMinRoll = PIDs[0][2];
-                        ADVANCED_TUNING.dMinPitch = PIDs[1][2];
-                        ADVANCED_TUNING.dMinYaw = PIDs[2][2];
+                        FC.ADVANCED_TUNING.dMinRoll = FC.PIDS[0][2];
+                        FC.ADVANCED_TUNING.dMinPitch = FC.PIDS[1][2];
+                        FC.ADVANCED_TUNING.dMinYaw = FC.PIDS[2][2];
                     } else {
-                        PIDs[0][2] = ADVANCED_TUNING.dMinRoll;
-                        PIDs[1][2] = ADVANCED_TUNING.dMinPitch;
-                        PIDs[2][2] = ADVANCED_TUNING.dMinYaw;
+                        FC.PIDS[0][2] = FC.ADVANCED_TUNING.dMinRoll;
+                        FC.PIDS[1][2] = FC.ADVANCED_TUNING.dMinPitch;
+                        FC.PIDS[2][2] = FC.ADVANCED_TUNING.dMinYaw;
                     }
                     TuningSliders.calculateNewPids();
                 }
@@ -1938,13 +1938,13 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.tuningHelpSliders').hide();
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.16.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.16.0")) {
             $('#pid-tuning .delta select').change(function() {
                 self.setDirty(true);
             });
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.31.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.31.0")) {
             pidController_e.change(function () {
                 self.setDirty(true);
 
@@ -1960,8 +1960,8 @@ TABS.pid_tuning.initialize = function (callback) {
             Promise.resolve(true)
             .then(function () {
                 var promise;
-                if (semver.gte(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE) && semver.lt(CONFIG.apiVersion, "1.31.0")) {
-                    PID.controller = pidController_e.val();
+                if (semver.gte(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE) && semver.lt(FC.CONFIG.apiVersion, "1.31.0")) {
+                    FC.PID.controller = pidController_e.val();
                     promise = MSP.promise(MSPCodes.MSP_SET_PID_CONTROLLER, mspHelper.crunch(MSPCodes.MSP_SET_PID_CONTROLLER));
                 }
                 return promise;
@@ -2031,12 +2031,12 @@ TABS.pid_tuning.renderModel = function () {
 
     if (!this.clock) { this.clock = new THREE.Clock(); }
 
-    if (RC.channels[0] && RC.channels[1] && RC.channels[2]) {
+    if (FC.RC.channels[0] && FC.RC.channels[1] && FC.RC.channels[2]) {
         var delta = this.clock.getDelta();
 
-        var roll  = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(RC.channels[0], this.currentRates.roll_rate,  this.currentRates.rc_rate,       this.currentRates.rc_expo,       this.currentRates.superexpo, this.currentRates.deadband,    this.currentRates.roll_rate_limit),
-            pitch = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(RC.channels[1], this.currentRates.pitch_rate, this.currentRates.rc_rate_pitch, this.currentRates.rc_pitch_expo, this.currentRates.superexpo, this.currentRates.deadband,    this.currentRates.pitch_rate_limit),
-            yaw   = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(RC.channels[2], this.currentRates.yaw_rate,   this.currentRates.rc_rate_yaw,   this.currentRates.rc_yaw_expo,   this.currentRates.superexpo, this.currentRates.yawDeadband, this.currentRates.yaw_rate_limit);
+        var roll  = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(FC.RC.channels[0], this.currentRates.roll_rate,  this.currentRates.rc_rate,       this.currentRates.rc_expo,       this.currentRates.superexpo, this.currentRates.deadband,    this.currentRates.roll_rate_limit),
+            pitch = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(FC.RC.channels[1], this.currentRates.pitch_rate, this.currentRates.rc_rate_pitch, this.currentRates.rc_pitch_expo, this.currentRates.superexpo, this.currentRates.deadband,    this.currentRates.pitch_rate_limit),
+            yaw   = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(FC.RC.channels[2], this.currentRates.yaw_rate,   this.currentRates.rc_rate_yaw,   this.currentRates.rc_yaw_expo,   this.currentRates.superexpo, this.currentRates.yawDeadband, this.currentRates.yaw_rate_limit);
 
         this.model.rotateBy(-degToRad(pitch), -degToRad(yaw), -degToRad(roll));
 
@@ -2079,14 +2079,14 @@ TABS.pid_tuning.refresh = function (callback) {
 TABS.pid_tuning.setProfile = function () {
     var self = this;
 
-    self.currentProfile = CONFIG.profile;
+    self.currentProfile = FC.CONFIG.profile;
     $('.tab-pid_tuning select[name="profile"]').val(self.currentProfile);
 };
 
 TABS.pid_tuning.setRateProfile = function () {
     var self = this;
 
-    self.currentRateProfile = CONFIG.rateProfile;
+    self.currentRateProfile = FC.CONFIG.rateProfile;
     $('.tab-pid_tuning select[name="rate_profile"]').val(self.currentRateProfile);
 };
 
@@ -2095,7 +2095,7 @@ TABS.pid_tuning.setDirty = function (isDirty) {
 
     self.dirty = isDirty;
     $('.tab-pid_tuning select[name="profile"]').prop('disabled', isDirty);
-    if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
         $('.tab-pid_tuning select[name="rate_profile"]').prop('disabled', isDirty);
     }
 };
@@ -2107,16 +2107,16 @@ TABS.pid_tuning.checkUpdateProfile = function (updateRateProfile) {
 
         if (!self.updating && !self.dirty) {
             var changedProfile = false;
-            if (self.currentProfile !== CONFIG.profile) {
+            if (self.currentProfile !== FC.CONFIG.profile) {
                 self.setProfile();
 
                 changedProfile = true;
             }
 
             var changedRateProfile = false;
-            if (semver.gte(CONFIG.apiVersion, "1.20.0")
+            if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")
                 && updateRateProfile
-                && self.currentRateProfile !== CONFIG.rateProfile) {
+                && self.currentRateProfile !== FC.CONFIG.rateProfile) {
                 self.setRateProfile();
 
                 changedRateProfile = true;
@@ -2125,13 +2125,13 @@ TABS.pid_tuning.checkUpdateProfile = function (updateRateProfile) {
             if (changedProfile || changedRateProfile) {
                 self.refresh(function () {
                     if (changedProfile) {
-                        GUI.log(i18n.getMessage('pidTuningReceivedProfile', [CONFIG.profile + 1]));
-                        CONFIG.profile = self.currentProfile;
+                        GUI.log(i18n.getMessage('pidTuningReceivedProfile', [FC.CONFIG.profile + 1]));
+                        FC.CONFIG.profile = self.currentProfile;
                     }
 
                     if (changedRateProfile) {
-                        GUI.log(i18n.getMessage('pidTuningReceivedRateProfile', [CONFIG.rateProfile + 1]));
-                        CONFIG.rateProfile = self.currentRateProfile
+                        GUI.log(i18n.getMessage('pidTuningReceivedRateProfile', [FC.CONFIG.rateProfile + 1]));
+                        FC.CONFIG.rateProfile = self.currentRateProfile
                     }
                 });
             }
@@ -2142,13 +2142,13 @@ TABS.pid_tuning.checkUpdateProfile = function (updateRateProfile) {
 TABS.pid_tuning.checkRC = function() {
     // Function monitors for change in the primary axes rc received data and returns true if a change is detected.
 
-    if (!this.oldRC) { this.oldRC = [RC.channels[0], RC.channels[1], RC.channels[2]]; }
+    if (!this.oldRC) { this.oldRC = [FC.RC.channels[0], FC.RC.channels[1], FC.RC.channels[2]]; }
 
-    // Monitor RC.channels and detect change of value;
+    // Monitor FC.RC.channels and detect change of value;
     var rateCurveUpdateRequired = false;
     for(var i=0; i<this.oldRC.length; i++) { // has the value changed ?
-        if(this.oldRC[i] != RC.channels[i]) {
-            this.oldRC[i] = RC.channels[i];
+        if(this.oldRC[i] != FC.RC.channels[i]) {
+            this.oldRC[i] = FC.RC.channels[i];
             rateCurveUpdateRequired = true;     // yes, then an update of the values displayed on the rate curve graph is required
         }
     }
@@ -2158,16 +2158,16 @@ TABS.pid_tuning.checkRC = function() {
 TABS.pid_tuning.checkThrottle = function() {
     // Function monitors for change in the received rc throttle data and returns true if a change is detected.
     if (!this.oldThrottle) {
-        this.oldThrottle = RC.channels[3];
+        this.oldThrottle = FC.RC.channels[3];
         return true;
     }
-    var updateRequired = this.oldThrottle != RC.channels[3];
-    this.oldThrottle = RC.channels[3];
+    var updateRequired = this.oldThrottle != FC.RC.channels[3];
+    this.oldThrottle = FC.RC.channels[3];
     return updateRequired;
 };
 
 TABS.pid_tuning.updatePidControllerParameters = function () {
-    if (semver.gte(CONFIG.apiVersion, "1.20.0") && semver.lt(CONFIG.apiVersion, "1.31.0") && $('.tab-pid_tuning select[name="controller"]').val() === '0') {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.20.0") && semver.lt(FC.CONFIG.apiVersion, "1.31.0") && $('.tab-pid_tuning select[name="controller"]').val() === '0') {
         $('.pid_tuning .YAW_JUMP_PREVENTION').show();
 
         $('#pid-tuning .delta').show();
@@ -2177,7 +2177,7 @@ TABS.pid_tuning.updatePidControllerParameters = function () {
     } else {
         $('.pid_tuning .YAW_JUMP_PREVENTION').hide();
 
-        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
             $('#pid-tuning .dtermSetpointTransition').hide();
             $('#pid-tuning .dtermSetpoint').hide();
         } else {
@@ -2327,10 +2327,10 @@ TABS.pid_tuning.updateRatesLabels = function() {
                 stickContext.font = (24 * windowScale) + "pt Verdana, Arial, sans-serif";
             }
 
-            if(RC.channels[0] && RC.channels[1] && RC.channels[2]) {
-                currentValues.push(self.rateCurve.drawStickPosition(RC.channels[0], self.currentRates.roll_rate, self.currentRates.rc_rate, self.currentRates.rc_expo, self.currentRates.superexpo, self.currentRates.deadband, self.currentRates.roll_rate_limit, maxAngularVel, stickContext, '#FF8080') + ' deg/s');
-                currentValues.push(self.rateCurve.drawStickPosition(RC.channels[1], self.currentRates.pitch_rate, self.currentRates.rc_rate_pitch, self.currentRates.rc_pitch_expo, self.currentRates.superexpo, self.currentRates.deadband, self.currentRates.pitch_rate_limit, maxAngularVel, stickContext, '#80FF80') + ' deg/s');
-                currentValues.push(self.rateCurve.drawStickPosition(RC.channels[2], self.currentRates.yaw_rate, self.currentRates.rc_rate_yaw, self.currentRates.rc_yaw_expo, self.currentRates.superexpo, self.currentRates.yawDeadband, self.currentRates.yaw_rate_limit, maxAngularVel, stickContext, '#8080FF') + ' deg/s');
+            if(FC.RC.channels[0] && FC.RC.channels[1] && FC.RC.channels[2]) {
+                currentValues.push(self.rateCurve.drawStickPosition(FC.RC.channels[0], self.currentRates.roll_rate, self.currentRates.rc_rate, self.currentRates.rc_expo, self.currentRates.superexpo, self.currentRates.deadband, self.currentRates.roll_rate_limit, maxAngularVel, stickContext, '#FF8080') + ' deg/s');
+                currentValues.push(self.rateCurve.drawStickPosition(FC.RC.channels[1], self.currentRates.pitch_rate, self.currentRates.rc_rate_pitch, self.currentRates.rc_pitch_expo, self.currentRates.superexpo, self.currentRates.deadband, self.currentRates.pitch_rate_limit, maxAngularVel, stickContext, '#80FF80') + ' deg/s');
+                currentValues.push(self.rateCurve.drawStickPosition(FC.RC.channels[2], self.currentRates.yaw_rate, self.currentRates.rc_rate_yaw, self.currentRates.rc_yaw_expo, self.currentRates.superexpo, self.currentRates.yawDeadband, self.currentRates.yaw_rate_limit, maxAngularVel, stickContext, '#8080FF') + ' deg/s');
             } else {
                 currentValues = [];
             }
@@ -2388,8 +2388,8 @@ TABS.pid_tuning.updateFilterWarning = function() {
     } else {
         warning_e.hide();
     }
-    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-        if (FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (FC.FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
             warningDynamicNotch_e.hide();
         } else {
             warningDynamicNotch_e.show();
@@ -2414,18 +2414,18 @@ TABS.pid_tuning.updatePIDColors = function(clear = false) {
         element.css({ "background-color": cssUtil.getColorForPercentage(change, cssUtil.colorTables.pidSlider) });
     };
 
-    PID_names.forEach(function(elementPid, indexPid) {
+    FC.PID_NAMES.forEach(function(elementPid, indexPid) {
         $(".pid_tuning ." + elementPid + " input").each(function(indexInput) {
-            setTuningElementColor($(this), PIDS_ACTIVE[indexPid][indexInput], PIDs[indexPid][indexInput]);
+            setTuningElementColor($(this), FC.PIDS_ACTIVE[indexPid][indexInput], FC.PIDS[indexPid][indexInput]);
         });
     });
 
-    setTuningElementColor($('.pid_tuning input[name="dMinRoll"]'), ADVANCED_TUNING_ACTIVE.dMinRoll, ADVANCED_TUNING.dMinRoll);
-    setTuningElementColor($('.pid_tuning input[name="dMinPitch"]'), ADVANCED_TUNING_ACTIVE.dMinPitch, ADVANCED_TUNING.dMinPitch);
-    setTuningElementColor($('.pid_tuning input[name="dMinYaw"]'), ADVANCED_TUNING_ACTIVE.dMinYaw, ADVANCED_TUNING.dMinYaw);
-    setTuningElementColor($('.pid_tuning .ROLL input[name="f"]'), ADVANCED_TUNING_ACTIVE.feedforwardRoll, ADVANCED_TUNING.feedforwardRoll);
-    setTuningElementColor($('.pid_tuning .PITCH input[name="f"]'), ADVANCED_TUNING_ACTIVE.feedforwardPitch, ADVANCED_TUNING.feedforwardPitch);
-    setTuningElementColor($('.pid_tuning .YAW input[name="f"]'), ADVANCED_TUNING_ACTIVE.feedforwardYaw, ADVANCED_TUNING.feedforwardYaw);
+    setTuningElementColor($('.pid_tuning input[name="dMinRoll"]'), FC.ADVANCED_TUNING_ACTIVE.dMinRoll, FC.ADVANCED_TUNING.dMinRoll);
+    setTuningElementColor($('.pid_tuning input[name="dMinPitch"]'), FC.ADVANCED_TUNING_ACTIVE.dMinPitch, FC.ADVANCED_TUNING.dMinPitch);
+    setTuningElementColor($('.pid_tuning input[name="dMinYaw"]'), FC.ADVANCED_TUNING_ACTIVE.dMinYaw, FC.ADVANCED_TUNING.dMinYaw);
+    setTuningElementColor($('.pid_tuning .ROLL input[name="f"]'), FC.ADVANCED_TUNING_ACTIVE.feedforwardRoll, FC.ADVANCED_TUNING.feedforwardRoll);
+    setTuningElementColor($('.pid_tuning .PITCH input[name="f"]'), FC.ADVANCED_TUNING_ACTIVE.feedforwardPitch, FC.ADVANCED_TUNING.feedforwardPitch);
+    setTuningElementColor($('.pid_tuning .YAW input[name="f"]'), FC.ADVANCED_TUNING_ACTIVE.feedforwardYaw, FC.ADVANCED_TUNING.feedforwardYaw);
 };
 
 TABS.pid_tuning.changeRatesType = function(rateTypeID) {
@@ -2487,15 +2487,15 @@ TABS.pid_tuning.changeRatesSystem = function(sameType) {
     let rcRateDefault = (1).toFixed(2), rateDefault = (0.7).toFixed(2), expoDefault = (0).toFixed(2);
 
     if (sameType) { // if selected rates type is different from the saved one, set values to default instead of reading
-        pitch_rate_e.val(RC_tuning.pitch_rate.toFixed(2));
-        roll_rate_e.val(RC_tuning.roll_rate.toFixed(2));
-        yaw_rate_e.val(RC_tuning.yaw_rate.toFixed(2));
-        rc_rate_pitch_e.val(RC_tuning.rcPitchRate.toFixed(2));
-        rc_rate_e.val(RC_tuning.RC_RATE.toFixed(2));
-        rc_rate_yaw_e.val(RC_tuning.rcYawRate.toFixed(2));
-        rc_pitch_expo_e.val(RC_tuning.RC_PITCH_EXPO.toFixed(2));
-        rc_expo_e.val(RC_tuning.RC_EXPO.toFixed(2));
-        rc_yaw_expo_e.val(RC_tuning.RC_YAW_EXPO.toFixed(2));
+        pitch_rate_e.val(FC.RC_TUNING.pitch_rate.toFixed(2));
+        roll_rate_e.val(FC.RC_TUNING.roll_rate.toFixed(2));
+        yaw_rate_e.val(FC.RC_TUNING.yaw_rate.toFixed(2));
+        rc_rate_pitch_e.val(FC.RC_TUNING.rcPitchRate.toFixed(2));
+        rc_rate_e.val(FC.RC_TUNING.RC_RATE.toFixed(2));
+        rc_rate_yaw_e.val(FC.RC_TUNING.rcYawRate.toFixed(2));
+        rc_pitch_expo_e.val(FC.RC_TUNING.RC_PITCH_EXPO.toFixed(2));
+        rc_expo_e.val(FC.RC_TUNING.RC_EXPO.toFixed(2));
+        rc_yaw_expo_e.val(FC.RC_TUNING.RC_YAW_EXPO.toFixed(2));
     }
 
     switch(self.currentRatesType) {
@@ -2513,15 +2513,15 @@ TABS.pid_tuning.changeRatesSystem = function(sameType) {
             expoStep = 1;
 
             if (sameType) {
-                pitch_rate_e.val((RC_tuning.pitch_rate * 100).toFixed(0));
-                roll_rate_e.val((RC_tuning.roll_rate * 100).toFixed(0));
-                yaw_rate_e.val((RC_tuning.yaw_rate * 100).toFixed(0));
-                rc_rate_pitch_e.val((RC_tuning.rcPitchRate * 1000).toFixed(0));
-                rc_rate_e.val((RC_tuning.RC_RATE * 1000).toFixed(0));
-                rc_rate_yaw_e.val((RC_tuning.rcYawRate * 1000).toFixed(0));
-                rc_pitch_expo_e.val((RC_tuning.RC_PITCH_EXPO * 100).toFixed(0));
-                rc_expo_e.val((RC_tuning.RC_EXPO * 100).toFixed(0));
-                rc_yaw_expo_e.val((RC_tuning.RC_YAW_EXPO * 100).toFixed(0));
+                pitch_rate_e.val((FC.RC_TUNING.pitch_rate * 100).toFixed(0));
+                roll_rate_e.val((FC.RC_TUNING.roll_rate * 100).toFixed(0));
+                yaw_rate_e.val((FC.RC_TUNING.yaw_rate * 100).toFixed(0));
+                rc_rate_pitch_e.val((FC.RC_TUNING.rcPitchRate * 1000).toFixed(0));
+                rc_rate_e.val((FC.RC_TUNING.RC_RATE * 1000).toFixed(0));
+                rc_rate_yaw_e.val((FC.RC_TUNING.rcYawRate * 1000).toFixed(0));
+                rc_pitch_expo_e.val((FC.RC_TUNING.RC_PITCH_EXPO * 100).toFixed(0));
+                rc_expo_e.val((FC.RC_TUNING.RC_EXPO * 100).toFixed(0));
+                rc_yaw_expo_e.val((FC.RC_TUNING.RC_YAW_EXPO * 100).toFixed(0));
             } else {
                 rcRateDefault = (370).toFixed(0);
                 rateDefault = (80).toFixed(0);
@@ -2551,12 +2551,12 @@ TABS.pid_tuning.changeRatesSystem = function(sameType) {
             rcRateStep = 10;
 
             if (sameType) {
-                pitch_rate_e.val((RC_tuning.pitch_rate * 1000).toFixed(0));
-                roll_rate_e.val((RC_tuning.roll_rate * 1000).toFixed(0));
-                yaw_rate_e.val((RC_tuning.yaw_rate * 1000).toFixed(0));
-                rc_rate_pitch_e.val((RC_tuning.rcPitchRate * 1000).toFixed(0));
-                rc_rate_e.val((RC_tuning.RC_RATE * 1000).toFixed(0));
-                rc_rate_yaw_e.val((RC_tuning.rcYawRate * 1000).toFixed(0));
+                pitch_rate_e.val((FC.RC_TUNING.pitch_rate * 1000).toFixed(0));
+                roll_rate_e.val((FC.RC_TUNING.roll_rate * 1000).toFixed(0));
+                yaw_rate_e.val((FC.RC_TUNING.yaw_rate * 1000).toFixed(0));
+                rc_rate_pitch_e.val((FC.RC_TUNING.rcPitchRate * 1000).toFixed(0));
+                rc_rate_e.val((FC.RC_TUNING.RC_RATE * 1000).toFixed(0));
+                rc_rate_yaw_e.val((FC.RC_TUNING.rcYawRate * 1000).toFixed(0));
             } else {
                 rcRateDefault = (200).toFixed(0);
                 rateDefault = (670).toFixed(0);
@@ -2574,9 +2574,9 @@ TABS.pid_tuning.changeRatesSystem = function(sameType) {
             rateStep = 10;
 
             if (sameType) {
-                pitch_rate_e.val((RC_tuning.pitch_rate * 1000).toFixed(0));
-                roll_rate_e.val((RC_tuning.roll_rate * 1000).toFixed(0));
-                yaw_rate_e.val((RC_tuning.yaw_rate * 1000).toFixed(0));
+                pitch_rate_e.val((FC.RC_TUNING.pitch_rate * 1000).toFixed(0));
+                roll_rate_e.val((FC.RC_TUNING.roll_rate * 1000).toFixed(0));
+                yaw_rate_e.val((FC.RC_TUNING.yaw_rate * 1000).toFixed(0));
             } else {
                 rateDefault = (670).toFixed(0);
             }

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -19,7 +19,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
          {name: 'BLACKBOX',     groups: ['peripherals'], sharableWith: ['msp'], notSharableWith: ['telemetry'], maxPorts: 1}
     ];
 
-    if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
         var ltmFunctionRule = {name: 'TELEMETRY_LTM',        groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['peripherals'], maxPorts: 1};
         functionRules.push(ltmFunctionRule);
     } else {
@@ -27,33 +27,33 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         functionRules.push(mspFunctionRule);
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.18.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.18.0")) {
         var mavlinkFunctionRule = {name: 'TELEMETRY_MAVLINK',    groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['peripherals'], maxPorts: 1};
         functionRules.push(mavlinkFunctionRule);
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
         functionRules.push({ name: 'ESC_SENSOR', groups: ['sensors'], maxPorts: 1 });
         functionRules.push({ name: 'TBS_SMARTAUDIO', groups: ['peripherals'], maxPorts: 1 });
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.27.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.27.0")) {
         functionRules.push({ name: 'IRC_TRAMP', groups: ['peripherals'], maxPorts: 1 });
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.32.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.32.0")) {
         functionRules.push({ name: 'TELEMETRY_IBUS', groups: ['telemetry'], maxPorts: 1 });
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
         functionRules.push({ name: 'RUNCAM_DEVICE_CONTROL', groups: ['peripherals'], maxPorts: 1 });
     }
 
-    if (semver.gte(CONFIG.apiVersion, "1.37.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
         functionRules.push({ name: 'LIDAR_TF', groups: ['peripherals'], maxPorts: 1 });
     }
 
-    if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
         functionRules.push({ name: 'FRSKY_OSD', groups: ['peripherals'], maxPorts: 1 });
     }
 
@@ -71,7 +71,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         '250000'
     ];
 
-    if (semver.gte(CONFIG.apiVersion, "1.31.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
         mspBaudRates = mspBaudRates.concat(['500000', '1000000']);
     }
 
@@ -116,7 +116,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
 
     function load_configuration_from_fc() {
         let promise;
-        if(semver.gte(CONFIG.apiVersion, "1.42.0")) {
+        if(semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
             promise = MSP.promise(MSPCodes.MSP_VTX_CONFIG);
         } else {
             promise = Promise.resolve();
@@ -128,7 +128,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         function on_configuration_loaded_handler() {
             $('#content').load("./tabs/ports.html", on_tab_loaded_handler);
 
-            board_definition = BOARD.find_board_definition(CONFIG.boardIdentifier);
+            board_definition = BOARD.find_board_definition(FC.CONFIG.boardIdentifier);
             console.log('Using board definition', board_definition);
         }
     }
@@ -136,7 +136,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
     function update_ui() {
         self.analyticsChanges = {};
 
-        if (semver.lt(CONFIG.apiVersion, "1.6.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.6.0")) {
 
             $(".tab-ports").removeClass("supported");
             return;
@@ -187,10 +187,10 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         const portIdentifierTemplateE = $('#tab-ports-templates .portIdentifier');
         var port_configuration_template_e = $('#tab-ports-templates .portConfiguration');
 
-        for (var portIndex = 0; portIndex < SERIAL_CONFIG.ports.length; portIndex++) {
+        for (var portIndex = 0; portIndex < FC.SERIAL_CONFIG.ports.length; portIndex++) {
             const portIdentifierE = portIdentifierTemplateE.clone();
             var port_configuration_e = port_configuration_template_e.clone();
-            var serialPort = SERIAL_CONFIG.ports[portIndex];
+            var serialPort = FC.SERIAL_CONFIG.ports[portIndex];
 
             port_configuration_e.data('serialPort', serialPort);
 
@@ -296,11 +296,11 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         }
 
         let vtxTableNotConfigured = true;
-        if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-            vtxTableNotConfigured = VTX_CONFIG.vtx_table_available &&
-                                        (VTX_CONFIG.vtx_table_bands == 0 ||
-                                        VTX_CONFIG.vtx_table_channels == 0 ||
-                                        VTX_CONFIG.vtx_table_powerlevels == 0);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            vtxTableNotConfigured = FC.VTX_CONFIG.vtx_table_available &&
+                                        (FC.VTX_CONFIG.vtx_table_bands == 0 ||
+                                        FC.VTX_CONFIG.vtx_table_channels == 0 ||
+                                        FC.VTX_CONFIG.vtx_table_powerlevels == 0);
         } else {
             $('.vtxTableNotSet').hide();
         }
@@ -321,7 +321,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
                 lastVtxControlSelected = vtxControlSelected;
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
                 if (vtxControlSelected && vtxTableNotConfigured) {
                     $('.vtxTableNotSet').show();
                 } else {
@@ -354,7 +354,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
        self.analyticsChanges = {};
 
         // update configuration based on current ui state
-        SERIAL_CONFIG.ports = [];
+        FC.SERIAL_CONFIG.ports = [];
 
         var ports_e = $('.tab-ports .portConfiguration').each(function (portConfiguration_e) {
 
@@ -399,7 +399,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
                 blackbox_baudrate: blackboxBaudrate,
                 identifier: oldSerialPort.identifier
             };
-            SERIAL_CONFIG.ports.push(serialPort);
+            FC.SERIAL_CONFIG.ports.push(serialPort);
         });
 
         mspHelper.sendSerialConfig(save_to_eeprom);

--- a/src/js/tabs/power.js
+++ b/src/js/tabs/power.js
@@ -53,7 +53,7 @@ TABS.power.initialize = function (callback) {
         $('#content').load("./tabs/power.html", process_html);
     }
 
-    this.supported = semver.gte(CONFIG.apiVersion, "1.33.0");
+    this.supported = semver.gte(FC.CONFIG.apiVersion, "1.33.0");
 
     if (!this.supported) {
         load_html();
@@ -64,7 +64,7 @@ TABS.power.initialize = function (callback) {
     function updateDisplay(voltageDataSource, currentDataSource) {
         // voltage meters
 
-        if (BATTERY_CONFIG.voltageMeterSource == 0) {
+        if (FC.BATTERY_CONFIG.voltageMeterSource == 0) {
             $('.boxVoltageConfiguration').hide();
         } else {
             $('.boxVoltageConfiguration').show();
@@ -72,7 +72,7 @@ TABS.power.initialize = function (callback) {
 
         if (!voltageDataSource) {
             voltageDataSource = [];
-            for (var index = 0; index < VOLTAGE_METER_CONFIGS.length; index++) {
+            for (var index = 0; index < FC.VOLTAGE_METER_CONFIGS.length; index++) {
                 voltageDataSource[index] = {
                     vbatscale: parseInt($('input[name="vbatscale-' + index + '"]').val()),
                     vbatresdivval: parseInt($('input[name="vbatresdivval-' + index + '"]').val()),
@@ -84,23 +84,23 @@ TABS.power.initialize = function (callback) {
         var template = $('#tab-power-templates .voltage-meters .voltage-meter');
         var destination = $('.tab-power .voltage-meters');
         destination.empty();
-        for (var index = 0; index < VOLTAGE_METERS.length; index++) {
+        for (var index = 0; index < FC.VOLTAGE_METERS.length; index++) {
             var meterElement = template.clone();
             $(meterElement).attr('id', 'voltage-meter-' + index);
 
-            var message = i18n.getMessage('powerVoltageId' + VOLTAGE_METERS[index].id);
+            var message = i18n.getMessage('powerVoltageId' + FC.VOLTAGE_METERS[index].id);
             $(meterElement).find('.label').text(message)
             destination.append(meterElement);
 
             meterElement.hide();
-            if ((BATTERY_CONFIG.voltageMeterSource == 1 && VOLTAGE_METERS[index].id == 10)  // TODO: replace hardcoded constants
-                || (BATTERY_CONFIG.voltageMeterSource == 2 && VOLTAGE_METERS[index].id >= 50)) {
+            if ((FC.BATTERY_CONFIG.voltageMeterSource == 1 && FC.VOLTAGE_METERS[index].id == 10)  // TODO: replace hardcoded constants
+                || (FC.BATTERY_CONFIG.voltageMeterSource == 2 && FC.VOLTAGE_METERS[index].id >= 50)) {
                 meterElement.show();
             }
         }
 
         var template = $('#tab-power-templates .voltage-configuration');
-        for (var index = 0; index < VOLTAGE_METER_CONFIGS.length; index++) {
+        for (var index = 0; index < FC.VOLTAGE_METER_CONFIGS.length; index++) {
             var destination = $('#voltage-meter-' + index + ' .configuration');
             var element = template.clone();
 
@@ -124,7 +124,7 @@ TABS.power.initialize = function (callback) {
         });
 
         // amperage meters
-        if (BATTERY_CONFIG.currentMeterSource == 0) {
+        if (FC.BATTERY_CONFIG.currentMeterSource == 0) {
             $('.boxAmperageConfiguration').hide();
         } else {
             $('.boxAmperageConfiguration').show();
@@ -132,7 +132,7 @@ TABS.power.initialize = function (callback) {
 
         if (!currentDataSource) {
             currentDataSource = [];
-            for (var index = 0; index < CURRENT_METER_CONFIGS.length; index++) {
+            for (var index = 0; index < FC.CURRENT_METER_CONFIGS.length; index++) {
                 currentDataSource[index] = {
                     scale: parseInt($('input[name="amperagescale-' + index + '"]').val()),
                     offset: parseInt($('input[name="amperageoffset-' + index + '"]').val())
@@ -142,24 +142,24 @@ TABS.power.initialize = function (callback) {
         var template = $('#tab-power-templates .amperage-meters .amperage-meter');
         var destination = $('.tab-power .amperage-meters');
         destination.empty();
-        for (var index = 0; index < CURRENT_METERS.length; index++) {
+        for (var index = 0; index < FC.CURRENT_METERS.length; index++) {
             var meterElement = template.clone();
             $(meterElement).attr('id', 'amperage-meter-' + index);
 
-            var message = i18n.getMessage('powerAmperageId' + CURRENT_METERS[index].id);
+            var message = i18n.getMessage('powerAmperageId' + FC.CURRENT_METERS[index].id);
             $(meterElement).find('.label').text(message)
             destination.append(meterElement);
 
             meterElement.hide();
-            if ((BATTERY_CONFIG.currentMeterSource == 1 && CURRENT_METERS[index].id == 10)              // TODO: replace constants
-                || (BATTERY_CONFIG.currentMeterSource == 2 && CURRENT_METERS[index].id == 80)
-                || (BATTERY_CONFIG.currentMeterSource == 3 && CURRENT_METERS[index].id >= 50 && CURRENT_METERS[index].id < 80)) {
+            if ((FC.BATTERY_CONFIG.currentMeterSource == 1 && FC.CURRENT_METERS[index].id == 10)              // TODO: replace constants
+                || (FC.BATTERY_CONFIG.currentMeterSource == 2 && FC.CURRENT_METERS[index].id == 80)
+                || (FC.BATTERY_CONFIG.currentMeterSource == 3 && FC.CURRENT_METERS[index].id >= 50 && FC.CURRENT_METERS[index].id < 80)) {
                 meterElement.show();
             }
         }
 
         var template = $('#tab-power-templates .amperage-configuration');
-        for (var index = 0; index < CURRENT_METER_CONFIGS.length; index++) {
+        for (var index = 0; index < FC.CURRENT_METER_CONFIGS.length; index++) {
             var destination = $('#amperage-meter-' + index + ' .configuration');
             var element = template.clone();
 
@@ -174,7 +174,7 @@ TABS.power.initialize = function (callback) {
         }
 
         $('input[name="amperagescale-0"]').change(function () {
-            if (BATTERY_CONFIG.currentMeterSource === 1) {
+            if (FC.BATTERY_CONFIG.currentMeterSource === 1) {
                 let value = parseInt($(this).val());
 
                 if (value !== currentDataSource[0].scale) {
@@ -184,7 +184,7 @@ TABS.power.initialize = function (callback) {
         });
 
         $('input[name="amperagescale-1"]').change(function () {
-            if (BATTERY_CONFIG.currentMeterSource === 2) {
+            if (FC.BATTERY_CONFIG.currentMeterSource === 2) {
                 let value = parseInt($(this).val());
 
                 if (value !== currentDataSource[1].scale) {
@@ -193,7 +193,7 @@ TABS.power.initialize = function (callback) {
             }
         });
 
-        if(BATTERY_CONFIG.voltageMeterSource == 1 || BATTERY_CONFIG.currentMeterSource == 1 || BATTERY_CONFIG.currentMeterSource == 2) {
+        if(FC.BATTERY_CONFIG.voltageMeterSource == 1 || FC.BATTERY_CONFIG.currentMeterSource == 1 || FC.BATTERY_CONFIG.currentMeterSource == 2) {
             $('.calibration').show();
         } else {
             $('.calibration').hide();
@@ -226,18 +226,18 @@ TABS.power.initialize = function (callback) {
         var element = template.clone();
         destination.append(element);
 
-        if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
             $('input[name="mincellvoltage"]').prop('step','0.01');
             $('input[name="maxcellvoltage"]').prop('step','0.01');
             $('input[name="warningcellvoltage"]').prop('step','0.01');
         }
 
-        $('input[name="mincellvoltage"]').val(BATTERY_CONFIG.vbatmincellvoltage);
-        $('input[name="maxcellvoltage"]').val(BATTERY_CONFIG.vbatmaxcellvoltage);
-        $('input[name="warningcellvoltage"]').val(BATTERY_CONFIG.vbatwarningcellvoltage);
-        $('input[name="capacity"]').val(BATTERY_CONFIG.capacity);
+        $('input[name="mincellvoltage"]').val(FC.BATTERY_CONFIG.vbatmincellvoltage);
+        $('input[name="maxcellvoltage"]').val(FC.BATTERY_CONFIG.vbatmaxcellvoltage);
+        $('input[name="warningcellvoltage"]').val(FC.BATTERY_CONFIG.vbatwarningcellvoltage);
+        $('input[name="capacity"]').val(FC.BATTERY_CONFIG.capacity);
 
-        var haveFc = (semver.lt(CONFIG.apiVersion, "1.35.0") || (CONFIG.boardType == 0 || CONFIG.boardType == 2));
+        var haveFc = (semver.lt(FC.CONFIG.apiVersion, "1.35.0") || (FC.CONFIG.boardType == 0 || FC.CONFIG.boardType == 2));
 
         var batteryMeterTypes = [
             i18n.getMessage('powerBatteryVoltageMeterTypeNone'),
@@ -264,7 +264,7 @@ TABS.power.initialize = function (callback) {
             currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeVirtual'));
             currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeEsc'));
 
-            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
                 currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeMsp'));
             }
         }
@@ -275,23 +275,23 @@ TABS.power.initialize = function (callback) {
             currentMeterType_e.append('<option value="' + i + '">' + currentMeterTypes[i] + '</option>');
         }
 
-        updateDisplay(VOLTAGE_METER_CONFIGS, CURRENT_METER_CONFIGS);
+        updateDisplay(FC.VOLTAGE_METER_CONFIGS, FC.CURRENT_METER_CONFIGS);
 
         var batteryMeterType_e = $('select.batterymetersource');
 
         var sourceschanged = false;
-        batteryMeterType_e.val(BATTERY_CONFIG.voltageMeterSource);
+        batteryMeterType_e.val(FC.BATTERY_CONFIG.voltageMeterSource);
         batteryMeterType_e.change(function () {
-            BATTERY_CONFIG.voltageMeterSource = parseInt($(this).val());
+            FC.BATTERY_CONFIG.voltageMeterSource = parseInt($(this).val());
 
             updateDisplay();
             sourceschanged = true;
         });
 
         var currentMeterType_e = $('select.currentmetersource');
-        currentMeterType_e.val(BATTERY_CONFIG.currentMeterSource);
+        currentMeterType_e.val(FC.BATTERY_CONFIG.currentMeterSource);
         currentMeterType_e.change(function () {
-            BATTERY_CONFIG.currentMeterSource = parseInt($(this).val());
+            FC.BATTERY_CONFIG.currentMeterSource = parseInt($(this).val());
 
             updateDisplay();
             sourceschanged = true;
@@ -299,18 +299,18 @@ TABS.power.initialize = function (callback) {
 
         function get_slow_data() {
             MSP.send_message(MSPCodes.MSP_VOLTAGE_METERS, false, false, function () {
-                for (var i = 0; i < VOLTAGE_METERS.length; i++) {
+                for (var i = 0; i < FC.VOLTAGE_METERS.length; i++) {
                     var elementName = '#voltage-meter-' + i + ' .value';
                     var element = $(elementName);
-                    element.text(i18n.getMessage('powerVoltageValue', [VOLTAGE_METERS[i].voltage]));
+                    element.text(i18n.getMessage('powerVoltageValue', [FC.VOLTAGE_METERS[i].voltage]));
                 }
             });
 
             MSP.send_message(MSPCodes.MSP_CURRENT_METERS, false, false, function () {
-                for (var i = 0; i < CURRENT_METERS.length; i++) {
+                for (var i = 0; i < FC.CURRENT_METERS.length; i++) {
                     var elementName = '#amperage-meter-' + i + ' .value';
                     var element = $(elementName);
-                    element.text(i18n.getMessage('powerAmperageValue', [CURRENT_METERS[i].amperage.toFixed(2)]));
+                    element.text(i18n.getMessage('powerAmperageValue', [FC.CURRENT_METERS[i].amperage.toFixed(2)]));
                 }
             });
 
@@ -319,13 +319,13 @@ TABS.power.initialize = function (callback) {
                 var element;
 
                 element = $(elementPrefix + '-connection-state .value');
-                element.text(BATTERY_STATE.cellCount > 0 ? i18n.getMessage('powerBatteryConnectedValueYes', [BATTERY_STATE.cellCount]) : i18n.getMessage('powerBatteryConnectedValueNo'));
+                element.text(FC.BATTERY_STATE.cellCount > 0 ? i18n.getMessage('powerBatteryConnectedValueYes', [FC.BATTERY_STATE.cellCount]) : i18n.getMessage('powerBatteryConnectedValueNo'));
                 element = $(elementPrefix + '-voltage .value');
-                element.text(i18n.getMessage('powerVoltageValue', [BATTERY_STATE.voltage]));
+                element.text(i18n.getMessage('powerVoltageValue', [FC.BATTERY_STATE.voltage]));
                 element = $(elementPrefix + '-mah-drawn .value');
-                element.text(i18n.getMessage('powerMahValue', [BATTERY_STATE.mAhDrawn]));
+                element.text(i18n.getMessage('powerMahValue', [FC.BATTERY_STATE.mAhDrawn]));
                 element = $(elementPrefix + '-amperage .value');
-                element.text(i18n.getMessage('powerAmperageValue', [BATTERY_STATE.amperage]));
+                element.text(i18n.getMessage('powerAmperageValue', [FC.BATTERY_STATE.amperage]));
             });
 
         }
@@ -361,17 +361,17 @@ TABS.power.initialize = function (callback) {
         });
 
         $('a.calibrationmanager').click(function() {
-            if (BATTERY_CONFIG.voltageMeterSource == 1 && BATTERY_STATE.voltage > 0.1){
+            if (FC.BATTERY_CONFIG.voltageMeterSource == 1 && FC.BATTERY_STATE.voltage > 0.1){
                 $('.vbatcalibration').show();
             } else {
                 $('.vbatcalibration').hide();
             }
-            if ((BATTERY_CONFIG.currentMeterSource == 1 || BATTERY_CONFIG.currentMeterSource == 2) && BATTERY_STATE.amperage > 0.1) {
+            if ((FC.BATTERY_CONFIG.currentMeterSource == 1 || FC.BATTERY_CONFIG.currentMeterSource == 2) && FC.BATTERY_STATE.amperage > 0.1) {
                 $('.amperagecalibration').show();
             } else {
                 $('.amperagecalibration').hide();
             }
-            if (BATTERY_STATE.cellCount == 0) {
+            if (FC.BATTERY_STATE.cellCount == 0) {
                 $('.vbatcalibration').hide();
                 $('.amperagecalibration').hide();
                 $('.calibrate').hide();
@@ -397,26 +397,26 @@ TABS.power.initialize = function (callback) {
         var vbatscalechanged = false;
         var amperagescalechanged = false;
         $('a.calibrate').click(function() {
-            if (BATTERY_CONFIG.voltageMeterSource == 1) {
+            if (FC.BATTERY_CONFIG.voltageMeterSource == 1) {
                 var vbatcalibration = parseFloat($('input[name="vbatcalibration"]').val());
                 if (vbatcalibration != 0) {
-                    var vbatnewscale = Math.round(VOLTAGE_METER_CONFIGS[0].vbatscale * (vbatcalibration / VOLTAGE_METERS[0].voltage));
+                    var vbatnewscale = Math.round(FC.VOLTAGE_METER_CONFIGS[0].vbatscale * (vbatcalibration / FC.VOLTAGE_METERS[0].voltage));
                     if (vbatnewscale >= 10 && vbatnewscale <= 255) {
-                        VOLTAGE_METER_CONFIGS[0].vbatscale = vbatnewscale;
+                        FC.VOLTAGE_METER_CONFIGS[0].vbatscale = vbatnewscale;
                         vbatscalechanged = true;
                     }
                 }
             }
-            var ampsource = BATTERY_CONFIG.currentMeterSource;
+            var ampsource = FC.BATTERY_CONFIG.currentMeterSource;
             if (ampsource == 1 || ampsource == 2) {
                 var amperagecalibration = parseFloat($('input[name="amperagecalibration"]').val());
-                var amperageoffset = CURRENT_METER_CONFIGS[ampsource - 1].offset / 1000;
+                var amperageoffset = FC.CURRENT_METER_CONFIGS[ampsource - 1].offset / 1000;
                 if (amperagecalibration != 0) {
-                    if (CURRENT_METERS[ampsource - 1].amperage != amperageoffset && amperagecalibration != amperageoffset) {
-                        var amperagenewscale = Math.round(CURRENT_METER_CONFIGS[ampsource - 1].scale *
-                            ((CURRENT_METERS[ampsource - 1].amperage -  amperageoffset) / (amperagecalibration - amperageoffset)));
+                    if (FC.CURRENT_METERS[ampsource - 1].amperage != amperageoffset && amperagecalibration != amperageoffset) {
+                        var amperagenewscale = Math.round(FC.CURRENT_METER_CONFIGS[ampsource - 1].scale *
+                            ((FC.CURRENT_METERS[ampsource - 1].amperage -  amperageoffset) / (amperagecalibration - amperageoffset)));
                         if (amperagenewscale > -16000 && amperagenewscale < 16000 && amperagenewscale != 0) {
-                            CURRENT_METER_CONFIGS[ampsource - 1].scale = amperagenewscale;
+                            FC.CURRENT_METER_CONFIGS[ampsource - 1].scale = amperagenewscale;
                             amperagescalechanged = true;
                         }
                     }
@@ -448,7 +448,7 @@ TABS.power.initialize = function (callback) {
 
                     calibrationconfirmed = true;
                     GUI.calibrationManagerConfirmation.close();
-                    updateDisplay(VOLTAGE_METER_CONFIGS, CURRENT_METER_CONFIGS);
+                    updateDisplay(FC.VOLTAGE_METER_CONFIGS, FC.CURRENT_METER_CONFIGS);
                     $('.calibration').hide();
                 });
 
@@ -461,21 +461,21 @@ TABS.power.initialize = function (callback) {
         });
 
         $('a.save').click(function () {
-            for (var index = 0; index < VOLTAGE_METER_CONFIGS.length; index++) {
-                VOLTAGE_METER_CONFIGS[index].vbatscale = parseInt($('input[name="vbatscale-' + index + '"]').val());
-                VOLTAGE_METER_CONFIGS[index].vbatresdivval = parseInt($('input[name="vbatresdivval-' + index + '"]').val());
-                VOLTAGE_METER_CONFIGS[index].vbatresdivmultiplier = parseInt($('input[name="vbatresdivmultiplier-' + index + '"]').val());
+            for (var index = 0; index < FC.VOLTAGE_METER_CONFIGS.length; index++) {
+                FC.VOLTAGE_METER_CONFIGS[index].vbatscale = parseInt($('input[name="vbatscale-' + index + '"]').val());
+                FC.VOLTAGE_METER_CONFIGS[index].vbatresdivval = parseInt($('input[name="vbatresdivval-' + index + '"]').val());
+                FC.VOLTAGE_METER_CONFIGS[index].vbatresdivmultiplier = parseInt($('input[name="vbatresdivmultiplier-' + index + '"]').val());
             }
 
-            for (var index = 0; index < CURRENT_METER_CONFIGS.length; index++) {
-                CURRENT_METER_CONFIGS[index].scale = parseInt($('input[name="amperagescale-' + index + '"]').val());
-                CURRENT_METER_CONFIGS[index].offset = parseInt($('input[name="amperageoffset-' + index + '"]').val());
+            for (var index = 0; index < FC.CURRENT_METER_CONFIGS.length; index++) {
+                FC.CURRENT_METER_CONFIGS[index].scale = parseInt($('input[name="amperagescale-' + index + '"]').val());
+                FC.CURRENT_METER_CONFIGS[index].offset = parseInt($('input[name="amperageoffset-' + index + '"]').val());
             }
 
-            BATTERY_CONFIG.vbatmincellvoltage = parseFloat($('input[name="mincellvoltage"]').val());
-            BATTERY_CONFIG.vbatmaxcellvoltage = parseFloat($('input[name="maxcellvoltage"]').val());
-            BATTERY_CONFIG.vbatwarningcellvoltage = parseFloat($('input[name="warningcellvoltage"]').val());
-            BATTERY_CONFIG.capacity = parseInt($('input[name="capacity"]').val());
+            FC.BATTERY_CONFIG.vbatmincellvoltage = parseFloat($('input[name="mincellvoltage"]').val());
+            FC.BATTERY_CONFIG.vbatmaxcellvoltage = parseFloat($('input[name="maxcellvoltage"]').val());
+            FC.BATTERY_CONFIG.vbatwarningcellvoltage = parseFloat($('input[name="warningcellvoltage"]').val());
+            FC.BATTERY_CONFIG.capacity = parseInt($('input[name="capacity"]').val());
 
             analytics.sendChangeEvents(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, self.analyticsChanges);
 
@@ -491,7 +491,7 @@ TABS.power.initialize = function (callback) {
         }
 
         function save_voltage_config() {
-            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
                 mspHelper.sendVoltageConfig(save_amperage_config);
             } else {
                 MSP.send_message(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG), false, save_amperage_config);
@@ -499,7 +499,7 @@ TABS.power.initialize = function (callback) {
         }
 
         function save_amperage_config() {
-            if (semver.gte(CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
                 mspHelper.sendCurrentConfig(save_to_eeprom);
             } else {
                 MSP.send_message(MSPCodes.MSP_SET_CURRENT_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_CURRENT_METER_CONFIG), false, save_to_eeprom);

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -32,7 +32,7 @@ TABS.receiver.initialize = function (callback) {
 
     function load_rc_configs() {
         var next_callback = load_rx_config;
-        if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
             MSP.send_message(MSPCodes.MSP_RC_DEADBAND, false, false, next_callback);
         } else {
             next_callback();
@@ -41,7 +41,7 @@ TABS.receiver.initialize = function (callback) {
 
     function load_rx_config() {
         var next_callback = load_mixer_config;
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             MSP.send_message(MSPCodes.MSP_RX_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -62,12 +62,12 @@ TABS.receiver.initialize = function (callback) {
         // translate to user-selected language
         i18n.localizePage();
 
-        if (semver.lt(CONFIG.apiVersion, "1.15.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.15.0")) {
             $('.deadband').hide();
         } else {
-            $('.deadband input[name="yaw_deadband"]').val(RC_DEADBAND_CONFIG.yaw_deadband);
-            $('.deadband input[name="deadband"]').val(RC_DEADBAND_CONFIG.deadband);
-            $('.deadband input[name="3ddeadbandthrottle"]').val(RC_DEADBAND_CONFIG.deadband3d_throttle);
+            $('.deadband input[name="yaw_deadband"]').val(FC.RC_DEADBAND_CONFIG.yaw_deadband);
+            $('.deadband input[name="deadband"]').val(FC.RC_DEADBAND_CONFIG.deadband);
+            $('.deadband input[name="3ddeadbandthrottle"]').val(FC.RC_DEADBAND_CONFIG.deadband3d_throttle);
 
             $('.deadband input[name="deadband"]').change(function () {
                 tab.deadband = parseInt($(this).val());
@@ -77,17 +77,17 @@ TABS.receiver.initialize = function (callback) {
             }).change();
         }
 
-        if (semver.lt(CONFIG.apiVersion, "1.15.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.15.0")) {
             $('.sticks').hide();
         } else {
-            $('.sticks input[name="stick_min"]').val(RX_CONFIG.stick_min);
-            $('.sticks input[name="stick_center"]').val(RX_CONFIG.stick_center);
-            $('.sticks input[name="stick_max"]').val(RX_CONFIG.stick_max);
+            $('.sticks input[name="stick_min"]').val(FC.RX_CONFIG.stick_min);
+            $('.sticks input[name="stick_center"]').val(FC.RX_CONFIG.stick_center);
+            $('.sticks input[name="stick_max"]').val(FC.RX_CONFIG.stick_max);
         }
 
-        if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-            $('select[name="rcInterpolation-select"]').val(RX_CONFIG.rcInterpolation);
-            $('input[name="rcInterpolationInterval-number"]').val(RX_CONFIG.rcInterpolationInterval);
+        if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+            $('select[name="rcInterpolation-select"]').val(FC.RX_CONFIG.rcInterpolation);
+            $('input[name="rcInterpolationInterval-number"]').val(FC.RX_CONFIG.rcInterpolationInterval);
 
             $('select[name="rcInterpolation-select"]').change(function () {
                 tab.updateRcInterpolationParameters();
@@ -106,7 +106,7 @@ TABS.receiver.initialize = function (callback) {
             bar_container = $('.tab-receiver .bars'),
             aux_index = 1;
 
-        var num_bars = (RC.active_channels > 0) ? RC.active_channels : 8;
+        var num_bars = (FC.RC.active_channels > 0) ? FC.RC.active_channels : 8;
 
         for (var i = 0; i < num_bars; i++) {
             var name;
@@ -122,7 +122,7 @@ TABS.receiver.initialize = function (callback) {
                     <li class="meter">\
                         <div class="meter-bar">\
                             <div class="label"></div>\
-                            <div class="fill' + (RC.active_channels == 0 ? 'disabled' : '') + '">\
+                            <div class="fill' + (FC.RC.active_channels == 0 ? 'disabled' : '') + '">\
                                 <div class="label"></div>\
                             </div>\
                         </div>\
@@ -164,8 +164,8 @@ TABS.receiver.initialize = function (callback) {
         var RC_MAP_Letters = ['A', 'E', 'R', 'T', '1', '2', '3', '4'];
 
         var strBuffer = [];
-        for (var i = 0; i < RC_MAP.length; i++) {
-            strBuffer[RC_MAP[i]] = RC_MAP_Letters[i];
+        for (var i = 0; i < FC.RC_MAP.length; i++) {
+            strBuffer[FC.RC_MAP[i]] = RC_MAP_Letters[i];
         }
 
         // reconstruct
@@ -223,11 +223,11 @@ TABS.receiver.initialize = function (callback) {
         var rssi_channel_e = $('select[name="rssi_channel"]');
         rssi_channel_e.append('<option value="0">' + i18n.getMessage("receiverRssiChannelDisabledOption") + '</option>');
         //1-4 reserved for Roll Pitch Yaw & Throttle, starting at 5
-        for (var i = 5; i < RC.active_channels + 1; i++) {
+        for (var i = 5; i < FC.RC.active_channels + 1; i++) {
             rssi_channel_e.append('<option value="' + i + '">' + i18n.getMessage("controlAxisAux" + (i-4)) + '</option>');
         }
 
-        $('select[name="rssi_channel"]').val(RSSI_CONFIG.channel);
+        $('select[name="rssi_channel"]').val(FC.RSSI_CONFIG.channel);
 
         var rateHeight = TABS.receiver.rateChartHeight;
 
@@ -239,42 +239,42 @@ TABS.receiver.initialize = function (callback) {
         });
 
         $('a.update').click(function () {
-            if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
-                RX_CONFIG.stick_max = parseInt($('.sticks input[name="stick_max"]').val());
-                RX_CONFIG.stick_center = parseInt($('.sticks input[name="stick_center"]').val());
-                RX_CONFIG.stick_min = parseInt($('.sticks input[name="stick_min"]').val());
-                RC_DEADBAND_CONFIG.yaw_deadband = parseInt($('.deadband input[name="yaw_deadband"]').val());
-                RC_DEADBAND_CONFIG.deadband = parseInt($('.deadband input[name="deadband"]').val());
-                RC_DEADBAND_CONFIG.deadband3d_throttle = ($('.deadband input[name="3ddeadbandthrottle"]').val());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
+                FC.RX_CONFIG.stick_max = parseInt($('.sticks input[name="stick_max"]').val());
+                FC.RX_CONFIG.stick_center = parseInt($('.sticks input[name="stick_center"]').val());
+                FC.RX_CONFIG.stick_min = parseInt($('.sticks input[name="stick_min"]').val());
+                FC.RC_DEADBAND_CONFIG.yaw_deadband = parseInt($('.deadband input[name="yaw_deadband"]').val());
+                FC.RC_DEADBAND_CONFIG.deadband = parseInt($('.deadband input[name="deadband"]').val());
+                FC.RC_DEADBAND_CONFIG.deadband3d_throttle = ($('.deadband input[name="3ddeadbandthrottle"]').val());
             }
 
             // catch rc map
             var RC_MAP_Letters = ['A', 'E', 'R', 'T', '1', '2', '3', '4'];
             var strBuffer = $('input[name="rcmap"]').val().split('');
 
-            for (var i = 0; i < RC_MAP.length; i++) {
-                RC_MAP[i] = strBuffer.indexOf(RC_MAP_Letters[i]);
+            for (var i = 0; i < FC.RC_MAP.length; i++) {
+                FC.RC_MAP[i] = strBuffer.indexOf(RC_MAP_Letters[i]);
             }
 
             // catch rssi aux
-            RSSI_CONFIG.channel = parseInt($('select[name="rssi_channel"]').val());
+            FC.RSSI_CONFIG.channel = parseInt($('select[name="rssi_channel"]').val());
 
 
-            if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
-                RX_CONFIG.rcInterpolation = parseInt($('select[name="rcInterpolation-select"]').val());
-                RX_CONFIG.rcInterpolationInterval = parseInt($('input[name="rcInterpolationInterval-number"]').val());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
+                FC.RX_CONFIG.rcInterpolation = parseInt($('select[name="rcInterpolation-select"]').val());
+                FC.RX_CONFIG.rcInterpolationInterval = parseInt($('input[name="rcInterpolationInterval-number"]').val());
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
-                RX_CONFIG.rcSmoothingInputCutoff = parseInt($('input[name="rcSmoothingInputHz-number"]').val());
-                RX_CONFIG.rcSmoothingDerivativeCutoff = parseInt($('input[name="rcSmoothingDerivativeCutoff-number"]').val());
-                RX_CONFIG.rcSmoothingDerivativeType = parseInt($('select[name="rcSmoothingDerivativeType-select"]').val());
-                RX_CONFIG.rcInterpolationChannels = parseInt($('select[name="rcSmoothingChannels-select"]').val());
-                RX_CONFIG.rcSmoothingInputType = parseInt($('select[name="rcSmoothingInputType-select"]').val());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                FC.RX_CONFIG.rcSmoothingInputCutoff = parseInt($('input[name="rcSmoothingInputHz-number"]').val());
+                FC.RX_CONFIG.rcSmoothingDerivativeCutoff = parseInt($('input[name="rcSmoothingDerivativeCutoff-number"]').val());
+                FC.RX_CONFIG.rcSmoothingDerivativeType = parseInt($('select[name="rcSmoothingDerivativeType-select"]').val());
+                FC.RX_CONFIG.rcInterpolationChannels = parseInt($('select[name="rcSmoothingChannels-select"]').val());
+                FC.RX_CONFIG.rcSmoothingInputType = parseInt($('select[name="rcSmoothingInputType-select"]').val());
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-                RX_CONFIG.rcSmoothingAutoSmoothness = parseInt($('input[name="rcSmoothingAutoSmoothness-number"]').val());
+            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                FC.RX_CONFIG.rcSmoothingAutoSmoothness = parseInt($('input[name="rcSmoothingAutoSmoothness-number"]').val());
             }
 
             function save_rssi_config() {
@@ -283,7 +283,7 @@ TABS.receiver.initialize = function (callback) {
 
             function save_rc_configs() {
                 var next_callback = save_rx_config;
-                if (semver.gte(CONFIG.apiVersion, "1.15.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_RC_DEADBAND, mspHelper.crunch(MSPCodes.MSP_SET_RC_DEADBAND), false, next_callback);
                 } else {
                     next_callback();
@@ -292,7 +292,7 @@ TABS.receiver.initialize = function (callback) {
 
             function save_rx_config() {
                 var next_callback = save_to_eeprom;
-                if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
                     MSP.send_message(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -338,8 +338,8 @@ TABS.receiver.initialize = function (callback) {
         });
 
         let showBindButton = false;
-        if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
-            showBindButton = bit_check(CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.SUPPORTS_RX_BIND);
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
+            showBindButton = bit_check(FC.CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.SUPPORTS_RX_BIND);
 
             $("a.bind").click(function() {
                 MSP.send_message(MSPCodes.MSP2_BETAFLIGHT_BIND);
@@ -350,23 +350,23 @@ TABS.receiver.initialize = function (callback) {
         $(".bind_btn").toggle(showBindButton);
 
         // RC Smoothing
-        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
             $('.tab-receiver .rcSmoothing').show();
 
             var rc_smoothing_protocol_e = $('select[name="rcSmoothing-select"]');
             rc_smoothing_protocol_e.change(function () {
-                RX_CONFIG.rcSmoothingType = $(this).val();
+                FC.RX_CONFIG.rcSmoothingType = $(this).val();
                 updateInterpolationView();
             });
-            rc_smoothing_protocol_e.val(RX_CONFIG.rcSmoothingType);
+            rc_smoothing_protocol_e.val(FC.RX_CONFIG.rcSmoothingType);
 
             const rcSmoothingNumberElement = $('input[name="rcSmoothingInputHz-number"]');
             const rcSmoothingDerivativeNumberElement = $('input[name="rcSmoothingDerivativeCutoff-number"]');
-            rcSmoothingNumberElement.val(RX_CONFIG.rcSmoothingInputCutoff);
-            rcSmoothingDerivativeNumberElement.val(RX_CONFIG.rcSmoothingDerivativeCutoff);
+            rcSmoothingNumberElement.val(FC.RX_CONFIG.rcSmoothingInputCutoff);
+            rcSmoothingDerivativeNumberElement.val(FC.RX_CONFIG.rcSmoothingDerivativeCutoff);
             $('.tab-receiver .rcSmoothing-input-cutoff').show();
             $('select[name="rcSmoothing-input-manual-select"]').val("1");
-            if (RX_CONFIG.rcSmoothingInputCutoff == 0) {
+            if (FC.RX_CONFIG.rcSmoothingInputCutoff == 0) {
                 $('.tab-receiver .rcSmoothing-input-cutoff').hide();
                 $('select[name="rcSmoothing-input-manual-select"]').val("0");
             }
@@ -376,14 +376,14 @@ TABS.receiver.initialize = function (callback) {
                     $('.tab-receiver .rcSmoothing-input-cutoff').hide();
                 }
                 if ($(this).val() == 1) {
-                    rcSmoothingNumberElement.val(RX_CONFIG.rcSmoothingInputCutoff);
+                    rcSmoothingNumberElement.val(FC.RX_CONFIG.rcSmoothingInputCutoff);
                     $('.tab-receiver .rcSmoothing-input-cutoff').show();
                 }
             }).change();
 
             $('.tab-receiver .rcSmoothing-derivative-cutoff').show();
             $('select[name="rcSmoothing-input-derivative-select"]').val("1");
-            if (RX_CONFIG.rcSmoothingDerivativeCutoff == 0) {
+            if (FC.RX_CONFIG.rcSmoothingDerivativeCutoff == 0) {
                 $('select[name="rcSmoothing-input-derivative-select"]').val("0");
                 $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
             }
@@ -394,22 +394,22 @@ TABS.receiver.initialize = function (callback) {
                 }
                 if ($(this).val() == 1) {
                     $('.tab-receiver .rcSmoothing-derivative-cutoff').show();
-                    rcSmoothingDerivativeNumberElement.val(RX_CONFIG.rcSmoothingDerivativeCutoff);
+                    rcSmoothingDerivativeNumberElement.val(FC.RX_CONFIG.rcSmoothingDerivativeCutoff);
                 }
             }).change();
 
             var rc_smoothing_derivative_type = $('select[name="rcSmoothingDerivativeType-select"]');
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                 rc_smoothing_derivative_type.append($(`<option value="3">${i18n.getMessage("receiverRcSmoothingDerivativeTypeAuto")}</option>`));
             }
 
-            rc_smoothing_derivative_type.val(RX_CONFIG.rcSmoothingDerivativeType);
+            rc_smoothing_derivative_type.val(FC.RX_CONFIG.rcSmoothingDerivativeType);
             var rc_smoothing_channels = $('select[name="rcSmoothingChannels-select"]');
-            rc_smoothing_channels.val(RX_CONFIG.rcInterpolationChannels);
+            rc_smoothing_channels.val(FC.RX_CONFIG.rcInterpolationChannels);
             var rc_smoothing_input_type = $('select[name="rcSmoothingInputType-select"]');
-            rc_smoothing_input_type.val(RX_CONFIG.rcSmoothingInputType);
+            rc_smoothing_input_type.val(FC.RX_CONFIG.rcSmoothingInputType);
 
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
                 $('select[name="rcSmoothing-input-manual-select"], select[name="rcSmoothing-input-derivative-select"]').change(function() {
                     if ($('select[name="rcSmoothing-input-manual-select"]').val() == 0 || $('select[name="rcSmoothing-input-derivative-select"]').val() == 0) {
                         $('.tab-receiver .rcSmoothing-auto-smoothness').show();
@@ -420,7 +420,7 @@ TABS.receiver.initialize = function (callback) {
                 $('select[name="rcSmoothing-input-manual-select"]').change();
 
                 var rc_smoothing_auto_smoothness = $('input[name="rcSmoothingAutoSmoothness-number"]');
-                rc_smoothing_auto_smoothness.val(RX_CONFIG.rcSmoothingAutoSmoothness);
+                rc_smoothing_auto_smoothness.val(FC.RX_CONFIG.rcSmoothingAutoSmoothness);
             } else {
                 $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
             }
@@ -439,7 +439,7 @@ TABS.receiver.initialize = function (callback) {
         }
 
         // Only show the MSP control sticks if the MSP Rx feature is enabled
-        $(".sticks_btn").toggle(FEATURE_CONFIG.features.isEnabled('RX_MSP'));
+        $(".sticks_btn").toggle(FC.FEATURE_CONFIG.features.isEnabled('RX_MSP'));
 
         $('select[name="rx_refresh_rate"]').change(function () {
             var plot_update_rate = parseInt($(this).val(), 10);
@@ -452,7 +452,7 @@ TABS.receiver.initialize = function (callback) {
             }
 
             // setup plot
-            var RX_plot_data = new Array(RC.active_channels);
+            var RX_plot_data = new Array(FC.RC.active_channels);
             for (var i = 0; i < RX_plot_data.length; i++) {
                 RX_plot_data[i] = [];
             }
@@ -473,17 +473,17 @@ TABS.receiver.initialize = function (callback) {
 
             function update_ui() {
 
-                if (RC.active_channels > 0) {
+                if (FC.RC.active_channels > 0) {
 
                     // update bars with latest data
-                    for (var i = 0; i < RC.active_channels; i++) {
-                        meter_fill_array[i].css('width', ((RC.channels[i] - meter_scale.min) / (meter_scale.max - meter_scale.min) * 100).clamp(0, 100) + '%');
-                        meter_label_array[i].text(RC.channels[i]);
+                    for (var i = 0; i < FC.RC.active_channels; i++) {
+                        meter_fill_array[i].css('width', ((FC.RC.channels[i] - meter_scale.min) / (meter_scale.max - meter_scale.min) * 100).clamp(0, 100) + '%');
+                        meter_label_array[i].text(FC.RC.channels[i]);
                     }
     
                     // push latest data to the main array
-                    for (var i = 0; i < RC.active_channels; i++) {
-                        RX_plot_data[i].push([samples, RC.channels[i]]);
+                    for (var i = 0; i < FC.RC.active_channels; i++) {
+                        RX_plot_data[i].push([samples, FC.RC.channels[i]]);
                     }
     
                     // Remove old data from array
@@ -583,15 +583,15 @@ TABS.receiver.initModelPreview = function () {
     this.model = new Model($('.model_preview'), $('.model_preview canvas'));
 
     this.useSuperExpo = false;
-    if (semver.gte(CONFIG.apiVersion, "1.20.0") || (semver.gte(CONFIG.apiVersion, "1.16.0") && FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES'))) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.20.0") || (semver.gte(FC.CONFIG.apiVersion, "1.16.0") && FC.FEATURE_CONFIG.features.isEnabled('SUPEREXPO_RATES'))) {
         this.useSuperExpo = true;
     }
 
     var useOldRateCurve = false;
-    if (CONFIG.flightControllerIdentifier == 'CLFL' && semver.lt(CONFIG.apiVersion, '2.0.0')) {
+    if (FC.CONFIG.flightControllerIdentifier == 'CLFL' && semver.lt(FC.CONFIG.apiVersion, '2.0.0')) {
         useOldRateCurve = true;
     }
-    if (CONFIG.flightControllerIdentifier == 'BTFL' && semver.lt(CONFIG.flightControllerVersion, '2.8.0')) {
+    if (FC.CONFIG.flightControllerIdentifier == 'BTFL' && semver.lt(FC.CONFIG.flightControllerVersion, '2.8.0')) {
         useOldRateCurve = true;
     }
 
@@ -605,12 +605,12 @@ TABS.receiver.renderModel = function () {
 
     if (!this.clock) { this.clock = new THREE.Clock(); }
 
-    if (RC.channels[0] && RC.channels[1] && RC.channels[2]) {
+    if (FC.RC.channels[0] && FC.RC.channels[1] && FC.RC.channels[2]) {
         var delta = this.clock.getDelta();
 
-        var roll  = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(RC.channels[0], RC_tuning.roll_rate, RC_tuning.RC_RATE, RC_tuning.RC_EXPO, this.useSuperExpo, this.deadband, RC_tuning.roll_rate_limit),
-            pitch = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(RC.channels[1], RC_tuning.pitch_rate, RC_tuning.rcPitchRate, RC_tuning.RC_PITCH_EXPO, this.useSuperExpo, this.deadband, RC_tuning.pitch_rate_limit),
-            yaw   = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(RC.channels[2], RC_tuning.yaw_rate, RC_tuning.rcYawRate, RC_tuning.RC_YAW_EXPO, this.useSuperExpo, this.yawDeadband, RC_tuning.yaw_rate_limit);
+        var roll  = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(FC.RC.channels[0], FC.RC_TUNING.roll_rate, FC.RC_TUNING.RC_RATE, FC.RC_TUNING.RC_EXPO, this.useSuperExpo, this.deadband, FC.RC_TUNING.roll_rate_limit),
+            pitch = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(FC.RC.channels[1], FC.RC_TUNING.pitch_rate, FC.RC_TUNING.rcPitchRate, FC.RC_TUNING.RC_PITCH_EXPO, this.useSuperExpo, this.deadband, FC.RC_TUNING.pitch_rate_limit),
+            yaw   = delta * this.rateCurve.rcCommandRawToDegreesPerSecond(FC.RC.channels[2], FC.RC_TUNING.yaw_rate, FC.RC_TUNING.rcYawRate, FC.RC_TUNING.RC_YAW_EXPO, this.useSuperExpo, this.yawDeadband, FC.RC_TUNING.yaw_rate_limit);
 
         this.model.rotateBy(-degToRad(pitch), -degToRad(yaw), -degToRad(roll));
     }
@@ -642,7 +642,7 @@ TABS.receiver.refresh = function (callback) {
 };
 
 TABS.receiver.updateRcInterpolationParameters = function () {
-    if (semver.gte(CONFIG.apiVersion, "1.20.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
         if ($('select[name="rcInterpolation-select"]').val() === '3') {
             $('.tab-receiver .rc-interpolation-manual').show();
         } else {
@@ -659,13 +659,13 @@ function updateInterpolationView() {
     $('.tab-receiver .rcSmoothing-input-type').show();
     $('.tab-receiver .rcSmoothing-derivative-manual').show();
     $('.tab-receiver .rcSmoothing-input-manual').show();
-    if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
-        if (RX_CONFIG.rcSmoothingDerivativeCutoff == 0 || RX_CONFIG.rcSmoothingInputCutoff == 0) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (FC.RX_CONFIG.rcSmoothingDerivativeCutoff == 0 || FC.RX_CONFIG.rcSmoothingInputCutoff == 0) {
             $('.tab-receiver .rcSmoothing-auto-smoothness').show();
         }
     }
 
-    if (RX_CONFIG.rcSmoothingType == 0) {
+    if (FC.RX_CONFIG.rcSmoothingType == 0) {
         $('.tab-receiver .rcInterpolation').show();
         $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
         $('.tab-receiver .rcSmoothing-input-cutoff').hide();
@@ -675,10 +675,10 @@ function updateInterpolationView() {
         $('.tab-receiver .rcSmoothing-input-manual').hide();
         $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
     }
-    if (RX_CONFIG.rcSmoothingDerivativeCutoff == 0) {
+    if (FC.RX_CONFIG.rcSmoothingDerivativeCutoff == 0) {
         $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
     }
-    if (RX_CONFIG.rcSmoothingInputCutoff == 0) {
+    if (FC.RX_CONFIG.rcSmoothingInputCutoff == 0) {
         $('.tab-receiver .rcSmoothing-input-cutoff').hide();
     }
 }

--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -10,12 +10,12 @@ TABS.sensors.initialize = function (callback) {
 
     function initSensorData(){
         for (var i = 0; i < 3; i++) {
-            SENSOR_DATA.accelerometer[i] = 0;
-            SENSOR_DATA.gyroscope[i] = 0;
-            SENSOR_DATA.magnetometer[i] = 0;
-            SENSOR_DATA.sonar = 0;
-            SENSOR_DATA.altitude = 0;
-            SENSOR_DATA.debug[i] = 0;
+            FC.SENSOR_DATA.accelerometer[i] = 0;
+            FC.SENSOR_DATA.gyroscope[i] = 0;
+            FC.SENSOR_DATA.magnetometer[i] = 0;
+            FC.SENSOR_DATA.sonar = 0;
+            FC.SENSOR_DATA.altitude = 0;
+            FC.SENSOR_DATA.debug[i] = 0;
         }
     }
 
@@ -187,17 +187,17 @@ TABS.sensors.initialize = function (callback) {
         var checkboxes = $('.tab-sensors .info .checkboxes input');
         checkboxes.parent().show();
         
-        if (CONFIG.boardType == 0 || CONFIG.boardType == 2) { 
-            if (!have_sensor(CONFIG.activeSensors, 'acc')) {
+        if (FC.CONFIG.boardType == 0 || FC.CONFIG.boardType == 2) { 
+            if (!have_sensor(FC.CONFIG.activeSensors, 'acc')) {
                 checkboxes.eq(1).prop('disabled', true);
             }
-            if (!have_sensor(CONFIG.activeSensors, 'mag')) {
+            if (!have_sensor(FC.CONFIG.activeSensors, 'mag')) {
                 checkboxes.eq(2).prop('disabled', true);
             }
-            if (!(have_sensor(CONFIG.activeSensors, 'baro') || (semver.gte(CONFIG.apiVersion, "1.40.0") && have_sensor(CONFIG.activeSensors, 'gps')))) {
+            if (!(have_sensor(FC.CONFIG.activeSensors, 'baro') || (semver.gte(FC.CONFIG.apiVersion, "1.40.0") && have_sensor(FC.CONFIG.activeSensors, 'gps')))) {
                 checkboxes.eq(3).prop('disabled', true);
             }
-            if (!have_sensor(CONFIG.activeSensors, 'sonar')) {
+            if (!have_sensor(FC.CONFIG.activeSensors, 'sonar')) {
                 checkboxes.eq(4).prop('disabled', true);
             }
         } else {
@@ -243,7 +243,7 @@ TABS.sensors.initialize = function (callback) {
         });
 
         let altitudeHint_e = $('.tab-sensors #sensorsAltitudeHint');
-        if (semver.lt(CONFIG.apiVersion, "1.40.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.40.0")) {
             altitudeHint_e.hide();
         }
 
@@ -367,57 +367,57 @@ TABS.sensors.initialize = function (callback) {
                 if (checkboxes[0]) {
                     updateGraphHelperSize(gyroHelpers);
 
-                    samples_gyro_i = addSampleToData(gyro_data, samples_gyro_i, SENSOR_DATA.gyroscope);
+                    samples_gyro_i = addSampleToData(gyro_data, samples_gyro_i, FC.SENSOR_DATA.gyroscope);
                     drawGraph(gyroHelpers, gyro_data, samples_gyro_i);
-                    raw_data_text_ements.x[0].text(SENSOR_DATA.gyroscope[0].toFixed(2));
-                    raw_data_text_ements.y[0].text(SENSOR_DATA.gyroscope[1].toFixed(2));
-                    raw_data_text_ements.z[0].text(SENSOR_DATA.gyroscope[2].toFixed(2));
+                    raw_data_text_ements.x[0].text(FC.SENSOR_DATA.gyroscope[0].toFixed(2));
+                    raw_data_text_ements.y[0].text(FC.SENSOR_DATA.gyroscope[1].toFixed(2));
+                    raw_data_text_ements.z[0].text(FC.SENSOR_DATA.gyroscope[2].toFixed(2));
                 }
 
                 if (checkboxes[1]) {
                     updateGraphHelperSize(accelHelpers);
 
-                    samples_accel_i = addSampleToData(accel_data, samples_accel_i, SENSOR_DATA.accelerometer);
+                    samples_accel_i = addSampleToData(accel_data, samples_accel_i, FC.SENSOR_DATA.accelerometer);
                     drawGraph(accelHelpers, accel_data, samples_accel_i);
-                    raw_data_text_ements.x[1].text(SENSOR_DATA.accelerometer[0].toFixed(2));
-                    raw_data_text_ements.y[1].text(SENSOR_DATA.accelerometer[1].toFixed(2));
-                    raw_data_text_ements.z[1].text(SENSOR_DATA.accelerometer[2].toFixed(2));
+                    raw_data_text_ements.x[1].text(FC.SENSOR_DATA.accelerometer[0].toFixed(2));
+                    raw_data_text_ements.y[1].text(FC.SENSOR_DATA.accelerometer[1].toFixed(2));
+                    raw_data_text_ements.z[1].text(FC.SENSOR_DATA.accelerometer[2].toFixed(2));
                 }
 
                 if (checkboxes[2]) {
                     updateGraphHelperSize(magHelpers);
 
-                    samples_mag_i = addSampleToData(mag_data, samples_mag_i, SENSOR_DATA.magnetometer);
+                    samples_mag_i = addSampleToData(mag_data, samples_mag_i, FC.SENSOR_DATA.magnetometer);
                     drawGraph(magHelpers, mag_data, samples_mag_i);
-                    raw_data_text_ements.x[2].text(SENSOR_DATA.magnetometer[0].toFixed(2));
-                    raw_data_text_ements.y[2].text(SENSOR_DATA.magnetometer[1].toFixed(2));
-                    raw_data_text_ements.z[2].text(SENSOR_DATA.magnetometer[2].toFixed(2));
+                    raw_data_text_ements.x[2].text(FC.SENSOR_DATA.magnetometer[0].toFixed(2));
+                    raw_data_text_ements.y[2].text(FC.SENSOR_DATA.magnetometer[1].toFixed(2));
+                    raw_data_text_ements.z[2].text(FC.SENSOR_DATA.magnetometer[2].toFixed(2));
                 }
             }
 
             function update_altitude_graph() {
                 updateGraphHelperSize(altitudeHelpers);
 
-                samples_altitude_i = addSampleToData(altitude_data, samples_altitude_i, [SENSOR_DATA.altitude]);
+                samples_altitude_i = addSampleToData(altitude_data, samples_altitude_i, [FC.SENSOR_DATA.altitude]);
                 drawGraph(altitudeHelpers, altitude_data, samples_altitude_i);
-                raw_data_text_ements.x[3].text(SENSOR_DATA.altitude.toFixed(2));
+                raw_data_text_ements.x[3].text(FC.SENSOR_DATA.altitude.toFixed(2));
             }
 
             function update_sonar_graphs() {
                 updateGraphHelperSize(sonarHelpers);
 
-                samples_sonar_i = addSampleToData(sonar_data, samples_sonar_i, [SENSOR_DATA.sonar]);
+                samples_sonar_i = addSampleToData(sonar_data, samples_sonar_i, [FC.SENSOR_DATA.sonar]);
                 drawGraph(sonarHelpers, sonar_data, samples_sonar_i);
-                raw_data_text_ements.x[4].text(SENSOR_DATA.sonar.toFixed(2));
+                raw_data_text_ements.x[4].text(FC.SENSOR_DATA.sonar.toFixed(2));
             }
 
             function update_debug_graphs() {
                 for (var i = 0; i < 4; i++) {
                     updateGraphHelperSize(debugHelpers[i]);
 
-                    addSampleToData(debug_data[i], samples_debug_i, [SENSOR_DATA.debug[i]]);
+                    addSampleToData(debug_data[i], samples_debug_i, [FC.SENSOR_DATA.debug[i]]);
                     drawGraph(debugHelpers[i], debug_data[i], samples_debug_i);
-                    raw_data_text_ements.x[5 + i].text(SENSOR_DATA.debug[i]);
+                    raw_data_text_ements.x[5 + i].text(FC.SENSOR_DATA.debug[i]);
                 }
                 samples_debug_i++;
             }

--- a/src/js/tabs/servos.js
+++ b/src/js/tabs/servos.js
@@ -30,7 +30,7 @@ TABS.servos.initialize = function (callback) {
 
     function update_ui() {
 
-        if (semver.lt(CONFIG.apiVersion, "1.12.0") || SERVO_CONFIG.length === 0) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.12.0") || FC.SERVO_CONFIG.length === 0) {
 
             $(".tab-servos").removeClass("supported");
             return;
@@ -40,14 +40,14 @@ TABS.servos.initialize = function (callback) {
 
         let servoCheckbox = '';
         let servoHeader = '';
-        for (let i = 0; i < RC.active_channels-4; i++) {
+        for (let i = 0; i < FC.RC.active_channels-4; i++) {
             servoHeader = servoHeader + '\
                 <th >A' + (i+1) + '</th>\
             ';
         }
         servoHeader = servoHeader + '<th style="width: 110px" i18n="servosDirectionAndRate"></th>';
 
-        for (let i = 0; i < RC.active_channels; i++) {
+        for (let i = 0; i < FC.RC.active_channels; i++) {
             servoCheckbox = servoCheckbox + '\
                 <td class="channel"><input type="checkbox"/></td>\
             ';
@@ -62,17 +62,17 @@ TABS.servos.initialize = function (callback) {
             $('div.tab-servos table.fields').append('\
                 <tr> \
                     <td style="text-align: center">' + name + '</td>\
-                    <td class="middle"><input type="number" min="500" max="2500" value="' + SERVO_CONFIG[obj].middle + '" /></td>\
-                    <td class="min"><input type="number" min="500" max="2500" value="' + SERVO_CONFIG[obj].min +'" /></td>\
-                    <td class="max"><input type="number" min="500" max="2500" value="' + SERVO_CONFIG[obj].max +'" /></td>\
+                    <td class="middle"><input type="number" min="500" max="2500" value="' + FC.SERVO_CONFIG[obj].middle + '" /></td>\
+                    <td class="min"><input type="number" min="500" max="2500" value="' + FC.SERVO_CONFIG[obj].min +'" /></td>\
+                    <td class="max"><input type="number" min="500" max="2500" value="' + FC.SERVO_CONFIG[obj].max +'" /></td>\
                     ' + servoCheckbox + '\
                     <td class="direction">\
                     </td>\
                 </tr> \
             ');
 
-            if (SERVO_CONFIG[obj].indexOfChannelToForward >= 0) {
-                $('div.tab-servos table.fields tr:last td.channel input').eq(SERVO_CONFIG[obj].indexOfChannelToForward).prop('checked', true);
+            if (FC.SERVO_CONFIG[obj].indexOfChannelToForward >= 0) {
+                $('div.tab-servos table.fields tr:last td.channel input').eq(FC.SERVO_CONFIG[obj].indexOfChannelToForward).prop('checked', true);
             }
 
             // adding select box and generating options
@@ -87,7 +87,7 @@ TABS.servos.initialize = function (callback) {
             }
 
             // select current rate
-            select.val(SERVO_CONFIG[obj].rate);
+            select.val(FC.SERVO_CONFIG[obj].rate);
 
             $('div.tab-servos table.fields tr:last').data('info', {'obj': obj});
 
@@ -112,15 +112,15 @@ TABS.servos.initialize = function (callback) {
                     channelIndex = undefined;
                 }
 
-                SERVO_CONFIG[info.obj].indexOfChannelToForward = channelIndex;
+                FC.SERVO_CONFIG[info.obj].indexOfChannelToForward = channelIndex;
 
 
-                SERVO_CONFIG[info.obj].middle = parseInt($('.middle input', this).val());
-                SERVO_CONFIG[info.obj].min = parseInt($('.min input', this).val());
-                SERVO_CONFIG[info.obj].max = parseInt($('.max input', this).val());
+                FC.SERVO_CONFIG[info.obj].middle = parseInt($('.middle input', this).val());
+                FC.SERVO_CONFIG[info.obj].min = parseInt($('.min input', this).val());
+                FC.SERVO_CONFIG[info.obj].max = parseInt($('.max input', this).val());
 
                 const val = parseInt($('.direction select', this).val());
-                SERVO_CONFIG[info.obj].rate = val;
+                FC.SERVO_CONFIG[info.obj].rate = val;
             });
 
             //

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -29,11 +29,11 @@ TABS.setup.initialize = function (callback) {
         // translate to user-selected language
         i18n.localizePage();
 
-        if (semver.lt(CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE)) {
+        if (semver.lt(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE)) {
             $('#content .backup').addClass('disabled');
             $('#content .restore').addClass('disabled');
 
-            GUI.log(i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE]));
+            GUI.log(i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE]));
         }
 
         // initialize 3D Model
@@ -47,12 +47,12 @@ TABS.setup.initialize = function (callback) {
         $('span.heading').text(i18n.getMessage('initialSetupAttitude', [0]));
 
         // check if we have accelerometer and magnetometer
-        if (!have_sensor(CONFIG.activeSensors, 'acc')) {
+        if (!have_sensor(FC.CONFIG.activeSensors, 'acc')) {
             $('a.calibrateAccel').addClass('disabled');
             $('default_btn').addClass('disabled');
         }
 
-        if (!have_sensor(CONFIG.activeSensors, 'mag')) {
+        if (!have_sensor(FC.CONFIG.activeSensors, 'mag')) {
             $('a.calibrateMag').addClass('disabled');
             $('default_btn').addClass('disabled');
         }
@@ -61,7 +61,7 @@ TABS.setup.initialize = function (callback) {
 
         $('#arming-disable-flag').attr('title', i18n.getMessage('initialSetupArmingDisableFlagsTooltip'));
 
-        if (semver.gte(CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
             if (isExpertModeEnabled()) {
                 $('.initialSetupRebootBootloader').show();
             } else {
@@ -151,7 +151,7 @@ TABS.setup.initialize = function (callback) {
 
         // reset yaw button hook
         $('div#interactive_block > a.reset').click(function () {
-            self.yaw_fix = SENSOR_DATA.kinematics[2] * - 1.0;
+            self.yaw_fix = FC.SENSOR_DATA.kinematics[2] * - 1.0;
             $(this).text(i18n.getMessage('initialSetupButtonResetZaxisValue', [self.yaw_fix]));
 
             console.log('YAW reset to 0 deg, fix: ' + self.yaw_fix + ' deg');
@@ -194,7 +194,7 @@ TABS.setup.initialize = function (callback) {
             pitch_e = $('dd.pitch'),
             heading_e = $('dd.heading');
 
-        if (semver.lt(CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
             arming_disable_flags_e.hide();
         }
 
@@ -220,26 +220,26 @@ TABS.setup.initialize = function (callback) {
                                       'MSP',
                                      ];
 
-            if (semver.gte(CONFIG.apiVersion, "1.38.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.38.0")) {
                 disarmFlagElements.splice(disarmFlagElements.indexOf('THROTTLE'), 0, 'RUNAWAY_TAKEOFF');
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.39.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
                 disarmFlagElements = disarmFlagElements.concat(['PARALYZE',
                                                                 'GPS']);
             }
 
-            if (semver.gte(CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
                 disarmFlagElements.splice(disarmFlagElements.indexOf('OSD_MENU'), 1);
                 disarmFlagElements = disarmFlagElements.concat(['RESC']);
                 disarmFlagElements = disarmFlagElements.concat(['RPMFILTER']);
             }
-            if (semver.gte(CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
                 disarmFlagElements.splice(disarmFlagElements.indexOf('THROTTLE'), 0, 'CRASH');
                 disarmFlagElements = disarmFlagElements.concat(['REBOOT_REQD',
                                                                 'DSHOT_BBANG']);
             }
-            if (semver.gte(CONFIG.apiVersion, API_VERSION_1_43)) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                 disarmFlagElements = disarmFlagElements.concat(['NO_ACC_CAL', 'MOTOR_PROTO']);
             }
 
@@ -250,14 +250,14 @@ TABS.setup.initialize = function (callback) {
             arming_disable_flags_e.append('<span id="initialSetupArmingAllowed" i18n="initialSetupArmingAllowed" style="display: none;"></span>');
 
             // Arming disabled flags
-            for (var i = 0; i < CONFIG.armingDisableCount; i++) {
+            for (var i = 0; i < FC.CONFIG.armingDisableCount; i++) {
 
                 // All the known elements but the ARM_SWITCH (it must be always the last element)
                 if (i < disarmFlagElements.length - 1) {
                     arming_disable_flags_e.append('<span id="initialSetupArmingDisableFlags' + i + '" class="cf_tip disarm-flag" title="' + i18n.getMessage('initialSetupArmingDisableFlagsTooltip' + disarmFlagElements[i]) + '" style="display: none;">' + disarmFlagElements[i] + '</span>');
 
                 // The ARM_SWITCH, always the last element
-                } else if (i == CONFIG.armingDisableCount - 1) {
+                } else if (i == FC.CONFIG.armingDisableCount - 1) {
                     arming_disable_flags_e.append('<span id="initialSetupArmingDisableFlags' + i + '" class="cf_tip disarm-flag" title="' + i18n.getMessage('initialSetupArmingDisableFlagsTooltipARM_SWITCH') + '" style="display: none;">ARM_SWITCH</span>');
 
                 // Unknown disarm flags
@@ -273,36 +273,36 @@ TABS.setup.initialize = function (callback) {
 
             MSP.send_message(MSPCodes.MSP_STATUS, false, false, function() {
 
-                $('#initialSetupArmingAllowed').toggle(CONFIG.armingDisableFlags == 0);
+                $('#initialSetupArmingAllowed').toggle(FC.CONFIG.armingDisableFlags == 0);
 
-                for (var i = 0; i < CONFIG.armingDisableCount; i++) {
-                    $('#initialSetupArmingDisableFlags'+i).css('display',(CONFIG.armingDisableFlags & (1 << i)) == 0 ? 'none':'inline-block');
+                for (var i = 0; i < FC.CONFIG.armingDisableCount; i++) {
+                    $('#initialSetupArmingDisableFlags'+i).css('display',(FC.CONFIG.armingDisableFlags & (1 << i)) == 0 ? 'none':'inline-block');
                 }
 
             });
 
             MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
-                bat_voltage_e.text(i18n.getMessage('initialSetupBatteryValue', [ANALOG.voltage]));
-                bat_mah_drawn_e.text(i18n.getMessage('initialSetupBatteryMahValue', [ANALOG.mAhdrawn]));
-                bat_mah_drawing_e.text(i18n.getMessage('initialSetupBatteryAValue', [ANALOG.amperage.toFixed(2)]));
-                rssi_e.text(i18n.getMessage('initialSetupRSSIValue', [((ANALOG.rssi / 1023) * 100).toFixed(0)]));
+                bat_voltage_e.text(i18n.getMessage('initialSetupBatteryValue', [FC.ANALOG.voltage]));
+                bat_mah_drawn_e.text(i18n.getMessage('initialSetupBatteryMahValue', [FC.ANALOG.mAhdrawn]));
+                bat_mah_drawing_e.text(i18n.getMessage('initialSetupBatteryAValue', [FC.ANALOG.amperage.toFixed(2)]));
+                rssi_e.text(i18n.getMessage('initialSetupRSSIValue', [((FC.ANALOG.rssi / 1023) * 100).toFixed(0)]));
             });
 
-            if (have_sensor(CONFIG.activeSensors, 'gps')) {
+            if (have_sensor(FC.CONFIG.activeSensors, 'gps')) {
                 MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, function () {
-                    gpsFix_e.html((GPS_DATA.fix) ? i18n.getMessage('gpsFixTrue') : i18n.getMessage('gpsFixFalse'));
-                    gpsSats_e.text(GPS_DATA.numSat);
-                    gpsLat_e.text((GPS_DATA.lat / 10000000).toFixed(4) + ' deg');
-                    gpsLon_e.text((GPS_DATA.lon / 10000000).toFixed(4) + ' deg');
+                    gpsFix_e.html((FC.GPS_DATA.fix) ? i18n.getMessage('gpsFixTrue') : i18n.getMessage('gpsFixFalse'));
+                    gpsSats_e.text(FC.GPS_DATA.numSat);
+                    gpsLat_e.text((FC.GPS_DATA.lat / 10000000).toFixed(4) + ' deg');
+                    gpsLon_e.text((FC.GPS_DATA.lon / 10000000).toFixed(4) + ' deg');
                 });
             }
         }
 
         function get_fast_data() {
             MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, function () {
-                roll_e.text(i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[0]]));
-                pitch_e.text(i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[1]]));
-                heading_e.text(i18n.getMessage('initialSetupAttitude', [SENSOR_DATA.kinematics[2]]));
+                roll_e.text(i18n.getMessage('initialSetupAttitude', [FC.SENSOR_DATA.kinematics[0]]));
+                pitch_e.text(i18n.getMessage('initialSetupAttitude', [FC.SENSOR_DATA.kinematics[1]]));
+                heading_e.text(i18n.getMessage('initialSetupAttitude', [FC.SENSOR_DATA.kinematics[2]]));
 
                 self.renderModel();
                 self.updateInstruments();
@@ -322,9 +322,9 @@ TABS.setup.initializeInstruments = function() {
     var heading = $.flightIndicator('#heading', 'heading', options);
 
     this.updateInstruments = function() {
-        attitude.setRoll(SENSOR_DATA.kinematics[0]);
-        attitude.setPitch(SENSOR_DATA.kinematics[1]);
-        heading.setHeading(SENSOR_DATA.kinematics[2]);
+        attitude.setRoll(FC.SENSOR_DATA.kinematics[0]);
+        attitude.setPitch(FC.SENSOR_DATA.kinematics[1]);
+        heading.setHeading(FC.SENSOR_DATA.kinematics[2]);
     };
 };
 
@@ -335,9 +335,9 @@ TABS.setup.initModel = function () {
 };
 
 TABS.setup.renderModel = function () {
-    var x = (SENSOR_DATA.kinematics[1] * -1.0) * 0.017453292519943295,
-        y = ((SENSOR_DATA.kinematics[2] * -1.0) - this.yaw_fix) * 0.017453292519943295,
-        z = (SENSOR_DATA.kinematics[0] * -1.0) * 0.017453292519943295;
+    var x = (FC.SENSOR_DATA.kinematics[1] * -1.0) * 0.017453292519943295,
+        y = ((FC.SENSOR_DATA.kinematics[2] * -1.0) - this.yaw_fix) * 0.017453292519943295,
+        z = (FC.SENSOR_DATA.kinematics[0] * -1.0) * 0.017453292519943295;
 
     this.model.rotateTo(x, y, z);
 };

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -115,8 +115,8 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
         //googleAnalytics.sendAppView('Transponder');
     }
     // transponder supported added in MSP API Version 1.16.0
-    if ( CONFIG ) {
-        TABS.transponder.available = semver.gte(CONFIG.apiVersion, "1.16.0");
+    if ( FC.CONFIG ) {
+        TABS.transponder.available = semver.gte(FC.CONFIG.apiVersion, "1.16.0");
     }
     //////////////
     if ( !TABS.transponder.available ) {
@@ -243,9 +243,9 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
             let hexRegExp = new RegExp('[0-9a-fA-F]{' + (transponderProvider.dataLength * 2) + '}', 'gi');
 
             if ( !dataString.match(hexRegExp) ) {
-                TRANSPONDER.data = [];
+                FC.TRANSPONDER.data = [];
             } else {
-                TRANSPONDER.data = hexToBytes(dataString);
+                FC.TRANSPONDER.data = hexToBytes(dataString);
             }
             _persistentInputValues[transponderProvider.id] = dataString;
         };
@@ -260,7 +260,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
      */
     function toggleTransponderType() {
 
-        TRANSPONDER.provider = $(this).val();
+        FC.TRANSPONDER.provider = $(this).val();
         let defaultProvider = $(this).attr('data-defaultValue');
         if ( defaultProvider == $(this).val() ) {
             $('.save_reboot').hide();
@@ -271,25 +271,25 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
         }
 
         let clearValue = true;
-        buildDataBlockForTransponderProviders(TRANSPONDER.providers.find(function(provider) {
-            return provider.id == TRANSPONDER.provider;
-        }), bytesToHex(TRANSPONDER.data), clearValue);
+        buildDataBlockForTransponderProviders(FC.TRANSPONDER.providers.find(function(provider) {
+            return provider.id == FC.TRANSPONDER.provider;
+        }), bytesToHex(FC.TRANSPONDER.data), clearValue);
     }
 
 
     MSP.send_message(MSPCodes.MSP_TRANSPONDER_CONFIG, false, false, load_html);
 
     function process_html() {
-        $(".tab-transponder").toggleClass("transponder-supported", TABS.transponder.available && TRANSPONDER.supported);
+        $(".tab-transponder").toggleClass("transponder-supported", TABS.transponder.available && FC.TRANSPONDER.supported);
 
         i18n.localizePage();
 
-        if ( TABS.transponder.available && TRANSPONDER.providers.length > 0 ) {
+        if ( TABS.transponder.available && FC.TRANSPONDER.providers.length > 0 ) {
 
-            fillByTransponderProviders(TRANSPONDER.providers, TRANSPONDER.provider, toggleTransponderType);
-            buildDataBlockForTransponderProviders(TRANSPONDER.providers.find(function(provider) {
-                return provider.id == TRANSPONDER.provider;
-            }), bytesToHex(TRANSPONDER.data));
+            fillByTransponderProviders(FC.TRANSPONDER.providers, FC.TRANSPONDER.provider, toggleTransponderType);
+            buildDataBlockForTransponderProviders(FC.TRANSPONDER.providers.find(function(provider) {
+                return provider.id == FC.TRANSPONDER.provider;
+            }), bytesToHex(FC.TRANSPONDER.data));
 
 
             $('a.save').click(function() {
@@ -311,8 +311,8 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
                     });
                 }
 
-                if (TRANSPONDER.provider !== "0" && TRANSPONDER.data.length !== TRANSPONDER.providers.find(function(provider) {
-                        return provider.id == TRANSPONDER.provider;
+                if (FC.TRANSPONDER.provider !== "0" && FC.TRANSPONDER.data.length !== FC.TRANSPONDER.providers.find(function(provider) {
+                        return provider.id == FC.TRANSPONDER.provider;
                     }).dataLength ) {
                     GUI.log(i18n.getMessage('transponderDataInvalid'));
                 } else {

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -23,7 +23,7 @@ TABS.vtx.initialize = function (callback) {
 
     self.analyticsChanges = {};
 
-    this.supported = semver.gte(CONFIG.apiVersion, "1.42.0");
+    this.supported = semver.gte(FC.CONFIG.apiVersion, "1.42.0");
 
     if (!this.supported) {
         load_html();
@@ -65,14 +65,14 @@ TABS.vtx.initialize = function (callback) {
                 TABS.vtx.VTXTABLE_BAND_LIST = [];
                 vtxtable_bands.counter = 1;
             } else {
-                TABS.vtx.VTXTABLE_BAND_LIST.push(Object.assign({}, VTXTABLE_BAND));
+                TABS.vtx.VTXTABLE_BAND_LIST.push(Object.assign({}, FC.VTXTABLE_BAND));
                 vtxtable_bands.counter++;
             }
 
             const buffer = [];
             buffer.push8(vtxtable_bands.counter);
 
-            if (vtxtable_bands.counter <= VTX_CONFIG.vtx_table_bands) {
+            if (vtxtable_bands.counter <= FC.VTX_CONFIG.vtx_table_bands) {
                 MSP.send_message(MSPCodes.MSP_VTXTABLE_BAND, buffer, false, vtxtable_bands);
             } else {
                 vtxtable_bands.counter = undefined;
@@ -88,14 +88,14 @@ TABS.vtx.initialize = function (callback) {
                 TABS.vtx.VTXTABLE_POWERLEVEL_LIST = [];
                 vtxtable_powerlevels.counter = 1;
             } else {
-                TABS.vtx.VTXTABLE_POWERLEVEL_LIST.push(Object.assign({}, VTXTABLE_POWERLEVEL));
+                TABS.vtx.VTXTABLE_POWERLEVEL_LIST.push(Object.assign({}, FC.VTXTABLE_POWERLEVEL));
                 vtxtable_powerlevels.counter++;
             }
 
             const buffer = [];
             buffer.push8(vtxtable_powerlevels.counter);
 
-            if (vtxtable_powerlevels.counter <= VTX_CONFIG.vtx_table_powerlevels) {
+            if (vtxtable_powerlevels.counter <= FC.VTX_CONFIG.vtx_table_powerlevels) {
                 MSP.send_message(MSPCodes.MSP_VTXTABLE_POWERLEVEL, buffer, false, vtxtable_powerlevels);
             } else {
                 vtxtable_powerlevels.counter = undefined;
@@ -144,12 +144,12 @@ TABS.vtx.initialize = function (callback) {
     function read_vtx_config_json(vtxConfig, vtxcallback_after_read) {
 
         // Bands and channels
-        VTX_CONFIG.vtx_table_bands = vtxConfig.vtx_table.bands_list.length;
+        FC.VTX_CONFIG.vtx_table_bands = vtxConfig.vtx_table.bands_list.length;
 
 
         let maxChannels = 0;
         TABS.vtx.VTXTABLE_BAND_LIST = [];
-        for (let i = 1; i <= VTX_CONFIG.vtx_table_bands; i++) {
+        for (let i = 1; i <= FC.VTX_CONFIG.vtx_table_bands; i++) {
             TABS.vtx.VTXTABLE_BAND_LIST[i - 1] = {};
             TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_number = i;
             TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_name = vtxConfig.vtx_table.bands_list[i - 1].name;
@@ -160,13 +160,13 @@ TABS.vtx.initialize = function (callback) {
             maxChannels = Math.max(maxChannels, TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_frequencies.length);
         }
 
-        VTX_CONFIG.vtx_table_channels = maxChannels;
+        FC.VTX_CONFIG.vtx_table_channels = maxChannels;
 
         // Power levels
-        VTX_CONFIG.vtx_table_powerlevels = vtxConfig.vtx_table.powerlevels_list.length;
+        FC.VTX_CONFIG.vtx_table_powerlevels = vtxConfig.vtx_table.powerlevels_list.length;
 
         TABS.vtx.VTXTABLE_POWERLEVEL_LIST = [];
-        for (let i = 1; i <= VTX_CONFIG.vtx_table_powerlevels; i++) {
+        for (let i = 1; i <= FC.VTX_CONFIG.vtx_table_powerlevels; i++) {
             TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1] = {};
             TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1].vtxtable_powerlevel_number = i;
             TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1].vtxtable_powerlevel_value = vtxConfig.vtx_table.powerlevels_list[i - 1].value;
@@ -197,15 +197,15 @@ TABS.vtx.initialize = function (callback) {
         });
 
         // Supported?
-        const vtxSupported = VTX_CONFIG.vtx_type !== 0 && VTX_CONFIG.vtx_type !== 255;
-        const vtxTableNotConfigured = vtxSupported && VTX_CONFIG.vtx_table_available &&
-            (VTX_CONFIG.vtx_table_bands === 0 || VTX_CONFIG.vtx_table_channels === 0 || VTX_CONFIG.vtx_table_powerlevels === 0);
+        const vtxSupported = FC.VTX_CONFIG.vtx_type !== 0 && FC.VTX_CONFIG.vtx_type !== 255;
+        const vtxTableNotConfigured = vtxSupported && FC.VTX_CONFIG.vtx_table_available &&
+            (FC.VTX_CONFIG.vtx_table_bands === 0 || FC.VTX_CONFIG.vtx_table_channels === 0 || FC.VTX_CONFIG.vtx_table_powerlevels === 0);
 
-        TABS.vtx.vtxTableFactoryBandsSupported = VTX_CONFIG.vtx_type === 3;
+        TABS.vtx.vtxTableFactoryBandsSupported = FC.VTX_CONFIG.vtx_type === 3;
 
         $(".vtx_supported").toggle(vtxSupported);
         $(".vtx_not_supported").toggle(!vtxSupported);
-        $(".vtx_table_available").toggle(vtxSupported && VTX_CONFIG.vtx_table_available);
+        $(".vtx_table_available").toggle(vtxSupported && FC.VTX_CONFIG.vtx_table_available);
         $(".vtx_table_not_configured").toggle(vtxTableNotConfigured);
         $(".vtx_table_save_pending").toggle(TABS.vtx.vtxTableSavePending);
         $(".factory_band").toggle(TABS.vtx.vtxTableFactoryBandsSupported);
@@ -215,63 +215,63 @@ TABS.vtx.initialize = function (callback) {
 
         // Insert actual values in the fields
         // Values of the selected mode
-        $("#vtx_frequency").val(VTX_CONFIG.vtx_frequency);
-        $("#vtx_band").val(VTX_CONFIG.vtx_band);
+        $("#vtx_frequency").val(FC.VTX_CONFIG.vtx_frequency);
+        $("#vtx_band").val(FC.VTX_CONFIG.vtx_band);
 
         $("#vtx_band").change(populateChannelSelect).change();
 
-        $("#vtx_channel").val(VTX_CONFIG.vtx_channel);
-        if (VTX_CONFIG.vtx_table_available) {
-            $("#vtx_channel").attr("max", VTX_CONFIG.vtx_table_channels);
+        $("#vtx_channel").val(FC.VTX_CONFIG.vtx_channel);
+        if (FC.VTX_CONFIG.vtx_table_available) {
+            $("#vtx_channel").attr("max", FC.VTX_CONFIG.vtx_table_channels);
         }
 
-        $("#vtx_power").val(VTX_CONFIG.vtx_power);
-        $("#vtx_pit_mode").prop('checked', VTX_CONFIG.vtx_pit_mode);
-        $("#vtx_pit_mode_frequency").val(VTX_CONFIG.vtx_pit_mode_frequency);
-        $("#vtx_low_power_disarm").val(VTX_CONFIG.vtx_low_power_disarm);
+        $("#vtx_power").val(FC.VTX_CONFIG.vtx_power);
+        $("#vtx_pit_mode").prop('checked', FC.VTX_CONFIG.vtx_pit_mode);
+        $("#vtx_pit_mode_frequency").val(FC.VTX_CONFIG.vtx_pit_mode_frequency);
+        $("#vtx_low_power_disarm").val(FC.VTX_CONFIG.vtx_low_power_disarm);
 
         // Values of the current values
         const yesMessage =  i18n.getMessage("yes");
         const noMessage =  i18n.getMessage("no");
 
-        $("#vtx_device_ready_description").text(VTX_CONFIG.vtx_device_ready ? yesMessage : noMessage);
-        $("#vtx_type_description").text(i18n.getMessage(`vtxType_${VTX_CONFIG.vtx_type}`));
-        $("#vtx_channel_description").text(VTX_CONFIG.vtx_channel);
-        $("#vtx_frequency_description").text(VTX_CONFIG.vtx_frequency);
-        $("#vtx_pit_mode_description").text(VTX_CONFIG.vtx_pit_mode ? yesMessage : noMessage);
-        $("#vtx_pit_mode_frequency_description").text(VTX_CONFIG.vtx_pit_mode_frequency);
-        $("#vtx_low_power_disarm_description").text(i18n.getMessage(`vtxLowPowerDisarmOption_${VTX_CONFIG.vtx_low_power_disarm}`));
+        $("#vtx_device_ready_description").text(FC.VTX_CONFIG.vtx_device_ready ? yesMessage : noMessage);
+        $("#vtx_type_description").text(i18n.getMessage(`vtxType_${FC.VTX_CONFIG.vtx_type}`));
+        $("#vtx_channel_description").text(FC.VTX_CONFIG.vtx_channel);
+        $("#vtx_frequency_description").text(FC.VTX_CONFIG.vtx_frequency);
+        $("#vtx_pit_mode_description").text(FC.VTX_CONFIG.vtx_pit_mode ? yesMessage : noMessage);
+        $("#vtx_pit_mode_frequency_description").text(FC.VTX_CONFIG.vtx_pit_mode_frequency);
+        $("#vtx_low_power_disarm_description").text(i18n.getMessage(`vtxLowPowerDisarmOption_${FC.VTX_CONFIG.vtx_low_power_disarm}`));
 
-        if (VTX_CONFIG.vtx_band === 0) {
+        if (FC.VTX_CONFIG.vtx_band === 0) {
             $("#vtx_band_description").text(i18n.getMessage("vtxBand_0"));
         } else {
-            if (VTX_CONFIG.vtx_table_available && TABS.vtx.VTXTABLE_BAND_LIST[VTX_CONFIG.vtx_band - 1]) {
-                let bandName = TABS.vtx.VTXTABLE_BAND_LIST[VTX_CONFIG.vtx_band - 1].vtxtable_band_name;
+            if (FC.VTX_CONFIG.vtx_table_available && TABS.vtx.VTXTABLE_BAND_LIST[FC.VTX_CONFIG.vtx_band - 1]) {
+                let bandName = TABS.vtx.VTXTABLE_BAND_LIST[FC.VTX_CONFIG.vtx_band - 1].vtxtable_band_name;
                 if (bandName.trim() === '') {
-                    bandName = VTX_CONFIG.vtx_band;
+                    bandName = FC.VTX_CONFIG.vtx_band;
                 }
                 $("#vtx_band_description").text(bandName);
             } else {
-                $("#vtx_band_description").text(VTX_CONFIG.vtx_band);
+                $("#vtx_band_description").text(FC.VTX_CONFIG.vtx_band);
             }
         }
 
-        if (VTX_CONFIG.vtx_power === 0) {
+        if (FC.VTX_CONFIG.vtx_power === 0) {
             $("#vtx_power_description").text(i18n.getMessage("vtxPower_0"));
         } else {
-            if (VTX_CONFIG.vtx_table_available) {
-                let powerLevel = TABS.vtx.VTXTABLE_POWERLEVEL_LIST[VTX_CONFIG.vtx_power - 1].vtxtable_powerlevel_label;
+            if (FC.VTX_CONFIG.vtx_table_available) {
+                let powerLevel = TABS.vtx.VTXTABLE_POWERLEVEL_LIST[FC.VTX_CONFIG.vtx_power - 1].vtxtable_powerlevel_label;
                 if (powerLevel.trim() === '') {
-                    powerLevel = VTX_CONFIG.vtx_power;
+                    powerLevel = FC.VTX_CONFIG.vtx_power;
                 }
                 $("#vtx_power_description").text(powerLevel);
             } else {
-                const levelText = i18n.getMessage('vtxPower_X', {powerLevel: VTX_CONFIG.vtx_power});
+                const levelText = i18n.getMessage('vtxPower_X', {powerLevel: FC.VTX_CONFIG.vtx_power});
                 $("#vtx_power_description").text(levelText);
             }
         }
 
-        $("#vtx_table_powerlevels").val(VTX_CONFIG.vtx_table_powerlevels);
+        $("#vtx_table_powerlevels").val(FC.VTX_CONFIG.vtx_table_powerlevels);
 
         // Populate power levels
         for (let i = 1; i <= TABS.vtx.VTXTABLE_POWERLEVEL_LIST.length; i++) {
@@ -279,8 +279,8 @@ TABS.vtx.initialize = function (callback) {
             $(`#vtx_table_powerlabels_${i}`).val(TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1].vtxtable_powerlevel_label);
         }
 
-        $("#vtx_table_bands").val(VTX_CONFIG.vtx_table_bands);
-        $("#vtx_table_channels").val(VTX_CONFIG.vtx_table_channels);
+        $("#vtx_table_bands").val(FC.VTX_CONFIG.vtx_table_bands);
+        $("#vtx_table_channels").val(FC.VTX_CONFIG.vtx_table_channels);
 
         // Populate VTX Table
         let hasFactoryBands = false;
@@ -317,7 +317,7 @@ TABS.vtx.initialize = function (callback) {
             }
         }
 
-        $("#vtx_frequency_channel").prop('checked', VTX_CONFIG.vtx_band === 0 && VTX_CONFIG.vtx_frequency > 0).change(frequencyOrBandChannel);
+        $("#vtx_frequency_channel").prop('checked', FC.VTX_CONFIG.vtx_band === 0 && FC.VTX_CONFIG.vtx_frequency > 0).change(frequencyOrBandChannel);
 
         if ($("#vtx_frequency_channel").prop('checked')) {
             $(".field.vtx_channel").hide();
@@ -440,8 +440,8 @@ TABS.vtx.initialize = function (callback) {
             const selectBand = $(".field #vtx_band");
 
             selectBand.append(new Option(i18n.getMessage('vtxBand_0'), 0));
-            if (VTX_CONFIG.vtx_table_available) {
-                for (let i = 1; i <= VTX_CONFIG.vtx_table_bands; i++) {
+            if (FC.VTX_CONFIG.vtx_table_available) {
+                for (let i = 1; i <= FC.VTX_CONFIG.vtx_table_bands; i++) {
                     let bandName = TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_name;
                     if (bandName.trim() === '') {
                         bandName = i18n.getMessage('vtxBand_X', {bandName: i});
@@ -463,7 +463,7 @@ TABS.vtx.initialize = function (callback) {
             selectChannel.empty();
 
             selectChannel.append(new Option(i18n.getMessage('vtxChannel_0'), 0));
-            if (VTX_CONFIG.vtx_table_available) {
+            if (FC.VTX_CONFIG.vtx_table_available) {
                 if (TABS.vtx.VTXTABLE_BAND_LIST[selectedBand - 1]) {
                     for (let i = 1; i <= TABS.vtx.VTXTABLE_BAND_LIST[selectedBand - 1].vtxtable_band_frequencies.length; i++) {
                         const channelName = TABS.vtx.VTXTABLE_BAND_LIST[selectedBand - 1].vtxtable_band_frequencies[i - 1];
@@ -482,9 +482,9 @@ TABS.vtx.initialize = function (callback) {
         function populatePowerSelect() {
             const selectPower = $(".field #vtx_power");
 
-            if (VTX_CONFIG.vtx_table_available) {
+            if (FC.VTX_CONFIG.vtx_table_available) {
                 selectPower.append(new Option(i18n.getMessage('vtxPower_0'), 0));
-                for (let i = 1; i <= VTX_CONFIG.vtx_table_powerlevels; i++) {
+                for (let i = 1; i <= FC.VTX_CONFIG.vtx_table_powerlevels; i++) {
                     let powerLevel = TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1].vtxtable_powerlevel_label;
                     if (powerLevel.trim() === '') {
                         powerLevel = i18n.getMessage('vtxPower_X', {powerLevel: i});
@@ -492,7 +492,7 @@ TABS.vtx.initialize = function (callback) {
                     selectPower.append(new Option(powerLevel, i));
                 }
             } else {
-                const powerMaxMinValues = getPowerValues(VTX_CONFIG.vtx_type);
+                const powerMaxMinValues = getPowerValues(FC.VTX_CONFIG.vtx_type);
                 for (let i = powerMaxMinValues.min; i <= powerMaxMinValues.max; i++) {
                     if (i === 0) {
                         selectPower.append(new Option(i18n.getMessage('vtxPower_0'), 0));
@@ -508,8 +508,8 @@ TABS.vtx.initialize = function (callback) {
 
             let powerMinMax = {};
 
-            if (VTX_CONFIG.vtx_table_available) {
-                powerMinMax = {min: 1, max: VTX_CONFIG.vtx_table_powerlevels};
+            if (FC.VTX_CONFIG.vtx_table_available) {
+                powerMinMax = {min: 1, max: FC.VTX_CONFIG.vtx_table_powerlevels};
             } else {
 
                 switch (vtxType) {
@@ -568,8 +568,8 @@ TABS.vtx.initialize = function (callback) {
         const suffix = 'lua';
 
         let filename;
-        if(CONFIG.name && CONFIG.name.trim() !== '') {
-            filename = CONFIG.name.trim().replace(' ', '_');
+        if(FC.CONFIG.name && FC.CONFIG.name.trim() !== '') {
+            filename = FC.CONFIG.name.trim().replace(' ', '_');
         }else{
             filename = suggestedName;
         }
@@ -819,8 +819,8 @@ TABS.vtx.initialize = function (callback) {
             }
 
 
-            if (save_vtx_powerlevels.counter < VTX_CONFIG.vtx_table_powerlevels) {
-                VTXTABLE_POWERLEVEL = Object.assign({}, TABS.vtx.VTXTABLE_POWERLEVEL_LIST[save_vtx_powerlevels.counter]);
+            if (save_vtx_powerlevels.counter < FC.VTX_CONFIG.vtx_table_powerlevels) {
+                FC.VTXTABLE_POWERLEVEL = Object.assign({}, TABS.vtx.VTXTABLE_POWERLEVEL_LIST[save_vtx_powerlevels.counter]);
                 MSP.send_message(MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL, mspHelper.crunch(MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL), false, save_vtx_powerlevels);
             } else {
                 save_vtx_powerlevels.counter = undefined;
@@ -838,8 +838,8 @@ TABS.vtx.initialize = function (callback) {
             }
 
 
-            if (save_vtx_bands.counter < VTX_CONFIG.vtx_table_bands) {
-                VTXTABLE_BAND = Object.assign({}, TABS.vtx.VTXTABLE_BAND_LIST[save_vtx_bands.counter]);
+            if (save_vtx_bands.counter < FC.VTX_CONFIG.vtx_table_bands) {
+                FC.VTXTABLE_BAND = Object.assign({}, TABS.vtx.VTXTABLE_BAND_LIST[save_vtx_bands.counter]);
                 MSP.send_message(MSPCodes.MSP_SET_VTXTABLE_BAND, mspHelper.crunch(MSPCodes.MSP_SET_VTXTABLE_BAND), false, save_vtx_bands);
             } else {
                 save_vtx_bands.counter = undefined;
@@ -871,29 +871,29 @@ TABS.vtx.initialize = function (callback) {
         // General config
         const frequencyEnabled = $("#vtx_frequency_channel").prop('checked');
         if (frequencyEnabled) {
-            VTX_CONFIG.vtx_frequency = parseInt($("#vtx_frequency").val());
-            VTX_CONFIG.vtx_band = 0;
-            VTX_CONFIG.vtx_channel = 0;
+            FC.VTX_CONFIG.vtx_frequency = parseInt($("#vtx_frequency").val());
+            FC.VTX_CONFIG.vtx_band = 0;
+            FC.VTX_CONFIG.vtx_channel = 0;
         } else {
-            VTX_CONFIG.vtx_band = parseInt($("#vtx_band").val());
-            VTX_CONFIG.vtx_channel = parseInt($("#vtx_channel").val());
-            VTX_CONFIG.vtx_frequency = 0;
-            if (semver.lt(CONFIG.apiVersion, "1.42.0")) {
-                if (VTX_CONFIG.vtx_band > 0 || VTX_CONFIG.vtx_channel > 0) {
-                    VTX_CONFIG.vtx_frequency = (band - 1) * 8 + (channel - 1);
+            FC.VTX_CONFIG.vtx_band = parseInt($("#vtx_band").val());
+            FC.VTX_CONFIG.vtx_channel = parseInt($("#vtx_channel").val());
+            FC.VTX_CONFIG.vtx_frequency = 0;
+            if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
+                if (FC.VTX_CONFIG.vtx_band > 0 || FC.VTX_CONFIG.vtx_channel > 0) {
+                    FC.VTX_CONFIG.vtx_frequency = (band - 1) * 8 + (channel - 1);
                 }
             }
         }
-        VTX_CONFIG.vtx_power = parseInt($("#vtx_power").val());
-        VTX_CONFIG.vtx_pit_mode = $("#vtx_pit_mode").prop('checked');
-        VTX_CONFIG.vtx_low_power_disarm = parseInt($("#vtx_low_power_disarm").val());
-        VTX_CONFIG.vtx_table_clear = true;
+        FC.VTX_CONFIG.vtx_power = parseInt($("#vtx_power").val());
+        FC.VTX_CONFIG.vtx_pit_mode = $("#vtx_pit_mode").prop('checked');
+        FC.VTX_CONFIG.vtx_low_power_disarm = parseInt($("#vtx_low_power_disarm").val());
+        FC.VTX_CONFIG.vtx_table_clear = true;
 
         // Power levels
-        VTX_CONFIG.vtx_table_powerlevels = parseInt($("#vtx_table_powerlevels").val());
+        FC.VTX_CONFIG.vtx_table_powerlevels = parseInt($("#vtx_table_powerlevels").val());
 
         TABS.vtx.VTXTABLE_POWERLEVEL_LIST = [];
-        for (let i = 1; i <= VTX_CONFIG.vtx_table_powerlevels; i++) {
+        for (let i = 1; i <= FC.VTX_CONFIG.vtx_table_powerlevels; i++) {
             TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1] = {};
             TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1].vtxtable_powerlevel_number = i;
             TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1].vtxtable_powerlevel_value = parseInt($(`#vtx_table_powerlevels_${i}`).val());
@@ -901,10 +901,10 @@ TABS.vtx.initialize = function (callback) {
         }
 
         // Bands and channels
-        VTX_CONFIG.vtx_table_bands = parseInt($("#vtx_table_bands").val());
-        VTX_CONFIG.vtx_table_channels = parseInt($("#vtx_table_channels").val());
+        FC.VTX_CONFIG.vtx_table_bands = parseInt($("#vtx_table_bands").val());
+        FC.VTX_CONFIG.vtx_table_channels = parseInt($("#vtx_table_channels").val());
         TABS.vtx.VTXTABLE_BAND_LIST = [];
-        for (let i = 1; i <= VTX_CONFIG.vtx_table_bands; i++) {
+        for (let i = 1; i <= FC.VTX_CONFIG.vtx_table_bands; i++) {
             TABS.vtx.VTXTABLE_BAND_LIST[i - 1] = {};
             TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_number = i;
             TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_name = $(`#vtx_table_band_name_${i}`).val();
@@ -912,7 +912,7 @@ TABS.vtx.initialize = function (callback) {
             TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_is_factory_band = TABS.vtx.vtxTableFactoryBandsSupported ? $(`#vtx_table_band_factory_${i}`).prop('checked') : false;
 
             TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_frequencies = [];
-            for (let j = 1; j <= VTX_CONFIG.vtx_table_channels; j++) {
+            for (let j = 1; j <= FC.VTX_CONFIG.vtx_table_channels; j++) {
                 TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_frequencies.push(parseInt($(`#vtx_table_band_channel_${i}_${j}`).val()));
             }
         }
@@ -930,7 +930,7 @@ TABS.vtx.initialize = function (callback) {
         vtxConfig.vtx_table = {};
 
         vtxConfig.vtx_table.bands_list = [];
-        for (let i = 1; i <= VTX_CONFIG.vtx_table_bands; i++) {
+        for (let i = 1; i <= FC.VTX_CONFIG.vtx_table_bands; i++) {
             vtxConfig.vtx_table.bands_list[i - 1] = {};
             vtxConfig.vtx_table.bands_list[i - 1].name = TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_name;
             vtxConfig.vtx_table.bands_list[i - 1].letter = TABS.vtx.VTXTABLE_BAND_LIST[i - 1].vtxtable_band_letter;
@@ -939,7 +939,7 @@ TABS.vtx.initialize = function (callback) {
         }
 
         vtxConfig.vtx_table.powerlevels_list = [];
-        for (let i = 1; i <= VTX_CONFIG.vtx_table_powerlevels; i++) {
+        for (let i = 1; i <= FC.VTX_CONFIG.vtx_table_powerlevels; i++) {
             vtxConfig.vtx_table.powerlevels_list[i - 1] = {};
             vtxConfig.vtx_table.powerlevels_list[i - 1].value = TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1].vtxtable_powerlevel_value;
             vtxConfig.vtx_table.powerlevels_list[i - 1].label = TABS.vtx.VTXTABLE_POWERLEVEL_LIST[i - 1].vtxtable_powerlevel_label;


### PR DESCRIPTION
This is a BIG and RISKY pull request.

- Moves all the global vars defined in the `FC.js` file inside the FC object. This helps to produce cleaner code and removes a lot of global variables.
- Fixed most Sonar issues of `FC.js` too.

The IDE helped with the change, but it was unable to find all the references, so I needed a regexp, with a test and error process to find the rest, so there is a risk of a forgotten one or a bad replaced one, but now that we are far from the next release and we have time to find some bug I think is the moment to do it.
