### PR TITLE
WebSerial unsupported alert

### DIFF
--- a/src/js/webSerial.js
+++ b/src/js/webSerial.js
@@ -1,5 +1,9 @@
 import { webSerialDevices, vendorIdNames } from "./serial_devices";
 
+if (!("serial" in navigator)) {
+      alert("WebSerial is not supported by this Browser.\nChrome, Edge, or Opera required.");
+}
+
 async function* streamAsyncIterable(reader, keepReadingFlag) {
     try {
         while (keepReadingFlag()) {


### PR DESCRIPTION
- maybe not the best solution, but simple enough.
- could not find a way to close the tab, as the internet alludes not possible in some browsers or rather not possible without custom (about:config) settings.
![image](https://github.com/user-attachments/assets/61df40e8-fe57-4fb2-8173-b5f8707111ef)
