### PR TITLE
Make CI a reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,20 +8,16 @@ env:
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-      - '*-maintenance'
   pull_request:
     branches:
       - master
       - '*-maintenance'
+  workflow_call:
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-20.04
-
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,7 @@ env:
 
 name: CI
 
-on:
-  pull_request:
-    branches:
-      - master
-      - '*-maintenance'
-  workflow_call:
+on: workflow_call
 
 jobs:
   test:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -11,7 +11,7 @@ env:
     **Use only for testing.**
   releaseNotes: This is a release build. It does not contain the debug console.
 
-name: Push
+name: Nightly
 
 on:
   push:
@@ -24,8 +24,8 @@ jobs:
     name: CI
     uses: ./.github/workflows/ci.yml
 
-  nightly:
-    name: Release Nightly
+  release:
+    name: Release
     needs: ci
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,12 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+      - master
+      - '*-maintenance'
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,24 +11,28 @@ env:
     **Use only for testing.**
   releaseNotes: This is a release build. It does not contain the debug console.
 
-name: Nightly Build
+name: Push
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  push:
+    branches:
+      - master
+      - '*-maintenance'
 
 jobs:
-  release-nightly:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+
+  nightly:
     name: Release Nightly
+    needs: ci
     runs-on: ubuntu-20.04
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' }}
     steps:
-      - name: Fetch release assets
-        uses: dawidd6/action-download-artifact@09385b76de790122f4da9c82b17bccf858b9557c # v2.16.0
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v2
         with:
           path: release-assets/
-          workflow: ${{ github.event.workflow_run.workflow_id }}
 
       - name: Select release notes
         id: notes
@@ -37,6 +41,7 @@ jobs:
           echo "::set-output name=notes::$(test -e "$1" && echo '${{ env.debugReleaseNotes }}' || echo '${{ env.releaseNotes }}')"
 
       - name: Release
+        continue-on-error: true
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v0.1.14
         with:
           token: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
One of the reasons I moved the nightly build into a separate file was to avoid having a 'skipped' nightly build step shown on every pull request. Now however there is a skipped nightly job for every pull request under the Actions tab.

This makes the CI workflow only run on pull requests, but also makes it reusable by a workflow that only runs on push events and releases the nightly build. This separation avoids skipping jobs and steps based on conditionals.
