### PR TITLE
Added EXPRESSLRS to the list of SPI protocols

### DIFF
--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -310,6 +310,7 @@ TABS.receiver.initialize = function (callback) {
                 spiRxTypes.push(
                     'FRSKY_X_V2',
                     'FRSKY_X_LBT_V2',
+                    'EXPRESSLRS',
                 );
             }
 


### PR DESCRIPTION
Added EXPRESSLRS to the list of protocols in the RX dropdown menu. 
In line with:
https://github.com/betaflight/betaflight/blob/master/src/main/cli/settings.c#L273