### PR TITLE
Remove right margin for .helpicon in .gui_box_titlebar

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1327,7 +1327,7 @@ dialog {
         margin-top: -3px;
     }
     .helpicon {
-        margin-top: 0px;
+        margin: 0;
     }
 }
 .gui_box_bottombar {


### PR DESCRIPTION
Removed unnecessary right margin in gui_box_titlebar for icon.

<img width="174" alt="screenshot 2024-07-30 at 09 15 06" src="https://github.com/user-attachments/assets/cfda1037-0112-4964-901d-6a47544a5851">
