### PR TITLE
Add 'Pilot name' to the Configurator UI; rename 'Display name' to 'Pilot name'; rename 'name' to 'craft_name'

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4993,7 +4993,7 @@
         "description": "One of the elements of the OSD"
     },
     "osdDescElementCraftName": {
-        "message": "Craft name as set in Configuration tab"
+        "message": "Craft name as set in the Configuration tab.</br>Can also be set via the \"craft_name\" CLI variable."
     },
     "osdTextElementAltitude": {
         "message": "Altitude",
@@ -5341,7 +5341,14 @@
         "description": "One of the elements of the OSD"
     },
     "osdDescElementDisplayName": {
-        "message": "Display name as set by the \"display_name\" cli command"
+        "message": "Can also be set via the \"display_name\" CLI variable."
+    },
+    "osdTextElementPilotName": {
+        "message": "Pilot name",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPilotName": {
+        "message": "Pilot name as set in the Configuration tab.</br>Can also be set via the \"pilot_name\" CLI variable."
     },
     "osdTextElementEscRpmFreq": {
         "message": "ESC RPM frequency",
@@ -6278,6 +6285,15 @@
     },
     "craftName": {
         "message": "Craft name"
+    },
+    "configurationCraftNameHelp": {
+        "message": "Can be show in logs, backup file names and the OSD.</br>Can be set via the <b>craft_name</b> CLI variable."
+    },
+    "configurationPilotName": {
+        "message": "Pilot name"
+    },
+    "configurationPilotNameHelp": {
+        "message": "Can be show in the OSD.</br>Can be set via <b>pilot_name</b> CLI variable."
     },
     "configurationFpvCamAngleDegrees": {
         "message": "FPV Camera Angle [degrees]"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -17,8 +17,10 @@ const INITIAL_CONFIG = {
     profile:                          0,
     uid:                              [0, 0, 0],
     accelerometerTrims:               [0, 0],
-    name:                             '',
-    displayName:                      'JOE PILOT',
+    name:                             '', // present for backwards compatibility before MSP v1.45
+    craftName:                        '',
+    displayName:                      '', // present for backwards compatibility before MSP v1.45
+    pilotName:                        '',
     numProfiles:                      3,
     rateProfile:                      0,
     boardType:                        0,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -757,8 +757,11 @@ function generateFilename(prefix, suffix) {
         if (FC.CONFIG.flightControllerIdentifier) {
             filename = `${FC.CONFIG.flightControllerIdentifier}_${filename}`;
         }
-        if(FC.CONFIG.name && FC.CONFIG.name.trim() !== '') {
-            filename = `${filename}_${FC.CONFIG.name.trim().replace(' ', '_')}`;
+        const craftName = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)
+            ? FC.CONFIG.craftName
+            : FC.CONFIG.name;
+        if (craftName.trim() !== '') {
+            filename = `${filename}_${craftName.trim().replace(' ', '_')}`;
         }
     }
 

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -8,8 +8,8 @@ const MSPCodes = {
     MSP_BOARD_INFO:                 4,
     MSP_BUILD_INFO:                 5,
 
-    MSP_NAME:                       10,
-    MSP_SET_NAME:                   11,
+    MSP_NAME:                       10, // DEPRECATED IN MSP 1.45
+    MSP_SET_NAME:                   11, // DEPRECATED IN MSP 1.45
 
     MSP_BATTERY_CONFIG:             32,
     MSP_SET_BATTERY_CONFIG:         33,
@@ -192,4 +192,10 @@ const MSPCodes = {
     MSP2_SET_MOTOR_OUTPUT_REORDERING:    0x3002,
     MSP2_SEND_DSHOT_COMMAND:        0x3003,
     MSP2_GET_VTX_DEVICE_STATUS:     0x3004,
+    MSP2_GET_TEXT:                  0x3006,
+    MSP2_SET_TEXT:                  0x3007,
+
+    // MSP2_GET_TEXT and MSP2_SET_TEXT variable types
+    MSP2TEXT_PILOT_NAME:                 1,
+    MSP2TEXT_CRAFT_NAME:                 2,
 };

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -919,6 +919,25 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 break;
 
+            case MSPCodes.MSP2_GET_TEXT:
+                // type byte
+                const textType = data.readU8();
+                // length byte followed by the actual characters
+                const textLength = data.readU8() || 0;
+
+                if (textType === MSPCodes.MSP2TEXT_PILOT_NAME) {
+                    FC.CONFIG.pilotName = '';
+                    for (let i = 0; i < textLength; i++) {
+                        FC.CONFIG.pilotName += String.fromCharCode(data.readU8());
+                    }
+                } else if (textType === MSPCodes.MSP2TEXT_CRAFT_NAME) {
+                    FC.CONFIG.craftName = '';
+                    for (let i = 0; i < textLength; i++) {
+                        FC.CONFIG.craftName += String.fromCharCode(data.readU8());
+                    }
+                }
+                break;
+
             case MSPCodes.MSP_SET_CHANNEL_FORWARDING:
                 console.log('Channel forwarding saved');
                 break;
@@ -1687,6 +1706,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
             case MSPCodes.MSP_SET_NAME:
                 console.log('Name set');
                 break;
+            case MSPCodes.MSP2_SET_TEXT:
+                console.log('Text set');
+                break;
             case MSPCodes.MSP_SET_FILTER_CONFIG:
                 // removed as this fires a lot with firmware sliders console.log('Filter config set');
                 break;
@@ -1793,8 +1815,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
 
 /**
  * Encode the request body for the MSP request with the given code and return it as an array of bytes.
+ * The second (optional) 'modifierCode' argument can be used to extend/specify the behavior of certain MSP codes
+ * (e.g. 'MSPCodes.MSP2_GET_TEXT' and 'MSPCodes.MSP2_SET_TEXT')
  */
-MspHelper.prototype.crunch = function(code) {
+MspHelper.prototype.crunch = function(code, modifierCode = undefined) {
     const buffer = [];
     const self = this;
 
@@ -2319,6 +2343,44 @@ MspHelper.prototype.crunch = function(code) {
             }
             break;
 
+        case MSPCodes.MSP2_GET_TEXT:
+            if (modifierCode === MSPCodes.MSP2TEXT_PILOT_NAME) {
+                // type byte
+                buffer.push8(MSPCodes.MSP2TEXT_PILOT_NAME);
+            } else if (modifierCode === MSPCodes.MSP2TEXT_CRAFT_NAME) {
+                // type byte
+                buffer.push8(MSPCodes.MSP2TEXT_CRAFT_NAME);
+            }
+            break;
+
+        case MSPCodes.MSP2_SET_TEXT:
+            if (modifierCode === MSPCodes.MSP2TEXT_PILOT_NAME) {
+                // type byte
+                buffer.push8(MSPCodes.MSP2TEXT_PILOT_NAME);
+
+                const MAX_NAME_LENGTH = 16;
+                const pilotNameLength = Math.min(MAX_NAME_LENGTH, FC.CONFIG.pilotName.length);
+                // length byte followed by the actual characters
+                buffer.push8(pilotNameLength);
+
+                for (let i = 0; i < pilotNameLength; i++) {
+                    buffer.push8(FC.CONFIG.pilotName.charCodeAt(i));
+                }
+            } else if (modifierCode === MSPCodes.MSP2TEXT_CRAFT_NAME) {
+                // type byte
+                buffer.push8(MSPCodes.MSP2TEXT_CRAFT_NAME);
+
+                const MAX_NAME_LENGTH = 16;
+                const craftNameLength = Math.min(MAX_NAME_LENGTH, FC.CONFIG.craftName.length);
+                // length byte followed by the actual characters
+                buffer.push8(craftNameLength);
+
+                for (let i = 0; i < craftNameLength; i++) {
+                    buffer.push8(FC.CONFIG.craftName.charCodeAt(i));
+                }
+            }
+            break;
+
         case MSPCodes.MSP_SET_BLACKBOX_CONFIG:
             buffer.push8(FC.BLACKBOX.blackboxDevice)
                 .push8(FC.BLACKBOX.blackboxRateNum)
@@ -2473,7 +2535,7 @@ MspHelper.prototype.crunch = function(code) {
             break;
 
         default:
-            return false;
+            return buffer;
     }
 
     return buffer;

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -26,7 +26,16 @@ onboard_logging.initialize = function (callback) {
                 MSP.send_message(MSPCodes.MSP_SDCARD_SUMMARY, false, false, function() {
                     MSP.send_message(MSPCodes.MSP_BLACKBOX_CONFIG, false, false, function() {
                         MSP.send_message(MSPCodes.MSP_ADVANCED_CONFIG, false, false, function() {
-                            MSP.send_message(MSPCodes.MSP_NAME, false, false, load_html);
+                            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+                                MSP.send_message(
+                                    MSPCodes.MSP2_GET_TEXT,
+                                    mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.MSP2TEXT_CRAFT_NAME),
+                                    false,
+                                    load_html,
+                                );
+                            } else {
+                                MSP.send_message(MSPCodes.MSP_NAME, false, false, load_html);
+                            }
                         });
                     });
                 });

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -78,6 +78,13 @@
                                 <label> <input type="text" name="craftName" maxlength="32" style="width:100px;"/> <span
                                     i18n="craftName"></span>
                                 </label>
+                                <div class="helpicon cf_tip" i18n_title="configurationCraftNameHelp"></div>
+                            </div>
+                            <div class="number pilotName">
+                                <label> <input type="text" name="pilotName" maxlength="32" style="width:100px;"/> <span
+                                    i18n="configurationPilotName"></span>
+                                </label>
+                                <div class="helpicon cf_tip" i18n_title="configurationPilotNameHelp"></div>
                             </div>
                         </div>
                     </div> <!-- END PERSONALIZATION-->
@@ -384,7 +391,7 @@
                             </div>
                         </div>
                     </div>
-                    
+
                     <div class="beepers">
                         <!-- BEEPER -->
                         <div class="beepers">


### PR DESCRIPTION
Fixes #1877

Related firmware changes @ https://github.com/betaflight/betaflight/pull/11391

---

**scope**

This PR renames:
- the `Display name` OSD / configuration element (and the internal `FC.CONFIG.displayName`) to `Pilot name` (hence `FC.CONFIG.pilotName`).
- the internal  `FC.CONFIG.name` to `FC.CONFIG.craftName` (with no functional impact)

It also adds the option to set the `pilot name` through the configurator UI. The value can be show in the OSD (independently of the current craft name which can already be managed through the configurator UI).

See the commit messages for further details around the changes.

---

**backwards compatibility**

The configurator should still be backwards compatible with firmwares running MSP older than `v1.45`:
  - The `DISPLAY_NAME` and `PILOT_NAME` OSD elements have the same position within the elements list and are also semantically identical
  - The `Display name` element is still shown _only_ on MSP versions before `v1.45` (and the new `Pilot name` element is **not** visible) - e.g:
  ![display_name_backwards_compatibility](https://user-images.githubusercontent.com/3475899/196010848-d45dfb1f-d4a8-499b-818e-db5ec077244f.png)
    - :information_source: It uses the legacy `display_name` value - however it cannot be previewed **nor** managed through the UI.
  - The new `Pilot name` element is shown _only_ on MSP versions greater or equal to `v1.45` (and the old `Display name` element is **not** visible) - e.g:
  ![pilot_name](https://user-images.githubusercontent.com/3475899/196010887-6c95d0a0-27ba-4598-a0a9-e46de7fdc99e.png)
    - :information_source: It uses the new `pilot_name` value - which can both be previewed and managed through the UI.

In addition, the `craftName` (ex. `name`) property will be retrieved set via:

- `MSP_NAME` / `MSP_SET_NAME` for MSP versions **before** `v1.45`
- `MSP2_GET_TEXT` / `MSP_SET_TEXT` for MSP  `v1.45` _or greater_

---

**Testing:**

1. Get and flash the updated firmware from https://github.com/betaflight/betaflight/pull/11391
  - Alternatively you can see the UI changes by using the `Virtual Mode`. However that will not let you persist any changes.
2. Run the configurator locally via `yarn start` (I can also try to provide a build for a specific platform but I might not be able to test it myself)
3. See the changes in the `Configuration` and `OSD` tabs.

---

Screenshots:

![image](https://user-images.githubusercontent.com/3475899/152718412-0f7564ca-33d9-4f19-b883-396ddaaa6010.png)
![image](https://user-images.githubusercontent.com/3475899/152718663-21ba1283-2c66-41f5-9bb9-88052ef2510d.png)