### PR TITLE
Add AUTOPILOT_POSITION and OPTICALFLOW debug modes

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -860,6 +860,28 @@ function update() {
             'debug[5]': 'TPA Argument (Wing)',
         };
 
+        DEBUG.fieldNames.OPTICALFLOW = {
+            'debug[all]': 'Debug OPTICALFLOW',
+            'debug[0]': 'Quality',
+            'debug[1]': 'Raw flow rates X',
+            'debug[2]': 'Raw flow rates Y',
+            'debug[3]': 'Processed flow rates X',
+            'debug[4]': 'Processed flow rates Y',
+            'debug[5]': 'Delta time',
+        };
+        
+        DEBUG.fieldNames.AUTOPILOT_POSITION = {
+            'debug[all]': 'Autopilot Position',
+            'debug[0]': 'Distance',
+            'debug[1]': 'GPS Distance',
+            'debug[2]': 'PID Sum EF',
+            'debug[3]': 'Autopilot Angle',
+            'debug[4]': 'pidP',
+            'debug[5]': 'pidI',
+            'debug[6]': 'pidD',
+            'debug[7]': 'pidA',
+        };
+
         DEBUG.enableFields.splice(DEBUG.enableFields.indexOf("Gyro") + 1, 0, "Attitude");
         DEBUG.enableFields.push("Servo");
     }

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -821,7 +821,8 @@ function update() {
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
         DEBUG.modes.splice(DEBUG.modes.indexOf('GPS_RESCUE_THROTTLE_PID'), 1, 'AUTOPILOT_ALTITUDE');
         DEBUG.modes.splice(DEBUG.modes.indexOf('GYRO_SCALED'), 1);
-
+        DEBUG.modes.splice(DEBUG.modes.indexOf('RANGEFINDER_QUALITY') + 1, 0, 'OPTICALFLOW');
+        DEBUG.modes.push('AUTOPILOT_POSITION');
         delete DEBUG.fieldNames.GPS_RESCUE_THROTTLE_PID;
         delete DEBUG.fieldNames.GYRO_SCALED;
 

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -861,7 +861,7 @@ function update() {
         };
 
         DEBUG.fieldNames.OPTICALFLOW = {
-            'debug[all]': 'Debug OPTICALFLOW',
+            'debug[all]': 'Optical Flow',
             'debug[0]': 'Quality',
             'debug[1]': 'Raw flow rates X',
             'debug[2]': 'Raw flow rates Y',

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -875,7 +875,7 @@ function update() {
             'debug[0]': 'Distance',
             'debug[1]': 'GPS Distance',
             'debug[2]': 'PID Sum EF',
-            'debug[3]': 'Autopilot Angle',
+            'debug[3]': 'Angle',
             'debug[4]': 'pidP',
             'debug[5]': 'pidI',
             'debug[6]': 'pidD',


### PR DESCRIPTION
There are debug modes bugs after OPTICALFLOW debug was added. The GYRO_SAMPLE and other debugs did not work properly.
Resolved by updating debug modes list for 4.6 BF version.

The Blackbox explorer is updated in this PR: https://github.com/betaflight/blackbox-log-viewer/pull/803
