### PR TITLE
Replace timeout/interval functions by Node ones

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -4,10 +4,25 @@ window.googleAnalytics = analytics;
 window.analytics = null;
 
 $(document).ready(function () {
+
+    useGlobalNodeFunctions();
+
     if (typeof cordovaApp === 'undefined') {
         appReady();
     }
 });
+
+function useGlobalNodeFunctions() {
+    // The global functions of Node continue working on background. This is good to continue flashing,
+    // for example, when the window is minimized
+    if (GUI.isNWJS()) {
+        console.log("Replacing timeout/interval functions with Node versions");
+        window.setTimeout = global.setTimeout;
+        window.clearTimeout = global.clearTimeout;
+        window.setInterval = global.setInterval;
+        window.clearInterval = global.clearInterval;
+    }
+}
 
 function appReady() {
     $.getJSON('version.json', function(data) {


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/2170

This is an ugly hack to replace the standard `setTimeout` and `setInterval` functions by their equivalents in the Node api (where available). 
The biggest difference between both is that the Node one does not pause the execution when the windows is out of the focus, letting us continue flashing for example or any other operation that depends of this kind of timers.