### PR TITLE
Cordova/Android: improving logo and text position

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -968,6 +968,7 @@ input[type="number"]::-webkit-inner-spin-button {
     background-image: url(../images/light-wide-2.svg);
     background-repeat: no-repeat;
     background-position: center 20px;
+    background-position-x: 12px;
     background-size: 80%;
     height: 120px;
     position: relative;
@@ -975,7 +976,7 @@ input[type="number"]::-webkit-inner-spin-button {
 }
 #tab_logoversion .logo_text {
     display: block !important;
-    left: 100px;
+    left: 82px;
     top: 62px;
 }
 


### PR DESCRIPTION
I have aligned the tab_container logo trying to get a better result, this also helps to allow more large target names.

Before:
![cordovafirst](https://user-images.githubusercontent.com/43983086/88180883-51228480-cc2e-11ea-9ee6-96f1c136bcbb.jpg)
Now:
![cordovaresult](https://user-images.githubusercontent.com/43983086/88180886-51bb1b00-cc2e-11ea-893a-7d29923f51d7.jpg)

