### PR TITLE
Add center crosshair to the OSD helper lines

### DIFF
--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -224,10 +224,27 @@
 		}
 
 		&:active {
+
+			&:before {
+				content: '';
+				position: absolute;
+				top: 50%;
+				left: 40%;
+				border-top: 0.3em dashed var(--gimbalCrosshair);
+				width: 20%;
+				transform: translateY(-50%);
+				pointer-events: none;
+			}
+
+			&:after:extend(.tab-osd .preview:active:before) {
+				transform: translateY(-50%) rotate(90deg);
+			}
+
 			.char {
 				border: 1px dashed rgba(55, 55, 55, 0.5) ;
 			}
 		}
+
 	}
 	.char.mouseover {
 		background: rgba(255,255,255,0.4);


### PR DESCRIPTION
To help centering elements, this PR adds a crosshair in the center of the OSD when moving elements:
![image](https://user-images.githubusercontent.com/2673520/212356489-80a4bc1d-d239-4a12-b345-f96f876571f7.png)

![image](https://user-images.githubusercontent.com/2673520/212357007-dbadb6d4-e89c-460f-a8f6-59b9ae93be63.png)

I have added it with CSS only, maybe is better to use some SVG or similar, but for a first version is enough. After feedback from users, maybe is better to add some vertical/horizontal lines too to help with the border elements.