### PR TITLE
Show magADC values without re-scaling in Sensors Tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3097,7 +3097,7 @@
         "message": "Accelerometer - g (deg)"
     },
     "sensorsMagTitle": {
-        "message": "Magnetometer - Ga"
+        "message": "Magnetometer"
     },
     "sensorsAltitudeTitle": {
         "message": "Altitude - meters"

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -239,9 +239,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.SENSOR_DATA.gyroscope[2] = data.read16() * (4 / 16.4);
 
                 // no clue about scaling factor
-                FC.SENSOR_DATA.magnetometer[0] = data.read16() / 1090;
-                FC.SENSOR_DATA.magnetometer[1] = data.read16() / 1090;
-                FC.SENSOR_DATA.magnetometer[2] = data.read16() / 1090;
+                FC.SENSOR_DATA.magnetometer[0] = data.read16();
+                FC.SENSOR_DATA.magnetometer[1] = data.read16();
+                FC.SENSOR_DATA.magnetometer[2] = data.read16();
                 break;
             case MSPCodes.MSP_SERVO:
                 const servoCount = data.byteLength / 2;

--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -429,9 +429,9 @@ sensors.initialize = function (callback) {
 
                     samples_mag_i = addSampleToData(mag_data, samples_mag_i, FC.SENSOR_DATA.magnetometer);
                     drawGraph(magHelpers, mag_data, samples_mag_i);
-                    raw_data_text_ements.x[2].text(FC.SENSOR_DATA.magnetometer[0].toFixed(2));
-                    raw_data_text_ements.y[2].text(FC.SENSOR_DATA.magnetometer[1].toFixed(2));
-                    raw_data_text_ements.z[2].text(FC.SENSOR_DATA.magnetometer[2].toFixed(2));
+                    raw_data_text_ements.x[2].text(FC.SENSOR_DATA.magnetometer[0].toFixed(0));
+                    raw_data_text_ements.y[2].text(FC.SENSOR_DATA.magnetometer[1].toFixed(0));
+                    raw_data_text_ements.z[2].text(FC.SENSOR_DATA.magnetometer[2].toFixed(0));
                 }
             }
 

--- a/src/tabs/sensors.html
+++ b/src/tabs/sensors.html
@@ -143,8 +143,13 @@
                         <dt i18n="sensorsScale"></dt>
                         <dd class="scale">
                             <select name="mag_scale">
-                                <option value="0.5">0.5</option>
-                                <option value="1" selected="selected">1</option>
+                                <option value="100">100</option>
+                                <option value="200">200</option>
+                                <option value="500">500</option>
+                                <option value="1000">1000</option>
+                                <option value="2000" selected="selected">2000</option>
+                                <option value="5000">5000</option>
+                                <option value="10000">10000</option>
                             </select>
                         </dd>
                         <dt>X:</dt>


### PR DESCRIPTION
## Changes:
- the Mag value shown in Configurator's Sensors tab now shows the un-modified magADC[axis] value, without any scaling.  Previously the magADC values were divided by 1090, the LSB/Gauss sensitivity value for the HMC5883L.  This sensitivity factor was applied to all mag units, regardless of their individual sensitivity factor.  For example, the sensitivity for the QMC5883L is 3000 LSB/Gauss, and for the IST Mag, it is 330 LSB/Gauss.  Using 1090 for these Mags resulted in incorrect Gauss values
- removed the text `- Ga` from the title of the Mag data, since the value is no longer Gauss. 
- increased the available Y axis ranges, from 100 to 10,000.   With a QMC, the default of 3000 LSB/Gauss results in peak magADC values of around 1700 or higher.  Previously these peak values would have been clipped.  Now the incoming Mag values can be visualised in their full range, even if the QMC is set to its maximum sensitivity of 12000 LSB/Gauss.

## Fixes:
- an issue where with a QMC5883L, the highest graph scaling option of 1.0 clipped the magnetic field strength values in the Sensors Mag graph, making it difficult to visualise the max and min values.
- an issue where the reported value was supposed to be in Gauss, but the reported value was in fact only accurate in Gauss for the HMC5883L, for all other Mag units the reported value was incorrect.

## Notes:
Using un-scaled magADC values greatly simplifies the calculation of the Mag Cal value to be used for a given axis.

If the user points a given axis directly into (parallel to) the field, it will return its most positive, or Maximum, value when the values of the other two axes are zero.  

The Minimum value can be found by rotating the quad 180 degrees until it points directly away from (anti-parallel to) the field, and seeking out the most negative value, which again will be when the other two axes read zero.

The Cal value to use for that axis is the simple average of the two values, ie `((Max + Min)/2)`.  For instance, if the Max value was 1800 and the Min was -1400, the cal value for the axis would be `((1800 - 1400)/2)`, or 200.

Once that calibration value is applied, a check can be made that the Max and Min values are numerically equal, by repeating the above test.  In the above example, after applying a Cal value for the axis of 200, a re-check should show the Max of 1600 `(1800 - 200)` and the Min of -1600 `(-1400 - 200)`.  

As a simple check of an existing calibration, the Cal factor is correct when `Max = -Min` for each axis.