### PR TITLE
Fix cpuload value status update after disconnect

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -11,6 +11,7 @@ const INITIAL_CONFIG = {
     capability:                       0,
     cycleTime:                        0,
     i2cError:                         0,
+    cpuload:                          0,
     activeSensors:                    0,
     mode:                             0,
     profile:                          0,


### PR DESCRIPTION
After Vue status_bar implementation, cpuload is doesnt sending an init value when port is disconected, this PR fix it.