### PR TITLE
Fix UI toolbar buttons at tethered logging

### DIFF
--- a/src/css/tabs/logging.less
+++ b/src/css/tabs/logging.less
@@ -1,4 +1,6 @@
 .tab-logging {
+	height: 100%;
+
 	.properties {
 		margin-top: 10px;
 		dt {

--- a/src/tabs/logging.html
+++ b/src/tabs/logging.html
@@ -1,4 +1,4 @@
-<div class="tab-logging toolbar_fixed_bottom">
+<div class="tab-logging">
     <div class="content_wrapper">
         <div class="tab_title" i18n="tabLogging"></div>
         <div class="cf_doc_version_bt">
@@ -65,7 +65,7 @@
             </dl>
         </div>
     </div>
-    <div class="content_toolbar">
+    <div class="content_toolbar  toolbar_fixed_bottom">
         <div class="btn file_btn">
             <a class="log_file" href="#" i18n="loggingButtonLogFile"></a>
         </div>
@@ -77,3 +77,4 @@
         </div>
     </div>
 </div>
+


### PR DESCRIPTION
The buttons toolbar at tethered logging are misaligned. This PR fixes them:

Before:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/143fad4b-df66-4537-a61d-65e9f15db217)

After:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/83f02465-4fb9-4ec5-ae97-4bb7452aa25d)
