### PR TITLE
Fix battery status and optimize and fix status pull

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -55,7 +55,7 @@ const INITIAL_ANALOG = {
     mAhdrawn:                   0,
     rssi:                       0,
     amperage:                   0,
-    last_received_timestamp:    Date.now(), // FIXME this code lies, it's never been received at this point
+    last_received_timestamp:    0,
 };
 
 const INITIAL_BATTERY_CONFIG = {
@@ -74,7 +74,7 @@ const FC = {
     ADJUSTMENT_RANGES: null,
     ADVANCED_TUNING: null,
     ADVANCED_TUNING_ACTIVE: null,
-    ANALOG: {...INITIAL_CONFIG},
+    ANALOG: {...INITIAL_ANALOG},
     ARMING_CONFIG: null,
     AUX_CONFIG: null,
     AUX_CONFIG_IDS: null,
@@ -170,7 +170,7 @@ const FC = {
         // Using `Object.assign` instead of reassigning to
         // trigger the updates on the Vue side
         Object.assign(this.CONFIG, INITIAL_CONFIG);
-        Object.assign(this.ANALOG, INITIAL_CONFIG);
+        Object.assign(this.ANALOG, INITIAL_ANALOG);
         Object.assign(this.BATTERY_CONFIG, INITIAL_BATTERY_CONFIG);
 
         this.BF_CONFIG = {

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -219,7 +219,7 @@ class GuiControl {
             }
         }, timeout);
 
-        this.timeout_array.push(data); // push to primary timeout array
+        self.timeout_array.push(data); // push to primary timeout array
 
         return data;
     }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -319,7 +319,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.ANALOG.rssi = data.readU16(); // 0-1023
                 FC.ANALOG.amperage = data.read16() / 100; // A
                 FC.ANALOG.voltage = data.readU16() / 100;
-                FC.ANALOG.last_received_timestamp = Date.now();
+                FC.ANALOG.last_received_timestamp = performance.now();
                 break;
             case MSPCodes.MSP_VOLTAGE_METERS:
                 FC.VOLTAGE_METERS = [];

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -604,12 +604,10 @@ function onConnect() {
 
         MSP.send_message(MSPCodes.MSP_FEATURE_CONFIG, false, false);
         MSP.send_message(MSPCodes.MSP_BATTERY_CONFIG, false, false);
-
-        getStatus();
-
         MSP.send_message(MSPCodes.MSP_DATAFLASH_SUMMARY, false, false);
 
         if (FC.CONFIG.boardType === 0 || FC.CONFIG.boardType === 2) {
+            console.log('Board type is 0 or 2, requesting MSP2_COMMON_MOTOR_MIXER');
             startLiveDataRefreshTimer();
         }
     }
@@ -668,18 +666,13 @@ export function read_serial(info) {
     }
 }
 
