### PR TITLE
Remove PIDS_ACTIVE

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -455,9 +455,11 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 for (let i = 0, needle = 0; i < (data.byteLength / 3); i++, needle += 3) {
                     // main for loop selecting the pid section
                     for (let j = 0; j < 3; j++) {
-                        FC.PIDS_ACTIVE[i][j] = data.readU8();
-                        FC.PIDS[i][j] = FC.PIDS_ACTIVE[i][j];
+                        FC.PIDS[i][j] = data.readU8();
                     }
+                }
+                if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                    FC.PIDS_ACTIVE = FC.PIDS.map(array => array.slice());
                 }
                 break;
 
@@ -621,7 +623,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 break;
             case MSPCodes.MSP_SET_PID:
                 console.log('PID settings saved');
-                FC.PIDS_ACTIVE = FC.PIDS.map(array => array.slice());
+                if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                    FC.PIDS_ACTIVE = FC.PIDS.map(array => array.slice());
+                }
                 break;
             case MSPCodes.MSP_SET_RC_TUNING:
                 console.log('RC Tuning saved');

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -98,7 +98,11 @@ pid_tuning.initialize = function (callback) {
             // Assign each value
             searchRow.each((indexInput, element) => {
                 if (FC.PIDS[indexPid][indexInput] !== undefined) {
-                    $(element).val(FC.PIDS_ACTIVE[indexPid][indexInput]);
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+                        $(element).val(FC.PIDS[indexPid][indexInput]);
+                    } else {
+                        $(element).val(FC.PIDS_ACTIVE[indexPid][indexInput]);
+                    }
                 }
             });
         });
@@ -2732,11 +2736,13 @@ pid_tuning.updatePIDColors = function(clear = false) {
         element.css({ "background-color": getColorForPercentage(change, colorTables.pidSlider) });
     };
 
-    FC.PID_NAMES.forEach(function(elementPid, indexPid) {
-        $(`.pid_tuning .${elementPid} input`).each(function(indexInput) {
-            setTuningElementColor($(this), FC.PIDS_ACTIVE[indexPid][indexInput], FC.PIDS[indexPid][indexInput]);
+    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
+        FC.PID_NAMES.forEach(function(elementPid, indexPid) {
+            $(`.pid_tuning .${elementPid} input`).each(function(indexInput) {
+                setTuningElementColor($(this), FC.PIDS_ACTIVE[indexPid][indexInput], FC.PIDS[indexPid][indexInput]);
+            });
         });
-    });
+    }
 
     setTuningElementColor($('.pid_tuning input[name="dMinRoll"]'), FC.ADVANCED_TUNING_ACTIVE.dMinRoll, FC.ADVANCED_TUNING.dMinRoll);
     setTuningElementColor($('.pid_tuning input[name="dMinPitch"]'), FC.ADVANCED_TUNING_ACTIVE.dMinPitch, FC.ADVANCED_TUNING.dMinPitch);


### PR DESCRIPTION
as it's no longer used in pid tuning since 4.3

Have to look into `LEVEL` and `MAG` PIDF values as we should be able to save them.
For MAG we see a default value of 40.