### PR TITLE
Add search and order to the blackbox debug modes list

### DIFF
--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -353,6 +353,22 @@ TABS.onboard_logging.initialize = function (callback) {
             }
 
             debugModeSelect.val(FC.PID_ADVANCED_CONFIG.debugMode);
+
+            // Convert to select2 and order alphabetic
+            debugModeSelect.select2({
+                sorter(data) {
+                    return data.sort(function(a, b) {
+                        if (a.text === "NONE" || b.text === i18n.getMessage('onboardLoggingDebugModeUnknown')) {
+                            return -1;
+                        } else if (b.text ==="NONE" || a.text === i18n.getMessage('onboardLoggingDebugModeUnknown')) {
+                            return 1;
+                        } else {
+                            return a.text.localeCompare(b.text);
+                        }
+                    });
+                },
+            });
+
         } else {
             $('.blackboxDebugMode').hide();
         }


### PR DESCRIPTION
Now that we have the select2 library styled ready to use, this PR adds it to the long list of blackbox debug modes. In this way we can search in a fast way the mode we want.

It adds too an alphabetic order over the elements. Except the NONE (always first) and the UNKNOWN (always last) elements.

![image](https://user-images.githubusercontent.com/2673520/91314319-baaa2b80-e7b6-11ea-93db-1c8e6da23851.png)
