### PR TITLE
Adding dark and light theme names to the sponsor request (params to API)

### DIFF
--- a/src/js/BuildApi.js
+++ b/src/js/BuildApi.js
@@ -172,8 +172,8 @@ export default class BuildApi {
         this.load(url, onSuccess, onFailure);
     }
 
-    loadSponsorTile(onSuccess, onFailure) {
-        const url = `${this._url}/api/configurator/sponsors`;
+    loadSponsorTile(mode, onSuccess, onFailure) {
+        const url = `${this._url}/api/configurator/sponsors/${mode}`;
         this.load(url, onSuccess, onFailure);
     }
 }

--- a/src/js/DarkTheme.js
+++ b/src/js/DarkTheme.js
@@ -9,6 +9,7 @@ const css_dark = [
 
 const DarkTheme = {
     configEnabled: undefined,
+    enabled: false,
 };
 
 DarkTheme.isDarkThemeEnabled = function (callback) {
@@ -61,12 +62,13 @@ DarkTheme.setConfig = function (result) {
 
 DarkTheme.applyDark = function () {
     css_dark.forEach((el) => $(`link[href="${el}"]`).prop('disabled', false));
+    this.enabled = true;
 };
 
 DarkTheme.applyNormal = function () {
     css_dark.forEach((el) => $(`link[href="${el}"]`).prop('disabled', true));
+    this.enabled = false;
 };
-
 
 export function setDarkTheme(enabled) {
     DarkTheme.setConfig(enabled);

--- a/src/js/DarkTheme.js
+++ b/src/js/DarkTheme.js
@@ -8,14 +8,14 @@ const css_dark = [
 ];
 
 const DarkTheme = {
-    configEnabled: undefined,
+    configSetting: undefined,
     enabled: false,
 };
 
 DarkTheme.isDarkThemeEnabled = function (callback) {
-    if (this.configEnabled === 0) {
+    if (this.configSetting === 0) {
         callback(true);
-    } else if (this.configEnabled === 2) {
+    } else if (this.configSetting === 2) {
         if (GUI.isCordova()) {
             cordova.plugins.ThemeDetection.isDarkModeEnabled(function(success) {
                 callback(success.value);
@@ -48,14 +48,14 @@ DarkTheme.apply = function() {
 };
 
 DarkTheme.autoSet = function() {
-    if (this.configEnabled === 2) {
+    if (this.configSetting === 2) {
         this.apply();
     }
 };
 
 DarkTheme.setConfig = function (result) {
-    if (this.configEnabled !== result) {
-        this.configEnabled = result;
+    if (this.configSetting !== result) {
+        this.configSetting = result;
         this.apply();
     }
 };

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -19,6 +19,7 @@ import { gui_log } from '../gui_log';
 import semver from 'semver';
 import { checkChromeRuntimeError, urlExists } from '../utils/common';
 import { generateFilename } from '../utils/generate_filename';
+import DarkTheme from '../DarkTheme';
 
 const firmware_flasher = {
     targets: null,
@@ -55,7 +56,7 @@ firmware_flasher.initialize = function (callback) {
                 return;
             }
 
-            self.releaseLoader.loadSponsorTile(
+            self.releaseLoader.loadSponsorTile(DarkTheme.enabled ? 'dark' : 'light',
                 (content) => {
                     if (content) {
                         $('div.tab_sponsor').html(content);

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -179,7 +179,7 @@ options.initCordovaForceComputerUI = function () {
 
 options.initDarkTheme = function () {
     $('#darkThemeSelect')
-        .val(DarkTheme.configEnabled)
+        .val(DarkTheme.configSetting)
         .change(function () {
             const value = parseInt($(this).val());
 


### PR DESCRIPTION
I couldn't see any way to identify whether or not the dark theme was enabled or not. So added the property to DarkTheme.

If anyway has a better idea please let me know.
