### PR TITLE
Added Virtual Mode (Virtual Fc Part 1 & 2)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -52,6 +52,13 @@
     "portsSelectManual": {
         "message": "Manual Selection"
     },
+    "portsSelectVirtual": {
+        "message": "Virtual Mode (Experimental)",
+        "description": "Configure a Virtual Flight Controller without the need of a physical FC."
+    },
+    "virtualMSPVersion": {
+        "message": "Virtual Firmware Version"
+    },
     "portOverrideText": {
         "message": "Port:"
     },    

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -224,6 +224,13 @@ input[type="number"]::-webkit-inner-spin-button {
     color: var(--subtleAccent);
 }
 
+#firmware-virtual-option {
+    height: 76px;
+    width: 180px;
+    margin-right: 15px;
+    display: none;
+}
+
 #port-override-option {
     height: 76px;
     margin-top: 7px;

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -1,0 +1,212 @@
+'use strict';
+
+const VirtualFC = {
+    // these values are manufactured to unlock all the functionality of the configurator, they dont represent actual hardware
+    setVirtualConfig() {
+        const virtualFC = FC;
+
+        virtualFC.resetState();
+
+        virtualFC.CONFIG.flightControllerVersion = "4.2.4";
+        virtualFC.CONFIG.apiVersion = CONFIGURATOR.virtualApiVersion;
+
+        virtualFC.FEATURE_CONFIG.features = new Features(FC.CONFIG);
+        virtualFC.FEATURE_CONFIG.features.setMask(0);
+
+        virtualFC.BEEPER_CONFIG.beepers = new Beepers(FC.CONFIG);
+        virtualFC.BEEPER_CONFIG.dshotBeaconConditions = new Beepers(FC.CONFIG, [ "RX_LOST", "RX_SET" ]);
+
+        virtualFC.MIXER_CONFIG.mixer = 3;
+
+        virtualFC.MOTOR_DATA = Array.from({length: 8});
+        virtualFC.MOTOR_3D_CONFIG = true;
+        virtualFC.MOTOR_CONFIG = {
+            minthrottle: 1070,
+            maxthrottle: 2000,
+            mincommand: 1000,
+            motor_count: 4,
+            motor_poles: 14,
+            use_dshot_telemetry: true,
+            use_esc_sensor: false,
+        };
+
+        virtualFC.SERVO_CONFIG = Array.from({length: 8});
+
+        for (let i = 0; i < virtualFC.SERVO_CONFIG.length; i++) {
+            virtualFC.SERVO_CONFIG[i] = {
+                middle: 1500,
+                min: 1000,
+                max: 2000,
+                indexOfChannelToForward: 255,
+                rate: 100,
+                reversedInputSources: 0,
+            };
+        }
+
+        virtualFC.ADJUSTMENT_RANGES = Array.from({length: 16});
+
+        for (let i = 0; i < virtualFC.ADJUSTMENT_RANGES.length; i++) {
+            virtualFC.ADJUSTMENT_RANGES[i] = {
+                slotIndex: 0,
+                auxChannelIndex: 0,
+                range: {
+                    start: 900,
+                    end: 900,
+                },
+                adjustmentFunction: 0,
+                auxSwitchChannelIndex: 0,
+            };
+        }
+
+        virtualFC.SERIAL_CONFIG.ports = Array.from({length: 6});
+
+        virtualFC.SERIAL_CONFIG.ports[0] = {
+            identifier: 20,
+            auxChannelIndex: 0,
+            functions: ["MSP"],
+            msp_baudrate: 115200,
+            gps_baudrate: 57600,
+            telemetry_baudrate: "AUTO",
+            blackbox_baudrate: 115200,
+        };
+
+        for (let i = 1; i < virtualFC.SERIAL_CONFIG.ports.length; i++) {
+            virtualFC.SERIAL_CONFIG.ports[i] = {
+                identifier: i-1,
+                auxChannelIndex: 0,
+                functions: [],
+                msp_baudrate: 115200,
+                gps_baudrate: 57600,
+                telemetry_baudrate: "AUTO",
+                blackbox_baudrate: 115200,
+            };
+        }
+
+        virtualFC.LED_STRIP = Array.from({length: 256});
+
+        for (let i = 0; i < virtualFC.LED_STRIP.length; i++) {
+            virtualFC.LED_STRIP[i] = {
+                x: 0,
+                y: 0,
+                functions: ["c"],
+                color: 0,
+                directions: [],
+                parameters: 0,
+            };
+        }
+
+        virtualFC.ANALOG = {
+            voltage: 12,
+            mAhdrawn: 1200,
+            rssi: 100,
+            amperage: 3,
+        };
+
+        virtualFC.CONFIG.sampleRateHz  = 12000;
+        virtualFC.PID_ADVANCED_CONFIG.pid_process_denom = 2;
+
+        virtualFC.BLACKBOX.supported = true;
+
+        virtualFC.VTX_CONFIG.vtx_type = 1;
+
+        virtualFC.BATTERY_CONFIG = {
+            vbatmincellvoltage: 1,
+            vbatmaxcellvoltage: 4,
+            vbatwarningcellvoltage: 3,
+            capacity: 10000,
+            voltageMeterSource: 1,
+            currentMeterSource: 1,
+        };
+
+        virtualFC.BATTERY_STATE = {
+            cellCount: 10,
+            voltage: 20,
+            mAhDrawn: 1000,
+            amperage: 3,
+        };
+
+        virtualFC.DATAFLASH = {
+            ready: true,
+            supported: true,
+            sectors: 1024,
+            totalSize: 40000,
+            usedSize: 10000,
+        };
+
+        virtualFC.SDCARD = {
+            supported: true,
+            state: 1,
+            freeSizeKB: 1024,
+            totalSizeKB: 2048,
+        };
+
+        virtualFC.SENSOR_CONFIG = {
+            acc_hardware: 1,
+            baro_hardware: 1,
+            mag_hardware: 1,
+        };
+
+        virtualFC.RC = {
+            channels: Array.from({length: 16}),
+            active_channels: 16,
+        };
+        for (let i = 0; i < virtualFC.RC.channels.length; i++) {
+            virtualFC.RC.channels[i] = 1500;
+        }
+
+        // from https://github.com/betaflight/betaflight/blob/master/docs/Modes.md
+        virtualFC.AUX_CONFIG = ["ARM","ANGLE","HORIZON","ANTI GRAVITY","MAG","HEADFREE","HEADADJ","CAMSTAB","PASSTHRU","BEEPERON","LEDLOW","CALIB",
+        "OSD","TELEMETRY","SERVO1","SERVO2","SERVO3","BLACKBOX","FAILSAFE","AIRMODE","3D","FPV ANGLE MIX","BLACKBOX ERASE","CAMERA CONTROL 1",
+        "CAMERA CONTROL 2","CAMERA CONTROL 3","FLIP OVER AFTER CRASH","BOXPREARM","BEEP GPS SATELLITE COUNT","VTX PIT MODE","USER1","USER2",
+        "USER3","USER4","PID AUDIO","PARALYZE","GPS RESCUE","ACRO TRAINER","DISABLE VTX CONTROL","LAUNCH CONTROL"];
+        FC.AUX_CONFIG_IDS = [0,1,2,4,5,6,7,8,12,13,15,17,19,20,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,39,40,41,42,43,44,45,46,47,48,49];
+
+        for (let i = 0; i < 16; i++) {
+            virtualFC.RXFAIL_CONFIG[i] = {
+                mode: 1,
+                value: 1500,
+            };
+        }
+
+        // 11 1111 (pass bitchecks)
+        virtualFC.CONFIG.activeSensors = 63;
+    },
+    setupVirtualOSD(){
+        const virtualOSD = OSD;
+
+        virtualOSD.data.video_system = 1;
+        virtualOSD.data.unit_mode = 1;
+
+        virtualOSD.virtualMode = {
+            itemPositions: Array.from({length: 60}),
+            statisticsState: [],
+            warningFlags: 0,
+            timerData: [],
+        };
+
+        virtualOSD.data.state = {
+            haveMax7456Configured: true,
+            haveOsdFeature: true,
+            haveMax7456FontDeviceConfigured: true,
+            isMax7456FontDeviceDetected: true,
+            haveSomeOsd: true,
+        };
+
+        virtualOSD.data.parameters = {
+            cameraFrameWidth: 30,
+            cameraFrameHeight: 30,
+        };
+
+        virtualOSD.data.osd_profiles = {
+            number: 3,
+            selected: 0,
+        };
+
+        virtualOSD.data.alarms = {
+            rssi: { display_name: i18n.getMessage('osdTimerAlarmOptionRssi'), value: 0 },
+            cap: { display_name: i18n.getMessage('osdTimerAlarmOptionCapacity'), value: 0 },
+            alt: { display_name: i18n.getMessage('osdTimerAlarmOptionAltitude'), value: 0 },
+            time: { display_name: 'Minutes', value: 0 },
+        };
+    },
+};

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -928,6 +928,14 @@ function configuration_restore(callback) {
             }
         }
 
