### PR TITLE
Fix presets UI buttons bar

### DIFF
--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.less
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.less
@@ -37,7 +37,7 @@
 	padding-bottom: 6px;
 	margin-top: 12px;
 	overflow-y: scroll;
-	height: 270px;
+	height: 260px;
 	font-size: 110%;
 	white-space: pre-line;
 	user-select: text;
@@ -86,7 +86,7 @@ ol {
 	padding-left: 25px;
 }
 #presets_detailed_dialog_properties {
-	height: 360px;
+	height: 466px;
 }
 #presets_options_panel {
 	.ms-choice {
@@ -110,6 +110,14 @@ ol {
 	display: inline-block;
 }
 #presets_detailed_dialog {
+	.content_toolbar {
+		width: unset;
+		margin-left: auto;
+		margin-right: -12px;
+		.btn {
+			display: contents;
+		}
+	}
 	.ms-drop {
 		ul {
 			>li.hide-radio {

--- a/src/tabs/presets/presets.less
+++ b/src/tabs/presets/presets.less
@@ -253,7 +253,7 @@
 #presets_detailed_dialog {
 	width: 600px;
 	height: 520px;
-	padding: 12px;
+	padding: 12px 12px 0px 12px;
 }
 #presets_sources_dialog {
 	width: 600px;


### PR DESCRIPTION
Fixes the presets toolbar UI.

Before:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/80f72f46-b323-4536-9d5e-b9e3adad1ea5)

After:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/5bbe830e-4fd7-4dc4-b106-446e01588d49)

This is a fast fix, I'm sure @VitroidFPV will not like that presets use size fixed for all. So maybe a UI refactor will be needed in a future.