### PR TITLE
Made VTX Frequency Input bigger

### DIFF
--- a/src/css/tabs/vtx.less
+++ b/src/css/tabs/vtx.less
@@ -48,7 +48,7 @@
 		width: 28px;
 	}
 	input.frequency_input {
-		width: 48px;
+		width: 64px;
 	}
 	.vtx_table_box {
 		min-width: 750px;


### PR DESCRIPTION
It is very annoying that in Betaflight 11.0 currently the frequency input in the VTX Tab is very small, and doesn't fit the usual 4-character Mhz frequency values.

This makes the input field a bit larger for the value to fit.

Before:
<img width="292" alt="Screenshot 2024-08-31 at 13 30 13" src="https://github.com/user-attachments/assets/4212a73d-e3f7-44ba-a1c5-39f8569d12fa">

In the screenshot above, the text field has 4 digits, but is not visible.

After:
<img width="292" alt="Screenshot 2024-08-31 at 13 29 20" src="https://github.com/user-attachments/assets/f9461b81-7384-4883-9469-6794e23375b2">
