### PR TITLE
Fix tab switch

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -355,7 +355,7 @@ class GuiControl {
     }
     selectDefaultTabWhenConnected() {
         const result = getConfig(['rememberLastTab', 'lastTab']);
-        const tab = result.rememberLastTab && result.lastTab && this.allowedTabs.indexOf(result.lastTab.substring(4)) !== -1 ? result.lastTab : 'tab_setup';
+        const tab = result.rememberLastTab && result.lastTab && this.allowedTabs.includes(result.lastTab.substring(4)) ? result.lastTab : 'tab_setup';
 
         $(`#tabs ul.mode-connected .${tab} a`).trigger('click');
     }

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -355,7 +355,7 @@ class GuiControl {
     }
     selectDefaultTabWhenConnected() {
         const result = getConfig(['rememberLastTab', 'lastTab']);
-        const tab = result.rememberLastTab && result.lastTab ? result.lastTab : 'tab_setup';
+        const tab = result.rememberLastTab && result.lastTab && this.allowedTabs.indexOf(result.lastTab.substring(4)) !== -1 ? result.lastTab : 'tab_setup';
 
         $(`#tabs ul.mode-connected .${tab} a`).trigger('click');
     }


### PR DESCRIPTION
Fixes not able to connect after removing firmware cloud option when user was on a tab previous using that option.

To reproduce. 

- Enable remember last tab in options tab
- Flash firmware with servo support
- Click servo tab
- Flash firmware without servo support
- Press connect

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/b18a2234-49b2-4bfb-905d-37009807e38e)
