### PR TITLE
Presets: shorter index.json file, added option groups, preset priority, updated search, source versioning

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6372,8 +6372,12 @@
         "message": "Do you really want to close the configurator?"
     },
     "dropDownSelectAll": {
-        "message": "[Select all]",
+        "message": "[Select/deselect all]",
         "description": "Select all item in the drop down/multiple select"
+    },
+    "dropDownFilterDisabled": {
+        "message": "Select...",
+        "description": "Text indicating nothing is selected in the drop down/multiple select (filter disabled)"
     },
     "dropDownAll": {
         "message": "All",
@@ -6570,5 +6574,13 @@
     "presetsTooManyPresetsFound": {
         "message": "Reached the maximum limit of the shown presets number",
         "description": "Message that apprears on presets tab if too many presets found"
+    },
+    "presetsOptionsPlaceholder": {
+        "message": "ATTENTION! Review the list of options",
+        "description": "Placeholder for the options list dropdown"
+    },
+    "presetsVersionMismatch": {
+        "message": "Preset source version mismatch.<br/>Required version: {{versionRequired}}<br/>Preset source version: {{versionSource}}<br/>Using this preset source could be dangerous.<br/>Do you want to continue?",
+        "description": "Placeholder for the options list dropdown"
     }
 }

--- a/src/main.html
+++ b/src/main.html
@@ -137,6 +137,7 @@
     <script type="text/javascript" src="./tabs/presets/PickedPreset.js"></script>
     <script type="text/javascript" src="./tabs/presets/DetailedDialog/PresetsDetailedDialog.js"></script>
     <script type="text/javascript" src="./tabs/presets/TitlePanel/PresetTitlePanel.js"></script>
+    <script type="text/javascript" src="./tabs/presets/PresetsRepoIndexed/PresetParser.js"></script>
     <script type="text/javascript" src="./tabs/presets/PresetsRepoIndexed/PresetsRepoIndexed.js"></script>
     <script type="text/javascript" src="./tabs/presets/PresetsRepoIndexed/PresetsGithubRepo.js"></script>
     <script type="text/javascript" src="./tabs/presets/PresetsRepoIndexed/PresetsWebsiteRepo.js"></script>

--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.css
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.css
@@ -46,6 +46,11 @@
     padding-left: 20px;
 }
 
+#presets_options_panel .ms-choice {
+    border-color: var(--accentBorder);
+    border-width: 2px;
+}
+
 #presets_detailed_dialog_loading {
     height: 300px;
 }

