### PR TITLE
Fix build release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,8 +41,7 @@ jobs:
         id: notes
         run: |
           set -- release-assets/Betaflight-Configurator-Debug-*
-          echo "::set-output name=notes::$(test -e "$1" && echo '${{ env.debug_release_notes }}' || echo '${{ env.release_n
-      otes }}')"
+          echo "::set-output name=notes::$(test -e "$1" && echo '${{ env.debug_release_notes }}' || echo '${{ env.release_notes }}')"
 
       - name: Get current date
         id: date


### PR DESCRIPTION
Nightly builds did not update.

This PR removes the return char in the middle of the line that breaks the line.

Thanks to @daleckystepan for bringing this to our attention and @McGiverGim spotting the line.