### PR TITLE
Firmware flasher fix for the release notes show

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -84,7 +84,7 @@ firmware_flasher.initialize = function (callback) {
             }
 
             let formattedNotes = summary.notes.replace(/#(\d+)/g, '[#$1](https://github.com/betaflight/betaflight/pull/$1)');
-            formattedNotes = marked(formattedNotes);
+            formattedNotes = marked.parse(formattedNotes);
             $('div.release_info .notes').html(formattedNotes);
             $('div.release_info .notes').find('a').each(function() {
                 $(this).attr('target', '_blank');


### PR DESCRIPTION
Release notes for 4.2/4.1 etc are not shown now. Causing console error also:

![image](https://user-images.githubusercontent.com/2925027/155433196-49467f77-0572-4db8-a9f4-0fa499552fb1.png)

This is a fix.
