### PR TITLE
hover point throttle curve adjustment

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2338,6 +2338,9 @@
     "receiverThrottleExpo": {
         "message": "Throttle EXPO"
     },
+    "receiverThrottleHover": {
+        "message": "Hover Point"
+    },
     "receiverStickMin": {
         "message": "'Stick Low' Threshold"
     },

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -284,6 +284,7 @@ const FC = {
             dynamic_THR_PID: 0, // moved in 1.45 to ADVANCED_TUNING
             throttle_MID: 0,
             throttle_EXPO: 0,
+            throttle_HOVER: 0,
             dynamic_THR_breakpoint: 0, // moved in 1.45 to ADVANCED_TUNING
             RC_YAW_EXPO: 0,
             rcYawRate: 0,

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -284,7 +284,6 @@ const FC = {
             dynamic_THR_PID: 0, // moved in 1.45 to ADVANCED_TUNING
             throttle_MID: 0,
             throttle_EXPO: 0,
-            throttle_HOVER: 0,
             dynamic_THR_breakpoint: 0, // moved in 1.45 to ADVANCED_TUNING
             RC_YAW_EXPO: 0,
             rcYawRate: 0,
@@ -296,6 +295,7 @@ const FC = {
             pitch_rate_limit: 1998,
             yaw_rate_limit: 1998,
             rates_type: 0,
+            throttle_HOVER: 0,
         };
 
         this.AUX_CONFIG = [];

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -466,6 +466,7 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.RC_TUNING.pitch_rate_limit = data.readU16();
                     FC.RC_TUNING.yaw_rate_limit = data.readU16();
                     FC.RC_TUNING.rates_type = data.readU8();
+                    FC.RC_TUNING.throttle_HOVER = parseFloat((data.readU8() / 100).toFixed(2));
                     break;
                 case MSPCodes.MSP_PID:
                     // PID data arrived, we need to scale it and save to appropriate bank / array
@@ -1839,6 +1840,11 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
 
             // Introduced in 1.43
             buffer.push8(FC.RC_TUNING.rates_type);
+
+            // Introduced in 1.47
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                buffer.push8(Math.round(FC.RC_TUNING.throttle_HOVER * 100));
+            }
             break;
         case MSPCodes.MSP_SET_RX_MAP:
             for (let i = 0; i < FC.RC_MAP.length; i++) {

--- a/src/tabs/pid_tuning.html
+++ b/src/tabs/pid_tuning.html
@@ -1062,12 +1062,14 @@
                             <thead>
                                 <tr>
                                     <th i18n="receiverThrottleMid"></th>
+                                    <th i18n="receiverThrottleHover"></th>
                                     <th i18n="receiverThrottleExpo"></th>
                                 </tr>
                             </thead>
                             <tbody>
                                 <tr>
                                     <td><input type="number" name="mid" step="0.01" min="0" max="1" /></td>
+                                    <td><input type="number" name="hover" step="0.01" min="0" max="1" value="0.5"/></td>
                                     <td><input type="number" name="expo" step="0.01" min="0" max="1" /></td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION
- added input for value adjustment
- added text to locales
- adjusted throttle curve math to take hover point into account
- requires firmware PR: https://github.com/betaflight/betaflight/pull/14229

Hi, I'd like to propose a new feature / change to an existing feature: setting the hover point of a quad to 50% of the throttle stick range.

I have been using subtrim in EdgeTX in center only mode to achieve this already, but it is a quad specific setting which I'd like to have in Betaflight.

Setting the hover point to 50% stick travel gives you a lot more "resolution" between 0 throttle and the hover point, therefore making flying at lower throttle in tight spaces a lot easier.

https://discord.com/channels/868013470023548938/1303071076342956072

https://github.com/user-attachments/assets/d0d4d1c4-afed-4889-b8ca-b7319125f966