### PR TITLE
Add missing callback (to be able to flash after creating backup)

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1474,6 +1474,7 @@ firmware_flasher.backupConfig = function (callback) {
                     clearInterval(disconnect);
                     // Allow auto-detect after CLI reset
                     self.allowBoardDetection = true;
+                    callback();
                 }
                 count++;
             }, 100);


### PR DESCRIPTION
This PR is part of #3758

Somehow we missed the missing callback while flashing and creating a backup the callback was missing.

