### PR TITLE
Fixed Android File System

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6141,7 +6141,7 @@
         "message": "File name"
     },
     "dialogFileNameDescription": {
-        "message": "The file will be saved in the '{{folder}}' folder in your internal storage."
+        "message": "The file will be saved in the 'Android/data/betaflight-configurator/{{folder}}' folder in your internal storage."
     },
     "dialogFileAlreadyExistsTitle": {
         "message": "This file already exists!"

--- a/src/js/cordova_chromeapi.js
+++ b/src/js/cordova_chromeapi.js
@@ -309,7 +309,7 @@ const chromeapiFilesystem = {
             options.suggestedName = 'newfile';
         }
         const extension = self.getFileExtension(options.suggestedName);
-        const folder = 'Betaflight configurator';
+        const folder = 'files';
         navigator.notification.prompt(i18n.getMessage('dialogFileNameDescription', {
             folder: folder,
         }), function(res) {
@@ -319,10 +319,9 @@ const chromeapiFilesystem = {
                 if (newExtension === undefined) {
                     fileName += `.${extension}`;
                 }
-                window.resolveLocalFileSystemURL(cordova.file.externalRootDirectory, function(rootEntry) {
+                window.resolveLocalFileSystemURL(cordova.file.externalApplicationStorageDirectory, function(rootEntry) {
                     rootEntry.getDirectory(folder, { create: true }, function(directoryEntry) {
                         directoryEntry.getFile(fileName, { create: false }, function(fileEntry) {
-                            console.log(fileEntry);
                             navigator.notification.confirm(i18n.getMessage('dialogFileAlreadyExistsDescription'), function(resp) {
                                 if (resp === 1) {
                                     chromeCallbackWithSuccess(fileEntry, callback);


### PR DESCRIPTION
Fixed the issue #2664.

On Android, files will be saved in `/Android/data/betaflight-configurator/files` instead of `/Betaflight configurator` due to the new Android 11 access restrictions.