### PR TITLE
Refactor: writeConfiguration

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2278,9 +2278,6 @@
     "auxiliaryButtonSave": {
         "message": "Save"
     },
-    "auxiliaryEepromSaved": {
-        "message": "EEPROM <span class=\"message-positive\">saved</span>"
-    },
     "auxiliaryAutoChannelSelect": {
       "message": "AUTO"
     },
@@ -3578,9 +3575,6 @@
     "ledStripClearAllButton": {
         "message": "Clear ALL",
         "description": "In the LED STRIP, clear all leds"
-    },
-    "ledStripEepromSaved": {
-        "message": "EEPROM <span class=\"message-positive\">saved</span>"
     },
     "ledStripVtxOverlay": {
         "message": "VTX (uses vtx frequency to assign color)"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2643,9 +2643,6 @@
     "transponderDataInvalid": {
         "message": "Transponder data is <span class=\"message-negative\">invalid</span>"
     },
-    "transponderEepromSaved": {
-        "message": "EEPROM <span class=\"message-positive\">saved</span>"
-    },
     "servosFirmwareUpgradeRequired": {
         "message": "Servos requires firmware &gt;= 1.10.0. and target support."
     },

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2730,7 +2730,7 @@ MspHelper.prototype.sendSerialConfig = function(callback) {
     MSP.send_message(mspCode, mspHelper.crunch(mspCode), false, callback);
 };
 
-MspHelper.prototype.writeConfiguration = function(reboot) {
+MspHelper.prototype.writeConfiguration = function(reboot, callback) {
     setTimeout(function() {
         MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
             gui_log(i18n.getMessage('configurationEepromSaved'));
@@ -2739,6 +2739,9 @@ MspHelper.prototype.writeConfiguration = function(reboot) {
                 GUI.tab_switch_cleanup(function() {
                     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
                 });
+            }
+            if (callback) {
+                callback();
             }
         });
     }, 100); // 100ms delay before sending MSP_EEPROM_WRITE to ensure that all settings have been received

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -14,8 +14,9 @@ import huffmanDecodeBuf from "../huffman";
 import { defaultHuffmanTree, defaultHuffmanLenIndex } from "../default_huffman_tree";
 import { updateTabList } from "../utils/updateTabList";
 import { showErrorDialog } from "../utils/showErrorDialog";
-import { TABS } from "../gui";
+import GUI, { TABS } from "../gui";
 import { OSD } from "../tabs/osd";
+import { reinitializeConnection } from "../serial_backend";
 
 // Used for LED_STRIP
 const ledDirectionLetters    = ['n', 'e', 's', 'w', 'u', 'd'];      // in LSB bit order
@@ -2729,13 +2730,15 @@ MspHelper.prototype.sendSerialConfig = function(callback) {
     MSP.send_message(mspCode, mspHelper.crunch(mspCode), false, callback);
 };
 
-MspHelper.prototype.writeConfiguration = function(callback) {
+MspHelper.prototype.writeConfiguration = function(reboot) {
     setTimeout(function() {
         MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
             gui_log(i18n.getMessage('configurationEepromSaved'));
             console.log('Configuration saved to EEPROM');
-            if (callback) {
-                callback();
+            if (reboot) {
+                GUI.tab_switch_cleanup(function() {
+                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
+                });
             }
         });
     }, 100); // 100ms delay before sending MSP_EEPROM_WRITE to ensure that all settings have been received

--- a/src/js/tabs/auxiliary.js
+++ b/src/js/tabs/auxiliary.js
@@ -7,7 +7,6 @@ import FC from '../fc';
 import MSP from '../msp';
 import MSPCodes from '../msp/MSPCodes';
 import adjustBoxNameIfPeripheralWithModeID from '../peripherals';
-import { gui_log } from '../gui_log';
 import { getTextWidth } from '../utils/common';
 import inflection from "inflection";
 
@@ -403,9 +402,7 @@ auxiliary.initialize = function (callback) {
             mspHelper.sendModeRanges(save_to_eeprom);
 
             function save_to_eeprom() {
-                mspHelper.writeConfiguration(function () {
-                    gui_log(i18n.getMessage('auxiliaryEepromSaved'));
-                });
+                mspHelper.writeConfiguration(false);
             }
         });
 

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -2,13 +2,11 @@ import semver from 'semver';
 import { i18n } from '../localization';
 import GUI, { TABS } from '../gui';
 import { tracking } from "../Analytics";
-import { reinitializeConnection } from '../serial_backend';
 import { mspHelper } from '../msp/MSPHelper';
 import FC from '../fc';
 import MSP from '../msp';
 import MSPCodes from '../msp/MSPCodes';
 import { API_VERSION_1_42, API_VERSION_1_43, API_VERSION_1_45 } from '../data_storage';
-import { gui_log } from '../gui_log';
 import { updateTabList } from '../utils/updateTabList';
 
 const configuration = {
@@ -431,10 +429,6 @@ configuration.initialize = function (callback) {
                 FC.CONFIG.name = $('input[name="craftName"]').val().trim();
             }
 
-            function save_serial_config() {
-                mspHelper.sendSerialConfig(save_config);
-            }
-
             function save_config() {
                 Promise
                 .resolve(true)
@@ -453,18 +447,10 @@ configuration.initialize = function (callback) {
                 .then(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45) ?
                     MSP.promise(MSPCodes.MSP2_SET_TEXT, mspHelper.crunch(MSPCodes.MSP2_SET_TEXT, MSPCodes.PILOT_NAME)) : Promise.resolve(true))
                 .then(() => MSP.promise(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG)))
-                .then(() => mspHelper.writeConfiguration(reboot));
+                .then(() => mspHelper.writeConfiguration(true));
             }
 
-            function reboot() {
-                gui_log(i18n.getMessage('configurationEepromSaved'));
-
-                GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
-                });
-            }
-
-            save_serial_config();
+            mspHelper.sendSerialConfig(save_config);
         });
 
         // status data pulled via separate timer with static speed

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -1,13 +1,11 @@
 import { i18n } from "../localization";
 import GUI, { TABS } from '../gui';
