### PR TITLE
Watt Hours Consumed OSD element and post Flight Stat

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4925,6 +4925,13 @@
     "osdDescElementMahDrawn": {
         "message": "Total battery capacity used"
     },
+    "osdTextElementWhDrawn": {
+        "message": "Battery current Wh drawn",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWhDrawn": {
+        "message": "Total battery capacity used in Wh"
+    },
     "osdTextElementCraftName": {
         "message": "Craft name",
         "description": "One of the elements of the OSD"
@@ -5399,6 +5406,13 @@
     },
     "osdDescStatUsedMah": {
         "message": "Battery capacity used"
+    },
+    "osdTextStatUsedWh": {
+        "message": "Battery Wh used",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUsedWh": {
+        "message": "Battery capacity used in Wh"
     },
     "osdTextStatMaxAltitude": {
         "message": "Altitude maximum",

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -721,6 +721,15 @@ OSD.loadDisplayFields = function() {
                 return semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_36) ? ` 690${FONT.symbol(SYM.MAH)}` : `${FONT.symbol(SYM.MAH)}690`;
             },
         },
+        WH_DRAWN: {
+            name: 'WH_DRAWN',
+            text: 'osdTextElementWhDrawn',
+            desc: 'osdDescElementWhDrawn',
+            defaultPosition: -1,
+            draw_order: 145,
+            positionable: true,
+            preview: '1.10 WH',
+        },
         CRAFT_NAME: {
             name: 'CRAFT_NAME',
             text: 'osdTextElementCraftName',
@@ -1352,6 +1361,11 @@ OSD.constants = {
             text: 'osdTextStatUsedMah',
             desc: 'osdDescStatUsedMah',
         },
+        USED_WH: {
+            name: 'USED_WH',
+            text: 'osdTextStatUsedWh',
+            desc: 'osdDescStatUsedWh',
+        },
         MAX_ALTITUDE: {
             name: 'MAX_ALTITUDE',
             text: 'osdTextStatMaxAltitude',
@@ -1624,6 +1638,7 @@ OSD.chooseFields = function() {
             F.VTX_CHANNEL,
             F.CURRENT_DRAW,
             F.MAH_DRAWN,
+            F.WH_DRAWN,
             F.GPS_SPEED,
             F.GPS_SATS,
             F.ALTITUDE,
@@ -1791,6 +1806,7 @@ OSD.chooseFields = function() {
             F.MAX_ALTITUDE,
             F.BLACKBOX,
             F.BLACKBOX_LOG_NUMBER,
+            F.USED_WH,
         ];
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_41)) {
             OSD.constants.STATISTIC_FIELDS = OSD.constants.STATISTIC_FIELDS.concat([


### PR DESCRIPTION
A feature request was made to implement watt hour consumed on the osd.
This allows pilots who prefer reading Wh over other battery stats can
judge battery consumption.
