### PR TITLE
Don't trigger font upload when enter is pressed in alarm time field

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -3495,13 +3495,6 @@ osd.initialize = function(callback) {
             });
         });
 
-        $(document).keypress(function(e) {
-            if (e.which === 13) { // enter
-                // Trigger regular Flashing sequence
-                $('a.flash_font').click();
-            }
-        });
-
         self.analyticsChanges = {};
 
         MSP.promise(MSPCodes.MSP_RX_CONFIG)


### PR DESCRIPTION
Fixes: https://github.com/betaflight/betaflight/issues/13345

Font upload should only be trigger by pressing the upload button, not by editing the alarm time field.