### PR TITLE
Revert "Mark nightly as prerelease"

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -52,7 +52,7 @@ jobs:
           tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
           files: release-assets/Betaflight-Configurator-*/**
           draft: false
-          prerelease: true
+          prerelease: false
           fail_on_unmatched_files: true
           body: |
             ${{ steps.notes.outputs.notes }}


### PR DESCRIPTION
Revert this change. With the change, @Asizon observed that the new "prerelease" releases did not appear in the main page as release, because we have an older one without this tag, and it always shows this old release.

The fastest way to fix that is simply revert it.