### PR TITLE
Move some code of portOverride from serial_backend to vue

### DIFF
--- a/src/components/port-picker/PortOverrideOption.vue
+++ b/src/components/port-picker/PortOverrideOption.vue
@@ -5,18 +5,28 @@
     ><span>{{ $t("portOverrideText") }}</span>
       <input
         id="port-override"
-        v-model="value"
+        :value="value"
         type="text"
+        @change="inputValue($event)"
       ></label>
   </div>
 </template>
 
 <script>
+import { set as setConfig } from '../../js/ConfigStorage';
+
 export default {
-  data() {
-    return {
-      value: "/dev/rfcomm0",
-    };
+  props: {
+    value: {
+      type: String,
+      default: "/dev/rfcomm0",
+    },
+  },
+  methods: {
+    inputValue(event) {
+      setConfig({'portOverride': event.target.value});
+      this.$emit("input", event.target.value);
+    },
   },
 };
 </script>

--- a/src/components/port-picker/PortsInput.vue
+++ b/src/components/port-picker/PortsInput.vue
@@ -87,7 +87,7 @@
 </template>
 
 <script>
-import { get as getConfig, set as setConfig } from '../../js/ConfigStorage';
+import { set as setConfig } from '../../js/ConfigStorage';
 import { EventBus } from '../eventBus';
 
 export default {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -17,7 +17,7 @@ const PortHandler = new function () {
     this.portPicker = {
         selectedPort: DEFAULT_PORT,
         selectedBauds: DEFAULT_BAUDS,
-        portOverride: "/dev/rfcomm0",
+        portOverride: getConfig('portOverride', '/dev/rfcomm0').portOverride,
         virtualMspVersion: "1.46.0",
         autoConnect: getConfig('autoConnect').autoConnect,
     };

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -54,17 +54,6 @@ function disconnectHandler(event) {
 
 export function initializeSerialBackend() {
 
-    // TODO move to Vue
-    $('#port-override').change(function () {
-        setConfig({'portOverride': $('#port-override').val()});
-    });
-
-    // TODO move to Vue
-    const data = getConfig('portOverride');
-    if (data.portOverride) {
-        $('#port-override').val(data.portOverride);
-    }
-
     $("div.connect_controls a.connect").on('click', connectDisconnect);
 
     EventBus.$on('port-handler:auto-select-device', function(device) {


### PR DESCRIPTION
Fix two remaining todo in the `serial_backend.js`, moving the reading/writing of the `portOverride` to vue/port_handler.