### PR TITLE
Add Acro center sensitivity to Betaflight Rates

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6999,6 +6999,9 @@
     "pidTuningRcRateActual": {
         "message": "Center Sensitivity"
     },
+    "pidTuningAcroCenterSensitiviy": {
+        "message": "Center-Max Sensitivity"
+    },
     "dialogRatesTypeTitle": {
         "message": "Rates type change"
     },

--- a/src/css/tabs/pid_tuning.less
+++ b/src/css/tabs/pid_tuning.less
@@ -181,7 +181,7 @@
 	.pid_titlebar {
 		th {
 			padding: 5px;
-			text-align: left;
+			text-align: center;
 			border-right: 1px solid var(--subtleAccent);
 			&:first-child {
 				text-align: left;

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -1613,6 +1613,11 @@ pid_tuning.initialize = function (callback) {
         self.maxAngularVelPitchElement   = $('.pid_tuning .maxAngularVelPitch');
         self.maxAngularVelYawElement     = $('.pid_tuning .maxAngularVelYaw');
 
+        // Only used with Betaflight Rates
+        self.acroCenterSensitivityRollElement = $('.pid_tuning .acroCenterSensitivityRoll');
+        self.acroCenterSensitivityPitchElement = $('.pid_tuning .acroCenterSensitivityPitch');
+        self.acroCenterSensitivityYawElement = $('.pid_tuning .acroCenterSensitivityYaw');
+
         rcCurveElement.width = 1000;
         rcCurveElement.height = 1000;
 
@@ -2697,13 +2702,33 @@ pid_tuning.updateRatesLabels = function() {
                 );
             }
 
-            // Add labels for angleCenterSensitivity
+            // Only show Acro Center - Max Sensitivity for betaflight rates
+            const centerSensitivyLabel = $('#pid-tuning .pid_titlebar .centerSensitivity');
 
+            const isBetaflightRates = self.currentRatesType === FC.RATES_TYPE.BETAFLIGHT;
+
+            $('#pid-tuning .pid_titlebar .name').text(isBetaflightRates ? 'Acro' : '').css("text-align", "center");
+
+            centerSensitivyLabel.toggle(isBetaflightRates);
+
+            self.acroCenterSensitivityRollElement.toggle(isBetaflightRates);
+            self.acroCenterSensitivityPitchElement.toggle(isBetaflightRates);
+            self.acroCenterSensitivityYawElement.toggle(isBetaflightRates);
+
+            $('#pid-tuning .pid_titlebar .maxVel').toggle(!isBetaflightRates);
+            self.maxAngularVelRollElement.toggle(!isBetaflightRates);
+            self.maxAngularVelPitchElement.toggle(!isBetaflightRates);
+            self.maxAngularVelYawElement.toggle(!isBetaflightRates);
+
+            // Add labels for Angle Center Sensitivity
             const angleLimit = FC.ADVANCED_TUNING.levelAngleLimit;
             const maxAngleRollRate = parseInt(maxAngularVelRoll);
             const maxAnglePitchRate = parseInt(maxAngularVelPitch);
+            const maxAngleYawRate = parseInt(maxAngularVelYaw);
+
             const rcRate = self.currentRates.rc_rate;
             const rcRatePitch = self.currentRates.rc_rate_pitch;
+            const rcRateYaw = self.currentRates.rc_rate_yaw;
 
             function getOffsetForBalloon(value) {
                 return curveWidth - (Math.ceil(stickContext.measureText(value).width) / (stickContext.canvas.clientWidth / stickContext.canvas.clientHeight)) - 40;
@@ -2734,24 +2759,32 @@ pid_tuning.updateRatesLabels = function() {
 
                 const RC_RATE_INCREMENTAL = 14.54;
 
+                const getRcRateModified = rate => rate > 2.0 ? (rate - 2.0) * RC_RATE_INCREMENTAL + 2.0: rate;
+                const getAcroSensitivityFraction = (exponent, rate) => ((1 - exponent) * getRcRateModified(rate) * 200).toFixed(0);
+                const getAngleSensitivityFraction = (exponent, rate) => (angleLimit * ((1 - exponent) * getRcRateModified(rate) * 200 / maxAngleRollRate)).toFixed(1);
+
                 // ROLL
                 const expo = self.currentRates.rc_expo;
-                const rcRateModified = rcRate > 2.0 ? (rcRate - 2.0) * RC_RATE_INCREMENTAL + 2.0: rcRate;
-                const sensitivityFractionRoll = (angleLimit * ((1 - expo) * rcRateModified * 200 / maxAngleRollRate)).toFixed(1);
-
-                const sensitivityFractionRollText = `${sensitivityFractionRoll}...${angleLimit}`;
-                const sensitivityFractionRollOffset = getOffsetForBalloon(sensitivityFractionRollText);
+                const angleCenterSensitivityFractionRoll = getAngleSensitivityFraction(expo, rcRate);
+                const angleCenterSensitivityFractionRollText = `${angleCenterSensitivityFractionRoll} - ${angleLimit}`;
+                const angleCenterSensitivityFractionRollOffset = getOffsetForBalloon(angleCenterSensitivityFractionRollText);
+                const acroCenterSensitivityFractionRoll = getAcroSensitivityFraction(expo, rcRate);
+                self.acroCenterSensitivityRollElement.text(`${acroCenterSensitivityFractionRoll} - ${maxAngleRollRate}`);
                 // PITCH
                 const expoPitch = self.currentRates.rc_pitch_expo;
-                const rcRateModifiedPitch = rcRatePitch > 2.0 ? (rcRatePitch - 2.0) * RC_RATE_INCREMENTAL + 2.0: rcRatePitch;
-                const sensitivityFractionPitch = (angleLimit * ((1 - expoPitch) * rcRateModifiedPitch * 200 / maxAnglePitchRate)).toFixed(1);
-
-                const sensitivityFractionPitchText = `${sensitivityFractionPitch}...${angleLimit}`;
-                const sensitivityFractionPitchOffset = getOffsetForBalloon(sensitivityFractionPitchText);
+                const angleCenterSensitivityFractionPitch = getAngleSensitivityFraction(expoPitch, rcRatePitch);
+                const angleCenterSensitivityFractionPitchText = `${angleCenterSensitivityFractionPitch} - ${angleLimit}`;
+                const angleCenterSensitivityFractionPitchOffset = getOffsetForBalloon(angleCenterSensitivityFractionPitchText);
+                const acroCenterSensitivityFractionPitch = getAcroSensitivityFraction(expoPitch, rcRatePitch);
+                self.acroCenterSensitivityPitchElement.text(`${acroCenterSensitivityFractionPitch} - ${maxAnglePitchRate}`);
+                // YAW
+                const expoYaw = self.currentRates.rc_yaw_expo;
+                const acroCenterSensitivityFractionYaw = getAcroSensitivityFraction(expoYaw, rcRateYaw);
+                self.acroCenterSensitivityYawElement.text(`${acroCenterSensitivityFractionYaw} - ${maxAngleYawRate}`);
 
                 balloons.push(
-                    {value: parseInt(sensitivityFractionRoll), balloon: function() {drawBalloonLabel(stickContext, sensitivityFractionRollText, sensitivityFractionRollOffset, curveHeight - 150, 'none', BALLOON_COLORS.roll, balloonsDirty);}},
-                    {value: parseInt(sensitivityFractionPitch), balloon: function() {drawBalloonLabel(stickContext, sensitivityFractionPitchText, sensitivityFractionPitchOffset, curveHeight - 50, 'none', BALLOON_COLORS.pitch, balloonsDirty);}},
+                    {value: parseInt(angleCenterSensitivityFractionRoll), balloon: function() {drawBalloonLabel(stickContext, angleCenterSensitivityFractionRollText, angleCenterSensitivityFractionRollOffset, curveHeight - 150, 'none', BALLOON_COLORS.roll, balloonsDirty);}},
+                    {value: parseInt(angleCenterSensitivityFractionPitch), balloon: function() {drawBalloonLabel(stickContext, angleCenterSensitivityFractionPitchText, angleCenterSensitivityFractionPitchOffset, curveHeight - 50, 'none', BALLOON_COLORS.pitch, balloonsDirty);}},
                 );
             }
 
@@ -2894,6 +2927,7 @@ pid_tuning.changeRatesSystem = function(sameType) {
     const rcRateLabel = $('#pid-tuning .pid_titlebar .rc_rate');
     const rateLabel = $('#pid-tuning .pid_titlebar .rate');
     const rcExpoLabel = $('#pid-tuning .pid_titlebar .rc_expo');
+    const centerSensitivyLabel = $('#pid-tuning .pid_titlebar .centerSensitivity');
 
     // default values for betaflight curve. all the default values produce the same betaflight default curve (or at least near enough)
     let rcRateDefault = (1).toFixed(2), rateDefault = (0.7).toFixed(2), expoDefault = (0).toFixed(2);
@@ -3006,7 +3040,7 @@ pid_tuning.changeRatesSystem = function(sameType) {
             rcRateLabel.text(i18n.getMessage("pidTuningRcRate"));
             rateLabel.text(i18n.getMessage("pidTuningRate"));
             rcExpoLabel.text(i18n.getMessage("pidTuningRcExpo"));
-
+            centerSensitivyLabel.text(i18n.getMessage("pidTuningAcroCenterSensitiviy"));
             break;
     }
 

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -2707,8 +2707,6 @@ pid_tuning.updateRatesLabels = function() {
 
             const isBetaflightRates = self.currentRatesType === FC.RATES_TYPE.BETAFLIGHT;
 
-            $('#pid-tuning .pid_titlebar .name').text(isBetaflightRates ? 'Acro' : '').css("text-align", "center");
-
             centerSensitivyLabel.toggle(isBetaflightRates);
 
             self.acroCenterSensitivityRollElement.toggle(isBetaflightRates);

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -976,6 +976,7 @@
                                 <th class="rc_rate" i18n="pidTuningRcRate"></th>
                                 <th class="rate" i18n="pidTuningRate"></th>
                                 <th class="rc_expo" i18n="pidTuningRcExpo"></th>
+                                <th class="new_rates centerSensitivity" i18n="pidTuningRcRateActual"></th>
                                 <th class="new_rates maxVel" i18n="pidTuningMaxVel"></th>
                             </tr>
                             <tr class="pid_titlebar2">
@@ -1001,6 +1002,7 @@
                                     <input type="number" class="expo_input" name="rc_expo" step="0.01" min="0" max="1" />
                                     <div class="bracket"></div>
                                 </td>
+                                <td class="new_rates acroCenterSensitivityRoll"></td>
                                 <td class="new_rates maxAngularVelRoll"></td>
                             </tr>
                             <tr class="PITCH">
@@ -1014,6 +1016,7 @@
                                 <td>
                                     <input type="number" class="expo_input" name="rc_pitch_expo" step="0.01" min="0" max="1" />
                                 </td>
+                                <td class="new_rates acroCenterSensitivityPitch"></td>
                                 <td class="new_rates maxAngularVelPitch"></td>
                             </tr>
                             <tr class="YAW">
@@ -1027,6 +1030,7 @@
                                 <td>
                                     <input type="number" class="expo_input" name="rc_yaw_expo" step="0.01" min="0" max="1" />
                                 </td>
+                                <td class="new_rates acroCenterSensitivityYaw"></td>
                                 <td class="new_rates maxAngularVelYaw"></td>
                             </tr>
                         </table>


### PR DESCRIPTION
This PR makes two important and useful changes to the Rates display window:

1. For `Angle Mode` users, displays centre and max stick sensitivity while in Actual and Betaflight Rates.  The centre sensitivity is the amount of angle change per unit change in stick position, expressed in degrees as if that sensitivity was to continue linearly to full stick position.  The max sensitivity is set by the user's `angle_limit` CLI value, the maximum angle allowed at full stick input. 

Note that in Betaflight 4.5, the old `angle_expo_roll` and `angle_expo_pitch` parameters are deprecated and have been removed.  The *shape* of the currently selected rates curve determines the centre sensitivity.  The values shown by this PR gives centre and max Angle Mode sensitivity values that are absolute and can be directly compared from one quad to the next.

The user should configure their Rates to suit their acro preference.  Usually this will also result in a good Angle mode experience, and will facilitate a smooth transition to Acro Trainer or Horizon Mode.  If the user wants greater centre sensitivity, they need to change the shape of the curve, so that the slope in the centre is steeper.  In Actual Rates this means increasing the centre sensitivity value.  In Betaflight rates more than one parameter affect Center Sensitivity.  Regardless of Rates model, the user can use the Angle Mode centre sensitivity value when adjusting their Angle Mode stick feel.

2. The second big change is to displays centre sensitivity, as well as max rate,for Betaflight Rates.  This makes it easy for users of Betaflight Rates to transition to Actual Rates.  The centre sensitivity value is directly comparable to (identical to) the centre sensitivity value in Actual Rates.  

In both cases the centre sensitivity values update dynamically when the use modify their rates curves.

Note that in 4.5, the Angle Mode user can configure different Rates curves, and that Rates curves can be changed 'on the fly', even mid-flight. However it's generally best to configure your rates to suit your Acro preference, and adapt to how they feel in Angle Mode.  

Note also that in Angle Mode the `angle_limit` value affects overall stick sensitivity.  If you fly Acro and find Angle Mode a bit 'dull' in the centre, consider increasing `angle_limit` rather than changing your rates.

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/16848a1e-b5a6-4356-9984-28e20323bc44)
