### PR TITLE
Add RSSI dBm alarm configurable in the OSD tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6236,6 +6236,11 @@
         "message": "Link Quality",
         "description": "Text of the link quality alarm"
       },
+      "osdTimerAlarmOptionRssiDbm": {
+        "message": "RSSI dBm",
+        "description": "Text of the RSSI dBm alarm"
+      },
+  
     "osdWarningTextArmingDisabled": {
         "message": "Arming disabled",
         "description": "One of the warnings that can be selected to be shown in the OSD"

--- a/src/js/data_storage.js
+++ b/src/js/data_storage.js
@@ -7,7 +7,7 @@ export const API_VERSION_1_47 = '1.47.0';
 const CONFIGURATOR = {
     // all versions are specified and compared using semantic versioning http://semver.org/
     API_VERSION_ACCEPTED: API_VERSION_1_44,
-    API_VERSION_MAX_SUPPORTED: API_VERSION_1_46,
+    API_VERSION_MAX_SUPPORTED: API_VERSION_1_47,
 
     connectionValid: false,
     connectionValidCliOnly: false,

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -6,7 +6,7 @@ import VirtualFC from "../VirtualFC";
 import FC from "../fc";
 import MSP from "../msp";
 import MSPCodes from "../msp/MSPCodes";
-import CONFIGURATOR, { API_VERSION_1_45, API_VERSION_1_46 } from "../data_storage";
+import CONFIGURATOR, { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47 } from "../data_storage";
 import LogoManager from "../LogoManager";
 import { gui_log } from "../gui_log";
 import semver from "semver";
@@ -2178,6 +2178,11 @@ OSD.msp = {
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
                 result.push16(OSD.data.alarms.link_quality.value);
             }
+
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                result.push16(OSD.data.alarms.rssi_dbm.value);
+            }
+
         }
         return result;
     },
@@ -2390,6 +2395,10 @@ OSD.msp = {
 
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
             d.alarms['link_quality'] = { display_name: i18n.getMessage('osdTimerAlarmOptionLinkQuality'), value: view.readU16() };
+        }
+
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+            d.alarms['rssi_dbm'] = { display_name: i18n.getMessage('osdTimerAlarmOptionRssiDbm'), value: view.read16() };
         }
 
         this.processOsdElements(d, itemsPositionsRead);


### PR DESCRIPTION
This PR adds the possibility of configuring the RSSI DBM value alarm in the Configurator, OSD tab:

![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/1ba67446-040a-4a45-8807-b607bbff4886)

This needs this firmware PR:
https://github.com/betaflight/betaflight/pull/13682

Fixes https://github.com/betaflight/betaflight-configurator/issues/3766