### PR TITLE
Fix missing mag

### DIFF
--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -341,6 +341,7 @@ setup.initialize = function (callback) {
                 'AK8975',
                 'AK8963',
                 'QMC5883',
+                'LIS2MDL',
                 'LIS3MDL',
                 'MPU925X_AK8963',
                 'IST8310',


### PR DESCRIPTION
Noticed IST8310 was not shown on setup tab due to missing element.

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/3359d43f-eee8-4d57-82ff-55d6ba6ce645)
