### PR TITLE
Fix port selection blank under some situations

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -124,12 +124,12 @@ PortHandler.selectActivePort = function(suggestedDevice) {
 
     // Return the same that is connected to serial
     if (serial.connected) {
-        selectedPort = serial.getConnectedPort();
+        selectedPort = this.currentSerialPorts.find(device => device === serial.getConnectedPort());
     }
 
     // Return the same that is connected to usb (dfu mode)
     if (usb.usbDevice) {
-        selectedPort = usb.getConnectedPort();
+        selectedPort = this.currentUsbPorts.find(device => device === usb.getConnectedPort());
     }
 
     // Return the suggested device (the new device that has been detected)


### PR DESCRIPTION
I've verified that sometimes, the port disappears from the combo, but the serial or dfu remains in state "connected". This leads to situations where the combo selection is blank, but there are targets in the list that can be selected.
The final fix is to "disconnect" the serial or the dfu connection before sending the "device" lost message, but to make more solid the port_picker, this simple fix maintains the selection only if the device exists in the combo.