### PR TITLE
Styled progress bar on preset apply screen

### DIFF
--- a/src/tabs/presets/presets.less
+++ b/src/tabs/presets/presets.less
@@ -95,6 +95,17 @@
 		width: 100%;
 		height: 20px;
 		margin-top: 12px;
+        border-radius: 4px;
+        appearance: none;
+        -webkit-appearance: none;
+        overflow: hidden;
+        &::-webkit-progress-bar {
+            background-color: var(--surface-500);
+        }
+        &::-webkit-progress-value {
+            background-color: var(--primary-500);
+            border-radius: 0 4px 4px 0;
+        }
 	}
 	.ms-drop {
 		z-index: 2001;


### PR DESCRIPTION
Styled the progress bar that is shown while preset/presets are applied to match other UI elements & progress bars

Before:
<img width="300" alt="Screenshot 2024-09-30 at 00 04 20" src="https://github.com/user-attachments/assets/72d59c58-f616-4f69-a4d4-feac83d8d4b8">

After:
<img width="310" alt="Screenshot 2024-09-30 at 00 04 36" src="https://github.com/user-attachments/assets/d6d3578b-97fc-45d4-a49e-9102bcb9ec93">
