### PR TITLE
Enhanced sat list for M8N/M9N

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1455,7 +1455,7 @@
         "description": "Option to use Galileo in the GPS configuration"
     },
     "configurationGPSGalileoHelp": {
-        "message": "When enabled, this removes the QZSS system (Japanese) and replaces it for the Galileo system (European).",
+        "message": "When enabled, the GPS module will also track the Galileo satellite system, usually resulting in more locked satellites. On Betaflight 4.2.x or earlier, it also disables the QZSS augmentation system.",
         "description": "Help text for the option to use Galileo in the GPS configuration"
     },
     "configurationGPSHomeOnce": {
@@ -2432,11 +2432,47 @@
     "gpsSignalStr": {
         "message": "Signal Strength"
     },
+    "gpsSignalGnssId": {
+        "message": "Gnss ID"
+    },
     "gpsSignalSatId": {
         "message": "Sat ID"
     },
-    "gpsSignalQty": {
-        "message": "Qty"
+    "gpsSignalStatusQly": {
+        "message": "Status / Quality"
+    },
+    "gnssQualityNoSignal": {
+        "message": "no signal"
+    },
+    "gnssQualitySearching": {
+        "message": "searching"
+    },
+    "gnssQualityAcquired": {
+        "message": "acquired"
+    },
+    "gnssQualityUnusable": {
+        "message": "unusable"
+    },
+    "gnssQualityLocked": {
+        "message": "locked"
+    },
+    "gnssQualityFullyLocked": {
+        "message": "fully locked"
+    },
+    "gnssUsedUnused": {
+        "message": "unused"
+    },
+    "gnssUsedUsed": {
+        "message": "used"
+    },
+    "gnssHealthyUnknown": {
+        "message": "unknown"
+    },
+    "gnssHealthyHealthy": {
+        "message": "healthy"
+    },
+    "gnssHealthyUnhealthy": {
+        "message": "unhealthy"
     },
 
     "motorsVoltage": {

--- a/src/css/tabs/gps.css
+++ b/src/css/tabs/gps.css
@@ -1,3 +1,16 @@
+.tab-gps .GPS_signal_strength table td:nth-child(2) {
+    text-align: center;
+}
+
+.tab-gps .GPS_signal_strength table td:nth-child(3) {
+    text-align: center;
+}
+
+.tab-gps .GPS_signal_strength table td:nth-child(4) {
+    text-align: left;
+    padding-left: 10px;
+}
+
 .tab-gps progress {
     width: 100%;
     border-radius: 3px;

--- a/src/tabs/gps.html
+++ b/src/tabs/gps.html
@@ -7,7 +7,7 @@
 
 
         <div class="grid-row">
-            <div class="grid-col col3">
+            <div class="grid-col col5">
                 <div class="gui_box grey">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" i18n="gpsHead"></div>
@@ -45,8 +45,7 @@
                         </table>
                     </div>
                 </div>
-            </div>
-            <div class="grid-col col3">
+
                 <div class="gui_box grey">
                     <div class="gui_box_titlebar">
                         <div class="spacer_box_title" i18n="gpsSignalStrHead"></div>
@@ -54,95 +53,208 @@
                     <div class="spacer_box GPS_signal_strength">
                         <table class="cf_table">
                             <tr class="titles">
-                                <td style="width: 20%;" i18n="gpsSignalSatId"></td>
-                                <td style="width: 15%;" i18n="gpsSignalQty"></td>
-                                <td style="width: 65%;" i18n="gpsSignalStr"></td>
+                                <td style="width: 12%;" i18n="gpsSignalGnssId"></td>
+                                <td style="width: 10%;" i18n="gpsSignalSatId"></td>
+                                <td style="width: 25%;" i18n="gpsSignalStr"></td>
+                                <td style="width: 53%;" i18n="gpsSignalStatusQly"></td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr>
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
+                            </tr>
+                            <tr>
+                                <td>0</td>
+                                <td>0</td>
+                                <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                             <tr class="noboarder">
                                 <td>0</td>
                                 <td>0</td>
                                 <td><progress value="0" max="99"></progress></td>
+                                <td>0</td>
                             </tr>
                         </table>
                     </div>
                 </div>
             </div>
-            <div class="grid-col col6">
+            <div class="grid-col col7">
                 <div class="gui_box grey gps_map">
                     <div class="gui_box_titlebar" style="margin-bottom: 0px;">
                         <div class="spacer_box_title" i18n="gpsMapHead"></div>


### PR DESCRIPTION
Modified the sat list in order to show extra info from the following PR: https://github.com/betaflight/betaflight/pull/10921

New layout:
![Screenshot 2021-09-17 at 06 36 43](https://user-images.githubusercontent.com/2266058/133726563-20a95fc0-a58c-49b1-8b81-7d800c383b87.png)

New sat list in action:
<img width="403" alt="Screenshot 2021-09-09 at 17 42 34" src="https://user-images.githubusercontent.com/2266058/133726700-95873ade-889a-4722-bb0e-3c8a2c6efe6b.png">
