### PR TITLE
Improved message when save lua VTX file

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6211,7 +6211,6 @@
         "message": "This table represents all the frequencies that can be used for your VTX. You can have several bands and for each band you must configure:<br><b>- $t(vtxTableBandTitleName.message):</b> Name that you want to assign to this band, like BOSCAM_A, FATSHARK or RACEBAND.<br><b>- $t(vtxTableBandTitleLetter.message):</b> Short letter that references the band.<br><b>- $t(vtxTableBandTitleFactory.message):</b> This indicates if it is a factory band. If enabled Betaflight sends to the VTX a band and channel number. The VTX will then use its built-in frequency table and the frequencies configured here are only to show the value in the OSD and other places. If it is not enabled, then Betaflight will send to the VTX the real frequency configured here.<br><b>- Frequencies:</b> Frequencies for this band.<br /><br />Remember that not all frequencies are legal at your country. You must put a value of <b>zero</b> to each frequency index that you are not allowed to use to disable it.",
         "description": "Help for the table of bands-channels that appears in the VTX tab"
     },
-
     "vtxSavedFileOk": {
         "message": "VTX Config file <span class=\"message-positive\">saved</span>",
         "description": "Message in the GUI log when the VTX Config file is saved"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6221,12 +6221,12 @@
         "description": "Message in the GUI log when the VTX Config file is saved"
     },
     "vtxSavedLuaFileOk": {
-        "message": "lua VTX Config file <span class="message-positive">saved",
+        "message": "lua VTX Config file <span class=\"message-positive\">saved",
         "description": "Message in the GUI log when the lua VTX Config file is saved"
     },
         "vtxSavedLuaFileKo": {
-        "message": "<span class="message-negative">Error while saving the lua VTX Config file",
-        "description": "Message in the GUI log when the lau VTX Config file saving has failed"
+        "message": "<span class=\"message-negative\">Error while saving the lua VTX Config file",
+        "description": "Message in the GUI log when the lua VTX Config file saving has failed"
     },
     "vtxLoadFileOk": {
         "message": "VTX Config file <span class=\"message-positive\">loaded</span>",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6223,7 +6223,7 @@
         "message": "lua VTX Config file <span class=\"message-positive\">saved</span>",
         "description": "Message in the GUI log when the lua VTX Config file is saved"
     },
-        "vtxSavedLuaFileKo": {
+    "vtxSavedLuaFileKo": {
         "message": "<span class=\"message-negative\">Error while saving the lua VTX Config file",
         "description": "Message in the GUI log when the lua VTX Config file saving has failed"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6220,6 +6220,14 @@
         "message": "<span class=\"message-negative\">Error</span> while saving the VTX Config file",
         "description": "Message in the GUI log when the VTX Config file is saved"
     },
+    "vtxSavedLuaFileOk": {
+        "message": "lua VTX Config file <span class="message-positive">saved",
+        "description": "Message in the GUI log when the lua VTX Config file is saved"
+    },
+        "vtxSavedLuaFileKo": {
+        "message": "<span class="message-negative">Error while saving the lua VTX Config file",
+        "description": "Message in the GUI log when the lau VTX Config file saving has failed"
+    },
     "vtxLoadFileOk": {
         "message": "VTX Config file <span class=\"message-positive\">loaded</span>",
         "description": "Message in the GUI log when the VTX Config file is loaded"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6220,7 +6220,7 @@
         "description": "Message in the GUI log when the VTX Config file is saved"
     },
     "vtxSavedLuaFileOk": {
-        "message": "lua VTX Config file <span class=\"message-positive\">saved",
+        "message": "lua VTX Config file <span class=\"message-positive\">saved</span>",
         "description": "Message in the GUI log when the lua VTX Config file is saved"
     },
         "vtxSavedLuaFileKo": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6224,7 +6224,7 @@
         "description": "Message in the GUI log when the lua VTX Config file is saved"
     },
     "vtxSavedLuaFileKo": {
-        "message": "<span class=\"message-negative\">Error while saving the lua VTX Config file",
+        "message": "<span class=\"message-negative\">Error</span> while saving the lua VTX Config file",
         "description": "Message in the GUI log when the lua VTX Config file saving has failed"
     },
     "vtxLoadFileOk": {

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -633,7 +633,7 @@ vtx.initialize = function (callback) {
 
                 writer.onerror = function(){
                     console.error('Failed to write VTX table lua file');
-                    GUI.log(i18n.getMessage('vtxSavedFileKo'));
+                    GUI.log(i18n.getMessage('vtxSavedLuaFileKo'));
                 };
 
                 writer.onwriteend = function() {
@@ -646,7 +646,7 @@ vtx.initialize = function (callback) {
                     writer.onwriteend = function() {
                         analytics.sendEvent(analytics.EVENT_CATEGORIES.FLIGHT_CONTROLLER, 'VtxTableLuaSave', text.length);
                         console.log('Write VTX table lua file end');
-                        GUI.log(i18n.getMessage('vtxSavedFileOk'));
+                        GUI.log(i18n.getMessage('vtxSavedLuaFileOk'));
                     };
 
                     writer.write(data);
@@ -656,7 +656,7 @@ vtx.initialize = function (callback) {
 
             }, function (){
                 console.error('Failed to get VTX table lua file writer');
-                GUI.log(i18n.getMessage('vtxSavedFileKo'));
+                GUI.log(i18n.getMessage('vtxSavedLuaFileKo'));
             });
         });
     }


### PR DESCRIPTION
Improve message when save LUA file with VTX configuration

Require 2 more strings in Crowdin (here with danish translation)

    "vtxSavedLuaFileOk": {
        "message": "VTX konfiguration <span class=\"message-positive\">gemt</span> i lua fil",
        "description": "Message in the GUI log when the VTX Config lua file is saved"
    },
    "vtxSavedLuaFileKo": {
        "message": "<span class=\"message-negative\">Fejl</span> ved gemning af lua VTX konfigurations fil",
        "description": "Message in the GUI log when the VTX Config lua file saving has failed"
    },