### PR TITLE
Make tab_container scrollable when it is needed

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -921,6 +921,7 @@ input[type="number"]::-webkit-inner-spin-button {
     width: 200px;
     border-right: 4px solid var(--accent);
     background-color: #2e2e2e;
+    overflow: auto;
 }
 
 #tabs {


### PR DESCRIPTION
Some tabs are not visible if container overflows the screen, fixed it.