### PR TITLE
Hide telemetry protocols for CRSF, FPORT and GHST

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7338,6 +7338,9 @@
     "firmwareFlasherTelemetryProtocolDescription": {
         "message": "Select the telemetry protocol you would like included in this build. Note this is a drop down, but only one item maybe selected. There are also some telemetry protocols that will be enabled, regardless of your selection here based on the radio protocol selected, e.g. CRSF."
     },
+    "firmwareFlasherOptionLabelTelemetryProtocolIncluded": {
+        "message": "This Radio Protocol has Telemetry included"
+    },
     "firmwareFlasherOptionsDescription": {
         "message": "Select the generic options you would like included in this build. Note this is a drop down, and multiple items maybe selected. Such items as fixes, e.g. AKK VTX, are included here."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7339,7 +7339,7 @@
         "message": "Select the telemetry protocol you would like included in this build. Note this is a drop down, but only one item maybe selected. There are also some telemetry protocols that will be enabled, regardless of your selection here based on the radio protocol selected, e.g. CRSF."
     },
     "firmwareFlasherOptionLabelTelemetryProtocolIncluded": {
-        "message": "This Radio Protocol has Telemetry included"
+        "message": "Automatically Included"
     },
     "firmwareFlasherOptionsDescription": {
         "message": "Select the generic options you would like included in this build. Note this is a drop down, and multiple items maybe selected. Such items as fixes, e.g. AKK VTX, are included here."

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -206,18 +206,20 @@ firmware_flasher.initialize = function (callback) {
             $('select[name="telemetryProtocols"]').attr('disabled', hasTelemetryEnabledByDefault);
 
             if (hasTelemetryEnabledByDefault) {
-                $('select[name="telemetryProtocols"] option:selected').val('-1');
+                if ($('select[name="telemetryProtocols"] option[value="-1"]').length === 0) {
+                    $('select[name="telemetryProtocols"]').prepend($('<option>', {
+                        value: '-1',
+                        selected: 'selected',
+                        text: i18n.getMessage('firmwareFlasherOptionLabelTelemetryProtocolIncluded'),
+                    }));
+                } else {
+                    $('select[name="telemetryProtocols"] option:first').attr('selected', 'selected').text(i18n.getMessage('firmwareFlasherOptionLabelTelemetryProtocolIncluded'));
+                }
+            } else {
+                if ($('select[name="telemetryProtocols"] option[value="-1"]').length) {
+                    $('select[name="telemetryProtocols"] option:first').remove();
+                }
             }
-
-            $('select[name="telemetryProtocols"]').select2({
-                templateSelection: function (data) {
-                    if (data.id === '-1') {
-                        return hasTelemetryEnabledByDefault ? i18n.getMessage('firmwareFlasherOptionLabelTelemetryProtocolIncluded') : '[None]';
-                    }
-
-                    return data.text;
-                },
-            });
         }
 
         function buildOptions(data) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -215,10 +215,8 @@ firmware_flasher.initialize = function (callback) {
                 } else {
                     $('select[name="telemetryProtocols"] option:first').attr('selected', 'selected').text(i18n.getMessage('firmwareFlasherOptionLabelTelemetryProtocolIncluded'));
                 }
-            } else {
-                if ($('select[name="telemetryProtocols"] option[value="-1"]').length) {
-                    $('select[name="telemetryProtocols"] option:first').remove();
-                }
+            } else if ($('select[name="telemetryProtocols"] option[value="-1"]').length) {
+                $('select[name="telemetryProtocols"] option:first').remove();
             }
         }
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -195,6 +195,31 @@ firmware_flasher.initialize = function (callback) {
             });
         }
 
+        function toggleTelemetryProtocolInfo() {
+            const radioProtocol = $('select[name="radioProtocols"] option:selected').val();
+            const hasTelemetryEnabledByDefault = [
+                'USE_SERIALRX_CRSF',
+                'USE_SERIALRX_FPORT',
+                'USE_SERIALRX_GHST',
+            ].includes(radioProtocol);
+
+            $('select[name="telemetryProtocols"]').attr('disabled', hasTelemetryEnabledByDefault);
+
+            if (hasTelemetryEnabledByDefault) {
+                $('select[name="telemetryProtocols"] option:selected').val('-1');
+            }
+
+            $('select[name="telemetryProtocols"]').select2({
+                templateSelection: function (data) {
+                    if (data.id === '-1') {
+                        return hasTelemetryEnabledByDefault ? i18n.getMessage('firmwareFlasherOptionLabelTelemetryProtocolIncluded') : '[None]';
+                    }
+
+                    return data.text;
+                },
+            });
+        }
+
         function buildOptions(data) {
             if (!navigator.onLine) {
                 return;
@@ -208,6 +233,8 @@ firmware_flasher.initialize = function (callback) {
             if (!self.validateBuildKey()) {
                 preselectRadioProtocolFromStorage();
             }
+
+            toggleTelemetryProtocolInfo();
         }
 
         function preselectRadioProtocolFromStorage() {
@@ -435,6 +462,8 @@ firmware_flasher.initialize = function (callback) {
             if (selectedProtocol) {
                 setConfig({"ffRadioProtocol" : selectedProtocol});
             }
+
+            toggleTelemetryProtocolInfo();
         });
 
         $('select[name="board"]').on('change', function() {

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -167,7 +167,6 @@
                         <strong i18n="firmwareFlasherBuildTelemetryProtocols"></strong>
                         <div id="telemetryProtocolInfo" class="build-options-wrapper">
                             <select id="telemetryProtocols" name="telemetryProtocols" class="select2">
-                                <option value="-1">placeholder</option>
                             </select>
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherTelemetryProtocolDescription"></div>
                         </div>

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -167,6 +167,7 @@
                         <strong i18n="firmwareFlasherBuildTelemetryProtocols"></strong>
                         <div id="telemetryProtocolInfo" class="build-options-wrapper">
                             <select id="telemetryProtocols" name="telemetryProtocols" class="select2">
+                                <option value="-1">placeholder</option>
                             </select>
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherTelemetryProtocolDescription"></div>
                         </div>


### PR DESCRIPTION
![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/387d19d2-f3f3-4157-b3ee-2cba098503f4)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/3ddbf185-802d-4a0a-ae7e-fccf2e1be696)

Inspired after watching https://youtu.be/FMbBfef_R-g