### PR TITLE
Fixed non working quad-status-wrapper

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -682,12 +682,12 @@ function update_live_status() {
                 $(".armedicon").removeClass('active');
             }
         }
-    }
-    if (FC.AUX_CONFIG[index] === 'FAILSAFE') {
-        if (bit_check(FC.CONFIG.mode, i)) {
-            $(".failsafeicon").addClass('active');
-        } else {
-            $(".failsafeicon").removeClass('active');
+        if (FC.AUX_CONFIG[i] === 'FAILSAFE') {
+            if (bit_check(FC.CONFIG.mode, i)) {
+                $(".failsafeicon").addClass('active');
+            } else {
+                $(".failsafeicon").removeClass('active');
+            }
         }
     }
 


### PR DESCRIPTION
Reported issue by @haslinghuis . The bucle was broken in the middle so it doesnt work anymore, fixed now.

![image](https://user-images.githubusercontent.com/43983086/102636813-67892980-4155-11eb-852e-6e24c36d7b5c.png)
