### PR TITLE
Azure-pipelines android build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -66,6 +66,13 @@ stages:
       inputs:
         targetPath: '$(System.DefaultWorkingDirectory)/release'
         artifact: 'betaflight-configurator-windows'
+    - script: yarn gulp release --android
+      displayName: 'Run yarn release for android'
+    - task: PublishPipelineArtifact@1
+      displayName: 'Publish Android release'
+      inputs:
+        targetPath: '$(System.DefaultWorkingDirectory)/release'
+        artifact: 'betaflight-configurator-android'
 
   - job: 'MacOS'
     pool:
@@ -144,6 +151,7 @@ stages:
         githubReleasePrerelease: false
         githubIgnoreAssets: false
         githubReleaseAsset: |
+          $(Pipeline.Workspace)/betaflight-configurator-android/**
           $(Pipeline.Workspace)/betaflight-configurator-windows/**
           $(Pipeline.Workspace)/betaflight-configurator-macos/**
           $(Pipeline.Workspace)/betaflight-configurator-linux/**


### PR DESCRIPTION
Allow Azure to build Android Beta releases for testing. Android plataform cant be conpiled in debug mode so I have added same value for releasesBuilds and nonreleases builds `-yarn gulp release --android` for both cases. I have tested and compiles without problems. I have used Windows plataform to build it after win32 build and publish finished.