### PR TITLE
[10.10-MAINT] update macos build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             releaseArgs: --linux64
 
           - name: macOS
-            os: macos-11
+            os: macos-12
             releaseArgs: --osx64
 
           - name: Windows


### PR DESCRIPTION
`macos-11` runner image has been removed.