### PR TITLE
Use the "show manual" preference in the porthandler to show or hide the option

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -52,6 +52,10 @@
     "disconnect": {
         "message": "Disconnect"
     },
+    "portsSelectNoSelection": {
+        "message": "Select your device",
+        "description": "Text for the option to select a device in the port selection dropdown"
+    },
     "portsSelectManual": {
         "message": "Manual Selection"
     },

--- a/src/components/port-picker/PortPicker.vue
+++ b/src/components/port-picker/PortPicker.vue
@@ -14,6 +14,8 @@
       :value="value"
       :connected-devices="connectedDevices"
       :disabled="disabled"
+      :show-virtual-option="showVirtualOption"
+      :show-manual-option="showManualOption"
       @input="updateValue(null, $event)"
     />
   </div>
@@ -31,24 +33,32 @@ export default {
     PortsInput,
   },
   props: {
-    value: {
-      type: Object,
-      default: () => ({
-        selectedPort: "manual",
-        selectedBaud: 115200,
-        portOverride: "/dev/rfcomm0",
-        virtualMspVersion: "1.46.0",
-        autoConnect: true,
-      }),
-    },
-    connectedDevices: {
-      type: Array,
-      default: () => [],
-    },
-    disabled: {
-      type: Boolean,
-      default: false,
-    },
+      value: {
+        type: Object,
+        default: () => ({
+          selectedPort: "noselection",
+          selectedBaud: 115200,
+          portOverride: "/dev/rfcomm0",
+          virtualMspVersion: "1.46.0",
+          autoConnect: true,
+        }),
+      },
+      connectedDevices: {
+        type: Array,
+        default: () => [],
+      },
+      showVirtualOption: {
+        type: Boolean,
+        default: true,
+      },
+      showManualOption: {
+        type: Boolean,
+        default: true,
+      },
+      disabled: {
+        type: Boolean,
+        default: false,
+      },
   },
   methods: {
     updateValue(key, value) {

--- a/src/components/port-picker/PortsInput.vue
+++ b/src/components/port-picker/PortsInput.vue
@@ -13,11 +13,20 @@
         :disabled="disabled"
         @change="onChangePort"
       >
-        <option value="manual">
+        <option
+          value="noselection"
+          disabled
+        >
+          {{ $t("portsSelectNoSelection") }}
+        </option>
+        <option
+          v-show="showManualOption"
+          value="manual"
+        >
           {{ $t("portsSelectManual") }}
         </option>
         <option
-          v-if="showVirtual"
+          v-show="showVirtualOption"
           value="virtual"
         >
           {{ $t("portsSelectVirtual") }}
@@ -84,7 +93,7 @@ export default {
     value: {
       type: Object,
       default: () => ({
-        selectedPort: 'manual',
+        selectedPort: 'noselection',
         selectedBauds: 115200,
         autoConnect: true,
       }),
@@ -96,7 +105,15 @@ export default {
     disabled: {
         type: Boolean,
         default: false,
-      },
+    },
+    showVirtualOption: {
+      type: Boolean,
+      default: true,
+    },
+    showManualOption: {
+      type: Boolean,
+      default: true,
+    },
   },
   data() {
       return {
@@ -118,21 +135,9 @@ export default {
           ],
       };
   },
-  mounted() {
-    EventBus.$on('config-storage:set', this.setShowVirtual);
-    this.setShowVirtual('showVirtualMode');
-  },
-  destroyed() {
-    EventBus.$off('config-storage:set', this.setShowVirtual);
-  },
   methods: {
     updateValue(key, value) {
       this.$emit('input', { ...this.value, [key]: value });
-    },
-    setShowVirtual(element) {
-      if (element === 'showVirtualMode') {
-        this.showVirtual = getConfig('showVirtualMode').showVirtualMode;
-      }
     },
     onChangePort(event) {
       if (event.target.value === 'requestpermission') {

--- a/src/index.html
+++ b/src/index.html
@@ -29,6 +29,8 @@
         <port-picker
             v-model="PortHandler.portPicker"
             :connected-devices="PortHandler.currentPorts"
+            :show-virtual-option="PortHandler.showVirtualMode"
+            :show-manual-option="PortHandler.showManualMode"
             :disabled="PortHandler.portPickerDisabled"
         ></port-picker>
         <div class="header-wrapper">

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -10,7 +10,7 @@ import { EventBus } from "../components/eventBus";
 
 const serial = serialShim();
 
-const DEFAULT_PORT = 'manual';
+const DEFAULT_PORT = 'noselection';
 const DEFAULT_BAUDS = 115200;
 
 const PortHandler = new function () {
@@ -30,8 +30,8 @@ const PortHandler = new function () {
     this.port_available = false;
     this.showAllSerialDevices = false;
     this.useMdnsBrowser = false;
-    this.showVirtualMode = false;
-    this.showManualMode = false;
+    this.showVirtualMode = getConfig('showVirtualMode').showVirtualMode;
+    this.showManualMode = getConfig('showManualMode').showManualMode;
 };
 
 PortHandler.initialize = function () {
@@ -40,21 +40,29 @@ PortHandler.initialize = function () {
     EventBus.$on('ports-input:change', this.onChangeSelectedPort.bind(this));
 
     serial.addEventListener("addedDevice", this.check_serial_devices.bind(this));
-
     serial.addEventListener("removedDevice", this.check_serial_devices.bind(this));
 
     this.reinitialize();    // just to prevent code redundancy
 };
 
+PortHandler.setShowVirtualMode = function (showVirtualMode) {
+    this.showVirtualMode = showVirtualMode;
+    this.selectActivePort();
+};
+
+PortHandler.setShowManualMode = function (showManualMode) {
+    this.showManualMode = showManualMode;
+    this.selectActivePort();
+};
+
 PortHandler.reinitialize = function () {
     this.initialPorts = false;
+
 
     if (this.usbCheckLoop) {
         clearTimeout(this.usbCheckLoop);
     }
 
-    this.showVirtualMode = getConfig('showVirtualMode').showVirtualMode;
-    this.showManualMode = getConfig('showManualMode').showManualMode;
     this.showAllSerialDevices = getConfig('showAllSerialDevices').showAllSerialDevices;
     this.useMdnsBrowser = getConfig('useMdnsBrowser').useMdnsBrowser;
 
@@ -286,14 +294,14 @@ PortHandler.askPermissionPort = function() {
 };
 
 PortHandler.selectActivePort = function() {
-    const ports = this.currentPorts;
-    const OS = GUI.operating_system;
+
     let selectedPort;
-    for (let i = 0; i < ports.length; i++) {
-        const portName = ports[i].displayName;
+
+    const deviceFilter = ['AT32', 'CP210', 'SPR', 'STM'];
+    for (let port of this.currentPorts) {
+        const portName = port.displayName;
         if (portName) {
-            const pathSelect = ports[i].path;
-            const deviceFilter = ['AT32', 'CP210', 'SPR', 'STM'];
+            const pathSelect = port.path;
             const deviceRecognized = deviceFilter.some(device => portName.includes(device));
             const legacyDeviceRecognized = portName.includes('usb');
             if (deviceRecognized || legacyDeviceRecognized) {
@@ -303,7 +311,17 @@ PortHandler.selectActivePort = function() {
             }
         }
     }
+
+    if (!selectedPort)  {
+        if (this.showVirtualMode) {
+            selectedPort = "virtual";
+        } else if (this.showManualMode) {
+            selectedPort = "manual";
+        }
+    }
+
     this.portPicker.selectedPort = selectedPort || DEFAULT_PORT;
+    console.log(`Porthandler default device is '${this.portPicker.selectedPort}'`);
 };
 
 PortHandler.port_detected = function(name, code, timeout, ignore_timeout) {

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -141,8 +141,9 @@ options.initShowVirtualMode = function() {
     showVirtualModeElement
         .prop('checked', !!result.showVirtualMode)
         .on('change', () => {
-            setConfig({ showVirtualMode: showVirtualModeElement.is(':checked') });
-            PortHandler.reinitialize();
+            const checked = showVirtualModeElement.is(':checked');
+            setConfig({ showVirtualMode: checked });
+            PortHandler.setShowVirtualMode(checked);
         });
 };
 
@@ -152,8 +153,9 @@ options.initUseManualConnection = function() {
     showManualModeElement
         .prop('checked', !!result.showManualMode)
         .on('change', () => {
-            setConfig({ showManualMode: showManualModeElement.is(':checked') });
-            PortHandler.reinitialize();
+            const checked = showManualModeElement.is(':checked');
+            setConfig({ showManualMode: checked });
+            PortHandler.setShowManualMode(checked);
         });
 };
 


### PR DESCRIPTION
Right now the manual port is always shown. This PR does some things:
- Makes the ports combo respect the show manual or not option
- Adds a default "Select your device" disabled option to the list of ports, and is the default one when there is no other ports in the list.
- With each change, first, tries to select a "real" one port, if not exists the "virtual" and then the "manual". As last option it defaults to "Select your device".

The port handler needs a bigger refactor, this are only the first steps.