### PR TITLE
Removed unneeded BOXNAME polling.

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -696,7 +696,6 @@ function update_live_status() {
     });
 
     if (GUI.active_tab != 'cli') {
-        MSP.send_message(MSPCodes.MSP_BOXNAMES, false, false);
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_32)) {
             MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
         } else {


### PR DESCRIPTION
Currently `MSP_BOXNAME` is being polled 10 times a second. Taking into consideration that the response to this command is > 300 bytes, this is contributing the majority of the 'at rest' data transfer when a flight controller is connected:

Before:

![image](https://user-images.githubusercontent.com/4742747/128880728-4e5a3e62-674d-4cdf-966f-98e40519f7d2.png)

After:

![image](https://user-images.githubusercontent.com/4742747/128882487-b2e38b74-b5ec-47cd-abdb-731b6ab426d0.png)

This behaviour was added about 5 years ago in [`0518ed6` (#19)](https://github.com/betaflight/betaflight-configurator/pull/19/commits/0518ed6993c0df30ed53e9f0ffd21bbb840acfcd), but it is not actually needed, as the list of supported modes only changes on startup.