### PR TITLE
Add portable build to windows

### DIFF
--- a/assets/windows/installer.iss
+++ b/assets/windows/installer.iss
@@ -14,7 +14,7 @@
 #define CompanyUrl "https://betaflight.com/"
 #define ExecutableFileName "betaflight-configurator.exe"
 #define GroupName "Betaflight"
-#define InstallerFileName "betaflight-configurator-installer_" + version + "_" + archName
+#define InstallerFileName "betaflight-configurator_" + version + "_" + archName + "-installer"
 #define SourcePath "..\..\" + sourceFolder + "\betaflight-configurator\" + archName
 #define TargetFolderName "Betaflight-Configurator"
 #define UpdatesUrl "https://github.com/betaflight/betaflight-configurator/releases"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -249,8 +249,8 @@ function getRunDebugAppCommand(arch) {
     return command;
 }
 
-function getReleaseFilename(platform, ext) {
-    return `${metadata.name}_${metadata.version}_${platform}.${ext}`;
+function getReleaseFilename(platform, ext, portable = false) {
+    return `${metadata.name}_${metadata.version}_${platform}${portable ? "-portable" : ""}.${ext}`;
 }
 
 function clean_dist() {
@@ -688,7 +688,7 @@ function release_win(arch, appDirectory, done) {
 // Create distribution package (zip) for windows and linux platforms
 function release_zip(arch, appDirectory) {
     const src = path.join(appDirectory, metadata.name, arch, '**');
-    const output = getReleaseFilename(arch, 'zip');
+    const output = getReleaseFilename(arch, 'zip', true);
     const base = path.join(appDirectory, metadata.name, arch);
 
     return compressFiles(src, base, output, 'Betaflight Configurator');
@@ -885,12 +885,18 @@ function listReleaseTasks(isReleaseBuild, appDirectory) {
     }
 
     if (platforms.indexOf('win32') !== -1) {
+        releaseTasks.push(function release_win32_zip() {
+            return release_zip('win32', appDirectory);
+        });
         releaseTasks.push(function release_win32(done) {
             return release_win('win32', appDirectory, done);
         });
     }
 
     if (platforms.indexOf('win64') !== -1) {
+        releaseTasks.push(function release_win64_zip() {
+            return release_zip('win64', appDirectory);
+        });
         releaseTasks.push(function release_win64(done) {
             return release_win('win64', appDirectory, done);
         });


### PR DESCRIPTION
This adds a "portable" zip build to windows (win32 and win64) releases. In this way some of the complains about having different versions installed, or about problems with the installer will be gone.

It modifies the name of the "installer" to be similar to the portable one. The linux version adds the portable word too.

![image](https://user-images.githubusercontent.com/2673520/148069942-215239fd-ec20-4e48-bdf1-d488038ea9e2.png)
