### PR TITLE
Presets: fix a bug when saving freezes the progress dialog (because of the \r in the CLI text)

### DIFF
--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -61,7 +61,7 @@ TABS.presets.getPickedPresetsCli = function() {
     this.pickedPresetList.forEach(pickedPreset => {
         result.push(...pickedPreset.presetCli);
     });
-    result = result.filter(command => command !== "");
+    result = result.filter(command => command.trim() !== "");
     return result;
 };
 


### PR DESCRIPTION
Bug noted by @haslinghuis

The bug:
if you try to "load backup" from the file with `\r\n` instead of `\n` it might freeze the saving progress dialog.
It happens because the firmware does not reply to the empty CLI commands with only `\r` and the callback of data response is not being called.

This PR fixes this bug by **not** sending the lines that contain only `\r` to CLI engine.
[test_CRLF.txt](https://github.com/betaflight/betaflight-configurator/files/8313561/test_CRLF.txt)