### PR TITLE
leocb_3 portuguese translator

### DIFF
--- a/locales/pt_BR/leocb_3
+++ b/locales/pt_BR/leocb_3
@@ -1,0 +1,2 @@
+Part of Hacktoberfest translators appreciation
+leocb is a Portuguese (br/pt) translator and proofreader on Betaflight configurator Crowdin


### PR DESCRIPTION
Part of Hacktoberfest translators appreciation
leocb is a Portuguese (br/pt) translator and proofreader on Betaflight configurator Crowdin