### PR TITLE
Clarify the usage of crash flip arrow

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5447,7 +5447,7 @@
         "description": "One of the elements of the OSD"
     },
     "osdDescElementFlipArrow": {
-        "message": "Arrow showing which side motors are up in turtle mode"
+        "message": "Arrow showing which side motors are up in turtle mode (accelerometer must be enabled)"
     },
     "osdTextElementLinkQuality": {
         "message": "Link quality",


### PR DESCRIPTION
Probably it's just me, but it has been puzzling me for a while why I cannot get crash flip arrow to display despite it's enabled on the OSD.