### PR TITLE
Indicate configuration saving on LED Strip tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6564,13 +6564,13 @@
         "message": "Save",
         "description": "Save button in the VTX tab"
     },
-    "vtxButtonSaving": {
+    "buttonSaving": {
         "message": "Saving",
-        "description": "Show state of the Save button in the VTX tab"
+        "description": "Show state of the Save button in the VTX/LED tab"
     },
-    "vtxButtonSaved": {
+    "buttonSaved": {
         "message": "Saved",
-        "description": "Saved action button in the VTX tab"
+        "description": "Saved action button in the VTX/LED tab"
     },
     "vtxSmartAudioUnlocked": {
         "message": "{{version}} unlocked",

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -556,6 +556,10 @@ led_strip.initialize = function (callback, scrollPosition) {
         });
 
         $('a.save').on('click', function () {
+            const saveButton = $('a.save');
+            const oldText = saveButton.text();
+            saveButton.html(i18n.getMessage('buttonSaving')).addClass('disabled');
+
             mspHelper.sendLedStripConfig(send_led_strip_colors);
 
             function send_led_strip_colors() {
@@ -567,7 +571,20 @@ led_strip.initialize = function (callback, scrollPosition) {
             }
 
             function save_to_eeprom() {
-                mspHelper.writeConfiguration(false);
+                mspHelper.writeConfiguration(false, save_completed);
+            }
+
+            function save_completed() {
+                const buttonDelay = 1500;
+
+                 // Allow firmware to make relevant changes before initialization
+                setTimeout(() => {
+                    saveButton.html(i18n.getMessage('buttonSaved'));
+
+                    setTimeout(() => {
+                        saveButton.html(oldText).removeClass('disabled');
+                    }, buttonDelay);
+                }, buttonDelay);
             }
         });
 

--- a/src/js/tabs/vtx.js
+++ b/src/js/tabs/vtx.js
@@ -899,15 +899,15 @@ vtx.initialize = function (callback) {
 
             const saveButton = $("#save_button");
             const oldText = saveButton.text();
-            const buttonDelay = 2000;
+            const buttonDelay = 1500;
 
-            saveButton.html(i18n.getMessage('vtxButtonSaving')).addClass('disabled');
+            saveButton.html(i18n.getMessage('buttonSaving')).addClass('disabled');
 
             clearInterval(TABS.vtx.intervalId);
 
              // Allow firmware to make relevant changes before initialization
             setTimeout(() => {
-                saveButton.html(i18n.getMessage('vtxButtonSaved'));
+                saveButton.html(i18n.getMessage('buttonSaved'));
 
                 setTimeout(() => {
                     TABS.vtx.initialize();


### PR DESCRIPTION
![image](https://github.com/betaflight/betaflight-configurator/assets/62965528/d16c586d-de2d-4f05-ab7b-f28484567002)
Same as on VTX Tab, reduced delay from 2000 to 1500ms.

I'm using the same messages as on the vtx tab so I made the localization messages generic.