### PR TITLE
Fix PortHandler

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -5,7 +5,7 @@ let connectionTimestamp;
 let clicks = false;
 
 function initializeSerialBackend() {
-    GUI.updateManualPortVisibility = function(){
+    GUI.updateManualPortVisibility = function() {
         const selected_port = $('div#port-picker #port option:selected');
         if (selected_port.data().isManual) {
             $('#port-override-option').show();
@@ -19,12 +19,8 @@ function initializeSerialBackend() {
         else {
             $('#firmware-virtual-option').hide();
         }
-        if (selected_port.data().isDFU) {
-            $('select#baud').hide();
-        }
-        else {
-            $('select#baud').show();
-        }
+
+        $('#auto-connect-and-baud').toggle(!selected_port.data().isDFU);
     };
 
     GUI.updateManualPortVisibility();


### PR DESCRIPTION
@McGiverGim found an issue with some GUI function continuous being called.

Fixes and improves following issues:

- [x] GUI updates were done in PortHandler every 500ms, moving them where status needs change.
- [x] Isolated PortHandler change handler in firmware flasher tab as it was working on other tabs.
- [x] PortHandler was cutting of text and adjusted the correction.
- [x] Auto-detect button was not always updated correctly.
- [x] Add recognition for SPRacing boards.
- [x] Disable flash button when flashing.
- [x] Don't check serial devices in DFU mode.
- [x] Don't check USB devices in serial mode. 

Due to changes it was needed to rethink how to enable the auto-detect button.