### PR TITLE
Simplified Tuning update

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -255,11 +255,6 @@
     text-align: right;
     border: 1px solid var(--subtleAccent);
     border-radius: 3px;
-    background-color: #f9f9f9;
-}
-
-.tab-pid_tuning .subtab-pid table input:disabled {
-    background-color: #dddddd;
 }
 
 .tab-pid_tuning .subtab-filter table input,

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -674,6 +674,10 @@ const FC = {
             slider_i_gain:                      0,
             slider_roll_pitch_ratio:            0,
             slider_pitch_pi_gain:               0,
+
+            slider_pids_valid:                  0,
+            slider_gyro_valid:                  0,
+            slider_dterm_valid:                 0,
         };
 
         this.DEFAULT_TUNING_SLIDERS = {
@@ -691,6 +695,10 @@ const FC = {
             slider_dterm_filter_multiplier:     100,
             slider_gyro_filter:                 1,
             slider_gyro_filter_multiplier:      100,
+
+            slider_pids_valid:                  1,
+            slider_gyro_valid:                  1,
+            slider_dterm_valid:                 1,
         };
     },
 
@@ -877,20 +885,13 @@ const FC = {
             versionPidDefaults = [
                 45, 80, 40, 30, 120,
                 47, 84, 46, 34, 125,
-                45, 90,  0,  0, 120,
+                45, 80,  0,  0, 120,
             ];
         }
         return versionPidDefaults;
     },
 
     getSliderDefaults() {
-        const sliderDefaults = this.DEFAULT_TUNING_SLIDERS;
-        // change slider defaults here
-        if (semver.gte(this.CONFIG.apiVersion, API_VERSION_1_44)) {
-            sliderDefaults.slider_roll_pitch_ratio = 115;
-            sliderDefaults.slider_pitch_pi_gain = 105;
-        }
-
-        return sliderDefaults;
+        return this.DEFAULT_TUNING_SLIDERS;
     },
 };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -250,14 +250,6 @@ function startProcess() {
 
             const tab = tabClass.substring(4);
             const tabName = $(self).text();
-            let timeout = 0;
-
-            if (GUI.active_tab === 'pid_tuning') {
-                if (TABS.pid_tuning.retainConfiguration) {
-                    TABS.pid_tuning.restoreInitialSettings();
-                    timeout = 500;
-                }
-            }
 
             if (tabRequiresConnection && !CONFIGURATOR.connectionValid) {
                 GUI.log(i18n.getMessage('tabSwitchConnectionRequired'));
@@ -401,15 +393,7 @@ function startProcess() {
                         TABS.onboard_logging.initialize(content_ready);
                         break;
                     case 'cli':
-                        // Add a little timeout to let MSP comands finish
-                        if (timeout > 0) {
-                            GUI.timeout_add('wait_for_msp_finished', () => {
-                                MSP.disconnect_cleanup();
-                                TABS.cli.initialize(content_ready, GUI.nwGui);
-                            }, timeout);
-                        } else {
-                            TABS.cli.initialize(content_ready, GUI.nwGui);
-                        }
+                        TABS.cli.initialize(content_ready, GUI.nwGui);
                         break;
                     case 'presets':
                         TABS.presets.initialize(content_ready, GUI.nwGui);

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -117,8 +117,14 @@ const MSPCodes = {
 
     MSP_MOTOR_TELEMETRY:            139,
 
-    MSP_TUNING_SLIDERS:             140,
-    MSP_SET_TUNING_SLIDERS:         141,
+    MSP_SIMPLIFIED_TUNING:          140,
+    MSP_SET_SIMPLIFIED_TUNING:      141,
+
+    MSP_CALCULATE_SIMPLIFIED_PID:   142,    // calculate slider values in temp profile
+    MSP_CALCULATE_SIMPLIFIED_GYRO:  143,
+    MSP_CALCULATE_SIMPLIFIED_DTERM: 144,
+
+    MSP_VALIDATE_SIMPLIFIED_TUNING: 145,    // validate slider values in temp profile
 
     MSP_STATUS_EX:                  150,
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -52,6 +52,82 @@ function MspHelper() {
     self.mspMultipleCache = [];
 }
 
+
+MspHelper.readPidSliderSettings = function(data) {
+    FC.TUNING_SLIDERS.slider_pids_mode = data.readU8();
+    FC.TUNING_SLIDERS.slider_master_multiplier = data.readU8();
+    FC.TUNING_SLIDERS.slider_roll_pitch_ratio = data.readU8();
+    FC.TUNING_SLIDERS.slider_i_gain = data.readU8();
+    FC.TUNING_SLIDERS.slider_d_gain = data.readU8();
+    FC.TUNING_SLIDERS.slider_pi_gain = data.readU8();
+    FC.TUNING_SLIDERS.slider_dmax_gain = data.readU8();
+    FC.TUNING_SLIDERS.slider_feedforward_gain = data.readU8();
+    FC.TUNING_SLIDERS.slider_pitch_pi_gain = data.readU8();
+    data.readU32(); // reserved for future use
+    data.readU32(); // reserved for future use
+};
+
+MspHelper.writePidSliderSettings = function(buffer) {
+    buffer
+    .push8(FC.TUNING_SLIDERS.slider_pids_mode)
+    .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
+    .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
+    .push8(FC.TUNING_SLIDERS.slider_i_gain)
+    .push8(FC.TUNING_SLIDERS.slider_d_gain)
+    .push8(FC.TUNING_SLIDERS.slider_pi_gain)
+    .push8(FC.TUNING_SLIDERS.slider_dmax_gain)
+    .push8(FC.TUNING_SLIDERS.slider_feedforward_gain)
+    .push8(FC.TUNING_SLIDERS.slider_pitch_pi_gain)
+    .push32(0)  // reserved for future use
+    .push32(0); // reserved for future use
+};
+
+MspHelper.readDtermFilterSliderSettings = function(data) {
+    FC.TUNING_SLIDERS.slider_dterm_filter = data.readU8();
+    FC.TUNING_SLIDERS.slider_dterm_filter_multiplier = data.readU8();
+    FC.FILTER_CONFIG.dterm_lowpass_hz = data.readU16();
+    FC.FILTER_CONFIG.dterm_lowpass2_hz = data.readU16();
+    FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz = data.readU16();
+    FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz = data.readU16();
+    data.readU32(); // reserved for future use
+    data.readU32(); // reserved for future use
+};
+
+MspHelper.writeDtermFilterSliderSettings = function(buffer) {
+    buffer
+    .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
+    .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
+    .push16(FC.FILTER_CONFIG.dterm_lowpass_hz)
+    .push16(FC.FILTER_CONFIG.dterm_lowpass2_hz)
+    .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz)
+    .push16(FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz)
+    .push32(0)  // reserved for future use
+    .push32(0); // reserved for future use
+};
+
+MspHelper.readGyroFilterSliderSettings = function(data) {
+    FC.TUNING_SLIDERS.slider_gyro_filter = data.readU8();
+    FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = data.readU8();
+    FC.FILTER_CONFIG.gyro_lowpass_hz = data.readU16();
+    FC.FILTER_CONFIG.gyro_lowpass2_hz = data.readU16();
+    FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz = data.readU16();
+    FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz = data.readU16();
+    data.readU32(); // reserved for future use
+    data.readU32(); // reserved for future use
+};
+
+MspHelper.writeGyroFilterSliderSettings = function(buffer) {
+    buffer
+    .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
+    .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier)
+    .push16(FC.FILTER_CONFIG.gyro_lowpass_hz)
+    .push16(FC.FILTER_CONFIG.gyro_lowpass2_hz)
+    .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz)
+    .push16(FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz)
+    .push32(0)  // reserved for future use
+    .push32(0); // reserved for future use
+};
+
 MspHelper.prototype.process_data = function(dataHandler) {
     const self = this;
     const data = dataHandler.dataView; // DataView (allowing us to view arrayBuffer as struct/union)
@@ -1485,30 +1561,58 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
                 break;
 
-            case MSPCodes.MSP_SET_TUNING_SLIDERS:
-	        // This is done in a loop whenever the sliders are moved. Avoid logging to optimise the performance.
+            case MSPCodes.MSP_SET_SIMPLIFIED_TUNING:
+                console.log('Tuning Sliders sent');
                 break;
 
-            case MSPCodes.MSP_TUNING_SLIDERS:
-                FC.TUNING_SLIDERS.slider_pids_mode = data.readU8();
-                FC.TUNING_SLIDERS.slider_master_multiplier = data.readU8();
-                FC.TUNING_SLIDERS.slider_roll_pitch_ratio = data.readU8();
-                FC.TUNING_SLIDERS.slider_i_gain = data.readU8();
-                FC.TUNING_SLIDERS.slider_d_gain = data.readU8();
-                FC.TUNING_SLIDERS.slider_pi_gain = data.readU8();
-                FC.TUNING_SLIDERS.slider_dmax_gain = data.readU8();
-                FC.TUNING_SLIDERS.slider_feedforward_gain = data.readU8();
-                FC.TUNING_SLIDERS.slider_pitch_pi_gain = data.readU8();
-                FC.TUNING_SLIDERS.slider_dterm_filter = data.readU8();
-                FC.TUNING_SLIDERS.slider_dterm_filter_multiplier = data.readU8();
-                FC.TUNING_SLIDERS.slider_gyro_filter = data.readU8();
-                FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = data.readU8();
-                break;
+            case MSPCodes.MSP_SIMPLIFIED_TUNING:
+                MspHelper.readPidSliderSettings(data);
+                MspHelper.readDtermFilterSliderSettings(data);
+                MspHelper.readGyroFilterSliderSettings(data);
 
+                break;
+            case MSPCodes.MSP_CALCULATE_SIMPLIFIED_PID:
+
+                if (FC.TUNING_SLIDERS.slider_pids_mode > 0) {
+                    FC.PIDS[0][0] = data.readU8();
+                    FC.PIDS[0][1] = data.readU8();
+                    FC.PIDS[0][2] = data.readU8();
+                    FC.ADVANCED_TUNING.dMinRoll = data.readU8();
+                    FC.ADVANCED_TUNING.feedforwardRoll = data.readU16();
+
+                    FC.PIDS[1][0] = data.readU8();
+                    FC.PIDS[1][1] = data.readU8();
+                    FC.PIDS[1][2] = data.readU8();
+                    FC.ADVANCED_TUNING.dMinPitch = data.readU8();
+                    FC.ADVANCED_TUNING.feedforwardPitch = data.readU16();
+                }
+
+                if (FC.TUNING_SLIDERS.slider_pids_mode > 1) {
+                    FC.PIDS[2][0] = data.readU8();
+                    FC.PIDS[2][1] = data.readU8();
+                    FC.PIDS[2][2] = data.readU8();
+                    FC.ADVANCED_TUNING.dMinYaw = data.readU8();
+                    FC.ADVANCED_TUNING.feedforwardYaw = data.readU16();
+                }
+
+                break;
+            case MSPCodes.MSP_CALCULATE_SIMPLIFIED_GYRO:
+                MspHelper.readGyroFilterSliderSettings(data);
+
+                break;
+            case MSPCodes.MSP_CALCULATE_SIMPLIFIED_DTERM:
+                MspHelper.readDtermFilterSliderSettings(data);
+
+                break;
+            case MSPCodes.MSP_VALIDATE_SIMPLIFIED_TUNING:
+                FC.TUNING_SLIDERS.slider_pids_valid = data.readU8();
+                FC.TUNING_SLIDERS.slider_gyro_valid = data.readU8();
+                FC.TUNING_SLIDERS.slider_dterm_valid = data.readU8();
+
+                break;
             case MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL:
                 console.log("VTX powerlevel sent");
                 break;
-
             case MSPCodes.MSP_SET_MODE_RANGE:
                 console.log('Mode range saved');
                 break;
@@ -2313,21 +2417,24 @@ MspHelper.prototype.crunch = function(code) {
             buffer.push8(1);
             break;
 
-        case MSPCodes.MSP_SET_TUNING_SLIDERS:
-            buffer
-                .push8(FC.TUNING_SLIDERS.slider_pids_mode)
-                .push8(FC.TUNING_SLIDERS.slider_master_multiplier)
-                .push8(FC.TUNING_SLIDERS.slider_roll_pitch_ratio)
-                .push8(FC.TUNING_SLIDERS.slider_i_gain)
-                .push8(FC.TUNING_SLIDERS.slider_d_gain)
-                .push8(FC.TUNING_SLIDERS.slider_pi_gain)
-                .push8(FC.TUNING_SLIDERS.slider_dmax_gain)
-                .push8(FC.TUNING_SLIDERS.slider_feedforward_gain)
-                .push8(FC.TUNING_SLIDERS.slider_pitch_pi_gain)
-                .push8(FC.TUNING_SLIDERS.slider_dterm_filter)
-                .push8(FC.TUNING_SLIDERS.slider_dterm_filter_multiplier)
-                .push8(FC.TUNING_SLIDERS.slider_gyro_filter)
-                .push8(FC.TUNING_SLIDERS.slider_gyro_filter_multiplier);
+        case MSPCodes.MSP_SET_SIMPLIFIED_TUNING:
+            MspHelper.writePidSliderSettings(buffer);
+            MspHelper.writeDtermFilterSliderSettings(buffer);
+            MspHelper.writeGyroFilterSliderSettings(buffer);
+
+            break;
+        case MSPCodes.MSP_CALCULATE_SIMPLIFIED_PID:
+            MspHelper.writePidSliderSettings(buffer);
+
+            break;
+
+        case MSPCodes.MSP_CALCULATE_SIMPLIFIED_GYRO:
+            MspHelper.writeGyroFilterSliderSettings(buffer);
+
+            break;
+        case MSPCodes.MSP_CALCULATE_SIMPLIFIED_DTERM:
+            MspHelper.writeDtermFilterSliderSettings(buffer);
+
             break;
 
         default:


### PR DESCRIPTION
Simplified Tuning Update to go with https://github.com/betaflight/betaflight/pull/11114

This PR also bring slider defaults back to 1 by adjusting the PID defaults array having the same values.
With the new MSP commands we were able to remove some hacks which were needed before.

🥇 Many thanks to:

- @ctzsnooze for functional design and testing and coding up the lowpass sketch.
- @limonspb for implementing new MSP commands in firmware making it much easier to implement the code + bug fixes
- @klutvott123 for guarding the MSP changes to be compatible and in line with standards.