### PR TITLE
CI fix changes listing and tag name

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,7 +61,7 @@ jobs:
             ${{ github.ref_name }} ([link](${{ github.event.repository.html_url }}/tree/${{ github.ref_name }}))
 
             ### Latest changeset:
-            ${{ github.sha }} ([link](https://github.com/${{ github.repository }}/commit/${{ github.sha }}))
+            ${{ github.event.head_commit.id }} ([link](${{ github.event.head_commit.url }}))
 
             ### Changes:
-            ${{ github.event.workflow_run.head_commit.message }}
+            ${{ github.event.head_commit.message }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -40,12 +40,16 @@ jobs:
           set -- release-assets/Betaflight-Configurator-Debug-*
           echo "::set-output name=notes::$(test -e "$1" && echo '${{ env.debugReleaseNotes }}' || echo '${{ env.releaseNotes }}')"
 
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=today::$(date '+%Y%m%d')"
+
       - name: Release
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v0.1.14
         with:
           token: ${{ secrets.REPO_TOKEN }}
           repository: ${{ env.repoNightly }}
-          tag_name: build-${{ github.run_number }}
+          tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
           files: release-assets/Betaflight-Configurator-*/**
           draft: false
           prerelease: false


### PR DESCRIPTION
This fixes the missing changes listing in the release notes of the nightly build and adds date to the release tag.

I discussed with @McGiverGim how I was hoping to change the way releases are tagged to e.g. `build-123` or `v10.7.2-123` instead of being based on dates, which is already part of the tag and release. However, unfortunately it turned out to not be simple to preserve release ordering in the web listing and probably requires removing or renaming all the existing tags.
So instead this PR also brings back the date based tags.