### PR TITLE
Custom protocol URI scheme to open the configurator (btfltcp://)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,11 +37,14 @@ module.exports = {
         cordovaChromeapi: true,
         appAvailability: true,
         // end cordova bindings
-        
+
         // globals for vite
         __APP_PRODUCTNAME__: "readonly",
         __APP_VERSION__: "readonly",
-        __APP_REVISION__: "readonly",     
+        __APP_REVISION__: "readonly",
+
+        // globals for NW.js
+        nw: true,
     },
     // ignore src/dist folders
     ignorePatterns: ["src/dist/*"],

--- a/assets/linux/betaflight-configurator.desktop
+++ b/assets/linux/betaflight-configurator.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=Betaflight Configurator
 Comment=Crossplatform configuration tool for the Betaflight flight control system
-Exec=/opt/betaflight/betaflight-configurator/betaflight-configurator
+Exec=/opt/betaflight/betaflight-configurator/betaflight-configurator %u
 Icon=/opt/betaflight/betaflight-configurator/icon/bf_icon_128.png
 Terminal=false
 Type=Application
 Categories=Utility
+MimeType=x-scheme-handler/btfltcp

--- a/assets/windows/installer.iss
+++ b/assets/windows/installer.iss
@@ -168,3 +168,9 @@ begin
         end;
     end;
 end;
+
+[Registry]
+Root: HKA; Subkey: "Software\Classes\btfltcp"; ValueType: "string"; ValueData: "URL:Custom Protocol"; Flags: uninsdeletekey
+Root: HKA; Subkey: "Software\Classes\btfltcp"; ValueType: "string"; ValueName: "URL Protocol"; ValueData: ""
+Root: HKA; Subkey: "Software\Classes\btfltcp\DefaultIcon"; ValueType: "string"; ValueData: "{app}\{cm:AppName}.exe,0"
+Root: HKA; Subkey: "Software\Classes\btfltcp\shell\open\command"; ValueType: "string"; ValueData: """{app}\{cm:AppName}.exe"" ""%1"""

--- a/cordova/config_template.xml
+++ b/cordova/config_template.xml
@@ -17,6 +17,7 @@
     <preference name="AutoHideSplashScreen" value="false"/>
     <platform name="android">
         <allow-intent href="market:*"/>
+        <allow-intent href="btfltcp://*"/>
         <icon src="resources/android/icon/drawable-ldpi-icon.png" density="ldpi"/>
         <icon src="resources/android/icon/drawable-mdpi-icon.png" density="mdpi"/>
         <icon src="resources/android/icon/drawable-hdpi-icon.png" density="hdpi"/>
@@ -44,6 +45,12 @@
                 <action android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED"/>
             </intent-filter>
             <meta-data android:name="android.hardware.usb.action.USB_DEVICE_ATTACHED" android:resource="@xml/usb_device_filter"/>
+            <intent-filter>
+                <data android:scheme="btfltcp" />
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+            </intent-filter>
         </config-file>
         <resource-file src="usb_device_filter.xml" target="app/src/main/res/xml/usb_device_filter.xml"/>
         <resource-file src="manifest.json" target="app/src/main/assets/www/manifest.json"/>

--- a/cordova/package_template.json
+++ b/cordova/package_template.json
@@ -17,6 +17,7 @@
     "cordova-plugin-chrome-apps-runtime": "^2.0.0",
     "cordova-plugin-chrome-apps-storage": "^1.0.4",
     "bf-cordova-plugin-chrome-apps-usb": "^2.0.1",
+    "cordova-plugin-customurlscheme": "^5.0.2",
     "cordova-plugin-dialogs": "^2.0.2",
     "cordova-plugin-file": "^6.0.2",
     "cordova-plugin-filechooser": "^1.2.0",
@@ -41,6 +42,12 @@
       "cordova-plugin-chrome-apps-common": {},
       "cordova-plugin-chrome-apps-runtime": {},
       "cordova-plugin-chrome-apps-storage": {},
+      "cordova-plugin-customurlscheme": {
+        "URL_SCHEME": "btfltcp",
+        "ANDROID_SCHEME": " ",
+        "ANDROID_HOST": " ",
+        "ANDROID_PATHPREFIX": "/"
+      },
       "cordova-plugin-whitelist": {},
       "cordova-plugin-splashscreen": {},
       "cordova-plugin-permission": {},

