### PR TITLE
FIX: Load firmware online button not enabled if not in expert mode

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -279,17 +279,17 @@ firmware_flasher.initialize = function (callback) {
                     const expertMode = $('.tab-firmware_flasher input.expert_mode').is(':checked');
                     if (!expertMode) {
                         $('div.commitSelection').hide();
-                        return;
-                    }
-                    $('div.commitSelection').show();
+                    } else {
+                        $('div.commitSelection').show();
 
-                    self.releaseLoader.loadCommits(summary.release, (commits) => {
-                        const select_e = $('select[name="commits"]');
-                        select_e.empty();
-                        commits.forEach((commit) => {
-                            select_e.append($(`<option value='${commit.sha}'>${commit.message}</option>`));
+                        self.releaseLoader.loadCommits(summary.release, (commits) => {
+                            const select_e = $('select[name="commits"]');
+                            select_e.empty();
+                            commits.forEach((commit) => {
+                                select_e.append($(`<option value='${commit.sha}'>${commit.message}</option>`));
+                            });
                         });
-                    });
+                    }
                 }
 
                 if (summary.configuration && !self.isConfigLocal) {


### PR DESCRIPTION
As per the label on the tin.

If the expert mode was not enabled, and the cloud build was true, then the load firmware online would not be enabled.

A work around is to select a non-cloud build firmware option, and then reselect the cloud build firmware. This is not ideal for users - so this is considered an urgent fix.