### PR TITLE
Added yarn gulp debug-no-start command

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,8 +116,10 @@ gulp.task('apps', appsBuild);
 
 const debugAppsBuild = gulp.series(gulp.parallel(clean_debug, gulp.series(clean_dist, debugDistBuild)), debug, gulp.series(cordova_apps(false)), gulp.parallel(listPostBuildTasks(DEBUG_DIR)));
 
-const debugBuild = gulp.series(debugDistBuild, debug, gulp.parallel(listPostBuildTasks(DEBUG_DIR)), start_debug);
+const debugBuildNoStart = gulp.series(debugDistBuild, debug, gulp.parallel(listPostBuildTasks(DEBUG_DIR)));
+const debugBuild = gulp.series(debugBuildNoStart, start_debug);
 gulp.task('debug', debugBuild);
+gulp.task('debug-no-start', debugBuildNoStart);
 
 const releaseBuild = gulp.series(gulp.parallel(clean_release, appsBuild), gulp.parallel(listReleaseTasks(true, APPS_DIR)));
 gulp.task('release', releaseBuild);


### PR DESCRIPTION
` yarn gulp debug-no-start` command allows building debug version of the Configurator without starting it afterward. Makes it handy to debug Configurator directly in VS code.

For debugging under Windows 10:
(to be added in wiki after merging this PR)
(credits to Pierre Gazzano for the initial launch.json text and idea)

create launch.json file in .vscode folder with the following content:
```
{
    "version": "0.2.0",
    "configurations": [
        {
            "name": "Launch Betaflight",
            "type": "nwjs",
            "request": "launch",
            "runtimeExecutable": "${workspaceRoot}/debug/betaflight-configurator/win64/betaflight-configurator.exe",
            "runtimeArgs": [
                "${workspaceRoot}",
                "--remote-debugging-port=9222"
            ],
            "port": 9222,
            "nwjsVersion": "any",
            "webRoot":"${workspaceRoot}/src",
            "preLaunchTask": "build and copy package.json",
            "postDebugTask": "delete package.json"
        },
        {
            "type": "nwjs",
            "request": "attach",
            "name": "Attach to Betaflight",
            "port": 9222,
            "webRoot":"${workspaceRoot}/src/js",
            "verbose":true,
            "reloadAfterAttached": true
        }
    ]
}
```



create tasks.json file in .vscode folder with the following content:
```
{
    "version": "2.0.0",
    "tasks": [
        {
            "label": "delete package.json",
            "type": "shell",
            "command": "rm .\\src\\package.json",
            "problemMatcher": [],
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "presentation": {
                "showReuseMessage": false
            }
        },
        {
            "label": "build debug no start",
            "type": "shell",
            "command": "yarn gulp debug-no-start; copy -Path package.json -Destination .\\src\\package.json -Force",
            "problemMatcher": [],
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "presentation": {
                "showReuseMessage": false
            }
        },
        {
            "label": "copy package.json",
            "type": "shell",
            "command": "copy -Path package.json -Destination .\\src\\package.json -Force",
            "problemMatcher": [],
            "group": {
                "kind": "build",
                "isDefault": true
            },
            "presentation": {
                "showReuseMessage": false
            }
        },
        {
            "label": "build and copy package.json",
            "dependsOn": [
                "build debug no start",
                "copy package.json"
            ],
            "presentation": {
                "showReuseMessage": false
            }
        }
    ]
}
```
Press F5 in VS code - it will build Configurator and launch it. Now can set breakpoints directly in the VS code.