### PR TITLE
Show all serial devices option PWA

### DIFF
--- a/src/components/status-bar/ReadingStat.vue
+++ b/src/components/status-bar/ReadingStat.vue
@@ -2,7 +2,12 @@
   <span>
     <span class="message">{{ $t(message) }}</span>
     <span class="value">{{ value }}</span>
-    <span class="unit" v-if="unit">{{ unit }}</span>
+    <span
+      v-if="unit"
+      class="unit"
+    >
+      {{ unit }}
+    </span>
   </span>
 </template>
 

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -49,6 +49,10 @@ PortHandler.setShowManualMode = function (showManualMode) {
     this.selectActivePort();
 };
 
+PortHandler.setShowAllSerialDevices = function (showAllSerialDevices) {
+    this.showAllSerialDevices = showAllSerialDevices;
+};
+
 PortHandler.addedSerialDevice = function (device) {
     this.updateCurrentSerialPortsList()
     .then(() => {
@@ -108,7 +112,7 @@ PortHandler.sortPorts = function(ports) {
 };
 
 PortHandler.askSerialPermissionPort = function() {
-    serial.requestPermissionDevice()
+    serial.requestPermissionDevice(this.showAllSerialDevices)
     .then((port) => {
         // When giving permission to a new device, the port is selected in the handleNewDevice method, but if the user
         // selects a device that had already permission, or cancels the permission request, we need to select the port

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -129,8 +129,9 @@ options.initShowAllSerialDevices = function() {
     showAllSerialDevicesElement
         .prop('checked', !!result.showAllSerialDevices)
         .on('change', () => {
-            setConfig({ showAllSerialDevices: showAllSerialDevicesElement.is(':checked') });
-            PortHandler.reinitialize();
+            const checked = showAllSerialDevicesElement.is(':checked');
+            setConfig({ showAllSerialDevices: checked });
+            PortHandler.setShowAllSerialDevices(checked);
         });
 };
 

--- a/src/js/webSerial.js
+++ b/src/js/webSerial.js
@@ -75,9 +75,10 @@ class WebSerial extends EventTarget {
     }
 
     createPort(port) {
+        const displayName = vendorIdNames[port.getInfo().usbVendorId] ? vendorIdNames[port.getInfo().usbVendorId] : `VID:${port.getInfo().usbVendorId} PID:${port.getInfo().usbProductId}`;
         return {
             path: `serial_${this.portCounter++}`,
-            displayName: `Betaflight ${vendorIdNames[port.getInfo().usbVendorId]}`,
+            displayName: `Betaflight ${displayName}`,
             vendorId: port.getInfo().usbVendorId,
             productId: port.getInfo().usbProductId,
             port: port,
@@ -85,9 +86,7 @@ class WebSerial extends EventTarget {
     }
 
     async loadDevices() {
-        const ports = await navigator.serial.getPorts({
-            filters: webSerialDevices,
-        });
+        const ports = await navigator.serial.getPorts();
 
         this.portCounter = 1;
         this.ports = ports.map(function (port) {
@@ -95,12 +94,11 @@ class WebSerial extends EventTarget {
         }, this);
     }
 
-    async requestPermissionDevice() {
+    async requestPermissionDevice(showAllSerialDevices = false) {
         let newPermissionPort = null;
         try {
-            const userSelectedPort = await navigator.serial.requestPort({
-                filters: webSerialDevices,
-            });
+            const options = showAllSerialDevices ? {} : { filters: webSerialDevices };
+            const userSelectedPort = await navigator.serial.requestPort(options);
             newPermissionPort = this.ports.find(port => port.port === userSelectedPort);
             if (!newPermissionPort) {
                 newPermissionPort = this.handleNewDevice(userSelectedPort);


### PR DESCRIPTION
This PR has two commits: 
- The first one is a simply lint fix (we now don't verify it in the CI now).
- The second one adds the support for the "Show all serial devices" option. It works a little different than before: it's only used when the user is giving or not permissions for the device. Once it has permission, the port always lists all the devices with permissions. We can modify that, adding a "manual" filtering, but I think it's not necessary seeing the type of use of this option and that complicates the flow.

