### PR TITLE
Styled the cloud build progress bar

### DIFF
--- a/src/css/tabs/firmware_flasher.less
+++ b/src/css/tabs/firmware_flasher.less
@@ -40,6 +40,19 @@
 			}
 		}
 	}
+    .buildProgress {
+        border-radius: 4px;
+        appearance: none;
+        -webkit-appearance: none;
+        overflow: hidden;
+        &::-webkit-progress-bar {
+            background-color: var(--surface-500);
+        }
+        &::-webkit-progress-value {
+            background-color: var(--primary-500);
+            border-radius: 0 4px 4px 0;
+        }
+    }
 	ul {
 		li {
 			list-style: initial;


### PR DESCRIPTION
Made so the small progress bar that shows the state of the cloud build is the Betaflight theme color:

<img width="334" alt="Screenshot 2024-10-21 at 16 31 40" src="https://github.com/user-attachments/assets/3f55e6dc-bcd6-4809-b529-6675f44877f2">
