### PR TITLE
Fix elrs connection

### DIFF
--- a/cordova/config_template.xml
+++ b/cordova/config_template.xml
@@ -47,6 +47,9 @@
         </config-file>
         <resource-file src="usb_device_filter.xml" target="app/src/main/res/xml/usb_device_filter.xml"/>
         <resource-file src="manifest.json" target="app/src/main/assets/www/manifest.json"/>
+        <edit-config file="app/src/main/AndroidManifest.xml" mode="merge" target="/manifest/application">
+            <application android:usesCleartextTraffic="true" />
+        </edit-config>
     </platform>
     <platform name="ios">
         <allow-intent href="itms:*"/>

--- a/src/js/mdns_discovery.js
+++ b/src/js/mdns_discovery.js
@@ -1,0 +1,134 @@
+'use strict';
+
+const MDNS_INTERVAL = 10000;
+const TCP_CHECK_INTERVAL = 5000;
+const TCP_TIMEOUT = 2000;
+
+const MdnsDiscovery = new function() {
+    this.mdnsBrowser = {
+        services: [],
+        browser: null,
+    };
+
+    this.tcpCheckLock = false;
+};
+
+MdnsDiscovery.initialize = function() {
+    const self = this;
+
+    if (GUI.isCordova()) {
+        const zeroconf = cordova.plugins.zeroconf;
+
+        function reinit() {
+            zeroconf.registerAddressFamily = 'ipv4'; // or 'ipv6' ('any' by default)
+            zeroconf.watchAddressFamily = 'ipv4'; // or 'ipv6' ('any' by default)
+            zeroconf.watch("_http._tcp.", "local.", (result) => {
+                const action = result.action;
+                const service = result.service;
+
+                if (action === 'resolved' && service.name.includes("elrs_rx")) {
+                    console.log("Zeroconf Service Changed", service);
+                    self.mdnsBrowser.services.push({
+                        addresses: service.ipv4Addresses,
+                        txt: service.txtRecord,
+                        fqdn: `${service.name}._http._tcp.local.`,
+                        ready: true,
+                    });
+                }
+                else if (action === 'added' && service.name.includes("elrs_rx")) {
+                    //restart zeroconf if service ip doesn't arrive in 1000ms
+                    setTimeout(() => {
+                        if (self.mdnsBrowser.services.length === 0 || self.mdnsBrowser.services.filter(s => s.fqdn === `${service.name}._http._tcp.local.`)[0].ready === false) {
+                            zeroconf.close();
+                            reinit();
+                        }
+                    },1000);
+                }
+            });
+        }
+    reinit();
+    } else {
+        const bonjour = require('bonjour')();
+
+        self.mdnsBrowser.browser = bonjour.find({ type: 'http' }, service => {
+            console.log("Found HTTP service", service);
+            self.mdnsBrowser.services.push({
+                addresses: service.addresses,
+                txt: service.txt,
+                fqdn: service.fqdn,
+                ready: true,
+            });
+        });
+    }
+
+    setInterval(() => {
+        if (GUI.isCordova() && self.mdnsBrowser.services.length > 0) {
+            //ping removed services and enable them if they are online
+            const inactiveServices = self.mdnsBrowser.services.filter(s => s.ready === false);
+            inactiveServices.forEach(function (service) {
+                $.ajax({
+                    url: `http://${service.addresses[0]}`,
+                    success: () => {
+                        self.mdnsBrowser.services = self.mdnsBrowser.services
+                        .map(s => {
+                            if (s.fqdn === service.fqdn) {
+                                return {...s, ready: true};
+                            }
+                            return s;
+                        });
+                    },
+                    error: () => {},
+                    timeout: TCP_TIMEOUT,
+                });
+            });
+        }
+        else if (!GUI.connected_to && self.mdnsBrowser.browser) {
+            self.mdnsBrowser.browser.update();
+        }
+    }, MDNS_INTERVAL);
+
+    setInterval(() => {
+        self.tcpCheck();
+    }, TCP_CHECK_INTERVAL);
+};
+
+MdnsDiscovery.tcpCheck = function() {
+    const self = this;
+
+    if (!self.tcpCheckLock) {
+        self.tcpCheckLock = true;
+        if (PortHandler.initialPorts?.length > 0) {
+            const tcpPorts = PortHandler.initialPorts.filter(p => p.path.startsWith('tcp://'));
+            tcpPorts.forEach(function (port) {
+                const removePort = () => {
+                    if (GUI.isCordova()) {
+                        //disable offline services instead of removing them
+                        self.mdnsBrowser.services = self.mdnsBrowser.services
+                        .map(s => {
+                            if (s.fqdn === port.fqdn) {
+                                return {...s, ready: false};
+                              }
+                              return s;
+                            });
+                    }
+                    else {
+                        self.mdnsBrowser.browser._removeService(port.fqdn);
+                        self.mdnsBrowser.services = self.mdnsBrowser.services.filter(s => s.fqdn !== port.fqdn);
+                    }
+                };
+                $.ajax({
+                    url: `http://${port.path.split('//').pop()}`,
+                    error: removePort,
+                    timeout: TCP_TIMEOUT,
+                });
+            });
+
+            //timeout is 2000ms for every found port, so wait that time before checking again
+            setTimeout(() => {
+                self.tcpCheckLock = false;
+            }, Math.min(tcpPorts.length, 1) * (TCP_TIMEOUT + 1));
+        } else {
+            self.tcpCheckLock = false;
+        }
+    }
+};

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -145,6 +145,7 @@ function initializeSerialBackend() {
         ConfigStorage.set({'auto_connect': GUI.auto_connect});
     });
 
+    MdnsDiscovery.initialize();
     PortHandler.initialize();
     PortUsage.initialize();
 }

--- a/src/main.html
+++ b/src/main.html
@@ -93,6 +93,7 @@
     <script type="text/javascript" src="./js/port_usage.js"></script>
     <script type="text/javascript" src="./js/serial.js"></script>
     <script type="text/javascript" src="./js/gui.js"></script>
+    <script type="text/javascript" src="./js/mdns_discovery.js"></script>
     <script type="text/javascript" src="./js/huffman.js"></script>
     <script type="text/javascript" src="./js/default_huffman_tree.js"></script>
     <script type="text/javascript" src="./js/model.js"></script>


### PR DESCRIPTION
The previous .get() method was broken, `self.mdnsBrowser.init` was pointless and the `remove()` function does not delete the services properly.
This PR hopefully fixes these.
On android it doesn't remove offline devices but disables and pings them while they become online again. I also copied the connect button click code from serial backend only to be unified.

Thanks to @haslinghuis the whole mdns code went to a different class thus keeping the code clean.

Fixes #3050
Merges: #3094