### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,16 @@
 #
 # After building, artifacts are released to a seperate repository.
 
-env:
-  debugBuild: true
-
 name: CI
 
-on: workflow_call
+on: 
+  workflow_call:
+    inputs:
+      debug_build:
+        description: 'Specifies if it is a debug build or a release build'
+        default: true
+        required: false
+        type: boolean
 
 jobs:
   test:
@@ -74,14 +78,14 @@ jobs:
       - run: yarn install --immutable --immutable-cache --check-cache
 
       - run: yarn gulp release ${{ matrix.releaseArgs }}
-        if: ${{ !env.debugBuild }}
+        if: ${{ !inputs.debug_build && matrix.name != 'Android' }}
 
       - run: yarn gulp debug-release ${{ matrix.releaseArgs }}
-        if: ${{ env.debugBuild }}
+        if: ${{ inputs.debug_build || matrix.name == 'Android' }}
 
       - name: Publish build artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: Betaflight-Configurator${{ env.debugBuild == 'true' && '-Debug' || '' }}-${{ matrix.name }}
+          name: Betaflight-Configurator${{ inputs.debug_build == 'true' && '-Debug' || '' }}-${{ matrix.name }}
           path: release/
           retention-days: 90

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,15 +1,16 @@
 # You'll need to setup the follwing environment variables:
-#   env.repoNightly - The repository to release nightly builds to e.g. betaflight-configurator-nightly
-#   env.releaseNotes - The release notes to be published as part of the github release
+#   env.repo_nightly - The repository to release nightly builds to e.g. betaflight-configurator-nightly
+#   env.release_notes - The release notes to be published as part of the github release
+#   env.debug_release_notes - The release notes to be published as part of the github debug release
 #   secrets.REPO_TOKEN - A GitHub token with permissions to push and publish releases to the nightly repo
 
 env:
-  repoNightly: betaflight/betaflight-configurator-nightlies
-  debugReleaseNotes: >
+  repo_nightly: betaflight/betaflight-configurator-nightlies
+  debug_release_notes: >
     This is an automated development build.
     It may be unstable and result in corrupted configurations or data loss.
     **Use only for testing.**
-  releaseNotes: This is a release build. It does not contain the debug console.
+  release_notes: This is a release build. It does not contain the debug console.
 
 name: Nightly
 
@@ -23,9 +24,11 @@ jobs:
   ci:
     name: CI
     uses: ./.github/workflows/ci.yml
+    with:
+      debug_build: true
 
   release:
-    name: Release
+    name: Nightly release
     needs: ci
     runs-on: ubuntu-20.04
     steps:
@@ -38,7 +41,8 @@ jobs:
         id: notes
         run: |
           set -- release-assets/Betaflight-Configurator-Debug-*
-          echo "::set-output name=notes::$(test -e "$1" && echo '${{ env.debugReleaseNotes }}' || echo '${{ env.releaseNotes }}')"
+          echo "::set-output name=notes::$(test -e "$1" && echo '${{ env.debug_release_notes }}' || echo '${{ env.release_n
+      otes }}')"
 
       - name: Get current date
         id: date
@@ -48,7 +52,7 @@ jobs:
         uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v0.1.14
         with:
           token: ${{ secrets.REPO_TOKEN }}
-          repository: ${{ env.repoNightly }}
+          repository: ${{ env.repo_nightly }}
           tag_name: v${{ steps.date.outputs.today }}.${{ github.run_number }}
           files: release-assets/Betaflight-Configurator-*/**
           draft: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+# You'll need to setup the follwing environment variables:
+#   secrets.REPO_TOKEN - A GitHub token with permissions to push and publish releases to the repo
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      title:
+        description: 'Title to assign to the release'
+        required: true
+        type: string
+
+      tag:
+        description: 'Tag to assign to the release source code'
+        required: true
+        type: string
+
+      generate_release_notes:
+        description: 'Generate release notes?'
+        required: true
+        type: boolean
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+    with:
+      debug_build: false
+
+  release:
+    name: Release
+    needs: ci
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Fetch build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          path: release-assets/
+
+      - name: Release
+        uses: softprops/action-gh-release@1e07f4398721186383de40550babbdf2b84acfc5 # v0.1.14
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          name: ${{ github.event.inputs.title }}
+          tag_name: ${{ github.event.inputs.tag }}
+          generate_release_notes: ${{ github.event.inputs.generate_release_notes }}
+          files: release-assets/Betaflight-Configurator-*/**
+          draft: true
+          prerelease: false
+          fail_on_unmatched_files: true          


### PR DESCRIPTION
This is for discussion, I'm not too sure if this can be useful.

This creates a new Github Action workflow, executed manually, that prepares a draft with the release (final or RC) of the Configurator.

It builds all the artifacts for Linux, Windows, MacOS and Android, and creates a draft release that we can "modify" before publishing. In this way we don't need to have all the systems and build manually to create the release.

It asks for the release name/tag name/default release notes.

![image](https://user-images.githubusercontent.com/2673520/155836731-2d3e372a-cbb2-4939-b852-06a379fea779.png)

After finished, it creates something like this:

![image](https://user-images.githubusercontent.com/2673520/155836760-91f88a69-16fa-4302-8dd4-68e54ba425f1.png)

Where we can modify and press publish when we want. It will create the tag and the release.

Some things I have observed:
- For Android, it builds a debug version and not a release version for two reasons, that we will need to look into if we want an automated release build. 
1. We have a "custom" step in the build system for the Android build when is a release version where it prompts the user for the version that it must use, and of course it fails when is an automated build. We can discuss if it is necessary or we can get it from the `package.json` always:
https://github.com/betaflight/betaflight-configurator/blob/51a6b60b0a002941a96fc5fe71f170180cd8cc54/gulpfile.js#L298-L316
2. We will need to have in a GitHub SECRET or somewhere the correct certificate to use to generate the Android Store build. I don't know who has it, I suppose that @mikeller or maybe someone more. So we need to "remove" the debug Android build and upload the correct one in the draft.
- The version is taken from the `package.json`, to create the RC versions I don't know how we are doing it now. @blckmn can you explain? I suppose modify this file in local only and create versions? I think remember there was a problem with this, so we will need to test it and modify the `package.json` before generating the version. 

I wait for your thoughts... The Configurator is the most complicated, do the same for the Firmware or the Blackbox will be easier.



