### PR TITLE
Revert "Update Crowdin configuration file"

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,8 +1,30 @@
-preserve_hierarchy: 
-files:
-  - source: /locales/en/messages.json
-    translation: /locales/%two_letters_code%/%original_file_name%
-    languages_mapping:
-      two_letters_code:
-        pt-BR: pt_BR
-        zh-CN: zh_CN
+#
+# Files configuration
+#
+"preserve_hierarchy": false
+
+files: [
+ {
+  #
+  # Source files filter
+  # e.g. "/resources/en/*.json"
+  #
+  "source" : "/locales/en/messages.json",
+
+  #
+  # where translations live
+  # e.g. "/resources/%two_letters_code%/%original_file_name%"
+  #
+  "translation" : "/locales/%two_letters_code%/%original_file_name%",
+
+  #
+  # Often software projects have custom names for locale directories. crowdin-cli allows you to map your own languages to be understandable by Crowdin.
+  #
+  "languages_mapping" : {
+    "two_letters_code" : {
+      "pt-BR" : "pt_BR",
+      "zh-CN" : "zh_CN"
+     }
+  }
+ }
+]


### PR DESCRIPTION
This reverts commit 5204c39af47bd2bf333458e7eb2537a0847fdb8a.

This commit was pushed by the Crowdin-GitHub integration. The new file format does not seem right, the downloaded files from Crowdin are wrong. This commit reverts it trying to make it work again but maybe it breaks the upload of the messages file to Crowdin.

It's an urgent PR, so please merge this soon to see if it works and what it breaks.