### PR TITLE
Fix persistent settings

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2591,7 +2591,12 @@
     "motorsRemapDialogStartOver": {
         "message": "Start over"
     },
-
+    "motorsButtonReset": {
+        "message": "Reset"
+    },
+    "motorsButtonSave": {
+        "message": "Save and Reboot"
+    },
     "escDshotDirectionDialog-Title": {
         "message": "Motor Direction - <strong class=\"message-negative-italic\">Warning: Ensure props are removed!</strong>"
     },

--- a/src/css/tabs/motors.css
+++ b/src/css/tabs/motors.css
@@ -256,6 +256,16 @@
     width: calc(100% - 160px);
 }
 
+.tab-motors .btn .disabled {
+    cursor: default;
+    color: #fff;
+    background-color: #AFAFAF;
+    border: none;
+    pointer-events: none;
+    text-shadow: none;
+    opacity: 0.5;
+}
+
 .tab-motors #dialogMotorOutputReorder-closebtn {
     margin-right: 0px;
     margin-bottom: 0px;
@@ -298,10 +308,13 @@
 }
 
 .tab-motors #dialog-settings-changed {
-    width: 400px;
-    height: 100px;
+    height: 120px;
 }
 
+.tab-motors #dialog-settings-reset-confirmbtn {
+    margin-bottom: 12px;
+    position: relative;
+}
 .tab-motors #dialog-settings-changed-confirmbtn {
     margin-right: 0px;
     margin-bottom: 0px;
@@ -322,7 +335,7 @@
     flex-grow: 1;
 }
 
-.tab-motors .tool-buttons {
+.tab-motors .dialog-buttons {
     float: right;
     margin-bottom: -3%;
 }

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -151,7 +151,7 @@ Features.prototype.generateElements = function (featuresElements) {
             if (listElements.length === 0) {
                 newElements.push($('<option class="feature" value="-1" i18n="featureNone" />'));
             }
-            const newElement = $(`<option class="feature" id="feature-${i}" name="${rawFeatureName}" value="${featureBit}" i18n="feature${rawFeatureName}" />`);
+            const newElement = $(`<option class="feature" id="feature${i}" name="${rawFeatureName}" value="${featureBit}" i18n="feature${rawFeatureName}" />`);
 
             newElements.push(newElement);
             listElements.push(newElement);
@@ -161,7 +161,7 @@ Features.prototype.generateElements = function (featuresElements) {
                 featureName = `<td><div>${rawFeatureName}</div></td>`;
             }
 
-            let element = `<tr><td><input class="feature toggle" id="feature-${i}"`;
+            let element = `<tr><td><input class="feature toggle" id="feature${i}"`;
             element += `name="${self._features[i].name}" title="${self._features[i].name}"`;
             element += `type="checkbox"/></td><td><div>${featureName}</div>`;
             element += `<span class="xs" i18n="feature${self._features[i].name}"></span></td>`;

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -17,7 +17,7 @@
                                 <div class="spacer_box_title" i18n="configurationMixer"></div>
                             </div>
                             <div class="spacer_box">
-                                <select class="mixerList">
+                                <select class="mixerList" id="mixer">
                                     <!-- list generated here -->
                                 </select>
                             </div>
@@ -53,7 +53,7 @@
                                 </div>
                                 <div class="selectProtocol">
                                     <label>
-                                        <select class="escprotocol">
+                                        <select class="escprotocol" id="escprotocol">
                                             <!-- list generated here -->
                                         </select>
                                         <span i18n="configurationEscProtocol"></span>
@@ -155,23 +155,23 @@
                                             <th i18n="configurationFeatureName"></th>
                                         </tr>
                                     </thead>
-                                    <tbody class="features 3D" style="margin-bottom:10px;">
+                                    <tbody class="features 3D" id="features_3d" style="margin-bottom:10px;">
                                         <!-- table generated here -->
                                     </tbody>
                                 </table>
                                 <div class="_3dSettings">
                                     <div class="number">
-                                        <label> <input type="number" name="3ddeadbandlow" step="1" min="1250" max="1600" />
+                                        <label> <input type="number" name="_3ddeadbandlow" step="1" min="1250" max="1600" />
                                             <span i18n="configuration3dDeadbandLow"></span>
                                         </label>
                                     </div>
                                     <div class="number">
-                                        <label> <input type="number" name="3ddeadbandhigh" step="1" min="1400" max="1750" />
+                                        <label> <input type="number" name="_3ddeadbandhigh" step="1" min="1400" max="1750" />
                                             <span i18n="configuration3dDeadbandHigh"></span>
                                         </label>
                                     </div>
                                     <div class="number">
-                                        <label> <input type="number" name="3dneutral" step="1" min="1400" max="1600" />
+                                        <label> <input type="number" name="_3dneutral" step="1" min="1400" max="1600" />
                                             <span i18n="configuration3dNeutral"></span>
                                         </label>
                                     </div>
@@ -361,13 +361,13 @@
         <div class="clear-both"></div>
 
         <div class="content_toolbar">
-            <div class="btn tool-buttons">
-                <a href="#" id="motorOutputReorderDialogOpen" class="regular-button" i18n="motorOutputReorderDialogOpen"></a>
-                <a href="#" id="escDshotDirectionDialog-Open" class="regular-button" i18n="escDshotDirectionDialog-Open"></a>
+            <div class="btn">
+                <a href="#" id="motorOutputReorderDialogOpen" class="tool regular-button" i18n="motorOutputReorderDialogOpen"></a>
+                <a href="#" id="escDshotDirectionDialog-Open" class="tool regular-button" i18n="escDshotDirectionDialog-Open"></a>
             </div>
 
-            <div class="btn save_btn">
-                <a class="save" href="#" i18n="configurationButtonSave"></a>
+            <div class="btn">
+                <a class="save disabled" href="#" i18n="motorsButtonSave"></a>
             </div>
         </div>
 
@@ -376,8 +376,9 @@
     <dialog id="dialog-settings-changed">
         <div id="dialog-settings-changed-content-wrapper">
             <div id="dialog-settings-changed-content"></div>
-            <div>
-                <a href="#" id="dialog-settings-changed-confirmbtn" class="regular-button right" i18n="motorsDialogSettingsChangedOk"></a>
+            <div class="btn dialog-buttons">
+                <a href="#" id="dialog-settings-reset-confirmbtn" class="regular-button" i18n="motorsButtonReset"></a>
+                <a href="#" id="dialog-settings-changed-confirmbtn" class="regular-button" i18n="motorsDialogSettingsChangedOk"></a>
             </div>
         </div>
     </dialog>


### PR DESCRIPTION
Fixes: #2413 

- [x] Fixed persisent behavior when changing settings including the flip-flopping of buttons by disabling where applicable.

Moved to separate PRs:
- [x] The number of motors detected is coming from models now. (#2436)
- [x] Fixed some UI design issues - should look better on 1366 and 1920 (#2448)
- [x] Fixed duplicate MSP calls at loading (#2449)

This PR is replacing the buttons with a new set. Had to rename some variables to be used properly (i.e. variables starting with a digit or containing a hyphen were not allowed). The code is defining default configuration dynamically and captures all configuration changes and pushes those changes to an object and removes them if equal to initial state. As a result if the object is empty there are no changes so we can switch back the buttons to original state.