### PR TITLE
Remove setup-node cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
 
       - run: yarn install --immutable --immutable-cache --check-cache
 
@@ -78,7 +77,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: '.nvmrc'
-          cache: yarn
 
       - name: Install Java JDK 8
         uses: actions/setup-java@v3


### PR DESCRIPTION
As stated in the setup-node action documentation, the cache is used to store **global** node_modules dependencies.

As far as I know, we are not using those dependencies. We use only local node_modules dependencies, that we are caching manually in the CI.

This PR removes the cache of the setup-node to speed up a little the process.