### PR TITLE
Improved messaging if build request fails

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3421,6 +3421,9 @@
     "firmwareFlasherCloudBuildFailTimeOut": {
         "message": "timed out (please retry)"
     },
+    "firmwareFlasherCloudBuildFailRequest": {
+        "message": "build request error (please check build configuration, e.g. custom defines)"
+    },
     "firmwareFlasherCloudBuildFail": {
         "message": "failed (please check log)"
     },

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -926,7 +926,10 @@ firmware_flasher.initialize = function (callback) {
                             });
                         }, retrySeconds * 1000);
                     });
-                }, onLoadFailed);
+                }, () => {
+                    updateStatus('FailRequest', '', 0, false);
+                    onLoadFailed();
+                });
             }
 
             if (self.targetDetail) { // undefined while list is loading or while running offline


### PR DESCRIPTION
To test, you can introduce an invalid char into the custom defines.

e.g. `TEST$ERROR` in custom defines.