### PR TITLE
Fixing a sporadic timing error prevents a backup from being written correctly to a file

### DIFF
--- a/src/tabs/presets/CliEngine.js
+++ b/src/tabs/presets/CliEngine.js
@@ -270,6 +270,7 @@ CliEngine.s_carriageReturnCode = 13;
 CliEngine.s_tabCode = 9;
 CliEngine.s_enterKeyCode = 13;
 CliEngine.s_commandDiffAll = "diff all";
+CliEngine.s_commandDumpAll = "dump all";
 CliEngine.s_commandDefaultsNoSave = "defaults nosave";
 CliEngine.s_commandSave = "save";
 CliEngine.s_commandExit = "exit";

--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -187,7 +187,13 @@ TABS.presets.onSaveConfigClick = function() {
         const suffix = 'txt';
         const text = cliStrings.join("\n");
         const filename = generateFilename(prefix, suffix);
-        return GUI.saveToTextFileDialog(text, filename, suffix);
+        if (text.length > 50) {
+            return GUI.saveToTextFileDialog(text, filename, suffix);
+        }
+        else {
+            waitingDialog.close();
+            return GUI.showInformationDialog(saveFailedDialogSettings);
+        }
     })
     .then(() => {
         waitingDialog.close();
@@ -208,12 +214,12 @@ TABS.presets.readDumpAll = function() {
     this.cliEngine.subscribeOnRowCame(str => {
         lastCliStringReceived = performance.now();
 
-        if (CliEngine.s_commandDiffAll !== str && CliEngine.s_commandSave !== str) {
+        if (CliEngine.s_commandDumpAll !== str && CliEngine.s_commandSave !== str) {
             diffAll.push(str);
         }
     });
 
-    this.cliEngine.sendLine(CliEngine.s_commandDiffAll);
+    this.cliEngine.sendLine(CliEngine.s_commandDumpAll);
 
     return new Promise(resolve => {
         GUI.interval_add(readingDumpIntervalName, () => {


### PR DESCRIPTION
On mac I found a sporadic timing error which prevents to write a complete backup into a file. It must be something with the connection between FC and BF configurator, if there is a delay there, the case occurs

Problem was found here
`       GUI.interval_add(readingDumpIntervalName, () => {
            const currentTime = performance.now();
            if (currentTime - lastCliStringReceived > 500) {
                this.cliEngine.unsubscribeOnRowCame();
                GUI.interval_remove(readingDumpIntervalName);
                resolve(diffAll);
            }
`
Unfortunately increasing 500 to a bigger number do not fix this issue.
Sometimes it returns more or less nothing.

Based on a sporadic error my fix is not high spophisticated. In function `TABS.presets.onSaveConfigClick` I check text length, if it is to small, quit function with a warning otherwise write file.

Change `diff all` to `dump all` based on function name which is called.

