### PR TITLE
FIX: Adjusting setting of ajax default header as not being passed for version check

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -80,7 +80,6 @@ function appReady() {
     cleanupLocalStorage();
 
     i18n.init(function() {
-        startProcess();
 
         // pass the configurator version as a custom header for every AJAX request.
         $.ajaxSetup({
@@ -88,6 +87,8 @@ function appReady() {
                 'X-CFG-VER': `${CONFIGURATOR.version}`,
             },
         });
+
+        startProcess();
 
         checkSetupAnalytics(function (analyticsService) {
             analyticsService.sendEvent(analyticsService.EVENT_CATEGORIES.APPLICATION, 'SelectedLanguage', i18n.selectedLanguage);


### PR DESCRIPTION
The version check was occurring before the default ajax header was being set. This resulted in a "non-current" return, because the header was missing.