-import { reinitializeConnection } from "../serial_backend";
 import { mspHelper } from "../msp/MSPHelper";
 import MSP from "../msp";
 import FC from "../fc";
 import MSPCodes from "../msp/MSPCodes";
 import adjustBoxNameIfPeripheralWithModeID from "../peripherals";
 import { API_VERSION_1_43, API_VERSION_1_44, API_VERSION_1_45 } from "../data_storage";
-import { gui_log } from "../gui_log";
 import semver from 'semver';
 
 const failsafe = {};
@@ -364,19 +362,7 @@ failsafe.initialize = function (callback) {
             }
 
             function save_gps_rescue() {
-                MSP.send_message(MSPCodes.MSP_SET_GPS_RESCUE, mspHelper.crunch(MSPCodes.MSP_SET_GPS_RESCUE), false, save_to_eeprom);
-            }
-
-            function save_to_eeprom() {
-                MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, reboot);
-            }
-
-            function reboot() {
-                gui_log(i18n.getMessage('configurationEepromSaved'));
-
-                GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
-                });
+                MSP.send_message(MSPCodes.MSP_SET_GPS_RESCUE, mspHelper.crunch(MSPCodes.MSP_SET_GPS_RESCUE), false, mspHelper.writeConfiguration(true));
             }
 
             MSP.send_message(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG), false, save_failssafe_config);

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -5,10 +5,8 @@ import GUI, { TABS } from '../gui';
 import FC from '../fc';
 import MSP from "../msp";
 import MSPCodes from "../msp/MSPCodes";
-import { gui_log } from '../gui_log';
 import { have_sensor } from "../sensor_helpers";
 import { mspHelper } from '../msp/MSPHelper';
-import { reinitializeConnection } from '../serial_backend';
 import { updateTabList } from '../utils/updateTabList';
 
 const gps = {};
