### PR TITLE
Improve custom defaults area detection

### DIFF
--- a/src/js/ConfigInserter.js
+++ b/src/js/ConfigInserter.js
@@ -44,6 +44,15 @@ function getCustomDefaultsArea(firmware) {
     result.startAddress = readUint32(firmware, index);
     result.endAddress = readUint32(firmware, index);
 
+    // verify that addresses are valid
+    if (seek(firmware, result.startAddress).byteIndex === undefined) {
+        return;
+    }
+
+    if (seek(firmware, result.endAddress).byteIndex === undefined) {
+        return;
+    }
+
     return result;
 }
 
@@ -91,7 +100,7 @@ export default class ConfigInserter {
         const input = `# Betaflight\n${config}\0`;
         const customDefaultsArea = getCustomDefaultsArea(firmware);
 
-        if (!customDefaultsArea || customDefaultsArea.endAddress - customDefaultsArea.startAddress === 0) {
+        if (!customDefaultsArea || customDefaultsArea.endAddress - customDefaultsArea.startAddress <= 0) {
             return false;
         } else if (input.length >= customDefaultsArea.endAddress - customDefaultsArea.startAddress) {
             throw new Error(`Custom defaults area too small (${customDefaultsArea.endAddress - customDefaultsArea.startAddress} bytes), ${input.length + 1} bytes needed.`);


### PR DESCRIPTION
The custom defaults area is defined by a start and end address located at `0x08002800`. This improves the custom defaults area detection by checking that both addresses are valid and by also assuming that custom defaults are not supported when `endAddress < startAddress`.

While the configurator tells users not to flash non-Betaflight firmware with the configurator, it has to be assumed that some will. If the configurator incorrectly detects that the firmware supports custom defaults in that case, it will modify the hex file and corrupt the firmware. Therefore, the detection whether custom defaults are supported should be as robust as possible. 

A further improvement could be to add a magic number before the start address and the configurator would check if the magic number is valid when detecting the custom defaults area.