### PR TITLE
Indicate inactive dyn notch on looprates < 2kHz

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3917,7 +3917,7 @@
         "message": "Dynamic Notch Filter tracks peak gyro noise frequencies and places one to five notch filters with their center at these frequencies on every axis."
     },
     "pidTuningDynamicNotchFilterDisabledWarning": {
-        "message": "<strong>Notice:</strong> The dynamic notch filter is disabled. In order to configure and use it, please enable the 'DYNAMIC_FILTER' feature in the '$t(configurationFeatures.message)' section of the '$t(tabConfiguration.message)' tab."
+        "message": "<strong>Notice:</strong> The dynamic notch filter is disabled. In order to configure and use it, please enable the 'DYNAMIC_FILTER' feature in the '$t(configurationFeatures.message)' section of the '$t(tabConfiguration.message)' tab. Also make sure the PID looprate is at least 2kHz."
     },
     "pidTuningDynamicNotchRange": {
         "message": "Dynamic Notch Filter Range"

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -381,8 +381,14 @@ TABS.pid_tuning.initialize = function (callback) {
             $('.smartfeedforward').hide();
 
             // Dynamic Notch Filter
+            const sampleRateHz = FC.CONFIG.sampleRateHz / FC.PID_ADVANCED_CONFIG.pid_process_denom;
+
+            let isDynamicNotchActive = FC.FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER');
+            isDynamicNotchActive = isDynamicNotchActive || FC.FILTER_CONFIG.dyn_notch_count !== 0;
+            isDynamicNotchActive = isDynamicNotchActive && sampleRateHz >= 2000;
+
             if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
-                if (FC.FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')) {
+                if (isDynamicNotchActive) {
                     $('.dynamicNotch span.inputSwitch').hide();
                 } else {
                     $('.dynamicNotch').hide();
@@ -409,12 +415,10 @@ TABS.pid_tuning.initialize = function (callback) {
                 $('.dynamicNotchMaxHz').hide();
             }
 
-            const dynamicNotchSwitch_e = $('.pid_filter input[id="dynamicNotchEnabled"]');
+            $('.pid_filter input[id="dynamicNotchEnabled"]').on('change', function() {
 
-            dynamicNotchSwitch_e.on('change', function() {
-
-                const checked = $(this).is(':checked');
                 const count = parseInt(dynamicNotchCount_e.val());
+                const checked = $(this).is(':checked');
 
                 if (checked && !count) {
                     dynamicNotchCount_e.val(FILTER_DEFAULT.dyn_notch_count);
@@ -426,7 +430,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 $('.dynamicNotchWidthPercent').toggle(semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44) && checked);
                 $('.dynamicNotchCount').toggle(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44) && checked);
 
-            }).prop('checked', FC.FILTER_CONFIG.dyn_notch_count !== 0 || FC.FEATURE_CONFIG.features.isEnabled('DYNAMIC_FILTER')).trigger('change');
+            }).prop('checked', isDynamicNotchActive).trigger('change');
 
             // RPM Filter
             $('.rpmFilter').toggle(FC.MOTOR_CONFIG.use_dshot_telemetry);


### PR DESCRIPTION
While testing some PR's I noticed that the configurator never indicated in any way that the dynamic notch is disabled on PID looprates smaller than 2kHz. So I added some indication for that.

### Behavior if PID looprate < 2kHz:

**BF 4.2 and earlier:** 
- dynamic notch GUI gets hidden
- Added note about disability at looprates < 2kHz

**BF 4.3:**
- dynamic notch switch is off, indicating disability