### PR TITLE
Added darkmode and cordova compatibility to receiver tab  rx plot

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -453,6 +453,10 @@ progress[value]::-webkit-progress-bar {
     background-color: #4e4e4e;
 }
 
+.tab-motors text {
+    fill: white;
+}
+
 
 /* ONBOARD LOGGING TAB */
 
@@ -750,6 +754,14 @@ progress[value]::-webkit-progress-bar {
 .tab-receiver .hybrid_element input {
     background-color: #3a3a3a;
     color: white;
+}
+
+.tab-receiver .plot_control {
+    background-color: #2f2f2f;
+}
+
+.tab-receiver text {
+    fill: white;
 }
 
 

--- a/src/css/tabs/receiver.css
+++ b/src/css/tabs/receiver.css
@@ -10,7 +10,7 @@
 
 .tab-receiver .spacer {
     padding-left: 10px;
-    padding-right: 9px;
+    padding-right: 10px;
     width: calc(100% - 10px);
 }
 
@@ -430,7 +430,7 @@
   }
 
 .tab-receiver #RX_plot {
-    width: calc(100% - 181px);
+    width: calc(100% - 201px);
     height: 200px;
 }
 
@@ -557,5 +557,23 @@
 @media all and (max-width: 575px) {
     .tab-receiver .bars {
         margin-bottom: 10px;
+    }
+
+    .tab-receiver .spacer {
+        padding-left: 0px;
+        padding-right: 0px;
+        width: 100%;
+    }
+
+    .tab-receiver #RX_plot {
+        width: calc(100% - 120px);
+    }
+
+    .tab-receiver .plot_control {
+        width: 112px;
+    }
+
+    .tab-receiver .plot_control .row {
+        display: inherit;
     }
 }


### PR DESCRIPTION
This PR fixes darkmode and cordova android styles for the new rx plot element in receiver tab, also added minor white text fix for motors plot.

![rxplot](https://user-images.githubusercontent.com/43983086/95677466-075e9000-0bc6-11eb-94a8-05847c16a08a.jpg)
