### PR TITLE
Relax MSP timeout

### DIFF
--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -56,7 +56,7 @@ const MSP = {
     packet_error:               0,
     unsupported:                0,
 
-    MIN_TIMEOUT:                50,
+    MIN_TIMEOUT:                100,
     MAX_TIMEOUT:                2000,
     timeout:                    200,
 


### PR DESCRIPTION
Perhaps 50ms is a tad low. So adjusting for 100ms. This is still an improvement as in the past we had a fixed 1000ms timeout.

Default in firmware:

`set serial_update_rate_hz = 100`