### PR TITLE
Bugfix: Getting rid of unnecessary sliders updates to the firmware

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -906,7 +906,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz = 0;
                         FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = 0;
                         FC.FILTER_CONFIG.gyro_lowpass_hz = 0;
-                        TuningSliders.updateFiltersInFirmware();
+                        self.updateFiltersInFirmware();
                     }
                 } else {
                     // lowpass 1 is disabled, set the master switch off, only show label
@@ -920,7 +920,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         gyroLowpassDynMaxFrequency.val(cutoffMax);
                         FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz = cutoffMin;
                         FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = cutoffMax;
-                        TuningSliders.updateFiltersInFirmware();
+                        self.updateFiltersInFirmware();
                     }
                 }
                 gyroLowpassOption.toggle(checked);
@@ -951,7 +951,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     }
                     gyroLowpassOptionStatic.hide();
                     gyroLowpassOptionDynamic.show();
-                    TuningSliders.updateFiltersInFirmware();
+                    self.updateFiltersInFirmware();
                 } else {
                     // static, set the dynamic field min to zero
                     gyroLowpassDynMinFrequency.val(0);
@@ -968,7 +968,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     }
                     gyroLowpassOptionStatic.show();
                     gyroLowpassOptionDynamic.hide();
-                    TuningSliders.updateFiltersInFirmware();
+                    self.updateFiltersInFirmware();
                 }
             });
 
@@ -980,7 +980,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 if (FC.TUNING_SLIDERS.slider_gyro_filter) {
                     cutoff = checked ? Math.floor(FILTER_DEFAULT.gyro_lowpass2_hz * FC.TUNING_SLIDERS.slider_gyro_filter_multiplier / 100) : 0;
                     FC.FILTER_CONFIG.gyro_lowpass2_hz = cutoff;
-                    TuningSliders.updateFiltersInFirmware();
+                    self.updateFiltersInFirmware();
                 }
 
                 gyroLowpass2Frequency.val(checked ? cutoff : 0).attr('disabled', !checked);
@@ -1005,7 +1005,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz = 0;
                         FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = 0;
                         FC.FILTER_CONFIG.dterm_lowpass_hz = 0;
-                        TuningSliders.updateFiltersInFirmware();
+                        self.updateFiltersInFirmware();
                     }
                 } else {
                     // lowpass 1 is disabled, set the master switch off, only show label
@@ -1021,7 +1021,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         dtermLowpassDynMaxFrequency.val(cutoffMax);
                         FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz = cutoffMin;
                         FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = cutoffMax;
-                        TuningSliders.updateFiltersInFirmware();
+                        self.updateFiltersInFirmware();
                     }
                 }
                 dtermLowpassOption.toggle(checked);
@@ -1052,7 +1052,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     }
                     dtermLowpassOptionStatic.hide();
                     dtermLowpassOptionDynamic.show();
-                    TuningSliders.updateFiltersInFirmware();
+                    self.updateFiltersInFirmware();
                 } else {
                     // static, set the dynamic field min to zero
                     dtermLowpassDynMinFrequency.val(0);
@@ -1069,7 +1069,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     }
                     dtermLowpassOptionStatic.show();
                     dtermLowpassOptionDynamic.hide();
-                    TuningSliders.updateFiltersInFirmware();
+                    self.updateFiltersInFirmware();
                 }
             });
 
@@ -1080,7 +1080,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 if (FC.TUNING_SLIDERS.slider_dterm_filter) {
                     cutoff = checked ? Math.floor(FILTER_DEFAULT.dterm_lowpass2_hz * FC.TUNING_SLIDERS.slider_dterm_filter_multiplier / 100) : 0;
                     FC.FILTER_CONFIG.dterm_lowpass2_hz = cutoff;
-                    TuningSliders.updateFiltersInFirmware();
+                    self.updateFiltersInFirmware();
                 }
 
                 dtermLowpass2Frequency.val(checked ? cutoff : 0).attr('disabled', !checked);
