### PR TITLE
Add OSD_TOTAL_PACKS (with betaflight/pull/10808)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5325,6 +5325,13 @@
     "osdDescTotalFlights": {
         "message": "Approximate total number of flights"
     },
+    "osdTextTotalPacks": {
+        "message": "Total packs",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescTotalPacks": {
+        "message": "Number of flown packs"
+    },
     "osdTextElementUpDownReference": {
         "message": "Up (Pitch 90 deg)/Down (Pitch -90 deg) Reference",
         "description": "OSD Symbol to show when pitch is approaching vertical (90 deg, U) and D for nose down (-90 deg, D)"
@@ -5507,6 +5514,13 @@
     },
     "osdDescStatTotalFlights": {
         "message": "Total number of flights"
+    },
+    "osdTextStatTotalPacks": {
+        "message": "Packs count total",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalPacks": {
+        "message": "Total number of flown packs"
     },
     "osdTextStatTotalFlightTime": {
         "message": "Fly time total",

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1268,12 +1268,21 @@ OSD.loadDisplayFields = function() {
             positionable: true,
             preview: "#9876",
         },
+        TOTAL_PACKS: {
+            name: 'OSD_TOTAL_PACKS',
+            text: 'osdTextTotalPacks',
+            desc: 'osdDescTotalPacks',
+            defaultPosition: -1,
+            draw_order: 465,
+            positionable: true,
+            preview: "#123",
+        },
         OSD_UP_DOWN_REFERENCE: {
             name: 'OSD_UP_DOWN_REFERENCE',
             text: 'osdTextElementUpDownReference',
             desc: 'osdDescUpDownReference',
             defaultPosition: 238,
-            draw_order: 465,
+            draw_order: 470,
             positionable: true,
             preview: 'U',
         },
@@ -1282,7 +1291,7 @@ OSD.loadDisplayFields = function() {
             text: 'osdTextElementTxUplinkPower',
             desc: 'osdDescTxUplinkPower',
             defaultPosition: -1,
-            draw_order: 470,
+            draw_order: 475,
             positionable: true,
             preview: `${FONT.symbol(SYM.RSSI)}250MW`,
         },
@@ -1441,6 +1450,11 @@ OSD.constants = {
             name: 'STAT_TOTAL_FLIGHTS',
             text: 'osdTextStatTotalFlights',
             desc: 'osdDescStatTotalFlights',
+        },
+        STAT_TOTAL_PACKS: {
+            name: 'STAT_TOTAL_PACKS',
+            text: 'osdTextStatTotalPacks',
+            desc: 'osdDescStatTotalPacks',
         },
         STAT_TOTAL_FLIGHT_TIME: {
             name: 'STAT_TOTAL_FLIGHT_TIME',
@@ -1710,6 +1724,7 @@ OSD.chooseFields = function() {
                                                         F.TOTAL_FLIGHTS,
                                                         F.OSD_UP_DOWN_REFERENCE,
                                                         F.OSD_TX_UPLINK_POWER,
+                                                        F.TOTAL_PACKS,
                                                     ]);
                                                 }
                                             }
@@ -1808,6 +1823,11 @@ OSD.chooseFields = function() {
                 F.STAT_TOTAL_FLIGHT_TIME,
                 F.STAT_TOTAL_FLIGHT_DIST,
                 F.MIN_RSSI_DBM,
+            ]);
+        }
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+            OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([
+                F.STAT_TOTAL_PACKS,
             ]);
         }
     }


### PR DESCRIPTION
### Add OSD_TOTAL_PACKS

Satisfies `Needs coordination with betaflight-configurator` label on the [original PR #10808](https://github.com/betaflight/betaflight/pull/10808).

I tested the betaflight-configurator on Linux64 platform, and with modified Betaflight 4.3 (the one in PR) on STM32F7X2 target
```
# config: manufacturer_id: AIKO, board_name: AIKONF7, version: 34f72565, date: 2019-10-03T17:08:47Z
```

All settings went good on BF configurator and seems OK.

I'll test the feature itself this weekend ; all is looking good on the betaflight-configurator side.