### PR TITLE
Use object-fit for sponsor logos

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1165,9 +1165,10 @@ dialog {
     min-height: 65px;
 }
 .img_sponsor {
-    height: 100%;
-    max-height: 50px;
+    object-fit: contain;
     margin: 5px 15px;
+    width: 150px;
+    height: 50px;
 }
 .note {
     background-color: #fff7cd;

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1162,13 +1162,14 @@ dialog {
     margin-bottom: 15px;
 }
 .tab_sponsor {
-    min-height: 65px;
+    min-height: 60px;
 }
 .img_sponsor {
     object-fit: contain;
     margin: 5px 15px;
+    max-height: 45px;
     width: 150px;
-    height: 50px;
+    height: 45px;
 }
 .note {
     background-color: #fff7cd;


### PR DESCRIPTION
- using object-fit for business logo's to ensures the image is fully visible within the aspect ratio box
- breakpoint on landing tab is 800px
- breakpoint on firmware flasher tab is 840px
- 4 logo's seems to fit on most mobile devices.

https://developer.mozilla.org/en-US/docs/Web/CSS/object-fit

`Master`

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/045c7417-d992-4628-9529-e1a80d73eaf3)

`PR`

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/96a19537-7626-4858-9240-d4464b4da3a2)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/1672498a-7265-4aba-a184-9b4a3c381c2d)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/fec7176a-67af-458f-b0a8-1c95379bef10)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/e4f923c9-c2b0-4414-b6f9-995088166b88)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/824c44e2-815c-4f67-84c3-b58afb6fa6dd)

![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/2f19cc45-3b19-4096-9c61-a2ecf62275c8)
