### PR TITLE
Fix detection of port at boot

### DIFF
--- a/src/components/port-picker/PortsInput.vue
+++ b/src/components/port-picker/PortsInput.vue
@@ -12,6 +12,13 @@
         :disabled="disabled"
         @change="onChangePort"
       >
+        <option
+          v-for="connectedDevice in connectedDevices"
+          :key="connectedDevice.path"
+          :value="connectedDevice.path"
+        >
+          {{ connectedDevice.displayName }}
+        </option>
         <option value="manual">
           {{ $t("portsSelectManual") }}
         </option>
@@ -20,13 +27,6 @@
           value="virtual"
         >
           {{ $t("portsSelectVirtual") }}
-        </option>
-        <option
-          v-for="connectedDevice in connectedDevices"
-          :key="connectedDevice.path"
-          :value="connectedDevice.path"
-        >
-          {{ connectedDevice.displayName }}
         </option>
         <option value="requestpermission">
           {{ $t("portsSelectPermission") }}

--- a/src/components/port-picker/PortsInput.vue
+++ b/src/components/port-picker/PortsInput.vue
@@ -6,19 +6,13 @@
     <div class="dropdown dropdown-dark">
       <select
         id="port"
+        :key="value.selectedPort"
         :value="value.selectedPort"
         class="dropdown-select"
         :title="$t('firmwareFlasherManualPort')"
         :disabled="disabled"
         @change="onChangePort"
       >
-        <option
-          v-for="connectedDevice in connectedDevices"
-          :key="connectedDevice.path"
-          :value="connectedDevice.path"
-        >
-          {{ connectedDevice.displayName }}
-        </option>
         <option value="manual">
           {{ $t("portsSelectManual") }}
         </option>
@@ -27,6 +21,13 @@
           value="virtual"
         >
           {{ $t("portsSelectVirtual") }}
+        </option>
+        <option
+          v-for="connectedDevice in connectedDevices"
+          :key="connectedDevice.path"
+          :value="connectedDevice.path"
+        >
+          {{ connectedDevice.displayName }}
         </option>
         <option value="requestpermission">
           {{ $t("portsSelectPermission") }}


### PR DESCRIPTION
Portpicker input is not updated on boot as manual is the first option. However on connect it still would pick the detected port.
Reordering select to set any detected port as first option.