### PR TITLE
Use attitude heading

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -818,8 +818,8 @@
         "message": "Reset Z axis, offset: $1 deg"
     },
     "initialSetupHeading": {
-        "message": "Heading:",
-        "description": "Heading shown on Setup tab"
+        "message": "Yaw:",
+        "description": "Heading [yaw] attitude value shown on Setup tab"
     },
     "initialSetupMixerHead": {
         "message": "Mixer Type"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2823,8 +2823,8 @@
         "description": "Show GPS position - Latitude / Longitude"
     },
     "gpsHeading": {
-        "message": "Heading Mag / GPS:",
-        "description": "Show GPS heading - Magnetic / GPS course over ground"
+        "message": "Heading IMU / GPS:",
+        "description": "Show IMU / GPS heading - Attitude / GPS course over ground"
     },
     "gpsSpeed": {
         "message": "Speed:"

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -52,11 +52,15 @@ gps.initialize = async function (callback) {
         }
 
         function get_gpsvinfo_data() {
-            MSP.send_message(MSPCodes.MSP_GPS_SV_INFO, false, false, hasMag ? get_imu_data : update_ui);
+            MSP.send_message(MSPCodes.MSP_GPS_SV_INFO, false, false, get_imu_data);
         }
 
         function get_imu_data() {
-            MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, update_ui);
+            MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, get_attitude_data);
+        }
+
+        function get_attitude_data() {
+            MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, update_ui);
         }
 
         // To not flicker the divs while the fix is unstable
@@ -201,7 +205,7 @@ gps.initialize = async function (callback) {
             const gspUnitText = i18n.getMessage('gpsPositionUnit');
             $('.GPS_info td.alt').text(`${alt} m`);
             $('.GPS_info td.latLon a').prop('href', url).text(`${lat.toFixed(6)} / ${lon.toFixed(6)} ${gspUnitText}`);
-            $('.GPS_info td.heading').text(`${imuHeading.toFixed(4)} / ${gpsHeading.toFixed(4)} ${gspUnitText}`);
+            $('.GPS_info td.heading').text(`${imuHeading.toFixed(0)} / ${gpsHeading.toFixed(0)} ${gspUnitText}`);
             $('.GPS_info td.speed').text(`${FC.GPS_DATA.speed} cm/s`);
             $('.GPS_info td.sats').text(FC.GPS_DATA.numSat);
             $('.GPS_info td.distToHome').text(`${FC.GPS_DATA.distanceToHome} m`);
@@ -299,7 +303,7 @@ gps.initialize = async function (callback) {
                 action: 'center',
                 lat: lat,
                 lon: lon,
-                heading: imuHeading,
+                heading: gpsHeading,
             };
 
             frame = document.getElementById('map');

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -185,6 +185,7 @@ gps.initialize = async function (callback) {
             const lat = FC.GPS_DATA.lat / 10000000;
             const lon = FC.GPS_DATA.lon / 10000000;
             const url = `https://maps.google.com/?q=${lat},${lon}`;
+            const imuHeading = FC.SENSOR_DATA.kinematics[2];
             const magHeading = hasMag ? Math.atan2(FC.SENSOR_DATA.magnetometer[1], FC.SENSOR_DATA.magnetometer[0]) : undefined;
             const magHeadingDeg = magHeading === undefined ? 0 : magHeading * 180 / Math.PI;
             const gpsHeading = FC.GPS_DATA.ground_course / 100;
@@ -200,7 +201,7 @@ gps.initialize = async function (callback) {
             const gspUnitText = i18n.getMessage('gpsPositionUnit');
             $('.GPS_info td.alt').text(`${alt} m`);
             $('.GPS_info td.latLon a').prop('href', url).text(`${lat.toFixed(6)} / ${lon.toFixed(6)} ${gspUnitText}`);
-            $('.GPS_info td.heading').text(`${magHeadingDeg.toFixed(4)} / ${gpsHeading.toFixed(4)} ${gspUnitText}`);
+            $('.GPS_info td.heading').text(`${imuHeading.toFixed(4)} / ${gpsHeading.toFixed(4)} ${gspUnitText}`);
             $('.GPS_info td.speed').text(`${FC.GPS_DATA.speed} cm/s`);
             $('.GPS_info td.sats').text(FC.GPS_DATA.numSat);
             $('.GPS_info td.distToHome').text(`${FC.GPS_DATA.distanceToHome} m`);
@@ -298,7 +299,7 @@ gps.initialize = async function (callback) {
                 action: 'center',
                 lat: lat,
                 lon: lon,
-                heading: magHeading,
+                heading: imuHeading,
             };
 
             frame = document.getElementById('map');

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -52,15 +52,15 @@ gps.initialize = async function (callback) {
         }
 
         function get_gpsvinfo_data() {
-            MSP.send_message(MSPCodes.MSP_GPS_SV_INFO, false, false, get_imu_data);
-        }
-
-        function get_imu_data() {
-            MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, get_attitude_data);
+            MSP.send_message(MSPCodes.MSP_GPS_SV_INFO, false, false, get_attitude_data);
         }
 
         function get_attitude_data() {
-            MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, update_ui);
+            MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, hasMag ? get_imu_data : update_ui);
+        }
+
+        function get_imu_data() {
+            MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, update_ui);
         }
 
         // To not flicker the divs while the fix is unstable

