### PR TITLE
Fix OSD speed unit preview

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -713,7 +713,8 @@ OSD.loadDisplayFields = function() {
             draw_order: 810,
             positionable: true,
             preview(osdData) {
-                const unit = FONT.symbol(osdData.unit_mode === 0 || osdData.unit_mode === 1 ? SYM.MPH : SYM.KPH);
+                const UNIT_METRIC = OSD.constants.UNIT_TYPES.indexOf("METRIC");
+                const unit = FONT.symbol(osdData.unit_mode === UNIT_METRIC ? SYM.KPH : SYM.MPH);
                 return `${FONT.symbol(SYM.SPEED)}40${unit}`;
             },
         },


### PR DESCRIPTION
The GPS Speed OSD element preview is wrong, depending on the units.
It is showing `km/h` for British, and `mp/h` for Imperial and Metric.

This PR changes this, using `km/h` for Metric, and `mp/h` for Imperial and British, like in the firmware part:
https://github.com/betaflight/betaflight/blob/025ee87a7aca068e3659fd066b8a9afbed123361/src/main/osd/osd_elements.c#L492-L505