### PR TITLE
Fix firmware flash button when non-english is selected and FC is conn…

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -261,7 +261,7 @@ function startProcess() {
                 return;
             }
 
-            if (GUI.allowedTabs.indexOf(tab) < 0 && tabName === "Firmware Flasher") {
+            if (GUI.allowedTabs.indexOf(tab) < 0 && tab === "firmware_flasher") {
                 if (GUI.connected_to || GUI.connecting_to) {
                     $('a.connect').click();
                 } else {


### PR DESCRIPTION
fixes the following bug found by @Asizon 
1. Open Configurator
2. On the landing page of the configurator change the language to something else, not English
3. Plug FC
4. Click Connect - connect with the FC
5. CLick flash firmware

Expected:
Firmware flasher tab is opened.
Actual:
nothing happens