### PR TITLE
Fix markers on aux tab

### DIFF
--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -409,16 +409,16 @@ TABS.auxiliary.initialize = function (callback) {
             }
             return channelPosition;
         }
-        
+
         function update_marker(auxChannelIndex, channelPosition) {
             const percentage = (channelPosition - 900) / (2100-900) * 100;
-            
+
             $('.modes .ranges .range').each( function () {
-                const auxChannelCandidateIndex = $(this).find('.channel').val();
+                const auxChannelCandidateIndex = parseInt($(this).find('.channel').val());
                 if (auxChannelCandidateIndex !== auxChannelIndex) {
                     return;
                 }
-                
+
                 $(this).find('.marker').css('left', percentage + '%');
             });
         }


### PR DESCRIPTION
Little markers on aux tab currently not moving: always showing 1500. (master branch)
This is a fix.

![image](https://user-images.githubusercontent.com/2925027/102732587-b6bf8d80-4300-11eb-83aa-4180fcdd9889.png)
