### PR TITLE
Separated "Use Filter Slider" dropdown for clarity

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4115,6 +4115,9 @@
     "pidTuningNonProfileFilterSettings": {
         "message": "Profile independent Filter Settings"
     },
+    "pidTuningFilterUseDTermSlider": {
+        "message": "Use D Term Filter Slider"
+    },
     "pidTuningFilterSlidersHelp": {
         "message": "These sliders adjust the Gyro and D-term filters.<br /><br />For more filtering:<br /> - Sliders to left<br> - Lower cutoff frequencies.<br /><br /> Stronger filtering keeps motors cooler by removing more noise, but delays the gyro signal more and may worsen prop-wash or cause resonant oscillations. Less responsive quads eg X-Class do best with stronger filtering. <br><br>For less filtering:<br /> - Sliders to the right<br /> - Higher cutoff frequencies <br><br>Less filtering reduces gyro signal delay, and often improves propwash. Moving the gyro lowpass filter right is usually OK, but moving the D filter to the right is usually not required, and can easily result in very hot motors.",
         "description": "Overall helpicon message for filter tuning sliders"
@@ -4454,6 +4457,9 @@
     },
     "pidTuningFilterSettings": {
         "message": "Profile dependent Filter Settings"
+    },
+    "pidTuningFilterUseGyroSlider": {
+        "message": "Use Gyro Filter Slider"
     },
     "pidTuningDTermLowpass": {
         "message": "D Term Lowpass 1"

--- a/src/css/tabs/pid_tuning.less
+++ b/src/css/tabs/pid_tuning.less
@@ -173,6 +173,9 @@
 				box-sizing: content-box;
 			}
 		}
+		.cf_column .pid_titlebar tr:first-child {
+			border-bottom: 1px solid var(--subtleAccent);
+		}
 	}
 	.sliderDivider {
 		padding: 3px;
@@ -183,7 +186,6 @@
 		th {
 			padding: 5px;
 			text-align: left;
-			border-right: 1px solid var(--subtleAccent);
 			&:first-child {
 				text-align: left;
 				border-top-left-radius: 3px;

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1270,6 +1270,9 @@
                         <table class="pid_titlebar new_rates">
                             <tr>
                                 <th i18n="pidTuningNonProfileFilterSettings"></th>
+                            </tr>
+                            <tr>
+                                <th i18n="pidTuningFilterUseGyroSlider"></th>
                                 <td>
                                     <select id="sliderGyroFilterModeSelect" class="sliderMode">
                                         <option value="0" i18n="pidTuningOptionOff"></option>
@@ -1580,6 +1583,9 @@
                         <table class="pid_titlebar new_rates">
                             <tr>
                                 <th i18n="pidTuningFilterSettings"></th>
+                            </tr>
+                            <tr>
+                                <th i18n="pidTuningFilterUseDTermSlider"></th>
                                 <td>
                                     <select id="sliderDTermFilterModeSelect" class="sliderMode">
                                         <option value="0" i18n="pidTuningOptionOff"></option>


### PR DESCRIPTION
As suggested by Joshua Bardwell [here](https://youtu.be/5YFGRPxEV2s?t=233) it is not good that the UI is very confusing in the Filter tab.
Here's how the UI looks after these changes:

![image](https://github.com/betaflight/betaflight-configurator/assets/54041533/8a0e3928-e9bc-49ef-b102-aa0aaa6ddfbb)

It makes it a bit clearer that the ON/OFF dropdowns don't affect the "Profile Independent" and "Profile Dependent" Filter settings, instead they affect the sliders.