### PR TITLE
Refactor preview of osd battery usage

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -308,20 +308,15 @@ OSD.generateAltitudePreview = function(osdData) {
 
 OSD.generateBatteryUsagePreview = function(osdData) {
     const variantSelected = OSD.getVariantForPreview(osdData, 'MAIN_BATT_USAGE');
+
     let value;
     switch (variantSelected) {
         case 0:
-            value = FONT.symbol(SYM.PB_START) + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL)
-                + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL)
-                + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_END) + FONT.symbol(SYM.PB_EMPTY)
-                + FONT.symbol(SYM.PB_CLOSE);
+            value = FONT.symbol(SYM.PB_START) + FONT.symbol(SYM.PB_FULL).repeat(9) + FONT.symbol(SYM.PB_END) + FONT.symbol(SYM.PB_EMPTY) + FONT.symbol(SYM.PB_CLOSE);
             break;
 
         case 1:
-            value = FONT.symbol(SYM.PB_START) + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL)
-                + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_FULL) + FONT.symbol(SYM.PB_END) + FONT.symbol(SYM.PB_EMPTY)
-                + FONT.symbol(SYM.PB_EMPTY) + FONT.symbol(SYM.PB_EMPTY) + FONT.symbol(SYM.PB_EMPTY) + FONT.symbol(SYM.PB_EMPTY)
-                + FONT.symbol(SYM.PB_CLOSE);
+            value = FONT.symbol(SYM.PB_START) + FONT.symbol(SYM.PB_FULL).repeat(5) + FONT.symbol(SYM.PB_END) + FONT.symbol(SYM.PB_EMPTY).repeat(5) + FONT.symbol(SYM.PB_CLOSE);
             break;
 
         case 2:


### PR DESCRIPTION
As discussed with @chmelevskij and @haslinghuis here: https://github.com/betaflight/betaflight-configurator/pull/2468 this PR does a simply refactor of the preview for osd battery usage.

I liked the @chmelevskij idea, but after implementing @haslinghuis one, I think the first is not necessary. It needs to declare some vars that will be used only at some cases of the switch. After using the `repeat` I think is enough.