### PR TITLE
Fix typo in german translation

### DIFF
--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -5087,7 +5087,7 @@
         "description": "Text of one of the fields of the VTX tab"
     },
     "vtxLowPowerDisarmHelp": {
-        "message": "Wenn aktiviert, verwendet der VTX die niedrigste verfügbare Leistung, sobaled disarmed wird (außer wenn ein Failafe aufgetreten ist).",
+        "message": "Wenn aktiviert, verwendet der VTX die niedrigste verfügbare Leistung, sobald disarmed wird (außer wenn ein Failsafe aufgetreten ist).",
         "description": "Help text for the low power disarm field of the VTX tab"
     },
     "vtxLowPowerDisarmOption_0": {


### PR DESCRIPTION
Two typos I noticed while using the german translation