### PR TITLE
Add `no-extra-semi` to match what's in sonarcloud

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
         "no-trailing-spaces": "error",
         "eol-last": "error",
         semi: "error",
+        "no-extra-semi": "error",
         "comma-dangle": ["error", "always-multiline"],
         "no-var": "error",
         "prefer-template": "error",


### PR DESCRIPTION
Trying to catch it earlier
<img width="877" alt="Screenshot 2022-08-19 at 22 18 11" src="https://user-images.githubusercontent.com/7774918/185708542-540f4280-48e4-4a83-aa16-2ed691ab9a6a.png">
