### PR TITLE
Presets fix: search bar z-index should keep it above the presets panels

### DIFF
--- a/src/tabs/presets/presets.less
+++ b/src/tabs/presets/presets.less
@@ -185,6 +185,7 @@
 	position: sticky;
 	top: 0px;
 	background-color: var(--boxBackground);
+	z-index: 10;
 }
 .ms-drop {
 	background-color: var(--boxBackground) !important;


### PR DESCRIPTION
PR [#3052](https://github.com/betaflight/betaflight-configurator/pull/3052)  introduced a visual bug when scrolling through presets on PC.
Current:
![image](https://user-images.githubusercontent.com/2925027/197110943-fda2db0f-5910-4e55-a964-c7fcfb850522.png)

Fixed:
![image](https://user-images.githubusercontent.com/2925027/197110811-be793c3f-c504-42c8-8d39-d59a231e122d.png)
