### PR TITLE
Fix for motor sliders behaving weirdly when MSP is overloaded

### DIFF
--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -320,8 +320,7 @@ const MSP = {
         for (const instance of this.callbacks) {
             if (instance.code === code) {
                 requestExists = true;
-
-                break;
+                clearTimeout(instance.timer);
             }
         }
 
@@ -341,16 +340,14 @@ const MSP = {
             'start': performance.now(),
         };
 
-        if (!requestExists) {
-            obj.timer = setTimeout(() => {
-                console.warn(`MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} TIMEOUT: ${this.timeout} QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`);
-                serial.send(bufferOut, (_sendInfo) => {
-                    obj.stop = performance.now();
-                    const executionTime = Math.round(obj.stop - obj.start);
-                    this.timeout = Math.max(this.MIN_TIMEOUT, Math.min(executionTime, this.MAX_TIMEOUT));
-                });
-            }, this.timeout);
-        }
+        obj.timer = setTimeout(() => {
+            console.warn(`MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} TIMEOUT: ${this.timeout} QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`);
+            serial.send(bufferOut, (_sendInfo) => {
+                obj.stop = performance.now();
+                const executionTime = Math.round(obj.stop - obj.start);
+                this.timeout = Math.max(this.MIN_TIMEOUT, Math.min(executionTime, this.MAX_TIMEOUT));
+            });
+        }, this.timeout);
 
         this.callbacks.push(obj);
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -945,8 +945,8 @@ motors.initialize = async function (callback) {
             mspHelper.setArmingEnabled(enabled, enabled);
         });
 
-        let bufferingSetMotor = [],
-        buffer_delay = false;
+        let lastMotorsCommand = null;
+        let buffer_delay = false;
 
         $('div.sliders input:not(.master)').on('input', function () {
             const index = $(this).index();
@@ -959,17 +959,13 @@ motors.initialize = async function (callback) {
                 buffer.push16(val);
             }
 
-            bufferingSetMotor.push(buffer);
+            lastMotorsCommand = buffer;
 
             if (!buffer_delay) {
                 buffer_delay = setTimeout(function () {
-                    buffer = bufferingSetMotor.pop();
-
-                    MSP.send_message(MSPCodes.MSP_SET_MOTOR, buffer);
-
-                    bufferingSetMotor = [];
+                    MSP.send_message(MSPCodes.MSP_SET_MOTOR, lastMotorsCommand);
                     buffer_delay = false;
-                }, 10);
+                }, 100);
             }
         });
 


### PR DESCRIPTION
**This PR needs a careful review by someone who knows MSP stuff.**
The issue it is fixing:

https://github.com/betaflight/betaflight-configurator/assets/2925027/c6dea658-9068-4f97-9022-81bf78c117ce

The issue occurs sometimes, when bidirectional dshot is ON + other MSP stuff is active: GPS, baro.

The fix proposes:

- 100ms motor sliders delay instead of 10ms, so we don't overwhelm MSP when the user moves motor sliders.
- Small MSP refactoring: In the current master, when multiple of the same commands are sent in the queue, only the oldest command is getting a second change to be sent with the timeout. The fix clears timeout for the old command, and sets up a new timeout for the latest command.