### PR TITLE
Update all workflows to use ubuntu-22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
 
@@ -39,11 +39,11 @@ jobs:
       matrix:
         include:
           - name: Android
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             releaseArgs: --android
 
           - name: Linux
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             releaseArgs: --linux64
 
           - name: macOS

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   stale:
     name: 'Check and close stale issues'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/stale@v4
       with:


### PR DESCRIPTION
See reminder: https://github.com/betaflight/betaflight-configurator/pull/2913

`ubuntu-22.04` seems to be finished now:

![image](https://user-images.githubusercontent.com/8344830/169386562-905d0d15-e3c1-41ac-85ff-21895bbbda5b.png)

Need to check for Java availability: https://github.com/actions/virtual-environments/issues/5490

Has to wait until Android and Apple are happy. 