### PR TITLE
Style: Fix contrast issues on dark mode

### DIFF
--- a/src/css/dark-theme.less
+++ b/src/css/dark-theme.less
@@ -2,15 +2,8 @@ body.dark-theme {
     .helpicon {
         background-image: url(../images/icons/cf_icon_info_white.svg);
         opacity: 0.3;
-    }
-    .cf {
-        .helpicon {
-            background-image: url(../images/icons/cf_icon_info_grey.svg);
-            opacity: 0.4;
-            &:hover {
-                background-image: url(../images/icons/cf_icon_info_grey.svg);
-                opacity: 1;
-            }
+        &:hover {
+            opacity: 0.5;
         }
     }
     .gui_box_titlebar {
@@ -34,35 +27,6 @@ body.dark-theme {
         .logowrapper {
             img {
                 content: url(../images/bf_logo_black.svg);
-            }
-        }
-    }
-    .tab-pid_tuning {
-        .profile {
-            .helpicon {
-                background-image: url(../images/icons/cf_icon_info_grey.svg);
-                opacity: 0.4;
-                &:hover {
-                    opacity: 1;
-                }
-            }
-        }
-        .rate_profile {
-            .helpicon {
-                background-image: url(../images/icons/cf_icon_info_grey.svg);
-                opacity: 0.4;
-                &:hover {
-                    opacity: 1;
-                }
-            }
-        }
-        .pid_titlebar {
-            .helpicon {
-                background-image: url(../images/icons/cf_icon_info_grey.svg);
-                opacity: 0.4;
-                &:hover {
-                    opacity: 1;
-                }
             }
         }
     }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1295,6 +1295,12 @@ dialog {
     &:hover {
         background-color: var(--primary-400);
     }
+    &.disabled {
+        background-color: var(--surface-500);
+        border: 1px solid var(--surface-400);
+        color: var(--surface-900);
+        cursor: default;
+    }
 }
 .regular-button.pushed {
     background-color: var(--primary-transparent-3);

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -981,7 +981,7 @@ pid_tuning.initialize = function (callback) {
     }
 
     function drawAxes(curveContext, width, height) {
-        curveContext.strokeStyle = '#000000';
+        curveContext.strokeStyle = '#888888';
         curveContext.lineWidth = 4;
 
         // Horizontal
@@ -1512,7 +1512,7 @@ pid_tuning.initialize = function (callback) {
                 thrlabel = `${Math.round(thrPercent <= 0 ? 0 : realthr)}%` +
                     ` = ${Math.round(thrPercent <= 0 ? 0 : expothr)}%`,
                 textWidth = context.measureText(thrlabel);
-            context.fillStyle = '#000';
+            context.fillStyle = '#888888';
             context.scale(textWidth / throttleCurve.clientWidth, 1);
             context.fillText(thrlabel, 5, 5 + fontSize);
             context.restore();
@@ -2071,7 +2071,7 @@ pid_tuning.updateRatesLabels = function() {
 
         const drawAxisLabel = function(context, axisLabel, x, y, align, color) {
 
-            context.fillStyle = color || '#000000' ;
+            context.fillStyle = color || '#888888' ;
             context.textAlign = align || 'center';
             context.fillText(axisLabel, x, y);
         };

--- a/src/tabs/auxiliary.html
+++ b/src/tabs/auxiliary.html
@@ -68,7 +68,7 @@
             <div class="marker"></div>
         </div>
         <div class="delete">
-            <a class="deleteRange" href="#">&nbsp;</a>
+            <a class="deleteRange invertable" href="#">&nbsp;</a>
         </div>
     </div>
     <div class="link">


### PR DESCRIPTION
Fixes https://github.com/betaflight/betaflight-configurator/issues/4278 and more.

![image](https://github.com/user-attachments/assets/70b9d67f-94d5-4d90-b487-af02779e5cd6)
![image](https://github.com/user-attachments/assets/ddc49df5-9ebb-47be-85c8-64b0334f0c0b)

![image](https://github.com/user-attachments/assets/6d239b6c-8276-4888-a166-b86510a4ddf9)
![image](https://github.com/user-attachments/assets/49e0af87-6e02-4327-b6ed-2e1040705866)
...

For the canvas-rendered parts I used a neutral (50% value) color that should work well on both dark and light mode, having two options that switch between light and dark mode would be better but I'm not sure how best to implement that consistently
![image](https://github.com/user-attachments/assets/6895d095-3e7b-4942-9443-de3085a27cff)
