### PR TITLE
Vertically centered label and its radiobutton in OSD tab

### DIFF
--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -431,7 +431,7 @@
         div {
             label {
                 display: inline-flex;
-                gap: 5px;
+                gap: 3px;
                 margin-right: 10px;
             }
         }

--- a/src/css/tabs/osd.less
+++ b/src/css/tabs/osd.less
@@ -430,6 +430,8 @@
     .spacer_box {
         div {
             label {
+                display: inline-flex;
+                gap: 5px;
                 margin-right: 10px;
             }
         }


### PR DESCRIPTION
Fixed position of label and its radiobutton as shown on the screenshots:

<img width="551" alt="screenshot 2024-07-29 at 16 28 31" src="https://github.com/user-attachments/assets/c3a347ba-a3a4-4536-b302-bbcc64554e7d">
<img width="558" alt="screenshot 2024-07-29 at 16 29 10" src="https://github.com/user-attachments/assets/f1adb60a-5390-4f74-af0c-5eced63d8926">
