### PR TITLE
Prevent detection when busy

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -146,25 +146,25 @@ PortHandler.check_usb_devices = function (callback) {
 
                 self.portPickerElement.val('DFU').trigger('change');
                 self.setPortsInputWidth();
+                self.dfu_available = true;
             }
-            self.dfu_available = true;
-        } else {
-            if (dfuElement.length) {
-               dfuElement.remove();
-               self.setPortsInputWidth();
-            }
+        } else if (dfuElement.length) {
+            dfuElement.remove();
+            self.setPortsInputWidth();
             self.dfu_available = false;
-        }
-        if (callback) {
-            callback(self.dfu_available);
         }
         if (!$('option:selected', self.portPickerElement).data().isDFU) {
             if (!(GUI.connected_to || GUI.connect_lock)) {
                 FC.resetState();
             }
+
             if (self.dfu_available) {
                 self.portPickerElement.trigger('change');
             }
+        }
+
+        if (callback) {
+            callback(self.dfu_available);
         }
     });
 };
@@ -227,9 +227,8 @@ PortHandler.detectPort = function(currentPorts) {
         // Signal board verification
         if (GUI.active_tab === 'firmware_flasher' && TABS.firmware_flasher.allowBoardDetection) {
             TABS.firmware_flasher.boardNeedsVerification = true;
+            self.portPickerElement.trigger('change');
         }
-
-        self.portPickerElement.trigger('change');
 
         // auto-connect if enabled
         if (GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -27,7 +27,7 @@ const firmware_flasher = {
     sponsor: new Sponsor(),
     localFirmwareLoaded: false,
     selectedBoard: undefined,
-    boardNeedsVerification: true,
+    boardNeedsVerification: false,
     allowBoardDetection: true,
     cloudBuildKey: null,
     cloudBuildOptions: null,
@@ -51,7 +51,6 @@ firmware_flasher.initialize = function (callback) {
 
     // reset on tab change
     self.selectedBoard = undefined;
-    self.boardNeedsVerification = true;
     self.allowBoardDetection = true;
 
     self.cloudBuildKey = null;
@@ -481,8 +480,6 @@ firmware_flasher.initialize = function (callback) {
             }
 
             if (!GUI.connect_lock) {
-                // self.boardNeedsVerification = self.selectedBoard === undefined || target !== self.selectedBoard;
-                // self.updateDetectBoardButton();
                 self.selectedBoard = target;
                 console.log('board changed to', target);
 
@@ -969,7 +966,7 @@ firmware_flasher.initialize = function (callback) {
                     } else {
                         if (!self.isFlashing) {
                             // Porthandler resets board on port detect
-                            if (self.boardNeedsVerification) {
+                            if (self.allowBoardDetection && self.boardNeedsVerification) {
                                 // reset to prevent multiple calls
                                 self.boardNeedsVerification = false;
                                 self.verifyBoard();
@@ -1001,8 +998,10 @@ firmware_flasher.initialize = function (callback) {
 
         detectBoardElement.on('click', () => {
             detectBoardElement.toggleClass('disabled', true);
-            // self.boardNeedsVerification = false;
+            self.boardNeedsVerification = false;
+
             self.verifyBoard();
+            // prevent spamming the button
             setTimeout(() => detectBoardElement.toggleClass('disabled', false), 1000);
         });
 
@@ -1223,7 +1222,7 @@ firmware_flasher.isSerialPortAvailable = function() {
 };
 
 firmware_flasher.updateDetectBoardButton = function() {
-    $('a.detect-board').toggleClass('disabled', !this.isSerialPortAvailable() && this.boardNeedsVerification);
+    $('a.detect-board').toggleClass('disabled', !this.isSerialPortAvailable() && this.boardNeedsVerification && this.allowBoardDetection);
 };
 
 firmware_flasher.validateBuildKey = function() {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -691,7 +691,10 @@ firmware_flasher.initialize = function (callback) {
 
         // UI Hooks
         $('a.load_file').on('click', function () {
+            // Reset button when loading a new firmware
             self.enableFlashButton(false);
+            self.enableLoadRemoteFileButton(false);
+
             self.developmentFirmwareLoaded = false;
 
             chrome.fileSystem.chooseEntry({
@@ -777,6 +780,8 @@ firmware_flasher.initialize = function (callback) {
                 return;
             }
 
+            // Reset button when loading a new firmware
+            self.enableFlashButton(false);
             self.enableLoadRemoteFileButton(false);
 
             self.localFirmwareLoaded = false;


### PR DESCRIPTION
Prevent auto-detection during verify board and backup on flash as it might disturb other processes.

Excluded is to make the button smarter as it does have lot's of events

enable autodetect when

- initialize tab
- new port is detected
- board is switched and was not same target
- abort flashing after flash firmware is cancelled

disable autodetect when

- in DFU mode
- board is switched and was same target
- using autodetect to verify board (which triggers port change)
- using backup on flash (which also triggers port change)
- load firmware