### PR TITLE
Fix disabled state of autodetect button

### DIFF
--- a/src/css/tabs/firmware_flasher.less
+++ b/src/css/tabs/firmware_flasher.less
@@ -102,10 +102,14 @@
                 align-items: center;
                 gap: 0.5rem;
             }
-            &.disabled span {
-                background-color: var(--surface-500);
-                color: var(--text);
+            &.disabled {
+                pointer-events: none;
                 cursor: default;
+                span {
+                    background-color: var(--surface-500);
+                    color: var(--text);
+                    cursor: default;
+                }
             }
         }
     }

--- a/src/tabs/firmware_flasher.html
+++ b/src/tabs/firmware_flasher.html
@@ -49,7 +49,7 @@
                                     <select name="board">
                                         <option value="0" i18n="firmwareFlasherOptionLoading">Loading ...</option>
                                     </select>
-                                    <a href="#" class="detect-board disabled cf_tip_wide" i18n_title="firmwareFlasherOnlineSelectBoardDescription">
+                                    <a href="#" class="detect-board cf_tip_wide" i18n_title="firmwareFlasherOnlineSelectBoardDescription">
                                         <span><div i18n="firmwareFlasherDetectBoardButton"></div><em class="fas fa-search"></em></span>
                                     </a>
                                 </div>


### PR DESCRIPTION
This PR fixes two things:
- The auto-detect board button, appears as disabled when the page loads.
- With the button disabled, if the user presses it the auto-detect action occurs. It does not matter if it has the state disabled or not.

We can do this more complicated, but I think this solution is valid enough.