### PR TITLE
Fix disarm flag elements

### DIFF
--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -208,10 +208,11 @@ setup.initialize = function (callback) {
                 'NO_GYRO',
                 'FAILSAFE',
                 'RX_FAILSAFE',
-                'BAD_RX_RECOVERY',
+                'NOT_DISARMED',
                 'BOXFAILSAFE',
                 'RUNAWAY_TAKEOFF',
-                'CRASH_DETECTED', // THROTTLE before 1.42
+                'CRASH_DETECTED',
+                'THROTTLE',
                 'ANGLE',
                 'BOOT_GRACE_TIME',
                 'NOPREARM',


### PR DESCRIPTION
Noticed disarm disable flag did show PARALYZE, adding missing element and rename BAD_RX_RECOVERY to keep in sync with firmware.