### PR TITLE
Presets: show warning dialog when preset options list has not been op…

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6589,5 +6589,9 @@
     "presetsVersionMismatch": {
         "message": "Preset source version mismatch.<br/>Required version: {{versionRequired}}<br/>Preset source version: {{versionSource}}<br/>Using this preset source could be dangerous.<br/>Do you want to continue?",
         "description": "Placeholder for the options list dropdown"
+    },
+    "presetsReviewOptionsWarning": {
+        "message": "Please, review the list of options before picking this preset.",
+        "description": "Dialog text to prompt user to review options for the preset"
     }
 }

--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.css
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.css
@@ -9,6 +9,11 @@
     margin-bottom: 2ex;
 }
 
+/* multiple select for options - force placeholder color to black/white */
+#presets_detailed_dialog_content_wrapper .ms-choice>span.placeholder {
+    color: var(--defaultText);
+}
+
 .presets-detailed-dialog-property-table {
     margin-top: 10px;
     margin-bottom: 10px;

--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
@@ -23,6 +23,7 @@ class PresetsDetailedDialog {
         this._preset = preset;
         this._setLoadingState(true);
         this._domDialog[0].showModal();
+        this._optionsShowedAtLeastOnce = false;
 
         this._presetsRepo.loadPreset(this._preset)
             .then(() => {
@@ -139,6 +140,7 @@ class PresetsDetailedDialog {
             onClick: () => this._optionsSelectionChanged(),
             onCheckAll: () => this._optionsSelectionChanged(),
             onUncheckAll: () => this._optionsSelectionChanged(),
+            onOpen: () => this._optionsOpened(),
             hideOptgroupCheckboxes: true,
             singleRadio: true,
             selectAll: false,
@@ -152,6 +154,10 @@ class PresetsDetailedDialog {
                 return style;
             },
         });
+    }
+
+    _optionsOpened() {
+        this._optionsShowedAtLeastOnce = true;
     }
 
     _addOptionGroup(parentElement, optionGroup) {
@@ -210,7 +216,14 @@ class PresetsDetailedDialog {
     }
 
     _onApplyButtonClicked() {
-        if (!this._preset.completeWarning) {
+        if (this._preset.force_options_review && !this._optionsShowedAtLeastOnce) {
+            const dialogOptions = {
+                title: i18n.getMessage("warningTitle"),
+                text: i18n.getMessage("presetsReviewOptionsWarning"),
+                buttonConfirmText: i18n.getMessage("close"),
+            };
+            GUI.showInformationDialog(dialogOptions);
+        } else if (!this._preset.completeWarning) {
             this._pickPresetFwVersionCheck();
         } else {
             GUI.showYesNoDialog(this._finalDialogYesNoSettings);

--- a/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
+++ b/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
@@ -6,7 +6,7 @@ class PresetParser {
     }
 
     readPresetProperties(preset, strings) {
-        const propertiesToRead = ["description", "discussion", "warning", "disclaimer", "include_warning", "include_disclaimer", "discussion"];
+        const propertiesToRead = ["description", "discussion", "warning", "disclaimer", "include_warning", "include_disclaimer", "discussion", "force_options_review"];
         const propertiesMetadata = {};
         preset.options = [];
 
@@ -110,9 +110,25 @@ class PresetParser {
             case this._settings.MetadataTypes.FILE_PATH_ARRAY:
                 this._processArrayProperty(preset, line, propertyName);
                 break;
+            case this._settings.MetadataTypes.BOOLEAN:
+                this._processBooleanProperty(preset, line, propertyName);
+                break;
             default:
                 this.console.err(`Parcing preset: unknown property type '${this._settings.presetsFileMetadata[property].type}' for the property '${propertyName}'`);
         }
+    }
+
+    _processBooleanProperty(preset, line, propertyName) {
+        const trueValues = ["true", "yes"];
+
+        const lineLowCase = line.toLowerCase();
+        let result = false;
+
+        if (trueValues.includes(lineLowCase)) {
+            result = true;
+        }
+
+        preset[propertyName] = result;
     }
 
     _processArrayProperty(preset, line, propertyName) {


### PR DESCRIPTION
### Problem:
Very sad that the users still tend to miss the list of options.
For **some** presets it is **critical** to review the options and select.

This change checks if a preset has `#$ FORCE_OPTIONS_REVIEW: TRUE`
and if it has, then it forces the user to review options (to open drop down at least once).
![image](https://user-images.githubusercontent.com/2925027/151101226-d79af2b7-81c9-41a0-aef5-71a78944ed5c.png)

## How to check this PR (before https://github.com/betaflight/firmware-presets/pull/173 is merged):
0. Download configurator from [here ](https://dev.azure.com/Betaflight/Betaflight%20Nightlies/_build/results?buildId=5745&view=artifacts&pathAsName=false&type=publishedArtifacts)if the current PR is not merged yet.
1. add preset source:
     https://github.com/limonspb/firmware-presets
     branch: mandate
2. find whoop preset by Justice
3. Try to pick it without opening options