### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,103 @@
+# Builds Betaflight Configurator on Windows, Android, Linux and macOS platforms.
+#
+# After building, artifacts are released to a seperate repository.
+
+env:
+  debugBuild: true
+
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+      - '*-maintenance'
+  pull_request:
+    branches:
+      - master
+      - '*-maintenance'
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - run: yarn install --immutable --immutable-cache --check-cache
+
+      - name: Run unit tests
+        run: yarn test
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@043296c976c53f4536194ebe3841ed720e04d496 # v1.26
+        if: always()
+        with:
+          files: test-results-junit/**/*.xml
+          comment_mode: 'off'
+
+  build:
+    name: Build (${{ matrix.name }})
+    needs: test
+    runs-on:  ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - name: Android
+            os: ubuntu-20.04
+            releaseArgs: --android
+
+          - name: Linux
+            os: ubuntu-20.04
+            releaseArgs: --linux64
+
+          - name: macOS
+            os: macos-11
+            releaseArgs: --osx64
+
+          - name: Windows
+            os: windows-2022
+            releaseArgs: --win64
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache NW.js
+        uses: actions/cache@v2
+        with:
+          path: cache/
+          key: ${{ runner.os }}-${{ hashFiles('gulpfile.js') }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+          cache: yarn
+
+      - name: Install Java JDK 8
+        uses: actions/setup-java@v2
+        if: ${{ matrix.name == 'Android' }}
+        with:
+          distribution: temurin
+          java-version: '8'
+
+      - run: yarn install --immutable --immutable-cache --check-cache
+
+      - run: yarn gulp release ${{ matrix.releaseArgs }}
+        if: ${{ !env.debugBuild }}
+
+      - run: yarn gulp debug-release ${{ matrix.releaseArgs }}
+        if: ${{ env.debugBuild }}
+
+      - name: Publish build artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: Betaflight-Configurator${{ env.debugBuild == 'true' && '-Debug' || '' }}-${{ matrix.name }}
+          path: release/
+          retention-days: 10

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,63 @@
+# You'll need to setup the follwing environment variables:
+#   env.repoNightly - The repository to release nightly builds to e.g. betaflight-configurator-nightly
+#   env.releaseNotes - The release notes to be published as part of the github release
+#   secrets.REPO_TOKEN - A GitHub token with permissions to push and publish releases to the nightly repo
+
+env:
+  repoNightly: betaflight/betaflight-configurator-nightlies
+  debugReleaseNotes: >
+    This is an automated development build.
+    It may be unstable and result in corrupted configurations or data loss.
+    **Use only for testing.**
+  releaseNotes: This is a release build. It does not contain the debug console.
+
+name: Nightly Build
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+jobs:
+  release-nightly:
+    name: Release Nightly
+    runs-on: ubuntu-20.04
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
+    steps:
+      - name: Fetch release assets
+        uses: dawidd6/action-download-artifact@09385b76de790122f4da9c82b17bccf858b9557c # v2.16.0
+        with:
+          path: release-assets/
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+
+      - name: Select release notes
+        id: notes
+        run: |
+          set -- release-assets/Betaflight-Configurator-Debug-*
+          echo "::set-output name=notes::$(test -e "$1" && echo '${{ env.debugReleaseNotes }}' || echo '${{ env.releaseNotes }}')"
+
+      - name: Release
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v0.1.14
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+          repository: ${{ env.repoNightly }}
+          tag_name: build-${{ github.run_number }}
+          files: release-assets/Betaflight-Configurator-*/**
+          draft: false
+          prerelease: false
+          fail_on_unmatched_files: true
+          name: '${{ github.repository }}: ${{ github.ref_name }}'
+          body: |
+            ${{ steps.notes.outputs.notes }}
+
+            ### Repository:
+            ${{ github.repository }} ([link](${{ github.event.repository.html_url }}))
+
+            ### Branch:
+            ${{ github.ref_name }} ([link](${{ github.event.repository.html_url }}/tree/${{ github.ref_name }}))
+
+            ### Latest changeset:
+            ${{ github.sha }} ([link](https://github.com/${{ github.repository }}/commit/${{ github.sha }}))
+
+            ### Changes:
+            ${{ github.event.workflow_run.head_commit.message }}

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "karma": "^4.0.1",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^3.0.0",
+    "karma-junit-reporter": "^2.0.1",
     "karma-mocha": "^1.3.0",
     "karma-rollup-preprocessor": "^7.0.5",
     "karma-sinon": "^1.0.5",

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -35,7 +35,7 @@ module.exports = function(config) {
             outputFile: 'test_results.xml',
         },
         junitReporter: {
-            outputDir: 'test-results-junit'
+            outputDir: 'test-results-junit',
         },
         singleRun: true,
         preprocessors: {

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -6,7 +6,7 @@ const NODE_ENV = process.env.NODE_ENV || 'test';
 
 module.exports = function(config) {
     config.set({
-        reporters: ['tfs', 'spec'],
+        reporters: ['tfs', 'spec','junit'],
         basePath: '../',
         frameworks: ['mocha', 'chai', 'sinon-chai'],
         files: [
@@ -33,6 +33,9 @@ module.exports = function(config) {
         tfsReporter: {
             outputDir: 'testresults',
             outputFile: 'test_results.xml',
+        },
+        junitReporter: {
+            outputDir: 'test-results-junit'
         },
         singleRun: true,
         preprocessors: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5453,6 +5453,14 @@ karma-chrome-launcher@^3.0.0:
   dependencies:
     which "^1.2.1"
 
+karma-junit-reporter@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-2.0.1.tgz#d34eef7f0b2fd064e0896954e8851a90cf14c8f3"
+  integrity sha512-VtcGfE0JE4OE1wn0LK8xxDKaTP7slN8DO3I+4xg6gAi1IoAHAXOJ1V9G/y45Xg6sxdxPOR3THCFtDlAfBo9Afw==
+  dependencies:
+    path-is-absolute "^1.0.0"
+    xmlbuilder "12.0.0"
+
 karma-mocha@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/karma-mocha/-/karma-mocha-1.3.0.tgz#eeaac7ffc0e201eb63c467440d2b69c7cf3778bf"
@@ -10130,6 +10138,11 @@ xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
   integrity sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=
+
+xmlbuilder@12.0.0:
+  version "12.0.0"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-12.0.0.tgz#e2ed675e06834a089ddfb84db96e2c2b03f78c1a"
+  integrity sha512-lMo8DJ8u6JRWp0/Y4XLa/atVDr75H9litKlb2E5j3V3MesoL50EBgZDWoLT3F/LztVnG67GjPXLZpqcky/UMnQ==
 
 xmlbuilder@^9.0.0, xmlbuilder@^9.0.7:
   version "9.0.7"


### PR DESCRIPTION
GitHub Actions workflow for running tests and building on all platforms.

Nightly release is not included, but I can add it here or in later PR if preferred.