### PR TITLE
Fix gps color

### DIFF
--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -267,29 +267,17 @@ gps.initialize = async function (callback) {
 
                         let quality = i18n.getMessage(qualityArray[FC.GPS_DATA.quality[i] & 0x7]);
                         let used = i18n.getMessage(usedArray[(FC.GPS_DATA.quality[i] & 0x8) >> 3]);
-                        let usedColor = '';
+                        let usedColor;
 
                         // Add color to the text
-                        // 2nd column: no signal = red, unusable = red, searching = red, locked = yellow and fully locked = green
-                        if (quality.startsWith(i18n.getMessage('gnssQualityFullyLocked'))) {
-                            usedColor = 'locked';
-                            quality = `<span class="colorToggle ready">${quality}</span>`;
-                        } else if (quality.startsWith(i18n.getMessage('gnssQualityLocked'))) {
-                            usedColor = 'notReady';
-                            quality = `<span class="colorToggle locked">${quality}</span>`;
-                        } else {
-                            quality = `<span class="colorToggle">${quality}</span>`;
-                        }
+                        usedColor = quality.startsWith(i18n.getMessage('gnssQualityFullyLocked')) ? 'ready' : quality.startsWith(i18n.getMessage('gnssQualityLocked')) ? 'locked' : 'low';
+                        const qualityHtml = `<span class="colorToggle ${usedColor}">${quality}</span>`;
 
-                        // 1st column: unused = red, used = green
-                        if (used.startsWith(i18n.getMessage('gnssUsedUsed'))) {
-                            used = `<span class="colorToggle ready">${used}</span>`;
-                        } else {
-                            used = `<span class="colorToggle">${used}</span>`;
-                        }
+                        usedColor = used.startsWith(i18n.getMessage('gnssUsedUsed')) ? 'ready' : 'low';
+                        const usedHtml = `<span class="colorToggle ${usedColor}">${used}</span>`;
 
-                        rowContent += `<td style="text-align: left;  width: 17%;">${used}</td>
-                                       <td style="text-align: left;  width: 33%;">${quality}</td>`;
+                        rowContent += `<td style="text-align: left;  width: 17%;">${usedHtml}</td>
+                                       <td style="text-align: left;  width: 33%;">${qualityHtml}</td>`;
                     }
                     eSsTable.append(`<tr>${rowContent}</tr>`);
                 }

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -265,15 +265,14 @@ gps.initialize = async function (callback) {
                         rowContent += `<td>${FC.GPS_DATA.svid[i]}</td>`;
                         rowContent += `<td><meter value="${FC.GPS_DATA.cno[i]}" max="55"></meter></td>`;
 
-                        let quality = i18n.getMessage(qualityArray[FC.GPS_DATA.quality[i] & 0x7]);
-                        let used = i18n.getMessage(usedArray[(FC.GPS_DATA.quality[i] & 0x8) >> 3]);
-                        let usedColor;
+                        const quality = i18n.getMessage(qualityArray[FC.GPS_DATA.quality[i] & 0x7]);
+                        const used = i18n.getMessage(usedArray[(FC.GPS_DATA.quality[i] & 0x8) >> 3]);
 
                         // Add color to the text
-                        usedColor = quality.startsWith(i18n.getMessage('gnssQualityFullyLocked')) ? 'ready' : quality.startsWith(i18n.getMessage('gnssQualityLocked')) ? 'locked' : 'low';
-                        const qualityHtml = `<span class="colorToggle ${usedColor}">${quality}</span>`;
+                        const qualityColor = quality.startsWith(i18n.getMessage('gnssQualityFullyLocked')) ? 'ready' : quality.startsWith(i18n.getMessage('gnssQualityLocked')) ? 'locked' : 'low';
+                        const qualityHtml = `<span class="colorToggle ${qualityColor}">${quality}</span>`;
 
-                        usedColor = used.startsWith(i18n.getMessage('gnssUsedUsed')) ? 'ready' : 'low';
+                        const usedColor = used.startsWith(i18n.getMessage('gnssUsedUsed')) ? 'ready' : 'low';
                         const usedHtml = `<span class="colorToggle ${usedColor}">${used}</span>`;
 
                         rowContent += `<td style="text-align: left;  width: 17%;">${usedHtml}</td>

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -285,7 +285,7 @@ gps.initialize = async function (callback) {
                         if (used.startsWith(i18n.getMessage('gnssUsedUsed'))) {
                             used = `<span class="colorToggle ready">${used}</span>`;
                         } else {
-                            used = `<span class="colorToggle ${usedColor}">${used}</span>`;
+                            used = `<span class="colorToggle">${used}</span>`;
                         }
 
                         rowContent += `<td style="text-align: left;  width: 17%;">${used}</td>


### PR DESCRIPTION
Fixes status column color

[status]
unused => red
USED => green

[quality]
no signal => red
searching => red
locked => orange
fully locked => green


Circus before:

![Screenshot from 2024-11-04 15-27-50](https://github.com/user-attachments/assets/3d590b04-e586-4a59-aa2e-676f5ba10b54)

Clarity after:

![image](https://github.com/user-attachments/assets/57a229ee-ab32-41e1-9dc0-9b66b6c3471d)

