### PR TITLE
Add bluetooth support

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -84,11 +84,11 @@
         "description": "Configure a Virtual Flight Controller without the need of a physical FC."
     },
     "portsSelectPermission": {
-        "message": "--- I can't find my device ---",
+        "message": "--- I can't find my USB device ---",
         "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access the device."
     },
     "portsSelectPermissionBluetooth": {
-        "message": "--- find my Bluetooth device ---",
+        "message": "--- I can't find my Bluetooth device---",
         "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access a Bluetooth device."
     },
     "bluetoothConnected": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -87,6 +87,19 @@
         "message": "--- I can't find my device ---",
         "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access the device."
     },
+    "portsSelectPermissionBluetooth": {
+        "message": "--- find my Bluetooth device ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access a Bluetooth device."
+    },
+    "bluetoothConnected": {
+        "message": "Connected to Bluetooth device: $1"
+    },
+    "bluetoothConnectionType": {
+        "message": "Bluetooth connection type: $1"
+    },
+    "bluetoothConnectionError": {
+        "message": "Bluetooth error: $1"
+    },
     "virtualMSPVersion": {
         "message": "Virtual Firmware Version"
     },

--- a/src/components/port-picker/PortPicker.vue
+++ b/src/components/port-picker/PortPicker.vue
@@ -12,6 +12,7 @@
     />
     <PortsInput
       :value="value"
+      :connected-bluetooth-devices="connectedBluetoothDevices"
       :connected-serial-devices="connectedSerialDevices"
       :connected-usb-devices="connectedUsbDevices"
       :disabled="disabled"
@@ -44,11 +45,15 @@ export default {
           autoConnect: true,
         }),
       },
