### PR TITLE
Cli tab: added Save button

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2875,7 +2875,12 @@
         "message": "CLI reboot detected"
     },
     "cliSaveToFileBtn": {
-        "message": "Save to File"
+        "message": "Export to file",
+        "description": "Button in the CLI tab to export the CLI output contents to a file"
+    },
+    "cliSaveBtn": {
+        "message": "Save and reboot",
+        "description": "Button in the CLI tab that saves current FC state and restarts FC (equivalent to 'save' CLI command)"
     },
     "cliClearOutputHistoryBtn": {
         "message": "Clear output history"
@@ -2887,7 +2892,8 @@
         "message": "Copied!"
     },
     "cliLoadFromFileBtn": {
-        "message": "Load from file"
+        "message": "Import from file",
+        "description": "Button in the CLI tab to import CLI commands from file"
     },
     "cliConfirmSnippetDialogTitle": {
         "message": "Loaded file <strong>{{fileName}}</strong>. Review the loaded commands"

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -139,6 +139,8 @@ TABS.cli.initialize = function (callback) {
                 .focus();
         });
 
+        $('.tab-cli .cli-save').on("click", () => executeCommands("save\r"));
+
         $('.tab-cli .save').click(function() {
             const prefix = 'cli';
             const suffix = 'txt';

--- a/src/tabs/cli.html
+++ b/src/tabs/cli.html
@@ -13,6 +13,9 @@
     </div>
     <div class="content_toolbar xs-compressed">
         <div class="btn save_btn">
+            <a class="cli-save" href="#" i18n="cliSaveBtn"></a>
+        </div>
+        <div class="btn save_btn">
             <a class="save" href="#" i18n="cliSaveToFileBtn"></a>
         </div>
         <div class="btn save_btn">


### PR DESCRIPTION
By @ctzsnooze  request adding "Save" button. Technically its a new feature, so need to think about adding to 10.8. But it's a very small change.

The "Cancel" button is not needed cuz (by @KarateBrot) users can just click disconnect or to any other tab.
Renamed Save/Load to File to Import/Export from/to file

![image](https://user-images.githubusercontent.com/2925027/164205729-72c42672-3e86-4c3f-b9fb-c8a8bcf0f58c.png)