### PR TITLE
Make virtual mode an option using msp backup and restore

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -109,6 +109,10 @@
         "message": "Show all serial devices (for manufacturers or development)",
         "description": "Do not filter serial devices using VID/PID values (for manufacturers or development)"
     },
+    "showVirtualMode": {
+        "message": "Enable virtual connection mode",
+        "description": "Text for the option to enable or disable the virtual FC"
+    },
     "cordovaForceComputerUI": {
         "message": "Use computers interface instead of phones interface"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -810,13 +810,16 @@
         "message": "Restore settings to <strong>default</strong>"
     },
     "initialSetupButtonBackup": {
-        "message": "Backup"
+        "message": "Backup JSON"
     },
     "initialSetupButtonRestore": {
-        "message": "Restore"
+        "message": "Restore JSON"
     },
     "initialSetupButtonRebootBootloader": {
         "message": "Activate Boot Loader / DFU"
+    },
+    "initialSetupBackupRestoreHeader": {
+        "message": "Experimental Backup and Restore"
     },
     "initialSetupBackupRestoreText": {
         "message": "<strong>Backup</strong> your configuration in case of an accident, <strong>CLI</strong> settings are <span class=\"message-negative\">not</span> included - use the command 'diff all' in CLI for this."

--- a/src/css/tabs/setup.css
+++ b/src/css/tabs/setup.css
@@ -106,7 +106,7 @@
     width: 50%;
     float: left;
 }
-.instrumentsbox {
+.backupRestore {
     margin-bottom: 0;
 }
 @media all and (max-width: 575px) {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -13,6 +13,8 @@ const PortHandler = new function () {
     this.port_removed_callbacks = [];
     this.dfu_available = false;
     this.port_available = false;
+    this.showAllSerialDevices = false;
+    this.showVirtualMode = false;
 };
 
 PortHandler.initialize = function () {
@@ -30,6 +32,9 @@ PortHandler.initialize = function () {
 
 PortHandler.check = function () {
     const self = this;
+
+    ConfigStorage.get('showVirtualMode', res => self.showVirtualMode = res.showVirtualMode);
+    ConfigStorage.get('showAllSerialDevices', res => self.showAllSerialDevices = res.showAllSerialDevices);
 
     self.check_usb_devices();
     self.check_serial_devices();
@@ -79,17 +84,20 @@ PortHandler.check_usb_devices = function (callback) {
                     data: {isDFU: true},
                 }));
 
-                self.portPickerElement.append($('<option/>', {
-                    value: 'virtual',
-                    text: i18n.getMessage('portsSelectVirtual'),
-                    data: {isVirtual: true},
-                }));
+                if (self.showVirtualMode) {
+                    self.portPickerElement.append($('<option/>', {
+                        value: 'virtual',
+                        text: i18n.getMessage('portsSelectVirtual'),
+                        data: {isVirtual: true},
+                    }));
+                }
 
                 self.portPickerElement.append($('<option/>', {
                     value: 'manual',
                     text: i18n.getMessage('portsSelectManual'),
                     data: {isManual: true},
                 }));
+
                 self.portPickerElement.val('DFU').change();
                 self.setPortsInputWidth();
             }
@@ -241,11 +249,13 @@ PortHandler.updatePortSelect = function (ports) {
         }));
     }
 