+        if (CONFIGURATOR.virtualMode) {
+            FC.resetState();
+            FC.CONFIG.apiVersion = CONFIGURATOR.virtualApiVersion;
+
+            sensor_status(FC.CONFIG.activeSensors);
+            update_dataflash_global();
+        }
+
         upload();
     }
 }

--- a/src/js/data_storage.js
+++ b/src/js/data_storage.js
@@ -25,6 +25,8 @@ var CONFIGURATOR = {
 
     connectionValid: false,
     connectionValidCliOnly: false,
+    virtualMode: false,
+    virtualApiVersion: '0.0.1',
     cliActive: false,
     cliValid: false,
     gitChangesetId: 'unknown',

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -98,7 +98,7 @@ function closeSerial() {
     // automatically close the port when application closes
     const connectionId = serial.connectionId;
 
-    if (connectionId && CONFIGURATOR.connectionValid) {
+    if (connectionId && CONFIGURATOR.connectionValid && !CONFIGURATOR.virtualMode) {
         // code below is handmade MSP message (without pretty JS wrapper), it behaves exactly like MSP.send_message
         // sending exit command just in case the cli tab was open.
         // reset motors to default (mincommand)

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -56,6 +56,10 @@ const MSP = {
     JUMBO_FRAME_SIZE_LIMIT:     255,
 
     read: function (readInfo) {
+        if (CONFIGURATOR.virtualMode) {
+            return;
+        }
+
         const data = new Uint8Array(readInfo.data);
 
         for (const chunk of data) {
@@ -310,6 +314,13 @@ const MSP = {
         return bufferOut;
     },
     send_message: function (code, data, callback_sent, callback_msp, doCallbackOnError) {
+        if (CONFIGURATOR.virtualMode) {
+            if (callback_msp) {
+                callback_msp();
+            }
+            return;
+        }
+
         if (code === undefined) {
             return;
         }

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -17,6 +17,9 @@ const PortHandler = new function () {
 PortHandler.initialize = function () {
     this.portPickerElement = $('div#port-picker #port');
 
+    // fill dropdown with version numbers
+    generateVirtualApiVersions();
+
     // start listening, check after TIMEOUT_CHECK ms
     this.check();
 };
@@ -70,6 +73,12 @@ PortHandler.check_usb_devices = function (callback) {
                     value: "DFU",
                     text: usbText,
                     data: {isDFU: true},
+                }));
+
+                self.portPickerElement.append($('<option/>', {
+                    value: 'virtual',
+                    text: i18n.getMessage('portsSelectVirtual'),
+                    data: {isVirtual: true},
                 }));
 
                 self.portPickerElement.append($('<option/>', {
@@ -212,6 +221,12 @@ PortHandler.updatePortSelect = function (ports) {
             data: {isManual: false},
         }));
     }
+
+    this.portPickerElement.append($("<option/>", {
+        value: 'virtual',
+        text: i18n.getMessage('portsSelectVirtual'),
+        data: {isVirtual: true},
+    }));
 
     this.portPickerElement.append($("<option/>", {
         value: 'manual',

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -102,6 +102,8 @@ TABS.gps.initialize = function (callback) {
             }
         }
 
+        let frame = document.getElementById('map');
+
         // enable data pulling
         GUI.interval_add('gps_pull', function gps_update() {
             // avoid usage of the GPS commands until a GPS sensor is detected for targets that are compiled without GPS support.
@@ -136,8 +138,6 @@ TABS.gps.initialize = function (callback) {
                 set_offline();
             }
         });
-
-        let frame = document.getElementById('map');
 
         $('#zoom_in').click(function() {
             console.log('zoom in');

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -29,11 +29,18 @@ TABS.setup.initialize = function (callback) {
         // translate to user-selected language
         i18n.localizePage();
 
+        const backupButton = $('#content .backup');
+
         if (semver.lt(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE)) {
-            $('#content .backup').addClass('disabled');
+            backupButton.addClass('disabled');
             $('#content .restore').addClass('disabled');
 
             GUI.log(i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE]));
+        }
+
+        // saving and uploading an imaginary config to hardware is a bad idea
+        if (CONFIGURATOR.virtualMode) {
+            backupButton.addClass('disabled');
         }
 
         // initialize 3D Model
@@ -157,7 +164,7 @@ TABS.setup.initialize = function (callback) {
             console.log(`YAW reset to 0 deg, fix: ${self.yaw_fix} deg`);
         });
 
-        $('#content .backup').click(function () {
+        backupButton.click(function () {
             if ($(this).hasClass('disabled')) {
                 return;
             }

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -42,3 +42,34 @@ function bytesToSize(bytes) {
     }
     return false;
 }
+
+const majorFirmwareVersions = {
+    '1.43': '4.2.*',
+    '1.42': '4.1.*',
+    '1.41': '4.0.*',
+    '1.40': '3.5.*',
+    '1.39': '3.4.*',
+    '1.37': '3.3.0',
+    '1.36': '3.2.*',
+    '1.31': '3.1.0',
+};
+
+function generateVirtualApiVersions() {
+    const firmwareVersionDropdown = document.getElementById('firmware-version-dropdown');
+    const max = semver.minor(CONFIGURATOR.API_VERSION_MAX_SUPPORTED);
+
+    for (let i = max; i > 0; i--) {
+        const option = document.createElement("option");
+        const verNum = `1.${i}`;
+        option.value = `${verNum}.0`;
+        option.text = `MSP: ${verNum} `;
+
+        if (majorFirmwareVersions.hasOwnProperty(verNum)) {
+            option.text += ` | Firmware: ${majorFirmwareVersions[verNum]}`;
+        } else if (i === max) {
+            option.text += ` | Latest Firmware`;
+        }
+
+        firmwareVersionDropdown.appendChild(option);
+    }
+}

--- a/src/main.html
+++ b/src/main.html
@@ -76,6 +76,7 @@
     <script type="text/javascript" src="./js/ConfigStorage.js"></script>
     <script type="text/javascript" src="./js/data_storage.js"></script>
     <script type="text/javascript" src="./js/fc.js"></script>
+    <script type="text/javascript" src="./js/VirtualFC.js"></script>
     <script type="text/javascript" src="./js/port_handler.js"></script>
     <script type="text/javascript" src="./js/port_usage.js"></script>
     <script type="text/javascript" src="./js/serial.js"></script>
@@ -164,6 +165,11 @@
                     <span i18n="portOverrideText">Port:</span>
                     <input id="port-override" type="text" value="/dev/rfcomm0"/>
                 </label>
+            </div>
+            <div id="firmware-virtual-option">
+                <div class="dropdown dropdown-dark">
+                    <select id="firmware-version-dropdown" class="dropdown-select" i18n_title="virtualMSPVersion"></select>
+                </div>
             </div>
             <div id="portsinput">
                 <div class="dropdown dropdown-dark">


### PR DESCRIPTION
Fixes #2148, Fixes #2149. And I believe also helps with this #2259.
- You can now connect in virtual mode and select a firmware API version. This loads a default virtual config that unlocks almost all of the features, the only missing feature is the race transponder because I didn't have the hardware and couldn't find enough information about how it works.
- I modified the OSD so it doesn't require communication with hardware in virtual mode to update the screen.
- The restore feature works, and with this, you can potentially debug other people's configurations.
- I disabled the backup feature because saving and uploading imaginary configurations on hardware is a bad idea.
- I disabled the MSP in virtual mode but I still call the callbacks because otherwise, I would have to rewrite all the MSP requests that use callbacks and that would only make a mess.
- I did as much testing as I could but I believe there may still be some bugs so I labeled this feature as experimental.
- #2284 is needed for this.