@@ -1509,6 +1509,7 @@ TABS.pid_tuning.initialize = function (callback) {
     }
 
     function process_html() {
+        TABS.pid_tuning.isHtmlProcessing = true;
         FC.FEATURE_CONFIG.features.generateElements($('.tab-pid_tuning .features'));
 
         if (semver.lt(FC.CONFIG.apiVersion, "1.16.0") || semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
@@ -2245,7 +2246,7 @@ TABS.pid_tuning.initialize = function (callback) {
                             FC.PIDS[1][2] = FC.ADVANCED_TUNING.dMinPitch;
                             FC.PIDS[2][2] = FC.ADVANCED_TUNING.dMinYaw;
                         }
-                        TuningSliders.calculateNewPids();
+                        self.calculateNewPids();
                     }
                 });
             }
@@ -2259,7 +2260,7 @@ TABS.pid_tuning.initialize = function (callback) {
                     const setMode = parseInt($(this).val());
 
                     TuningSliders.sliderPidsMode = setMode;
-                    TuningSliders.calculateNewPids();
+                    self.calculateNewPids();
                     TuningSliders.updateFormPids();
                     TuningSliders.updatePidSlidersDisplay();
 
@@ -2366,7 +2367,7 @@ TABS.pid_tuning.initialize = function (callback) {
                         TuningSliders.sliderFeedforwardGainLegacy = sliderValue;
                     }
                 }
-                TuningSliders.calculateNewPids();
+                self.calculateNewPids();
                 self.analyticsChanges['PidTuningSliders'] = "On";
             });
             if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
@@ -2422,7 +2423,7 @@ TABS.pid_tuning.initialize = function (callback) {
                 }
                 slider.val(value);
 
-                TuningSliders.calculateNewPids();
+                self.calculateNewPids();
             });
 
             // enable PID sliders button
@@ -2491,11 +2492,11 @@ TABS.pid_tuning.initialize = function (callback) {
                 const sliderValue = isInt(slider.val()) ? parseInt(slider.val()) : parseFloat(slider.val());
                 if (slider.is('#sliderGyroFilterMultiplier')) {
                     TuningSliders.sliderGyroFilterMultiplier = sliderValue;
-                    TuningSliders.calculateNewGyroFilters();
+                    self.calculateNewGyroFilters();
                     self.analyticsChanges['GyroFilterTuningSlider'] = "On";
                 } else if (slider.is('#sliderDTermFilterMultiplier')) {
                     TuningSliders.sliderDTermFilterMultiplier = sliderValue;
-                    TuningSliders.calculateNewDTermFilters();
+                    self.calculateNewDTermFilters();
                     self.analyticsChanges['DTermFilterTuningSlider'] = "On";
                 }
             });
@@ -2505,10 +2506,10 @@ TABS.pid_tuning.initialize = function (callback) {
                 slider.val(1);
                 if (slider.is('#sliderGyroFilterMultiplier')) {
                     TuningSliders.sliderGyroFilterMultiplier = 1;
-                    TuningSliders.calculateNewGyroFilters();
+                    self.calculateNewGyroFilters();
                 } else if (slider.is('#sliderDTermFilterMultiplier')) {
                     TuningSliders.sliderDTermFilterMultiplier = 1;
-                    TuningSliders.calculateNewDTermFilters();
+                    self.calculateNewDTermFilters();
                 }
             });
 
