### PR TITLE
Fixes CLI text color on dark theme

### DIFF
--- a/src/css/tabs/cli.less
+++ b/src/css/tabs/cli.less
@@ -56,6 +56,7 @@
 		border: 1px solid var(--surface-500);
 		resize: none;
         background-color: var(--surface-200);
+        color: var(--surface-900);
 	}
 	textarea[name='supportWarningDialogInput'] {
 		-webkit-box-sizing: border-box;


### PR DESCRIPTION
Fixes CLI text color on dark theme, see attached example of dark font textbox on dark theme.

![Screenshot_2024-06-23_at_17 02 43](https://github.com/betaflight/betaflight-configurator/assets/7066184/ea94898d-f2b4-46bd-9e68-7d19d7d180ef)
