### PR TITLE
OSD Tab - Improve the way osd elements picker + timer section render/wrap

### DIFF
--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -526,8 +526,8 @@ button {
 
 .timers-container .timer-detail {
     padding-left: 15px;
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-top: 3px;
+    padding-bottom: 3px;
 }
 
 .timers-container label {

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -423,6 +423,24 @@ button {
   width: 100%;
 }
 
+.tab-osd .switchable-field-flex {
+    display: flex;
+}
+
+.tab-osd .switchable-field-flex .switchable-field-description {
+    display: flex;
+    flex-direction: column;
+    /*
+     min width here is counterintuitive/seems to do nothing. but important, stops the variant selects overflowing
+     see https: //stackoverflow.com/questions/36230944/prevent-flex-items-from-overflowing-a-container
+    */
+    min-width: 0;
+}
+
+.tab-osd .switchable-field-flex .switchable-field-description .osd-variant {
+    margin-top: 5px;
+}
+
 .spacer_box_title span {
   font-size: 11px;
   font-weight: normal;
@@ -455,7 +473,7 @@ button {
 
 .tab-osd .preview {
   width: 360px;
-  float: left; 
+  float: left;
   position: sticky;
   top: 0;
   margin-left: calc((100% - 360px) / 3);

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -429,16 +429,20 @@ button {
 
 .tab-osd .switchable-field-flex .switchable-field-description {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     /*
      min width here is counterintuitive/seems to do nothing. but important, stops the variant selects overflowing
      see https: //stackoverflow.com/questions/36230944/prevent-flex-items-from-overflowing-a-container
     */
     min-width: 0;
+    justify-content: space-between;
+    width: 100%;
+    flex-wrap: wrap;
 }
 
+
 .tab-osd .switchable-field-flex .switchable-field-description .osd-variant {
-    margin-top: 5px;
+    flex-grow: 2;
 }
 
 .spacer_box_title span {

--- a/src/css/tabs/osd.css
+++ b/src/css/tabs/osd.css
@@ -524,9 +524,20 @@ button {
   display: inline !important;
 }
 
+.timers-container .timer-detail {
+    padding-left: 15px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
 .timers-container label {
-  margin-left: 15px !important;
   margin-right: 5px !important;
+  display: inline-block;
+  width: 80px;
+}
+
+.timers-container input, .timers-container select {
+    width: 150px;
 }
 
 @media only screen and (max-width: 1055px) , only screen and (max-device-width: 1055px) {

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2636,7 +2636,7 @@ TABS.osd.initialize = function(callback) {
                                 timerTableRow.append(`<td>${tim.index + 1}</td>`);
 
                                 // Source
-                                const sourceTimerTableData = $('<td class="osd_tip"></td>');
+                                const sourceTimerTableData = $('<td class="timer-detail osd_tip"></td>');
                                 sourceTimerTableData.attr('title', i18n.getMessage('osdTimerSourceTooltip'));
                                 sourceTimerTableData.append(`<label for="timerSource_${tim.index}" class="char-label">${i18n.getMessage('osdTimerSource')}</label>`);
                                 const src = $(`<select class="timer-option" id="timerSource_${tim.index}"></select>`);
@@ -2659,7 +2659,7 @@ TABS.osd.initialize = function(callback) {
                                 // Precision
                                 timerTableRow = $('<tr />');
                                 timerTable.append(timerTableRow);
-                                const precisionTimerTableData = $('<td class="osd_tip"></td>');
+                                const precisionTimerTableData = $('<td class="timer-detail osd_tip"></td>');
                                 precisionTimerTableData.attr('title', i18n.getMessage('osdTimerPrecisionTooltip'));
                                 precisionTimerTableData.append(`<label for="timerPrec_${tim.index}" class="char-label">${i18n.getMessage('osdTimerPrecision')}</label>`);
                                 const precision = $(`<select class="timer-option osd_tip" id="timerPrec_${tim.index}"></select>`);
@@ -2683,7 +2683,7 @@ TABS.osd.initialize = function(callback) {
                                 // Alarm
                                 timerTableRow = $('<tr />');
                                 timerTable.append(timerTableRow);
-                                const alarmTimerTableData = $('<td class="osd_tip"></td>');
+                                const alarmTimerTableData = $('<td class="timer-detail osd_tip"></td>');
                                 alarmTimerTableData.attr('title', i18n.getMessage('osdTimerAlarmTooltip'));
                                 alarmTimerTableData.append(`<label for="timerAlarm_${tim.index}" class="char-label">${i18n.getMessage('osdTimerAlarm')}</label>`);
                                 const alarm = $(`<input class="timer-option osd_tip" name="alarm" type="number" min=0 id="timerAlarm_${tim.index}"/>`);

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2877,7 +2877,7 @@ TABS.osd.initialize = function(callback) {
                             enabledCount++;
                         }
 
-                        const $field = $(`<div class="switchable-field field-${field.index}"></div>`);
+                        const $field = $(`<div class="switchable-field switchable-field-flex field-${field.index}"></div>`);
                         let desc = null;
                         if (field.desc && field.desc.length) {
                             desc = i18n.getMessage(field.desc);
@@ -2917,7 +2917,9 @@ TABS.osd.initialize = function(callback) {
                         }
 
                         const finalFieldName = titleizeField(field);
-                        $field.append(`<label for="${field.name}" class="char-label">${finalFieldName}</label>`);
+                        const $labelAndVariant = $('<div class="switchable-field-description"></div>');
+                        $labelAndVariant.append(`<label for="${field.name}" class="char-label">${finalFieldName}</label>`);
+
 
 
                         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44) && field.variants && field.variants.length > 0) {
@@ -2941,7 +2943,7 @@ TABS.osd.initialize = function(callback) {
 
                             selectVariant.val(field.variant);
 
-                            $field.append(selectVariant);
+                            $labelAndVariant.append(selectVariant);
                         }
 
                         if (field.positionable && field.isVisible[OSD.getCurrentPreviewProfile()]) {
@@ -2961,6 +2963,7 @@ TABS.osd.initialize = function(callback) {
                             );
                         }
 
+                        $field.append($labelAndVariant);
                         // Insert in alphabetical order, with unknown fields at the end
                         $field.name = field.name;
                         insertOrdered($displayFields, $field);


### PR DESCRIPTION
The OSD element picker bit looked a bit messy once the viewport is narrower and it starts to wrap so I've tidied it up a bit...

Before

![Screenshot 2022-05-11 at 09 43 50](https://user-images.githubusercontent.com/194052/167818372-aff1d2c7-ae2f-4073-90d9-073725e8fdb1.png)

After

![Screenshot 2022-05-11 at 10 31 44](https://user-images.githubusercontent.com/194052/167818403-df629c7b-ec1c-4f8c-9562-b27b269dc37d.png)

