### PR TITLE
Fixed CLI load modal title background color

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1518,10 +1518,14 @@ button.active {
     padding-top: 5px;
 }
 .jBox-container {
-    background: var(--surface-200) !important;
+    background: var(--surface-300) !important;
     border: 2px solid var(--primary-500);
     color: var(--text);
     border-radius: 0.5rem !important;
+}
+.jBox-title {
+    background: var(--surface-300) !important;
+    border-bottom: 1px solid var(--surface-950) !important;
 }
 .jBox-content {
     padding: 0.5rem;


### PR DESCRIPTION
Fixed the Load from File modal background, which in dark mode was white making the text invisible as shown below:
 
<img width="500px" alt="Before" src="https://github.com/user-attachments/assets/ef596d77-33db-453e-82e8-31ab7df82170">
<hr>

I modified the background and border to use the CSS variables so it properly adapts to light/dark theme like so:
<img width="500px" alt="After" src="https://github.com/user-attachments/assets/b005a532-9027-49ab-8ebf-ae0abb9cb381">

Additionally I fixed the border (that had static color as well, thus breaking in light mode) and the modal background (made it surface color) so it matches all the other parts of the UI.