### PR TITLE
Adding custom define input box

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6740,5 +6740,11 @@
     },
     "firmwareFlasherBranchDescription": {
         "message": "Especially useful for developers, you can select a merged PR, specify a commit sha, or specify a 'yet to be merged' PR by typing in: pull/{PR number}/head ."
+    },
+    "firmwareFlasherCustomDefinesDescription": {
+        "message": "For developers, you can add any defines you need, separated by a `space`, but without the `USE_` prefix, it will be added automatically for you."
+    },
+    "firmwareFlasherBuildCustomDefines": {
+        "message": "Custom Defines"
     }
 }

--- a/src/css/dark-theme.less
+++ b/src/css/dark-theme.less
@@ -324,8 +324,16 @@ button {
 				}
 			}
 		}
-		select {
+		input {
 			background-color: #3a3a3a;
+			color: white;
+			border: solid 1px var(--subtleAccent);
+			border-radius: 3px;
+			min-height: 20px;
+			padding: 2px;
+		}
+		select {
+			background-color: #424242;
 			color: white;
 		}
 	}

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -807,6 +807,9 @@ firmware_flasher.initialize = function (callback) {
 
                 if (summary.releaseType === "Unstable") {
                     request.commit = $('select[name="commits"] option:selected').val();
+                    $('input[name="customDefines"]').val().split(' ').map(element => element.trim()).forEach(v => {
+                        request.options.push(v);
+                    });
                 }
 
                 self.releaseLoader.requestBuild(request, (info) => {

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -200,6 +200,13 @@
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherBranchDescription"></div>
                         </div>
                     </div>
+                    <div style="width: 49%; float: right;">
+                        <strong i18n="firmwareFlasherBuildCustomDefines"></strong>
+                        <div id="customDefinesInfo">
+                            <input id="customDefines" name="customDefines" style="width: 95%"></input>
+                            <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherCustomDefinesDescription"></div>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
For development purposes add ability to put in custom defines.

Note the prefix USE_ is not to be used as it is added by the build platform.