### PR TITLE
[10.10-maintenance] gulpfile.js - remove gconf2 requirement

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -827,7 +827,7 @@ function release_rpm(arch, appDirectory, done) {
             vendor: metadata.author,
             summary: metadata.description,
             license: 'GNU General Public License v3.0',
-            requires: ['GConf2', 'libatomic'],
+            requires: ['libatomic'],
             prefix: '/opt',
             files: [{
                 cwd: path.join(appDirectory, metadata.name, arch),


### PR DESCRIPTION
- uncertain if this is acceptable/proper for all distributions.
- needs testing
- built and installed fine on Debian 12 that already has both gconf2 and dconf installed.
- tried requirement `DConf` as well with no noticable difference.
- need for this is debatable.
