### PR TITLE
New led functions gps bar battery bar altitude

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3799,6 +3799,18 @@
         "message": "GPS",
         "description": "One of the modes of the Led Strip"
     },
+    "ledStripFunctionGPSBarOption": {
+        "message": "GPS Bar",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionBatteryBarOption": {
+        "message": "Battery Bar",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionAltitudeOption": {
+        "message": "Altitude",
+        "description": "One of the modes of the Led Strip"
+    },
     "ledStripFunctionRingOption": {
         "message": "Ring",
         "description": "One of the modes of the Led Strip"
@@ -3892,6 +3904,14 @@
     "ledStripModeColorsModeGPSLocked": {
         "message": "GPS: locked",
         "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeGpsDefault": {
+        "message": "Default",
+        "description": "One of the modes in GPS Mode in Led Strip"
+    },
+    "ledStripModeGpsBar": {
+        "message": "Bar",
+        "description": "One of the modes in GPS Mode in Led Strip"
     },
     "ledStripWiring": {
         "message": "LED Strip Wiring",

--- a/src/css/tabs/led_strip.less
+++ b/src/css/tabs/led_strip.less
@@ -160,6 +160,29 @@
 			margin-left: 4px;
 		}
 	}
+	.gPoint.function-p {
+		background: rgb(0, 128, 85);
+		box-shadow: inset 0 0 30px rgba(0, 0, 0, .7);
+		border-color: rgb(52, 155, 255);
+	}
+	.gPoint.function-e {
+		background: rgb(0, 0, 128);
+		box-shadow: inset 0 0 30px rgba(0, 0, 0, .7);
+		border-color: rgb(52, 155, 255);
+	}
+	.gPoint.function-u {
+		background: linear-gradient( to bottom right, rgba(191, 0, 255, 0.5) 0%, rgba(0, 179, 255, 0.5) 33%, rgba(0, 4, 255, 0.5) 66%, rgba(191, 0, 255, 0.5) 100%);
+		box-shadow: inset 0 0 30px rgba(0, 0, 0, .7);
+		border-color: grey;
+		.overlay-color {
+			float: left;
+			height: 15px;
+			width: 15px;
+			margin-top: -23px;
+			margin-left: 4px;
+			border-radius: 4px;
+		}
+	}
 	.gPoint {
 		select {
 			background: #000;
@@ -209,6 +232,9 @@
 		}
 		.function-a {
 			background: rgb(52, 155, 255);
+		}
+		.function-u {
+			background: linear-gradient( to bottom right, rgba(191, 0, 255, 0.5) 0%, rgba(0, 179, 255, 0.5) 33%, rgba(0, 4, 255, 0.5) 66%, rgba(191, 0, 255, 0.5) 100%);
 		}
 		.function-l {
 			background: magenta;

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -20,7 +20,7 @@ import { reinitializeConnection } from "../serial_backend";
 
 // Used for LED_STRIP
 const ledDirectionLetters    = ['n', 'e', 's', 'w', 'u', 'd'];      // in LSB bit order
-const ledBaseFunctionLetters = ['c', 'f', 'a', 'l', 's', 'g', 'r']; // in LSB bit
+const ledBaseFunctionLetters = ['c', 'f', 'a', 'p', 'e', 'u', 'l', 's', 'g', 'r']; // in LSB bit
 let ledOverlayLetters        = ['t', 'y', 'o', 'b', 'v', 'i', 'w']; // in LSB bit
 
 function MspHelper() {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -20,7 +20,7 @@ import { reinitializeConnection } from "../serial_backend";
 
 // Used for LED_STRIP
 const ledDirectionLetters    = ['n', 'e', 's', 'w', 'u', 'd'];      // in LSB bit order
-const ledBaseFunctionLetters = ['c', 'f', 'a', 'p', 'e', 'u', 'l', 's', 'g', 'r']; // in LSB bit
+const ledBaseFunctionLetters = ['c', 'f', 'a', 'l', 's', 'g', 'r', 'p', 'e', 'u']; // in LSB bit
 let ledOverlayLetters        = ['t', 'y', 'o', 'b', 'v', 'i', 'w']; // in LSB bit
 
 function MspHelper() {

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -19,7 +19,7 @@ led_strip.initialize = function (callback, scrollPosition) {
     const functionTag = '.function-';
 
     TABS.led_strip.functions = ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l', 'o', 'y'];
-    TABS.led_strip.baseFuncs = ['c', 'f', 'a', 'l', 's', 'g', 'r'];
+    TABS.led_strip.baseFuncs = ['c', 'f', 'a', 'p', 'e', 'u', 'l', 's', 'g', 'r'];
     TABS.led_strip.overlays =  ['t', 'y', 'o', 'b', 'v', 'i', 'w'];
 
     if (semver.lt(FC.CONFIG.apiVersion,API_VERSION_1_46)) {
@@ -429,6 +429,7 @@ led_strip.initialize = function (callback, scrollPosition) {
             const that = this;
 
             const mode = Number($(that).val());
+   
             $('.mode_colors').find('button').each(function() {
                 for (let i = 0; i < 6; i++) {
                     for (let j = 0; j < 6; j++) {
@@ -439,7 +440,6 @@ led_strip.initialize = function (callback, scrollPosition) {
                     }
                 }
             });
-
             $('.mode_colors').each(function() { setModeBackgroundColor($(this)); });
         });
 
@@ -463,6 +463,9 @@ led_strip.initialize = function (callback, scrollPosition) {
                                     break;
                                 case 'b':
                                 case 'i':
+                                case 'p':
+                                case 'e':
+                                case 'u':
                                     if (areOverlaysActive(`function-${f}`))
                                         p.addClass(`function-${letter}`);
                                     break;
@@ -817,6 +820,9 @@ led_strip.initialize = function (callback, scrollPosition) {
             case "function-c":
             case "function-a":
             case "function-f":
+            case "function-p":
+            case "function-e":
+            case "function-u":
             case "function-s":
             case "function-l":
             case "function-r":
@@ -910,11 +916,14 @@ led_strip.initialize = function (callback, scrollPosition) {
         switch (activeFunction) {
             case "":           // none
             case "function-f": // Modes & Orientation
+                $('.modeSelect').show();
+                $('.special_colors').hide();
             case "function-l": // Battery
                 // $('.mode_color-6-3').show(); // background
                 $('.special_colors').hide();
                 break;
             case "function-g": // GPS
+                $('.modeSelect').show();
                 $('.mode_color-6-5').show(); // no sats
                 $('.mode_color-6-6').show(); // no lock
                 $('.mode_color-6-7').show(); // locked
@@ -924,6 +933,7 @@ led_strip.initialize = function (callback, scrollPosition) {
                 $('.mode_color-6-4').show(); // blink background
                 break;
             case "function-a": // Arm state
+                $('.modeSelect').hide();
                 $('.mode_color-6-0').show(); // disarmed
                 $('.mode_color-6-1').show(); // armed
                 break;
@@ -1034,7 +1044,7 @@ led_strip.initialize = function (callback, scrollPosition) {
 
     function drawColorBoxesInColorLedPoints() {
         $('.gPoint').each(function() {
-            if ($(this).is('.function-c') || $(this).is('.function-r') || $(this).is('.function-b')) {
+            if ($(this).is('.function-c') || $(this).is('.function-r') || $(this).is('.function-b') || $(this).is('.function-u')) {
                 $(this).find('.overlay-color').show();
 
                 for (let colorIndex = 0; colorIndex < 16; colorIndex++) {

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -427,9 +427,7 @@ led_strip.initialize = function (callback, scrollPosition) {
         $('.modeSelect').on('change', function() {
 
             const that = this;
-
             const mode = Number($(that).val());
-   
             $('.mode_colors').find('button').each(function() {
                 for (let i = 0; i < 6; i++) {
                     for (let j = 0; j < 6; j++) {

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -428,6 +428,7 @@ led_strip.initialize = function (callback, scrollPosition) {
 
             const that = this;
             const mode = Number($(that).val());
+
             $('.mode_colors').find('button').each(function() {
                 for (let i = 0; i < 6; i++) {
                     for (let j = 0; j < 6; j++) {

--- a/src/js/tabs/led_strip.js
+++ b/src/js/tabs/led_strip.js
@@ -19,7 +19,7 @@ led_strip.initialize = function (callback, scrollPosition) {
     const functionTag = '.function-';
 
     TABS.led_strip.functions = ['i', 'w', 'f', 'a', 't', 'r', 'c', 'g', 's', 'b', 'l', 'o', 'y'];
-    TABS.led_strip.baseFuncs = ['c', 'f', 'a', 'p', 'e', 'u', 'l', 's', 'g', 'r'];
+    TABS.led_strip.baseFuncs = ['c', 'f', 'a', 'l', 's', 'g', 'r', 'p', 'e', 'u'];
     TABS.led_strip.overlays =  ['t', 'y', 'o', 'b', 'v', 'i', 'w'];
 
     if (semver.lt(FC.CONFIG.apiVersion,API_VERSION_1_46)) {

--- a/src/tabs/led_strip.html
+++ b/src/tabs/led_strip.html
@@ -44,6 +44,9 @@
                     <option value="function-c"  i18n="ledStripFunctionColorOption"></option>
                     <option value="function-f"  i18n="ledStripFunctionModesOption"></option>
                     <option value="function-a"  i18n="ledStripFunctionArmOption"></option>
+                    <option value="function-p"  i18n="ledStripFunctionGPSBarOption"></option>
+                    <option value="function-e"  i18n="ledStripFunctionBatteryBarOption"></option>
+                    <option value="function-u"  i18n="ledStripFunctionAltitudeOption"></option>
                     <option value="function-l"  i18n="ledStripFunctionBatteryOption"></option>
                     <option value="function-s"  i18n="ledStripFunctionRSSIOption"></option>
                     <option value="function-g"  i18n="ledStripFunctionGPSOption"></option>
@@ -124,7 +127,7 @@
             <div class="mode_colors">
                 <div class="section" i18n="ledStripModeColorsTitle"></div>
 
-                <select id="ledStripModeColorsModeSelect" class="modeSelect">
+                <select id="ledStripModeColorsModeSelect" class="modeSelect gps">
                     <option value="0" i18n="ledStripModeColorsModeOrientation"></option>
                     <option value="1" i18n="ledStripModeColorsModeHeadfree"></option>
                     <option value="2" i18n="ledStripModeColorsModeHorizon"></option>
@@ -190,6 +193,12 @@
 
             <div class="special_colors mode_colors">
                 <div class="section" i18n="ledStripModesSpecialColorsTitle"></div>
+
+                <select id="ledStripModeGpsModeSelect" class="modeSelect flightmode">
+                    <option value="0" i18n="ledStripModeGpsDefault"></option>
+                    <option value="1" i18n="ledStripModeGpsBar"></option>
+                </select>
+
                 <button class="mode_color-6-0" i18n_title="colorGreen" i18n="ledStripModeColorsModeDisarmed"></button>
                 <button class="mode_color-6-1" i18n_title="colorBlue" i18n="ledStripModeColorsModeArmed"></button>
                 <button class="mode_color-6-2" i18n_title="colorWhite" i18n="ledStripModeColorsModeAnimation"></button>

--- a/src/tabs/led_strip.html
+++ b/src/tabs/led_strip.html
@@ -44,13 +44,13 @@
                     <option value="function-c"  i18n="ledStripFunctionColorOption"></option>
                     <option value="function-f"  i18n="ledStripFunctionModesOption"></option>
                     <option value="function-a"  i18n="ledStripFunctionArmOption"></option>
-                    <option value="function-p"  i18n="ledStripFunctionGPSBarOption"></option>
-                    <option value="function-e"  i18n="ledStripFunctionBatteryBarOption"></option>
-                    <option value="function-u"  i18n="ledStripFunctionAltitudeOption"></option>
                     <option value="function-l"  i18n="ledStripFunctionBatteryOption"></option>
                     <option value="function-s"  i18n="ledStripFunctionRSSIOption"></option>
                     <option value="function-g"  i18n="ledStripFunctionGPSOption"></option>
                     <option value="function-r"  i18n="ledStripFunctionRingOption"></option>
+                    <option value="function-p"  i18n="ledStripFunctionGPSBarOption"></option>
+                    <option value="function-e"  i18n="ledStripFunctionBatteryBarOption"></option>
+                    <option value="function-u"  i18n="ledStripFunctionAltitudeOption"></option>
                 </select>
             </div>
 


### PR DESCRIPTION
Check the corresponding betaflight PR: https://github.com/betaflight/betaflight/pull/13404
This updates the configurator led_strip tab with the 3 new basefunctions

1. GPS Bar (`p`): The amount of glowing LEDs indicates the amount of GPS satellites. Goes from red to green upon GPS lock.
2. Battery Bar (`e`): Shows the battery percentage in a loading bar style. Goes from green to red depending on the battery level.
3. Altitude (`u`): Set a starting color. The color changes based on your current barometer altitude.