### PR TITLE
Expert mode toggle refactoring

### DIFF
--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -115,7 +115,7 @@ TuningSliders.initialize = function() {
         this.setDMinFeatureEnabled($('#dMinSwitch').is(':checked'));
     }
 
-    this.setExpertMode($('input[name="expertModeCheckbox"]').is(':checked'));
+    this.setExpertMode(isExpertModeEnabled());
 
     this.initPidSlidersPosition();
     this.initGyroFilterSliderPosition();
@@ -130,8 +130,8 @@ TuningSliders.initialize = function() {
     this.updateFilterSlidersDisplay();
 };
 
-TuningSliders.setExpertMode = function() {
-    this.expertMode = isExpertModeEnabled();
+TuningSliders.setExpertMode = function(expertModeEnabled) {
+    this.expertMode = expertModeEnabled;
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
         document.getElementById('sliderDMaxGain').disabled = !this.expertMode;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -515,8 +515,8 @@ function startProcess() {
             $(expertModeCheckbox).prop('checked', true);
         }
 
-        $(expertModeCheckbox).change(function () {
-            const checked = $(this).is(':checked');
+        $(expertModeCheckbox).on("change", () => {
+            const checked = $(expertModeCheckbox).is(':checked');
             checkSetupAnalytics(function (analyticsService) {
                 analyticsService.setDimension(analyticsService.DIMENSIONS.CONFIGURATOR_EXPERT_MODE, checked ? 'On' : 'Off');
             });
@@ -525,8 +525,12 @@ function startProcess() {
                 updateTabList(FC.FEATURE_CONFIG.features);
             }
 
-            TuningSliders.setExpertMode(checked);
-        }).change();
+            if (GUI.active_tab) {
+                TABS[GUI.active_tab]?.expertModeChanged?.(checked);
+            }
+        });
+
+        $(expertModeCheckbox).trigger("change");
     });
 
     ConfigStorage.get('cliAutoComplete', function (result) {

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -3017,3 +3017,8 @@ TABS.pid_tuning.changeRatesTypeLogo = function() {
             break;
     }
 };
+
+
+TABS.pid_tuning.expertModeChanged = function(expertModeEnabled) {
+    TuningSliders.setExpertMode(expertModeEnabled);
+};


### PR DESCRIPTION
Fixing error that TuningSliders.setExpertMode is being called even when PID tab is not selected.

Refactoring expert mode toggle.
With this change any tab can easily subscribe to expert mode change just by defining this function:

```
TABS.YOUR_TAB.expertModeChanged = function(expertModeEnabled) {
     // actions when expert mode has changed
};
```