### PR TITLE
Adding Configurator support for new OSD feature Camera Angle Reference

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5110,6 +5110,9 @@
     "osdSetupAlarmsTitle": {
         "message": "Alarms"
     },
+    "osdSetupCarTitle": {
+        "message": "Camera Angle Reference"
+    },
     "osdSetupStatsTitle": {
         "message": "Post Flight Statistics"
     },
@@ -5289,6 +5292,20 @@
     },
     "osdDescElementHorizonSidebars": {
         "message": "Sidebars around artificial horizon indicator"
+    },
+    "osdTextElementCameraAngleReference": {
+        "message": "Camera Angle Reference",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCameraAngleReference": {
+        "message": "Camera angle reference for flying with FPV tilt gimbal"
+    },
+    "osdTextElementCameraAngleReferenceSidebar": {
+        "message": "Camera Angle Reference Sidebar",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCameraAngleReferenceSidebar": {
+        "message": "Sidebar for Camera angle reference"
     },
     "osdTextElementCurrentDraw": {
         "message": "Battery current draw",
@@ -6164,7 +6181,46 @@
       "message": "Altitude",
       "description": "Text of the altitude alarm"
     },
-
+    "osdCarOptionScale": {
+       "message": "Scale",
+       "description": "Scale"
+    },
+    "osdCarOptionWidth": {
+       "message": "Width",
+       "description": "Width"
+    },
+    "osdCarOptionChannel": {
+        "message": "Channel",
+        "description": "Channel"
+    },
+    "osdCarOptionDots": {
+        "message": "Dots",
+        "description": "Dots"
+    },
+    "osdCarOptionSbarScale": {
+        "message": "Sidebar Scale",
+        "description": "Sidebar Scale"
+    },
+    "osdCarOptionSbarLow": {
+        "message": "Sidebar Angle 1/5",
+        "description": "Sidebar Scale"
+    },
+    "osdCarOptionSbarMidLow": {
+        "message": "Sidebar Angle 2/5",
+        "description": "Sidebar Scale"
+    },
+    "osdCarOptionSbarMid": {
+        "message": "Sidebar Angle 3/5",
+        "description": "Sidebar Scale"
+    },
+    "osdCarOptionSbarMidHigh": {
+        "message": "Sidebar Angle 4/5",
+        "description": "Sidebar Scale"
+    },
+    "osdCarOptionSbarHigh": {
+        "message": "Sidebar Angle 5/5",
+        "description": "Sidebar Scale"
+    },
     "osdWarningTextArmingDisabled": {
         "message": "Arming disabled",
         "description": "One of the warnings that can be selected to be shown in the OSD"
@@ -6312,6 +6368,9 @@
     },
     "osdSectionHelpAlarms": {
         "message": "Set the thresholds used for OSD elements with alarm states."
+    },
+    "osdSectionHelpCar": {
+        "message": "Set the Camera Angle Reference parameter values"
     },
     "osdSectionHelpStats": {
         "message": "Set the values dispalyed on the post flight statistics screen."

--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -347,6 +347,30 @@
 			font-weight: normal;
 		}
 	}
+    .car {
+        label {
+            display: block;
+            width: 100%;
+            border-bottom: 1px solid var(--subtleAccent);
+            margin-top: 5px;
+            padding-bottom: 5px;
+            &:last-child {
+                border-bottom: none;
+                padding-bottom: 0;
+            }
+        }
+        input {
+            width: 55px;
+            padding-left: 3px;
+            height: 18px;
+            line-height: 20px;
+            text-align: left;
+            border-radius: 3px;
+            margin-right: 11px;
+            font-size: 11px;
+            font-weight: normal;
+        }
+    }
 	.grid-row {
 		justify-content: flex-start;
 		gap: 7px;

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -233,6 +233,18 @@ const VirtualFC = {
             alt: { display_name: i18n.getMessage('osdTimerAlarmOptionAltitude'), value: 0 },
             time: { display_name: 'Minutes', value: 0 },
         };
+        virtualOSD.data.car = {
+            scale: { display_name: i18n.getMessage('osdCarOptionScale'), value: 0 },
+            width: { display_name: i18n.getMessage('osdCarOptionWidth'), value: 0 },
+            channel: { display_name: i18n.getMessage('osdCarOptionChannel'), value: 0 },
+            dots: { display_name: i18n.getMessage('osdCarOptionDots'), value: 0 },
+            sbar_scale: { display_name: i18n.getMessage('osdCarOptionSbarScale'), value: 0 },
+            sbar_low: { display_name: i18n.getMessage('osdCarOptionSbarLow'), value: 0 },
+            sbar_mid_low: { display_name: i18n.getMessage('osdCarOptionSbarMidLow'), value: 0 },
+            sbar_mid: { display_name: i18n.getMessage('osdCarOptionSbarMid'), value: 0 },
+            sbar_mid_high: { display_name: i18n.getMessage('osdCarOptionSbarMidHigh'), value: 0 },
+            sbar_high: { display_name: i18n.getMessage('osdCarOptionSbarHigh'), value: 0 },
+        };
     },
 };
 

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -111,6 +111,14 @@
                                 <div class="alarms"></div>
                             </div>
                         </div>
+                        <div class="gui_box grey car-container requires-osd-feature" style="display:none;">
+                            <div class="gui_box_titlebar cf_tip">
+                                <div class="spacer_box_title" i18n="osdSetupCarTitle"></div>
+                            </div>
+                            <div class="spacer_box">
+                                <div class="car"></div>
+                            </div>
+                        </div>
                         <div class="gui_box grey warnings-container requires-osd-feature" style="display:none;">
                             <div class="gui_box_titlebar cf_tip" style="margin-bottom: 0px;">
                                 <div class="spacer_box_title">


### PR DESCRIPTION
Camera Angle Reference OSD Feature

Requires: https://github.com/betaflight/betaflight/pull/13070

This is my first pull request so be gentle.  Will be submitting the Betaflight pull request directly after submitting configurator and will reference this pull request in the other.

This is an OSD visual reference for current camera angle intended to be used with a single axis tilt gimbal, like those shown on medlindrone.com

This is currently configured via CLI, will add a GUI for it in the future.

There are five new cli parameters:
    -osd_car_pos (osd element position)
    -osd_car_channel (channel controlling the gimbal/apl)
    -osd_car_scale (scale for adjusting vertical scale / sensitivity) 
    -osd_car_width (width for adjusting witdh between dots)
    -osd_car_dots (number of dots on each side)  

Discussion  https://github.com/betaflight/betaflight/discussions/12438