### PR TITLE
Bigger OSD grid support

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4718,6 +4718,10 @@
         "message": "NTSC",
         "description": "Option for the video format in the OSD"
     },
+    "osdSetupVideoFormatOptionHd": {
+        "message": "HD",
+        "description": "Option for the video format in the OSD"
+    },
     "osdSetupUnitsTitle": {
         "message": "Units"
     },

--- a/src/css/dark-theme.less
+++ b/src/css/dark-theme.less
@@ -512,10 +512,7 @@ progress[value] {
 	.preview {
 		background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), url(../images/osd-bg-1.jpg);
 		background-size: cover;
-		&:active {
-			background: linear-gradient(rgba(0, 0, 0, 0.2), rgba(0, 0, 0, 0.2)), url(../../images/osd-bg-1-grid.png), url(../../images/osd-bg-1.jpg);
-			background-size: cover;
-		}
+
 	}
 	input[type='checkbox'] {
 		&:after {

--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -222,6 +222,12 @@
 		.char[draggable="true"] {
 			cursor: move;
 		}
+
+		&:active {
+			.char {
+				border: 1px dashed rgba(55, 55, 55, 0.5) ;
+			}
+		}
 	}
 	.char.mouseover {
 		background: rgba(255,255,255,0.4);
@@ -308,15 +314,6 @@
 	select.osd-variant {
 		max-width: 100%;
 	}
-
-    .preview {
-        &:active {
-            .char {
-                border: 1px dashed rgba(55, 55, 55, 0.5) ;
-            }
-        }
-    }
-
 
 	.alarms {
 		label {

--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -214,6 +214,7 @@
 			margin: 0;
 			flex: 1 1 auto;
 			flex-wrap: nowrap;
+            border: 1px solid transparent;
 			img {
 				flex: 1 1 auto;
 			}
@@ -307,24 +308,16 @@
 	select.osd-variant {
 		max-width: 100%;
 	}
-	.video-pal {
-		.preview {
-			&:active {
-				background: url(../../images/osd-bg-1-grid-pal.png), url(../../images/osd-bg-1.jpg);
-				background-size: 100% 100%, cover;
-				background-repeat: no-repeat;
-			}
-		}
-	}
-	.video-ntsc {
-		.preview {
-			&:active {
-				background: url(../../images/osd-bg-1-grid-ntsc.png), url(../../images/osd-bg-1.jpg);
-				background-size: 100% 100%, cover;
-				background-repeat: no-repeat;
-			}
-		}
-	}
+
+    .preview {
+        &:active {
+            .char {
+                border: 1px dashed rgba(55, 55, 55, 0.5) ;
+            }
+        }
+    }
+
+
 	.alarms {
 		label {
 			display: block;

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -175,7 +175,7 @@ const VirtualFC = {
         // 11 1111 (pass bitchecks)
         virtualFC.CONFIG.activeSensors = 63;
     },
-    setupVirtualOSD(){
+    setupVirtualOSD(OSD){
         const virtualOSD = OSD;
 
         virtualOSD.data.video_system = 1;

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1880,9 +1880,7 @@ OSD.updateDisplaySize = function() {
         y: OSD.constants.VIDEO_LINES[videoType],
         total: null,
     };
-    // Adjust css background grid
-    const previewLayoutElement = $(".tab-osd .display-layout");
-    videoType === 'PAL' || videoType == 'HD' ? previewLayoutElement.addClass('video-pal').removeClass('video-ntsc') : previewLayoutElement.addClass('video-ntsc').removeClass('video-pal');
+
 };
 
 OSD.drawByOrder = function(selectedPosition, field, charCode, x, y) {


### PR DESCRIPTION
Consider this a draft/proof of concept + not ready for merge, because:

1. The firmware doesn't support this feature yet.....
2. The implementation here should be improved a little - eg: it needs MSP version feature switches; more testing + potentially updating to match however the firmware implements this.

It is configurator side changes to support different grid sizes for the OSD; initially hoping for support along the lines of the HD OSD found in iNav (50 * 18) which is supported by HDZero + others; but the changes make the configurator able relatively easily to support any size.

Not much to it; but in brief I have:

- Added a new 'HD' size alongside the existing PAL/NTSC options.
- Replaced the single width of 30 (front FONT.constants.SIZES.LINE) with new OSD.constants.VIDEO_COLS, matching the existing OSD.constants.VIDEO_LINES
- In CSS, the grid that shows as you drag elements now uses a dashed border instead of a background image, so that we don't need to keep creating new images for every size.
- Also a trivial fix for virtual mode; OSD needs to be passed now - guessing the OSD var was previously in the global scope.

It seems to work in so far as I can use the UI, set up a PAL/NTSC OSD as usual + can also set up an HD one including saving/retrieving it from an FC (running BF 4.3) - positions are saved, survive a power cycle etc.

More than happy to own the feature + work on this further should the firmware team decide to implement the feature. 