### PR TITLE
Request permission before connect in USB flashing

### DIFF
--- a/src/js/protocols/webstm32.js
+++ b/src/js/protocols/webstm32.js
@@ -100,7 +100,10 @@ class STM32Protocol {
         serial.removeEventListener('disconnect', (event) => this.handleDisconnect(event.detail));
 
         if (disconnectionResult && this.rebootMode) {
-            DFU.connect(this.hex, this.serialOptions);
+            DFU.requestPermission()
+            .then((device) => {
+                DFU.connect(device.path, this.hex, this.serialOptions);
+            });
         } else {
             GUI.connect_lock = false;
         }

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -578,7 +578,10 @@ firmware_flasher.initialize = function (callback) {
 
             if (isDFU) {
                 tracking.sendEvent(tracking.EVENT_CATEGORIES.FLASHING, 'DFU Flashing', { filename: self.filename || null });
-                DFU.connect(firmware, options);
+                DFU.requestPermission()
+                .then((device) => {
+                    DFU.connect(device.path, firmware, options);
+                });
             } else if (isSerial) {
                 if ($('input.updating').is(':checked')) {
                     options.no_reboot = true;
@@ -923,7 +926,10 @@ firmware_flasher.initialize = function (callback) {
                 tracking.sendEvent(tracking.EVENT_CATEGORIES.FLASHING, 'ExitDfu', null);
                 try {
                     console.log('Closing DFU');
-                    DFU.connect(self.parsed_hex, { exitDfu: true });
+                    DFU.requestPermission()
+                    .then((device) => {
+                        DFU.connect(device.path, self.parsed_hex, { exitDfu: true });
+                    });
                 } catch (e) {
                     console.log(`Exiting DFU failed: ${e.message}`);
                 }


### PR DESCRIPTION
Before trying to "auto-flash" after connecting, detecting, etc. we need to divide the current process (connect) in two parts:
- Request permission
- Connect

In this way, we can decide, in a future PR, to:
- request permission or use the detected DFU port before connect
- connect after receiving the event of new DFU
- trying to put the FC in DFU mode, and if not received the new DFU event, request permission
- etc.

But it's easier to divide this into small PRs.