### PR TITLE
add ToolTip for AirMode

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1324,7 +1324,7 @@
         "message": "Permanently enable Airmode"
     },
     "featureAIRMODETip": {
-        "message": "Keeps the PID loop active at zero-throttle, especially I-Term, to allow maintaining control of the craft."
+        "message": "Airmode allows for maintaining PID control at low throttle. Whereas in standard mode, when roll, pitch, and yaw calculations saturate a motor, all motors are equally reduced. If a motor goes below minimum, it gets clipped off. For example, with throttle just above minimum and a quick roll is attempted, two motors can't go any lower, resulting in half the power (half of the PID gain). If inputs demand more than a 100% difference between high and low motors, the low motors get clipped, causing an imbalance by unevenly reducing the gain."
     },
     "featureRX_SPI": {
         "message": "SPI Rx (e.g. built-in Rx)"
@@ -2411,7 +2411,7 @@
         "description": "Help text to ANTIGRAVITY mode"
     },
     "auxiliaryHelpMode_AIRMODE": {
-        "message": "In the standard mixer / mode, when the roll, pitch and yaw gets calculated and saturates a motor, all motors will be reduced equally. When a motor goes below minimum it gets clipped off. Say you had your throttle just above minimum and tried to pull a quick roll - since two motors can't go any lower, you essentially get half the power (half of your PID gain). If your inputs would have asked for more than a 100% difference between the high and low motors, the low motors would get clipped, breaking the symmetry of the motor balance by unevenly reducing the gain",
+        "message": "$t(featureAIRMODETip.message)",
         "description": "Help text to AIRMODE mode"
     },
     "auxiliaryHelpMode_BEEPER": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1323,6 +1323,9 @@
     "featureAIRMODE": {
         "message": "Permanently enable Airmode"
     },
+    "featureAIRMODETip": {
+        "message": "Keeps the PID loop active at zero-throttle, especially I-Term, to allow maintaining control of the craft."
+    },
     "featureRX_SPI": {
         "message": "SPI Rx (e.g. built-in Rx)"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2411,7 +2411,7 @@
         "description": "Help text to ANTIGRAVITY mode"
     },
     "auxiliaryHelpMode_AIRMODE": {
-        "message": "AirMode allows for maintaining PID control at low throttle. For more information please see <a href=\"https://betaflight.com/docs/development/modes#airmode\" target=\"_blank\" rel=\"noopener noreferrer\">AirMode</a> on Betaflight.com.",
+        "message": "AirMode allows for maintaining drone stability at low throttle. For more information please see <a href=\"https://betaflight.com/docs/development/modes#airmode\" target=\"_blank\" rel=\"noopener noreferrer\">AirMode</a> on Betaflight.com.",
         "description": "Help text to AIRMODE mode"
     },
     "auxiliaryHelpMode_BEEPER": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1324,7 +1324,7 @@
         "message": "Permanently enable Airmode"
     },
     "featureAIRMODETip": {
-        "message": "Airmode allows for maintaining PID control at low throttle. Whereas in standard mode, when roll, pitch, and yaw calculations saturate a motor, all motors are equally reduced. If a motor goes below minimum, it gets clipped off. For example, with throttle just above minimum and a quick roll is attempted, two motors can't go any lower, resulting in half the power (half of the PID gain). If inputs demand more than a 100% difference between high and low motors, the low motors get clipped, causing an imbalance by unevenly reducing the gain."
+        "message": "$t(auxiliaryHelpMode_AIRMODE.message)"
     },
     "featureRX_SPI": {
         "message": "SPI Rx (e.g. built-in Rx)"
@@ -2411,7 +2411,7 @@
         "description": "Help text to ANTIGRAVITY mode"
     },
     "auxiliaryHelpMode_AIRMODE": {
-        "message": "$t(featureAIRMODETip.message)",
+        "message": "AirMode allows for maintaining PID control at low throttle. Whereas in standard mode, when roll, pitch, and yaw calculations saturate a motor, all motors are equally reduced. If a motor goes below minimum, it gets clipped off. For example, with throttle just above minimum and a quick roll is attempted, two motors can't go any lower, resulting in half the power (half of the PID gain). If inputs demand more than a 100% difference between high and low motors, the low motors get clipped, causing an imbalance by unevenly reducing the gain.",
         "description": "Help text to AIRMODE mode"
     },
     "auxiliaryHelpMode_BEEPER": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2411,7 +2411,7 @@
         "description": "Help text to ANTIGRAVITY mode"
     },
     "auxiliaryHelpMode_AIRMODE": {
-        "message": "AirMode allows for maintaining PID control at low throttle. Whereas in standard mode, when roll, pitch, and yaw calculations saturate a motor, all motors are equally reduced. If a motor goes below minimum, it gets clipped off. For example, with throttle just above minimum and a quick roll is attempted, two motors can't go any lower, resulting in half the power (half of the PID gain). If inputs demand more than a 100% difference between high and low motors, the low motors get clipped, causing an imbalance by unevenly reducing the gain.",
+        "message": "AirMode allows for maintaining PID control at low throttle. For more information please see <a href=\"https://betaflight.com/docs/development/modes#airmode\" target=\"_blank\" rel=\"noopener noreferrer\">AirMode</a> on Betaflight.com.",
         "description": "Help text to AIRMODE mode"
     },
     "auxiliaryHelpMode_BEEPER": {

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -26,7 +26,7 @@ const Features = function (config) {
         {bit: 18, group: 'other', name: 'OSD', haveTip: true, dependsOn: 'OSD'},
         {bit: 20, group: 'other', name: 'CHANNEL_FORWARDING', dependsOn: 'SERVOS'},
         {bit: 21, group: 'other', name: 'TRANSPONDER', haveTip: true, dependsOn: 'TRANSPONDER'},
-        {bit: 22, group: 'other', name: 'AIRMODE'},
+        {bit: 22, group: 'other', name: 'AIRMODE', haveTip: true},
         {bit: 25, group: 'rxMode', mode: 'select', name: 'RX_SPI'},
         {bit: 27, group: 'escSensor', name: 'ESC_SENSOR'},
         {bit: 28, group: 'antiGravity', name: 'ANTI_GRAVITY', haveTip: true, hideName: true},


### PR DESCRIPTION
- https://discord.com/channels/868013470023548938/1019022739044057128/1293513438156296222
- modifies and re-uses `auxiliaryHelpMode_AIRMODE`
- link opens https://betaflight.com/docs/development/modes#airmode

![image](https://github.com/user-attachments/assets/01a59f11-e72b-4d37-97f1-4b0f38db36ae)
![image](https://github.com/user-attachments/assets/1139b74f-6f74-4698-a26e-085327baa17f)


