### PR TITLE
Fix sponsor background on landing page

### DIFF
--- a/src/css/tabs/landing.less
+++ b/src/css/tabs/landing.less
@@ -6,7 +6,6 @@
 		min-height: 100%;
 		height: 100%;
 		overflow-y: auto;
-		background-color: #2e2e2e;
 	}
 	.content_top {
 		height: 140px;


### PR DESCRIPTION
![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/f2741e95-dd9e-4844-bad2-90ab0ed205b1)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/081dd814-733d-4df8-a6ea-f355960b5043)

Not sure about Axis image - did some further investigation and both show light or dark mode - but still the axis image is flipped.

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/09edabaf-2a16-4830-a09a-0203ae70631f)
