### PR TITLE
Better translation of GPS status texts in german

### DIFF
--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -2398,16 +2398,16 @@
         "message": "suche"
     },
     "gnssQualityAcquired": {
-        "message": "erworben"
+        "message": "gesehen"
     },
     "gnssQualityUnusable": {
         "message": "unbrauchbar"
     },
     "gnssQualityLocked": {
-        "message": "gesperrt"
+        "message": "Signal empfangen"
     },
     "gnssQualityFullyLocked": {
-        "message": "komplett gesperrt"
+        "message": "Signal OK"
     },
     "gnssUsedUnused": {
         "message": "nicht verwendet"


### PR DESCRIPTION
The previous translations were too literal to be understandable in german. I've updated the texts to better transport their meaning.
