### PR TITLE
Specify a default locale for nwjs.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "version": "10.8.0",
   "main": "main.html",
   "chromium-args": "--disable-features=nw2",
+  "default_locale": "en",
   "scripts": {
     "start": "run-script-os",
     "start:default": "NODE_ENV=development NW_PRE_ARGS=--load-extension='./node_modules/nw-vue-devtools-prebuilt/extension' gulp debug",


### PR DESCRIPTION
Fixes error message: "Failed to load extension from ... Localization used, but default_locale wasn't specified in the manifest".

The error message is misleading, since the manifest.json does have a default local setting, but nwjs ignores it when package.json exists.
