### PR TITLE
Fix MSP_BOARD_INFO accumulation and localStorage Quota Exceeded

### DIFF
--- a/src/js/FirmwareCache.js
+++ b/src/js/FirmwareCache.js
@@ -44,14 +44,14 @@ let FirmwareCache = (function () {
         function persist(data) {
             let obj = {};
             obj[CACHEKEY] = data;
-            ConfigStorage.set(obj);
+            SessionStorage.set(obj);
         }
 
         /**
          * @param {Function} callback
          */
         function load(callback) {
-            const obj = ConfigStorage.get(CACHEKEY);
+            const obj = SessionStorage.get(CACHEKEY);
             let entries = typeof obj === "object" && obj.hasOwnProperty(CACHEKEY)
                 ? obj[CACHEKEY]
                 : [];
@@ -75,13 +75,13 @@ let FirmwareCache = (function () {
         }
         let key = oldest[0];
         let cacheKey = withCachePrefix(key);
-        const obj = ConfigStorage.get(cacheKey);
+        const obj = SessionStorage.get(cacheKey);
         /** @type {CacheItem} */
         const cached = typeof obj === "object" && obj.hasOwnProperty(cacheKey) ? obj[cacheKey] : null;
         if (cached === null) {
             return undefined;
         }
-        ConfigStorage.remove(cacheKey);
+        SessionStorage.remove(cacheKey);
         onRemoveFromCache(cached.release);
         return oldest;
     };
@@ -138,7 +138,7 @@ let FirmwareCache = (function () {
             release: release,
             hexdata: hexdata,
         };
-        ConfigStorage.set(obj);
+        SessionStorage.set(obj);
         onPutToCache(release);
     }
 
@@ -157,7 +157,7 @@ let FirmwareCache = (function () {
             return;
         }
         let cacheKey = withCachePrefix(key);
-        const obj = ConfigStorage.get(cacheKey);
+        const obj = SessionStorage.get(cacheKey);
         const cached = typeof obj === "object" && obj.hasOwnProperty(cacheKey) ? obj[cacheKey] : null;
         callback(cached);
     }
@@ -174,7 +174,7 @@ let FirmwareCache = (function () {
         for (let key of journal.keys()) {
             cacheKeys.push(withCachePrefix(key));
         }
-        const obj = ConfigStorage.get(cacheKeys);
+        const obj = SessionStorage.get(cacheKeys);
         if (typeof obj !== "object") {
             return;
         }
@@ -186,7 +186,7 @@ let FirmwareCache = (function () {
                 onRemoveFromCache(item.release);
             }
         }
-        ConfigStorage.remove(cacheKeys);
+        SessionStorage.remove(cacheKeys);
         journal.clear();
         JournalStorage.persist(journal.toJSON());
     }

--- a/src/js/SessionStorage.js
+++ b/src/js/SessionStorage.js
@@ -1,21 +1,19 @@
 'use strict';
 
-// idea here is to abstract around the use of chrome.storage.local as it functions differently from "localStorage" and IndexedDB
-// localStorage deals with strings, not objects, so the objects have been serialized.
-const ConfigStorage = {
+const SessionStorage = {
     // key can be one string, or array of strings
     get: function(key) {
         let result = {};
         if (Array.isArray(key)) {
             key.forEach(function (element) {
                 try {
-                    result = {...result, ...JSON.parse(localStorage.getItem(element))};
+                    result = {...result, ...JSON.parse(sessionStorage.getItem(element))};
                 } catch (e) {
                     console.error(e);
                 }
             });
         } else {
-            const keyValue = localStorage.getItem(key);
+            const keyValue = sessionStorage.getItem(key);
             if (keyValue) {
                 try {
                     result = JSON.parse(keyValue);
@@ -27,22 +25,21 @@ const ConfigStorage = {
 
         return result;
     },
-    // set takes an object like {'userLanguageSelect':'DEFAULT'}
     set: function(input) {
         Object.keys(input).forEach(function (element) {
             const tmpObj = {};
             tmpObj[element] = input[element];
             try {
-                localStorage.setItem(element, JSON.stringify(tmpObj));
+                sessionStorage.setItem(element, JSON.stringify(tmpObj));
             } catch (e) {
                 console.error(e);
             }
         });
     },
     remove: function(item) {
-        localStorage.removeItem(item);
+        sessionStorage.removeItem(item);
     },
     clear: function() {
-        localStorage.clear();
+        sessionStorage.clear();
     },
 };

--- a/src/js/jenkins_loader.js
+++ b/src/js/jenkins_loader.js
@@ -21,7 +21,7 @@ JenkinsLoader.prototype.loadJobs = function (viewName, callback) {
         callback(jobs);
     };
 
-    const result = ConfigStorage.get([cacheLastUpdateTag, jobsDataTag]);
+    const result = SessionStorage.get([cacheLastUpdateTag, jobsDataTag]);
     const jobsDataTimestamp = $.now();
     const cachedJobsData = result[jobsDataTag];
     const cachedJobsLastUpdate = result[cacheLastUpdateTag];
@@ -49,7 +49,7 @@ JenkinsLoader.prototype.loadJobs = function (viewName, callback) {
             const object = {};
             object[jobsDataTag] = jobs;
             object[cacheLastUpdateTag] = $.now();
-            ConfigStorage.set(object);
+            SessionStorage.set(object);
 
             wrappedCallback(jobs);
         }).fail(xhr => {
@@ -68,7 +68,7 @@ JenkinsLoader.prototype.loadBuilds = function (jobName, callback) {
     const buildsDataTag = `${jobUrl}BuildsData`;
     const cacheLastUpdateTag = `${jobUrl}BuildsLastUpdate`;
 
-    const result = ConfigStorage.get([cacheLastUpdateTag, buildsDataTag]);
+    const result = SessionStorage.get([cacheLastUpdateTag, buildsDataTag]);
     const buildsDataTimestamp = $.now();
     const cachedBuildsData = result[buildsDataTag];
     const cachedBuildsLastUpdate = result[cacheLastUpdateTag];
@@ -100,8 +100,7 @@ JenkinsLoader.prototype.loadBuilds = function (jobName, callback) {
             const object = {};
             object[buildsDataTag] = builds;
             object[cacheLastUpdateTag] = $.now();
-            ConfigStorage.set(object);
-
+            SessionStorage.set(object);
             self._parseBuilds(jobUrl, jobName, builds, callback);
         }).fail(xhr => {
             GUI.log(i18n.getMessage('buildServerLoadFailed', [jobName, `HTTP ${xhr.status}`]));

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -28,8 +28,30 @@ function readConfiguratorVersionMetadata() {
     CONFIGURATOR.gitRevision = manifest.gitRevision;
 }
 
+function cleanupLocalStorage() {
+
+    const cleanupLocalStorageList = [
+        'cache',
+        'firmware',
+        'https',
+        'selected_board',
+        'unifiedConfigLast',
+        'unifiedSourceCache',
+    ];
+
+    for (const key in localStorage) {
+        for (const item of cleanupLocalStorageList) {
+            if (key.includes(item)) {
+                localStorage.removeItem(key);
+            }
+        }
+    }
+}
+
 function appReady() {
     readConfiguratorVersionMetadata();
+
+    cleanupLocalStorage();
 
     i18n.init(function() {
         startProcess();

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -843,38 +843,43 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
 
             case MSPCodes.MSP_BOARD_INFO:
-                let boardIdentifier = '';
+                FC.CONFIG.boardIdentifier = '';
+
                 for (let i = 0; i < 4; i++) {
-                    boardIdentifier += String.fromCharCode(data.readU8());
+                    FC.CONFIG.boardIdentifier += String.fromCharCode(data.readU8());
                 }
-                FC.CONFIG.boardIdentifier = boardIdentifier;
+
                 FC.CONFIG.boardVersion = data.readU16();
+                FC.CONFIG.boardType = 0;
 
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_35)) {
                     FC.CONFIG.boardType = data.readU8();
-                } else {
-                    FC.CONFIG.boardType = 0;
                 }
+
+                FC.CONFIG.targetCapabilities = 0;
+                FC.CONFIG.targetName = '';
 
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_37)) {
                     FC.CONFIG.targetCapabilities = data.readU8();
-
-                    let length = data.readU8();
+                    const length = data.readU8();
                     for (let i = 0; i < length; i++) {
                         FC.CONFIG.targetName += String.fromCharCode(data.readU8());
                     }
-                } else {
-                    FC.CONFIG.targetCapabilities = 0;
-                    FC.CONFIG.targetName = "";
                 }
+
+                FC.CONFIG.boardName = '';
+                FC.CONFIG.manufacturerId = '';
+                FC.CONFIG.signature = [];
 
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
                     let length = data.readU8();
+
                     for (let i = 0; i < length; i++) {
                         FC.CONFIG.boardName += String.fromCharCode(data.readU8());
                     }
 
                     length = data.readU8();
+
                     for (let i = 0; i < length; i++) {
                         FC.CONFIG.manufacturerId += String.fromCharCode(data.readU8());
                     }
@@ -882,10 +887,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     for (let i = 0; i < self.SIGNATURE_LENGTH; i++) {
                         FC.CONFIG.signature.push(data.readU8());
                     }
-                } else {
-                    FC.CONFIG.boardName = "";
-                    FC.CONFIG.manufacturerId = "";
-                    FC.CONFIG.signature = [];
                 }
 
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {

--- a/src/js/release_checker.js
+++ b/src/js/release_checker.js
@@ -11,7 +11,7 @@ const ReleaseChecker = function (releaseName, releaseUrl) {
 
 ReleaseChecker.prototype.loadReleaseData = function (processFunction) {
     const self = this;
-    const result = ConfigStorage.get([self._releaseLastUpdateTag, self._releaseDataTag]);
+    const result = SessionStorage.get([self._releaseLastUpdateTag, self._releaseDataTag]);
     const releaseDataTimestamp = $.now();
     const cacheReleaseData = result[self._releaseDataTag];
     const cachedReleaseLastUpdate = result[self._releaseLastUpdateTag];
@@ -23,7 +23,7 @@ ReleaseChecker.prototype.loadReleaseData = function (processFunction) {
             const data = {};
             data[self._releaseDataTag] = releaseData;
             data[self._releaseLastUpdateTag] = releaseDataTimestamp;
-            ConfigStorage.set(data);
+            SessionStorage.set(data);
 
             self._processReleaseData(releaseData, processFunction);
         }).fail(function (data) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -158,7 +158,7 @@ firmware_flasher.initialize = function (callback) {
 
             TABS.firmware_flasher.releases = builds;
 
-            result = ConfigStorage.get('selected_board');
+            result = SessionStorage.get('selected_board');
             if (result.selected_board) {
                 const boardBuilds = builds[result.selected_board];
                 $('select[name="board"]').val(boardBuilds ? result.selected_board : 0).trigger('change');
@@ -243,7 +243,7 @@ firmware_flasher.initialize = function (callback) {
             if (builds && hasUnifiedTargetBuild(builds)) {
                 console.log('loaded some builds for later');
                 const storageTag = 'unifiedSourceCache';
-                result = ConfigStorage.get(storageTag);
+                result = SessionStorage.get(storageTag);
                 let storageObj = result[storageTag];
                 if (!storageObj || !storageObj.lastUpdate || checkTime - storageObj.lastUpdate > expirationPeriod) {
                     console.log('go get', unifiedSource);
@@ -254,7 +254,7 @@ firmware_flasher.initialize = function (callback) {
                         newDataObj.lastUpdate = checkTime;
                         newDataObj.data = data;
                         newStorageObj[storageTag] = newDataObj;
-                        ConfigStorage.set(newStorageObj);
+                        SessionStorage.set(newStorageObj);
 
                         parseUnifiedBuilds(data, builds);
                     }).fail(xhr => {
@@ -312,7 +312,7 @@ firmware_flasher.initialize = function (callback) {
             TABS.firmware_flasher.releases = releases;
             TABS.firmware_flasher.unifiedConfigs = unifiedConfigs;
 
-            result = ConfigStorage.get('selected_board');
+            result = SessionStorage.get('selected_board');
             if (result.selected_board) {
                 const boardReleases = TABS.firmware_flasher.unifiedConfigs[result.selected_board]
                     || TABS.firmware_flasher.releases[result.selected_board];
@@ -410,7 +410,12 @@ firmware_flasher.initialize = function (callback) {
 
             if (!GUI.connect_lock) {
                 TABS.firmware_flasher.unifiedConfigs = {};
-                buildTypesToShow[build_type].loader();
+
+                try {
+                    buildTypesToShow[build_type].loader();
+                } catch (err) {
+                    console.error(err);
+                }
             }
 
             ConfigStorage.set({'selected_build_type': build_type});
@@ -554,7 +559,7 @@ firmware_flasher.initialize = function (callback) {
                 }
 
                 if (target !== '0') {
-                    ConfigStorage.set({'selected_board': target});
+                    SessionStorage.set({'selected_board': target});
                 }
 
                 TABS.firmware_flasher.selectedBoard = target;
@@ -610,7 +615,7 @@ firmware_flasher.initialize = function (callback) {
                         const storageTag = 'unifiedConfigLast';
                         const expirationPeriod = 3600; // One of your earth hours.
                         const checkTime = Math.floor(Date.now() / 1000); // Lets deal in seconds.
-                        result = ConfigStorage.get(storageTag);
+                        result = SessionStorage.get(storageTag);
                         let storageObj = result[storageTag];
                         const unifiedConfigList = TABS.firmware_flasher.unifiedConfigs[target];
                         const manufacturerIds = Object.keys(unifiedConfigList);
@@ -653,7 +658,7 @@ firmware_flasher.initialize = function (callback) {
                                                 targetId: targetId,
                                                 lastUpdate: checkTime,
                                             };
-                                            ConfigStorage.set(newStorageObj);
+                                            SessionStorage.set(newStorageObj);
 
                                             populateBuilds(builds, target, manufacturerId, duplicateName, TABS.firmware_flasher.releases[bareBoard], processNext);
                                         });
@@ -1170,10 +1175,10 @@ firmware_flasher.initialize = function (callback) {
             function setAcknowledgementTimestamp() {
                 const storageObj = {};
                 storageObj[storageTag] = Date.now();
-                ConfigStorage.set(storageObj);
+                SessionStorage.set(storageObj);
             }
 
-            result = ConfigStorage.get(storageTag);
+            result = SessionStorage.get(storageTag);
             if (!result[storageTag] || Date.now() - result[storageTag] > DAY_MS) {
 
                 showAcknowledgementDialog(setAcknowledgementTimestamp);
@@ -1392,7 +1397,7 @@ firmware_flasher.showDialogVerifyBoard = function (selected, verified, onAbort, 
     if (!dialogVerifyBoard.hasAttribute('open')) {
         dialogVerifyBoard.showModal();
         $('#dialog-verify-board-abort-confirmbtn').click(function() {
-            ConfigStorage.set({'selected_board': FC.CONFIG.boardName});
+            SessionStorage.set({'selected_board': FC.CONFIG.boardName});
             dialogVerifyBoard.close();
             onAbort();
         });

--- a/src/main.html
+++ b/src/main.html
@@ -88,6 +88,7 @@
     <script type="text/javascript" src="./js/utils/VtxDeviceStatus/SmartAudioDeviceStatus.js"></script>
     <script type="text/javascript" src="./js/utils/VtxDeviceStatus/Rtc6705DeviceStatus.js"></script>
     <script type="text/javascript" src="./js/ConfigStorage.js"></script>
+    <script type="text/javascript" src="./js/SessionStorage.js"></script>
     <script type="text/javascript" src="./js/data_storage.js"></script>
     <script type="text/javascript" src="./js/fc.js"></script>
     <script type="text/javascript" src="./js/VirtualFC.js"></script>


### PR DESCRIPTION
Fixes: #2938 

- [x] Fixes `FC.CONFIG.boardName` parameter accumulating previous values.
- [x] Move `Loader` function in a `try catch error` statement.
- [x] Move `Jenkins` + firmware `cache` from `localStorage` to new `SessionStorage` to fix `Exceeded Quota` error.
- [x] Remove old keys from LocalStorage. 