### PR TITLE
[chore] migrate remaining deprecated chrome storage API calls to ConfigStorage JSON implementation.

### DIFF
--- a/src/js/ConfigStorage.js
+++ b/src/js/ConfigStorage.js
@@ -4,7 +4,7 @@
 // localStorage deals with strings, not objects, so the objects have been serialized.
 const ConfigStorage = {
     // key can be one string, or array of strings
-    get: function(key, callback) {
+    get: function(key) {
         let result = {};
         if (Array.isArray(key)) {
             key.forEach(function (element) {
@@ -14,7 +14,6 @@ const ConfigStorage = {
                     // is okay
                 }
             });
-            callback?.(result);
         } else {
             const keyValue = window.localStorage.getItem(key);
             if (keyValue) {
@@ -23,9 +22,6 @@ const ConfigStorage = {
                 } catch (e) {
                     // It's fine if we fail that parse
                 }
-                callback?.(result);
-            } else {
-                callback?.(result);
             }
         }
 
@@ -38,5 +34,8 @@ const ConfigStorage = {
             tmpObj[element] = input[element];
             window.localStorage.setItem(element, JSON.stringify(tmpObj));
         });
+    },
+    remove: function(item) {
+        window.localStorage.removeItem(item);
     },
 };

--- a/src/js/cordova_startup.js
+++ b/src/js/cordova_startup.js
@@ -22,29 +22,27 @@ const cordovaUI = {
         if (screenWidth > 575 && screenHeight > 575) {
             self.canChangeUI = false;
         }
-        ConfigStorage.get('cordovaForceComputerUI', function (result) {
-            if (result.cordovaForceComputerUI === undefined) {
-                if ((orientation === 'landscape' && screenHeight <= 575)
-                    || (orientation === 'portrait' && screenWidth <= 575)) {
-                    ConfigStorage.set({'cordovaForceComputerUI': false});
-                } else {
-                    ConfigStorage.set({'cordovaForceComputerUI': true});
-                }
+        const result = ConfigStorage.get('cordovaForceComputerUI');
+        if (result.cordovaForceComputerUI === undefined) {
+            if ((orientation === 'landscape' && screenHeight <= 575)
+                || (orientation === 'portrait' && screenWidth <= 575)) {
+                ConfigStorage.set({'cordovaForceComputerUI': false});
+            } else {
+                ConfigStorage.set({'cordovaForceComputerUI': true});
             }
-        });
+        }
         self.set();
     },
     set: function() {
         const self = this;
-        ConfigStorage.get('cordovaForceComputerUI', function (result) {
-            if (result.cordovaForceComputerUI) {
-                window.screen.orientation.lock('landscape');
-                $('body').css('zoom', self.uiZoom);
-            } else {
-                window.screen.orientation.lock('portrait');
-                $('body').css('zoom', 1);
-            }
-        });
+        const result = ConfigStorage.get('cordovaForceComputerUI');
+        if (result.cordovaForceComputerUI) {
+            window.screen.orientation.lock('landscape');
+            $('body').css('zoom', self.uiZoom);
+        } else {
+            window.screen.orientation.lock('portrait');
+            $('body').css('zoom', 1);
+        }
     },
 };
 

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -389,13 +389,12 @@ GuiControl.prototype.content_ready = function (callback) {
 };
 
 GuiControl.prototype.selectDefaultTabWhenConnected = function() {
-    ConfigStorage.get(['rememberLastTab', 'lastTab'], function (result) {
-        if (result.rememberLastTab && result.lastTab) {
-            $(`#tabs ul.mode-connected .${result.lastTab} a`).click();
-        } else {
-            $('#tabs ul.mode-connected .tab_setup a').click();
-        }
-    });
+    const result = ConfigStorage.get(['rememberLastTab', 'lastTab']);
+    if (result.rememberLastTab && result.lastTab) {
+        $(`#tabs ul.mode-connected .${result.lastTab} a`).click();
+    } else {
+        $('#tabs ul.mode-connected .tab_setup a').click();
+    }
 };
 
 GuiControl.prototype.isNWJS = function () {

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -190,22 +190,16 @@ i18n.localizePage = function(forceReTranslate) {
  * returns the current locale to the callback
  */
 function getStoredUserLocale(cb) {
+    let userLanguage = 'DEFAULT';
     if (typeof ConfigStorage !== 'undefined') {
-        ConfigStorage.get('userLanguageSelect', function (result) {
-            let userLanguage = 'DEFAULT';
-            if (result.userLanguageSelect) {
-                userLanguage = result.userLanguageSelect;
-            }
-            i18n.selectedLanguage = userLanguage;
-
-            userLanguage = getValidLocale(userLanguage);
-
-            cb(userLanguage);
-        });
-    } else {
-        const userLanguage = getValidLocale('DEFAULT');
-        cb(userLanguage);
+        const result = ConfigStorage.get('userLanguageSelect');
+        if (result.userLanguageSelect) {
+            userLanguage = result.userLanguageSelect;
+        }
+        i18n.selectedLanguage = userLanguage;
     }
+    userLanguage = getValidLocale(userLanguage);
+    cb(userLanguage);
 }
 
 function getValidLocale(userLocale) {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -32,9 +32,12 @@ PortHandler.initialize = function () {
 
 PortHandler.check = function () {
     const self = this;
+    let result;
 
-    ConfigStorage.get('showVirtualMode', res => self.showVirtualMode = res.showVirtualMode);
-    ConfigStorage.get('showAllSerialDevices', res => self.showAllSerialDevices = res.showAllSerialDevices);
+    result = ConfigStorage.get('showVirtualMode');
+    self.showVirtualMode = result.showVirtualMode;
+    result = ConfigStorage.get('showAllSerialDevices');
+    self.showAllSerialDevices = result.showAllSerialDevices;
 
     self.check_usb_devices();
     self.check_serial_devices();
@@ -168,17 +171,16 @@ PortHandler.detectPort = function(currentPorts) {
         currentPorts = self.updatePortSelect(currentPorts);
         console.log(`PortHandler - Found: ${JSON.stringify(newPorts)}`);
 
-        ConfigStorage.get('last_used_port', function (result) {
-            if (result.last_used_port) {
-                if (result.last_used_port.includes('tcp')) {
-                    self.portPickerElement.val('manual');
-                } else if (newPorts.length === 1) {
-                    self.portPickerElement.val(newPorts[0].path);
-                } else if (newPorts.length > 1) {
-                    self.selectPort(currentPorts);
-                }
+        const result = ConfigStorage.get('last_used_port');
+        if (result.last_used_port) {
+            if (result.last_used_port.includes('tcp')) {
+                self.portPickerElement.val('manual');
+            } else if (newPorts.length === 1) {
+                self.portPickerElement.val(newPorts[0].path);
+            } else if (newPorts.length > 1) {
+                self.selectPort(currentPorts);
             }
-        });
+        }
 
         self.port_available = true;
         // Signal board verification

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -33,16 +33,17 @@ function initializeSerialBackend() {
         ConfigStorage.set({'portOverride': $('#port-override').val()});
     });
 
-    ConfigStorage.get('portOverride', function (data) {
+    const data = ConfigStorage.get('portOverride');
+    if (data.portOverride) {
         $('#port-override').val(data.portOverride);
-    });
+    }
 
     $('div#port-picker #port').change(function (target) {
         GUI.updateManualPortVisibility();
     });
 
     $('div.connect_controls a.connect').click(function () {
-        if (GUI.connect_lock != true) { // GUI control overrides the user control
+        if (!GUI.connect_lock) { // GUI control overrides the user control
 
             const toggleStatus = function() {
                 clicks = !clicks;
@@ -113,40 +114,39 @@ function initializeSerialBackend() {
     });
 
     // auto-connect
-    ConfigStorage.get('auto_connect', function (result) {
-        if (result.auto_connect === undefined || result.auto_connect) {
-            // default or enabled by user
-            GUI.auto_connect = true;
+    const result = ConfigStorage.get('auto_connect');
+    if (result.auto_connect === undefined || result.auto_connect) {
+        // default or enabled by user
+        GUI.auto_connect = true;
 
-            $('input.auto_connect').prop('checked', true);
+        $('input.auto_connect').prop('checked', true);
+        $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectEnabled'));
+
+        $('select#baud').val(115200).prop('disabled', true);
+    } else {
+        // disabled by user
+        GUI.auto_connect = false;
+
+        $('input.auto_connect').prop('checked', false);
+        $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectDisabled'));
+    }
+
+    // bind UI hook to auto-connect checkbos
+    $('input.auto_connect').change(function () {
+        GUI.auto_connect = $(this).is(':checked');
+
+        // update title/tooltip
+        if (GUI.auto_connect) {
             $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectEnabled'));
 
             $('select#baud').val(115200).prop('disabled', true);
         } else {
-            // disabled by user
-            GUI.auto_connect = false;
-
-            $('input.auto_connect').prop('checked', false);
             $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectDisabled'));
+
+            if (!GUI.connected_to && !GUI.connecting_to) $('select#baud').prop('disabled', false);
         }
 
-        // bind UI hook to auto-connect checkbox
-        $('input.auto_connect').change(function () {
-            GUI.auto_connect = $(this).is(':checked');
-
-            // update title/tooltip
-            if (GUI.auto_connect) {
-                $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectEnabled'));
-
-                $('select#baud').val(115200).prop('disabled', true);
-            } else {
-                $('input.auto_connect, span.auto_connect').prop('title', i18n.getMessage('autoConnectDisabled'));
-
-                if (!GUI.connected_to && !GUI.connecting_to) $('select#baud').prop('disabled', false);
-            }
-
-            ConfigStorage.set({'auto_connect': GUI.auto_connect});
-        });
+        ConfigStorage.set({'auto_connect': GUI.auto_connect});
     });
 
     PortHandler.initialize();

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -540,16 +540,15 @@ TABS.auxiliary.initialize = function (callback) {
         }
 
         let hideUnusedModes = false;
-        ConfigStorage.get('hideUnusedModes', function (result) {
-            $("input#switch-toggle-unused")
-                .change(function() {
-                    hideUnusedModes = $(this).prop("checked");
-                    ConfigStorage.set({ hideUnusedModes: hideUnusedModes });
-                    update_ui();
-                })
-                .prop("checked", !!result.hideUnusedModes)
-                .change();
-        });
+        const result = ConfigStorage.get('hideUnusedModes');
+        $("input#switch-toggle-unused")
+            .change(function() {
+                hideUnusedModes = $(this).prop("checked");
+                ConfigStorage.set({ hideUnusedModes: hideUnusedModes });
+                update_ui();
+            })
+            .prop("checked", !!result.hideUnusedModes)
+            .change();
 
         // update ui instantly on first load
         update_ui();

--- a/src/js/tabs/logging.js
+++ b/src/js/tabs/logging.js
@@ -99,18 +99,17 @@ logging.initialize = function (callback) {
             }
         });
 
-        ConfigStorage.get('logging_file_entry', function (result) {
-            if (result.logging_file_entry) {
-                chrome.fileSystem.restoreEntry(result.logging_file_entry, function (entry) {
-                    if (checkChromeRuntimeError()) {
-                        return;
-                    }
+        const result = ConfigStorage.get('logging_file_entry');
+        if (result.logging_file_entry) {
+            chrome.fileSystem.restoreEntry(result.logging_file_entry, function (entry) {
+                if (checkChromeRuntimeError()) {
+                    return;
+                }
 
-                    fileEntry = entry;
-                    prepare_writer(true);
-                });
-            }
-        });
+                fileEntry = entry;
+                prepare_writer(true);
+            });
+        }
 
         GUI.content_ready(callback);
     }

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -559,22 +559,21 @@ TABS.motors.initialize = function (callback) {
         });
 
         // set refresh speeds according to configuration saved in storage
-        ConfigStorage.get(['motors_tab_sensor_settings', 'motors_tab_gyro_settings', 'motors_tab_accel_settings'], function (result) {
-            if (result.motors_tab_sensor_settings) {
-                $('.tab-motors select[name="sensor_choice"]').val(result.motors_tab_sensor_settings.sensor);
-            }
+        const result = ConfigStorage.get(['motors_tab_sensor_settings', 'motors_tab_gyro_settings', 'motors_tab_accel_settings']);
+        if (result.motors_tab_sensor_settings) {
+            $('.tab-motors select[name="sensor_choice"]').val(result.motors_tab_sensor_settings.sensor);
+        }
 
-            if (result.motors_tab_gyro_settings) {
-                TABS.motors.sensorGyroRate = result.motors_tab_gyro_settings.rate;
-                TABS.motors.sensorGyroScale = result.motors_tab_gyro_settings.scale;
-            }
+        if (result.motors_tab_gyro_settings) {
+            TABS.motors.sensorGyroRate = result.motors_tab_gyro_settings.rate;
+            TABS.motors.sensorGyroScale = result.motors_tab_gyro_settings.scale;
+        }
 
-            if (result.motors_tab_accel_settings) {
-                TABS.motors.sensorAccelRate = result.motors_tab_accel_settings.rate;
-                TABS.motors.sensorAccelScale = result.motors_tab_accel_settings.scale;
-            }
-            $('.tab-motors .sensor select:first').change();
-        });
+        if (result.motors_tab_accel_settings) {
+            TABS.motors.sensorAccelRate = result.motors_tab_accel_settings.rate;
+            TABS.motors.sensorAccelScale = result.motors_tab_accel_settings.scale;
+        }
+        $('.tab-motors .sensor select:first').change();
 
         // Amperage
         function power_data_pull() {

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -32,83 +32,78 @@ options.cleanup = function (callback) {
 };
 
 options.initShowWarnings = function () {
-    ConfigStorage.get('showPresetsWarningBackup', function (result) {
-        if (result.showPresetsWarningBackup) {
-            $('div.presetsWarningBackup input').prop('checked', true);
-        }
+    const result = ConfigStorage.get('showPresetsWarningBackup');
+    if (result.showPresetsWarningBackup) {
+        $('div.presetsWarningBackup input').prop('checked', true);
+    }
 
-        $('div.presetsWarningBackup input').change(function () {
-            const checked = $(this).is(':checked');
-            ConfigStorage.set({'showPresetsWarningBackup': checked});
-        }).change();
-    });
+    $('div.presetsWarningBackup input').change(function () {
+        const checked = $(this).is(':checked');
+        ConfigStorage.set({'showPresetsWarningBackup': checked});
+    }).change();
 };
 
 options.initPermanentExpertMode = function () {
-    ConfigStorage.get('permanentExpertMode', function (result) {
-        if (result.permanentExpertMode) {
-            $('div.permanentExpertMode input').prop('checked', true);
-        }
+    const result = ConfigStorage.get('permanentExpertMode');
+    if (result.permanentExpertMode) {
+        $('div.permanentExpertMode input').prop('checked', true);
+    }
 
-        $('div.permanentExpertMode input').change(function () {
-            const checked = $(this).is(':checked');
+    $('div.permanentExpertMode input').change(function () {
+        const checked = $(this).is(':checked');
 
-            ConfigStorage.set({'permanentExpertMode': checked});
+        ConfigStorage.set({'permanentExpertMode': checked});
 
-            $('input[name="expertModeCheckbox"]').prop('checked', checked).change();
-        }).change();
-    });
+        $('input[name="expertModeCheckbox"]').prop('checked', checked).change();
+    }).change();
 };
 
 options.initRememberLastTab = function () {
-    ConfigStorage.get('rememberLastTab', function (result) {
-        $('div.rememberLastTab input')
-            .prop('checked', !!result.rememberLastTab)
-            .change(function() { ConfigStorage.set({rememberLastTab: $(this).is(':checked')}); })
-            .change();
-    });
+    const result = ConfigStorage.get('rememberLastTab');
+    $('div.rememberLastTab input')
+        .prop('checked', !!result.rememberLastTab)
+        .change(function() { ConfigStorage.set({rememberLastTab: $(this).is(':checked')}); })
+        .change();
 };
 
 options.initCheckForConfiguratorUnstableVersions = function () {
-    ConfigStorage.get('checkForConfiguratorUnstableVersions', function (result) {
-        if (result.checkForConfiguratorUnstableVersions) {
-            $('div.checkForConfiguratorUnstableVersions input').prop('checked', true);
-        }
+    const result = ConfigStorage.get('checkForConfiguratorUnstableVersions');
+    if (result.checkForConfiguratorUnstableVersions) {
+        $('div.checkForConfiguratorUnstableVersions input').prop('checked', true);
+    }
 
-        $('div.checkForConfiguratorUnstableVersions input').change(function () {
-            const checked = $(this).is(':checked');
+    $('div.checkForConfiguratorUnstableVersions input').change(function () {
+        const checked = $(this).is(':checked');
 
-            ConfigStorage.set({'checkForConfiguratorUnstableVersions': checked});
+        ConfigStorage.set({'checkForConfiguratorUnstableVersions': checked});
 
-            checkForConfiguratorUpdates();
-        });
+        checkForConfiguratorUpdates();
     });
 };
 
 options.initAnalyticsOptOut = function () {
-    ConfigStorage.get('analyticsOptOut', function (result) {
-        if (result.analyticsOptOut) {
-            $('div.analyticsOptOut input').prop('checked', true);
-        }
+    const result = ConfigStorage.get('analyticsOptOut');
+    if (result.analyticsOptOut) {
+        $('div.analyticsOptOut input').prop('checked', true);
+    }
 
-        $('div.analyticsOptOut input').change(function () {
-            const checked = $(this).is(':checked');
+    $('div.analyticsOptOut input').change(function () {
+        const checked = $(this).is(':checked');
 
-            ConfigStorage.set({'analyticsOptOut': checked});
+        ConfigStorage.set({'analyticsOptOut': checked});
 
-            checkSetupAnalytics(function (analyticsService) {
-                if (checked) {
-                    analyticsService.sendEvent(analyticsService.EVENT_CATEGORIES.APPLICATION, 'OptOut');
-                }
+        checkSetupAnalytics(function (analyticsService) {
+            if (checked) {
+                analyticsService.sendEvent(analyticsService.EVENT_CATEGORIES.APPLICATION, 'OptOut');
+            }
 
-                analyticsService.setOptOut(checked);
+            analyticsService.setOptOut(checked);
 
-                if (!checked) {
-                    analyticsService.sendEvent(analyticsService.EVENT_CATEGORIES.APPLICATION, 'OptIn');
-                }
-            });
-        }).change();
-    });
+            if (!checked) {
+                analyticsService.sendEvent(analyticsService.EVENT_CATEGORIES.APPLICATION, 'OptIn');
+            }
+        });
+    }).change();
 };
 
 options.initCliAutoComplete = function () {
@@ -122,45 +117,53 @@ options.initCliAutoComplete = function () {
         }).change();
 };
 
+options.initAutoConnectConnectionTimeout = function () {
+    const result = ConfigStorage.get('connectionTimeout');
+    if (result.connectionTimeout) {
+        $('#connectionTimeoutSelect').val(result.connectionTimeout);
+    }
+    $('#connectionTimeoutSelect').on('change', function () {
+        const value = parseInt($(this).val());
+        ConfigStorage.set({'connectionTimeout': value});
+    });
+};
+
 options.initShowAllSerialDevices = function() {
     const showAllSerialDevicesElement = $('div.showAllSerialDevices input');
-    ConfigStorage.get('showAllSerialDevices', result => {
-        showAllSerialDevicesElement
-            .prop('checked', !!result.showAllSerialDevices)
-            .on('change', () => ConfigStorage.set({ showAllSerialDevices: showAllSerialDevicesElement.is(':checked') }))
-            .trigger('change');
-    });
+    const result = ConfigStorage.get('showAllSerialDevices');
+    showAllSerialDevicesElement
+        .prop('checked', !!result.showAllSerialDevices)
+        .on('change', () => ConfigStorage.set({ showAllSerialDevices: showAllSerialDevicesElement.is(':checked') }))
+        .trigger('change');
 };
 
 options.initShowVirtualMode = function() {
     const showVirtualModeElement = $('div.showVirtualMode input');
-    ConfigStorage.get('showVirtualMode', result => {
-        showVirtualModeElement
-            .prop('checked', !!result.showVirtualMode)
-            .on('change', () => {
-                ConfigStorage.set({ showVirtualMode: showVirtualModeElement.is(':checked') });
-                PortHandler.initialPorts = false;
-            })
-            .trigger('change');
-    });
+    const result = ConfigStorage.get('showVirtualMode');
+    showVirtualModeElement
+        .prop('checked', !!result.showVirtualMode)
+        .on('change', () => {
+            ConfigStorage.set({ showVirtualMode: showVirtualModeElement.is(':checked') });
+            PortHandler.initialPorts = false;
+        })
+        .trigger('change');
 };
 
 options.initCordovaForceComputerUI = function () {
     if (GUI.isCordova() && cordovaUI.canChangeUI) {
-        ConfigStorage.get('cordovaForceComputerUI', function (result) {
-            if (result.cordovaForceComputerUI) {
-                $('div.cordovaForceComputerUI input').prop('checked', true);
+        const result = ConfigStorage.get('cordovaForceComputerUI');
+        if (result.cordovaForceComputerUI) {
+            $('div.cordovaForceComputerUI input').prop('checked', true);
+        }
+
+        $('div.cordovaForceComputerUI input').change(function () {
+            const checked = $(this).is(':checked');
+
+            ConfigStorage.set({'cordovaForceComputerUI': checked});
+
+            if (typeof cordovaUI.set === 'function') {
+                cordovaUI.set();
             }
-
-            $('div.cordovaForceComputerUI input').change(function () {
-                const checked = $(this).is(':checked');
-
-                ConfigStorage.set({'cordovaForceComputerUI': checked});
-
-                if (typeof cordovaUI.set === 'function') {
-                    cordovaUI.set();
-                }
-            });
         });
     } else {
         $('div.cordovaForceComputerUI').hide();

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -783,13 +783,12 @@ TABS.receiver.initialize = function (callback) {
             GUI.interval_add('receiver_pull', get_rc_refresh_data, plotUpdateRate, true);
         });
 
-        ConfigStorage.get('rx_refresh_rate', function (result) {
-            if (result.rxRefreshRate) {
-                rxRefreshRate.val(result.rxRefreshRate).change();
-            } else {
-                rxRefreshRate.change(); // start with default value
-            }
-        });
+        const result = ConfigStorage.get('rx_refresh_rate');
+        if (result.rxRefreshRate) {
+            rxRefreshRate.val(result.rxRefreshRate).change();
+        } else {
+            rxRefreshRate.change(); // start with default value
+        }
 
         // Setup model for preview
         tab.initModelPreview();

--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -428,40 +428,39 @@ TABS.sensors.initialize = function (callback) {
             }
         });
 
-        ConfigStorage.get('sensor_settings', function (result) {
-            // set refresh speeds according to configuration saved in storage
-            if (result.sensor_settings) {
-                $('.tab-sensors select[name="gyro_refresh_rate"]').val(result.sensor_settings.rates.gyro);
-                $('.tab-sensors select[name="gyro_scale"]').val(result.sensor_settings.scales.gyro);
+        const result = ConfigStorage.get('sensor_settings');
+        // set refresh speeds according to configuration saved in storage
+        if (result.sensor_settings) {
+            $('.tab-sensors select[name="gyro_refresh_rate"]').val(result.sensor_settings.rates.gyro);
+            $('.tab-sensors select[name="gyro_scale"]').val(result.sensor_settings.scales.gyro);
 
-                $('.tab-sensors select[name="accel_refresh_rate"]').val(result.sensor_settings.rates.accel);
-                $('.tab-sensors select[name="accel_scale"]').val(result.sensor_settings.scales.accel);
+            $('.tab-sensors select[name="accel_refresh_rate"]').val(result.sensor_settings.rates.accel);
+            $('.tab-sensors select[name="accel_scale"]').val(result.sensor_settings.scales.accel);
 
-                $('.tab-sensors select[name="mag_refresh_rate"]').val(result.sensor_settings.rates.mag);
-                $('.tab-sensors select[name="mag_scale"]').val(result.sensor_settings.scales.mag);
+            $('.tab-sensors select[name="mag_refresh_rate"]').val(result.sensor_settings.rates.mag);
+            $('.tab-sensors select[name="mag_scale"]').val(result.sensor_settings.scales.mag);
 
-                $('.tab-sensors select[name="altitude_refresh_rate"]').val(result.sensor_settings.rates.altitude);
-                $('.tab-sensors select[name="sonar_refresh_rate"]').val(result.sensor_settings.rates.sonar);
+            $('.tab-sensors select[name="altitude_refresh_rate"]').val(result.sensor_settings.rates.altitude);
+            $('.tab-sensors select[name="sonar_refresh_rate"]').val(result.sensor_settings.rates.sonar);
 
-                $('.tab-sensors select[name="debug_refresh_rate"]').val(result.sensor_settings.rates.debug);
+            $('.tab-sensors select[name="debug_refresh_rate"]').val(result.sensor_settings.rates.debug);
 
-                // start polling data by triggering refresh rate change event
-                $('.tab-sensors .rate select:first').change();
-            } else {
-                // start polling immediatly (as there is no configuration saved in the storage)
-                $('.tab-sensors .rate select:first').change();
+            // start polling data by triggering refresh rate change event
+            $('.tab-sensors .rate select:first').change();
+        } else {
+            // start polling immediatly (as there is no configuration saved in the storage)
+            $('.tab-sensors .rate select:first').change();
+        }
+
+        const resultGraphs = ConfigStorage.get('graphs_enabled');
+        if (resultGraphs.graphs_enabled) {
+            const _checkboxes = $('.tab-sensors .info .checkboxes input');
+            for (let i = 0; i < resultGraphs.graphs_enabled.length; i++) {
+                _checkboxes.eq(i).not(':disabled').prop('checked', resultGraphs.graphs_enabled[i]).change();
             }
-            ConfigStorage.get('graphs_enabled', function (resultGraphs) {
-                if (resultGraphs.graphs_enabled) {
-                    const _checkboxes = $('.tab-sensors .info .checkboxes input');
-                    for (let i = 0; i < resultGraphs.graphs_enabled.length; i++) {
-                        _checkboxes.eq(i).not(':disabled').prop('checked', resultGraphs.graphs_enabled[i]).change();
-                    }
-                } else {
-                    $('.tab-sensors .info input:lt(4):not(:disabled)').prop('checked', true).change();
-                }
-            });
-        });
+        } else {
+            $('.tab-sensors .info input:lt(4):not(:disabled)').prop('checked', true).change();
+        }
 
         // status data pulled via separate timer with static speed
         GUI.interval_add('status_pull', function status_pull() {


### PR DESCRIPTION
We need to migrate deprecated API's.

This PR is removing `chrome.storage API` and uses the `ConfigStorage.js` we had in place already instead.

Deprecated API | Suggested API | Link
-- | -- | --
chrome.storage | Cache API | https://web.dev/storage-for-the-web/
chrome.fileSystem| Native FileSystem API | https://web.dev/file-system-access/
chrome.serial | Web Serial API | https://web.dev/serial/
chrome.sockets.tcp | WebSockets | https://web.dev/websocketstream/
chrome.usb | Web USB API | https://web.dev/usb/