### PR TITLE
Fix HID mode connection

### DIFF
--- a/src/js/serial_devices.js
+++ b/src/js/serial_devices.js
@@ -8,12 +8,13 @@ export const vendorIdNames = {
 
 export const serialDevices = [
     { vendorId: 1027, productId: 24577 }, // FT232R USB UART
+    { vendorId: 1155, productId: 12886 }, // STM32 in HID mode
     { vendorId: 1155, productId: 22336 }, // STM Electronics Virtual COM Port
     { vendorId: 4292, productId: 60000 }, // CP210x
     { vendorId: 4292, productId: 60001 }, // CP210x
     { vendorId: 4292, productId: 60002 }, // CP210x
-    { vendorId: 0x2e3c, productId: 0x5740 }, // AT32 VCP
-    { vendorId: 0x314B, productId: 0x5740 }, // APM32 VCP
+    { vendorId: 11836, productId: 22336 }, // AT32 VCP
+    { vendorId: 12619, productId: 22336 }, // APM32 VCP
 ];
 
 export const webSerialDevices = serialDevices.map(


### PR DESCRIPTION
- Updates serial device filter as after using `set usb_hid_cdc = ON` device won't be recognized by configurator.
- Thanks to @onlyn1ght for reporting.