### PR TITLE
Update receiver.html

### DIFF
--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -115,8 +115,8 @@
                         <select class="hybrid_helper"
                                 name="rcmap_helper">
                             <option i18n="receiverChannelDefaultOption" value="AETR1234"></option>
-                            <option value="AETR1234">FrSky / Futaba / Hitec</option>
-                            <option value="TAER1234">Spektrum / Graupner / JR</option>
+                            <option value="AETR1234">FrSky / Futaba / Hitec (AETR1234)</option>
+                            <option value="TAER1234">Spektrum / Graupner / JR (TAER1234)</option>
                         </select>
                     </div>
                 </div>


### PR DESCRIPTION
It is not clear from the dropdown what `FrSky / Futaba / Hitec` and `Spektrum / Graupner / JR` refer to. This PR adds the channel map to the dropdown.
e.g. `Spektrum / Graupner / JR` becomes `Spektrum / Graupner / JR (TAER1234)`
