### PR TITLE
Add Link Quality alarm value to the OSD tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6155,6 +6155,10 @@
       "message": "Altitude",
       "description": "Text of the altitude alarm"
     },
+    "osdTimerAlarmOptionLinkQuality": {
+        "message": "Link Quality",
+        "description": "Text of the link quality alarm"
+      },
     "osdWarningTextArmingDisabled": {
         "message": "Arming disabled",
         "description": "One of the warnings that can be selected to be shown in the OSD"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2212,6 +2212,10 @@ OSD.msp = {
                 result.push8(OSD.data.parameters.cameraFrameWidth);
                 result.push8(OSD.data.parameters.cameraFrameHeight);
             }
+
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                result.push16(OSD.data.alarms.link_quality.value);
+            }
         }
         return result;
     },
@@ -2422,6 +2426,10 @@ OSD.msp = {
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_43)) {
             d.parameters.cameraFrameWidth = view.readU8();
             d.parameters.cameraFrameHeight = view.readU8();
+        }
+
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+            d.alarms['link_quality'] = { display_name: i18n.getMessage('osdTimerAlarmOptionLinkQuality'), value: view.readU16() };
         }
 
         this.processOsdElements(d, itemsPositionsRead);


### PR DESCRIPTION
Now that ELRS is the main radio control link, I think is important to let the user config the link quality (the recommended rssi value to be used with ELRS) directly in the Configurator OSD tab, like other alarms.

![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/81728b20-a5bb-4956-b54e-542f65b65987)

This PR needs to be merged after the firmware part: https://github.com/betaflight/betaflight/pull/13121