### PR TITLE
Update EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,12 @@
 root = true
 
 [*]
-insert_final_newline = true
 indent_style = space
 indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.{yml,yaml}]
+indent_size = 2


### PR DESCRIPTION
Adds more settings to the `.editorconfig`.

I noticed some `json` files are using an indent size of 2 and some 4, do we have a preference?
