### PR TITLE
Show idleMinRpm on motor tab (active profile)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1355,6 +1355,10 @@
         "message": "The pole count is the number of magnets on the bell of the motor. Do NOT count the stators where the windings are located. 5\" motors usually have 14 magnets, 3\" or smaller often have 12 magnets.",
         "description": "Help text for the Motor poles field of the ESC/Motor configuration"
     },
+    "configurationMotorIdleRpmHelp" : {
+        "message": "You will be able to edit Dynamic Idle setting on the PID tuning tab as this setting is profile dependant. When Dynamic Idle is set to zero static motor idle will apply",
+        "description": "Help text for dynamic idle setting" 
+    },
     "configurationThrottleMinimum": {
         "message": "Minimum Throttle (Lowest ESC value when armed)"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1356,7 +1356,7 @@
         "description": "Help text for the Motor poles field of the ESC/Motor configuration"
     },
     "configurationMotorIdleRpmHelp" : {
-        "message": "You will be able to edit Dynamic Idle setting on the PID tuning tab as this setting is profile dependant. When Dynamic Idle is set to zero static motor idle will apply",
+        "message": "This is the dynamic idle value from the active PID profile. When Dynamic Idle is set to zero, only static motor idle will apply. Change the Dynamic Idle settings on the PID tuning tab.",
         "description": "Help text for dynamic idle setting" 
     },
     "configurationThrottleMinimum": {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -103,6 +103,12 @@ input[type="number"] {
         margin-left: 5px;
     }
 }
+.noarrows {
+    input::-webkit-outer-spin-button,
+    input::-webkit-inner-spin-button {
+        -webkit-appearance: none;
+    }
+}
 .clear-both {
     clear: both;
 }

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -1164,13 +1164,10 @@ motors.initialize = async function (callback) {
             FC.PID_ADVANCED_CONFIG.motor_pwm_rate = parseInt($('input[name="unsyncedpwmfreq"]').val());
             FC.PID_ADVANCED_CONFIG.digitalIdlePercent = parseFloat($('input[name="digitalIdlePercent"]').val());
 
-            FC.ADVANCED_TUNING.idleMinRpm = parseInt($('input[name="idleMinRpm"]').val());
-
             await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_MIXER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MIXER_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_MOTOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_MOTOR_3D_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_3D_CONFIG));
