### PR TITLE
Add DFU devices to the port handler

### DIFF
--- a/src/components/port-picker/PortPicker.vue
+++ b/src/components/port-picker/PortPicker.vue
@@ -12,7 +12,8 @@
     />
     <PortsInput
       :value="value"
-      :connected-devices="connectedDevices"
+      :connected-serial-devices="connectedSerialDevices"
+      :connected-usb-devices="connectedUsbDevices"
       :disabled="disabled"
       :show-virtual-option="showVirtualOption"
       :show-manual-option="showManualOption"
@@ -43,7 +44,11 @@ export default {
           autoConnect: true,
         }),
       },
-      connectedDevices: {
+      connectedUsbDevices: {
+        type: Array,
+        default: () => [],
+      },
+      connectedSerialDevices: {
         type: Array,
         default: () => [],
       },

--- a/src/components/port-picker/PortsInput.vue
+++ b/src/components/port-picker/PortsInput.vue
@@ -32,11 +32,18 @@
           {{ $t("portsSelectVirtual") }}
         </option>
         <option
-          v-for="connectedDevice in connectedDevices"
-          :key="connectedDevice.path"
-          :value="connectedDevice.path"
+          v-for="connectedSerialDevice in connectedSerialDevices"
+          :key="connectedSerialDevice.path"
+          :value="connectedSerialDevice.path"
         >
-          {{ connectedDevice.displayName }}
+          {{ connectedSerialDevice.displayName }}
+        </option>
+        <option
+          v-for="connectedUsbDevice in connectedUsbDevices"
+          :key="connectedUsbDevice.path"
+          :value="connectedUsbDevice.path"
+        >
+          {{ connectedUsbDevice.displayName }}
         </option>
         <option value="requestpermission">
           {{ $t("portsSelectPermission") }}
@@ -100,7 +107,11 @@ export default {
         autoConnect: true,
       }),
     },
