### PR TITLE
Flasher tab: show commit field no matter what, if expert mode enabled

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -310,10 +310,6 @@ firmware_flasher.initialize = function (callback) {
                                     select_e.append($(`<option value='${commit.sha}'>${commit.message}</option>`));
                                 });
                             });
-
-                            $('div.commitSelection').show();
-                        } else {
-                            $('div.commitSelection').hide();
                         }
                     }
 
@@ -901,9 +897,7 @@ firmware_flasher.initialize = function (callback) {
                     });
 
                     if ($('input[name="expertModeCheckbox"]').is(':checked')) {
-                        if (targetDetail.releaseType === "Unstable") {
-                            request.commit = $('select[name="commits"] option:selected').val();
-                        }
+                        request.commit = $('select[name="commits"] option:selected').val();
 
                         $('input[name="customDefines"]').val().split(' ').map(element => element.trim()).forEach(v => {
                             request.options.push(v);


### PR DESCRIPTION
After this PR the "Select commit" text input will show up regardless (if in expert mode)
This will allow triggering cloud build API with make commands specifically for a certain branch/release on top of any PRs.

I think this change also requires Cloud build modification. I can see that request includes # commit:
![image](https://user-images.githubusercontent.com/2925027/230539408-ec3beab2-4e32-43a9-b911-85142a215192.png)
however, the build log does not reflect it:

https://build.betaflight.com/api/builds/24d611898699d3424bbbcdbc2a837ad3/log
https://build.betaflight.com/api/builds/24d611898699d3424bbbcdbc2a837ad3/json