### PR TITLE
Fix port picker trigger event

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -227,8 +227,9 @@ PortHandler.detectPort = function(currentPorts) {
         // Signal board verification
         if (GUI.active_tab === 'firmware_flasher' && TABS.firmware_flasher.allowBoardDetection) {
             TABS.firmware_flasher.boardNeedsVerification = true;
-            self.portPickerElement.trigger('change');
         }
+
+        self.portPickerElement.trigger('change');
 
         // auto-connect if enabled
         if (GUI.auto_connect && !GUI.connecting_to && !GUI.connected_to) {


### PR DESCRIPTION
Port picker change event was not triggered upon changing flight controller. As a consequence updateManualPortVisibility was not triggered to update the connection area.

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/98e7eb03-cfc6-4f4b-bed2-a163f71ce004)