-            await MSP.promise(MSPCodes.MSP_SET_PID_ADVANCED, mspHelper.crunch(MSPCodes.MSP_SET_PID_ADVANCED));
             await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_ARMING_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ARMING_CONFIG));
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -281,6 +281,7 @@ motors.initialize = async function (callback) {
             dshotBidir:         FC.MOTOR_CONFIG.use_dshot_telemetry,
             motorPoles:         FC.MOTOR_CONFIG.motor_poles,
             digitalIdlePercent: FC.PID_ADVANCED_CONFIG.digitalIdlePercent,
+            idleMinRpm:         FC.ADVANCED_TUNING.idleMinRpm,
             _3ddeadbandlow:     FC.MOTOR_3D_CONFIG.deadband3d_low,
             _3ddeadbandhigh:    FC.MOTOR_3D_CONFIG.deadband3d_high,
             _3dneutral:         FC.MOTOR_3D_CONFIG.neutral,
@@ -693,6 +694,8 @@ motors.initialize = async function (callback) {
         unsyncedPWMSwitchElement.prop('checked', FC.PID_ADVANCED_CONFIG.use_unsyncedPwm !== 0).trigger("change");
         $('input[name="unsyncedpwmfreq"]').val(FC.PID_ADVANCED_CONFIG.motor_pwm_rate);
         $('input[name="digitalIdlePercent"]').val(FC.PID_ADVANCED_CONFIG.digitalIdlePercent);
+        $('input[name="idleMinRpm"]').val(FC.ADVANCED_TUNING.idleMinRpm);
+
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_42)) {
             dshotBidirElement.prop('checked', FC.MOTOR_CONFIG.use_dshot_telemetry).trigger("change");
 
@@ -771,6 +774,7 @@ motors.initialize = async function (callback) {
             divUnsyncedPWMFreq.toggle(protocolConfigured && !digitalProtocol);
 
             $('div.digitalIdlePercent').toggle(protocolConfigured && digitalProtocol);
+            $('div.idleMinRpm').toggle(protocolConfigured && digitalProtocol && FC.MOTOR_CONFIG.use_dshot_telemetry);
 
             if (FC.ADVANCED_TUNING.idleMinRpm && FC.MOTOR_CONFIG.use_dshot_telemetry) {
                 $('div.digitalIdlePercent').hide();
@@ -1160,10 +1164,13 @@ motors.initialize = async function (callback) {
             FC.PID_ADVANCED_CONFIG.motor_pwm_rate = parseInt($('input[name="unsyncedpwmfreq"]').val());
             FC.PID_ADVANCED_CONFIG.digitalIdlePercent = parseFloat($('input[name="digitalIdlePercent"]').val());
 
+            FC.ADVANCED_TUNING.idleMinRpm = parseInt($('input[name="idleMinRpm"]').val());
+
             await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_MIXER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MIXER_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_MOTOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_MOTOR_3D_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_3D_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_PID_ADVANCED, mspHelper.crunch(MSPCodes.MSP_SET_PID_ADVANCED));
             await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_ARMING_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ARMING_CONFIG));
 

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -105,11 +105,11 @@
                                 <div class="number idleMinRpm">
                                     <label>
                                         <div class="numberspacer">
-                                            <input type="number" name="idleMinRpm" min="0" max="100" step="1"/>
+                                            <input type="number" name="idleMinRpm" min="0" max="100" step="1" readonly/>
                                         </div>
                                         <span i18n="pidTuningIdleMinRpm"></span>
                                     </label>
-                                    <div class="helpicon cf_tip" i18n_title="pidTuningIdleMinRpmHelp"></div>
+                                    <div class="helpicon cf_tip" i18n_title="configurationMotorIdleRpmHelp"></div>
                                 </div>
                                 <div class="number digitalIdlePercent">
                                     <label>

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -102,15 +102,6 @@
                                     </label>
                                     <div class="helpicon cf_tip" i18n_title="configurationMotorPolesHelp"></div>
                                 </div>
-                                <div class="number digitalIdlePercent">
-                                    <label>
-                                        <div class="numberspacer">
-                                            <input type="number" name="digitalIdlePercent" min="0.00" max="20.00" step="0.01"/>
-                                        </div>
-                                        <span i18n="configurationDigitalIdlePercent"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
-                                </div>
                                 <div class="number idleMinRpm">
                                     <label>
                                         <div class="numberspacer">
@@ -119,6 +110,15 @@
                                         <span i18n="pidTuningIdleMinRpm"></span>
                                     </label>
                                     <div class="helpicon cf_tip" i18n_title="pidTuningIdleMinRpmHelp"></div>
+                                </div>
+                                <div class="number digitalIdlePercent">
+                                    <label>
+                                        <div class="numberspacer">
+                                            <input type="number" name="digitalIdlePercent" min="0.00" max="20.00" step="0.01"/>
+                                        </div>
+                                        <span i18n="configurationDigitalIdlePercent"></span>
+                                    </label>
+                                    <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
                                 <div class="number minthrottle">
                                     <label>

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -104,7 +104,7 @@
                                 </div>
                                 <div class="number idleMinRpm">
                                     <label>
-                                        <div class="numberspacer">
+                                        <div class="numberspacer noarrows">
                                             <input type="number" name="idleMinRpm" min="0" max="100" step="1" readonly/>
                                         </div>
                                         <span i18n="pidTuningIdleMinRpm"></span>

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -111,6 +111,15 @@
                                     </label>
                                     <div class="helpicon cf_tip" i18n_title="configurationDigitalIdlePercentHelp"></div>
                                 </div>
+                                <div class="number idleMinRpm">
+                                    <label>
+                                        <div class="numberspacer">
+                                            <input type="number" name="idleMinRpm" min="0" max="100" step="1"/>
+                                        </div>
+                                        <span i18n="pidTuningIdleMinRpm"></span>
+                                    </label>
+                                    <div class="helpicon cf_tip" i18n_title="pidTuningIdleMinRpmHelp"></div>
+                                </div>
                                 <div class="number minthrottle">
                                     <label>
                                         <div class="numberspacer">


### PR DESCRIPTION
This PR adds the ability to configure either idleMinRpm (enabled and for active PID profile only) or digitalIdlePercent (disabled)  depending on Bidirectional Dshot setting. This way it makes more sense to users which setting is used.

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/5c76b2fe-f9fd-4beb-a6ba-32375b0348bc)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/bc242a09-38bc-4b70-80f3-3f7e38917875)

When idleMinRpm is disabled and Bidirectional Dshot is enabled we get:

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/26ae69ef-4f51-4531-8feb-a9d0e8d2867a)