### PR TITLE
Improve sponsors tab layout

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1163,14 +1163,12 @@ dialog {
 }
 .tab_sponsor {
     display: none;
-    height: 50px;
-    max-height: 50px;
     margin: 0 auto 10px auto;
 }
 .img_sponsor {
     height: 100%;
-    padding-left: 10px;
-    padding-right: 10px;
+    max-height: 50px;
+    padding: 5px 10px;
 }
 .note {
     background-color: #fff7cd;


### PR DESCRIPTION
Minimal improvement to sponsor logos on welcome screen.

Closes #3797

Note: IMHO ideally this layout would be rewritten to use flex display. However in a spirit of keeping bugfixes targeted and minimal this implements only necessary changes within exisiting block display.

<details>
<summary><h2>Screenshots</h2></summary>

![image](https://github.com/betaflight/betaflight-configurator/assets/2130305/e28a2ca9-823d-4499-a4ad-8e454ee68768)

![image](https://github.com/betaflight/betaflight-configurator/assets/2130305/2b73451d-fddd-43bb-a1d5-e1ea17de4e46)
</details> 


