### PR TITLE
Expose Cloud Build Options and hide tabs and features

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -549,6 +549,9 @@
     "buildServerSupportRequestSubmission": {
         "message": "<br>*** Support data submitted *** <br>Id: $1<br><br><br># copy ID and provide to the betaflight team."
     },
+    "buildKey": {
+        "message": "Build Key: <strong>$1</strong>"
+    },
     "supportWarningDialogTitle": {
         "message": "Confirm Data Submission"
     },

--- a/src/js/BuildApi.js
+++ b/src/js/BuildApi.js
@@ -149,6 +149,18 @@ export default class BuildApi {
         });
     }
 
+    requestBuildOptions(key, onSuccess, onFailure) {
+
+        const url = `${this._url}/api/builds/${key}/json`;
+        $.get(url, function (data) {
+            onSuccess(data);
+        }).fail(xhr => {
+            if (onFailure !== undefined) {
+                onFailure();
+            }
+        });
+    }
+
     loadOptions(onSuccess, onFailure) {
 
         const url = `${this._url}/api/options`;

--- a/src/js/data_storage.js
+++ b/src/js/data_storage.js
@@ -6,12 +6,13 @@ export const API_VERSION_1_42 = '1.42.0';
 export const API_VERSION_1_43 = '1.43.0';
 export const API_VERSION_1_44 = '1.44.0';
 export const API_VERSION_1_45 = '1.45.0';
+export const API_VERSION_1_46 = '1.46.0';
 
 const CONFIGURATOR = {
     // all versions are specified and compared using semantic versioning http://semver.org/
     API_VERSION_ACCEPTED: API_VERSION_1_41,
     API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE: API_VERSION_1_41,
-    API_VERSION_MAX_SUPPORTED: API_VERSION_1_45,
+    API_VERSION_MAX_SUPPORTED: API_VERSION_1_46,
 
     connectionValid: false,
     connectionValidCliOnly: false,

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -8,6 +8,8 @@ const INITIAL_CONFIG = {
     flightControllerVersion:          '',
     version:                          0,
     buildInfo:                        '',
+    buildKey:                         '',
+    buildOptions:                     [],
     multiType:                        0,
     msp_version:                      0, // not specified using semantic versioning
     capability:                       0,

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -33,19 +33,16 @@ class GuiControl {
             'options',
             'help',
         ];
-        this.defaultAllowedFCTabsWhenConnected = [
+
+        this.defaultAllowedTabsCloudBuild = [
             'setup',
             'failsafe',
-            'transponder',
-            'osd',
             'power',
             'adjustments',
             'auxiliary',
             'presets',
             'cli',
             'configuration',
-            'gps',
-            'led_strip',
             'logging',
             'onboard_logging',
             'modes',
@@ -54,9 +51,18 @@ class GuiControl {
             'ports',
             'receiver',
             'sensors',
+        ];
+
+        this.defaultCloudBuildTabOptions = [
+            'gps',
+            'led_strip',
+            'osd',
             'servos',
+            'transponder',
             'vtx',
         ];
+
+        this.defaultAllowedFCTabsWhenConnected = [ ...this.defaultAllowedTabsCloudBuild, ...this.defaultCloudBuildTabOptions];
 
         this.allowedTabs = this.defaultAllowedTabsWhenDisconnected;
 

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -202,6 +202,7 @@ const MSPCodes = {
     CRAFT_NAME:                     2,
     PID_PROFILE_NAME:               3,
     RATE_PROFILE_NAME:              4,
+    BUILD_KEY:                      5,
 };
 
 export default MSPCodes;

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -851,6 +851,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     case MSPCodes.RATE_PROFILE_NAME:
                         FC.CONFIG.rateProfileNames[FC.CONFIG.rateProfile] = self.getText(data);
                         break;
+                    case MSPCodes.BUILD_KEY:
+                        FC.CONFIG.buildKey = self.getText(data);
+                        break;
                     default:
                         console.log('Unsupport text type');
                         break;

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -28,24 +28,15 @@ ports.initialize = function (callback) {
         { name: 'TELEMETRY_SMARTPORT',  groups: ['telemetry'], maxPorts: 1 },
         { name: 'RX_SERIAL',            groups: ['rx'], maxPorts: 1 },
         { name: 'BLACKBOX',             groups: ['peripherals'], sharableWith: ['msp'], notSharableWith: ['telemetry'], maxPorts: 1 },
+        { name: 'TELEMETRY_LTM',        groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['peripherals'], maxPorts: 1 },
+        { name: 'TELEMETRY_MAVLINK',    groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['peripherals'], maxPorts: 1 },
+        { name: 'IRC_TRAMP',            groups: ['peripherals'], maxPorts: 1 },
+        { name: 'ESC_SENSOR',           groups: ['sensors'], maxPorts: 1 },
+        { name: 'TBS_SMARTAUDIO',       groups: ['peripherals'], maxPorts: 1 },
+        { name: 'TELEMETRY_IBUS',       groups: ['telemetry'], maxPorts: 1 },
+        { name: 'RUNCAM_DEVICE_CONTROL', groups: ['peripherals'], maxPorts: 1 },
+        { name: 'LIDAR_TF',             groups: ['peripherals'], maxPorts: 1 },
     ];
-
-    const ltmFunctionRule = {name: 'TELEMETRY_LTM', groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['peripherals'], maxPorts: 1};
-    functionRules.push(ltmFunctionRule);
-
-    const mavlinkFunctionRule = {name: 'TELEMETRY_MAVLINK', groups: ['telemetry'], sharableWith: ['msp'], notSharableWith: ['peripherals'], maxPorts: 1};
-    functionRules.push(mavlinkFunctionRule);
-
-    functionRules.push({ name: 'IRC_TRAMP', groups: ['peripherals'], maxPorts: 1 });
-
-    functionRules.push({ name: 'ESC_SENSOR', groups: ['sensors'], maxPorts: 1 });
-    functionRules.push({ name: 'TBS_SMARTAUDIO', groups: ['peripherals'], maxPorts: 1 });
-
-    functionRules.push({ name: 'TELEMETRY_IBUS', groups: ['telemetry'], maxPorts: 1 });
-
-    functionRules.push({ name: 'RUNCAM_DEVICE_CONTROL', groups: ['peripherals'], maxPorts: 1 });
-
-    functionRules.push({ name: 'LIDAR_TF', groups: ['peripherals'], maxPorts: 1 });
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
         functionRules.push({ name: 'FRSKY_OSD', groups: ['peripherals'], maxPorts: 1 });
@@ -424,6 +415,7 @@ ports.initialize = function (callback) {
         let enableBlackbox = false;
         let enableEsc = false;
         let enableGps = false;
+        let enableVtx = false;
 
         for (const port of FC.SERIAL_CONFIG.ports) {
             const func = port.functions;
@@ -446,6 +438,10 @@ ports.initialize = function (callback) {
 
             if (func.includes('GPS')) {
                 enableGps = true;
+            }
+
+            if (func.includes('IRC_TRAMP') || func.includes('TBS_SMARTAUDIO')) {
+                enableVtx = true;
             }
         }
 
@@ -477,6 +473,12 @@ ports.initialize = function (callback) {
             featureConfig.enable('GPS');
         } else {
             featureConfig.disable('GPS');
+        }
+
+        if (enableVtx) {
+            featureConfig.enable('VTX');
+        } else {
+            featureConfig.disable('VTX');
         }
 
         mspHelper.sendSerialConfig(save_features);

--- a/src/js/utils/updateTabList.js
+++ b/src/js/utils/updateTabList.js
@@ -1,53 +1,22 @@
 import semver from "semver";
-import { API_VERSION_1_42 } from "../data_storage";
+import { API_VERSION_1_42, API_VERSION_1_45 } from "../data_storage";
 import FC from "../fc";
-import { isExpertModeEnabled } from "./isExportModeEnabled";
 
 export function updateTabList(features) {
+    const isExpertModeEnabled = $('input[name="expertModeCheckbox"]').is(':checked');
 
-    if (isExpertModeEnabled()) {
-        $('#tabs ul.mode-connected li.tab_failsafe').show();
-        $('#tabs ul.mode-connected li.tab_adjustments').show();
-        $('#tabs ul.mode-connected li.tab_servos').show();
-        $('#tabs ul.mode-connected li.tab_sensors').show();
-        $('#tabs ul.mode-connected li.tab_logging').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_failsafe').hide();
-        $('#tabs ul.mode-connected li.tab_adjustments').hide();
-        $('#tabs ul.mode-connected li.tab_servos').hide();
-        $('#tabs ul.mode-connected li.tab_sensors').hide();
-        $('#tabs ul.mode-connected li.tab_logging').hide();
-    }
+    $('#tabs ul.mode-connected li.tab_failsafe').toggle(isExpertModeEnabled);
+    $('#tabs ul.mode-connected li.tab_adjustments').toggle(isExpertModeEnabled);
+    $('#tabs ul.mode-connected li.tab_servos').toggle(isExpertModeEnabled);
+    $('#tabs ul.mode-connected li.tab_sensors').toggle(isExpertModeEnabled);
+    $('#tabs ul.mode-connected li.tab_logging').toggle(isExpertModeEnabled);
 
-    if (features.isEnabled('GPS') && isExpertModeEnabled()) {
-        $('#tabs ul.mode-connected li.tab_gps').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_gps').hide();
-    }
-
-    if (features.isEnabled('LED_STRIP')) {
-        $('#tabs ul.mode-connected li.tab_led_strip').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_led_strip').hide();
-    }
-
-    if (features.isEnabled('TRANSPONDER')) {
-        $('#tabs ul.mode-connected li.tab_transponder').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_transponder').hide();
-    }
-
-    if (features.isEnabled('OSD')) {
-        $('#tabs ul.mode-connected li.tab_osd').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_osd').hide();
-    }
-
-    $('#tabs ul.mode-connected li.tab_power').show();
-
-    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
-        $('#tabs ul.mode-connected li.tab_vtx').show();
-    } else {
-        $('#tabs ul.mode-connected li.tab_vtx').hide();
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45 || FC.CONFIG.buildKey.length !== 32)) {
+        $('#tabs ul.mode-connected li.tab_gps').toggle(features.isEnabled('GPS'));
+        $('#tabs ul.mode-connected li.tab_led_strip').toggle(features.isEnabled('LED_STRIP'));
+        $('#tabs ul.mode-connected li.tab_servos').toggle(features.isEnabled('CHANNEL_FORWARDING') || features.isEnabled('SERVO_TILT'));
+        $('#tabs ul.mode-connected li.tab_transponder').toggle(features.isEnabled('TRANSPONDER'));
+        $('#tabs ul.mode-connected li.tab_osd').toggle(features.isEnabled('OSD'));
+        $('#tabs ul.mode-connected li.tab_vtx').toggle(features.isEnabled('VTX') && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42));
     }
 }

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -135,7 +135,7 @@
                                         <th i18n="configurationFeatureName"></th>
                                     </tr>
                                 </thead>
-                                <tbody class="features gps other" id="noline">
+                                <tbody class="features other" id="noline">
                                     <!-- table generated here -->
                                 </tbody>
                             </table>


### PR DESCRIPTION
- [x] Keeps default behavior when BUILD_KEY or internet connection is not available
- [x] Retrieve cloud build options using BUILD_KEY in auto-detect and serial backend
- [x] Hides features which are not in cloud build (configuration tab and telemetry for receiver tab)
- [x] Shows tabs which are in cloud build and hide if not.

Please test with firmware https://github.com/betaflight/betaflight/pull/12388 as this would address:
- [x] features can be enabled but we still have to save to eeprom to activate - this should be done in firmware with cloud build options but not sure how we macro that up with DEFAULT_FEATURES

:thinking: Future improvements:

- [ ] moving feature switch to respective tab
- [ ] having port configuration on each tab with label for function, if there is already a function a warning will indicate saving will disable the previous function.
- [ ] receiver configuration
- [ ] motor protocol configuration


As example a very simple build for a LOS build:

![image](https://user-images.githubusercontent.com/8344830/218000543-4ba93381-c0cc-4c8f-92ad-0f9ca7f035c0.png)

we see:

![image](https://user-images.githubusercontent.com/8344830/218000306-d2d2e0a8-7256-45c9-91d3-8b30774f7791.png)


As for a more sophisticated build like:

![image](https://user-images.githubusercontent.com/8344830/218000794-d735edf9-e422-4896-a070-a7bcebeff254.png)

we see:

![image](https://user-images.githubusercontent.com/8344830/218002839-4ddae81c-ec84-446e-a5ee-f5c55853ba21.png)

Originally we see features which are not available in firmware:

![image](https://user-images.githubusercontent.com/8344830/218001431-e4e2e4bc-a85f-4c06-841a-2e93640e5a7d.png)
