### PR TITLE
Presets fix: proper Esc key handling for preset dialogs

### DIFF
--- a/src/components/MotorOutputReordering/MotorOutputReorderingComponent.js
+++ b/src/components/MotorOutputReordering/MotorOutputReorderingComponent.js
@@ -92,12 +92,7 @@ class MotorOutputReorderComponent
         function reboot()
         {
             GUI.log(i18n.getMessage('configurationEepromSaved'));
-
-            GUI.tab_switch_cleanup(function()
-            {
-                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
-                reinitialiseConnection(self);
-            });
+            GUI.tab_switch_cleanup(() => MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(TABS.motors)));
         }
 
         FC.MOTOR_OUTPUT_ORDER = Array.from(this._newMotorOutputReorder);

--- a/src/tabs/presets/CliEngine.js
+++ b/src/tabs/presets/CliEngine.js
@@ -208,7 +208,7 @@ class CliEngine
                 CONFIGURATOR.cliEngineActive = false;
                 CONFIGURATOR.cliEngineValid = false;
                 GUI.log(i18n.getMessage('cliReboot'));
-                reinitialiseConnection(this._currentTab);
+                reinitializeConnection(this._currentTab);
             }
         }
 

--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
@@ -25,6 +25,7 @@ class PresetsDetailedDialog {
         this._setLoadingState(true);
         this._domDialog[0].showModal();
         this._optionsShowedAtLeastOnce = false;
+        this._isPresetPickedOnClose = false;
 
         this._presetsRepo.loadPreset(this._preset)
             .then(() => {
@@ -231,9 +232,10 @@ class PresetsDetailedDialog {
         this._readDom();
 
         this._domButtonApply.on("click", () => this._onApplyButtonClicked());
-        this._domButtonCancel.on("click", () => this._onCancelButtonClicked(false));
+        this._domButtonCancel.on("click", () => this._onCancelButtonClicked());
         this._domButtonCliShow.on("click", () => this._showCliText(true));
         this._domButtonCliHide.on("click", () => this._showCliText(false));
+        this._domDialog.on("close", () => this._onClose());
     }
 
     _onApplyButtonClicked() {
@@ -256,7 +258,8 @@ class PresetsDetailedDialog {
         const pickedPreset = new PickedPreset(this._preset, cliStrings);
         this._pickedPresetList.push(pickedPreset);
         this._onPresetPickedCallback?.();
-        this._onCancelButtonClicked(true);
+        this._isPresetPickedOnClose = true;
+        this._onCancelButtonClicked();
     }
 
     _pickPresetFwVersionCheck() {
@@ -284,9 +287,12 @@ class PresetsDetailedDialog {
         }
     }
 
-    _onCancelButtonClicked(isPresetPicked) {
-        this._destroyOptionsSelect();
+    _onCancelButtonClicked() {
         this._domDialog[0].close();
-        this._openPromiseResolve?.(isPresetPicked);
+    }
+
+    _onClose() {
+        this._destroyOptionsSelect();
+        this._openPromiseResolve?.(this._isPresetPickedOnClose);
     }
 }

--- a/src/tabs/presets/SourcesDialog/SourcesDialog.js
+++ b/src/tabs/presets/SourcesDialog/SourcesDialog.js
@@ -124,11 +124,15 @@ class PresetsSourcesDialog {
 
     _setupEvents() {
         this._domButtonClose.on("click", () => this._onCloseButtonClick());
+        this._domDialog.on("close", () => this._onClose());
     }
 
     _onCloseButtonClick() {
-        this._sourceSelectedPromiseResolve?.();
         this._domDialog[0].close();
+    }
+
+    _onClose() {
+        this._sourceSelectedPromiseResolve?.();
     }
 
     _readPanels() {


### PR DESCRIPTION
By default the ESC key closes `<dialog>s` that were opened with showModal()
For this reason, the dialog-clear logic can't be inside the "Close" button click. It has to be inside "close" event. That will make the behavior consistent regardless if the user clicked "close" or pressed the ESC key.

This PR also fixes spelling (reinitiali**s**eConnection -> reinitiali**z**eConnection) leftover after this PR: https://github.com/betaflight/betaflight-configurator/pull/2758

After this PR the following dialogs must behave well when user presses the ESC key inside of them:
Preset detailed dialog
Dialog with preset source selection
Dialog with CLI errors on load backup/applying presets.
