### PR TITLE
Added latest Rc Smoothing changes

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1679,19 +1679,19 @@
     "receiverRcSmoothingManual": {
         "message": "Manual"
     },
-    "receiverRcSmoothingAutoSmoothness": {
-        "message": "Auto Smoothness",
-        "description": "Auto Smoothness parameter for RC smoothing"
+    "receiverRcSmoothingAutoFactor": {
+        "message": "Auto Factor",
+        "description": "Auto Factor parameter for RC smoothing"
     },
-    "receiverRcSmoothingAutoSmoothnessHelp": {
-        "message": "Adjusts the Auto smoothing calculation, 10 is the default smoothing to delay ratio. Increasing the number will smooth RC inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs. ",
-        "description": "Auto Smoothness parameter help message"
+    "receiverRcSmoothingAutoFactorHelp": {
+        "message": "Adjusts the Auto factor calculation, 10 is the default factor to delay ratio. Increasing the number will smooth RC inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs. ",
+        "description": "Auto Factor parameter help message"
     },
-    "receiverRcDerivativeTypeSelect": {
-        "message": "Derivative Cutoff Type"
+    "receiverRcFeedforwardTypeSelect": {
+        "message": "FeedForward Cutoff Type"
     },
-    "receiverRcInputTypeSelect": {
-        "message": "Input Cutoff Type"
+    "receiverRcSetpointTypeSelect": {
+        "message": "Setpoint Cutoff Type"
     },
     "receiverRcSmoothingInterpolation": {
         "message": "Interpolation"
@@ -1702,43 +1702,43 @@
     "receiverRcSmoothingTypeHelp": {
         "message": "Type of RC smoothing used"
     },
-    "rcSmoothingInputCutoffHelp": {
-        "message": "The cutoff frequency in Hz used by the input filter. Using lower values will result in smoother inputs and are more appropriate for slower receiver protocols. Most users should leave this at 0 corresponding to \"Auto\"."
+    "rcSmoothingSetpointCutoffHelp": {
+        "message": "The cutoff frequency in Hz used by the setpoint filter. Using lower values will result in smoother inputs and are more appropriate for slower receiver protocols. Most users should leave this at 0 corresponding to \"Auto\"."
     },
-    "rcSmoothingDerivativeCutoffHelp": {
-        "message": "The cutoff frequency in Hz used by the setpoint derivative filter. Using lower values will result in smoother inputs and are more appropriate for slower receiver protocols. Most users should leave this at 0 corresponding to \"Auto\"."
+    "rcSmoothingFeedforwardCutoffHelp": {
+        "message": "The cutoff frequency in Hz used by the feedforward filter. Using lower values will result in smoother inputs and are more appropriate for slower receiver protocols. Most users should leave this at 0 corresponding to \"Auto\"."
     },
     "rcSmoothingChannelsSmoothedHelp": {
         "message": "The channels smoothing applies to"
     },
-    "rcSmoothingDerivativeTypeHelp": {
-        "message": "The type of filtering method used for the setpoint derivative. Starting with 4.2 the default value of \"Auto\" is recommended. For 4.1 and earlier most users should use the default \"BIQUAD\" value as it provides a good balance between smoothness and delay. \"PT1\" reduces the delay slightly but provides less smoothing."
+    "rcSmoothingFeedforwardTypeHelp": {
+        "message": "The type of filtering method used for the feedforward. Starting with 4.2 the default value of \"Auto\" is recommended. For 4.1 and earlier most users should use the default \"BIQUAD\" value as it provides a good balance between smoothness and delay. \"PT1\" reduces the delay slightly but provides less smoothing."
     },
-    "rcSmoothingInputTypeHelp": {
-        "message": "The type of filtering method used for the input. Most users should use the default \"BIQUAD\" value as it provides a good balance between smoothness and delay. \"PT1\" reduces the delay slightly but provides less smoothing."
+    "rcSmoothingSetpointTypeHelp": {
+        "message": "The type of filtering method used for the setpoint. Most users should use the default \"BIQUAD\" value as it provides a good balance between smoothness and delay. \"PT1\" reduces the delay slightly but provides less smoothing."
     },
-    "receiverRcSmoothingInputManual": {
-        "message": "Selects whether the input filter cutoff frequency is automatically calculated (recommended) or manually selected by the user. Using \"Manual\" is not recommended for receiver protocols like Crossfire which can change in flight."
+    "receiverRcSmoothingSetpointManual": {
+        "message": "Selects whether the setpoint filter cutoff frequency is automatically calculated (recommended) or manually selected by the user. Using \"Manual\" is not recommended for receiver protocols like Crossfire which can change in flight."
     },
-    "receiverRcSmoothingDerivativeManual": {
-        "message": "Selects whether the setpoint derivative filter cutoff frequency is automatically calculated (recommended) or manually selected by the user. Using \"Manual\" is not recommended for receiver protocols like Crossfire which can change in flight."
+    "receiverRcSmoothingFeedforwardManual": {
+        "message": "Selects whether the feedforward filter cutoff frequency is automatically calculated (recommended) or manually selected by the user. Using \"Manual\" is not recommended for receiver protocols like Crossfire which can change in flight."
     },
-    "receiverRcSmoothingInputHz": {
-        "message": "Input Cutoff Frequency"
+    "receiverRcSmoothingSetpointHz": {
+        "message": "Setpoint Cutoff Frequency"
     },
-    "receiverRcSmoothingDerivativeCutoff": {
-        "message": "Derivative Cutoff Frequency"
+    "receiverRcSmoothingFeedforwardCutoff": {
+        "message": "FeedForward Cutoff Frequency"
     },
-    "receiverRcInputType": {
-        "message": "Input Filter Type"
+    "receiverRcSetpointType": {
+        "message": "Setpoint Filter Type"
     },
-    "receiverRcDerivativeType": {
-        "message": "Derivative Filter Type"
+    "receiverRcFeedforwardType": {
+        "message": "Feedforward Filter Type"
     },
-    "receiverRcSmoothingDerivativeTypeOff": {
+    "receiverRcSmoothingFeedforwardTypeOff": {
         "message": "Off"
     },
-    "receiverRcSmoothingDerivativeTypeAuto": {
+    "receiverRcSmoothingFeedforwardTypeAuto": {
         "message": "Auto"
     },
     "receiverRcSmoothingChannel": {
@@ -1770,6 +1770,9 @@
     },
     "receiverRcInterpolationInterval": {
         "message": "RC Interpolation Interval [ms]"
+    },
+    "receiverRcSmoothingMode": {
+        "message": "Smoothing Mode"
     },
     "pidTuningFeedforwardTransition": {
         "message": "Transition"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -540,12 +540,13 @@ const FC = {
             rxSpiRfChannelCount:          0,
             fpvCamAngleDegrees:           0,
             rcSmoothingType:              0,
-            rcSmoothingInputCutoff:       0,
-            rcSmoothingDerivativeCutoff:  0,
+            rcSmoothingSetpointCutoff:    0,
+            rcSmoothingFeedforwardCutoff: 0,
             rcSmoothingInputType:         0,
             rcSmoothingDerivativeType:    0,
-            rcSmoothingAutoSmoothness:    0,
+            rcSmoothingAutoFactor:        0,
             usbCdcHidType:                0,
+            rcSmoothingMode:              0,
         };
 
         this.FAILSAFE_CONFIG = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -976,13 +976,16 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                             FC.RX_CONFIG.rcInterpolationChannels = data.readU8();
                             FC.RX_CONFIG.rcSmoothingType = data.readU8();
-                            FC.RX_CONFIG.rcSmoothingInputCutoff = data.readU8();
-                            FC.RX_CONFIG.rcSmoothingDerivativeCutoff = data.readU8();
+                            FC.RX_CONFIG.rcSmoothingSetpointCutoff = data.readU8();
+                            FC.RX_CONFIG.rcSmoothingFeedforwardCutoff = data.readU8();
                             FC.RX_CONFIG.rcSmoothingInputType = data.readU8();
                             FC.RX_CONFIG.rcSmoothingDerivativeType = data.readU8();
                             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                                 FC.RX_CONFIG.usbCdcHidType = data.readU8();
-                                FC.RX_CONFIG.rcSmoothingAutoSmoothness = data.readU8();
+                                FC.RX_CONFIG.rcSmoothingAutoFactor = data.readU8();
+                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                                    FC.RX_CONFIG.rcSmoothingMode = data.readU8();
+                                }
                             }
                         }
                     } else {
@@ -1882,13 +1885,16 @@ MspHelper.prototype.crunch = function(code) {
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                         buffer.push8(FC.RX_CONFIG.rcInterpolationChannels)
                             .push8(FC.RX_CONFIG.rcSmoothingType)
-                            .push8(FC.RX_CONFIG.rcSmoothingInputCutoff)
-                            .push8(FC.RX_CONFIG.rcSmoothingDerivativeCutoff)
+                            .push8(FC.RX_CONFIG.rcSmoothingSetpointCutoff)
+                            .push8(FC.RX_CONFIG.rcSmoothingFeedforwardCutoff)
                             .push8(FC.RX_CONFIG.rcSmoothingInputType)
                             .push8(FC.RX_CONFIG.rcSmoothingDerivativeType);
                         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                             buffer.push8(FC.RX_CONFIG.usbCdcHidType)
-                                  .push8(FC.RX_CONFIG.rcSmoothingAutoSmoothness);
+                                .push8(FC.RX_CONFIG.rcSmoothingAutoFactor);
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                                buffer.push8(FC.RX_CONFIG.rcSmoothingMode);
+                            }
                         }
                     }
                 }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -417,15 +417,15 @@ TABS.receiver.initialize = function (callback) {
             }
 
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
-                FC.RX_CONFIG.rcSmoothingInputCutoff = parseInt($('input[name="rcSmoothingInputHz-number"]').val());
-                FC.RX_CONFIG.rcSmoothingDerivativeCutoff = parseInt($('input[name="rcSmoothingDerivativeCutoff-number"]').val());
-                FC.RX_CONFIG.rcSmoothingDerivativeType = parseInt($('select[name="rcSmoothingDerivativeType-select"]').val());
+                FC.RX_CONFIG.rcSmoothingSetpointCutoff = parseInt($('input[name="rcSmoothingSetpointHz-number"]').val());
+                FC.RX_CONFIG.rcSmoothingFeedforwardCutoff = parseInt($('input[name="rcSmoothingFeedforwardCutoff-number"]').val());
+                FC.RX_CONFIG.rcSmoothingDerivativeType = parseInt($('select[name="rcSmoothingFeedforwardType-select"]').val());
                 FC.RX_CONFIG.rcInterpolationChannels = parseInt($('select[name="rcSmoothingChannels-select"]').val());
-                FC.RX_CONFIG.rcSmoothingInputType = parseInt($('select[name="rcSmoothingInputType-select"]').val());
+                FC.RX_CONFIG.rcSmoothingInputType = parseInt($('select[name="rcSmoothingSetpointType-select"]').val());
             }
 
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
-                FC.RX_CONFIG.rcSmoothingAutoSmoothness = parseInt($('input[name="rcSmoothingAutoSmoothness-number"]').val());
+                FC.RX_CONFIG.rcSmoothingAutoFactor = parseInt($('input[name="rcSmoothingAutoFactor-number"]').val());
             }
 
             function save_rssi_config() {
@@ -524,98 +524,99 @@ TABS.receiver.initialize = function (callback) {
         $(".bind_btn").toggle(showBindButton);
 
         // RC Smoothing
+        const smoothingOnOff = ((semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) ?
+            FC.RX_CONFIG.rcSmoothingMode : FC.RX_CONFIG.rcSmoothingType);
+
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
             $('.tab-receiver .rcSmoothing').show();
 
             const rc_smoothing_protocol_e = $('select[name="rcSmoothing-select"]');
             rc_smoothing_protocol_e.change(function () {
-                FC.RX_CONFIG.rcSmoothingType = $(this).val();
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                    FC.RX_CONFIG.rcSmoothingMode = parseFloat($(this).val());
+                } else {
+                    FC.RX_CONFIG.rcSmoothingType = parseFloat($(this).val());
+                }
                 updateInterpolationView();
             });
-            rc_smoothing_protocol_e.val(FC.RX_CONFIG.rcSmoothingType);
+            rc_smoothing_protocol_e.val(smoothingOnOff);
 
-            const rcSmoothingNumberElement = $('input[name="rcSmoothingInputHz-number"]');
-            const rcSmoothingDerivativeNumberElement = $('input[name="rcSmoothingDerivativeCutoff-number"]');
-            rcSmoothingNumberElement.val(FC.RX_CONFIG.rcSmoothingInputCutoff);
-            rcSmoothingDerivativeNumberElement.val(FC.RX_CONFIG.rcSmoothingDerivativeCutoff);
-            $('.tab-receiver .rcSmoothing-input-cutoff').show();
-            $('select[name="rcSmoothing-input-manual-select"]').val("1");
-            if (FC.RX_CONFIG.rcSmoothingInputCutoff == 0) {
-                $('.tab-receiver .rcSmoothing-input-cutoff').hide();
-                $('select[name="rcSmoothing-input-manual-select"]').val("0");
+            const rcSmoothingNumberElement = $('input[name="rcSmoothingSetpointHz-number"]');
+            const rcSmoothingFeedforwardNumberElement = $('input[name="rcSmoothingFeedforwardCutoff-number"]');
+            rcSmoothingNumberElement.val(FC.RX_CONFIG.rcSmoothingSetpointCutoff);
+            rcSmoothingFeedforwardNumberElement.val(FC.RX_CONFIG.rcSmoothingFeedforwardCutoff);
+            $('.tab-receiver .rcSmoothing-setpoint-cutoff').show();
+            $('select[name="rcSmoothing-setpoint-manual-select"]').val("1");
+            if (FC.RX_CONFIG.rcSmoothingSetpointCutoff === 0) {
+                $('.tab-receiver .rcSmoothing-setpoint-cutoff').hide();
+                $('select[name="rcSmoothing-setpoint-manual-select"]').val("0");
             }
-            $('select[name="rcSmoothing-input-manual-select"]').change(function () {
-                if ($(this).val() == 0) {
+            $('select[name="rcSmoothing-setpoint-manual-select"]').change(function () {
+                if ($(this).val() === "0") {
                     rcSmoothingNumberElement.val(0);
-                    $('.tab-receiver .rcSmoothing-input-cutoff').hide();
+                    $('.tab-receiver .rcSmoothing-setpoint-cutoff').hide();
                 }
-                if ($(this).val() == 1) {
-                    rcSmoothingNumberElement.val(FC.RX_CONFIG.rcSmoothingInputCutoff);
-                    $('.tab-receiver .rcSmoothing-input-cutoff').show();
+                if ($(this).val() === "1") {
+                    rcSmoothingNumberElement.val(FC.RX_CONFIG.rcSmoothingSetpointCutoff);
+                    $('.tab-receiver .rcSmoothing-setpoint-cutoff').show();
                 }
             }).change();
 
-            $('.tab-receiver .rcSmoothing-derivative-cutoff').show();
-            $('select[name="rcSmoothing-input-derivative-select"]').val("1");
-            if (FC.RX_CONFIG.rcSmoothingDerivativeCutoff == 0) {
-                $('select[name="rcSmoothing-input-derivative-select"]').val("0");
-                $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
+            $('.tab-receiver .rcSmoothing-feedforward-cutoff').show();
+            $('select[name="rcSmoothing-feedforward-select"]').val("1");
+            if (FC.RX_CONFIG.rcSmoothingFeedforwardCutoff === 0) {
+                $('select[name="rcSmoothing-feedforward-select"]').val("0");
+                $('.tab-receiver .rcSmoothing-feedforward-cutoff').hide();
             }
-            $('select[name="rcSmoothing-input-derivative-select"]').change(function () {
-                if ($(this).val() == 0) {
-                    $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
-                    rcSmoothingDerivativeNumberElement.val(0);
+            $('select[name="rcSmoothing-feedforward-select"]').change(function () {
+                if ($(this).val() === "0") {
+                    $('.tab-receiver .rcSmoothing-feedforward-cutoff').hide();
+                    rcSmoothingFeedforwardNumberElement.val(0);
                 }
-                if ($(this).val() == 1) {
-                    $('.tab-receiver .rcSmoothing-derivative-cutoff').show();
-                    rcSmoothingDerivativeNumberElement.val(FC.RX_CONFIG.rcSmoothingDerivativeCutoff);
+                if ($(this).val() === "1") {
+                    $('.tab-receiver .rcSmoothing-feedforward-cutoff').show();
+                    rcSmoothingFeedforwardNumberElement.val(FC.RX_CONFIG.rcSmoothingFeedforwardCutoff);
                 }
             }).change();
 
-            const rcSmoothingDerivativeType = $('select[name="rcSmoothingDerivativeType-select"]');
+            const rcSmoothingFeedforwardType = $('select[name="rcSmoothingFeedforwardType-select"]');
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
-                rcSmoothingDerivativeType.append($(`<option value="3">${i18n.getMessage("receiverRcSmoothingDerivativeTypeAuto")}</option>`));
+                rcSmoothingFeedforwardType.append($(`<option value="3">${i18n.getMessage("receiverRcSmoothingFeedforwardTypeAuto")}</option>`));
             }
 
-            rcSmoothingDerivativeType.val(FC.RX_CONFIG.rcSmoothingDerivativeType);
+            rcSmoothingFeedforwardType.val(FC.RX_CONFIG.rcSmoothingDerivativeType);
             const rcSmoothingChannels = $('select[name="rcSmoothingChannels-select"]');
             rcSmoothingChannels.val(FC.RX_CONFIG.rcInterpolationChannels);
-            const rcSmoothingInputType = $('select[name="rcSmoothingInputType-select"]');
-            rcSmoothingInputType.val(FC.RX_CONFIG.rcSmoothingInputType);
+            const rcSmoothingSetpointType = $('select[name="rcSmoothingSetpointType-select"]');
+            rcSmoothingSetpointType.val(FC.RX_CONFIG.rcSmoothingInputType);
 
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
-                $('select[name="rcSmoothing-input-manual-select"], select[name="rcSmoothing-input-derivative-select"]').change(function() {
-                    if ($('select[name="rcSmoothing-input-manual-select"]').val() == 0 || $('select[name="rcSmoothing-input-derivative-select"]').val() == 0) {
-                        $('.tab-receiver .rcSmoothing-auto-smoothness').show();
+                $('select[name="rcSmoothing-setpoint-manual-select"], select[name="rcSmoothing-feedforward-select"]').change(function() {
+                    if ($('select[name="rcSmoothing-setpoint-manual-select"]').val() === "0" || $('select[name="rcSmoothing-feedforward-select"]').val() === "0") {
+                        $('.tab-receiver .rcSmoothing-auto-factor').show();
                     } else {
-                        $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
+                        $('.tab-receiver .rcSmoothing-auto-factor').hide();
                     }
                 });
-                $('select[name="rcSmoothing-input-manual-select"]').change();
+                $('select[name="rcSmoothing-setpoint-manual-select"]').change();
 
-                const rcSmoothingAutoSmoothness = $('input[name="rcSmoothingAutoSmoothness-number"]');
-                rcSmoothingAutoSmoothness.val(FC.RX_CONFIG.rcSmoothingAutoSmoothness);
+                const rcSmoothingAutoFactor = $('input[name="rcSmoothingAutoFactor-number"]');
+                rcSmoothingAutoFactor.val(FC.RX_CONFIG.rcSmoothingAutoFactor);
             } else {
-                $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
+                $('.tab-receiver .rcSmoothing-auto-factor').hide();
             }
 
             updateInterpolationView();
         } else {
             $('.tab-receiver .rcInterpolation').show();
-            $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
-            $('.tab-receiver .rcSmoothing-input-cutoff').hide();
-            $('.tab-receiver .rcSmoothing-derivative-type').hide();
-            $('.tab-receiver .rcSmoothing-input-type').hide();
-            $('.tab-receiver .rcSmoothing-derivative-manual').hide();
-            $('.tab-receiver .rcSmoothing-input-manual').hide();
+            $('.tab-receiver .rcSmoothing-feedforward-cutoff').hide();
+            $('.tab-receiver .rcSmoothing-setpoint-cutoff').hide();
+            $('.tab-receiver .rcSmoothing-feedforward-type').hide();
+            $('.tab-receiver .rcSmoothing-setpoint-type').hide();
+            $('.tab-receiver .rcSmoothing-feedforward-manual').hide();
+            $('.tab-receiver .rcSmoothing-setpoint-manual').hide();
             $('.tab-receiver .rc-smoothing-type').hide();
-            $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
-        }
-
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
-            $('.tab-receiver .rcSmoothing-derivative-type').hide();
-            $('.tab-receiver .rcSmoothing-input-type').hide();
-            $('.tab-receiver input[name="rcSmoothingAutoSmoothness-number"]').attr("max", "250");
+            $('.tab-receiver .rcSmoothing-auto-factor').hide();
         }
 
         // Only show the MSP control sticks if the MSP Rx feature is enabled
@@ -865,33 +866,56 @@ TABS.receiver.updateRcInterpolationParameters = function () {
 };
 
 function updateInterpolationView() {
+    const smoothingOnOff = ((semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) ?
+        FC.RX_CONFIG.rcSmoothingMode : FC.RX_CONFIG.rcSmoothingType);
+
     $('.tab-receiver .rcInterpolation').hide();
-    $('.tab-receiver .rcSmoothing-derivative-cutoff').show();
-    $('.tab-receiver .rcSmoothing-input-cutoff').show();
-    $('.tab-receiver .rcSmoothing-derivative-type').show();
-    $('.tab-receiver .rcSmoothing-input-type').show();
-    $('.tab-receiver .rcSmoothing-derivative-manual').show();
-    $('.tab-receiver .rcSmoothing-input-manual').show();
+    $('.tab-receiver .rcSmoothing-feedforward-cutoff').show();
+    $('.tab-receiver .rcSmoothing-setpoint-cutoff').show();
+    $('.tab-receiver .rcSmoothing-feedforward-type').show();
+    $('.tab-receiver .rcSmoothing-setpoint-type').show();
+    $('.tab-receiver .rcSmoothing-feedforward-manual').show();
+    $('.tab-receiver .rcSmoothing-setpoint-manual').show();
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
-        if (FC.RX_CONFIG.rcSmoothingDerivativeCutoff == 0 || FC.RX_CONFIG.rcSmoothingInputCutoff == 0) {
-            $('.tab-receiver .rcSmoothing-auto-smoothness').show();
+        if (FC.RX_CONFIG.rcSmoothingFeedforwardCutoff === 0 || FC.RX_CONFIG.rcSmoothingSetpointCutoff === 0) {
+            $('.tab-receiver .rcSmoothing-auto-factor').show();
         }
     }
 
-    if (FC.RX_CONFIG.rcSmoothingType == 0) {
-        $('.tab-receiver .rcInterpolation').show();
-        $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
-        $('.tab-receiver .rcSmoothing-input-cutoff').hide();
-        $('.tab-receiver .rcSmoothing-derivative-type').hide();
-        $('.tab-receiver .rcSmoothing-input-type').hide();
-        $('.tab-receiver .rcSmoothing-derivative-manual').hide();
-        $('.tab-receiver .rcSmoothing-input-manual').hide();
-        $('.tab-receiver .rcSmoothing-auto-smoothness').hide();
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+        $('.tab-receiver .rcSmoothing-feedforward-type').hide();
+        $('.tab-receiver .rcSmoothing-setpoint-type').hide();
+        $('.tab-receiver .rc-smoothing-channels').hide();
+        $('.tab-receiver input[name="rcSmoothingAutoFactor-number"]').attr("max", "250");
+        $('.tab-receiver .rcSmoothingType').hide();
+        $('.rcSmoothingOff').text('OFF');
+        $('.rcSmoothingOn').text('ON');
+    } else {
+        $('.tab-receiver .rcSmoothingMode').hide();
     }
-    if (FC.RX_CONFIG.rcSmoothingDerivativeCutoff == 0) {
-        $('.tab-receiver .rcSmoothing-derivative-cutoff').hide();
+
+    if (smoothingOnOff === 0) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+            $('.tab-receiver .rcSmoothing-feedforward-cutoff').hide();
+            $('.tab-receiver .rcSmoothing-setpoint-cutoff').hide();
+            $('.tab-receiver .rcSmoothing-feedforward-manual').hide();
+            $('.tab-receiver .rcSmoothing-setpoint-manual').hide();
+            $('.tab-receiver .rcSmoothing-auto-factor').hide();
+        } else {
+            $('.tab-receiver .rcInterpolation').show();
+            $('.tab-receiver .rcSmoothing-feedforward-cutoff').hide();
+            $('.tab-receiver .rcSmoothing-setpoint-cutoff').hide();
+            $('.tab-receiver .rcSmoothing-feedforward-type').hide();
+            $('.tab-receiver .rcSmoothing-setpoint-type').hide();
+            $('.tab-receiver .rcSmoothing-feedforward-manual').hide();
+            $('.tab-receiver .rcSmoothing-setpoint-manual').hide();
+            $('.tab-receiver .rcSmoothing-auto-factor').hide();
+        }
     }
-    if (FC.RX_CONFIG.rcSmoothingInputCutoff == 0) {
-        $('.tab-receiver .rcSmoothing-input-cutoff').hide();
+    if (FC.RX_CONFIG.rcSmoothingFeedforwardCutoff === 0) {
+        $('.tab-receiver .rcSmoothing-feedforward-cutoff').hide();
+    }
+    if (FC.RX_CONFIG.rcSmoothingSetpointCutoff === 0) {
+        $('.tab-receiver .rcSmoothing-setpoint-cutoff').hide();
     }
 }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -888,8 +888,8 @@ function updateInterpolationView() {
         $('.tab-receiver .rc-smoothing-channels').hide();
         $('.tab-receiver input[name="rcSmoothingAutoFactor-number"]').attr("max", "250");
         $('.tab-receiver .rcSmoothingType').hide();
-        $('.rcSmoothingOff').text('OFF');
-        $('.rcSmoothingOn').text('ON');
+        $('.tab-receiver .rcSmoothingOff').text(i18n.getMessage('off'));
+        $('.tab-receiver .rcSmoothingOn').text(i18n.getMessage('on'));
     } else {
         $('.tab-receiver .rcSmoothingMode').hide();
     }

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -156,14 +156,17 @@
                         <tr class="rc-smoothing-type">
                             <td>
                                 <select name="rcSmoothing-select">
-                                    <option value="0" i18n="receiverRcSmoothingInterpolation"></option>
-                                    <option value="1" i18n="receiverRcSmoothingFilter"></option>
+                                    <option class="rcSmoothingOff" value="0" i18n="receiverRcSmoothingInterpolation"></option>
+                                    <option class="rcSmoothingOn" value="1" i18n="receiverRcSmoothingFilter"></option>
                                 </select>
                             </td>
                             <td colspan="2">
                                 <div>
-                                    <label>
+                                    <label class="rcSmoothingType">
                                         <span i18n="receiverRcSmoothingType"></span>
+                                    </label>
+                                    <label class="rcSmoothingMode">
+                                        <span i18n="receiverRcSmoothingMode"></span>
                                     </label>
                                 </div>
                             </td>
@@ -186,9 +189,9 @@
                                 </div>
                             </td>
                         </tr>
-                        <tr class="rcSmoothing-input-manual">
+                        <tr class="rcSmoothing-setpoint-manual">
                             <td>
-                                <select name="rcSmoothing-input-manual-select">
+                                <select name="rcSmoothing-setpoint-manual-select">
                                     <option value="0" i18n="receiverRcSmoothingAuto"></option>
                                     <option value="1" i18n="receiverRcSmoothingManual"></option>
                                 </select>
@@ -196,28 +199,28 @@
                             <td>
                                 <div>
                                     <label>
-                                        <span i18n="receiverRcInputTypeSelect"></span>
+                                        <span i18n="receiverRcSetpointTypeSelect"></span>
                                     </label>
                                 </div>
                             </td>
                             <td>
-                                <div class="helpicon cf_tip" i18n_title="receiverRcSmoothingInputManual"></div>
+                                <div class="helpicon cf_tip" i18n_title="receiverRcSmoothingSetpointManual"></div>
                             </td>
                         </tr>
-                        <tr class="rcSmoothing-input-manual">
-                            <td class="rcSmoothing-input-cutoff"><input type="number" name="rcSmoothingInputHz-number" step="1" min="1" max="255"/></td>
-                            <td class="rcSmoothing-input-cutoff" colspan="2">
+                        <tr class="rcSmoothing-setpoint-manual">
+                            <td class="rcSmoothing-setpoint-cutoff"><input type="number" name="rcSmoothingSetpointHz-number" step="1" min="1" max="255"/></td>
+                            <td class="rcSmoothing-setpoint-cutoff" colspan="2">
                                 <div>
                                     <label>
-                                        <span i18n="receiverRcSmoothingInputHz"></span>
+                                        <span i18n="receiverRcSmoothingSetpointHz"></span>
                                     </label>
-                                    <div class="helpicon cf_tip" i18n_title="rcSmoothingInputCutoffHelp"></div>
+                                    <div class="helpicon cf_tip" i18n_title="rcSmoothingSetpointCutoffHelp"></div>
                                 </div>
                             </td>
                         </tr>
-                        <tr class="rcSmoothing-input-type">
+                        <tr class="rcSmoothing-setpoint-type">
                             <td>
-                                <select name="rcSmoothingInputType-select">
+                                <select name="rcSmoothingSetpointType-select">
                                     <option value="0">PT1</option>
                                     <option value="1">BIQUAD</option>
                                 </select>
@@ -225,17 +228,17 @@
                             <td>
                                 <div>
                                     <label>
-                                        <span i18n="receiverRcInputType"></span>
+                                        <span i18n="receiverRcSetpointType"></span>
                                     </label>
                                 </div>
                             </td>
                             <td>
-                                <div class="helpicon cf_tip" i18n_title="rcSmoothingInputTypeHelp"></div>
+                                <div class="helpicon cf_tip" i18n_title="rcSmoothingSetpointTypeHelp"></div>
                             </td>
                         </tr>
-                        <tr class="rcSmoothing-derivative-manual">
+                        <tr class="rcSmoothing-feedforward-manual">
                             <td>
-                                <select name="rcSmoothing-input-derivative-select">
+                                <select name="rcSmoothing-feedforward-select">
                                     <option value="0" i18n="receiverRcSmoothingAuto"></option>
                                     <option value="1" i18n="receiverRcSmoothingManual"></option>
                                 </select>
@@ -243,29 +246,29 @@
                             <td>
                                 <div>
                                     <label>
-                                        <span i18n="receiverRcDerivativeTypeSelect"></span>
+                                        <span i18n="receiverRcFeedforwardTypeSelect"></span>
                                     </label>
                                 </div>
                             </td>
                             <td>
-                                <div class="helpicon cf_tip" i18n_title="receiverRcSmoothingDerivativeManual"></div>
+                                <div class="helpicon cf_tip" i18n_title="receiverRcSmoothingFeedforwardManual"></div>
                             </td>
                         </tr>
-                        <tr class="rcSmoothing-derivative-manual">
-                            <td class="rcSmoothing-derivative-cutoff"><input type="number" name="rcSmoothingDerivativeCutoff-number" step="1" min="1" max="255"/></td>
-                            <td colspan="2" class="rcSmoothing-derivative-cutoff">
+                        <tr class="rcSmoothing-feedforward-manual">
+                            <td class="rcSmoothing-feedforward-cutoff"><input type="number" name="rcSmoothingFeedforwardCutoff-number" step="1" min="1" max="255"/></td>
+                            <td colspan="2" class="rcSmoothing-feedforward-cutoff">
                                 <div>
                                     <label>
-                                        <span i18n="receiverRcSmoothingDerivativeCutoff"></span>
+                                        <span i18n="receiverRcSmoothingFeedforwardCutoff"></span>
                                     </label>
-                                    <div class="helpicon cf_tip" i18n_title="rcSmoothingDerivativeCutoffHelp"></div>
+                                    <div class="helpicon cf_tip" i18n_title="rcSmoothingFeedforwardCutoffHelp"></div>
                                 </div>
                             </td>
                         </tr>
-                        <tr class="rcSmoothing-input-type">
+                        <tr class="rcSmoothing-setpoint-type">
                             <td>
-                                <select name="rcSmoothingDerivativeType-select">
-                                    <option value="0" i18n="receiverRcSmoothingDerivativeTypeOff"></option>
+                                <select name="rcSmoothingFeedforwardType-select">
+                                    <option value="0" i18n="receiverRcSmoothingFeedforwardTypeOff"></option>
                                     <option value="1">PT1</option>
                                     <option value="2">BIQUAD</option>
                                 </select>
@@ -273,27 +276,27 @@
                             <td>
                                 <div>
                                     <label>
-                                        <span i18n="receiverRcDerivativeType"></span>
+                                        <span i18n="receiverRcFeedforwardType"></span>
                                     </label>
                                 </div>
                             </td>
                             <td>
-                                <div class="helpicon cf_tip" i18n_title="rcSmoothingDerivativeTypeHelp"></div>
+                                <div class="helpicon cf_tip" i18n_title="rcSmoothingFeedforwardTypeHelp"></div>
                             </td>
                         </tr>
-                        <tr class="rcSmoothing-auto-smoothness">
+                        <tr class="rcSmoothing-auto-factor">
                             <td>
-                                <input type="number" name="rcSmoothingAutoSmoothness-number" step="1" min="0" max="50">
+                                <input type="number" name="rcSmoothingAutoFactor-number" step="1" min="0" max="50">
                             </td>
                             <td>
                                 <div>
                                     <label>
-                                        <span i18n="receiverRcSmoothingAutoSmoothness"></span>
+                                        <span i18n="receiverRcSmoothingAutoFactor"></span>
                                     </label>
                                 </div>
                             </td>
                             <td>
-                                <div class="helpicon cf_tip" i18n_title="receiverRcSmoothingAutoSmoothnessHelp"></div>
+                                <div class="helpicon cf_tip" i18n_title="receiverRcSmoothingAutoFactorHelp"></div>
                             </td>
                         </tr>
                         <tr class="rcInterpolation">


### PR DESCRIPTION
This PR goes with part of https://github.com/betaflight/betaflight/pull/10727 and now is 100% coordination finished with this PR changes.
Added Rc smoothing changes maintaining the compatibility and functions of the previous one. I have used some constants but im not sure were they need to go @McGiverGim . I also use text replaces for i18n, but we can think on create new html group and hide the old, what do you think guys?

![image](https://user-images.githubusercontent.com/43983086/123688486-5894d980-d852-11eb-9e9d-7ba8a3491e78.png)