--- a/cordova/yarn.lock
+++ b/cordova/yarn.lock
@@ -669,6 +669,11 @@ cordova-plugin-chrome-apps-storage@^1.0.4:
   resolved "https://registry.yarnpkg.com/cordova-plugin-chrome-apps-storage/-/cordova-plugin-chrome-apps-storage-1.0.4.tgz#f83b1e16e54b774ba375f6ff5378fda829b161fd"
   integrity sha1-+DseFuVLd0ujdfb/U3j9qCmxYf0=
 
+cordova-plugin-customurlscheme@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/cordova-plugin-customurlscheme/-/cordova-plugin-customurlscheme-5.0.2.tgz#c6246e469a2c23772ebfb545138354cb0dc1a683"
+  integrity sha512-g139Av7iYD3xcSsCd5S6a7B7dp4GTqGYtvdhh44g4OS38+aX6XkC1lsCRmROuhLIs4fkwJqkrvxacH9H4U9Gsg==
+
 cordova-plugin-dialogs@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/cordova-plugin-dialogs/-/cordova-plugin-dialogs-2.0.2.tgz#ac3ce8b73bc885ff847078d5b533e7a4ed418a2f"
@@ -713,6 +718,11 @@ cordova-plugin-whitelist@^1.3.4:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/cordova-plugin-whitelist/-/cordova-plugin-whitelist-1.3.4.tgz#31938545c7c3e7de35c20ab08c2c3afa06e8a3f9"
   integrity sha512-EYC5eQFVkoYXq39l7tYKE6lEjHJ04mvTmKXxGL7quHLdFPfJMNzru/UYpn92AOfpl3PQaZmou78C7EgmFOwFQQ==
+
+cordova-plugin-zeroconf@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/cordova-plugin-zeroconf/-/cordova-plugin-zeroconf-1.4.2.tgz#0d8a7de4b2d7932149a57fb9cd37dee8366ff450"
+  integrity sha512-l/ETv/oCq8mPQoYk+qIxFoMwRB7IFxpEQSjsU8V5PLAWQY/OnaFb1Th3IcqQhWMy8+63YfjhyElz1tEqwZUlxA==
 
 cordova-serve@^3.0.0:
   version "3.0.0"

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,16 +40,24 @@ const CORDOVA_DIR = './cordova/';
 const CORDOVA_DIST_DIR = './dist_cordova/';
 
 const LINUX_INSTALL_DIR = '/opt/betaflight';
-
 const NODE_ENV = process.env.NODE_ENV || 'production';
 
 const NAME_REGEX = /-/g;
+
+const URI_SCHEME = 'btfltcp';
 
 const nwBuilderOptions = {
     version: '0.72.0',
     files: `${DIST_DIR}**/*`,
     macIcns: './src/images/bf_icon.icns',
-    macPlist: { 'CFBundleDisplayName': 'Betaflight Configurator'},
+    macPlist: {
+        'CFBundleDisplayName': 'Betaflight Configurator',
+        'CFBundleIdentifier': `com.protocol.registry.${URI_SCHEME}`,
+        'CFBundleURLTypes': [{
+            'CFBundleURLName': `URL : ${URI_SCHEME}`,
+            'CFBundleURLSchemes': [URI_SCHEME],
+        }],
+    },
     winIco: './src/images/bf_icon.ico',
     zip: false,
 };
