### PR TITLE
Reverted THREE library to 0.97.0 to get CanvasRenderer back.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "object-hash": "^2.0.3",
     "semver-min": "^0.6.5",
     "short-unique-id": "^1.1.1",
-    "three": "~0.110.0",
+    "three": "~0.97.0",
     "universal-ga": "^1.2.0"
   },
   "devDependencies": {

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -87,7 +87,7 @@ var Model = function (wrapper, canvas) {
 };
 
 Model.prototype.loadJSON = function (model_file, callback) {
-    const loader = new THREE.LegacyJSONLoader();
+    const loader = new THREE.JSONLoader();
 
     loader.load(`./resources/models/${model_file}.json`, function (geometry, materials) {
         const modelMaterial = new THREE.MeshFaceMaterial(materials);

--- a/src/main.html
+++ b/src/main.html
@@ -58,7 +58,8 @@
     <script type="text/javascript" src="./js/libraries/d3.min.js"></script>
     <script type="text/javascript" src="./js/libraries/jquery.nouislider.all.min.js"></script>
     <script type="text/javascript" src="./node_modules/three/build/three.min.js"></script>
-    <script type="text/javascript" src="./node_modules/three/examples/js/loaders/deprecated/LegacyJSONLoader.js"></script>
+    <script type="text/javascript" src="./node_modules/three/examples/js/renderers/CanvasRenderer.js"></script>
+    <script type="text/javascript" src="./node_modules/three/examples/js/renderers/Projector.js"></script>
     <script type="text/javascript" src="./js/libraries/jquery.flightindicators.js"></script>
     <script type="text/javascript" src="./node_modules/semver-min/umd/index.js"></script>
     <script type="text/javascript" src="./js/libraries/switchery/switchery.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6063,10 +6063,10 @@ thenify@^3.3.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@~0.110.0:
-  version "0.110.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.110.0.tgz#8719591de1336269113ee79f4268ba247b2324f8"
-  integrity sha512-wlurH8XBO9Sd5VIw8nBa+taLR20kqaI4e9FiuMh6tqK8eOS2q2R+ZoUyufbyDTVTHhs8GiTbv0r2CMLkwerFJg==
+three@~0.97.0:
+  version "0.97.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.97.0.tgz#76141e1b0ace14246fe9198a458fefddc98a4e30"
+  integrity sha512-ctZF79O1R2aMIDnz9cV5GUIONyFnYvfQKg4+EAwEVaEr1mgy99rglstH6hhRdIThu3SOa4Ns5da/Ee5fTbWc9A==
 
 through2-filter@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
This will fix errors for devices without WebGL support.