### PR TITLE
Fix light mode

### DIFF
--- a/src/css/tabs/pid_tuning.less
+++ b/src/css/tabs/pid_tuning.less
@@ -134,7 +134,6 @@
 			font-style: normal;
 			font-weight: normal;
 			line-height: 19px;
-			color: #7d7d7d;
 			font-size: 11px;
 		}
 	}


### PR DESCRIPTION
@TheIsotopes found an issue in non darkmode. This PR should fix the label.

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/259c15c0-abc9-46e3-a11f-9418e642c264)
