### PR TITLE
Added Dynamic notch new parameters (Count and Bandwidth)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3708,6 +3708,9 @@
     "pidTuningDynamicNotchFilterHelp": {
         "message": "Dynamic Notch Filter tracks peak motors noise frequency and places one or two notch filters with their center at that frequency."
     },
+    "pidTuningMultiDynamicNotchFilterHelp": {
+        "message": "Dynamic Notch Filter tracks peak gyro noise frequencies and places one to five notch filters with their center at these frequencies on every axis."
+    },
     "pidTuningDynamicNotchFilterDisabledWarning": {
         "message": "<strong>Notice:</strong> The dynamic notch filter is disabled. In order to configure and use it, please enable the 'DYNAMIC_FILTER' feature in the '$t(configurationFeatures.message)' section of the '$t(tabConfiguration.message)' tab."
     },
@@ -3721,10 +3724,16 @@
         "message": "Dynamic Notch Q"
     },
     "pidTuningDynamicNotchMinHz": {
-        "message": "Dynamic Notch Min Hz"
+        "message": "Dynamic Notch Min Frequency [Hz]"
     },
     "pidTuningDynamicNotchMaxHz": {
-        "message": "Dynamic Notch Max Hz"
+        "message": "Dynamic Notch Max Frequency [Hz]"
+    },
+    "pidTuningDynamicNotchCount": {
+        "message": "Dynamic Notch Count"
+    },
+    "pidTuningDynamicNotchBandwidthHz": {
+        "message": "Dynamic Notch Bandwidth Frequency [Hz]"
     },
     "pidTuningDynamicNotchRangeHelp": {
         "message": "The dynamic notch has three frequency ranges in which it can operate: LOW(80-330hz) for lower revving quads like 6+ inches, MEDIUM(140-550hz) for a normal 5 inch quad, HIGH(230-800hz) for very high revving 2.5-3 inch quads. AUTO option selects the range depending on the value of the Gyro Dynamic Lowpass 1 Filter's max cutoff frequency."
@@ -3740,6 +3749,12 @@
     },
     "pidTuningDynamicNotchMaxHzHelp": {
         "message": "Set this to the highest incoming noise frequency that is needed to be controlled by the dynamic notch."
+    },
+    "pidTuningDynamicNotchCountHelp": {
+        "message": "Sets the number of dynamic notches per axis. With RPM filter enabled a value of 1 or 2 is recommended. Without RPM filter a value of 4 or 5 is recommended. Lower numbers will reduce filter delay, however it may increase motor temperature."
+    },
+    "pidTuningDynamicNotchBandwidthHzHelp": {
+        "message": "Bandwidth in Hz adjusts how narrow or wide every dynamic notch will be. Higher values makes it wider and broader. Lower values makes it narrower and more precise, however it may increase motor temperature. Having a really high value will increase filter delay."
     },
     "pidTuningRpmFilterGroup": {
         "message": "Gyro RPM Filter",

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1097,6 +1097,8 @@ MspHelper.prototype.process_data = function(dataHandler) {
                             }
                             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
                                 FC.FILTER_CONFIG.dyn_lpf_curve_expo = data.readU8();
+                                FC.FILTER_CONFIG.dyn_notch_count = data.readU8();
+                                FC.FILTER_CONFIG.dyn_notch_bandwidth_hz = data.readU16();
                             }
                         }
                     }
@@ -2065,7 +2067,9 @@ MspHelper.prototype.crunch = function(code) {
                     buffer.push16(FC.FILTER_CONFIG.dyn_notch_max_hz);
                 }
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
-                    buffer.push8(FC.FILTER_CONFIG.dyn_lpf_curve_expo);
+                    buffer.push8(FC.FILTER_CONFIG.dyn_lpf_curve_expo)
+                          .push8(FC.FILTER_CONFIG.dyn_notch_count)
+                          .push16(FC.FILTER_CONFIG.dyn_notch_bandwidth_hz);
                 }
             }
             break;

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -385,12 +385,22 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.pid_filter select[name="dynamicNotchRange"]').val(FC.FILTER_CONFIG.dyn_notch_range);
             dynamicNotchWidthPercent_e.val(FC.FILTER_CONFIG.dyn_notch_width_percent);
             dynamicNotchQ_e.val(FC.FILTER_CONFIG.dyn_notch_q);
