### PR TITLE
Flasher - fix for select2 height mismatch + padding

### DIFF
--- a/src/css/select2_custom.css
+++ b/src/css/select2_custom.css
@@ -2,11 +2,11 @@
 .select2 {
     font-family: Arial, Helvetica, sans-serif;
     font-weight: 400;
-    font-size: 13.3333px;    
+    font-size: 13.3333px;
 }
 
 .select2-selection__rendered {
-    line-height: 18.5px !important;
+    line-height: 18px !important;
     padding-left: 4px !important;
     color: var(--defaultText) !important;
     border-radius: 2px !important;
@@ -15,12 +15,13 @@
 .select2-container .select2-selection--single {
     height: 20px !important;
     border-radius: 3px !important;
-    border: 0.5px solid var(--subtleAccent) !important;
+    border: 1px solid var(--subtleAccent) !important;
     cursor: default !important;
 }
 
 .select2-selection__arrow {
     height: 19px !important;
+    top: 0 !important;
 }
 .select2-selection__arrow b {
     height: 5px !important;

--- a/src/css/tabs/firmware_flasher.css
+++ b/src/css/tabs/firmware_flasher.css
@@ -125,6 +125,7 @@
 
 .tab-firmware_flasher .cf_table td:last-child {
     text-align: left;
+    padding-left: 8px;
 }
 
 .tab-firmware_flasher .options .flash_on_connect_wrapper {


### PR DESCRIPTION
See discussion on #2837 

Addresses:

1. Mismatched height between select2 + regular select
2. The closeness of select boxes to the explanation to the side ?

I believe this is a better/cleaner fix than the platform specific CSS injection in #2837 

Screenshots:

ubuntu

![ubuntu](https://user-images.githubusercontent.com/194052/160603459-a9b585eb-c282-4a37-9bfe-1c8a03450abb.png)

mac 

![mac](https://user-images.githubusercontent.com/194052/160603464-5ffe87c8-cacb-4073-b43f-ede26a62c79e.png)

win

![win](https://user-images.githubusercontent.com/194052/160603452-dfefbbfc-7c34-4e4e-bce5-f12964906dc1.png)

