### PR TITLE
Hide second iterm relax tooltip

### DIFF
--- a/src/css/tabs/pid_tuning.css
+++ b/src/css/tabs/pid_tuning.css
@@ -164,7 +164,7 @@
 }
 
 .tab-pid_tuning table.compensation td:first-child:not(.filterTable) {
-    width: 65px;
+    width: 75px;
     text-align: center;
     vertical-align: top;
     padding-top: 4px;

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -648,13 +648,13 @@
                                             <span i18n="pidTuningItermRelaxType"></span>
                                         </label>
                                     </span>
-
-                                    <div class="helpicon cf_tip" i18n_title="pidTuningItermRelaxCutoffHelp"></div>
+                                    
                                     <span class="itermRelaxCutoff suboption">
                                         <input type="number" name="itermRelaxCutoff" step="1" min="1" max="100" />
                                         <label for="itermRelaxCutoff">
                                             <span i18n="pidTuningItermRelaxCutoff"></span>
                                         </label>
+                                        <div class="helpicon cf_tip" i18n_title="pidTuningItermRelaxCutoffHelp"></div>
                                     </span>
                                 </td>
                             </tr>


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/2719

![image](https://user-images.githubusercontent.com/2673520/152156929-8f6296df-057c-4bbc-bc6c-9359886796ad.png)

This PR includes two commits:
- The first, hides the cutoff iterm relax tooltip when the iterm relax is disabled.
- The second one, gives a little more room to the first column of the table. This is a workaround to the real problem: we can have some translations bigger than the original, so the column must auto adjust. If someone wants to look at the auto adjust and fix it in a real manner will be great. But for now, with this change the current translations will fit. 

The final result, in native english is:
![image](https://user-images.githubusercontent.com/2673520/152157205-a47e25de-ab8b-4e1f-a446-f5fa7f0c81df.png)

