### PR TITLE
Remove Dynamic Notch from "Features"

### DIFF
--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -84,9 +84,13 @@ const Features = function (config) {
 
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {
             features.push(
-                {bit: 28, group: 'antiGravity', name: 'ANTI_GRAVITY', haveTip: true, hideName: true},
-                {bit: 29, group: 'other', name: 'DYNAMIC_FILTER'}
+                {bit: 28, group: 'antiGravity', name: 'ANTI_GRAVITY', haveTip: true, hideName: true}
             );
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44)) { // DYNAMIC_FILTER got removed from FEATURES in BF 4.3 / API 1.44
+                features.push(
+                    {bit: 29, group: 'other', name: 'DYNAMIC_FILTER'}
+                );
+            }
         }
 
         if (!semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36)) {

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1423,7 +1423,7 @@
                                 </td>
                             </tr>
 
-                            <tr>
+                            <tr class="newFilter rpmFilter">
                                 <th class="rpmFilter" colspan="2">
                                     <div class="pid_mode rpmFilter">
                                         <div i18n="pidTuningRpmFilterGroup"></div>
@@ -1455,7 +1455,7 @@
                                 </td>
                             </tr>
 
-                            <tr>
+                            <tr class="newFilter dynamicNotch">
                                 <th class="dynamicNotch" colspan="2">
                                     <div class="pid_mode dynamicNotch">
                                         <div i18n="pidTuningDynamicNotchFilterGroup"></div>
@@ -1463,87 +1463,55 @@
                                     </div>
                                 </th>
                             </tr>
-                            <tr class="newFilter dynamicNotch dynamicNotchRange">
-                                <td>
-                                    <select name="dynamicNotchRange">
-                                        <!--  Populated on execution -->
-                                    </select>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDynamicNotchRange"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchRangeHelp"></div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr class="newFilter dynamicNotch dynamicNotchWidthPercent">
-                                <td>
-                                    <input type="number" name="dynamicNotchWidthPercent" step="1" min="0" max="20"/>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDynamicNotchWidthPercent"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchWidthPercentHelp"></div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr class="newFilter dynamicNotch dynamicNotchQ">
-                                <td>
-                                    <input type="number" name="dynamicNotchQ" step="1" min="1" max="1000"/>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDynamicNotchQ"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchQHelp"></div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr class="newFilter dynamicNotch dynamicNotchCount">
-                                <td>
-                                    <input type="number" name="dynamicNotchCount" step="1" min="0" max="5"/>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDynamicNotchCount"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchCountHelp"></div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr class="newFilter dynamicNotch">
-                                <td>
-                                    <input type="number" name="dynamicNotchMinHz" step="1" min="60" max="1000"/>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDynamicNotchMinHz"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMinHzHelp"></div>
-                                    </div>
-                                </td>
-                            </tr>
-                            <tr class="newFilter dynamicNotch dynamicNotchMaxHz">
-                                <td>
-                                    <input type="number" name="dynamicNotchMaxHz" step="1" min="200" max="1000"/>
-                                </td>
-                                <td>
-                                    <div>
-                                        <label>
-                                            <span i18n="pidTuningDynamicNotchMaxHz"></span>
-                                        </label>
-                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMaxHzHelp"></div>
-                                    </div>
-                                </td>
-                            </tr>
 
+                            <tr class="newFilter dynamicNotch">
+
+                                <td>
+                                    <span class="inputSwitch"><input type="checkbox" id="dynamicNotchEnabled" class="toggle" /></span>
+                                </td>
+
+                                <td colspan="2">
+                                    <span i18n="pidTuningDynamicNotchFilterGroup"></span>
+
+                                    <span class="suboption dynamicNotchRange">
+                                        <select name="dynamicNotchRange">
+                                            <!--  Populated on execution -->
+                                        </select>
+                                        <label><span i18n="pidTuningDynamicNotchRange"></span></label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchRangeHelp"></div>
+                                    </span>
+
+                                    <span class="suboption dynamicNotchWidthPercent">
+                                        <input type="number" name="dynamicNotchWidthPercent" step="1" min="0" max="20"/>
+                                        <label><span i18n="pidTuningDynamicNotchWidthPercent"></span></label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchWidthPercentHelp"></div>
+                                    </span>
+
+                                    <span class="suboption dynamicNotchCount">
+                                        <input type="number" name="dynamicNotchCount" step="1" min="1" max="5"/>
+                                        <label><span i18n="pidTuningDynamicNotchCount"></span></label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchCountHelp"></div>
+                                    </span>
+
+                                    <span class="suboption dynamicNotchQ">
+                                        <input type="number" name="dynamicNotchQ" step="1" min="1" max="1000"/>
+                                        <label><span i18n="pidTuningDynamicNotchQ"></span></label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchQHelp"></div>
+                                    </span>
+
+                                    <span class="suboption dynamicNotchMinHz">
+                                        <input type="number" name="dynamicNotchMinHz" step="1" min="60" max="1000"/>
+                                        <label><span i18n="pidTuningDynamicNotchMinHz"></span></label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMinHzHelp"></div>
+                                    </span>
+
+                                    <span class="suboption dynamicNotchMaxHz">
+                                        <input type="number" name="dynamicNotchMaxHz" step="1" min="200" max="1000"/>
+                                        <label><span i18n="pidTuningDynamicNotchMaxHz"></span></label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningDynamicNotchMaxHzHelp"></div>
+                                    </span>
+                                </td>
+                            </tr>
                         </table>
                     </div>
                     <div class="gui_box grey topspacer pid_filter two_columns_second">


### PR DESCRIPTION
# General

This is the counterpart to PR https://github.com/betaflight/betaflight/pull/10673

For **BF 4.3 / API 1.44** onwards I got rid of the "DYNAMIC_FILTER" switch in the configuration tab. Instead I introduced an on/off switch in the filters tab, so finally all filters can be enabled and disabled from inside the filters tab.

Thanks to @haslinghuis for giving me code that was nearly ready to use. He basically made half of this PR.

# Todo

- [x] Wait for #2638 to get merged
- [x] Rebase
- [x] Update dyn notch settings layout according to new rfc slider layout style
- [x] Bugfixes
- [x] Mark PR as ready for review

# Preview

![features](https://user-images.githubusercontent.com/19867640/144315983-93352e6a-1761-4a76-b615-7c3c787878a2.png)

![dynNotchSwitch](https://user-images.githubusercontent.com/19867640/144316021-ca2b50d6-ece0-4015-afcf-82a82e512467.png)