### PR TITLE
Replace API versions by constants

### DIFF
--- a/src/js/Beepers.js
+++ b/src/js/Beepers.js
@@ -26,7 +26,7 @@ class Beepers {
             { bit: 18, name: 'BLACKBOX_ERASE', visible: true },
         ];
 
-        if (semver.gte(config.apiVersion, "1.37.0")) {
+        if (semver.gte(config.apiVersion, API_VERSION_1_37)) {
             beepers.push(
                 { bit: 19, name: 'CRASH_FLIP', visible: true },
                 { bit: 20, name: 'CAM_CONNECTION_OPEN', visible: true },
@@ -34,7 +34,7 @@ class Beepers {
             );
         }
 
-        if (semver.gte(config.apiVersion, "1.39.0")) {
+        if (semver.gte(config.apiVersion, API_VERSION_1_39)) {
             beepers.push(
                 { bit: 22, name: 'RC_SMOOTHING_INIT_FAIL', visible: true }
             );

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -21,7 +21,7 @@ var Features = function (config) {
         {bit: 17, group: 'other', name: 'DISPLAY', haveTip: true}
     ];
 
-    if (!semver.gte(config.apiVersion, "1.33.0")) {
+    if (!semver.gte(config.apiVersion, API_VERSION_1_33)) {
         features.push(
             {bit: 19, group: 'other', name: 'BLACKBOX', haveTip: true}
         );
@@ -33,7 +33,7 @@ var Features = function (config) {
         );
     }
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.15.0") && !semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.15.0") && !semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
         features.push(
             {bit: 8, group: 'rxFailsafe', name: 'FAILSAFE', haveTip: true}
         );
@@ -57,7 +57,7 @@ var Features = function (config) {
                 features.push(
                     {bit: 23, group: 'superexpoRates', name: 'SUPEREXPO_RATES'}
                 );
-            } else if (!semver.gte(config.apiVersion, "1.33.0")) {
+            } else if (!semver.gte(config.apiVersion, API_VERSION_1_33)) {
                 features.push(
                     {bit: 23, group: 'other', name: 'SDCARD'}
                 );
@@ -68,28 +68,28 @@ var Features = function (config) {
             features.push(
                 {bit: 18, group: 'other', name: 'OSD'}
             );
-            if (!semver.gte(FC.CONFIG.apiVersion, "1.35.0")) {
+            if (!semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_35)) {
               features.push(
                 {bit: 24, group: 'other', name: 'VTX'}
               )
             }
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
             features.push(
                 {bit: 25, group: 'rxMode', mode: 'select', name: 'RX_SPI'},
                 {bit: 27, group: 'escSensor', name: 'ESC_SENSOR'}
             );
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             features.push(
                 {bit: 28, group: 'antiGravity', name: 'ANTI_GRAVITY', haveTip: true, hideName: true},
                 {bit: 29, group: 'other', name: 'DYNAMIC_FILTER'}
             );
         }
 
-        if (!semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (!semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             features.push(
                 {bit: 1, group: 'batteryVoltage', name: 'VBAT'},
                 {bit: 11, group: 'batteryCurrent', name: 'CURRENT_METER'}

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -116,13 +116,13 @@ function configuration_backup(callback) {
         if (semver.gte(FC.CONFIG.apiVersion, "1.19.0")) {
             uniqueData.push(MSPCodes.MSP_LED_STRIP_MODECOLOR);
         }
-        if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
             uniqueData.push(MSPCodes.MSP_MOTOR_CONFIG);
             uniqueData.push(MSPCodes.MSP_RSSI_CONFIG);
             uniqueData.push(MSPCodes.MSP_GPS_CONFIG);
             uniqueData.push(MSPCodes.MSP_FEATURE_CONFIG);
         }
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             uniqueData.push(MSPCodes.MSP_MODE_RANGES_EXTRA);
         }
     }
@@ -166,16 +166,16 @@ function configuration_backup(callback) {
                     configuration.FAILSAFE_CONFIG = jQuery.extend(true, {}, FC.FAILSAFE_CONFIG);
                     configuration.RXFAIL_CONFIG = jQuery.extend(true, [], FC.RXFAIL_CONFIG);
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                     configuration.RSSI_CONFIG = jQuery.extend(true, {}, FC.RSSI_CONFIG);
                     configuration.FEATURE_CONFIG = jQuery.extend(true, {}, FC.FEATURE_CONFIG);
                     configuration.MOTOR_CONFIG = jQuery.extend(true, {}, FC.MOTOR_CONFIG);
                     configuration.GPS_CONFIG = jQuery.extend(true, {}, FC.GPS_CONFIG);
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                     configuration.BEEPER_CONFIG = jQuery.extend(true, {}, FC.BEEPER_CONFIG);
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     configuration.MODE_RANGES_EXTRA = jQuery.extend(true, [], FC.MODE_RANGES_EXTRA);
                 }
 
@@ -768,7 +768,7 @@ function configuration_restore(callback) {
                 }
 
                 function upload_mode_ranges() {
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                         if (configuration.MODE_RANGES_EXTRA == undefined) {
                             FC.MODE_RANGES_EXTRA = [];
 
@@ -824,7 +824,7 @@ function configuration_restore(callback) {
                         uniqueData.push(MSPCodes.MSP_SET_RX_CONFIG);
                         uniqueData.push(MSPCodes.MSP_SET_FAILSAFE_CONFIG);
                     }
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                         uniqueData.push(MSPCodes.MSP_SET_FEATURE_CONFIG);
                         uniqueData.push(MSPCodes.MSP_SET_MOTOR_CONFIG);
                         uniqueData.push(MSPCodes.MSP_SET_GPS_CONFIG);

--- a/src/js/data_storage.js
+++ b/src/js/data_storage.js
@@ -1,5 +1,17 @@
 'use strict';
 
+const API_VERSION_1_31 = '1.31.0';
+const API_VERSION_1_32 = '1.32.0';
+const API_VERSION_1_33 = '1.33.0';
+const API_VERSION_1_34 = '1.34.0';
+const API_VERSION_1_35 = '1.35.0';
+const API_VERSION_1_36 = '1.36.0';
+const API_VERSION_1_37 = '1.37.0';
+const API_VERSION_1_38 = '1.38.0';
+const API_VERSION_1_39 = '1.39.0';
+const API_VERSION_1_40 = '1.40.0';
+const API_VERSION_1_41 = '1.41.0';
+const API_VERSION_1_42 = '1.42.0';
 const API_VERSION_1_43 = '1.43.0';
 const API_VERSION_1_44 = '1.44.0';
 

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -564,11 +564,11 @@ const FC = {
                 }
 
                 if ((flightControllerIdentifier === 'BTFL' && semver.gte(flightControllerVersion, "2.6.0")) ||
-                    (flightControllerIdentifier === 'CLFL' && semver.gte(apiVersion, "1.31.0"))) {
+                    (flightControllerIdentifier === 'CLFL' && semver.gte(apiVersion, API_VERSION_1_31))) {
                     result.push('JETIEXBUS');
                 }
 
-                if (semver.gte(apiVersion, "1.31.0")) {
+                if (semver.gte(apiVersion, API_VERSION_1_31)) {
                     result.push('CRSF');
                 }
 
@@ -576,15 +576,15 @@ const FC = {
                     result.push('SPEKTRUM2048/SRXL');
                 }
 
-                if (semver.gte(apiVersion, "1.35.0")) {
+                if (semver.gte(apiVersion, API_VERSION_1_35)) {
                     result.push('TARGET_CUSTOM');
                 }
 
-                if (semver.gte(apiVersion, "1.37.0")) {
+                if (semver.gte(apiVersion, API_VERSION_1_37)) {
                     result.push('FrSky FPort');
                 }
 
-                if (semver.gte(apiVersion, "1.42.0")) {
+                if (semver.gte(apiVersion, API_VERSION_1_42)) {
                     result.push('SPEKTRUM SRXL2');
                 }
 
@@ -756,7 +756,7 @@ const FC = {
 
     boardHasVcp() {
         let hasVcp = false;
-        if (semver.gte(this.CONFIG.apiVersion, "1.37.0")) {
+        if (semver.gte(this.CONFIG.apiVersion, API_VERSION_1_37)) {
             hasVcp = bit_check(this.CONFIG.targetCapabilities, this.TARGET_CAPABILITIES_FLAGS.HAS_VCP);
         } else {
             hasVcp = BOARD.find_board_definition(this.CONFIG.boardIdentifier).vcp;
@@ -773,9 +773,9 @@ const FC = {
     getFilterDefaults() {
         const versionFilterDefaults = this.DEFAULT;
 
-        if (semver.eq(this.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.eq(this.CONFIG.apiVersion, API_VERSION_1_40)) {
             versionFilterDefaults.dterm_lowpass2_hz = 200;
-        } else if (semver.gte(this.CONFIG.apiVersion, "1.41.0")) {
+        } else if (semver.gte(this.CONFIG.apiVersion, API_VERSION_1_41)) {
             versionFilterDefaults.gyro_lowpass_hz = 150;
             versionFilterDefaults.gyro_lowpass_type = this.FILTER_TYPE_FLAGS.BIQUAD;
             versionFilterDefaults.gyro_lowpass2_hz = 0;
@@ -784,7 +784,7 @@ const FC = {
             versionFilterDefaults.dterm_lowpass_type = this.FILTER_TYPE_FLAGS.BIQUAD;
             versionFilterDefaults.dterm_lowpass2_hz = 150;
             versionFilterDefaults.dterm_lowpass2_type = this.FILTER_TYPE_FLAGS.BIQUAD;
-            if (semver.gte(this.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(this.CONFIG.apiVersion, API_VERSION_1_42)) {
                 versionFilterDefaults.gyro_lowpass_hz = 200;
                 versionFilterDefaults.gyro_lowpass_dyn_min_hz = 200;
                 versionFilterDefaults.gyro_lowpass_dyn_max_hz = 500;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -655,13 +655,13 @@ function updateTabList(features) {
         $('#tabs ul.mode-connected li.tab_osd').hide();
     }
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
         $('#tabs ul.mode-connected li.tab_power').show();
     } else {
         $('#tabs ul.mode-connected li.tab_power').hide();
     }
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
         $('#tabs ul.mode-connected li.tab_vtx').show();
     } else {
         $('#tabs ul.mode-connected li.tab_vtx').hide();

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -95,7 +95,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     FC.CONFIG.numProfiles = data.readU8();
                     FC.CONFIG.rateProfile = data.readU8();
 
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                       // Read flight mode flags
                       var byteCount = data.readU8();
                       for (let i = 0; i < byteCount; i++) {
@@ -197,7 +197,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.ANALOG.rssi = data.readU16(); // 0-1023
                 FC.ANALOG.amperage = data.read16() / 100; // A
                 FC.ANALOG.last_received_timestamp = Date.now();
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     FC.ANALOG.voltage = data.readU16() / 100;
                 }
                 break;
@@ -232,14 +232,14 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.BATTERY_STATE.voltage = data.readU8() / 10.0; // V
                 FC.BATTERY_STATE.mAhDrawn = data.readU16(); // mAh
                 FC.BATTERY_STATE.amperage = data.readU16() / 100; // A
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     FC.BATTERY_STATE.batteryState = data.readU8();
                     FC.BATTERY_STATE.voltage = data.readU16() / 100;
                 }
                 break;
 
             case MSPCodes.MSP_VOLTAGE_METER_CONFIG:
-                if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+                if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                     FC.MISC.vbatscale = data.readU8(); // 10-200
                     FC.MISC.vbatmincellvoltage = data.readU8() / 10; // 10-50
                     FC.MISC.vbatmaxcellvoltage = data.readU8() / 10; // 10-50
@@ -271,7 +271,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 break;
             case MSPCodes.MSP_CURRENT_METER_CONFIG:
-                if (semver.lt(FC.CONFIG.apiVersion, "1.36.0"))  {
+                if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36))  {
                     FC.BF_CONFIG.currentscale = data.read16();
                     FC.BF_CONFIG.currentoffset = data.read16();
                     FC.BF_CONFIG.currentmetertype = data.readU8();
@@ -307,7 +307,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.BATTERY_CONFIG.capacity = data.readU16();
                 FC.BATTERY_CONFIG.voltageMeterSource = data.readU8();
                 FC.BATTERY_CONFIG.currentMeterSource = data.readU8();
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     FC.BATTERY_CONFIG.vbatmincellvoltage = data.readU16() / 100;
                     FC.BATTERY_CONFIG.vbatmaxcellvoltage = data.readU16() / 100;
                     FC.BATTERY_CONFIG.vbatwarningcellvoltage = data.readU16() / 100;
@@ -344,18 +344,18 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 } else {
                     FC.RC_TUNING.RC_YAW_EXPO = 0;
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                     FC.RC_TUNING.rcPitchRate = parseFloat((data.readU8() / 100).toFixed(2));
                     FC.RC_TUNING.RC_PITCH_EXPO = parseFloat((data.readU8() / 100).toFixed(2));
                 } else {
                     FC.RC_TUNING.rcPitchRate = 0;
                     FC.RC_TUNING.RC_PITCH_EXPO = 0;
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     FC.RC_TUNING.throttleLimitType = data.readU8();
                     FC.RC_TUNING.throttleLimitPercent = data.readU8();
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                     FC.RC_TUNING.roll_rate_limit = data.readU16();
                     FC.RC_TUNING.pitch_rate_limit = data.readU16();
                     FC.RC_TUNING.yaw_rate_limit = data.readU16();
@@ -380,7 +380,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     FC.ARMING_CONFIG.auto_disarm_delay = data.readU8();
                     FC.ARMING_CONFIG.disarm_kill_switch = data.readU8();
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                     FC.ARMING_CONFIG.small_angle = data.readU8();
                 }
                 break;
@@ -411,7 +411,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.MOTOR_CONFIG.minthrottle = data.readU16(); // 0-2000
                 FC.MOTOR_CONFIG.maxthrottle = data.readU16(); // 0-2000
                 FC.MOTOR_CONFIG.mincommand = data.readU16(); // 0-2000
-                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                     FC.MOTOR_CONFIG.motor_count = data.readU8();
                     FC.MOTOR_CONFIG.motor_poles = data.readU8();
                     FC.MOTOR_CONFIG.use_dshot_telemetry = data.readU8() != 0;
@@ -421,7 +421,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
             case MSPCodes.MSP_GPS_CONFIG:
                 FC.GPS_CONFIG.provider = data.readU8();
                 FC.GPS_CONFIG.ublox_sbas = data.readU8();
-                if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_34)) {
                     FC.GPS_CONFIG.auto_config = data.readU8();
                     FC.GPS_CONFIG.auto_baud = data.readU8();
 
@@ -503,7 +503,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP_SERVO_CONFIGURATIONS:
                 FC.SERVO_CONFIG = []; // empty the array as new data is coming in
-                if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                     if (data.byteLength % 12 == 0) {
                         for (let i = 0; i < data.byteLength; i += 12) {
                             var arr = {
@@ -676,7 +676,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP_MIXER_CONFIG:
                 FC.MIXER_CONFIG.mixer = data.readU8();
-                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                     FC.MIXER_CONFIG.reverseMotorDir = data.readU8();
                 }
                 break;
@@ -689,10 +689,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
             case MSPCodes.MSP_BEEPER_CONFIG:
                 FC.BEEPER_CONFIG.beepers.setDisabledMask(data.readU32());
-                if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                     FC.BEEPER_CONFIG.dshotBeaconTone = data.readU8();
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                     FC.BEEPER_CONFIG.dshotBeaconConditions.setDisabledMask(data.readU32());
                 }
                 break;
@@ -704,7 +704,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP_SET_REBOOT:
-                if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                     var rebootType = data.read8();
                     if ((rebootType === self.REBOOT_TYPES.MSC) || (rebootType === self.REBOOT_TYPES.MSC_UTC)) {
                         if (data.read8() === 0) {
@@ -758,13 +758,13 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.CONFIG.boardIdentifier = identifier;
                 FC.CONFIG.boardVersion = data.readU16();
 
-                if (semver.gte(FC.CONFIG.apiVersion, "1.35.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_35)) {
                     FC.CONFIG.boardType = data.readU8();
                 } else {
                     FC.CONFIG.boardType = 0;
                 }
 
-                if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                     FC.CONFIG.targetCapabilities = data.readU8();
 
                     let length = data.readU8();
@@ -776,7 +776,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     FC.CONFIG.targetName = "";
                 }
 
-                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                     let length = data.readU8();
                     for (let i = 0; i < length; i++) {
                         FC.CONFIG.boardName += String.fromCharCode(data.readU8());
@@ -796,13 +796,13 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     FC.CONFIG.signature = [];
                 }
 
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     FC.CONFIG.mcuTypeId = data.readU8();
                 } else {
                     FC.CONFIG.mcuTypeId = 255;
                 }
 
-                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                     FC.CONFIG.configurationState = data.readU8();
                 }
 
@@ -955,19 +955,19 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     FC.RX_CONFIG.rcInterpolation = data.readU8();
                     FC.RX_CONFIG.rcInterpolationInterval = data.readU8();
                     FC.RX_CONFIG.airModeActivateThreshold = data.readU16();
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
                         FC.RX_CONFIG.rxSpiProtocol = data.readU8();
                         FC.RX_CONFIG.rxSpiId = data.readU32();
                         FC.RX_CONFIG.rxSpiRfChannelCount = data.readU8();
                         FC.RX_CONFIG.fpvCamAngleDegrees = data.readU8();
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                             FC.RX_CONFIG.rcInterpolationChannels = data.readU8();
                             FC.RX_CONFIG.rcSmoothingType = data.readU8();
                             FC.RX_CONFIG.rcSmoothingInputCutoff = data.readU8();
                             FC.RX_CONFIG.rcSmoothingDerivativeCutoff = data.readU8();
                             FC.RX_CONFIG.rcSmoothingInputType = data.readU8();
                             FC.RX_CONFIG.rcSmoothingDerivativeType = data.readU8();
-                            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                                 FC.RX_CONFIG.usbCdcHidType = data.readU8();
                                 FC.RX_CONFIG.rcSmoothingAutoSmoothness = data.readU8();
                             }
@@ -1022,10 +1022,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
                     if (semver.gte(FC.CONFIG.apiVersion, "1.25.0")) {
                         let gyroUse32kHz = data.readU8();
-                        if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                             FC.PID_ADVANCED_CONFIG.gyroUse32kHz = gyroUse32kHz;
                         } 
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                             FC.PID_ADVANCED_CONFIG.motorPwmInversion = data.readU8();
                             FC.SENSOR_ALIGNMENT.gyro_to_use = data.readU8(); // We don't want to double up on storing this state
                             FC.PID_ADVANCED_CONFIG.gyroHighFsr = data.readU8();
@@ -1052,10 +1052,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         FC.FILTER_CONFIG.gyro_notch2_hz = data.readU16();
                         FC.FILTER_CONFIG.gyro_notch2_cutoff = data.readU16();
                     }
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                         FC.FILTER_CONFIG.dterm_lowpass_type = data.readU8();
                     }
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                         FC.FILTER_CONFIG.gyro_hardware_lpf = data.readU8();
                         let gyro_32khz_hardware_lpf = data.readU8();
                         FC.FILTER_CONFIG.gyro_lowpass_hz = data.readU16();
@@ -1063,7 +1063,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         FC.FILTER_CONFIG.gyro_lowpass_type = data.readU8();
                         FC.FILTER_CONFIG.gyro_lowpass2_type = data.readU8();
                         FC.FILTER_CONFIG.dterm_lowpass2_hz = data.readU16();
-                        if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                             FC.FILTER_CONFIG.gyro_32khz_hardware_lpf = gyro_32khz_hardware_lpf;
                         } else {
                             FC.FILTER_CONFIG.gyro_32khz_hardware_lpf = 0;
@@ -1073,7 +1073,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = data.readU16();
                             FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz = data.readU16();
                             FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = data.readU16();
-                            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                                 FC.FILTER_CONFIG.dyn_notch_range = data.readU8();
                                 FC.FILTER_CONFIG.dyn_notch_width_percent = data.readU8();
                                 FC.FILTER_CONFIG.dyn_notch_q = data.readU16();
@@ -1104,7 +1104,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     FC.ADVANCED_TUNING.deltaMethod = data.readU8();
                     FC.ADVANCED_TUNING.vbatPidCompensation = data.readU8();
                     if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                             FC.ADVANCED_TUNING.feedforwardTransition = data.readU8();
                         } else {
                             FC.ADVANCED_TUNING.dtermSetpointTransition = data.readU8();
@@ -1119,14 +1119,14 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             FC.ADVANCED_TUNING.levelAngleLimit = data.readU8();
                             FC.ADVANCED_TUNING.levelSensitivity = data.readU8();
 
-                            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                                 FC.ADVANCED_TUNING.itermThrottleThreshold = data.readU16();
                                 FC.ADVANCED_TUNING.itermAcceleratorGain = data.readU16();
 
-                                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                                     FC.ADVANCED_TUNING.dtermSetpointWeight = data.readU16();
 
-                                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                                         FC.ADVANCED_TUNING.itermRotation = data.readU8();
                                         FC.ADVANCED_TUNING.smartFeedforward = data.readU8();
                                         FC.ADVANCED_TUNING.itermRelax = data.readU8();
@@ -1139,7 +1139,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                         FC.ADVANCED_TUNING.feedforwardYaw   = data.readU16();
                                         FC.ADVANCED_TUNING.antiGravityMode  = data.readU8();
                                     
-                                        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                                             FC.ADVANCED_TUNING.dMinRoll = data.readU8();
                                             FC.ADVANCED_TUNING.dMinPitch = data.readU8();
                                             FC.ADVANCED_TUNING.dMinYaw = data.readU8();
@@ -1148,7 +1148,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                             FC.ADVANCED_TUNING.useIntegratedYaw = data.readU8();
                                             FC.ADVANCED_TUNING.integratedYawRelax = data.readU8();
 
-                                            if(semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                                            if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                                                 FC.ADVANCED_TUNING.itermRelaxCutoff = data.readU8();
 
                                                 if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
@@ -1186,7 +1186,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 var ledDirectionLetters =       ['n', 'e', 's', 'w', 'u', 'd'];      // in LSB bit order
                 var ledFunctionLetters =        ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l']; // in LSB bit order
                 var ledBaseFunctionLetters =    ['c', 'f', 'a', 'l', 's', 'g', 'r']; // in LSB bit
-                if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+                if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                     var ledOverlayLetters =     ['t', 'o', 'b', 'n', 'i', 'w']; // in LSB bit
                 } else {
                     var ledOverlayLetters =     ['t', 'o', 'b', 'v', 'i', 'w']; // in LSB bit
@@ -1197,7 +1197,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
                     ledCount = data.byteLength / 4;
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     // According to betaflight/src/main/msp/msp.c
                     // API 1.41 - add indicator for advanced profile support and the current profile selection
                     // 0 = basic ledstrip available
@@ -1357,7 +1357,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.BLACKBOX.blackboxDevice = data.readU8();
                 FC.BLACKBOX.blackboxRateNum = data.readU8();
                 FC.BLACKBOX.blackboxRateDenom = data.readU8();
-                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                     FC.BLACKBOX.blackboxPDenom = data.readU16();
                 }
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
@@ -1369,7 +1369,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             case MSPCodes.MSP_TRANSPONDER_CONFIG:
                 var bytesRemaining = data.byteLength;
-                if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                     var providerCount = data.readU8();
                     bytesRemaining--;
 
@@ -1420,7 +1420,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.VTX_CONFIG.vtx_device_ready = data.readU8() != 0;
                 FC.VTX_CONFIG.vtx_low_power_disarm = data.readU8();
 
-                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                     FC.VTX_CONFIG.vtx_pit_mode_frequency = data.readU16();
                     FC.VTX_CONFIG.vtx_table_available = data.readU8() != 0;
                     FC.VTX_CONFIG.vtx_table_bands = data.readU8();
@@ -1648,16 +1648,16 @@ MspHelper.prototype.crunch = function(code) {
         case MSPCodes.MSP_SET_BEEPER_CONFIG:
             var beeperDisabledMask = FC.BEEPER_CONFIG.beepers.getDisabledMask();
             buffer.push32(beeperDisabledMask);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                 buffer.push8(FC.BEEPER_CONFIG.dshotBeaconTone);
             }
-            if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                 buffer.push32(FC.BEEPER_CONFIG.dshotBeaconConditions.getDisabledMask());
             }
             break;
         case MSPCodes.MSP_SET_MIXER_CONFIG:
             buffer.push8(FC.MIXER_CONFIG.mixer)
-            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 buffer.push8(FC.MIXER_CONFIG.reverseMotorDir);
             }
             break;
@@ -1698,15 +1698,15 @@ MspHelper.prototype.crunch = function(code) {
                     buffer.push8(Math.round(FC.RC_TUNING.rcYawRate * 100));
                 }
             }
-            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                 buffer.push8(Math.round(FC.RC_TUNING.rcPitchRate * 100));
                 buffer.push8(Math.round(FC.RC_TUNING.RC_PITCH_EXPO * 100));
             }
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 buffer.push8(FC.RC_TUNING.throttleLimitType);
                 buffer.push8(FC.RC_TUNING.throttleLimitPercent);
             }
-            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 buffer.push16(FC.RC_TUNING.roll_rate_limit);
                 buffer.push16(FC.RC_TUNING.pitch_rate_limit);
                 buffer.push16(FC.RC_TUNING.yaw_rate_limit);
@@ -1727,7 +1727,7 @@ MspHelper.prototype.crunch = function(code) {
         case MSPCodes.MSP_SET_ARMING_CONFIG:
             buffer.push8(FC.ARMING_CONFIG.auto_disarm_delay)
                 .push8(FC.ARMING_CONFIG.disarm_kill_switch);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                 buffer.push8(FC.ARMING_CONFIG.small_angle);
             }
             break;
@@ -1756,7 +1756,7 @@ MspHelper.prototype.crunch = function(code) {
             buffer.push16(FC.MOTOR_CONFIG.minthrottle)
                 .push16(FC.MOTOR_CONFIG.maxthrottle)
                 .push16(FC.MOTOR_CONFIG.mincommand);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 buffer.push8(FC.MOTOR_CONFIG.motor_poles);
                 buffer.push8(FC.MOTOR_CONFIG.use_dshot_telemetry ? 1 : 0);
             }
@@ -1764,7 +1764,7 @@ MspHelper.prototype.crunch = function(code) {
         case MSPCodes.MSP_SET_GPS_CONFIG:
             buffer.push8(FC.GPS_CONFIG.provider)
                 .push8(FC.GPS_CONFIG.ublox_sbas);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_34)) {
                 buffer.push8(FC.GPS_CONFIG.auto_config)
                     .push8(FC.GPS_CONFIG.auto_baud);
 
@@ -1802,14 +1802,14 @@ MspHelper.prototype.crunch = function(code) {
                 .push16(FC.BATTERY_CONFIG.capacity)
                 .push8(FC.BATTERY_CONFIG.voltageMeterSource)
                 .push8(FC.BATTERY_CONFIG.currentMeterSource);
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     buffer.push16(Math.round(FC.BATTERY_CONFIG.vbatmincellvoltage * 100))
                         .push16(Math.round(FC.BATTERY_CONFIG.vbatmaxcellvoltage * 100))
                         .push16(Math.round(FC.BATTERY_CONFIG.vbatwarningcellvoltage * 100));
                 }
             break;
         case MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG:
-            if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 buffer.push8(FC.MISC.vbatscale)
                     .push8(Math.round(FC.MISC.vbatmincellvoltage * 10))
                     .push8(Math.round(FC.MISC.vbatmaxcellvoltage * 10))
@@ -1820,7 +1820,7 @@ MspHelper.prototype.crunch = function(code) {
             }
            break;
         case MSPCodes.MSP_SET_CURRENT_METER_CONFIG:
-            if (semver.lt(FC.CONFIG.apiVersion, "1.36.0"))  {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36))  {
                 buffer.push16(FC.BF_CONFIG.currentscale)
                     .push16(FC.BF_CONFIG.currentoffset)
                     .push8(FC.BF_CONFIG.currentmetertype)
@@ -1840,19 +1840,19 @@ MspHelper.prototype.crunch = function(code) {
                 buffer.push8(FC.RX_CONFIG.rcInterpolation)
                     .push8(FC.RX_CONFIG.rcInterpolationInterval)
                     .push16(FC.RX_CONFIG.airModeActivateThreshold);
-                if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
                     buffer.push8(FC.RX_CONFIG.rxSpiProtocol)
                         .push32(FC.RX_CONFIG.rxSpiId)
                         .push8(FC.RX_CONFIG.rxSpiRfChannelCount)
                         .push8(FC.RX_CONFIG.fpvCamAngleDegrees);
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                         buffer.push8(FC.RX_CONFIG.rcInterpolationChannels)
                             .push8(FC.RX_CONFIG.rcSmoothingType)
                             .push8(FC.RX_CONFIG.rcSmoothingInputCutoff)
                             .push8(FC.RX_CONFIG.rcSmoothingDerivativeCutoff)
                             .push8(FC.RX_CONFIG.rcSmoothingInputType)
                             .push8(FC.RX_CONFIG.rcSmoothingDerivativeType);
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                             buffer.push8(FC.RX_CONFIG.usbCdcHidType)
                                   .push8(FC.RX_CONFIG.rcSmoothingAutoSmoothness);
                         }
@@ -1874,7 +1874,7 @@ MspHelper.prototype.crunch = function(code) {
             break;
 
         case MSPCodes.MSP_SET_TRANSPONDER_CONFIG:
-            if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                 buffer.push8(FC.TRANSPONDER.provider); //
             }
             for (let i = 0; i < FC.TRANSPONDER.data.length; i++) {
@@ -1956,7 +1956,7 @@ MspHelper.prototype.crunch = function(code) {
             buffer.push8(FC.SENSOR_ALIGNMENT.align_gyro)
                 .push8(FC.SENSOR_ALIGNMENT.align_acc)
                 .push8(FC.SENSOR_ALIGNMENT.align_mag);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 buffer.push8(FC.SENSOR_ALIGNMENT.gyro_to_use)
                 .push8(FC.SENSOR_ALIGNMENT.gyro_1_align)
                 .push8(FC.SENSOR_ALIGNMENT.gyro_2_align);
@@ -1973,11 +1973,11 @@ MspHelper.prototype.crunch = function(code) {
 
                 if (semver.gte(FC.CONFIG.apiVersion, "1.25.0")) {
                     let gyroUse32kHz = 0;
-                    if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                         gyroUse32kHz = FC.PID_ADVANCED_CONFIG.gyroUse32kHz;
                     }
                     buffer.push8(gyroUse32kHz);
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                         buffer.push8(FC.PID_ADVANCED_CONFIG.motorPwmInversion)
                               .push8(FC.SENSOR_ALIGNMENT.gyro_to_use) // We don't want to double up on storing this state
                               .push8(FC.PID_ADVANCED_CONFIG.gyroHighFsr)
@@ -2003,12 +2003,12 @@ MspHelper.prototype.crunch = function(code) {
                     buffer.push16(FC.FILTER_CONFIG.gyro_notch2_hz)
                         .push16(FC.FILTER_CONFIG.gyro_notch2_cutoff)
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                     buffer.push8(FC.FILTER_CONFIG.dterm_lowpass_type);
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                     let gyro_32khz_hardware_lpf = 0;
-                    if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                         gyro_32khz_hardware_lpf = FC.FILTER_CONFIG.gyro_32khz_hardware_lpf;
                     }
                     buffer.push8(FC.FILTER_CONFIG.gyro_hardware_lpf)
@@ -2019,14 +2019,14 @@ MspHelper.prototype.crunch = function(code) {
                           .push8(FC.FILTER_CONFIG.gyro_lowpass2_type)
                           .push16(FC.FILTER_CONFIG.dterm_lowpass2_hz);
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     buffer.push8(FC.FILTER_CONFIG.dterm_lowpass2_type)
                           .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz)
                           .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz)
                           .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz)
                           .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz);
                 }
-                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                     buffer.push8(FC.FILTER_CONFIG.dyn_notch_range)
                           .push8(FC.FILTER_CONFIG.dyn_notch_width_percent)
                           .push16(FC.FILTER_CONFIG.dyn_notch_q)
@@ -2051,7 +2051,7 @@ MspHelper.prototype.crunch = function(code) {
                     .push8(FC.ADVANCED_TUNING.vbatPidCompensation);
 
                 if (semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                         buffer.push8(FC.ADVANCED_TUNING.feedforwardTransition);
                     } else {
                         buffer.push8(FC.ADVANCED_TUNING.dtermSetpointTransition);
@@ -2067,14 +2067,14 @@ MspHelper.prototype.crunch = function(code) {
                         buffer.push8(FC.ADVANCED_TUNING.levelAngleLimit)
                             .push8(FC.ADVANCED_TUNING.levelSensitivity);
 
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                             buffer.push16(FC.ADVANCED_TUNING.itermThrottleThreshold)
                                 .push16(FC.ADVANCED_TUNING.itermAcceleratorGain);
 
-                            if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                                 buffer.push16(FC.ADVANCED_TUNING.dtermSetpointWeight);
 
-                                if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                                     buffer.push8(FC.ADVANCED_TUNING.itermRotation)
                                           .push8(FC.ADVANCED_TUNING.smartFeedforward)
                                           .push8(FC.ADVANCED_TUNING.itermRelax)
@@ -2087,7 +2087,7 @@ MspHelper.prototype.crunch = function(code) {
                                           .push16(FC.ADVANCED_TUNING.feedforwardYaw)
                                           .push8(FC.ADVANCED_TUNING.antiGravityMode);
 
-                                    if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                                         buffer.push8(FC.ADVANCED_TUNING.dMinRoll)
                                               .push8(FC.ADVANCED_TUNING.dMinPitch)
                                               .push8(FC.ADVANCED_TUNING.dMinYaw)
@@ -2096,7 +2096,7 @@ MspHelper.prototype.crunch = function(code) {
                                               .push8(FC.ADVANCED_TUNING.useIntegratedYaw)
                                               .push8(FC.ADVANCED_TUNING.integratedYawRelax);
                                           
-                                        if(semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                                        if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                                             buffer.push8(FC.ADVANCED_TUNING.itermRelaxCutoff);
 
                                             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
@@ -2138,7 +2138,7 @@ MspHelper.prototype.crunch = function(code) {
             buffer.push8(FC.BLACKBOX.blackboxDevice)
                 .push8(FC.BLACKBOX.blackboxRateNum)
                 .push8(FC.BLACKBOX.blackboxRateDenom);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 buffer.push16(FC.BLACKBOX.blackboxPDenom);
             }
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
@@ -2172,7 +2172,7 @@ MspHelper.prototype.crunch = function(code) {
         case MSPCodes.MSP_SET_RTC:
             var now = new Date();
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 var timestamp = now.getTime();
                 var secs = timestamp / 1000;
                 var millis = timestamp % 1000;
@@ -2196,7 +2196,7 @@ MspHelper.prototype.crunch = function(code) {
                   .push8(FC.VTX_CONFIG.vtx_pit_mode ? 1 : 0)
                   .push8(FC.VTX_CONFIG.vtx_low_power_disarm);
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 buffer.push16(FC.VTX_CONFIG.vtx_pit_mode_frequency)
                       .push8(FC.VTX_CONFIG.vtx_band)
                       .push8(FC.VTX_CONFIG.vtx_channel)
@@ -2294,11 +2294,11 @@ MspHelper.prototype.setRawRx = function(channels) {
 MspHelper.prototype.dataflashRead = function(address, blockSize, onDataCallback) {
     var outData = [address & 0xFF, (address >> 8) & 0xFF, (address >> 16) & 0xFF, (address >> 24) & 0xFF];
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
         outData = outData.concat([blockSize & 0xFF, (blockSize >> 8) & 0xFF]);
     }
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
         // Allow compression
         outData = outData.concat([1]);
     }
@@ -2310,7 +2310,7 @@ MspHelper.prototype.dataflashRead = function(address, blockSize, onDataCallback)
             var headerSize = 4;
             var dataSize = response.data.buffer.byteLength - headerSize;
             var dataCompressionType = 0;
-            if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
                 headerSize = headerSize + 3;
                 dataSize = response.data.readU16();
                 dataCompressionType = response.data.readU8();
@@ -2383,7 +2383,7 @@ MspHelper.prototype.sendServoConfigurations = function(onCompleteCallback) {
                 .push16(servoConfiguration.middle)
                 .push8(servoConfiguration.rate);
 
-            if (semver.lt(FC.CONFIG.apiVersion, "1.33.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                 buffer.push8(servoConfiguration.angleAtMin)
                     .push8(servoConfiguration.angleAtMax);
             }
@@ -2443,7 +2443,7 @@ MspHelper.prototype.sendModeRanges = function(onCompleteCallback) {
             .push8((modeRange.range.start - 900) / 25)
             .push8((modeRange.range.end - 900) / 25);
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             var modeRangeExtra = FC.MODE_RANGES_EXTRA[modeRangeIndex];
             
             buffer.push8(modeRangeExtra.modeLogic)
@@ -2573,7 +2573,7 @@ MspHelper.prototype.sendLedStripConfig = function(onCompleteCallback) {
         var ledDirectionLetters =        ['n', 'e', 's', 'w', 'u', 'd'];      // in LSB bit order
         var ledFunctionLetters =         ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l']; // in LSB bit order
         var ledBaseFunctionLetters =     ['c', 'f', 'a', 'l', 's', 'g', 'r']; // in LSB bit
-        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             var ledOverlayLetters =      ['t', 'o', 'b', 'w', 'i', 'w']; // in LSB bit
         } else {
             var ledOverlayLetters =      ['t', 'o', 'b', 'v', 'i', 'w']; // in LSB bit
@@ -2761,7 +2761,9 @@ MspHelper.prototype.sendRxFailConfig = function(onCompleteCallback) {
 }
 
 MspHelper.prototype.setArmingEnabled = function(doEnable, disableRunawayTakeoffPrevention, onCompleteCallback) {
-    if (semver.gte(FC.CONFIG.apiVersion, "1.37.0") && (FC.CONFIG.armingDisabled === doEnable || FC.CONFIG.runawayTakeoffPreventionDisabled !== disableRunawayTakeoffPrevention)) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)
+        && (FC.CONFIG.armingDisabled === doEnable || FC.CONFIG.runawayTakeoffPreventionDisabled !== disableRunawayTakeoffPrevention)) {
+
         FC.CONFIG.armingDisabled = !doEnable;
         FC.CONFIG.runawayTakeoffPreventionDisabled = disableRunawayTakeoffPrevention;
 

--- a/src/js/protocols/stm32.js
+++ b/src/js/protocols/stm32.js
@@ -141,7 +141,7 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
 
             GUI.log(i18n.getMessage('apiVersionReceived', [FC.CONFIG.apiVersion]));
 
-            if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
 
                 self.msp_connector.disconnect(function (disconnectionResult) {
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -425,7 +425,7 @@ function processName() {
 }
 
 function setRtc() {
-    if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
         MSP.send_message(MSPCodes.MSP_SET_RTC, mspHelper.crunch(MSPCodes.MSP_SET_RTC), false, finishOpen);
     } else {
         finishOpen();
@@ -497,7 +497,7 @@ function onConnect() {
         $('#tabs ul.mode-connected').show();
 
         MSP.send_message(MSPCodes.MSP_FEATURE_CONFIG, false, false);
-        if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
             MSP.send_message(MSPCodes.MSP_BATTERY_CONFIG, false, false);
         }
         MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
@@ -635,7 +635,7 @@ function have_sensor(sensors_detected, sensor_code) {
         case 'sonar':
             return bit_check(sensors_detected, 4);
         case 'gyro':
-            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 return bit_check(sensors_detected, 5);
             } else {
                 return true;
@@ -659,7 +659,7 @@ function update_live_status() {
 
     if (GUI.active_tab != 'cli') {
         MSP.send_message(MSPCodes.MSP_BOXNAMES, false, false);
-        if (semver.gte(FC.CONFIG.apiVersion, "1.32.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_32)) {
             MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
         } else {
             MSP.send_message(MSPCodes.MSP_STATUS, false, false);

--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -37,7 +37,7 @@ TABS.adjustments.initialize = function (callback) {
         // update selected slot
         //
         
-        if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             var adjustmentList = $(newAdjustment).find('.adjustmentSlot .slot');
             adjustmentList.val(adjustmentRange.slotIndex);
         }
@@ -165,7 +165,7 @@ TABS.adjustments.initialize = function (callback) {
         }
         
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             $('.tab-adjustments .adjustmentSlotsHelp').hide();
             $('.tab-adjustments .adjustmentSlotHeader').hide();
             $('.tab-adjustments .adjustmentSlot').hide();
@@ -199,7 +199,7 @@ TABS.adjustments.initialize = function (callback) {
                 if ($(adjustmentElement).find('.enable').prop("checked")) {
                     var rangeValues = $(this).find('.range .channel-slider').val();
                     var slotIndex = 0;
-                    if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
+                    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                         slotIndex = parseInt($(this).find('.adjustmentSlot .slot').val());
                     }
 
@@ -291,13 +291,13 @@ TABS.adjustments.adjust_template = function () {
     var selectFunction = $('#functionSelectionSelect');
     var elementsNumber;
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
         elementsNumber = 31; // OSD Profile Select & LED Profile Select
-    } else if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+    } else if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
         elementsNumber = 29; // PID Audio
-    } else if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+    } else if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
         elementsNumber = 26; // PID Audio
-    } else if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+    } else if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
         elementsNumber = 25; // Horizon Strength
     } else {
         elementsNumber = 24; // Setpoint transition
@@ -308,7 +308,7 @@ TABS.adjustments.adjust_template = function () {
     }
     
     // For 1.40, the D Setpoint has been replaced, so we replace it with the correct values
-    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
 
         var element22 = selectFunction.find("option[value='22']");
         var element23 = selectFunction.find("option[value='23']");

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -9,7 +9,7 @@ TABS.auxiliary.initialize = function (callback) {
 
     function get_mode_ranges() {
         MSP.send_message(MSPCodes.MSP_MODE_RANGES, false, false, 
-            semver.gte(FC.CONFIG.apiVersion, "1.41.0") ? get_mode_ranges_extra : get_box_ids);
+            semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41) ? get_mode_ranges_extra : get_box_ids);
     }
 
     function get_mode_ranges_extra() {
@@ -57,7 +57,7 @@ TABS.auxiliary.initialize = function (callback) {
         $(newMode).find('a.addLink').data('modeElement', newMode);
 
         // hide link button for ARM
-        if (modeId == 0 || semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (modeId == 0 || semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             $(newMode).find('.addLink').hide();
         }
 
@@ -75,7 +75,7 @@ TABS.auxiliary.initialize = function (callback) {
         logicOption.val(0);
         logicList.append(logicOption);
         
-        if(semver.gte(FC.CONFIG.apiVersion, "1.41.0")){
+        if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)){
             var logicOption = logicOptionTemplate.clone();
             logicOption.text(i18n.getMessage('auxiliaryModeLogicAND'));
             logicOption.val(1);
@@ -271,7 +271,7 @@ TABS.auxiliary.initialize = function (callback) {
                     modeLogic: 0,
                     linkedTo: 0
                 };
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     modeRangeExtra = FC.MODE_RANGES_EXTRA[modeRangeIndex];
                 }
                 
@@ -451,7 +451,7 @@ TABS.auxiliary.initialize = function (callback) {
                     if (i == 0) {
                         var armSwitchActive = false;
                         
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                             if (FC.CONFIG.armingDisableCount > 0) {
                                 // check the highest bit of the armingDisableFlags. This will be the ARMING_DISABLED_ARMSWITCH flag.
                                 var armSwitchMask = 1 << (FC.CONFIG.armingDisableCount - 1);

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -19,7 +19,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         GUI.configuration_loaded = true;
     }
 
-    if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
         //Show old battery configuration for pre-BF-3.2
         self.SHOW_OLD_BATTERY_CONFIG = true;
     } else {
@@ -32,7 +32,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_beeper_config() {
         var next_callback = load_serial_config;
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             MSP.send_message(MSPCodes.MSP_BEEPER_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -61,7 +61,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_motor_config() {
         var next_callback = load_gps_config;
-        if(semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+        if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
             MSP.send_message(MSPCodes.MSP_MOTOR_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -70,7 +70,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_gps_config() {
         var next_callback = load_acc_trim;
-        if(semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+        if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
             MSP.send_message(MSPCodes.MSP_GPS_CONFIG, false, false, load_acc_trim);
         } else {
             next_callback();
@@ -83,7 +83,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_misc() {
         var next_callback = load_arming_config;
-        if (semver.lt(FC.CONFIG.apiVersion, "1.33.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
             MSP.send_message(MSPCodes.MSP_MISC, false, false, next_callback);
         } else {
             next_callback();
@@ -178,7 +178,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_rx_config() {
         const next_callback = load_filter_config;
-        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
             MSP.send_message(MSPCodes.MSP_RX_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -187,7 +187,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
     function load_filter_config() {
         const next_callback = load_html;
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             MSP.send_message(MSPCodes.MSP_FILTER_CONFIG, false, false, next_callback);
         } else {
             next_callback();
@@ -216,7 +216,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             var mixer = FC.MIXER_CONFIG.mixer
             var reverse = "";
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 reverse = FC.MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
             }
 
@@ -260,7 +260,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         var dshotBeaconCondition_e = $('tbody.dshotBeaconConditions');
         var dshotBeaconSwitch_e = $('tr.dshotBeaconSwitch');
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
             for (var i = 1; i <= 5; i++) {
                 dshotBeeperBeaconTone.append('<option value="' + (i) + '">'+ (i) + '</option>');
             }
@@ -276,7 +276,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         dshotBeeperBeaconTone.val(FC.BEEPER_CONFIG.dshotBeaconTone);
 
         var template = $('.beepers .beeper-template');
-        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
             dshotBeaconSwitch_e.hide();
             FC.BEEPER_CONFIG.dshotBeaconConditions.generateElements(template, dshotBeaconCondition_e);
 
@@ -306,7 +306,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         var destination = $('.beepers .beeper-configuration');
         var beeper_e = $('.tab-configuration .beepers');
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             FC.BEEPER_CONFIG.beepers.generateElements(template, destination);
         } else {
             beeper_e.hide();
@@ -327,7 +327,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'CW 270° flip'
         ];
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             alignments.push('Custom');
         }
 
@@ -395,7 +395,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             });
 
             // Multi gyro config
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
 
                 gyro_align_content_e.show();
                 legacy_gyro_alignment_e.hide();
@@ -473,17 +473,17 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             escProtocols.push('BRUSHED');
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
             escProtocols.push('DSHOT150');
             escProtocols.push('DSHOT300');
             escProtocols.push('DSHOT600');
 
-            if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 escProtocols.push('DSHOT1200');
             }
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             escProtocols.push('PROSHOT1000');
         }
 
@@ -508,7 +508,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         $('input[id="unsyncedPWMSwitch"]').prop('checked', FC.PID_ADVANCED_CONFIG.use_unsyncedPwm !== 0).change();
         $('input[name="unsyncedpwmfreq"]').val(FC.PID_ADVANCED_CONFIG.motor_pwm_rate);
         $('input[name="digitalIdlePercent"]').val(FC.PID_ADVANCED_CONFIG.digitalIdlePercent);
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             let dshotBidirectional_e = $('input[id="dshotBidir"]');
             dshotBidirectional_e.prop('checked', FC.MOTOR_CONFIG.use_dshot_telemetry).change();
 
@@ -548,8 +548,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('input[name="motorPoles"]').val(FC.MOTOR_CONFIG.motor_poles);
         }
 
-        $('#escProtocolTooltip').toggle(semver.lt(FC.CONFIG.apiVersion, "1.42.0"));
-        $('#escProtocolTooltipNoDSHOT1200').toggle(semver.gte(FC.CONFIG.apiVersion, "1.42.0"));
+        $('#escProtocolTooltip').toggle(semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42));
+        $('#escProtocolTooltipNoDSHOT1200').toggle(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42));
 
         function updateVisibility() {
             // Hide unused settings
@@ -581,8 +581,8 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('div.digitalIdlePercent').toggle(protocolConfigured && digitalProtocol);
             $('.escSensor').toggle(protocolConfigured && digitalProtocol);
 
-            $('div.checkboxDshotBidir').toggle(protocolConfigured && semver.gte(FC.CONFIG.apiVersion, "1.42.0") && digitalProtocol);
-            $('div.motorPoles').toggle(protocolConfigured && rpmFeaturesVisible && semver.gte(FC.CONFIG.apiVersion, "1.42.0"));
+            $('div.checkboxDshotBidir').toggle(protocolConfigured && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42) && digitalProtocol);
+            $('div.motorPoles').toggle(protocolConfigured && rpmFeaturesVisible && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42));
 
             $('.escMotorStop').toggle(protocolConfigured);
 
@@ -655,7 +655,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
              gyroTextElement.val(gyroContent);
          };
 
-         if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+         if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
              gyroUse32kHzElement.prop('checked', FC.PID_ADVANCED_CONFIG.gyroUse32kHz !== 0);
 
              gyroUse32kHzElement.change(function () {
@@ -687,7 +687,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 pidBaseFreq = FC.CONFIG.sampleRateHz / 1000;
             } else {
                 pidBaseFreq = 8;
-                if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, "1.41.0") && gyroUse32kHzElement.is(':checked')) {
+                if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41) && gyroUse32kHzElement.is(':checked')) {
                     pidBaseFreq = 32;
                 }
                 pidBaseFreq = pidBaseFreq / parseInt($(this).val());
@@ -723,9 +723,9 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         $('input[name="craftName"]').val(FC.CONFIG.name);
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
             $('input[name="fpvCamAngleDegrees"]').val(FC.RX_CONFIG.fpvCamAngleDegrees);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 $('input[name="fpvCamAngleDegrees"]').attr("max", 90);
             }
         } else {
@@ -741,7 +741,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             'NMEA',
             'UBLOX'
         ];
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             gpsProtocols.push('MSP');
         }
 
@@ -804,7 +804,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
         }).prop('checked', FC.GPS_CONFIG.auto_config === 1).change();
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_34)) {
             gpsAutoBaudGroup.show();
             gpsAutoConfigGroup.show();
         } else {
@@ -863,7 +863,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         // select current serial RX type
         serialRXSelectEl.val(FC.RX_CONFIG.serialrx_provider);
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
             var spiRxTypes = [
                 'NRF24_V202_250K',
                 'NRF24_V202_1M',
@@ -876,7 +876,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 'FRSKY_D'
             ];
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                 spiRxTypes.push(
                     'FRSKY_X',
                     'A7105_FLYSKY',
@@ -885,7 +885,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 );
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 spiRxTypes.push(
                     'SFHSS',
                     'SPEKTRUM',
@@ -950,13 +950,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             $('div.cycles').show();
         }
 
-        if(semver.gte(FC.CONFIG.apiVersion, "1.37.0") || !isExpertModeEnabled()) {
+        if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37) || !isExpertModeEnabled()) {
             $('input[id="disarmkillswitch"]').prop('checked', true);
             $('div.disarm').hide();
         }
 
-        $('._smallAngle').toggle(semver.gte(FC.CONFIG.apiVersion, "1.37.0"));
-        if(semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+        $('._smallAngle').toggle(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37));
+        if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
             $('input[id="configurationSmallAngle"]').val(FC.ARMING_CONFIG.small_angle);
         }
 
@@ -987,7 +987,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 $('div.batterymetertype').hide();
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 $('input[name="mincellvoltage"]').prop('step','0.01');
                 $('input[name="maxcellvoltage"]').prop('step','0.01');
                 $('input[name="warningcellvoltage"]').prop('step','0.01');
@@ -1153,7 +1153,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         });
 
         $('input[id="accHardwareSwitch"]').change(function() {
-            if(semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
               var checked = $(this).is(':checked');
               $('.accelNeeded').toggle(checked);
             }
@@ -1206,14 +1206,14 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 FC.ARMING_CONFIG.auto_disarm_delay = parseInt($('input[name="autodisarmdelay"]').val());
                 FC.ARMING_CONFIG.disarm_kill_switch = $('input[id="disarmkillswitch"]').is(':checked') ? 1 : 0;
             }
-            if(semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                 FC.ARMING_CONFIG.small_angle = parseInt($('input[id="configurationSmallAngle"]').val());
             }
 
             FC.MOTOR_CONFIG.minthrottle = parseInt($('input[name="minthrottle"]').val());
             FC.MOTOR_CONFIG.maxthrottle = parseInt($('input[name="maxthrottle"]').val());
             FC.MOTOR_CONFIG.mincommand = parseInt($('input[name="mincommand"]').val());
-            if(semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 FC.MOTOR_CONFIG.motor_poles = parseInt($('input[name="motorPoles"]').val());
             }
 
@@ -1234,7 +1234,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
                 FC.MOTOR_3D_CONFIG.neutral = parseInt($('input[name="3dneutral"]').val());
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 FC.SENSOR_ALIGNMENT.gyro_to_use = parseInt(orientation_gyro_to_use_e.val());
             }
 
@@ -1255,11 +1255,11 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             FC.PID_ADVANCED_CONFIG.pid_process_denom = value;
 
             FC.PID_ADVANCED_CONFIG.digitalIdlePercent = parseFloat($('input[name="digitalIdlePercent"]').val());
-            if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 FC.PID_ADVANCED_CONFIG.gyroUse32kHz = $('input[id="gyroUse32kHz"]').is(':checked') ? 1 : 0;
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
                 FC.RX_CONFIG.fpvCamAngleDegrees = parseInt($('input[name="fpvCamAngleDegrees"]').val());
             }
 
@@ -1278,7 +1278,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_beeper_config() {
                 var next_callback = save_misc;
-                if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                     MSP.send_message(MSPCodes.MSP_SET_BEEPER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BEEPER_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1287,7 +1287,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_misc() {
                 var next_callback = save_mixer_config;
-                if(semver.lt(FC.CONFIG.apiVersion, "1.33.0")) {
+                if(semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                     MSP.send_message(MSPCodes.MSP_SET_MISC, mspHelper.crunch(MSPCodes.MSP_SET_MISC), false, next_callback);
                 } else {
                     next_callback();
@@ -1306,7 +1306,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_motor_config() {
                 var next_callback = save_gps_config;
-                if(semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+                if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                     MSP.send_message(MSPCodes.MSP_SET_MOTOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1314,13 +1314,13 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
             }
 
             function save_gps_config() {
-                if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_34)) {
                     FC.GPS_CONFIG.auto_baud = $('input[name="gps_auto_baud"]').is(':checked') ? 1 : 0;
                     FC.GPS_CONFIG.auto_config = $('input[name="gps_auto_config"]').is(':checked') ? 1 : 0;
                 }
 
                 var next_callback = save_motor_3d_config;
-                if(semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+                if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
                     MSP.send_message(MSPCodes.MSP_SET_GPS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_GPS_CONFIG), false, next_callback);
                 } else {
                     next_callback();
@@ -1404,7 +1404,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
 
             function save_filter_config() {
                 const next_callback = save_to_eeprom;
-                if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                     MSP.send_message(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG), false, next_callback);
                 } else {
                     next_callback();

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -19,7 +19,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
     
     function load_rxfail_config() {
         MSP.send_message(MSPCodes.MSP_RXFAIL_CONFIG, false, false, 
-                semver.gte(FC.CONFIG.apiVersion, "1.41.0") ? load_gps_rescue : get_box_names);
+                semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41) ? load_gps_rescue : get_box_names);
     }
 
     function load_gps_rescue() {
@@ -135,7 +135,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
 
         for (i = 0; i < FC.RXFAIL_CONFIG.length; i++) {
             if (i < channelNames.length) {
-                if (semver.lt(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     fullChannels_e.append('\
                         <div class="number">\
                             <div class="channelprimary">\
@@ -236,7 +236,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
 
         FC.FEATURE_CONFIG.features.generateElements($('.tab-failsafe .featuresNew'));
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
           $('tbody.rxFailsafe').hide();
           toggleStage2(true);
         } else {
@@ -283,7 +283,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 break;
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
             // `failsafe_kill_switch` has been renamed to `failsafe_switch_mode`.
             // It is backwards compatible with `failsafe_kill_switch`
             $('select[name="failsafe_switch_mode"]').val(FC.FAILSAFE_CONFIG.failsafe_switch_mode);
@@ -295,9 +295,9 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         }
 
         // The GPS Rescue tab is only available for 1.40 or later, and the parameters for 1.41
-        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 // Load GPS Rescue parameters
                 $('input[name="gps_rescue_angle"]').val(FC.GPS_RESCUE.angle);
                 $('input[name="gps_rescue_initial_altitude"]').val(FC.GPS_RESCUE.initialAltitudeM);
@@ -355,14 +355,14 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 FC.FAILSAFE_CONFIG.failsafe_procedure = 2;
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                 FC.FAILSAFE_CONFIG.failsafe_switch_mode = $('select[name="failsafe_switch_mode"]').val();
             }
             else {
                 FC.FAILSAFE_CONFIG.failsafe_switch_mode = $('input[name="failsafe_kill_switch"]').is(':checked') ? 1 : 0;
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 // Load GPS Rescue parameters
                 FC.GPS_RESCUE.angle             = $('input[name="gps_rescue_angle"]').val();
                 FC.GPS_RESCUE.initialAltitudeM  = $('input[name="gps_rescue_initial_altitude"]').val();
@@ -392,7 +392,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
 
             function save_feature_config() {
                 MSP.send_message(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG), false, 
-                        semver.gte(FC.CONFIG.apiVersion, "1.41.0") ? save_gps_rescue : save_to_eeprom);
+                        semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41) ? save_gps_rescue : save_to_eeprom);
             }
 
             function save_gps_rescue() {

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -50,7 +50,7 @@ TABS.gps.initialize = function (callback) {
             var lon = FC.GPS_DATA.lon / 10000000;
             var url = 'https://maps.google.com/?q=' + lat + ',' + lon;
             var alt = FC.GPS_DATA.alt;
-            if (semver.lt(FC.CONFIG.apiVersion, "1.39.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                 alt = alt / 10;
             }
 

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -18,7 +18,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     } else {
         TABS.led_strip.functions = ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l', 'o', 'n'];
         TABS.led_strip.baseFuncs = ['c', 'f', 'a', 'l', 's', 'g', 'r'];
-        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             TABS.led_strip.overlays =  ['t', 'o', 'b', 'n', 'i', 'w'];
         } else {
             TABS.led_strip.overlays =  ['t', 'o', 'b', 'v', 'i', 'w'];
@@ -75,7 +75,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
         for (var i = 0; i < 256; i++) {
             if (semver.lte(FC.CONFIG.apiVersion, "1.19.0")) {
                 theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-s"> </span><span class="overlay-w"> </span><span class="overlay-i"> </span><span class="overlay-color"> </span></div>');
-            } else if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+            } else if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-o"> </span><span class="overlay-b"> </span><span class="overlay-n"> </span><span class="overlay-i"> </span><span class="overlay-w"> </span><span class="overlay-color"> </span></div>');
             } else {
                 theHTML[theHTMLlength++] = ('<div class="gPoint"><div class="indicators"><span class="north"></span><span class="south"></span><span class="west"></span><span class="east"></span><span class="up">U</span><span class="down">D</span></div><span class="wire"></span><span class="overlay-t"> </span><span class="overlay-o"> </span><span class="overlay-b"> </span><span class="overlay-v"> </span><span class="overlay-i"> </span><span class="overlay-w"> </span><span class="overlay-color"> </span></div>');
@@ -105,7 +105,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
             });
         }
 
-        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             $('.vtxOverlay').hide();
             $('.landingBlinkOverlay').show();
         }
@@ -806,7 +806,7 @@ TABS.led_strip.initialize = function (callback, scrollPosition) {
     }
 
     function isVtxActive(activeFunction) {
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             switch (activeFunction) {
                 case "function-v":
                 case "function-c":

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -85,7 +85,7 @@ TABS.motors.initialize = function (callback) {
     }
 
     // Get information from Betaflight
-    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
         // BF 3.2.0+
         MSP.send_message(MSPCodes.MSP_MOTOR_CONFIG, false, false, get_arm_status);
     } else {
@@ -221,7 +221,7 @@ TABS.motors.initialize = function (callback) {
     function update_model(mixer) {
         var reverse = "";
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             reverse = FC.MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
         }
 
@@ -251,7 +251,7 @@ TABS.motors.initialize = function (callback) {
 
         $('#motorsEnableTestMode').prop('checked', false);
 
-        if (semver.lt(FC.CONFIG.apiVersion, "1.42.0") || !(FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor)) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42) || !(FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor)) {
             $(".motor_testing .telemetry").hide();
         } else {
             // Hide telemetry from unused motors (to hide the tooltip in an empty blank space)

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -69,7 +69,7 @@ TABS.onboard_logging.initialize = function (callback) {
              *
              * The best we can do on those targets is check the BLACKBOX feature bit to identify support for Blackbox instead.
              */
-            if ((FC.BLACKBOX.supported || FC.DATAFLASH.supported) && (semver.gte(FC.CONFIG.apiVersion, "1.33.0") || FC.FEATURE_CONFIG.features.isEnabled('BLACKBOX'))) {
+            if ((FC.BLACKBOX.supported || FC.DATAFLASH.supported) && (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33) || FC.FEATURE_CONFIG.features.isEnabled('BLACKBOX'))) {
                 blackboxSupport = 'yes';
             } else {
                 blackboxSupport = 'no';
@@ -106,7 +106,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 $(".tab-onboard_logging a.save-settings").click(function() {
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
                         FC.BLACKBOX.blackboxSampleRate = parseInt(loggingRatesSelect.val(), 10);
-                    } else if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                    } else if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                         FC.BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);
                     } else {
                         var rate = loggingRatesSelect.val().split('/');
@@ -114,7 +114,7 @@ TABS.onboard_logging.initialize = function (callback) {
                         FC.BLACKBOX.blackboxRateDenom = parseInt(rate[1], 10);
                     }
                     FC.BLACKBOX.blackboxDevice = parseInt(deviceSelect.val(), 10);
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                         FC.PID_ADVANCED_CONFIG.debugMode = parseInt(debugModeSelect.val());
                         MSP.send_message(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG), false, save_to_eeprom);
                     }
@@ -134,7 +134,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 }
             }).change();
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                 if ((FC.SDCARD.supported && deviceSelect.val() == 2) || (FC.DATAFLASH.supported && deviceSelect.val() == 1)) {
 
                     $(".tab-onboard_logging")
@@ -144,7 +144,7 @@ TABS.onboard_logging.initialize = function (callback) {
                          analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'RebootMsc');
 
                         var buffer = [];
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                             if (GUI.operating_system === "Linux") {
                                 // Reboot into MSC using UTC time offset instead of user timezone
                                 // Linux seems to expect that the FAT file system timestamps are UTC based
@@ -169,7 +169,7 @@ TABS.onboard_logging.initialize = function (callback) {
     function populateDevices(deviceSelect) {
         deviceSelect.empty();
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.33.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33)) {
             deviceSelect.append('<option value="0">' + i18n.getMessage('blackboxLoggingNone') + '</option>');
             if (FC.DATAFLASH.supported) {
                 deviceSelect.append('<option value="1">' + i18n.getMessage('blackboxLoggingFlash') + '</option>');
@@ -204,7 +204,7 @@ TABS.onboard_logging.initialize = function (callback) {
 
             let pidRateBase = 8000;
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, "1.41.0") && FC.PID_ADVANCED_CONFIG.gyroUse32kHz !== 0) {
+            if (semver.gte(FC.CONFIG.apiVersion, "1.25.0") && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_41) && FC.PID_ADVANCED_CONFIG.gyroUse32kHz !== 0) {
                 pidRateBase = 32000;
             }
             pidRate = pidRateBase / FC.PID_ADVANCED_CONFIG.gyro_sync_denom / FC.PID_ADVANCED_CONFIG.pid_process_denom;
@@ -222,7 +222,7 @@ TABS.onboard_logging.initialize = function (callback) {
                 loggingRatesSelect.append(`<option value="${i}">1/${2**i} (${loggingFrequency}${loggingFrequencyUnit})</option>`);
             }
             loggingRatesSelect.val(FC.BLACKBOX.blackboxSampleRate);
-        } else if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        } else if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             loggingRates = [
                 {text: "Disabled", hz: 0,     p_denom: 0},
                 {text: "500 Hz",   hz: 500,   p_denom: 16},
@@ -278,7 +278,7 @@ TABS.onboard_logging.initialize = function (callback) {
     function populateDebugModes(debugModeSelect) {
         var debugModes = [];
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             $('.blackboxDebugMode').show();
 
             debugModes = [
@@ -435,7 +435,7 @@ TABS.onboard_logging.initialize = function (callback) {
             .toggleClass("sdcard-initializing", FC.SDCARD.state === MSP.SDCARD_STATE_CARD_INIT || FC.SDCARD.state === MSP.SDCARD_STATE_FS_INIT)
             .toggleClass("sdcard-ready", FC.SDCARD.state === MSP.SDCARD_STATE_READY);
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
             var mscIsReady = dataflashPresent || (FC.SDCARD.state === MSP.SDCARD_STATE_READY);
             $(".tab-onboard_logging")
                 .toggleClass("msc-not-ready", !mscIsReady);
@@ -535,7 +535,7 @@ TABS.onboard_logging.initialize = function (callback) {
     function flash_save_begin() {
         if (GUI.connected_to) {
             if (FC.boardHasVcp()) {
-                if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
                     self.blockSize = self.VCP_BLOCK_SIZE;
                 } else {
                     self.blockSize = self.VCP_BLOCK_SIZE_3_0;

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -72,7 +72,7 @@ SYM.loadSymbols = function() {
      * - Symbols used in this versions
      * - That were moved or didn't exist in the font file
      */
-    if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
         SYM.AH_CENTER_LINE = 0x26;
         SYM.AH_CENTER = 0x7E;
         SYM.AH_CENTER_LINE_RIGHT = 0x27;
@@ -543,7 +543,7 @@ OSD.loadDisplayFields = function() {
             },
             draw_order: 40,
             positionable() {
-                return semver.gte(FC.CONFIG.apiVersion, "1.39.0") ? true : false;
+                return semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39) ? true : false;
             },
             preview() {
                 return FONT.symbol(SYM.AH_CENTER_LINE) + FONT.symbol(SYM.AH_CENTER) + FONT.symbol(SYM.AH_CENTER_LINE_RIGHT);
@@ -562,7 +562,7 @@ OSD.loadDisplayFields = function() {
             },
             draw_order: 10,
             positionable() {
-                return semver.gte(FC.CONFIG.apiVersion, "1.39.0") ? true : false;
+                return semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39) ? true : false;
             },
             preview() {
                 const artificialHorizon = [];
@@ -599,7 +599,7 @@ OSD.loadDisplayFields = function() {
             },
             draw_order: 50,
             positionable() {
-                return semver.gte(FC.CONFIG.apiVersion, "1.39.0") ? true : false;
+                return semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39) ? true : false;
             },
             preview() {
 
@@ -645,7 +645,7 @@ OSD.loadDisplayFields = function() {
             draw_order: 130,
             positionable: true,
             preview() {
-                return semver.gte(FC.CONFIG.apiVersion, "1.36.0") ? ` 42.00${FONT.symbol(SYM.AMP)}` : `${FONT.symbol(SYM.AMP)}42.0`;
+                return semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36) ? ` 42.00${FONT.symbol(SYM.AMP)}` : `${FONT.symbol(SYM.AMP)}42.0`;
             },
         },
         MAH_DRAWN: {
@@ -656,7 +656,7 @@ OSD.loadDisplayFields = function() {
             draw_order: 140,
             positionable: true,
             preview() {
-                return semver.gte(FC.CONFIG.apiVersion, "1.36.0") ? ` 690${FONT.symbol(SYM.MAH)}` : `${FONT.symbol(SYM.MAH)}690`;
+                return semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36) ? ` 690${FONT.symbol(SYM.MAH)}` : `${FONT.symbol(SYM.MAH)}690`;
             },
         },
         CRAFT_NAME: {
@@ -788,7 +788,7 @@ OSD.loadDisplayFields = function() {
             draw_order: 200,
             positionable: true,
             preview() {
-                return semver.gte(FC.CONFIG.apiVersion, "1.36.0") ? ' 142W' : '142W';
+                return semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36) ? ' 142W' : '142W';
             },
         },
         PID_RATE_PROFILE: {
@@ -1491,7 +1491,7 @@ OSD.chooseFields = function() {
             F.HORIZON_SIDEBARS,
         ];
 
-        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                 F.ONTIME,
                 F.FLYTIME,
@@ -1514,31 +1514,31 @@ OSD.chooseFields = function() {
             F.GPS_SATS,
             F.ALTITUDE,
         ]);
-        if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
             OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                 F.PID_ROLL,
                 F.PID_PITCH,
                 F.PID_YAW,
                 F.POWER,
             ]);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.32.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_32)) {
                 OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                     F.PID_RATE_PROFILE,
-                    semver.gte(FC.CONFIG.apiVersion, "1.36.0") ? F.WARNINGS : F.BATTERY_WARNING,
+                    semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36) ? F.WARNINGS : F.BATTERY_WARNING,
                     F.AVG_CELL_VOLTAGE,
                 ]);
-                if (semver.gte(FC.CONFIG.apiVersion, "1.34.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_34)) {
                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                         F.GPS_LON,
                         F.GPS_LAT,
                         F.DEBUG,
                     ]);
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.35.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_35)) {
                         OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                             F.PITCH_ANGLE,
                             F.ROLL_ANGLE,
                         ]);
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                             OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                 F.MAIN_BATT_USAGE,
                                 F.DISARMED,
@@ -1550,22 +1550,22 @@ OSD.chooseFields = function() {
                                 F.ESC_TEMPERATURE,
                                 F.ESC_RPM,
                             ]);
-                            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                                 OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                     F.REMAINING_TIME_ESTIMATE,
                                     F.RTC_DATE_TIME,
                                     F.ADJUSTMENT_RANGE,
                                     F.CORE_TEMPERATURE,
                                 ]);
-                                if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                         F.ANTI_GRAVITY,
                                     ]);
-                                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                                         OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                             F.G_FORCE,
                                         ]);
-                                        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                                             OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                                 F.MOTOR_DIAG,
                                                 F.LOG_STATUS,
@@ -1577,7 +1577,7 @@ OSD.chooseFields = function() {
                                                 F.DISPLAY_NAME,
                                                 F.ESC_RPM_FREQ,
                                             ]);
-                                            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                                                 OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                                     F.RATE_PROFILE_NAME,
                                                     F.PID_PROFILE_NAME,
@@ -1634,7 +1634,7 @@ OSD.chooseFields = function() {
     // that needs to be implemented here as well. Simply appending new stats does not
     // require a completely new section for the version - only reordering.
 
-    if (semver.lt(FC.CONFIG.apiVersion, "1.39.0")) {
+    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
         OSD.constants.STATISTIC_FIELDS = [
             F.MAX_SPEED,
             F.MIN_BATTERY,
@@ -1649,7 +1649,7 @@ OSD.chooseFields = function() {
             F.MAX_DISTANCE,
             F.BLACKBOX_LOG_NUMBER,
         ];
-        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
             OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([
                 F.RTC_DATE_TIME,
             ]);
@@ -1671,7 +1671,7 @@ OSD.chooseFields = function() {
             F.BLACKBOX,
             F.BLACKBOX_LOG_NUMBER,
         ];
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([
                 F.MAX_G_FORCE,
                 F.MAX_ESC_TEMP,
@@ -1681,7 +1681,7 @@ OSD.chooseFields = function() {
                 F.MAX_FFT,
             ]);
         }
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([
                 F.TOTAL_FLIGHTS,
                 F.TOTAL_FLIGHT_TIME,
@@ -1702,14 +1702,14 @@ OSD.chooseFields = function() {
         F.VISUAL_BEEPER,
         F.CRASH_FLIP_MODE,
     ];
-    if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
             F.ESC_FAIL,
             F.CORE_TEMPERATURE,
             F.RC_SMOOTHING_FAILURE,
         ]);
     }
-    if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
             F.FAILSAFE,
             F.LAUNCH_CONTROL,
@@ -1723,7 +1723,7 @@ OSD.chooseFields = function() {
         'TOTAL_ARMED_TIME',
         'LAST_ARMED_TIME',
     ];
-    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
         OSD.constants.TIMER_TYPES = OSD.constants.TIMER_TYPES.concat([
             'ON_ARM_TIME',
         ]);
@@ -1840,14 +1840,14 @@ OSD.msp = {
             // watch out, order matters! match the firmware
             result.push8(OSD.data.alarms.rssi.value);
             result.push16(OSD.data.alarms.cap.value);
-            if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 result.push16(OSD.data.alarms.time.value);
             } else {
                 // This value is unused by the firmware with configurable timers
                 result.push16(0);
             }
             result.push16(OSD.data.alarms.alt.value);
-            if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                 let warningFlags = 0;
                 for (let i = 0; i < OSD.data.warnings.length; i++) {
                     if (OSD.data.warnings[i].enabled) {
@@ -1856,7 +1856,7 @@ OSD.msp = {
                 }
                 console.log(warningFlags);
                 result.push16(warningFlags);
-                if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     result.push32(warningFlags);
 
                     result.push8(OSD.data.osd_profiles.selected + 1);
@@ -1907,13 +1907,13 @@ OSD.msp = {
                 d.alarms = {};
                 d.alarms['rssi'] = { display_name: i18n.getMessage('osdTimerAlarmOptionRssi'), value: view.readU8() };
                 d.alarms['cap'] = { display_name: i18n.getMessage('osdTimerAlarmOptionCapacity'), value: view.readU16() };
-                if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+                if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                     d.alarms['time'] = { display_name: 'Minutes', value: view.readU16() };
                 } else {
                     // This value was obsoleted by the introduction of configurable timers, and has been reused to encode the number of display elements sent in this command
                     view.readU8();
                     const tmp = view.readU8();
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                         displayItemsCountActual = tmp;
                     }
                 }
@@ -1924,12 +1924,12 @@ OSD.msp = {
 
         d.state = {};
         d.state.haveSomeOsd = (d.flags !== 0);
-        d.state.haveMax7456Configured = bit_check(d.flags, 4) || (d.flags === 1 && semver.lt(FC.CONFIG.apiVersion, "1.34.0"));
+        d.state.haveMax7456Configured = bit_check(d.flags, 4) || (d.flags === 1 && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_34));
         d.state.haveFrSkyOSDConfigured = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43) && bit_check(d.flags, 3);
         d.state.haveMax7456FontDeviceConfigured = d.state.haveMax7456Configured || d.state.haveFrSkyOSDConfigured;
         d.state.isMax7456FontDeviceDetected = bit_check(d.flags, 5) || (d.state.haveMax7456FontDeviceConfigured && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_43));
-        d.state.haveOsdFeature = bit_check(d.flags, 0) || (d.flags === 1 && semver.lt(FC.CONFIG.apiVersion, "1.34.0"));
-        d.state.isOsdSlave = bit_check(d.flags, 1) && semver.gte(FC.CONFIG.apiVersion, "1.34.0");
+        d.state.haveOsdFeature = bit_check(d.flags, 0) || (d.flags === 1 && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_34));
+        d.state.isOsdSlave = bit_check(d.flags, 1) && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_34);
 
         d.displayItems = [];
         d.statItems = [];
@@ -1953,7 +1953,7 @@ OSD.msp = {
             itemsPositionsRead.push(v);
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             // Parse statistics display enable
             const expectedStatsCount = view.readU8();
             if (expectedStatsCount !== OSD.constants.STATISTIC_FIELDS.length) {
@@ -2009,7 +2009,7 @@ OSD.msp = {
             // Parse enabled warnings
             let warningCount = OSD.constants.WARNINGS.length;
             let warningFlags = view.readU16();
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 warningCount = view.readU8();
                 // the flags were replaced with a 32bit version
                 warningFlags = view.readU32();
@@ -2036,7 +2036,7 @@ OSD.msp = {
             }
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             // OSD profiles
             d.osd_profiles.number = view.readU8();
             d.osd_profiles.selected = view.readU8() - 1;
@@ -2385,7 +2385,7 @@ TABS.osd.initialize = function(callback) {
                             $alarms.append($input);
                         }
 
-                        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                             // Timers
                             $('.timers-container').show();
                             const $timers = $('#timer-fields').empty();
@@ -2903,7 +2903,7 @@ TABS.osd.initialize = function(callback) {
         fontPresetsElement.change(function() {
             const $font = $('.fontpresets option:selected');
             let fontver = 1;
-            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 fontver = 2;
             }
             $('.font-manager-version-info').text(i18n.getMessage(`osdDescribeFontVersion${fontver}`));

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -140,7 +140,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_filter input[name="dTermNotchCutoff"]').val(FC.FILTER_CONFIG.dterm_notch_cutoff);
 
             var dtermSetpointTransitionNumberElement = $('input[name="dtermSetpointTransition-number"]');
-            if (semver.gte(FC.CONFIG.apiVersion, "1.38.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_38)) {
                 dtermSetpointTransitionNumberElement.attr('min', 0.00);
             } else {
                 dtermSetpointTransitionNumberElement.attr('min', 0.01);
@@ -167,7 +167,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_sensitivity').hide();
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             $('.pid_filter select[name="dtermLowpassType"]').val(FC.FILTER_CONFIG.dterm_lowpass_type);
             $('.antigravity input[name="itermThrottleThreshold"]').val(FC.ADVANCED_TUNING.itermThrottleThreshold);
             $('.antigravity input[name="itermAcceleratorGain"]').val(FC.ADVANCED_TUNING.itermAcceleratorGain / 1000);
@@ -188,7 +188,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     if (FC.ADVANCED_TUNING.antiGravityMode == 0) {
                         $('.antigravity .antiGravityThres').hide();
                     }
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                         $('.antigravity .antiGravityMode').show();
                     } else {
                         $('.antigravity .antiGravityMode').hide();
@@ -205,12 +205,12 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.antigravity').hide();
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
             $('.pid_tuning input[name="rc_rate_pitch"]').val(FC.RC_TUNING.rcPitchRate.toFixed(2));
             $('.pid_tuning input[name="rc_pitch_expo"]').val(FC.RC_TUNING.RC_PITCH_EXPO.toFixed(2));
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
 
             $('.pid_filter input[name="gyroLowpass2Frequency"]').val(FC.FILTER_CONFIG.gyro_lowpass2_hz);
             $('.pid_filter select[name="gyroLowpassType"]').val(FC.FILTER_CONFIG.gyro_lowpass_type);
@@ -229,7 +229,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('#pid_main .pid_titlebar2 th').attr('colspan', 4);
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
 
             // I Term Rotation
             $('input[id="itermrotation"]').prop('checked', FC.ADVANCED_TUNING.itermRotation !== 0);
@@ -254,7 +254,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
                 if (checked) {
                     $('.itermrelax .suboption').show();
-                    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                         $('.itermRelaxCutoff').show();
                     } else {
                         $('.itermRelaxCutoff').hide();
@@ -320,7 +320,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('#pid-tuning .feedforwardTransition').hide();
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             $('select[id="throttleLimitType"]').val(FC.RC_TUNING.throttleLimitType);
             $('.throttle_limit input[name="throttleLimitPercent"]').val(FC.RC_TUNING.throttleLimitPercent);
 
@@ -359,7 +359,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.integratedYaw').hide();
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             const dynamicNotchWidthPercent_e = $('.pid_filter input[name="dynamicNotchWidthPercent"]');
             const dynamicNotchQ_e = $('.pid_filter input[name="dynamicNotchQ"]');
 
@@ -532,7 +532,7 @@ TABS.pid_tuning.initialize = function (callback) {
             adjustDMin($(this), dMinElement);
         }).change();
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             var dMinSwitch = $('#dMinSwitch');
             dMinSwitch.prop('checked', FC.ADVANCED_TUNING.dMinRoll > 0 || FC.ADVANCED_TUNING.dMinPitch > 0 || FC.ADVANCED_TUNING.dMinYaw > 0);
             dMinSwitch.change(function() {
@@ -871,20 +871,20 @@ TABS.pid_tuning.initialize = function (callback) {
             FC.ADVANCED_TUNING.levelSensitivity = parseInt($('.pid_tuning input[name="sensitivity"]').val());
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             FC.FILTER_CONFIG.dterm_lowpass_type = $('.pid_filter select[name="dtermLowpassType"]').val();
             FC.ADVANCED_TUNING.itermThrottleThreshold = parseInt($('.antigravity input[name="itermThrottleThreshold"]').val());
             FC.ADVANCED_TUNING.itermAcceleratorGain = parseInt($('.antigravity input[name="itermAcceleratorGain"]').val() * 1000);
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
             FC.FILTER_CONFIG.gyro_lowpass2_hz = parseInt($('.pid_filter input[name="gyroLowpass2Frequency"]').val());
             FC.FILTER_CONFIG.gyro_lowpass_type = parseInt($('.pid_filter select[name="gyroLowpassType"]').val());
             FC.FILTER_CONFIG.gyro_lowpass2_type = parseInt($('.pid_filter select[name="gyroLowpass2Type"]').val());
             FC.FILTER_CONFIG.dterm_lowpass2_hz = parseInt($('.pid_filter input[name="dtermLowpass2Frequency"]').val());
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
 
             FC.ADVANCED_TUNING.itermRotation = $('input[id="itermrotation"]').is(':checked') ? 1 : 0;
             FC.ADVANCED_TUNING.smartFeedforward = $('input[id="smartfeedforward"]').is(':checked') ? 1 : 0;
@@ -908,7 +908,7 @@ TABS.pid_tuning.initialize = function (callback) {
             FC.ADVANCED_TUNING.antiGravityMode = $('select[id="antiGravityMode"]').val();
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             FC.RC_TUNING.throttleLimitType = $('select[id="throttleLimitType"]').val();
             FC.RC_TUNING.throttleLimitPercent = parseInt($('.throttle_limit input[name="throttleLimitPercent"]').val());
 
@@ -934,7 +934,7 @@ TABS.pid_tuning.initialize = function (callback) {
             FC.ADVANCED_TUNING.useIntegratedYaw = $('input[id="useIntegratedYaw"]').is(':checked') ? 1 : 0;
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             FC.FILTER_CONFIG.dyn_notch_range = parseInt($('.pid_filter select[name="dynamicNotchRange"]').val());
             FC.FILTER_CONFIG.dyn_notch_width_percent = parseInt($('.pid_filter input[name="dynamicNotchWidthPercent"]').val());
             FC.FILTER_CONFIG.dyn_notch_q = parseInt($('.pid_filter input[name="dynamicNotchQ"]').val());
@@ -1081,7 +1081,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.tab-pid_tuning .pidTuningSuperexpoRates').hide();
         }
 
-        if (semver.lt(FC.CONFIG.apiVersion, "1.39.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
             $('input[name="dtermSetpoint-number"]').attr('max', self.SETPOINT_WEIGHT_RANGE_LEGACY);
         }
 
@@ -1120,12 +1120,12 @@ TABS.pid_tuning.initialize = function (callback) {
             self.currentRates.superexpo = true;
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             $('.pid_tuning input[name="sensitivity"]').hide();
             $('.pid_tuning .levelSensitivityHeader').empty();
         }
 
-        if (semver.lt(FC.CONFIG.apiVersion, "1.37.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
             self.currentRates.rc_rate_pitch = self.currentRates.rc_rate;
             self.currentRates.rc_expo_pitch = self.currentRates.rc_expo;
         }
@@ -1191,7 +1191,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         function loadRateProfilesList() {
             var numberOfRateProfiles = 6;
-            if (semver.lt(FC.CONFIG.apiVersion, "1.37.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                 numberOfRateProfiles = 3;
             }
 
@@ -1338,7 +1338,7 @@ TABS.pid_tuning.initialize = function (callback) {
             var filterTypeValues = [];
             filterTypeValues.push("PT1");
             filterTypeValues.push("BIQUAD");
-            if (semver.lt(FC.CONFIG.apiVersion, "1.39.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                 filterTypeValues.push("FIR");
             }
             return filterTypeValues;
@@ -1363,7 +1363,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 dynamicNotchRangeSelect.append('<option value="' + key + '">' + value + '</option>');
             });
         }
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             populateDynamicNotchRangeSelect(loadDynamicNotchRangeValues());
         }
 
@@ -1400,7 +1400,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         var pidController_e = $('select[name="controller"]');
 
-        if (semver.lt(FC.CONFIG.apiVersion, "1.31.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
             var pidControllerList;
 
 
@@ -1457,7 +1457,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_tuning .roll_pitch_rate').hide();
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
             $('.pid_tuning .bracket').hide();
             $('.pid_tuning input[name=rc_rate]').parent().attr('class', 'pid_data');
             $('.pid_tuning input[name=rc_rate]').parent().attr('rowspan', 1);
@@ -1520,11 +1520,11 @@ TABS.pid_tuning.initialize = function (callback) {
                         updateNeeded = true;
                     }
 
-                    if (targetElement.attr('name') === 'rc_rate' && semver.lt(FC.CONFIG.apiVersion, "1.37.0")) {
+                    if (targetElement.attr('name') === 'rc_rate' && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                         self.currentRates.rc_rate_pitch = targetValue;
                     }
 
-                    if (targetElement.attr('name') === 'rc_expo' && semver.lt(FC.CONFIG.apiVersion, "1.37.0")) {
+                    if (targetElement.attr('name') === 'rc_expo' && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                         self.currentRates.rc_pitch_expo = targetValue;
                     }
 
@@ -1696,7 +1696,7 @@ TABS.pid_tuning.initialize = function (callback) {
         var DIALOG_MODE_RATEPROFILE = 1;
         var dialogCopyProfileMode;
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
 
             var selectProfile = $('.selectProfile');
             var selectRateProfile = $('.selectRateProfile');
@@ -1762,7 +1762,7 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.copyrateprofilebtn').hide();
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             // filter and tuning sliders
             TuningSliders.initialize();
 
@@ -1959,7 +1959,7 @@ TABS.pid_tuning.initialize = function (callback) {
             });
         }
 
-        if (semver.lt(FC.CONFIG.apiVersion, "1.31.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
             pidController_e.change(function () {
                 self.setDirty(true);
 
@@ -1975,7 +1975,7 @@ TABS.pid_tuning.initialize = function (callback) {
             Promise.resolve(true)
             .then(function () {
                 var promise;
-                if (semver.gte(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE) && semver.lt(FC.CONFIG.apiVersion, "1.31.0")) {
+                if (semver.gte(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_PID_CONTROLLER_CHANGE) && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
                     FC.PID.controller = pidController_e.val();
                     promise = MSP.promise(MSPCodes.MSP_SET_PID_CONTROLLER, mspHelper.crunch(MSPCodes.MSP_SET_PID_CONTROLLER));
                 }
@@ -2182,7 +2182,7 @@ TABS.pid_tuning.checkThrottle = function() {
 };
 
 TABS.pid_tuning.updatePidControllerParameters = function () {
-    if (semver.gte(FC.CONFIG.apiVersion, "1.20.0") && semver.lt(FC.CONFIG.apiVersion, "1.31.0") && $('.tab-pid_tuning select[name="controller"]').val() === '0') {
+    if (semver.gte(FC.CONFIG.apiVersion, "1.20.0") && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_31) && $('.tab-pid_tuning select[name="controller"]').val() === '0') {
         $('.pid_tuning .YAW_JUMP_PREVENTION').show();
 
         $('#pid-tuning .delta').show();
@@ -2192,7 +2192,7 @@ TABS.pid_tuning.updatePidControllerParameters = function () {
     } else {
         $('.pid_tuning .YAW_JUMP_PREVENTION').hide();
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
             $('#pid-tuning .dtermSetpointTransition').hide();
             $('#pid-tuning .dtermSetpoint').hide();
         } else {
@@ -2403,7 +2403,7 @@ TABS.pid_tuning.updateFilterWarning = function() {
     } else {
         warning_e.hide();
     }
-    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
         if (FC.FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
             warningDynamicNotch_e.hide();
         } else {

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -32,7 +32,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         functionRules.push(mavlinkFunctionRule);
     }
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
         functionRules.push({ name: 'ESC_SENSOR', groups: ['sensors'], maxPorts: 1 });
         functionRules.push({ name: 'TBS_SMARTAUDIO', groups: ['peripherals'], maxPorts: 1 });
     }
@@ -41,15 +41,15 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         functionRules.push({ name: 'IRC_TRAMP', groups: ['peripherals'], maxPorts: 1 });
     }
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.32.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_32)) {
         functionRules.push({ name: 'TELEMETRY_IBUS', groups: ['telemetry'], maxPorts: 1 });
     }
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
         functionRules.push({ name: 'RUNCAM_DEVICE_CONTROL', groups: ['peripherals'], maxPorts: 1 });
     }
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.37.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
         functionRules.push({ name: 'LIDAR_TF', groups: ['peripherals'], maxPorts: 1 });
     }
 
@@ -71,7 +71,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         '250000'
     ];
 
-    if (semver.gte(FC.CONFIG.apiVersion, "1.31.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_31)) {
         mspBaudRates = mspBaudRates.concat(['500000', '1000000']);
     }
 
@@ -116,7 +116,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
 
     function load_configuration_from_fc() {
         let promise;
-        if(semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             promise = MSP.promise(MSPCodes.MSP_VTX_CONFIG);
         } else {
             promise = Promise.resolve();
@@ -296,7 +296,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
         }
 
         let vtxTableNotConfigured = true;
-        if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             vtxTableNotConfigured = FC.VTX_CONFIG.vtx_table_available &&
                                         (FC.VTX_CONFIG.vtx_table_bands == 0 ||
                                         FC.VTX_CONFIG.vtx_table_channels == 0 ||
@@ -321,7 +321,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
                 lastVtxControlSelected = vtxControlSelected;
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 if (vtxControlSelected && vtxTableNotConfigured) {
                     $('.vtxTableNotSet').show();
                 } else {

--- a/src/js/tabs/power.js
+++ b/src/js/tabs/power.js
@@ -53,7 +53,7 @@ TABS.power.initialize = function (callback) {
         $('#content').load("./tabs/power.html", process_html);
     }
 
-    this.supported = semver.gte(FC.CONFIG.apiVersion, "1.33.0");
+    this.supported = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_33);
 
     if (!this.supported) {
         load_html();
@@ -226,7 +226,7 @@ TABS.power.initialize = function (callback) {
         var element = template.clone();
         destination.append(element);
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             $('input[name="mincellvoltage"]').prop('step','0.01');
             $('input[name="maxcellvoltage"]').prop('step','0.01');
             $('input[name="warningcellvoltage"]').prop('step','0.01');
@@ -237,7 +237,7 @@ TABS.power.initialize = function (callback) {
         $('input[name="warningcellvoltage"]').val(FC.BATTERY_CONFIG.vbatwarningcellvoltage);
         $('input[name="capacity"]').val(FC.BATTERY_CONFIG.capacity);
 
-        var haveFc = (semver.lt(FC.CONFIG.apiVersion, "1.35.0") || (FC.CONFIG.boardType == 0 || FC.CONFIG.boardType == 2));
+        var haveFc = (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_35) || (FC.CONFIG.boardType == 0 || FC.CONFIG.boardType == 2));
 
         var batteryMeterTypes = [
             i18n.getMessage('powerBatteryVoltageMeterTypeNone'),
@@ -264,7 +264,7 @@ TABS.power.initialize = function (callback) {
             currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeVirtual'));
             currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeEsc'));
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 currentMeterTypes.push(i18n.getMessage('powerBatteryCurrentMeterTypeMsp'));
             }
         }
@@ -491,7 +491,7 @@ TABS.power.initialize = function (callback) {
         }
 
         function save_voltage_config() {
-            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 mspHelper.sendVoltageConfig(save_amperage_config);
             } else {
                 MSP.send_message(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG), false, save_amperage_config);
@@ -499,7 +499,7 @@ TABS.power.initialize = function (callback) {
         }
 
         function save_amperage_config() {
-            if (semver.gte(FC.CONFIG.apiVersion, "1.36.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
                 mspHelper.sendCurrentConfig(save_to_eeprom);
             } else {
                 MSP.send_message(MSPCodes.MSP_SET_CURRENT_METER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_CURRENT_METER_CONFIG), false, save_to_eeprom);

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -265,7 +265,7 @@ TABS.receiver.initialize = function (callback) {
                 FC.RX_CONFIG.rcInterpolationInterval = parseInt($('input[name="rcInterpolationInterval-number"]').val());
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                 FC.RX_CONFIG.rcSmoothingInputCutoff = parseInt($('input[name="rcSmoothingInputHz-number"]').val());
                 FC.RX_CONFIG.rcSmoothingDerivativeCutoff = parseInt($('input[name="rcSmoothingDerivativeCutoff-number"]').val());
                 FC.RX_CONFIG.rcSmoothingDerivativeType = parseInt($('select[name="rcSmoothingDerivativeType-select"]').val());
@@ -273,7 +273,7 @@ TABS.receiver.initialize = function (callback) {
                 FC.RX_CONFIG.rcSmoothingInputType = parseInt($('select[name="rcSmoothingInputType-select"]').val());
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 FC.RX_CONFIG.rcSmoothingAutoSmoothness = parseInt($('input[name="rcSmoothingAutoSmoothness-number"]').val());
             }
 
@@ -350,7 +350,7 @@ TABS.receiver.initialize = function (callback) {
         $(".bind_btn").toggle(showBindButton);
 
         // RC Smoothing
-        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
             $('.tab-receiver .rcSmoothing').show();
 
             var rc_smoothing_protocol_e = $('select[name="rcSmoothing-select"]');
@@ -409,7 +409,7 @@ TABS.receiver.initialize = function (callback) {
             var rc_smoothing_input_type = $('select[name="rcSmoothingInputType-select"]');
             rc_smoothing_input_type.val(FC.RX_CONFIG.rcSmoothingInputType);
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 $('select[name="rcSmoothing-input-manual-select"], select[name="rcSmoothing-input-derivative-select"]').change(function() {
                     if ($('select[name="rcSmoothing-input-manual-select"]').val() == 0 || $('select[name="rcSmoothing-input-derivative-select"]').val() == 0) {
                         $('.tab-receiver .rcSmoothing-auto-smoothness').show();
@@ -692,7 +692,7 @@ function updateInterpolationView() {
     $('.tab-receiver .rcSmoothing-input-type').show();
     $('.tab-receiver .rcSmoothing-derivative-manual').show();
     $('.tab-receiver .rcSmoothing-input-manual').show();
-    if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
         if (FC.RX_CONFIG.rcSmoothingDerivativeCutoff == 0 || FC.RX_CONFIG.rcSmoothingInputCutoff == 0) {
             $('.tab-receiver .rcSmoothing-auto-smoothness').show();
         }

--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -194,7 +194,7 @@ TABS.sensors.initialize = function (callback) {
             if (!have_sensor(FC.CONFIG.activeSensors, 'mag')) {
                 checkboxes.eq(2).prop('disabled', true);
             }
-            if (!(have_sensor(FC.CONFIG.activeSensors, 'baro') || (semver.gte(FC.CONFIG.apiVersion, "1.40.0") && have_sensor(FC.CONFIG.activeSensors, 'gps')))) {
+            if (!(have_sensor(FC.CONFIG.activeSensors, 'baro') || (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40) && have_sensor(FC.CONFIG.activeSensors, 'gps')))) {
                 checkboxes.eq(3).prop('disabled', true);
             }
             if (!have_sensor(FC.CONFIG.activeSensors, 'sonar')) {
@@ -243,7 +243,7 @@ TABS.sensors.initialize = function (callback) {
         });
 
         let altitudeHint_e = $('.tab-sensors #sensorsAltitudeHint');
-        if (semver.lt(FC.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
             altitudeHint_e.hide();
         }
 

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -61,7 +61,7 @@ TABS.setup.initialize = function (callback) {
 
         $('#arming-disable-flag').attr('title', i18n.getMessage('initialSetupArmingDisableFlagsTooltip'));
 
-        if (semver.gte(FC.CONFIG.apiVersion, "1.40.0")) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
             if (isExpertModeEnabled()) {
                 $('.initialSetupRebootBootloader').show();
             } else {
@@ -194,7 +194,7 @@ TABS.setup.initialize = function (callback) {
             pitch_e = $('dd.pitch'),
             heading_e = $('dd.heading');
 
-        if (semver.lt(FC.CONFIG.apiVersion, "1.36.0")) {
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             arming_disable_flags_e.hide();
         }
 
@@ -220,21 +220,21 @@ TABS.setup.initialize = function (callback) {
                                       'MSP',
                                      ];
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.38.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_38)) {
                 disarmFlagElements.splice(disarmFlagElements.indexOf('THROTTLE'), 0, 'RUNAWAY_TAKEOFF');
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.39.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                 disarmFlagElements = disarmFlagElements.concat(['PARALYZE',
                                                                 'GPS']);
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, "1.41.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                 disarmFlagElements.splice(disarmFlagElements.indexOf('OSD_MENU'), 1);
                 disarmFlagElements = disarmFlagElements.concat(['RESC']);
                 disarmFlagElements = disarmFlagElements.concat(['RPMFILTER']);
             }
-            if (semver.gte(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 disarmFlagElements.splice(disarmFlagElements.indexOf('THROTTLE'), 0, 'CRASH');
                 disarmFlagElements = disarmFlagElements.concat(['REBOOT_REQD',
                                                                 'DSHOT_BBANG']);

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -23,7 +23,7 @@ TABS.vtx.initialize = function (callback) {
 
     self.analyticsChanges = {};
 
-    this.supported = semver.gte(FC.CONFIG.apiVersion, "1.42.0");
+    this.supported = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42);
 
     if (!this.supported) {
         load_html();
@@ -877,7 +877,7 @@ TABS.vtx.initialize = function (callback) {
             FC.VTX_CONFIG.vtx_band = parseInt($("#vtx_band").val());
             FC.VTX_CONFIG.vtx_channel = parseInt($("#vtx_channel").val());
             FC.VTX_CONFIG.vtx_frequency = 0;
-            if (semver.lt(FC.CONFIG.apiVersion, "1.42.0")) {
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 if (FC.VTX_CONFIG.vtx_band > 0 || FC.VTX_CONFIG.vtx_channel > 0) {
                     FC.VTX_CONFIG.vtx_frequency = (band - 1) * 8 + (channel - 1);
                 }


### PR DESCRIPTION
We have started to replace the comparisons of the MSP API version against constants.

This PR replaces all of them because some users were copying the old method. Now we have only one of them.