### PR TITLE
Sort rate models

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1273,7 +1273,7 @@ firmware_flasher.verifyBoard = function() {
             const boardSelect = $('select[name="board"]');
             const boardSelectOptions = $('select[name="board"] option');
             const target = boardSelect.val();
-    
+
             boardSelectOptions.each((_, e) => {
                 if ($(e).text() === board) {
                     targetAvailable = true;

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -470,6 +470,8 @@ pid_tuning.initialize = function (callback) {
                 ratesTypeListElement.append(`<option value="${i}">${ratesList[i].name}</option>`);
             }
 
+            ratesTypeListElement.sortSelect();
+
             self.currentRatesType = FC.RC_TUNING.rates_type;
             self.previousRatesType = null;
             ratesTypeListElement.val(self.currentRatesType);


### PR DESCRIPTION
Sorts Rates models so that they are in alphabetical order, ie with our current default, ‘Actual’ rates, first, then our previous default, ‘Betaflight’ rates, second, then the others. 

I anticipate removing support for the archaic other protocols at some point in the near future. 