### PR TITLE
Disable video modes that are not in the firmware

### DIFF
--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -313,6 +313,9 @@
 		border: 1px solid var(--subtleAccent);
 		border-radius: 3px;
 	}
+	input[type="radio"]:disabled {
+		cursor: not-allowed;
+	}
 	select {
 		background: var(--boxBackground);
 		color: var(--defaultText);

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2780,19 +2780,20 @@ osd.initialize = function(callback) {
                     // video mode
                     const $videoTypes = $('.video-types').empty();
                     for (let i = 0; i < OSD.constants.VIDEO_TYPES.length; i++) {
-                        // Remove SD or HD option depending on the build
+                        // Disable SD or HD option depending on the build
+                        let disabled = false;
                         if (FC.CONFIG.buildOptions) {
                             if (OSD.constants.VIDEO_TYPES[i] !== 'HD' && !FC.CONFIG.buildOptions.includes('USE_OSD_SD')) {
-                                continue;
+                                disabled = true;
                             }
                             if (OSD.constants.VIDEO_TYPES[i] === 'HD' && !FC.CONFIG.buildOptions.includes('USE_OSD_HD')) {
-                                continue;
+                                disabled = true;
                             }
                         }
                         const type = OSD.constants.VIDEO_TYPES[i];
                         const videoFormatOptionText = i18n.getMessage(`osdSetupVideoFormatOption${inflection.camelize(type.toLowerCase())}`);
                         const $checkbox = $('<label/>')
-                            .append($(`<input name="video_system" type="radio"/>${videoFormatOptionText}</label>`)
+                            .append($(`<input name="video_system" ${disabled ? 'disabled' : ''} type="radio"/>${videoFormatOptionText}</label>`)
                             .prop('checked', i === OSD.data.video_system)
                             .data('type', type)
                             .data('type', i),

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2782,7 +2782,7 @@ osd.initialize = function(callback) {
                     for (let i = 0; i < OSD.constants.VIDEO_TYPES.length; i++) {
                         // Disable SD or HD option depending on the build
                         let disabled = false;
-                        if (FC.CONFIG.buildOptions) {
+                        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45) && FC.CONFIG.buildOptions.length) {
                             if (OSD.constants.VIDEO_TYPES[i] !== 'HD' && !FC.CONFIG.buildOptions.includes('USE_OSD_SD')) {
                                 disabled = true;
                             }

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2780,6 +2780,15 @@ osd.initialize = function(callback) {
                     // video mode
                     const $videoTypes = $('.video-types').empty();
                     for (let i = 0; i < OSD.constants.VIDEO_TYPES.length; i++) {
+                        // Remove SD or HD option depending on the build
+                        if (FC.CONFIG.buildOptions) {
+                            if (OSD.constants.VIDEO_TYPES[i] !== 'HD' && !FC.CONFIG.buildOptions.includes('USE_OSD_SD')) {
+                                continue;
+                            }
+                            if (OSD.constants.VIDEO_TYPES[i] === 'HD' && !FC.CONFIG.buildOptions.includes('USE_OSD_HD')) {
+                                continue;
+                            }
+                        }
                         const type = OSD.constants.VIDEO_TYPES[i];
                         const videoFormatOptionText = i18n.getMessage(`osdSetupVideoFormatOption${inflection.camelize(type.toLowerCase())}`);
                         const $checkbox = $('<label/>')

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2791,7 +2791,8 @@ osd.initialize = function(callback) {
                             }
                         }
                         const type = OSD.constants.VIDEO_TYPES[i];
-                        const videoFormatOptionText = i18n.getMessage(`osdSetupVideoFormatOption${inflection.camelize(type.toLowerCase())}`);
+                        let videoFormatOptionText = i18n.getMessage(`osdSetupVideoFormatOption${inflection.camelize(type.toLowerCase())}`);
+                        videoFormatOptionText = disabled ? `<span style="color:#AFAFAF">${videoFormatOptionText}</span>` : videoFormatOptionText;
                         const $checkbox = $('<label/>')
                             .append($(`<input name="video_system" ${disabled ? 'disabled' : ''} type="radio"/>${videoFormatOptionText}</label>`)
                             .prop('checked', i === OSD.data.video_system)


### PR DESCRIPTION
Disable elements not included in the build instead of hiding them.

See also https://github.com/betaflight/betaflight/pull/13320#issuecomment-1907224847

Recommendation is either use `OSD_SD` or `OSD_HD` not both as switching elements is not accounted for in firmware. 