### PR TITLE
Fix local download of hex file

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -814,6 +814,9 @@ firmware_flasher.initialize = function (callback) {
                 self.releaseLoader.requestBuild(request, (info) => {
                     console.info("Build requested:", info);
 
+                    // Complete the summary object to be used later
+                    summary.file = info.file;
+
                     if (!summary.cloudBuild) {
                         // it is a previous release, so simply load the hex
                         self.releaseLoader.loadTargetHex(info.url, (hex) => onLoadSuccess(hex, info.file), onLoadFailed);
@@ -1008,9 +1011,8 @@ firmware_flasher.initialize = function (callback) {
             }
         }
 
-        $('span.progressLabel a.save_firmware').click(function () {
-            const summary = $('select[name="firmware_version"] option:selected').data('summary');
-            chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: summary.file, accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
+        $('span.progressLabel').on('click', 'a.save_firmware', function () {
+            chrome.fileSystem.chooseEntry({type: 'saveFile', suggestedName: self.summary.file, accepts: [{description: 'HEX files', extensions: ['hex']}]}, function (fileEntry) {
                 if (checkChromeRuntimeError()) {
                     return;
                 }


### PR DESCRIPTION
When users clicks on the progress bar, in the name of the hex file, the Configurator must show a save file dialog to store the file in local. 
Now, it does nothing because the JQuery attach command is being executed before the DOM for the file link is created. This PR fixes it.
It adds too the file name to the summary variable, that it seems was lost at some refactoring. I don't know if this is the best place to put it but it works.