### PR TITLE
chore: use `i18next` vue package

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
+    "@panter/vue-i18next": "^0.15.2",
     "bluebird": "^3.7.2",
     "djv": "^2.1.3-alpha.0",
     "i18next": "^19.0.0",
@@ -62,8 +63,7 @@
     "short-unique-id": "^1.1.1",
     "three": "~0.97.0",
     "universal-ga": "^1.2.0",
-    "vue": "2.6.12",
-    "vue-i18n": "8.21.1"
+    "vue": "2.6.12"
   },
   "devDependencies": {
     "@quanle94/innosetup": "^6.0.2",
@@ -77,7 +77,6 @@
     "del": "^5.0.0",
     "follow-redirects": "^1.10.0",
     "fs-extra": "^8.1.0",
-    "postcss": "^8.1.1",
     "gulp": "^4.0.2",
     "gulp-concat": "~2.6.1",
     "gulp-debian": "~0.1.8",
@@ -98,6 +97,7 @@
     "mocha": "^7.0.1",
     "nw-builder": "^3.5.7",
     "os": "^0.1.1",
+    "postcss": "^8.1.1",
     "rollup": "^2.28.2",
     "rollup-plugin-vue": "^5.*.*",
     "rpm-builder": "^1.2.1",

--- a/src/components/vueI18n.js
+++ b/src/components/vueI18n.js
@@ -1,18 +1,10 @@
 import Vue from "vue";
-import VueI18n from "vue-i18n";
+import VueI18Next from "@panter/vue-i18next";
 
-Vue.use(VueI18n);
+Vue.use(VueI18Next);
 
-const vueI18n = new VueI18n(i18next);
-
-i18next.on("initialized", () => {
-    vueI18n.setLocaleMessage("en", i18next.getDataByLanguage("en").messages);
-});
-
-i18next.on("languageChanged", (lang) => {
-    vueI18n.setLocaleMessage(lang, i18next.getDataByLanguage(lang).messages);
-    vueI18n.locale = lang;
-    document.querySelector("html").setAttribute("lang", lang);
-});
+// NOTE: this relies on global `i18next` eventually
+// it should be consumed through modules.
+const vueI18n = new VueI18Next(i18next);
 
 export default vueI18n;

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,6 +60,13 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@panter/vue-i18next@^0.15.2":
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/@panter/vue-i18next/-/vue-i18next-0.15.2.tgz#814f6774237e444eb9b69156e9c507d41b7fbd32"
+  integrity sha512-7VX9GyxHJNEJKa2CRzC294Oz5EEbzVDZ1o3O/P8gL/PWBmcFOFsuivRbP/1a9ga2ihv/NBzoCWMCNIEEeCcONQ==
+  dependencies:
+    deepmerge "^2.0.0"
+
 "@quanle94/innosetup@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@quanle94/innosetup/-/innosetup-6.0.2.tgz#b678b67240486302a08e3469151faca2c29f80ab"
@@ -1793,6 +1800,11 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deepmerge@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 deepmerge@^4.2.1, deepmerge@^4.2.2:
   version "4.2.2"
@@ -7402,11 +7414,6 @@ void-elements@^2.0.0, void-elements@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
-
-vue-i18n@8.21.1:
-  version "8.21.1"
-  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.21.1.tgz#afa8e6390a5de3b65bd17533c4269181f86f1d61"
-  integrity sha512-KEakJLI7R6+UCmhJOMZ0K7C+Zf5FcMh7QDkBRaEq39V7d9JgSrTDBf/9HuHU3TaxQYXx4fUi5PTIPdwLXq+iow==
 
 vue-runtime-helpers@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
This PR is to add better localisation compatibility between old codebase and new vue components.