### PR TITLE
Workflow improvement - add option for non-PR manual builds

### DIFF
--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -1,0 +1,18 @@
+name: Manual Build
+run-name: Manual Build ${{ github.ref_name }} ${{ ((inputs.debug_build == true) && '(debug)') || '' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+        debug_build:
+          description: 'Specifies if it is a debug build or a release build'
+          default: true
+          required: false
+          type: boolean
+
+jobs:
+  ci:
+    name: CI
+    uses: ./.github/workflows/ci.yml
+    with:
+      debug_build: ${{ inputs.debug_build }}


### PR DESCRIPTION
* allow manually triggered builds via `manual-build.yml` (artifacts only, no release).
* allows fork-owners to easily build all OS versions via actions tab.
* useful for fork-owner testing, prior to making PR's.
* names the workflow-run appropriately with branch-name and `debug` if applicable.
* reference discussions in https://github.com/betaflight/betaflight-configurator/pull/3043

![image](https://user-images.githubusercontent.com/56646290/195628333-93d70e20-9dea-484a-987d-fe225c6036d4.png)