### PR TITLE
Do not wait on reinitialize connection for firmware flasher tab

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -803,7 +803,7 @@ export function reinitializeConnection(callback) {
     const reconnect = setInterval(waitforSerial, 100);
 
     function waitforSerial() {
-        if (connectionTimestamp !== previousTimeStamp && CONFIGURATOR.connectionValid) {
+        if ((connectionTimestamp !== previousTimeStamp && CONFIGURATOR.connectionValid) || GUI.active_tab === 'firmware_flasher') {
             console.log(`Serial connection available after ${attempts / 10} seconds`);
             clearInterval(reconnect);
             gui_log(i18n.getMessage('deviceReady'));

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1238,7 +1238,7 @@ firmware_flasher.verifyBoard = function() {
     const self = this;
 
     if (!self.isSerialPortAvailable()) {
-        gui_log(i18n.getMessage('firmwareFlasherNoValidPort'));
+        // return silently as port-picker will trigger again when port is available
         return;
     }
 


### PR DESCRIPTION
This PR is part of #3758

BEFORE:

```
Porthandler detected device Betaflight STM32F7x2 on port: /dev/ttyACM0
serial_backend.js:109 Connecting to: /dev/ttyACM0
serial.js:123 serial: connection opened with ID: 1 , Baud: 115200
serial_backend.js:335 Requesting configuration data
MSPHelper.js:1599 Arming disable
MSPHelper.js:1602 Real time clock set
Clipboard.js:18 NW GUI Clipboard available
serial.js:253 serial: closed connection with ID: 1, Sent: 251 bytes, Received: 67303 bytes
port_handler.js:177 PortHandler - Removed: [{"path":"/dev/ttyACM0","displayName":"Betaflight STM32F7x2","vendorId":1155,"productId":22336}]
port_handler.js:218 PortHandler - Found: [{"path":"/dev/ttyACM0","displayName":"Betaflight STM32F7x2","vendorId":1155,"productId":22336}]
serial.js:123 serial: connection opened with ID: 2 , Baud: 115200
firmware_flasher.js:484 board changed to SPEEDYBEEF7V3
serial.js:253 serial: closed connection with ID: 2, Sent: 38 bytes, Received: 158 bytes
==> serial_backend.js:818 failed to get serial connection, gave up after 10 seconds
```

AFTER:

```
Porthandler detected device Betaflight STM32F7x2 on port: /dev/ttyACM0
serial_backend.js:109 Connecting to: /dev/ttyACM0
serial.js:123 serial: connection opened with ID: 1 , Baud: 115200
serial_backend.js:335 Requesting configuration data
MSPHelper.js:1599 Arming disable
MSPHelper.js:1602 Real time clock set
Clipboard.js:18 NW GUI Clipboard available
serial.js:253 serial: closed connection with ID: 1, Sent: 246 bytes, Received: 67298 bytes
==> serial_backend.js:807 Serial connection available after 0 seconds
port_handler.js:177 PortHandler - Removed: [{"path":"/dev/ttyACM0","displayName":"Betaflight STM32F7x2","vendorId":1155,"productId":22336}]
port_handler.js:218 PortHandler - Found: [{"path":"/dev/ttyACM0","displayName":"Betaflight STM32F7x2","vendorId":1155,"productId":22336}]
serial.js:123 serial: connection opened with ID: 2 , Baud: 115200
firmware_flasher.js:484 board changed to SPEEDYBEEF7V3
serial.js:253 serial: closed connection with ID: 2, Sent: 38 bytes, Received: 158 bytes
```

