### PR TITLE
Detect GitHub branch name automatically from URL

### DIFF
--- a/src/tabs/presets/SourcesDialog/PresetSource.js
+++ b/src/tabs/presets/SourcesDialog/PresetSource.js
@@ -9,4 +9,18 @@ export default class PresetSource {
     static isUrlGithubRepo(url) {
         return url.trim().toLowerCase().startsWith("https://github.com/");
     }
+
+    static containsBranchName(url) {
+        return url.includes("/tree/");
+    }
+
+    static getBranchName(url) {
+        const pattern = /https:\/\/github\.com\/[^\/]+\/[^\/]+\/tree\/([^\/]+)/;
+        const match = url.match(pattern);
+        if (match) {
+            return match[1];
+        } else {
+            return null;
+        }
+    }
 }

--- a/src/tabs/presets/SourcesDialog/PresetSource.js
+++ b/src/tabs/presets/SourcesDialog/PresetSource.js
@@ -17,10 +17,7 @@ export default class PresetSource {
     static getBranchName(url) {
         const pattern = /https:\/\/github\.com\/[^\/]+\/[^\/]+\/tree\/([^\/]+)/;
         const match = url.match(pattern);
-        if (match) {
-            return match[1];
-        } else {
-            return null;
-        }
+
+        return match ? match[1] : null;
     }
 }

--- a/src/tabs/presets/SourcesDialog/SourcePanel.js
+++ b/src/tabs/presets/SourcesDialog/SourcePanel.js
@@ -147,6 +147,10 @@ export default class SourcePanel {
 
     _onInputChange() {
         this._checkIfGithub();
+        if (PresetSource.containsBranchName(this._domEditUrl.val())) {
+            this._domEditGitHubBranch.val(PresetSource.getBranchName(this._domEditUrl.val()));
+            this._domEditUrl.val(this._domEditUrl.val().split("/tree/")[0]);
+        }
         this._setIsSaved(false);
     }
 


### PR DESCRIPTION
Implemented a regex that checks if the branch name is included in the link, and if so it sets the branch name automatically and removes it from the GitHub link.

Example:
Pasting `https://github.com/YarosMallorca/firmware-presets/tree/custom-presets` into the presets dialog will result in:

Before:
<img width="605" alt="Screenshot 2024-07-02 at 18 15 53" src="https://github.com/betaflight/betaflight-configurator/assets/54041533/1f1c458b-16ca-4687-9ab4-2c0d6ad779a8">

After:
<img width="604" alt="Screenshot 2024-07-02 at 18 16 13" src="https://github.com/betaflight/betaflight-configurator/assets/54041533/9331668e-d8f9-4ec9-9808-519ef77aa9ff">
