### PR TITLE
More Space Between Sponsors

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1162,13 +1162,12 @@ dialog {
     margin-bottom: 15px;
 }
 .tab_sponsor {
-    display: none;
-    margin: 0 auto 10px auto;
+    min-height: 65px;
 }
 .img_sponsor {
     height: 100%;
     max-height: 50px;
-    padding: 5px 10px;
+    margin: 5px 15px;
 }
 .note {
     background-color: #fff7cd;


### PR DESCRIPTION
1) Separates the sponsor logos a bit more
2) Sponsor div is now "static" in size, so that the divs below do not change their position on the initial load.