### PR TITLE
Make "Activate bootloader" button use bootloader in flash if it exists

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -824,6 +824,15 @@ const FC = {
         return hasVcp;
     },
 
+    boardHasFlashBootloader() {
+        let hasFlashBootloader = false;
+        if (semver.gte(this.CONFIG.apiVersion, API_VERSION_1_42)) {
+            hasFlashBootloader = bit_check(this.CONFIG.targetCapabilities, this.TARGET_CAPABILITIES_FLAGS.HAS_FLASH_BOOTLOADER);
+        }
+
+        return hasFlashBootloader;
+    },
+
     FILTER_TYPE_FLAGS: {
         PT1: 0,
         BIQUAD: 1,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -40,6 +40,7 @@ function MspHelper() {
         BOOTLOADER: 1,
         MSC: 2,
         MSC_UTC: 3,
+        BOOTLOADER_FLASH: 4,
     };
 
     self.RESET_TYPES = {

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -93,7 +93,7 @@ TABS.setup.initialize = function (callback) {
 
             $('a.rebootBootloader').click(function () {
                 const buffer = [];
-                buffer.push(mspHelper.REBOOT_TYPES.BOOTLOADER);
+                buffer.push(FC.boardHasFlashBootloader() ? mspHelper.REBOOT_TYPES.BOOTLOADER_FLASH : mspHelper.REBOOT_TYPES.BOOTLOADER);
                 MSP.send_message(MSPCodes.MSP_SET_REBOOT, buffer, false);
             });
         } else {


### PR DESCRIPTION
There's missing code that causes rebooting into the wrong bootloader when pressing the button.
From the discussion in https://github.com/betaflight/betaflight/issues/11334 it looks like this button should reboot into the bootloader that allows flashing firmware. For targets that have bootloader in flash, this is the one we want.
~~In addition to this I propose we change the behaviour of the `bl` command to use the default bootloader.~~
Edit: Logic in cli code looks like it already behaves as it should

Fixes https://github.com/betaflight/betaflight/issues/11334
