### PR TITLE
Warn when selected rx protocol is not in build configuration

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1636,8 +1636,11 @@
     "configurationSerialRX": {
         "message": "Serial Receiver Provider"
     },
+    "someRXTypesDisabled": {
+        "message": "Some Receiver Providers are not supported by current Build Configuration."
+    },
     "serialRXNotSupported": {
-        "message": "The selected Receiver Provider is not supported by the current Build Options. Select another Provider or Update Firmware with the correct Radio Protocol selected in Build Configuration."
+        "message": "The selected Receiver Provider is not supported by the current Build Configuration. Select another Provider or Update Firmware with the correct Radio Protocol selected in Build Configuration."
     },
     "configurationSpiRX": {
         "message": "SPI Bus Receiver Provider"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1636,6 +1636,9 @@
     "configurationSerialRX": {
         "message": "Serial Receiver Provider"
     },
+    "serialRXNotSupported": {
+        "message": "The selected Receiver Provider is not supported by the current Build Options. Select another Provider or Update Firmware with the correct Radio Protocol selected in Build Configuration."
+    },
     "configurationSpiRX": {
         "message": "SPI Bus Receiver Provider"
     },

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -795,6 +795,52 @@ const FC = {
         return serialRxTypes;
     },
 
+    getSupportedSerialRxTypes: () => {
+        if (FC.CONFIG.buildOptions?.length) {
+            const options = FC.CONFIG.buildOptions;
+            let supportedRxTypes = ['NONE', 'TARGET_CUSTOM'];
+            if (options.includes('USE_SERIALRX_SPEKTRUM')) {
+                supportedRxTypes.push('SPEKTRUM1024');
+                supportedRxTypes.push('SPEKTRUM2048');
+                supportedRxTypes.push('SPEKTRUM2048/SRXL');
+            }
+            if (options.includes('USE_SERIALRX_SBUS')) {
+                supportedRxTypes.push('SBUS');
+            }
+            if (options.includes('USE_SERIALRX_SUMD')) {
+                supportedRxTypes.push('SUMD');
+            }
+            if (options.includes('USE_SERIALRX_SUMH')) {
+                supportedRxTypes.push('SUMH');
+            }
+            if (options.includes('USE_SERIALRX_XBUS')) {
+                supportedRxTypes.push('XBUS_MODE_B');
+                supportedRxTypes.push('XBUS_MODE_B_RJ01');
+            }
+            if (options.includes('USE_SERIALRX_IBUS')) {
+                supportedRxTypes.push('IBUS');
+            }
+            if (options.includes('USE_SERIALRX_JETIEXBUS')) {
+                supportedRxTypes.push('JETIEXBUS');
+            }
+            if (options.includes('USE_SERIALRX_CRSF')) {
+                supportedRxTypes.push('CRSF');
+            }
+            if (options.includes('USE_SERIALRX_FPORT')) {
+                supportedRxTypes.push('FPORT');
+            }
+            if (options.includes('USE_SERIALRX_SRXL2')) {
+                supportedRxTypes.push('SPEKTRUM SRXL2');
+            }
+            if (options.includes('USE_SERIALRX_GHST')) {
+                supportedRxTypes.push('IRC GHOST');
+            }
+            return supportedRxTypes;
+        } else {
+            return this.getSerialRxTypes();
+        }
+    },
+
     calculateHardwareName() {
         let name;
         if (this.CONFIG.targetName) {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -798,7 +798,10 @@ const FC = {
     getSupportedSerialRxTypes: () => {
         if (FC.CONFIG.buildOptions?.length) {
             const options = FC.CONFIG.buildOptions;
-            let supportedRxTypes = ['NONE', 'TARGET_CUSTOM'];
+            let supportedRxTypes = ['NONE',];
+            if (options.includes('USE_SERIALRX_TARGET_CUSTOM')) {
+                supportedRxTypes.push('TARGET_CUSTOM');
+            }  
             if (options.includes('USE_SERIALRX_SPEKTRUM')) {
                 supportedRxTypes.push('SPEKTRUM1024');
                 supportedRxTypes.push('SPEKTRUM2048');

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -256,6 +256,57 @@ receiver.initialize = function (callback) {
             serialRxSelectElement.append(`<option value="${index}">${serialRxType}</option>`);
         });
 
+        const warnRxProtocolNotInBuildOptions = function () {
+          let warning = false;
+          const config = FC.CONFIG;
+          if (config.buildOptions?.length) {
+            const serialRxValue = parseInt($('select.serialRX').val());
+            const serialRxProtocol = FC.getSerialRxTypes()[serialRxValue];
+            switch (serialRxProtocol) {
+              case 'SPEKTRUM1024':
+              case 'SPEKTRUM2048':
+              case 'SPEKTRUM2048/SRXL':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_SPEKTRUM');
+                break;
+              case 'SBUS':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_SBUS');
+                break;
+              case 'SUMD':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_SUMD');
+                break;
+              case 'SUMH':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_SUMH');
+                break;
+              case 'XBUS_MODE_B':
+              case 'XBUS_MODE_B_RJ01':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_XBUS');
+                break;
+              case 'IBUS':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_IBUS');
+                break;
+              case 'JETIEXBUS':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_JETIEXBUS');
+                break;
+              case 'CRSF':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_CRSF');
+                break;
+              case 'TARGET_CUSTOM':
+                warning = false;
+                break;
+              case 'FPORT':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_FPORT');
+                break;
+              case 'SPEKTRUM SRXL2':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_SRXL2');
+                break;
+              case 'IRC GHOST':
+                warning = ! config.buildOptions.includes('USE_SERIALRX_GHST');
+                break;
+            }
+          }
+          $('.serialRXNotSupported').toggle(warning);
+        };
+
         serialRxSelectElement.change(function () {
             const serialRxValue = parseInt($(this).val());
 
@@ -267,10 +318,14 @@ receiver.initialize = function (callback) {
             tab.analyticsChanges['SerialRx'] = newValue;
 
             FC.RX_CONFIG.serialrx_provider = serialRxValue;
+
+            warnRxProtocolNotInBuildOptions();
         });
 
         // select current serial RX type
         serialRxSelectElement.val(FC.RX_CONFIG.serialrx_provider);
+
+        warnRxProtocolNotInBuildOptions();
 
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
             serialRxSelectElement.sortSelect("NONE").select2();

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -251,60 +251,22 @@ receiver.initialize = function (callback) {
 
         $('select[name="rssi_channel"]').val(FC.RSSI_CONFIG.channel);
 
+        const supportedRxTypes = FC.getSupportedSerialRxTypes();
         const serialRxSelectElement = $('select.serialRX');
+        let allRxTypesEnabled = true;
         FC.getSerialRxTypes().forEach((serialRxType, index) => {
-            serialRxSelectElement.append(`<option value="${index}">${serialRxType}</option>`);
+            const enabled = supportedRxTypes.includes(serialRxType);
+            if (!enabled) allRxTypesEnabled = false;
+            const disable = enabled ? "" : "disabled";
+            serialRxSelectElement.append(`<option value="${index}" ${disable} >${serialRxType}</option>`);
         });
 
         const warnRxProtocolNotInBuildOptions = function () {
-          let warning = false;
-          const config = FC.CONFIG;
-          if (config.buildOptions?.length) {
-            const serialRxValue = parseInt($('select.serialRX').val());
-            const serialRxProtocol = FC.getSerialRxTypes()[serialRxValue];
-            switch (serialRxProtocol) {
-              case 'SPEKTRUM1024':
-              case 'SPEKTRUM2048':
-              case 'SPEKTRUM2048/SRXL':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_SPEKTRUM');
-                break;
-              case 'SBUS':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_SBUS');
-                break;
-              case 'SUMD':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_SUMD');
-                break;
-              case 'SUMH':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_SUMH');
-                break;
-              case 'XBUS_MODE_B':
-              case 'XBUS_MODE_B_RJ01':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_XBUS');
-                break;
-              case 'IBUS':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_IBUS');
-                break;
-              case 'JETIEXBUS':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_JETIEXBUS');
-                break;
-              case 'CRSF':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_CRSF');
-                break;
-              case 'TARGET_CUSTOM':
-                warning = false;
-                break;
-              case 'FPORT':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_FPORT');
-                break;
-              case 'SPEKTRUM SRXL2':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_SRXL2');
-                break;
-              case 'IRC GHOST':
-                warning = ! config.buildOptions.includes('USE_SERIALRX_GHST');
-                break;
-            }
-          }
-          $('.serialRXNotSupported').toggle(warning);
+          const serialRxValue = parseInt($('select.serialRX').val());
+          const serialRxType = FC.getSerialRxTypes()[serialRxValue];
+          const supported = supportedRxTypes.includes(serialRxType);
+          $('.someRXTypesDisabled').toggle(supported && (! allRxTypesEnabled));
+          $('.serialRXNotSupported').toggle(! supported);
         };
 
         serialRxSelectElement.change(function () {

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -42,6 +42,8 @@
                                 <!-- list generated here -->
                             </select>
                             <span i18n="configurationSerialRX"></span>
+                            <div class="note serialRXNotSupported" i18n="serialRXNotSupported">
+                            </div>
                         </div>
                         <div class="spiRxBox spacer_box">
                             <div class="note">

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -42,6 +42,8 @@
                                 <!-- list generated here -->
                             </select>
                             <span i18n="configurationSerialRX"></span>
+                            <div class="note someRXTypesDisabled" i18n="someRXTypesDisabled">
+                            </div>
                             <div class="note serialRXNotSupported" i18n="serialRXNotSupported">
                             </div>
                         </div>


### PR DESCRIPTION
User can select a receiver protocol when upgrading the firmware. Later, the protocol can be selected in the receiver tab. Only the protocol selected at the firmware upgrade time would work. Let's warn the user if the protocol selected in the receiver tab will not work.