### PR TITLE
ci.yml - workflow_dispatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,13 @@ on:
         default: true
         required: false
         type: boolean
+  workflow_dispatch:
+    inputs:
+        debug_build:
+          description: 'Specifies if it is a debug build or a release build'
+          default: true
+          required: false
+          type: boolean
 
 jobs:
   test:


### PR DESCRIPTION
* allow manual trigger of github workflow action `ci.yml`.
* allows fork-owners to easily build all OS versions via actions tab.
* useful for fork-owner testing prior to making PR's.

![image](https://user-images.githubusercontent.com/56646290/195128855-40b3eeb4-a929-432f-abb0-00e938df711f.png)