### PR TITLE
10.7.1 fix: Make tab_container scrollable when it is needed

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -968,6 +968,7 @@ input[type="number"]::-webkit-inner-spin-button {
     width: 200px;
     border-right: 4px solid var(--accent);
     background-color: #2e2e2e;
+    overflow: auto;
 }
 
 #tab_logoversion {


### PR DESCRIPTION
Cherry-pick of  this @Asizon PR:
https://github.com/betaflight/betaflight-configurator/pull/2292

it fixes that on some monitors it is impossible to scroll down to CLI in expert mode and when GPS and LED tabs are visible.