### PR TITLE
Fix [missing] build options

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -119,6 +119,9 @@ const FIRMWARE_BUILD_OPTIONS = {
     USE_RACE_PRO:               16419,
     USE_SERVOS:                 16420,
     USE_VTX:                    16421,
+    USE_ALTHOLD_MODE:           16422,
+    USE_SOFTSERIAL:             16423,
+    USE_WING:                   16424,
 };
 
 const FC = {


### PR DESCRIPTION
:smirk:  forgot to add the options to FC.

before:
![Screenshot from 2024-10-31 00-02-11](https://github.com/user-attachments/assets/2029a6b0-74e3-4766-bfab-fb838285b8d2)

after:
![Screenshot from 2024-10-31 01-10-42](https://github.com/user-attachments/assets/0569917b-1a0e-49e3-9eb5-b1009ee611af)

