### PR TITLE
Fix board name in logo and status bar

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -143,27 +143,6 @@ const FC = {
     // and bridges the vue and rest of the code
     CONFIG: {
         ...INITIAL_CONFIG,
-        get hardwareName() {
-            let name;
-            if (this.targetName) {
-                name = this.targetName;
-            } else {
-                name = this.boardIdentifier;
-            }
-
-            if (this.boardName && this.boardName !== name) {
-                name = `${this.boardName}(${name})`;
-            }
-
-            if (this.manufacturerId) {
-                name = `${this.manufacturerId}/${name}`;
-            }
-
-            return name;
-        },
-        set hardwareName(name) {
-            // NOOP, can't really be set. Maybe implement some logic?
-        },
     },
     COPY_PROFILE: null,
     CURRENT_METERS: null,
@@ -816,7 +795,7 @@ const FC = {
         return serialRxTypes;
     },
 
-    getHardwareName() {
+    calculateHardwareName() {
         let name;
         if (this.CONFIG.targetName) {
             name = this.CONFIG.targetName;
@@ -832,7 +811,7 @@ const FC = {
             name = `${this.CONFIG.manufacturerId}/${name}`;
         }
 
-        return name;
+        this.CONFIG.hardwareName = name;
     },
 
     MCU_TYPES: {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -833,6 +833,9 @@ MspHelper.prototype.process_data = function(dataHandler) {
                 FC.CONFIG.sampleRateHz = data.readU16();
                 FC.CONFIG.configurationProblems = data.readU32();
 
+                // Refresh the hardware name (it's a calculated field)
+                FC.calculateHardwareName();
+
                 break;
 
             case MSPCodes.MSP_NAME:

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -394,7 +394,7 @@ function processCustomDefaults() {
 
 function processBoardInfo() {
 
-    gui_log(i18n.getMessage('boardInfoReceived', [FC.getHardwareName(), FC.CONFIG.boardVersion]));
+    gui_log(i18n.getMessage('boardInfoReceived', [FC.CONFIG.hardwareName, FC.CONFIG.boardVersion]));
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
         checkReportProblems();
@@ -405,7 +405,7 @@ function processBoardInfo() {
         boardIdentifier: FC.CONFIG.boardIdentifier,
         targetName: FC.CONFIG.targetName,
         boardName: FC.CONFIG.boardName,
-        hardware: FC.getHardwareName(),
+        hardware: FC.CONFIG.hardwareName,
         manufacturerId: FC.CONFIG.manufacturerId,
         apiVersion: FC.CONFIG.apiVersion,
         flightControllerVersion: FC.CONFIG.flightControllerVersion,


### PR DESCRIPTION
Fixes the board name in the logo and taskbar, that was blank until now.