### PR TITLE
Stop motor test with Any key

### DIFF
--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -44,7 +44,7 @@ TABS.motors = {
     DSHOT_3D_NEUTRAL: 1500,
 };
 
-TABS.motors.initialize = function (callback) {
+TABS.motors.initialize = async function (callback) {
     const self = this;
 
     self.armed = false;
@@ -59,18 +59,25 @@ TABS.motors.initialize = function (callback) {
         GUI.active_tab = 'motors';
     }
 
-    MSP.promise(MSPCodes.MSP_STATUS)
-    .then(() => MSP.promise(MSPCodes.MSP_PID_ADVANCED))
-    .then(() => MSP.promise(MSPCodes.MSP_FEATURE_CONFIG))
-    .then(() => MSP.promise(MSPCodes.MSP_MIXER_CONFIG))
-    .then(() => FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor ? MSP.promise(MSPCodes.MSP_MOTOR_TELEMETRY) : true)
-    .then(() => MSP.promise(MSPCodes.MSP_MOTOR_CONFIG))
-    .then(() => MSP.promise(MSPCodes.MSP_MOTOR_3D_CONFIG))
-    .then(() => MSP.promise(MSPCodes.MSP2_MOTOR_OUTPUT_REORDERING))
-    .then(() => MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG))
-    .then(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42) ? MSP.promise(MSPCodes.MSP_FILTER_CONFIG) : true)
-    .then(() => semver.gte(FC.CONFIG.apiVersion, "1.8.0") ? MSP.promise(MSPCodes.MSP_ARMING_CONFIG) : true)
-    .then(() => load_html());
+    await MSP.promise(MSPCodes.MSP_STATUS);
+    await MSP.promise(MSPCodes.MSP_PID_ADVANCED);
+    await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
+    await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
+    if (FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor) {
+        await MSP.promise(MSPCodes.MSP_MOTOR_TELEMETRY);
+    }
+    await MSP.promise(MSPCodes.MSP_MOTOR_CONFIG);
+    await MSP.promise(MSPCodes.MSP_MOTOR_3D_CONFIG);
+    await MSP.promise(MSPCodes.MSP2_MOTOR_OUTPUT_REORDERING);
+    await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG);
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
+        await MSP.promise(MSPCodes.MSP_FILTER_CONFIG);
+    }
+    if (semver.gte(FC.CONFIG.apiVersion, "1.8.0")) {
+        await MSP.promise(MSPCodes.MSP_ARMING_CONFIG);
+    }
+
+    load_html();
 
     function load_html() {
         $('#content').load("./tabs/motors.html", process_html);
@@ -226,7 +233,7 @@ TABS.motors.initialize = function (callback) {
         const motorsEnableTestModeElement = $('#motorsEnableTestMode');
         self.analyticsChanges = {};
 
-        motorsEnableTestModeElement.prop('checked', false);
+        motorsEnableTestModeElement.prop('checked', false).trigger('change');
 
         if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42) || !(FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor)) {
             $(".motor_testing .telemetry").hide();
@@ -240,6 +247,7 @@ TABS.motors.initialize = function (callback) {
         function setContentButtons(motorsTesting=false) {
             $('.btn .tool').toggleClass("disabled", self.configHasChanged || motorsTesting);
             $('.btn .save').toggleClass("disabled", !self.configHasChanged);
+            $('.btn .stop').toggleClass("disabled", !motorsTesting);
         }
 
         const defaultConfiguration = {
@@ -865,7 +873,16 @@ TABS.motors.initialize = function (callback) {
 
         setSlidersDefault();
 
-        motorsEnableTestModeElement.change(function () {
+        const ignoreKeys = [
+            'PageUp',
+            'PageDown',
+            'End',
+            'Home',
+            'ArrowUp',
+            'ArrowDown',
+        ];
+
+        motorsEnableTestModeElement.on('change', function () {
             let enabled = $(this).is(':checked');
             // prevent or disable testing if configHasChanged flag is set.
             if (self.configHasChanged) {
@@ -877,16 +894,35 @@ TABS.motors.initialize = function (callback) {
                 // disable input
                 motorsEnableTestModeElement.prop('checked', false);
             }
+
+            function disableMotorTest(e) {
+                if (motorsEnableTestModeElement.is(':checked')) {
+                    if (!ignoreKeys.includes(e.code)) {
+                        motorsEnableTestModeElement.prop('checked', false).trigger('change');
+                    }
+                }
+            }
+
+            if (enabled) {
+                document.addEventListener('keydown', e => disableMotorTest(e));
+                // enable Status and Motor data pulling
+                GUI.interval_add('motor_and_status_pull', get_status, 50, true);
+            } else {
+                document.removeEventListener('keydown', e => disableMotorTest(e));
+                GUI.interval_remove("motor_and_status_pull");
+            }
+
             setContentButtons(enabled);
             setSlidersEnabled(enabled);
 
             $('div.sliders input').trigger('input');
 
             mspHelper.setArmingEnabled(enabled, enabled);
-        }).change();
+        });
 
         let bufferingSetMotor = [],
         buffer_delay = false;
+
         $('div.sliders input:not(.master)').on('input', function () {
             const index = $(this).index();
             let buffer = [];
@@ -936,7 +972,7 @@ TABS.motors.initialize = function (callback) {
         }
 
         if (motorsRunning) {
-            motorsEnableTestModeElement.prop('checked', true).change();
+            motorsEnableTestModeElement.prop('checked', true).trigger('change');
 
             // motors are running adjust sliders to current values
 
@@ -1063,7 +1099,7 @@ TABS.motors.initialize = function (callback) {
             }
         }
 
-        $('a.save').on('click', function() {
+        $('a.save').on('click', async function() {
             // gather data that doesn't have automatic change event bound
             FC.MOTOR_CONFIG.minthrottle = parseInt($('input[name="minthrottle"]').val());
             FC.MOTOR_CONFIG.maxthrottle = parseInt($('input[name="maxthrottle"]').val());
@@ -1086,24 +1122,28 @@ TABS.motors.initialize = function (callback) {
                 FC.PID_ADVANCED_CONFIG.gyroUse32kHz = $('input[id="gyroUse32kHz"]').is(':checked') ? 1 : 0;
             }
 
-            MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG))
-            .then(() => MSP.promise(MSPCodes.MSP_SET_MIXER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MIXER_CONFIG)))
-            .then(() => MSP.promise(MSPCodes.MSP_SET_MOTOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_CONFIG)))
-            .then(() => MSP.promise(MSPCodes.MSP_SET_MOTOR_3D_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_3D_CONFIG)))
-            .then(() => MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG)))
-            .then(() => MSP.promise(MSPCodes.MSP_SET_ARMING_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ARMING_CONFIG)))
-            .then(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42) ?
-                MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG)) : true)
-            .then(() => MSP.promise(MSPCodes.MSP_EEPROM_WRITE))
-            .then(() => reboot());
+            await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_MIXER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MIXER_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_MOTOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_MOTOR_3D_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_3D_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_ARMING_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ARMING_CONFIG));
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
+                await MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG));
+            }
+            await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
 
             analytics.sendSaveAndChangeEvents(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, self.analyticsChanges, 'motors');
             self.analyticsChanges = {};
             self.configHasChanged = false;
