### PR TITLE
Fix reset options

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -226,9 +226,9 @@ const FC = {
     resetState () {
         // Using `Object.assign` instead of reassigning to
         // trigger the updates on the Vue side
-        Object.assign(this.CONFIG, INITIAL_CONFIG);
-        Object.assign(this.ANALOG, INITIAL_ANALOG);
-        Object.assign(this.BATTERY_CONFIG, INITIAL_BATTERY_CONFIG);
+        this.CONFIG = JSON.parse(JSON.stringify(INITIAL_CONFIG));
+        this.ANALOG = JSON.parse(JSON.stringify(INITIAL_ANALOG));
+        this.BATTERY_CONFIG = JSON.parse(JSON.stringify(INITIAL_BATTERY_CONFIG));
 
         this.BF_CONFIG = {
             currentscale:               0,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -796,7 +796,6 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log("Fw git rev:", FC.CONFIG.gitRevision);
 
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
-                    FC.CONFIG.buildOptions = [];
                     let option = data.readU16();
                     while (option) {
                         FC.CONFIG.buildOptions.push(option);

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -796,6 +796,7 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 console.log("Fw git rev:", FC.CONFIG.gitRevision);
 
                 if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                    FC.CONFIG.buildOptions = [];
                     let option = data.readU16();
                     while (option) {
                         FC.CONFIG.buildOptions.push(option);

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -158,14 +158,15 @@ PortHandler.check_usb_devices = function (callback) {
             dfuElement.remove();
             self.setPortsInputWidth();
             self.dfu_available = false;
-        }
-        if ($('option:selected', self.portPickerElement).val() !== 'DFU') {
-            if (!(GUI.connected_to || GUI.connect_lock)) {
-                FC.resetState();
-            }
 
-            if (self.dfu_available) {
-                self.portPickerElement.trigger('change');
+            if ($('option:selected', self.portPickerElement).val() !== 'DFU') {
+                if (!(GUI.connected_to || GUI.connect_lock)) {
+                    FC.resetState();
+                }
+
+                if (self.dfu_available) {
+                    self.portPickerElement.trigger('change');
+                }
             }
         }
 


### PR DESCRIPTION
- Resets the build options when switching flight controller using [deep copy](https://developer.mozilla.org/en-US/docs/Glossary/Deep_copy)
- Do not call `FC.resetState()` two times a second in portHandler
- Fixes after connecting another FC after a build with local build retaining options:

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/9c799144-5e3f-416a-b599-c5e032e604a9)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/e8ba07a3-7782-4157-b19f-41a470ce435e)
