### PR TITLE
Fixed rate modes background color for Darktheme

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -660,6 +660,9 @@ progress[value]::-webkit-progress-bar {
     background: #542415;
 }
 
+.tab-pid_tuning .cf .rates_logo_bg {
+    background-color: #ffffff33;
+}
 
 /* PORTS TAB */
 


### PR DESCRIPTION
Fixed rate modes logo background color when using Darktheme:

![image](https://user-images.githubusercontent.com/43983086/94986431-ffb44100-055e-11eb-86ce-3ed6b503289f.png)