--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
@@ -125,22 +125,57 @@ class PresetsDetailedDialog {
 
     _createOptionsSelect(options) {
         options.forEach(option => {
-            let selectedString = "selected=\"selected\"";
-            if (!option.checked) {
-                selectedString = "";
+            if (!option.childs) {
+                this._addOption(this._domOptionsSelect, option, false);
+            } else {
+                this._addOptionGroup(this._domOptionsSelect, option);
             }
-
-            this._domOptionsSelect.append(`<option value="${option.name}" ${selectedString}>${option.name}</option>`);
         });
 
         this._domOptionsSelect.multipleSelect({
-            placeholder: i18n.getMessage("dropDownAll"),
+            placeholder: i18n.getMessage("presetsOptionsPlaceholder"),
             formatSelectAll () { return i18n.getMessage("dropDownSelectAll"); },
             formatAllSelected() { return i18n.getMessage("dropDownAll"); },
             onClick: () => this._optionsSelectionChanged(),
             onCheckAll: () => this._optionsSelectionChanged(),
             onUncheckAll: () => this._optionsSelectionChanged(),
+            hideOptgroupCheckboxes: true,
+            singleRadio: true,
+            selectAll: false,
+            styler: function (row) {
+                let style = "";
+                if (row.type === 'optgroup') {
+                    style = 'font-weight: bold;';
+                } else if (row.classes.includes("optionHasParent")) {
+                    style = 'padding-left: 22px;';
+                }
+                return style;
+            },
         });
+    }
+
+    _addOptionGroup(parentElement, optionGroup) {
+        const optionGroupElement = $(`<optgroup label="${optionGroup.name}"></optgroup>`);
+
+        optionGroup.childs.forEach(option => {
+            this._addOption(optionGroupElement, option, true);
+        });
+
+        parentElement.append(optionGroupElement);
+    }
+
+    _addOption(parentElement, option, hasParent) {
+        let selectedString = "selected=\"selected\"";
+        if (!option.checked) {
+            selectedString = "";
+        }
+
+        let classString = "";
+        if (hasParent) {
+            classString = "class=\"optionHasParent\"";
+        }
+
+        parentElement.append(`<option value="${option.name}" ${selectedString} ${classString}>${option.name}</option>`);
     }
 
     _optionsSelectionChanged() {

--- a/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
+++ b/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
@@ -1,0 +1,224 @@
+'use strict';
+
+class PresetParser {
+    constructor(settings) {
+        this._settings = settings;
+    }
+
+    readPresetProperties(preset, strings) {
+        const propertiesToRead = ["description", "discussion", "warning", "disclaimer", "include_warning", "include_disclaimer", "discussion"];
+        const propertiesMetadata = {};
+        preset.options = [];
+
+        propertiesToRead.forEach(propertyName => {
+            // metadata of each property, name, type, optional true/false; example:
+            // keywords: {type: MetadataTypes.WORDS_ARRAY, optional: true}
+            propertiesMetadata[propertyName] = this._settings.presetsFileMetadata[propertyName];
+            preset[propertyName] = undefined;
+        });
+
+        preset._currentOptionGroup = undefined;
+
+        for (const line of strings) {
+            if (line.startsWith(this._settings.MetapropertyDirective)) {
+                this._parseAttributeLine(preset, line, propertiesMetadata);
+            }
+        }
+
+        delete preset._currentOptionGroup;
+    }
+
+    _parseAttributeLine(preset, line, propertiesMetadata) {
+        line = line.slice(this._settings.MetapropertyDirective.length).trim(); // (#$ DESCRIPTION: foo) -> (DESCRIPTION: foo)
+        const lowCaseLine = line.toLowerCase();
+        let isProperty = false;
+
+        for (const propertyName in propertiesMetadata) {
+            const lineBeginning = `${propertyName.toLowerCase()}:`; // "description:"
+
+            if (lowCaseLine.startsWith(lineBeginning)) {
+                line = line.slice(lineBeginning.length).trim(); // (Title: foo) -> (foo)
+                this._parseProperty(preset, line, propertyName);
+                isProperty = true;
+            }
+        }
+
+        if (!isProperty && lowCaseLine.startsWith(this._settings.OptionsDirectives.OPTION_DIRECTIVE)) {
+            this._parseOptionDirective(preset, line);
+        }
+    }
+
+    _parseOptionDirective(preset, line) {
+        const lowCaseLine = line.toLowerCase();
+
+        if (lowCaseLine.startsWith(this._settings.OptionsDirectives.BEGIN_OPTION_DIRECTIVE)) {
+            const option = this._getOption(line);
+            if (!preset._currentOptionGroup) {
+                preset.options.push(option);
+            } else {
+                preset._currentOptionGroup.childs.push(option);
+            }
+        } else if (lowCaseLine.startsWith(this._settings.OptionsDirectives.BEGIN_OPTION_GROUP_DIRECTIVE)) {
+            const optionGroup = this._getOptionGroup(line);
+            preset._currentOptionGroup = optionGroup;
+            preset.options.push(optionGroup);
+        } else if (lowCaseLine.startsWith(this._settings.OptionsDirectives.END_OPTION_GROUP_DIRECTIVE)) {
+            preset._currentOptionGroup = undefined;
+        }
+    }
+
+    _getOption(line) {
+        const directiveRemoved = line.slice(this._settings.OptionsDirectives.BEGIN_OPTION_DIRECTIVE.length).trim();
+        const directiveRemovedLowCase = directiveRemoved.toLowerCase();
+        const OptionChecked = this._isOptionChecked(directiveRemovedLowCase);
+
+        const regExpRemoveChecked = new RegExp(this._escapeRegex(this._settings.OptionsDirectives.OPTION_CHECKED), 'gi');
+        const regExpRemoveUnchecked = new RegExp(this._escapeRegex(this._settings.OptionsDirectives.OPTION_UNCHECKED), 'gi');
+        let optionName = directiveRemoved.replace(regExpRemoveChecked, "");
+        optionName = optionName.replace(regExpRemoveUnchecked, "").trim();
+
+        return {
+            name: optionName.slice(1).trim(),
+            checked: OptionChecked,
+        };
+    }
+
+    _getOptionGroup(line) {
+        const directiveRemoved = line.slice(this._settings.OptionsDirectives.BEGIN_OPTION_GROUP_DIRECTIVE.length).trim();
+
+        return {
+            name: directiveRemoved.slice(1).trim(),
+            childs: [],
+        };
+    }
+
+    _isOptionChecked(lowCaseLine) {
+        return lowCaseLine.includes(this._settings.OptionsDirectives.OPTION_CHECKED);
+    }
+
+    _parseProperty(preset, line, propertyName) {
+        switch(this._settings.presetsFileMetadata[propertyName].type) {
+            case this._settings.MetadataTypes.STRING_ARRAY:
+                this._processArrayProperty(preset, line, propertyName);
+                break;
+            case this._settings.MetadataTypes.STRING:
+                this._processStringProperty(preset, line, propertyName);
+                break;
+            case this._settings.MetadataTypes.FILE_PATH:
+                this._processStringProperty(preset, line, propertyName);
+                break;
+            case this._settings.MetadataTypes.FILE_PATH_ARRAY:
+                this._processArrayProperty(preset, line, propertyName);
+                break;
+            default:
+                this.console.err(`Parcing preset: unknown property type '${this._settings.presetsFileMetadata[property].type}' for the property '${propertyName}'`);
+        }
+    }
+
+    _processArrayProperty(preset, line, propertyName) {
+        if (!preset[propertyName]) {
+            preset[propertyName] = [];
+        }
+
+        preset[propertyName].push(line);
+    }
+
+    _processStringProperty(preset, line, propertyName) {
+        preset[propertyName] = line;
+    }
+
+    _getOptionName(line) {
+        const directiveRemoved = line.slice(this._settings.OptionsDirectives.BEGIN_OPTION_DIRECTIVE.length).trim();
+        const regExpRemoveChecked = new RegExp(this._escapeRegex(this._settings.OptionsDirectives.OPTION_CHECKED +":"), 'gi');
+        const regExpRemoveUnchecked = new RegExp(this._escapeRegex(this._settings.OptionsDirectives.OPTION_UNCHECKED +":"), 'gi');
+        let optionName = directiveRemoved.replace(regExpRemoveChecked, "");
+        optionName = optionName.replace(regExpRemoveUnchecked, "").trim();
+        return optionName;
+    }
+
+    _escapeRegex(string) {
+        return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
+
+    removeUncheckedOptions(strings, checkedOptions) {
+        let resultStrings = [];
+        let isCurrentOptionExcluded = false;
+        const lowerCasedCheckedOptions = checkedOptions.map(optionName => optionName.toLowerCase());
+
+        strings.forEach(str => {
+            if (this._isLineAttribute(str)) {
+                const line = this._removeAttributeDirective(str);
+
+                if (this._isOptionBegin(line)) {
+                    const optionNameLowCase = this._getOptionName(line).toLowerCase();
+
+                    if (!lowerCasedCheckedOptions.includes(optionNameLowCase)) {
+                        isCurrentOptionExcluded = true;
+                    }
+                } else if (this._isOptionEnd(line)) {
+                    isCurrentOptionExcluded = false;
+                }
+            } else if (!isCurrentOptionExcluded) {
+                resultStrings.push(str);
+            }
+        });
+
+        resultStrings = this._removeExcessiveEmptyLines(resultStrings);
+
+        return resultStrings;
+    }
+
+    _removeExcessiveEmptyLines(strings) {
+        // removes empty lines if there are two or more in a row leaving just one empty line
+        const result = [];
+        let lastStringEmpty = false;
+
+        strings.forEach(str => {
+            if ("" !== str || !lastStringEmpty) {
+                result.push(str);
+            }
+
+            if ("" === str) {
+                lastStringEmpty = true;
+            } else {
+                lastStringEmpty = false;
+            }
+        });
+
+        return result;
+    }
+
+    _isLineAttribute(line) {
+        return line.trim().startsWith(this._settings.MetapropertyDirective);
+    }
+
+    _isOptionBegin(line) {
+        const lowCaseLine = line.toLowerCase();
+        return lowCaseLine.startsWith(this._settings.OptionsDirectives.BEGIN_OPTION_DIRECTIVE);
+    }
+
+    _isOptionEnd(line) {
+        const lowCaseLine = line.toLowerCase();
+        return lowCaseLine.startsWith(this._settings.OptionsDirectives.END_OPTION_DIRECTIVE);
+    }
+
+    _removeAttributeDirective(line) {
+        return line.trim().slice(this._settings.MetapropertyDirective.length).trim();
+    }
+
+    isIncludeFound(strings) {
+        for (const str of strings) {
+            const match = PresetParser._sRegExpInclude.exec(str);
+
+            if (match !== null) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+}
+
+// Reg exp extracts file/path.txt from # include: file/path.txt
+PresetParser._sRegExpInclude = /^#\$[ ]+?INCLUDE:[ ]+?(?<filePath>\S+$)/;

--- a/src/tabs/presets/presets.css
+++ b/src/tabs/presets/presets.css
@@ -287,9 +287,23 @@
 }
 
 /* hack-fix for multiple-select with small font size. Originally checkboxes are not ligned with the text options when the font size is smaller than 0.7em */
-.tab-presets
-.ms-drop input[type="radio"], .ms-drop input[type="checkbox"] {
+.tab-presets .ms-drop input[type="radio"], .ms-drop input[type="checkbox"] {
     margin-top: 0.1rem !important;
+}
+
+/* hack-fix for multiple-select. Places "X" button vertically in the middle for the current font. "X" icon clears the current selection. */
+.tab-presets .ms-choice>div.icon-close {
+    padding-top: 3px;
+}
+
+/* hack-fix for multiple-select. Prevents "X" button from changing color on hover. "X" icon clears the current selection */
+.tab-presets .ms-choice > div.icon-close:hover::before {
+    color: rgb(136, 136, 136);
+}
+
+/* hack-fix for multiple-select. Makes "X" button bigger. "X" icon clears the current selection */
+.tab-presets .ms-choice>div.icon-close {
+    font-size: 16px;
 }
 
 .presets_filter_table_wrapper {


### PR DESCRIPTION
please review this PR and merge together-simultaneously with:
https://github.com/betaflight/firmware-presets/pull/163

Configurator TEST binaries [HERE](https://dev.azure.com/Betaflight/Betaflight%20Nightlies/_build/results?buildId=5611&view=artifacts&pathAsName=false&type=publishedArtifacts)
**To test this PR, please, add this preset custom source:**
url: `https://github.com/limonspb/firmware-presets/`
branch: `option_group`
![image](https://user-images.githubusercontent.com/2925027/149610936-da7ecc8e-9b07-4538-bbb7-5ab12f4733ad.png)

This PR makes a couple of fixes and a couple of preset modifications that will help us to maintain presets in the future.
Some of these changes are made out of users' feedback.

1. Adding preset option groups. Some crazy :) people making presets with 15+ options sort of abusing the system. With all them being in a single list it makes it pretty hard on the end user. This PR allows authors to group #$ options:
![image](https://user-images.githubusercontent.com/2925027/149611095-9e58d989-a314-4c15-b79a-91cefb983c6f.png)

2. Adding presets search priotiry. This moves some "garbage" or "service" presets like defaults etc lower than the useful presets like real tune presets, rc link etc. Every preset can have attribute #$ PRIORITY: value. By default TUNE gets the highest priority. Some categories also have higher priority by default.

3. Cleaning index.json - it was a mistake to include pretty much all the preset attributes to index.json. It makes index.json grow fast and makes search slow. With the new update index.json has ONLY preset attributes that are search related: TITLE, AUTHOR, FIRMWARE_VERSION, PRIORITY, STATUS, KEYWORDS, PATH. With this change configurator actually has to parse all other attributes by itself.

4. Versioning for preset sources. We will need for the future for sure. With the new update every preset source has it's own version. Configurator checks if the version does not match with the expected version it prompts a user:
![image](https://user-images.githubusercontent.com/2925027/149611335-1004b11f-8b60-4cf3-9799-aab1ad348db9.png)

5. Minor style updates and placeholders updates. Making category and firmware version searchable with the text string.
