### PR TITLE
Fix virtual mode after serial connection

### DIFF
--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -19,6 +19,7 @@ const VirtualFC = {
         virtualFC.CONFIG.cpuTemp = 48;
 
         virtualFC.CONFIG.buildInfo = "now";
+        virtualFC.CONFIG.buildOptions = [];
 
         virtualFC.CONFIG.craftName = "BetaFlight" ;
         virtualFC.CONFIG.pilotName = "BF pilot" ;


### PR DESCRIPTION
Starting virtual mode on startup works, but after having serial connection we get:

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/730392a0-b684-4292-a25f-75688176983a)
