### PR TITLE
RFC Dynamic Idle

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1281,6 +1281,9 @@
     "configurationDigitalIdlePercent": {
         "message": "Motor Idle Throttle Value [percent]"
     },
+    "configurationDigitalIdlePercentDisabled": {
+        "message": "Motor Idle Throttle Value % is disabled because Dynamic Idle is enabled with value at {{dynamicIdle}}rpm in PID tuning tab"
+    },
     "configurationDigitalIdlePercentHelp": {
         "message": "The 'DShot idle' value is the percent of maximum throttle that is sent to the ESCs when the throttle at minimum stick position and the craft is armed. Increase it to gain more idle speed and avoid desyncs.  Too high and the craft feels floaty."
     },
@@ -4016,6 +4019,9 @@
     },
     "pidTuningIdleMinRpmHelp": {
         "message": "Dynamic Idle improves control at low rpm and reduces risk of motor desyncs. It corrects problems caused by airflow speeding up or slowing down the props, improving PID authority, stability, motor braking and responsiveness. The Dynamic Idle rpm should be set to be about 20% below the rpm of your Dshot Idle value (see the $t(tabMotorTesting.message) tab). Usually there is no need to change your DShot idle value from defaults. For longer inverted hang time, DShot idle value and Minimum rpm should be lowered together.<br /><br />Visit <a href=\"https://github.com/betaflight/betaflight/wiki/Tuning-Dynamic-Idle\"target=\"_blank\" rel=\"noopener noreferrer\">this wiki entry</a> for more info."
+    },
+    "pidTuningIdleMinRpmDisabled": {
+        "message": "Dynamic Idle is disabled as Dshot Telemetry is disabled"
     },
     "pidTuningAcroTrainerAngleLimit": {
         "message": "Acro Trainer Angle Limit"

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -61,6 +61,7 @@ TABS.motors.initialize = function (callback) {
     }
 
     MSP.promise(MSPCodes.MSP_STATUS)
+    .then(() => MSP.promise(MSPCodes.MSP_PID_ADVANCED))
     .then(() => MSP.promise(MSPCodes.MSP_FEATURE_CONFIG))
     .then(() => MSP.promise(MSPCodes.MSP_MIXER_CONFIG))
     .then(() => FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor ? MSP.promise(MSPCodes.MSP_MOTOR_TELEMETRY) : true)
@@ -735,6 +736,16 @@ TABS.motors.initialize = function (callback) {
             divUnsyncedPWMFreq.toggle(protocolConfigured && !digitalProtocol);
 
             $('div.digitalIdlePercent').toggle(protocolConfigured && digitalProtocol);
+
+            $('input[name="digitalIdlePercent"]').prop('disabled', protocolConfigured && digitalProtocol && FC.ADVANCED_TUNING.idleMinRpm && FC.MOTOR_CONFIG.use_dshot_telemetry);
+
+            if (FC.ADVANCED_TUNING.idleMinRpm && FC.MOTOR_CONFIG.use_dshot_telemetry) {
+                const dynamicIdle = FC.ADVANCED_TUNING.idleMinRpm * 100;
+                $('span.digitalIdlePercentDisabled').text(i18n.getMessage('configurationDigitalIdlePercentDisabled', { dynamicIdle }));
+            } else {
+                $('span.digitalIdlePercentDisabled').text(i18n.getMessage('configurationDigitalIdlePercent'));
+            }
+
             $('.escSensor').toggle(protocolConfigured && digitalProtocol);
 
             $('div.checkboxDshotBidir').toggle(protocolConfigured && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42) && digitalProtocol);

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -456,7 +456,13 @@ TABS.pid_tuning.initialize = function (callback) {
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
             $('.pid_tuning input[name="motorLimit"]').val(FC.ADVANCED_TUNING.motorOutputLimit);
             $('.pid_tuning input[name="cellCount"]').val(FC.ADVANCED_TUNING.autoProfileCellCount);
-            $('input[name="idleMinRpm-number"]').val(FC.ADVANCED_TUNING.idleMinRpm);
+            $('input[name="idleMinRpm-number"]').val(FC.ADVANCED_TUNING.idleMinRpm).prop('disabled', !FC.MOTOR_CONFIG.use_dshot_telemetry);
+
+            if (FC.MOTOR_CONFIG.use_dshot_telemetry) {
+                $('span.pidTuningIdleMinRpmDisabled').text(i18n.getMessage('pidTuningIdleMinRpm'));
+            } else {
+                $('span.pidTuningIdleMinRpmDisabled').text(i18n.getMessage('pidTuningIdleMinRpmDisabled'));
+            }
         } else {
             $('.motorOutputLimit').hide();
             $('.idleMinRpm').hide();

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -105,9 +105,9 @@
                                         <div class="numberspacer">
                                             <input type="number" name="digitalIdlePercent" min="0.00" max="20.00" step="0.01"/>
                                         </div>
-                                        <span i18n="configurationDigitalIdlePercent"></span>
+                                        <span class="digitalIdlePercentDisabled"></span>
+                                        <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                     </label>
-                                    <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
                                 <div class="number minthrottle">
                                     <label>

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -670,7 +670,7 @@
                                 <td colspan="2">
                                     <div>
                                         <label>
-                                            <span i18n="pidTuningIdleMinRpm"></span>
+                                            <span class="pidTuningIdleMinRpmDisabled"></span>
                                         </label>
                                         <div class="helpicon cf_tip" i18n_title="pidTuningIdleMinRpmHelp"></div>
                                     </div>


### PR DESCRIPTION
PR implementing https://github.com/betaflight/betaflight/pull/11043

This PR also makes sure the user only can use (dynamic) idle using the right setup.

PID Tuning tab:
![Screenshot from 2021-11-21 21-58-29](https://user-images.githubusercontent.com/8344830/142778751-378e1f1a-3d05-43f2-ac04-0c6065e57276.png)

Motors tab:
![Screenshot from 2021-11-21 21-50-50](https://user-images.githubusercontent.com/8344830/142778705-06947329-b017-4dfa-9c46-3fb744691d72.png)


