### PR TITLE
Adjust LQ OSD element preview according to selected serial RX provider

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -345,6 +345,12 @@ OSD.generateTemperaturePreview = function (osd_data, temperature) {
     return preview;
 }
 
+OSD.generateLQPreview = function() {
+    const CRSF_PROVIDER = 9;
+    let isXF = FC.RX_CONFIG.serialrx_provider == CRSF_PROVIDER;
+    return FONT.symbol(SYM.LINK_QUALITY) + (isXF ? '2:100' : '8');
+}
+
 OSD.generateCraftName = function (osd_data) {
     var preview = 'CRAFT_NAME';
     if (FC.CONFIG.name != '') {
@@ -1015,7 +1021,7 @@ OSD.loadDisplayFields = function() {
             default_position: -1,
             draw_order: 390,
             positionable: true,
-            preview: FONT.symbol(SYM.LINK_QUALITY) + '8'
+            preview: OSD.generateLQPreview,
         },
         FLIGHT_DIST: {
             name: 'FLIGHT_DISTANCE',
@@ -2175,7 +2181,6 @@ TABS.osd.initialize = function (callback) {
     }
 
     $('#content').load("./tabs/osd.html", function () {
-
         // Prepare symbols depending on the version
         SYM.loadSymbols();
         OSD.loadDisplayFields();
@@ -2943,7 +2948,10 @@ TABS.osd.initialize = function (callback) {
 
         self.analyticsChanges = {};
 
-        GUI.content_ready(callback);
+        MSP.promise(MSPCodes.MSP_RX_CONFIG)
+            .finally(() => {
+                GUI.content_ready(callback);
+            });
     });
 };
 


### PR DESCRIPTION
When the OSD Tab is activated the RX config gets queried through MSP unconditionally because it seems to me that there's no way to distinguish between the default value of `serialrx_provider` (which is `0`) and when `serialrx_provider` is not yet set.

![improved-lq-preview](https://user-images.githubusercontent.com/33358/87726828-1b117a80-c7c0-11ea-8335-feb94c2e1a81.png)
