### PR TITLE
cordova_serial.requestPermission() driver fix

### DIFF
--- a/cordova/usb_device_filter.xml
+++ b/cordova/usb_device_filter.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <usb-device vendor-id="1155" product-id="22336" /> <!--STMicroelectronics / Virtual COM Port -->
+    <usb-device vendor-id="4292" product-id="60000" /> <!--CP2102 and other CP210x single port devices -->
 </resources>

--- a/src/js/cordova_chromeapi.js
+++ b/src/js/cordova_chromeapi.js
@@ -60,6 +60,13 @@ const chromeapiSerial = {
         stopBits: 'one',
         ctsFlowControl: false,
     },
+    getDriver: function(vid, pid) {
+        if (vid === 4292 && pid === 60000) {
+            return 'Cp21xxSerialDriver'; //for Silabs CP2102 and all other CP210x
+        }  else {
+            return 'CdcAcmSerialDriver';
+        }
+    },
     setConnectionOptions: function(ConnectionOptions) {
         if (ConnectionOptions.persistent) {
             this.connection.persistent = ConnectionOptions.persistent;
@@ -158,7 +165,7 @@ const chromeapiSerial = {
             const vid = parseInt(pathSplit[0]);
             const pid = parseInt(pathSplit[1]);
             console.log(`${self.logHeader}request permission (vid=${vid} / pid=${pid})`);
-            cordova_serial.requestPermission({vid: vid, pid: pid}, function() {
+            cordova_serial.requestPermission({vid: vid, pid: pid, driver: self.getDriver(vid, pid)}, function() {
                 const options = self.getCordovaSerialConnectionOptions();
                 cordova_serial.open(options, function () {
                     cordova_serial.registerReadCallback(function (data) {


### PR DESCRIPTION
Fight controller based on silabs CP2104 was not working as function call cordova_serial.requestPermission() without specify the driver parameter uses the default driver "CdcAcmSerialDriver" which is the wrong when usb-uart chip is a CP2104. This chip requires the driver "Cp21xxSerialDriver". It fixes #2437 
