### PR TITLE
Use firmware options on introduction

### DIFF
--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -1,5 +1,5 @@
 import { bit_check, bit_set, bit_clear } from "./bit";
-import { API_VERSION_1_44, API_VERSION_1_45 } from './data_storage';
+import { API_VERSION_1_44, API_VERSION_1_45, API_VERSION_1_46 } from './data_storage';
 import semver from "semver";
 import { tracking } from "./Analytics";
 import $ from 'jquery';
@@ -49,8 +49,10 @@ const Features = function (config) {
                 self._features.push(feature);
             }
         }
+    }
 
-        // Add TELEMETRY feature if any of the following build options are enabled
+    // Add TELEMETRY feature if any of the following protocols are used: CRSF, GHST, FPORT
+    if (semver.gte(config.apiVersion, API_VERSION_1_46)) {
         let enableTelemetry = false;
         if (config.buildOptions.some(opt => opt.includes('CRSF') || opt.includes('GHST') || opt.includes('FPORT'))) {
             enableTelemetry = true;

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -49,6 +49,16 @@ const Features = function (config) {
                 self._features.push(feature);
             }
         }
+
+        // Add TELEMETRY feature if any of the following build options are enabled
+        let enableTelemetry = false;
+        if (config.buildOptions.some(opt => opt.includes('CRSF') || opt.includes('GHST') || opt.includes('FPORT'))) {
+            enableTelemetry = true;
+        }
+
+        if (enableTelemetry) {
+            self._features.push({bit: 10, group: 'telemetry', name: 'TELEMETRY', haveTip: true, dependsOn: 'TELEMETRY'});
+        }
     }
 
     self._features.sort((a, b) => a.name.localeCompare(b.name, window.navigator.language, { ignorePunctuation: true }));

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -8,7 +8,7 @@ import semver from 'semver';
 import vtxDeviceStatusFactory from "../utils/VtxDeviceStatus/VtxDeviceStatusFactory";
 import MSP from "../msp";
 import MSPCodes from "./MSPCodes";
-import { API_VERSION_1_42, API_VERSION_1_43, API_VERSION_1_44, API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47 } from '../data_storage';
+import { API_VERSION_1_42, API_VERSION_1_43, API_VERSION_1_44, API_VERSION_1_45, API_VERSION_1_46 } from '../data_storage';
 import EscProtocols from "../utils/EscProtocols";
 import huffmanDecodeBuf from "../huffman";
 import { defaultHuffmanTree, defaultHuffmanLenIndex } from "../default_huffman_tree";
@@ -795,7 +795,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.CONFIG.gitRevision = String.fromCharCode.apply(null, buff);
                 console.log("Fw git rev:", FC.CONFIG.gitRevision);
 
