### PR TITLE
Background pattern on full landing tab

### DIFF
--- a/src/css/tabs/landing.less
+++ b/src/css/tabs/landing.less
@@ -1,5 +1,7 @@
 .tab-landing {
 	min-height: 100%;
+	background: #fff url(../../images/pattern.png);
+	background-size: 300px;
 	overflow: hidden;
 	.content_wrapper {
 		padding: 0;
@@ -10,8 +12,6 @@
 	.content_top {
 		height: 140px;
 		padding: 20px;
-		background: #fff url(../../images/pattern.png);
-		background-size: 300px;
 		margin-bottom: 15px;
 	}
 	.content_mid {


### PR DESCRIPTION
This PR will show the background pattern on full landing tab and not only on the content_top

before this PR:

![before](https://github.com/betaflight/betaflight-configurator/assets/29702171/e42fa1d7-f991-46fa-8a74-df46ba63f99a)

after this PR (looks much better):

![after](https://github.com/betaflight/betaflight-configurator/assets/29702171/40b044a7-6808-4d6e-8711-85370a64a232)
