### PR TITLE
Remove CI name to be equal than tag

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -54,7 +54,6 @@ jobs:
           draft: false
           prerelease: false
           fail_on_unmatched_files: true
-          name: '${{ github.repository }}: ${{ github.ref_name }}'
           body: |
             ${{ steps.notes.outputs.notes }}
 


### PR DESCRIPTION
According to the documentation, if empty, it will be equal than the tag.

![image](https://user-images.githubusercontent.com/2673520/153819641-41751709-f4a3-4b1c-bcf4-7773bb55c09c.png)
