### PR TITLE
Remove underscore from _locales

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -287,7 +287,7 @@ function dist_yarn() {
 
 function dist_locale() {
     return gulp.src('./locales/**/*', { base: 'locales'})
-        .pipe(gulp.dest(`${DIST_DIR}_locales`));
+        .pipe(gulp.dest(`${DIST_DIR}locales`));
 }
 
 function dist_libraries() {
@@ -826,7 +826,6 @@ function cordova_dist() {
     if (platforms.indexOf('android') !== -1) {
         distTasks.push(clean_cordova);
         distTasks.push(cordova_copy_www);
-        distTasks.push(cordova_locales_www);
         distTasks.push(cordova_resources);
         distTasks.push(cordova_include_www);
         distTasks.push(cordova_copy_src);
@@ -872,13 +871,6 @@ function clean_cordova() {
 function cordova_copy_www() {
     return gulp.src(`${DIST_DIR}**`, { base: DIST_DIR })
         .pipe(gulp.dest(`${CORDOVA_DIST_DIR}www/`));
-}
-function cordova_locales_www(cb) {
-    fs.renameSync(`${CORDOVA_DIST_DIR}www/_locales`, `${CORDOVA_DIST_DIR}www/i18n`);
-    gulp.src(`${CORDOVA_DIST_DIR}www/js/localization.js`)
-        .pipe(replace('/_locales', './i18n'))
-        .pipe(gulp.dest(`${CORDOVA_DIST_DIR}www/js`));
-    cb();
 }
 function cordova_resources() {
     return gulp.src('assets/android/**')

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "version": "10.8.0",
   "main": "main.html",
   "chromium-args": "--disable-features=nw2",
-  "default_locale": "en",
   "scripts": {
     "start": "run-script-os",
     "start:default": "NODE_ENV=development NW_PRE_ARGS=--load-extension='./node_modules/nw-vue-devtools-prebuilt/extension' gulp debug",

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -32,7 +32,7 @@ i18n.init = function(cb) {
                 defaultNS:['messages'],
                 fallbackLng: languageFallback,
                 backend: {
-                    loadPath: './_locales/{{lng}}/{{ns}}.json',
+                    loadPath: './locales/{{lng}}/{{ns}}.json',
                     parse: i18n.parseInputFile,
                 },
                 initImmediate: false,


### PR DESCRIPTION
This modifies the `_locales` dist folder to `locales`. We was done with underscore to maintain compatibility with Chrome apps. Now it is not needed, so I removed it to simplify the `gulpfile`.

It produced some kind of errors in `Android` too, so they renamed it to `i18n`. I have removed this change and I hope it will work in Android, but the Android app is broken at this moment so I can't test it.