### PR TITLE
Add help to modes at Mode tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2286,6 +2286,126 @@
     "auxiliaryModeLogicAND": {
       "message": "AND"
     },
+    "auxiliaryHelpMode_ARM": {
+        "message": "Use to toggle ARM.<br>Enables motors and flight stabilisation",
+        "description": "Help text to ARM mode"
+    },
+    "auxiliaryHelpMode_ANGLE": {
+        "message": "Use to toggle ANGLE.<br>In this auto-leveled mode the roll and pitch channels control the angle between the relevant axis and the vertical, achieving leveled flight just by leaving the sticks centered",
+        "description": "Help text to ANGLE mode"
+    },
+    "auxiliaryHelpMode_HORIZON": {
+        "message": "Use to toggle HORIZON.<br>This hybrid mode works exactly like the ANGLE mode with centered roll and pitch sticks (thus enabling auto-leveled flight), then gradually behaves more and more like the default RATE mode as the sticks are moved away from the center position",
+        "description": "Help text to HORIZON mode"
+    },
+    "auxiliaryHelpMode_MAG": {
+        "message": "Use to toggle MAG.<br>Heading lock",
+        "description": "Help text to MAG mode"
+    },
+    "auxiliaryHelpMode_HEADFREE": {
+        "message": "Use to toggle HEADFREE.<br>In this mode, the \"head\" of the multicopter is always pointing to the same direction as when the feature was activated. This means that when the multicopter rotates around the Z axis (yaw), the controls will always respond according the same \"head\" direction.<br>With this mode it is easier to control the multicopter, even fly it with the physical head towards you since the controls always respond the same. This is a friendly mode to new users of multicopters and can prevent losing the control when you don't know the head direction",
+        "description": "Help text to HEADFREE mode"
+    },
+    "auxiliaryHelpMode_PASSTHRU": {
+        "message": "Use to toggle PASSTHRU.<br>Pass roll, yaw, and pitch directly from rx to servos in airplane mix",
+        "description": "Help text to PASSTHRU mode"
+    },
+    "auxiliaryHelpMode_FAILSAFE": {
+        "message": "Use to toggle FAILSAFE.<br>Enter failsafe stage 2 manually",
+        "description": "Help text to FAILSAFE mode"
+    },
+    "auxiliaryHelpMode_GPSRESCUE": {
+        "message": "Use to toggle GPS RESCUE.<br>Enable 'GPS Rescue' to return the craft to the location where it was last armed",
+        "description": "Help text to GPS RESCUE mode"
+    },
+    "auxiliaryHelpMode_HEADADJ": {
+        "message": "Use to toggle HEAD ADJ.<br>Heading Adjust - Sets a new yaw origin for HEADFREE mode",
+        "description": "Help text to HEAD ADJ mode"
+    },
+    "auxiliaryHelpMode_BEEPER": {
+        "message": "Use to toggle BEEPER.<br>Enable beeping - useful for locating a crashed aircraft",
+        "description": "Help text to BEEPER mode"
+    },
+    "auxiliaryHelpMode_LEDLOW": {
+        "message": "Use to toggle LEDLOW.<br>Switch off LED_STRIP output",
+        "description": "Help text to LEDLOW mode"
+    },
+    "auxiliaryHelpMode_OSDDISABLE": {
+        "message": "Use to toggle OSD.<br>Enable/Disable On-Screen-Display",
+        "description": "Help text to OSD mode"
+    },
+    "auxiliaryHelpMode_TELEMETRY": {
+        "message": "Use to toggle TELEMETRY.<br>Enable telemetry via switch",
+        "description": "Help text to TELEMETRY mode"
+    },
+    "auxiliaryHelpMode_BLACKBOX": {
+        "message": "Use to toggle BLACKBOX.<br>Enable BlackBox logging",
+        "description": "Help text to BLACKBOX mode"
+    },
+    "auxiliaryHelpMode_AIRMODE": {
+        "message": "Use to toggle AIRMODE.<br>In the standard mixer / mode, when the roll, pitch and yaw gets calculated and saturates a motor, all motors will be reduced equally. When a motor goes below minimum it gets clipped off. Say you had your throttle just above minimum and tried to pull a quick roll - since two motors can't go any lower, you essentially get half the power (half of your PID gain). If your inputs would have asked for more than a 100% difference between the high and low motors, the low motors would get clipped, breaking the symmetry of the motor balance by unevenly reducing the gain",
+        "description": "Help text to AIRMODE mode"
+    },
+    "auxiliaryHelpMode_FPVANGLEMIX": {
+        "message": "Use to toggle FPV ANGLE MIX.<br>Apply yaw rotation relative to a FPV camera mounted at a preset angle",
+        "description": "Help text to FPV ANGLE MIX mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL1": {
+        "message": "Use to toggle customized CAMERA CONTROL 1",
+        "description": "Help text to customized CAMERA CONTROL 1 mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL2": {
+        "message": "Use to toggle customized CAMERA CONTROL 2",
+        "description": "Help text to customized CAMERA CONTROL 2 mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL3": {
+        "message": "Use to toggle customized CAMERA CONTROL 3",
+        "description": "Help text to customized CAMERA CONTROL 3 mode"
+    },
+    "auxiliaryHelpMode_FLIPOVERAFTERCRASH": {
+        "message": "Use to toggle FLIP OVER AFTER CRASH.<br>Reverse the motors to flip over an upside down craft after a crash (DShot required)",
+        "description": "Help text to FLIP OVER AFTER CRASH mode"
+    },
+    "auxiliaryHelpMode_PREARM": {
+        "message": "Use to toggle PREARM.<br>When arming, wait for this switch to be activated before actually arming",
+        "description": "Help text to PREARM mode"
+    },
+    "auxiliaryHelpMode_GPSBEEPSATELLITECOUNT": {
+        "message": "Use to toggle GPS BEEP SATELLITE COUNT.<br>Use a number of beeps to indicate the number of GPS satellites found",
+        "description": "Help text to GPS BEEP SATELLITE COUNT mode"
+    },
+    "auxiliaryHelpMode_VTXPITMODE": {
+        "message": "Use to toggle VTX PIT MODE.<br>Switch the VTX into pit mode (low output power, if supported)",
+        "description": "Help text to VTX PIT MODE mode"
+    },
+    "auxiliaryHelpMode_PARALYZE": {
+        "message": "Use to toggle PARALYZE.<br>Permanently disable a crashed craft until it is power cycled",
+        "description": "Help text to PARALYZE mode"
+    },
+    "auxiliaryHelpMode_ACROTRAINER": {
+        "message": "Use to toggle ACRO TRAINER.<br>Enable 'acro trainer' angle limiting in acro mode",
+        "description": "Help text to ACRO TRAINER mode"
+    },
+    "auxiliaryHelpMode_VTXCONTROLDISABLE": {
+        "message": "Use to toggle VTX CONTROL DISABLE.<br>Disable the control of VTX settings through the OSD",
+        "description": "Help text to VTX CONTROL DISABLE mode"
+    },
+    "auxiliaryHelpMode_LAUNCHCONTROL": {
+        "message": "Use to toggle LAUNCH CONTROL.<br>Race start assistance system",
+        "description": "Help text to LAUNCH CONTROL mode"
+    },
+    "auxiliaryHelpMode_STICKCONTROLDISABLE": {
+        "message": "Use to toggle STICK CONTROL DISABLE.<br>Disable/enable stick command",
+        "description": "Help text to STICK CONTROL DISABLE mode"
+    },
+    "auxiliaryHelpMode_BEEPERMUTE": {
+        "message": "Use to toggle BEEPERMUTE.<br>Disable/enable beeper including warning, status and BEEPER mode",
+        "description": "Help text to BEEPERMUTE mode"
+    },
+    "auxiliaryHelpMode_READY": {
+        "message": "Use to toggle READY.<br>Added in BF4.4, you can now show ‘READY’ in the OSD using a switch. This is a niche improvement for racing situations where all pilot video feeds are on one central screen. The pilot can flick a switch to indicate that they are ready to fly, and the word READY appears on their OSD. The race director can then tell if all pilots are ready by looking at the central screen. On arming, the READY text disappears",
+        "description": "Help text to READY mode"
+    },
     "adjustmentsHelp": {
         "message": "Configure adjustment switches. See the 'in-flight adjustments' section of the manual for details. The changes that adjustment functions make are not saved automatically."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2287,123 +2287,123 @@
       "message": "AND"
     },
     "auxiliaryHelpMode_ARM": {
-        "message": "Use to toggle ARM.<br>Enables motors and flight stabilisation",
+        "message": "Enables motors and flight stabilisation",
         "description": "Help text to ARM mode"
     },
     "auxiliaryHelpMode_ANGLE": {
-        "message": "Use to toggle ANGLE.<br>In this auto-leveled mode the roll and pitch channels control the angle between the relevant axis and the vertical, achieving leveled flight just by leaving the sticks centered",
+        "message": "In this auto-leveled mode the roll and pitch channels control the angle between the relevant axis and the vertical, achieving leveled flight just by leaving the sticks centered",
         "description": "Help text to ANGLE mode"
     },
     "auxiliaryHelpMode_HORIZON": {
-        "message": "Use to toggle HORIZON.<br>This hybrid mode works exactly like the ANGLE mode with centered roll and pitch sticks (thus enabling auto-leveled flight), then gradually behaves more and more like the default RATE mode as the sticks are moved away from the center position",
+        "message": "This hybrid mode works exactly like the ANGLE mode with centered roll and pitch sticks (thus enabling auto-leveled flight), then gradually behaves more and more like the default RATE mode as the sticks are moved away from the center position",
         "description": "Help text to HORIZON mode"
     },
     "auxiliaryHelpMode_MAG": {
-        "message": "Use to toggle MAG.<br>Heading lock",
+        "message": "Heading lock to Magnetometer direction",
         "description": "Help text to MAG mode"
     },
     "auxiliaryHelpMode_HEADFREE": {
-        "message": "Use to toggle HEADFREE.<br>In this mode, the \"head\" of the multicopter is always pointing to the same direction as when the feature was activated. This means that when the multicopter rotates around the Z axis (yaw), the controls will always respond according the same \"head\" direction.<br>With this mode it is easier to control the multicopter, even fly it with the physical head towards you since the controls always respond the same. This is a friendly mode to new users of multicopters and can prevent losing the control when you don't know the head direction",
+        "message": "In this mode, the \"head\" of the multicopter is always pointing to the same direction as when the feature was activated. This means that when the multicopter rotates around the Z axis (yaw), the controls will always respond according the same \"head\" direction.<br>With this mode it is easier to control the multicopter, even fly it with the physical head towards you since the controls always respond the same. This is a friendly mode to new users of multicopters and can prevent losing the control when you don't know the head direction",
         "description": "Help text to HEADFREE mode"
     },
     "auxiliaryHelpMode_PASSTHRU": {
-        "message": "Use to toggle PASSTHRU.<br>Pass roll, yaw, and pitch directly from rx to servos in airplane mix",
+        "message": "Pass roll, yaw, and pitch directly from rx to servos in airplane mix",
         "description": "Help text to PASSTHRU mode"
     },
     "auxiliaryHelpMode_FAILSAFE": {
-        "message": "Use to toggle FAILSAFE.<br>Enter failsafe stage 2 manually",
+        "message": "Enter failsafe stage 2 manually",
         "description": "Help text to FAILSAFE mode"
     },
     "auxiliaryHelpMode_GPSRESCUE": {
-        "message": "Use to toggle GPS RESCUE.<br>Enable 'GPS Rescue' to return the craft to the location where it was last armed",
+        "message": "Enable 'GPS Rescue' to return the craft to the location where it was last armed",
         "description": "Help text to GPS RESCUE mode"
     },
     "auxiliaryHelpMode_HEADADJ": {
-        "message": "Use to toggle HEAD ADJ.<br>Heading Adjust - Sets a new yaw origin for HEADFREE mode",
+        "message": "Heading Adjust - Sets a new yaw origin for HEADFREE mode",
         "description": "Help text to HEAD ADJ mode"
     },
     "auxiliaryHelpMode_BEEPER": {
-        "message": "Use to toggle BEEPER.<br>Enable beeping - useful for locating a crashed aircraft",
+        "message": "Enable beeping - useful for locating a crashed aircraft",
         "description": "Help text to BEEPER mode"
     },
     "auxiliaryHelpMode_LEDLOW": {
-        "message": "Use to toggle LEDLOW.<br>Switch off LED_STRIP output",
+        "message": "Switch off LED_STRIP output",
         "description": "Help text to LEDLOW mode"
     },
     "auxiliaryHelpMode_OSDDISABLE": {
-        "message": "Use to toggle OSD.<br>Enable/Disable On-Screen-Display",
+        "message": "Enable/Disable On-Screen-Display",
         "description": "Help text to OSD mode"
     },
     "auxiliaryHelpMode_TELEMETRY": {
-        "message": "Use to toggle TELEMETRY.<br>Enable telemetry via switch",
+        "message": "Enable telemetry via switch",
         "description": "Help text to TELEMETRY mode"
     },
     "auxiliaryHelpMode_BLACKBOX": {
-        "message": "Use to toggle BLACKBOX.<br>Enable BlackBox logging",
+        "message": "Enable BlackBox logging",
         "description": "Help text to BLACKBOX mode"
     },
     "auxiliaryHelpMode_AIRMODE": {
-        "message": "Use to toggle AIRMODE.<br>In the standard mixer / mode, when the roll, pitch and yaw gets calculated and saturates a motor, all motors will be reduced equally. When a motor goes below minimum it gets clipped off. Say you had your throttle just above minimum and tried to pull a quick roll - since two motors can't go any lower, you essentially get half the power (half of your PID gain). If your inputs would have asked for more than a 100% difference between the high and low motors, the low motors would get clipped, breaking the symmetry of the motor balance by unevenly reducing the gain",
+        "message": "In the standard mixer / mode, when the roll, pitch and yaw gets calculated and saturates a motor, all motors will be reduced equally. When a motor goes below minimum it gets clipped off. Say you had your throttle just above minimum and tried to pull a quick roll - since two motors can't go any lower, you essentially get half the power (half of your PID gain). If your inputs would have asked for more than a 100% difference between the high and low motors, the low motors would get clipped, breaking the symmetry of the motor balance by unevenly reducing the gain",
         "description": "Help text to AIRMODE mode"
     },
     "auxiliaryHelpMode_FPVANGLEMIX": {
-        "message": "Use to toggle FPV ANGLE MIX.<br>Apply yaw rotation relative to a FPV camera mounted at a preset angle",
+        "message": "Apply yaw rotation relative to a FPV camera mounted at a preset angle",
         "description": "Help text to FPV ANGLE MIX mode"
     },
     "auxiliaryHelpMode_CAMERACONTROL1": {
-        "message": "Use to toggle customized CAMERA CONTROL 1",
+        "message": "Use to toggle customized CAMERA CONTROL 1. Check in vendor manual",
         "description": "Help text to customized CAMERA CONTROL 1 mode"
     },
     "auxiliaryHelpMode_CAMERACONTROL2": {
-        "message": "Use to toggle customized CAMERA CONTROL 2",
+        "message": "Use to toggle customized CAMERA CONTROL 2. Check in vendor manual",
         "description": "Help text to customized CAMERA CONTROL 2 mode"
     },
     "auxiliaryHelpMode_CAMERACONTROL3": {
-        "message": "Use to toggle customized CAMERA CONTROL 3",
+        "message": "Use to toggle customized CAMERA CONTROL 3. Check in vendor manual",
         "description": "Help text to customized CAMERA CONTROL 3 mode"
     },
     "auxiliaryHelpMode_FLIPOVERAFTERCRASH": {
-        "message": "Use to toggle FLIP OVER AFTER CRASH.<br>Reverse the motors to flip over an upside down craft after a crash (DShot required)",
+        "message": "Reverse the motors to flip over an upside down craft after a crash (DShot required)",
         "description": "Help text to FLIP OVER AFTER CRASH mode"
     },
     "auxiliaryHelpMode_PREARM": {
-        "message": "Use to toggle PREARM.<br>When arming, wait for this switch to be activated before actually arming",
+        "message": "When arming, wait for this switch to be activated before actually arming",
         "description": "Help text to PREARM mode"
     },
     "auxiliaryHelpMode_GPSBEEPSATELLITECOUNT": {
-        "message": "Use to toggle GPS BEEP SATELLITE COUNT.<br>Use a number of beeps to indicate the number of GPS satellites found",
+        "message": "Use a number of beeps to indicate the number of GPS satellites found",
         "description": "Help text to GPS BEEP SATELLITE COUNT mode"
     },
     "auxiliaryHelpMode_VTXPITMODE": {
-        "message": "Use to toggle VTX PIT MODE.<br>Switch the VTX into pit mode (low output power, if supported)",
+        "message": "Switch the VTX into pit mode (low output power, if supported)",
         "description": "Help text to VTX PIT MODE mode"
     },
     "auxiliaryHelpMode_PARALYZE": {
-        "message": "Use to toggle PARALYZE.<br>Permanently disable a crashed craft until it is power cycled",
+        "message": "Permanently disable a crashed craft until it is power cycled",
         "description": "Help text to PARALYZE mode"
     },
     "auxiliaryHelpMode_ACROTRAINER": {
-        "message": "Use to toggle ACRO TRAINER.<br>Enable 'acro trainer' angle limiting in acro mode",
+        "message": "Enable 'acro trainer' angle limiting in acro mode",
         "description": "Help text to ACRO TRAINER mode"
     },
     "auxiliaryHelpMode_VTXCONTROLDISABLE": {
-        "message": "Use to toggle VTX CONTROL DISABLE.<br>Disable the control of VTX settings through the OSD",
+        "message": "Disable the control of VTX settings through the OSD",
         "description": "Help text to VTX CONTROL DISABLE mode"
     },
     "auxiliaryHelpMode_LAUNCHCONTROL": {
-        "message": "Use to toggle LAUNCH CONTROL.<br>Race start assistance system",
+        "message": "Race start assistance system",
         "description": "Help text to LAUNCH CONTROL mode"
     },
     "auxiliaryHelpMode_STICKCONTROLDISABLE": {
-        "message": "Use to toggle STICK CONTROL DISABLE.<br>Disable/enable stick command",
+        "message": "Disable/enable stick command",
         "description": "Help text to STICK CONTROL DISABLE mode"
     },
     "auxiliaryHelpMode_BEEPERMUTE": {
-        "message": "Use to toggle BEEPERMUTE.<br>Disable/enable beeper including warning, status and BEEPER mode",
+        "message": "Disable/enable beeper including warning, status and BEEPER mode",
         "description": "Help text to BEEPERMUTE mode"
     },
     "auxiliaryHelpMode_READY": {
-        "message": "Use to toggle READY.<br>Added in BF4.4, you can now show ‘READY’ in the OSD using a switch. This is a niche improvement for racing situations where all pilot video feeds are on one central screen. The pilot can flick a switch to indicate that they are ready to fly, and the word READY appears on their OSD. The race director can then tell if all pilots are ready by looking at the central screen. On arming, the READY text disappears",
+        "message": "Added in BF4.4, you can now show 'READY' in the OSD using a switch. This is a niche improvement for racing situations where all pilot video feeds are on one central screen. The pilot can flick a switch to indicate that they are ready to fly, and the word READY appears on their OSD. The race director can then tell if all pilots are ready by looking at the central screen. On arming, the READY text disappears",
         "description": "Help text to READY mode"
     },
     "adjustmentsHelp": {

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -9,6 +9,7 @@ import MSPCodes from '../msp/MSPCodes';
 import adjustBoxNameIfPeripheralWithModeID from '../peripherals';
 import { gui_log } from '../gui_log';
 import { getTextWidth } from '../utils/common';
+import inflection from "inflection";
 
 const auxiliary = {};
 
@@ -54,14 +55,14 @@ auxiliary.initialize = function (callback) {
         let modeName = FC.AUX_CONFIG[modeIndex];
         // Adjust the name of the box if a peripheral is selected
         const modeNameAjusted = adjustBoxNameIfPeripheralWithModeID(modeId, modeName);
-        // remove blanks to use modeName as key in help index
-        modeName = modeName.replaceAll(' ', '');
+        // Camlize modeName
+        const modeNameCamel = inflection.camelize(modeName.replace(/\s+/g, ''));
 
         $(newMode).attr('id', `mode-${modeIndex}`);
         $(newMode).find('.name').text(modeNameAjusted);
 
         // add help to mode
-        $(newMode).find('.helpicon').attr('i18n_title', `auxiliaryHelpMode_${modeName}`);
+        $(newMode).find('.helpicon').attr('i18n_title', `auxiliaryHelpMode_${modeNameCamel}`);
 
         $(newMode).data('index', modeIndex);
         $(newMode).data('id', modeId);

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -53,10 +53,15 @@ auxiliary.initialize = function (callback) {
 
         let modeName = FC.AUX_CONFIG[modeIndex];
         // Adjust the name of the box if a peripheral is selected
-        modeName = adjustBoxNameIfPeripheralWithModeID(modeId, modeName);
+        const modeNameAjusted = adjustBoxNameIfPeripheralWithModeID(modeId, modeName);
+        // remove blanks to use modeName as key in help index
+        modeName = modeName.replaceAll(' ', '');
 
         $(newMode).attr('id', `mode-${modeIndex}`);
-        $(newMode).find('.name').text(modeName);
+        $(newMode).find('.name').text(modeNameAjusted);
+
+        // add help to mode
+        $(newMode).find('.helpicon').attr('i18n_title', `auxiliaryHelpMode_${modeName}`);
 
         $(newMode).data('index', modeIndex);
         $(newMode).data('id', modeId);

--- a/src/tabs/auxiliary.html
+++ b/src/tabs/auxiliary.html
@@ -27,6 +27,7 @@
     <div class="modes">
         <div class="mode">
             <div class="info">
+                <div class="helpicon cf_tip" i18n_title="auxiliaryHelpMode_"></div>
                 <p class="name"></p>
                 <div class="buttons">
                     <a class="addLink sm-min" href="#" i18n="auxiliaryAddLink"></a>


### PR DESCRIPTION
This PR add help to Betaflight modes.
When new to Betaflight, you spend many hours to understand the modes, here are some help to reduce that time.
Help text come from betaflight.com where present.
![image](https://user-images.githubusercontent.com/99370924/233847221-65329f5c-3e09-4001-8324-30cb016565aa.png)
