### PR TITLE
Fix no osd chip detection warning

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2518,6 +2518,9 @@ TABS.osd.initialize = function (callback) {
 
                     if (!OSD.data.state.isMax7456FontDeviceDetected || !OSD.data.state.haveMax7456FontDeviceConfigured) {
                         $('.requires-max7456-font-device-detected').addClass('disabled');
+                    }
+
+                    if (!OSD.data.state.isMax7456FontDeviceDetected) {
                         $('.noOsdChipDetect').show();
                     }
 

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2279,10 +2279,6 @@ TABS.osd.initialize = function (callback) {
 
                     OSD.msp.decode(info);
 
-                    if (OSD.data.state.haveMax7456FontDeviceConfigured && !OSD.data.state.isMax7456FontDeviceDetected) {
-                        $('.noOsdChipDetect').show();
-                    }
-
                     if (OSD.data.state.haveSomeOsd == 0) {
                         $('.unsupported').fadeIn();
                         return;
@@ -2522,6 +2518,7 @@ TABS.osd.initialize = function (callback) {
 
                     if (!OSD.data.state.isMax7456FontDeviceDetected || !OSD.data.state.haveMax7456FontDeviceConfigured) {
                         $('.requires-max7456-font-device-detected').addClass('disabled');
+                        $('.noOsdChipDetect').show();
                     }
 
                     if (!OSD.data.state.haveOsdFeature) {


### PR DESCRIPTION
Fixed non working osd warning for MAX7456 devices after https://github.com/betaflight/betaflight-configurator/pull/1852
For MAX7456 devices that only powered with battery `OSD.data.state.haveMax7456FontDeviceConfigured` is always false if not battery pluged, then warning message is never appears.