### PR TITLE
Mcu ID for lua vtx table

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5673,7 +5673,7 @@
         "description": "Save Lua script button in the VTX tab"
     },
     "vtxLuaFileHelp" :{
-        "message": "The '$t(vtxButtonSaveLua.message)' button will allow you to save a <i>craftname</i>.lua file containing the vtx table configuration that can be used with the betaflight lua scripts. (See more <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https://github.com/betaflight/betaflight-tx-lua-scripts/\">here</a>.)",
+        "message": "The '$t(vtxButtonSaveLua.message)' button will allow you to save a <i>mcuid</i>.lua file containing the VTX table configuration that can be used with the <a href=\"https://github.com/betaflight/betaflight-tx-lua-scripts/\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight TX Lua Scripts</a>.<br><br>Version 1.6.0 and above can use the file as is, but for older versions of the scripts it should be renamed to match the modelname on the TX.",
         "description": "Tooltip message for the Save Lua script button in the VTX tab"
     },
     "vtxButtonLoadFile": {

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -608,16 +608,13 @@ TABS.vtx.initialize = function (callback) {
     }
 
     function save_lua() {
-        const suggestedName = 'model01';
         const suffix = 'lua';
 
-        let filename;
-        if(FC.CONFIG.name && FC.CONFIG.name.trim() !== '') {
-            filename = FC.CONFIG.name.trim().replace(' ', '_');
-        }else{
-            filename = suggestedName;
-        }
-        filename += `.${suffix}`;
+        const uid0 = FC.CONFIG.uid[0].toString(16).padStart(8, '0');
+        const uid1 = FC.CONFIG.uid[1].toString(16).padStart(8, '0');
+        const uid2 = FC.CONFIG.uid[2].toString(16).padStart(8, '0');
+
+        const filename = `${uid0}${uid1}${uid2}.${suffix}`;
 
         const accepts = [{
             description: `${suffix.toUpperCase()} files`, extensions: [suffix],


### PR DESCRIPTION
Use mcu ID as filename for the vtx table .lua file.

Version 1.6.0 of the betaflight lua scripts will use the vtx tables with a mcu ID that matches the mcu ID of the craft. 