### PR TITLE
DON'T MERGE! Flashing timeout increase to 1000ms

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1297,7 +1297,7 @@ firmware_flasher.initialize = function (callback) {
                             // Trigger regular Flashing sequence
                             GUI.timeout_add('initialization_timeout', function () {
                                 $('a.flash_firmware').click();
-                            }, 100); // timeout so bus have time to initialize after being detected by the system
+                            }, 1000); // timeout so bus have time to initialize after being detected by the system
                         } else {
                             GUI.log(i18n.getMessage('firmwareFlasherPreviousDevice', [port]));
                         }


### PR DESCRIPTION
seems like some users having problems with flashing on windows. Configurator does nothing on "flash" button. Console drops this error:

![image](https://user-images.githubusercontent.com/2925027/147538131-9d6981d5-9648-4e8a-8b66-cb4ad365c8f3.png)

this is just a test PR to see if that is the issue.