### PR TITLE
Fix reconnection issue in cli

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -262,7 +262,7 @@ function startProcess() {
                 if (GUI.connected_to || GUI.connecting_to) {
                     $('a.connect').click();
                 } else {
-                    self.disconnect();
+                    serial.disconnect();
                 }
                 $('div.open_firmware_flasher a.flash').click();
             } else if (GUI.allowedTabs.indexOf(tab) < 0) {

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -344,7 +344,7 @@ const MSP = {
 
         if (!requestExists) {
             obj.timer = setInterval(function () {
-                console.log(`MSP data request timed-out: ${code} direction: ${MSP.message_direction} tab: ${GUI.active_tab}`);
+                console.warn(`MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab}`);
 
                 serial.send(bufferOut, false);
             }, 1000); // we should be able to define timeout in the future

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -66,7 +66,7 @@ function initializeSerialBackend() {
                 $('select#baud').hide();
             } else if (portName !== '0') {
                 if (!clicks) {
-                    console.log(`${serial.connectionType}: connecting to: ${portName}`);
+                    console.log(`Connecting to: ${portName}`);
                     GUI.connecting_to = portName;
 
                     // lock port select & baud while we are connecting / connected
@@ -90,8 +90,7 @@ function initializeSerialBackend() {
                     }
                     GUI.timeout_kill_all();
                     GUI.interval_kill_all();
-                    GUI.tab_switch_cleanup();
-                    GUI.tab_switch_in_progress = false;
+                    GUI.tab_switch_cleanup(() => GUI.tab_switch_in_progress = false);
 
                     function onFinishCallback() {
                         finishClose(toggleStatus);


### PR DESCRIPTION
On master it is not possible to go to `OSD` or `Sensor` tab from `CLI`.

This PR should solve this by using an interval to check for a valid connection and removing the duplicate call to the tab cleanup function by removing the call in the disconnect routine in `$('div.connect_controls a.connect')` and only use the call in the tab change request in `$('a', ui_tabs)`.

EDIT:
After lots of testing and input from @Asizon digging further the issue is sending or disconnecting when device_lost has occurred. Rebasing the serial code did solve the issue and some bugs were fixed.   

Tested on Matek F411 on Linux (Fedora 32) and Matek F722 on Windows (10)