@@ -344,26 +342,14 @@ gps.initialize = async function (callback) {
             frame.contentWindow.postMessage(message, '*');
         });
 
-        $('a.save').on('click', function() {
+        $('a.save').on('click', async function() {
             // fill some data
             FC.GPS_CONFIG.auto_baud = $('input[name="gps_auto_baud"]').is(':checked') ? 1 : 0;
             FC.GPS_CONFIG.auto_config = $('input[name="gps_auto_config"]').is(':checked') ? 1 : 0;
 
-            async function saveConfiguration() {
-                await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
-                await MSP.promise(MSPCodes.MSP_SET_GPS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_GPS_CONFIG));
-                await mspHelper.writeConfiguration(reboot);
-            }
-
-            function reboot() {
-                gui_log(i18n.getMessage('configurationEepromSaved'));
-
-                GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
-                });
-            }
-
-            saveConfiguration();
+            await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_GPS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_GPS_CONFIG));
+            mspHelper.writeConfiguration(true);
         });
 
         GUI.content_ready(callback);

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -6,7 +6,6 @@ import semver from 'semver';
 import MSP from "../msp";
 import MSPCodes from "../msp/MSPCodes";
 import { API_VERSION_1_46 } from '../data_storage';
-import { gui_log } from "../gui_log";
 
 const led_strip = {
         wireMode: false,
@@ -567,9 +566,7 @@ led_strip.initialize = function (callback, scrollPosition) {
             }
 
             function save_to_eeprom() {
-                mspHelper.writeConfiguration(function() {
-                    gui_log(i18n.getMessage('ledStripEepromSaved'));
-                });
+                mspHelper.writeConfiguration(false);
             }
         });
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -6,7 +6,6 @@ import MotorOutputReorderComponent from "../../components/MotorOutputReordering/
 import EscDshotDirectionComponent from "../../components/EscDshotDirection/EscDshotDirectionComponent";
 import DshotCommand from "../../js/utils/DshotCommand.js";
 import { tracking } from "../Analytics";
-import { reinitializeConnection } from "../serial_backend";
 import { bit_check } from "../bit";
 import { mspHelper } from "../msp/MSPHelper";
 import FC from "../fc";
@@ -15,7 +14,6 @@ import { mixerList } from "../model";
 import MSPCodes from "../msp/MSPCodes";
 import { API_VERSION_1_42, API_VERSION_1_44 } from "../data_storage";
 import EscProtocols from "../utils/EscProtocols";
-import { gui_log } from "../gui_log";
 import { updateTabList } from "../utils/updateTabList";
 import { isInt, getMixerImageSrc } from "../utils/common";
 import semver from 'semver';
@@ -1167,7 +1165,7 @@ motors.initialize = async function (callback) {
             self.analyticsChanges = {};
             self.configHasChanged = false;
 
-            mspHelper.writeConfiguration(reboot);
+            mspHelper.writeConfiguration(true);
         });
 
         $('a.stop').on('click', () => motorsEnableTestModeElement.prop('checked', false).trigger('change'));
@@ -1186,11 +1184,6 @@ motors.initialize = async function (callback) {
         }
 
         content_ready();
-    }
-
-    function reboot() {
-        gui_log(i18n.getMessage('configurationEepromSaved'));
-        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
     }
 
     function showDialogMixerReset(message) {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -1,7 +1,6 @@
 import { i18n } from "../localization";
 import GUI, { TABS } from '../gui';
 import { tracking } from "../Analytics";
-import { reinitializeConnection } from "../serial_backend";
 import { mspHelper } from "../msp/MSPHelper";
 import FC from "../fc";
 import MSP from "../msp";
@@ -56,18 +55,6 @@ onboard_logging.initialize = function (callback) {
             return a;
 
         return gcd(b, a % b);
-    }
-
-    function save_to_eeprom() {
-        mspHelper.writeConfiguration(reboot);
-    }
-
-    function reboot() {
-        gui_log(i18n.getMessage('configurationEepromSaved'));
-
-        GUI.tab_switch_cleanup(function() {
-            MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
-        });
     }
 
     function load_html() {
@@ -142,7 +129,7 @@ onboard_logging.initialize = function (callback) {
                         await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
                     }
 
-                    save_to_eeprom();
+                    mspHelper.writeConfiguration(true);
                 });
             }
 

