### PR TITLE
[github actions] fix release assets upload

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -32,10 +32,10 @@ jobs:
           set -x
           ASSETS=()
           for asset in Betaflight-*/*; do
-            ASSETS+=("-a" "$asset")
+            ASSETS+=("$asset")
             echo "$asset"
           done
           TAG_NAME="${GITHUB_REF##*/}"
-          gh release edit "${ASSETS[@]}" "${TAG_NAME}"
+          gh release upload "${TAG_NAME}" "${ASSETS[@]}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
           path: release-assets/
 
       - name: Release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
+        uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           name: ${{ github.event.inputs.title }}


### PR DESCRIPTION
- fix github actions release upload assets
- https://cli.github.com/manual/gh_release_upload
- update softprops/action-gh-release to v2

![image](https://github.com/betaflight/betaflight-configurator/assets/56646290/b181e65a-623f-4ff5-b39f-c06b2e822e3b)
![image](https://github.com/betaflight/betaflight-configurator/assets/56646290/27d5bac0-e5e5-4daf-abf6-8eecbaf606de)


