### PR TITLE
[BUG-FIX] Fix Port Detection using VID/PID

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -105,6 +105,10 @@
         "message": "Set connection timeout to allow longer initialisation on device plugin or reboot",
         "description": "Change timeout on auto-connect and reboot so the bus has more time to initialize after being detected by the system"
     },
+    "showAllSerialDevices": {
+        "message": "Show all serial devices (for manufacturers or development)",
+        "description": "Do not filter serial devices using VID/PID values (for manufacturers or development)"
+    },
     "cordovaForceComputerUI": {
         "message": "Use computers interface instead of phones interface"
     },

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -3,8 +3,8 @@
 const TIMEOUT_CHECK = 500 ; // With 250 it seems that it produces a memory leak and slowdown in some versions, reason unknown
 
 const usbDevices = { filters: [
-    {'vendorId': 1155, 'productId': 57105},
-    {'vendorId': 10473, 'productId': 393},
+    {'vendorId': 1155, 'productId': 57105}, // STM Device in DFU Mode || Digital Radio in USB mode
+    {'vendorId': 10473, 'productId': 393},  // GD32 DFU Bootloader
 ] };
 
 const PortHandler = new function () {

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -15,6 +15,14 @@ const serial = {
     transmitting:   false,
     outputBuffer:   [],
 
+    serialDevices: [
+        {'vendorId': 1027, 'productId': 24577}, // FT232R USB UART
+        {'vendorId': 1155, 'productId': 22336}, // STM Electronics Virtual COM Port
+        {'vendorId': 4292, 'productId': 60000}, // CP210x
+        {'vendorId': 4292, 'productId': 60001}, // CP210x
+        {'vendorId': 4292, 'productId': 60002}, // CP210x
+    ],
+
     connect: function (path, options, callback) {
         const self = this;
         const testUrl = path.match(/^tcp:\/\/([A-Za-z0-9\.-]+)(?:\:(\d+))?$/);
@@ -258,13 +266,21 @@ const serial = {
         }
     },
     getDevices: function (callback) {
+        const self = this;
+
         chrome.serial.getDevices(function (devices_array) {
             const devices = [];
             devices_array.forEach(function (device) {
-                devices.push({
-                              path: device.path,
-                              displayName: device.displayName,
-                             });
+                const isFC = self.serialDevices.some(el => el.vendorId === device.vendorId) && self.serialDevices.some(el => el.productId === device.productId);
+
+                if (isFC) {
+                    devices.push({
+                        path: device.path,
+                        displayName: device.displayName,
+                        vendorId: device.vendorId,
+                        productId: device.productId,
+                    });
+                }
             });
 
             callback(devices);

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -270,10 +270,13 @@ const serial = {
 
         chrome.serial.getDevices(function (devices_array) {
             const devices = [];
-            devices_array.forEach(function (device) {
-                const isFC = self.serialDevices.some(el => el.vendorId === device.vendorId) && self.serialDevices.some(el => el.productId === device.productId);
+            let showAllSerialDevices = false;
 
-                if (isFC) {
+            devices_array.forEach(function (device) {
+                ConfigStorage.get('showAllSerialDevices', res => showAllSerialDevices = res.showAllSerialDevices);
+                const isKnownSerialDevice = self.serialDevices.some(el => el.vendorId === device.vendorId) && self.serialDevices.some(el => el.productId === device.productId);
+
+                if (isKnownSerialDevice || showAllSerialDevices) {
                     devices.push({
                         path: device.path,
                         displayName: device.displayName,

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -15,6 +15,7 @@ options.initialize = function (callback) {
         TABS.options.initAnalyticsOptOut();
         TABS.options.initCliAutoComplete();
         TABS.options.initAutoConnectConnectionTimeout();
+        TABS.options.initShowAllSerialDevices();
         TABS.options.initCordovaForceComputerUI();
         TABS.options.initDarkTheme();
 
@@ -131,6 +132,17 @@ options.initAutoConnectConnectionTimeout = function () {
             ConfigStorage.set({'connectionTimeout': value});
         });
     });
+};
+
+options.initShowAllSerialDevices = function() {
+    const showAllSerialDevicesElement = $('div.showAllSerialDevices input');
+    ConfigStorage.get('showAllSerialDevices', result => {
+        showAllSerialDevicesElement
+            .prop('checked', !!result.showAllSerialDevices)
+            .on('change', () => ConfigStorage.set({ showAllSerialDevices: showAllSerialDevicesElement.is(':checked') }))
+            .trigger('change');
+    });
+
 };
 
 options.initCordovaForceComputerUI = function () {

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -46,6 +46,12 @@
                     </select>
                     <span i18n="connectionTimeout"></span>
                 </div>
+                <div class="showAllSerialDevices margin-bottom">
+                    <div>
+                        <input type="checkbox" class="toggle" />
+                    </div>
+                    <span class="freelabel" i18n="showAllSerialDevices"></span>
+                </div>
                 <div class="cordovaForceComputerUI margin-bottom">
                     <div>
                         <input type="checkbox" class="toggle" />


### PR DESCRIPTION
This PR filters out VID/PID ports not associated with BF hardware. I have left the PortHandler detector intact as it works for 99% in other use cases.

Included an option for manufacturers and developers:
![Screenshot from 2021-12-03 21-59-15](https://user-images.githubusercontent.com/8344830/144684900-e3d58548-110c-42f8-a65d-0e53016a207d.png)


@mikeller requested to use id's instead of product names as names won't work in all instances.

@SteveCEvans This is a first attempt and needs testing as I don't have the hardware to confirm

More info: https://github.com/betaflight/betaflight/pull/10596