### PR TITLE
Not wrap header elements

### DIFF
--- a/src/css/main.css
+++ b/src/css/main.css
@@ -416,6 +416,10 @@ input[type="number"]::-webkit-inner-spin-button {
     }
 }
 
+#sensor-status > ul {
+    display: flex;
+}
+
 #sensor-status li {
     float: left;
     height: 67px;
@@ -640,6 +644,7 @@ input[type="number"]::-webkit-inner-spin-button {
     background-color: #434343;
     background-image: -webkit-linear-gradient(top, transparent, rgba(0, 0, 0, 0.55));
     text-shadow: 0 1px rgba(0, 0, 0, 1.0);
+    white-space: nowrap;
 }
 
 @media all and (min-width: 1125px) {


### PR DESCRIPTION
When we reduce at minimum resolution the Configurator, and the Virtual FC is enabled, the elements in the header go wrong:
![image](https://user-images.githubusercontent.com/2673520/169475963-79f08ae3-6312-4828-93b8-c5d634c8973e.png)

This fixes that, the logo is reduced to the minimum, but there is not space to play more:
![image](https://user-images.githubusercontent.com/2673520/169475822-84d9d20f-f46c-4601-967c-d4c7f0e45eba.png)
