### PR TITLE
Add IRC Ghost Serial Rx Protocol

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -544,7 +544,7 @@ const FC = {
                     result.push('SPEKTRUM SRXL2');
                 }
 
-                if (semver.gte(apiVersion, "1.44.0")) {
+                if (semver.gte(apiVersion, API_VERSION_1_44)) {
                     result.push('IRC GHOST');
                 }
 

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -544,6 +544,10 @@ const FC = {
                     result.push('SPEKTRUM SRXL2');
                 }
 
+                if (semver.gte(apiVersion, "1.44.0")) {
+                    result.push('IRC GHOST');
+                }
+
                 return result;
             },
         };


### PR DESCRIPTION
Enable 'IRC Ghost' protocol for Api version 1.44 and later. Will be accompanied by a similar PR in betaflight to install the driver. 

