### PR TITLE
Display average RPM on motor tab

### DIFF
--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -235,7 +235,7 @@
                                             </select>
                                         </div>
                                     </div>
-                
+
                                     <div class="row">
                                         <div class="left-cell">
                                             <div i18n="sensorsScale"></div>
@@ -319,7 +319,7 @@
                                 <li><span class="motor-5 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
                                 <li><span class="motor-6 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
                                 <li><span class="motor-7 cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
-                                <li>&nbsp;</li>
+                                <li><span class="motor-master cf_tip" i18n_title="motorsTelemetryHelp">&nbsp;</span></li>
                             </ul>
                         </div>
                         <div class="sliders">


### PR DESCRIPTION
Display average motor RPM above Master slider if the following conditions are met:
* DSHOT telemetry is enabled
* There is no telemetry error
* All motors are given the same output (i. e. the Master slider is used to change motor output)
I'm using average RPM when setting up dynamic idle RPM, but so far I had to calculate it manually and so I thought it would be useful to let the Configurator do the calculation instead.