### PR TITLE
Expose [local] firmware build options

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1119,6 +1119,18 @@
     "initialSetupInfoBuildEmpty": {
         "message": "Local Build - no Cloud information"
     },
+    "initialSetupInfoBuildType": {
+        "message": "Build type"
+    },
+    "initialSetupInfoBuildLocal": {
+        "message": "Local Build"
+    },
+    "initialSetupInfoBuildCloud": {
+        "message": "Cloud Build"
+    },
+    "initialSetupNoBuildInfo": {
+        "message": "No build information available"
+    },
     "initialSetupNotOnline": {
         "message": "Server unavailable"
     },

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -234,10 +234,18 @@
                                     <td id="build-date" i18n="initialSetupInfoBuildDate"></td>
                                     <td class="build-date"></td>
                                 </tr>
+                                <tr>
+                                    <td id="build-type" i18n="initialSetupInfoBuildType"></td>
+                                    <td class="build-type"></td>
+                                </tr>
                                 </tr>
                                     <tr>
                                     <td id="build-info" i18n="initialSetupInfoBuildInfo"></td>
                                     <td class="build-info"></td>
+                                </tr>
+                                <tr>
+                                    <td id="build-options" i18n="initialSetupInfoBuildOptions"></td>
+                                    <td class="build-options"></td>
                                 </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
Since firmware 4.5 build options are provided by firmware instead of relying on cloud queries.

- Add build type to setup tab
- Keep using cloud info for build log and config
- Expose build options for local firmware builds

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/6930ebe9-629d-4127-b4a7-f9aa8a8209b8)
![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/31494d32-b2c1-497c-aa0d-391508cfd4dd)

