### PR TITLE
Fix pid tuning

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -41,7 +41,7 @@ TABS.pid_tuning.initialize = function (callback) {
             return MSP.promise(MSPCodes.MSP_PID_CONTROLLER);
         }
     }).then(function() {
-        return MSP.promise(MSPCodes.MSP_PIDNAMES)
+        return MSP.promise(MSPCodes.MSP_PIDNAMES);
     }).then(function() {
         return MSP.promise(MSPCodes.MSP_PID);
     }).then(function() {


### PR DESCRIPTION
Fixed missing semicolon in `src/js/tabs/pid_tuning.js`