### PR TITLE
Fix for preset options that are outside of any groups

### DIFF
--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.js
@@ -201,7 +201,7 @@ export default class PresetsDetailedDialog {
         const groupIndex = selectedOptionKey.slice(firstUnderscoreIndex + 1, lastUnderscoreIndex);
 
         const group = this._preset.options[groupIndex];
-        if (group.isExclusive) {
+        if (group?.isExclusive) {
             // clear all options within group
             const valuesWithinGroup = this._domOptionsSelect.find(`optgroup[label="${group.name}"]`)
                 .children()


### PR DESCRIPTION
Quick fix after https://github.com/betaflight/betaflight-configurator/pull/3940

Problem that is being fixed:
Currently if preset has options outside of any groups it causes error when clicked on such options:
1. Error in console
2. These options are being ignored in the final CLI
3. These options are being unchecked when clicked on any group options.

To reproduce:
1. Open Karate Race 6S preset
2. select "new spice" like that:
![image](https://github.com/user-attachments/assets/e4f7adc1-59d6-49f1-a6f1-110f8b51817a)
3. Click on "Tracer/ERLS 250hz".
This will disable "new spice", so you will see this:
![image](https://github.com/user-attachments/assets/fd5a9fa2-5359-49ca-9574-e8da9dffcd54)