### PR TITLE
Fix missing PID filter slider labels

### DIFF
--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1271,6 +1271,7 @@
                             <tr>
                                 <th i18n="pidTuningNonProfileFilterSettings"></th>
                                 <td>
+                                    <span i18n="pidTuningGyroSliderEnabled"></span>
                                     <select id="sliderGyroFilterModeSelect" class="sliderMode">
                                         <option value="0" i18n="pidTuningOptionOff"></option>
                                         <option value="1" i18n="pidTuningOptionOn"></option>
@@ -1581,6 +1582,7 @@
                             <tr>
                                 <th i18n="pidTuningFilterSettings"></th>
                                 <td>
+                                    <span i18n="pidTuningDTermSliderEnabled"></span>
                                     <select id="sliderDTermFilterModeSelect" class="sliderMode">
                                         <option value="0" i18n="pidTuningOptionOff"></option>
                                         <option value="1" i18n="pidTuningOptionOn"></option>


### PR DESCRIPTION
![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/d7beb68a-d550-4cb8-9112-b158fcf33ea4)
