### PR TITLE
THREE.MeshFaceMaterial has been removed. Use an Array instead.

### DIFF
--- a/src/js/model.js
+++ b/src/js/model.js
@@ -90,8 +90,8 @@ Model.prototype.loadJSON = function (model_file, callback) {
     const loader = new THREE.JSONLoader();
 
     loader.load(`./resources/models/${model_file}.json`, function (geometry, materials) {
-        const modelMaterial = new THREE.MeshFaceMaterial(materials);
-        const model = new THREE.Mesh(geometry, modelMaterial);
+
+        const model = new THREE.Mesh(geometry, materials);
 
         model.scale.set(15, 15, 15);
 


### PR DESCRIPTION
Removing MeshFaceMaterial by passing `materials` directly seems to solve it.

https://stackoverflow.com/questions/51552786/how-to-use-an-array-in-three-js-instead-of-meshfacematerial

The other one is harder to find:

`THREE.Loader.createMaterial: colorAmbient is no longer supported.`