### PR TITLE
Fix landing tab facebook logo

### DIFF
--- a/src/css/tabs/landing.css
+++ b/src/css/tabs/landing.css
@@ -102,7 +102,7 @@
     padding: 0 15px;
 }
 
-.tab-landing .content_mid_bottom .logo {
+.tab-landing .content_mid_bottom .logoFacebook {
     float: left;
     width: 40px;
 }

--- a/src/tabs/landing.html
+++ b/src/tabs/landing.html
@@ -34,7 +34,7 @@
                 </div>
             </div>
             <div class="content_mid_bottom">
-                <div class="logo">
+                <div class="logoFacebook">
                     <img src="./images/flogo_RGB_HEX-1024.svg" alt="Facebook" width="30" />
                 </div>
                 <div class="text4" i18n="defaultFacebookText"></div>


### PR DESCRIPTION
After Vue Betaflight logo implementation, logo class is used also by Facebook logo and broken it. Replaced used class name for this logo to avoid Betaflight logo appears.

![image (3)](https://user-images.githubusercontent.com/43983086/96266049-7ec96080-0fc6-11eb-9bef-eb079f37ca0d.png)
