### PR TITLE
Fixed parsing of firmware versions to support multi-digit versions.

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -419,7 +419,7 @@ firmware_flasher.initialize = function (callback) {
         function populateBuilds(builds, target, manufacturerId, duplicateName, targetVersions, callback) {
             if (targetVersions) {
                 targetVersions.forEach(function(descriptor) {
-                    const versionRegex = /^(\d.\d.\d(?:-\w+)?)(?: #(\d+))?$/;
+                    const versionRegex = /^(\d+.\d+.\d+(?:-\w+)?)(?: #(\d+))?$/;
                     const versionParts = descriptor.version.match(versionRegex);
                     if (!versionParts) {
                         return;


### PR DESCRIPTION
This _would_ be needed to support the 4.2.10 release. :rofl: 