### PR TITLE
Rpm defaults fix for 4.3

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1512,10 +1512,7 @@
         "message": "Dynamic Notch values change"
     },
     "dialogDynFiltersChangeNote": {
-        "message": "<span class=\"message-negative\"><b>WARNING: Some dynamic notch values have been changed to default values</b></span> because the RPM filtering has been activated/deactivated.<br> Please, check before flying."
-    },
-    "dialogDynFiltersConfirm": {
-        "message": "OK"
+        "message": "<span class=\"message-negative\"><b>WARNING: This change will enable/disable RPM filtering, increasing/decreasing filter delay/effectiveness.</b></span><br><br>Reset the dynamic notch filters to recommended values?"
     },
     "portsIdentifier": {
         "message": "Identifier"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -642,8 +642,7 @@ const FC = {
             dyn_notch_q:                    120,
             dyn_notch_width_percent:          8,
             dyn_notch_count:                  3,
-            dyn_notch_q_rpm:                250, // default with rpm filtering
-            dyn_notch_width_percent_rpm:      0,
+            dyn_notch_q_rpm:                500, // default with rpm filtering
             dyn_notch_count_rpm:              1,
             dyn_notch_min_hz:               150,
             dyn_notch_max_hz:               600,
@@ -858,7 +857,6 @@ const FC = {
                 versionFilterDefaults.dterm_lowpass2_type = this.FILTER_TYPE_FLAGS.PT1;
             }
             if (semver.gte(this.CONFIG.apiVersion, API_VERSION_1_44)) {
-                versionFilterDefaults.dyn_notch_q_rpm = 500;
                 versionFilterDefaults.dyn_notch_q = 300;
                 versionFilterDefaults.gyro_lowpass_hz = 250;
                 versionFilterDefaults.gyro_lowpass_dyn_min_hz = 250;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -725,21 +725,8 @@ function showErrorDialog(message) {
     dialog.showModal();
 }
 
-function showDialogDynFiltersChange() {
-    const dialogDynFiltersChange = $('.dialogDynFiltersChange')[0];
-
-    if (!dialogDynFiltersChange.hasAttribute('open')) {
-        dialogDynFiltersChange.showModal();
-
-        $('.dialogDynFiltersChange-confirmbtn').click(function() {
-            dialogDynFiltersChange.close();
-        });
-    }
-}
-
 // TODO: all of these are used as globals in other parts.
 // once moved to modules extract to own module.
-window.showDialogDynFiltersChange = showDialogDynFiltersChange;
 window.googleAnalytics = analytics;
 window.analytics = null;
 window.showErrorDialog = showErrorDialog;

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -675,7 +675,6 @@ TABS.motors.initialize = function (callback) {
             dshotBidirElement.on("change", function () {
                 const value = $(this).prop('checked');
                 const newValue = (value !== FC.MOTOR_CONFIG.use_dshot_telemetry) ? 'On' : 'Off';
-
                 self.analyticsChanges['BidirectionalDshot'] = newValue;
                 FC.MOTOR_CONFIG.use_dshot_telemetry = value;
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -5,6 +5,8 @@ TABS.pid_tuning = {
     showAllPids: false,
     updating: true,
     dirty: false,
+    previousFilterDynQ: null,
+    previousFilterDynCount: null,
     currentProfile: null,
     currentRateProfile: null,
     currentRatesType: null,
@@ -446,28 +448,37 @@ TABS.pid_tuning.initialize = function (callback) {
 
                 rpmFilterHarmonics_e.attr('disabled', !checked);
                 rpmFilterMinHz_e.attr('disabled', !checked);
+                self.previousFilterDynQ = FC.FILTER_CONFIG.dyn_notch_q;
+                self.previousFilterDynCount = FC.FILTER_CONFIG.dyn_notch_count;
 
                 if (harmonics == 0) {
                     rpmFilterHarmonics_e.val(FILTER_DEFAULT.gyro_rpm_notch_harmonics);
                 }
 
-                if (checked !== (FC.FILTER_CONFIG.gyro_rpm_notch_harmonics !== 0)) { // if rpmFilterEnabled is not the same value as saved in the fc
+                const dialogSettings = {
+                    title: i18n.getMessage("dialogDynFiltersChangeTitle"),
+                    text: i18n.getMessage("dialogDynFiltersChangeNote"),
+                    buttonYesText: i18n.getMessage("presetsWarningDialogYesButton"),
+                    buttonNoText: i18n.getMessage("presetsWarningDialogNoButton"),
+                    buttonYesCallback: () => _dynFilterChange(),
+                    buttonNoCallback:  null,
+                };
+
+                const _dynFilterChange = function() {
                     if (checked) {
                         dynamicNotchCount_e.val(FILTER_DEFAULT.dyn_notch_count_rpm);
                         dynamicNotchQ_e.val(FILTER_DEFAULT.dyn_notch_q_rpm);
-                        dynamicNotchWidthPercent_e.val(FILTER_DEFAULT.dyn_notch_width_percent_rpm);
                     } else {
                         dynamicNotchCount_e.val(FILTER_DEFAULT.dyn_notch_count);
                         dynamicNotchQ_e.val(FILTER_DEFAULT.dyn_notch_q);
-                        dynamicNotchWidthPercent_e.val(FILTER_DEFAULT.dyn_notch_width_percent);
                     }
+                };
 
-                    showDialogDynFiltersChange();
-
-                } else { // same value, return saved values
-                    dynamicNotchCount_e.val(FC.FILTER_CONFIG.dyn_notch_count);
-                    dynamicNotchQ_e.val(FC.FILTER_CONFIG.dyn_notch_q);
-                    dynamicNotchWidthPercent_e.val(FC.FILTER_CONFIG.dyn_notch_width_percent);
+                if (checked !== (FC.FILTER_CONFIG.gyro_rpm_notch_harmonics !== 0)) { // if rpmFilterEnabled is not the same value as saved in the fc
+                    GUI.showYesNoDialog(dialogSettings);
+                } else {
+                    dynamicNotchCount_e.val(self.previousFilterDynCount);
+                    dynamicNotchQ_e.val(self.previousFilterDynQ);
                 }
 
                 $('.rpmFilter span.suboption').toggle(checked);

--- a/src/main.html
+++ b/src/main.html
@@ -459,17 +459,6 @@
         </div>
     </dialog>
 
-    <dialog class="dialogDynFiltersChange">
-        <h3 i18n="dialogDynFiltersChangeTitle"></h3>
-        <div class="content">
-            <div i18n="dialogDynFiltersChangeNote" style="margin-top: 10px"></div>
-
-        </div>
-        <div class="buttons">
-            <a href="#" class="dialogDynFiltersChange-confirmbtn regular-button" i18n="dialogDynFiltersConfirm"></a>
-        </div>
-    </dialog>
-
     <ul class="hidden"> <!-- Sonar says so -->
         <li id="dialogReportProblems-listItemTemplate" class="dialogReportProblems-listItem"></li>
     </ul>


### PR DESCRIPTION
-Removed non used rpm defaults from 4.2 to avoid msp complications with outdated and not suported version by this.
-Allows confirm or decline dyn values changes.