### PR TITLE
Fix Load Firmware buttons reactivation after flash

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1021,12 +1021,14 @@ TABS.firmware_flasher.initialize = function (callback) {
         });
 
         portPickerElement.change(function () {
-            if ($('option:selected', this).data().isDFU && !GUI.connect_lock) {
-                exitDfuElement.removeClass('disabled');
-            } else if (!GUI.connect_lock) {
-                $("a.load_remote_file").removeClass('disabled');
-                $("a.load_file").removeClass('disabled');
-                exitDfuElement.addClass('disabled');
+            if (!GUI.connect_lock) {
+				if ($('option:selected', this).data().isDFU) {
+                    exitDfuElement.removeClass('disabled');
+                } else {
+                    $("a.load_remote_file").removeClass('disabled');
+                    $("a.load_file").removeClass('disabled');
+                    exitDfuElement.addClass('disabled');
+                }                   
             }
         }).change();
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1022,13 +1022,13 @@ TABS.firmware_flasher.initialize = function (callback) {
 
         portPickerElement.change(function () {
             if (!GUI.connect_lock) {
-				if ($('option:selected', this).data().isDFU) {
+                if ($('option:selected', this).data().isDFU) {
                     exitDfuElement.removeClass('disabled');
                 } else {
                     $("a.load_remote_file").removeClass('disabled');
                     $("a.load_file").removeClass('disabled');
                     exitDfuElement.addClass('disabled');
-                }                   
+                }
             }
         }).change();
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1023,7 +1023,9 @@ TABS.firmware_flasher.initialize = function (callback) {
         portPickerElement.change(function () {
             if ($('option:selected', this).data().isDFU && !GUI.connect_lock) {
                 exitDfuElement.removeClass('disabled');
-            } else {
+            } else if (!GUI.connect_lock) {
+                $("a.load_remote_file").removeClass('disabled');
+                $("a.load_file").removeClass('disabled');
                 exitDfuElement.addClass('disabled');
             }
         }).change();


### PR DESCRIPTION
Since we are disabling these `Load Firmware` buttons during flash, this PR reenable these buttons when flash finished using same dfuElement portPickerElement function.