### PR TITLE
Fix dual permission dialog when flashing

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -35,8 +35,8 @@ PortHandler.initialize = function () {
 
     usb.addEventListener("addedDevice", (event) => this.addedUsbDevice(event.detail));
 
-    this.addedUsbDevice();
     this.addedSerialDevice();
+    this.addedUsbDevice();
 };
 
 PortHandler.setShowVirtualMode = function (showVirtualMode) {

--- a/src/js/protocols/webstm32.js
+++ b/src/js/protocols/webstm32.js
@@ -99,7 +99,7 @@ class STM32Protocol {
         serial.removeEventListener('connect', (event) => this.handleConnect(event.detail));
         serial.removeEventListener('disconnect', (event) => this.handleDisconnect(event.detail));
 
-        if (disconnectionResult) {
+        if (disconnectionResult && this.rebootMode) {
             DFU.connect(this.hex, this.serialOptions);
         } else {
             GUI.connect_lock = false;

--- a/src/js/protocols/webstm32.js
+++ b/src/js/protocols/webstm32.js
@@ -145,6 +145,22 @@ class STM32Protocol {
                 }
             };
 
+            // Need to request permission [pairing] per USB device once [after clearing browser data]
+            setTimeout(async () => {
+                if (!PortHandler.dfuAvailable) {
+                    console.log('Checking for paired devices');
+                    const pairedDevices = await DFU.getDevices();
+
+                    if (!pairedDevices.length) {
+                        console.log('Requesting permission as no paired DFU device was found');
+                        const port = await DFU.requestPermission();
+                        if (port) {
+                            console.log('DFU device found on port', port);
+                        }
+                    }
+                }
+            }, 1000);
+
             const dfuWaitInterval = setInterval(waitForDfu, 1000);
         } else {
             GUI.connect_lock = false;


### PR DESCRIPTION
~~- First commit only worked when we already had requested permission before.~~
- ~~On a clean browser or when device has not been paired yet we need to request permission - so in this case we still have two dialogs.~~
- ~~Once paired we skip the first permission dialog.~~
- ~~The second permission request in the DFU class is also used in other places.~~
- Commit 3 reduced all overhead calling DFU connect as it will request the required permission and waits for the device in the first place - and also works with unpaired devices :partying_face: 


![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/58cab20a-deac-4128-b3a5-b3758b454c0e)



