### PR TITLE
Add CPU LOAD warning to the OSD tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6468,6 +6468,15 @@
     "osdWarningRSNR": {
         "message": "Warns when RSNR value is below alarm setting"
     },
+    "osdWarningTextLoad": {
+        "message": "LOAD",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLoad": {
+        "message": "Warns if the CPU LOAD of the flight controller is too high",
+        "description": "Description of one of the warnings that can be selected to be shown in the OSD"
+    },
+
     "osdWarningTextUnknown": {
         "message": "Unknown $1"
     },

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1822,6 +1822,11 @@ OSD.constants = {
             text: 'osdWarningTextRSNR',
             desc: 'osdWarningRSNR',
         },
+        LOAD: {
+            name: 'LOAD',
+            text: 'osdWarningTextLoad',
+            desc: 'osdWarningLoad',
+        },
 
     },
     FONT_TYPES: [
@@ -2089,6 +2094,11 @@ OSD.chooseFields = function() {
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
             F.RSNR,
+        ]);
+    }
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+        OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
+            F.LOAD,
         ]);
     }
 };


### PR DESCRIPTION
It seems we forgot this in the latest release, so it will be good to cherry pick this to the maintenance branch too.