### PR TITLE
GPS updates

### DIFF
--- a/src/css/tabs/gps.less
+++ b/src/css/tabs/gps.less
@@ -23,7 +23,7 @@
 			background-color: #ececec;
 		}
 	}
-	progress {
+	meter {
 		width: 100%;
 		border-radius: 3px;
 	}
@@ -199,14 +199,14 @@
 		float: left;
 	}
 }
-progress[value] {
-	&::-webkit-progress-bar {
+meter[value] {
+	&::-webkit-meter-bar {
 		background-color: #d2d2d2;
 		border-radius: 2px;
 		box-shadow: 1px 1px 0 rgba(255, 255, 255, 0.95);
 		box-shadow: 0 0 3px rgba(0, 0, 0, 0.25) inset;
 	}
-	&::-webkit-progress-value {
+	&::-webkit-meter-value {
 		background-image: -webkit-linear-gradient(top, rgba(255, 255, 255, .15), rgba(0, 0, 0, .15)), -webkit-linear-gradient(left, #ffbb00, #ffbb00);
 		border-radius: 2px;
 		box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.25) inset;

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -224,7 +224,7 @@ gps.initialize = async function (callback) {
                         <tr>
                             <td>-</td>
                             <td>${FC.GPS_DATA.svid[i]}</td>
-                            <td><progress value="${FC.GPS_DATA.cno[i]}" max="99"></progress></td>
+                            <td><meter value="${FC.GPS_DATA.cno[i]}" max="55"></meter></td>
                             <td>${FC.GPS_DATA.quality[i]}</td>
                         </tr>
                     `);
@@ -235,7 +235,7 @@ gps.initialize = async function (callback) {
                         <tr>
                             <td>-</td>
                             <td>-</td>
-                            <td><progress value="0" max="99"></progress></td>
+                            <td><meter value="0" max="55"></meter></td>
                             <td> </td>
                         </tr>
                     `);
@@ -256,11 +256,11 @@ gps.initialize = async function (callback) {
 
                     if (FC.GPS_DATA.chn[i] >= 7) {
                         rowContent += '<td>-</td>';
-                        rowContent += `<td><progress value="${0}" max="99"></progress></td>`;
+                        rowContent += `<td><meter value="${0}" max="55"></meter></td>`;
                         rowContent += `<td> </td>`;
                     } else {
                         rowContent += `<td>${FC.GPS_DATA.svid[i]}</td>`;
-                        rowContent += `<td><progress value="${FC.GPS_DATA.cno[i]}" max="99"></progress></td>`;
+                        rowContent += `<td><meter value="${FC.GPS_DATA.cno[i]}" max="55"></meter></td>`;
 
                         let quality = i18n.getMessage(qualityArray[FC.GPS_DATA.quality[i] & 0x7]);
                         let used = i18n.getMessage(usedArray[(FC.GPS_DATA.quality[i] & 0x8) >> 3]);

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -1,6 +1,6 @@
 import { i18n } from "../localization";
 import semver from 'semver';
-import { API_VERSION_1_43 } from '../data_storage';
+import { API_VERSION_1_43, API_VERSION_1_46 } from '../data_storage';
 import GUI, { TABS } from '../gui';
 import FC from '../fc';
 import MSP from "../msp";
@@ -132,7 +132,10 @@ gps.initialize = async function (callback) {
 
         }).val(FC.GPS_CONFIG.provider).change();
 
-        gpsAutoBaudElement.prop('checked', FC.GPS_CONFIG.auto_baud === 1);
+        // auto_baud is no longer used in API 1.46
+        if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+            gpsAutoBaudElement.prop('checked', FC.GPS_CONFIG.auto_baud === 1);
+        }
 
         gpsAutoConfigElement.on('change', function () {
             const checked = $(this).is(":checked");
@@ -146,7 +149,7 @@ gps.initialize = async function (callback) {
             const enableSbasVisible = checked && ubloxSelected;
             gpsUbloxSbasGroup.toggle(enableSbasVisible);
 
-            gpsAutoBaudGroup.toggle(ubloxSelected || mspSelected);
+            gpsAutoBaudGroup.toggle((ubloxSelected || mspSelected) && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_46));
             gpsAutoConfigGroup.toggle(ubloxSelected || mspSelected);
 
         }).prop('checked', FC.GPS_CONFIG.auto_config === 1).trigger('change');

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -320,7 +320,7 @@ onboard_logging.initialize = function (callback) {
                 {text: "GPS_RESCUE_VELOCITY"},
                 {text: "GPS_RESCUE_HEADING"},
                 {text: "GPS_RESCUE_TRACKING"},
-                {text: "GPS_UNIT_CONNECTION"},
+                {text: "GPS_CONNECTION"},
                 {text: "ATTITUDE"},
                 {text: "VTX_MSP"},
                 {text: "GPS_DOP"},


### PR DESCRIPTION
Changes:
- GPS `auto_baud` is no longer used in firmware 4.5
- Rename `GPS_UNIT_CONNECTION` to `GPS_CONNECTION`
- Signal Strength progress bar to meter and adjust range to 0-55:

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/d5181037-eecd-4cbf-ae46-933b1a9a654e)
