### PR TITLE
Fix CLI autocomplete background color

### DIFF
--- a/src/css/tabs/cli.less
+++ b/src/css/tabs/cli.less
@@ -111,7 +111,7 @@
 		padding: 2px 5px;
 	}
 	.active {
-		background-color: rgb(255, 187, 0);
+		background-color: var(--surface-600);
 	}
 	a {
 		&:hover {


### PR DESCRIPTION
The background of the autocomplete makes the text not visible. Fix it.

Before:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/91f30af2-a465-44f5-b629-53507738b164)

After:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/43bada37-db26-4b71-9284-e1d83bffea14)

