### PR TITLE
Remove scrollTop workaround

### DIFF
--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -911,7 +911,7 @@ function configuration_restore(callback) {
                 GUI.log(i18n.getMessage('eeprom_saved_ok'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection('setup', _callback));
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(_callback));
                 });
             }
         }

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -806,7 +806,7 @@ function update_dataflash_global() {
      }
 }
 
-function reinitializeConnection(originatorTab, callback) {
+function reinitializeConnection(callback) {
 
     // Close connection gracefully if it still exists.
     const previousTimeStamp = connectionTimestamp;
@@ -830,7 +830,6 @@ function reinitializeConnection(originatorTab, callback) {
             clearInterval(reconnect);
             await MSP.promise(MSPCodes.MSP_STATUS);
             GUI.log(i18n.getMessage('deviceReady'));
-            originatorTab.initialize(false, $('#content').scrollTop());
             callback?.();
         } else {
             attempts++;

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -462,7 +462,7 @@ TABS.cli.read = function (readInfo) {
             CONFIGURATOR.cliActive = false;
             CONFIGURATOR.cliValid = false;
             GUI.log(i18n.getMessage('cliReboot'));
-            reinitializeConnection(self);
+            reinitializeConnection();
         }
 
     }

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -626,7 +626,7 @@ TABS.configuration.initialize = function (callback) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection());
                 });
             }
 

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -2,12 +2,8 @@
 
 TABS.failsafe = {};
 
-TABS.failsafe.initialize = function (callback, scrollPosition) {
-    const self = this;
-
-    if (GUI.active_tab != 'failsafe') {
-        GUI.active_tab = 'failsafe';
-    }
+TABS.failsafe.initialize = function (callback) {
+    GUI.active_tab = 'failsafe';
 
     function load_rx_config() {
         MSP.send_message(MSPCodes.MSP_RX_CONFIG, false, false, load_failssafe_config);
@@ -219,11 +215,6 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
             FC.RXFAIL_CONFIG[i].value = parseInt($(this).val());
         });
 
-        // for some odd reason chrome 38+ changes scroll according to the touched select element
-        // i am guessing this is a bug, since this wasn't happening on 37
-        // code below is a temporary fix, which we will be able to remove in the future (hopefully)
-        $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
-
         // fill stage 1 Valid Pulse Range Settings
         $('input[name="rx_min_usec"]').val(FC.RX_CONFIG.rx_min_usec);
         $('input[name="rx_max_usec"]').val(FC.RX_CONFIG.rx_max_usec);
@@ -413,7 +404,7 @@ TABS.failsafe.initialize = function (callback, scrollPosition) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection());
                 });
             }
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -1162,7 +1162,7 @@ TABS.motors.initialize = async function (callback) {
     async function reboot() {
         GUI.log(i18n.getMessage('configurationEepromSaved'));
         await MSP.promise(MSPCodes.MSP_SET_REBOOT);
-        reinitializeConnection(self);
+        reinitializeConnection();
     }
 
     function showDialogMixerReset(message) {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -48,7 +48,7 @@ TABS.onboard_logging.initialize = function (callback) {
         GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
-            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection());
         });
     }
 

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -4,7 +4,7 @@ TABS.ports = {
     analyticsChanges: {},
 };
 
-TABS.ports.initialize = function (callback, scrollPosition) {
+TABS.ports.initialize = function (callback) {
     const self = this;
 
     let board_definition = {};
@@ -412,7 +412,7 @@ TABS.ports.initialize = function (callback, scrollPosition) {
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             GUI.tab_switch_cleanup(function() {
-                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection());
             });
         }
     }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -476,7 +476,7 @@ TABS.receiver.initialize = function (callback) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
                 if (boot) {
                     GUI.tab_switch_cleanup(function() {
-                        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(tab));
+                        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection());
                     });
                 }
             }

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -5,7 +5,7 @@ TABS.transponder = {
     available: false,
 };
 
-TABS.transponder.initialize = function(callback, scrollPosition) {
+TABS.transponder.initialize = function(callback) {
 
     let _persistentInputValues = {};
 
@@ -303,7 +303,7 @@ TABS.transponder.initialize = function(callback, scrollPosition) {
                         GUI.log(i18n.getMessage('transponderEepromSaved'));
                         if ( $(_this).hasClass('reboot') ) {
                             GUI.tab_switch_cleanup(function() {
-                                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+                                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection());
                             });
                         }
                     });


### PR DESCRIPTION
Very intermittent I got the `originatorTab` undefined bug. As it was implemented as workaround for a bug in NWjs 0.38 it seems to be no longer needed. There are other mechanisms to return to last enabled tab now so no need to initialize as it would be taken care of while reloading tab after reboot anyway.