### PR TITLE
Replace i18next http backend by filesystem sync backend

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "bluebird": "^3.7.2",
     "djv": "^2.1.3-alpha.0",
     "i18next": "^19.0.0",
-    "i18next-http-backend": "^1.0.21",
+    "i18next-fs-backend": "^1.0.7",
     "inflection": "^1.12.0",
     "jbox": "^1.0.8",
     "jquery": "^3.5.1",

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -20,8 +20,10 @@ const languageFallback = {
 i18n.init = function(cb) {
     getStoredUserLocale(function(userLanguage) {
 
+        const I18NextFsBackend = require('i18next-fs-backend');
+
         i18next
-            .use(i18nextHttpBackend)
+            .use(I18NextFsBackend)
             .init({
                 lng: userLanguage,
                 getAsync: false,
@@ -30,9 +32,10 @@ i18n.init = function(cb) {
                 defaultNS:['messages'],
                 fallbackLng: languageFallback,
                 backend: {
-                    loadPath: '/_locales/{{lng}}/{{ns}}.json',
+                    loadPath: './_locales/{{lng}}/{{ns}}.json',
                     parse: i18n.parseInputFile,
                 },
+                initImmediate: false,
             },
             function(err) {
                 if (err !== undefined) {

--- a/src/main.html
+++ b/src/main.html
@@ -50,7 +50,6 @@
     <!-- CORDOVA_INCLUDE js/cordova_startup.js -->
     <script type="text/javascript" src="./node_modules/lru_map/lru.js"></script>
     <script type="text/javascript" src="./node_modules/i18next/i18next.min.js"></script>
-    <script type="text/javascript" src="./node_modules/i18next-http-backend/i18nextHttpBackend.min.js"></script>
     <script type="text/javascript" src="./node_modules/marked/marked.min.js"></script>
     <script type="text/javascript" src="./node_modules/universal-ga/lib/analytics.min.js"></script>
     <script type="text/javascript" src="./node_modules/short-unique-id/dist/short-unique-id.min.js"></script>

--- a/src/main_cordova.html
+++ b/src/main_cordova.html
@@ -40,7 +40,6 @@
     </div>
     <script type="text/javascript" src="./node_modules/jquery/dist/jquery.min.js"></script>
     <script type="text/javascript" src="./node_modules/i18next/i18next.min.js"></script>
-    <script type="text/javascript" src="./node_modules/i18next-xhr-backend/i18nextXHRBackend.min.js"></script>
     <script type="text/javascript" src="./js/localization.js"></script>
     <script type="text/javascript" src="cordova.js"></script>
     <script type="text/javascript" src="./js/main_cordova.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3354,12 +3354,10 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-i18next-http-backend@^1.0.21:
-  version "1.0.21"
-  resolved "https://registry.yarnpkg.com/i18next-http-backend/-/i18next-http-backend-1.0.21.tgz#cee901b3527dad5165fa91de973b6aa6404c1c37"
-  integrity sha512-UDeHoV2B+31Gr++0KFAVjM5l+SEwePpF6sfDyaDq5ennM9QNJ78PBEMPStwkreEm4h5C8sT7M1JdNQrLcU1Wdg==
-  dependencies:
-    node-fetch "2.6.1"
+i18next-fs-backend@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/i18next-fs-backend/-/i18next-fs-backend-1.0.7.tgz#00ca4587e306f8948740408389dda73461a5d07f"
+  integrity sha512-aAZ3rvshe1Zbl6JSCWrWWqbZS5JpmVNG+84YqLcgdYcm9uAxzw4xWxnA/a3044Nm2PKXE62CT+pIZjk7OEYtTw==
 
 i18next@^19.0.0:
   version "19.5.1"
@@ -4864,11 +4862,6 @@ node-environment-flags@1.0.6:
   dependencies:
     object.getownpropertydescriptors "^2.0.3"
     semver "^5.7.0"
-
-node-fetch@2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
-  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-pre-gyp@^0.12.0:
   version "0.12.0"


### PR DESCRIPTION
This fixes the errors that appear in the console:
![image](https://user-images.githubusercontent.com/2673520/96697513-4b068600-138c-11eb-9068-54658abbed4d.png)

This errors are because our i18next resources loading is totally async, and we use a system of callbacks to load it. But the Vue code is not waiting for this, so it tries to load messages before initialization of the resources.

This is another of the benefits of removing the Chrome support: we can make use of the new node filesystem sync backend, and use the `require` to load it.

This must be merged after https://github.com/betaflight/betaflight-configurator/pull/2237 to fix the problem, and this will need a rebase for sure.