### PR TITLE
Add some missing style and minor bugfix

### DIFF
--- a/src/css/tabs/led_strip.less
+++ b/src/css/tabs/led_strip.less
@@ -237,6 +237,12 @@
 	}
 	.modifiers {
 		display: inline-block;
+		.auxSelect {
+			border: 1px solid var(--subtleAccent);
+			border-radius: 3px;
+			background: var(--boxBackground);
+			color: var(--defaultText);
+		}
 	}
 	.colorDefineSliders {
 		display: inline-block;
@@ -357,6 +363,12 @@
 	.mode_colors {
 		button.btnOn {
 			border-color: #000;
+		}
+		.modeSelect {
+			border: 1px solid var(--subtleAccent);
+			border-radius: 3px;
+			background: var(--boxBackground);
+			color: var(--defaultText);
 		}
 	}
 	.indicators {

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -400,7 +400,7 @@ led_strip.initialize = function (callback, scrollPosition) {
 
                         if (feature_o.is(':checked') !== newVal) {
                             feature_o.prop('checked', newVal);
-                            feature_o.change();
+                            feature_o.trigger('change');
                         }
                     });
 
@@ -503,10 +503,28 @@ led_strip.initialize = function (callback, scrollPosition) {
         }
 
         // UI: check-box toggle
-        $('.checkbox').change(function(e) {
+        $('.checkbox').on('change', function(e) {
             if (e.originalEvent) {
                 // user-triggered event
                 const that = $(this).find('input');
+
+                //disable Blink always or Larson scanner, both functions are not working properly at the same time
+                if (that.is('.function-o')) {
+                    const blink = $('.checkbox .function-b');
+                    if (blink.is(':checked')) {
+                        blink.prop('checked', false);
+                        blink.trigger('change');
+                        toggleSwitch(blink, 'b');
+                    }
+                } else if (that.is('.function-b')) {
+                    const larson = $('.checkbox .function-o');
+                    if ($('.checkbox .function-o').is(':checked')) {
+                        larson.prop('checked', false);
+                        larson.trigger('change');
+                        toggleSwitch(larson, 'o');
+                    }
+                }
+
                 if ($('.ui-selected').length > 0) {
 
                     TABS.led_strip.overlays.forEach(function(letter) {
@@ -519,11 +537,11 @@ led_strip.initialize = function (callback, scrollPosition) {
                             if (ret) {
                                 if (letter == 'b' && cbn.is(':checked')) {
                                     cbn.prop('checked', false);
-                                    cbn.change();
+                                    cbn.trigger('change');
                                     toggleSwitch(cbn, 'n');
                                 } else if (letter == 'n' && cbb.is(':checked')) {
                                     cbb.prop('checked', false);
-                                    cbb.change();
+                                    cbb.trigger('change');
                                     toggleSwitch(cbb, 'b');
                                 }
                             }
@@ -577,8 +595,7 @@ led_strip.initialize = function (callback, scrollPosition) {
 
         });
 
-        $('a.save').click(function () {
-
+        $('a.save').on('click', function () {
             mspHelper.sendLedStripConfig(send_led_strip_colors);
 
             function send_led_strip_colors() {
@@ -848,26 +865,15 @@ led_strip.initialize = function (callback, scrollPosition) {
 
 
         // set color modifiers (check-boxes) visibility
-        $('.overlays').hide();
-        $('.modifiers').hide();
-        $('.blinkers').hide();
-        $('.warningOverlay').hide();
-        $('.vtxOverlay').hide();
+        $('.overlays').toggle(areOverlaysActive(activeFunction));
 
-        if (areOverlaysActive(activeFunction))
-            $('.overlays').show();
+        $('.modifiers').toggle(areModifiersActive(activeFunction));
 
-        if (areModifiersActive(activeFunction))
-            $('.modifiers').show();
+        $('.blinkers').toggle(areBlinkersActive(activeFunction));
 
-        if (areBlinkersActive(activeFunction))
-            $('.blinkers').show();
+        $('.warningOverlay').toggle(isWarningActive(activeFunction));
 
-        if (isWarningActive(activeFunction))
-            $('.warningOverlay').show();
-
-        if (isVtxActive(activeFunction))
-            $('.vtxOverlay').show();
+        $('.vtxOverlay').toggle(isVtxActive(activeFunction));
 
         // set directions visibility
         if (semver.lt(FC.CONFIG.apiVersion, "1.20.0")) {
@@ -991,7 +997,7 @@ led_strip.initialize = function (callback, scrollPosition) {
 
     function unselectOverlay(func, overlay) {
         $(`input.function-${overlay}`).prop('checked', false);
-        $(`input.function-${overlay}`).change();
+        $(`input.function-${overlay}`).trigger('change');
         $('.ui-selected').each(function() {
             if (func === '' || $(this).is(functionTag + func)) {
                 $(this).removeClass(`function-${overlay}`);
@@ -1121,7 +1127,7 @@ led_strip.initialize = function (callback, scrollPosition) {
                 return mc.color;
             }
         }
-        return "";
+        return 3; //index of Throttle, use as default
     }
 
     function setModeColor(mode, dir, color) {


### PR DESCRIPTION
I added the missing styles to the selectable lists, those white boxes in dark mode just hurt my eyes so I made this fix. The `Larson scanner` and the `Blink always` overlays didn't worked with each other properly so they toggle each other, only one of them can be used at a time. I noticed that the channel based color modifier doesn't have default value so I nominated the Throttle for this. Also updated deprecated .change() function.

~~While I was making this fix it stood out that the switch animations doesn't work if I select anyting on the Led table. It is not related to my code, I tried to fix it but I couldn't. If anybody has time I would appreciate a fix for this.~~
Edit: I could fix it.