### PR TITLE
Upgrade stale bot action to version 4

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,6 +1,7 @@
 name: 'Close stale issues'
 
 on:
+  workflow_dispatch:
   schedule:
   - cron: "30 4 * * *"
 
@@ -9,7 +10,7 @@ jobs:
     name: 'Check and close stale issues'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/stale@v3
+    - uses: actions/stale@v4
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         operations-per-run: 30


### PR DESCRIPTION
This upgrades the stale bot to version 4.

It adds too the option to trigger the workflow in a manual way, it can be useful sometimes. It does not hurt.