### PR TITLE
Fix sensor status calls

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1,6 +1,5 @@
 import '../injected_methods';
 import { update_dataflash_global } from "../update_dataflash_global";
-import { sensor_status } from "../sensor_helpers";
 import { bit_check, bit_set } from "../bit";
 import { i18n } from "../localization";
 import { gui_log } from "../gui_log";
@@ -193,7 +192,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.CONFIG.mode = data.readU32();
                 FC.CONFIG.profile = data.readU8();
 
-                sensor_status(FC.CONFIG.activeSensors, FC.GPS_DATA.fix);
                 break;
             case MSPCodes.MSP_STATUS_EX:
                 FC.CONFIG.cycleTime = data.readU16();
@@ -223,7 +221,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                     FC.CONFIG.cpuTemp = data.readU16();
                 }
 
-                sensor_status(FC.CONFIG.activeSensors, FC.GPS_DATA.fix);
                 break;
 
             case MSPCodes.MSP_RAW_IMU:

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -765,8 +765,9 @@ async function update_live_status() {
 
         if (have_sensor(FC.CONFIG.activeSensors, 'gps')) {
             await MSP.promise(MSPCodes.MSP_RAW_GPS);
-            sensor_status(FC.CONFIG.activeSensors, FC.GPS_DATA.fix);
         }
+
+        sensor_status(FC.CONFIG.activeSensors, FC.GPS_DATA.fix);
 
         statuswrapper.show();
     }


### PR DESCRIPTION
Fix calling `sensor_status` in `update_live_status` in serial_backend so it is no longer needed to call it from MSP message requests as with gps enabled it got called twice within the same timer loop.

Related to https://github.com/betaflight/betaflight/pull/13177