### PR TITLE
Add installation notes for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ In most Linux distributions your user won't have access to serial interfaces by 
 sudo usermod -aG dialout ${USER}
 ```
 
+Post-installation errors can be prevented by making sure the directory `/usr/share/desktop-directories` exists. To make sure it exists, run the following command before installing the package:
+
+```
+sudo mkdir /usr/share/desktop-directories/
+```
+
+The `libatomic` library must also be installed before installing Betaflight Configurator. (If the library is missing, the installation will succeed but Betaflight Configurator will not start.) Some Linux distributions (e.g. Fedora) will install it automatically. On Debian or Ubuntu you can install it as follows:
+
+```
+sudo apt install libatomic1
+```
+
 #### Graphics Issues
 
 If you experience graphics display problems or smudged/dithered fonts display issues in Betaflight Configurator, try invoking the `betaflight-configurator` executable file with the `--disable-gpu` command line switch. This will switch off hardware graphics acceleration. Likewise, setting your graphics card antialiasing option to OFF (e.g. FXAA parameter on NVidia graphics cards) might be a remedy as well.


### PR DESCRIPTION
## Overview

Adds some installation notes to the README in order to make the installation easier on Debian, and potentially other Linux distributions.
I didn't come up with the solutions, they were provided by @haslinghuis in #2129 and #2137. Thank you!! :slightly_smiling_face: 

## Test plan

I've verified these commands in **Debian 11 (Bullseye)** and **Betaflight Configurator 10.7.2**. As a test plan, I'd suggest:

- [x] Confirm that creating the directory as described in the README won't cause any loss of data if the directory already exists.
- [x] On Ubuntu or Debian confirm that once the directory is present, the installation succeeds without errors:
     ```
     sudo apt install ./betaflight-configurator_10.7.2_amd64.deb
     ```
- [x] Confirm that `libatomic1` can be installed on Ubuntu or Debian as described in the README.
- [x] On Fedora or another RPM-based distribution, confirm that installing the RPM package causes `libatomic` to be installed automatically:
    ```
    sudo dnf install ./betaflight-configurator-10.7.2-1.x86_64.rpm
    ```
- [x] Confirm that installing that package allows Betaflight Configurator to start.
