### PR TITLE
Fix readonly field

### DIFF
--- a/src/css/tabs/motors.less
+++ b/src/css/tabs/motors.less
@@ -102,6 +102,13 @@
 			padding: 0 5px;
 			background-color: #ececec;
 		}
+		input[readonly] {
+			background-color: #AFAFAF;
+			border: none;
+			pointer-events: none;
+			text-shadow: none;
+			opacity: 0.5;
+		}
 		span {
 			margin-left: 0;
 		}


### PR DESCRIPTION
Adds grey background color to readonly field in motors tab for idleMinRpm

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/6a148be4-7224-4758-a6fd-ba8ed5d6404f)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/b687e509-cf6b-44c7-8512-68891e845c03)
