### PR TITLE
Bump gulp-debian library

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,23 +94,7 @@ jobs:
         if: ${{ !inputs.debug_build && matrix.name != 'Android' }}
 
       - run: yarn gulp debug-release ${{ matrix.releaseArgs }}
-        if: ${{ inputs.debug_build || matrix.name == 'Android' }}
-
-      # Modern Ubuntu builds .deb with ZST compression; however, Debian does not yet support
-      - name: repack .deb file with xz compression
-        if: ${{ matrix.name == 'Linux' }}
-        run: |
-          set -x
-          sudo apt install binutils zstd
-          cd release
-          debfile=$(find ./ -name "*.deb")
-          ar x $debfile
-          zstd -d < control.tar.zst | xz > control.tar.xz  
-          zstd -d < data.tar.zst | xz > data.tar.xz  
-          rm *.deb
-          rm *.zst
-          ar -m -c -a sdsd $debfile debian-binary control.tar.xz data.tar.xz
-          rm debian-binary control.tar.xz data.tar.xz
+        if: ${{ inputs.debug_build }}
 
       - name: Publish build artifacts
         uses: actions/upload-artifact@v3

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ const del = require('del');
 const NwBuilder = require('nw-builder');
 const innoSetup = require('@quanle94/innosetup');
 const deb = require('gulp-debian');
+const conffiles = './test/configs';
 const buildRpm = require('rpm-builder');
 const commandExistsSync = require('command-exists').sync;
 const targz = require('targz');
@@ -742,6 +743,7 @@ function release_deb(arch, appDirectory, done) {
                 `chmod -R +Xr ${LINUX_INSTALL_DIR}/${metadata.name}/`,
             ],
             prerm: [`xdg-desktop-menu uninstall ${metadata.name}.desktop`],
+            conffiles: './test/configs/opt/etc/dummy.cfg',
             depends: ['libgconf-2-4', 'libatomic1'],
             changelog: [],
             _target: `${LINUX_INSTALL_DIR}/${metadata.name}`,

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "glob": "^8.0.3",
     "gulp": "^4.0.2",
     "gulp-concat": "~2.6.1",
-    "gulp-debian": "^0.1.9",
+    "gulp-debian": "^0.3.2",
     "gulp-json-editor": "^2.5.6",
     "gulp-less": "^5.0.0",
     "gulp-prompt": "^1.2.0",

--- a/test/configs/opt/etc/dummy.cfg
+++ b/test/configs/opt/etc/dummy.cfg
@@ -1,0 +1,5 @@
+
+# Only for test purpose!
+# You configuration starts here:
+option1 = true;
+option2 = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8089,6 +8089,13 @@ find-versions@^3.2.0:
   dependencies:
     semver-regex "^2.0.0"
 
+find@^0.2.8:
+  version "0.2.9"
+  resolved "https://registry.yarnpkg.com/find/-/find-0.2.9.tgz#4b73f1ff9e56ad91b76e716407fe5ffe6554bb8c"
+  integrity sha512-7a4/LCiInB9xYMnAUEjLilL9FKclwbwK7VlXw+h5jMvT2TDFeYFCHM24O1XdnC/on/hx8mxVO3FTQkyHZnOghQ==
+  dependencies:
+    traverse-chain "~0.1.0"
+
 findup-sync@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/findup-sync/-/findup-sync-2.0.0.tgz#9326b1488c22d1a6088650a86901b2d9a90a2cbc"
@@ -8864,11 +8871,12 @@ gulp-concat@~2.6.1:
     through2 "^2.0.0"
     vinyl "^2.0.0"
 
-gulp-debian@^0.1.9:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/gulp-debian/-/gulp-debian-0.1.9.tgz#80e4a8cfc0f0904312f07e66a06ca3c024edc153"
-  integrity sha512-hY16Lj5IdxY213L9Sl6SlEgpCvf8/ny3SQ4S9dyG8MHqRx0fPpui5CRodhQK5lA2oScxP8qi4wfK4fIDr5xF3g==
+gulp-debian@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/gulp-debian/-/gulp-debian-0.3.2.tgz#0b5a32366ae0a159529b9b7285e31bb73998da9d"
+  integrity sha512-P9zqKFQ9xRG1wvcJUYiBxUEypoPcDsFJxmxyJ6PSyfF2iOcsIk1mPTp47Qs0Q36bdWvrauvGTvJxscFIhK1U3A==
   dependencies:
+    find "^0.2.8"
     fs-extra "^5.0.0"
     gulp-util "^3.0.8"
     through2 "^2.0.1"
@@ -10619,7 +10627,7 @@ jsonfile@^2.1.0:
 jsonfile@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-4.0.0.tgz#8771aae0799b64076b76640fca058f9c10e33ecb"
-  integrity sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=
+  integrity sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==
   optionalDependencies:
     graceful-fs "^4.1.6"
 
@@ -11235,7 +11243,7 @@ loupe@^2.3.1:
 lower-case@^1.1.1:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
-  integrity sha1-miyr0bno4K6ZOkv31YdcOcQujqw=
+  integrity sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==
 
 lower-case@^2.0.2:
   version "2.0.2"
@@ -16073,7 +16081,7 @@ timers-ext@^0.1.7:
 title-case@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/title-case/-/title-case-2.1.1.tgz#3e127216da58d2bc5becf137ab91dae3a7cd8faa"
-  integrity sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=
+  integrity sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==
   dependencies:
     no-case "^2.2.0"
     upper-case "^1.0.3"
@@ -16198,6 +16206,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
+traverse-chain@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/traverse-chain/-/traverse-chain-0.1.0.tgz#61dbc2d53b69ff6091a12a168fd7d433107e40f1"
+  integrity sha512-up6Yvai4PYKhpNp5PkYtx50m3KbwQrqDwbuZP/ItyL64YEWHAvH6Md83LFLV/GRSk/BoUVwwgUzX6SOQSbsfAg==
 
 trim-newlines@^1.0.0:
   version "1.0.0"
@@ -16646,7 +16659,7 @@ update-browserslist-db@^1.0.9:
 upper-case@^1.0.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
-  integrity sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg=
+  integrity sha512-WRbjgmYzgXkCV7zNVpy5YgrHgbBv126rMALQQMrmzOVC4GM2waQ9x7xtm8VU+1yF2kWyPzI9zbZ48n4vSxwfSA==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight-configurator/issues/3154

The `gulp-debian` library has been updated with `xz` as default compression type..