### PR TITLE
Add tests again to the Github Actions

### DIFF
--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -3,6 +3,7 @@ on:
   workflow_run:
     workflows: ["PR"]
     types: [completed]
+    branches: ['*-maintenance']
 
 jobs:
   artifacts-url-comments:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
   build:
     name: Build (${{ matrix.name }})
     needs: test
+    if: ${{ endsWith(github.ref, 'maintenance') }}
     runs-on:  ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/hide-artifact-links.yml
+++ b/.github/workflows/hide-artifact-links.yml
@@ -3,6 +3,7 @@ name: Hide artifact links comments
 on:
   pull_request_target:
     types: [synchronize, reopened]
+    branches: ['*-maintenance']
 
 jobs:
   hide-artifacts-link-comments:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,7 @@ name: Nightly
 on:
   push:
     branches:
+      - master
       - '*-maintenance'
 
 jobs:
@@ -29,6 +30,7 @@ jobs:
   release:
     name: Nightly release
     needs: ci
+    if: ${{ endsWith(github.ref, 'maintenance') }}
     runs-on: ubuntu-22.04
     steps:
       - name: Fetch build artifacts

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,6 +3,7 @@ name: PR
 on:
   pull_request:
     branches:
+      - master
       - '*-maintenance'
 
 concurrency:

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -1,7 +1,5 @@
 import GUI from "./gui.js";
 import CONFIGURATOR from "./data_storage.js";
-import serialNWJS from "./serial.js";
-import serialWeb from "./webSerial.js";
 import { isWeb } from "./utils/isWeb.js";
 import { serialShim } from "./serial_shim.js";
 


### PR DESCRIPTION
This adds the Github Actions to the PWA (master) version of the Configurator again. In this way we pass the (few) tests that we have and, principally, the lint.

The problem is that tests don't pass right now. The `port_handler.js` access the `serialShim()` and seems that the test engine doesn't detect this function. If we fix that the `webSerial.js` will not find the `navigator.serial`.

I suppose we need some kind of mock but I'm not too sure how to do it. @Benky I know it has passed a lot of time from this, but maybe you have some time to make this working again? Any other is able to fix this?