### PR TITLE
Let the OSD preview be bigger

### DIFF
--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -368,7 +368,7 @@
 		}
 		.osd-preview {
 			flex: 2 0 auto;
-			max-width: 740px;
+			max-width: 1480px;
 		}
 		.osd-profile {
 			flex: 1 1 auto;


### PR DESCRIPTION
When we add the option to make the OSD preview bigger, we limited it to 740px. Now that we have HD options, maybe is a little small.
This PR let's it grow more. It looks ok with QHD resolutions, for example:
![image](https://user-images.githubusercontent.com/2673520/212645937-38c5ef25-8e0d-44c1-8e89-ef85abb9428b.png)

and it scales nicelly to smaller ones:
![image](https://user-images.githubusercontent.com/2673520/212646814-0b6a72e8-abca-43fa-a810-ebec27f23df5.png)

if someone has some big 4K or more monitor a test will be appreciated. The preview must be only a little bigger than in QHD.
