### PR TITLE
Discord link fix: make permanent (never expire)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -714,7 +714,7 @@
         "message": "We also have a <a href=\"https://www.facebook.com/groups/betaflightgroup/\" target=\"_blank\" rel=\"noopener noreferrer\">Facebook Group</a>.<br />Join us to get a place to talk about Betaflight, ask configuration questions, or just hang out with fellow pilots."
     },
     "defaultDiscordText": {
-        "message": "Betaflight <a href=\"https://discord.gg/YXcUpdf3\" target=\"_blank\" rel=\"noopener noreferrer\">Discord Server</a>.<br />Share your flight experience, talk about Betaflight, help other people or get some help for yourself from the community."
+        "message": "Betaflight <a href=\"https://discord.betaflight.com/invite\" target=\"_blank\" rel=\"noopener noreferrer\">Discord Server</a>.<br />Share your flight experience, talk about Betaflight, help other people or get some help for yourself from the community."
     },
     "defaultChangelogHead": {
         "message": "Configurator - Changelog"


### PR DESCRIPTION
Forgot that by default discord invite link is being expired after 7 days.
Changing the link to a permanent one.