### PR TITLE
Mark nightly as prerelease

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
           tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
           files: release-assets/Betaflight-Configurator-*/**
           draft: false
-          prerelease: false
+          prerelease: true
           fail_on_unmatched_files: true
           body: |
             ${{ steps.notes.outputs.notes }}


### PR DESCRIPTION
Mark uploaded release in nightly as prerelease to let cleat to users that is not ready for production and can be unstable.

![image](https://user-images.githubusercontent.com/2673520/154428008-a98c7e2f-6311-4ea3-a60f-a627f56aec95.png)
