### PR TITLE
Firmware flasher: build config help icons style fix

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -2362,7 +2362,7 @@ button.active {
 	.default_btn {
 		margin-bottom: 10px;
 	}
-	.gui_box_titlebar {
+	.gui_box .gui_box_titlebar {
 		font-size: 12px;
 		height: 24px;
 		padding-bottom: 0;
@@ -2370,6 +2370,9 @@ button.active {
 		float: left;
 		.switchery {
 			margin-top: -3px;
+		}
+		.helpicon {
+			margin-top: 1px;
 		}
 	}
 	.spacer_box_title {

--- a/src/css/tabs/firmware_flasher.less
+++ b/src/css/tabs/firmware_flasher.less
@@ -1,4 +1,12 @@
 .tab-firmware_flasher {
+	.build-options-wrapper {
+		.select2-container {
+			width: calc(100% - 30px)!important;
+		}
+		.helpicon {
+			margin-top: 8px;
+		}
+	}
 	.info {
 		padding: 2px 18px;
 		position: relative;
@@ -231,7 +239,7 @@
 	}
 }
 #customDefines {
-	width: calc(95% - 10px);
+	width: calc(100% - 40px);
 	height: 26px;
 }
 #build_configuration_toggle_label_text {

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -161,16 +161,16 @@
                 <div class="margin-bottom">
                     <div style="width: 49%; float: left;">
                         <strong i18n="firmwareFlasherBuildRadioProtocols"></strong>
-                        <div id="radioProtocolInfo">
-                            <select id="radioProtocols" name="radioProtocols" multiple="multiple" class="select2" style="width: 95%">
+                        <div id="radioProtocolInfo" class="build-options-wrapper">
+                            <select id="radioProtocols" name="radioProtocols" multiple="multiple" class="select2">
                             </select>
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherRadioProtocolDescription"></div>
                         </div>
                     </div>
                     <div style="width: 49%; float: right;">
                         <strong i18n="firmwareFlasherBuildTelemetryProtocols"></strong>
-                        <div id="telemetryProtocolInfo">
-                            <select id="telemetryProtocols" name="telemetryProtocols" multiple="multiple" class="select2" style="width: 95%">
+                        <div id="telemetryProtocolInfo" class="build-options-wrapper">
+                            <select id="telemetryProtocols" name="telemetryProtocols" multiple="multiple" class="select2">
                             </select>
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherTelemetryProtocolDescription"></div>
                         </div>
@@ -181,16 +181,16 @@
                 <div class="margin-bottom">
                     <div style="width: 49%; float: left;">
                         <strong i18n="firmwareFlasherBuildOptions"></strong>
-                        <div id="optionsInfo">
-                            <select id="options" name="options" multiple="multiple" class="select2" style="width: 95%">
+                        <div id="optionsInfo" class="build-options-wrapper">
+                            <select id="options" name="options" multiple="multiple" class="select2">
                             </select>
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherOptionsDescription"></div>
                         </div>
                     </div>
                     <div style="width: 49%; float: right;">
                         <strong i18n="firmwareFlasherBuildMotorProtocols"></strong>
-                        <div id="motorProtocolInfo">
-                            <select id="motorProtocols" name="motorProtocols" multiple="multiple" class="select2" style="width: 95%">
+                        <div id="motorProtocolInfo" class="build-options-wrapper">
+                            <select id="motorProtocols" name="motorProtocols" multiple="multiple" class="select2">
                             </select>
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherMotorProtocolDescription"></div>
                         </div>
@@ -201,15 +201,15 @@
                 <div class="margin-bottom">
                     <div style="width: 49%; float: left;">
                         <strong i18n="firmwareFlasherBranch"></strong>
-                        <div id="branchInfo">
-                            <select id="commits" name="commits" class="select2" style="width: 95%">
+                        <div id="branchInfo" class="build-options-wrapper">
+                            <select id="commits" name="commits" class="select2">
                             </select>
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherBranchDescription"></div>
                         </div>
                     </div>
                     <div style="width: 49%; float: right;" class="hide-in-classic-build-mode">
                         <strong i18n="firmwareFlasherBuildCustomDefines"></strong>
-                        <div id="customDefinesInfo">
+                        <div id="customDefinesInfo" class="build-options-wrapper">
                             <input id="customDefines" name="customDefines"></input>
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherCustomDefinesDescription"></div>
                         </div>


### PR DESCRIPTION
A few small style fixes for help icons in build configuration

![image](https://user-images.githubusercontent.com/2925027/203179363-d8547a25-147a-47e5-b9cc-06a80b7e60dd.png)