### PR TITLE
Fix AT32 detection

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -327,7 +327,8 @@ PortHandler.selectPort = function(ports) {
             const pathSelect = ports[i].path;
             const isWindows = (OS === 'Windows');
             const isTty = pathSelect.includes('tty');
-            const deviceRecognized = portName.includes('STM') || portName.includes('CP210') || portName.startsWith('SPR');
+            const deviceFilter = ['AT32', 'CP210', 'SPR', 'STM32'];
+            const deviceRecognized = deviceFilter.some(device => portName.includes(device));
             const legacyDeviceRecognized = portName.includes('usb');
             if (isWindows && deviceRecognized || isTty && (deviceRecognized || legacyDeviceRecognized)) {
                 this.portPickerElement.val(pathSelect);


### PR DESCRIPTION
- Fixes when AT32 FC is attached before starting configurator it was not possible to use auto-detect on firmware flasher tab.