### PR TITLE
Bump NWjs to 0.54.1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,7 +51,7 @@ const NODE_ENV = process.env.NODE_ENV || 'production';
 let gitChangeSetId;
 
 const nwBuilderOptions = {
-    version: '0.54.0',
+    version: '0.54.1',
     files: `${DIST_DIR}**/*`,
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},


### PR DESCRIPTION
Bumps NWjs from 0.54.0 to 0.54.1 fixing an issue with not being able to select a custom image using Font Manager.

Also tried 0.55.0 but @kevinsummer pointed out a problem with registering the Notification Center App ID as `io.nwjs.nwjs.framework.alertnotificationservice` instead of `com.nw-builder.betaflight-configurator`.

See https://github.com/betaflight/betaflight-configurator/issues/2274