### PR TITLE
Remove gulp appdmg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: cache/
-          key: nwjs-${{ inputs.debug_build && 'debug' || 'release' }}-${{ runner.os }}-${{ hashFiles('gulpfile.js') }}
+          key: nwjs-${{ inputs.debug_build && 'debug' || 'release' }}-${{ runner.os }}
 
       - name: Cache node_modules
         uses: actions/cache@v4

--- a/README.md
+++ b/README.md
@@ -125,36 +125,6 @@ The web app should behave directly as in production, available at http://localho
 
 `yarn test`
 
-### App build and release
-
-The tasks are defined in `gulpfile.js` and can be run with through yarn:
-```
-yarn gulp <taskname> [[platform] [platform] ...]
-```
-
-List of possible values of `<task-name>`:
-* **dist** copies all the JS and CSS files in the `./dist` folder [2].
-* **apps** builds the apps in the `./apps` folder [1].
-* **debug** builds debug version of the apps in the `./debug` folder [1][3].
-* **release** zips up the apps into individual archives in the `./release` folder [1].
-
-[1] Running this task on macOS or Linux requires Wine, since it's needed to set the icon for the Windows app (build for specific platform to avoid errors).
-[2] For Android platform, **dist** task will generate folders and files in the `./dist_cordova` folder.
-[3] For Android platform, you need to configure an emulator or to plug an Android device with USB debugging enabled
-
-#### Build or release app for one specific platform
-To build or release only for one specific platform you can append the plaform after the `task-name`.
-If no platform is provided, the build for the host platform is run.
-
-* **MacOS X** use `yarn gulp <task-name> --osx64`
-* **Linux** use `yarn gulp <task-name> --linux64`
-* **Windows** use `yarn gulp <task-name> --win64`
-* **Android** use `yarn gulp <task-name> --android`
-
-**Note:** Support for cross-platform building is very limited due to the requirement for platform specific build tools. If in doubt, build on the target platform.
-
-You can also use multiple platforms e.g. `yarn gulp <taskname> --osx64 --linux64`. Other platforms like `--win32`, `--linux32` and `--armv8` can be used too, but they are not officially supported, so use them at your own risk.
-
 #### Leverage GitHub-Actions to build binaries
 
 You can use the GitHub `Actions` tab in your fork to build binaries as well. Select `Actions`>`Manual Build`>`Run Workflow`. Choose your custom branch and click `Run workflow`. The workflow will dispatch in a few moments and upon completion, the build "Artifacts" will be available for download from within the workflow run.

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "review": "vite build && vite preview",
     "pretest": "yarn run lint",
     "test": "vitest",
-    "lint": "eslint --ext .js,.vue src gulpfile.js gulp-appdmg.js",
-    "lint:fix": "eslint --fix src gulpfile.js gulp-appdmg.js",
+    "lint": "eslint --ext .js,.vue src",
+    "lint:fix": "eslint --fix src",
     "storybook": "start-storybook -p 6006"
   },
   "repository": {


### PR DESCRIPTION
- removes gulpfile.js gulp-appdmg.js from linting
- removes gulpefile.js from CI caching
- removes legacy NWjs building from Readme