### PR TITLE
Add missing filters

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -621,6 +621,7 @@ const FC = {
             gyro_notch2_cutoff:             100,
             gyro_notch2_hz:                 200,
             gyro_rpm_notch_harmonics:         3,
+            gyro_rpm_notch_min_hz:          100,
             dterm_lowpass_hz:               100,
             dterm_lowpass_dyn_min_hz:       150,
             dterm_lowpass_dyn_max_hz:       250,
@@ -635,6 +636,8 @@ const FC = {
             dyn_notch_width_percent:          8,
             dyn_notch_q_rpm:                250, // default with rpm filtering
             dyn_notch_width_percent_rpm:      0,
+            dyn_notch_min_hz:               150,
+            dyn_notch_max_hz:               600,
         };
 
         this.DEFAULT_PIDS = [


### PR DESCRIPTION
Add missing filters and defaults.

Filter | Range | Default | CLI | MSP
--- | --- | --- | --- | ---
dyn_notch_min_hz | 60 250 | 150 | Yes | Yes
dyn_notch_max_hz | 200-1000 | 600 | Yes | Yes

Toggling bidirectional Dshot sets `dynamic notch to default values`.
Found these missing while verifying MSP commands in configuration and motor tab.