### PR TITLE
Fix intermittent connect failure

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -761,7 +761,7 @@ export function reinitializeConnection(callback) {
             clearInterval(reconnect);
             gui_log(i18n.getMessage('deviceReady'));
 
-            if (callback === typeof('function')) {
+            if (typeof callback === 'function') {
                 callback();
             }
         } else {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -11,7 +11,7 @@ import FC from '../fc';
 import MSP from '../msp';
 import MSPCodes from '../msp/MSPCodes';
 import PortHandler, { usbDevices } from '../port_handler';
-import CONFIGURATOR, { API_VERSION_1_39, API_VERSION_1_45 } from '../data_storage';
+import { API_VERSION_1_39, API_VERSION_1_45 } from '../data_storage';
 import serial from '../serial';
 import STM32DFU from '../protocols/stm32usbdfu';
 import { gui_log } from '../gui_log';
@@ -581,6 +581,7 @@ firmware_flasher.initialize = function (callback) {
 
                 function onFinishClose() {
                     MSP.clearListeners();
+                    MSP.disconnect_cleanup();
                 }
 
                 function onClose(success) {
@@ -589,7 +590,6 @@ firmware_flasher.initialize = function (callback) {
                     }
 
                     serial.disconnect(onFinishClose);
-                    MSP.disconnect_cleanup();
                 }
 
                 function onFinish() {
@@ -646,6 +646,7 @@ firmware_flasher.initialize = function (callback) {
                     console.log(`Requesting board information`);
                     MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, () => {
                         gui_log(i18n.getMessage('apiVersionReceived', FC.CONFIG.apiVersion));
+
                         if (FC.CONFIG.apiVersion.includes('null')) {
                             onClose(false); // not supported
                         } else if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_39)) {
@@ -684,8 +685,7 @@ firmware_flasher.initialize = function (callback) {
                         if (!(serial.connected || serial.connectionId)) {
                             serial.connect(port, {bitrate: baud}, onConnect);
                         } else {
-                            console.warn('Attempting to connect while there still is a connection', serial.connected, serial.connectionId);
-                            serial.disconnect();
+                            console.warn('Attempting to connect while there still is a connection', serial.connected, serial.connectionId, serial.openCanceled);
                         }
                     } else {
                         console.log('Releases not loaded yet');

--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -2,7 +2,6 @@ import semver from 'semver';
 import { i18n } from "../localization";
 import GUI, { TABS } from '../gui';
 import { tracking } from "../Analytics";
-import { reinitializeConnection } from '../serial_backend';
 import { mspHelper } from '../msp/MSPHelper';
 import FC from '../fc';
 import MSP from '../msp';
@@ -296,8 +295,7 @@ ports.initialize = function (callback) {
 
         const pheripheralsSelectElement = $('select[name="function-peripherals"]');
         pheripheralsSelectElement.on('change', function() {
-            let vtxControlSelected = undefined;
-            let mspControlSelected = undefined;
+            let vtxControlSelected, mspControlSelected;
 
             pheripheralsSelectElement.each(function(index, element) {
                 const value = $(element).val();
@@ -476,11 +474,7 @@ ports.initialize = function (callback) {
         }
 
         function save_to_eeprom() {
-            mspHelper.writeConfiguration(function() {
-                GUI.tab_switch_cleanup(function() {
-                    MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false, reinitializeConnection);
-                });
-            });
+            mspHelper.writeConfiguration(true);
         }
     }
 };


### PR DESCRIPTION
Fixing some errors which are intermittent and sometimes hard to produce

- [serial-backend] callback in `reinitializeConnection` function had wrong condition.
- [firmware-flasher] no need for serial disconnect in `verifyBoard` function if connection is still active. (patience does)
- [ports] fix callback for `writeConfiguration` helper function.

![Screenshot from 2023-07-17 23-57-53](https://github.com/betaflight/betaflight-configurator/assets/8344830/17397628-29d1-456d-a81e-57ab15be1aeb)
