### PR TITLE
Fixed text color in motors & PID tabs for light mode

### DIFF
--- a/src/css/tabs/motors.less
+++ b/src/css/tabs/motors.less
@@ -10,6 +10,7 @@
         gap: 1rem;
     }
     .danger {
+		color: var(--text);
         .switchery {
             margin-right: 0.1rem;
         }

--- a/src/css/tabs/pid_tuning.less
+++ b/src/css/tabs/pid_tuning.less
@@ -91,6 +91,7 @@
 			font-weight: normal;
 			text-overflow: ellipsis;
 			overflow: hidden;
+			color: var(--text)
 		}
 		tr {
 			td {


### PR DESCRIPTION
**Before:**
![PID Before](https://github.com/betaflight/betaflight-configurator/assets/54041533/e4dede9c-9b9f-4b2f-88ad-c9770ed6a833)
![Motor Warning Before](https://github.com/betaflight/betaflight-configurator/assets/54041533/86971ca8-97bb-4090-8a8c-139bfcec47d8)


**After:**

![PID After](https://github.com/betaflight/betaflight-configurator/assets/54041533/d6400b9a-a09f-4d42-881d-0b13645c16a0)
![Motor Warning After](https://github.com/betaflight/betaflight-configurator/assets/54041533/604696ec-bb08-427e-8542-16fcb101c221)
