### PR TITLE
Disable Exit Dfu Mode and Load Firmware buttons while flashing

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1021,7 +1021,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         });
 
         portPickerElement.change(function () {
-            if ($('option:selected', this).data().isDFU) {
+            if ($('option:selected', this).data().isDFU && !GUI.connect_lock) {
                 exitDfuElement.removeClass('disabled');
             } else {
                 exitDfuElement.addClass('disabled');
@@ -1096,6 +1096,8 @@ TABS.firmware_flasher.initialize = function (callback) {
 
         function startFlashing() {
             exitDfuElement.addClass('disabled');
+            $("a.load_remote_file").addClass('disabled');
+            $("a.load_file").addClass('disabled');
             if (!GUI.connect_lock) { // button disabled while flashing is in progress
                 if (self.parsed_hex) {
                     try {


### PR DESCRIPTION
@Asizon pointed out using

1. bl command in cli or Active Boot Loader / DFU button on setup tab disables Exit Dfu Mode button after pressing Flash Button.
2. firmware_flasher tab directly the button stays enabled after pressing Flash button.

This PR fixes point 2 to behave like point 1

Added disabling the Load Firmware (Local / Online) buttons also while flashing