### PR TITLE
Fix css in gps tab

### DIFF
--- a/src/css/tabs/gps.less
+++ b/src/css/tabs/gps.less
@@ -51,6 +51,9 @@
 			height: 20px;
 			margin: 0 10px 5px 0;
 			border: 1px solid var(--subtleAccent);
+			border-radius: 3px;
+			background: var(--boxBackground);
+			color: var(--defaultText);
 		}
 		.select {
 			>div {


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/62965528/221379308-ce7dd159-208b-4157-944c-6b2f6a5cb884.png)

After:
![image](https://user-images.githubusercontent.com/62965528/221379260-1c567298-a264-4a2f-a245-676d57fa247a.png)