### PR TITLE
Remove deprecated Github Action set-output option

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,11 +41,11 @@ jobs:
         id: notes
         run: |
           set -- release-assets/Betaflight-Configurator-Debug-*
-          echo "::set-output name=notes::$(test -e "$1" && echo '${{ env.debug_release_notes }}' || echo '${{ env.release_notes }}')"
+          echo "notes=$(test -e "$1" && echo '${{ env.debug_release_notes }}' || echo '${{ env.release_notes }}')" >> $GITHUB_OUTPUT
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=today::$(date '+%Y%m%d')"
+        run: echo "today=$(date '+%Y%m%d')" >> $GITHUB_OUTPUT
 
       - name: Release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15


### PR DESCRIPTION
Upgrade the set-output commands because they are deprecated.