### PR TITLE
Adjust RX Plot graph elements

### DIFF
--- a/src/css/tabs/receiver.less
+++ b/src/css/tabs/receiver.less
@@ -250,7 +250,7 @@
 		}
 	}
 	#RX_plot {
-        height: 13rem;
+        height: 208px;
         color: var(--text);
 		.line {
 			&:nth-child(1) {

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -269,11 +269,11 @@
             <div class="spacer">
                 <div class="wrapper graphAndLabel">
                     <svg id="RX_plot" class="col-span-5">
-                        <g class="grid x" transform="translate(40, 180)"></g>
-                        <g class="grid y" transform="translate(40, 10)"></g>
-                        <g class="data" transform="translate(41, 1)"></g>
-                        <g class="axis x" transform="translate(40, 180)"></g>
+                        <g class="axis x" transform="translate(40, 188)"></g>
                         <g class="axis y" transform="translate(40, 10)"></g>
+                        <g class="grid x" transform="translate(40, 188)"></g>
+                        <g class="grid y" transform="translate(40, 10)"></g>
+                        <g class="data" transform="translate(40, 10)"></g>
                     </svg>
 
                     <div class="plot_control">


### PR DESCRIPTION
The current RX plot graph has some elements out of the position. For example this is the graph with the signal on 1500:

![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/dd111367-db60-4301-857d-f68707a2a514)

This PR fixes this. Is a fast fix, it will be better to calculate the transform points on the js side, in the D3 code, but it works:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/8c626c08-fc1a-4514-9775-19932bf694e0)
