### PR TITLE
Remove hard coded number

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -497,6 +497,54 @@ const FC = {
             rcSmoothingDerivativeType:    0,
             rcSmoothingAutoSmoothness:    0,
             usbCdcHidType:                0,
+            serialRxTypes: [
+                'SPEKTRUM1024',
+                'SPEKTRUM2048',
+                'SBUS',
+                'SUMD',
+                'SUMH',
+                'XBUS_MODE_B',
+                'XBUS_MODE_B_RJ01',
+            ],
+
+            getSerialRxTypes: () => {
+                const apiVersion = this.CONFIG.apiVersion;
+                const flightControllerIdentifier = this.CONFIG.flightControllerIdentifier;
+                const flightControllerVersion = this.CONFIG.flightControllerVersion;
+                // js way of cloning an array
+                const result = [...this.RX_CONFIG.serialRxTypes];
+
+                if (semver.gte(apiVersion, "1.15.0")) {
+                    result.push('IBUS');
+                }
+
+                if ((flightControllerIdentifier === 'BTFL' && semver.gte(flightControllerVersion, "2.6.0")) ||
+                    (flightControllerIdentifier === 'CLFL' && semver.gte(apiVersion, "1.31.0"))) {
+                    result.push('JETIEXBUS');
+                }
+
+                if (semver.gte(apiVersion, "1.31.0")) {
+                    result.push('CRSF');
+                }
+
+                if (semver.gte(apiVersion, "1.24.0")) {
+                    result.push('SPEKTRUM2048/SRXL');
+                }
+
+                if (semver.gte(apiVersion, "1.35.0")) {
+                    result.push('TARGET_CUSTOM');
+                }
+
+                if (semver.gte(apiVersion, "1.37.0")) {
+                    result.push('FrSky FPort');
+                }
+
+                if (semver.gte(apiVersion, "1.42.0")) {
+                    result.push('SPEKTRUM SRXL2');
+                }
+
+                return result;
+            },
         };
 
         this.FAILSAFE_CONFIG = {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -843,52 +843,12 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             gpsBaudrateElement.parent().hide();
         }
 
-        // generate serial RX
-        var serialRXtypes = [
-            'SPEKTRUM1024',
-            'SPEKTRUM2048',
-            'SBUS',
-            'SUMD',
-            'SUMH',
-            'XBUS_MODE_B',
-            'XBUS_MODE_B_RJ01'
-        ];
+        const serialRXSelectEl = $('select.serialRX');
+        FC.RX_CONFIG.getSerialRxTypes().forEach((serialRxType, index) => {
+            serialRXSelectEl.append(`<option value="${index}">${serialRxType}</option>`);
+        });
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.15.0")) {
-            serialRXtypes.push('IBUS');
-        }
-
-        if ((FC.CONFIG.flightControllerIdentifier === 'BTFL' && semver.gte(FC.CONFIG.flightControllerVersion, "2.6.0")) ||
-            (FC.CONFIG.flightControllerIdentifier === 'CLFL' && semver.gte(FC.CONFIG.apiVersion, "1.31.0"))) {
-            serialRXtypes.push('JETIEXBUS');
-        }
-
-        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0"))  {
-            serialRXtypes.push('CRSF');
-        }
-
-        if (semver.gte(FC.CONFIG.apiVersion, "1.24.0"))  {
-            serialRXtypes.push('SPEKTRUM2048/SRXL');
-        }
-
-        if (semver.gte(FC.CONFIG.apiVersion, "1.35.0"))  {
-            serialRXtypes.push('TARGET_CUSTOM');
-        }
-
-        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0"))  {
-            serialRXtypes.push('FrSky FPort');
-        }
-
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0"))  {
-            serialRXtypes.push('SPEKTRUM SRXL2');
-        }
-
-        var serialRX_e = $('select.serialRX');
-        for (var i = 0; i < serialRXtypes.length; i++) {
-            serialRX_e.append('<option value="' + i + '">' + serialRXtypes[i] + '</option>');
-        }
-
-        serialRX_e.change(function () {
+        serialRXSelectEl.change(function () {
             var serialRxValue = parseInt($(this).val());
 
             var newValue;
@@ -901,7 +861,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         });
 
         // select current serial RX type
-        serialRX_e.val(FC.RX_CONFIG.serialrx_provider);
+        serialRXSelectEl.val(FC.RX_CONFIG.serialrx_provider);
 
         if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
             var spiRxTypes = [

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -346,8 +346,8 @@ OSD.generateTemperaturePreview = function (osd_data, temperature) {
 }
 
 OSD.generateLQPreview = function() {
-    const CRSF_PROVIDER = 9;
-    let isXF = FC.RX_CONFIG.serialrx_provider == CRSF_PROVIDER;
+    const crsfIndex = FC.RX_CONFIG.getSerialRxTypes().findIndex(name => name === 'CRSF');
+    const isXF = crsfIndex === FC.RX_CONFIG.serialrx_provider;
     return FONT.symbol(SYM.LINK_QUALITY) + (isXF ? '2:100' : '8');
 }
 


### PR DESCRIPTION
This is a fix for #2125 that removes the hard coded index of the `CRFS` serial RX provider (which I believe was clumsy).