-      connectedUsbDevices: {
+      connectedBluetoothDevices: {
         type: Array,
         default: () => [],
       },
       connectedSerialDevices: {
+        type: Array,
+        default: () => [],
+      },
+      connectedUsbDevices: {
         type: Array,
         default: () => [],
       },

--- a/src/components/port-picker/PortsInput.vue
+++ b/src/components/port-picker/PortsInput.vue
@@ -31,6 +31,13 @@
           {{ $t("portsSelectVirtual") }}
         </option>
         <option
+          v-for="connectedBluetoothDevice in connectedBluetoothDevices"
+          :key="connectedBluetoothDevice.path"
+          :value="connectedBluetoothDevice.path"
+        >
+          {{ connectedBluetoothDevice.displayName }}
+        </option>
+        <option
           v-for="connectedSerialDevice in connectedSerialDevices"
           :key="connectedSerialDevice.path"
           :value="connectedSerialDevice.path"
@@ -46,6 +53,9 @@
         </option>
         <option value="requestpermission">
           {{ $t("portsSelectPermission") }}
+        </option>
+        <option value="requestpermissionbluetooth">
+          {{ $t("portsSelectPermissionBluetooth") }}
         </option>
       </select>
     </div>
@@ -114,6 +124,10 @@ export default {
       type: Array,
       default: () => [],
     },
+    connectedBluetoothDevices: {
+      type: Array,
+      default: () => [],
+    },
     disabled: {
         type: Boolean,
         default: false,
@@ -154,6 +168,8 @@ export default {
     onChangePort(event) {
       if (event.target.value === 'requestpermission') {
         EventBus.$emit('ports-input:request-permission');
+      } else if (event.target.value === 'requestpermissionbluetooth') {
+        EventBus.$emit('ports-input:request-permission-bluetooth');
       } else {
         EventBus.$emit('ports-input:change', event.target.value);
       }

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -5,7 +5,7 @@ import serialWeb from "./webSerial.js";
 import { isWeb } from "./utils/isWeb.js";
 import { serialShim } from "./serial_shim.js";
 
-const serial = serialShim();
+let serial = serialShim();
 
 const MSP = {
     symbols: {
@@ -309,6 +309,9 @@ const MSP = {
         return bufferOut;
     },
     send_message(code, data, callback_sent, callback_msp, doCallbackOnError) {
+        // Hack to make BT work
+        serial = serialShim();
+
         const connected = isWeb() ? serial.connected : serial.connectionId;
 
         if (code === undefined || !connected || CONFIGURATOR.virtualMode) {

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -1,8 +1,5 @@
 import GUI from "./gui.js";
 import CONFIGURATOR from "./data_storage.js";
-import serialNWJS from "./serial.js";
-import serialWeb from "./webSerial.js";
-import { isWeb } from "./utils/isWeb.js";
 import { serialShim } from "./serial_shim.js";
 
 let serial = serialShim();
@@ -57,7 +54,7 @@ const MSP = {
     packet_error:               0,
     unsupported:                0,
 
-    MIN_TIMEOUT:                100,
+    MIN_TIMEOUT:                200,
     MAX_TIMEOUT:                2000,
     timeout:                    200,
 
@@ -312,7 +309,7 @@ const MSP = {
         // Hack to make BT work
         serial = serialShim();
 
-        const connected = isWeb() ? serial.connected : serial.connectionId;
+        const connected = serial.connected;
 
         if (code === undefined || !connected || CONFIGURATOR.virtualMode) {
             if (callback_msp) {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -95,6 +95,7 @@ PortHandler.addedBluetoothDevice = function (device) {
         }
     });
 };
+
 PortHandler.removedBluetoothDevice = function (device) {
     this.updateCurrentBluetoothPortsList()
     .then(() => {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -135,10 +135,12 @@ PortHandler.updateCurrentUsbPortsList = async function () {
 };
 
 PortHandler.updateCurrentBluetoothPortsList = async function () {
-    const ports = await BT.getDevices();
-    const orderedPorts = this.sortPorts(ports);
-    this.bluetoothAvailable = orderedPorts.length > 0;
-    this.currentBluetoothPorts = orderedPorts;
+    if (BT.bluetooth) {
+        const ports = await BT.getDevices();
+        const orderedPorts = this.sortPorts(ports);
+        this.bluetoothAvailable = orderedPorts.length > 0;
+        this.currentBluetoothPorts = orderedPorts;
+    }
 };
 
 PortHandler.sortPorts = function(ports) {
@@ -151,13 +153,15 @@ PortHandler.sortPorts = function(ports) {
 };
 
 PortHandler.askBluetoothPermissionPort = function() {
-    BT.requestPermissionDevice()
-    .then((port) => {
-        // When giving permission to a new device, the port is selected in the handleNewDevice method, but if the user
-        // selects a device that had already permission, or cancels the permission request, we need to select the port
-        // so do it here too
-        this.selectActivePort(port);
-    });
+    if (BT.bluetooth) {
+        BT.requestPermissionDevice()
+        .then((port) => {
+            // When giving permission to a new device, the port is selected in the handleNewDevice method, but if the user
+            // selects a device that had already permission, or cancels the permission request, we need to select the port
+            // so do it here too
+            this.selectActivePort(port);
+        });
+    }
 };
 
 PortHandler.askSerialPermissionPort = function() {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -25,7 +25,6 @@ const PortHandler = new function () {
     this.bluetoothAvailable = false;
     this.dfuAvailable = false;
     this.portAvailable = false;
-
     this.showAllSerialDevices = false;
     this.showVirtualMode = getConfig('showVirtualMode', false).showVirtualMode;
     this.showManualMode = getConfig('showManualMode', false).showManualMode;
@@ -217,7 +216,6 @@ PortHandler.selectActivePort = function(suggestedDevice) {
 
     // Return some bluetooth port that is recognized by the filter
     if (!selectedPort) {
-        console.log("BT ports recognized by the filter", this.currentBluetoothPorts);
         selectedPort = this.currentBluetoothPorts.find(device => deviceFilter.some(filter => device.displayName.includes(filter)));
         if (selectedPort) {
             selectedPort = selectedPort.path;

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -88,7 +88,7 @@ PortHandler.removedSerialDevice = function (device) {
 PortHandler.addedBluetoothDevice = function (device) {
     this.updateCurrentBluetoothPortsList()
     .then(() => {
-        const selectedPort = this.selectActivePort();
+        const selectedPort = this.selectActivePort(device);
         if (!device || selectedPort === device.path) {
             // Send this event when the port handler auto selects a new device
             EventBus.$emit('port-handler:auto-select-bluetooth-device', selectedPort);
@@ -186,7 +186,7 @@ PortHandler.selectActivePort = function(suggestedDevice) {
     }
 
     // Return the same that is connected to bluetooth
-    if (BT.connected) {
+    if (BT.device) {
         selectedPort = this.currentBluetoothPorts.find(device => device === BT.getConnectedPort());
     }
 

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -2,6 +2,7 @@ import { get as getConfig } from "./ConfigStorage";
 import { EventBus } from "../components/eventBus";
 import serial from "./webSerial";
 import usb from "./protocols/webusbdfu";
+import BT from "./protocols/bluetooth";
 
 const DEFAULT_PORT = 'noselection';
 const DEFAULT_BAUDS = 115200;
@@ -9,6 +10,8 @@ const DEFAULT_BAUDS = 115200;
 const PortHandler = new function () {
     this.currentSerialPorts = [];
     this.currentUsbPorts = [];
+    this.currentBluetoothPorts = [];
+
     this.portPicker = {
         selectedPort: DEFAULT_PORT,
         selectedBauds: DEFAULT_BAUDS,
@@ -16,9 +19,13 @@ const PortHandler = new function () {
         virtualMspVersion: "1.46.0",
         autoConnect: getConfig('autoConnect', false).autoConnect,
     };
+
     this.portPickerDisabled = false;
+
+    this.bluetoothAvailable = false;
     this.dfuAvailable = false;
     this.portAvailable = false;
+
     this.showAllSerialDevices = false;
     this.showVirtualMode = getConfig('showVirtualMode', false).showVirtualMode;
     this.showManualMode = getConfig('showManualMode', false).showManualMode;
@@ -27,14 +34,19 @@ const PortHandler = new function () {
 
 PortHandler.initialize = function () {
 
+    EventBus.$on('ports-input:request-permission-bluetooth', this.askBluetoothPermissionPort.bind(this));
     EventBus.$on('ports-input:request-permission', this.askSerialPermissionPort.bind(this));
     EventBus.$on('ports-input:change', this.onChangeSelectedPort.bind(this));
+
+    BT.addEventListener("addedDevice", (event) => this.addedBluetoothDevice(event.detail));
+    BT.addEventListener("removedDevice", (event) => this.addedBluetoothDevice(event.detail));
 
     serial.addEventListener("addedDevice", (event) => this.addedSerialDevice(event.detail));
     serial.addEventListener("removedDevice", (event) => this.removedSerialDevice(event.detail));
 
     usb.addEventListener("addedDevice", (event) => this.addedUsbDevice(event.detail));
 
+    this.addedBluetoothDevice();
     this.addedSerialDevice();
     this.addedUsbDevice();
 };
@@ -73,6 +85,25 @@ PortHandler.removedSerialDevice = function (device) {
     });
 };
 
+PortHandler.addedBluetoothDevice = function (device) {
+    this.updateCurrentBluetoothPortsList()
+    .then(() => {
+        const selectedPort = this.selectActivePort();
+        if (!device || selectedPort === device.path) {
+            // Send this event when the port handler auto selects a new device
+            EventBus.$emit('port-handler:auto-select-bluetooth-device', selectedPort);
+        }
+    });
+};
+PortHandler.removedBluetoothDevice = function (device) {
+    this.updateCurrentBluetoothPortsList()
+    .then(() => {
+        if (this.portPicker.selectedPort === device.path) {
+            this.selectActivePort();
+        }
+    });
+};
+
 PortHandler.addedUsbDevice = function (device) {
     this.updateCurrentUsbPortsList()
     .then(() => {
@@ -102,12 +133,31 @@ PortHandler.updateCurrentUsbPortsList = async function () {
     this.currentUsbPorts = orderedPorts;
 };
 
+PortHandler.updateCurrentBluetoothPortsList = async function () {
+    const ports = await BT.getDevices();
+    const orderedPorts = this.sortPorts(ports);
+    this.bluetoothAvailable = orderedPorts.length > 0;
+    this.currentBluetoothPorts = orderedPorts;
+};
+
 PortHandler.sortPorts = function(ports) {
     return ports.sort(function(a, b) {
         return a.path.localeCompare(b.path, window.navigator.language, {
             numeric: true,
             sensitivity: 'base',
         });
+    });
+};
+
+PortHandler.askBluetoothPermissionPort = function() {
+    BT.requestPermissionDevice()
+    .then((port) => {
+        // When giving permission to a new device, the port is selected in the handleNewDevice method, but if the user
+        // selects a device that had already permission, or cancels the permission request, we need to select the port
+        // so do it here too
+        console.log("BT permission granted", port);
+        console.log("Port picker selected port", this.portPicker.selectedPort);
+        this.selectActivePort(port);
     });
 };
 
@@ -136,6 +186,12 @@ PortHandler.selectActivePort = function(suggestedDevice) {
         selectedPort = this.currentUsbPorts.find(device => device === usb.getConnectedPort());
     }
 
+    // Return the same that is connected to bluetooth
+    if (BT.bluetoothDevice) {
+        console.log("BT connected port", BT.bluetoothDevice, BT.getConnectedPort());
+        selectedPort = BT.getConnectedPort();
+    }
+
     // Return the suggested device (the new device that has been detected)
     if (!selectedPort && suggestedDevice) {
         selectedPort = suggestedDevice.path;
@@ -152,6 +208,15 @@ PortHandler.selectActivePort = function(suggestedDevice) {
     // Return some serial port that is recognized by the filter
     if (!selectedPort) {
         selectedPort = this.currentSerialPorts.find(device => deviceFilter.some(filter => device.displayName.includes(filter)));
+        if (selectedPort) {
+            selectedPort = selectedPort.path;
+        }
+    }
+
+    // Return some bluetooth port that is recognized by the filter
+    if (!selectedPort) {
+        console.log("BT ports recognized by the filter", this.currentBluetoothPorts);
+        selectedPort = this.currentBluetoothPorts.find(device => deviceFilter.some(filter => device.displayName.includes(filter)));
         if (selectedPort) {
             selectedPort = selectedPort.path;
         }

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -155,8 +155,6 @@ PortHandler.askBluetoothPermissionPort = function() {
         // When giving permission to a new device, the port is selected in the handleNewDevice method, but if the user
         // selects a device that had already permission, or cancels the permission request, we need to select the port
         // so do it here too
-        console.log("BT permission granted", port);
-        console.log("Port picker selected port", this.portPicker.selectedPort);
         this.selectActivePort(port);
     });
 };
@@ -187,9 +185,8 @@ PortHandler.selectActivePort = function(suggestedDevice) {
     }
 
     // Return the same that is connected to bluetooth
-    if (BT.bluetoothDevice) {
-        console.log("BT connected port", BT.bluetoothDevice, BT.getConnectedPort());
-        selectedPort = BT.getConnectedPort();
+    if (BT.connected) {
+        selectedPort = this.currentBluetoothPorts.find(device => device === BT.getConnectedPort());
     }
 
     // Return the suggested device (the new device that has been detected)

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -237,7 +237,7 @@ PortHandler.selectActivePort = function(suggestedDevice) {
     // Return the default port if no other port was selected
     this.portPicker.selectedPort = selectedPort || DEFAULT_PORT;
 
-    console.log(`Porthandler automatically selected device is '${this.portPicker.selectedPort}'`);
+    console.log(`[PORTHANDLER] automatically selected device is '${this.portPicker.selectedPort}'`);
     return selectedPort;
 };
 

--- a/src/js/protocols/bluetooth.js
+++ b/src/js/protocols/bluetooth.js
@@ -1,0 +1,444 @@
+import { i18n } from "../localization";
+import { gui_log } from "../gui_log";
+
+/*  Certain flags needs to be enabled in the browser to use BT
+ *
+ *  app.commandLine.appendSwitch('enable-web-bluetooth', "true");
+ *  app.commandLine.appendSwitch('disable-hid-blocklist')
+ *  app.commandLine.appendSwitch('enable-experimental-web-platform-features');
+ *
+ */
+
+const bluetoothDevices = [
+    { name: "CC2541 based",             serviceUuid: '0000ffe0-0000-1000-8000-00805f9b34fb', writeCharateristic: '0000ffe1-0000-1000-8000-00805f9b34fb', readCharateristic: '0000ffe1-0000-1000-8000-00805f9b34fb', delay: 30 },
+    { name: "Nordic Semiconductor NRF", serviceUuid: '6e400001-b5a3-f393-e0a9-e50e24dcca9e', writeCharateristic: '6e400003-b5a3-f393-e0a9-e50e24dcca9e', readCharateristic: '6e400002-b5a3-f393-e0a9-e50e24dcca9e', delay: 30 },
+    { name: "SpeedyBee Type 2",         serviceUuid: '0000abf0-0000-1000-8000-00805f9b34fb', writeCharateristic: '0000abf1-0000-1000-8000-00805f9b34fb', readCharateristic: '0000abf2-0000-1000-8000-00805f9b34fb', delay:  0 },
+    { name: "SpeedyBee Type 1",         serviceUuid: '00001000-0000-1000-8000-00805f9b34fb', writeCharateristic: '00001001-0000-1000-8000-00805f9b34fb', readCharateristic: '00001002-0000-1000-8000-00805f9b34fb', delay:  0 },
+];
+
+const BT_WRITE_BUFFER_LENGTH = 20;
+
+async function* streamAsyncIterable(reader, keepReadingFlag) {
+    try {
+        while (keepReadingFlag()) {
+            const { done, value } = await reader.read();
+            if (done) {
+                return;
+            }
+            yield value;
+        }
+    } finally {
+        reader.releaseLock();
+    }
+}
+
+class BT extends EventTarget {
+    constructor() {
+        super();
+        this.connected = false;
+        this.openRequested = false;
+        this.openCanceled = false;
+        this.closeRequested = false;
+        this.transmitting = false;
+        this.connectionInfo = null;
+
+        this.bitrate = 0;
+        this.bytesSent = 0;
+        this.bytesReceived = 0;
+        this.failed = 0;
+
+        this.logHead = "[BLUETOOTH]";
+
+        this.portCounter = 0;
+        this.ports = [];
+        this.port = null;
+        this.reader = null;
+        this.writer = null;
+        this.reading = false;
+
+        this.connect = this.connect.bind(this);
+
+        navigator.bluetooth.addEventListener("connect", e => this.handleNewDevice(e.target));
+        navigator.bluetooth.addEventListener("disconnect", e => this.handleRemovedDevice(e.target));
+
+        this.loadDevices();
+    }
+
+    handleNewDevice(device) {
+
+        const added = this.createPort(device);
+        this.ports.push(added);
+        this.dispatchEvent(new CustomEvent("addedDevice", { detail: added }));
+
+        return added;
+    }
+
+    handleRemovedDevice(device) {
+        const removed = this.ports.find(port => port.port === device);
+        this.ports = this.ports.filter(port => port.port !== device);
+        this.dispatchEvent(new CustomEvent("removedDevice", { detail: removed }));
+    }
+
+    handleReceiveBytes(info) {
+        this.bytesReceived += info.detail.byteLength;
+    }
+
+    handleDisconnect() {
+        this.disconnect();
+        this.closeRequested = true;
+    }
+
+    getConnectedPort() {
+        return this.port;
+    }
+
+    createPort(device) {
+        return {
+            path: `bluetooth_${this.portCounter++}`,
+            displayName: device.name,
+            vendorId: "unknown",
+            productId: device.id,
+            port: device,
+        };
+    }
+
+    async loadDevices() {
+        const ports = await navigator.bluetooth.getDevices();
+
+        this.portCounter = 1;
+        this.ports = ports.map(function (port) {
+            return this.createPort(port);
+        }, this);
+    }
+
+    async requestPermissionDevice() {
+        let newPermissionPort = null;
+
+        const uuids = [];
+        bluetoothDevices.forEach(device => {
+            uuids.push(device.serviceUuid);
+        });
+
+        const options = { acceptAllDevices: true, optionalServices: uuids };
+
+        try {
+            const userSelectedPort = await navigator.bluetooth.requestDevice(options);
+            newPermissionPort = this.ports.find(port => port.port === userSelectedPort);
+            if (!newPermissionPort) {
+                newPermissionPort = this.handleNewDevice(userSelectedPort);
+            }
+            console.info(`${this.logHead} User selected Bluetooth device from permissions:`, newPermissionPort.path);
+        } catch (error) {
+            console.error(`${this.logHead} User didn't select any Bluetooth device when requesting permission:`, error);
+        }
+        return newPermissionPort;
+    }
+
+    async getDevices() {
+        return this.ports;
+    }
+
+    async connect(path, options) {
+        this.openRequested = true;
+        this.closeRequested = false;
+
+        this.port = this.ports.find(device => device.path === path).port;
+
+        console.log(`${this.logHead} Opening connection with ID: ${path}, Baud: ${options.baudRate}`, this.port, options);
+
+        this.port.addEventListener('gattserverdisconnected', this.handleDisconnect);
+
+        try {
+            console.log(`${this.logHead} Connecting to GATT Server`);
+
+            await this.connectServer();
+
+            gui_log(i18n.getMessage('bluetoothConnected', [this.port.name]));
+
+            await this.getServices();
+            await this.getCharacteristics();
+            await this.startNotifications();
+        } catch (error) {
+            gui_log(i18n.getMessage('bluetoothConnectionError', [error]));
+        }
+
+        // Bluetooth API doesn't provide a way for getInfo() or similar to get the connection info
+        // const connectionInfo = this.port.getInfo();
+
+        // console.log(`${this.logHead}Connection info:`, connectionInfo);
+
+        const connectionInfo = true;
+        // this.writer = this.port.writable.getWriter();
+        // this.reader = this.port.readable.getReader();
+
+        if (connectionInfo && !this.openCanceled) {
+            this.connected = true;
+            this.connectionId = path;
+            this.bitrate = options.baudRate;
+            this.bytesReceived = 0;
+            this.bytesSent = 0;
+            this.failed = 0;
+            this.openRequested = false;
+
+            this.port.addEventListener("disconnect", this.handleDisconnect.bind(this));
+            this.addEventListener("receive", this.handleReceiveBytes);
+
+            console.log(
+                `${this.logHead} Connection opened with ID: ${connectionInfo.connectionId}, Baud: ${options.baudRate}`,
+            );
+
+            this.dispatchEvent(
+                new CustomEvent("connect", { detail: connectionInfo }),
+            );
+            // Check if we need the helper function or could polyfill
+            // the stream async iterable interface:
+            // https://web.dev/streams/#asynchronous-iteration
+
+
+            this.reading = true;
+            for await (let value of streamAsyncIterable(this.reader, () => this.reading)) {
+                this.dispatchEvent(
+                    new CustomEvent("receive", { detail: value }),
+                );
+            }
+        } else if (connectionInfo && this.openCanceled) {
+            this.connectionId = connectionInfo.connectionId;
+
+            console.log(
+                `${this.logHead} Connection opened with ID: ${connectionInfo.connectionId}, but request was canceled, disconnecting`,
+            );
+            // some bluetooth dongles/dongle drivers really doesn't like to be closed instantly, adding a small delay
+            setTimeout(() => {
+                this.openRequested = false;
+                this.openCanceled = false;
+                this.disconnect(() => {
+                    this.dispatchEvent(new CustomEvent("connect", { detail: false }));
+                });
+            }, 150);
+        } else if (this.openCanceled) {
+            console.log(
+                `${this.logHead} Connection didn't open and request was canceled`,
+            );
+            this.openRequested = false;
+            this.openCanceled = false;
+            this.dispatchEvent(new CustomEvent("connect", { detail: false }));
+        } else {
+            this.openRequested = false;
+            console.log(`${this.logHead} Failed to open bluetooth port`);
+            this.dispatchEvent(new CustomEvent("connect", { detail: false }));
+        }
+    }
+
+    async connectServer() {
+        this.server = await this.port.gatt?.connect();
+    }
+
+    async getService (service) {
+        this.selectedService = await this.server.getPrimaryService(service);
+        return this.selectedService;
+    }
+
+    async getServices() {
+        console.log(`${this.logHead} Get primary services`);
+
+        this.services = await this.server.getPrimaryServices();
+
+        this.service = this.services.find(service => {
+            this.deviceDescription = bluetoothDevices.find(device => device.serviceUuid == service.uuid);
+            console.log(`${this.logHead} Device description`, this.deviceDescription);
+            return this.deviceDescription;
+        });
+
+        if (!this.deviceDescription) {
+            throw new Error("Unsupported device");
+        }
+
+        gui_log(i18n.getMessage('bluetoothConnectionType', [this.deviceDescription.name]));
+
+        console.log(`${this.logHead} Connected to service:`, this.deviceDescription.name);
+        console.log(`${this.logHead} Connected to service:`, this.service.uuid);
+
+        return this.service;
+    }
+
+    async getCharacteristic (char) {
+        this.characteristic = await this.selectedService.getCharacteristic(char);
+        return this.characteristic;
+    }
+
+    async getCharacteristics(connectedService) {
+        const characteristics = await connectedService.getCharacteristics();
+
+        console.info(`${this.logHead} Found characteristics: ${characteristics}`);
+
+        characteristics.forEach(characteristic => {
+            console.log("Characteristic: ", characteristic);
+            if (characteristic.uuid == this.deviceDescription.writeCharateristic) {
+                this.writeCharacteristic = characteristic;
+            }
+
+            if (characteristic.uuid == this.deviceDescription.readCharateristic) {
+                this.readCharacteristic = characteristic;
+            }
+            console.log("Characteristic found: ", characteristic.uuid, this.deviceDescription.writeCharateristic, this.deviceDescription.readCharateristic);
+            return this.writeCharacteristic && this.readCharacteristic;
+        });
+
+        if (!this.writeCharacteristic) {
+            throw new Error("Unexpected write charateristic found - should be", this.deviceDescription.writeCharateristic);
+        }
+
+        if (!this.readCharacteristic) {
+            throw new Error("Unexpected read charateristic found - should be", this.deviceDescription.readCharateristic);
+        }
+
+        this.readCharacteristic.addEventListener('characteristicvaluechanged', this.handleOnCharateristicValueChanged.bind(this));
+
+        return await this.readCharacteristic.readValue();
+    }
+
+    async handleDisconnect() {
+        this.disconnect();
+    }
+
+    handleOnCharateristicValueChanged(event) {
+        console.info(`${this.logHead} data bytes received: ${event.target.value.byteLength}`);
+
+        const buffer = new Uint8Array(event.target.value.byteLength);
+
+        for (let i = 0; i < event.target.value.byteLength; i++) {
+            buffer[i] = event.target.value.getUint8(i);
+        }
+
+        console.info(`${this.logHead} data received: ${buffer}`);
+    }
+
+    startNotifications() {
+        if (!this.readCharacteristic) {
+            throw new Error("No read charateristic");
+        }
+
+        if (!this.readCharacteristic.properties.notify) {
+            throw new Error("Read charateristic unable to notify.");
+        }
+
+        return this.readCharacteristic.startNotifications();
+    }
+
+    async disconnect() {
+        this.connected = false;
+        this.transmitting = false;
+        this.reading = false;
+        this.bytesReceived = 0;
+        this.bytesSent = 0;
+
+        // if we are already closing, don't do it again
+        if (this.closeRequested) {
+            return;
+        }
+
+        const doCleanup = async () => {
+            this.removeEventListener('receive', this.handleReceiveBytes);
+            if (this.reader) {
+                this.reader.cancel();
+                this.reader.releaseLock();
+                this.reader = null;
+            }
+            if (this.writer) {
+                await this.writer.releaseLock();
+                this.writer = null;
+            }
+            if (this.port) {
+                this.port.removeEventListener("disconnect", this.handleDisconnect.bind(this));
+                // await this.port.close();
+                this.port.removeEventListener('gattserverdisconnected', this.handleDisconnect);
+                this.readCharacteristic.removeEventListener('characteristicvaluechanged', this.handleOnCharateristicValueChanged.bind(this));
+
+                if (this.port.gatt.connected) {
+                    this.port.gatt.disconnect();
+                }
+
+                this.writeCharacteristic = false;
+                this.readCharacteristic = false;
+                this.deviceDescription = false;
+                this.port = null;
+            }
+        };
+
+        try {
+            await doCleanup();
+
+            console.log(
+                `${this.logHead} Connection with ID: ${this.connectionId} closed, Sent: ${this.bytesSent} bytes, Received: ${this.bytesReceived} bytes`,
+            );
+
+            this.connectionId = false;
+            this.bitrate = 0;
+            this.dispatchEvent(new CustomEvent("disconnect", { detail: true }));
+        } catch (error) {
+            console.error(error);
+            console.error(
+                `${this.logHead} Failed to close connection with ID: ${this.connectionId} closed, Sent: ${this.bytesSent} bytes, Received: ${this.bytesReceived} bytes`,
+            );
+            this.dispatchEvent(new CustomEvent("disconnect", { detail: false }));
+        } finally {
+            if (this.openCanceled) {
+                this.openCanceled = false;
+            }
+        }
+    }
+
+    async send(data) {
+        if (this.writer) {
+            await this.writer.write(data);
+            this.bytesSent += data.byteLength;
+        } else {
+            console.error(
+                `${this.logHead} Failed to send data, bluetooth port not open`,
+            );
+        }
+        return {
+            bytesSent: data.byteLength,
+        };
+    }
+
+    async getValue () {
+        this.currentValue = await this.characteristic.readValue();
+        return this.currentValue;
+      }
+
+    async writeValue(data) {
+        await this.characteristic.writeValue(data);
+    }
+
+    async ___send (data) {
+        if (!this.writeCharacteristic) {
+            return;
+        }
+
+        let sent = 0;
+        const dataBuffer = new Uint8Array(data);
+
+        for (let i = 0; i < dataBuffer.length; i += BT_WRITE_BUFFER_LENGTH) {
+            let length = BT_WRITE_BUFFER_LENGTH;
+
+            if (i + BT_WRITE_BUFFER_LENGTH > dataBuffer.length) {
+                length = dataBuffer.length % BT_WRITE_BUFFER_LENGTH;
+            }
+
+            const outBuffer = dataBuffer.subarray(i, i + length);
+            sent += outBuffer.length;
+
+            console.log(`${this.logHead} Sending data: ${outBuffer}`);
+
+            await this.writeCharacteristic.writeValue(outBuffer);
+        }
+
+        return {
+            bytesSent: sent,
+            resultCode: 0,
+        };
+    }
+}
+
+export default new BT();

--- a/src/js/protocols/bluetooth.js
+++ b/src/js/protocols/bluetooth.js
@@ -50,9 +50,9 @@ class BT extends EventTarget {
 
         this.connect = this.connect.bind(this);
 
-        navigator.bluetooth.addEventListener("connect", e => this.handleNewDevice(e.target));
-        navigator.bluetooth.addEventListener("disconnect", e => this.handleRemovedDevice(e.target));
-        navigator.bluetooth.addEventListener("gatserverdisconnected", e => this.handleRemovedDevice(e.target));
+        this.bluetooth.addEventListener("connect", e => this.handleNewDevice(e.target));
+        this.bluetooth.addEventListener("disconnect", e => this.handleRemovedDevice(e.target));
+        this.bluetooth.addEventListener("gatserverdisconnected", e => this.handleRemovedDevice(e.target));
 
         this.loadDevices();
     }
@@ -96,7 +96,7 @@ class BT extends EventTarget {
     }
 
     async loadDevices() {
-        const devices = await navigator.bluetooth.getDevices();
+        const devices = await this.bluetooth.getDevices();
 
         this.portCounter = 1;
         this.devices = devices.map(device => this.createPort(device));
@@ -113,7 +113,7 @@ class BT extends EventTarget {
         const options = { acceptAllDevices: true, optionalServices: uuids };
 
         try {
-            const userSelectedPort = await navigator.bluetooth.requestDevice(options);
+            const userSelectedPort = await this.bluetooth.requestDevice(options);
             newPermissionPort = this.devices.find(port => port.port === userSelectedPort);
             if (!newPermissionPort) {
                 newPermissionPort = this.handleNewDevice(userSelectedPort);
@@ -130,7 +130,7 @@ class BT extends EventTarget {
     }
 
     getAvailability() {
-        navigator.bluetooth.getAvailability().then((available) => {
+        this.bluetooth.getAvailability().then((available) => {
             console.log(`${this.logHead} Bluetooth available:`, available);
             this.available = available;
             return available;
@@ -184,7 +184,7 @@ class BT extends EventTarget {
                 new CustomEvent("connect", { detail: connectionInfo }),
             );
         } else if (connectionInfo && this.openCanceled) {
-            this.connectionId = connectionInfo.connectionId;
+            this.connectionId = this.device.port;
 
             console.log(
                 `${this.logHead} Connection opened with ID: ${connectionInfo.connectionId}, but request was canceled, disconnecting`,
@@ -248,7 +248,6 @@ class BT extends EventTarget {
             if (characteristic.uuid == this.deviceDescription.readCharacteristic) {
                 this.readCharacteristic = characteristic;
             }
-            // console.log("Characteristic found: ", characteristic.uuid, this.deviceDescription.writeCharacteristic, this.deviceDescription.readCharacteristic);
             return this.writeCharacteristic && this.readCharacteristic;
         });
 
@@ -340,7 +339,7 @@ class BT extends EventTarget {
         }
     }
 
-    async send (data) {
+    async send(data) {
         if (!this.writeCharacteristic) {
             return;
         }

--- a/src/js/protocols/bluetooth.js
+++ b/src/js/protocols/bluetooth.js
@@ -90,9 +90,7 @@ class BT extends EventTarget {
         const ports = await navigator.bluetooth.getDevices();
 
         this.portCounter = 1;
-        this.ports = ports.map(function (port) {
-            return this.createPort(port);
-        }, this);
+        this.ports = ports.map(port => this.createPort(port));
     }
 
     async requestPermissionDevice() {
@@ -130,7 +128,7 @@ class BT extends EventTarget {
 
         console.log(`${this.logHead} Opening connection with ID: ${path}, Baud: ${options.baudRate}`, this.port, options);
 
-        this.port.addEventListener('gattserverdisconnected', this.handleDisconnect);
+        this.port.addEventListener('gattserverdisconnected', this.handleDisconnect.bind(this));
 
         try {
             console.log(`${this.logHead} Connecting to GATT Server`);

--- a/src/js/protocols/bluetooth.js
+++ b/src/js/protocols/bluetooth.js
@@ -292,15 +292,11 @@ class BT extends EventTarget {
     }
 
     onCharacteristicValueChanged(event) {
-        console.info(`${this.logHead} data bytes received: ${event.target.value.byteLength}`);
-
         const buffer = new Uint8Array(event.target.value.byteLength);
 
         for (let i = 0; i < event.target.value.byteLength; i++) {
             buffer[i] = event.target.value.getUint8(i);
         }
-
-        console.info(`${this.logHead} data received: ${buffer}`);
 
         this.dispatchEvent(new CustomEvent("receive", { detail: buffer }));
     }

--- a/src/js/protocols/bluetooth.js
+++ b/src/js/protocols/bluetooth.js
@@ -121,6 +121,14 @@ class BT extends EventTarget {
         return this.devices;
     }
 
+    getAvailability() {
+        navigator.bluetooth.getAvailability().then((available) => {
+            console.log(`${this.logHead} Bluetooth available:`, available);
+            this.available = available;
+            return available;
+        });
+    }
+
     async connect(path, options) {
         this.openRequested = true;
         this.closeRequested = false;

--- a/src/js/protocols/bluetooth.js
+++ b/src/js/protocols/bluetooth.js
@@ -143,7 +143,7 @@ class BT extends EventTarget {
 
         this.device = this.devices.find(device => device.path === path).port;
 
-        console.log(`${this.logHead} Opening connection with ID: ${path}, Baud: ${options.baudRate}`, this.device, options);
+        console.log(`${this.logHead} Opening connection with ID: ${path}, Baud: ${options.baudRate}`);
 
         this.device.addEventListener('gattserverdisconnected', this.handleDisconnect.bind(this));
 
@@ -166,7 +166,7 @@ class BT extends EventTarget {
 
         if (connectionInfo && !this.openCanceled) {
             this.connected = true;
-            this.connectionId = path;
+            this.connectionId = this.device.port;
             this.bitrate = options.baudRate;
             this.bytesReceived = 0;
             this.bytesSent = 0;
@@ -177,7 +177,7 @@ class BT extends EventTarget {
             this.addEventListener("receive", this.handleReceiveBytes);
 
             console.log(
-                `${this.logHead} Connection opened with ID: ${connectionInfo.connectionId}, Baud: ${options.baudRate}`,
+                `${this.logHead} Connection opened with ID: ${this.connectionId}, Baud: ${options.baudRate}`,
             );
 
             this.dispatchEvent(
@@ -222,7 +222,6 @@ class BT extends EventTarget {
 
         this.service = this.services.find(service => {
             this.deviceDescription = bluetoothDevices.find(device => device.serviceUuid == service.uuid);
-            console.log(`${this.logHead} Device description`, this.deviceDescription);
             return this.deviceDescription;
         });
 
@@ -232,7 +231,6 @@ class BT extends EventTarget {
 
         gui_log(i18n.getMessage('bluetoothConnectionType', [this.deviceDescription.name]));
 
-        console.log(`${this.logHead} Connected to service:`, this.deviceDescription.name);
         console.log(`${this.logHead} Connected to service:`, this.service.uuid);
 
         return this.service;
@@ -242,7 +240,7 @@ class BT extends EventTarget {
         const characteristics = await this.service.getCharacteristics();
 
         characteristics.forEach(characteristic => {
-            console.log("Characteristic: ", characteristic);
+            // console.log("Characteristic: ", characteristic);
             if (characteristic.uuid == this.deviceDescription.writeCharacteristic) {
                 this.writeCharacteristic = characteristic;
             }
@@ -250,7 +248,7 @@ class BT extends EventTarget {
             if (characteristic.uuid == this.deviceDescription.readCharacteristic) {
                 this.readCharacteristic = characteristic;
             }
-            console.log("Characteristic found: ", characteristic.uuid, this.deviceDescription.writeCharacteristic, this.deviceDescription.readCharacteristic);
+            // console.log("Characteristic found: ", characteristic.uuid, this.deviceDescription.writeCharacteristic, this.deviceDescription.readCharacteristic);
             return this.writeCharacteristic && this.readCharacteristic;
         });
 

--- a/src/js/protocols/bluetooth.js
+++ b/src/js/protocols/bluetooth.js
@@ -44,6 +44,7 @@ class BT extends EventTarget {
 
         navigator.bluetooth.addEventListener("connect", e => this.handleNewDevice(e.target));
         navigator.bluetooth.addEventListener("disconnect", e => this.handleRemovedDevice(e.target));
+        navigator.bluetooth.addEventListener("gatserverdisconnected", e => this.handleRemovedDevice(e.target));
 
         this.loadDevices();
     }

--- a/src/js/protocols/bluetooth.js
+++ b/src/js/protocols/bluetooth.js
@@ -22,6 +22,14 @@ const bluetoothDevices = [
 class BT extends EventTarget {
     constructor() {
         super();
+
+        if (!this.bluetooth && window && window.navigator && window.navigator.bluetooth) {
+            this.bluetooth = navigator.bluetooth;
+        } else {
+            console.error(`${this.logHead} Bluetooth API not available`);
+            return;
+        }
+
         this.connected = false;
         this.openRequested = false;
         this.openCanceled = false;

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -106,12 +106,7 @@ export function initializeSerialBackend() {
 
 function connectDisconnect() {
     const selectedPort = PortHandler.portPicker.selectedPort;
-    let portName;
-    if (selectedPort === 'manual') {
-        portName = PortHandler.portPicker.portOverride;
-    } else {
-        portName = selectedPort;
-    }
+    let portName = selectedPort === 'manual' ? PortHandler.portPicker.portOverride : selectedPort;
 
     if (!GUI.connect_lock && selectedPort !== 'noselection' && !selectedPort.path?.startsWith('usb_')) {
         // GUI control overrides the user control
@@ -129,14 +124,10 @@ function connectDisconnect() {
             PortHandler.portPickerDisabled = true;
             $('div.connect_controls div.connect_state').text(i18n.getMessage('connecting'));
 
-            CONFIGURATOR.virtualMode = false;
+            CONFIGURATOR.virtualMode = selectedPort === 'virtual';
+            CONFIGURATOR.bluetoothMode = selectedPort.startsWith('bluetooth');
 
-            if (selectedPort.startsWith('bluetooth')) {
-                CONFIGURATOR.bluetoothMode = true;
-            }
-
-            if (selectedPort === 'virtual') {
-                CONFIGURATOR.virtualMode = true;
+            if (CONFIGURATOR.virtualMode) {
                 CONFIGURATOR.virtualApiVersion = PortHandler.portPicker.virtualMspVersion;
 
                 // Hack to get virtual working on the web

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -106,7 +106,7 @@ export function initializeSerialBackend() {
 
 function connectDisconnect() {
     const selectedPort = PortHandler.portPicker.selectedPort;
-    let portName = selectedPort === 'manual' ? PortHandler.portPicker.portOverride : selectedPort;
+    const portName = selectedPort === 'manual' ? PortHandler.portPicker.portOverride : selectedPort;
 
     if (!GUI.connect_lock && selectedPort !== 'noselection' && !selectedPort.path?.startsWith('usb_')) {
         // GUI control overrides the user control
@@ -694,7 +694,6 @@ function onClosed(result) {
 }
 
 export function read_serial(info) {
-    // console.log(`[READ_SERIAL]`, new Uint8Array(info));
     if (CONFIGURATOR.cliActive) {
         MSP.clearListeners();
         MSP.disconnect_cleanup();

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -110,6 +110,11 @@ function connectDisconnect() {
         const selectedPort = portName;
 
         if (!isConnected) {
+            // prevent connection when we do not have permission
+            if (selectedPort.startsWith('requestpermission')) {
+                return;
+            }
+
             console.log(`Connecting to: ${portName}`);
             GUI.connecting_to = portName;
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -141,7 +141,7 @@ function connectDisconnect() {
                 BT.addEventListener('connect', connectHandler);
                 BT.addEventListener('disconnect', disconnectHandler);
 
-                BT.connect();
+                BT.connect(portName, { baudRate });
 
             } else {
                 serial = serialShim();
@@ -186,7 +186,12 @@ function finishClose(finishedCallback) {
         $('#dialogResetToCustomDefaults')[0].close();
     }
 
-    serial.disconnect(onClosed);
+    if (PortHandler.portPicker.selectedPort.startsWith('bluetooth')) {
+        // BT.removeEventListener('receive', read_serial_adapter);
+        BT.disconnect();
+    } else {
+        serial.disconnect(onClosed);
+    }
 
     MSP.disconnect_cleanup();
     PortUsage.reset();
@@ -286,6 +291,7 @@ function onOpen(openInfo) {
         $('input[name="expertModeCheckbox"]').prop('checked', result).trigger('change');
 
         if (PortHandler.portPicker.selectedPort.startsWith('bluetooth')) {
+            serial = BT;
             BT.addEventListener('receive', read_serial_adapter);
         } else if (isWeb()) {
             serial.removeEventListener('receive', read_serial_adapter);
@@ -667,11 +673,7 @@ function onConnect() {
 }
 
 function onClosed(result) {
-    if (result) { // All went as expected
-        gui_log(i18n.getMessage('serialPortClosedOk'));
-    } else { // Something went wrong
-        gui_log(i18n.getMessage('serialPortClosedFail'));
-    }
+    gui_log(i18n.getMessage(result ? 'serialPortClosedOk' : 'serialPortClosedFail'));
 
     $('#tabs ul.mode-connected').hide();
     $('#tabs ul.mode-connected-cli').hide();

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -767,15 +767,13 @@ export function reinitializeConnection(callback) {
         }, 500);
     }
 
-    if (CONFIGURATOR.bluetoothMode) {
-        // TODO: find the right event to trigger the reconnection
-        return setTimeout(function() {
-            $('a.connect').trigger('click');
-        }, 500);
-    }
-
     rebootTimestamp = Date.now();
     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
+
+    if (CONFIGURATOR.bluetoothMode) {
+        // Bluetooth devices are not disconnected when rebooting
+        connectDisconnect();
+    }
 
     gui_log(i18n.getMessage('deviceRebooting'));
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -115,7 +115,7 @@ function connectDisconnect() {
                 return;
             }
 
-            console.log(`Connecting to: ${portName}`);
+            console.log(`[SERIAL-BACKEND] Connecting to: ${portName}`);
             GUI.connecting_to = portName;
 
             // lock port select & baud while we are connecting / connected
@@ -283,7 +283,7 @@ function onOpen(openInfo) {
         mspHelper = new MspHelper();
         MSP.listen(mspHelper.process_data.bind(mspHelper));
         MSP.timeout = 250;
-        console.log(`Requesting configuration data`);
+        console.log(`[SERIAL-BACKEND] Requesting configuration data`);
 
         MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
             gui_log(i18n.getMessage('apiVersionReceived', FC.CONFIG.apiVersion));

--- a/src/js/serial_shim.js
+++ b/src/js/serial_shim.js
@@ -1,8 +1,6 @@
 import CONFIGURATOR from "./data_storage";
-// import serialNWJS from "./serial.js";
+import serialNWJS from "./serial.js";
 import serialWeb from "./webSerial.js";
-// import { isWeb } from "./utils/isWeb";
 import BT from "./protocols/bluetooth.js";
 
-// export let serialShim = () => CONFIGURATOR.virtualMode ? serialNWJS : isWeb() ? serialWeb : serialNWJS;
-export let serialShim = () => CONFIGURATOR.bluetoothMode ? BT : serialWeb;
+export let serialShim = () => CONFIGURATOR.virtualMode ? serialNWJS : CONFIGURATOR.bluetoothMode ? BT : serialWeb;

--- a/src/js/serial_shim.js
+++ b/src/js/serial_shim.js
@@ -1,6 +1,8 @@
 import CONFIGURATOR from "./data_storage";
-import serialNWJS from "./serial.js";
+// import serialNWJS from "./serial.js";
 import serialWeb from "./webSerial.js";
-import { isWeb } from "./utils/isWeb";
+// import { isWeb } from "./utils/isWeb";
+import BT from "./protocols/bluetooth.js";
 
-export let serialShim = () => CONFIGURATOR.virtualMode ? serialNWJS : isWeb() ? serialWeb : serialNWJS;
+// export let serialShim = () => CONFIGURATOR.virtualMode ? serialNWJS : isWeb() ? serialWeb : serialNWJS;
+export let serialShim = () => CONFIGURATOR.bluetoothMode ? BT : serialWeb;

--- a/src/js/webSerial.js
+++ b/src/js/webSerial.js
@@ -96,10 +96,13 @@ class WebSerial extends EventTarget {
 
     async requestPermissionDevice(showAllSerialDevices = false) {
         let newPermissionPort = null;
+
         try {
             const options = showAllSerialDevices ? {} : { filters: webSerialDevices };
             const userSelectedPort = await navigator.serial.requestPort(options);
+
             newPermissionPort = this.ports.find(port => port.port === userSelectedPort);
+
             if (!newPermissionPort) {
                 newPermissionPort = this.handleNewDevice(userSelectedPort);
             }

--- a/src/js/webSerial.js
+++ b/src/js/webSerial.js
@@ -29,7 +29,7 @@ class WebSerial extends EventTarget {
         this.bytesReceived = 0;
         this.failed = 0;
 
-        this.logHead = "SERIAL: ";
+        this.logHead = "[SERIAL] ";
 
         this.portCounter = 0;
         this.ports = [];


### PR DESCRIPTION
`chrome://bluetooth-internals/#devices`

MSP and CLI are working on 
- KAKUTEH7
- SDMODELH7
- SPEEDYBEE F405 and F7V3.

References:

- https://webbluetoothcg.github.io/web-bluetooth/#ua-bluetooth-address
- https://github.com/WebBluetoothCG/web-bluetooth/blob/main/data-filters-explainer.md
- https://developer.mozilla.org/en-US/docs/Web/API/Web_Bluetooth_API
- https://googlechrome.github.io/samples/web-bluetooth/index.html
- https://developer.chrome.com/docs/capabilities/bluetooth
- https://github.com/WICG/serial/blob/main/EXPLAINER_BLUETOOTH.md#non-standard-service-class-ids

Requires enabling of certain flags using `chrome://flags/`
![image](https://github.com/betaflight/betaflight-configurator/assets/8344830/b0a4ea19-6b3b-470c-b855-fd2b56496d8d)

Known issues:

- portHandler does not display the port in port_picker
- reboot requires another strategy