### PR TITLE
Temporary fix for Crowdin integration

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -17,6 +17,9 @@ files: [
   #
   "translation" : "/locales/%two_letters_code%/%original_file_name%",
 
+  # ONLY AS TEMPORARY WORKAROUND
+  # preserve translations and validations of changed strings
+  "update_option": "update_without_changes",
   #
   # Often software projects have custom names for locale directories. crowdin-cli allows you to map your own languages to be understandable by Crowdin.
   #


### PR DESCRIPTION
The Crowdin integration is not working right, it removes correct translations when uploading the new messages file.
Crowdin support has suggested to use the `update_without_changes` parameter in a temporary manner to synchronize repos: https://developer.crowdin.com/configuration-file/?q=configuration%20file#changed-strings-update
