### PR TITLE
Fix: arm status [icon]

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -628,7 +628,7 @@ input[type="number"] {
 	transition: none;
 	background-image: url(../images/icons/cf_icon_link_grey.svg);
 }
-.armedicon.active {user-select
+.armedicon.active {
 	background-image: url(../images/icons/cf_icon_armed_active.svg);
 }
 .failsafeicon.active {
@@ -1727,8 +1727,6 @@ dialog {
 }
 .buildInfoBtn {
 	position: relative;
-	margin-bottom: 0px;
-	margin-top: 3px;
 	margin: 4px;
 	float: right;
 	a {

--- a/src/js/sensor_helpers.js
+++ b/src/js/sensor_helpers.js
@@ -1,4 +1,3 @@
-import FC from './fc';
 import { bit_check } from './bit';
 
 export function have_sensor(sensors_detected, sensor_code) {
@@ -29,7 +28,7 @@ export function sensor_status(sensors_detected = 0, gps_fix_state = 0) {
     }
 
     // update UI (if necessary)
-    if (sensor_status.previous_sensors_detected == sensors_detected && sensor_status.previous_gps_fix_state == gps_fix_state) {
+    if (sensor_status.previous_sensors_detected === sensors_detected && sensor_status.previous_gps_fix_state === gps_fix_state) {
         return;
     }
 
@@ -47,10 +46,7 @@ export function sensor_status(sensors_detected = 0, gps_fix_state = 0) {
         $(".accicon", eSensorStatus).removeClass("active");
     }
 
-    if (
-        (FC.CONFIG.boardType == 0 || FC.CONFIG.boardType == 2) &&
-        have_sensor(sensors_detected, "gyro")
-    ) {
+    if (have_sensor(sensors_detected, "gyro")) {
         $(".gyro", eSensorStatus).addClass("on");
         $(".gyroicon", eSensorStatus).addClass("active");
     } else {

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -671,30 +671,11 @@ async function update_live_status() {
 
     if (GUI.active_tab !== 'cli' && GUI.active_tab !== 'presets') {
         await MSP.promise(MSPCodes.MSP_ANALOG);
-        await MSP.promise(MSPCodes.MSP_BOXNAMES);
-        await MSP.promise(MSPCodes.MSP_STATUS_EX);
 
-        const active = (performance.now() - FC.ANALOG.last_received_timestamp) < 300;
-
-        for (let i = 0; i < FC.AUX_CONFIG.length; i++) {
-            if (FC.AUX_CONFIG[i] === 'ARM') {
-                $(".armedicon").toggleClass('active', bit_check(FC.CONFIG.mode, i));
-            }
-            if (FC.AUX_CONFIG[i] === 'FAILSAFE') {
-                $(".failsafeicon").toggleClass('active', bit_check(FC.CONFIG.mode, i));
-            }
-        }
-
-        let nbCells = Math.floor(FC.ANALOG.voltage / FC.BATTERY_CONFIG.vbatmaxcellvoltage) + 1;
-
-        if (FC.ANALOG.voltage === 0) {
-            nbCells = 1;
-        }
-
+        const nbCells = FC.ANALOG.voltage === 0 ? 1 : Math.floor(FC.ANALOG.voltage / FC.BATTERY_CONFIG.vbatmaxcellvoltage) + 1;
         const min = FC.BATTERY_CONFIG.vbatmincellvoltage * nbCells;
         const max = FC.BATTERY_CONFIG.vbatmaxcellvoltage * nbCells;
         const warn = FC.BATTERY_CONFIG.vbatwarningcellvoltage * nbCells;
-
         const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8; // Maybe is better to add a call to MSP_BATTERY_STATE but is not available for all versions
 
         if (FC.ANALOG.voltage < min && FC.ANALOG.voltage > NO_BATTERY_VOLTAGE_MAXIMUM) {
@@ -710,13 +691,25 @@ async function update_live_status() {
             }
         }
 
-        if (have_sensor(FC.CONFIG.activeSensors, 'gps')) {
-            await MSP.promise(MSPCodes.MSP_RAW_GPS);
+        await MSP.promise(MSPCodes.MSP_BOXNAMES);
+        await MSP.promise(MSPCodes.MSP_STATUS_EX);
+
+        const active = (performance.now() - FC.ANALOG.last_received_timestamp) < 300;
+        $(".linkicon").toggleClass('active', active);
+
+        for (let i = 0; i < FC.AUX_CONFIG.length; i++) {
+            if (FC.AUX_CONFIG[i] === 'ARM') {
+                $(".armedicon").toggleClass('active', bit_check(FC.CONFIG.mode, i));
+            }
+            if (FC.AUX_CONFIG[i] === 'FAILSAFE') {
+                $(".failsafeicon").toggleClass('active', bit_check(FC.CONFIG.mode, i));
+            }
         }
 
-        sensor_status(FC.CONFIG.activeSensors, FC.GPS_DATA.fix);
-
-        $(".linkicon").toggleClass('active', active);
+        if (have_sensor(FC.CONFIG.activeSensors, 'gps')) {
+            await MSP.promise(MSPCodes.MSP_RAW_GPS);
+            sensor_status(FC.CONFIG.activeSensors, FC.GPS_DATA.fix);
+        }
 
         statuswrapper.show();
     }

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -252,7 +252,7 @@ motors.initialize = async function (callback) {
         const motorsEnableTestModeElement = $('#motorsEnableTestMode');
         self.analyticsChanges = {};
 
-        motorsEnableTestModeElement.prop('checked', false).trigger('change');
+        motorsEnableTestModeElement.prop('checked', self.armed);
 
         if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_42) || !(FC.MOTOR_CONFIG.use_dshot_telemetry || FC.MOTOR_CONFIG.use_esc_sensor)) {
             $(".motor_testing .telemetry").hide();

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -24,7 +24,7 @@ setup.initialize = function (callback) {
     }
 
     function load_status() {
-        MSP.send_message(MSPCodes.MSP_STATUS, false, false, load_mixer_config);
+        MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false, load_mixer_config);
     }
 
     function load_mixer_config() {
@@ -362,7 +362,7 @@ setup.initialize = function (callback) {
                     }
                     sensor_e.append(i18n.getMessage('sensorStatusSonarShort'), ': ', sonarElements[[FC.SENSOR_CONFIG.sonar_hardware]]);
                 }
-});
+            });
         };
 
         const showFirmwareInfo = function() {
@@ -401,7 +401,7 @@ setup.initialize = function (callback) {
         showFirmwareInfo();
 
         // Show Sonar info box if sensor exist
-        if (! have_sensor(FC.CONFIG.activeSensors, 'sonar')) {
+        if (!have_sensor(FC.CONFIG.activeSensors, 'sonar')) {
             $('.sonarBox').hide();
         }
 


### PR DESCRIPTION
- Loading setup tab is faster then status polling can fill the data so `arming-disable-flags` was not set at first load.
- Armedicon was not working due to CSS bug.
- Motor test was allowed to switch tabs before for testing purposes, now it again picks up status upon re-entering the tab.