### PR TITLE
bump nwjs to latest version

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ const LINUX_INSTALL_DIR = '/opt/betaflight';
 var gitChangeSetId;
 
 var nwBuilderOptions = {
-    version: '0.44.6',
+    version: '0.47.0',
     files: './dist/**/*',
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},


### PR DESCRIPTION
- bump nwjs to version 0.47.0

- replaces #1989 

- fixes [this issue](https://github.com/betaflight/betaflight-configurator/pull/1893#issuecomment-589936165)
