### PR TITLE
Remove space for hidden buttons in the toolbar

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1218,12 +1218,6 @@ dialog {
         bottom: 0;
         left: 100%;
         z-index: 2000;
-        div[style='display: none;'] {
-            &:first-child {
-                visibility: hidden;
-                display: block !important;
-            }
-        }
     }
 }
 .content_toolbar.xs-compressed {


### PR DESCRIPTION
For some reason, we have that the first button of the toolbar must use the space assigned to it when it is hidden. I'm pretty sure this was for some reason, but now I can't remember why and I've tested all the tabs and all seems ok without this.

Before:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/e71a1404-a681-4cc3-a935-a6e79a07002c)

After:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/9cbd3954-5b35-4222-ac67-da2e4a94bc19)
