### PR TITLE
Add softserial as build option

### DIFF
--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -1,5 +1,5 @@
 import { bit_check, bit_set, bit_clear } from "./bit";
-import { API_VERSION_1_45, API_VERSION_1_46 } from './data_storage';
+import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47 } from './data_storage';
 import semver from "semver";
 import { tracking } from "./Analytics";
 import $ from 'jquery';
@@ -13,7 +13,7 @@ const Features = function (config) {
         {bit: 3, group: 'rxMode', mode: 'select', name: 'RX_SERIAL'},
         {bit: 4, group: 'escMotorStop', name: 'MOTOR_STOP'},
         {bit: 5, group: 'other', name: 'SERVO_TILT', haveTip: true, dependsOn: 'SERVOS'},
-        {bit: 6, group: 'other', name: 'SOFTSERIAL', haveTip: true, dependsOn: 'SOFTSERIAL'},
+        {bit: 6, group: 'other', name: 'SOFTSERIAL', haveTip: true},
         {bit: 7, group: 'other', name: 'GPS', haveTip: true, dependsOn: 'GPS'},
         {bit: 9, group: 'other', name: 'SONAR', haveTip: true, dependsOn: 'RANGEFINDER'},
         {bit: 10, group: 'telemetry', name: 'TELEMETRY', haveTip: true, dependsOn: 'TELEMETRY'},
@@ -34,6 +34,18 @@ const Features = function (config) {
 
     self._features = features;
 
+    function addFeatureDependsOn(obj, featureName, dependsOn) {
+        obj.forEach(f => {
+            if (f.name === featureName) {
+                f.dependsOn = dependsOn;
+            }
+        });
+    }
+
+    if (semver.gte(config.apiVersion, API_VERSION_1_47)) {
+        addFeatureDependsOn(self._features, 'SOFTSERIAL', 'SOFTSERIAL');
+    }
+
     if (config.buildOptions?.length) {
         // Filter features based on build options
         if (semver.gte(config.apiVersion, API_VERSION_1_45)) {
@@ -46,7 +58,7 @@ const Features = function (config) {
             }
         }
 
-        // Add TELEMETRY feature if any of the following protocols are used: CRSF, GHST, FPORT
+        // Add TELEMETRY feature if any of the following protocols are used: CRSF, GHST, FPORT, JETI
         if (semver.gte(config.apiVersion, API_VERSION_1_46)) {
             let enableTelemetry = false;
             if (config.buildOptions.some(opt => opt.includes('CRSF') || opt.includes('GHST') || opt.includes('FPORT') || opt.includes('JETI'))) {

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -13,7 +13,7 @@ const Features = function (config) {
         {bit: 3, group: 'rxMode', mode: 'select', name: 'RX_SERIAL'},
         {bit: 4, group: 'escMotorStop', name: 'MOTOR_STOP'},
         {bit: 5, group: 'other', name: 'SERVO_TILT', haveTip: true, dependsOn: 'SERVOS'},
-        {bit: 6, group: 'other', name: 'SOFTSERIAL', haveTip: true},
+        {bit: 6, group: 'other', name: 'SOFTSERIAL', haveTip: true, dependsOn: 'SOFTSERIAL'},
         {bit: 7, group: 'other', name: 'GPS', haveTip: true, dependsOn: 'GPS'},
         {bit: 9, group: 'other', name: 'SONAR', haveTip: true, dependsOn: 'RANGEFINDER'},
         {bit: 10, group: 'telemetry', name: 'TELEMETRY', haveTip: true, dependsOn: 'TELEMETRY'},


### PR DESCRIPTION
- implements https://github.com/betaflight/betaflight/pull/13305

- [x] `SoftSerial` build option needs to be added to other options on the cloud server https://github.com/betaflight/betaflight/pull/13974
- [x] Needs #define `BUILD_OPTION_SOFTSERIAL` 16423 available in [cloud build options](https://build.betaflight.com/api/options/4.6.0)