### PR TITLE
Update NWjs to 0.83

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -46,7 +46,7 @@ const NODE_ENV = process.env.NODE_ENV || 'production';
 const NAME_REGEX = /-/g;
 
 const nwBuilderOptions = {
-    version: '0.72.0',
+    version: '0.83.0',
     files: `${DIST_DIR}**/*`,
     macIcns: './src/images/bf_icon.icns',
     macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},


### PR DESCRIPTION
Check to fix virus issues reported with current build on Windows. Previous we were not able to go up due to icon issue which seems solved now.