### PR TITLE
Sort and translate font name at OSD tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5058,8 +5058,8 @@
         "message": "OSD Profile {{profileNumber}}",
         "description": "Content of the selector for the OSD Profile in the preview"
     },
-    "osdSetupPreviewSelectFontElement": {
-        "message": "Font {{fontName}}",
+    "osdSetupPreviewSelectFont": {
+        "message": "Font",
         "description": "Content of the selector for the OSD Font in the preview"
     },
     "osdSetupFontTypeDefault": {
@@ -5074,9 +5074,9 @@
         "message": "Large",
         "description": "Font Large"
     },
-    "osdSetupFontTypeExtraLarge": {
-        "message": "Extra Large",
-        "description": "Font Extra Large"
+    "osdSetupFontTypeLargeExtra": {
+        "message": "Large Extra",
+        "description": "Font Large Extra"
     },
     "osdSetupFontTypeBetaflight": {
         "message": "Betaflight",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5062,6 +5062,46 @@
         "message": "Font {{fontName}}",
         "description": "Content of the selector for the OSD Font in the preview"
     },
+    "osdSetupFontTypeDefault": {
+        "message": "Default",
+        "description": "Font Default"
+    },
+    "osdSetupFontTypeBold": {
+        "message": "Bold",
+        "description": "Font Bold"
+    },
+    "osdSetupFontTypeLarge": {
+        "message": "Large",
+        "description": "Font Large"
+    },
+    "osdSetupFontTypeExtraLarge": {
+        "message": "Extra Large",
+        "description": "Font Extra Large"
+    },
+    "osdSetupFontTypeBetaflight": {
+        "message": "Betaflight",
+        "description": "Font Betaflight"
+    },
+    "osdSetupFontTypeDigital": {
+        "message": "Digital",
+        "description": "Font Digital"
+    },
+    "osdSetupFontTypeClarity": {
+        "message": "Clarity",
+        "description": "Font Clarity"
+    },
+    "osdSetupFontTypeVision": {
+        "message": "Vision",
+        "description": "Font Vision"
+    },
+    "osdSetupFontTypeImpact": {
+        "message": "Impact",
+        "description": "Font Impact"
+    },
+    "osdSetupFontTypeImpactMini": {
+        "message": "Impact Mini",
+        "description": "Font Impact Mini"
+    },
     "osdSetupPreviewCheckZoom": {
         "message": "Zoom",
         "description": "Check to select a bigger display of the OSD preview in small screens"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1833,7 +1833,7 @@ OSD.constants = {
         { file: "default", name: "osdSetupFontTypeDefault" },
         { file: "bold", name: "osdSetupFontTypeBold" },
         { file: "large", name: "osdSetupFontTypeLarge" },
-        { file: "extra_large", name: "osdSetupFontTypeExtraLarge" },
+        { file: "extra_large", name: "osdSetupFontTypeLargeExtra" },
         { file: "betaflight", name: "osdSetupFontTypeBetaflight" },
         { file: "digital", name: "osdSetupFontTypeDigital" },
         { file: "clarity", name: "osdSetupFontTypeClarity" },
@@ -3043,12 +3043,11 @@ osd.initialize = function(callback) {
 
                         // Standard fonts
                         OSD.constants.FONT_TYPES.forEach(function(e) {
-                            const optionText = i18n.getMessage('osdSetupPreviewSelectFontElement', {fontName : i18n.getMessage(e.name)});
-                            osdFontSelectorElement.append(new Option(optionText, e.file));
+                            osdFontSelectorElement.append(new Option(i18n.getMessage(e.name), e.file));
                         });
 
                         // Sort the element, if need to group, do it by lexical sort, ie. by naming of (the translated) selection text
-                        osdFontSelectorElement.sortSelect(i18n.getMessage("osdSetupFontTypeDefault"));
+                        osdFontSelectorElement.sortSelect(i18n.getMessage("osdSetupPreviewSelectFont"));
 
                         osdFontSelectorElement.change(function() {
                             // Change the font selected in the Font Manager, in this way it is easier to flash if the user likes it

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1830,16 +1830,16 @@ OSD.constants = {
 
     },
     FONT_TYPES: [
-        { file: "default", name: "Default" },
-        { file: "bold", name: "Bold" },
-        { file: "large", name: "Large" },
-        { file: "extra_large", name: "Extra Large" },
-        { file: "betaflight", name: "Betaflight" },
-        { file: "digital", name: "Digital" },
-        { file: "clarity", name: "Clarity" },
-        { file: "vision", name: "Vision" },
-        { file: "impact", name: "Impact" },
-        { file: "impact_mini", name: "Impact Mini" },
+        { file: "default", name: "osdSetupFontTypeDefault" },
+        { file: "bold", name: "osdSetupFontTypeBold" },
+        { file: "large", name: "osdSetupFontTypeLarge" },
+        { file: "extra_large", name: "osdSetupFontTypeExtraLarge" },
+        { file: "betaflight", name: "osdSetupFontTypeBetaflight" },
+        { file: "digital", name: "osdSetupFontTypeDigital" },
+        { file: "clarity", name: "osdSetupFontTypeClarity" },
+        { file: "vision", name: "osdSetupFontTypeVision" },
+        { file: "impact", name: "osdSetupFontTypeImpact" },
+        { file: "impact_mini", name: "osdSetupFontTypeImpactMini" },
     ],
 };
 
@@ -2666,10 +2666,13 @@ osd.initialize = function(callback) {
             const option = $('<option>', {
                 "data-font-file": e.file,
                 value: e.file,
-                text: e.name,
+                text: i18n.getMessage(e.name),
             });
             fontPresetsElement.append($(option));
         });
+
+        // Sort the element, if need to group, do it by lexical sort, ie. by naming of (the translated) selection text
+        fontPresetsElement.sortSelect(i18n.getMessage("osdSetupFontTypeDefault"));
 
         const fontbuttons = $('.fontpresets_wrapper');
         fontbuttons.append($('<button>', { class: "load_font_file", i18n: "osdSetupOpenFont" }));
@@ -3040,9 +3043,12 @@ osd.initialize = function(callback) {
 
                         // Standard fonts
                         OSD.constants.FONT_TYPES.forEach(function(e) {
-                            const optionText = i18n.getMessage('osdSetupPreviewSelectFontElement', {fontName : e.name});
+                            const optionText = i18n.getMessage('osdSetupPreviewSelectFontElement', {fontName : i18n.getMessage(e.name)});
                             osdFontSelectorElement.append(new Option(optionText, e.file));
                         });
+
+                        // Sort the element, if need to group, do it by lexical sort, ie. by naming of (the translated) selection text
+                        osdFontSelectorElement.sortSelect(i18n.getMessage("osdSetupFontTypeDefault"));
 
                         osdFontSelectorElement.change(function() {
                             // Change the font selected in the Font Manager, in this way it is easier to flash if the user likes it

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -3047,7 +3047,7 @@ osd.initialize = function(callback) {
                         });
 
                         // Sort the element, if need to group, do it by lexical sort, ie. by naming of (the translated) selection text
-                        osdFontSelectorElement.sortSelect(i18n.getMessage("osdSetupPreviewSelectFont"));
+                        osdFontSelectorElement.sortSelect(i18n.getMessage("osdSetupFontTypeDefault"));
 
                         osdFontSelectorElement.change(function() {
                             // Change the font selected in the Font Manager, in this way it is easier to flash if the user likes it

--- a/src/tabs/osd.html
+++ b/src/tabs/osd.html
@@ -43,6 +43,7 @@
                                    <select class="osdprofile-selector">
                                        <!--  Populated at runtime -->
                                    </select>
+                                   <label id="osdprofile-selector-font" i18n="osdSetupPreviewSelectFont"></label>
                                    <select class="osdfont-selector">
                                        <!-- Populated at runtime -->
                                    </select>


### PR DESCRIPTION
- Translate font name
- Sort optionlist for fonts at OSD tab by translated name

Now:
![image](https://github.com/betaflight/betaflight-configurator/assets/99370924/41e3444e-151a-44cf-a39c-bc4a3568182e)
![image](https://github.com/betaflight/betaflight-configurator/assets/99370924/d420e212-e5bd-4d7a-afda-c5a3f9631641)

Before:
![image](https://github.com/betaflight/betaflight-configurator/assets/99370924/83f61f70-ae93-40ce-b8a5-650bbcdc77a3)
![image](https://github.com/betaflight/betaflight-configurator/assets/99370924/c05310af-8a7a-4c0b-b4c9-d049b6e0afe4)
