### PR TITLE
Add FW Filter Slider Support

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -995,19 +995,20 @@ TABS.pid_tuning.initialize = function (callback) {
 
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
             FC.TUNING_SLIDERS.slider_pids_mode = parseInt($('#sliderPidsModeSelect').val());
-            FC.TUNING_SLIDERS.slider_master_multiplier = TuningSliders.sliderMasterMultiplier * 100;
-            FC.TUNING_SLIDERS.slider_roll_pitch_ratio = TuningSliders.sliderRollPitchRatio * 100;
-            FC.TUNING_SLIDERS.slider_i_gain = TuningSliders.sliderIGain * 100;
-            FC.TUNING_SLIDERS.slider_pd_ratio = TuningSliders.sliderPDRatio * 100;
-            FC.TUNING_SLIDERS.slider_pd_gain = TuningSliders.sliderPDGain * 100;
-            FC.TUNING_SLIDERS.slider_dmin_ratio = TuningSliders.sliderDMinRatio * 100;
-            FC.TUNING_SLIDERS.slider_ff_gain = TuningSliders.sliderFFGain * 100;
+            //rounds slider values to nearies multiple of 5 and passes to the FW. Avoid dividing calc by (* x 100)/5 = 20
+            FC.TUNING_SLIDERS.slider_master_multiplier = Math.round(TuningSliders.sliderMasterMultiplier * 20) * 5;
+            FC.TUNING_SLIDERS.slider_roll_pitch_ratio = Math.round(TuningSliders.sliderRollPitchRatio * 20) * 5;
+            FC.TUNING_SLIDERS.slider_i_gain = Math.round(TuningSliders.sliderIGain * 20) * 5;
+            FC.TUNING_SLIDERS.slider_pd_ratio = Math.round(TuningSliders.sliderPDRatio * 20) * 5;
+            FC.TUNING_SLIDERS.slider_pd_gain = Math.round(TuningSliders.sliderPDGain * 20) * 5;
+            FC.TUNING_SLIDERS.slider_dmin_ratio = Math.round(TuningSliders.sliderDMinRatio * 20) * 5;
+            FC.TUNING_SLIDERS.slider_ff_gain = Math.round(TuningSliders.sliderFFGain * 20) * 5;
 
             FC.TUNING_SLIDERS.slider_dterm_filter = TuningSliders.sliderDTermFilter ? 1 : 0;
-            FC.TUNING_SLIDERS.slider_dterm_filter_multiplier = TuningSliders.sliderDTermFilterMultiplier * 100;
+            FC.TUNING_SLIDERS.slider_dterm_filter_multiplier = Math.round(TuningSliders.sliderDTermFilterMultiplier * 20) * 5;
 
             FC.TUNING_SLIDERS.slider_gyro_filter = TuningSliders.sliderGyroFilter ? 1 : 0;
-            FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = TuningSliders.sliderGyroFilterMultiplier * 100;
+            FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = Math.round(TuningSliders.sliderGyroFilterMultiplier * 20) * 5;
         }
     }
 
@@ -1928,6 +1929,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 }
                 // if values were previously changed manually and then sliders are reactivated, reset pids to previous valid values if available, else default
                 TuningSliders.resetPidSliders();
+                TuningSliders.updatePidSlidersDisplay();
                 // disable integrated yaw when enabling sliders
                 if ($('input[id="useIntegratedYaw"]').is(':checked')) {
                     $('input[id="useIntegratedYaw"]').prop('checked', true).click();
@@ -1945,7 +1947,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 } else {
                     slider.attr('step', SLIDER_STEP_UPPER);
                 }
