### PR TITLE
Fix: Mixer preview images in web builds

### DIFF
--- a/src/css/tabs/motors.less
+++ b/src/css/tabs/motors.less
@@ -54,7 +54,7 @@
 		border-bottom: 1px solid var(--subtleAccent);
 	}
 	.mixerPreview {
-		img {
+		svg {
 			width: 150px;
 			height: 150px;
 			margin-left: 15px;

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -229,7 +229,11 @@ motors.initialize = async function (callback) {
 
     function update_model(mixer) {
         const imgSrc = getMixerImageSrc(mixer, FC.MIXER_CONFIG.reverseMotorDir);
-        $('.mixerPreview img').attr('src', imgSrc);
+
+        $.get(imgSrc, function(data) {
+            const svg = $(data).find('svg');
+            $('.mixerPreview').html(svg);
+        }, 'xml');
 
         const motorOutputReorderConfig = new MotorOutputReorderConfig(100);
         const domMotorOutputReorderDialogOpen = $('#motorOutputReorderDialogOpen');
@@ -350,10 +354,12 @@ motors.initialize = async function (callback) {
         mixerListElement.sortSelect();
 
         function refreshMixerPreview() {
-            const mixer = FC.MIXER_CONFIG.mixer;
-            const reverse = FC.MIXER_CONFIG.reverseMotorDir ? "_reversed" : "";
+            const imgSrc = getMixerImageSrc(FC.MIXER_CONFIG.mixer, FC.MIXER_CONFIG.reverseMotorDir);
 
-            $('.mixerPreview img').attr('src', `./resources/motor_order/${mixerList[mixer - 1].image}${reverse}.svg`);
+            $.get(imgSrc, function(data) {
+                const svg = $(data).find('svg');
+                $('.mixerPreview').html(svg);
+            }, 'xml');
         }
 
         const reverseMotorSwitchElement = $('#reverseMotorSwitch');

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -227,13 +227,17 @@ motors.initialize = async function (callback) {
         lines.attr('d', graphHelpers.line);
     }
 
-    function update_model(mixer) {
-        const imgSrc = getMixerImageSrc(mixer, FC.MIXER_CONFIG.reverseMotorDir);
-
+    function replace_mixer_preview(imgSrc) {
         $.get(imgSrc, function(data) {
             const svg = $(data).find('svg');
             $('.mixerPreview').html(svg);
         }, 'xml');
+    }
+
+    function update_model(mixer) {
+        const imgSrc = getMixerImageSrc(mixer, FC.MIXER_CONFIG.reverseMotorDir);
+
+        replace_mixer_preview(imgSrc);
 
         const motorOutputReorderConfig = new MotorOutputReorderConfig(100);
         const domMotorOutputReorderDialogOpen = $('#motorOutputReorderDialogOpen');
@@ -355,11 +359,7 @@ motors.initialize = async function (callback) {
 
         function refreshMixerPreview() {
             const imgSrc = getMixerImageSrc(FC.MIXER_CONFIG.mixer, FC.MIXER_CONFIG.reverseMotorDir);
-
-            $.get(imgSrc, function(data) {
-                const svg = $(data).find('svg');
-                $('.mixerPreview').html(svg);
-            }, 'xml');
+            replace_mixer_preview(imgSrc);
         }
 
         const reverseMotorSwitchElement = $('#reverseMotorSwitch');


### PR DESCRIPTION
Web version wouldn't load <img> tags with SVG sources for some reason. Uses SVG directly in place of <img> now