### PR TITLE
Added new DSHOT debug modes

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6759,8 +6759,12 @@
         "message": "Bidirectional DShot (requires supported ESC firmware)",
         "description": "Feature for the ESC/Motor"
     },
+    "configurationDshotEdt": {
+        "message": "Built-in sensors",
+        "description": "ESC/Motor feature"
+    },
     "configurationDshotBidirHelp": {
-        "message": "Sends ESC data to the FC via DShot telemetry.  Required by RPM Filtering and dynamic idle. <br> <br>Note: Requires a compatible ESC with appropriate firmware, eg JESC, Jazzmac, BLHeli-32.",
+        "message": "Sends ESC data to the FC via DShot telemetry.  Required by RPM Filtering and dynamic idle. <br> <br>Note: Requires a compatible ESC with appropriate firmware, eg Bluejay, AM32, JESC, Jazzmac, BLHeli-32.",
         "description": "Description of the Bidirectional DShot feature of the ESC/Motor"
     },
     "configurationGyroSyncDenom": {

--- a/src/css/tabs/onboard_logging.less
+++ b/src/css/tabs/onboard_logging.less
@@ -167,7 +167,7 @@
 	.blackboxRate {
 		select {
 			float: left;
-			width: 180px;
+			width: 260px;
 			height: 20px;
 			margin: 0 10px 5px 0;
 			border: 1px solid var(--subtleAccent);
@@ -202,7 +202,7 @@
 	.blackboxDebugMode {
 		select {
 			float: left;
-			width: 180px;
+			width: 260px;
 			height: 20px;
 			margin: 0 10px 5px 0;
 			border: 1px solid var(--subtleAccent);
@@ -215,7 +215,7 @@
 	.blackboxDevice {
 		select {
 			float: left;
-			width: 180px;
+			width: 260px;
 			height: 20px;
 			margin: 0 10px 5px 0;
 			border: 1px solid var(--subtleAccent);

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -37,6 +37,7 @@ const VirtualFC = {
             motor_count: 4,
             motor_poles: 14,
             use_dshot_telemetry: true,
+            use_dshot_edt: true,
             use_esc_sensor: false,
         };
 

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -90,6 +90,13 @@ const DEBUG = {
         {text: "MAG_CALIB"},
         {text: "MAG_TASK_RATE"},
         {text: "EZLANDING"},
+        {text: "DSHOT_STATUS_N_TEMPERATURE"},
+        {text: "DSHOT_STATUS_N_VOLTAGE"},
+        {text: "DSHOT_STATUS_N_CURRENT"},
+        {text: "DSHOT_STATUS_N_DEBUG1"},
+        {text: "DSHOT_STATUS_N_DEBUG2"},
+        {text: "DSHOT_STATUS_N_STRESS_LVL"},
+        {text: "DSHOT_STATUS_N_ERPM_FRACTION_18"},
     ],
 
     fieldNames : {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -359,6 +359,7 @@ const FC = {
             motor_count:                0,
             motor_poles:                0,
             use_dshot_telemetry:        false,
+            use_dshot_edt:              false,
             use_esc_sensor:             false,
         };
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -497,6 +497,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     FC.MOTOR_CONFIG.use_dshot_telemetry = data.readU8() != 0;
                     FC.MOTOR_CONFIG.use_esc_sensor = data.readU8() != 0;
                 }
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                    FC.MOTOR_CONFIG.use_dshot_edt = data.readU8() != 0;
+                }
                 break;
             case MSPCodes.MSP_GPS_CONFIG:
                 FC.GPS_CONFIG.provider = data.readU8();
@@ -1798,6 +1801,9 @@ MspHelper.prototype.crunch = function(code, modifierCode = undefined) {
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
                 buffer.push8(FC.MOTOR_CONFIG.motor_poles);
                 buffer.push8(FC.MOTOR_CONFIG.use_dshot_telemetry ? 1 : 0);
+            }
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                buffer.push8(FC.MOTOR_CONFIG.use_dshot_edt ? 1 : 0);
             }
             break;
         case MSPCodes.MSP_SET_GPS_CONFIG:

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -89,8 +89,12 @@
                                 <div class="number checkboxDshotBidir">
                                     <div style="float: left; height: 20px; margin-right: 14px; margin-left: 3px;">
                                         <input type="checkbox" id="dshotBidir" class="toggle" />
+	                                    <span class="freelabel" i18n="configurationDshotBidir"></span>
                                     </div>
-                                    <span class="freelabel" i18n="configurationDshotBidir"></span>
+                                    <div style="float: left; height: 20px; margin-right: 14px; margin-left: 3px;" class="checkboxDshotEdt">
+                                        <input type="checkbox" id="dshotEdt" class="toggle" />
+	                                    <span class="freelabel" id="dshotEdtLabel" i18n="configurationDshotEdt"></span>
+                                    </div>
                                     <div class="helpicon cf_tip" i18n_title="configurationDshotBidirHelp"></div>
                                 </div>
                                 <div class="number motorPoles">


### PR DESCRIPTION
This pr matches functionality in https://github.com/betaflight/betaflight/pull/12170 and https://github.com/betaflight/betaflight/pull/11694

Added new DSHOT EDT modes to blackbox tab. As their names are longer than usual I made the drop down list controls wider.
Also added FAILSAFE mode I found in blackbox explorer.

It can be used with Bluejay 0.20.1 RC2 or above.

<hr>
Depends on https://github.com/betaflight/betaflight/pull/12170
