### PR TITLE
Fix import of inflection library

### DIFF
--- a/src/main.html
+++ b/src/main.html
@@ -76,7 +76,7 @@
     <script type="text/javascript" src="./node_modules/switchery-latest/dist/switchery.min.js"></script>
     <script type="text/javascript" src="./node_modules/bluebird/js/browser/bluebird.min.js"></script>
     <script type="text/javascript" src="./js/libraries/jquery.ba-throttle-debounce.min.js"></script>
-    <script type="text/javascript" src="./node_modules/inflection/inflection.min.js"></script>
+    <script type="text/javascript" src="./node_modules/inflection/lib/inflection.js"></script>
     <script type="text/javascript" src="./js/libraries/analytics.js"></script>
     <script type="text/javascript" src="./js/utils/window_watchers.js"></script>
     <script type="text/javascript" src="./js/utils/VtxDeviceStatus/VtxDeviceStatusFactory.js"></script>


### PR DESCRIPTION
This PR https://github.com/betaflight/betaflight-configurator/pull/3030 breaks the `inflection` library. In this new version the library has moved to a `node.js` library, with `require` to use it, that we don't use. This PR moves the path to point to the new location of the library.