-    connectedDevices: {
+    connectedSerialDevices: {
+      type: Array,
+      default: () => [],
+    },
+    connectedUsbDevices: {
       type: Array,
       default: () => [],
     },

--- a/src/index.html
+++ b/src/index.html
@@ -28,7 +28,8 @@
         ></betaflight-logo>
         <port-picker
             v-model="PortHandler.portPicker"
-            :connected-devices="PortHandler.currentPorts"
+            :connected-serial-devices="PortHandler.currentSerialPorts"
+            :connected-usb-devices="PortHandler.currentUsbPorts"
             :show-virtual-option="PortHandler.showVirtualMode"
             :show-manual-option="PortHandler.showManualMode"
             :disabled="PortHandler.portPickerDisabled"

--- a/src/js/protocols/webusbdfu.js
+++ b/src/js/protocols/webusbdfu.js
@@ -88,7 +88,7 @@ class WEBUSBDFU_protocol extends EventTarget {
     createPort(port) {
         return {
             path: `usb_${port.serialNumber}`,
-            displayName: `Betaflight DFU ${port.productName}`,
+            displayName: `Betaflight ${port.productName}`,
             vendorId: port.manufacturerName,
             productId: port.productName,
             port: port,

--- a/src/js/protocols/webusbdfu.js
+++ b/src/js/protocols/webusbdfu.js
@@ -18,8 +18,9 @@ import { i18n } from "../localization";
 import { gui_log } from "../gui_log";
 import { usbDevices } from "../usb_devices";
 
-class WEBUSBDFU_protocol {
+class WEBUSBDFU_protocol extends EventTarget {
     constructor() {
+        super();
         this.callback = null;
         this.hex = null;
         this.verify_hex = [];
@@ -70,6 +71,53 @@ class WEBUSBDFU_protocol {
         this.chipInfo = null; // information about chip's memory
         this.flash_layout = { 'start_address': 0, 'total_size': 0, 'sectors': [] };
         this.transferSize = 2048; // Default USB DFU transfer size for F3,F4 and F7
+
+        navigator.usb.addEventListener("connect", e => this.handleNewDevice(e.device));
+        navigator.usb.addEventListener("disconnect", e => this.handleNewDevice(e.device));
+    }
+    handleNewDevice(device) {
+        const added = this.createPort(device);
+        this.dispatchEvent(new CustomEvent("addedDevice", { detail: added }));
+
+        return added;
+    }
+    handleRemovedDevice(device) {
+        const removed = this.createPort(device);
+        this.dispatchEvent(new CustomEvent("removedDevice", { detail: removed }));
+    }
+    createPort(port) {
+        return {
+            path: `usb_${port.serialNumber}`,
+            displayName: `Betaflight DFU ${port.productName}`,
+            vendorId: port.manufacturerName,
+            productId: port.productName,
+            port: port,
+        };
+    }
+    async getDevices() {
+        const ports = await navigator.usb.getDevices(usbDevices);
+        const customPorts = ports.map(function (port) {
+            return this.createPort(port);
+        }, this);
+
+        return customPorts;
+    }
+    async requestPermission() {
+        let newPermissionPort = null;
+        try {
+            const userSelectedPort = await navigator.usb.requestDevice(usbDevices);
+            console.info("User selected USB device from permissions:", userSelectedPort);
+            console.log(`WebUSB Version: ${userSelectedPort.deviceVersionMajor}.${userSelectedPort.deviceVersionMinor}.${userSelectedPort.deviceVersionSubminor}`);
+
+            newPermissionPort = this.handleNewDevice(userSelectedPort);
+        } catch (error) {
+            console.error("User didn't select any USB device when requesting permission:", error);
+        }
+        return newPermissionPort;
+
+    }
+    getConnectedPort() {
+        return this.usbDevice ? `usb_${this.usbDevice.serialNumber}` : null;
     }
     connect(hex, options, callback) {
         this.hex = hex;

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -67,7 +67,7 @@ export function initializeSerialBackend() {
 
     $("div.connect_controls a.connect").on('click', connectDisconnect);
 
-    EventBus.$on('port-handler:auto-select-device', function(device) {
+    EventBus.$on('port-handler:auto-select-serial-device', function(device) {
         if (!GUI.connected_to && !GUI.connecting_to
             && ((PortHandler.portPicker.autoConnect && !["manual", "virtual"].includes(device))
                 || Date.now() - rebootTimestamp < REBOOT_CONNECT_MAX_TIME_MS)) {

--- a/src/js/webSerial.js
+++ b/src/js/webSerial.js
@@ -105,9 +105,9 @@ class WebSerial extends EventTarget {
             if (!newPermissionPort) {
                 newPermissionPort = this.handleNewDevice(userSelectedPort);
             }
-            console.info("User selected device from permissions:", newPermissionPort.path);
+            console.info(`${this.logHead}User selected SERIAL device from permissions:`, newPermissionPort.path);
         } catch (error) {
-            console.error("User didn't select any device when requesting permission:", error);
+            console.error(`${this.logHead}User didn't select any SERIAL device when requesting permission:`, error);
         }
         return newPermissionPort;
     }


### PR DESCRIPTION
This adds the DFU devices to the port-handler. 

In this approach, I maintain two different lists for devices: one for the serial devices and other for the usb dfu devices. I think it's easier to have it in this way because we use them in different manners, the usb dfu devices for firmware flasher and the the serial for configuration.

I've modified the usb library to add the minimum methods needed for that but the firmware flasher, at this point, don't use them for nothing. I think is better to go with this PR, and once merged, modify the firmware flasher to use it.

This is the list of things missing to make work the firmware flasher:
- At the connect method of the usb library, pass the selected port in the porthandler in place of the current asking for permission.
- We have now events to detect a new DFU, so we can use them to start flashing if auto-flash is enabled or if at FC mode send a reboot to DFU and start flashing.
- We need some place to give "permissions" to a new DFU device. There are several possibilities, for example:
1. Add a simple button at the firmware flasher. Maybe good as first temporary version but I think is confuse for the user (it has a permission in the combo and other in the tab).
2. Try to do it automatically, if after moving from serial to dfu we don't see the dfu, ask permission. It's the easiest for the user, but if the FC is at dfu mode when connected, it will not work.
3. Expand the current `I can't find my device`, to show a popup with some explanation that we need permissions the first time and give two buttons (one for serial and the other for dfu). I think this will be the best one, because the user has only one place to search new devices and is more or less intuitive.

@haslinghuis you did all the work in the firmware flasher for PWA, do you have time to do the changes (or at least some) once this is approved? If not I can do it by myself, but I think it will be faster if you can do it. And there is one problem remaining in this code, maybe you know how to fix it: I check if `usb.usbDevice` is null or not to "assign" it as default port. The problem is after flashing, the new serial device is detected before this usb.usbDevice returns to null value, so the port picker does not "select" this new serial device after flashing. I think we need to close the usb connection earlier or be sure to assign null to this value.
