### PR TITLE
Simplify serial dropdown list and include CRSF

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1120,7 +1120,7 @@
         "message": "Configure via the BlackBox tab after enabling."
     },
     "featureRX_SPI": {
-        "message": "SPI (e.g. built-in Rx)"
+        "message": "SPI Rx (e.g. built-in Rx)"
     },
     "featureESC_SENSOR": {
         "message": "Use KISS/BLHeli_32 ESC telemetry <b>over a separate wire</b>"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1045,7 +1045,7 @@
         "message": "&lt;Select One&gt;"
     },
     "featureRX_PPM": {
-        "message": "PPM RX input"
+        "message": "PPM (single wire PWM)"
     },
     "featureVBAT": {
         "message": "Battery voltage monitoring"
@@ -1054,7 +1054,7 @@
         "message": "In-flight level calibration"
     },
     "featureRX_SERIAL": {
-        "message": "Serial-based receiver (SPEKSAT, SBUS, SUMD)"
+        "message": "Serial (CRSF, SBUS, Ghost...)"
     },
     "featureMOTOR_STOP": {
         "message": "Don't spin the motors when armed"
@@ -1090,10 +1090,10 @@
         "message": "3D mode (for use with reversible ESCs)"
     },
     "featureRX_PARALLEL_PWM": {
-        "message": "PWM RX input (one wire per channel)"
+        "message": "PWM (one wire per channel)"
     },
     "featureRX_MSP": {
-        "message": "MSP RX input (control via MSP port)"
+        "message": "MSP (control via MSP port)"
     },
     "featureRSSI_ADC": {
         "message": "Analog RSSI input"
@@ -1120,7 +1120,7 @@
         "message": "Configure via the BlackBox tab after enabling."
     },
     "featureRX_SPI": {
-        "message": "SPI RX support"
+        "message": "SPI (e.g. built-in Rx)"
     },
     "featureESC_SENSOR": {
         "message": "Use KISS/BLHeli_32 ESC telemetry <b>over a separate wire</b>"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1045,7 +1045,7 @@
         "message": "&lt;Select One&gt;"
     },
     "featureRX_PPM": {
-        "message": "PPM (single wire PWM)"
+        "message": "PPM/CPPM (single wire)"
     },
     "featureVBAT": {
         "message": "Battery voltage monitoring"


### PR DESCRIPTION
For discussion:

Update to the Serial Rx Dropdown menu.  Current messages overflow the available space and seem unnecessarily verbose.  

CRSF is a commonly used protocol used today, whereas Spectrum satellites are very uncommon, yet `SPEKSAT` has been the first in the list for a long time.  

Changes:

|    Old   |   New   |
|----|----|
| PPM RX input | PPM/CPPM (single wire) |
| Serial-based receiver (SPEKSAT, SBUS, SUMD | Serial (CRSF, SBUS, Ghost... |
| PWM RX input (one wire per channel) | PWM (one wire per channel) |
| MSP RX input (control via MSP port) | MSP (control via MSP port) |
| SPI RX support | SPI (e.g. built-in Rx) |

New appearance
![Screen Shot 2021-11-27 at 12 21 04](https://user-images.githubusercontent.com/11737748/143663856-4c70a871-748a-4932-830f-e8528bd7888a.jpg)


Old appearance...
![Screen Shot 2021-11-27 at 11 45 37](https://user-images.githubusercontent.com/11737748/143663373-4fdc059f-937a-4130-b0d5-03c911007895.jpg)
Old list:
![Screen Shot 2021-11-27 at 12 07 45](https://user-images.githubusercontent.com/11737748/143663820-c90a5323-9a6d-4cb4-97c4-04fecdf40198.jpg)
