### PR TITLE
Move upload translations action to own  workflow

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,15 +27,6 @@ jobs:
     with:
       debug_build: true
 
-  upload-translations:
-    if: ${{ github.ref_name == 'master' }}
-    name: Upload translations
-    needs: ci
-    uses: ./.github/workflows/translations-upload.yml
-    secrets:
-      CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
-      CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
-
   release:
     name: Nightly release
     needs: ci

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -1,13 +1,14 @@
 name: Translations upload to Crowdin
 
+concurrency: upload-crowdin
+
 on:
   workflow_dispatch:
-  workflow_call:
-    secrets:
-      CROWDIN_PROJECT_ID:
-        required: true
-      CROWDIN_PERSONAL_TOKEN:
-        required: true
+  push:
+    branches:
+      - master
+    paths:
+      - 'locales/en/**'
 
 jobs:
   betaflight-messages-to-crowdin:
@@ -31,4 +32,3 @@ jobs:
         upload_translations: false
 
         download_translations: false
-        


### PR DESCRIPTION
Our current workflow that uploads the translations to Crowdin is executed during the nightly build. This has a problem: if we merge several PRs at the same time, we start several nightly builds without any control of what of them finish first. 
We can upload some updated messages file to Crowdin, and after that, upload some old messages files from an earlier merge, that ends deleting the new strings until other merge with the correct strings end.

This PR fixes that:
- Moves the upload translation to it's own execution, out of the nightly
- Filters by file modified, to execute only when there are changes in the `locales/en/` files
- Uses concurrency to have only one execution at a time, giving priority to the latest merge
