### PR TITLE
Fix changing blackbox rate for 4.2 and older firmware

### DIFF
--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -117,8 +117,8 @@ onboard_logging.initialize = function (callback) {
                     }
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44)) {
                         FC.BLACKBOX.blackboxSampleRate = parseInt(loggingRatesSelect.val(), 10);
-                        FC.BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);
                     }
+                    FC.BLACKBOX.blackboxPDenom = parseInt(loggingRatesSelect.val(), 10);
                     FC.BLACKBOX.blackboxDevice = parseInt(deviceSelect.val(), 10);
 
                     await MSP.promise(MSPCodes.MSP_SET_BLACKBOX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BLACKBOX_CONFIG));


### PR DESCRIPTION
When I change the blackbox rate on a board with firware version 4.2 installed, setting is not saved. Here is simple fix for that. This bug also exists in version 10.9 of configurator.