+            $('.pid_filter input[name="dynamicNotchCount"]').val(FC.FILTER_CONFIG.dyn_notch_count);
+            $('.pid_filter input[name="dynamicNotchBandwidthHz"]').val(FC.FILTER_CONFIG.dyn_notch_bandwidth_hz);
             $('.pid_filter input[name="dynamicNotchMinHz"]').val(FC.FILTER_CONFIG.dyn_notch_min_hz);
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
                 $('.pid_filter input[name="dynamicNotchMinHz"]').attr("max","250");
                 $('.pid_filter input[name="dynamicNotchMaxHz"]').val(FC.FILTER_CONFIG.dyn_notch_max_hz);
             } else {
                 $('.dynamicNotchMaxHz').hide();
+            }
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                $('.dynamicNotchHelp').attr('title', i18n.getMessage('pidTuningMultiDynamicNotchFilterHelp'));
+                $('.dynamicNotchWidthPercent').hide();
+                $('.dynamicNotchQ').hide();
+            } else {
+                $('.dynamicNotchCount').hide();
+                $('.dynamicNotchBandwidthHz').hide();
             }
 
             $('.rpmFilter').toggle(FC.MOTOR_CONFIG.use_dshot_telemetry);
@@ -991,6 +1001,8 @@ TABS.pid_tuning.initialize = function (callback) {
             FC.FILTER_CONFIG.dyn_lpf_curve_expo = parseInt($('.pid_filter input[name="dtermLowpassDynExpo"]').val());
             FC.ADVANCED_TUNING.vbat_sag_compensation = $('input[id="vbatSagCompensation"]').is(':checked') ? parseInt($('input[name="vbatSagValue"]').val()) : 0;
             FC.ADVANCED_TUNING.thrustLinearization = $('input[id="thrustLinearization"]').is(':checked') ? parseInt($('input[name="thrustLinearValue"]').val()) : 0;
+            FC.FILTER_CONFIG.dyn_notch_count = parseInt($('.pid_filter input[name="dynamicNotchCount"]').val());
+            FC.FILTER_CONFIG.dyn_notch_bandwidth_hz = parseInt($('.pid_filter input[name="dynamicNotchBandwidthHz"]').val());
         }
 
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1332,7 +1332,7 @@
                                 <th class="dynamicNotch" colspan="2">
                                     <div class="pid_mode dynamicNotch">
                                         <div i18n="pidTuningDynamicNotchFilterGroup" ></div>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchFilterHelp" ></div>
+                                        <div class="helpicon cf_tip dynamicNotchHelp" i18n_title="pidTuningDynamicNotchFilterHelp" ></div>
                                     </div>
                                 </th>
                             </tr>
@@ -1351,7 +1351,7 @@
                                     </div>
                                 </td>
                             </tr>
-                            <tr class="newFilter dynamicNotch">
+                            <tr class="newFilter dynamicNotch dynamicNotchWidthPercent">
                                 <td>
                                     <input type="number" name="dynamicNotchWidthPercent" step="1" min="0" max="20"/>
                                 </td>
@@ -1364,7 +1364,7 @@
                                     </div>
                                 </td>
                             </tr>
-                            <tr class="newFilter dynamicNotch">
+                            <tr class="newFilter dynamicNotch dynamicNotchQ">
                                 <td>
                                     <input type="number" name="dynamicNotchQ" step="1" min="1" max="1000"/>
                                 </td>
@@ -1374,6 +1374,32 @@
                                             <span i18n="pidTuningDynamicNotchQ"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchQHelp" ></div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr class="newFilter dynamicNotch dynamicNotchCount">
+                                <td>
+                                    <input type="number" name="dynamicNotchCount" step="1" min="0" max="5"/>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningDynamicNotchCount"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchCountHelp" ></div>
+                                    </div>
+                                </td>
+                            </tr>
+                            <tr class="newFilter dynamicNotch dynamicNotchBandwidthHz">
+                                <td>
+                                    <input type="number" name="dynamicNotchBandwidthHz" step="1" min="6" max="500"/>
+                                </td>
+                                <td>
+                                    <div>
+                                        <label>
+                                            <span i18n="pidTuningDynamicNotchBandwidthHz"></span>
+                                        </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchBandwidthHzHelp" ></div>
                                     </div>
                                 </td>
                             </tr>


### PR DESCRIPTION
To go with https://github.com/betaflight/betaflight/pull/10554
This PR adds the new Multi Dynamic notch parameters. Apart of this we need to adjust the old @fgiudice98 code that changes Q and width when Dshot Bidir is enabled. We are testing to find the best values for `dyn_notch_count` and `dyn_notch_bandwidth_hz` when Dshot Bidir is enabled.

![image](https://user-images.githubusercontent.com/43983086/113973730-0e94ec80-983d-11eb-8666-2a1f70032b8a.png)
