### PR TITLE
repackage .deb with xz compression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,22 @@ jobs:
       - run: yarn gulp debug-release ${{ matrix.releaseArgs }}
         if: ${{ inputs.debug_build || matrix.name == 'Android' }}
 
+      # Modern Ubuntu builds .deb with ZST compression; however, Debian does not yet support
+      - name: repack .deb file with xz compression
+        if: ${{ matrix.name == 'Linux' }}
+        run: |
+          set -x
+          sudo apt install binutils zstd
+          cd release
+          debfile=$(find ./ -name "*.deb")
+          ar x $debfile
+          zstd -d < control.tar.zst | xz > control.tar.xz  
+          zstd -d < data.tar.zst | xz > data.tar.xz  
+          rm *.deb
+          rm *.zst
+          ar -m -c -a sdsd $debfile debian-binary control.tar.xz data.tar.xz
+          rm debian-binary control.tar.xz data.tar.xz
+
       - name: Publish build artifacts
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
* repackage ubuntu's .deb file as xz rather than zst
* ref: https://gist.github.com/goproslowyo/fe95c8e07c73593e2099687eeda78bc5
* fixes #3154 
* i'm not certain i like this approach, but it solves the problem -- i'll leave it to BF team to decide.
* adds about 4 minutes to Linux build :(
* PR marked to "Allow edits"