### PR TITLE
Fix board select trigger after flashing

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3294,6 +3294,10 @@
         "message": "Configurator has <span class=\"message-positive\">successfully</span> detected and verified the board: <strong>{{boardName}}</strong>",
         "description": "Board verification has succeeded."
     },
+    "firmwareFlasherBoardVerficationTargetNotAvailable": {
+        "message": "Configurator has detected the board: <strong>{{boardName}}</strong> but no official Betaflight target was found",
+        "description": "Board verification has succeeded, but the target is not available as offical Betaflight target."
+    },
     "firmwareFlasherBoardVerificationFail": {
         "message": "Configurator <span class=\"message-negative\">failed</span> to verify the board, if this does not work please try switching tab slowly to retry, make a new usb connection or connect first if you might have forgotten to apply custom defaults",
         "description": "Sometimes MSP values cannot be read from firmware correctly"

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -797,9 +797,23 @@ firmware_flasher.initialize = function (callback) {
 
                 function onFinish() {
                     const board = FC.CONFIG.boardName;
+                    const boardSelect = $('select[name="board"]');
+                    const boardSelectOptions = $('select[name="board"] option');
+                    const target = boardSelect.val();
+                    let targetAvailable = false;
+
                     if (board) {
-                        $('select[name="board"]').val(board).trigger('change');
-                        GUI.log(i18n.getMessage('firmwareFlasherBoardVerificationSuccess', {boardName: board}));
+                        boardSelectOptions.each((_, e) => {
+                            if ($(e).text() === board) {
+                                targetAvailable = true;
+                            }
+                        });
+
+                        if (board !== target) {
+                            boardSelect.val(board).trigger('change');
+                        }
+                        GUI.log(i18n.getMessage(targetAvailable ? 'firmwareFlasherBoardVerificationSuccess' : 'firmwareFlasherBoardVerficationTargetNotAvailable',
+                            { boardName: board }));
                     } else {
                         GUI.log(i18n.getMessage('firmwareFlasherBoardVerificationFail'));
                     }
@@ -869,7 +883,7 @@ firmware_flasher.initialize = function (callback) {
         function updateDetectBoardButton() {
             const isDfu = portPickerElement.val().includes('DFU');
             const isBusy = GUI.connect_lock;
-            const isLoaded = self.releases ? Object.keys(self.releases).length > 1 : false;
+            const isLoaded = self.releases ? Object.keys(self.releases).length > 0 : false;
             const isAvailable = PortHandler.port_available || false;
             const isButtonDisabled = isDfu || isBusy || !isLoaded || !isAvailable;
 


### PR DESCRIPTION
- [x] Fixes: https://github.com/betaflight/betaflight-configurator/issues/2773

![image](https://user-images.githubusercontent.com/8344830/151280270-847b448c-2398-4e54-9edc-6e9c41812e17.png)
- [x] Also thanks to @Zuldan who found another edge case: when detecting an board as unofficial target it showed as successfully detected and verified. Now the code also checks if the board exists as target:
```
2022-01-27 @20:53:17 -- Configurator has detected the board: SPRACINGH7RF but no official Betaflight target was found
2022-01-27 @20:53:35 -- Query board information to preselect right firmware
2022-01-27 @20:53:35 -- Configurator has successfully detected and verified the board: MATEKF411
```