### PR TITLE
Enable video transmitter tab

### DIFF
--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -1,5 +1,5 @@
 import { bit_check, bit_set, bit_clear } from "./bit";
-import { API_VERSION_1_44, API_VERSION_1_45 } from './data_storage';
+import { API_VERSION_1_44, API_VERSION_1_45, API_VERSION_1_46 } from './data_storage';
 import semver from "semver";
 import { tracking } from "./Analytics";
 
@@ -40,6 +40,7 @@ const Features = function (config) {
 
     self._features = features;
 
+    // Filter features based on build options
     if (semver.gte(config.apiVersion, API_VERSION_1_45) && config.buildOptions.length) {
         self._features = [];
 
@@ -48,6 +49,11 @@ const Features = function (config) {
                 self._features.push(feature);
             }
         }
+    }
+
+    // Enable vtx feature if not already enabled in firmware. This is needed for the vtx tab to show up.
+    if (semver.gte(config.apiVersion, API_VERSION_1_46) && config.buildOptions.some(opt => opt.includes('VTX'))) {
+        self.enable('VTX');
     }
 
     self._features.sort((a, b) => a.name.localeCompare(b.name, window.navigator.language, { ignorePunctuation: true }));

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -34,7 +34,7 @@ class GuiControl {
             'help',
         ];
 
-        this.defaultAllowedTabsCloudBuild = [
+        this.defaultAllowedTabs = [
             'setup',
             'failsafe',
             'power',
@@ -62,7 +62,7 @@ class GuiControl {
             'vtx',
         ];
 
-        this.defaultAllowedFCTabsWhenConnected = [ ...this.defaultAllowedTabsCloudBuild, ...this.defaultCloudBuildTabOptions];
+        this.defaultAllowedFCTabsWhenConnected = [ ...this.defaultAllowedTabs, ...this.defaultCloudBuildTabOptions];
 
         this.allowedTabs = this.defaultAllowedTabsWhenDisconnected;
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -536,9 +536,10 @@ function setRtc() {
 
 function finishOpen() {
     CONFIGURATOR.connectionValid = true;
+
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45) && FC.CONFIG.buildOptions.length) {
 
-        GUI.allowedTabs = GUI.defaultAllowedTabsCloudBuild;
+        GUI.allowedTabs = Array.from(GUI.defaultAllowedTabs);
 
         for (const tab of GUI.defaultCloudBuildTabOptions) {
             if (FC.CONFIG.buildOptions.some(opt => opt.toLowerCase().includes(tab))) {
@@ -547,7 +548,7 @@ function finishOpen() {
         }
 
     } else {
-        GUI.allowedTabs = GUI.defaultAllowedFCTabsWhenConnected.slice();
+        GUI.allowedTabs = Array.from(GUI.defaultAllowedFCTabsWhenConnected);
     }
 
     if (GUI.isCordova()) {

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -414,7 +414,6 @@ ports.initialize = function (callback) {
         let enableBlackbox = false;
         let enableEsc = false;
         let enableGps = false;
-        let enableVtx = false;
 
         for (const port of FC.SERIAL_CONFIG.ports) {
             const func = port.functions;
@@ -437,10 +436,6 @@ ports.initialize = function (callback) {
 
             if (func.includes('GPS')) {
                 enableGps = true;
-            }
-
-            if (func.includes('IRC_TRAMP') || func.includes('TBS_SMARTAUDIO')) {
-                enableVtx = true;
             }
         }
 
@@ -472,12 +467,6 @@ ports.initialize = function (callback) {
             featureConfig.enable('GPS');
         } else {
             featureConfig.disable('GPS');
-        }
-
-        if (enableVtx) {
-            featureConfig.enable('VTX');
-        } else {
-            featureConfig.disable('VTX');
         }
 
         mspHelper.sendSerialConfig(save_features);

--- a/src/js/utils/updateTabList.js
+++ b/src/js/utils/updateTabList.js
@@ -1,3 +1,7 @@
+import semver from "semver";
+import { API_VERSION_1_42, API_VERSION_1_46 } from "../data_storage";
+import FC from "../fc";
+
 export function updateTabList(features) {
     const isExpertModeEnabled = $('input[name="expertModeCheckbox"]').is(':checked');
 
@@ -11,5 +15,10 @@ export function updateTabList(features) {
     $('#tabs ul.mode-connected li.tab_led_strip').toggle(features.isEnabled('LED_STRIP'));
     $('#tabs ul.mode-connected li.tab_transponder').toggle(features.isEnabled('TRANSPONDER'));
     $('#tabs ul.mode-connected li.tab_osd').toggle(features.isEnabled('OSD'));
-    $('#tabs ul.mode-connected li.tab_vtx').toggle(features.isEnabled('VTX'));
+
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+        $('#tabs ul.mode-connected li.tab_vtx').toggle(features.isEnabled('VTX'));
+    } else {
+        $('#tabs ul.mode-connected li.tab_vtx').toggle(semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42));
+    }
 }


### PR DESCRIPTION
Fixes #3504

- Fixes backwards compatibility
- Enables virtual vtx feature if vtx build option is present independent of port settings.