### PR TITLE
Revert NWjs for Linux only

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -48,7 +48,7 @@ const NODE_ENV = process.env.NODE_ENV || 'production';
 const NAME_REGEX = /-/g;
 
 const nwBuilderOptions = {
-    version: '0.60.0',
+    version: os.platform() === 'linux' ? '0.54.1' : '0.60.0',    // linux has a bug with moving OSD elements
     files: `${DIST_DIR}**/*`,
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},


### PR DESCRIPTION
Mike on Slack did report an issue:

After updating NWjs `0.54.1` to `0.60.0` it seems OSD elements can't be moved on Linux platform.
We need NWjs >= `0.59.x` for Windows users so we can't simply revert to `0.54.1`

So this is a temporary fix until we have a better solution.

See https://github.com/betaflight/betaflight-configurator/pull/2797 for more details

Note: With Node 16 it's working with NWjs 0.62 ( not with 0.60 ), but there is still a big area appearing while selecting and moving an element.