### PR TITLE
Fix new feedforwardgroup options

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -512,6 +512,8 @@ const FC = {
             feedforward_averaging:      0,
             feedforward_smooth_factor:  0,
             feedforward_boost:          0,
+            feedforward_max_rate_limit: 0,
+            feedforward_jitter_factor:  0,
             vbat_sag_compensation:      0,
             thrustLinearization:        0,
         };

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -552,8 +552,6 @@ TABS.pid_tuning.initialize = function (callback) {
         } else {
             $('.vbatSagCompensation').hide();
             $('.thrustLinearization').hide();
-            $('.feedforwardMaxRateLimit').hide();
-            $('.feedforwardJitterFactor').hide();
 
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_40)) {
                 $('.pid_tuning .ROLL input[name="f"]').val(FC.ADVANCED_TUNING.feedforwardRoll > 0 ? FC.ADVANCED_TUNING.feedforwardRoll : PID_DEFAULT[4]);
@@ -1352,6 +1350,8 @@ TABS.pid_tuning.initialize = function (callback) {
             FC.ADVANCED_TUNING.feedforward_averaging = $('select[id="feedforwardAveraging"]').val();
             FC.ADVANCED_TUNING.feedforward_smooth_factor = parseInt($('input[name="feedforwardSmoothFactor"]').val());
             FC.ADVANCED_TUNING.feedforward_boost = parseInt($('input[name="feedforwardBoost"]').val());
+            FC.ADVANCED_TUNING.feedforward_max_rate_limit = parseInt($('input[name="feedforwardMaxRateLimit"]').val());
+            FC.ADVANCED_TUNING.feedforward_jitter_factor = parseInt($('input[name="feedforwardJitterFactor"]').val());
             FC.FILTER_CONFIG.dyn_lpf_curve_expo = parseInt($('.pid_filter input[name="dtermLowpassDynExpo"]').val());
             FC.ADVANCED_TUNING.vbat_sag_compensation = $('input[id="vbatSagCompensation"]').is(':checked') ? parseInt($('input[name="vbatSagValue"]').val()) : 0;
             FC.ADVANCED_TUNING.thrustLinearization = $('input[id="thrustLinearization"]').is(':checked') ? parseInt($('input[name="thrustLinearValue"]').val()) : 0;

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -605,7 +605,7 @@
                                     <div class="helpicon cf_tip" i18n_title="pidTuningFeedforwardGroupHelp"></div>
                                     <span i18n="pidTuningFeedforwardGroup"></span>
 
-                                    <span class="feedforwardJitterFactor suboption">
+                                    <span class="feedforwardOption feedforwardJitterFactor suboption">
                                         <input type="number" name="feedforwardJitterFactor" step="1" min="0" max="20"/>
                                         <label>
                                             <span i18n="pidTuningFeedforwardJitter"></span>
@@ -639,7 +639,7 @@
                                         </label>
                                     </span>
 
-                                    <span class="feedforwardMaxRateLimit suboption">
+                                    <span class="feedforwardOption feedforwardMaxRateLimit suboption">
                                         <input type="number" name="feedforwardMaxRateLimit" step="1" min="0" max="150"/>
                                         <label>
                                             <span i18n="pidTuningFeedforwardMaxRateLimit"></span>


### PR DESCRIPTION
I dont know were and why we loose msp write lines for these two new feedforward options.
Maybe we loose afeter this @haslinghuis  ??? is really weird. Also added these 2 new parameters to fc.js
https://github.com/betaflight/betaflight-configurator/commit/92948e22129cd4d0081bb5ce278536bba9dd5aa2
