### PR TITLE
feat: drop jquery debounce for local implementation

### DIFF
--- a/libraries/jquery.ba-throttle-debounce.min.js
+++ b/libraries/jquery.ba-throttle-debounce.min.js
@@ -1,9 +1,0 @@
-/*
- * jQuery throttle / debounce - v1.1 - 3/7/2010
- * http://benalman.com/projects/jquery-throttle-debounce-plugin/
- * 
- * Copyright (c) 2010 "Cowboy" Ben Alman
- * Dual licensed under the MIT and GPL licenses.
- * http://benalman.com/about/license/
- */
-(function(b,c){var $=b.jQuery||b.Cowboy||(b.Cowboy={}),a;$.throttle=a=function(e,f,j,i){var h,d=0;if(typeof f!=="boolean"){i=j;j=f;f=c}function g(){var o=this,m=+new Date()-d,n=arguments;function l(){d=+new Date();j.apply(o,n)}function k(){h=c}if(i&&!h){l()}h&&clearTimeout(h);if(i===c&&m>e){l()}else{if(f!==true){h=setTimeout(i?k:l,i===c?e-m:e)}}}if($.guid){g.guid=j.guid=j.guid||$.guid++}return g};$.debounce=function(d,e,f){return f===c?a(d,e,false):a(d,f,e!==false)}})(this);

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "jquery-touchswipe": "^1.6.19",
     "jquery-ui-npm": "^1.12.0",
     "jsdom": "^21.0.0",
+    "lodash.debounce": "^4.0.8",
     "marked": "^4.1.1",
     "multicast-dns": "^7.2.5",
     "multiple-select": "^1.5.2",

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -14,6 +14,7 @@ import semver from "semver";
 import jBox from "jbox";
 import inflection from "inflection";
 import { checkChromeRuntimeError } from "../utils/common";
+import debounce from "lodash.debounce";
 
 const FONT = {};
 const SYM = {};
@@ -3078,7 +3079,7 @@ osd.initialize = function(callback) {
                                 $(`<input type="number" class="${field.index} position"></input>`)
                                     .data('field', field)
                                     .val(field.position)
-                                    .change($.debounce(250, function() {
+                                    .change(debounce(function() {
                                         const fieldChanged = $(this).data('field');
                                         const position = parseInt($(this).val());
                                         fieldChanged.position = position;
@@ -3086,7 +3087,7 @@ osd.initialize = function(callback) {
                                             .then(function() {
                                                 updateOsdView();
                                             });
-                                    })),
+                                    }, 250)),
                             );
                         }
 

--- a/src/main.html
+++ b/src/main.html
@@ -62,7 +62,6 @@
     <script type="text/javascript" src="./js/libraries/jquery.nouislider.all.min.js"></script>
     <script type="text/javascript" src="./js/libraries/jquery.flightindicators.js"></script>
     <script type="text/javascript" src="./node_modules/bluebird/js/browser/bluebird.min.js"></script>
-    <script type="text/javascript" src="./js/libraries/jquery.ba-throttle-debounce.min.js"></script>
     <script type="text/javascript" src="./node_modules/jquery-textcomplete/dist/jquery.textcomplete.min.js"></script>
     <script type="text/javascript" src="./node_modules/jquery-touchswipe/jquery.touchSwipe.min.js"></script>
     <script type="text/javascript" src="./node_modules/select2/dist/js/select2.min.js"></script>

--- a/yarn.lock
+++ b/yarn.lock
@@ -10314,7 +10314,7 @@ lodash._root@^3.0.0:
 lodash.debounce@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
-  integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.defaults@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
Drop minimized jquery debounc library from `libraries` in favour of local implementation