### PR TITLE
[10.9-maintenance] Double sliding fix for build configuration panel

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -278,7 +278,7 @@ firmware_flasher.initialize = function (callback) {
         });
 
         function selectFirmware(release) {
-            $('div.build_configuration').slideUp();
+            $('div.build_configuration').hide();
             $('div.release_info').slideUp();
 
             if (!self.localFirmwareLoaded) {
@@ -298,7 +298,7 @@ firmware_flasher.initialize = function (callback) {
                 self.targetDetail = response;
 
                 if (response.cloudBuild === true) {
-                    $('div.build_configuration').slideDown();
+                    $('div.build_configuration').show();
 
                     const expertMode = $('.tab-firmware_flasher input.expert_mode').is(':checked');
                     if (expertMode) {
@@ -409,7 +409,7 @@ firmware_flasher.initialize = function (callback) {
 
                 $('div.git_info').slideUp();
                 $('div.release_info').slideUp();
-                $('div.build_configuration').slideUp();
+                $('div.build_configuration').hide();
 
                 if (!self.localFirmwareLoaded) {
                     self.enableFlashing(false);
@@ -728,7 +728,7 @@ firmware_flasher.initialize = function (callback) {
 
                 // hide github info (if it exists)
                 $('div.git_info').slideUp();
-                $('div.build_configuration').slideUp();
+                $('div.build_configuration').hide();
 
                 chrome.fileSystem.getDisplayPath(fileEntry, function (path) {
                     console.log('Loading file from:', path);


### PR DESCRIPTION
when toggling expert mode (flasher tab) the build configuration panel slides up and down twice.
This quick fix replaces sliding with just show/hide.

A proper fix would require some good refactoring.

For now, no animation is better than double animation