### PR TITLE
Set the rollupReplace default param - removes warning message.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -439,6 +439,7 @@ function dist_rollup() {
                 }),
                 rollupReplace({
                     'process.env.NODE_ENV': JSON.stringify(NODE_ENV),
+                    'preventAssignment': true,
                 }),
                 resolve(),
                 commonjs(),


### PR DESCRIPTION
- will need to confirm "true" has no impact, otherwise should set it to false.
