### PR TITLE
attempt to fix mac flashing

### DIFF
--- a/src/js/msp/MSPConnector.js
+++ b/src/js/msp/MSPConnector.js
@@ -21,7 +21,7 @@ MSPConnectorImpl.prototype.connect = function (port, baud, onConnectCallback, on
         if (openInfo) {
             const disconnectAndCleanup = function() {
                 serial.disconnect(function(result) {
-                    console.log('Disconnected');
+                    console.log(`MSP request for serial disconnection, result: ${result}`);
 
                     MSP.clearListeners();
 
@@ -37,7 +37,7 @@ MSPConnectorImpl.prototype.connect = function (port, baud, onConnectCallback, on
             GUI.timeout_add('msp_connector', function () {
                 if (!CONFIGURATOR.connectionValid) {
                     GUI.log(i18n.getMessage('noConfigurationReceived'));
-
+                    console.log('MSP disconnecting, no valid connection within 10s');
                     disconnectAndCleanup();
                 }
             }, 10000);
@@ -51,12 +51,13 @@ MSPConnectorImpl.prototype.connect = function (port, baud, onConnectCallback, on
                 CONFIGURATOR.connectionValid = true;
 
                 GUI.timeout_remove('msp_connector');
-                console.log('Connected');
+                console.log('MSP has valid serial connection');
 
                 self.onConnectCallback();
             });
         } else {
             GUI.log(i18n.getMessage('serialPortOpenFail'));
+            console.log('MSP failed to open a serial connection');
             self.onFailureCallback();
         }
     });
@@ -67,7 +68,7 @@ MSPConnectorImpl.prototype.disconnect = function(onDisconnectCallback) {
 
     serial.disconnect(function (result) {
         MSP.clearListeners();
-        console.log('Disconnected');
+        console.log(`MSP Serial disconnection ${result}`);
 
         self.onDisconnectCallback(result);
     });

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1225,11 +1225,14 @@ firmware_flasher.initialize = function (callback) {
         }
 
         function startFlashing() {
+            GUI.log('startFlashing');
             exitDfuElement.addClass('disabled');
             $("a.load_remote_file").addClass('disabled');
             $("a.load_file").addClass('disabled');
             if (!GUI.connect_lock) { // button disabled while flashing is in progress
+                GUI.log('not blocked by connect_lock');
                 if (self.parsed_hex) {
+                    GUI.log('we have a parsed_hex to flash');
                     try {
                         if (self.unifiedTarget.config && !self.parsed_hex.configInserted) {
                             const configInserter = new ConfigInserter();
@@ -1245,9 +1248,11 @@ firmware_flasher.initialize = function (callback) {
 
                         flashFirmware(self.parsed_hex);
                     } catch (e) {
+                        GUI.log('flashingFailed');
                         console.log(`Flashing failed: ${e.message}`);
                     }
                 } else {
+                    GUI.log('no parsed_hex to flash');
                     $('span.progressLabel').attr('i18n','firmwareFlasherFirmwareNotLoaded').removeClass('i18n-replaced');
                     i18n.localizePage();
                 }


### PR DESCRIPTION
This is a test build based over Fix reboot #2758 in an attempt to improve flashing of boards on MacOSX, especially when flashing a local file.

It is Do Not Merge / for discussion at this stage.  Most of the changes are log entries for debugging.  The main functional change is to set the timeout for `startFlashing` to 5000 (5s), not just 1s.

The other changes are drafts to correct what appear to be logical issues, eg a check fails but the messages don't reflect the failed check.

The reason for these changes is that Mac users often get flashing failures.  After pressing `Flash Firmware`, the board goes into DFU mode, but then cannot be flashed.  If Configurator is rebooted, then they can flash.  

The existing code seems to disconnect the normal connection, wait 1 second, then immediately start trying to flash.  It seems strange that it doesn't first check for the presence of a DFU connection.  On the mac, the 1 second wait isn't enough and then Configurator is locked up saying Connecting to DFU, even though the serial connection shows DFU at the top.  It will not flash like this and Configurator usually has to be quit and re-opened to work.

These changes improve matters quite a lot, but waiting 5s while not checking the status of the connection, and then 'hoping' we have a DFU connection, doesn't seem right to me.

So this is for discussion and hopefully someone with a Mac who understands JS better than me can help out.  I can definitely flash much more reliably with these changes.  However I am not expert enough to know what to do to really fix the problems Mac users experience.