### PR TITLE
Fixed UI bug - Toolbar floating on some tabs

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1570,90 +1570,30 @@ table {
     font-size: 11px;
     margin-left: 3px;
 }
-.tab-setup {
-    height: fit-content;
-    position: relative;
-}
-.tab-landing {
-    height: fit-content;
-    position: relative;
-}
-.tab-adjustments {
-    height: fit-content;
-    position: relative;
-}
-.tab-auxiliary {
-    height: fit-content;
-    position: relative;
-}
-.tab-cli {
-    height: fit-content;
-    position: relative;
-}
-.tab-configuration {
-    height: fit-content;
-    position: relative;
-}
-.tab-failsafe {
-    height: fit-content;
-    position: relative;
-}
-.tab-firmware_flasher {
-    height: fit-content;
-    position: relative;
-}
-.tab-gps {
-    height: fit-content;
-    position: relative;
-}
-.tab-help {
-    height: fit-content;
-    position: relative;
-}
-.tab-led-strip {
-    height: 100%;
-    position: relative;
-}
-.tab-logging {
-    height: fit-content;
-    position: relative;
-}
-.tab-modes {
-    height: fit-content;
-    position: relative;
-}
-.tab-motors {
-    height: fit-content;
-    position: relative;
-}
-.tab-pid_tuning {
-    height: fit-content;
-    position: relative;
-}
-.tab-ports {
-    height: fit-content;
-    position: relative;
-}
-.tab-receiver {
-    height: fit-content;
-    position: relative;
-}
-.tab-sensors {
-    height: fit-content;
-    position: relative;
-}
-.tab-servos {
-    height: fit-content;
-    position: relative;
-}
+.tab-setup,
+.tab-landing,
+.tab-adjustments,
+.tab-auxiliary,
+.tab-cli,
+.tab-configuration,
+.tab-failsafe,
+.tab-firmware_flasher,
+.tab-gps,
+.tab-help,
+.tab-led-strip,
+.tab-logging,
+.tab-modes,
+.tab-motors,
+.tab-pid_tuning,
+.tab-ports,
+.tab-receiver,
+.tab-sensors,
+.tab-servos,
 .tab-osd {
     height: fit-content;
     position: relative;
 }
-.tab-power {
-    height: 100%;
-    position: relative;
-}
+.tab-power,
 .tab-vtx {
     height: 100%;
     position: relative;

--- a/src/css/tabs/motors.less
+++ b/src/css/tabs/motors.less
@@ -1,5 +1,4 @@
 .tab-motors {
-	height: 100%;
     .spacer {
         display: flex;
         flex-direction: column;

--- a/src/css/tabs/servos.less
+++ b/src/css/tabs/servos.less
@@ -1,6 +1,4 @@
 .tab-servos {
-	height: 100%;
-
 	.title {
 		margin-top: 0;
 		line-height: 30px;

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -361,15 +361,6 @@
 
     </div> <!-- END CONTENT_WRAPPER -->
 
-    <div class="content_toolbar toolbar_fixed_bottom">
-        <div class="btn">
-            <a class="save disabled" href="#" i18n="motorsButtonSave"></a>
-        </div>
-        <div class="btn">
-            <a class="stop disabled" href="#" i18n="escDshotDirectionDialog-StopWizard"></a>
-        </div>
-    </div>
-
     <dialog id="dialog-mixer-reset">
         <div id="dialog-mixer-reset-content-wrapper">
             <div id="dialog-mixer-reset-content"></div>
@@ -406,4 +397,13 @@
             <a href="#" id="escDshotDirectionDialog-closebtn" class="regular-button right" i18n="close"></a>
         </div>
     </dialog>
+</div>
+
+<div class="content_toolbar toolbar_fixed_bottom">
+    <div class="btn">
+        <a class="save disabled" href="#" i18n="motorsButtonSave"></a>
+    </div>
+    <div class="btn">
+        <a class="stop disabled" href="#" i18n="escDshotDirectionDialog-StopWizard"></a>
+    </div>
 </div>

--- a/src/tabs/presets/presets.html
+++ b/src/tabs/presets/presets.html
@@ -77,13 +77,6 @@
         </div>
     </div>
 
-    <div class="content_toolbar toolbar_fixed_bottom">
-        <div class="btn">
-            <a href="#" id="presets_save_button" class="tool regular-button" i18n="presetsButtonSave"></a>
-            <a href="#" id="presets_cancel_button" class="tool regular-button" i18n="presetsButtonCancel"></a>
-        </div>
-    </div>
-
     <dialog id="presets_detailed_dialog">
     </dialog>
 
@@ -114,4 +107,10 @@
         </div>
     </dialog>
 
+</div>
+<div class="content_toolbar toolbar_fixed_bottom">
+    <div class="btn">
+        <a href="#" id="presets_save_button" class="tool regular-button" i18n="presetsButtonSave"></a>
+        <a href="#" id="presets_cancel_button" class="tool regular-button" i18n="presetsButtonCancel"></a>
+    </div>
 </div>

--- a/src/tabs/presets/presets.less
+++ b/src/tabs/presets/presets.less
@@ -1,5 +1,4 @@
 .tab-presets {
-	height: 100%;
 	.content_wrapper {
 		height: calc(100% - 30px - 3ex);
 		overflow-y: scroll;
@@ -294,9 +293,6 @@
 }
 @media only screen and (max-width: 1055px) {
 	.tab-presets {
-		.content_wrapper {
-			height: calc(100% - 87px);
-		}
 		.content_toolbar {
 			margin-top: 5px;
 		}


### PR DESCRIPTION
Fixed an issue where the bottom toolbar would float when scrolling down, and presets tab wouldn't be 100% height.

Before:
<img width="300" alt="Screenshot 2024-07-05 at 01 33 55" src="https://github.com/betaflight/betaflight-configurator/assets/54041533/dee6e7bb-9c35-4a9a-8b9c-892409f398c6">

After:
<img width="300" alt="Screenshot 2024-07-05 at 01 34 38" src="https://github.com/betaflight/betaflight-configurator/assets/54041533/3e8a7276-ec64-438e-98ac-bd0c3c1f9189">
