### PR TITLE
Update actions to use latest github hosted runner

### DIFF
--- a/.github/workflows/artifact-links.yml
+++ b/.github/workflows/artifact-links.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   artifacts-url-comments:
     name: Add artifact links to PR and issues
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Add artifact links to PR and issues
         uses: tonyhallett/artifacts-url-comments@v1.1.0

--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   close-pr:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -16,7 +16,7 @@ jobs:
   release:
     name: Attach Release Artifacts
     needs: ci
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -44,11 +44,11 @@ jobs:
       matrix:
         include:
           - name: Android
-            os: ubuntu-22.04
+            os: ubuntu-latest
             releaseArgs: --android
 
           - name: Linux
-            os: ubuntu-22.04
+            os: ubuntu-latest
             releaseArgs: --linux64
 
           - name: macOS

--- a/.github/workflows/hide-artifact-links.yml
+++ b/.github/workflows/hide-artifact-links.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   hide-artifacts-link-comments:
     name: Hide artifact links
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Hide comments
         uses: int128/hide-comment-action@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -29,7 +29,7 @@ jobs:
   release:
     name: Nightly release
     needs: ci
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
   release:
     name: Release
     needs: ci
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Fetch build artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   stale:
     name: 'Check and close stale issues'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/stale@v8
       with:

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   crowdin-translations-to-pr:
     name: Create a PR with the latest translations from Crowdin
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/translations-upload.yml
+++ b/.github/workflows/translations-upload.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   betaflight-messages-to-crowdin:
     name: Messages file to Crowdin
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v4


### PR DESCRIPTION
- update runner to use `ubuntu-latest`
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories