### PR TITLE
Update azure windows image

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,6 +18,7 @@ variables:
   debugReleaseNotes: This is a nightly build off the tip of 'master'. It may be unstable and result in corrupted configurations or data loss. **Use only for testing.**
   releaseNotes: This is a release build. It does not contain the debug console.
   linuxVmImage: 'ubuntu-20.04'
+  windowsVmImage: 'windows-2022'
 
 parameters:
   - name: releaseBuild
@@ -46,7 +47,7 @@ stages:
 
   - job: 'Windows'
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: '$(windowsVmImage)'
 
     steps:
     - task: UseNode@1
@@ -78,7 +79,7 @@ stages:
 
   - job: 'Android'
     pool:
-      vmImage: 'vs2017-win2016'
+      vmImage: '$(windowsVmImage)'
 
     steps:
     - task: UseNode@1


### PR DESCRIPTION
Win 2016 image is close to leaving support, updated to the last win2022 image.
`The windows-2016 environment will be deprecated on November 15, 2021, and removed on March 15, 2022.`