### PR TITLE
Change displaying of instruments in the setup tab.

### DIFF
--- a/src/css/tabs/setup.less
+++ b/src/css/tabs/setup.less
@@ -58,6 +58,10 @@
             grid-template-columns: 1fr !important;
         }
     }
+    .instrumentsbox {
+        flex-direction: row;
+        justify-content: center;
+    }
 }
 #accel_calib_running {
 	display: none;


### PR DESCRIPTION
A simple change of displaying "instruments" in the setup tab.

<img width="1039" alt="screenshot 2024-07-26 at 11 13 35" src="https://github.com/user-attachments/assets/edc70603-6bef-4800-be7b-8e4a3ca73979">
<img width="1042" alt="screenshot 2024-07-26 at 11 12 51" src="https://github.com/user-attachments/assets/189bdc78-3c69-4dc5-b5d7-1f74029c4c8c">
<img width="663" alt="screenshot 2024-07-26 at 11 14 48" src="https://github.com/user-attachments/assets/04e85326-4f7e-463d-aa05-6aa5280a6e5f">
<img width="663" alt="screenshot 2024-07-26 at 11 14 20" src="https://github.com/user-attachments/assets/45b9fa0a-0a8e-424b-be5c-2aa36adcde93">
