### PR TITLE
Prearm until first arm

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1461,6 +1461,9 @@
     "configurationGyroCalOnFirstArm": {
         "message": "Calibrate Gyro on first arm"
     },
+    "configurationPrearmUntilFirstArm": {
+        "message": "If enabled, prearm switch will be required only for first arm until reboot"
+    },
     "configurationDigitalIdlePercent": {
         "message": "Motor Idle ( %, static)"
     },

--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -1346,6 +1346,9 @@
     "configurationGyroCalOnFirstArm": {
         "message": "Калибровка Gyro на первом арме"
     },
+    "configurationPrearmUntilFirstArm": {
+        "message": "Есди включено, то переключатель Преарм будет требоваться только при первом Арме"
+    },
     "configurationDigitalIdlePercent": {
         "message": "Режим холостого хода (% статический)"
     },

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -372,6 +372,7 @@ const FC = {
             disarm_kill_switch:         0,
             small_angle:                0,
             gyro_cal_on_first_arm:      0,
+            prearm_until_first_arm:     0,
         };
 
         this.FC_CONFIG = {


### PR DESCRIPTION
Adds an ability to pre-arm only at first arming until reboot.
This corresponds to the pull request on Betaflight "Prearm until first arm #13920"
https://github.com/betaflight/betaflight/pull/13920