### PR TITLE
Fixed progress bar not updating on top header

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -82,7 +82,7 @@
                 <div class="noflash_global" i18n="sensorDataFlashNotFound"></div>
                 <ul class="dataflash-contents_global">
                     <div class="legend" i18n="sensorDataFlashFreeSpace"></div>
-                    <progress class="dataflash-progress_global" value="32" max="100"></progress>
+                    <progress class="dataflash-progress_global" max="100"></progress>
                 </ul>
                 <div id="expertMode">
                     <label>

--- a/src/js/update_dataflash_global.js
+++ b/src/js/update_dataflash_global.js
@@ -28,10 +28,7 @@ export function update_dataflash_global() {
            display: 'block',
         });
 
-        $(".progress-bar__fill").css({
-           width: `${100-(FC.DATAFLASH.totalSize - FC.DATAFLASH.usedSize) / FC.DATAFLASH.totalSize * 100}%`,
-           display: 'block',
-        });
+        $(".dataflash-progress_global").val(`${100-(FC.DATAFLASH.totalSize - FC.DATAFLASH.usedSize) / FC.DATAFLASH.totalSize * 100}`);
         $(".dataflash-contents_global div").text(`Dataflash: free ${formatFilesize(FC.DATAFLASH.totalSize - FC.DATAFLASH.usedSize)}`);
      } else {
         $(".noflash_global").css({


### PR DESCRIPTION
Fixes the top progress bar being stuck on one value (not updating). I caused this behavior when I fixed the UI in #4135 (oops, sorry).

Hopefully, this is the last time I have to fix this element 🤣 Thanks to MikeNomatter from the BF discord for reporting this!

<img src="https://github.com/user-attachments/assets/a01b0185-6a84-4bdd-b335-ad2186b4d407" height="300px" />
