### PR TITLE
Fixes multiple-select in darkmode

### DIFF
--- a/src/css/dark-theme.css
+++ b/src/css/dark-theme.css
@@ -904,3 +904,9 @@ progress[value]::-webkit-progress-bar {
 .select2-results>.select2-results__options {
     background-color: #3a3a3a !important;
 }
+
+/* MULTIPLE-SELECT */
+
+.ms-drop ul>li.hide-radio:focus, .ms-drop ul>li.hide-radio:hover {
+    background-color: var(--subtleAccent);
+}

--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.css
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.css
@@ -73,6 +73,10 @@
     display: inline-block;
 }
 
+#presets_detailed_dialog .ms-drop ul>li.hide-radio:focus, .ms-drop ul>li.hide-radio:hover {
+    background: none !important;
+}
+
 @media all and (max-width: 575px) {
     .presets_detailed_dialog_text {
         height: unset;


### PR DESCRIPTION
Fixes muiltiple-select hover in darkmode. This plugin is used for new Presets feature.

Before:
![nok](https://user-images.githubusercontent.com/43983086/150078025-9cfc3a35-d7b3-4f12-ba9f-bc44d77a325b.jpg)

With this PR:
![ok](https://user-images.githubusercontent.com/43983086/150078045-9f4a7c3d-f0f7-497f-a62b-616afebb5704.jpg)
