### PR TITLE
Firmware flasher: classic build toggle - moved to build configuration header

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1439,6 +1439,9 @@ dialog {
 	float: left;
 	margin-bottom: 7px;
 	font-weight: 600;
+	.switchery {
+		margin-top: -3px;
+	}
 }
 .gui_box_bottombar {
 	background-color: #e4e4e4;
@@ -2365,6 +2368,9 @@ button.active {
 		padding-bottom: 0;
 		margin-bottom: 5px;
 		float: left;
+		.switchery {
+			margin-top: -3px;
+		}
 	}
 	.spacer_box_title {
 		padding-left: 10px;
@@ -2464,6 +2470,9 @@ button.active {
 		padding-bottom: 0;
 		margin-bottom: 5px;
 		float: left;
+		.switchery {
+			margin-top: -3px;
+		}
 	}
 	.spacer_box_title {
 		padding-left: 10px;

--- a/src/css/tabs/firmware_flasher.less
+++ b/src/css/tabs/firmware_flasher.less
@@ -188,6 +188,12 @@
 			font-size: 11px;
 		}
 	}
+	.build_configuration_toggle_wrapper {
+		float: left;
+		position: absolute;
+		padding-left: 15px;
+		padding-top: 4px;
+	}
 }
 .btn {
 	.disabled {
@@ -225,6 +231,11 @@
 	}
 }
 #customDefines {
-	width: calc(95% - 6px);
+	width: calc(95% - 10px);
 	height: 26px;
+}
+#build_configuration_toggle_label_text {
+	margin-left: 6px;
+	padding-top: 2px;
+	margin-right: 10px;
 }

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -650,11 +650,7 @@ firmware_flasher.initialize = function (callback) {
         $('input.classicbuild_mode').change(function () {
             const status = $(this).is(':checked');
 
-            $('select[name="radioProtocols"]').attr('disabled', status);
-            $('select[name="telemetryProtocols"]').attr('disabled', status);
-            $('select[name="motorProtocols"]').attr('disabled', status);
-            $('select[name="options"]').attr('disabled', status);
-            $('input[name="customDefines"]').attr('disabled', status);
+            $('.hide-in-classic-build-mode').toggle(!status);
         });
         $('input.classicbuild_mode').change();
 

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -132,38 +132,32 @@
                 <p i18n="firmwareFlasherTargetWarning"></p>
             </div>
         </div>
-    
+
         <div class="clear-both"></div>
         <div class="git_info">
             <div class="title" i18n="firmwareFlasherGithubInfoHead"></div>
             <p>
-                <strong i18n="firmwareFlasherHash"></strong> 
+                <strong i18n="firmwareFlasherHash"></strong>
                 <a i18n_title="firmwareFlasherUrl" class="hash" href="#" target="_blank"></a><br />
                 <strong i18n="firmwareFlasherCommiter"></strong> <span class="committer"></span><br />
-                <strong i18n="firmwareFlasherDate"></strong> <span class="date"></span><br /> 
+                <strong i18n="firmwareFlasherDate"></strong> <span class="date"></span><br />
                 <strong i18n="firmwareFlasherMessage"></strong> <span class="message"></span>
             </p>
         </div>
 
-        <div class="build_configuration gui_box">
+        <div class="build_configuration gui_box" style="position: relative;">
             <div class="darkgrey_box gui_box_titlebar">
+                <div class="build_configuration_toggle_wrapper">
+                    <label id="build_configuration_toggle_label">
+                        <input class="classicbuild_mode toggle" type="checkbox" name="classicBuildModeCheckbox" />
+                        <span id="build_configuration_toggle_label_text" i18n="classicBuild"></span>
+                    </label>
+                    <div class="helpicon cf_tip_wide" i18n_title="classicBuildModeDescription"></div>
+                </div>
                 <div class="spacer_box_title" style="text-align: center;" i18n="firmwareFlasherBuildConfigurationHead">
                 </div>
             </div>
-            <div class="spacer" style="margin-bottom: 10px;">
-                <div class="margin-bottom">
-                    <div style="width: 49%; float: left;">
-                        <label>
-                            <input class="classicbuild_mode toggle" type="checkbox" name="classicBuildModeCheckbox" />
-                            <span i18n="classicBuild"></span>
-                        </label>
-                        <div class="helpicon cf_tip_wide" i18n_title="classicBuildModeDescription"></div>
-                    </div>
-                    <div style="width: 49%; float: right;">
-                    </div>
-                </div>
-            </div>
-            <div class="spacer" style="margin-bottom: 10px;">
+            <div class="spacer hide-in-classic-build-mode" style="margin-bottom: 10px;">
                 <div class="margin-bottom">
                     <div style="width: 49%; float: left;">
                         <strong i18n="firmwareFlasherBuildRadioProtocols"></strong>
@@ -183,7 +177,7 @@
                     </div>
                 </div>
             </div>
-            <div class="spacer" style="margin-bottom: 10px;">
+            <div class="spacer hide-in-classic-build-mode" style="margin-bottom: 10px;">
                 <div class="margin-bottom">
                     <div style="width: 49%; float: left;">
                         <strong i18n="firmwareFlasherBuildOptions"></strong>
@@ -213,7 +207,7 @@
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherBranchDescription"></div>
                         </div>
                     </div>
-                    <div style="width: 49%; float: right;">
+                    <div style="width: 49%; float: right;" class="hide-in-classic-build-mode">
                         <strong i18n="firmwareFlasherBuildCustomDefines"></strong>
                         <div id="customDefinesInfo">
                             <input id="customDefines" name="customDefines"></input>


### PR DESCRIPTION
Firmware flasher:
- Classic build toggle - moved to build configuration header
- Hide build configuration fields instead of disabling them because they are not used in classic mode.
- Addressed this comment: https://github.com/betaflight/betaflight-configurator/pull/3089#issuecomment-1321098880

![image](https://user-images.githubusercontent.com/2925027/202899317-a8e6fb4d-ec17-429f-9fa0-dab2ced39dc9.png)
