### PR TITLE
Flasher tab: fix wiki button

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -313,10 +313,10 @@ class GuiControl {
 
         this.switchery();
 
-        if (CONFIGURATOR.connectionValid) {
-            // Build link to in-use CF version documentation
-            const documentationButton = $('div#content #button-documentation');
-            documentationButton.html("Wiki");
+        const documentationButton = $('div#content #button-documentation');
+        documentationButton.html("Wiki");
+
+        if (GUI.active_tab !== 'firmware_flasher') { // hack till we have a nice solution for individual wiki URLs for each page
             documentationButton.attr("href", "https://github.com/betaflight/betaflight/wiki");
         }
 


### PR DESCRIPTION
Fixes the wiki button on flasher tab. Bug pointed by @haslinghuis 

For the future: I think that the wiki button needs a change. Either remove it from everywhere or make it more meaningful.
Now it just points to the same wiki page.

Also, the "Firmware Flasher" header is not necessary in my opinion.... maybe :)