### PR TITLE
Upload transations automatically only if master

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,7 @@ jobs:
       debug_build: true
 
   upload-translations:
+    if: ${{ github.ref_name == 'master' }}
     name: Upload translations
     needs: ci
     uses: ./.github/workflows/translations-upload.yml


### PR DESCRIPTION
This PR changes the upload of messages file to Crowdin, only when the merge is to the master branch.

Without this, if we merge to some maintenance branch, it would upload the file to a maintenance branch in Crowdin. This is correct, but can confuse users. If we need to do this at some moment, we can use the manual launch and will work.