### PR TITLE
Feature: Create Development tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -340,6 +340,9 @@
     "tabOptions": {
         "message": "Options"
     },
+    "tabDevelopment": {
+        "message": "Development"
+    },
 
     "tabSetup": {
         "message": "Setup"
@@ -6279,7 +6282,7 @@
         "message": "RSSI dBm",
         "description": "Text of the RSSI dBm alarm"
       },
-  
+
     "osdWarningTextArmingDisabled": {
         "message": "Arming disabled",
         "description": "One of the warnings that can be selected to be shown in the OSD"

--- a/src/index.html
+++ b/src/index.html
@@ -133,6 +133,7 @@
                     <li class="tab_help" id="tab_help"><a href="#" i18n="tabHelp" class="tabicon ic_help" i18n_title="tabHelp"></a></li>
                     <li class="tab_options" id="tab_options"><a href="#" i18n="tabOptions" class="tabicon ic_config" i18n_title="tabOptions"></a></li>
                     <li class="tab_firmware_flasher" id="tabFirmware"><a href="#" i18n="tabFirmwareFlasher" class="tabicon ic_flasher" i18n_title="tabFirmwareFlasher"></a></li>
+                    <li class="tab_development" id="tab_development"><a href="#" i18n="tabDevelopment" class="tabicon ic_config" i18n_title="tabDevelopment"></a></li>
                 </ul>
                 <ul class="mode-connected">
                     <li class="tab_setup"><a href="#" i18n="tabSetup" class="tabicon ic_setup" i18n_title="tabSetup"></a></li>

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -4,6 +4,8 @@ import Switchery from 'switchery-latest';
 import jBox from 'jbox';
 import $ from 'jquery';
 
+const appMode = import.meta.env.MODE;
+
 const TABS = {};
 
 const GUI_MODES = {
@@ -59,6 +61,10 @@ class GuiControl {
             'servos',
             'transponder',
         ];
+
+        if (appMode === 'development') {
+            this.defaultAllowedTabsWhenDisconnected.push('development');
+        }
 
         this.defaultAllowedFCTabsWhenConnected = [ ...this.defaultAllowedTabs, ...this.defaultCloudBuildTabOptions];
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -91,6 +91,8 @@ function appReady() {
 
     cleanupLocalStorage();
 
+    updateTabList();
+
     i18n.init(function() {
 
         // pass the configurator version as a custom header for every AJAX request.
@@ -433,6 +435,11 @@ function startProcess() {
                     case 'presets':
                         import("../tabs/presets/presets").then(({ presets }) =>
                             presets.initialize(content_ready),
+                        );
+                        break;
+                    case 'development':
+                        import("./tabs/development").then(({ development }) =>
+                            development.initialize(content_ready),
                         );
                         break;
 

--- a/src/js/tabs/development.js
+++ b/src/js/tabs/development.js
@@ -1,0 +1,25 @@
+import GUI, { TABS } from '../gui';
+import { i18n } from '../localization';
+import $ from 'jquery';
+
+const development = {};
+development.initialize = function (callback) {
+
+    if (GUI.active_tab != 'development') {
+        GUI.active_tab = 'development';
+    }
+
+    $('#content').load("./tabs/development.html", function () {
+        i18n.localizePage();
+
+        GUI.content_ready(callback);
+    });
+};
+
+development.cleanup = function (callback) {
+    if (callback) callback();
+};
+
+TABS.development = development;
+
+export { development };

--- a/src/js/utils/updateTabList.js
+++ b/src/js/utils/updateTabList.js
@@ -1,8 +1,13 @@
 import $ from 'jquery';
 import FC from '../fc';
 
+const appMode = import.meta.env.MODE;
+
 export function updateTabList(features) {
     const isExpertModeEnabled = $('input[name="expertModeCheckbox"]').is(':checked');
+    const isDevelopmentMode = appMode === 'development';
+
+    $('#tabs ul.mode-disconnected li.tab_development').toggle(isDevelopmentMode);
 
     $('#tabs ul.mode-connected li.tab_failsafe').toggle(isExpertModeEnabled);
     $('#tabs ul.mode-connected li.tab_adjustments').toggle(isExpertModeEnabled);
@@ -10,8 +15,8 @@ export function updateTabList(features) {
     $('#tabs ul.mode-connected li.tab_logging').toggle(isExpertModeEnabled);
     $('#tabs ul.mode-connected li.tab_servos').toggle(isExpertModeEnabled && FC.CONFIG?.buildOptions?.includes('USE_SERVOS'));
 
-    $('#tabs ul.mode-connected li.tab_gps').toggle(features.isEnabled('GPS'));
-    $('#tabs ul.mode-connected li.tab_led_strip').toggle(features.isEnabled('LED_STRIP'));
-    $('#tabs ul.mode-connected li.tab_transponder').toggle(features.isEnabled('TRANSPONDER'));
-    $('#tabs ul.mode-connected li.tab_osd').toggle(features.isEnabled('OSD'));
+    $('#tabs ul.mode-connected li.tab_gps').toggle(features?.isEnabled('GPS'));
+    $('#tabs ul.mode-connected li.tab_led_strip').toggle(features?.isEnabled('LED_STRIP'));
+    $('#tabs ul.mode-connected li.tab_transponder').toggle(features?.isEnabled('TRANSPONDER'));
+    $('#tabs ul.mode-connected li.tab_osd').toggle(features?.isEnabled('OSD'));
 }

--- a/src/main.html
+++ b/src/main.html
@@ -223,6 +223,7 @@
                     <li class="tab_help" id="tab_help"><a href="#" i18n="tabHelp" class="tabicon ic_help" i18n_title="tabHelp"></a></li>
                     <li class="tab_options" id="tab_options"><a href="#" i18n="tabOptions" class="tabicon ic_config" i18n_title="tabOptions"></a></li>
                     <li class="tab_firmware_flasher" id="tabFirmware"><a href="#" i18n="tabFirmwareFlasher" class="tabicon ic_flasher" i18n_title="tabFirmwareFlasher"></a></li>
+                    <li class="tab_development" id="tab_development"><a href="#" i18n="tabDevelopment" class="tabicon ic_config" i18n_title="tabDevelopment"></a></li>
                 </ul>
                 <ul class="mode-connected">
                     <li class="tab_setup"><a href="#" i18n="tabSetup" class="tabicon ic_setup" i18n_title="tabSetup"></a></li>

--- a/src/tabs/development.html
+++ b/src/tabs/development.html
@@ -1,0 +1,105 @@
+<div class="tab-development">
+    <div class="content_wrapper">
+
+        <div class="grid-box col1">
+            <div class="grid-box col2">
+                <div class="col-span-2">
+                    <div class="gui_box">
+                        <div class="gui_box_titlebar">
+                            <div class="spacer_box_title">Wide GUI Box</div>
+                        </div>
+                        <div class="spacer_box">
+                            <div>Spacer Box Content</div>
+                            Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptates reiciendis magnam tempora eligendi, nobis sapiente consectetur commodi harum. Debitis voluptatibus iure provident ea esse eveniet eaque inventore? Consequatur, sapiente iste?
+                        </div>
+                    </div>
+                </div>
+                <div class="col-span-1">
+                    <div class="gui_box">
+                        <div class="gui_box_titlebar">
+                            <div class="spacer_box_title">GUI Box</div>
+                        </div>
+                        <div class="spacer_box">
+                            <div>Spacer Box Content</div>
+                            Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptates reiciendis magnam tempora eligendi, nobis sapiente consectetur commodi harum. Debitis voluptatibus iure provident ea esse eveniet eaque inventore? Consequatur, sapiente iste?
+                        </div>
+                    </div>
+                </div>
+                <div class="col-span-1">
+                    <div class="gui_box">
+                        <div class="gui_box_titlebar">
+                            <div class="spacer_box_title">GUI Box</div>
+                        </div>
+                        <div class="spacer_box">
+                            <div>Spacer Box Content</div>
+                            Lorem ipsum dolor sit amet consectetur adipisicing elit. Voluptates reiciendis magnam tempora eligendi, nobis sapiente consectetur commodi harum. Debitis voluptatibus iure provident ea esse eveniet eaque inventore? Consequatur, sapiente iste?
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="note">
+                <div>
+                    Note Content
+                </div>
+                <div>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugit doloribus amet voluptas error corporis veniam recusandae adipisci a rerum distinctio asperiores omnis inventore eum, illum aut delectus vel pariatur alias.
+                </div>
+            </div>
+
+            <div class="danger">
+                <div>
+                    Danger Content
+                </div>
+                <div>
+                    Lorem ipsum dolor sit amet, consectetur adipisicing elit. Fugit doloribus amet voluptas error corporis veniam recusandae adipisci a rerum distinctio asperiores omnis inventore eum, illum aut delectus vel pariatur alias.
+                </div>
+            </div>
+
+            <div class="default_btn">
+                <a href="#">Button</a>
+            </div>
+
+            <div class="default_btn" style="width: fit-content">
+                <a href="#">Button</a>
+            </div>
+
+            <div class="default_btn" style="width: fit-content">
+                <a href="#" class="disabled">Button</a>
+            </div>
+
+            <label>
+                <input class="toggle" type="checkbox" />
+                <span></span>
+            </label>
+
+            <label>
+                <input class="togglesmall" type="checkbox" />
+                <span></span>
+            </label>
+
+            <select style="width: fit-content">
+                <option value="0">Option 1</option>
+                <option value="1">Option 2</option>
+                <option value="2">Option 3</option>
+                <option value="3">Option 4 with more text</option>
+            </select>
+
+            <input type="text" style="width: fit-content">
+
+        </div>
+
+    </div>
+
+</div>
+<div class="content_toolbar toolbar_fixed_bottom">
+    <div class="btn">
+        <a href="#">B</a>
+    </div>
+    <div class="btn">
+        <a href="#">Button</a>
+    </div>
+    <div class="btn">
+        <a href="#">Very Long Button With A Lot Of Text To Break On Small Screens</a>
+    </div>
+</div>


### PR DESCRIPTION
Needing to go to different tabs during UI development to test various elements that may not even be present together can get in the way of making sure that everything looks and works like it should.

This PR adds a simple `Development` tab that's available directly in the "unconnected" state (saving time having to wait for connections to initialize and finish), it's only accessible in a local development environment. It's filled with basic UI elements for now, but it should be expanded with other UI elements to test as needed. It can also be used to mock up new elements or entire tabs in development without needing to edit/replace other functional tabs, maintaining full functionality

![image](https://github.com/betaflight/betaflight-configurator/assets/76877124/292ba8fd-4816-4b2e-a0b0-28494e291644)

Please add/suggest additional elements to be added!