### PR TITLE
Add MSP2_UBLOX_REQUEST_SV_INFO

### DIFF
--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -199,7 +199,7 @@ const MSPCodes = {
     MSP2_GET_LED_STRIP_CONFIG_VALUES:   0x3008,
     MSP2_SET_LED_STRIP_CONFIG_VALUES:   0x3009,
     MSP2_SENSOR_CONFIG_ACTIVE:          0x300A,
-    MSP2_GPS_REQUEST_SV_INFO:           0x300B,
+    MSP2_UBLOX_REQUEST_SV_INFO:         0x300B,
 
     // MSP2_GET_TEXT and MSP2_SET_TEXT variable types
     PILOT_NAME:                     1,

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -199,6 +199,7 @@ const MSPCodes = {
     MSP2_GET_LED_STRIP_CONFIG_VALUES:   0x3008,
     MSP2_SET_LED_STRIP_CONFIG_VALUES:   0x3009,
     MSP2_SENSOR_CONFIG_ACTIVE:          0x300A,
+    MSP2_GPS_REQUEST_SV_INFO:           0x300B,
 
     // MSP2_GET_TEXT and MSP2_SET_TEXT variable types
     PILOT_NAME:                     1,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1612,6 +1612,10 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log('DSHOT command sent');
                 break;
 
+            case MSPCodes.MSP2_UBLOX_REQUEST_SV_INFO:
+                console.log('UBLOX SV info requested');
+                break;
+
             case MSPCodes.MSP_MULTIPLE_MSP:
 
                 let hasReturnedSomeCommand = false; // To avoid infinite loops

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -29,6 +29,11 @@ gps.initialize = async function (callback) {
 
     await MSP.promise(MSPCodes.MSP_GPS_CONFIG);
 
+    // GPS SV info request added in 1.46 for UBLOX protocol
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46) && FC.GPS_CONFIG.provider === 1) {
+        await MSP.promise(MSPCodes.MSP2_GPS_REQUEST_SV_INFO);
+    }
+
     load_html();
 
     function load_html() {

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -31,7 +31,7 @@ gps.initialize = async function (callback) {
 
     // GPS SV info request added in 1.46 for UBLOX protocol
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46) && FC.GPS_CONFIG.provider === 1) {
-        await MSP.promise(MSPCodes.MSP2_GPS_REQUEST_SV_INFO);
+        await MSP.promise(MSPCodes.MSP2_UBLOX_REQUEST_SV_INFO);
     }
 
     load_html();


### PR DESCRIPTION
See https://github.com/betaflight/betaflight/pull/13240

Should fix configurator missing satellite data request more reliable.

- Adds `MSP2_UBLOX_REQUEST_SV_INFO` request to activate SatInfo polling in firmware.
- SatInfo will be turned off upon ARMING the quad.