### PR TITLE
Fix local flashing messaging

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -730,7 +730,15 @@ firmware_flasher.initialize = function (callback) {
                                     let config = cleanUnifiedConfigFile(e.target.result);
                                     if (config !== null) {
                                         setBoardConfig(config, file.name);
-                                        flashingMessageLocal(file.name);
+
+                                        if (self.isConfigLocal && !self.parsed_hex) {
+                                            self.flashingMessage(i18n.getMessage('firmwareFlasherLoadedConfig'), self.FLASH_MESSAGE_TYPES.NEUTRAL);
+                                        }
+
+                                        if ((self.isConfigLocal && self.parsed_hex && !self.localFirmwareLoaded) || self.localFirmwareLoaded) {
+                                            self.enableFlashing(true);
+                                            self.flashingMessage(i18n.getMessage('firmwareFlasherFirmwareLocalLoaded', self.parsed_hex.bytes_total), self.FLASH_MESSAGE_TYPES.NEUTRAL);
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
When using local config and firmware while flashing the status message was not updated