### PR TITLE
Add missing MSP_SET_OSD_CANVAS support

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1707,6 +1707,10 @@ MspHelper.prototype.crunch = function(code, modifierCode = undefined) {
             buffer.push8(FC.BEEPER_CONFIG.dshotBeaconTone);
             buffer.push32(FC.BEEPER_CONFIG.dshotBeaconConditions.getDisabledMask());
             break;
+        case MSPCodes.MSP_SET_OSD_CANVAS:
+            buffer.push8(OSD.data.VIDEO_COLS[OSD.data.video_system]);
+            buffer.push8(OSD.data.VIDEO_ROWS[OSD.data.video_system]);
+            break;
         case MSPCodes.MSP_SET_MIXER_CONFIG:
             buffer.push8(FC.MIXER_CONFIG.mixer);
             buffer.push8(FC.MIXER_CONFIG.reverseMotorDir);

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -16,6 +16,7 @@ import inflection from "inflection";
 import { checkChromeRuntimeError } from "../utils/common";
 import debounce from "lodash.debounce";
 import $ from 'jquery';
+import { mspHelper } from "../msp/MSPHelper";
 
 const FONT = {};
 const SYM = {};
@@ -3354,6 +3355,7 @@ osd.initialize = function(callback) {
         });
 
         $('a.save').click(function() {
+            MSP.promise(MSPCodes.MSP_SET_OSD_CANVAS, mspHelper.crunch(MSPCodes.MSP_SET_OSD_CANVAS));
             MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
             gui_log(i18n.getMessage('osdSettingsSaved'));
             const oldText = $(this).html();


### PR DESCRIPTION
Activating

https://github.com/betaflight/betaflight/blob/1e093159658d889eec49abf90c2802296b36ba78/src/main/msp/msp.c#L4312-L4331

to set `displayPortDevice` to `MSP` automatically