@@ -793,6 +801,7 @@ function release_deb(arch, appDirectory, done) {
                 `chown root:root ${LINUX_INSTALL_DIR}`,
                 `chown -R root:root ${LINUX_INSTALL_DIR}/${metadata.name}`,
                 `xdg-desktop-menu install ${LINUX_INSTALL_DIR}/${metadata.name}/${metadata.name}.desktop`,
+                `xdg-mime default ${LINUX_INSTALL_DIR}/${metadata.name}/${metadata.name}.desktop x-scheme-handler/${URI_SCHEME}`,
                 `chmod +xr ${LINUX_INSTALL_DIR}/${metadata.name}/chrome_crashpad_handler`,
                 `chmod +xr ${LINUX_INSTALL_DIR}/${metadata.name}/${metadata.name}`,
                 `chmod -R +Xr ${LINUX_INSTALL_DIR}/${metadata.name}/`,
@@ -838,6 +847,7 @@ function release_rpm(arch, appDirectory, done) {
                 `chown root:root ${LINUX_INSTALL_DIR}`,
                 `chown -R root:root ${LINUX_INSTALL_DIR}/${metadata.name}`,
                 `xdg-desktop-menu install ${LINUX_INSTALL_DIR}/${metadata.name}/${metadata.name}.desktop`,
+                `xdg-mime default ${LINUX_INSTALL_DIR}/${metadata.name}/${metadata.name}.desktop x-scheme-handler/${URI_SCHEME}`,
                 `chmod +xr ${LINUX_INSTALL_DIR}/${metadata.name}/chrome_crashpad_handler`,
                 `chmod +xr ${LINUX_INSTALL_DIR}/${metadata.name}/${metadata.name}`,
                 `chmod -R +Xr ${LINUX_INSTALL_DIR}/${metadata.name}/`,

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7378,5 +7378,9 @@
     "betaflightSupportButton": {
         "message": "Wiki",
         "description": "Text for the button to open the support URL"
+    },
+    "enableURIScheme": {
+        "message": "Enable the <strong>btfltcp://</strong> URI scheme handling (experimental)",
+        "description": "Handle the custom <strong>btfltcp://</strong> URI scheme by opening the configurator once the scheme is invoked and connecting to the referenced TCP address (experimental)"
     }
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -10,6 +10,7 @@ import GUI, { TABS } from './gui.js';
 import { get as getConfig, set as setConfig } from './ConfigStorage.js';
 import { tracking, checkSetupAnalytics } from './Analytics.js';
 import { initializeSerialBackend } from './serial_backend.js';
+import { handleURIScheme } from './uri_scheme.js';
 import FC from './fc.js';
 import CONFIGURATOR from './data_storage.js';
 import serial from './serial.js';
@@ -108,6 +109,8 @@ function appReady() {
         });
 
         initializeSerialBackend();
+
+        handleURIScheme(getConfig('enableURIScheme').enableURIScheme).catch(err => console.error(err));
     });
 }
 

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -138,11 +138,7 @@ PortHandler.check_usb_devices = function (callback) {
                     data: {isDFU: true},
                 }));
 
-                self.portPickerElement.append($('<option/>', {
-                    value: 'manual',
-                    text: i18n.getMessage('portsSelectManual'),
-                    data: {isManual: true},
-                }));
+                self.addManualPortSelectOption();
 
                 self.portPickerElement.val('DFU').trigger('change');
                 self.setPortsInputWidth();
@@ -294,11 +290,7 @@ PortHandler.updatePortSelect = function (ports) {
         }));
     }
 
-    this.portPickerElement.append($("<option/>", {
-        value: 'manual',
-        text: i18n.getMessage('portsSelectManual'),
-        data: {isManual: true},
-    }));
+    this.addManualPortSelectOption();
 
     this.setPortsInputWidth();
     return ports;
@@ -321,6 +313,14 @@ PortHandler.selectPort = function(ports) {
             }
         }
     }
