### PR TITLE
release_notes - correctly state that nightly is a debug release

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -10,7 +10,7 @@ env:
     This is an automated development build.
     It may be unstable and result in corrupted configurations or data loss.
     **Use only for testing.**
-  release_notes: This is a release build. It does not contain the debug console.
+  release_notes: This is a debug build. It contains the debug console.
 
 name: Nightly
 


### PR DESCRIPTION
* nightly builds currently and incorrectly state `This is a release build. It does not contain the debug console.`
* this PR changes it to `This is a debug build. It contains the debug console.`

![image](https://user-images.githubusercontent.com/56646290/200015511-111cb0c4-ce60-4040-acbd-6fc7a1c3a071.png)
