### PR TITLE
10.10-maintenance update - including background colour activation cherry pick

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "betaflight-configurator",
   "productName": "Betaflight Configurator",
   "description": "Crossplatform configuration tool for Betaflight flight control system.",
-  "version": "11.0.0",
+  "version": "10.10.1",
   "main": "main.html",
   "chromium-args": "--disable-features=nw2",
   "scripts": {

--- a/src/css/tabs/auxiliary.less
+++ b/src/css/tabs/auxiliary.less
@@ -63,39 +63,6 @@
 			border-radius: 3px;
 		}
 	}
-	.mode.on {
-		.info {
-			background: var(--accent);
-			color: black;
-		}
-		&:nth-child(odd) {
-			.info {
-				background: var(--accent);
-			}
-		}
-	}
-	.mode.off {
-		.info {
-			background: #828885;
-			color: white;
-		}
-		&:nth-child(odd) {
-			.info {
-				background: #828885;
-			}
-		}
-	}
-	.mode.disabled {
-		.info {
-			background: var(--error);
-			color: var(--quietText);
-		}
-		&:nth-child(odd) {
-			.info {
-				background: var(--error);
-			}
-		}
-	}
 	.modes {
 		width: 100%;
 	}
@@ -103,6 +70,40 @@
 		background-color: #f9f9f9;
 		vertical-align: top;
 		display: flex;
+
+		&.on {
+			.info {
+				background: var(--accent) !important;
+				color: black;
+			}
+			&:nth-child(odd) {
+				.info {
+					background: var(--accent) !important;
+				}
+			}
+		}
+		&.off {
+			.info {
+				background: #828885 !important;
+				color: white;
+			}
+			&:nth-child(odd) {
+				.info {
+					background: #828885 !important;
+				}
+			}
+		}
+		&.disabled {
+			.info {
+				background: var(--error) !important;
+				color: var(--quietText);
+			}
+			&:nth-child(odd) {
+				.info {
+					background: var(--error) !important;
+				}
+			}
+		}	
 		.name {
 			min-height: 80px;
 			padding: 5px 0;

--- a/src/js/data_storage.js
+++ b/src/js/data_storage.js
@@ -13,7 +13,7 @@ const CONFIGURATOR = {
     // all versions are specified and compared using semantic versioning http://semver.org/
     API_VERSION_ACCEPTED: API_VERSION_1_41,
     API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE: API_VERSION_1_41,
-    API_VERSION_MAX_SUPPORTED: API_VERSION_1_47,
+    API_VERSION_MAX_SUPPORTED: API_VERSION_1_46,
 
     connectionValid: false,
     connectionValidCliOnly: false,


### PR DESCRIPTION
- Revert version change, and add 10.10.1
- Fix background color activation in modes tab in dark mode (#3961) (cherry picked from commit 66e822d3f3a5e31e306cfafd271e089b340fd27e)
