### PR TITLE
vtx_osd_variant_fix

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4869,6 +4869,14 @@
     "osdDescElementVtxChannel": {
         "message": "Current VTX channel and power"
     },
+    "osdTextElementVTXchannelVariantPower": {
+        "message": "VTX power",
+        "description": "One of the variants of the VTX channel element of the OSD"        
+    },
+    "osdTextElementVTXchannelVariantFull": {
+        "message": "Band:Channel:Pwr:Pit",
+        "description": "One of the variants of the VTX channel element of the OSD"
+    },
     "osdTextElementVoltageWarning": {
         "message": "Battery voltage warning",
         "description": "One of the elements of the OSD"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -306,6 +306,21 @@ OSD.generateAltitudePreview = function(osdData) {
     return `${FONT.symbol(SYM.ALTITUDE)}399${variantSelected === 0? '.7' : ''}${unit}`;
 };
 
+OSD.generateVTXChannelPreview = function(osdData) {
+    const variantSelected = OSD.getVariantForPreview(osdData, 'VTX_CHANNEL');
+    let value;
+    switch (variantSelected) {
+        case 0:
+            value = 'R:2:200:P';
+            break;
+
+        case 1:
+            value = '200';
+            break;
+    }
+    return value;
+};
+
 OSD.generateBatteryUsagePreview = function(osdData) {
     const variantSelected = OSD.getVariantForPreview(osdData, 'MAIN_BATT_USAGE');
 
@@ -565,7 +580,13 @@ OSD.loadDisplayFields = function() {
             defaultPosition: 1,
             draw_order: 120,
             positionable: true,
-            preview: 'R:2:200:P',
+            variants: [
+                'osdTextElementVTXchannelVariantFull',
+                'osdTextElementVTXchannelVariantPower',
+            ],
+            preview(osdData) {
+                return OSD.generateVTXChannelPreview(osdData);
+            },
         },
         VOLTAGE_WARNING: {
             name: 'VOLTAGE_WARNING',


### PR DESCRIPTION
this is a PR to replace https://github.com/betaflight/betaflight-configurator/pull/2755 i had too many github issues to salvage

I've created an osd variant for VTX channel that displays only the VTXpower.

pull request is partial approved in betaflight here
https://github.com/betaflight/betaflight/pull/11275

![image](https://user-images.githubusercontent.com/11393479/176271425-aa719c00-2df1-4f4b-ab82-df840a7c3550.png)
![image](https://user-images.githubusercontent.com/11393479/176271460-d3d9388c-ae35-4df8-b582-4e6d17dac204.png)
![image](https://user-images.githubusercontent.com/11393479/176271487-7c80a1bd-ad71-4963-ad03-ca64a88e70c4.png)