@@ -2610,13 +2611,6 @@ TABS.pid_tuning.initialize = function (callback) {
             }).then(function () {
                 return MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
             }).then(function () {
-                let promise;
-                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
-                    promise = MSP.promise(MSPCodes.MSP_SET_TUNING_SLIDERS, mspHelper.crunch(MSPCodes.MSP_SET_TUNING_SLIDERS));
-                }
-
-                return promise;
-            }).then(function () {
                 return MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
             }).then(function () {
                 self.updating = false;
@@ -2650,6 +2644,7 @@ TABS.pid_tuning.initialize = function (callback) {
         self.analyticsChanges = {};
 
         GUI.content_ready(callback);
+        TABS.pid_tuning.isHtmlProcessing = false;
     }
 };
 
@@ -2772,7 +2767,6 @@ TABS.pid_tuning.restoreInitialSettings = function () {
         .then(() => MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG)))
         .then(() => MSP.promise(MSPCodes.MSP_SET_RC_TUNING, mspHelper.crunch(MSPCodes.MSP_SET_RC_TUNING)))
         .then(() => MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG)))
-        .then(() => MSP.promise(MSPCodes.MSP_SET_TUNING_SLIDERS, mspHelper.crunch(MSPCodes.MSP_SET_TUNING_SLIDERS)))
         .then(() => {
             TABS.pid_tuning.retainConfiguration = false;
 
@@ -3084,6 +3078,30 @@ TABS.pid_tuning.updateRatesLabels = function() {
 
             stickContext.restore();
         }
+    }
+};
+
+TABS.pid_tuning.updateFiltersInFirmware = function() {
+    if (!TABS.pid_tuning.isHtmlProcessing) {
+        TuningSliders.updateFiltersInFirmware();
+    }
+};
+
+TABS.pid_tuning.calculateNewPids = function() {
+    if (!TABS.pid_tuning.isHtmlProcessing) {
+        TuningSliders.calculateNewPids();
+    }
+};
+
+TABS.pid_tuning.calculateNewGyroFilters = function() {
+    if (!TABS.pid_tuning.isHtmlProcessing) {
+        TuningSliders.calculateNewGyroFilters();
+    }
+};
+
+TABS.pid_tuning.calculateNewDTermFilters = function() {
+    if (!TABS.pid_tuning.isHtmlProcessing) {
+        TuningSliders.calculateNewDTermFilters();
     }
 };
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -888,7 +888,7 @@ TABS.pid_tuning.initialize = function (callback) {
 
         } else {
 
-            // firmware 4.3 filter selectors for lowpass 1 and 2
+            // firmware 4.3 filter selectors for lowpass 1 and 2; sliders are not yet initialized here
             gyroLowpassEnabled.change(function() {
                 const checked = $(this).is(':checked');
                 let cutoffMin = FILTER_DEFAULT.gyro_lowpass_dyn_min_hz;
@@ -914,8 +914,8 @@ TABS.pid_tuning.initialize = function (callback) {
                         // user is trying to enable the lowpass filter, but it was off (both cutoffs are zero)
                         // initialise in dynamic mode with values at sliders, or use defaults
                         gyroLowpassFilterMode.val(1).change();
-                        cutoffMin = Math.floor(cutoffMin * TuningSliders.sliderGyroFilterMultiplier);
-                        cutoffMax = Math.floor(cutoffMax * TuningSliders.sliderGyroFilterMultiplier);
+                        cutoffMin = Math.floor(cutoffMin * FC.TUNING_SLIDERS.slider_gyro_filter_multiplier / 100);
+                        cutoffMax = Math.floor(cutoffMax * FC.TUNING_SLIDERS.slider_gyro_filter_multiplier / 100);
                         gyroLowpassDynMinFrequency.val(cutoffMin);
                         gyroLowpassDynMaxFrequency.val(cutoffMax);
                         FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz = cutoffMin;
@@ -940,9 +940,9 @@ TABS.pid_tuning.initialize = function (callback) {
                     FC.FILTER_CONFIG.gyro_lowpass_hz = 0;
                     // if dyn min is zero, set dyn min to sliders or default
                     if (!FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz) {
-                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44) && TuningSliders.sliderGyroFilter) {
-                            cutoffMin = Math.floor(cutoffMin * TuningSliders.sliderGyroFilterMultiplier);
-                            cutoffMax = Math.floor(cutoffMax * TuningSliders.sliderGyroFilterMultiplier);
+                        if (FC.TUNING_SLIDERS.slider_gyro_filter) {
+                            cutoffMin = Math.floor(cutoffMin * FC.TUNING_SLIDERS.slider_gyro_filter_multiplier / 100);
+                            cutoffMax = Math.floor(cutoffMax * FC.TUNING_SLIDERS.slider_gyro_filter_multiplier / 100);
                         }
                         gyroLowpassDynMinFrequency.val(cutoffMin);
                         gyroLowpassDynMaxFrequency.val(cutoffMax);
@@ -960,8 +960,8 @@ TABS.pid_tuning.initialize = function (callback) {
                     FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = 0;
                     // If static is zero, set the dynamic cutoff field according to sliders or default
                     if (!FC.FILTER_CONFIG.gyro_lowpass_hz) {
-                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44) && TuningSliders.sliderGyroFilter) {
-                            cutoff = Math.floor(FILTER_DEFAULT.gyro_lowpass_hz * TuningSliders.sliderGyroFilterMultiplier);
+                        if (FC.TUNING_SLIDERS.slider_gyro_filter) {
+                            cutoff = Math.floor(FILTER_DEFAULT.gyro_lowpass_hz * FC.TUNING_SLIDERS.slider_gyro_filter_multiplier / 100);
                         }
                         gyroLowpassFrequency.val(cutoff);
                         FC.FILTER_CONFIG.gyro_lowpass_hz = cutoff;
@@ -977,8 +977,8 @@ TABS.pid_tuning.initialize = function (callback) {
                 const checked = $(this).is(':checked');
                 let cutoff = FC.FILTER_CONFIG.gyro_lowpass2_hz > 0 ? FC.FILTER_CONFIG.gyro_lowpass2_hz : FILTER_DEFAULT.gyro_lowpass2_hz;
 
-                if (TuningSliders.sliderGyroFilter) {
-                    cutoff = checked ? Math.floor(FILTER_DEFAULT.gyro_lowpass2_hz * TuningSliders.sliderGyroFilterMultiplier) : 0;
+                if (FC.TUNING_SLIDERS.slider_gyro_filter) {
+                    cutoff = checked ? Math.floor(FILTER_DEFAULT.gyro_lowpass2_hz * FC.TUNING_SLIDERS.slider_gyro_filter_multiplier / 100) : 0;
                     FC.FILTER_CONFIG.gyro_lowpass2_hz = cutoff;
                     TuningSliders.updateFiltersInFirmware();
                 }
@@ -1013,9 +1013,9 @@ TABS.pid_tuning.initialize = function (callback) {
                         // user is trying to enable the lowpass filter, but it was off (both cutoffs are zero)
                         // initialise in dynamic mode with values at sliders, or use defaults
                         dtermLowpassFilterMode.val(1).change();
-                        if (TuningSliders.sliderDTermFilter) {
-                            cutoffMin = Math.floor(cutoffMin * TuningSliders.sliderDTermFilterMultiplier);
-                            cutoffMax = Math.floor(cutoffMax * TuningSliders.sliderDTermFilterMultiplier);
+                        if (FC.TUNING_SLIDERS.slider_dterm_filter) {
+                            cutoffMin = Math.floor(cutoffMin * FC.TUNING_SLIDERS.slider_dterm_filter_multiplier / 100);
+                            cutoffMax = Math.floor(cutoffMax * FC.TUNING_SLIDERS.slider_dterm_filter_multiplier / 100);
                         }
                         dtermLowpassDynMinFrequency.val(cutoffMin);
                         dtermLowpassDynMaxFrequency.val(cutoffMax);
@@ -1041,9 +1041,9 @@ TABS.pid_tuning.initialize = function (callback) {
                     FC.FILTER_CONFIG.dterm_lowpass_hz = 0;
                     // if dyn min is zero, set dyn min to sliders or default
                     if (!FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz) {
-                        if (TuningSliders.sliderDTermFilter) {
-                            cutoffMin = Math.floor(cutoffMin * TuningSliders.sliderDTermFilterMultiplier);
-                            cutoffMax = Math.floor(cutoffMax * TuningSliders.sliderDTermFilterMultiplier);
+                        if (FC.TUNING_SLIDERS.slider_dterm_filter) {
+                            cutoffMin = Math.floor(cutoffMin * FC.TUNING_SLIDERS.slider_dterm_filter_multiplier / 100);
+                            cutoffMax = Math.floor(cutoffMax * FC.TUNING_SLIDERS.slider_dterm_filter_multiplier / 100);
                         }
                         dtermLowpassDynMinFrequency.val(cutoffMin);
                         dtermLowpassDynMaxFrequency.val(cutoffMax);
@@ -1061,8 +1061,8 @@ TABS.pid_tuning.initialize = function (callback) {
                     FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = 0;
                     // If static is zero, set the dynamic cutoff field according to sliders or default
                     if (!FC.FILTER_CONFIG.dterm_lowpass_hz) {
-                        if (TuningSliders.sliderDTermFilter) {
-                            cutoff = Math.floor(FILTER_DEFAULT.dterm_lowpass_hz * TuningSliders.sliderDTermFilterMultiplier);
+                        if (FC.TUNING_SLIDERS.slider_dterm_filter) {
+                            cutoff = Math.floor(FILTER_DEFAULT.dterm_lowpass_hz * FC.TUNING_SLIDERS.slider_dterm_filter_multiplier / 100 );
                         }
                         dtermLowpassFrequency.val(cutoff);
                         FC.FILTER_CONFIG.dterm_lowpass_hz = cutoff;
@@ -1077,8 +1077,8 @@ TABS.pid_tuning.initialize = function (callback) {
                 const checked = $(this).is(':checked');
                 let cutoff = FC.FILTER_CONFIG.dterm_lowpass2_hz > 0 ? FC.FILTER_CONFIG.dterm_lowpass2_hz : FILTER_DEFAULT.dterm_lowpass2_hz;
 
-                if (TuningSliders.sliderDTermFilter) {
-                    cutoff = checked ? Math.floor(FILTER_DEFAULT.dterm_lowpass2_hz * TuningSliders.sliderDTermFilterMultiplier) : 0;
+                if (FC.TUNING_SLIDERS.slider_dterm_filter) {
+                    cutoff = checked ? Math.floor(FILTER_DEFAULT.dterm_lowpass2_hz * FC.TUNING_SLIDERS.slider_dterm_filter_multiplier / 100) : 0;
                     FC.FILTER_CONFIG.dterm_lowpass2_hz = cutoff;
                     TuningSliders.updateFiltersInFirmware();
                 }


### PR DESCRIPTION
Currently, this PR branch is sitting on top of this branch:
https://github.com/betaflight/betaflight-configurator/pull/2684
so please review only the second commit

This is an attempt to fix the following bug (steps to reproduce):
1. reset FC to defaults (PID sliders enabled)
2. Connect, open CLI
3. Type `set p_roll = 100` -> Enter
4. type `save` -> Enter
5. Connect Configurator, open PIDs tab

Expected behaviour - behaviour after this fix:
- PID Sliders are still enabled
- roll P value is shown as 100
- roll P value is not being updated even when you click save or reset
- roll P value is being updated **ONLY** once you move sliders

Current behavior:
- PID Sliders are still enabled - OK
roll P value is not 100, but is set to 45 - default for sliders - NOT OK.

**After this bugfix we still got a similar problem with filters, but that is probably some bugs in the firmware too.**
1. start from defaults (sliders ON)
2. in CLI: `set gyro_lpf2_static_hz = 666`
3. save
4. in CLI: `get gyro_lpf2_static_hz`

Expected: 666
Actual: 500

