### PR TITLE
Add dependency on libatomic1 library for Linux

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -710,6 +710,7 @@ function release_deb(arch, appDirectory, done) {
     if (!commandExistsSync('dpkg-deb')) {
         console.warn(`dpkg-deb command not found, not generating deb package for ${arch}`);
         done();
+        return null;
     }
 
     return gulp.src([path.join(appDirectory, metadata.name, arch, '*')])
@@ -728,7 +729,7 @@ function release_deb(arch, appDirectory, done) {
                 `xdg-desktop-menu install ${LINUX_INSTALL_DIR}/${metadata.name}/${metadata.name}.desktop`,
             ],
             prerm: [`xdg-desktop-menu uninstall ${metadata.name}.desktop`],
-            depends: 'libgconf-2-4',
+            depends: ['libgconf-2-4', 'libatomic1'],
             changelog: [],
             _target: `${LINUX_INSTALL_DIR}/${metadata.name}`,
             _out: RELEASE_DIR,
@@ -739,10 +740,11 @@ function release_deb(arch, appDirectory, done) {
 
 function release_rpm(arch, appDirectory, done) {
 
-    // Check if dpkg-deb exists
+    // Check if rpmbuild exists
     if (!commandExistsSync('rpmbuild')) {
         console.warn(`rpmbuild command not found, not generating rpm package for ${arch}`);
         done();
+        return;
     }
 
     // The buildRpm does not generate the folder correctly, manually
@@ -755,7 +757,7 @@ function release_rpm(arch, appDirectory, done) {
             vendor: metadata.author,
             summary: metadata.description,
             license: 'GNU General Public License v3.0',
-            requires: 'libgconf-2-4',
+            requires: ['libgconf-2-4', 'libatomic1'],
             prefix: '/opt',
             files: [{
                 cwd: path.join(appDirectory, metadata.name, arch),

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "glob": "^7.1.6",
     "gulp": "^4.0.2",
     "gulp-concat": "~2.6.1",
-    "gulp-debian": "~0.1.8",
+    "gulp-debian": "^0.1.9",
     "gulp-json-editor": "^2.5.4",
     "gulp-prompt": "^1.2.0",
     "gulp-rename": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7866,7 +7866,7 @@ gulp-concat@~2.6.1:
     through2 "^2.0.0"
     vinyl "^2.0.0"
 
-gulp-debian@~0.1.8:
+gulp-debian@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/gulp-debian/-/gulp-debian-0.1.9.tgz#80e4a8cfc0f0904312f07e66a06ca3c024edc153"
   integrity sha512-hY16Lj5IdxY213L9Sl6SlEgpCvf8/ny3SQ4S9dyG8MHqRx0fPpui5CRodhQK5lA2oScxP8qi4wfK4fIDr5xF3g==


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/2933

I tested Ubuntu and seemed to work. I don't have now a way to test RPM part.