### PR TITLE
Show the throttle limit in the graph

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -250,6 +250,8 @@ const FC = {
             rcYawRate:                  0,
             rcPitchRate:                0,
             RC_PITCH_EXPO:              0,
+            throttleLimitType:          0,
+            throttleLimitPercent:       100,
             roll_rate_limit:            1998,
             pitch_rate_limit:           1998,
             yaw_rate_limit:             1998,


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/3852

This PR adds a correct curve preview when using CLIP or SCALE in the throttle.

I'm not good at maths, so I'm sure there are better ways of doing this, but at least seems to be working.

![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/2ebcdfa4-519d-4ad9-85e4-8ca3a9e72638)
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/ff376632-224b-4460-babf-499f73236750)

I don't use this feature myself so any test will be appreciated, @ChrisRosser maybe can you do some tests?