### PR TITLE
Action to create a PR with translations

### DIFF
--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -1,0 +1,46 @@
+name: Translations download and PR
+
+on: 
+  workflow_dispatch:
+  schedule:
+  - cron: '00 3 * * 1'
+
+
+
+jobs:
+  crowdin-translations-to-pr:
+    name: Create a PR with the latest translations from Crowdin
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Download Crowdin translations and create PR
+      uses: crowdin/github-action@1.5.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+        token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+        config: 'crowdin.yml'
+
+        upload_sources: false
+        upload_translations: false
+
+        download_translations: true
+        crowdin_branch_name: master
+        download_translations_args: '-l ca -l da -l de -l es-ES -l eu -l fr -l gl -l hr -l hu -l id -l it -l ja -l ko -l lv -l nl -l pt-PT -l pt-BR -l pl -l ru -l sv-SE -l zh-CN -l zh-TW'
+        localization_branch_name: update_translations_crowdin
+        push_translations: true
+        commit_message: 'Update translations'
+
+        create_pull_request: true
+        pull_request_title: 'Update translations'
+        pull_request_body: |
+          **This is an automated PR.**
+
+          This PR updates the translations using the content from Crowdin. Thanks to all the translators for the really hard work!!!
+
+          If you want to help to make the localization better, or add a new language, go to [Crowdin](https://crowdin.com/project/betaflight-configurator) and start helping!.
+
+          [![Crowdin](https://d322cqt584bo4o.cloudfront.net/betaflight-configurator/localized.svg)](https://crowdin.com/project/betaflight-configurator)

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -23,8 +23,9 @@ files: [
   "languages_mapping" : {
     "two_letters_code" : {
       "pt-BR" : "pt_BR",
-      "zh-CN" : "zh_CN"
-     }
+      "zh-CN" : "zh_CN",
+      "zh-TW" : "zh_TW"
+    }
   }
  }
 ]


### PR DESCRIPTION
This PR adds a new Github Action to download the translations from Crowdin, and creates a PR with them.

<kbd>![image](https://user-images.githubusercontent.com/2673520/205602776-a1b687dc-a7bf-4f9c-b04b-6498f3a350dd.png)</kbd>

The actual Crowdin-Github integration, creates one, but is a little nightmare, with commits each few minutes with changes to each language, including the ones that we don't use. Is a little out of control. This PR does not remove it at this stage, but adds a new one with the "correct" files and format.

The Action is executed in two ways:
- I've scheduled it once at week, in the Sunday to Monday night, to get the translations from this week. To me the perfect way to do this will be once at day, to generate artifacts that translators can use to test the transaltions, but we need to get some approvers to merge this into master at some moment, and each launch will remove the approvations, so better start with one at week.
- It can be executed manually too, in this way we can lauch it when we are going to make a release, to get the latest translations, or we want to test something.

<kbd>![image](https://user-images.githubusercontent.com/2673520/205602629-358a7475-3823-433d-9ede-1b4ee3d798c7.png)</kbd>

For this Action to work we need to add two SECRETS to the repository configuration:
- secrets.CROWDIN_PROJECT_ID
- secrets.CROWDIN_PERSONAL_TOKEN

I can generate them in Crowdin and provide it, but maybe is better that we generate them by someone with more administrative tasks in the repo.

For the future:
- If this works as expected, maybe we can move the upload of the translations to a Github Action too, is more transparent and easy to control than the actual Crowdin integration.
- There is a parameter that can go in the `crowdin.yml` to define the languages to be exported. It's easier to maintain there, but seems not to be working for the Action at this moment. I will open an issue to Crowdin about it. Until them, I added the list to the Action itself.
