### PR TITLE
Fix latest version check

### DIFF
--- a/src/js/utils/checkForConfiguratorUpdates.js
+++ b/src/js/utils/checkForConfiguratorUpdates.js
@@ -13,8 +13,8 @@ function notifyOutdatedVersion(data) {
 
     if (data.isCurrent === false && data.updatedVersion !== undefined) {
 
-        CONFIGURATOR.latestVersion = data.UpdatedVersion.Version;
-        CONFIGURATOR.latestVersionReleaseUrl = data.UpdatedVersion.Url;
+        CONFIGURATOR.latestVersion = data.updatedVersion.version;
+        CONFIGURATOR.latestVersionReleaseUrl = data.updatedVersion.url;
 
         const message = i18n.getMessage('configuratorUpdateNotice', [CONFIGURATOR.latestVersion, CONFIGURATOR.latestVersionReleaseUrl]);
         gui_log(message);


### PR DESCRIPTION
@blckmn 

Maybe it failed because using debug version otherwise assume API works as:

- 10.9 should return `isCurrent` = true when type = stable;
- 10.10 should return `isCurrent` = true irrespective of type as long there is no 10.10.0RC1

Using `10.10` without checking unstable versions:

![image](https://user-images.githubusercontent.com/8344830/219978827-c00dcff4-02a6-4ea6-b6ea-37018492be1e.png)
