### PR TITLE
release.yml - target_commitish REF_NAME

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ github.event.inputs.title }}
           tag_name: ${{ github.event.inputs.tag }}
+          target_commitish: ${{ GITHUB.REF_NAME }}
           generate_release_notes: ${{ github.event.inputs.generate_release_notes }}
           files: release-assets/Betaflight-Configurator-*/**
           draft: true


### PR DESCRIPTION
* if a github action "release" workflow is manually triggered, and a branch is selected rather than master, then the draft-release wrongly points to master rather than the branch selected.
![image](https://user-images.githubusercontent.com/56646290/194569645-4587f60f-1c5b-4c39-8b56-8de3811b5f58.png)

* by adding `target_commitish: ${{ GITHUB.REF_NAME }}` to the `softprops/action-gh-release` step, this is rectified.
![image](https://user-images.githubusercontent.com/56646290/194569968-6c8acd5b-6f2c-4f16-bd6e-b8777e0aefb1.png)

--
* ignore my branch name, this was for personal/testing purposes