### PR TITLE
Define default values for options in the port handler

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -22,15 +22,15 @@ const PortHandler = new function () {
         selectedBauds: DEFAULT_BAUDS,
         portOverride: getConfig('portOverride', '/dev/rfcomm0').portOverride,
         virtualMspVersion: "1.46.0",
-        autoConnect: getConfig('autoConnect').autoConnect,
+        autoConnect: getConfig('autoConnect', false).autoConnect,
     };
     this.portPickerDisabled = false;
     this.dfuAvailable = false;
     this.portAvailable = false;
     this.showAllSerialDevices = false;
-    this.showVirtualMode = getConfig('showVirtualMode').showVirtualMode;
-    this.showManualMode = getConfig('showManualMode').showManualMode;
-    this.showAllSerialDevices = getConfig('showAllSerialDevices').showAllSerialDevices;
+    this.showVirtualMode = getConfig('showVirtualMode', false).showVirtualMode;
+    this.showManualMode = getConfig('showManualMode', false).showManualMode;
+    this.showAllSerialDevices = getConfig('showAllSerialDevices', false).showAllSerialDevices;
 };
 
 PortHandler.initialize = function () {


### PR DESCRIPTION
This is an intent of fix the out of sync elements in the port handler in the first run. Define a default value in place of the habitual undefined.