### PR TITLE
Add release/debug to nw.js cache key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: node_modules/
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node_modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Node.js
         uses: actions/setup-node@v3
@@ -66,13 +66,13 @@ jobs:
         uses: actions/cache@v3
         with:
           path: cache/
-          key: ${{ runner.os }}-${{ hashFiles('gulpfile.js') }}
+          key: nwjs-${{ inputs.debug_build && 'debug' || 'release' }}-${{ runner.os }}-${{ hashFiles('gulpfile.js') }}
 
       - name: Cache node_modules
         uses: actions/cache@v3
         with:
           path: node_modules/
-          key: ${{ runner.os }}-${{ hashFiles('yarn.lock') }}
+          key: node_modules-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
 
       - name: Install Node.js
         uses: actions/setup-node@v3


### PR DESCRIPTION
This PR makes two changes:
- Prepend the type of cache to the key. If we don't add it, we can end with two caches for different folders with the same key. And with this change, we can identify them easily in the list of stored caches.
- Adds debug/release to the nwjs cache. The downloaded file is different for both types. Until now is not a problem because we use a lot the debug and we use the release only for the final versions.

