### PR TITLE
Fix MSP flow, make MSP timeout dynamic

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -147,8 +147,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.CONFIG.mode = data.readU32();
                 FC.CONFIG.profile = data.readU8();
 
-                TABS.pid_tuning.checkUpdateProfile(false);
-
                 sensor_status(FC.CONFIG.activeSensors);
                 break;
             case MSPCodes.MSP_STATUS_EX:
@@ -173,8 +171,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                       FC.CONFIG.armingDisableCount = data.readU8(); // Flag count
                       FC.CONFIG.armingDisableFlags = data.readU32();
                     }
-
-                    TABS.pid_tuning.checkUpdateProfile(true);
                 }
 
                 sensor_status(FC.CONFIG.activeSensors);
@@ -274,10 +270,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.ANALOG.mAhdrawn = data.readU16();
                 FC.ANALOG.rssi = data.readU16(); // 0-1023
                 FC.ANALOG.amperage = data.read16() / 100; // A
-                FC.ANALOG.last_received_timestamp = Date.now();
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
                     FC.ANALOG.voltage = data.readU16() / 100;
                 }
+                FC.ANALOG.last_received_timestamp = Date.now();
                 break;
             case MSPCodes.MSP_VOLTAGE_METERS:
                 FC.VOLTAGE_METERS = [];
@@ -727,7 +723,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 }
                 break;
             case MSPCodes.MSP_SET_MOTOR:
-                console.log('Motor Speeds Updated');
                 break;
             case MSPCodes.MSP_UID:
                 FC.CONFIG.uid[0] = data.readU32();
@@ -1728,8 +1723,8 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     if (self.mspMultipleCache.length > 0) {
 
                         const partialBuffer = [];
-                        for (let i = 0; i < self.mspMultipleCache.length; i++) {
-                            partialBuffer.push8(self.mspMultipleCache[i]);
+                        for (const instance of self.mspMultipleCache) {
+                            partialBuffer.push8(instance);
                         }
 
                         MSP.send_message(MSPCodes.MSP_MULTIPLE_MSP, partialBuffer, false, dataHandler.callbacks);
@@ -1746,11 +1741,12 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log(`Unknown code detected: ${code}`);
         } else {
             console.log(`FC reports unsupported message error: ${code}`);
-
-            if (code === MSPCodes.MSP_SET_REBOOT) {
-                TABS.onboard_logging.mscRebootFailedCallback();
-            }
         }
+
+        if (code === MSPCodes.MSP_SET_REBOOT) {
+            TABS.onboard_logging.mscRebootFailedCallback();
+        }
+
     } else {
         console.warn(`code: ${code} - crc failed`);
     }

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -585,9 +585,11 @@ TABS.motors.initialize = async function (callback) {
 
         // Amperage
         function power_data_pull() {
-            motorVoltage.text(i18n.getMessage('motorsVoltageValue', [FC.ANALOG.voltage]));
-            motorMahDrawingElement.text(i18n.getMessage('motorsADrawingValue', [FC.ANALOG.amperage.toFixed(2)]));
-            motorMahDrawnElement.text(i18n.getMessage('motorsmAhDrawnValue', [FC.ANALOG.mAhdrawn]));
+            if (FC.ANALOG.last_received_timestamp) {
+                motorVoltage.text(i18n.getMessage('motorsVoltageValue', [FC.ANALOG.voltage]));
+                motorMahDrawingElement.text(i18n.getMessage('motorsADrawingValue', [FC.ANALOG.amperage.toFixed(2)]));
+                motorMahDrawnElement.text(i18n.getMessage('motorsmAhDrawnValue', [FC.ANALOG.mAhdrawn]));
+            }
         }
 
         GUI.interval_add('motors_power_data_pull_slow', power_data_pull, 250, true); // 4 fps

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1436,6 +1436,7 @@ TABS.pid_tuning.initialize = function (callback) {
     function process_html() {
         TABS.pid_tuning.isHtmlProcessing = true;
         FC.FEATURE_CONFIG.features.generateElements($('.tab-pid_tuning .features'));
+        self.checkUpdateProfile(false);
 
         if (semver.lt(FC.CONFIG.apiVersion, "1.16.0") || semver.gte(FC.CONFIG.apiVersion, "1.20.0")) {
             $('.tab-pid_tuning .pidTuningSuperexpoRates').hide();


### PR DESCRIPTION
- [x] Add dynamic timeout for MSP calls with a save range 250- 2000ms (bounces back gradually to 4 fps).
- [x] Fix `MSP_STATUS` vs `MSP_STATUS_EX` as it was called unsupported (without software version control).
- [x] Fix [some] MSP calls stumbling over each other, without callback.
- [x] Remove checkUpdate profile from MSPHelper library as code should be in the caller.
- [x] Disconnect after crc packet error threshold has exceeded.

Note:
With a lower timeout the code shows more timeouts but overall the code is processing more calls optimizing processing.