### PR TITLE
Fix motor output

### DIFF
--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -558,8 +558,12 @@ TABS.motors.initialize = function (callback) {
 
             $('div.values li').eq(index).text($(this).val());
 
-            for (var i = 0; i < 8; i++) {
-                var val = parseInt($('div.sliders input').eq(i).val());
+            for (let i = 0; i < FC.MOTOR_CONFIG.motor_count; i++) {
+                let val = parseInt($('div.sliders input').eq(i).val());
+                // adjust val to retain the same label while switching tabs
+                if (val !== 1000) {
+                    val++;
+                }
                 buffer.push16(val);
             }
 


### PR DESCRIPTION
Using Dshot or Proshot as motor protocol retain motor output after enabling and testing with a value above 1000 (before this change leaving and returning to the tab decreases the motor output by 1)

Beside switching between tabs it also fixes the following behavior when using sliders:

Slider | Bar
--- | ---
1000 | 1000
1001 | 1001
1002 | 1001
1003 | 1002
1004 | 1003
1998 | 1997
1999 | 1998
2000 | 2000

Only 1999 and 2000 will now give 2000 but I guess this edge won't be as important as the start of the slider.