### PR TITLE
Use the new render attritube for the diff in the issue yaml template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -46,11 +46,11 @@ body:
       label: Flight controller configuration
       description: |
         If this bug is related to a specific flight controller and/or configuration please specify it here.
-        Create a `diff` and post it here in a code block. Put (three backticks) at the start and end of the diff block (instructions  on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/).
-      value: |
-        ```
-          # REPLACE THIS LINE BY THE OUTPUT OF YOUR `diff`
-        ```
+        Create a `diff` and post it here. Instructions on how to do a diff: https://oscarliang.com/use-diff-not-dump-betaflight/
+        Don't add three backticks or any other format symbol at the start or end of the block, they will be added automatically.
+      placeholder: |
+          # PASTE HERE THE OUTPUT OF `diff` COMMAND IN THE CLI TAB
+      render: txt
 
   - type: markdown
     attributes:


### PR DESCRIPTION
Same change that was done here: https://github.com/betaflight/betaflight/pull/11663/files

Users seem to have a problem adding the three backticks symbol in he form to format the diff.
GitHub has added a new attribute, render, to add it automatically.
This change adds this new attribute and modifies the form, adding placeholder, etc. to simplify the use.