### PR TITLE
chore: add no-vars rule to match sonar cloud

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,5 +16,6 @@ module.exports = {
         "eol-last": "error",
         semi: "error",
         "comma-dangle": ["error", "always-multiline"],
+        "no-var": "error",
     },
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -364,7 +364,6 @@ function startProcess() {
                     case 'setup_osd':
                         TABS.setup_osd.initialize(content_ready);
                         break;
-
                     case 'configuration':
                         TABS.configuration.initialize(content_ready);
                         break;

--- a/src/js/protocols/stm32usbdfu.js
+++ b/src/js/protocols/stm32usbdfu.js
@@ -12,6 +12,9 @@
 */
 'use strict';
 
+// Task for the brave ones. There are quite a few shadow variables which clash when
+// const or let are used. So need to run thorough tests when chaning `var`
+/* eslint-disable no-var */
 var STM32DFU_protocol = function () {
     this.callback = null;
     this.hex = null;


### PR DESCRIPTION
match some of the rules to sonar cloud to reduce the amount on PRs