### PR TITLE
Change 'VTX (MSP)' to 'VTX (MSP + Displayport)' and lose 'OSD (MSP Displayport)' option

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1628,10 +1628,7 @@
         "message": "OSD (FrSky Protocol)"
     },
     "portsFunction_VTX_MSP": {
-        "message": "VTX (MSP)"
-    },
-    "portsFunction_MSP_DISPLAYPORT": {
-        "message": "OSD (MSP Displayport)"
+        "message": "VTX (MSP + Displayport)"
     },
     "pidTuningProfileOption": {
         "message": "Profile $1"

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -34,7 +34,6 @@ function MspHelper() {
     'LIDAR_TF': 15,
     'FRSKY_OSD': 16,
     'VTX_MSP': 17,
-    'MSP_DISPLAYPORT': 18,
     };
 
     self.REBOOT_TYPES = {

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -60,7 +60,6 @@ ports.initialize = function (callback) {
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
         functionRules.push({ name: 'VTX_MSP', groups: ['peripherals'], sharableWith: ['msp'], maxPorts: 1 });
-        functionRules.push({ name: 'MSP_DISPLAYPORT', groups: ['peripherals'], sharableWith: ['msp'], maxPorts: 1 });
     }
 
     for (const rule of functionRules) {


### PR DESCRIPTION
See also https://github.com/betaflight/betaflight/pull/11950

These two PR's remove the explicit MSP Displayport enablement, and instead have Displayport on MSP enabled at the same time at MSP VTX support if MSP is also enabled on the port. No traffic will flow on the serial port unless `osd_displayport_device = MSP`.

