### PR TITLE
Parse messages file and use i18next vue plugin

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -622,25 +622,32 @@
     },
 
     "statusbar_port_utilization": {
-        "message": "Port utilization:"
+        "message": "Port utilization:",
+        "description": "Port utilization text shown in the status bar"
     },
     "statusbar_usage_download": {
-        "message": "D: $1%"
+        "message": "D:",
+        "description": "References 'Download' in the status bar, port utilization. Keep one character long if possible"
     },
     "statusbar_usage_upload": {
-        "message": "U: $1%"
+        "message": "U:",
+        "description": "References 'Upload' in the status bar, port utilization. Keep one character long if possible"
     },
     "statusbar_packet_error": {
-        "message": "Packet error:"
+        "message": "Packet error:",
+        "description": "Packet error text shown in the status bar"
     },
     "statusbar_i2c_error": {
-        "message": "I2C error:"
+        "message": "I2C error:",
+        "description": "CPU load text shown in the status bar"
     },
     "statusbar_cycle_time": {
-        "message": "Cycle Time:"
+        "message": "Cycle Time:",
+        "description": "Cycle time text shown in the status bar"
     },
     "statusbar_cpu_load": {
-        "message": "CPU Load: $1%"
+        "message": "CPU Load:",
+        "description": "CPU load text shown in the status bar"
     },
 
     "dfu_connect_message": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.13.0",
+    "@panter/vue-i18next": "^0.15.2",
     "bluebird": "^3.7.2",
     "djv": "^2.1.3-alpha.0",
     "i18next": "^19.0.0",
@@ -67,8 +68,7 @@
     "short-unique-id": "^1.1.1",
     "three": "~0.97.0",
     "universal-ga": "^1.2.0",
