### PR TITLE
Resolved attitude log disabled flag enum position issue

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -859,7 +859,7 @@ function update() {
             'debug[5]': 'TPA Argument (Wing)',
         };
 
-        DEBUG.enableFields.splice(DEBUG.enableFields.indexOf("Gyro"), 0, "Attitude");
+        DEBUG.enableFields.splice(DEBUG.enableFields.indexOf("Accelerometer"), 0, "Attitude");
     }
 }
 

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -859,7 +859,7 @@ function update() {
             'debug[5]': 'TPA Argument (Wing)',
         };
 
-        DEBUG.enableFields.splice(DEBUG.enableFields.indexOf("Accelerometer"), 0, "Attitude");
+        DEBUG.enableFields.splice(DEBUG.enableFields.indexOf("Gyro") + 1, 0, "Attitude");
     }
 }
 


### PR DESCRIPTION
Bug fix for  #4248 PR.
Attitude log enabled flag position issue is resolved.
New log files:
- attitide log enabled 
[btfl_all_attitude_on.txt](https://github.com/user-attachments/files/18028870/btfl_all_attitude_on.txt)
- attitide log disabled 
[btfl_all_attitude_off.txt](https://github.com/user-attachments/files/18028874/btfl_all_attitude_off.txt)

Bad file. The attitude logging was disabled, but log contains quaternions field instead of gyro:
[bad_file.txt](https://github.com/user-attachments/files/18028881/bad_file.txt)






