### PR TITLE
Revert nwjs update to  0.54.1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ const NODE_ENV = process.env.NODE_ENV || 'production';
 const NAME_REGEX = /-/g;
 
 const nwBuilderOptions = {
-    version: '0.59.0',
+    version: '0.54.1',
     files: `${DIST_DIR}**/*`,
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},


### PR DESCRIPTION
Reverting nwjs udate to avoid posible issues.
Fixes https://github.com/betaflight/betaflight-configurator/issues/2713