### PR TITLE
Presets bugfix: automatically preselect current FC firmware version

### DIFF
--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -335,13 +335,16 @@ presets.multipleSelectComponentScrollFix = function() {
         when the number of items 199+. More details here:
         https://github.com/wenzhixin/multiple-select/issues/552
     */
+   return new Promise((resolve) => {
     GUI.timeout_add('hack_fix_multipleselect_scroll', () => {
         this._selectCategory.multipleSelect('refresh');
         this._selectKeyword.multipleSelect('refresh');
         this._selectAuthor.multipleSelect('refresh');
         this._selectFirmwareVersion.multipleSelect('refresh');
         this._selectStatus.multipleSelect('refresh');
+        resolve();
     }, 100);
+   });
 };
 
 presets.checkPresetSourceVersion = function() {
@@ -375,14 +378,12 @@ presets.prepareFilterFields = function() {
     this.prepareFilterSelectField(this._selectAuthor, this.presetsRepo.index.uniqueValues.author, 1);
     this.prepareFilterSelectField(this._selectFirmwareVersion, this.presetsRepo.index.uniqueValues.firmware_version, 2);
     this.prepareFilterSelectField(this._selectStatus, this.presetsRepo.index.settings.PresetStatusEnum, 2);
-    this.multipleSelectComponentScrollFix();
-
-    this.preselectFilterFields();
-    this._inputTextFilter.on('input', () => this.updateSearchResults());
-
-    this._freezeSearch = false;
-
-    this.updateSearchResults();
+    this.multipleSelectComponentScrollFix().then(() => {
+        this.preselectFilterFields();
+        this._inputTextFilter.on('input', () => this.updateSearchResults());
+        this._freezeSearch = false;
+        this.updateSearchResults();
+    });
 };
 
 presets.preselectFilterFields = function() {


### PR DESCRIPTION
It was intended that the Firmware selection dropdown automatically selects the current firmware version of the plugged in FC:
![image](https://user-images.githubusercontent.com/2925027/194468553-87382984-7b26-41fa-aa35-a6e01da18fcb.png)
However, because of the bug, it did not select anything showing all the presets by default regardless of the Firmware version the user plugged in.
The reason is the multipleSelect component hack for 199+ items that calls 'refresh' in 100ms after the page load.
The solution is to preselect the firmware version after this timeout, not before. Together with the other initializations.