### PR TITLE
Motor reorder and direction dialogs: hardcode throttle value to 6%

### DIFF
--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -1148,10 +1148,11 @@ TABS.motors.initialize = function (callback) {
     function setup_motor_output_reordering_dialog(callbackFunction, zeroThrottleValue)
     {
         const domDialogMotorOutputReorder = $('#dialogMotorOutputReorder');
+        const idleThrottleValue = zeroThrottleValue + 60;
 
         const motorOutputReorderComponent = new MotorOutputReorderComponent($('#dialogMotorOutputReorderContent'),
             callbackFunction, mixerList[FC.MIXER_CONFIG.mixer - 1].name,
-            zeroThrottleValue, zeroThrottleValue + 200);
+            zeroThrottleValue, idleThrottleValue);
 
         $('#dialogMotorOutputReorder-closebtn').click(closeDialogMotorOutputReorder);
 
@@ -1180,7 +1181,7 @@ TABS.motors.initialize = function (callback) {
     {
         const domEscDshotDirectionDialog = $('#escDshotDirectionDialog');
 
-        const idleThrottleValue = zeroThrottleValue + FC.PID_ADVANCED_CONFIG.digitalIdlePercent * 1000 / 100;
+        const idleThrottleValue = zeroThrottleValue + 60;
 
         const motorConfig = {
             numberOfMotors: self.numberOfValidOutputs,


### PR DESCRIPTION
Problem:
if a pilot is using dynamic idle, he can set dshot idle as low as he wants, for example, 1%.
In this case, motor direction dialog will spin motors at 1010, and this won't spin motors at all.

Second problem:
motor reorder dialog spins motors at 1200 always, which is a bit too high for average drones.

Dirty solution (until we fully implement this solution: https://github.com/betaflight/betaflight-configurator/pull/2766)
Spin motors at 6% in both motor direction and motor reorder dialogs regardless of the settings.
And hope it will cover most of the cases.