### PR TITLE
Change failsafe delays units to seconds in UI

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4246,13 +4246,13 @@
         "message": "Stage 2 - Settings"
     },
     "failsafeDelayItem": {
-        "message": "Guard time for stage 2 activation after signal lost [1 = 0.1 sec.]"
+        "message": "Guard time for stage 2 activation after signal lost [seconds]"
     },
     "failsafeDelayHelp": {
         "message": "Time for stage 1 to wait for recovery"
     },
     "failsafeThrottleLowItem": {
-        "message": "Failsafe Throttle Low Delay [1 = 0.1 sec.]"
+        "message": "Failsafe Throttle Low Delay [seconds]"
     },
     "failsafeThrottleLowHelp": {
         "message": "Just disarm the craft instead of executing the selected failsafe procedure when the throttle was low for this amount of time"
@@ -4261,7 +4261,7 @@
         "message": "Throttle value used while landing"
     },
     "failsafeOffDelayItem": {
-        "message": "Delay for turning off the Motors during Failsafe [1 = 0.1 sec.]"
+        "message": "Delay for turning off the Motors during Failsafe [seconds]"
     },
     "failsafeOffDelayHelp": {
         "message": "Time to stay in landing mode until the motors are turned off and the craft is disarmed"

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -249,9 +249,9 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
         }
 
         $('input[name="failsafe_throttle"]').val(FC.FAILSAFE_CONFIG.failsafe_throttle);
-        $('input[name="failsafe_off_delay"]').val(FC.FAILSAFE_CONFIG.failsafe_off_delay);
-        $('input[name="failsafe_throttle_low_delay"]').val(FC.FAILSAFE_CONFIG.failsafe_throttle_low_delay);
-        $('input[name="failsafe_delay"]').val(FC.FAILSAFE_CONFIG.failsafe_delay);
+        $('input[name="failsafe_off_delay"]').val((FC.FAILSAFE_CONFIG.failsafe_off_delay / 10.0).toFixed(1));
+        $('input[name="failsafe_throttle_low_delay"]').val((FC.FAILSAFE_CONFIG.failsafe_throttle_low_delay / 10.0).toFixed(1));
+        $('input[name="failsafe_delay"]').val((FC.FAILSAFE_CONFIG.failsafe_delay / 10.0).toFixed(1));
 
         // set stage 2 failsafe procedure
         $('input[type="radio"].procedure').change(function () {
@@ -345,9 +345,9 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             FC.RX_CONFIG.rx_max_usec = parseInt($('input[name="rx_max_usec"]').val());
 
             FC.FAILSAFE_CONFIG.failsafe_throttle = parseInt($('input[name="failsafe_throttle"]').val());
-            FC.FAILSAFE_CONFIG.failsafe_off_delay = parseInt($('input[name="failsafe_off_delay"]').val());
-            FC.FAILSAFE_CONFIG.failsafe_throttle_low_delay = parseInt($('input[name="failsafe_throttle_low_delay"]').val());
-            FC.FAILSAFE_CONFIG.failsafe_delay = parseInt($('input[name="failsafe_delay"]').val());
+            FC.FAILSAFE_CONFIG.failsafe_off_delay = Math.round(10.0 * parseFloat($('input[name="failsafe_off_delay"]').val()));
+            FC.FAILSAFE_CONFIG.failsafe_throttle_low_delay = Math.round(10.0 * parseFloat($('input[name="failsafe_throttle_low_delay"]').val()));
+            FC.FAILSAFE_CONFIG.failsafe_delay = Math.round(10.0 * parseFloat($('input[name="failsafe_delay"]').val()));
 
             if( $('input[id="land"]').is(':checked')) {
                 FC.FAILSAFE_CONFIG.failsafe_procedure = 0;

--- a/src/tabs/failsafe.html
+++ b/src/tabs/failsafe.html
@@ -77,13 +77,13 @@
                             <div class="helpicon cf_tip" i18n_title="failsafeKillSwitchHelp"></div>
                         </div>
                         <div class="number stage2">
-                            <label> <input type="number" name="failsafe_delay" min="0" max="200" /> <span
+                            <label> <input type="number" name="failsafe_delay" min="0" max="200" step="0.1" /> <span
                                 i18n="failsafeDelayItem"></span>
                             </label>
                             <div class="helpicon cf_tip" i18n_title="failsafeDelayHelp"></div>
                         </div>
                         <div class="number stage2">
-                            <label> <input type="number" name="failsafe_throttle_low_delay" min="0" max="300" /> <span
+                            <label> <input type="number" name="failsafe_throttle_low_delay" min="0" max="300" step="0.1" /> <span
                                 i18n="failsafeThrottleLowItem"></span>
                             </label>
                             <div class="helpicon cf_tip" i18n_title="failsafeThrottleLowHelp"></div>
@@ -106,7 +106,7 @@
                                     </label>
                                 </div>
                                 <div class="number">
-                                    <label> <input type="number" name="failsafe_off_delay" min="0" max="200" /> <span
+                                    <label> <input type="number" name="failsafe_off_delay" min="0" max="200" step="0.1" /> <span
                                         i18n="failsafeOffDelayItem"></span>
                                     </label>
                                     <div class="helpicon cf_tip" i18n_title="failsafeOffDelayHelp"></div>


### PR DESCRIPTION
Changing three elements to seconds instead of 0.1s on the Failsafe tab:

![image](https://user-images.githubusercontent.com/2925027/162345140-28c498ac-0074-4953-b7df-ea9879e1df90.png)
