### PR TITLE
Support flashing .hex files onto any suitable External flash partition.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -665,6 +665,9 @@
     "dfu_error_image_size": {
         "message": "<span class=\"message-negative\">Error</span>: Supplied image is larger then flash available on the chip! Image: $1 KiB, limit = $2 KiB"
     },
+    "dfu_error_image_mismatch": {
+        "message": "<span class=\"message-negative\">Error</span>: Supplied image is not suitable for the flash chip"
+    },
 
     "eeprom_saved_ok": {
         "message": "EEPROM <span class=\"message-positive\">saved</span>"


### PR DESCRIPTION
This allows uploading not only firmware, but system, osd logos/fonts and config backups too.
Additionally, the firmware partition is not always the 3rd partition on new FCs, other partitions can preceed it.

A partition is 'suitable' if it matches the length of the .hex file.