-    this.portPickerElement.append($("<option/>", {
-        value: 'virtual',
-        text: i18n.getMessage('portsSelectVirtual'),
-        data: {isVirtual: true},
-    }));
+    if (this.showVirtualMode) {
+        this.portPickerElement.append($("<option/>", {
+            value: 'virtual',
+            text: i18n.getMessage('portsSelectVirtual'),
+            data: {isVirtual: true},
+        }));
+    }
 
     this.portPickerElement.append($("<option/>", {
         value: 'manual',

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -270,13 +270,11 @@ const serial = {
 
         chrome.serial.getDevices(function (devices_array) {
             const devices = [];
-            let showAllSerialDevices = false;
 
             devices_array.forEach(function (device) {
-                ConfigStorage.get('showAllSerialDevices', res => showAllSerialDevices = res.showAllSerialDevices);
                 const isKnownSerialDevice = self.serialDevices.some(el => el.vendorId === device.vendorId) && self.serialDevices.some(el => el.productId === device.productId);
 
-                if (isKnownSerialDevice || showAllSerialDevices) {
+                if (isKnownSerialDevice || PortHandler.showAllSerialDevices) {
                     devices.push({
                         path: device.path,
                         displayName: device.displayName,

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -16,6 +16,7 @@ options.initialize = function (callback) {
         TABS.options.initCliAutoComplete();
         TABS.options.initAutoConnectConnectionTimeout();
         TABS.options.initShowAllSerialDevices();
+        TABS.options.initShowVirtualMode();
         TABS.options.initCordovaForceComputerUI();
         TABS.options.initDarkTheme();
 
@@ -142,7 +143,19 @@ options.initShowAllSerialDevices = function() {
             .on('change', () => ConfigStorage.set({ showAllSerialDevices: showAllSerialDevicesElement.is(':checked') }))
             .trigger('change');
     });
+};
 
+options.initShowVirtualMode = function() {
+    const showVirtualModeElement = $('div.showVirtualMode input');
+    ConfigStorage.get('showVirtualMode', result => {
+        showVirtualModeElement
+            .prop('checked', !!result.showVirtualMode)
+            .on('change', () => {
+                ConfigStorage.set({ showVirtualMode: showVirtualModeElement.is(':checked') });
+                PortHandler.initialPorts = false;
+            })
+            .trigger('change');
+    });
 };
 
 options.initCordovaForceComputerUI = function () {

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -29,34 +29,34 @@ TABS.setup.initialize = function (callback) {
         // translate to user-selected language
         i18n.localizePage();
 
-        if (CONFIGURATOR.virtualMode || semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
-            const backupButton = $('#content .backup');
+        const backupButton = $('#content .backup');
+        const restoreButton = $('#content .restore');
 
-            if (semver.lt(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE)) {
-                backupButton.addClass('disabled');
-                $('#content .restore').addClass('disabled');
+        backupButton.on('click', () => configuration_backup(() => GUI.log(i18n.getMessage('initialSetupBackupSuccess'))));
 
-                GUI.log(i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE]));
+        restoreButton.on('click', () => configuration_restore(() => {
+            // get latest settings
+            TABS.setup.initialize();
+
+            GUI.log(i18n.getMessage('initialSetupRestoreSuccess'));
+        }));
+
+        if (semver.lt(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE)) {
+            backupButton.addClass('disabled');
+            restoreButton.addClass('disabled');
+
+            GUI.log(i18n.getMessage('initialSetupBackupAndRestoreApiVersion', [FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE]));
+        }
+
+        if (CONFIGURATOR.virtualMode) {
+            // saving and uploading an imaginary config to hardware is a bad idea
+            backupButton.addClass('disabled');
+        } else if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+            restoreButton.addClass('disabled');
+
+            if (!PortHandler.showVirtualMode) {
+                $('.backupRestore').hide();
             }
-
-            if (CONFIGURATOR.virtualMode) {
-                // saving and uploading an imaginary config to hardware is a bad idea
-                backupButton.addClass('disabled');
-            }
-
-            backupButton.on('click', () => configuration_backup(() => GUI.log(i18n.getMessage('initialSetupBackupSuccess'))));
-
-            $('#content .restore').on('click', () => {
-                configuration_restore(() => {
-                    // get latest settings
-                    TABS.setup.initialize();
-
-                    GUI.log(i18n.getMessage('initialSetupRestoreSuccess'));
-                });
-            });
-
-        } else {
-            $('.backupRestore').hide();
         }
 
         // initialize 3D Model

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -51,7 +51,7 @@ TABS.setup.initialize = function (callback) {
         if (CONFIGURATOR.virtualMode) {
             // saving and uploading an imaginary config to hardware is a bad idea
             backupButton.addClass('disabled');
-        } else if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+        } else if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             restoreButton.addClass('disabled');
 
             if (!PortHandler.showVirtualMode) {

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -52,6 +52,12 @@
                     </div>
                     <span class="freelabel" i18n="showAllSerialDevices"></span>
                 </div>
+                <div class="showVirtualMode margin-bottom">
+                    <div>
+                        <input type="checkbox" class="toggle" />
+                    </div>
+                    <span class="freelabel" i18n="showVirtualMode"></span>
+                </div>
                 <div class="cordovaForceComputerUI margin-bottom">
                     <div>
                         <input type="checkbox" class="toggle" />

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -55,27 +55,6 @@
                 </div>
             </div>
         </div>
-        <div class="grid-row backupRestore">
-            <div class="grid-col col3">
-                <div class="grid-row">
-                    <div class="grid-col col6">
-                        <div class="default_btn">
-                            <a class="backup" href="#" i18n="initialSetupButtonBackup"></a>
-                        </div>
-                    </div>
-                    <div class="grid-col col6">
-                        <div class="default_btn">
-                            <a class="restore" href="#" i18n="initialSetupButtonRestore"></a>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="grid-col col9">
-                <div class="cell_setup">
-                    <span i18n="initialSetupBackupRestoreText"></span>
-                </div>
-            </div>
-        </div>
         <div class="grid-row">
             <div class="grid-col col3">
                 <div class="default_btn initialSetupRebootBootloader">
@@ -172,6 +151,22 @@
                         <div class="spacer_box_title" i18n="initialSetupInstrumentsHead"></div>
                     </div>
                     <span id="attitude"></span> <span id="heading"></span>
+                </div>
+                <div class="gui_box grey backupRestore">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" i18n="initialSetupBackupRestoreHeader"></div>
+                    </div>
+                    <div class="spacer_box">
+                        <div class="default_btn">
+                            <a class="backup" href="#" i18n="initialSetupButtonBackup"></a>
+                        </div>
+                        <div class="default_btn">
+                            <a class="restore" href="#" i18n="initialSetupButtonRestore"></a>
+                        </div>
+                        <div class="cell_setup">
+                            <span i18n="initialSetupBackupRestoreText"></span>
+                        </div>    
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
After some confusion in https://github.com/betaflight/betaflight-configurator/pull/2742 we decided to:

- [x] Remove virtual connection from PortHandler. [1]
- [x] Make virtual connection an option as most people don't use this feature. [1]
- [x] Restore backup and restore if option is enabled to be able to backup a real target and restore on a virtual one.
- [x] Remove restore button in serial mode from firmware >= 4.3 if virtual option enabled.
- [x] Move showAllSerialDevices to PortHandler for optimization. 

[1] _please re-enable Virtual Mode in Options tab if needed_.

![image](https://user-images.githubusercontent.com/8344830/149162652-6fc0cd47-6474-4021-a8b3-20ca7da8d4c6.png)
