### PR TITLE
Fix color of helpicon on hover

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -76,7 +76,7 @@ a.disabled {
     transition: none;
     &:hover {
         opacity: 0.9;
-        background-image: url(../images/icons/cf_icon_info_green.svg);
+        background-image: url(../images/icons/cf_icon_info_grey.svg);
         transition: none;
     }
 }


### PR DESCRIPTION
### Small fix helpicon on hover 

Before/After:
<img width="231" alt="screenshot 2024-08-30 at 07 34 38" src="https://github.com/user-attachments/assets/0ca3ffa6-3ef3-4240-8a2e-e485d3682370">
<img width="205" alt="screenshot 2024-08-30 at 07 34 55" src="https://github.com/user-attachments/assets/dfdd32df-bb68-4cb9-8380-aee0a42b09a6">
