### PR TITLE
Fix state if local target does not match board

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -688,9 +688,9 @@
         "message": "Detected device with total flash size $1 KiB"
     },
     "dfu_hex_address_errors": {
-        "message": "<span class=\"message-negative\">Error</span>: Firmware image contains addresses not found on target device"
+        "message": "Firmware image contains addresses not found on target device"
     },
-        "dfu_error_image_size": {
+    "dfu_error_image_size": {
         "message": "<span class=\"message-negative\">Error</span>: Supplied image is larger then flash available on the chip! Image: $1 KiB, limit = $2 KiB"
     },
 

--- a/src/js/protocols/stm32usbdfu.js
+++ b/src/js/protocols/stm32usbdfu.js
@@ -615,6 +615,13 @@ STM32DFU_protocol.prototype.upload_procedure = function (step) {
                         self.chipInfo = chipInfo;
                         self.flash_layout = chipInfo.internal_flash;
 
+                        if (TABS.firmware_flasher.parsed_hex.bytes_total > chipInfo.internal_flash.total_size) {
+                            const firmwareSize = TABS.firmware_flasher.parsed_hex.bytes_total;
+                            const boardSize = chipInfo.internal_flash.total_size;
+                            const bareBoard = TABS.firmware_flasher.bareBoard;
+                            console.log(`Firmware size ${firmwareSize} exceeds board memory size ${boardSize} (${bareBoard})`);
+                        }
+
                     } else if (typeof chipInfo.external_flash !== "undefined") {
                         // external flash
                         nextAction = 2; // no option bytes
@@ -642,7 +649,8 @@ STM32DFU_protocol.prototype.upload_procedure = function (step) {
 
                         if (unusableBlocks.length > 0) {
                             GUI.log(i18n.getMessage('dfu_hex_address_errors'));
-                            self.cleanup();
+                            TABS.firmware_flasher.flashingMessage(i18n.getMessage('dfu_hex_address_errors'), TABS.firmware_flasher.FLASH_MESSAGE_TYPES.INVALID);
+                            self.leave();
                         } else {
                             self.getFunctionalDescriptor(0, function (descriptor, resultCode) {
                                 self.transferSize = resultCode ? 2048 : descriptor.wTransferSize;


### PR DESCRIPTION
Thanks to @daleckystepan 

Problem: If flashing a target which does not match configurator is left in an unknown state.
Reproduce: Connect for example an F411 and load a F405 hex locally and start flashing.

![image](https://user-images.githubusercontent.com/8344830/156836849-6e672968-7289-4c04-8127-4e546d176549.png)

This PR updates the flash message and leaves DFU mode.

![image](https://user-images.githubusercontent.com/8344830/156837263-68d0598f-fbdb-48a3-83e8-2e45eea3919c.png)
