### PR TITLE
Prevent changing profiles if settings are not saved

### DIFF
--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -45,7 +45,7 @@ const D_MIN_RATIO = 0.85;
 
 TuningSliders.saveInitialSettings = function () {
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
-        this.initialSettings.sliderPidsMode = FC.TUNING_SLIDERS.slider_pids_mode;
+        this.initialSettings.sliderPidsModeSelect = FC.TUNING_SLIDERS.slider_pids_mode;
         this.initialSettings.sliderDGain = FC.TUNING_SLIDERS.slider_d_gain / 100;
         this.initialSettings.sliderPIGain = FC.TUNING_SLIDERS.slider_pi_gain / 100;
         this.initialSettings.sliderFeedforwardGain = FC.TUNING_SLIDERS.slider_feedforward_gain / 100;
@@ -63,11 +63,7 @@ TuningSliders.saveInitialSettings = function () {
 
 TuningSliders.restoreInitialSettings = function () {
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
-        if (this.sliderModeHasChanged && this.initialSetting.sliderPidsMode !== this.sliderPidsmode) {
-            $('#sliderPidsModeSelect').val(this.initialSettings.sliderPidsMode).trigger('change');
-        }
-
-        FC.TUNING_SLIDERS.slider_pids_mode = this.initialSettings.sliderPidsMode;
+        FC.TUNING_SLIDERS.slider_pids_mode = this.initialSettings.sliderPidsModeSelect;
 
         FC.TUNING_SLIDERS.slider_d_gain = Math.round(this.initialSettings.sliderDGain * 20) * 5;
         FC.TUNING_SLIDERS.slider_pi_gain = Math.round(this.initialSettings.sliderPIGain * 20) * 5;
@@ -88,12 +84,12 @@ TuningSliders.restoreInitialSettings = function () {
         .then(() => MSP.promise(MSPCodes.MSP_PID_ADVANCED))
         .then(() => MSP.promise(MSPCodes.MSP_FILTER_CONFIG))
         .then(() => {
-            TABS.pid_tuning.configChanges = {};
             if (GUI.active_tab === 'pid_tuning') {
                 this.updateFormPids();
                 TABS.pid_tuning.updatePIDColors();
             }
         });
+        TABS.pid_tuning.sliderRetainConfiguration = false;
     }
 };
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -252,7 +252,7 @@ function startProcess() {
             const tabName = $(self).text();
 
             if (GUI.active_tab === 'pid_tuning') {
-                if (TABS.pid_tuning.sliderRetainPosition || TABS.pid_tuning.sliderRetainMode || TABS.pid_tuning.sliderRetainConfiguration) {
+                if (TABS.pid_tuning.sliderRetainConfiguration) {
                     TuningSliders.restoreInitialSettings();
                 }
             }


### PR DESCRIPTION
Keep `isDirty` state consistent with firmware sliders.

Due to firmware sliders we save the current slider state to get PIDs etc loosing state in firmware until saved. So if user does not want to save we are storing and retrieving original state at tab load or using refresh.

Button `Reset all profiles` resets the `isDirty` flag so we can change to another profile while settings may have changed in the previous profile which could load saved settings to the wrong profile.

- set `isDirty` after reset profile button
- reset flags and resulting state after using refresh button.
- reset `isDirty` when changes are undone.

Problems solved:

- use `isDirty` and `sliderRetainConfiguration` flag to keep state and prevent going to another profile without saving.
- Fixes: #2619 reworked handlers and selectors (rates tab was using same selectors)
- disable input on RP or RPY according to `sliderMode`. This will users remind to save settings after changing `sliderMode`.
- Enabling PID sliders respects initial firmware setting (user can use reset profile button for setting sliders to default).