### PR TITLE
Fix css for large target names after Cordova changes

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -233,6 +233,7 @@ input[type="number"]::-webkit-inner-spin-button {
 
     .logo_text {
         font-size: inherit;
+        position: relative;
     }
 }
 


### PR DESCRIPTION
Cordova implementation comes with some changes on this css part, then I have fixed again logo_text style to allow large target names.

![image](https://user-images.githubusercontent.com/43983086/88165254-bae26480-cc15-11ea-8a96-c4c72dc01f59.png)

