### PR TITLE
Add MSP support for led profile and status

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -127,6 +127,7 @@ const FC = {
     LED_COLORS: null,
     LED_MODE_COLORS: null,
     LED_STRIP: null,
+    LED_STRIP_CONFIG: null,
     LED_CONFIG_VALUES: [],
     MISC: null, // DEPRECATED
     MIXER_CONFIG: null,
@@ -210,6 +211,7 @@ const FC = {
         };
 
         this.LED_STRIP =                [];
+        this.LED_STRIP_CONFIG =         [];
         this.LED_COLORS =               [];
         this.LED_MODE_COLORS =          [];
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1270,6 +1270,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
                         FC.LED_STRIP.push(led);
                     }
                 }
+
+                FC.LED_STRIP_CONFIG.status = data.readU8();   // basic or advanced
+                FC.LED_STRIP_CONFIG.profile = data.readU8();
+
                 break;
             case MSPCodes.MSP_SET_LED_STRIP_CONFIG:
                 console.log('Led strip config saved');
@@ -2603,6 +2607,9 @@ MspHelper.prototype.sendLedStripConfig = function(onCompleteCallback) {
         if (ledIndex == FC.LED_STRIP.length) {
             nextFunction = onCompleteCallback;
         }
+
+        buffer.push8(FC.LED_STRIP_CONFIG.status);   // basic or advanced
+        buffer.push8(FC.LED_STRIP_CONFIG.profile);
 
         MSP.send_message(MSPCodes.MSP_SET_LED_STRIP_CONFIG, buffer, false, nextFunction);
     }


### PR DESCRIPTION
Finally add support for https://github.com/betaflight/betaflight/pull/7491

Added a flag indicating the level of ledstrip support (to allow improved Configurator behavior) along with support for reading/setting the current ledstrip_profile `[RACE, BEACON, STATUS]`


ledstrip support flag `[STATUS]` is as follows:
0 = basic ledstrip available
1 = advanced ledstrip available

In follow up we could do something useful with this.