### PR TITLE
Fix display of OSD tab save/font buttons on Android.

### DIFF
--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -195,12 +195,14 @@
                     </div>
                 </div>
 
-                <div class="content_toolbar supported hide" style="left:0;">
-                    <div class="btn save">
-                        <a class="active save" href="#" i18n="osdSetupSave"></a>
-                    </div>
-                    <div class="btn">
-                        <a class="requires-max7456-font-device-detected fonts" id="fontmanager" href="#" i18n="osdSetupFontManager"></a>
+                <div class="supported hide">
+                    <div class="content_toolbar" style="left:0;">
+                        <div class="btn">
+                            <a class="requires-max7456-font-device-detected fonts" id="fontmanager" href="#" i18n="osdSetupFontManager"></a>
+                        </div>
+                        <div class="btn save">
+                            <a class="active save" href="#" i18n="osdSetupSave"></a>
+                        </div>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
Before:
![Screenshot 2022-06-06 at 16 16 53](https://user-images.githubusercontent.com/194052/172194072-b1e21f5c-0d4b-471e-9a1d-1d72fbf2446a.png)

After:

![Screenshot 2022-06-06 at 16 33 12](https://user-images.githubusercontent.com/194052/172194107-67393c0f-7343-4df2-9887-4ddacef11696.png)

The fadeIn call in osd.js causes the .content_toolbar element to end up as display: block; whereas the CSS has it display flex (and similar elements on other tabs use flex).

Fix I went for was to add a wrapper element that holds the 'supported' etc classes + gets faded in, leaving the main .content_toolbar element untampered with (ie: it remains display: flex).  Felt this is cleaner/simpler than messing with the JS to restore the flex properly after fadeIn.

Also then had to swap the order of the buttons to get them to display correctly.
