### PR TITLE
Fix and consolidate check for chrome.runtime.lastError

### DIFF
--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -233,8 +233,7 @@ LogoManager.openImage = function () {
             accepts: this.acceptFileTypes,
         };
         chrome.fileSystem.chooseEntry(dialogOptions, fileEntry => {
-            if (chrome.runtime.lastError) {
-                console.error(chrome.runtime.lastError.message);
+            if (checkChromeRuntimeError()) {
                 return;
             }
             // load and validate selected image

--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -216,8 +216,7 @@ function configuration_backup(callback) {
 
         // create or load the file
         chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: filename, accepts: accepts}, function (fileEntry) {
-            if (chrome.runtime.lastError) {
-                console.error(chrome.runtime.lastError.message);
+            if (checkChromeRuntimeError()) {
                 return;
             }
 
@@ -288,8 +287,7 @@ function configuration_restore(callback) {
 
     // load up the file
     chrome.fileSystem.chooseEntry({type: 'openFile', accepts: accepts}, function (fileEntry) {
-        if (chrome.runtime.lastError) {
-            console.error(chrome.runtime.lastError.message);
+        if (checkChromeRuntimeError()) {
             return;
         }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -592,37 +592,6 @@ function notifyOutdatedVersion(releaseData) {
     });
 }
 
-function microtime() {
-    return new Date().getTime() / 1000;
-}
-
-function millitime() {
-    return new Date().getTime();
-}
-
-const DEGREE_TO_RADIAN_RATIO = Math.PI / 180;
-
-function degToRad(degrees) {
-    return degrees * DEGREE_TO_RADIAN_RATIO;
-}
-
-function bytesToSize(bytes) {
-
-    let outputBytes;
-
-    if (bytes < 1024) {
-        outputBytes = `${bytes} Bytes`;
-    } else if (bytes < 1048576) {
-        outputBytes = `${(bytes / 1024).toFixed(3)} KB`;
-    } else if (bytes < 1073741824) {
-        outputBytes = `${(bytes / 1048576).toFixed(3)} MB`;
-    } else {
-        outputBytes = `${(bytes / 1073741824).toFixed(3)} GB`;
-    }
-
-    return outputBytes;
-}
-
 function isExpertModeEnabled() {
     return $('input[name="expertModeCheckbox"]').is(':checked');
 }

--- a/src/js/protocols/stm32usbdfu.js
+++ b/src/js/protocols/stm32usbdfu.js
@@ -102,24 +102,11 @@ STM32DFU_protocol.prototype.connect = function (device, hex, options, callback) 
     });
 };
 
-STM32DFU_protocol.prototype.checkChromeError = function() {
-    if (chrome.runtime.lastError) {
-        if(chrome.runtime.lastError.message)
-            console.log('reporting chrome error: ' + chrome.runtime.lastError.message);
-        else
-            console.log('reporting chrome error: ' + chrome.runtime.lastError);
-
-        return true;
-    }
-
-    return false;
-}
-
 STM32DFU_protocol.prototype.openDevice = function (device) {
     var self = this;
 
     chrome.usb.openDevice(device, function (handle) {
-        if(self.checkChromeError()) {
+        if (checkChromeRuntimeError()) {
             console.log('Failed to open USB device!');
             GUI.log(i18n.getMessage('usbDeviceOpenFail'));
             if(GUI.operating_system === 'Linux') {
@@ -140,7 +127,7 @@ STM32DFU_protocol.prototype.closeDevice = function () {
     var self = this;
 
     chrome.usb.closeDevice(this.handle, function closed() {
-        if(self.checkChromeError()) {
+        if (checkChromeRuntimeError()) {
             console.log('Failed to close USB device!');
             GUI.log(i18n.getMessage('usbDeviceCloseFail'));
         }
@@ -159,7 +146,7 @@ STM32DFU_protocol.prototype.claimInterface = function (interfaceNumber) {
         // Don't perform the error check on MacOS at this time as there seems to be a bug
         // where it always reports the Chrome error "Error claiming interface." even though
         // the interface is in fact successfully claimed.
-        if (self.checkChromeError() && (GUI.operating_system !== "MacOS")) {
+        if (checkChromeRuntimeError() && (GUI.operating_system !== "MacOS")) {
             console.log('Failed to claim USB device!');
             self.cleanup();
         }
@@ -204,7 +191,7 @@ STM32DFU_protocol.prototype.getString = function (index, callback) {
         'index':        0,  // specifies language
         'length':       255 // max length to retreive
     }, function (result) {
-        if(self.checkChromeError()) {
+        if (checkChromeRuntimeError()) {
             console.log('USB getString failed! ' + result.resultCode);
             callback("", result.resultCode);
             return;
@@ -224,7 +211,7 @@ STM32DFU_protocol.prototype.getInterfaceDescriptors = function (interfaceNum, ca
     var self = this;
 
     chrome.usb.getConfiguration( this.handle, function (config) {
-        if(self.checkChromeError()) {
+        if (checkChromeRuntimeError()) {
             console.log('USB getConfiguration failed!');
             callback([], -200);
             return;
@@ -273,7 +260,7 @@ STM32DFU_protocol.prototype.getInterfaceDescriptor = function (_interface, callb
         'index':        0,
         'length':       18 + _interface * 9
     }, function (result) {
-        if(self.checkChromeError()) {
+        if (checkChromeRuntimeError()) {
             console.log('USB getInterfaceDescriptor failed! ' + result.resultCode);
             callback({}, result.resultCode);
             return;
@@ -307,7 +294,7 @@ STM32DFU_protocol.prototype.getFunctionalDescriptor = function (_interface, call
         'index':        0,
         'length':       255
     }, function (result) {
-        if(self.checkChromeError()) {
+        if (checkChromeRuntimeError()) {
             console.log('USB getFunctionalDescriptor failed! ' + result.resultCode);
             callback({}, result.resultCode);
             return;
@@ -455,7 +442,7 @@ STM32DFU_protocol.prototype.controlTransfer = function (direction, request, valu
             'length':       length,
             'timeout':      timeout
         }, function (result) {
-            if(self.checkChromeError()) {
+            if (checkChromeRuntimeError()) {
                 console.log('USB controlTransfer IN failed for request ' + request + '!');
             }
             if (result.resultCode) console.log('USB transfer result code: ' + result.resultCode);
@@ -483,7 +470,7 @@ STM32DFU_protocol.prototype.controlTransfer = function (direction, request, valu
             'data':         arrayBuf,
             'timeout':      timeout
         }, function (result) {
-            if(self.checkChromeError()) {
+            if (checkChromeRuntimeError()) {
                 console.log('USB controlTransfer OUT failed for request ' + request + '!');
             }
             if (result.resultCode) console.log('USB transfer result code: ' + result.resultCode);

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -29,7 +29,7 @@ const serial = {
         self.connectionType = 'serial';
 
         chrome.serial.connect(path, options, function (connectionInfo) {
-            if (connectionInfo && !self.openCanceled && !self.checkChromeRunTimeError()) {
+            if (connectionInfo && !self.openCanceled && !checkChromeRuntimeError()) {
                 self.connected = true;
                 self.connectionId = connectionInfo.connectionId;
                 self.bitrate = connectionInfo.bitrate;
@@ -57,7 +57,7 @@ const serial = {
                                                 self.errorHandler(getInfo.error, 'receive');
                                             }
                                         } else {
-                                            self.checkChromeRunTimeError();
+                                            checkChromeRuntimeError();
                                         }
                                     });
                                 });
@@ -151,7 +151,7 @@ const serial = {
             name: 'Betaflight',
             bufferSize: 65535,
         }, function(createInfo) {
-            if (createInfo && !self.openCanceled || !self.checkChromeRunTimeError()) {
+            if (createInfo && !self.openCanceled || !checkChromeRuntimeError()) {
                 self.connectionId = createInfo.socketId;
                 self.bitrate = 115200; // fake
                 self.bytesReceived = 0;
@@ -159,9 +159,9 @@ const serial = {
                 self.failed = 0;
 
                 chrome.sockets.tcp.connect(createInfo.socketId, self.connectionIP, self.connectionPort, function (result) {
-                    if (result === 0 || !self.checkChromeRunTimeError()) {
+                    if (result === 0 || !checkChromeRuntimeError()) {
                         chrome.sockets.tcp.setNoDelay(createInfo.socketId, true, function (noDelayResult) {
-                            if (noDelayResult === 0 || !self.checkChromeRunTimeError()) {
+                            if (noDelayResult === 0 || !checkChromeRuntimeError()) {
                                 self.onReceive.addListener(function log_bytesReceived(info) {
                                     self.bytesReceived += info.data.byteLength;
                                 });
@@ -206,14 +206,14 @@ const serial = {
 
             if (self.connectionType === 'tcp') {
                 chrome.sockets.tcp.disconnect(self.connectionId, function () {
-                    self.checkChromeRunTimeError();
+                    checkChromeRuntimeError();
                     console.log(`${self.connectionType}: disconnecting socket.`);
                 });
             }
 
             const disconnectFn = (self.connectionType === 'serial') ? chrome.serial.disconnect : chrome.sockets.tcp.close;
             disconnectFn(self.connectionId, function (result) {
-                self.checkChromeRunTimeError();
+                checkChromeRuntimeError();
 
                 result = result || self.connectionType === 'tcp';
                 console.log(`${self.connectionType}: ${result ? 'closed' : 'failed to close'} connection with ID: ${self.connectionId}, Sent: ${self.bytesSent} bytes, Received: ${self.bytesReceived} bytes`);
@@ -268,7 +268,7 @@ const serial = {
 
             const sendFn = (self.connectionType === 'serial') ? chrome.serial.send : chrome.sockets.tcp.send;
             sendFn(self.connectionId, _data, function (sendInfo) {
-                self.checkChromeRunTimeError();
+                checkChromeRuntimeError();
 
                 if (sendInfo === undefined) {
                     console.log('undefined send error');
@@ -410,13 +410,5 @@ const serial = {
         } else {
             self.disconnect();
         }
-    },
-    checkChromeRunTimeError: function () {
-        // must be called after each chrome API call
-        if (chrome.runtime.lastError) {
-            console.error(chrome.runtime.lastError.message);
-            return true;
-        }
-        return false;
     },
 };

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -148,8 +148,7 @@ TABS.cli.initialize = function (callback) {
             }];
 
             chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: filename, accepts: accepts}, function(entry) {
-                if (chrome.runtime.lastError) {
-                    console.error(chrome.runtime.lastError.message);
+                if (checkChromeRuntimeError()) {
                     return;
                 }
 
@@ -204,13 +203,7 @@ TABS.cli.initialize = function (callback) {
             ];
 
             chrome.fileSystem.chooseEntry({type: 'openFile', accepts: accepts}, function(entry) {
-                if (chrome.runtime.lastError) {
-                    console.error(chrome.runtime.lastError.message);
-                    return;
-                }
-
-                if (!entry) {
-                    console.log('No file selected');
+                if (checkChromeRuntimeError()) {
                     return;
                 }
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -870,9 +870,7 @@ TABS.firmware_flasher.initialize = function (callback) {
                     }
                 ]
             }, function (fileEntry) {
-                if (chrome.runtime.lastError) {
-                    console.error(chrome.runtime.lastError.message);
-
+                if (checkChromeRuntimeError()) {
                     return;
                 }
 
@@ -1131,8 +1129,7 @@ TABS.firmware_flasher.initialize = function (callback) {
         $('span.progressLabel a.save_firmware').click(function () {
             var summary = $('select[name="firmware_version"] option:selected').data('summary');
             chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: summary.file, accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
-                if (chrome.runtime.lastError) {
-                    console.error(chrome.runtime.lastError.message);
+                if (checkChromeRuntimeError()) {
                     return;
                 }
 

--- a/src/js/tabs/logging.js
+++ b/src/js/tabs/logging.js
@@ -102,6 +102,10 @@ TABS.logging.initialize = function (callback) {
         ConfigStorage.get('logging_file_entry', function (result) {
             if (result.logging_file_entry) {
                 chrome.fileSystem.restoreEntry(result.logging_file_entry, function (entry) {
+                    if (checkChromeRuntimeError()) {
+                        return;
+                    }
+
                     fileEntry = entry;
                     prepare_writer(true);
                 });
@@ -240,8 +244,7 @@ TABS.logging.initialize = function (callback) {
 
         // create or load the file
         chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: filename, accepts: accepts}, function(entry) {
-            if (!entry) {
-                console.log('No file selected');
+            if (checkChromeRuntimeError()) {
                 return;
             }
 

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -609,12 +609,8 @@ TABS.onboard_logging.initialize = function (callback) {
 
         chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: filename,
                 accepts: [{description: suffix.toUpperCase() + ' files', extensions: [suffix]}]}, function(fileEntry) {
-            const error = chrome.runtime.lastError;
-
-            if (error) {
-                console.error(error.message);
-
-                if (error.message !== "User cancelled") {
+            if (checkChromeRuntimeError()) {
+                if (chrome.runtime.lastError.message !== "User cancelled") {
                     GUI.log(i18n.getMessage('dataflashFileWriteFailed'));
                 }
                 return;

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -175,11 +175,11 @@ FONT.parseMCMFontFile = function(dataFontFile) {
 FONT.openFontFile = function() {
     return new Promise(function(resolve) {
         chrome.fileSystem.chooseEntry({ type: 'openFile', accepts: [{ description: 'MCM files', extensions: ['mcm'] }] }, function(fileEntry) {
-            FONT.data.loaded_font_file = fileEntry.name;
-            if (chrome.runtime.lastError) {
-                console.error(chrome.runtime.lastError.message);
+            if (checkChromeRuntimeError()) {
                 return;
             }
+
+            FONT.data.loaded_font_file = fileEntry.name;
             fileEntry.file(function(file) {
                 const reader = new FileReader();
                 reader.onloadend = function(e) {
@@ -2970,8 +2970,7 @@ TABS.osd.initialize = function(callback) {
 
         $(document).on('click', 'span.progressLabel a.save_font', function() {
             chrome.fileSystem.chooseEntry({ type: 'saveFile', suggestedName: 'baseflight', accepts: [{ description: 'MCM files', extensions: ['mcm'] }] }, function(fileEntry) {
-                if (chrome.runtime.lastError) {
-                    console.error(chrome.runtime.lastError.message);
+                if (checkChromeRuntimeError()) {
                     return;
                 }
 

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -579,14 +579,7 @@ TABS.vtx.initialize = function (callback) {
         }];
 
         chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: filename, accepts}, function(entry) {
-
-            if (chrome.runtime.lastError) {
-                console.error(chrome.runtime.lastError.message);
-                return;
-            }
-
-            if (!entry) {
-                console.log('No file selected');
+            if (checkChromeRuntimeError()) {
                 return;
             }
 
@@ -632,9 +625,7 @@ TABS.vtx.initialize = function (callback) {
         }];
 
         chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: filename, accepts}, function(entry) {
-
-            if (chrome.runtime.lastError) {
-                console.error(chrome.runtime.lastError.message);
+            if (checkChromeRuntimeError()) {
                 return;
             }
 
@@ -685,14 +676,7 @@ TABS.vtx.initialize = function (callback) {
         }];
 
         chrome.fileSystem.chooseEntry({type: 'openFile', accepts}, function(entry) {
-
-            if (chrome.runtime.lastError) {
-                console.error(chrome.runtime.lastError.message);
-                return;
-            }
-
-            if (!entry) {
-                console.log('No file selected');
+            if (checkChromeRuntimeError()) {
                 return;
             }
 

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -1,0 +1,44 @@
+'use strict';
+
+function microtime() {
+    return new Date().getTime() / 1000;
+}
+
+function millitime() {
+    return new Date().getTime();
+}
+
+const DEGREE_TO_RADIAN_RATIO = Math.PI / 180;
+
+function degToRad(degrees) {
+    return degrees * DEGREE_TO_RADIAN_RATIO;
+}
+
+function bytesToSize(bytes) {
+
+    let outputBytes;
+
+    if (bytes < 1024) {
+        outputBytes = `${bytes} Bytes`;
+    } else if (bytes < 1048576) {
+        outputBytes = `${(bytes / 1024).toFixed(3)} KB`;
+    } else if (bytes < 1073741824) {
+        outputBytes = `${(bytes / 1048576).toFixed(3)} MB`;
+    } else {
+        outputBytes = `${(bytes / 1073741824).toFixed(3)} GB`;
+    }
+
+    return outputBytes;
+}
+
+/*
+ *  checkChromeRuntimeError() has to be called after each chrome API call
+ */
+
+ function checkChromeRuntimeError() {
+    if (chrome.runtime.lastError) {
+        console.error(`Chrome API Error: ${chrome.runtime.lastError.message}.\n Traced ${(new Error).stack}`);
+        return true;
+    }
+    return false;
+}

--- a/src/main.html
+++ b/src/main.html
@@ -69,6 +69,7 @@
     <script type="text/javascript" src="./js/libraries/jquery.ba-throttle-debounce.min.js"></script>
     <script type="text/javascript" src="./node_modules/inflection/inflection.min.js"></script>
     <script type="text/javascript" src="./js/libraries/analytics.js"></script>
+    <script type="text/javascript" src="./js/utils/common.js"></script>
     <script type="text/javascript" src="./js/utils/css.js"></script>
     <script type="text/javascript" src="./js/utils/window_watchers.js"></script>
     <script type="text/javascript" src="./js/injected_methods.js"></script>


### PR DESCRIPTION
 `Fixes #2350`

- Fixes a misplaced error check in osd tab where an argument is accessed after the user cancels the operation.
- Added missing error checking in tethered logging tab.
- Created `utils/common.js` for common used functions like `checkChromeRuntimeError()` and changed codebase to use this function.

Fixes: #2350
