### PR TITLE
Updated NW.js to 0.54.0.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,7 @@ const NODE_ENV = process.env.NODE_ENV || 'production';
 let gitChangeSetId;
 
 const nwBuilderOptions = {
-    version: '0.50.2',
+    version: '0.54.0',
     files: `${DIST_DIR}**/*`,
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},


### PR DESCRIPTION
To go with https://github.com/betaflight/blackbox-log-viewer/pull/518.