### PR TITLE
Fixed color of BBL Progress Bar

### DIFF
--- a/src/css/tabs/onboard_logging.less
+++ b/src/css/tabs/onboard_logging.less
@@ -125,12 +125,15 @@
 	}
 	progress {
 		&::-webkit-progress-bar {
-			height: 24px;
-			background-color: var(--surface-300);
+			background-color: var(--surface-500);
 		}
 		&::-webkit-progress-value {
-			background-color: #bcf;
+			background-color: var(--primary-500);
+            border-radius: 0 4px 4px 0;
 		}
+        border-radius: 4px;
+        overflow: hidden;
+        height: 24px;
 		display: block;
 		width: 100%;
 		margin: 1em 0;


### PR DESCRIPTION
Fixes color of the BBL Progress Bar.
Closes #4219 

<img width="510" alt="Screenshot 2024-10-22 at 12 37 50" src="https://github.com/user-attachments/assets/95ddb372-eac3-49d7-8655-711589de76c0">
