### PR TITLE
Verify board from firmware before flashing

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3146,6 +3146,24 @@
     "firmwareFlasherFlashTrigger": {
         "message": "Detected: <strong>$1</strong> - triggering flash on connect"
     },
+    "firmwareFlasherVerifyBoard": {
+        "message": "<h3>Firmware mismatch</h3><br />The connected board is <strong>{{verified_board}}</strong> while you selected <strong>{{selected_board}}</strong>.<br /><br />Do you want to continue flashing?",
+        "description": "Make a quick connection to read firmware target and never flash a wrong target again"
+    },
+    "firmwareFlasherBoardVerificationSuccess": {
+        "message": "Configurator has <span class=\"message-positive\">successfully</span> detected and verified the board: <strong>{{boardName}}</strong>",
+        "description": "Board verification has succeeded."
+    },
+    "firmwareFlasherBoardVerificationFail": {
+        "message": "Configurator <span class=\"message-negative\">failed</span> to verify the board, if this does not work please try switching tab slowly to retry, make a new usb connection or connect first if you might have forgotten to apply custom defaults",
+        "description": "Sometimes MSP values cannot be read from firmware correctly"
+    },
+    "firmwareFlasherButtonAbort": {
+        "message": "Abort"
+    },
+    "firmwareFlasherButtonContinue": {
+        "message": "Continue"
+    },
     "unstableFirmwareAcknoledgementDialog": {
         "message": "You are about to flash a <strong>development build of the firmware</strong>. These builds are a work in progress, and any of the following can be the case:<strong><ul><li>the firmware does not work at all;</li><li>the firmware is not flyable;</li><li>there are safety issues with the firmware, for example flyaways</li><li>the firmware can cause the flight controller to become unresponsive, or damaged</li></ul></strong>If you proceed with flashing this firmware, <strong>you are assuming full responsibility for the risk of any of the above happening</strong>. Furthermore you acknowledge that it is necessary to perform <strong>thorough bench tests with props off</strong> before any attempts to fly this firmware."
     },

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -170,6 +170,11 @@ PortHandler.detectPort = function(currentPorts) {
             }
         });
 
+        // Signal board verification
+        if (GUI.active_tab === 'firmware_flasher') {
+            TABS.firmware_flasher.boardNeedsVerification = true;
+        }
+
         // auto-connect if enabled
         if (GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {
             // start connect procedure. We need firmware flasher protection over here

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -18,6 +18,10 @@ const serial = {
     connect: function (path, options, callback) {
         const self = this;
         const testUrl = path.match(/^tcp:\/\/([A-Za-z0-9\.-]+)(?:\:(\d+))?$/);
+        if (self.connectionId || self.connected) {
+            console.warn('We already connected. Aborting', self.connectionId, self.connected);
+            return;
+        }
         if (testUrl) {
             self.connectTcp(testUrl[1], testUrl[2], options, callback);
         } else if (path === 'virtual') {

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -180,4 +180,14 @@
             </div>
         </div>
     </dialog>
+
+    <dialog id="dialog-verify-board">
+        <div id="dialog-verify-board-content-wrapper">
+            <div id="dialog-verify-board-content"></div>
+            <div class="btn dialog-buttons">
+                <a href="#" id="dialog-verify-board-abort-confirmbtn" class="regular-button" i18n="firmwareFlasherButtonAbort"></a>
+                <a href="#" id="dialog-verify-board-continue-confirmbtn" class="regular-button" i18n="firmwareFlasherButtonContinue"></a>
+            </div>
+        </div>
+    </dialog>
 </div>


### PR DESCRIPTION
Read board info from firmware and present a warning if there is a mismatch before flashing to prevent the user flashing the wrong firmware.

- The verified firmware target is selected as default upon tab load.
- Changing port will be detected. User is still allowed to change target.
- The dialog has abort and continue so it does not interfere.
- Added some checks to avoid exceptions and make it more robust.
- Added a switch in firmware flasher to disable/enable detection on tab load or port change (needs tab reload)

Edit: just found a couple of feature request:
Fixes: https://github.com/betaflight/betaflight-configurator/issues/373
Fixes: https://github.com/betaflight/betaflight-configurator/issues/168
Fixes: https://github.com/betaflight/betaflight-configurator/issues/1682