### PR TITLE
Enforce preset mutally exclusive option groups

### DIFF
--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
@@ -199,10 +199,9 @@ export default class PresetsDetailedDialog {
         const firstUnderscoreIndex = selectedOptionKey.indexOf('_');
         const lastUnderscoreIndex = selectedOptionKey.lastIndexOf('_');
         const groupIndex = selectedOptionKey.slice(firstUnderscoreIndex + 1, lastUnderscoreIndex);
-        const optionIndex = selectedOptionKey.slice(lastUnderscoreIndex + 1);
 
         const group = this._preset.options[groupIndex];
-        if(group.isExclusive) {
+        if (group.isExclusive) {
             // clear all options within group
             const valuesWithinGroup = this._domOptionsSelect.find(`optgroup[label="${group.name}"]`)
                 .children()

--- a/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
+++ b/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
@@ -83,11 +83,22 @@ export default class PresetParser {
     }
 
     _getOptionGroup(line) {
-        const directiveRemoved = line.slice(this._settings.OptionsDirectives.BEGIN_OPTION_GROUP_DIRECTIVE.length).trim();
+        const lowercaseLine = line.toLowerCase();
+        const exlusiveDirective = this._settings.OptionsDirectives.EXCLUSIVE_OPTION_GROUP;
+        const isExclusiveGroup = lowercaseLine.includes(exlusiveDirective);
+
+        let directiveRemoved;
+        if(isExclusiveGroup) {
+            const exclusiveDirectiveLength = exlusiveDirective.length;
+            directiveRemoved = line.slice(lowercaseLine.lastIndexOf(exlusiveDirective) + exclusiveDirectiveLength).trim();
+        } else {
+            directiveRemoved = line.slice(this._settings.OptionsDirectives.BEGIN_OPTION_GROUP_DIRECTIVE.length).trim();
+        }
 
         return {
             name: directiveRemoved.slice(1).trim(),
             childs: [],
+            isExclusive: isExclusiveGroup,
         };
     }
 

--- a/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
+++ b/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
@@ -90,7 +90,7 @@ export default class PresetParser {
         let directiveRemoved;
         if(isExclusiveGroup) {
             const exclusiveDirectiveLength = exlusiveDirective.length;
-            directiveRemoved = line.slice(lowercaseLine.lastIndexOf(exlusiveDirective) + exclusiveDirectiveLength).trim();
+            directiveRemoved = line.slice(lowercaseLine.lastIndexOf(exlusiveDirective) + exclusiveDirectiveLength - 1).trim();
         } else {
             directiveRemoved = line.slice(this._settings.OptionsDirectives.BEGIN_OPTION_GROUP_DIRECTIVE.length).trim();
         }

--- a/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
+++ b/src/tabs/presets/PresetsRepoIndexed/PresetParser.js
@@ -88,7 +88,7 @@ export default class PresetParser {
         const isExclusiveGroup = lowercaseLine.includes(exlusiveDirective);
 
         let directiveRemoved;
-        if(isExclusiveGroup) {
+        if (isExclusiveGroup) {
             const exclusiveDirectiveLength = exlusiveDirective.length;
             directiveRemoved = line.slice(lowercaseLine.lastIndexOf(exlusiveDirective) + exclusiveDirectiveLength - 1).trim();
         } else {


### PR DESCRIPTION
This enables presets that use the (Exclusive) directive on option groups to only allow a single item within that group to be checked at a time.

See [this PR](https://github.com/betaflight/firmware-presets/pull/461) on the presets repository for the indexer/verifier updates.