### PR TITLE
Add APM32 Serial Device Support

### DIFF
--- a/src/js/serial_devices.js
+++ b/src/js/serial_devices.js
@@ -3,6 +3,7 @@ export const vendorIdNames = {
     1155: "STM Electronics",
     4292: "Silicon Labs",
     0x2e3c: "AT32",
+    0x314B: "Geehy Semiconductor",
 };
 
 export const serialDevices = [
@@ -12,6 +13,7 @@ export const serialDevices = [
     { vendorId: 4292, productId: 60001 }, // CP210x
     { vendorId: 4292, productId: 60002 }, // CP210x
     { vendorId: 0x2e3c, productId: 0x5740 }, // AT32 VCP
+    { vendorId: 0x314B, productId: 0x5740 }, // APM32 VCP
 ];
 
 export const webSerialDevices = serialDevices.map(


### PR DESCRIPTION
# Add APM32 Serial Device Support

## Description
This merge request introduces support for APM32 serial devices manufactured by Geehy Semiconductor. Specifically, it adds identification and support for devices with a Vendor ID (VID) of `0x314B` and a Product ID (PID) of `0x5740`.

## Changes
- Updated the `serial_devices.js` file to include the new device identification information.
- Added support for devices with Geehy Semiconductor's VID (`0x314B`) and PID (`0x5740`).

## Purpose
The purpose of this update is to expand our hardware support, enabling our software to be compatible with APM32 series serial devices. This will provide our users with a broader range of hardware options.

## Testing
- Verified the correct update of the `serial_devices.js` file.
- Conducted practical tests with an APM32 device having the specified VID and PID to ensure correct identification and functionality.

![Betaflight_Configurator_Geehy](https://github.com/betaflight/betaflight-configurator/assets/150499936/912eccf5-5242-4818-b4bf-2cff95edd444)