-async function getStatus() {
-    return MSP.promise(MSPCodes.MSP_STATUS_EX);
-}
-
 async function update_live_status() {
     const statuswrapper = $('#quad-status_wrapper');
 
     if (!GUI.cliActive) {
-        await MSP.promise(MSPCodes.MSP_BOXNAMES);
-        await getStatus();
-
         await MSP.promise(MSPCodes.MSP_ANALOG);
+        await MSP.promise(MSPCodes.MSP_BOXNAMES);
+        await MSP.promise(MSPCodes.MSP_STATUS_EX);
 
         const active = (performance.now() - FC.ANALOG.last_received_timestamp) < 300;
 
@@ -731,7 +724,7 @@ async function update_live_status() {
 
 function startLiveDataRefreshTimer() {
     // live data refresh
-    setInterval(update_live_status, 500);
+    setInterval(update_live_status, 250);
 }
 
 export function reinitializeConnection(callback) {
@@ -756,8 +749,8 @@ export function reinitializeConnection(callback) {
         if (connectionTimestamp !== previousTimeStamp && CONFIGURATOR.connectionValid) {
             console.log(`Serial connection available after ${attempts / 10} seconds`);
             clearInterval(reconnect);
-            getStatus();
             gui_log(i18n.getMessage('deviceReady'));
+
             if (callback === typeof('function')) {
                 callback();
             }

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -608,7 +608,6 @@ function onConnect() {
         MSP.send_message(MSPCodes.MSP_DATAFLASH_SUMMARY, false, false);
 
         if (FC.CONFIG.boardType === 0 || FC.CONFIG.boardType === 2) {
-            console.log('Board type is 0 or 2, requesting MSP2_COMMON_MOTOR_MIXER');
             startLiveDataRefreshTimer();
         }
     }
@@ -673,7 +672,6 @@ async function update_live_status() {
     const statuswrapper = $('#quad-status_wrapper');
 
     if (GUI.active_tab !== 'cli' && GUI.active_tab !== 'presets') {
-        console.log('Updating live status', liveDataRefreshTimerId);
         await MSP.promise(MSPCodes.MSP_ANALOG);
         await MSP.promise(MSPCodes.MSP_BOXNAMES);
         await MSP.promise(MSPCodes.MSP_STATUS_EX);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -28,6 +28,7 @@ import BuildApi from "./BuildApi";
 let mspHelper;
 let connectionTimestamp;
 let clicks = false;
+let liveDataRefreshTimerId = false;
 
 export function initializeSerialBackend() {
     GUI.updateManualPortVisibility = function() {
@@ -645,6 +646,8 @@ function onClosed(result) {
     const battery = $('#quad-status_wrapper');
     battery.hide();
 
+    clearLiveDataRefreshTimer();
+
     MSP.clearListeners();
 
     CONFIGURATOR.connectionValid = false;
@@ -669,7 +672,8 @@ export function read_serial(info) {
 async function update_live_status() {
     const statuswrapper = $('#quad-status_wrapper');
 
-    if (!GUI.cliActive) {
+    if (GUI.active_tab !== 'cli' && GUI.active_tab !== 'presets') {
+        console.log('Updating live status', liveDataRefreshTimerId);
         await MSP.promise(MSPCodes.MSP_ANALOG);
         await MSP.promise(MSPCodes.MSP_BOXNAMES);
         await MSP.promise(MSPCodes.MSP_STATUS_EX);
@@ -722,9 +726,17 @@ async function update_live_status() {
     }
 }
 
+function clearLiveDataRefreshTimer() {
+    if (liveDataRefreshTimerId) {
+        clearInterval(liveDataRefreshTimerId);
+        liveDataRefreshTimerId = false;
+    }
+}
+
 function startLiveDataRefreshTimer() {
     // live data refresh
-    setInterval(update_live_status, 250);
+    clearLiveDataRefreshTimer();
+    liveDataRefreshTimerId = setInterval(update_live_status, 250);
 }
 
 export function reinitializeConnection(callback) {

--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -281,11 +281,6 @@ adjustments.initialize = function (callback) {
         // enable data pulling
         GUI.interval_add('aux_data_pull', get_rc_data, 50);
 
-        // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function () {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-        }, 250, true);
-
         GUI.content_ready(callback);
     }
 };

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -385,11 +385,6 @@ failsafe.initialize = function (callback) {
         // translate to user-selected language
         i18n.localizePage();
 
-        // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-        }, 250, true);
-
         GUI.content_ready(callback);
     }
 };

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -19,7 +19,6 @@ gps.initialize = async function (callback) {
 
     await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
     await MSP.promise(MSPCodes.MSP_GPS_CONFIG);
-    await MSP.promise(MSPCodes.MSP_STATUS);
 
     const hasMag = have_sensor(FC.CONFIG.activeSensors, 'mag');
 
@@ -307,12 +306,6 @@ gps.initialize = async function (callback) {
         GUI.interval_add('gps_pull', function gps_update() {
             get_raw_gps_data();
         }, 75, true);
-
-        // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-        }, 250, true);
-
 
         //check for internet connection on load
         if (navigator.onLine) {

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -83,7 +83,6 @@ motors.initialize = async function (callback) {
 
     GUI.active_tab = 'motors';
 
-    await MSP.promise(MSPCodes.MSP_STATUS);
     await MSP.promise(MSPCodes.MSP_PID_ADVANCED);
     await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
     await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
@@ -1023,11 +1022,6 @@ motors.initialize = async function (callback) {
 
         // data pulling functions used inside interval timer
 
-        function getStatus() {
-            // status needed for arming flag
-            MSP.send_message(MSPCodes.MSP_STATUS, false, false, get_motor_data);
-        }
-
         function get_motor_data() {
             MSP.send_message(MSPCodes.MSP_MOTOR, false, false, get_motor_telemetry_data);
         }
@@ -1177,7 +1171,7 @@ motors.initialize = async function (callback) {
         $('a.stop').on('click', () => motorsEnableTestModeElement.prop('checked', false).trigger('change'));
 
         // enable Status and Motor data pulling
-        GUI.interval_add('motor_and_status_pull', getStatus, 50, true);
+        GUI.interval_add('motor_and_status_pull', get_motor_data, 50, true);
 
         setup_motor_output_reordering_dialog(SetupEscDshotDirectionDialogCallback, zeroThrottleValue);
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -54,9 +54,7 @@ pid_tuning.initialize = function (callback) {
     const FILTER_DEFAULT = FC.getFilterDefaults();
     const PID_DEFAULT = FC.getPidDefaults();
 
-    // requesting MSP_STATUS manually because it contains FC.CONFIG.profile
-    MSP.promise(MSPCodes.MSP_STATUS)
-        .then(() => MSP.promise(MSPCodes.MSP_PID_CONTROLLER))
+    MSP.promise(MSPCodes.MSP_PID_CONTROLLER)
         .then(() => MSP.promise(MSPCodes.MSP_PIDNAMES))
         .then(() => MSP.promise(MSPCodes.MSP_PID))
         .then(() => MSP.promise(MSPCodes.MSP_PID_ADVANCED))
@@ -2286,8 +2284,8 @@ pid_tuning.initialize = function (callback) {
         GUI.interval_add('receiver_pull', self.getReceiverData, 250, true);
 
         // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false, self.checkUpdateProfile(true));
+        GUI.interval_add('update_profile', function update_profile() {
+            self.checkUpdateProfile(true);
         }, 500, true);
 
         self.analyticsChanges = {};

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -850,11 +850,6 @@ receiver.initialize = function (callback) {
         // TODO: Combine two polls together
         GUI.interval_add('receiver_pull_for_model_preview', tab.getReceiverData, 33, false);
 
-        // status data pulled via separate timer with static speed
-        GUI.interval_add('status_pull', function status_pull() {
-            MSP.send_message(MSPCodes.MSP_STATUS);
-        }, 250, true);
-
         GUI.content_ready(callback);
     }
 };

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -378,36 +378,31 @@ setup.initialize = function (callback) {
 
         function get_slow_data() {
 
-            MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false, function() {
+            // Status info is acquired in the background using update_live_status() in serial_backend.js
 
-                $('#initialSetupArmingAllowed').toggle(FC.CONFIG.armingDisableFlags == 0);
+            $('#initialSetupArmingAllowed').toggle(FC.CONFIG.armingDisableFlags === 0);
 
-                for (let i = 0; i < FC.CONFIG.armingDisableCount; i++) {
-                    $(`#initialSetupArmingDisableFlags${i}`).css('display',(FC.CONFIG.armingDisableFlags & (1 << i)) == 0 ? 'none':'inline-block');
-                }
-
-            });
-
-            // GPS info
-            if (have_sensor(FC.CONFIG.activeSensors, 'gps')) {
-                MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, function () {
-                    gpsFix_e.html((FC.GPS_DATA.fix) ? i18n.getMessage('gpsFixTrue') : i18n.getMessage('gpsFixFalse'));
-                    gpsSats_e.text(FC.GPS_DATA.numSat);
-                    gpsLat_e.text(`${(FC.GPS_DATA.lat / 10000000).toFixed(4)} deg`);
-                    gpsLon_e.text(`${(FC.GPS_DATA.lon / 10000000).toFixed(4)} deg`);
-                });
+            for (let i = 0; i < FC.CONFIG.armingDisableCount; i++) {
+                $(`#initialSetupArmingDisableFlags${i}`).css('display',(FC.CONFIG.armingDisableFlags & (1 << i)) === 0 ? 'none':'inline-block');
             }
 
-            // System info
-            MSP.send_message(MSPCodes.MSP_ANALOG, false, false, function () {
-                bat_voltage_e.text(i18n.getMessage('initialSetupBatteryValue', [FC.ANALOG.voltage]));
-                bat_mah_drawn_e.text(i18n.getMessage('initialSetupBatteryMahValue', [FC.ANALOG.mAhdrawn]));
-                bat_mah_drawing_e.text(i18n.getMessage('initialSetupBatteryAValue', [FC.ANALOG.amperage.toFixed(2)]));
-                rssi_e.text(i18n.getMessage('initialSetupRSSIValue', [((FC.ANALOG.rssi / 1023) * 100).toFixed(0)]));
-                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
-                    cputemp_e.html(`${FC.CONFIG.cpuTemp.toFixed(0)} &#8451;`);
-                }
-            });
+            // System info is acquired in the background using update_live_status() in serial_backend.js
+
+            bat_voltage_e.text(i18n.getMessage('initialSetupBatteryValue', [FC.ANALOG.voltage]));
+            bat_mah_drawn_e.text(i18n.getMessage('initialSetupBatteryMahValue', [FC.ANALOG.mAhdrawn]));
+            bat_mah_drawing_e.text(i18n.getMessage('initialSetupBatteryAValue', [FC.ANALOG.amperage.toFixed(2)]));
+            rssi_e.text(i18n.getMessage('initialSetupRSSIValue', [((FC.ANALOG.rssi / 1023) * 100).toFixed(0)]));
+
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46) && FC.CONFIG.cpuTemp) {
+                cputemp_e.html(`${FC.CONFIG.cpuTemp.toFixed(0)} &#8451;`);
+            }
+
+            // GPS info is acquired in the background using update_live_status() in serial_backend.js
+
+            gpsFix_e.html((FC.GPS_DATA.fix) ? i18n.getMessage('gpsFixTrue') : i18n.getMessage('gpsFixFalse'));
+            gpsSats_e.text(FC.GPS_DATA.numSat);
+            gpsLat_e.text(`${(FC.GPS_DATA.lat / 10000000).toFixed(4)} deg`);
+            gpsLon_e.text(`${(FC.GPS_DATA.lon / 10000000).toFixed(4)} deg`);
         }
 
         function get_fast_data() {


### PR DESCRIPTION
LiveStatusUpdate stops intermittent. This PR fixes the update and removes duplicate status pulls optimizing (serial) communication.

- [x] FC.ANALOG was wrongly assigned with FC.INITIAL_CONFIG
- [x] Update date.now to performance.now
- [x] Increase timer for status polling from 100 to 250ms
- [x] Preset tabs was blocking the timer
- [x] Use setInterval instead of restarting GUI.timeout_add() which failed intermittent.
- [x] Cleanup of status polls as it's running consistent in serial backend.
