### PR TITLE
Remove event listener for flashing using Enter key.

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1201,13 +1201,6 @@ firmware_flasher.initialize = function (callback) {
             }
         }).change();
 
-        $(document).keypress(function (e) {
-            if (e.which === 13) { // enter
-                // Trigger regular Flashing sequence
-                $('a.flash_firmware').click();
-            }
-        });
-
         self.flashingMessage(i18n.getMessage('firmwareFlasherLoadFirmwareFile'), self.FLASH_MESSAGE_TYPES.NEUTRAL);
 
         GUI.content_ready(callback);

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -198,7 +198,7 @@
                     <div style="width: 49%; float: left;">
                         <strong i18n="firmwareFlasherBuildCustomDefines"></strong>
                         <div id="customDefinesInfo" class="build-options-wrapper">
-                            <input id="customDefines" name="customDefines" autocomplete="off">
+                            <input id="customDefines" name="customDefines">
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherCustomDefinesDescription"></div>
                         </div>
                     </div>

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -198,7 +198,7 @@
                     <div style="width: 49%; float: left;">
                         <strong i18n="firmwareFlasherBuildCustomDefines"></strong>
                         <div id="customDefinesInfo" class="build-options-wrapper">
-                            <input id="customDefines" name="customDefines" />
+                            <input id="customDefines" name="customDefines" autocomplete="off">
                             <div class="helpicon cf_tip_wide" i18n_title="firmwareFlasherCustomDefinesDescription"></div>
                         </div>
                     </div>


### PR DESCRIPTION
When using autocomplete the background does not observe darkmode. Also on enter to accept the field it triggers firmware flashing.

This PR
- disables autocomplete for the custom define field
- removes the keypress for flashing

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/6ad66ce0-7064-40e9-b1d1-f43025f2e650)
