### PR TITLE
FIX for motor dialogs for web? Or not the fix

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -79,7 +79,7 @@ export default defineConfig({
         serveLocalesPlugin(),
         copy({
             targets: [
-                { src: ["locales", "resources", "src/tabs", "src/images"], dest: "src/dist" },
+                { src: ["locales", "resources", "src/tabs", "src/images", "src/components"], dest: "src/dist" },
             ],
             hook: "writeBundle",
         }),


### PR DESCRIPTION
As @sugaarK and @haslinghuis pointed out, motor dialogs are not working in web (app.betaflight.com)
(reorder dialog and motor direction dialog)
Dialogs are empty followed by console errors:
![image](https://github.com/user-attachments/assets/5b74f4df-0152-4493-a1e4-890c146f539c)


local web debug build works good:
`yarn && yarn dev`

But local web release build has the same problem with motor dialogs:
`yarn build && yarn preview`

It looks like in the release web build these files are missing:
https://app.betaflight.com/components/MotorOutputReordering/Body.html
https://app.betaflight.com/components/EscDshotDirection/Body.html

tbh i have no idea what i am doing, but adding `"src/components"` folder into copy section of `vite.config.js` fixes the problem for local release build, and it seems like it fixes it in web:
https://deploy-preview-4158.dev.app.betaflight.com/

If anyone knows how to fix it in a proper way, please feel free to open a PR, i will close this one.
@chmelevskij @haslinghuis @VitroidFPV 