### PR TITLE
Add support for getting/setting elrs uid via receivers tab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ testresults/
 .eslintcache
 cordova/bundle.keystore
 
+# Junit test results
+test-results-junit/
+
 # OSX
 .DS_store
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1100,7 +1100,8 @@ function cordova_execbrowserify(file) {
     const filename = file.split('/').pop();
     const destpath = file.replace(filename, '');
     console.log(`Include required modules in ${file}`);
-    return browserify(file, { ignoreMissing: true })
+    return browserify(file, { ignoreMissing: true})
+        .transform("babelify", {presets: ["@babel/preset-env"] })
         .bundle()
         .pipe(source(filename))
         .pipe(gulp.dest(destpath));

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2183,6 +2183,9 @@
     "receiverButtonBindMessage": {
         "message": "Bind request sent to the flight controller."
     },
+    "receiverButtonPassphrase": {
+        "message": "Passphrase"
+    },
     "receiverButtonSticks": {
         "message": "Control sticks"
     },
@@ -6692,7 +6695,7 @@
         "description": "Warning message that shows up at the top of the preset sources dialog"
     },
     "presetsNoPresetsFound": {
-        "message": "No presets found for the given search paramteres",
+        "message": "No presets found for the given search parameters",
         "description": "Message that apprears on presets tab if no presets were found"
     },
     "presetsTooManyPresetsFound": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "vue": "^2.7.10"
   },
   "devDependencies": {
-    "@babel/core": "^7.19.3",
+    "@babel/core": "^7.19.6",
     "@quanle94/innosetup": "^6.0.2",
     "@rollup/plugin-alias": "^3.1.9",
     "@rollup/plugin-commonjs": "^22.0.2",
@@ -91,6 +91,7 @@
     "@storybook/addon-links": "^6.5.12",
     "@storybook/vue": "^6.5.12",
     "babel-loader": "^8.2.5",
+    "babelify": "^10.0.0",
     "browserify": "^17.0.0",
     "chai": "^4.3.6",
     "command-exists": "^1.2.9",

--- a/src/css/tabs/receiver.less
+++ b/src/css/tabs/receiver.less
@@ -605,6 +605,17 @@
 			margin-bottom: 0;
 		}
 	}
+	.elrsContainer {
+		float: left;
+		width: calc(100% - 20px);
+	}
+	.elrsUid {
+		float: left;
+		width: calc(100% - 20px);
+	}
+	.elrsPassphrase {
+		margin-left: 5px;
+	}
 	.gui_box_titlebar {
 		margin-bottom: 0;
 	}

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -555,6 +555,7 @@ const FC = {
             rcSmoothingAutoFactor:        0,
             usbCdcHidType:                0,
             rcSmoothingMode:              0,
+            elrsUid:                      0,
         };
 
         this.FAILSAFE_CONFIG = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1088,6 +1088,13 @@ MspHelper.prototype.process_data = function(dataHandler) {
                                 FC.RX_CONFIG.rcSmoothingAutoFactor = data.readU8();
                                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
                                     FC.RX_CONFIG.rcSmoothingMode = data.readU8();
+                                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+                                        const elrsUidLength = 6;
+                                        FC.RX_CONFIG.elrsUid = [];
+                                        for (let i = 0; i < elrsUidLength; i++) {
+                                            FC.RX_CONFIG.elrsUid.push(data.readU8());
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -2051,6 +2058,11 @@ MspHelper.prototype.crunch = function(code, modifierCode = undefined) {
                                 .push8(FC.RX_CONFIG.rcSmoothingAutoFactor);
                             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
                                 buffer.push8(FC.RX_CONFIG.rcSmoothingMode);
+                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+                                    FC.RX_CONFIG.elrsUid.forEach((b) => {
+                                        buffer.push8(b);
+                                    });
+                                }
                             }
                         }
                     }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -1,9 +1,13 @@
 import { i18n } from "../localization";
 
