### PR TITLE
Fix Expert Mode Switch

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -501,12 +501,12 @@ function startProcess() {
     });
 
     ConfigStorage.get('permanentExpertMode', function (result) {
-        const experModeCheckbox = 'input[name="expertModeCheckbox"]';
+        const expertModeCheckbox = 'input[name="expertModeCheckbox"]';
         if (result.permanentExpertMode) {
-            $(experModeCheckbox).prop('checked', true);
+            $(expertModeCheckbox).prop('checked', true);
         }
 
-        $(experModeCheckbox).change(function () {
+        $(expertModeCheckbox).change(function () {
             const checked = $(this).is(':checked');
             checkSetupAnalytics(function (analyticsService) {
                 analyticsService.setDimension(analyticsService.DIMENSIONS.CONFIGURATOR_EXPERT_MODE, checked ? 'On' : 'Off');

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -376,7 +376,7 @@ firmware_flasher.initialize = function (callback) {
         function showOrHideBuildTypeSelect() {
             const expertModeChecked = $(this).is(':checked');
 
-            globalExpertMode_e.prop('checked', expertModeChecked);
+            globalExpertMode_e.prop('checked', expertModeChecked).trigger('change');
             if (expertModeChecked) {
                 buildTypesToShow = buildTypes.concat(ciBuildsTypes);
                 buildBuildTypeOptionsList();


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight-configurator/issues/2552

The local Expert Mode switch in firmware_flasher is set by the global Expert Mode switch (when connected on any tab) but didn't trigger an update on the global switch after a change.