### PR TITLE
Presets fix: properly process options within option groups

### DIFF
--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
@@ -51,7 +51,7 @@ class PresetsDetailedDialog {
     }
 
     _getFinalCliText() {
-        const optionsToInclude = this._domOptionsSelect.multipleSelect("getSelects", "text");
+        const optionsToInclude = this._domOptionsSelect.multipleSelect("getSelects", "value");
         return this._presetsRepo.removeUncheckedOptions(this._preset.originalPresetCliStrings, optionsToInclude);
     }
 


### PR DESCRIPTION
Fixes this sad bug:
![image](https://user-images.githubusercontent.com/2925027/150265051-21a111bd-1d0c-4aba-a48e-89a5ea7897b3.png)

Apparently multiple select component returns selected "text" with the option group name for the selected item.
This fix replaces "text" with the "value". Value is ONLY the Option name without the group name.