### PR TITLE
Fix tcp boot issue

### DIFF
--- a/src/js/cordova_chromeapi.js
+++ b/src/js/cordova_chromeapi.js
@@ -211,18 +211,6 @@ const chromeapiSerial = {
             chromeCallbackWithError(`SERIAL (adapted from Cordova): ${error}`, callback(info));
         });
     },
-    getControlSignals: function(connectionId, callback) {
-        // Not supported yet
-        console.warn('chrome.serial.getControlSignals not supported yet');
-        chromeCallbackWithSuccess({}, callback);
-    },
-    setControlSignals: function(connectionId, signals, callback) {
-        // Not supported yet
-        console.warn('chrome.serial.setControlSignals not supported yet');
-        chromeCallbackWithSuccess({
-            result: false,
-        }, callback);
-    },
     // update: function() { },
     // getConnections: function() { },
     // flush: function() { },

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -112,7 +112,8 @@ function closeSerial() {
         bufView[3] = 0x74; // t
         bufView[4] = 0x0D; // enter
 
-        chrome.serial.send(connectionId, bufferOut, function () {
+        const sendFn = (serial.connectionType === 'serial' ? chrome.serial.send : chrome.sockets.tcp.send);
+        sendFn(connectionId, bufferOut, function () {
             console.log('Send exit');
         });
 
@@ -139,16 +140,12 @@ function closeSerial() {
 
             bufView[5 + 16] = checksum;
 
-            chrome.serial.send(connectionId, bufferOut, function () {
-                chrome.serial.disconnect(connectionId, function (result) {
-                    console.log(`SERIAL: Connection closed - ${result}`);
-                });
+            sendFn(connectionId, bufferOut, function () {
+                serial.disconnect();
             });
         }, 100);
     } else if (connectionId) {
-        chrome.serial.disconnect(connectionId, function (result) {
-            console.log(`SERIAL: Connection closed - ${result}`);
-        });
+        serial.disconnect();
     }
 }
 

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -137,16 +137,22 @@ PortHandler.detectPort = function(currentPorts) {
     const newPorts = self.array_difference(currentPorts, self.initialPorts);
 
     if (newPorts.length) {
+        // pick last_used_port for manual tcp auto-connect or detect and select new port for serial
         currentPorts = self.updatePortSelect(currentPorts);
         console.log(`PortHandler - Found: ${JSON.stringify(newPorts)}`);
-        // select / highlight new port, if connected -> select connected port
-        if (GUI.connected_to) {
-            self.portPickerElement.val(GUI.connected_to);
-        } else if (newPorts.length === 1) {
-            self.portPickerElement.val(newPorts[0].path);
-        } else if (newPorts.length > 1) {
-            self.selectPort(currentPorts);
-        }
+
+        ConfigStorage.get('last_used_port', function (result) {
+            if (result.last_used_port) {
+                if (result.last_used_port.includes('tcp')) {
+                    self.portPickerElement.val('manual');
+                } else if (newPorts.length === 1) {
+                    self.portPickerElement.val(newPorts[0].path);
+                } else if (newPorts.length > 1) {
+                    self.selectPort(currentPorts);
+                }
+            }
+        });
+
         // auto-connect if enabled
         if (GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {
             // start connect procedure. We need firmware flasher protection over here


### PR DESCRIPTION
Fixes: #2252 

Solves: reboot in manual `tcp` port mode using configurator 10.7.0.

Accomplished:

- [x] fixes configurator hangs on rebooting while in manual selection.
- [x] fixes not able to flash a target while in manual selection.
- [x] return to `port-override` if rebooting when connected manual.
- [x] use `auto-reconnect` to reboot in manual mode using `last_used_port` for `tcp` connection only.
- [x] keep using port detection for `serial` as it has no issues reported (instead of using `last_used_port`).
- [x] [re-]connect to `tcp` without first having a `serial` connection works but `msp` requests times out (communication seems slow)

Inspired by https://developer.chrome.com/apps/app_serial