### PR TITLE
Create new workflow to hide artifact links

### DIFF
--- a/.github/workflows/hide-artifact-links.yml
+++ b/.github/workflows/hide-artifact-links.yml
@@ -1,0 +1,17 @@
+name: Hide artifact links comments
+
+on:
+  pull_request_target:
+    types: [synchronize, reopened]
+
+jobs:
+  hide-artifacts-link-comments:
+    name: Hide artifact links
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Hide comments
+        uses: int128/hide-comment-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          starts-with: "Do you want to test this code? Here you have an automated build:"
+          ends-with: "WARNING: It may be unstable and result in corrupted configurations or data loss. Use only for testing!"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,12 +10,3 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
-  hide:
-    name: Hide artifact links
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Hide artifact links
-        uses: int128/hide-comment-action@v1
-        with:
-          starts-with: "Do you want to test this code? Here you have an automated build:"
-          ends-with: "WARNING: It may be unstable and result in corrupted configurations or data loss. Use only for testing!"


### PR DESCRIPTION
This fixes the hide artifact links comments, that is givin an error.

The permissions for any workflow thrown by a PR are read only ALWAYS. 

This is a workaround, executing the action as a principal workflow outside of the PR.