### PR TITLE
Cordova: use only version from package.json

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -15,7 +15,7 @@ function appReady() {
         CONFIGURATOR.gitChangesetId = data.gitChangesetId;
 
         // Version in the ChromeApp's manifest takes precedence.
-        if(chrome.runtime && chrome.runtime.getManifest) {
+        if(chrome.runtime && chrome.runtime.getManifest && !GUI.isCordova()) {
             const manifest = chrome.runtime.getManifest();
             CONFIGURATOR.version = manifest.version;
             // manifest.json for ChromeApp can't have a version


### PR DESCRIPTION
This pull request only concerns cordova (android app). The version that the application itself is showing in the top bar is now determined by `package.json` and no more by `manifest.json`. So, now, the version of the package and the version displayed in the configurator are the same.