### PR TITLE
Aesthetic CLI dropdown menu

### DIFF
--- a/src/css/tabs/cli.less
+++ b/src/css/tabs/cli.less
@@ -90,7 +90,7 @@
 }
 .cli-textcomplete-dropdown {
 	border: 1px solid var(--surface-500);
-	background-color: white;
+	background-color: var(--surface-300);
 	border-radius: 5px;
 	max-height: 50%;
 	overflow: auto;


### PR DESCRIPTION
Darker background of CLI dropdown menu instead of white BG with yellow font.

Example of white dropdownb menu with yellow font. 
![Screenshot_2024-06-23_at_17 02 43](https://github.com/betaflight/betaflight-configurator/assets/7066184/92cf16f5-9fd4-462c-ac56-07e73526aac6)

to something more in keeping with Betaflight colors.
![Screenshot 2024-06-28 at 22 03 02](https://github.com/betaflight/betaflight-configurator/assets/7066184/d6e37a64-4d5f-4139-b71f-477ba9c59d72)