+const MD5 = require('md5.js');
+
+
 const receiver = {
     rateChartHeight: 117,
     analyticsChanges: {},
     needReboot: false,
+    elrsPassphraseEnabled: false,
 };
 
 receiver.initialize = function (callback) {
@@ -12,6 +16,30 @@ receiver.initialize = function (callback) {
     if (GUI.active_tab !== 'receiver') {
         GUI.active_tab = 'receiver';
     }
+
+    function lookup_elrs_passphrase(uidString) {
+        const passphraseMap = ConfigStorage.get('passphrase_map').passphrase_map || {};
+        return passphraseMap[uidString] ?? 0;
+    }
+
+    function save_elrs_passphrase(uidString, passphrase) {
+        const passphraseMap = ConfigStorage.get('passphrase_map').passphrase_map ?? {};
+        passphraseMap[uidString] = passphrase;
+        ConfigStorage.set({'passphrase_map': passphraseMap});
+      }
+
+    function elrs_passphrase_to_bytes(text) {
+
+        let uidBytes = [0,0,0,0,0,0];
+        if (text) {
+            const bindingPhraseFull = `-DMY_BINDING_PHRASE="${text}"`;
+            const md5stream = new MD5();
+            md5stream.end(bindingPhraseFull);
+            const    buffer = md5stream.read().subarray(0, 6);
+            uidBytes = Uint8Array.from(buffer);
+        }
+        return uidBytes;
+      }
 
     function get_rc_data() {
         MSP.send_message(MSPCodes.MSP_RC, false, false, get_rssi_config);
@@ -310,6 +338,36 @@ receiver.initialize = function (callback) {
                 spiRxElement.append(`<option value="${i}">${spiRxTypes[i]}</option>`);
             }
 
+            if (FC.FEATURE_CONFIG.features.isEnabled('RX_SPI') &&
+                FC.RX_CONFIG.rxSpiProtocol == 19 &&
+                semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+
+                tab.elrsPassphraseEnabled = true;
+
+                const elrsUid = $('span.elrsUid');
+                const elrsUidString = FC.RX_CONFIG.elrsUid.join(',');
+
+                elrsUid.text(elrsUidString);
+
+                const elrsPassphrase = $('input.elrsPassphrase');
+
+                const passphraseString = lookup_elrs_passphrase(elrsUidString);
+                if (passphraseString) {
+                    elrsPassphrase.val(passphraseString);
+                }
+                elrsPassphrase.keyup(function() {
+                    const passphrase = $(this).val();
+                    if (passphrase) {
+                        elrsUid.text(elrs_passphrase_to_bytes(passphrase));
+                    } else {
+                        elrsUid.text("0.0.0.0.0.0");
+                    }
+                    updateSaveButton(true);
+                });
+            } else {
+                tab.elrsPassphraseEnabled = false;
+            }
+
             spiRxElement.change(function () {
                 const value = parseInt($(this).val());
 
@@ -381,6 +439,16 @@ receiver.initialize = function (callback) {
             }
         }
 
+        function checkShowElrsPassphrase() {
+            if (tab.elrsPassphraseEnabled) {
+                $('#elrsContainer').show();
+                $('input.elrsUid').show();
+            } else {
+                $('#elrsContainer').hide();
+                $('input.elrsUid').hide();
+            }
+        }
+
         $(featuresElement).filter('select').change(function () {
             const element = $(this);
             FC.FEATURE_CONFIG.features.updateData(element);
@@ -388,12 +456,14 @@ receiver.initialize = function (callback) {
             if (element.attr('name') === 'rxMode') {
                 checkShowSerialRxBox();
                 checkShowSpiRxBox();
+                checkShowElrsPassphrase();
                 updateSaveButton(true);
             }
         });
 
         checkShowSerialRxBox();
         checkShowSpiRxBox();
+        checkShowElrsPassphrase();
         updateSaveButton();
 
         $('a.refresh').click(function () {
@@ -440,6 +510,19 @@ receiver.initialize = function (callback) {
 
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 FC.RX_CONFIG.rcSmoothingAutoFactor = parseInt($('input[name="rcSmoothingAutoFactor-number"]').val());
+            }
+
+            if (tab.elrsPassphraseEnabled) {
+                const elrsUidChars = $('span.elrsUid')[0].innerText.split(',').map(uidChar => parseInt(uidChar, 10));
+                if (elrsUidChars.length === 6) {
+                    FC.RX_CONFIG.elrsUid = elrsUidChars;
+
+                    const elrsUid =  $('span.elrsUid')[0].innerText;
+                    const elrsPassphrase = $('input.elrsPassphrase').val();
+                    save_elrs_passphrase(elrsUid, elrsPassphrase);
+                } else {
+                    FC.RX_CONFIG.elrsUid = [0, 0, 0, 0, 0, 0];
+                }
             }
 
             function save_rssi_config() {

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -41,7 +41,7 @@
                             </select>
                             <span i18n="configurationReceiverMode"></span>
                         </div>
-                        <div class="serialRXBox spacer_box">
+                    <div class="serialRXBox spacer_box">
                             <div class="note">
                                 <p i18n="configurationSerialRXHelp"></p>
                             </div>
@@ -58,6 +58,15 @@
                                 <!-- list generated here -->
                             </select>
                             <span i18n="configurationSpiRX"></span>
+                        </div>
+                        <div id="elrsContainer" class="elrsContainer spacer_box">
+                            <div >
+                                <input type="text" class="elrsPassphrase">
+                                <span i18n="receiverButtonPassphrase"></span><br/>
+                            </div>
+                            <div>
+                                <span class="elrsUid"></span>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -83,21 +83,21 @@
     json5 "^2.2.1"
     semver "^6.3.0"
 
-"@babel/core@^7.19.3":
-  version "7.19.3"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.3.tgz#2519f62a51458f43b682d61583c3810e7dcee64c"
-  integrity sha512-WneDJxdsjEvyKtXKsaBGbDeiyOjR5vYq4HcShxnIbG0qixpoHjI3MqeZM9NDvsojNCEBItQE4juOo/bU6e72gQ==
+"@babel/core@^7.19.6":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.19.6.tgz#7122ae4f5c5a37c0946c066149abd8e75f81540f"
+  integrity sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==
   dependencies:
     "@ampproject/remapping" "^2.1.0"
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.3"
+    "@babel/generator" "^7.19.6"
     "@babel/helper-compilation-targets" "^7.19.3"
-    "@babel/helper-module-transforms" "^7.19.0"
-    "@babel/helpers" "^7.19.0"
-    "@babel/parser" "^7.19.3"
+    "@babel/helper-module-transforms" "^7.19.6"
+    "@babel/helpers" "^7.19.4"
+    "@babel/parser" "^7.19.6"
     "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.3"
-    "@babel/types" "^7.19.3"
+    "@babel/traverse" "^7.19.6"
+    "@babel/types" "^7.19.4"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.2"
@@ -113,12 +113,12 @@
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.19.3":
-  version "7.19.3"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.3.tgz#d7f4d1300485b4547cb6f94b27d10d237b42bf59"
-  integrity sha512-fqVZnmp1ncvZU757UzDheKZpfPgatqY59XtW2/j/18H7u76akb8xqvjw82f+i2UKd/ksYsSick/BCLQUUtJ/qQ==
+"@babel/generator@^7.19.6":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.19.6.tgz#9e481a3fe9ca6261c972645ae3904ec0f9b34a1d"
+  integrity sha512-oHGRUQeoX1QrKeJIKVe0hwjGqNnVYsM5Nep5zo0uE0m42sLH+Fsd2pStJ5sRM1bNyTUUoz0pe2lTeMJrb/taTA==
   dependencies:
-    "@babel/types" "^7.19.3"
+    "@babel/types" "^7.19.4"
     "@jridgewell/gen-mapping" "^0.3.2"
     jsesc "^2.5.1"
 
@@ -303,19 +303,19 @@
     "@babel/traverse" "^7.17.3"
     "@babel/types" "^7.17.0"
 
-"@babel/helper-module-transforms@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.0.tgz#309b230f04e22c58c6a2c0c0c7e50b216d350c30"
-  integrity sha512-3HBZ377Fe14RbLIA+ac3sY4PTgpxHVkFrESaWhoI5PuyXPBBX8+C34qblV9G89ZtycGJCmCI/Ut+VUDK4bltNQ==
+"@babel/helper-module-transforms@^7.19.6":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.19.6.tgz#6c52cc3ac63b70952d33ee987cbee1c9368b533f"
+  integrity sha512-fCmcfQo/KYr/VXXDIyd3CBGZ6AFhPFy1TfSEJ+PilGVlQT6jcbqtHAM4C1EciRqMza7/TpOUZliuSH+U6HAhJw==
   dependencies:
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-module-imports" "^7.18.6"
-    "@babel/helper-simple-access" "^7.18.6"
+    "@babel/helper-simple-access" "^7.19.4"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/helper-validator-identifier" "^7.18.6"
+    "@babel/helper-validator-identifier" "^7.19.1"
     "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.0"
-    "@babel/types" "^7.19.0"
+    "@babel/traverse" "^7.19.6"
+    "@babel/types" "^7.19.4"
 
 "@babel/helper-optimise-call-expression@^7.16.7":
   version "7.16.7"
@@ -366,12 +366,12 @@
   dependencies:
     "@babel/types" "^7.17.0"
 
-"@babel/helper-simple-access@^7.18.6":
-  version "7.18.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz#d6d8f51f4ac2978068df934b569f08f29788c7ea"
-  integrity sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==
+"@babel/helper-simple-access@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.19.4.tgz#be553f4951ac6352df2567f7daa19a0ee15668e7"
+  integrity sha512-f9Xq6WqBFqaDfbCzn2w85hwklswz5qsKlh7f08w4Y9yhJHpnNC0QemtSkK5YyOY8kPGvyiwdzZksGUhnGdaUIg==
   dependencies:
-    "@babel/types" "^7.18.6"
+    "@babel/types" "^7.19.4"
 
 "@babel/helper-skip-transparent-expression-wrappers@^7.16.0":
   version "7.16.0"
@@ -398,6 +398,11 @@
   version "7.18.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz#181f22d28ebe1b3857fa575f5c290b1aaf659b56"
   integrity sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==
+
+"@babel/helper-string-parser@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.19.4.tgz#38d3acb654b4701a9b77fb0615a96f775c3a9e63"
+  integrity sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==
 
 "@babel/helper-validator-identifier@^7.10.4":
   version "7.10.4"
@@ -443,14 +448,14 @@
     "@babel/traverse" "^7.17.9"
     "@babel/types" "^7.17.0"
 
-"@babel/helpers@^7.19.0":
-  version "7.19.0"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.19.0.tgz#f30534657faf246ae96551d88dd31e9d1fa1fc18"
-  integrity sha512-DRBCKGwIEdqY3+rPJgG/dKfQy9+08rHIAJx8q2p+HSWP87s2HCrQmaAMMyMll2kIXKCW0cO1RdQskx15Xakftg==
+"@babel/helpers@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.19.4.tgz#42154945f87b8148df7203a25c31ba9a73be46c5"
+  integrity sha512-G+z3aOx2nfDHwX/kyVii5fJq+bgscg89/dJNWpYeKeBv3v9xX8EIabmx1k6u9LS04H7nROFVRVK+e3k0VHp+sw==
   dependencies:
     "@babel/template" "^7.18.10"
-    "@babel/traverse" "^7.19.0"
-    "@babel/types" "^7.19.0"
+    "@babel/traverse" "^7.19.4"
+    "@babel/types" "^7.19.4"
 
 "@babel/highlight@^7.10.4":
   version "7.10.4"
@@ -484,10 +489,15 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.17.9.tgz#9c94189a6062f0291418ca021077983058e171ef"
   integrity sha512-vqUSBLP8dQHFPdPi9bc5GK9vRkYHJ49fsZdtoJ8EQ8ibpwk5rPKfvNIwChB0KVXcIjcepEBBd2VHC5r9Gy8ueg==
 
-"@babel/parser@^7.18.10", "@babel/parser@^7.18.4", "@babel/parser@^7.19.3":
+"@babel/parser@^7.18.10", "@babel/parser@^7.18.4":
   version "7.19.3"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.3.tgz#8dd36d17c53ff347f9e55c328710321b49479a9a"
   integrity sha512-pJ9xOlNWHiy9+FuFP09DEAFbAn4JskgRsVcc169w2xRBC3FRGuQEwjeIMMND9L2zc0iEhO/tGv4Zq+km+hxNpQ==
+
+"@babel/parser@^7.19.6":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.19.6.tgz#b923430cb94f58a7eae8facbffa9efd19130e7f8"
+  integrity sha512-h1IUp81s2JYJ3mRkdxJgs4UvmSsRvDrx5ICSJbPvtWYv5i1nTBGcBpnog+89rAFMwvvru6E5NUHdBe01UeSzYA==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.16.7":
   version "7.16.7"
@@ -1299,19 +1309,19 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/traverse@^7.19.0", "@babel/traverse@^7.19.3":
-  version "7.19.3"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.3.tgz#3a3c5348d4988ba60884e8494b0592b2f15a04b4"
-  integrity sha512-qh5yf6149zhq2sgIXmwjnsvmnNQC2iw70UFjp4olxucKrWd/dvlUsBI88VSLUsnMNF7/vnOiA+nk1+yLoCqROQ==
+"@babel/traverse@^7.19.4", "@babel/traverse@^7.19.6":
+  version "7.19.6"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.19.6.tgz#7b4c865611df6d99cb131eec2e8ac71656a490dc"
+  integrity sha512-6l5HrUCzFM04mfbG09AagtYyR2P0B71B1wN7PfSPiksDPz2k5H9CBC1tcZpz2M8OxbKTPccByoOJ22rUKbpmQQ==
   dependencies:
     "@babel/code-frame" "^7.18.6"
-    "@babel/generator" "^7.19.3"
+    "@babel/generator" "^7.19.6"
     "@babel/helper-environment-visitor" "^7.18.9"
     "@babel/helper-function-name" "^7.19.0"
     "@babel/helper-hoist-variables" "^7.18.6"
     "@babel/helper-split-export-declaration" "^7.18.6"
-    "@babel/parser" "^7.19.3"
-    "@babel/types" "^7.19.3"
+    "@babel/parser" "^7.19.6"
+    "@babel/types" "^7.19.4"
     debug "^4.1.0"
     globals "^11.1.0"
 
@@ -1323,12 +1333,21 @@
     "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.19.0", "@babel/types@^7.19.3":
+"@babel/types@^7.18.10", "@babel/types@^7.18.6", "@babel/types@^7.19.0":
   version "7.19.3"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.3.tgz#fc420e6bbe54880bce6779ffaf315f5e43ec9624"
   integrity sha512-hGCaQzIY22DJlDh9CH7NOxgKkFjBk0Cw9xDO1Xmh2151ti7wiGfQ3LauXzL4HP1fmFlTX6XjpRETTpUcv7wQLw==
   dependencies:
     "@babel/helper-string-parser" "^7.18.10"
+    "@babel/helper-validator-identifier" "^7.19.1"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.19.4":
+  version "7.19.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.19.4.tgz#0dd5c91c573a202d600490a35b33246fed8a41c7"
+  integrity sha512-M5LK7nAeS6+9j7hAq+b3fQs+pNfUtTGq+yFFfHnauFA8zQtLRfmuipmsKDKKLuyG+wC8ABW43A153YNawNTEtw==
+  dependencies:
+    "@babel/helper-string-parser" "^7.19.4"
     "@babel/helper-validator-identifier" "^7.19.1"
     to-fast-properties "^2.0.0"
 
@@ -4097,6 +4116,11 @@ babel-walk@3.0.0-canary-5:
   integrity sha512-GAwkz0AihzY5bkwIY5QDR+LvsRQgB/B+1foMPvi0FZPMl5fjD7ICiznUiBdLYMH1QYe6vqu4gWYytZOccLouFw==
   dependencies:
     "@babel/types" "^7.9.6"
+
+babelify@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/babelify/-/babelify-10.0.0.tgz#fe73b1a22583f06680d8d072e25a1e0d1d1d7fb5"
+  integrity sha512-X40FaxyH7t3X+JFAKvb1H9wooWKLRCi8pg3m8poqtdZaIng+bjzp9RvKQCvRjF9isHiPkXspbbXT/zwXLtwgwg==
 
 babylon@^6.18.0:
   version "6.18.0"


### PR DESCRIPTION
Dependent on https://github.com/betaflight/betaflight/pull/11192

Adds support for getting and setting elrs passphrase via receivers tab:
- Allows entering passphrase directly - uid bytes are displayed below entry
- Calls msp API to get/set uid
- Saves mapping of uid byte string to passphrase into localstorage so it can properly display any passphrases its seen

UI when passphrase is known (passphrase retrieved from storage):
![Screen Shot 2021-12-29 at 6 41 49 AM](https://user-images.githubusercontent.com/1479145/147681182-8a886f4b-1234-47e0-ae1c-baa9e63c3a07.png)

UI when passphrase is not known (not present in local storage):
![Screen Shot 2021-12-29 at 6 46 10 AM](https://user-images.githubusercontent.com/1479145/147681408-dbb658d3-bcd7-403d-aa3d-35f2006ac5d3.png)

UI when disabled (not spi rx, or older version of betaflight)
![Screen Shot 2021-12-29 at 6 46 55 AM](https://user-images.githubusercontent.com/1479145/147681466-afed685a-5745-4deb-8ee9-93ee03cee22f.png)



