### PR TITLE
Presets fix: remove cache for fetch

### DIFF
--- a/src/tabs/presets/PresetsRepoIndexed/PresetsRepoIndexed.js
+++ b/src/tabs/presets/PresetsRepoIndexed/PresetsRepoIndexed.js
@@ -12,7 +12,7 @@ class PresetsRepoIndexed {
     }
 
     loadIndex() {
-        return fetch(this._urlRaw + "index.json")
+        return fetch(this._urlRaw + "index.json", {cache: "no-cache"})
             .then(res => res.json())
             .then(out => this._index = out);
     }
@@ -205,7 +205,7 @@ class PresetsRepoIndexed {
 
     _loadPresetText(fullUrl) {
         return new Promise((resolve, reject) => {
-            fetch(fullUrl)
+            fetch(fullUrl, {cache: "no-cache"})
             .then(res => res.text())
             .then(text => resolve(text))
             .catch(err => {


### PR DESCRIPTION
Apparently, on Mac (@sugaarK) the automatic cache creates a problem:
it takes 20-30 hours for Configurator to pick that there is a change in index.json and in the preset files.
This fix removes caching for presets and should allow seeing the preset changes on the server right away.