### PR TITLE
Motors tab: moved motor tool buttons away from the bottom panel

### DIFF
--- a/src/css/tabs/motors.css
+++ b/src/css/tabs/motors.css
@@ -8,9 +8,9 @@
     border: 1px solid var(--subtleAccent);
     width: fit-content;
     height: 20px;
-    float: left;
     margin-right: 55px;
     border-radius: 3px;
+    min-width: 150px;
 }
 
 .tab-motors table {
@@ -59,7 +59,7 @@
 .tab-motors .mixerPreview img {
     width: 150px;
     height: 150px;
-    margin-left: 18px;
+    margin-left: 10px;
 }
 
 .tab-motors select .escprotocol {
@@ -156,6 +156,18 @@
     padding-bottom: 10px;
     float: left;
     width: calc(100% - 20px);
+}
+
+.tab-motors .spacer_box.mixer_settings {
+    padding-bottom: 0px;
+}
+
+.tab-motors .motor_direction_reversed {
+    padding-top: 10px;
+}
+
+.tab-motors .motor_tool_buttons {
+    padding-left: 10px;
 }
 
 .tab-motors .disarm {

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -16,10 +16,17 @@
                             <div class="gui_box_titlebar">
                                 <div class="spacer_box_title" i18n="configurationMixer"></div>
                             </div>
-                            <div class="spacer_box">
+                            <div class="spacer_box mixer_settings">
                                 <select class="mixerList" id="mixer">
                                     <!-- list generated here -->
                                 </select>
+                                <div class="motor_direction_reversed">
+                                    <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
+                                        <input type="checkbox" id="reverseMotorSwitch" class="toggle" />
+                                    </div>
+                                    <span class="freelabel" i18n="configurationReverseMotorSwitch"></span>
+                                    <div class="helpicon cf_tip" i18n_title="configurationReverseMotorSwitchHelp"></div>
+                                </div>
                             </div>
                             <div class="grid-row">
                                 <div class="grid-col col6">
@@ -28,14 +35,9 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="spacer_box reverseMotor">
-                                <div class="topBorderLine">
-                                    <div style="float: left; height: 20px; margin-right: 15px; margin-left: 3px;">
-                                        <input type="checkbox" id="reverseMotorSwitch" class="toggle" />
-                                    </div>
-                                    <span class="freelabel" i18n="configurationReverseMotorSwitch"></span>
-                                    <div class="helpicon cf_tip" i18n_title="configurationReverseMotorSwitchHelp"></div>
-                                </div>
+                            <div class="btn motor_tool_buttons">
+                                <a href="#" id="motorOutputReorderDialogOpen" class="tool regular-button" i18n="motorOutputReorderDialogOpen"></a>
+                                <a href="#" id="escDshotDirectionDialog-Open" class="tool regular-button" i18n="escDshotDirectionDialog-Open"></a>
                             </div>
                         </div>
                     </div>
@@ -362,11 +364,6 @@
 
         <div class="content_toolbar">
             <div class="btn">
-                <a href="#" id="motorOutputReorderDialogOpen" class="tool regular-button" i18n="motorOutputReorderDialogOpen"></a>
-                <a href="#" id="escDshotDirectionDialog-Open" class="tool regular-button" i18n="escDshotDirectionDialog-Open"></a>
-            </div>
-
-            <div class="btn">
                 <a class="save disabled" href="#" i18n="motorsButtonSave"></a>
             </div>
         </div>
@@ -409,5 +406,4 @@
             <a href="#" id="escDshotDirectionDialog-closebtn" class="regular-button right" i18n="close"></a>
         </div>
     </dialog>
-  
 </div>


### PR DESCRIPTION
Moved motor reorder and motor direction buttons.

### Bug:

Noticed on some phones there is no enough room for three buttons at the bottom panel. It looks like that (thanks to Andy for screenshot):
![image](https://user-images.githubusercontent.com/2925027/156748740-9f90bcd5-2f46-489a-a419-75511d1af4ea.png)


### The solution is to move these buttons to the first panel:
![image](https://user-images.githubusercontent.com/2925027/156748366-c6d219c7-c8c7-49d0-bb0f-4d4c4b017c8e.png)
