### PR TITLE
Fix botton toolbar again in modes an flasher tab

### DIFF
--- a/src/css/tabs/auxiliary.less
+++ b/src/css/tabs/auxiliary.less
@@ -1,5 +1,5 @@
 .tab-auxiliary {
-	height: 100%;
+	min-height: 100%;
 	.help {
 		padding: 10px;
 		background-color: #ffcb18;

--- a/src/css/tabs/firmware_flasher.less
+++ b/src/css/tabs/firmware_flasher.less
@@ -1,5 +1,5 @@
 .tab-firmware_flasher {
-    height: 100%;
+    min-height: 100%;
 	.build-options-wrapper {
 		.select2-container {
 			width: calc(100% - 2rem)!important;


### PR DESCRIPTION
This fixes the toolbar floating buttons problem reported on discord, in the modes tab, and I hope in the firmware flasher (I was not able to reproduce it there).

@haslinghuis can you try if this fixes it for your?

