### PR TITLE
Enable mouse scroll wheel control of sliders

### DIFF
--- a/src/css/tabs/pid_tuning.less
+++ b/src/css/tabs/pid_tuning.less
@@ -732,6 +732,7 @@
 		}
 	}
 	.slidersWarning {
+		text-align: center;
 		background: #ffa3a3;
 		border: 1px solid red;
 		font-weight: 600;

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -904,6 +904,8 @@ motors.initialize = async function (callback) {
             'Home',
             'ArrowUp',
             'ArrowDown',
+            'AltLeft',
+            'AltRight',
         ];
 
         motorsEnableTestModeElement.on('change', function () {
@@ -978,12 +980,20 @@ motors.initialize = async function (callback) {
             }
         });
 
+        $('div.sliders input:not(.master)').on('input wheel', function (e) {
+            self.scrollSlider($(this), e);
+        });
+
         $('div.sliders input.master').on('input', function () {
             const val = $(this).val();
 
             $('div.sliders input:not(:disabled, :last)').val(val);
             $('div.values li:not(:last)').slice(0, self.numberOfValidOutputs).text(val);
             $('div.sliders input:not(:last):first').trigger('input');
+        });
+
+        $('div.sliders input.master').on('input wheel', function (e) {
+            self.scrollSlider($(this), e);
         });
 
         // check if motors are already spinning
@@ -1314,6 +1324,25 @@ motors.refresh = function (callback) {
 
 motors.cleanup = function (callback) {
     if (callback) callback();
+};
+
+motors.scrollSlider = function(slider, e) {
+    if (slider.prop('disabled')) {
+        return;
+    }
+
+    if (!(e.originalEvent?.deltaY && e.originalEvent?.altKey)) {
+        return;
+    }
+
+    e.preventDefault();
+
+    const step = 25;
+    const delta = e.originalEvent.deltaY > 0 ? -step : step;
+    const val = parseInt(slider.val()) + delta;
+    const roundedVal = Math.round(val / step) * step;
+    slider.val(roundedVal);
+    slider.trigger('input');
 };
 
 TABS.motors = motors;

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2021,6 +2021,10 @@ pid_tuning.initialize = function (callback) {
                 self.analyticsChanges['PidTuningSliders'] = "On";
             });
 
+            allPidTuningSliders.each(function (i) {
+               self.sliderOnScroll($(this));
+            });
+
             // reset to middle with double click
             allPidTuningSliders.dblclick(function() {
                 const slider = $(this);
@@ -2116,6 +2120,10 @@ pid_tuning.initialize = function (callback) {
                     self.calculateNewDTermFilters();
                     self.analyticsChanges['DTermFilterTuningSlider'] = "On";
                 }
+            });
+
+            allFilterTuningSliders.each(function() {
+               self.sliderOnScroll($(this));
             });
 
             // reset to middle with double click
@@ -2968,6 +2976,29 @@ pid_tuning.changeRatesTypeLogo = function() {
 
 pid_tuning.expertModeChanged = function(expertModeEnabled) {
     TuningSliders.setExpertMode(expertModeEnabled);
+};
+
+pid_tuning.sliderOnScroll = function(slider, e) {
+    slider.parent().on('input wheel', function(e) {
+        if (slider.prop('disabled')) {
+            return;
+        }
+
+        if (!(e.originalEvent?.deltaY && e.originalEvent?.altKey)) {
+            return;
+        }
+
+        e.preventDefault();
+
+        const step = parseFloat(slider.attr('step'));
+        const delta = e.originalEvent.deltaY > 0 ? -step : step;
+        const preScrollSliderValue = isInt(slider.val()) ? parseInt(slider.val()) : parseFloat(slider.val());
+        const sliderValue =  (Math.floor(preScrollSliderValue * 100) + Math.floor(delta * 100)) / 100;
+
+        slider.val(sliderValue);
+        slider.trigger('input');
+        slider.trigger('change');
+    });
 };
 
 TABS.pid_tuning = pid_tuning;

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -66,9 +66,6 @@
                     <div class="note dMinDisabledNote">
                         <p i18n="pidTuningDMinDisabledNote"></p>
                     </div>
-                    <div class="note slidersWarning">
-                        <p i18n="pidTuningSliderWarning"></p>
-                    </div>
                     <div class="profile_name">
                         <div class="number">
                             <label> <input type="text" name="pidProfileName" maxlength="8" style="width:100px;"/> <span
@@ -373,6 +370,10 @@
                             </tr>
 
                          </table>
+                    </div>
+                    
+                    <div class="gui_box topspacer slidersWarning">
+                        <p i18n="pidTuningSliderWarning"></p>
                     </div>
 
                     <div class="gui_box topspacer nonExpertModeSlidersNote">
@@ -1183,9 +1184,6 @@
                 <div class="note dynamicNotchWarning">
                     <p i18n="pidTuningDynamicNotchFilterDisabledWarning"></p>
                 </div>
-                <div class="note slidersWarning">
-                    <p i18n="pidTuningSliderWarning"></p>
-                </div>
                 <div class="gui_box slidersDisabled">
                     <table class="note-button">
                         <td i18n="pidTuningSlidersDisabled"></td>
@@ -1253,6 +1251,10 @@
                             </td>
                         </tr>
                     </table>
+                </div>
+
+                <div class="gui_box topspacer slidersWarning">
+                    <p i18n="pidTuningSliderWarning"></p>
                 </div>
 
                 <div class="gui_box topspacer nonExpertModeSlidersNote">


### PR DESCRIPTION
This pull request adds the ability to manipulate the PID, filter, and motor sliders with the mouse's scroll wheel.

As demonstrated in the videos below, this is a convenient way of adjusting the sliders and, in the case of the motor sliders, enables you to easily set two motors to exactly the same value (which is almost impossible when clicking on them). The content pane can still be scrolled when the mouse is not directly over an active slider control.

https://github.com/betaflight/betaflight-configurator/assets/741710/bf1a58c9-7725-4384-b2ca-6280f1cfa7b2

https://github.com/betaflight/betaflight-configurator/assets/741710/5509de5b-c14f-4959-bd4d-0e1b943f415c

Since it is not a good experience having the sliders move about the screen while you are scrolling them, I have moved the PID/filter warning boxes from above the sliders to below them. This prevents the sliders from being pushed downwards when the warning appears.

I have also styled them to match the "notes" that they now sit on top of.

![image](https://github.com/betaflight/betaflight-configurator/assets/741710/b6ce8025-4eb0-4c4f-a896-b171d96649f2)

![image](https://github.com/betaflight/betaflight-configurator/assets/741710/dee96faa-f8b4-41d2-963a-8c93bd3ccea1)

