### PR TITLE
Put keyboard focus on the 'Close' button of the problems dialog.

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -429,6 +429,7 @@ function checkReportProblems() {
 
             problemDialog.showModal();
             $('#dialogReportProblems').scrollTop(0);
+            $('#dialogReportProblems-closebtn').focus();
         }
 
         processUid();


### PR DESCRIPTION
Makes it quicker/easier to dismiss by pressing the return key.

Without this the behavior is not consistent, if any problem message has a url in it the default action of the return key is to open the first link, with this the default action is always the close button.
