### PR TITLE
Update timing-accuracy debug field.

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -590,6 +590,7 @@ const DEBUG = {
             'debug[1]':'Late Tasks per second',
             'debug[2]':'Total delay in last second',
             'debug[3]':'Total Tasks per second',
+            'debug[4]':'Late Task Percentage',
         },
         'RX_EXPRESSLRS_SPI' : {
             'debug[all]':'ExpressLRS SPI Rx',

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -590,7 +590,7 @@ const DEBUG = {
             'debug[1]':'Late Tasks per second',
             'debug[2]':'Total delay in last second',
             'debug[3]':'Total Tasks per second',
-            'debug[4]':'Late Task Percentage',
+            'debug[4]':'Late Tasks per thousand',
         },
         'RX_EXPRESSLRS_SPI' : {
             'debug[all]':'ExpressLRS SPI Rx',


### PR DESCRIPTION
Add debug field for `lateTaskPercentage` introduced in https://github.com/betaflight/betaflight/pull/13330