### PR TITLE
Fixed race transponder icon

### DIFF
--- a/src/images/icons/cf_icon_transponder_grey.svg
+++ b/src/images/icons/cf_icon_transponder_grey.svg
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
-	 width="595.281px" height="841.891px" viewBox="0 0 595.281 841.891" enable-background="new 0 0 595.281 841.891"
+	 viewBox="0 0 595.281 841.891" enable-background="new 0 0 595.281 841.891"
 	 xml:space="preserve">
 <g>
 	<path fill="#818181" d="M127.71,440.9c-7.142,41.59,6.722,84.439,36.549,114.267s72.677,43.69,114.267,36.549


### PR DESCRIPTION
I fixed the SVG for the "Race Transponder", because before it wasn't getting rendered.

Before:
![before image](https://github.com/user-attachments/assets/89f4c1f2-8c6d-435e-9161-7b7d3f4a7d35)

After:
![after image](https://github.com/user-attachments/assets/782f574a-027d-4685-8f7b-02bcdd350024)
