### PR TITLE
Allow margin of 25 for aux ranges

### DIFF
--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -101,7 +101,7 @@ TABS.adjustments.initialize = function (callback) {
         $(rangeElement).find('.channel-slider').noUiSlider({
             start: rangeValues,
             behaviour: 'snap-drag',
-            margin: 50,
+            margin: 25,
             step: 25,
             connect: true,
             range: channel_range,

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -163,7 +163,7 @@ TABS.auxiliary.initialize = function (callback) {
         $(rangeElement).find('.channel-slider').noUiSlider({
             start: rangeValues,
             behaviour: 'snap-drag',
-            margin: 50,
+            margin: 25,
             step: 25,
             connect: true,
             range: channel_range,


### PR DESCRIPTION
Aux ranges that are 25 wide are actually supported and working fine when configured via CLI, but the UI has a lower limit of 50. This changes the UI to match the CLI behavior.