### PR TITLE
Update color for rx protocol warning

### DIFF
--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -44,7 +44,7 @@
                             <span i18n="configurationSerialRX"></span>
                             <div class="note someRXTypesDisabled" i18n="someRXTypesDisabled">
                             </div>
-                            <div class="note serialRXNotSupported" i18n="serialRXNotSupported">
+                            <div class="note gui_warning serialRXNotSupported" i18n="serialRXNotSupported">
                             </div>
                         </div>
                         <div class="spiRxBox spacer_box">


### PR DESCRIPTION
- When SBUS is set in a diff but not included in a build it still will be selected.
- Update the warning to highlight the configuration issue  
![image](https://github.com/user-attachments/assets/7eefe473-1462-4507-ab61-e74f63b4c956)

- Thanks to @nerdCopter: https://github.com/betaflight/betaflight-configurator/pull/4150#issuecomment-2388763461