### PR TITLE
BUILD: Automatically add the tag for the version (if not a debug build).

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,9 @@ jobs:
 
       - run: yarn install --immutable --immutable-cache --check-cache
 
+      - run: yarn version --no-git-tag-version --new-version ${{ github.ref_name }}
+        if: ${{ !inputs.debug_build }}
+
       - run: yarn gulp release ${{ matrix.releaseArgs }}
         if: ${{ !inputs.debug_build && matrix.name != 'Android' }}
 


### PR DESCRIPTION
To make the creation of the assets when doing release candidates simple.