### PR TITLE
ci: Remove publish unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,6 @@ jobs:
       - name: Run unit tests
         run: yarn test
 
-      - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@043296c976c53f4536194ebe3841ed720e04d496 # v1.26
-        if: always()
-        with:
-          files: test-results-junit/**/*.xml
-          comment_mode: 'off'
-
   build:
     name: Build (${{ matrix.name }})
     needs: test


### PR DESCRIPTION
This removes the CI step that publishes unit test results, because it doesn't really work with PRs from forked repos, and worse it fails on PRs from e.g. dependabot.

It looks like it possible to fix this by moving it to a separate workflow, but I'm not sure how useful that is.

I think it's best to remove this now and maybe look into this later, but this is not an important step but more a convenience.


