### PR TITLE
Presets FIX for loading broken BATCH configs - 'Save anyway' button did not work.

### DIFF
--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -123,7 +123,12 @@ TABS.presets.setupMenuButtons = function() {
     });
     this._domButtonaSaveAnyway.on("click", () => {
         this._domDialogCliErrors.close();
-        this.cliEngine.sendLine(CliEngine.s_commandSave);
+        this.cliEngine.sendLine(CliEngine.s_commandSave, null, () => {
+            // In case of batch CLI commands errors Firmware requeires extra "save" comand for CLI safety.
+            // No need for this safety in presets as preset tab already detected errors and showed them to the user.
+            // At this point user clicked "save anyway".
+            this.cliEngine.sendLine(CliEngine.s_commandSave);
+        });
         this.disconnectCliMakeSure();
     });
     this._domButtonSaveBackup.on("click", () => this.onSaveConfigClick());


### PR DESCRIPTION
This PR fixes a sad bug on the Presets tab when a person loads a broken configuration with the "load config" button.
To reproduce:
1. Save config with a button on presets tab into a local file
2. Open this file and intentionally add something like "qweqweqwe" in the middle
3. Save the file
4. Load this configuration with 'load config' button
5. A dialog with the error will show up
6. Click save anyway

Expected behaviour: CLI saves, Configurator restarts
Actual: FC gets stuck in CLI mode, Configurator freezes

This is happening because of this old PR:
https://github.com/betaflight/betaflight/pull/6713

it basically ignores the first "save" command if it happens within the batch CLI.

This fix basically just sends a second "save".