### PR TITLE
Fix MSP rx sticks window

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -404,6 +404,7 @@ function dist_rollup() {
                 'js/main_cordova': 'src/js/main_cordova.js',
                 'js/utils/common': 'src/js/utils/common.js',
                 'js/main': 'src/js/main.js',
+                'js/tabs/receiver_msp': 'src/js/tabs/receiver_msp.js',
             },
             plugins: [
                 alias({

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2239,7 +2239,8 @@
         "message": "Binding phrase"
     },
     "receiverButtonSticks": {
-        "message": "Control sticks"
+        "message": "Radio Emulator",
+        "description": "Button that opens a window with a radio emulator on the receiver tab. Actually only enabled for MSP protocol"
     },
     "receiverDataRefreshed": {
         "message": "RC Tuning data <strong>refreshed</strong>"

--- a/src/css/tabs/receiver_msp.less
+++ b/src/css/tabs/receiver_msp.less
@@ -97,7 +97,7 @@ a {
 		position: absolute;
 		left: 50%;
 		transform: translate(-50%);
-		margin-top: 0px;
+		margin-top: 20px;
 		margin-bottom: 0px;
 		margin-left: 0px;
 		background-color: var(--accent);

--- a/src/tabs/receiver_msp.html
+++ b/src/tabs/receiver_msp.html
@@ -1,20 +1,22 @@
+<!DOCTYPE html>
 <html>
 <head>
-<link type="text/css" rel="stylesheet" href="/css/opensans_webfontkit/fonts.css" media="all" />
-<script type="text/javascript" src="/node_modules/jquery/dist/jquery.min.js"></script>
-<script type="text/javascript" src="/node_modules/jquery-ui-npm/jquery-ui.min.js"></script>
-<script type="text/javascript" src="/js/libraries/jquery.nouislider.all.min.js"></script>
+    <title i18n="receiverButtonSticks"></title>
+    <link type="text/css" rel="stylesheet" href="/css/opensans_webfontkit/fonts.css" media="all" />
+    <script type="text/javascript" src="/node_modules/jquery/dist/jquery.min.js"></script>
+    <script type="text/javascript" src="/node_modules/jquery-ui-npm/jquery-ui.min.js"></script>
+    <script type="text/javascript" src="/js/libraries/jquery.nouislider.all.min.js"></script>
 
-<script type="text/javascript" src="/js/utils/window_watchers.js"></script>
-<script type="text/javascript" src="/js/tabs/receiver_msp.js"></script>
+    <script type="module" src="/js/tabs/receiver_msp.js"></script>
 
-<link type="text/css" rel="stylesheet" href="/js/libraries/jquery.nouislider.min.css">
-<link type="text/css" rel="stylesheet" href="/js/libraries/jquery.nouislider.pips.min.css">
+    <link type="text/css" rel="stylesheet" href="/js/libraries/jquery.nouislider.min.css">
+    <link type="text/css" rel="stylesheet" href="/js/libraries/jquery.nouislider.pips.min.css">
 
-<link type="text/css" rel="stylesheet" href="/css/main.css" media="all" />
-<link type="text/css" rel="stylesheet" href="/css/tabs/receiver_msp.css" media="all" />
+    <link type="text/css" rel="stylesheet" href="/css/theme.css" media="all" />
+    <link type="text/css" rel="stylesheet" href="/css/main.css" media="all" />
+    <link type="text/css" rel="stylesheet" href="/css/tabs/receiver_msp.css" media="all" />
 
-<link type="text/css" rel="stylesheet" href="/css/dark-theme.css" media="all" disabled/>
+    <link type="text/css" rel="stylesheet" href="/css/dark-theme.css" media="all" disabled/>
 </head>
 <body>
     <div class="control-gimbals">


### PR DESCRIPTION
Fixes the MSP emulator radio window, that was broken when moving to modules:

![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/bbf2e3ef-d381-45a5-a44e-a2dc4d34a2ee)

It renames the fature too to let it clear the functionality.
