### PR TITLE
Bump NWJS to v0.77.0

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ const NODE_ENV = process.env.NODE_ENV || 'production';
 const NAME_REGEX = /-/g;
 
 const nwBuilderOptions = {
-    version: '0.72.0',
+    version: '0.77.0',
     files: `${DIST_DIR}**/*`,
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},


### PR DESCRIPTION
The ARM64 architecture is supported on macOS starting from this release.

https://nwjs.io/blog/v0.77.0/