### PR TITLE
Fix mDNS browser

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -109,6 +109,10 @@
         "message": "Show all serial devices (for manufacturers or development)",
         "description": "Do not filter serial devices using VID/PID values (for manufacturers or development)"
     },
+    "useMdnsBrowser": {
+        "message": "Use mDNS Browser Device discovery on network (experimental)",
+        "description": "Enable mDNS Browser Device discovery in PortHandler (experimental)"
+    },
     "showVirtualMode": {
         "message": "Enable virtual connection mode",
         "description": "Text for the option to enable or disable the virtual FC"

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -21,6 +21,7 @@ const PortHandler = new function () {
     this.dfu_available = false;
     this.port_available = false;
     this.showAllSerialDevices = false;
+    this.useMdnsBrowser = false;
     this.showVirtualMode = false;
 };
 
@@ -40,11 +41,14 @@ PortHandler.initialize = function () {
 
 PortHandler.reinitialize = function () {
     this.initialPorts = false;
+
     if (this.usbCheckLoop) {
         clearTimeout(this.usbCheckLoop);
     }
+
     this.showVirtualMode = getConfig('showVirtualMode').showVirtualMode;
     this.showAllSerialDevices = getConfig('showAllSerialDevices').showAllSerialDevices;
+    this.useMdnsBrowser = getConfig('useMdnsBrowser').useMdnsBrowser;
 
     this.check();   // start listening, check after TIMEOUT_CHECK ms
 };
@@ -69,18 +73,23 @@ PortHandler.check_serial_devices = function () {
     const self = this;
 
     serial.getDevices(function(cp) {
+        let currentPorts = [];
 
-        let currentPorts = [
-            ...cp,
-            ...(MdnsDiscovery.mdnsBrowser.services?.filter(s => s.txt.vendor === 'elrs' && s.txt.type === 'rx' && s.ready === true)
-                .map(s => s.addresses.map(a => ({
-                    path: `tcp://${a}`,
-                    displayName: `${s.txt.target} - ${s.txt.version}`,
-                    fqdn: s.fqdn,
-                    vendorId: 0,
-                    productId: 0,
-                }))).flat() ?? []),
-        ].filter(Boolean);
+        if (self.useMdnsBrowser) {
+            currentPorts = [
+                ...cp,
+                ...(MdnsDiscovery.mdnsBrowser.services?.filter(s => s.txt?.vendor === 'elrs' && s.txt?.type === 'rx' && s.ready === true)
+                    .map(s => s.addresses.map(a => ({
+                        path: `tcp://${a}`,
+                        displayName: `${s.txt?.target} - ${s.txt?.version}`,
+                        fqdn: s.fqdn,
+                        vendorId: 0,
+                        productId: 0,
+                    }))).flat() ?? []),
+            ].filter(Boolean);
+        } else {
+            currentPorts = cp;
+        }
 
         // auto-select port (only during initialization)
         if (!self.initialPorts) {

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -21,6 +21,7 @@ options.initialize = function (callback) {
         TABS.options.initAnalyticsOptOut();
         TABS.options.initCliAutoComplete();
         TABS.options.initShowAllSerialDevices();
+        TABS.options.initUseMdnsBrowser();
         TABS.options.initShowVirtualMode();
         TABS.options.initCordovaForceComputerUI();
         TABS.options.initDarkTheme();
@@ -137,6 +138,17 @@ options.initShowVirtualMode = function() {
         .prop('checked', !!result.showVirtualMode)
         .on('change', () => {
             setConfig({ showVirtualMode: showVirtualModeElement.is(':checked') });
+            PortHandler.reinitialize();
+        });
+};
+
+options.initUseMdnsBrowser = function() {
+    const useMdnsBrowserElement = $('div.useMdnsBrowser input');
+    const result = getConfig('useMdnsBrowser');
+    useMdnsBrowserElement
+        .prop('checked', !!result.useMdnsBrowser)
+        .on('change', () => {
+            setConfig({ useMdnsBrowser: useMdnsBrowserElement.is(':checked') });
             PortHandler.reinitialize();
         });
 };

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -35,6 +35,12 @@
                     </div>
                     <span class="freelabel" i18n="showAllSerialDevices"></span>
                 </div>
+                <div class="useMdnsBrowser margin-bottom">
+                    <div>
+                        <input type="checkbox" class="toggle" />
+                    </div>
+                    <span class="freelabel" i18n="useMdnsBrowser"></span>
+                </div>
                 <div class="showVirtualMode margin-bottom">
                     <div>
                         <input type="checkbox" class="toggle" />


### PR DESCRIPTION
Fixes: #3336

Also mDSN browser in PortHandler is now disabled by default. Please use options tab to enable the feature.