### PR TITLE
Prevent issues with corrupted firmware using outdated configurator

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -267,7 +267,7 @@
         "message": "You are using an outdated version of the <b>Betaflight Configurator</b>.<br>$t(configuratorUpdateHelp.message)"
     },
     "configuratorUpdateHelp": {
-        "message": "Using a newer version of the firmware with an outdated version of Configurator means that changing some settings will result in a <strong>corrupted firmware configuration and a non-working craft</strong>. Furthermore, some features of the firmware will only be configurable in CLI.<br><strong>Betaflight Configurator version <b>$1</b> is available for download online</strong>, please visit <a href=\"$2\" target=\"_blank\" rel=\"noopener noreferrer\">this page</a> to download and install the latest version with fixes and improvements.<br>Please close the configurator window before updating."
+        "message": "Using a newer version of the firmware with an outdated version of Configurator means that changing some settings will result in a <strong>corrupted firmware configuration and a non-working craft</strong>.<br />Furthermore, some features of the firmware will only be configurable in CLI.<br g/><br /><strong>Betaflight Configurator version <b>$1</b> is available for download online</strong>.<br />Download and install the latest version of configurator with fixes and improvements <a href=\"$2\" target=\"_blank\" rel=\"noopener noreferrer\">here</a><br>Configurator window needs to be closed before updating."
     },
     "configuratorUpdateWebsite": {
         "message": "Go to Release Website"
@@ -517,10 +517,10 @@
         "message": "The following <strong>problems with your configuration</strong> were detected:"
     },
     "reportProblemsDialogFooter": {
-        "message": "Please <strong>fix these problems before attempting to fly your craft</strong>."
+        "message": "<span class=\"message-negative\"><strong>You need to fix these problems before attempting to fly your craft</span></strong>."
     },
     "reportProblemsDialogAPI_VERSION_MAX_SUPPORTED": {
-        "message": "<strong>the version of configurator that you are using ($3) is older than the firmware you are using ($4)</strong>.<br>$t(configuratorUpdateHelp.message)"
+        "message": "<span class=\"message-negative\"><strong>The configurator version used ($3) does not support firmware $4</strong></span>.<br>$t(configuratorUpdateHelp.message)"
     },
     "reportProblemsDialogMOTOR_PROTOCOL_DISABLED": {
         "message": "<strong>there is no motor output protocol selected</strong>.<br>Please select a motor output protocol appropriate for your ESCs in '$t(configurationEscFeatures.message)' on the '$t(tabMotorTesting.message)' tab.<br>$t(escProtocolDisabledMessage.message)"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -502,7 +502,7 @@
         "message": "This firmware version is <span class=\"message-negative\">not supported</span>. Please upgrade to firmware that supports api version <strong>$1</strong> or higher. Use CLI for backup before flashing. CLI backup/restore procedure is in the documention.<br />Alternatively download and use an old version of the configurator if you are not ready to upgrade."
     },
     "firmwareVersionNotSupportedMax": {
-        "message": "Configurator version <strong>$1</strong> supports firmware version up to version <strong>$2</strong>. Please upgrade the configurator to use api version <strong>$3</strong>."
+        "message": "This firmware version is <span class=\"message-negative\">not supported</span>. Please upgrade to a newer version of configurator. <br /><br /><a href=\"https://github.com/betaflight/betaflight-configurator/releases\" target=\"_blank\" rel=\"noopener noreferrer\">Download Betaflight Configurator</a>"
     },
     "firmwareTypeNotSupported": {
         "message": "Non - Betaflight firmware is <span class=\"message-negative\">not supported</span>, except for CLI mode."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -501,6 +501,9 @@
     "firmwareVersionNotSupported": {
         "message": "This firmware version is <span class=\"message-negative\">not supported</span>. Please upgrade to firmware that supports api version <strong>$1</strong> or higher. Use CLI for backup before flashing. CLI backup/restore procedure is in the documention.<br />Alternatively download and use an old version of the configurator if you are not ready to upgrade."
     },
+    "firmwareVersionNotSupportedMax": {
+        "message": "Configurator version <strong>$1</strong> supports firmware version up to version <strong>$2</strong>. Please upgrade the configurator to use api version <strong>$3</strong>."
+    },
     "firmwareTypeNotSupported": {
         "message": "Non - Betaflight firmware is <span class=\"message-negative\">not supported</span>, except for CLI mode."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -501,9 +501,6 @@
     "firmwareVersionNotSupported": {
         "message": "This firmware version is <span class=\"message-negative\">not supported</span>. Please upgrade to firmware that supports api version <strong>$1</strong> or higher. Use CLI for backup before flashing. CLI backup/restore procedure is in the documention.<br />Alternatively download and use an old version of the configurator if you are not ready to upgrade."
     },
-    "firmwareVersionNotSupportedMax": {
-        "message": "This firmware version is <span class=\"message-negative\">not supported</span>. Please upgrade to a newer version of configurator. <br /><br /><a href=\"https://github.com/betaflight/betaflight-configurator/releases\" target=\"_blank\" rel=\"noopener noreferrer\">Download Betaflight Configurator</a>"
-    },
     "firmwareTypeNotSupported": {
         "message": "Non - Betaflight firmware is <span class=\"message-negative\">not supported</span>, except for CLI mode."
     },

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -381,7 +381,7 @@ function onOpen(openInfo) {
                 if (semver.lt(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_ACCEPTED)) {
                     $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareVersionNotSupported', [CONFIGURATOR.API_VERSION_ACCEPTED]));
                 } else {
-                    $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareVersionNotSupportedMax', [CONFIGURATOR.getDisplayVersion(), CONFIGURATOR.API_VERSION_MAX_SUPPORTED, FC.CONFIG.apiVersion]));
+                    $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareVersionNotSupportedMax'));
                 }
 
                 $('.dialogConnectWarning-closebtn').click(function() {

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -342,7 +342,9 @@ function onOpen(openInfo) {
                 return;
             }
 
-            if (semver.gte(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_ACCEPTED)) {
+            const supported = semver.satisfies(FC.CONFIG.apiVersion, `${CONFIGURATOR.API_VERSION_ACCEPTED} - ${CONFIGURATOR.API_VERSION_MAX_SUPPORTED}`);
+
+            if (supported) {
                 MSP.send_message(MSPCodes.MSP_FC_VARIANT, false, false, function () {
                     if (FC.CONFIG.flightControllerIdentifier === 'BTFL') {
                         MSP.send_message(MSPCodes.MSP_FC_VERSION, false, false, function () {
@@ -376,7 +378,11 @@ function onOpen(openInfo) {
 
                 const dialog = $('.dialogConnectWarning')[0];
 
-                $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareVersionNotSupported', [CONFIGURATOR.API_VERSION_ACCEPTED]));
+                if (semver.lt(FC.CONFIG.apiVersion, CONFIGURATOR.API_VERSION_ACCEPTED)) {
+                    $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareVersionNotSupported', [CONFIGURATOR.API_VERSION_ACCEPTED]));
+                } else {
+                    $('.dialogConnectWarning-content').html(i18n.getMessage('firmwareVersionNotSupportedMax', [CONFIGURATOR.getDisplayVersion(), CONFIGURATOR.API_VERSION_MAX_SUPPORTED, FC.CONFIG.apiVersion]));
+                }
 
                 $('.dialogConnectWarning-closebtn').click(function() {
                     dialog.close();

--- a/src/js/utils/checkForConfiguratorUpdates.js
+++ b/src/js/utils/checkForConfiguratorUpdates.js
@@ -35,6 +35,8 @@ function notifyOutdatedVersion(data) {
         });
 
         dialog.showModal();
+    } else {
+        CONFIGURATOR.latestVersion = data.version;
     }
 }
 


### PR DESCRIPTION
- Configurator should not be able to connect to newer unsupported firmware versions, i.e. 10.10 should not be able to connect to 1.47 firmware. We cannot change earlier versions of configurators as I think we should start doing it now.
- Configurator 10.10 should be compatible with firmware 4.0 - 4.5 so there is no reason to use an older configurator besides firmware 3.x users.
- Main problem is users just ignore the dialog and don't know what is wrong.
- This PR does not allow 10.10 to work with 4.7 and so on.
- Please ignore version number here - as this is the original dialog:

BEFORE:
![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/631d50af-fb57-4760-a6cb-c14841a9e544)

NOW:
![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/5bd81db2-84d6-41de-b001-53ed84f9b632)
