### PR TITLE
Fix reboot

### DIFF
--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -911,7 +911,7 @@ function configuration_restore(callback) {
                 GUI.log(i18n.getMessage('eeprom_saved_ok'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitialiseConnection('setup', _callback));
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection('setup', _callback));
                 });
             }
         }

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -321,9 +321,10 @@ const MSP = {
             return;
         }
 
-        if (code === undefined) {
+        if (code === undefined || !serial.connectionId) {
             return;
         }
+
         let bufferOut;
         if (code <= 254) {
             bufferOut = this.encode_message_v1(code, data);

--- a/src/js/protocols/stm32.js
+++ b/src/js/protocols/stm32.js
@@ -116,7 +116,8 @@ STM32_protocol.prototype.connect = function (port, baud, hex, options, callback)
             if (disconnectionResult) {
                 // delay to allow board to boot in bootloader mode
                 // required to detect if a DFU device appears
-                setTimeout(startFlashing, 1000);
+                // MacOs seems to need about 5 seconds delay
+                setTimeout(startFlashing, GUI.operating_system === 'MacOS' ? 5000 : 1000);
             } else {
                 GUI.connect_lock = false;
             }

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -457,7 +457,7 @@ const serial = {
         if (GUI.connected_to || GUI.connecting_to) {
             $('a.connect').trigger('click');
         } else {
-            self.disconnect();
+            serial.disconnect();
         }
     },
 };

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -462,7 +462,7 @@ TABS.cli.read = function (readInfo) {
             CONFIGURATOR.cliActive = false;
             CONFIGURATOR.cliValid = false;
             GUI.log(i18n.getMessage('cliReboot'));
-            reinitialiseConnection(self);
+            reinitializeConnection(self);
         }
 
     }

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -626,8 +626,7 @@ TABS.configuration.initialize = function (callback) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
-                    reinitialiseConnection(self);
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
                 });
             }
 

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -413,8 +413,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
-                    reinitialiseConnection(self);
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
                 });
             }
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -1117,7 +1117,7 @@ TABS.motors.initialize = function (callback) {
 
     function reboot() {
         GUI.log(i18n.getMessage('configurationEepromSaved'));
-        MSP.promise(MSPCodes.MSP_SET_REBOOT, false, false).then(() => reinitialiseConnection());
+        MSP.promise(MSPCodes.MSP_SET_REBOOT, false, false).then(() => reinitializeConnection(self));
     }
 
     function showDialogMixerReset(message) {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -48,8 +48,7 @@ TABS.onboard_logging.initialize = function (callback) {
         GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
-            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
-            reinitialiseConnection(self);
+            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
         });
     }
 

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -412,8 +412,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             GUI.tab_switch_cleanup(function() {
-                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
-                reinitialiseConnection(self);
+                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
             });
         }
     }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -486,8 +486,7 @@ TABS.receiver.initialize = function (callback) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
                 if (boot) {
                     GUI.tab_switch_cleanup(function() {
-                        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
-                        reinitialiseConnection(tab);
+                        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(tab));
                     });
                 }
             }

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -303,8 +303,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
                         GUI.log(i18n.getMessage('transponderEepromSaved'));
                         if ( $(_this).hasClass('reboot') ) {
                             GUI.tab_switch_cleanup(function() {
-                                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
-                                reinitialiseConnection(self);
+                                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
                             });
                         }
                     });


### PR DESCRIPTION
- [x] Change `reinitializeConnection` to use `setTimeout` as `GUI.timeout_add` does not work here.
- [x] `reinitializeConnection` should be called in the callback of the MSP send command.
- [x] Move clicks variable from DOM to JS.
- [x] Don't send MSP command if there is no connection ID.
- [x] Close connection graceful in `reinitializeConnection` if it's still available. This is an API recommendation.
- [x] Added different timeout for MacOS (Thanks to @ctzsnooze)
- [x] Fixed some logging (@ctzsnooze) 