+
+            reboot();
         });
 
-        // enable Status and Motor data pulling
-        GUI.interval_add('motor_and_status_pull', get_status, 50, true);
+        $('a.stop').on('click', () => motorsEnableTestModeElement.prop('checked', false).trigger('change'));
+
+        // get initial motor status values
+        get_status();
 
         setup_motor_output_reordering_dialog(SetupEscDshotDirectionDialogCallback, zeroThrottleValue);
 
@@ -1115,12 +1155,13 @@ TABS.motors.initialize = function (callback) {
             GUI.content_ready(callback);
         }
 
-        GUI.content_ready(callback);
+        content_ready();
     }
 
-    function reboot() {
+    async function reboot() {
         GUI.log(i18n.getMessage('configurationEepromSaved'));
-        MSP.promise(MSPCodes.MSP_SET_REBOOT, false, false).then(() => reinitializeConnection(self));
+        await MSP.promise(MSPCodes.MSP_SET_REBOOT);
+        reinitializeConnection(self);
     }
 
     function showDialogMixerReset(message) {

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -365,6 +365,7 @@
         <div class="content_toolbar">
             <div class="btn">
                 <a class="save disabled" href="#" i18n="motorsButtonSave"></a>
+                <a class="stop disabled" href="#" i18n="escDshotDirectionDialog-StopWizard"></a>
             </div>
         </div>
 


### PR DESCRIPTION
Fixes: #2918

- [x] Add `ANY` key handler to stop motor test.
- [x] Add `Stop Motors` button. 
- [x] Only poll MSP status updates when testing is enabled.
- [x] Updates MSP promises to `async await`.
