### PR TITLE
Add flex to Android logo_text

### DIFF
--- a/src/components/betaflight-logo/BetaflightLogo.vue
+++ b/src/components/betaflight-logo/BetaflightLogo.vue
@@ -52,7 +52,7 @@
     border-bottom: 1px solid rgba(0, 0, 0, 0.3);
   }
   .tab_container .logo .logo_text {
-    display: block !important;
+    display: flex !important;
     left: 82px;
     top: 62px;
   }


### PR DESCRIPTION
To go with https://github.com/betaflight/betaflight-configurator/pull/2335
I forgot to change display mode for Android devices, changed it to flex.