### PR TITLE
Update setup-java action to version 3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
           cache: yarn
 
       - name: Install Java JDK 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         if: ${{ matrix.name == 'Android' }}
         with:
           distribution: temurin


### PR DESCRIPTION
Our build logs are showing a warning about the node version for setup-java:
![image](https://user-images.githubusercontent.com/2673520/195625084-f961ec60-02a9-41ec-b834-67cc747b1468.png)

This PR updates setup-java to version 3 to update the action to Node 16.