### PR TITLE
Allows the user to always open the last tab that was used *before* the CLI tab.

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -373,13 +373,11 @@ GuiControl.prototype.content_ready = function (callback) {
 
 GuiControl.prototype.selectDefaultTabWhenConnected = function() {
     ConfigStorage.get(['rememberLastTab', 'lastTab'], function (result) {
-        if (!(result.rememberLastTab
-                && !!result.lastTab
-                && result.lastTab.substring(4) !== "cli")) {
+        if (result.rememberLastTab && result.lastTab) {
+            $(`#tabs ul.mode-connected .${result.lastTab} a`).click();
+        } else {
             $('#tabs ul.mode-connected .tab_setup a').click();
-            return;
         }
-        $(`#tabs ul.mode-connected .${result.lastTab} a`).click();
     });
 };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -219,9 +219,15 @@ function startProcess() {
     // Tabs
     $("#tabs ul.mode-connected li").click(function() {
         // store the first class of the current tab (omit things like ".active")
-        ConfigStorage.set(
-            {lastTab: $(this).attr("class").split(' ')[0]}
-        );
+        const tabName = $(this).attr("class").split(' ')[0];
+
+        const tabNameWithoutPrefix = tabName.substring(4);
+        if (tabNameWithoutPrefix !== "cli") {
+            // Don't store 'cli' otherwise you can never connect to another tab.
+            ConfigStorage.set(
+                {lastTab: tabName},
+            );
+        }
     });
 
     if (GUI.isCordova()) {


### PR DESCRIPTION
This simply avoids storing 'tab_cli' as the last tab in the first place.

Previously:

* enable 'remember last tab'
* click <some tab that's not setup or cli>
* use tab.
* click 'cli' tab
* `exit`
* reconnect
* observe you're looking at the 'setup' tab.
* expected behaviour is to see the <some tab that's not setup or cli> again.
* click <some tab that's not setup or cli> to get back to where you were before you used the cli.

With this PR:

* enable 'remember last tab'
* click <some tab that's not setup or cli>
* use tab.
* click 'cli' tab
* `exit`
* reconnect
* observe you're looking at the <some tab that's not setup or cli> again.
