### PR TITLE
Fix max length of craft name and pilot name

### DIFF
--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -68,13 +68,13 @@
                     </div>
                     <div class="spacer_box">
                         <div class="number">
-                            <label> <input type="text" name="craftName" maxlength="32" style="width:100px;"/> <span
+                            <label> <input type="text" name="craftName" maxlength="16" style="width:100px;"/> <span
                                 i18n="craftName"></span>
                             </label>
                             <div class="helpicon cf_tip" i18n_title="configurationCraftNameHelp"></div>
                         </div>
                         <div class="number pilotName">
-                            <label> <input type="text" name="pilotName" maxlength="32" style="width:100px;"/> <span
+                            <label> <input type="text" name="pilotName" maxlength="16" style="width:100px;"/> <span
                                 i18n="configurationPilotName"></span>
                             </label>
                             <div class="helpicon cf_tip" i18n_title="configurationPilotNameHelp"></div>


### PR DESCRIPTION
CLI only accepts 16 char and MSP also sending only 16 char so it was a bug. The end of the name was chopped of if it was longer than 16 char.