### PR TITLE
Limit groundspeed in UI to 3m/s

### DIFF
--- a/src/tabs/failsafe.html
+++ b/src/tabs/failsafe.html
@@ -140,7 +140,7 @@
                                     <div class="helpicon cf_tip" i18n_title="failsafeGpsRescueItemMinDthHelp"></div>
                                 </div>
                                 <div class="number">
-                                    <label> <input type="number" name="gps_rescue_ground_speed" min="0.30" max="30.00" step="0.01"/> <span
+                                    <label> <input type="number" name="gps_rescue_ground_speed" min="3.00" max="30.00" step="0.01"/> <span
                                         i18n="failsafeGpsRescueItemGroundSpeed"></span>
                                     </label>
                                 </div>


### PR DESCRIPTION
Requested by @ctzsnooze 

Limit's groundspeed to 3.0 m/s instead of 0.3 m/s
CLI can override this range. As long user does not alter the setting in UI the CLI range is used otherwise the UI range comes into effect.