### PR TITLE
crowdin-action: use github action versioning

### DIFF
--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -16,7 +16,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Download Crowdin translations and create PR
-      uses: crowdin/github-action@1.5.1
+      uses: crowdin/github-action@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
Until now the Crowdin action didn't follow the Github actions conventions. Now it does, and this PR uses it.

This upgrades the action too to use the latest version of Crowdin CLI.