### PR TITLE
Presets fix: removed old event listener that caused console errors

### DIFF
--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -644,10 +644,6 @@ presets.resetInitialValues = function() {
     this._domProgressDialog.close();
 };
 
-presets.expertModeChanged = function(expertModeEnabled) {
-    this._domShowHideCli.toggle(expertModeEnabled);
-};
-
 window.TABS.presets = presets;
 export {
     presets,


### PR DESCRIPTION
Removed a piece of code from the medieval ages that was causing console errors.

The error pointed by @haslinghuis [here](https://github.com/betaflight/betaflight-configurator/pull/2618?notification_referrer_id=NT_kwDOACyh47IyNDk1ODkyMDE5OjI5MjUwMjc#issuecomment-1367072553)