### PR TITLE
Fix wiki

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -110,12 +110,8 @@ firmware_flasher.initialize = function (callback) {
             // Wiki link: #wiki found in unified target configuration, if board description exist or generel board missing
             let urlWiki = 'https://betaflight.com/docs/wiki/boards/missing';                // generel board missing
             const urlBoard = `https://betaflight.com/docs/wiki/boards/${summary.target}`;   // board description
-            if (summary.wiki === undefined) {                                               // override if #wiki exist in unified target configuration
-                if (urlExists(urlBoard)) {
-                    urlWiki = urlBoard;
-                }
-            } else {
-                urlWiki = summary.wiki;
+            if (urlExists(urlBoard)) {
+                urlWiki = urlBoard;
             }
             const targetWiki = $('#targetWikiInfoUrl');
             targetWiki.html(`&nbsp;&nbsp;&nbsp;[Wiki]`);

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -109,7 +109,7 @@ firmware_flasher.initialize = function (callback) {
 
             // Wiki link: #wiki found in unified target configuration, if board description exist or generel board missing
             let urlWiki = 'https://betaflight.com/docs/wiki/boards/missing';                // generel board missing
-            const urlBoard = `https://betaflight.com/docs/wiki/boards/'${summary.target}`; // board description
+            const urlBoard = `https://betaflight.com/docs/wiki/boards/${summary.target}`; // board description
             if (summary.wiki === undefined) {                                               // override if #wiki exist in unified target configuration
                 if (urlExists(urlBoard)) {
                     urlWiki = urlBoard;

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -109,7 +109,7 @@ firmware_flasher.initialize = function (callback) {
 
             // Wiki link: #wiki found in unified target configuration, if board description exist or generel board missing
             let urlWiki = 'https://betaflight.com/docs/wiki/boards/missing';                // generel board missing
-            const urlBoard = `https://betaflight.com/docs/wiki/boards/${summary.target}`; // board description
+            const urlBoard = `https://betaflight.com/docs/wiki/boards/${summary.target}`;   // board description
             if (summary.wiki === undefined) {                                               // override if #wiki exist in unified target configuration
                 if (urlExists(urlBoard)) {
                     urlWiki = urlBoard;

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -16,7 +16,7 @@ import serial from '../serial';
 import STM32DFU from '../protocols/stm32usbdfu';
 import { gui_log } from '../gui_log';
 import semver from 'semver';
-import { checkChromeRuntimeError } from '../utils/common';
+import { checkChromeRuntimeError, urlExists } from '../utils/common';
 import { generateFilename } from '../utils/generate_filename';
 
 const firmware_flasher = {
@@ -107,10 +107,19 @@ firmware_flasher.initialize = function (callback) {
             $('div.release_info #targetMCU').text(summary.mcu);
             $('div.release_info .configFilename').text(self.isConfigLocal ? self.configFilename : "[default]");
 
-            // Wiki link to url found in unified target configuration or if not defined to general wiki url
+            // Wiki link: #wiki found in unified target configuration, if board description exist or generel board missing
+            let urlWiki = 'https://betaflight.com/docs/wiki/boards/missing';                // generel board missing
+            const urlBoard = `https://betaflight.com/docs/wiki/boards/'${summary.target}`; // board description
+            if (summary.wiki === undefined) {                                               // override if #wiki exist in unified target configuration
+                if (urlExists(urlBoard)) {
+                    urlWiki = urlBoard;
+                }
+            } else {
+                urlWiki = summary.wiki;
+            }
             const targetWiki = $('#targetWikiInfoUrl');
             targetWiki.html(`&nbsp;&nbsp;&nbsp;[Wiki]`);
-            targetWiki.attr("href", summary.wiki === undefined ? "https://betaflight.com/docs/wiki/" : summary.wiki);
+            targetWiki.attr("href", urlWiki);
 
             if (summary.cloudBuild) {
                 $('div.release_info #cloudTargetInfo').show();

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -91,6 +91,18 @@ export function getTextWidth(text) {
     return Math.ceil(context.measureText(text).width);
 }
 
+export function urlExists(url) {
+    let http = new XMLHttpRequest ();
+
+    http.open('HEAD', url, false);
+    http.send();
+    if (http.status != 404) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
 /**
  * Returns jquery sorted option list with optional value staying on top of the list.
  *

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -96,11 +96,7 @@ export function urlExists(url) {
 
     http.open('HEAD', url, false);
     http.send();
-    if (http.status !== 404) {
-        return true;
-    } else {
-        return false;
-    }
+    return http.status !== 404;
 }
 
 /**

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -96,7 +96,7 @@ export function urlExists(url) {
 
     http.open('HEAD', url, false);
     http.send();
-    if (http.status != 404) {
+    if (http.status !== 404) {
         return true;
     } else {
         return false;


### PR DESCRIPTION
Part of solution to #3521 
Change the logic to get the right Wiki for board on flasher tab.

Logic to find right url are:
1. if board description exist in https://betaflight.com/docs/wiki/boards/ + target name
2. if no board description found, show board missing = https://betaflight.com/docs/wiki/boards/missing
