### PR TITLE
Update Azure Linux build version to latest

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -121,7 +121,7 @@ stages:
 
   - job: 'Linux'
     pool:
-      vmImage: 'ubuntu-16.04'
+      vmImage: 'ubuntu-latest'
 
     steps:
     - task: UseNode@1


### PR DESCRIPTION
The current used Linux version used in Azure pipelines is EOL, so we should update. Trying with `ubuntu-latest` first to see it if build otherwise we can use the latest Long Term version (20.04)