### PR TITLE
Fix css for <select> on motors tab

### DIFF
--- a/src/css/tabs/motors.css
+++ b/src/css/tabs/motors.css
@@ -10,7 +10,12 @@
     height: 20px;
     margin-right: 55px;
     border-radius: 3px;
+    float: left;
+}
+
+.tab-motors .mixer_settings select {
     min-width: 150px;
+    float: none;
 }
 
 .tab-motors table {


### PR DESCRIPTION
https://github.com/betaflight/betaflight-configurator/pull/2848 introduced a bug.
Thanks to @hydra for noticing.

This PR is a fix:
![image](https://user-images.githubusercontent.com/2925027/158035060-156d1461-2002-430a-a3c8-b6e64073cc3c.png)
