### PR TITLE
Detect board in firmware_flasher patch

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2986,7 +2986,7 @@
         "message": "Select build type to see available boards."
     },
     "firmwareFlasherOnlineSelectBoardDescription": {
-        "message": "Select your board to see available online firmware releases - Select the correct firmware appropriate for your board."
+        "message": "Select or auto-detect your board to see available online firmware releases - Select the correct firmware appropriate for your board."
     },
     "firmwareFlasherOnlineSelectBoardHint": {
         "message": "Starting with Betaflight 4.1, Betaflight is introducing support for <strong>Unified Targets</strong>. The concept of Unified Targets means that the same firmware .hex file can be used for all boards using the same MCU (F4, F7). To make the different boards work with the same firmware, a specific configuration file is deployed alongside the firmware when a Unified Target is flashed.<br>This version of Betaflight configurator supports flashing of Unified Targets with the respective board specific configurations in one step. The different firmware types that are available for each board are shown in the drop-down as follows:<br /><br /><strong>&lt;board name&gt;</strong> or<br><strong>&lt;board name&gt; (Legacy)</strong>:<br>non-unified target, or pre-4.1 versions of the firmware for Unified Targets.<br /><br /><strong>&lt;board name&gt; (&lt;manufacturer id&gt;)</strong>:<br>(4 character manufacturer id)<br>Unified Target.<br /><br /><strong>Please use Unified Targets where available.</strong> If you encounter problems using a Unified Target, please open an <a href=\"https://github.com/betaflight/betaflight/issues\" target=\"_blank\" rel=\"noopener noreferrer\">issue</a> and then use the non-unified target until the issue has been resolved."
@@ -3170,6 +3170,15 @@
     },
     "firmwareFlasherButtonContinue": {
         "message": "Continue"
+    },
+    "firmwareFlasherDetectBoardButton": {
+        "message": "Auto-detect"
+    },
+    "firmwareFlasherDetectBoardDescriptionHint": {
+        "message": "Auto-detect only works when not in DFU mode and when MSP communication is working. Sometimes you have to retry a few times or even reconnect USB. Try connecting as normal first as you could have forgotten to apply custom defaults. Please reboot after flashing - replug your USB."
+    },
+    "firmwareFlasherDetectBoardQuery": {
+        "message": "Query board information to preselect right firmware"
     },
     "unstableFirmwareAcknoledgementDialog": {
         "message": "You are about to flash a <strong>development build of the firmware</strong>. These builds are a work in progress, and any of the following can be the case:<strong><ul><li>the firmware does not work at all;</li><li>the firmware is not flyable;</li><li>there are safety issues with the firmware, for example flyaways</li><li>the firmware can cause the flight controller to become unresponsive, or damaged</li></ul></strong>If you proceed with flashing this firmware, <strong>you are assuming full responsibility for the risk of any of the above happening</strong>. Furthermore you acknowledge that it is necessary to perform <strong>thorough bench tests with props off</strong> before any attempts to fly this firmware."

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -78,8 +78,12 @@
     text-align: left;
 }
 
-.tab-firmware_flasher td {
-    text-align: left;
+.tab-firmware_flasher td.board-description {
+    padding: 1px 0 3px 0;
+}
+
+.tab-firmware_flasher .helpicon {
+    margin-top: 3px;
 }
 
 .tab-firmware_flasher .options label input {
@@ -200,6 +204,16 @@
     pointer-events: none;
     text-shadow: none;
     opacity: 0.5;
+}
+
+.tab-firmware_flasher .default_btn {
+    margin: 1px 7px 0 0;
+    width: fit-content;
+}
+
+.tab-firmware_flasher .default_btn a {
+    padding: 0 4px 2px 4px;
+    font-size: 11px;
 }
 
 #dialogUnstableFirmwareAcknoledgement .content {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -12,6 +12,7 @@ const PortHandler = new function () {
     this.port_detected_callbacks = [];
     this.port_removed_callbacks = [];
     this.dfu_available = false;
+    this.port_available = false;
 };
 
 PortHandler.initialize = function () {
@@ -118,6 +119,7 @@ PortHandler.removePort = function(currentPorts) {
 
     if (removePorts.length) {
         console.log(`PortHandler - Removed: ${JSON.stringify(removePorts)}`);
+        self.port_available = false;
         // disconnect "UI" - routine can't fire during atmega32u4 reboot procedure !!!
         if (GUI.connected_to) {
             for (let i = 0; i < removePorts.length; i++) {
@@ -170,6 +172,7 @@ PortHandler.detectPort = function(currentPorts) {
             }
         });
 
+        self.port_available = true;
         // Signal board verification
         if (GUI.active_tab === 'firmware_flasher') {
             TABS.firmware_flasher.boardNeedsVerification = true;
@@ -266,6 +269,7 @@ PortHandler.selectPort = function(ports) {
             const legacyDeviceRecognized = portName.includes('usb');
             if (isWindows && deviceRecognized || isTty && (deviceRecognized || legacyDeviceRecognized)) {
                 this.portPickerElement.val(pathSelect);
+                this.port_available = true;
                 console.log(`Porthandler detected device ${portName} on port: ${pathSelect}`);
             }
         }

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -18,10 +18,7 @@ const serial = {
     connect: function (path, options, callback) {
         const self = this;
         const testUrl = path.match(/^tcp:\/\/([A-Za-z0-9\.-]+)(?:\:(\d+))?$/);
-        if (self.connectionId || self.connected) {
-            console.warn('We already connected. Aborting', self.connectionId, self.connected);
-            return;
-        }
+
         if (testUrl) {
             self.connectTcp(testUrl[1], testUrl[2], options, callback);
         } else if (path === 'virtual') {

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -26,7 +26,14 @@
                         <td class="board-select"><select name="board">
                                 <option value="0" i18n="firmwareFlasherOptionLoading">Loading ...</option>
                         </select></td>
-                        <td><span class="description" i18n="firmwareFlasherOnlineSelectBoardDescription"></span><div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherOnlineSelectBoardHint"></div></td>
+                        <td class="board-description">
+                            <div class="btn default_btn">
+                                <a class="detect-board disabled" href="#" i18n="firmwareFlasherDetectBoardButton"></a>
+                            </div>
+                            <span class="description" i18n="firmwareFlasherOnlineSelectBoardDescription"></span>
+                            <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherOnlineSelectBoardHint"></div>
+                            <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherDetectBoardDescriptionHint"></div>
+                        </td>
                     </tr>
                     <tr>
                         <td><select name="firmware_version">


### PR DESCRIPTION
Patch for firmware flashing detect board feature introduced in #2485

Fixes: #2526
Fixes: #2498 

After much testing this patch provides the following changes (thanks for all feedback):

- Removes board verification on tab load and instead let the user check with a button reducing the connection load to avoid connection issues.
- Slapped a timer on the button to prevent spamming as requested by @Asizon
- Button is much smaller now and next to board selection as requested by @McGivergim
- Only present a dialog (when using MSP capabilities) in `msp32.js` when using online firmware as requested by @mikeller, @hydra and @Asizon 
- Like to keep the detection on port change.
- Does not remember non available board.
- Refreshes tab when trying to flash while no board is connected.

![Screenshot from 2021-07-01 13-27-24](https://user-images.githubusercontent.com/8344830/124117273-34aedf00-da70-11eb-9618-1d64c1775d16.png)