### PR TITLE
Fix cli output, reboot and timeout

### DIFF
--- a/src/js/backup_restore.js
+++ b/src/js/backup_restore.js
@@ -911,7 +911,7 @@ function configuration_restore(callback) {
                 GUI.log(i18n.getMessage('eeprom_saved_ok'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection('setup', _callback));
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(_callback));
                 });
             }
         }

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -74,19 +74,7 @@ const GuiControl = function () {
 };
 
 function GUI_checkOperatingSystem() {
-    if (navigator.appVersion.indexOf("Win") !== -1) {
-        return "Windows";
-    } else if (navigator.appVersion.indexOf("Mac") !== -1) {
-        return "MacOS";
-    } else if (navigator.appVersion.indexOf("Android") !== -1) {
-        return "Android";
-    } else if (navigator.appVersion.indexOf("Linux") !== -1) {
-        return "Linux";
-    } else if (navigator.appVersion.indexOf("X11") !== -1) {
-        return "UNIX";
-    } else {
-        return "Unknown";
-    }
+    return navigator.userAgentData.platform;
 }
 
 // Timer managing methods
@@ -390,11 +378,9 @@ GuiControl.prototype.content_ready = function (callback) {
 
 GuiControl.prototype.selectDefaultTabWhenConnected = function() {
     const result = ConfigStorage.get(['rememberLastTab', 'lastTab']);
-    if (result.rememberLastTab && result.lastTab) {
-        $(`#tabs ul.mode-connected .${result.lastTab} a`).click();
-    } else {
-        $('#tabs ul.mode-connected .tab_setup a').click();
-    }
+    const tab = result.rememberLastTab && result.lastTab ? result.lastTab : 'tab_setup';
+
+    $(`#tabs ul.mode-connected .${tab} a`).trigger('click');
 };
 
 GuiControl.prototype.isNWJS = function () {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -588,7 +588,7 @@ function startProcess() {
     $(expertModeCheckbox).trigger("change");
 
     result = ConfigStorage.get('cliAutoComplete');
-    CliAutoComplete.setEnabled(typeof result.cliAutoComplete === undefined || result.cliAutoComplete); // On by default
+    CliAutoComplete.setEnabled(typeof result.cliAutoComplete === "undefined" || result.cliAutoComplete); // On by default
 
     result = ConfigStorage.get('darkTheme');
     if (result.darkTheme === undefined || typeof result.darkTheme !== "number") {

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -351,7 +351,7 @@ const MSP = {
 
         if (!requestExists) {
             obj.timer = setInterval(function () {
-                console.warn(`MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} TIMEOUT: ${MSP.timeout}`);
+                console.warn(`MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} TIMEOUT: ${MSP.timeout} QUEUE: ${MSP.callbacks.length}`);
                 serial.send(bufferOut, function (_sendInfo) {
                     obj.stop = performance.now();
                     const executionTime = Math.round(obj.stop - obj.start);

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -462,7 +462,7 @@ cli.read = function (readInfo) {
             CONFIGURATOR.cliActive = false;
             CONFIGURATOR.cliValid = false;
             GUI.log(i18n.getMessage('cliReboot'));
-            reinitializeConnection(self);
+            reinitializeConnection();
         }
 
     }

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -627,7 +627,7 @@ configuration.initialize = function (callback) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
                 });
             }
 

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -2,8 +2,7 @@ import { i18n } from "../localization";
 
 const failsafe = {};
 
-failsafe.initialize = function (callback, scrollPosition) {
-    const self = this;
+failsafe.initialize = function (callback) {
 
     if (GUI.active_tab != 'failsafe') {
         GUI.active_tab = 'failsafe';
@@ -219,11 +218,6 @@ failsafe.initialize = function (callback, scrollPosition) {
             FC.RXFAIL_CONFIG[i].value = parseInt($(this).val());
         });
 
-        // for some odd reason chrome 38+ changes scroll according to the touched select element
-        // i am guessing this is a bug, since this wasn't happening on 37
-        // code below is a temporary fix, which we will be able to remove in the future (hopefully)
-        $('#content').scrollTop((scrollPosition) ? scrollPosition : 0);
-
         // fill stage 1 Valid Pulse Range Settings
         $('input[name="rx_min_usec"]').val(FC.RX_CONFIG.rx_min_usec);
         $('input[name="rx_max_usec"]').val(FC.RX_CONFIG.rx_max_usec);
@@ -413,7 +407,7 @@ failsafe.initialize = function (callback, scrollPosition) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
 
                 GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
                 });
             }
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -1153,10 +1153,9 @@ motors.initialize = async function (callback) {
         content_ready();
     }
 
-    async function reboot() {
+    function reboot() {
         GUI.log(i18n.getMessage('configurationEepromSaved'));
-        await MSP.promise(MSPCodes.MSP_SET_REBOOT);
-        reinitializeConnection(self);
+        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
     }
 
     function showDialogMixerReset(message) {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -49,7 +49,7 @@ onboard_logging.initialize = function (callback) {
         GUI.log(i18n.getMessage('configurationEepromSaved'));
 
         GUI.tab_switch_cleanup(function() {
-            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
         });
     }
 

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -413,7 +413,7 @@ ports.initialize = function (callback) {
             GUI.log(i18n.getMessage('configurationEepromSaved'));
 
             GUI.tab_switch_cleanup(function() {
-                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
             });
         }
     }

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -476,7 +476,7 @@ receiver.initialize = function (callback) {
                 GUI.log(i18n.getMessage('configurationEepromSaved'));
                 if (boot) {
                     GUI.tab_switch_cleanup(function() {
-                        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(tab));
+                        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
                     });
                 }
             }

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -302,7 +302,7 @@ transponder.initialize = function(callback) {
                         GUI.log(i18n.getMessage('transponderEepromSaved'));
                         if ( $(_this).hasClass('reboot') ) {
                             GUI.tab_switch_cleanup(function() {
-                                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection(self));
+                                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
                             });
                         }
                     });


### PR DESCRIPTION
- [x] Fixes cli where MSP request characters became visible in terminal or file output. See: https://github.com/betaflight/betaflight/pull/11764
- [x] Fixes `rememberLastTab` when off configurator still returned to last used tab.
- [x] Resets MSP timeout upon opening on each connection.
- [x] Fix sonar issues: updated deprecated `navigator.appVersion` 