### PR TITLE
Split header and fix i18n message

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4003,7 +4003,7 @@
         "message": "Absolute Control"
     },
     "pidTuningAbsoluteControlGainHelp": {
-        "message": "This feature solves some underlying problems of $t(pidTuningItermRotation.message) and should hopefully replace it at some point. This feature accumulates the absolute gyro error in quad coordinates and mixes a proportional correction into the setpoint. For it to work you need to enable AirMode and $t(pidTuningItermRelax.message) (for $t(pidTuningItermRelaxAxesOptionRP.message)). If you combine this feature with $t(pidTuningIntegratedYaw.message), you can set $t(pidTuningItermRelax.message) enabled for $t(pidTuningItermRelaxAxesOptionRPY.message)."
+        "message": "This feature solves some underlying problems of $t(pidTuningItermRotation.message) and should hopefully replace it at some point. This feature accumulates the absolute gyro error in quad coordinates and mixes a proportional correction into the setpoint. For it to work you need to enable AirMode and $t(pidTuningItermRelax.message) (for $t(pidTuningOptionRP.message)). If you combine this feature with $t(pidTuningIntegratedYaw.message), you can set $t(pidTuningItermRelax.message) enabled for $t(pidTuningOptionRPY.message)."
     },
     "pidTuningThrottleBoost": {
         "message": "Throttle Boost"

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -817,7 +817,12 @@
 }
 
 .tab-pid_tuning .tuningPIDSliders .pid_titlebar th:first-child {
-    width: 20%;
+    width: 6%;
+    text-align: right;
+    border-right: none;
+}
+.tab-pid_tuning .tuningPIDSliders .pid_titlebar th:nth-child(2) {
+    width: 14%;
     border-right: none;
 }
 
@@ -826,7 +831,7 @@
     border-right: none;
 }
 
-.tab-pid_tuning .tuningPIDSliders .pid_titlebar th:nth-child(2),
+.tab-pid_tuning .tuningPIDSliders .pid_titlebar th:nth-child(3),
 .tab-pid_tuning .tuningFilterSliders .pid_titlebar th:nth-child(2) {
     width: 30px;
 }
@@ -897,7 +902,7 @@
 }
 
 .tab-pid_tuning .subtab-pid .cf_column {
-    min-width: 472px;
+    min-width: 600px;
     flex: 1;
 }
 

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -174,6 +174,8 @@
                             <tr>
                                 <th scope="col">
                                     <div i18n="pidTuningSliderPidsMode" class="sm-min"></div>
+                                </th>
+                                <th scope="col">
                                     <select id="sliderPidsModeSelect" class="sliderMode">
                                         <option value="0" i18n="pidTuningOptionOff"></option>
                                         <option value="1" i18n="pidTuningOptionRP"></option>


### PR DESCRIPTION
- [x] Splits header so elements can fit on one row.
- [x] Fixes i18n message.

![Screenshot from 2021-10-10 20-36-01](https://user-images.githubusercontent.com/8344830/136708972-8d8cc560-7c9e-46f8-8988-f7b9145d1800.png)

We should have enough room to fit all elements on one row if we use an extra header in the first column and adjust width (about 8% + 12%).
Also think we need to adjust the second column to go down on smaller screens at around 600px to fit other labels too.