### PR TITLE
Add support for British units in OSD

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4251,6 +4251,10 @@
         "message": "Metric",
         "description": "Option for the units system used in the OSD"
     },
+    "osdSetupUnitsOptionBritish": {
+        "message": "British",
+        "description": "Option for the units system used in the OSD"
+    },
     "osdSetupTimersTitle": {
         "message": "Timers"
     },

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -339,6 +339,7 @@ OSD.generateTemperaturePreview = function (osd_data, temperature) {
             preview += Math.floor(temperature) + FONT.symbol(SYM.TEMP_F);
             break;
         case 1:
+        case 2:
             preview += temperature + FONT.symbol(SYM.TEMP_C);
             break;
     }
@@ -650,7 +651,8 @@ OSD.loadDisplayFields = function() {
             draw_order: 160,
             positionable: true,
             preview: function (osd_data) {
-                return FONT.symbol(SYM.ALTITUDE) + '399.7' + FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                const unit = FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                return `${FONT.symbol(SYM.ALTITUDE)}399.7${unit}`;
             }
         },
         ONTIME: {
@@ -686,7 +688,8 @@ OSD.loadDisplayFields = function() {
             draw_order: 810,
             positionable: true,
             preview: function (osd_data) {
-                return FONT.symbol(SYM.SPEED) + ' 40' + (osd_data.unit_mode === 0 ? FONT.symbol(SYM.MPH) : FONT.symbol(SYM.KPH));
+                const unit = FONT.symbol(osd_data.unit_mode === 0 || osd_data.unit_mode === 1 ? SYM.MPH : SYM.KPH);
+                return `${FONT.symbol(SYM.SPEED)}40${unit}`;
             }
         },
         GPS_SATS: {
@@ -841,7 +844,8 @@ OSD.loadDisplayFields = function() {
             draw_order: 840,
             positionable: true,
             preview: function (osd_data) {
-                return FONT.symbol(SYM.HOMEFLAG) + '432' + FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                const unit = FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                return `${FONT.symbol(SYM.HOMEFLAG)}432${unit}`;
             }
         },
         NUMERICAL_HEADING: {
@@ -861,7 +865,8 @@ OSD.loadDisplayFields = function() {
             draw_order: 300,
             positionable: true,
             preview: function (osd_data) {
-                return FONT.symbol(SYM.ARROW_SMALL_UP) + '8.7' + (osd_data.unit_mode === 0 ? FONT.symbol(SYM.FTPS) : FONT.symbol(SYM.MPS));
+                const unit = FONT.symbol(osd_data.unit_mode === 0 ? SYM.FTPS : SYM.MPS);
+                return `${FONT.symbol(SYM.ARROW_SMALL_UP)}8.7${unit}`;
             }
         },
         COMPASS_BAR: {
@@ -1031,7 +1036,8 @@ OSD.loadDisplayFields = function() {
             draw_order: 860,
             positionable: true,
             preview: function (osd_data) {
-                return FONT.symbol(SYM.TOTAL_DIST) + '653' + FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                const unit = FONT.symbol(osd_data.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                return `${FONT.symbol(SYM.TOTAL_DIST)}653${unit}`;
             }
         },
         STICK_OVERLAY_LEFT: {
@@ -1134,7 +1140,8 @@ OSD.loadDisplayFields = function() {
             draw_order: 455,
             positionable: true,
             preview: function (osdData) {
-                return `1234${FONT.symbol(SYM.MAH)}/${FONT.symbol(osdData.unit_mode === 0 ? SYM.MILES : SYM.KM)}`;
+                const unit = FONT.symbol(osdData.unit_mode === 0 ? SYM.MILES : SYM.KM);
+                return `1234${FONT.symbol(SYM.MAH)}/${unit}`;
             },
         },
 
@@ -1158,7 +1165,8 @@ OSD.constants = {
     },
     UNIT_TYPES: [
         'IMPERIAL',
-        'METRIC'
+        'METRIC',
+        'BRITISH',
     ],
     TIMER_PRECISION: [
         'SECOND',


### PR DESCRIPTION
On slack there was a demand for a British unit for speed and distance related elements in OSD.
It's tested on a IFLIGHT SUCCEX-D F7 TWING with DJI goggles and this PR adds visibility in OSD preview.

**Units**

| Unit | Speed | Distance |
| ---- | ------- | ---------- |
| Imperial | MPH | Miles |
| Metric | KPH | KM |
| British | MPH | KM |

**Affected OSD Elements**

| OSD Element | Imperial | Metric | British |
| --- | --- | --- | --- |
| Altitude | Feet | Metre | Metre |
| GPS Speed | MPH | KPH | MPH |
| Home Distance | Feet | Metre | Metre |
| Numerical Vario | FTPS | MPS | MPS |
| Flight Distance | Feet | Metre | Metre |
| OSD Efficiency | Miles | KM | KM |

Firmware part: https://github.com/betaflight/betaflight/pull/10080