### PR TITLE
feat: only use rollup output for build

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "nw-builder": "3.8.3",
     "os": "^0.1.2",
     "postcss": "^8.4.31",
-    "rollup": "^3.9.0",
+    "rollup": "^3.29.4",
     "rollup-plugin-copy": "^3.5.0",
     "rollup-plugin-vue": "^5.*.*",
     "rpm-builder": "^1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13263,10 +13263,17 @@ rollup-pluginutils@^2.8.2:
   dependencies:
     estree-walker "^0.6.1"
 
-rollup@^3.27.1, rollup@^3.9.0:
+rollup@^3.27.1:
   version "3.29.0"
   resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.0.tgz#1b40e64818afc979c7e5bef93de675829288986b"
   integrity sha512-nszM8DINnx1vSS+TpbWKMkxem0CDWk3cSit/WWCBVs9/JZ1I/XLwOsiUglYuYReaeWWSsW9kge5zE5NZtf/a4w==
+  optionalDependencies:
+    fsevents "~2.3.2"
+
+rollup@^3.29.4:
+  version "3.29.4"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-3.29.4.tgz#4d70c0f9834146df8705bfb69a9a19c9e1109981"
+  integrity sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==
   optionalDependencies:
     fsevents "~2.3.2"
 


### PR DESCRIPTION
Current build setup copies files into folder and then runs full yarn installation.

Since we are building everything based on the usage we don't need all the `node_modules` and friends.

This changes reduces final package size after unpack on mac by ~100mb. Need to verify other platforms

### Before

<img width="759" alt="Screenshot 2023-10-08 at 20 26 58" src="https://github.com/betaflight/betaflight-configurator/assets/7774918/5410c7c7-a9de-4890-bcb1-3a6a752859d5">
<img width="414" alt="Screenshot 2023-10-08 at 20 28 18" src="https://github.com/betaflight/betaflight-configurator/assets/7774918/36a3a654-21c7-4d2e-ad7d-bf83f9358e9a">

### After

<img width="760" alt="Screenshot 2023-10-08 at 20 25 56" src="https://github.com/betaflight/betaflight-configurator/assets/7774918/119c397d-9193-4182-ba3f-59f7df6dbd52">
<img width="485" alt="Screenshot 2023-10-08 at 20 27 29" src="https://github.com/betaflight/betaflight-configurator/assets/7774918/c789371f-528e-45ec-85a6-fd2d8ef4477d">
