### PR TITLE
10.7.1 bugfix: gyro slider

### DIFF
--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -214,10 +214,10 @@ TuningSliders.updateFilterSlidersDisplay = function() {
         $('.pid_filter input[name="gyroLowpass2Frequency"]').val() != Math.round(this.FILTER_DEFAULT.gyro_lowpass2_hz * this.gyroFilterSliderValue) ||
         $('.pid_filter select[name="gyroLowpass2Type"]').val() != this.FILTER_DEFAULT.gyro_lowpass2_type) {
 
-        $('.tuningFilterSliders .sliderLabels tr:first-child').hide();
+        $('#pidTuningGyroFilterSliderRow').hide();
         this.filterGyroSliderUnavailable = true;
     } else {
-        $('.tuningFilterSliders .sliderLabels tr:first-child').show()
+        $('#pidTuningGyroFilterSliderRow').show()
         this.cachedGyroSliderValues = true;
     }
 
@@ -227,10 +227,10 @@ TuningSliders.updateFilterSlidersDisplay = function() {
         $('.pid_filter input[name="dtermLowpass2Frequency"]').val() != Math.round(this.FILTER_DEFAULT.dterm_lowpass2_hz * this.dtermFilterSliderValue) ||
         $('.pid_filter select[name="dtermLowpass2Type"]').val() != this.FILTER_DEFAULT.dterm_lowpass2_type) {
 
-        $('.tuningFilterSliders .sliderLabels tr:last-child').hide();
+        $('#pidTuningDTermFilterSliderRow').hide();
         this.filterDTermSliderUnavailable = true;
     } else {
-        $('.tuningFilterSliders .sliderLabels tr:last-child').show();
+        $('#pidTuningDTermFilterSliderRow').show();
         this.cachedDTermSliderValues = true;
     }
 

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -971,7 +971,7 @@
                                 <span i18n="pidTuningGyroFilterSlider"></span>
                             </td>
                         </tr>
-                        <tr>
+                        <tr id="pidTuningGyroFilterSliderRow">
                             <td class="sm-min">
                                 <span i18n="pidTuningGyroFilterSlider"></span>
                             </td>
@@ -990,7 +990,7 @@
                                 <span i18n="pidTuningDTermFilterSlider"></span>
                             </td>
                         </tr>
-                        <tr>
+                        <tr id="pidTuningDTermFilterSliderRow">
                             <td class="sm-min">
                                 <span i18n="pidTuningDTermFilterSlider"></span>
                             </td>


### PR DESCRIPTION
in the current 10.7.1, the gyro slider is still visible when doing manual filters modifications.
This causes confusion and i think should be fixed.

Happens after this big PR:
https://github.com/betaflight/betaflight-configurator/pull/1946/
new `<TR>` was added:
![image](https://user-images.githubusercontent.com/2925027/142556271-4478c9fa-15e5-42fd-b66c-8ca4881420d2.png)
but the slider is still being referenced with the selector
.tuningFilterSliders .sliderLabels tr:**first-child**