### PR TITLE
Enable erase_chip by default

### DIFF
--- a/src/js/ConfigStorage.js
+++ b/src/js/ConfigStorage.js
@@ -3,7 +3,7 @@
  * @param {string | string[]} key string or array of strings
  * @returns {object}
  */
-export function get(key) {
+export function get(key, defaultValue = null) {
   let result = {};
   if (Array.isArray(key)) {
     key.forEach(function (element) {
@@ -22,6 +22,12 @@ export function get(key) {
         console.error(e);
       }
     }
+  }
+
+  // if default value is set and key is not found in localStorage, set default value
+  if (!Object.keys(result).length && defaultValue !== null) {
+    console.log('setting default value for', key, defaultValue);
+    result[key] = defaultValue;
   }
 
   return result;

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -74,6 +74,7 @@ function cleanupLocalStorage() {
         'selected_board',
         'unifiedConfigLast',
         'unifiedSourceCache',
+        'erase_chip',
     ];
 
     for (const key in localStorage) {
@@ -83,6 +84,8 @@ function cleanupLocalStorage() {
             }
         }
     }
+
+    setConfig({'erase_chip': true}); // force erase chip on first run
 }
 
 function appReady() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -66,7 +66,7 @@ function readConfiguratorVersionMetadata() {
 }
 
 function cleanupLocalStorage() {
-
+    // storage quota is 5MB, we need to clean up some stuff (more info see PR #2937)
     const cleanupLocalStorageList = [
         'cache',
         'firmware',
@@ -74,6 +74,7 @@ function cleanupLocalStorage() {
         'selected_board',
         'unifiedConfigLast',
         'unifiedSourceCache',
+        'erase_chip',
     ];
 
     for (const key in localStorage) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -74,7 +74,6 @@ function cleanupLocalStorage() {
         'selected_board',
         'unifiedConfigLast',
         'unifiedSourceCache',
-        'erase_chip',
     ];
 
     for (const key in localStorage) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -574,13 +574,14 @@ firmware_flasher.initialize = function (callback) {
             self.isFlashing = false;
         }
 
-        $('input.erase_chip').prop('checked', true); // force true because people flashing without regard for new configs
+        let result = getConfig('erase_chip');
+        $('input.erase_chip').prop('checked', result.erase_chip); // users can override this during the session
 
         $('input.erase_chip').change(function () {
             setConfig({'erase_chip': $(this).is(':checked')});
         }).change();
 
-        let result = getConfig('show_development_releases');
+        result = getConfig('show_development_releases');
         $('input.show_development_releases')
         .prop('checked', result.show_development_releases)
         .change(function () {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -574,12 +574,8 @@ firmware_flasher.initialize = function (callback) {
             self.isFlashing = false;
         }
 
-        let result = getConfig('erase_chip');
-        if (result.erase_chip) {
-            $('input.erase_chip').prop('checked', true);
-        } else {
-            $('input.erase_chip').prop('checked', false);
-        }
+        let result = getConfig('erase_chip', true);
+        $('input.erase_chip').prop('checked', result.erase_chip);
 
         $('input.erase_chip').change(function () {
             setConfig({'erase_chip': $(this).is(':checked')});

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -574,14 +574,13 @@ firmware_flasher.initialize = function (callback) {
             self.isFlashing = false;
         }
 
-        let result = getConfig('erase_chip', true);
-        $('input.erase_chip').prop('checked', result.erase_chip);
+        $('input.erase_chip').prop('checked', true); // force true because people flashing without regard for new configs
 
         $('input.erase_chip').change(function () {
             setConfig({'erase_chip': $(this).is(':checked')});
         }).change();
 
-        result = getConfig('show_development_releases');
+        let result = getConfig('show_development_releases');
         $('input.show_development_releases')
         .prop('checked', result.show_development_releases)
         .change(function () {


### PR DESCRIPTION
When migrating from previous version this settings was reported to disabled by default.