### PR TITLE
Remove unused mspHelper

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -4,9 +4,6 @@ var mspHelper;
 var connectionTimestamp;
 
 function initializeSerialBackend() {
-    mspHelper = new MspHelper();
-    mspHelper.process_data.bind(mspHelper);
-
     GUI.updateManualPortVisibility = function(){
         var selected_port = $('div#port-picker #port option:selected');
         if (selected_port.data().isManual) {


### PR DESCRIPTION
Removed unused definition and declaration. `onOpen` already defines and binds `msphelper`.