### PR TITLE
Add DEBUG2 OSD element

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5606,6 +5606,13 @@
     "osdDescElementDebug": {
         "message": "Debug variables"
     },
+    "osdTextElementDebug2": {
+        "message": "Debug2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDebug2": {
+        "message": "Debug variables for debug 4-7"
+    },
     "osdTextElementPIDRoll": {
         "message": "PID roll",
         "description": "One of the elements of the OSD"

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1513,6 +1513,15 @@ OSD.loadDisplayFields = function() {
             positionable: true,
             preview: '1:23.456',
         },
+        DEBUG2: {
+            name: 'DEBUG2',
+            text: 'osdTextElementDebug2',
+            desc: 'osdDescElementDebug2',
+            defaultPosition: -1,
+            draw_order: 560,
+            positionable: true,
+            preview: 'DBG2     0     0     0     0',
+        },
     };
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47) && have_sensor(FC.CONFIG.activeSensors, 'gps')) {
@@ -1960,6 +1969,11 @@ OSD.chooseFields = function() {
         ]);
     }
 
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+        OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
+            F.DEBUG2,
+        ]);
+    }
     // Choose statistic fields
     // Nothing much to do here, I'm preempting there being new statistics
     F = OSD.constants.ALL_STATISTIC_FIELDS;


### PR DESCRIPTION
- adds DEBUG2 OSD element introduced in https://github.com/betaflight/betaflight/pull/13800

![image](https://github.com/user-attachments/assets/cab21303-1ba2-44d5-a2ff-d65b22f12ffd)
