### PR TITLE
Fix autodetect for some older 4.5 firmware builds

### DIFF
--- a/src/js/utils/AutoDetect.js
+++ b/src/js/utils/AutoDetect.js
@@ -132,7 +132,7 @@ class AutoDetect {
             const buildDate = new Date(FC.CONFIG.buildInfo);
 
             if (TABS.firmware_flasher.validateBuildKey() && (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_46) || buildDate < supportedDate)) {
-                return TABS.firmware_flasher.buildApi.requestBuildOptions(TABS.firmware_flasher.cloudBuildKey, this.getCloudBuildOptions, this.getBoardInfo);
+                return TABS.firmware_flasher.buildApi.requestBuildOptions(TABS.firmware_flasher.cloudBuildKey, this.getCloudBuildOptions.bind(this), this.getBoardInfo.bind(this));
             }
         }
 


### PR DESCRIPTION
Fixes: 
![image](https://github.com/user-attachments/assets/e9a62db4-c2cf-457b-9593-d1c034f2f981)