+};
+
+PortHandler.addManualPortSelectOption = function() {
+    this.portPickerElement.append($("<option/>", {
+        value: 'manual',
+        text: i18n.getMessage('portsSelectManual'),
+        data: {isManual: true},
+    }));
 };
 
 PortHandler.setPortsInputWidth = function() {

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -26,9 +26,11 @@ const serial = {
 
     serialDevices,
 
+    tcpUrlRegex: /^tcp:\/\/([A-Za-z0-9._-]+)(?::(\d+))?$/,
+
     connect: function (path, options, callback) {
         const self = this;
-        const testUrl = path.match(/^tcp:\/\/([A-Za-z0-9\.-]+)(?:\:(\d+))?$/);
+        const testUrl = path.match(self.tcpUrlRegex);
 
         if (testUrl) {
             self.connectTcp(testUrl[1], testUrl[2], options, callback);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -52,7 +52,7 @@ function disconnectHandler(event) {
 export function initializeSerialBackend() {
     GUI.updateManualPortVisibility = function() {
         const selected_port = $('div#port-picker #port option:selected');
-        if (selected_port.data().isManual) {
+        if (selected_port.data().isManual && !isConnected) {
             $('#port-override-option').show();
         }
         else {
@@ -137,6 +137,7 @@ export function initializeSerialBackend() {
                         toggleStatus();
                     }
 
+                    GUI.updateManualPortVisibility();
                 } else {
                     if ($('div#flashbutton a.flash_state').hasClass('active') && $('div#flashbutton a.flash').hasClass('active')) {
                         $('div#flashbutton a.flash_state').removeClass('active');
@@ -148,9 +149,10 @@ export function initializeSerialBackend() {
 
                     function onFinishCallback() {
                         finishClose(toggleStatus);
+                        GUI.updateManualPortVisibility();
                     }
 
-                    mspHelper.setArmingEnabled(true, false, onFinishCallback);
+                    mspHelper?.setArmingEnabled(true, false, onFinishCallback);
                 }
             }
         }
@@ -284,6 +286,7 @@ function abortConnection() {
 
     // reset data
     isConnected = false;
+    GUI.updateManualPortVisibility();
 }
 
 /**

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -8,6 +8,7 @@ import { checkForConfiguratorUpdates } from '../utils/checkForConfiguratorUpdate
 import { checkSetupAnalytics } from '../Analytics';
 import $ from 'jquery';
 import CONFIGURATOR from '../data_storage';
+import { handleURIScheme } from '../uri_scheme.js';
 
 const options = {};
 options.initialize = function (callback) {
@@ -24,6 +25,7 @@ options.initialize = function (callback) {
         TABS.options.initCliAutoComplete();
         TABS.options.initShowAllSerialDevices();
         TABS.options.initUseMdnsBrowser();
+        TABS.options.initEnableURIScheme();
         TABS.options.initShowVirtualMode();
         TABS.options.initCordovaForceComputerUI();
         TABS.options.initDarkTheme();
@@ -153,6 +155,18 @@ options.initUseMdnsBrowser = function() {
         .on('change', () => {
             setConfig({ useMdnsBrowser: useMdnsBrowserElement.is(':checked') });
             PortHandler.reinitialize();
+        });
+};
+
+options.initEnableURIScheme = function() {
+    const enableURISchemeElement = $('div.enableURIScheme input');
+    const result = getConfig('enableURIScheme');
+    enableURISchemeElement
+        .prop('checked', !!result.enableURIScheme)
+        .on('change', () => {
+            const enableURIScheme = enableURISchemeElement.is(':checked');
+            setConfig({ enableURIScheme });
+            handleURIScheme(enableURIScheme).catch(err => console.error(err));
         });
 };
 

--- a/src/js/uri_scheme.js
+++ b/src/js/uri_scheme.js
@@ -1,0 +1,106 @@
+import $ from 'jquery';
+
+import GUI from './gui';
+import serial from './serial';
+import PortHandler from './port_handler';
+
+const URI_SCHEME = 'btfltcp://';
+let uriSchemeHandlerActive = false;
+
+export async function handleURIScheme(enabled = false) {
+    if (!enabled) {
+        if (uriSchemeHandlerActive) {
+            if (GUI.isNWJS()) {
+                unhandleNWJSOpenEvents();
+            } else if (GUI.isCordova()) {
+                unhandleCordovaOpenEvents();
+            }
+            console.log(`Stopped listening for ${URI_SCHEME} URI scheme invocations/events`);
+        }
+        uriSchemeHandlerActive = false;
+        return;
+    }
+
+    console.log(`Listening for ${URI_SCHEME} URI scheme invocations/events`);
+
+    if (GUI.isNWJS()) {
+        handleNWJSArgv();
+        handleNWJSOpenEvents();
+    } else if (GUI.isCordova()) {
+        handleCordovaOpenEvents();
+    }
+    uriSchemeHandlerActive = true;
+}
+
+function connectTcp(connectionString, eventType) {
+    if (!connectionString) {
+        return;
+    }
+
+    console.log(`Processing ${eventType} with connection string "${connectionString}"`);
+
+    // NOTE: On some platforms a trailing slash is added automatically (it needs to be excluded)
+    const connectionStringRegex = new RegExp(`^.*${URI_SCHEME}(.+?)/?$`);
+
+    const url = connectionString.match(connectionStringRegex)?.[1];
+    if (!url) {
+        console.log(`Invalid ${URI_SCHEME} connection string "${connectionString}" from ${eventType}`);
+        return;
+    }
+
+    const tcpUrl = `tcp://${url}`;
+    if (!serial.tcpUrlRegex.exec(tcpUrl)) {
+        console.log(`Invalid ${URI_SCHEME} TCP URL ${tcpUrl} (from ${eventType} with connection string "${connectionString}")`);
+        return;
+    }
+
+    console.log(`Connecting to ${tcpUrl} (from ${eventType} with connection string "${connectionString}")`);
+
+    // Explicitly add the 'manual' select option if the port options haven't loaded yet
+    // (e.g. during a cold start)
+    if ($('#port [value="manual"]').length === 0){
+        PortHandler.addManualPortSelectOption();
+    }
+
+    $('#port').val('manual').trigger('change');
+    $('#port-override').val(tcpUrl).trigger('change');
+    $('div.connect_controls a.connect').trigger('click');
+}
+
+
+function handleNWJSArgv() {
+    const connectionString = (nw?.App?.argv || []).at(-1) || '';
+
+    if (connectionString) {
+        connectTcp(connectionString, 'cold start');
+    }
+}
+
+function nwOpenEventListener(connectionString) {
+    connectTcp(connectionString, 'NW.js "open" event');
+}
+
+function handleNWJSOpenEvents() {
+    nw?.App?.on('open', nwOpenEventListener);
+}
+
+function unhandleNWJSOpenEvents() {
+    try {
+        if (nw?.App?.onOpen.hasListener(nwOpenEventListener)) {
+            nw?.App?.onOpen?.removeListener(nwOpenEventListener);
+        }
+    } catch (err) {
+        console.error('Could not remove the nw.App open event listener:', err);
+    }
+}
+
+function handleCordovaOpenEvents() {
+    // based on https://www.npmjs.com/package/cordova-plugin-customurlscheme
+    window.handleOpenURL = (url) => {
+        connectTcp(url, 'Android deep link event');
+    };
+}
+
+function unhandleCordovaOpenEvents() {
+    delete window.handleOpenURL;
+}

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -41,6 +41,12 @@
                     </div>
                     <span class="freelabel" i18n="useMdnsBrowser"></span>
                 </div>
+                <div class="enableURIScheme margin-bottom">
+                    <div>
+                        <input type="checkbox" class="toggle" />
+                    </div>
+                    <span class="freelabel" i18n="enableURIScheme"></span>
+                </div>
                 <div class="showVirtualMode margin-bottom">
                     <div>
                         <input type="checkbox" class="toggle" />


### PR DESCRIPTION
Fixes #2281 

This PR makes it possible to open the Betaflight Configurator and immediately initialize a TCP connection via a custom URI protocol scheme: `btfltcp://`. The IP/URL (and optionally the port) of the TCP host (e.g. an ExpressLRS receiver connected via WiFi) can be passed in as: `btfltcp://{{address}}:{{port}}` - thus e.g. `btfltcp://10.0.0.1`, `btfltcp://10.0.0.1:5761` or even `btfltcp://elrs_rx.local`.

The scheme is automatically registered with the OS by the Configurator on all platforms during installation (currently Linux, Windows, OSX and Android). On all NW.js builds (Linux, Windows and OSX), the invocations with the scheme are handled both on a "cold start" as well as while the Configurator is running. On the Cordova (Android) builds, the [`cordova-plugin-customurlscheme`](https://www.npmjs.com/package/cordova-plugin-customurlscheme) NPM dep. is used to both register and handle the invocations with the custom URI scheme.

## Testing
The changes (as of commit 57c1883e3ea698d92f16770a5d7d36de53c8cce1) have been tested on the following platforms: 
- [x] Linux (deb)
- [x] Linux (rpm) 
- [x] Android (emulated)
- [x] Android (physical)
- [ ] OSX
- [x] Windows 


:information_source: Please note that in order to test this feature you must select the `enableURIScheme` experimental configuration option (it is _not_ necessary to restart the configurator afterwards):

![btfltcp-option](https://github.com/betaflight/betaflight-configurator/assets/3475899/b547e267-3fee-423b-9576-d79bef8004b4)


## Next steps

- (question to maintainers :question: ) Should we do anything special for the SpeedyBee app or would they decide to handle the change on their own? It would be good to see if multiple Android applications can handle the same deep link / custom URI scheme (so that the user can choose which one to open).
- The ExpressLRS Web UI can be updated with a link to open the Betaflight Configurator (as simple as e.g. `<a href="btfltcp://{{ip}}">Open Betaflight Configurator</a>`)

## Demos

- Linux (cold start)

![btfltcp-linux-cold](https://github.com/betaflight/betaflight-configurator/assets/3475899/a229f02d-2d5c-4a34-8ba7-8a12d9222741)



- Linux (warm start)
![btfltcp-linux-warm](https://github.com/betaflight/betaflight-configurator/assets/3475899/95e51f04-4bf9-4db6-9390-ac028d48fdb1)



- Android (cold start)
![btfltcp-android-cold](https://github.com/betaflight/betaflight-configurator/assets/3475899/32331988-6851-4ca4-846b-1a0e54f3b8f8)


- Android (warm start)
![btfltcp-android-warm](https://github.com/betaflight/betaflight-configurator/assets/3475899/094a9a2d-f6e0-4048-b5de-41d75657323d)

- Experimental configuration option toggling
![btfltcp-experimental-option](https://github.com/betaflight/betaflight-configurator/assets/3475899/19feadc4-ed64-40da-902c-f3a4f4d31e2d)
