### PR TITLE
Clarify GPS Signal Strength

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2852,6 +2852,9 @@
     "gpsSignalStr": {
         "message": "Signal Strength"
     },
+    "gpsSignalLost": {
+        "message": "The GPS icon lights up only when the connection to the GPS module is confirmed.<br /><br />It will be red at first, changing to yellow when the 3D fix is attained.<br /><br />If the GPS icon does not light up, check your wiring and configuration, and confirm that the GPS module is receiving power.<br /><br />The CLI 'status' command provides more information about the state of the GPS connection."
+    },
     "gpsSignalGnssId": {
         "message": "Gnss ID"
     },

--- a/src/tabs/gps.html
+++ b/src/tabs/gps.html
@@ -75,6 +75,7 @@
                         <div class="helpicon cf_tip" i18n_title="gpsSignalStrHeadHelp"></div>
                     </div>
                     <div class="spacer_box GPS_signal_strength">
+                        <div class="signal_strength note" i18n="gpsSignalLost"></div>
                         <table class="cf_table">
                             <!-- Contents generated in gps.js -->
                         </table>


### PR DESCRIPTION
Only show GPS Signal Strength when GPS is active.

Currently when having SatInfo and powering off the GPS configurator only shows last frozen state.

Resetting data won't show values - we can show an informational message like:

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/5d98a0e6-a9ff-4666-8bed-3a01dd786146)

UPDATE:

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/e3961b59-e891-4ac1-99d9-0f35062ad23c)

EDIT:

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/0b21aa93-8b94-45c1-85ce-c6eea8c3b2d6)
