### PR TITLE
Add action to upload messages file to Crowdin

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,6 +27,11 @@ jobs:
     with:
       debug_build: true
 
+  upload-translations:
+    name: Upload translations
+    needs: ci
+    uses: ./.github/workflows/translations-upload.yml
+  
   release:
     name: Nightly release
     needs: ci

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -23,12 +23,12 @@ jobs:
         project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
         token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
         config: 'crowdin.yml'
+        crowdin_branch_name: ${{ github.ref_name }}
 
         upload_sources: false
         upload_translations: false
 
         download_translations: true
-        crowdin_branch_name: master
         download_translations_args: '-l ca -l da -l de -l es-ES -l eu -l fr -l gl -l hr -l hu -l id -l it -l ja -l ko -l lv -l nl -l pt-PT -l pt-BR -l pl -l ru -l sv-SE -l zh-CN -l zh-TW'
         localization_branch_name: update_translations_crowdin
         push_translations: true

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -1,0 +1,29 @@
+name: Translations upload to Crowdin
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  betaflight-messages-to-crowdin:
+    name: Messages file to Crowdin
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Upload messages file
+      uses: crowdin/github-action@1.5.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        project_id: ${{ secrets.CROWDIN_PROJECT_ID }}
+        token: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+        config: 'crowdin.yml'
+        crowdin_branch_name: ${{ github.ref_name }}
+
+        upload_sources: true
+        upload_translations: false
+
+        download_translations: false
+        

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,7 @@
+# ID used by the upload action to Crowdin
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+
 #
 # Files configuration
 #


### PR DESCRIPTION
This PR adds a Github Action to upload our `messages.json` to Crowdin foir localization.

This is the counterpart of https://github.com/betaflight/betaflight-configurator/pull/3113

Until now, we were using a Crowdin integration to do it. But it is a little out of our control, generating a PR branch with a commit with each change at each language, starting some of our workflows, etc... we can try to configure our workflows to ignore it, but I think is better to try to get more control of it.

With this PR, we will upload the new messages file after a merge is done to master, when executing our nightly workflow, if the test and build of the artifacts is ok. 

I have added too a manual option to trigger the workflow if something goes wrong with the nightly workflow but we want to upload the messages file.

@haslinghuis before merging this, let me know to stop the Crowdin integration and check if the first execution work as expected. I have tested it at my repo but I can't exactly replicate the Betaflight repo.