### PR TITLE
Adding ability to specify a classic build

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6781,6 +6781,6 @@
         "message": "Classic Mode"
     },
     "classicBuildModeDescription": {
-        "message": "This mode ignores all the parameters here, exception for the commit. This essentially achieves the same as the classic nightlies, and is provided for convenience."
+        "message": "This mode ignores all the parameters here, except for the commit. This essentially achieves the same as the classic nightlies, and is provided for convenience."
     }
 }

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6776,5 +6776,11 @@
     },
     "firmwareFlasherBuildCustomDefines": {
         "message": "Custom Defines"
+    },
+    "classicBuild": {
+        "message": "Classic Mode"
+    },
+    "classicBuildModeDescription": {
+        "message": "This mode ignores all the parameters here, exception for the commit. This essentially achieves the same as the classic nightlies, and is provided for convenience."
     }
 }

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -647,6 +647,16 @@ firmware_flasher.initialize = function (callback) {
             $('input.flash_manual_baud').prop('checked', false);
         }
 
+        $('input.classicbuild_mode').change(function () {
+            const status = $(this).is(':checked');
+
+            $('select[name="radioProtocols"').enabled = !status;
+            $('select[name="telemetryProtocols"').enabled = !status;
+            $('select[name="motorProtocols"').enabled = !status;
+            $('select[name="options"').enabled = !status;
+        });
+        $('input.classicbuild_mode').change();
+
         // bind UI hook so the status is saved on change
         $('input.flash_manual_baud').change(function() {
             const status = $(this).is(':checked');
@@ -778,23 +788,27 @@ firmware_flasher.initialize = function (callback) {
                     telemetryProtocols: [],
                     motorProtocols: [],
                     options: [],
+                    classicBuild: false,
                 };
 
-                $('select[name="radioProtocols"] option:selected').each(function () {
-                    request.radioProtocols.push($(this).val());
-                });
+                request.classicBuild = $('input[name="classicBuildModeCheckbox"]').is(':checked');
+                if (!request.classicBuild) {
+                    $('select[name="radioProtocols"] option:selected').each(function () {
+                        request.radioProtocols.push($(this).val());
+                    });
 
-                $('select[name="telemetryProtocols"] option:selected').each(function () {
-                    request.telemetryProtocols.push($(this).val());
-                });
+                    $('select[name="telemetryProtocols"] option:selected').each(function () {
+                        request.telemetryProtocols.push($(this).val());
+                    });
 
-                $('select[name="options"] option:selected').each(function () {
-                    request.options.push($(this).val());
-                });
+                    $('select[name="options"] option:selected').each(function () {
+                        request.options.push($(this).val());
+                    });
 
-                $('select[name="motorProtocols"] option:selected').each(function () {
-                    request.motorProtocols.push($(this).val());
-                });
+                    $('select[name="motorProtocols"] option:selected').each(function () {
+                        request.motorProtocols.push($(this).val());
+                    });
+                }
 
                 if (summary.releaseType === "Unstable") {
                     request.commit = $('select[name="commits"] option:selected').val();

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -650,10 +650,11 @@ firmware_flasher.initialize = function (callback) {
         $('input.classicbuild_mode').change(function () {
             const status = $(this).is(':checked');
 
-            $('select[name="radioProtocols"').enabled = !status;
-            $('select[name="telemetryProtocols"').enabled = !status;
-            $('select[name="motorProtocols"').enabled = !status;
-            $('select[name="options"').enabled = !status;
+            $('select[name="radioProtocols"]').attr('disabled', status);
+            $('select[name="telemetryProtocols"]').attr('disabled', status);
+            $('select[name="motorProtocols"]').attr('disabled', status);
+            $('select[name="options"]').attr('disabled', status);
+            $('input[name="customDefines"]').attr('disabled', status);
         });
         $('input.classicbuild_mode').change();
 

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -153,6 +153,19 @@
             <div class="spacer" style="margin-bottom: 10px;">
                 <div class="margin-bottom">
                     <div style="width: 49%; float: left;">
+                        <label>
+                            <input class="classicbuild_mode toggle" type="checkbox" name="classicBuildModeCheckbox" />
+                            <span i18n="classicBuild"></span>
+                        </label>
+                        <div class="helpicon cf_tip_wide" i18n_title="classicBuildModeDescription"></div>
+                    </div>
+                    <div style="width: 49%; float: right;">
+                    </div>
+                </div>
+            </div>
+            <div class="spacer" style="margin-bottom: 10px;">
+                <div class="margin-bottom">
+                    <div style="width: 49%; float: left;">
                         <strong i18n="firmwareFlasherBuildRadioProtocols"></strong>
                         <div id="radioProtocolInfo">
                             <select id="radioProtocols" name="radioProtocols" multiple="multiple" class="select2" style="width: 95%">


### PR DESCRIPTION
This means a user rather than using cloud options, can simply get all options (same as previous unified nightlies).
