### PR TITLE
Don't close on select cloud build options

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -383,7 +383,7 @@ firmware_flasher.initialize = function (callback) {
         $('select[name="radioProtocols"]').select2();
         $('select[name="telemetryProtocols"]').select2();
         $('select[name="motorProtocols"]').select2();
-        $('select[name="options"]').select2();
+        $('select[name="options"]').select2({ closeOnSelect: false });
         $('select[name="commits"]').select2({ tags: true });
 
         $('select[name="board"]').change(function() {


### PR DESCRIPTION
This PR modifies the behaviour of the options select from cloud build. Now it remains open, after each selection making it easier for the user to select/unselect more than one option.