### PR TITLE
Move hex_parser.js worker to an async function in a module

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -23,6 +23,7 @@ import { serialShim } from "../serial_shim.js";
 import { usbShim } from "../usb_shim.js";
 import STM32 from '../protocols/stm32';
 import { isWeb } from '../utils/isWeb.js';
+import read_hex_file from '../workers/hex_parser.js';
 
 let serial = serialShim();
 let dfu = usbShim();
@@ -67,16 +68,9 @@ firmware_flasher.initialize = function (callback) {
     function onDocumentLoad() {
 
         function parseHex(str, callback) {
-            // parsing hex in different thread
-            const worker = new Worker('./js/workers/hex_parser.js');
-
-            // "callback"
-            worker.onmessage = function (event) {
-                callback(event.data);
-            };
-
-            // send data/string over for processing
-            worker.postMessage(str);
+            read_hex_file(str).then((data) => {
+                callback(data);
+            });
         }
 
         function showLoadedHex(filename) {

--- a/src/js/workers/hex_parser.js
+++ b/src/js/workers/hex_parser.js
@@ -1,9 +1,12 @@
-'use strict';
+const TIME_LABEL = 'HEX_PARSER - File parsed in';
 
 // input = string
 // result = if hex file is valid, result is an object
 //          if hex file wasn't valid (crc check failed on any of the lines), result will be false
-function read_hex_file(data) {
+export default async function read_hex_file(data) {
+
+    console.time(TIME_LABEL);
+
     data = data.split("\n");
 
     // check if there is an empty line in the end of hex file, if there is, remove it
@@ -86,21 +89,11 @@ function read_hex_file(data) {
         }
     }
 
-    if (result.end_of_file && hexfile_valid) {
-        postMessage(result);
-    } else {
-        postMessage(null);
-    }
-}
-
-const TIME_LABEL = 'HEX_PARSER - File parsed in';
-
-onmessage = function(event) {
-    console.time(TIME_LABEL);
-
-    read_hex_file(event.data);
-
-    // terminate worker
     console.timeEnd(TIME_LABEL);
-    close();
-};
+
+    if (result.end_of_file && hexfile_valid) {
+        return result;
+    }
+
+    return null;
+}


### PR DESCRIPTION
The worker is not being "packaged" by vite, so move it to module. Fixes the problem found here: https://github.com/betaflight/betaflight-configurator/pull/3993