### PR TITLE
Motor reorder dialog fix: importing serial backend

### DIFF
--- a/src/components/MotorOutputReordering/MotorOutputReorderingComponent.js
+++ b/src/components/MotorOutputReordering/MotorOutputReorderingComponent.js
@@ -1,6 +1,7 @@
 import MotorOutputReorderConfig from "./MotorOutputReorderingConfig";
 import MotorOutputReorderCanvas from "./MotorOutputReorderingCanvas";
 import { mspHelper } from "../../js/msp/MSPHelper";
+import { reinitializeConnection } from "../../js/serial_backend";
 
 export default class MotorOutputReorderComponent
 {


### PR DESCRIPTION
Dialog was crashing at "SAVE" click.