### PR TITLE
Presets: minor fixes

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -18,6 +18,7 @@
     --pushedButton-fontColor:  #ffffff;
     --hoverButton-background: #ffcc3e;
     --superSubtleAccent: #595959;
+    --accentBorder: #bf8606;
 }
 
 .background_paper {

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -20,6 +20,7 @@
     --pushedButton-fontColor:  #000000;
     --hoverButton-background: #ffcc3e;
     --superSubtleAccent: #CCCCCC;
+    --accentBorder: #ffbb00;
 }
 
 * {

--- a/src/tabs/presets/PresetsRepoIndexed/PresetsRepoIndexed.js
+++ b/src/tabs/presets/PresetsRepoIndexed/PresetsRepoIndexed.js
@@ -103,7 +103,7 @@ class PresetsRepoIndexed {
     _parceInclude(strings, includeRowIndexes, promises)
     {
            for (let i = 0; i < strings.length; i++) {
-            const match = PresetsRepoIndexed._sRegExpInclude.exec(strings[i].toLowerCase());
+            const match = PresetsRepoIndexed._sRegExpInclude.exec(strings[i]);
 
             if (match !== null) {
                 includeRowIndexes.push(i);
@@ -143,7 +143,7 @@ class PresetsRepoIndexed {
 
     _isIncludeFound(strings) {
         for (const str of strings) {
-            const match = PresetsRepoIndexed._sRegExpInclude.exec(str.toLowerCase());
+            const match = PresetsRepoIndexed._sRegExpInclude.exec(str);
 
             if (match !== null) {
                 return true;
@@ -220,4 +220,4 @@ PresetsRepoIndexed._sCliCommentDirective = "#";
 PresetsRepoIndexed._sCliAttributeDirective = "#$";
 
 // Reg exp extracts file/path.txt from # include: file/path.txt
-PresetsRepoIndexed._sRegExpInclude = /^#\$[ ]+?include:[ ]+?(?<filePath>\S+$)/;
+PresetsRepoIndexed._sRegExpInclude = /^#\$[ ]+?INCLUDE:[ ]+?(?<filePath>\S+$)/;

--- a/src/tabs/presets/SourcesDialog/SourcePanel.js
+++ b/src/tabs/presets/SourcesDialog/SourcePanel.js
@@ -161,6 +161,7 @@ class SourcePanel {
     }
 
     _onActivateButtonClick() {
+        this._onSaveButtonClick();
         this.setActive(true);
         this._onActivateCallback?.(this);
     }

--- a/src/tabs/presets/presets.css
+++ b/src/tabs/presets/presets.css
@@ -125,6 +125,11 @@
     color: var(--defaultText);
 }
 
+.presets_filter_select_nonempty {
+    border-color: var(--accentBorder) !important;
+    border-width: 2px !important;
+}
+
 .presets_search_settings {
     position: sticky;
     top: 0px;

--- a/src/tabs/presets/presets.html
+++ b/src/tabs/presets/presets.html
@@ -71,7 +71,7 @@
             <div id="preset_list_wrapper">
                 <div id="presets_list_no_found" i18n="presetsNoPresetsFound"></div>
                 <div id="presets_list"></div>
-                <div id="presets_list_too_many_found" i18n="presetsTooManyPresetsFound">Too many found</div>
+                <div id="presets_list_too_many_found" i18n="presetsTooManyPresetsFound"></div>
             </div>
         </div>
     </div>

--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -244,7 +244,7 @@ TABS.presets.onHtmlLoad = function(callback) {
     this.readDom();
     this.setupMenuButtons();
     this.setupBackupWarning();
-    this._inputTextFilter.attr("placeholder", "example: \"karate racing\", or \"5'' freestyle\"");
+    this._inputTextFilter.attr("placeholder", "example: \"karate race\", or \"5'' freestyle\"");
 
     this.presetsDetailedDialog = new PresetsDetailedDialog($("#presets_detailed_dialog"), this.pickedPresetList, () => this.onPresetPickedCallback());
     this.presetsSourcesDialog = new PresetsSourcesDialog($("#presets_sources_dialog"));
@@ -320,7 +320,7 @@ TABS.presets.prepareFilterFields = function() {
 };
 
 TABS.presets.preselectFilterFields = function() {
-    this._selectCategory.multipleSelect('setSelects', ["TUNE"]);
+    this._selectCategory.multipleSelect('setSelects', ["TUNE", "RC_SMOOTHING", "RC_LINK", "RATES"]);
 
     const currentVersion = FC.CONFIG.flightControllerVersion;
     const selectedVersions = [];
@@ -359,11 +359,25 @@ TABS.presets.updateSearchResults = function() {
             searchString: this._inputTextFilter.val().trim(),
         };
 
+        this.updateSelectStyle();
         searchParams.authors = searchParams.authors.map(str => str.toLowerCase());
-
         const fitPresets = this.getFitPresets(searchParams);
         this.displayPresets(fitPresets);
     }
+};
+
+TABS.presets.updateSelectStyle = function() {
+    this.updateSingleSelectStyle(this._selectCategory);
+    this.updateSingleSelectStyle(this._selectKeyword);
+    this.updateSingleSelectStyle(this._selectAuthor);
+    this.updateSingleSelectStyle(this._selectFirmwareVersion);
+    this.updateSingleSelectStyle(this._selectStatus);
+};
+
+TABS.presets.updateSingleSelectStyle = function(select) {
+    const selectedOptions = select.multipleSelect("getSelects", "text");
+    const isSomethingSelected = (0 !== selectedOptions.length);
+    select.parent().find($(".ms-choice")).toggleClass("presets_filter_select_nonempty", isSomethingSelected);
 };
 
 TABS.presets.displayPresets = function(fitPresets) {


### PR DESCRIPTION
Four small changes/fixes:
1. Preselect not just TUNE but also RC_LINK, RATES and RC_SMOOTHING as probably the four most popular things.
2. Allow #$ INCLUDE of the files with upper case.
3. On the preset source dialog when making active a source it will save it's changes it automatically (if name, link were changed)
4. Small style change for the preset filter fields when something is selected there:
![image](https://user-images.githubusercontent.com/2925027/147998629-3b9af02c-31a8-4396-b133-6e3c96ecf8d8.png)