--- a/src/js/tabs/map.js
+++ b/src/js/tabs/map.js
@@ -106,8 +106,9 @@ function processMapEvents(e) {
                 iconFeature.setStyle(iconStyle);
                 const center = ol.proj.fromLonLat([e.data.lon, e.data.lat]);
                 mapView.setCenter(center);
-                const heading = e.data.heading === undefined ? 0 : e.data.heading;
-                mapView.setRotation(heading);
+                // TODO - add rotation for the icon
+                // const heading = e.data.heading === undefined ? 0 : e.data.heading;
+                // mapView.setRotation(heading);
                 iconGeometry.setCoordinates(center);
                 break;
 

--- a/src/js/tabs/map.js
+++ b/src/js/tabs/map.js
@@ -21,41 +21,41 @@ function initializeMap() {
     const lonLat = ol.proj.fromLonLat([DEFAULT_LON, DEFAULT_LAT]);
 
     mapView = new ol.View({
-                        center: lonLat,
-                        zoom: DEFAULT_ZOOM,
-                      });
+        center: lonLat,
+        zoom: DEFAULT_ZOOM,
+    });
 
     map = new ol.Map({
         target: 'map-canvas',
         layers: [
-          new ol.layer.Tile({
-            source: new ol.source.OSM(),
-          }),
+            new ol.layer.Tile({
+                source: new ol.source.OSM(),
+            }),
         ],
         view: mapView,
         controls: [],
-      });
+    });
 
-      const iconGPS = new ol.style.Icon(({
+    const iconGPS = new ol.style.Icon({
         anchor: [0.5, 1],
         opacity: 1,
         scale: 0.5,
         src: ICON_IMAGE_GPS,
-    }));
+    });
 
-    const iconMag = new ol.style.Icon(({
+    const iconMag = new ol.style.Icon({
         anchor: [0.5, 1],
         opacity: 1,
         scale: 0.5,
         src: ICON_IMAGE_MAG,
-    }));
+    });
 
-    const iconNoFix = new ol.style.Icon(({
+    const iconNoFix = new ol.style.Icon({
         anchor: [0.5, 1],
         opacity: 1,
         scale: 0.5,
         src: ICON_IMAGE_NOFIX,
-    }));
+    });
 
     iconStyleGPS = new ol.style.Style({
         image: iconGPS,
@@ -70,6 +70,7 @@ function initializeMap() {
     });
 
     iconGeometry = new ol.geom.Point(lonLat);
+
     iconFeature = new ol.Feature({
         geometry: iconGeometry,
     });


### PR DESCRIPTION
Summary from ctzsnooze:

Bugfix PR to:
- stop the Map from jumping like crazy when a Mag is enabled, and
- fix an issue where incorrect heading data would be shown in the Mag heading value in the GPS tab.

The PR displays the IMU heading value in the GPS tab, in place of the Mag X axis value, to the left of the GPS Heading value.

Previously the displayed Mag value was the Mag sensor X value converted to degrees.  The X axis data alone returns a false heading value if the pitch or roll of the quad changes a tiny bit, and is, practically speaking, useless in the GPS tab.

Additionally, it is the IMU heading that we show in the Setup tab as the 'yaw attitude' of the quad (the 'heading' of the quad).  It makes sense to use a consistent heading representation across Configurator.

Note that If a Mag is enabled, the IMU will derive heading from the Mag heading value, not the GPS value. If Mag is not enabled, the GPS heading will be shown.

Also note that the GPS Heading value will be incorrect (useless) unless the GPS is actually moving along the ground in a straight line at a velocity of at least 2m/s.  Hence in most situations where both the computer that is running Configurator, and the quad itself, are stationary, the GPS value will not make sense.

That's why in most cases when a Mag is enabled, the IMU value will be 'correct', and the GPS value will be quite different.  The only time both values will be the same is if the computer and quad are both walked, together, in the exact direction of the nose of the quad.

The 'madly jumping Map' issue was happening only when Mag was enabled.  At present this is fixed by locking the Map stationary, as it should be (north always upwards).  We are hoping to be able to rotate the icon, not the map, using the IMU value, but that may need to be in a different PR.

So this PR resolves the current problems with Mag display in the GPS tab.  It has been tested and works.

I recommend we merge it now.

C

Original comments:

Also iProposal for renaming heading to clarify witch value is used.

- setup tab uses `MSP_ATTITUDE` and `FC.SENSOR_DATA.kinematics[X,Y,Z]`.
- gps tab uses `MSP_RAW_IMU` and `FC.SENSOR_DATA.magnetometer[X,Y,Z]`.

`Heading` on setup tab can be confused with magnetometer heading so like to rename it to `Yaw`.
For gps tab we rename heading text to `Heading IMU / GPS:`.

- One problem found: Rotation using `magHeading`. @atomgomba may have some pointers. But did some investigation:

https://arduino.stackexchange.com/questions/18625/converting-three-axis-magnetometer-to-degrees

OpenLayers function `setRotation(rotation)` seems not working correctly with heading data.

All this assumes the XY plane is horizontal. Adding pitch or yaw movements would result in wrong calculation.

Here is a resource if we need a more accurate solution. https://www.mdpi.com/1424-8220/11/10/9182/pdf