--- a/src/js/tabs/power.js
+++ b/src/js/tabs/power.js
@@ -5,7 +5,6 @@ import { mspHelper } from '../msp/MSPHelper';
 import FC from '../fc';
 import MSP from '../msp';
 import MSPCodes from '../msp/MSPCodes';
-import { gui_log } from '../gui_log';
 import jBox from 'jbox';
 
 const power = {
@@ -500,12 +499,10 @@ power.initialize = function (callback) {
         }
 
         function save_to_eeprom() {
-            mspHelper.writeConfiguration(save_completed);
+            mspHelper.writeConfiguration(false, save_completed);
         }
 
         function save_completed() {
-            gui_log(i18n.getMessage('configurationEepromSaved'));
-
             TABS.power.initialize();
         }
 

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -2,7 +2,6 @@ import { i18n } from "../localization";
 import GUI, { TABS } from '../gui';
 import { get as getConfig, set as setConfig } from '../ConfigStorage';
 import { tracking } from "../Analytics";
-import { reinitializeConnection } from "../serial_backend";
 import { bit_check } from "../bit";
 import { mspHelper } from "../msp/MSPHelper";
 import FC from "../fc";
@@ -520,16 +519,7 @@ receiver.initialize = function (callback) {
             }
 
             function save_to_eeprom() {
-                MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, reboot);
-            }
-
-            function reboot() {
-                gui_log(i18n.getMessage('configurationEepromSaved'));
-                if (boot) {
-                    GUI.tab_switch_cleanup(function() {
-                        MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
-                    });
-                }
+                mspHelper.writeConfiguration(boot);
             }
 
             tracking.sendSaveAndChangeEvents(tracking.EVENT_CATEGORIES.FLIGHT_CONTROLLER, tab.analyticsChanges, 'receiver');

--- a/src/js/tabs/transponder.js
+++ b/src/js/tabs/transponder.js
@@ -1,6 +1,5 @@
 import { i18n } from "../localization";
 import GUI, { TABS } from '../gui';
-import { reinitializeConnection } from "../serial_backend";
 import { mspHelper } from '../msp/MSPHelper';
 import FC from "../fc";
 import MSP from "../msp";
@@ -302,14 +301,7 @@ transponder.initialize = function(callback) {
                 }
 
                 function save_to_eeprom() {
-                    MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, function() {
-                        gui_log(i18n.getMessage('transponderEepromSaved'));
-                        if ( $(_this).hasClass('reboot') ) {
-                            GUI.tab_switch_cleanup(function() {
-                                MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
-                            });
-                        }
-                    });
+                    mspHelper.writeConfiguration($(_this).hasClass('reboot'));
                 }
 
                 if (FC.TRANSPONDER.provider !== "0" && FC.TRANSPONDER.data.length !== FC.TRANSPONDER.providers.find(function(provider) {

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -903,12 +903,10 @@ vtx.initialize = function (callback) {
         }
 
         function save_to_eeprom() {
-            mspHelper.writeConfiguration(save_completed);
+            mspHelper.writeConfiguration(false, save_completed);
         }
 
         function save_completed() {
-            gui_log(i18n.getMessage('configurationEepromSaved'));
-
             TABS.vtx.vtxTableSavePending = false;
 
             const saveButton = $("#save_button");


### PR DESCRIPTION
Functions have been refactored to be defined in one place only:

`MspHelper.prototype.writeConfiguration = function(bool reboot)`

Add a new mspHelper for `MSP_EEPROM_WRITE` and optional `MSP_SET_REBOOT` to finish callback `reinitializeConnection`.

