### PR TITLE
Presets tab:  minor fix border inside the detailed preset dialog

### DIFF
--- a/src/tabs/presets/TitlePanel/PresetTitlePanel.js
+++ b/src/tabs/presets/TitlePanel/PresetTitlePanel.js
@@ -9,6 +9,7 @@ class PresetTitlePanel
         this._onLoadedCallback = onLoadedCallback;
         this._domId = `preset_title_panel_${PresetTitlePanel.s_panelCounter}`;
         this._preset = preset;
+        this._clickable = clickable;
 
         this._parentDiv.append(`<div class="${this._domId}"></div>`);
         this._domWrapperDiv = $(`.${this._domId}`);
@@ -41,6 +42,10 @@ class PresetTitlePanel
     }
 
     setPicked(isPicked) {
+        if (!this._clickable) {
+            return;
+        }
+
         this._preset.isPicked = isPicked;
 
         if (isPicked) {


### PR DESCRIPTION
Minor bugfix - removing the border
![image](https://user-images.githubusercontent.com/2925027/143671938-137bfa0f-4b68-486f-8808-839d361c19a2.png)
