### PR TITLE
Update link to documentation in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,7 @@
 
 2. Pull requests will only be accepted if they are opened against the `master` branch of our repository. Pull requests opened against other branches without prior consent from the maintainers will be closed;
 
-3. Please follow the coding style guidelines: https://github.com/betaflight/betaflight/blob/master/docs/development/CodingStyle.md
+3. Please follow the coding style guidelines: https://betaflight.com/docs/development/CodingStyle
 
 4. Keep your pull requests as small and concise as possible. One pull request should only ever add / update one feature. If the change that you are proposing has a wider scope, consider splitting it over multiple pull requests. In particular, pull requests that combine changes to features and one or more new targets are not acceptable.
 


### PR DESCRIPTION
Edit: Description below has been updated. The PR originally updated links in the language files too.

This link is 404ing as there is no `/docs` directory in the `betaflight` repo. I'm guessing those docs were moved to `betaflight.com` so I've updated the link to what I assume is the correct location within https://betaflight.com.