### PR TITLE
Prevent drag/dop and text selection on most elements.

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -874,7 +874,7 @@ input[type="number"]::-webkit-inner-spin-button {
     bottom: 0;
 }
 
-#log .wrapper > * {
+#log .wrapper > *, #log .wrapper > * > *{
     user-select: text;
 }
 

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -33,6 +33,10 @@
     -webkit-app-region: no-drag;
 }
 
+*[draggable="true"] {
+    -webkit-user-drag: element;
+}
+
 html, body {
     height: 100%;
 }

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -28,6 +28,9 @@
     border: 0;
     list-style: none;
     outline: none;
+    user-select: none;
+    -webkit-user-drag: none;
+    -webkit-app-region: no-drag;
 }
 
 html, body {
@@ -869,6 +872,10 @@ input[type="number"]::-webkit-inner-spin-button {
     padding: 5px 5px 4px 10px;
     position: relative;
     bottom: 0;
+}
+
+#log .wrapper > * {
+    user-select: text;
 }
 
 #log a {

--- a/src/css/tabs/cli.css
+++ b/src/css/tabs/cli.css
@@ -34,8 +34,12 @@
     font-family: monospace;
     color: white;
     box-sizing: border-box;
-    -webkit-user-select: text;
     float: left;
+}
+
+
+.tab-cli .window .wrapper, .tab-cli .window .wrapper > * {
+    user-select: text;
 }
 
 .tab-cli textarea[name='commands'] {


### PR DESCRIPTION
I've noticed, over the years, that it was possible to accidentally start a drag-and-drop operation when clicking various elements in the UI, something that shouldn't be possible and certainly isn't possible in native apps.

Similarly, when selecting text it was possible to accidentally select the text of UI elements, again something that shouldn't be possible unless specifically enabled.

This PR:
* disables text selection for everywhere except the CLI and the LOG.
* disables drag/drop for all elements.
