### PR TITLE
Fix auto AUX detection on Modes tab

### DIFF
--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -486,7 +486,7 @@ TABS.auxiliary.initialize = function (callback) {
                 }
             }
 
-            auto_select_channel(FC.RC.channels, FC.RSSI_CONFIG.channel);
+            auto_select_channel(FC.RC.channels, FC.RC.active_channels, FC.RSSI_CONFIG.channel);
 
             auxChannelCount = FC.RC.active_channels - 4;
 
@@ -502,7 +502,7 @@ TABS.auxiliary.initialize = function (callback) {
          * @param RC_channels
          * @param RC_channels
          */
-        function auto_select_channel(RC_channels, RSSI_channel) {
+        function auto_select_channel(RC_channels, activeChannels, RSSI_channel) {
             const auto_option = $('.tab-auxiliary select.channel option[value="-1"]:selected');
             if (auto_option.length === 0) {
                 prevChannelsValues = null;
@@ -515,9 +515,11 @@ TABS.auxiliary.initialize = function (callback) {
 
             if (!prevChannelsValues || RC_channels.length === 0) return fillPrevChannelsValues();
 
-            const diff_array = RC_channels.map(function(currentValue, index) {
+            let diff_array = RC_channels.map(function(currentValue, index) {
                 return Math.abs(prevChannelsValues[index] - currentValue);
             });
+
+            diff_array = diff_array.slice(0, activeChannels);
 
             const largest = diff_array.reduce(function(x,y){
                 return (x > y) ? x : y;


### PR DESCRIPTION
I am not sure since when we have this bug.
Automatic AUX detection is not working.
The reason is that `FC.RC.channels` size is always 32 no matter how many active channels there are.

The "empty" channels are filled with `undefined`.
Then it goes to `diff_array` with empty channels filled with `NaN` and then `diff_array.reduce` always returns NaN.

This is a little fix that trims `diff_array` with the number of active channels.

props to @MBoerlage for finding this bug in the development build :)