### PR TITLE
Fix secrets in Crowdin actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,10 @@ jobs:
     name: Upload translations
     needs: ci
     uses: ./.github/workflows/translations-upload.yml
-  
+    secrets:
+      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
   release:
     name: Nightly release
     needs: ci

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -1,8 +1,13 @@
 name: Translations upload to Crowdin
 
 on:
-  workflow_call:
   workflow_dispatch:
+  workflow_call:
+    secrets:
+      CROWDIN_PROJECT_ID:
+        required: true
+      CROWDIN_PERSONAL_TOKEN:
+        required: true
 
 jobs:
   betaflight-messages-to-crowdin:


### PR DESCRIPTION
The Crowdin upload action, is working when executed directly, by manual request, but not when executed as part of the nightly workflow. This is because the SECRETS environment variables are not available to `workflow_call`.

This PR fixes it adding manually the secrets needed.