### PR TITLE
Removed release notes from firmware flasher

### DIFF
--- a/src/css/tabs/firmware_flasher.less
+++ b/src/css/tabs/firmware_flasher.less
@@ -151,9 +151,6 @@
 				}
 			}
 		}
-		.notes {
-			padding: 5px;
-		}
 	}
 	.git_info {
 		display: none;

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -73,16 +73,6 @@ firmware_flasher.initialize = function (callback) {
                 $('div.release_info #cloudTargetInfo').hide();
             }
 
-            if (summary.notes) {
-                let formattedNotes = summary.notes.replace(/#(\d+)/g, '[#$1](https://github.com/betaflight/betaflight/pull/$1)');
-                formattedNotes = marked.parse(formattedNotes);
-                formattedNotes = DOMPurify.sanitize(formattedNotes);
-                $('div.release_info .notes').html(formattedNotes);
-                GUI.addLinksTargetBlank($('div.release_info .notes'));
-            } else {
-                $('div.release_info .notes').html('Release notes unavailable.');
-            }
-
             if (self.targets) {
                 $('div.release_info').slideDown();
                 $('.tab-firmware_flasher .content_wrapper').animate({ scrollTop: $('div.release_info').position().top }, 1000);

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -239,7 +239,7 @@
                     <span class="configFilename"></span>
                     <br />                    
                 </div>
-                <div class="margin-bottom" id="cloudTargetInfo">
+                <div id="cloudTargetInfo">
                     <strong i18n="firmwareFlasherCloudBuildDetails"></strong>
                     <a i18n_title="firmwareFlasherCloudBuildLogUrl" id="cloudTargetLog" href="#" target="_blank"></a>
                     <br />
@@ -247,8 +247,6 @@
                     <span id="cloudTargetStatus"></span>
                     <br />
                 </div>
-                <strong i18n="firmwareFlasherReleaseNotes"></strong>
-                <div class=notes></div>
             </div>
         </div>
 


### PR DESCRIPTION
The firmware version is a link to the release notes, so no need for this anymore

![image](https://user-images.githubusercontent.com/2925027/201611415-d993c171-e226-4a7d-8b4d-aeed86348c90.png)
