### PR TITLE
Fix for OSD grid overflowing the preview area as per #3202

### DIFF
--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -217,6 +217,8 @@
 			border: 1px solid transparent;
 			img {
 				flex: 1 1 auto;
+				max-width: 100%;
+				height: auto;
 			}
 		}
 		.char[draggable="true"] {


### PR DESCRIPTION
The overflowing issue in the screenshots in #3202 is caused by the images for each 'character' not shrinking below 12px wide; this css allows them to do that and then prevents the overflow.