### PR TITLE
Style: Fix jBox tooltip colors

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1773,7 +1773,7 @@ button.active {
     padding-top: 5px;
 }
 .jBox-container {
-    background: var(--surface-400);
+    background: var(--surface-200) !important;
     border: 2px solid var(--primary-500);
     color: var(--text);
     border-radius: 0.5rem !important;
@@ -1806,8 +1806,8 @@ button.active {
     &:after {
         width: 10px;
         height: 9px;
-        border: 2px solid var(--primary-500);
-        background-color: var(--primary-500);
+        border: 2px solid var(--primary-500) !important;
+        background-color: var(--primary-500) !important;
     }
 }
 #dialogResetToCustomDefaults-content {


### PR DESCRIPTION
Fixes some weird behavior where a dev server would display it correctly, but the built version would not

![image](https://github.com/betaflight/betaflight-configurator/assets/76877124/7fe811c6-c0b1-41e3-9b98-1eedd9293cf4)
![image](https://github.com/betaflight/betaflight-configurator/assets/76877124/876a2f9e-e8f4-4c87-9f0b-4b249e5df135)