### PR TITLE
Add OSD (MSP Displayport) option to port peripherals

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1630,6 +1630,9 @@
     "portsFunction_VTX_MSP": {
         "message": "VTX (MSP)"
     },
+    "portsFunction_MSP_DISPLAYPORT": {
+        "message": "OSD (MSP Displayport)"
+    },
     "pidTuningProfileOption": {
         "message": "Profile $1"
     },

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -34,6 +34,7 @@ function MspHelper() {
     'LIDAR_TF': 15,
     'FRSKY_OSD': 16,
     'VTX_MSP': 17,
+    'MSP_DISPLAYPORT': 18,
     };
 
     self.REBOOT_TYPES = {
@@ -2922,6 +2923,7 @@ MspHelper.prototype.serialPortFunctionsToMask = function(functions) {
             mask = bit_set(mask, bitIndex);
         }
     }
+
     return mask;
 };
 

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -62,6 +62,10 @@ ports.initialize = function (callback) {
         functionRules.push({ name: 'VTX_MSP', groups: ['peripherals'], maxPorts: 1 });
     }
 
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+        functionRules.push({ name: 'MSP_DISPLAYPORT', groups: ['peripherals'], maxPorts: 1 });
+    }
+
     for (const rule of functionRules) {
         rule.displayName = i18n.getMessage(`portsFunction_${rule.name}`);
     }


### PR DESCRIPTION
This PR compliments https://github.com/betaflight/betaflight/pull/11913 which removes `displayport_msp_serial` and instead uses the first port with the FUNCTION_MSP_DISPLAYPORT flag set, for connection to a suitable VTX.

This PR adds an extra port peripheral option thus:

![image](https://user-images.githubusercontent.com/11480839/197292743-8fd80547-561f-45c9-9db2-09ac76e46f14.png)


