### PR TITLE
Rename blackbox field entry "Unfiltered Gyro"

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -773,7 +773,7 @@ const DEBUG = {
         { text: "Motor" },
         { text: "GPS" },
         { text: "RPM" },
-        { text: "Unfiltered Gyro"},
+        { text: "Gyro (Unfiltered)"},
     ],
 };
 


### PR DESCRIPTION
Renames the entry for unfiltered gyro, so that it starts with "Gyro". The list items are alphanumerically sorted, so filtered and unfiltered gyro will now be "grouped".

![grafik](https://github.com/betaflight/betaflight-configurator/assets/19867640/f8e64baf-53b7-4d64-a514-2bc5705b27f6)
