### PR TITLE
LAND NOW OSD element (configurator part)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5021,6 +5021,13 @@
     "osdDescTotalFlights": {
         "message": "Approximate total number of flights"
     },
+    "osdTextLandNow": {
+        "message": "Land now warning",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescLandNow": {
+        "message": "Land now warning appears when the battery level is critical"
+    },
     "osdTextElementUpDownReference": {
         "message": "Up (Pitch 90 deg)/Down (Pitch -90 deg) Reference",
         "description": "OSD Symbol to show when pitch is approaching vertical (90 deg, U) and D for nose down (-90 deg, D)"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1190,6 +1190,15 @@ OSD.loadDisplayFields = function() {
             positionable: true,
             preview: 'U',
         },
+        OSD_LAND_NOW_WARNING: {
+            name: 'OSD_LAND_NOW_WARNING',
+            text: 'osdTextLandNow',
+            desc: 'osdDescLandNow',
+            defaultPosition: -1,
+            draw_order: 470,
+            positionable: true,
+            preview: 'LAND NOW',
+        },
     };
 };
 
@@ -1612,6 +1621,7 @@ OSD.chooseFields = function() {
                                                     OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
                                                         F.TOTAL_FLIGHTS,
                                                         F.OSD_UP_DOWN_REFERENCE,
+                                                        F.OSD_LAND_NOW_WARNING,
                                                     ]);
                                                 }
                                             }


### PR DESCRIPTION
A separate `LAND NOW` OSD element in addition to OSD warnings.

Configurator part for this PR:
https://github.com/betaflight/betaflight/pull/10750

and this feature request:
https://github.com/betaflight/betaflight/issues/10667

**should be merged after this one:**
https://github.com/betaflight/betaflight-configurator/pull/2427