### PR TITLE
Fix hide of dataflash element

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -451,7 +451,7 @@ input[type="number"] {
     display: none;
 }
 .dataflash-contents_global {
-    display: flex !important;
+    display: flex;
     flex-direction: column;
     gap: 0.5rem;
     padding: 0.5rem;


### PR DESCRIPTION
When no dataflash exists there is a problem in the layout.

Before:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/b5efa8ba-7fe5-4f0e-985a-7703ef174bbe)

After:
![image](https://github.com/betaflight/betaflight-configurator/assets/2673520/52543556-6a8b-4db9-8656-fc909d061bdd)

This happens because the display:none is override. The !important was added in the UI rework, but I don't know if it needs to be or not here. @VitroidFPV some idea why this was added?