### PR TITLE
Fix null when CLI autocomplete resource

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -438,7 +438,7 @@ CliAutoComplete._initTextcomplete = function() {
                     self.openLater();
                     return '$1$3 ';
                 }
-                return null;
+                return '$1';
             },
             context: function(text) {
                 const matchResource = text.match(/^\s*resource\s+(\w+)\s/i);
@@ -477,7 +477,7 @@ CliAutoComplete._initTextcomplete = function() {
                     sendOnEnter = true;
                     return '$1none ';
                 }
-                return null;
+                return '$1';
             },
             context: function(text) {
                 const m = text.match(/^\s*resource\s+(\w+)\s+(\d+\s)?/i);


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/2358

It seems that for the library we use is not the same `null` and `undefined` in the return of the `replace` function. To let the code consistent I return `$1` now that produces the same output than `undefined`.