### PR TITLE
Change Vite register type to prompt for PWA

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -34,6 +34,23 @@
     "dontShowAgain": {
         "message": "Don't show again"
     },
+    "pwaOnNeedRefreshTitle": {
+        "message": "The application needs to be updated",
+        "description": "Title of the window that appears when the app needs to be refreshed to get the latest changes"
+    },
+    "pwaOnNeedRefreshText": {
+        "message": "You need to refresh the page to get the latest changes. Refreshing it now will reload the page and you will lose any unsaved changes and will abort any operation in progress.<br><br>Do you want to refresh it now? You can also dismiss this message and refresh the page manually later.",
+        "description": "Text of the window that appears when the app needs to be refreshed to get the latest changes"
+    },
+
+    "pwaOnOffilenReadyTitle": {
+        "message": "The application is ready to be used offline",
+        "description": "Title of the window that appears when the app is ready to be installed and used offline"
+    },
+    "pwaOnOffilenReadyText": {
+        "message": "You can install it as an standalone application on your device if you want. Search for the option in your browser address bar or menu.",
+        "description": "Text of the window that appears when the app is ready to be installed and used offline"
+    },
     "operationNotSupported": {
         "message": "This operation is not supported by your hardware."
     },

--- a/src/js/browserMain.js
+++ b/src/js/browserMain.js
@@ -47,13 +47,29 @@ import "select2/dist/css/select2.min.css";
 import "multiple-select/dist/multiple-select.min.css";
 import "../components/EscDshotDirection/Styles.css";
 import "../css/dark-theme.less";
-
 import "./main";
 
+import GUI from './gui';
 import { registerSW } from 'virtual:pwa-register';
 
-registerSW({
+const updateSW = registerSW({
+    onNeedRefresh() {
+        console.log("Detected onNeedRefresh");
+        GUI.showYesNoDialog({
+            title: i18n.getMessage("pwaOnNeedRefreshTitle"),
+            text: i18n.getMessage("pwaOnNeedRefreshText"),
+            buttonYesText: i18n.getMessage("yes"),
+            buttonNoText: i18n.getMessage("no"),
+            buttonYesCallback: () => updateSW(),
+            buttonNoCallback: null,
+        });
+    },
     onOfflineReady() {
-        alert('App is ready for offline use.');
+        console.log("Detected onOfflineReady");
+        GUI.showInformationDialog({
+            title : i18n.getMessage("pwaOnOffilenReadyTitle"),
+            text: i18n.getMessage("pwaOnOffilenReadyText"),
+            buttonConfirmText: i18n.getMessage("OK"),
+        });
     },
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -84,7 +84,7 @@ export default defineConfig({
             hook: "writeBundle",
         }),
         VitePWA({
-            registerType: 'autoUpdate',
+            registerType: 'prompt',
             workbox: {
                 globPatterns: ['**/*.{js,css,html,ico,png,svg,json,mcm}'],
                 // 5MB


### PR DESCRIPTION
The PWA app refreshes itself when there are changes. This is not too friendly because it returns to the main page without user intervention, and can lead to lost of data, or failed flashing if there is some operation in progress.

This PR shows a modal window to let the user select to refresh now or not.

I think this is good as first version, but for the future is best to have some component for floating notifications. It will be less intrusive than a dialog in a full modal window.

IMPORTANT: there is a note in the Vite site (https://vite-pwa-org.netlify.app/guide/auto-update.html):

> DANGER
> Before you put your application into production, you need to be sure of the behavior you want for the service worker. Changing the behavior of the service worker from autoUpdate to prompt can be a pain.

I don't know exactly what this implies.