### PR TITLE
OSD Tx Uplink Power support

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5002,6 +5002,13 @@
     "osdDescUpDownReference": {
         "message": "OSD Symbol to show when pitch is approaching vertical (90 deg, U) and D for nose down (-90 deg, D)"
     },
+    "osdTextElementTxUplinkPower": {
+        "message": "Tx uplink power",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescTxUplinkPower": {
+        "message": "Shows a value of the Tx power (mW or W). Useful when <i>Dynamic Power</i> is enabled for supporting radios"
+    },
     "osdTextElementUnknown": {
         "message": "Unknown $1",
         "description": "One of the elements of the OSD"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1190,6 +1190,15 @@ OSD.loadDisplayFields = function() {
             positionable: true,
             preview: 'U',
         },
+        OSD_TX_UPLINK_POWER: {
+            name: 'OSD_TX_UPLINK_POWER',
+            text: 'osdTextElementTxUplinkPower',
+            desc: 'osdDescTxUplinkPower',
+            defaultPosition: -1,
+            draw_order: 470,
+            positionable: true,
+            preview: `${FONT.symbol(SYM.RSSI)}250MW`,
+        },
     };
 };
 
@@ -1612,6 +1621,7 @@ OSD.chooseFields = function() {
                                                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                                         F.TOTAL_FLIGHTS,
                                                         F.OSD_UP_DOWN_REFERENCE,
+                                                        F.OSD_TX_UPLINK_POWER,
                                                     ]);
                                                 }
                                             }


### PR DESCRIPTION
This PR introduces the new OSD element 'Tx Uplink Power'.
The main PR for this is https://github.com/betaflight/betaflight/pull/10582
C/P from FW PR:

> The New OSD element 'Uplink Tx Power' is added in this PR.
> Currently, only CRSF is supported since the lack of internal implementation of other protocols, but using this method, they can be implemented easily later.
> Possible values are 25, 100, 250, 500 displayed as 'mW' and 1, 2 displayed as 'W'.
> Displaying this value can improve flight security when Dynamic Power is enabled. A user can check at any moment how many power levels are available when LQ is dropping.
> There is no character space in the MCM table for the "mW" or "LQpwr" symbol, so "MW" (or "W") is appended after the power state level.