### PR TITLE
Disable Home and End button in Motor Tab

### DIFF
--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -898,6 +898,15 @@ TABS.motors.initialize = function (callback) {
             $('div.sliders input:not(:last):first').trigger('input');
         });
 
+        // After moving from NWjs 0.50.2 to 0.54.x Home and End buttons are swapped. Disable to avoid confusion
+        const disableHomeEndKey = event => {
+            if (event.key === 'Home' || event.key === 'End') {
+                event.preventDefault();
+            }
+        };
+
+        document.querySelectorAll('div.sliders input').forEach(e => e.addEventListener('keydown', event => disableHomeEndKey(event)));
+
         // check if motors are already spinning
         let motorsRunning = false;
 


### PR DESCRIPTION
Fixes: #2528 

After the update to NWjs 0.54.x (also tested with Node 14 on Fedora 34) `Home` and `End` buttons are swapped causing user confusion

Remapping did not work (could try more) - as I'm trapped in my own event handler - but personal new behavior is how it should be `Home = 1000` and `End = 2000`. But as this was not like this before and to avoid safety issues it's seems best to disable the buttons.