### PR TITLE
Presets: ignore CLI error messages caused by resetting defaults

### DIFF
--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -94,6 +94,14 @@ presets.applyCommandsList = function(strings) {
     });
 };
 
+presets.forceSave = function() {
+    this.cliEngine.sendLine(CliEngine.s_commandSave, null, () => {
+        // In case of batch CLI commands errors Firmware requeires extra "save" comand for CLI safety.
+        this.cliEngine.sendLine(CliEngine.s_commandSave);
+    });
+    this.disconnectCliMakeSure();
+};
+
 presets.onSaveClick = function() {
     this._domProgressDialogProgressBar.val(0);
     this._domProgressDialog.showModal();
@@ -111,8 +119,7 @@ presets.onSaveClick = function() {
                 this._domDialogCliErrorsSavePressed = false;
             } else {
                 this._domProgressDialog.close();
-                this.cliEngine.sendLine(CliEngine.s_commandSave);
-                this.disconnectCliMakeSure();
+                this.forceSave();
             }
         });
     });
@@ -156,13 +163,7 @@ presets.setupMenuButtons = function() {
     this._domButtonaSaveAnyway.on("click", () => {
         this._domDialogCliErrorsSavePressed = true;
         this._domDialogCliErrors[0].close();
-        this.cliEngine.sendLine(CliEngine.s_commandSave, null, () => {
-            // In case of batch CLI commands errors Firmware requeires extra "save" comand for CLI safety.
-            // No need for this safety in presets as preset tab already detected errors and showed them to the user.
-            // At this point user clicked "save anyway".
-            this.cliEngine.sendLine(CliEngine.s_commandSave);
-        });
-        this.disconnectCliMakeSure();
+        this.forceSave();
     });
 
     this._domDialogCliErrors.on("close", () => {

--- a/src/tabs/presets/presets.less
+++ b/src/tabs/presets/presets.less
@@ -67,6 +67,10 @@
 			color: red;
 			font-weight: bold;
 		}
+		.warning_message {
+			color: yellow;
+			font-weight: bold;
+		}
 	}
 	textarea[name='commands'] {
 		-webkit-box-sizing: border-box;


### PR DESCRIPTION
this PR is mainly for BF 4.4 where resetting to defaults causes CLI errors.
This makes the CLI dialog to show up every time the user hit "save" on presets tab, or loads a backup.

While working, i also noticed a bug that presets CLI messages timeout are being ignored.

The solution is to ignore errors that's popping right after resetting to defaults.