### PR TITLE
Cordova: add warning message when exiting the configurator

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5832,5 +5832,11 @@
     },
     "cordovaWebviewUsed": {
         "message": "used"
+    },
+    "cordovaExitAppTitle": {
+        "message": "Confirmation"
+    },
+    "cordovaExitAppMessage": {
+        "message": "Do you really want to close the configurator?"
     }
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -187,6 +187,19 @@ function startProcess() {
         chrome.runtime.onSuspend.addListener(closeHandler);
     } else if (GUI.isCordova()) {
         window.addEventListener('beforeunload', closeHandler);
+        document.addEventListener('backbutton', function(e) {
+            e.preventDefault();
+            navigator.notification.confirm(
+                i18n.getMessage('cordovaExitAppMessage'),
+                function(stat) {
+                    if (stat === 1) {
+                        navigator.app.exitApp();
+                    }
+                },
+                i18n.getMessage('cordovaExitAppTitle'),
+                [i18n.getMessage('yes'),i18n.getMessage('no')]
+            );
+        });
     }
 
     $('.connect_b a.connect').removeClass('disabled');


### PR DESCRIPTION
This pull request adds a warning message when the user press the return button of the device (#2100).
![Screenshot_20200708-155353_Betaflight Configurator](https://user-images.githubusercontent.com/48027865/86927188-4eeeff00-c133-11ea-9984-39dd8e528902.jpg)
