### PR TITLE
Remove setting of client version in the cloud build request

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -856,9 +856,6 @@ firmware_flasher.initialize = function (callback) {
                     target: targetDetail.target,
                     release: targetDetail.release,
                     options: [],
-                    client: {
-                        version: CONFIGURATOR.version,
-                    },
                 };
 
                 const coreBuild = (targetDetail.cloudBuild !== true) || $('input[name="coreBuildModeCheckbox"]').is(':checked');


### PR DESCRIPTION
Client as a property on the request is now ignored by the API, and the version is taken from the header that is always present.