-                if (!TuningSliders.expertMode) {
+                if (!TuningSliders.expertMode && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
                     if (slider.val() > NON_EXPERT_SLIDER_MAX) {
                         slider.val(NON_EXPERT_SLIDER_MAX);
                     } else if (slider.val() < NON_EXPERT_SLIDER_MIN) {
@@ -1963,9 +1965,6 @@ TABS.pid_tuning.initialize = function (callback) {
                     self.analyticsChanges['DTermFilterTuningSlider'] = "On";
                 }
             });
-            allFilterTuningSliders.mouseup(function() {
-                TuningSliders.updateFilterSlidersDisplay();
-            });
             // reset to middle with double click
             allFilterTuningSliders.dblclick(function() {
                 const slider = $(this);
@@ -1977,11 +1976,14 @@ TABS.pid_tuning.initialize = function (callback) {
                     TuningSliders.sliderDTermFilterMultiplier = 1;
                     TuningSliders.calculateNewDTermFilters();
                 }
-                TuningSliders.updateFilterSlidersDisplay();
             });
             // enable Filter sliders button
             $('a.buttonFilterTuningSliders').click(function() {
-                if (TuningSliders.sliderGyroFilter) {
+                if (TuningSliders.GyroSliderUnavailable) {
+                    //set Slider mode to ON when re-enabling Sliders
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                        FC.TUNING_SLIDERS.slider_gyro_filter = 1;
+                    }
                     // update switchery dynamically based on defaults
                     $('input[id="gyroLowpassDynEnabled"]').prop('checked', false).click();
                     $('input[id="gyroLowpassEnabled"]').prop('checked', true).click();
@@ -1989,7 +1991,12 @@ TABS.pid_tuning.initialize = function (callback) {
                     TuningSliders.resetGyroFilterSlider();
                     self.analyticsChanges['GyroFilterTuningSlider'] = "On";
                 }
-                if (TuningSliders.sliderDTermFilter) {
+                if (TuningSliders.DTermSliderUnavailable) {
+                    //set Slider mode to ON when re-enabling Sliders
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                        FC.TUNING_SLIDERS.slider_dterm_filter = 1;
+                    }
+                    // update switchery dynamically based on defaults
                     $('input[id="dtermLowpassDynEnabled"]').prop('checked', false).click();
                     $('input[id="dtermLowpassEnabled"]').prop('checked', true).click();
                     $('input[id="dtermLowpass2Enabled"]').prop('checked', false).click();
@@ -2006,10 +2013,10 @@ TABS.pid_tuning.initialize = function (callback) {
             // update on filter value or type changes
             $('.pid_filter tr:not(.newFilter) input, .pid_filter tr:not(.newFilter) select').on('input', function() {
                 TuningSliders.updateFilterSlidersDisplay();
-                if (TuningSliders.sliderGyroFilter) {
+                if (TuningSliders.GyroSliderUnavailable) {
                     self.analyticsChanges['GyroFilterTuningSlider'] = "Off";
                 }
-                if (TuningSliders.sliderDTermFilter) {
+                if (TuningSliders.DTermSliderUnavailable) {
                     self.analyticsChanges['DTermFilterTuningSlider'] = "Off";
                 }
             });

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -197,7 +197,7 @@
                                     <output type="number" name="sliderMasterMultiplier-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderMasterMultiplier" />
+                                    <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderMasterMultiplier" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningMasterSliderHelp"></div>
@@ -211,7 +211,7 @@
                                     <output type="number" name="sliderPDRatio-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderPDRatio" />
+                                    <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderPDRatio" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningPDRatioSliderHelp"></div>
@@ -225,7 +225,7 @@
                                     <output type="number" name="sliderPDGain-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderPDGain" />
+                                    <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderPDGain" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningPDGainSliderHelp"></div>
@@ -239,7 +239,7 @@
                                     <output type="number" name="sliderFFGain-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderFFGain" />
+                                    <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderFFGain" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningResponseSliderHelp"></div>
@@ -253,7 +253,7 @@
                                     <output type="number" name="sliderIGain-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderIGain" />
+                                    <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderIGain" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningIGainSliderHelp"></div>
@@ -266,7 +266,7 @@
                                     <output type="number" name="sliderDMinRatio-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderDMinRatio" />
+                                    <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderDMinRatio" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningDMinRatioSliderHelp"></div>
@@ -280,7 +280,7 @@
                                     <output type="number" name="sliderRollPitchRatio-number"></output>
                                 </td>
                                 <td colspan="3">
-                                    <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderRollPitchRatio" />
+                                    <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderRollPitchRatio" />
                                 </td>
                                 <td>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningRollPitchRatioSliderHelp"></div>
@@ -1070,7 +1070,7 @@
                                 <output type="number" name="sliderGyroFilterMultiplier-number"></output>
                             </td>
                             <td colspan="3">
-                                <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderGyroFilterMultiplier" />
+                                <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderGyroFilterMultiplier" />
                             </td>
                             <td>
                                 <div class="helpicon cf_tip" i18n_title="pidTuningGyroFilterSliderHelp"></div>
@@ -1089,7 +1089,7 @@
                                 <output type="number" name="sliderDTermFilterMultiplier-number"></output>
                             </td>
                             <td colspan="3">
-                                <input type="range" min="0.5" max="1.5" step="0.05" class="tuningSlider" id="sliderDTermFilterMultiplier" />
+                                <input type="range" min="0.5" max="1.5" step="0.025" class="tuningSlider" id="sliderDTermFilterMultiplier" />
                             </td>
                             <td>
                                 <div class="helpicon cf_tip" i18n_title="pidTuningDTermFilterSliderHelp"></div>


### PR DESCRIPTION
Added firmware side filter slider support.

**BIG CREDIT** to @haslinghuis as **he MADE THIS WORK**!!  Without his help, this would have not got done; under this PR at least.  

In the current Configurator Master, the firmware side filter sliders for API 1.44 and greater are not yet supported.  Calculations you see in the Configurator for the lowpass filter are based on legacy Configurator sliders functions (in current Master).  This PR adds TRUE support for BF 4.3 firmware-based filter sliders.  

It also fixed the bug with the PIDs grid in API <= 1.43 (BF 4.2 and lower) whereas when you type in the PID gain manually - disable the sliders - it is reset back to the previous value.  That should not happen for BF 4.2 and lower.