### PR TITLE
Fixed incorrect use of callback for control sticks window.

### DIFF
--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -506,7 +506,9 @@ TABS.receiver.initialize = function (callback) {
                     }
                 };
 
-                windowWatcherUtil.passValue(createdWindow, 'darkTheme', DarkTheme.isDarkThemeEnabled(DarkTheme.configEnabled));
+                DarkTheme.isDarkThemeEnabled(function(isEnabled) {
+                    windowWatcherUtil.passValue(createdWindow, 'darkTheme', isEnabled);
+                });
 
             });
         });


### PR DESCRIPTION
Fixes a bug when opening the Control sticks window:

```
Uncaught TypeError: callback is not a function
    at Object.DarkTheme.isDarkThemeEnabled (DarkTheme.js:24)
    at receiver.js:509
    at extensions::app.window:209
```

![image](https://user-images.githubusercontent.com/4742747/123720585-83297580-d8d8-11eb-993d-309592c3a150.png)


