### PR TITLE
Fix autocomplete of resource pin

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -438,7 +438,7 @@ CliAutoComplete._initTextcomplete = function() {
                     self.openLater();
                     return '$1$3 ';
                 }
-                return '$1';
+                return undefined;
             },
             context: function(text) {
                 const matchResource = text.match(/^\s*resource\s+(\w+)\s/i);
@@ -477,7 +477,7 @@ CliAutoComplete._initTextcomplete = function() {
                     sendOnEnter = true;
                     return '$1none ';
                 }
-                return '$1';
+                return undefined;
             },
             context: function(text) {
                 const m = text.match(/^\s*resource\s+(\w+)\s+(\d+\s)?/i);


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/2458

According to the doc: https://github.com/yuku/textcomplete/blob/main/packages/jquery-textcomplete/doc/how_to_use.md undefined must be returned to not "do nothing". It can be achieved removing the return or explicitly like here. I preferred this second way to let it clear the objective. This bug was produced in a Sonar clean of the code and was not noticed until now.

It seems that `$1` contains all but the "in progress" word. Another way to fix this is to modify the hints to add the "current" text, like is done in other places, and use it when pressing enter, but I preferred to go to the simplest solution.