### PR TITLE
Test throttle selector UI component

### DIFF
--- a/src/components/EscDshotDirection/EscDshotDirectionComponent.js
+++ b/src/components/EscDshotDirection/EscDshotDirectionComponent.js
@@ -91,6 +91,11 @@ class EscDshotDirectionComponent
         this._createMotorButtons();
         this._createWizardMotorButtons();
         this._domSecondActionDiv.toggle(false);
+        // TestThrottleSelectorComponent
+        //     .before(this._domMainContentBlock)
+        //     .onSelection((value) => {
+        //         // TODO
+        //     });
         i18n.localizePage();
 
         this._resetGui();

--- a/src/components/MotorOutputReordering/MotorOutputReorderingComponent.js
+++ b/src/components/MotorOutputReordering/MotorOutputReorderingComponent.js
@@ -36,8 +36,13 @@ class MotorOutputReorderComponent
 
     _setupdialog()
     {
-        i18n.localizePage();
         this._readDom();
+        // TestThrottleSelectorComponent
+        //     .before(this._domMainContentBlock)
+        //     .onSelection((value) => {
+        //         // TODO
+        //     });
+        i18n.localizePage();
 
         this._resetGui();
 

--- a/src/components/shared/TestThrottleSelector/TestThrottleSelectorComponent.js
+++ b/src/components/shared/TestThrottleSelector/TestThrottleSelectorComponent.js
@@ -1,0 +1,106 @@
+"use strict";
+
+class TestThrottleSelectorComponent {
+    static get containerPath() { return "./components/shared/TestThrottleSelector/container.html"; }
+    static get itemPath() { return "./components/shared/TestThrottleSelector/item.html"; }
+
+    /** @type {Array<number>} */
+    static get defaultOptions() { return [5, 10, 15, 20]; }
+
+    /**
+     * @param {HTMLElement} rootElement
+     * @param {Array<number>} options
+     * @param {number} selectedIndex
+     */
+    constructor(rootElement, options, selectedIndex) {
+        this.$root = rootElement;
+        this.options = options || TestThrottleSelectorComponent.defaultOptions;
+        this._selectedIndex = selectedIndex || 0;
+        this._domButtons = [];
+        this._onSelected = undefined; // fun(value) where `value` is 1000-2000
+    }
+
+    /**
+     * @param {HTMLElement} targetEl Target element for the component
+     * @param {Array<number>} options Throttle value options (between 0-100)
+     * @param {number} selectedIndex Index of default option (default: 0)
+     * @returns {TestThrottleSelectorComponent}
+     */
+    static before(targetEl, options, selectedIndex) {
+        return (new TestThrottleSelectorComponent(targetEl, options, selectedIndex)).mountPrepend();
+    }
+
+    /**
+     * @returns {TestThrottleSelectorComponent}
+     */
+    mountPrepend() {
+        return this._mount('prepend');
+    }
+
+    /**
+     * @returns {TestThrottleSelectorComponent}
+     */
+    mountAppend() {
+        return this._mount('append');
+    }
+
+    /**
+     * @param {string} position One of 'append' or 'prepend'
+     * @returns {TestThrottleSelectorComponent}
+     */
+    _mount(position) {
+        const pos = position || 'append';
+        const containerPath = TestThrottleSelectorComponent.containerPath;
+        const itemPath = TestThrottleSelectorComponent.itemPath;
+        $.get(containerPath, (containerTpl) => {
+            const container = $(containerTpl);
+            const list = container.find(".list");
+            this.$root[pos](container);
+            $.get(itemPath, (itemTpl) => {
+                this._domButtons = this.options.map((opt, optIndex) => {
+                    const btn = $(itemTpl.replace("{{ label }}", `${opt}%`))
+                        .on("click", () => { this.selectedIndex = optIndex; });
+                    btn.appendTo(list);
+                    return btn;
+                });
+
+                this.selectedIndex = this._selectedIndex;
+            });
+        });
+        return this;
+    }
+
+    /**
+     * @param {number} index Index of option to select
+     */
+    set selectedIndex(index) {
+        this._domButtons.forEach((btn, btnIndex) => {
+            if (index === btnIndex) {
+                btn.removeClass("inactive");
+            } else {
+                btn.addClass("inactive");
+            }
+        });
+        const isChanged = index !== this._selectedIndex;
+        if (isChanged && this._onSelected instanceof Function) {
+            this._callOnSelected(index);
+        }
+        this._selectedIndex = index;
+    }
+
+    get selectedIndex() { return this._selectedIndex; }
+
+    /**
+     * @param {Function} callback `fn(value)` where `value` is 1000-2000
+     * @returns {TestThrottleSelectorComponent}
+     */
+    onSelection(callback) {
+        this._onSelected = callback;
+    }
+
+    _callOnSelected(index) {
+        const opt = this.options[index];
+        const value = 1000 + Math.ceil(1000 * (opt / 100));
+        this._onSelected.call(this._onSelected, value);
+    }
+}

--- a/src/components/shared/TestThrottleSelector/container.html
+++ b/src/components/shared/TestThrottleSelector/container.html
@@ -1,0 +1,5 @@
+<div class="test-throttle-selector">
+    <div class="list">
+        <div class="test-throttle-selector-label" i18n="throttle">Throttle</div>
+    </div>
+</div>

--- a/src/components/shared/TestThrottleSelector/item.html
+++ b/src/components/shared/TestThrottleSelector/item.html
@@ -1,0 +1,1 @@
+<a class="regular-button test-throttle-selector-btn">{{ label }}</a>

--- a/src/components/shared/TestThrottleSelector/styles.css
+++ b/src/components/shared/TestThrottleSelector/styles.css
@@ -1,0 +1,27 @@
+.test-throttle-selector {
+    position: relative;
+    width: 25%;
+    margin-bottom: 1em;
+}
+
+.test-throttle-selector .list {
+    display: flex;
+    align-items: center;
+}
+
+.test-throttle-selector .test-throttle-selector-btn {
+    cursor: pointer;
+    flex: 1 1 auto;
+    text-align: center;
+    margin-right: 3px;
+}
+
+.test-throttle-selector .test-throttle-selector-btn.inactive {
+    background: #ccc;
+}
+
+.test-throttle-selector .test-throttle-selector-label {
+    flex: 1 1 auto;
+    font-weight: bold;
+    padding: 1.5ex;
+}

--- a/src/main.html
+++ b/src/main.html
@@ -44,6 +44,7 @@
     <link type="text/css" rel="stylesheet" href="./node_modules/switchery-latest/dist/switchery.min.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./css/switchery_custom.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./node_modules/@fortawesome/fontawesome-free/css/all.css" media="all"/>
+    <link type="text/css" rel="stylesheet" href="./components/shared/TestThrottleSelector/styles.css" media="all" />
     <link type="text/css" rel="stylesheet" href="./components/MotorOutputReordering/Styles.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./css/select2_custom.css" media="all"/>
     <link type="text/css" rel="stylesheet" href="./node_modules/select2/dist/css/select2.min.css" media="all"/>
@@ -136,6 +137,7 @@
     <script type="text/javascript" src="./js/TuningSliders.js"></script>
     <script type="text/javascript" src="./js/phones_ui.js"></script>
     <script type="text/javascript" src="./node_modules/jquery-touchswipe/jquery.touchSwipe.min.js"></script>
+    <script type="text/javascript" src="./components/shared/TestThrottleSelector/TestThrottleSelectorComponent.js"></script>
     <script type="text/javascript" src="./components/MotorOutputReordering/MotorOutputReorderingComponent.js"></script>
     <script type="text/javascript" src="./components/MotorOutputReordering/MotorOutputReorderingCanvas.js"></script>
     <script type="text/javascript" src="./components/MotorOutputReordering/MotorOutputReorderingConfig.js"></script>


### PR DESCRIPTION
This is a UI component for selecting throttle value in the motor setup dialogs. Currently it is not functional in the sense that throttle value changes do not take effect because actual motor control is better understood by @limonspb so take this as half-baked strictly UI feature to free limon from the hassle of dealing with HTML/CSS.

![Screenshot from 2022-01-20 10-22-10](https://user-images.githubusercontent.com/33358/150313903-d96d69bc-e335-4c6d-8da4-2cb549be0c42.png)

![Screenshot from 2022-01-20 10-21-43](https://user-images.githubusercontent.com/33358/150313926-0c290b21-fcfe-405a-a806-a5ee8bd5f17d.png)

