### PR TITLE
Add manual connection option

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -113,6 +113,10 @@
         "message": "Use mDNS Browser Device discovery on network (experimental)",
         "description": "Enable mDNS Browser Device discovery in PortHandler (experimental)"
     },
+    "showManualMode": {
+        "message": "Enable manual connection mode",
+        "description": "Text for the option to enable or disable manual connection mode"
+    },
     "showVirtualMode": {
         "message": "Enable virtual connection mode",
         "description": "Text for the option to enable or disable the virtual FC"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -55,6 +55,9 @@
     "portsSelectManual": {
         "message": "Manual Selection"
     },
+    "portsSelectNone": {
+        "message": "No connection available"
+    },
     "portsSelectVirtual": {
         "message": "Virtual Mode (Experimental)",
         "description": "Configure a Virtual Flight Controller without the need of a physical FC."

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -56,19 +56,23 @@ export function initializeSerialBackend() {
         const selected_port = $('#port').val();
 
         if (selected_port === 'manual') {
+        // const portSelect = document.querySelector('#port');
+
+        // console.log(`Port select value: ${portSelect.value}`);
+        // if (portSelect.value.startsWith("manual")) {
             $('#port-override-option').show();
-        }
-        else {
+        } else {
             $('#port-override-option').hide();
         }
         if (selected_port === 'virtual') {
+        // if (portSelect.value.startsWith("virtual")) {
             $('#firmware-virtual-option').show();
-        }
-        else {
+        } else {
             $('#firmware-virtual-option').hide();
         }
 
         $('#auto-connect-and-baud').toggle(selected_port !== 'DFU');
+        // $('#auto-connect-and-baud').toggle(!portSelect.value.startsWith("DFU"));
     };
 
     GUI.updateManualPortVisibility();
@@ -92,6 +96,16 @@ export function initializeSerialBackend() {
         const selectedPort = $('#port').val();
         let portName;
         if (selectedPort === 'manual') {
+    // $("div.connect_controls a.connect").on('click', function (e) {
+    //     const portSelect = document.querySelector('#port');
+    //     let portName;
+
+    //     if (portSelect.value.startsWith('none')) {
+    //         e.preventDefault();
+    //         return;
+    //     }
+
+    //     if (portSelect.value.startsWith("manual")) {
             portName = $('#port-override').val();
         } else {
             portName = String($('div#port-picker #port').val());
@@ -106,15 +120,18 @@ export function initializeSerialBackend() {
             const selectedPort = $('#port').val();
 
             if (selectedPort === 'DFU') {
-                $('select#baud').hide();
-            } else if (portName !== '0') {
-                if (!isConnected) {
-                    console.log(`Connecting to: ${portName}`);
-                    GUI.connecting_to = portName;
 
-                    // lock port select & baud while we are connecting / connected
-                    $('div#port-picker #port, div#port-picker #baud, div#port-picker #delay').prop('disabled', true);
-                    $('div.connect_controls div.connect_state').text(i18n.getMessage('connecting'));
+            // const portSelect = document.querySelector('#port');
+
+            // if (portSelect.value.startsWith('DFU')) {
+                $('select#baud').hide();
+                e.preventDefault();
+                return;
+            }
+
+            if (!isConnected) {
+                console.log(`Connecting to: ${portName}`);
+                GUI.connecting_to = portName;
 
                     const baudRate = parseInt($('#baud').val());
                     if (selectedPort === 'virtual') {
@@ -130,20 +147,25 @@ export function initializeSerialBackend() {
                         // Explicitly disconnect the event listeners before attaching the new ones.
                         serial.removeEventListener('connect', connectHandler);
                         serial.addEventListener('connect', connectHandler);
+                // // lock port select & baud while we are connecting / connected
+                // $('div#port-picker #port, div#port-picker #baud, div#port-picker #delay').prop('disabled', true);
+                // $('div.connect_controls div.connect_state').text(i18n.getMessage('connecting'));
+                // const baudRate = document.querySelector('div#port-picker #baud').value;
+                // console.log(`Baud rate: ${baudRate}`);
+                // if (portSelect.value.startsWith('virtual')) {
+                //     CONFIGURATOR.virtualMode = true;
+                //     CONFIGURATOR.virtualApiVersion = document.querySelector('#firmware-version-dropdown').value;
 
-                        serial.removeEventListener('disconnect', disconnectHandler);
-                        serial.addEventListener('disconnect', disconnectHandler);
+                //     serial.connect('virtual', {}, onOpenVirtual);
+                // } else if (isWeb()) {
+                //     // Explicitly disconnect the event listeners before attaching the new ones.
+                //     serial.removeEventListener('connect', connectHandler);
+                //     serial.addEventListener('connect', connectHandler);
 
-                        serial.connect({ baudRate });
-                    } else {
-                        serial.connect(
-                            portName,
-                            { bitrate: selected_baud },
-                            onOpen,
-                        );
-                        toggleStatus();
-                    }
+                    serial.removeEventListener('disconnect', disconnectHandler);
+                    serial.addEventListener('disconnect', disconnectHandler);
 
+                    serial.connect({ baudRate });
                 } else {
                     if ($('div#flashbutton a.flash_state').hasClass('active') && $('div#flashbutton a.flash').hasClass('active')) {
                         $('div#flashbutton a.flash_state').removeClass('active');
@@ -158,7 +180,28 @@ export function initializeSerialBackend() {
                     }
 
                     mspHelper?.setArmingEnabled(true, false, onFinishCallback);
+                    serial.connect(
+                        portName,
+                        { bitrate: selected_baud },
+                        onOpen,
+                    );
+                    toggleStatus();
                 }
+
+            // } else {
+            //     if ($('div#flashbutton a.flash_state').hasClass('active') && $('div#flashbutton a.flash').hasClass('active')) {
+            //         $('div#flashbutton a.flash_state').removeClass('active');
+            //         $('div#flashbutton a.flash').removeClass('active');
+            //     }
+            //     GUI.timeout_kill_all();
+            //     GUI.interval_kill_all();
+            //     GUI.tab_switch_cleanup(() => GUI.tab_switch_in_progress = false);
+
+            //     function onFinishCallback() {
+            //         finishClose(toggleStatus);
+            //     }
+
+            //     mspHelper.setArmingEnabled(true, false, onFinishCallback);
             }
         }
     });

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -585,10 +585,9 @@ firmware_flasher.initialize = function (callback) {
                 eraseAll = true;
             }
 
-            const portSelect = document.querySelector('#port');
-            if (!portSelect.value.startsWith('DFU')) {
-                if (portSelect.value !== '0') {
-                    const port = portSelect.value;
+            if (!$('option:selected', portPickerElement).data().isDFU) {
+                if (String(portPickerElement.val()) !== '0') {
+                    const port = String(portPickerElement.val());
 
                     if ($('input.updating').is(':checked')) {
                         options.no_reboot = true;
@@ -968,12 +967,10 @@ firmware_flasher.initialize = function (callback) {
             }
         });
 
-        const portSelect = document.querySelector('#port');
-
         portPickerElement.on('change', function () {
             if (GUI.active_tab === 'firmware_flasher') {
                 if (!GUI.connect_lock) {
-                    if (portSelect.value.startsWith('DFU')) {
+                    if ($('option:selected', this).data().isDFU) {
                         self.enableDfuExitButton(true);
                     } else {
                         if (!self.isFlashing) {
@@ -1230,16 +1227,6 @@ firmware_flasher.initialize = function (callback) {
 
 
 firmware_flasher.isSerialPortAvailable = function() {
-    // const selected_port = $('div#port-picker #port option:selected');
-    // const isBusy = GUI.connect_lock;
-    // const isDfu = PortHandler.dfu_available;
-    // const portSelect = document.querySelector('#port');
-    // console.log(portSelect.value.includes('manual'), portSelect.value, portSelect);
-    // console.log('isManual', selected_port.data().isManual, 'isVirtual', selected_port.data().isVirtual, 'isBusy', isBusy, 'isDfu', isDfu);
-    // const isManual = selected_port.data().isManual || false;
-    // const isVirtual = selected_port.data().isVirtual || false;
-
-    // return !isDfu && !isManual && !isVirtual && !isBusy;
     return PortHandler.port_available && !GUI.connect_lock;
 };
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -585,9 +585,10 @@ firmware_flasher.initialize = function (callback) {
                 eraseAll = true;
             }
 
-            if (!$('option:selected', portPickerElement).data().isDFU) {
-                if (String(portPickerElement.val()) !== '0') {
-                    const port = String(portPickerElement.val());
+            const portSelect = document.querySelector('#port');
+            if (!portSelect.value.startsWith('DFU')) {
+                if (portSelect.value !== '0') {
+                    const port = portSelect.value;
 
                     if ($('input.updating').is(':checked')) {
                         options.no_reboot = true;
@@ -967,10 +968,12 @@ firmware_flasher.initialize = function (callback) {
             }
         });
 
+        const portSelect = document.querySelector('#port');
+
         portPickerElement.on('change', function () {
             if (GUI.active_tab === 'firmware_flasher') {
                 if (!GUI.connect_lock) {
-                    if ($('option:selected', this).data().isDFU) {
+                    if (portSelect.value.startsWith('DFU')) {
                         self.enableDfuExitButton(true);
                     } else {
                         if (!self.isFlashing) {
@@ -1227,6 +1230,16 @@ firmware_flasher.initialize = function (callback) {
 
 
 firmware_flasher.isSerialPortAvailable = function() {
+    // const selected_port = $('div#port-picker #port option:selected');
+    // const isBusy = GUI.connect_lock;
+    // const isDfu = PortHandler.dfu_available;
+    // const portSelect = document.querySelector('#port');
+    // console.log(portSelect.value.includes('manual'), portSelect.value, portSelect);
+    // console.log('isManual', selected_port.data().isManual, 'isVirtual', selected_port.data().isVirtual, 'isBusy', isBusy, 'isDfu', isDfu);
+    // const isManual = selected_port.data().isManual || false;
+    // const isVirtual = selected_port.data().isVirtual || false;
+
+    // return !isDfu && !isManual && !isVirtual && !isBusy;
     return PortHandler.port_available && !GUI.connect_lock;
 };
 

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -25,6 +25,7 @@ options.initialize = function (callback) {
         TABS.options.initShowAllSerialDevices();
         TABS.options.initUseMdnsBrowser();
         TABS.options.initShowVirtualMode();
+        TABS.options.initUseManualConnection();
         TABS.options.initCordovaForceComputerUI();
         TABS.options.initDarkTheme();
         TABS.options.initShowDevToolsOnStartup();
@@ -141,6 +142,17 @@ options.initShowVirtualMode = function() {
         .prop('checked', !!result.showVirtualMode)
         .on('change', () => {
             setConfig({ showVirtualMode: showVirtualModeElement.is(':checked') });
+            PortHandler.reinitialize();
+        });
+};
+
+options.initUseManualConnection = function() {
+    const showManualModeElement = $('div.showManualMode input');
+    const result = getConfig('showManualMode');
+    showManualModeElement
+        .prop('checked', !!result.showManualMode)
+        .on('change', () => {
+            setConfig({ showManualMode: showManualModeElement.is(':checked') });
             PortHandler.reinitialize();
         });
 };

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -41,6 +41,12 @@
                     </div>
                     <span class="freelabel" i18n="useMdnsBrowser"></span>
                 </div>
+                <div class="showManualMode margin-bottom">
+                    <div>
+                        <input type="checkbox" class="toggle" />
+                    </div>
+                    <span class="freelabel" i18n="showManualMode"></span>
+                </div>
                 <div class="showVirtualMode margin-bottom">
                     <div>
                         <input type="checkbox" class="toggle" />


### PR DESCRIPTION
- Have observed users clicking the connect button without any connection available making manual connection an option would fix most `Failed to open serial port` events. During this process port_handler has been optimized.
- manual optional is now optional - as most users would only use serial connection
- removes brain overload after refactoring some code in porthandler
- made currentPorts global simplifying code
- during development encountered some issues which are fixed in:
  #3932
  #3933
  #3935

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/f6eea275-5540-4b45-9fad-73e9997881c8)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/e7c0bcee-7120-42a4-8545-f1a19cd705eb)
