### PR TITLE
Fix firmware flasher tab toolbar

### DIFF
--- a/src/css/tabs/firmware_flasher.less
+++ b/src/css/tabs/firmware_flasher.less
@@ -1,4 +1,5 @@
 .tab-firmware_flasher {
+    height: 100%;
 	.build-options-wrapper {
 		.select2-container {
 			width: calc(100% - 2rem)!important;


### PR DESCRIPTION
The firmware flasher buttons are not at the bottom, they are floating:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/cd8672df-8dca-4774-b622-89803c8b9575)

This PR fixes it to be aligned with the rest of tabs.