### PR TITLE
Verify addresses in hex files

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -670,7 +670,10 @@
     "dfu_device_flash_info": {
         "message": "Detected device with total flash size $1 KiB"
     },
-    "dfu_error_image_size": {
+    "dfu_hex_address_errors": {
+        "message": "<span class=\"message-negative\">Error</span>: Firmware image contains addresses not found on target device"
+    },
+        "dfu_error_image_size": {
         "message": "<span class=\"message-negative\">Error</span>: Supplied image is larger then flash available on the chip! Image: $1 KiB, limit = $2 KiB"
     },
 

--- a/src/js/protocols/stm32usbdfu.js
+++ b/src/js/protocols/stm32usbdfu.js
@@ -68,7 +68,7 @@ var STM32DFU_protocol = function () {
 };
 
 STM32DFU_protocol.prototype.connect = function (device, hex, options, callback) {
-    var self = this;
+    const self = this;
     self.hex = hex;
     self.callback = callback;
 
@@ -103,7 +103,7 @@ STM32DFU_protocol.prototype.connect = function (device, hex, options, callback) 
 };
 
 STM32DFU_protocol.prototype.openDevice = function (device) {
-    var self = this;
+    const self = this;
 
     chrome.usb.openDevice(device, function (handle) {
         if (checkChromeRuntimeError()) {
@@ -124,7 +124,7 @@ STM32DFU_protocol.prototype.openDevice = function (device) {
 };
 
 STM32DFU_protocol.prototype.closeDevice = function () {
-    var self = this;
+    const self = this;
 
     chrome.usb.closeDevice(this.handle, function closed() {
         if (checkChromeRuntimeError()) {
@@ -140,7 +140,7 @@ STM32DFU_protocol.prototype.closeDevice = function () {
 };
 
 STM32DFU_protocol.prototype.claimInterface = function (interfaceNumber) {
-    var self = this;
+    const self = this;
 
     chrome.usb.claimInterface(this.handle, interfaceNumber, function claimed() {
         // Don't perform the error check on MacOS at this time as there seems to be a bug
@@ -162,7 +162,7 @@ STM32DFU_protocol.prototype.claimInterface = function (interfaceNumber) {
 };
 
 STM32DFU_protocol.prototype.releaseInterface = function (interfaceNumber) {
-    var self = this;
+    const self = this;
 
     chrome.usb.releaseInterface(this.handle, interfaceNumber, function released() {
         console.log('Released interface: ' + interfaceNumber);
@@ -180,7 +180,7 @@ STM32DFU_protocol.prototype.resetDevice = function (callback) {
 };
 
 STM32DFU_protocol.prototype.getString = function (index, callback) {
-    var self = this;
+    const self = this;
 
     chrome.usb.controlTransfer(self.handle, {
         'direction':    'in',
@@ -208,7 +208,7 @@ STM32DFU_protocol.prototype.getString = function (index, callback) {
 };
 
 STM32DFU_protocol.prototype.getInterfaceDescriptors = function (interfaceNum, callback) {
-    var self = this;
+    const self = this;
 
     chrome.usb.getConfiguration( this.handle, function (config) {
         if (checkChromeRuntimeError()) {
@@ -250,7 +250,7 @@ STM32DFU_protocol.prototype.getInterfaceDescriptors = function (interfaceNum, ca
 
 
 STM32DFU_protocol.prototype.getInterfaceDescriptor = function (_interface, callback) {
-    var self = this;
+    const self = this;
     chrome.usb.controlTransfer(this.handle, {
         'direction':    'in',
         'recipient':    'device',
@@ -284,7 +284,7 @@ STM32DFU_protocol.prototype.getInterfaceDescriptor = function (_interface, callb
 };
 
 STM32DFU_protocol.prototype.getFunctionalDescriptor = function (_interface, callback) {
-    var self = this;
+    const self = this;
     chrome.usb.controlTransfer(this.handle, {
         'direction':    'in',
         'recipient':    'interface',
@@ -316,7 +316,7 @@ STM32DFU_protocol.prototype.getFunctionalDescriptor = function (_interface, call
 };
 
 STM32DFU_protocol.prototype.getChipInfo = function (_interface, callback) {
-    var self = this;
+    const self = this;
 
     self.getInterfaceDescriptors(0, function (descriptors, resultCode) {
         if (resultCode) {
@@ -420,7 +420,7 @@ STM32DFU_protocol.prototype.getChipInfo = function (_interface, callback) {
 };
 
 STM32DFU_protocol.prototype.controlTransfer = function (direction, request, value, _interface, length, data, callback, _timeout) {
-    var self = this;
+    const self = this;
 
     // timeout support was added in chrome v43
     var timeout;
@@ -482,7 +482,7 @@ STM32DFU_protocol.prototype.controlTransfer = function (direction, request, valu
 
 // routine calling DFU_CLRSTATUS until device is in dfuIDLE state
 STM32DFU_protocol.prototype.clearStatus = function (callback) {
-    var self = this;
+    const self = this;
 
     function check_status() {
         self.controlTransfer('in', self.request.GETSTATUS, 0, 0, 6, 0, function (data) {
@@ -504,7 +504,7 @@ STM32DFU_protocol.prototype.clearStatus = function (callback) {
 };
 
 STM32DFU_protocol.prototype.loadAddress = function (address, callback, abort) {
-    var self = this;
+    const self = this;
 
     self.controlTransfer('out', self.request.DNLOAD, 0, 0, 0, [0x21, address & 0xff, (address >> 8) & 0xff, (address >> 16) & 0xff, (address >> 24) & 0xff], function () {
         self.controlTransfer('in', self.request.GETSTATUS, 0, 0, 6, 0, function (data) {
@@ -550,7 +550,7 @@ STM32DFU_protocol.prototype.verify_flash = function (first_array, second_array) 
 };
 
 STM32DFU_protocol.prototype.isBlockUsable = function(startAddress, length) {
-    var self = this;
+    const self = this;
 
     let result = false;
 
@@ -591,7 +591,7 @@ STM32DFU_protocol.prototype.isBlockUsable = function(startAddress, length) {
 };
 
 STM32DFU_protocol.prototype.upload_procedure = function (step) {
-    var self = this;
+    const self = this;
 
     switch (step) {
         case 0:


### PR DESCRIPTION
 Verify target has all addresses found in the hex file instead of verifying the size.

As noted in PR #2512 simply verifying the size of the hex file is not extensible and is not how hex files are designed to be used.

A hex file can contains many non-contiguous blocks of data.

This also supports targets with any partition layout.

Additionally, this provides a more future-proof and flexible way of providing hex files which can now contain data for non-contiguous blocks, e.g. firmware + config, or firmware + osd fonts.

This replaces PR #2512

Tested on:

- SPRacingH7RF (External Flash, Different partition layout from previous FCs, image file matches partition size)
```@External Flash /0x90000000/111*8Kg,16*8Kg,1*8Kg,128*8Kg,0*8Ka```
- SPRacingH7EXTREME (External Flash, Partition larger than .hex file - Partition: 512KB, Hex: 448KB)
```"@External Flash /0x90000000/998*128Kg,1*128Kg,4*128Kg,21*128Ka```
- SPRacingF7DUAL (Internal Flash, Unified target, .hex spans multiple sectors)
```@Internal Flash  /0x08000000/04*016Kg,01*64Kg,03*128Kg```
