### PR TITLE
Fix: vtx tab -> vtx type

### DIFF
--- a/src/js/utils/VtxDeviceStatus/Rtc6705DeviceStatus.js
+++ b/src/js/utils/VtxDeviceStatus/Rtc6705DeviceStatus.js
@@ -1,5 +1,4 @@
 import VtxDeviceStatus, { VtxDeviceTypes } from './VtxDeviceStatus';
-import vtxDeviceStatusFactory from './VtxDeviceStatusFactory';
 
 class VtxDeviceStatusRtc6705 extends VtxDeviceStatus {
     constructor(dataView)
@@ -16,7 +15,5 @@ class VtxDeviceStatusRtc6705 extends VtxDeviceStatus {
         return VtxDeviceTypes.VTXDEV_RTC6705;
     }
 }
-
-vtxDeviceStatusFactory.registerVtxDeviceStatusClass(VtxDeviceStatusRtc6705);
 
 export default VtxDeviceStatusRtc6705;

--- a/src/js/utils/VtxDeviceStatus/SmartAudioDeviceStatus.js
+++ b/src/js/utils/VtxDeviceStatus/SmartAudioDeviceStatus.js
@@ -1,5 +1,4 @@
 import VtxDeviceStatus, { VtxDeviceTypes } from "./VtxDeviceStatus";
-import vtxDeviceStatusFactory from "./VtxDeviceStatusFactory";
 import { i18n } from "../../localization";
 
 class VtxDeviceStatusSmartAudio extends VtxDeviceStatus {
@@ -47,7 +46,5 @@ class VtxDeviceStatusSmartAudio extends VtxDeviceStatus {
         return VtxDeviceTypes.VTXDEV_SMARTAUDIO;
     }
 }
-
-vtxDeviceStatusFactory.registerVtxDeviceStatusClass(VtxDeviceStatusSmartAudio);
 
 export default VtxDeviceStatusSmartAudio;

--- a/src/js/utils/VtxDeviceStatus/TrampDeviceStatus.js
+++ b/src/js/utils/VtxDeviceStatus/TrampDeviceStatus.js
@@ -1,5 +1,4 @@
 import VtxDeviceStatus, { VtxDeviceTypes } from './VtxDeviceStatus';
-import vtxDeviceStatusFactory from './VtxDeviceStatusFactory';
 
 class VtxDeviceStatusTramp extends VtxDeviceStatus {
     constructor(dataView)
@@ -16,7 +15,5 @@ class VtxDeviceStatusTramp extends VtxDeviceStatus {
         return VtxDeviceTypes.VTXDEV_TRAMP;
     }
 }
-
-vtxDeviceStatusFactory.registerVtxDeviceStatusClass(VtxDeviceStatusTramp);
 
 export default VtxDeviceStatusTramp;

--- a/src/js/utils/VtxDeviceStatus/VtxDeviceStatusFactory.js
+++ b/src/js/utils/VtxDeviceStatus/VtxDeviceStatusFactory.js
@@ -1,4 +1,8 @@
 import VtxDeviceStatus from './VtxDeviceStatus';
+import VtxDeviceStatusSmartAudio from './SmartAudioDeviceStatus';
+import VtxDeviceStatusTramp from './TrampDeviceStatus';
+import VtxDeviceStatusMsp from './VtxMspDeviceStatus';
+import VtxDeviceStatusRtc6705 from './Rtc6705DeviceStatus';
 
 const vtxDeviceStatusFactory = {
     _vtxDeviceStatusClasses: [],
@@ -38,5 +42,10 @@ const vtxDeviceStatusFactory = {
         return result;
     },
 };
+
+vtxDeviceStatusFactory.registerVtxDeviceStatusClass(VtxDeviceStatusSmartAudio);
+vtxDeviceStatusFactory.registerVtxDeviceStatusClass(VtxDeviceStatusTramp);
+vtxDeviceStatusFactory.registerVtxDeviceStatusClass(VtxDeviceStatusMsp);
+vtxDeviceStatusFactory.registerVtxDeviceStatusClass(VtxDeviceStatusRtc6705);
 
 export default vtxDeviceStatusFactory;

--- a/src/js/utils/VtxDeviceStatus/VtxMspDeviceStatus.js
+++ b/src/js/utils/VtxDeviceStatus/VtxMspDeviceStatus.js
@@ -1,4 +1,3 @@
-import vtxDeviceStatusFactory from './VtxDeviceStatusFactory';
 import VtxDeviceStatus, { VtxDeviceTypes } from './VtxDeviceStatus';
 
 class VtxDeviceStatusMsp extends VtxDeviceStatus {
@@ -16,7 +15,5 @@ class VtxDeviceStatusMsp extends VtxDeviceStatus {
         return VtxDeviceTypes.VTXDEV_MSP;
     }
 }
-
-vtxDeviceStatusFactory.registerVtxDeviceStatusClass(VtxDeviceStatusMsp);
 
 export default VtxDeviceStatusMsp;


### PR DESCRIPTION
At some point, smartaudio version stopped being detected by the configurator 10.9. This is a fix.
Should be cherry-picked on 10.9-maintenance if approved.
![image](https://user-images.githubusercontent.com/2925027/220889732-7d3661fe-28ba-46be-a023-1083bf65233b.png)

@chmelevskij @haslinghuis  @blckmn 
