### PR TITLE
Moved getSerialRxTypes to not interfere with backup/restore

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -543,58 +543,6 @@ const FC = {
             rcSmoothingDerivativeType:    0,
             rcSmoothingAutoSmoothness:    0,
             usbCdcHidType:                0,
-            serialRxTypes: [
-                'SPEKTRUM1024',
-                'SPEKTRUM2048',
-                'SBUS',
-                'SUMD',
-                'SUMH',
-                'XBUS_MODE_B',
-                'XBUS_MODE_B_RJ01',
-            ],
-
-            getSerialRxTypes: () => {
-                const apiVersion = this.CONFIG.apiVersion;
-                const flightControllerIdentifier = this.CONFIG.flightControllerIdentifier;
-                const flightControllerVersion = this.CONFIG.flightControllerVersion;
-                // js way of cloning an array
-                const result = [...this.RX_CONFIG.serialRxTypes];
-
-                if (semver.gte(apiVersion, "1.15.0")) {
-                    result.push('IBUS');
-                }
-
-                if ((flightControllerIdentifier === 'BTFL' && semver.gte(flightControllerVersion, "2.6.0")) ||
-                    (flightControllerIdentifier === 'CLFL' && semver.gte(apiVersion, API_VERSION_1_31))) {
-                    result.push('JETIEXBUS');
-                }
-
-                if (semver.gte(apiVersion, API_VERSION_1_31)) {
-                    result.push('CRSF');
-                }
-
-                if (semver.gte(apiVersion, "1.24.0")) {
-                    result.push('SPEKTRUM2048/SRXL');
-                }
-
-                if (semver.gte(apiVersion, API_VERSION_1_35)) {
-                    result.push('TARGET_CUSTOM');
-                }
-
-                if (semver.gte(apiVersion, API_VERSION_1_37)) {
-                    result.push('FrSky FPort');
-                }
-
-                if (semver.gte(apiVersion, API_VERSION_1_42)) {
-                    result.push('SPEKTRUM SRXL2');
-                }
-
-                if (semver.gte(apiVersion, API_VERSION_1_44)) {
-                    result.push('IRC GHOST');
-                }
-
-                return result;
-            },
         };
 
         this.FAILSAFE_CONFIG = {
@@ -694,6 +642,58 @@ const FC = {
             46, 90, 38, 22, 95,
             30, 90,  0,  0, 90,
         ];
+    },
+
+    getSerialRxTypes: () => {
+        const apiVersion = FC.CONFIG.apiVersion;
+        const flightControllerIdentifier = FC.CONFIG.flightControllerIdentifier;
+        const flightControllerVersion = FC.CONFIG.flightControllerVersion;
+
+        // defaults
+        const serialRxTypes = [
+            'SPEKTRUM1024',
+            'SPEKTRUM2048',
+            'SBUS',
+            'SUMD',
+            'SUMH',
+            'XBUS_MODE_B',
+            'XBUS_MODE_B_RJ01',
+        ];
+
+        if (semver.gte(apiVersion, "1.15.0")) {
+            serialRxTypes.push('IBUS');
+        }
+
+        if ((flightControllerIdentifier === 'BTFL' && semver.gte(flightControllerVersion, "2.6.0")) ||
+            (flightControllerIdentifier === 'CLFL' && semver.gte(apiVersion, API_VERSION_1_31))) {
+                serialRxTypes.push('JETIEXBUS');
+        }
+
+        if (semver.gte(apiVersion, API_VERSION_1_31)) {
+            serialRxTypes.push('CRSF');
+        }
+
+        if (semver.gte(apiVersion, "1.24.0")) {
+            serialRxTypes.push('SPEKTRUM2048/SRXL');
+        }
+
+        if (semver.gte(apiVersion, API_VERSION_1_35)) {
+            serialRxTypes.push('TARGET_CUSTOM');
+        }
+
+        if (semver.gte(apiVersion, API_VERSION_1_37)) {
+            serialRxTypes.push('FrSky FPort');
+        }
+
+        if (semver.gte(apiVersion, API_VERSION_1_42)) {
+            serialRxTypes.push('SPEKTRUM SRXL2');
+        }
+
+        if (semver.gte(apiVersion, API_VERSION_1_44)) {
+            serialRxTypes.push('IRC GHOST');
+        }
+
+        return serialRxTypes;
     },
 
     getHardwareName() {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -844,7 +844,7 @@ TABS.configuration.initialize = function (callback, scrollPosition) {
         }
 
         const serialRXSelectEl = $('select.serialRX');
-        FC.RX_CONFIG.getSerialRxTypes().forEach((serialRxType, index) => {
+        FC.getSerialRxTypes().forEach((serialRxType, index) => {
             serialRXSelectEl.append(`<option value="${index}">${serialRxType}</option>`);
         });
 

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -345,7 +345,7 @@ OSD.generateTemperaturePreview = function(osdData, temperature) {
 };
 
 OSD.generateLQPreview = function() {
-    const crsfIndex = FC.RX_CONFIG.getSerialRxTypes().findIndex(name => name === 'CRSF');
+    const crsfIndex = FC.getSerialRxTypes().findIndex(name => name === 'CRSF');
     const isXF = crsfIndex === FC.RX_CONFIG.serialrx_provider;
     return FONT.symbol(SYM.LINK_QUALITY) + (isXF ? '2:100' : '8');
 };


### PR DESCRIPTION
This is needed for #2283.
This makes getSerialRxTypes() independent of FC.resetState() so it doesnt interfere with backup/restore operations.
When you restore getSerialRxTypes() used to be missing.