### PR TITLE
Cancel previous execution of PR github action

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,6 +6,10 @@ on:
       - master
       - '*-maintenance'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     name: CI


### PR DESCRIPTION
Cancel the previous execution of the CI for a PR, when the developer pushes new changes to the branch (new CI for the PR starts).