### PR TITLE
Fix Mac OSX Hide command problem

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -182,6 +182,13 @@ function startProcess() {
             GUI.nwGui.Shell.openExternal(url);
         });
         nwWindow.on('close', closeHandler);
+        // TODO: Remove visibilitychange Listener when upgrading to NW2
+        // capture Command H on MacOS and change it to minimize
+        document.addEventListener("visibilitychange", function() {
+            if (GUI.operating_system === "MacOS" && document.visibilityState === "hidden") {
+                nwWindow.minimize();
+            }
+        }, false);
     } else if (GUI.isCordova()) {
         window.addEventListener('beforeunload', closeHandler);
         document.addEventListener('backbutton', function(e) {


### PR DESCRIPTION
Fixes: #1940 by replacing `hide` window on MacOS with `minimize`. Only quirk with this solution that `quit` does not work in minimized state but it's a tradeoff with the `hide` function making `restore` imposible and having to force quit.

Thanks @ctzsnooze for testing. Tried to remove `"chromium-args": "--disable-features=nw2"` but this is still needed for file operations, opening links and changing settings as dark mode. Thanks @mikeller for pointing that out on Slack. See #1982 