### PR TITLE
Mag cal values

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3097,7 +3097,7 @@
         "message": "Accelerometer - g (deg)"
     },
     "sensorsMagTitle": {
-        "message": "Magnetometer - Ga"
+        "message": "Magnetometer"
     },
     "sensorsAltitudeTitle": {
         "message": "Altitude - meters"

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -239,9 +239,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.SENSOR_DATA.gyroscope[2] = data.read16() * (4 / 16.4);
 
                 // no clue about scaling factor
-                FC.SENSOR_DATA.magnetometer[0] = data.read16() / 1090;
-                FC.SENSOR_DATA.magnetometer[1] = data.read16() / 1090;
-                FC.SENSOR_DATA.magnetometer[2] = data.read16() / 1090;
+                FC.SENSOR_DATA.magnetometer[0] = data.read16();
+                FC.SENSOR_DATA.magnetometer[1] = data.read16();
+                FC.SENSOR_DATA.magnetometer[2] = data.read16();
                 break;
             case MSPCodes.MSP_SERVO:
                 const servoCount = data.byteLength / 2;

--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -216,17 +216,17 @@ sensors.initialize = function (callback) {
     function magCalX(newData) {
         magMaxX = Math.max(magMaxX, newData);
         magMinX = Math.min(magMinX, newData);
-        return ((magMaxX + magMinX)/2).toFixed(2);
+        return ((magMaxX + magMinX)/2).toFixed(0);
     }
     function magCalY(newData) {
         magMaxY = Math.max(magMaxY, newData);
         magMinY = Math.min(magMinY, newData);
-        return ((magMaxY + magMinY)/2).toFixed(2);
+        return ((magMaxY + magMinY)/2).toFixed(0);
     }
     function magCalZ(newData) {
         magMaxZ = Math.max(magMaxZ, newData);
         magMinZ = Math.min(magMinZ, newData);
-        return ((magMaxZ + magMinZ)/2).toFixed(2);
+        return ((magMaxZ + magMinZ)/2).toFixed(0);
     }
 
 
@@ -453,19 +453,20 @@ sensors.initialize = function (callback) {
                     samples_mag_i = addSampleToData(mag_data, samples_mag_i, FC.SENSOR_DATA.magnetometer);
                     drawGraph(magHelpers, mag_data, samples_mag_i);
 
-                    const magX = FC.SENSOR_DATA.magnetometer[0].toFixed(2);
-                    const magY = FC.SENSOR_DATA.magnetometer[1].toFixed(2);
-                    const magZ = FC.SENSOR_DATA.magnetometer[2].toFixed(2);
+                    const magX = FC.SENSOR_DATA.magnetometer[0];
+                    const magY = FC.SENSOR_DATA.magnetometer[1];
+                    const magZ = FC.SENSOR_DATA.magnetometer[2];
                     const magXSquared = Math.pow(FC.SENSOR_DATA.magnetometer[0], 2);
                     const magYSquared = Math.pow(FC.SENSOR_DATA.magnetometer[1], 2);
                     const magZSquared = Math.pow(FC.SENSOR_DATA.magnetometer[2], 2);
-                    const magSumSqR = Math.sqrt(magXSquared + magYSquared + magZSquared).toFixed(2);
+                    const magSumSqR = Math.sqrt(magXSquared + magYSquared + magZSquared).toFixed(0);
                     const magCalibrationX = magCalX(magX);
                     const magCalibrationY = magCalY(magY);
                     const magCalibrationZ = magCalZ(magZ);
 
                     samples_mag_i = addSampleToData(mag_data, samples_mag_i, FC.SENSOR_DATA.magnetometer);
                     drawGraph(magHelpers, mag_data, samples_mag_i);
+
 //                    raw_data_text_ements.x[2].text(FC.SENSOR_DATA.magnetometer[0].toFixed(2));
                     raw_data_text_ements.x[2].text(`${magX}  C${magCalibrationX}`);
 //                    raw_data_text_ements.y[2].text(FC.SENSOR_DATA.magnetometer[1].toFixed(2));

--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -207,6 +207,29 @@ sensors.initialize = function (callback) {
         }
     }
 
+    let magMaxX = 0;
+    let magMinX = 0;
+    let magMaxY = 0;
+    let magMinY = 0;
+    let magMaxZ = 0;
+    let magMinZ = 0;
+    function magCalX(newData) {
+        magMaxX = Math.max(magMaxX, newData);
+        magMinX = Math.min(magMinX, newData);
+        return ((magMaxX + magMinX)/2).toFixed(2);
+    }
+    function magCalY(newData) {
+        magMaxY = Math.max(magMaxY, newData);
+        magMinY = Math.min(magMinY, newData);
+        return ((magMaxY + magMinY)/2).toFixed(2);
+    }
+    function magCalZ(newData) {
+        magMaxZ = Math.max(magMaxZ, newData);
+        magMinZ = Math.min(magMinZ, newData);
+        return ((magMaxZ + magMinZ)/2).toFixed(2);
+    }
+
+
     $('#content').load("./tabs/sensors.html", function load_html() {
         // translate to user-selected language
         i18n.localizePage();
@@ -429,9 +452,28 @@ sensors.initialize = function (callback) {
 
                     samples_mag_i = addSampleToData(mag_data, samples_mag_i, FC.SENSOR_DATA.magnetometer);
                     drawGraph(magHelpers, mag_data, samples_mag_i);
-                    raw_data_text_ements.x[2].text(FC.SENSOR_DATA.magnetometer[0].toFixed(2));
-                    raw_data_text_ements.y[2].text(FC.SENSOR_DATA.magnetometer[1].toFixed(2));
-                    raw_data_text_ements.z[2].text(FC.SENSOR_DATA.magnetometer[2].toFixed(2));
+
+                    const magX = FC.SENSOR_DATA.magnetometer[0].toFixed(2);
+                    const magY = FC.SENSOR_DATA.magnetometer[1].toFixed(2);
+                    const magZ = FC.SENSOR_DATA.magnetometer[2].toFixed(2);
+                    const magXSquared = Math.pow(FC.SENSOR_DATA.magnetometer[0], 2);
+                    const magYSquared = Math.pow(FC.SENSOR_DATA.magnetometer[1], 2);
+                    const magZSquared = Math.pow(FC.SENSOR_DATA.magnetometer[2], 2);
+                    const magSumSqR = Math.sqrt(magXSquared + magYSquared + magZSquared).toFixed(2);
+                    const magCalibrationX = magCalX(magX);
+                    const magCalibrationY = magCalY(magY);
+                    const magCalibrationZ = magCalZ(magZ);
+
+                    samples_mag_i = addSampleToData(mag_data, samples_mag_i, FC.SENSOR_DATA.magnetometer);
+                    drawGraph(magHelpers, mag_data, samples_mag_i);
+//                    raw_data_text_ements.x[2].text(FC.SENSOR_DATA.magnetometer[0].toFixed(2));
+                    raw_data_text_ements.x[2].text(`${magX}  C${magCalibrationX}`);
+//                    raw_data_text_ements.y[2].text(FC.SENSOR_DATA.magnetometer[1].toFixed(2));
+                    raw_data_text_ements.y[2].text(`${magY}  C${magCalibrationY}`);
+//                    raw_data_text_ements.z[2].text(FC.SENSOR_DATA.magnetometer[2].toFixed(2));
+//                    raw_data_text_ements.z[2].text(`${magZ}  R${magSumSqR}`);
+                    raw_data_text_ements.z[2].text(`${magZ}  C${magCalibrationZ}`);
+
                 }
             }
 

--- a/src/js/tabs/sensors.js
+++ b/src/js/tabs/sensors.js
@@ -464,16 +464,14 @@ sensors.initialize = function (callback) {
                     const magCalibrationY = magCalY(magY);
                     const magCalibrationZ = magCalZ(magZ);
 
-                    samples_mag_i = addSampleToData(mag_data, samples_mag_i, FC.SENSOR_DATA.magnetometer);
-                    drawGraph(magHelpers, mag_data, samples_mag_i);
 
 //                    raw_data_text_ements.x[2].text(FC.SENSOR_DATA.magnetometer[0].toFixed(2));
-                    raw_data_text_ements.x[2].text(`${magX}  C${magCalibrationX}`);
+                    raw_data_text_ements.x[2].text(`${magX} ${magCalibrationX}`);
 //                    raw_data_text_ements.y[2].text(FC.SENSOR_DATA.magnetometer[1].toFixed(2));
-                    raw_data_text_ements.y[2].text(`${magY}  C${magCalibrationY}`);
+                    raw_data_text_ements.y[2].text(`${magY} ${magCalibrationY}`);
 //                    raw_data_text_ements.z[2].text(FC.SENSOR_DATA.magnetometer[2].toFixed(2));
 //                    raw_data_text_ements.z[2].text(`${magZ}  R${magSumSqR}`);
-                    raw_data_text_ements.z[2].text(`${magZ}  C${magCalibrationZ}`);
+                    raw_data_text_ements.z[2].text(`${magZ} ${magCalibrationZ} ${magSumSqR}`);
 
                 }
             }

--- a/src/tabs/sensors.html
+++ b/src/tabs/sensors.html
@@ -143,8 +143,13 @@
                         <dt i18n="sensorsScale"></dt>
                         <dd class="scale">
                             <select name="mag_scale">
-                                <option value="0.5">0.5</option>
-                                <option value="1" selected="selected">1</option>
+                                <option value="100">100</option>
+                                <option value="200">200</option>
+                                <option value="500">500</option>
+                                <option value="1000">1000</option>
+                                <option value="2000" selected="selected">2000</option>
+                                <option value="5000">5000</option>
+                                <option value="10000">10000</option>
                             </select>
                         </dd>
                         <dt>X:</dt>

--- a/src/tabs/sensors.html
+++ b/src/tabs/sensors.html
@@ -129,6 +129,9 @@
                         <dt i18n="sensorsRefresh"></dt>
                         <dd class="rate">
                             <select name="mag_refrash_rate">
+                                <option value="1">1 ms</option>
+                                <option value="2">2 ms</option>
+                                <option value="5">5 ms</option>
                                 <option value="10">10 ms</option>
                                 <option value="20">20 ms</option>
                                 <option value="30">30 ms</option>

--- a/src/tabs/sensors.html
+++ b/src/tabs/sensors.html
@@ -130,13 +130,13 @@
                         <dd class="rate">
                             <select name="mag_refrash_rate">
                                 <option value="1">1 ms</option>
-                                <option value="2">2 ms</option>
+                                <option value="2" selected="selected">2 ms</option>
                                 <option value="5">5 ms</option>
                                 <option value="10">10 ms</option>
                                 <option value="20">20 ms</option>
                                 <option value="30">30 ms</option>
                                 <option value="40">40 ms</option>
-                                <option value="50" selected="selected">50 ms</option>
+                                <option value="50">50ms</option>
                                 <option value="100">100 ms</option>
                                 <option value="250">250 ms</option>
                                 <option value="500">500 ms</option>
@@ -170,6 +170,9 @@
                     <g class="axis x" transform="translate(40, 120)"></g>
                     <g class="axis y" transform="translate(40, 10)"></g>
                 </svg>
+                <div>
+                    <p>Maybe sensor tab data would be better put here</p>
+                </div>
                 <div class="clear-both"></div>
             </div>
         </div>


### PR DESCRIPTION
## For testing only!

This PR makes two changes to the Sensors Tab display of Mag data.

- Uses 'raw' Mag units in the display of Mag sensor data, using PR [3593](https://github.com/betaflight/betaflight-configurator/pull/3593)

- For each axis, shows, to the right of the instantaneous Mag sensor value, the average of the min and max values received on that axis since the Sensors Tab was opened.  This value is preceded by 'C' for 'Cal`.

If the user goes `set mag_calibration = 0,0,0` and clears their existing cal values, they can move the quad around so that, sequentially, one Mag axis, and then its opposite end, is pointed North into the local magnetic field vector.  When a max and min have been defined, the value after C is the cal value to use for the axis. 

Also a previous calibration can be checked.  A good calibration will return within 1% of zero on each axis.  This can be used to validate the 'hard iron' or 'zero point' calibration that Betaflight uses.

I also calculate the root (sum of squares of x,y,x) value, into `magSumSqR` which can be thought of as the 'radius' of the 'sphere' of mag readings.  The value should equal the local value of the earths field, after correction for the internal gain of the sensor.  Furthermore, if there are no soft iron effects, the value should remain constant regardless of the angle of the quad.  If the 'sphere' appears deformed, the 'radius' will not be consistent, and the value will decrease, or increase, consistently, at certain angles.  BUT... I can't figure out how to display this `magSumSqR` value; if anyone could help me with that, I'd be grateful.

I made a small video temporarily here...

https://github.com/betaflight/betaflight-configurator/assets/11737748/a7348ee1-5d20-4e6b-886d-94d6809dd8d4

