### PR TITLE
Up to date Github actions and cache node_modules

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
 
       - name: List assets
         run: ls -al Betaflight-*/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     name: Test
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -54,16 +54,16 @@ jobs:
             os: windows-2022
             releaseArgs: --win64
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Cache NW.js
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: cache/
           key: ${{ runner.os }}-${{ hashFiles('gulpfile.js') }}
 
       - name: Install Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
           cache: yarn
@@ -84,7 +84,7 @@ jobs:
         if: ${{ inputs.debug_build || matrix.name == 'Android' }}
 
       - name: Publish build artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Betaflight-Configurator${{ inputs.debug_build == 'true' && '-Debug' || '' }}-${{ matrix.name }}
           path: release/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules/
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:
@@ -61,6 +67,12 @@ jobs:
         with:
           path: cache/
           key: ${{ runner.os }}-${{ hashFiles('gulpfile.js') }}
+
+      - name: Cache node_modules
+        uses: actions/cache@v3
+        with:
+          path: node_modules/
+          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: release-assets/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Fetch build artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           path: release-assets/
 


### PR DESCRIPTION
This PR contains two commits:
- The first is an update of some actions (checkout, cache, setup-node, download-artifact, upload-artifact) to the latest version available.
- The second one, adds the node_modules to the cache with a Github action. I've done some tests, but is difficult to say how better it goes. The actions execution is very variable, the `yarn install` command can take from 25 seconds to 3 minutes, and using the cache it takes only 1 second, and downloading the cache from 5 seconds to 20 seconds. So it seems to go better always but the exact time is unknown.

We have 5 executions (one for the test, one for each OS build) so this makes better all of them.