### PR TITLE
rfc filter sliders

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1815,6 +1815,9 @@
     "pidTuningOptionOff": {
         "message": "OFF"
     },
+    "pidTuningOptionOn": {
+        "message": "ON"
+    },
     "pidTuningFeedforwardAveragingOption2Point": {
         "message": "2 Point"
     },
@@ -3614,6 +3617,10 @@
         "message": "Raises or Lowers the default Gyro Lowpass Filters in proportion to each-other. The gyro filtering is applied before the PID loop.<br />General motor noise ranges per quad class:<br /><br />6\"+ quads - generally within 100hz to 330hz<br />5\" quads - generally within 220hz to 500hz<br />Whoop to 3\" quads - generally within 300hz to 850hz<br /><br />Generally, you want to set the slider to have the Gyro Lowpass 1 Dynamic Min/Max Cutoff range cover the above.<br />However, for smoother flights use More Filtering on the slider. To get a more aggressive filter tune, use Less Filtering on the slider.<br /><br />With Less Filtering BE CAREFUL to not get radical as to cause a fly-away or burn out motors.<br />Note frame resonance issues, bad bearings, and beat up props may cause you to need more filtering.",
         "description": "Gyro filtering tuning slider helpicon message"
     },
+    "pidTuningGyroSliderEnabled": {
+        "message": "Use Gyro Slider",
+        "description": "Disable or enable Gyro Filter Tuning Slider"
+    },
     "pidTuningDTermFilterSlider": {
         "message": "D Term Filter Multiplier:",
         "description": "D Term filter tuning slider label"
@@ -3621,6 +3628,10 @@
     "pidTuningDTermFilterSliderHelp": {
         "message": "Changes the D-term Lowpass Filter cutoffs.<br />Moving the slider to the left gives stronger D filtering (lower cutoff frequency); to the right gives less filtering (higher cutoff frequency).<br /><br />D-term is the most sensitive PID element to noise and resonance. It can amplify any high frequency noise by 10x to 100x plus. That's why the cutoffs for the D filters are much lower than the gyro filters.<br /><br />D-term filtering is applied after - in addition to - the gyro filtering. Strong D filtering will reduce motor heat on noisy quads and can be useful with high PID 'D' values to minimise D resonance at medium to high frequencies. However, strong D filtering may delay the D signal, worsening propwash handling and encouraging lower frequency D resonances. The default D filtering is optimal for most quads. Larger machines with high D may do better with stronger D filtering than defaults. Moving the D lowpass filter slider to the right is generally not required. On very clean builds, going to the right can attenuate propwash. It should be done very cautiously since having less filtering on D can result in sudden resonances (including motor grinding or taking off on arming) and extreme motor heat.",
         "description": "D Term filtering tuning slider helpicon message"
+    },
+    "pidTuningDTermSliderEnabled": {
+        "message": "Use D Term Slider",
+        "description": "Disable or enable D Term Filter Tuning Slider"
     },
     "pidTuningPidSlidersHelp": {
         "message": "Sliders to adjust the quad flight characteristics (PID gains)<br /><br />Damping (D gain): Resists fast movement, minimises P oscillation.<br /><br />Tracking (P and I gain): Enchances the responsiveness of the quad, if too high may cause trilling or oscillation.<br /><br />Stick Response (Feedforward): Increases the responsiveness of the quad to faster stick movements.<br /><br />Drift - Wobble (I gain, expert):  Fine adjustment of I.<br /><br />Dynamic D (D Max, expert):  Sets the maximum amount that D can be boosted to during fast movements.<br /><br />Pitch Damping (Pitch:Roll D ratio, expert): Increases the amount of damping on pitch relative to roll.<br /><br />Pitch Tracking (Pitch:Roll P, I and F ratio, expert): Increases stabilising strenght on pitch relative to roll.<br /><br />Master Multiplier (all gains, expert): Raises or Lowers all the PID gains, keeping their proportions constant.",
@@ -3633,6 +3644,14 @@
     "pidTuningSlidersDisabled": {
         "message": "<strong>Note:</strong> Sliders are disabled because values were changed manually. Clicking the '$t(pidTuningSliderEnableButton.message)' button will activate them again. This will reset the values and any unsaved changes will be lost.",
         "description": "Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningGyroSliderDisabled": {
+        "message": "<strong>Note:</strong> Gyro Slider is disabled because values were changed manually. Clicking the '$t(pidTuningGyroSliderEnableButton.message)' button will activate them again. This will reset the values and any unsaved changes will be lost.",
+        "description": "Gyro Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningDTermSliderDisabled": {
+        "message": "<strong>Note:</strong> DTerm Slider is disabled because values were changed manually. Clicking the '$t(pidTuningDTermSliderEnableButton.message)' button will activate them again. This will reset the values and any unsaved changes will be lost.",
+        "description": "DTerm Tuning sliders disabled note when manual changes are detected"
     },
     "pidTuningPidSlidersDisabled": {
         "message": "<strong>Note:</strong> Sliders are disabled. Clicking the '$t(pidTuningSliderEnableButton.message)' button will change the PID values to match your previously saved slider position.",
@@ -3762,26 +3781,44 @@
     "pidTuningGyroLowpassFiltersGroup": {
         "message": "Gyro Lowpass Filters"
     },
-    "pidTuningGyroLowpassFrequency": {
-        "message": "Gyro Lowpass 1 Cutoff Frequency [Hz]"
-    },
     "pidTuningGyroLowpassType": {
         "message": "Gyro Lowpass 1 Filter Type"
+    },    
+    "pidTuningGyroLowpassFrequency": {
+        "message": "Cutoff Frequency [Hz]"
+    },
+    "pidTuningGyroLowpass": {
+        "message": "Gyro Lowpass 1"
+    },
+    "pidTuningGyroLowpassMode": {
+        "message": "Mode"
+    },
+    "pidTuningLowpassStatic": {
+        "message": "STATIC"
+    },
+    "pidTuningLowpassDynamic": {
+        "message": "DYNAMIC"
+    },
+    "pidTuningLowpassFilterType": {
+        "message": "Filter Type"
+    },
+    "pidTuningGyroLowpassDyn": {
+        "message": "Gyro Lowpass Dynamic Filter"
     },
     "pidTuningGyroLowpassDynMinFrequency": {
-        "message": "Gyro Lowpass 1 Dynamic Min Cutoff Frequency [Hz]"
+        "message": "Min Cutoff Frequency [Hz]"
     },
     "pidTuningGyroLowpassDynMaxFrequency": {
-        "message": "Gyro Lowpass 1 Dynamic Max Cutoff Frequency [Hz]"
+        "message": "Max Cutoff Frequency [Hz]"
     },
     "pidTuningGyroLowpassDynType": {
         "message": "Gyro Lowpass 1 Dynamic Filter Type"
     },
-    "pidTuningGyroLowpass2Frequency": {
-        "message": "Gyro Lowpass 2 Cutoff Frequency [Hz]"
+    "pidTuningGyroLowpass2": {
+        "message": "Gyro Lowpass 2"
     },
-    "pidTuningGyroLowpass2Type": {
-        "message": "Gyro Lowpass 2 Filter Type"
+    "pidTuningGyroLowpass2Frequency": {
+        "message": "Cutoff Frequency [Hz]"
     },
     "pidTuningGyroLowpassFilterHelp": {
         "message": "Gyro lowpass filters attenuate higher frequency noise to keep it out of the PID loop. There are two independently configurable gyro filters; by default both are active.<br /><br />The first D lowpass can be static (fixed cutoff) or dynamic; the second D lowpass is always static. When a lowpass is in dynamic mode, filter will be stronger at low throttle, and the cutoff will go higher (less filtering) as throttle increases.<br /><br />Without RPM filtering, both PT1 filters should be enabled at default (or stronger) cutoffs, with lowpass 1 in dynamic mode.<br /><br />With RPM filtering, the gyro filter slider can often be moved some way to the right. On clean quads it can go all the way right, or alternatively a single static gyro lowpass filter at 500hz may be sufficient.<br /><br />A quad will have less propwash with the least gyro filter delay (sliders to the right, higher cutoff values).<br /><br />Always check for motor heat when shifting to less gyro filtering (sliders to the right). With minimal gyro filtering, it is essential to have enough D filtering! Take care!" 
@@ -3791,6 +3828,12 @@
     },
     "pidTuningGyroNotchFiltersGroup": {
         "message": "Gyro Notch Filters"
+    },
+    "pidTuningGyroNotchFilter": {
+        "message": "Gyro Notch Filter 1"
+    },
+    "pidTuningGyroNotchFilter2": {
+        "message": "Gyro Notch Filter 2"
     },
     "pidTuningGyroNotch1Frequency": {
         "message": "Gyro Notch Filter 1 Center Frequency [Hz]"
@@ -3852,6 +3895,9 @@
     "pidTuningDynamicNotchMaxHzHelp": {
         "message": "Set this to the highest incoming noise frequency that is needed to be controlled by the dynamic notch."
     },
+    "pidTuningGyroLowpassType": {
+        "message": "Gyro Lowpass 1 Filter Type"
+    },    
     "pidTuningDynamicNotchCountHelp": {
         "message": "Sets the number of dynamic notches per axis. With RPM filter enabled a value of 1 or 2 is recommended. Without RPM filter a value of 4 or 5 is recommended. Lower numbers will reduce filter delay, however it may increase motor temperature."
     },
@@ -3882,6 +3928,15 @@
     "pidTuningFilterSettings": {
         "message": "Profile dependent Filter Settings"
     },
+    "pidTuningDTermLowpass": {
+        "message": "D Term Lowpass 1"
+    },
+    "pidTuningDTermLowpassMode": {
+        "message": "Mode"
+    },
+    "pidTuningDTermLowpass2": {
+        "message": "D Term Lowpass 2"
+    },
     "pidTuningDTermLowpassFiltersGroup": {
         "message": "D Term Lowpass Filters"
     },
@@ -3889,13 +3944,16 @@
         "message": "D Term Lowpass 1 Filter Type"
     },
     "pidTuningDTermLowpassFrequency": {
-        "message": "D Term Lowpass 1 Cutoff Frequency [Hz]"
+        "message": "D Term Lowpass 1 Static Cutoff Frequency [Hz]"
     },
     "pidTuningDTermLowpass2Frequency": {
-        "message": "D Term Lowpass 2 Cutoff Frequency [Hz]"
+        "message": "D Term Lowpass 2 Static Cutoff Frequency [Hz]"
     },
     "pidTuningDTermLowpass2Type": {
         "message": "D Term Lowpass 2 Filter Type"
+    },
+    "pidTuningDTermLowpassDyn": {
+        "message": "D Term Lowpass Dynamic Filter"
     },
     "pidTuningDTermLowpassDynMinFrequency": {
         "message": "D Term Lowpass 1 Dynamic Min Cutoff Frequency [Hz]"
@@ -3903,11 +3961,11 @@
     "pidTuningDTermLowpassDynMaxFrequency": {
         "message": "D Term Lowpass 1 Dynamic Max Cutoff Frequency [Hz]"
     },
-    "pidTuningDTermLowpassDynType": {
-        "message": "D Term Lowpass 1 Dynamic Filter Type"
-    },
     "pidTuningDTermLowpassDynExpo": {
         "message": "D Term Lowpass 1 Dynamic Curve Expo"
+    },
+    "pidTuningDTermLowpassDynType": {
+        "message": "D Term Lowpass 1 Dynamic Filter Type"
     },
     "pidTuningDTermNotchFiltersGroup": {
         "message": "D Term Notch Filters"
@@ -3918,7 +3976,7 @@
     "pidTuningDTermNotchCutoff": {
         "message": "D Term Notch Filter Cutoff Frequency [Hz]"
     },
-    "pidTuningYawLospassFiltersGroup": {
+    "pidTuningYawLowpassFiltersGroup": {
         "message": "Yaw Lowpass Filters"
     },
     "pidTuningYawLowpassFrequency": {

--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -163,11 +163,15 @@
     padding-right: 5px;
 }
 
-.tab-pid_tuning table.compensation td:first-child {
+.tab-pid_tuning table.compensation td:first-child:not(.filterTable) {
     width: 65px;
     text-align: center;
     vertical-align: top;
     padding-top: 4px;
+}
+
+.tab-pid_tuning table.filterTable.compensation td:first-child {
+    width: 5%;
 }
 
 .tab-pid_tuning table.compensation td:last-child {
@@ -907,10 +911,6 @@
 
 .tab-pid_tuning table.filterTable {
     table-layout: auto;
-}
-
-.tab-pid_tuning table.filterTable td:first-child {
-    width: 25%;
 }
 
 @media only screen and (max-width: 1205px) {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -853,6 +853,7 @@ const FC = {
                 versionFilterDefaults.gyro_lowpass_hz = 250;
                 versionFilterDefaults.gyro_lowpass_dyn_min_hz = 250;
                 versionFilterDefaults.gyro_lowpass2_hz = 500;
+                versionFilterDefaults.dterm_lowpass_hz = 75;
                 versionFilterDefaults.dterm_lowpass_dyn_min_hz = 75;
                 versionFilterDefaults.dterm_lowpass_dyn_max_hz = 150;
             }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1501,7 +1501,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.TUNING_SLIDERS.slider_dterm_filter_multiplier = data.readU8();
                 FC.TUNING_SLIDERS.slider_gyro_filter = data.readU8();
                 FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = data.readU8();
-
                 break;
 
             case MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL:
@@ -1567,7 +1566,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log('Name set');
                 break;
             case MSPCodes.MSP_SET_FILTER_CONFIG:
-                console.log('Filter config set');
+                // removed as this fires a lot with firmware sliders console.log('Filter config set');
                 break;
             case MSPCodes.MSP_SET_ADVANCED_CONFIG:
                 console.log('Advanced config parameters set');
@@ -2311,19 +2310,20 @@ MspHelper.prototype.crunch = function(code) {
             break;
 
         case MSPCodes.MSP_SET_TUNING_SLIDERS:
-            buffer.push8(FC.TUNING_SLIDERS.slider_pids_mode)
-                  .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
-                  .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
-                  .push8(FC.TUNING_SLIDERS.slider_i_gain)
-                  .push8(FC.TUNING_SLIDERS.slider_d_gain)
-                  .push8(FC.TUNING_SLIDERS.slider_pi_gain)
-                  .push8(FC.TUNING_SLIDERS.slider_dmax_gain)
-                  .push8(FC.TUNING_SLIDERS.slider_feedforward_gain)
-                  .push8(FC.TUNING_SLIDERS.slider_pitch_pi_gain)
-                  .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
-                  .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
-                  .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
-                  .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier);
+            buffer
+                .push8(FC.TUNING_SLIDERS.slider_pids_mode)
+                .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
+                .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
+                .push8(FC.TUNING_SLIDERS.slider_i_gain)
+                .push8(FC.TUNING_SLIDERS.slider_d_gain)
+                .push8(FC.TUNING_SLIDERS.slider_pi_gain)
+                .push8(FC.TUNING_SLIDERS.slider_dmax_gain)
+                .push8(FC.TUNING_SLIDERS.slider_feedforward_gain)
+                .push8(FC.TUNING_SLIDERS.slider_pitch_pi_gain)
+                .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
+                .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
+                .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
+                .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier);
             break;
 
         default:

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1137,6 +1137,7 @@
                             </th>
                         </tr>
                     </table>
+
                     <table class="sliderLabels">
                         <tr class="xs sliderHeaders">
                             <td colspan="5">
@@ -1151,7 +1152,7 @@
                                 <output type="number" name="sliderGyroFilterMultiplier-number"></output>
                             </td>
                             <td colspan="3">
-                                <input type="range" min="0.0" max="2.0" step="0.05" class="tuningSlider" id="sliderGyroFilterMultiplier" />
+                                <input type="range" min="0.1" max="2.0" step="0.05" class="tuningSlider" id="sliderGyroFilterMultiplier" />
                             </td>
                             <td>
                                 <div class="helpicon cf_tip" i18n_title="pidTuningGyroFilterSliderHelp"></div>
@@ -1162,7 +1163,7 @@
                                 <span i18n="pidTuningDTermFilterSlider"></span>
                             </td>
                         </tr>
-                        <tr class="sliderDtermFilter">
+                        <tr class="sliderDTermFilter">
                             <td class="sm-min">
                                 <span i18n="pidTuningDTermFilterSlider"></span>
                             </td>
@@ -1170,7 +1171,7 @@
                                 <output type="number" name="sliderDTermFilterMultiplier-number"></output>
                             </td>
                             <td colspan="3">
-                                <input type="range" min="0.0" max="2.0" step="0.05" class="tuningSlider" id="sliderDTermFilterMultiplier" />
+                                <input type="range" min="0.1" max="2.0" step="0.05" class="tuningSlider" id="sliderDTermFilterMultiplier" />
                             </td>
                             <td>
                                 <div class="helpicon cf_tip" i18n_title="pidTuningDTermFilterSliderHelp"></div>
@@ -1192,123 +1193,161 @@
                         <table class="pid_titlebar new_rates">
                             <tr>
                                 <th i18n="pidTuningNonProfileFilterSettings"></th>
+                                <td>
+                                    <select id="sliderGyroFilterModeSelect" class="sliderMode">
+                                        <option value="0" i18n="pidTuningOptionOff"></option>
+                                        <option value="1" i18n="pidTuningOptionOn"></option>
+                                    </select>    
+                                </td>
                             </tr>
                         </table>
 
-                        <table class="filterTable">
+                        <table class="filterTable compensation">
                             <tr>
                                 <th colspan="2">
                                     <div class="pid_mode">
                                         <div i18n="pidTuningGyroLowpassFiltersGroup" ></div>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningGyroLowpassFilterHelp" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningGyroLowpassFilterHelp"></div>
                                     </div>
                                 </th>
                             </tr>
 
-                            <tr class="gyroLowpassDyn">
+                            <!-- legacy filter switches -->
+
+                            <tr class="gyroLowpassDynLegacy">
                                 <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="gyroLowpassDynEnabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" name="gyroLowpassDynMinFrequency" step="1" min="1" max="1000"/></span>
-                                    </span>
+	                                <span class="inputSwitch"><input type="checkbox" id="gyroLowpassDynEnabled" class="toggle" /></span>
                                 </td>
-                                <td>
-                                    <div>
+                                <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningGyroLowpassDyn"></div>
+                                    <span i18n="pidTuningGyroLowpassDyn"></span>
+
+                                    <span class="suboption">
+                                        <input type="number" name="gyroLowpassDynMinFrequency" step="1" min="1" max="1000"/>
                                         <label>
                                             <span i18n="pidTuningGyroLowpassDynMinFrequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
-
-                            <tr class="gyroLowpassDyn">
-                                <td>
-                                    <span class="inputValue"><input type="number" name="gyroLowpassDynMaxFrequency" step="1" min="1" max="1000"/></span>
-                                </td>
-                                <td>
-                                    <div>
+									</span>
+									<span class="suboption">
+                                        <input type="number" name="gyroLowpassDynMaxFrequency" step="1" min="1" max="1000"/>
                                         <label>
                                             <span i18n="pidTuningGyroLowpassDynMaxFrequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
-
-                            <tr class="gyroLowpassDyn">
-                                <td>
-                                    <select name="gyroLowpassDynType">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningGyroLowpassDynType"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                            </tr>
-
-                            <tr>
-                                <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="gyroLowpassEnabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpassFrequency" step="1" min="1" max="255"/></span>
                                     </span>
+									<span class="suboption">
+										<select name="gyroLowpassDynType">
+											<!--  Populated on execution -->
+										</select>
+										<label>
+											<span i18n="pidTuningGyroLowpassDynType"></span>
+										</label>
+									</span>
                                 </td>
+                            </tr>
+
+                            <tr class="gyroLowpassLegacy">
                                 <td>
-                                    <div>
+	                                <span class="inputSwitch"><input type="checkbox" id="gyroLowpassEnabled" class="toggle" /></span>
+                                </td>
+                                <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningGyroLowpass"></div>
+                                    <span i18n="pidTuningGyroLowpass"></span>
+
+                                    <span class="suboption">
+                                        <input type="number" class="nonProfile" name="gyroLowpassFrequency" step="1" min="1" max="255"/>
                                         <label>
                                             <span i18n="pidTuningGyroLowpassFrequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
-
-                            <tr>
-                                <td>
-                                    <select name="gyroLowpassType">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
+                                    </span>
+                                    <span class="suboption">
+                                        <select name="gyroLowpassType">
+                                            <!--  Populated on execution -->
+                                        </select>
                                         <label>
                                             <span i18n="pidTuningGyroLowpassType"></span>
                                         </label>
-                                    </div>
+                                    </span>
                                 </td>
                             </tr>
 
+                            <!-- firmware filter switches -->
+
+                            <tr class="gyroLowpass">
+                                <td>
+                                    <span class="inputSwitch"><input type="checkbox" id="gyroLowpassEnabled" class="toggle" /></span>
+                                </td>
+                                <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningGyroLowpass"></div>
+                                    <span i18n="pidTuningGyroLowpass"></span>
+
+                                    <span class="suboption gyroLowpassFilterModeGroup">
+                                        <span class="inputValue">
+                                            <select name="gyroLowpassFilterMode">
+                                                <option value="0" i18n="pidTuningLowpassStatic"></option>
+                                                <option value="1" i18n="pidTuningLowpassDynamic"></option>
+                                            </select>
+                                        </span>
+                                        <label>
+                                            <span i18n="pidTuningGyroLowpassMode"></span>
+                                        </label>
+                                    </span>
+
+                                    <span class="suboption static">
+                                        <input type="number" class="nonProfile" name="gyroLowpassFrequency" step="1" min="1" max="255"/>
+                                        <label>
+                                            <span i18n="pidTuningGyroLowpassFrequency"></span>
+                                        </label>
+                                    </span>
+
+                                    <span class="suboption dynamic">
+                                        <input type="number" name="gyroLowpassDynMinFrequency" step="1" min="1" max="1000"/>
+                                        <label>
+                                            <span i18n="pidTuningGyroLowpassDynMinFrequency"></span>
+                                        </label>
+                                    </span>
+
+                                    <span class="suboption dynamic">
+                                        <input type="number" name="gyroLowpassDynMaxFrequency" step="1" min="1" max="1000"/>
+                                        <label>
+                                            <span i18n="pidTuningGyroLowpassDynMaxFrequency"></span>
+                                        </label>
+                                    </span>
+
+                                    <span class="suboption">
+                                        <select name="gyroLowpassType">
+                                            <!--  Populated on execution -->
+                                        </select>
+                                        <label>
+                                            <span i18n="pidTuningLowpassFilterType"></span>
+                                        </label>
+                                    </span>
+
+                                </td>
+                            </tr>
 
                             <tr class="gyroLowpass2">
                                 <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="gyroLowpass2Enabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroLowpass2Frequency" step="1" min="1" max="16000"/></span>
-                                    </span>
+                                    <span class="inputSwitch"><input type="checkbox" id="gyroLowpass2Enabled" class="toggle" /></span>
                                 </td>
-                                <td>
-                                    <div>
+                                <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningGyroLowpass2"></div>
+                                    <span i18n="pidTuningGyroLowpass2"></span>
+
+                                    <span class="suboption">
+                                        <input type="number" class="nonProfile" name="gyroLowpass2Frequency" step="1" min="1" max="16000"/>
                                         <label>
                                             <span i18n="pidTuningGyroLowpass2Frequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
+                                    </span>
 
-                            <tr class="gyroLowpass2Type">
-                                <td>
-                                    <select name="gyroLowpass2Type">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
+                                    <span class="suboption">
+                                        <select name="gyroLowpass2Type">
+                                            <!--  Populated on execution -->
+                                        </select>
                                         <label>
-                                            <span i18n="pidTuningGyroLowpass2Type"></span>
+                                            <span i18n="pidTuningLowpassFilterType"></span>
                                         </label>
-                                    </div>
+                                    </span>
                                 </td>
                             </tr>
 
@@ -1321,107 +1360,88 @@
                                 </th>
                             </tr>
 
-                            <tr class="newFilter">
-                                <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="gyroNotch1Enabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroNotch1Frequency" step="1" min="1" max="16000"/></span>
-                                    </span>
-                                </td>
-                                <td>
-                                    <div>
+                            <tr class="newFilter gyroNotch1">
+                                <td><span class="inputSwitch"><input type="checkbox" id="gyroNotch1Enabled" class="toggle" /></span></td>
+                                <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningGyroNotchFilter"></div>
+                                    <span i18n="pidTuningGyroNotchFilter"></span>
+
+                                    <span class="suboption">
+                                        <input type="number" class="nonProfile" name="gyroNotch1Frequency" step="1" min="1" max="16000"/>
                                         <label>
                                             <span i18n="pidTuningGyroNotch1Frequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
+                                    </span>
 
-                            <tr class="newFilter">
-                                <td>
-                                    <input type="number" class="nonProfile" name="gyroNotch1Cutoff" step="1" min="0" max="16000"/>
-                                </td>
-                                <td>
-                                    <div>
+                                    <span class="suboption">
+                                        <input type="number" class="nonProfile" name="gyroNotch1Cutoff" step="1" min="0" max="16000"/>
                                         <label>
                                             <span i18n="pidTuningGyroNotch1Cutoff"></span>
                                         </label>
-                                    </div>
+                                    </span>
                                 </td>
                             </tr>
 
                             <tr class="newFilter gyroNotch2">
-                                <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="gyroNotch2Enabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="gyroNotch2Frequency" step="1" min="1" max="16000"/></span>
-                                    </span>
-                                </td>
-                                <td>
-                                    <div>
+                                <td><span class="inputSwitch"><input type="checkbox" id="gyroNotch2Enabled" class="toggle" /></span></td>
+                                <td colspan="2">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningGyroNotchFilter2"></div>
+                                    <span i18n="pidTuningGyroNotchFilter2"></span>
+
+                                    <span class="suboption">
+                                        <input type="number" class="nonProfile" name="gyroNotch2Frequency" step="1" min="1" max="16000"/>
                                         <label>
                                             <span i18n="pidTuningGyroNotch2Frequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
+                                    </span>
 
-                            <tr class="newFilter gyroNotch2">
-                                <td>
-                                    <input type="number" class="nonProfile" name="gyroNotch2Cutoff" step="1" min="0" max="16000"/>
-                                </td>
-                                <td>
-                                    <div>
+                                    <span class="suboption">
+                                        <input type="number" class="nonProfile" name="gyroNotch2Cutoff" step="1" min="0" max="16000"/>
                                         <label>
                                             <span i18n="pidTuningGyroNotch2Cutoff"></span>
                                         </label>
-                                    </div>
+                                    </span>
+
                                 </td>
                             </tr>
 
                             <tr>
                                 <th class="rpmFilter" colspan="2">
                                     <div class="pid_mode rpmFilter">
-                                        <div i18n="pidTuningRpmFilterGroup" ></div>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmFilterHelp" ></div>
+                                        <div i18n="pidTuningRpmFilterGroup"></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmFilterHelp"></div>
                                     </div>
                                 </th>
                             </tr>
+
                             <tr class="newFilter rpmFilter">
-                                <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="rpmFilterEnabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" class="nonProfile" name="rpmFilterHarmonics" step="1" min="1" max="3"/></span>
-                                    </span>
-                                </td>
-                                <td>
-                                    <div>
+                                <td><span class="inputSwitch"><input type="checkbox" id="rpmFilterEnabled" class="toggle" /></span></td>
+                                <td colspan="2">
+                                    <span i18n="pidTuningRpmFilterGroup"></span>
+
+                                    <span class="suboption">
+                                        <input type="number" class="nonProfile" name="rpmFilterHarmonics" step="1" min="1" max="3"/>
                                         <label>
                                             <span i18n="pidTuningRpmHarmonics"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmHarmonicsHelp" ></div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr class="newFilter rpmFilter">
-                                <td>
-                                    <input type="number" name="rpmFilterMinHz" step="1" min="50" max="200"/>
-                                </td>
-                                <td>
-                                    <div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmHarmonicsHelp"></div>
+                                    </span>
+
+                                    <span class="suboption">
+                                        <input type="number" name="rpmFilterMinHz" step="1" min="50" max="200"/>
                                         <label>
                                             <span i18n="pidTuningRpmMinHz"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmMinHzHelp" ></div>
-                                    </div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningRpmMinHzHelp"></div>
+                                    </span>
                                 </td>
                             </tr>
 
                             <tr>
                                 <th class="dynamicNotch" colspan="2">
                                     <div class="pid_mode dynamicNotch">
-                                        <div i18n="pidTuningDynamicNotchFilterGroup" ></div>
-                                        <div class="helpicon cf_tip dynamicNotchHelp" i18n_title="pidTuningDynamicNotchFilterHelp" ></div>
+                                        <div i18n="pidTuningDynamicNotchFilterGroup"></div>
+                                        <div class="helpicon cf_tip dynamicNotchHelp" i18n_title="pidTuningDynamicNotchFilterHelp"></div>
                                     </div>
                                 </th>
                             </tr>
@@ -1436,7 +1456,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchRange"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchRangeHelp" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchRangeHelp"></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1449,7 +1469,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchWidthPercent"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchWidthPercentHelp" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchWidthPercentHelp"></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1462,7 +1482,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchQ"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchQHelp" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchQHelp"></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1475,7 +1495,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchCount"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchCountHelp" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchCountHelp"></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1488,7 +1508,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchMinHz"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMinHzHelp" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMinHzHelp"></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1501,7 +1521,7 @@
                                         <label>
                                             <span i18n="pidTuningDynamicNotchMaxHz"></span>
                                         </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMaxHzHelp" ></div>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMaxHzHelp"></div>
                                     </div>
                                 </td>
                             </tr>
@@ -1512,201 +1532,219 @@
                         <table class="pid_titlebar new_rates">
                             <tr>
                                 <th i18n="pidTuningFilterSettings"></th>
+                                <td>
+                                    <select id="sliderDTermFilterModeSelect" class="sliderMode">
+                                        <option value="0" i18n="pidTuningOptionOff"></option>
+                                        <option value="1" i18n="pidTuningOptionOn"></option>
+                                    </select>    
+                                </td>
                             </tr>
                         </table>
 
-                        <table class="filterTable">
+                        <table class="filterTable compensation">
                             <tr>
-                                <th colspan="2">
+                                <th colspan="3">
                                     <div class="pid_mode">
                                         <div i18n="pidTuningDTermLowpassFiltersGroup" ></div>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpassFilterHelp" ></div>
-                                    </div>
-
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpassFilterHelp"></div>
                                     </div>
                                 </th>
                             </tr>
 
-                            <tr class="dtermLowpassDyn">
+                            <!-- Legacy filter switches -->
+                            <tr class="dtermLowpassDynLegacy">
                                 <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="dtermLowpassDynEnabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpassDynMinFrequency" step="1" min="1" max="1000"/></span>
-                                    </span>
+                                    <span class="inputSwitch"><input type="checkbox" id="dtermLowpassDynEnabled" class="toggle" /></span>
                                 </td>
-                                <td>
-                                    <div>
+                                <td colspan="3">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpassDyn"></div>
+                                    <span i18n="pidTuningDTermLowpassDyn"></span>
+
+                                    <span class="suboption">
+                                        <span class="inputValue"><input type="number" name="dtermLowpassDynMinFrequency" step="1" min="1" max="1000"/></span>
                                         <label>
                                             <span i18n="pidTuningDTermLowpassDynMinFrequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
+                                    </span>
 
-                            <tr class="dtermLowpassDyn">
-                                <td>
-                                    <span class="inputValue"><input type="number" name="dtermLowpassDynMaxFrequency" step="1" min="1" max="1000"/></span>
-                                </td>
-                                <td>
-                                    <div>
+                                    <span class="suboption">
+                                        <span class="inputValue"><input type="number" name="dtermLowpassDynMaxFrequency" step="1" min="1" max="1000"/></span>
                                         <label>
                                             <span i18n="pidTuningDTermLowpassDynMaxFrequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
+                                    </span>
 
-                            <tr class="dtermLowpassDyn">
-                                <td>
-                                    <select name="dtermLowpassDynType">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
+                                    <span class="suboption">
+                                        <select name="dtermLowpassDynType">
+                                            <!--  Populated on execution -->
+                                        </select>
                                         <label>
                                             <span i18n="pidTuningDTermLowpassDynType"></span>
                                         </label>
-                                    </div>
+									</span>
+									
                                 </td>
                             </tr>
-
-                            <tr class="dtermLowpassDyn dynLpfCurveExpo">
+                            
+                            <tr class="dtermLowpassLegacy">
                                 <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="dtermLowpassDynExpoEnabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpassDynExpo" step="1" min="1" max="10"/></span>
-                                    </span>
+	                                <span class="inputSwitch"><input type="checkbox" id="dtermLowpassEnabled" class="toggle" /></span>
                                 </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDTermLowpassDynExpo"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                            </tr>
+                                <td colspan="3">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpass"></div>
+                                    <span i18n="pidTuningDTermLowpass"></span>
 
-                            <tr>
-                                <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="dtermLowpassEnabled" class="toggle" /></span>
+                                    <span class="suboption">
                                         <span class="inputValue"><input type="number" name="dtermLowpassFrequency" step="1" min="1" max="16000"/></span>
-                                    </span>
-                                </td>
-                                <td>
-                                    <div>
                                         <label>
                                             <span i18n="pidTuningDTermLowpassFrequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
-
-                            <tr>
-                                <td>
-                                    <select name="dtermLowpassType">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
+									</span>
+                                    <span class="suboption">
+                                        <select name="dtermLowpassType">
+                                            <!--  Populated on execution -->
+                                        </select>
                                         <label>
                                             <span i18n="pidTuningDTermLowpassType"></span>
                                         </label>
-                                    </div>
+									</span>
+                                </td>
+                            </tr>
+
+                            <!-- firmware filter switches -->
+
+                            <tr class="dtermLowpass">
+                                <td>
+                                    <span class="inputSwitch"><input type="checkbox" id="dtermLowpassEnabled" class="toggle" /></span>
+                                </td>
+
+                                <td colspan="3">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpass"></div>
+                                    <span i18n="pidTuningDTermLowpass"></span>
+
+                                    <span class="suboption dtermLowpassFilterModeGroup">
+                                        <span class="inputValue">
+                                            <select name="dtermLowpassFilterMode">
+                                                <option value="0" i18n="pidTuningLowpassStatic"></option>
+                                                <option value="1" i18n="pidTuningLowpassDynamic"></option>
+                                            </select>
+                                        </span>
+                                        <label>
+                                            <span i18n="pidTuningDTermLowpassMode"></span>
+                                        </label>
+                                    </span>
+
+                                    <span class="suboption static">
+                                        <span class="inputValue"><input type="number" name="dtermLowpassFrequency" step="1" min="1" max="16000"/></span>
+                                        <label>
+                                            <span i18n="pidTuningDTermLowpassFrequency"></span>
+                                        </label>    
+                                    </span>    
+
+                                    <span class="suboption dynamic">
+                                        <span class="inputValue"><input type="number" name="dtermLowpassDynMinFrequency" step="1" min="1" max="1000"/></span>
+                                        <label>
+                                            <span i18n="pidTuningDTermLowpassDynMinFrequency"></span>
+                                        </label>
+                                    </span>
+ 
+                                    <span class="suboption dynamic">
+                                        <span class="inputValue"><input type="number" name="dtermLowpassDynMaxFrequency" step="1" min="1" max="1000"/></span>
+                                        <label>
+                                            <span i18n="pidTuningDTermLowpassDynMaxFrequency"></span>
+                                        </label>
+                                        </span>
+                    
+                                        <span class="suboption dynamic">
+                                            <span class="inputValue"><input type="number" name="dtermLowpassExpo" step="1" min="1" max="10"/></span>
+                                            <label>
+                                                <span i18n="pidTuningDTermLowpassDynExpo"></span>
+                                            </label>
+                                        </span>
+    
+                                        <span class="suboption">
+                                            <select name="dtermLowpassType">
+                                                <!--  Populated on execution -->
+                                            </select>
+                                            <label>
+                                                <span i18n="pidTuningLowpassFilterType"></span>
+                                            </label>
+                                        </span>
+                                    </span>
                                 </td>
                             </tr>
 
                             <tr class="dtermLowpass2">
                                 <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="dtermLowpass2Enabled" class="toggle" /></span>
-                                        <span class="inputValue"><input type="number" name="dtermLowpass2Frequency" step="1" min="1" max="16000"/></span>
-                                    </span>
+                                    <span class="inputSwitch"><input type="checkbox" id="dtermLowpass2Enabled" class="toggle" /></span>
                                 </td>
-                                <td>
-                                    <div>
+                                <td colspan="3">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningDTermLowpass2"></div>
+                                    <span i18n="pidTuningDTermLowpass2"></span>
+
+                                    <span class="suboption">
+                                        <span class="inputValue"><input type="number" name="dtermLowpass2Frequency" step="1" min="1" max="16000"/></span>
                                         <label>
                                             <span i18n="pidTuningDTermLowpass2Frequency"></span>
                                         </label>
-                                    </div>
-                                </td>
-                            </tr>
+                                    </span>
 
-                            <tr class="dtermLowpass2 dtermLowpass2TypeGroup">
-                                <td>
-                                    <select name="dtermLowpass2Type">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
+                                    <span class="suboption dtermLowpass2TypeGroup">
+                                        <select name="dtermLowpass2Type">
+                                            <!--  Populated on execution -->
+                                        </select>
                                         <label>
-                                            <span i18n="pidTuningDTermLowpass2Type"></span>
+                                            <span i18n="pidTuningLowpassFilterType"></span>
                                         </label>
-                                    </div>
+                                    </span>
                                 </td>
                             </tr>
 
                             <tr>
-                                <th colspan="2">
+                                <th colspan="3">
                                     <div class="pid_mode">
                                         <div  i18n="pidTuningDTermNotchFiltersGroup" ></div>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningNotchFilterHelp" ></div>
                                     </div>
-
                                 </th>
                             </tr>
 
-                            <tr class="newFilter">
-                                <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="dtermNotchEnabled" class="toggle" /></span>
+                            <tr class="newFilter dtermNotch">
+                                <td><span class="inputSwitch"><input type="checkbox" id="dtermNotchEnabled" class="toggle" /></span>
+                                <td colspan="3">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningDTermNotchFiltersGroup"></div>
+		                            <span i18n="pidTuningDTermNotchFiltersGroup"></span>
+
+                                    <span class="suboption">
                                         <span class="inputValue"><input type="number" name="dTermNotchFrequency" step="1" min="1" max="16000"/></span>
+                                        <label><span i18n="pidTuningDTermNotchFrequency"></span></label>
                                     </span>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDTermNotchFrequency"></span>
-                                        </label>
-                                    </div>
-                                </td>
-                            </tr>
 
-                            <tr class="newFilter">
-                                <td>
-                                    <input type="number" name="dTermNotchCutoff" step="1" min="0" max="16000"/>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDTermNotchCutoff"></span>
-                                        </label>
-                                    </div>
+                                    <span class="suboption">
+                                        <input type="number" name="dTermNotchCutoff" step="1" min="0" max="16000"/>
+                                        <label><span i18n="pidTuningDTermNotchCutoff"></span></label>
+                                    </span>
                                 </td>
                             </tr>
 
                             <tr>
-                                <th colspan="2">
-                                    <div class="pid_mode" i18n="pidTuningYawLospassFiltersGroup" ></div>
+                                <th colspan="3">
+                                    <div class="pid_mode" i18n="pidTuningYawLowpassFiltersGroup" ></div>
                                 </th>
                             </tr>
 
-                            <tr>
-                                <td>
-                                    <span class="groupSwitchValue">
-                                        <span class="inputSwitch"><input type="checkbox" id="yawLowpassEnabled" class="toggle" /></span>
+                            <tr class="yawLowpass">
+                                <td><span class="inputSwitch"><input type="checkbox" id="yawLowpassEnabled" class="toggle" /></span>
+                                <td colspan="3">
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningYawLowpassFiltersGroup"></div>
+		                            <span i18n="pidTuningYawLowpassFiltersGroup"></span>
+
+                                    <span class="suboption">
                                         <span class="inputValue"><input type="number" name="yawLowpassFrequency" step="1" min="1" max="500"/></span>
-                                    </span>
-                                </td>
-                                <td>
-                                    <div>
                                         <label>
                                             <span i18n="pidTuningYawLowpassFrequency"></span>
                                         </label>
-                                    </div>
+                                    </span>
                                 </td>
                             </tr>
                         </table>


### PR DESCRIPTION
Depends on:
https://github.com/betaflight/betaflight/pull/11038 (merged)
https://github.com/betaflight/betaflight/pull/11050

Fixes: #2611 
Fixes: #2620
<details>
  <summary>changes</summary>
Firmware Sliders are setting Gyro and DTerm filters now.

Observed behaviour with current filters:

1 Now changing lowpass 1 or static lowpass or lowpass 2 dynamic filter type disables gyro slider.
2 Now changing a lowpass 1, static or lowpass 2 values disables gyro / dterm slider.

This PR changes behavior to:

- [x] Decoupling gyro and dterm sliders in GUI to retain separate control (@mikeller).
- [x] Use firmware sliders for any valid filter combination (@ctzsnooze / @sugaarK).
- [x] Trying to get right values from firmware after switch change
- [x] Removed the need to save after switching filters.
- [x] Fixed enabling gyro slider with a hack.
- [x] Fixed enabling dterm slider with a hack.
- [x] Fix saving lowpass 1 type.
- [x] Reworked to fix html for legacy and firmware
- [x] Bring back some old i18n

Okay - we decided to change the whole thing (@ctzsnooze thanks for functional design)
</details
![Screenshot from 2021-11-11 06-53-21](https://user-images.githubusercontent.com/8344830/141245967-6b304039-a004-44c4-8720-d3bbdb92e87b.png)

Builds:
https://dev.azure.com/Betaflight/Betaflight%20Nightlies/_build/results?buildId=4419&view=artifacts&pathAsName=false&type=publishedArtifacts