### PR TITLE
Update port selection after initialization

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -162,6 +162,7 @@ PortHandler.check_serial_devices = function () {
             currentPorts = self.updatePortSelect(currentPorts);
             self.selectPort(currentPorts);
             self.initialPorts = currentPorts;
+            GUI.updateManualPortVisibility();
         } else {
             self.removePort(currentPorts);
             self.detectPort(currentPorts);


### PR DESCRIPTION
After the start of the configurator the msp selector or the manual port box didn't show up. This line fixes it. 