-                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
                     let option = data.readU16();
                     while (option) {
                         FC.CONFIG.buildOptions.push(option);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -10,7 +10,7 @@ import MSP from "./msp";
 import MSPCodes from "./msp/MSPCodes";
 import PortUsage from "./port_usage";
 import PortHandler from "./port_handler";
-import CONFIGURATOR, { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47 } from "./data_storage";
+import CONFIGURATOR, { API_VERSION_1_45, API_VERSION_1_46 } from "./data_storage";
 import UI_PHONES from "./phones_ui";
 import { bit_check } from './bit.js';
 import { sensor_status, have_sensor } from "./sensor_helpers";
@@ -353,7 +353,7 @@ function onOpen(openInfo) {
                                 gui_log(i18n.getMessage('buildInfoReceived', [FC.CONFIG.buildInfo]));
 
                                 // retrieve build options from the flight controller
-                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
                                     FC.processBuildOptions();
                                 }
 
@@ -540,7 +540,7 @@ function checkReportProblems() {
 }
 
 async function processBuildOptions() {
-    const supported = semver.satisfies(FC.CONFIG.apiVersion, `${API_VERSION_1_45} - ${API_VERSION_1_46}`);
+    const supported = semver.eq(FC.CONFIG.apiVersion, API_VERSION_1_45);
 
     // firmware 1_45 or higher is required to support cloud build options
     // firmware 1_46 or higher retrieves build options from the flight controller

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -12,7 +12,7 @@ import FC from '../fc';
 import MSP from '../msp';
 import MSPCodes from '../msp/MSPCodes';
 import PortHandler, { usbDevices } from '../port_handler';
-import { API_VERSION_1_39, API_VERSION_1_45, API_VERSION_1_47 } from '../data_storage';
+import { API_VERSION_1_39, API_VERSION_1_45, API_VERSION_1_46 } from '../data_storage';
 import serial from '../serial';
 import STM32DFU from '../protocols/stm32usbdfu';
 import { gui_log } from '../gui_log';
@@ -1305,7 +1305,7 @@ firmware_flasher.verifyBoard = function() {
 
     function getBoardInfo() {
         MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, function() {
-            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
                 FC.processBuildOptions();
                 self.cloudBuildOptions = FC.CONFIG.buildOptions;
             }
@@ -1327,7 +1327,7 @@ firmware_flasher.verifyBoard = function() {
                     // store FC.CONFIG.buildKey as the object gets destroyed after disconnect
                     self.cloudBuildKey = FC.CONFIG.buildKey;
 
-                    if (self.validateBuildKey() && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                    if (self.validateBuildKey() && semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
                         self.buildApi.requestBuildOptions(self.cloudBuildKey, getCloudBuildOptions, getBoardInfo);
                     } else {
                         getBoardInfo();

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1320,27 +1320,24 @@ firmware_flasher.verifyBoard = function() {
         getBoardInfo();
     }
 
-    function getBuildInfo() {
+    async function getBuildInfo() {
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45) && FC.CONFIG.flightControllerIdentifier === 'BTFL') {
-            MSP.send_message(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.BUILD_KEY), false, () => {
-                MSP.send_message(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.CRAFT_NAME), false, () => {
-                    MSP.send_message(MSPCodes.MSP_BUILD_INFO, false, false, () => {
+            await MSP.promise(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.BUILD_KEY));
+            await MSP.promise(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.CRAFT_NAME));
+            await MSP.promise(MSPCodes.MSP_BUILD_INFO);
 
-                        // store FC.CONFIG.buildKey as the object gets destroyed after disconnect
-                        self.cloudBuildKey = FC.CONFIG.buildKey;
+            // store FC.CONFIG.buildKey as the object gets destroyed after disconnect
+            self.cloudBuildKey = FC.CONFIG.buildKey;
 
-                        // 3/21/2024 is the date when the build key was introduced
-                        const supportedDate = new Date('3/21/2024');
-                        const buildDate = new Date(FC.CONFIG.buildInfo);
+            // 3/21/2024 is the date when the build key was introduced
+            const supportedDate = new Date('3/21/2024');
+            const buildDate = new Date(FC.CONFIG.buildInfo);
 
-                        if (self.validateBuildKey() && (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_46) || buildDate < supportedDate)) {
-                            self.buildApi.requestBuildOptions(self.cloudBuildKey, getCloudBuildOptions, getBoardInfo);
-                        } else {
-                            getBoardInfo();
-                        }
-                    });
-                });
-            });
+            if (self.validateBuildKey() && (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_46) || buildDate < supportedDate)) {
+                self.buildApi.requestBuildOptions(self.cloudBuildKey, getCloudBuildOptions, getBoardInfo);
+            } else {
+                getBoardInfo();
+            }
         } else {
             getBoardInfo();
         }


### PR DESCRIPTION
- Follow up on #3780 
- Enables testing on current firmware in master
- ~~We need defines for telemetry for CRSF, GHST and FPORT in firmware or hack them into configurator~~
- Add missing telemetry option in case of CRSF, GHST or FPORT
- Uses firmware options introduced in 4.5.0-4RC4 firmware and beyond
- Add backwards compatibility using cloud API for earlier 4.5 builds