### PR TITLE
Fix build options unreadable in dark mode

### DIFF
--- a/src/css/tabs/setup.less
+++ b/src/css/tabs/setup.less
@@ -115,7 +115,6 @@
     transition: all 0.2s;
     overflow-x: hidden;
     overflow-y: auto;
-    background-color: white;
     width: min-content;
     height: min-content;
 }


### PR DESCRIPTION
Fixes a bug where the build options (in the setup screen) aren't visible when using dark mode.

Before: 
<img width="250" alt="Screenshot 2024-09-29 at 23 00 00" src="https://github.com/user-attachments/assets/69d7a7b4-21e3-47d1-bce5-1848143ff76a">

After:
<img width="250" alt="Screenshot 2024-09-29 at 23 00 23" src="https://github.com/user-attachments/assets/cc6af844-8ae9-44cb-85b4-17b9a377e56d">