-    "vue": "2.6.12",
-    "vue-i18n": "8.21.1"
+    "vue": "2.6.12"
   },
   "devDependencies": {
     "@quanle94/innosetup": "^6.0.2",

--- a/src/components/betaflight-logo/BetaflightLogo.vue
+++ b/src/components/betaflight-logo/BetaflightLogo.vue
@@ -72,15 +72,15 @@
   <div class="logo">
     <div class="logo_text">
       <span>
-        {{ $t("versionLabelConfigurator.message") }}: {{ configuratorVersion }}
+        {{ $t("versionLabelConfigurator") }}: {{ configuratorVersion }}
         <br />
         <span v-if="firmwareVersion && firmwareId">
-          {{ $t("versionLabelFirmware.message") }}: {{ firmwareVersion }}
+          {{ $t("versionLabelFirmware") }}: {{ firmwareVersion }}
           {{ firmwareId }}
         </span>
         <br />
         <span v-if="hardwareId">
-          {{ $t("versionLabelTarget.message") }}: {{ hardwareId }}
+          {{ $t("versionLabelTarget") }}: {{ hardwareId }}
         </span>
       </span>
     </div>

--- a/src/components/init.js
+++ b/src/components/init.js
@@ -4,14 +4,6 @@ import BatteryLegend from "./quad-status/BatteryLegend.vue";
 import BetaflightLogo from "./betaflight-logo/BetaflightLogo.vue";
 import StatusBar from "./status-bar/StatusBar.vue";
 
-// a bit of a hack here to get around the current translations.
-// vue i18n provides slightly different api for this. But
-// it's also possible to provide custom formatter
-Vue.filter(
-    "stripEnd",
-    (value) => value.replace(/\$1%/, "")
-);
-
 // Most of the global objects can go here at first.
 // It's a bit of overkill for simple components,
 // but these instance would eventually have more children

--- a/src/components/status-bar/PortUtilization.vue
+++ b/src/components/status-bar/PortUtilization.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <span>{{ $t("statusbar_port_utilization.message") }}</span>
+    <span>{{ $t("statusbar_port_utilization") }}</span>
     <ReadingStat
       message="statusbar_usage_download"
       :value="usageDown"

--- a/src/components/status-bar/ReadingStat.vue
+++ b/src/components/status-bar/ReadingStat.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <span>{{ $t(message + ".message") | stripEnd }}</span>
+    <span>{{ $t(message) }}</span>
     <span>{{ value }}</span>
     <span v-if="unit">{{ unit }}</span>
   </span>

--- a/src/components/status-bar/StatusBarVersion.vue
+++ b/src/components/status-bar/StatusBarVersion.vue
@@ -1,12 +1,12 @@
 <template>
   <div class="version">
-    {{ $t("versionLabelConfigurator.message") }}: {{ configuratorVersion }}
+    {{ $t("versionLabelConfigurator") }}: {{ configuratorVersion }}
     <span v-if="firmwareVersion && firmwareId">
-      , {{ $t("versionLabelFirmware.message") }}: {{ firmwareVersion }}
+      , {{ $t("versionLabelFirmware") }}: {{ firmwareVersion }}
       {{ firmwareId }}
     </span>
     <span v-if="hardwareId">
-      , {{ $t("versionLabelTarget.message") }}: {{ hardwareId }}
+      , {{ $t("versionLabelTarget") }}: {{ hardwareId }}
     </span>
     ({{ gitChangesetId }})
   </div>

--- a/src/components/vueI18n.js
+++ b/src/components/vueI18n.js
@@ -1,18 +1,8 @@
 import Vue from "vue";
-import VueI18n from "vue-i18n";
+import VueI18Next from "@panter/vue-i18next";
 
-Vue.use(VueI18n);
+Vue.use(VueI18Next);
 
-const vueI18n = new VueI18n(i18next);
-
-i18next.on("initialized", () => {
-    vueI18n.setLocaleMessage("en", i18next.getDataByLanguage("en").messages);
-});
-
-i18next.on("languageChanged", (lang) => {
-    vueI18n.setLocaleMessage(lang, i18next.getDataByLanguage(lang).messages);
-    vueI18n.locale = lang;
-    document.querySelector("html").setAttribute("lang", lang);
-});
+const vueI18n = new VueI18Next(i18next);
 
 export default vueI18n;

--- a/yarn.lock
+++ b/yarn.lock
@@ -53,6 +53,13 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
+"@panter/vue-i18next@^0.15.2":
+  version "0.15.2"
+  resolved "https://registry.yarnpkg.com/@panter/vue-i18next/-/vue-i18next-0.15.2.tgz#814f6774237e444eb9b69156e9c507d41b7fbd32"
+  integrity sha512-7VX9GyxHJNEJKa2CRzC294Oz5EEbzVDZ1o3O/P8gL/PWBmcFOFsuivRbP/1a9ga2ihv/NBzoCWMCNIEEeCcONQ==
+  dependencies:
+    deepmerge "^2.0.0"
+
 "@quanle94/innosetup@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@quanle94/innosetup/-/innosetup-6.0.2.tgz#b678b67240486302a08e3469151faca2c29f80ab"
@@ -1786,6 +1793,11 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deepmerge@^2.0.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-2.2.1.tgz#5d3ff22a01c00f645405a2fbc17d0778a1801170"
+  integrity sha512-R9hc1Xa/NOBi9WRVUWg19rl1UB7Tt4kuPd+thNJgFZoxXsTz7ncaPaeIm+40oSGuP33DfMb4sZt1QIGiJzC4EA==
 
 deepmerge@^4.2.1, deepmerge@^4.2.2:
   version "4.2.2"
@@ -7469,11 +7481,6 @@ void-elements@^2.0.0, void-elements@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-2.0.1.tgz#c066afb582bb1cb4128d60ea92392e94d5e9dbec"
   integrity sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=
-
-vue-i18n@8.21.1:
-  version "8.21.1"
-  resolved "https://registry.yarnpkg.com/vue-i18n/-/vue-i18n-8.21.1.tgz#afa8e6390a5de3b65bd17533c4269181f86f1d61"
-  integrity sha512-KEakJLI7R6+UCmhJOMZ0K7C+Zf5FcMh7QDkBRaEq39V7d9JgSrTDBf/9HuHU3TaxQYXx4fUi5PTIPdwLXq+iow==
 
 vue-runtime-helpers@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
I think this fixes https://github.com/betaflight/betaflight-configurator/issues/2193

This has been built on top of https://github.com/betaflight/betaflight-configurator/pull/2229 so thanks to @chmelevskij for the base.

This PR modifies the way we load the translations to simplify and fix some of the problems that appeared with the inclusion of Vue.

This PR:
- Uses the code of @chmelevskij to change the i18n plugin of Vue to use one plugin of i18next. This helps to support some advanced features like nesting out of the box.
- Uses the new backend of i18next to implement a `parse` function, this lets us to change on the fly the contents of the messages file. The changes have been three:
1. Replace the old Chrome interpolation style `$1, $2, ...` for one directly compatible with `i18next`: `{{1}}, {{2}}, ...`.
2. Moves all the keys to the root, removing the `.message` at the end. So we change all the `XXXXXX.message` keys for the `XXXXXX` key. In this way we don't need to add the `.message` to any translation key from the Vue code.
3. Removes the `.message` of all the i18next nesting strings to maintain compatibility with 2.
- Modifies the wrapper `i18n.getMessage()` that we use in all the application to support the upper changes without the need to touch more code.
- Modifies the Vue components to remove the `.message` and remove the ugly hack used to make the old messages compatible with Vue..

I have modified too the three status bar messages to let them compatible with the way Vue that we have now and maintain coherence in all the status bar strings. This makes the translators to translate them again but they are only three little messages. If we don't want to change them we can remove the granularity of the Vue status bar.