### PR TITLE
Fix typos

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7341,19 +7341,19 @@
         "message": "Configuration Filename:"
     },
     "firmwareFlasherRadioProtocolDescription": {
-        "message": "Select the radio protocol you would like included in this build. Note this is a drop down, but only one item maybe selected."
+        "message": "Select the radio protocol you would like included in this build. Note this is a drop down, but only one item may be selected."
     },
     "firmwareFlasherTelemetryProtocolDescription": {
-        "message": "Select the telemetry protocol you would like included in this build. Note this is a drop down, but only one item maybe selected. There are also some telemetry protocols that will be enabled, regardless of your selection here based on the radio protocol selected, e.g. CRSF."
+        "message": "Select the telemetry protocol you would like included in this build. Note this is a drop down, but only one item may be selected. There are also some telemetry protocols that will be enabled, regardless of your selection here based on the radio protocol selected, e.g. CRSF."
     },
     "firmwareFlasherOptionLabelTelemetryProtocolIncluded": {
         "message": "Automatically Included"
     },
     "firmwareFlasherOptionsDescription": {
-        "message": "Select the generic options you would like included in this build. Note this is a drop down, and multiple items maybe selected. Such items as fixes, e.g. AKK VTX, are included here."
+        "message": "Select the generic options you would like included in this build. Note this is a drop down, and multiple items may be selected. Such items as fixes, e.g. AKK VTX, are included here."
     },
     "firmwareFlasherMotorProtocolDescription": {
-        "message": "Select the motor (ESC) protocol you would like included in this build. Note this is a drop down, but only one item maybe selected."
+        "message": "Select the motor (ESC) protocol you would like included in this build. Note this is a drop down, but only one item may be selected."
     },
     "firmwareFlasherBranchDescription": {
         "message": "Especially useful for developers, you can select a merged PR, specify a commit sha, or specify a 'yet to be merged' PR by typing in a # followed by the PR number e.g. #1234 (this is shorthand for the branch 'pull/1234/head')."


### PR DESCRIPTION
Fix a few 'maybe' typos, ex:
![image](https://github.com/betaflight/betaflight-configurator/assets/8084300/79e5eb3b-e8f9-4d66-9251-f90c2d3bdec7)

