### PR TITLE
Fix loading of preset title panel callback

### DIFF
--- a/src/tabs/presets/TitlePanel/PresetTitlePanel.js
+++ b/src/tabs/presets/TitlePanel/PresetTitlePanel.js
@@ -125,7 +125,10 @@ export default class PresetTitlePanel
 
         i18n.localizePage();
         this._domWrapperDiv.toggle(true);
-        this._onLoadedCallback?.();
+
+        if (typeof this._onLoadedCallback === 'function') {
+            this._onLoadedCallback();
+        }
     }
 
     _readDom()


### PR DESCRIPTION
Fixes:

```
PresetTitlePanel.js:128 Uncaught TypeError: this._onLoadedCallback is not a function
    at PresetTitlePanel._setupHtml (PresetTitlePanel.js:128:31)
    at HTMLDivElement.<anonymous> (PresetTitlePanel.js:58:100)
    at HTMLDivElement.<anonymous> (jquery.min.js:2:85383)
    at Function.each (jquery.min.js:2:3003)
    at S.fn.init.each (jquery.min.js:2:1481)
    at Object.<anonymous> (jquery.min.js:2:85365)
    at c (jquery.min.js:2:28327)
    at Object.fireWith [as resolveWith] (jquery.min.js:2:29072)
    at l (jquery.min.js:2:80045)
    at XMLHttpRequest.<anonymous> (jquery.min.js:2:82499)
```

@Benky please have a look.