### PR TITLE
Fix ELRS UUID

### DIFF
--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -52,7 +52,13 @@ receiver.initialize = function (callback) {
         if (text) {
             const bindingPhraseFull = `-DMY_BINDING_PHRASE="${text}"`;
             const hash = CryptoES.MD5(bindingPhraseFull).toString();
-            uidBytes = Uint8Array.from(Buffer.from(hash, 'hex')).subarray(0, 6);
+            // Buffer.from is not available in the browser
+            const bytes = hash.match(/.{1,2}/g).map(byte => parseInt(byte, 16));
+            const view = new DataView(new ArrayBuffer(6));
+            for (let i = 0; i < 6; i++) {
+                view.setUint8(i, bytes[i]);
+            }
+            uidBytes = Array.from(new Uint8Array(view.buffer));
         }
 
         return uidBytes;


### PR DESCRIPTION
`Buffer.from()` is not available in the browser

Waiting for: https://github.com/tc39/proposal-arraybuffer-base64
See also: https://sindresorhus.com/blog/goodbye-nodejs-buffer