### PR TITLE
Report problems in console when expert mode is enabled.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -523,6 +523,10 @@
     "resetToCustomDefaultsAccept": {
         "message": "Apply Custom Defaults"
     },
+    "reportProblemsLog": {
+        "message": "<span class=\"message-negative\">PROBLEM DETECTED:</span>"
+    },
+    
     "reportProblemsDialogHeader": {
         "message": "The following <strong>problems with your configuration</strong> were detected:"
     },

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -421,12 +421,16 @@ function checkReportProblems() {
             needsProblemReportingDialog = checkReportProblem('ACC_NEEDS_CALIBRATION', problemDialogList) || needsProblemReportingDialog;
         }
 
+        if (isExpertModeEnabled()) {
+            needsProblemReportingDialog = false
+        }
+        
         if (needsProblemReportingDialog) {
             const problemDialog = $('#dialogReportProblems')[0];
             $('#dialogReportProblems-closebtn').click(function() {
                 problemDialog.close();
             });
-
+            
             problemDialog.showModal();
             $('#dialogReportProblems').scrollTop(0);
         }

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -390,7 +390,9 @@ function checkReportProblems() {
 
     function checkReportProblem(problemName, problemDialogList) {
         if (bit_check(FC.CONFIG.configurationProblems, FC.CONFIGURATION_PROBLEM_FLAGS[problemName])) {
-            problemItemTemplate.clone().html(i18n.getMessage(`reportProblemsDialog${problemName}`)).appendTo(problemDialogList);
+            const problemMessage = i18n.getMessage(`reportProblemsDialog${problemName}`);
+            GUI.log(i18n.getMessage(`reportProblemsLog`) + problemMessage);
+            problemItemTemplate.clone().html(problemMessage).appendTo(problemDialogList);
 
             analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, PROBLEM_ANALYTICS_EVENT, problemName);
 
@@ -407,8 +409,11 @@ function checkReportProblems() {
 
         if (semver.gt(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MAX_SUPPORTED)) {
             const problemName = 'API_VERSION_MAX_SUPPORTED';
-            problemItemTemplate.clone().html(i18n.getMessage(`reportProblemsDialog${problemName}`,
-                [CONFIGURATOR.latestVersion, CONFIGURATOR.latestVersionReleaseUrl, CONFIGURATOR.version, FC.CONFIG.flightControllerVersion])).appendTo(problemDialogList);
+            const problemMessage = i18n.getMessage(`reportProblemsDialog${problemName}`,
+                [CONFIGURATOR.latestVersion, CONFIGURATOR.latestVersionReleaseUrl, CONFIGURATOR.version, FC.CONFIG.flightControllerVersion]);
+            GUI.log(i18n.getMessage(`reportProblemsLog`) + problemMessage);
+            problemItemTemplate.clone().html(problemMessage).appendTo(problemDialogList);
+
             needsProblemReportingDialog = true;
 
             analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, PROBLEM_ANALYTICS_EVENT,
@@ -422,15 +427,15 @@ function checkReportProblems() {
         }
 
         if (isExpertModeEnabled()) {
-            needsProblemReportingDialog = false
+            needsProblemReportingDialog = false;
         }
-        
+
         if (needsProblemReportingDialog) {
             const problemDialog = $('#dialogReportProblems')[0];
             $('#dialogReportProblems-closebtn').click(function() {
                 problemDialog.close();
             });
-            
+
             problemDialog.showModal();
             $('#dialogReportProblems').scrollTop(0);
         }


### PR DESCRIPTION
The point of this PR is to avoid wasting precious developer time as when developing code you have to continually click OK on a dialog that appears every time you connect.  This is especially true when running code from BF `master` branch with a release build of the configurator since the addition of the 'configurator is older than the firmware' problem.

If you're an expert it stands to reason that you know how to look at the console and that you've configured betaflight once before, and thus don't need to be reminded of _any_ problems every time you connect to a flight controller.

I'm happy to update this and add a 'developer mode' in addition to 'expert mode' and make this PR log to console and avoid the problems dialog when 'developer mode' is enabled.  The switch to enable 'developer mode' could be in the dropdown menu that appears when you click the 'gear' icon.

