### PR TITLE
Fix autocomplete

### DIFF
--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -289,23 +289,32 @@ CliAutoComplete._initTextcomplete = function() {
          * Then add `mousemove` handler. If the mouse moves we consider that mouse interaction
          * is desired so we reenable the `mouseover` handler
          */
+
+        const textCompleteDropDownElement = $('.textcomplete-dropdown');
+
         if (!savedMouseoverItemHandler) {
             // save the original 'mouseover' handeler
-            savedMouseoverItemHandler = $._data($('.textcomplete-dropdown')[0], 'events').mouseover[0].handler;
-        }
+            try {
+                savedMouseoverItemHandler = $._data(textCompleteDropDownElement[0], 'events').mouseover[0].handler;
+            } catch (error) {
+                console.log(error);
+            }
 
-        $('.textcomplete-dropdown')
-            .off('mouseover') // initially disable it
-            .off('mousemove') // avoid `mousemove` accumulation if previous show did not trigger `mousemove`
-            .on('mousemove', '.textcomplete-item', function(e) {
-                // the mouse has moved so reenable `mouseover`
-                $(this).parent()
+            if (savedMouseoverItemHandler) {
+                textCompleteDropDownElement
+                .off('mouseover') // initially disable it
+                .off('mousemove') // avoid `mousemove` accumulation if previous show did not trigger `mousemove`
+                .on('mousemove', '.textcomplete-item', function(e) {
+                        // the mouse has moved so reenable `mouseover`
+                    $(this).parent()
                     .off('mousemove')
                     .on('mouseover', '.textcomplete-item', savedMouseoverItemHandler);
 
-                // trigger the mouseover handler to select the item under the cursor
-                savedMouseoverItemHandler(e);
-            });
+                    // trigger the mouseover handler to select the item under the cursor
+                    savedMouseoverItemHandler(e);
+                });
+            }
+        }
     });
 
     // textcomplete autocomplete strategies


### PR DESCRIPTION
Fix `savedMouseoverItemHandler` which intermittent prevents cli auto complete to function:

```
CliAutoComplete.js:294 Uncaught TypeError: Cannot read properties of undefined (reading '0')
    at HTMLTextAreaElement.<anonymous> (CliAutoComplete.js:294:100)
    at HTMLTextAreaElement.dispatch (jquery.min.js:2:43090)
    at HTMLTextAreaElement.v.handle (jquery.min.js:2:41074)
    at Object.trigger (jquery.min.js:2:71513)
    at HTMLTextAreaElement.<anonymous> (jquery.min.js:2:72108)
    at Function.each (jquery.min.js:2:2976)
    at S.fn.init.each (jquery.min.js:2:1454)
    at S.fn.init.trigger (jquery.min.js:2:72084)
    at b.fire (jquery.textcomplete.min.js:2:3629)
    at b.activate (jquery.textcomplete.min.js:2:7021)
    at jquery.textcomplete.min.js:2:4219
    at searcher (CliAutoComplete.js:237:9)
    at Object.search (CliAutoComplete.js:351:17)
    at b.<anonymous> (jquery.textcomplete.min.js:2:4167)
    at b._search (jquery.textcomplete.min.js:2:2071)
    at b.trigger (jquery.textcomplete.min.js:2:3487)
```