### PR TITLE
Add gyro and magnetic custom alignment MSP

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1438,9 +1438,6 @@
     "configurationBoardAlignmentHelp": {
         "message": "Arbitrary board rotation in degrees, to allow mounting it sideways / upside down / rotated etc. When running external sensors, use the sensor alignments (Gyro, Acc, Mag) to define sensor position independent from board orientation. "
     },
-    "configurationMagAlignmentDefault": {
-        "message": "Default"
-    },
     "configurationMagAlignmentRoll": {
         "message": "$t(configurationBoardAlignmentRoll.message)"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1393,8 +1393,11 @@
     "configurationOtherFeaturesHelp": {
         "message": "<strong>Note:</strong> Not all features are supported by all flight controllers. If you enable a specific feature, and it is disabled after you hit 'Save and Reboot', it means that this feature is not supported on your board."
     },
+    "configurationMagAlignmentHelp": {
+        "message": "The magnetometer alignment is the orientation of the magnetometer sensor on the flight controller board. The default is usually correct, but if you have a custom build or a flight controller with a different magnetometer orientation, you may need to adjust this setting."
+    },
     "configurationBoardAlignment": {
-        "message": "Board and Sensor Alignment"
+        "message": "Board Alignment"
     },
     "configurationBoardAlignmentRoll": {
         "message": "Roll Degrees"
@@ -1404,6 +1407,39 @@
     },
     "configurationBoardAlignmentYaw": {
         "message": "Yaw Degrees"
+    },
+    "configurationGyroAlignment": {
+        "message": "Gyro Alignment"
+    },
+    "configurationGyroAlignmentHelp": {
+        "message": "The gyro alignment is the orientation of the gyro sensor on the flight controller board. The default is usually correct, but if you have a custom build or a flight controller with a different gyro orientation, you may need to adjust this setting."
+    },
+    "configurationGyroAlignmentRoll": {
+        "message": "$t(configurationBoardAlignmentRoll.message)"
+    },
+    "configurationGyroAlignmentPitch": {
+        "message": "$t(configurationBoardAlignmentPitch.message)"
+    },
+    "configurationGyroAlignmentYaw": {
+        "message": "$t(configurationBoardAlignmentYaw.message)"
+    },
+    "configurationMagAlignment": {
+        "message": "Mag Alignment"
+    },
+    "configurationBoardAlignmentHelp": {
+        "message": "Arbitrary board rotation in degrees, to allow mounting it sideways / upside down / rotated etc. When running external sensors, use the sensor alignments (Gyro, Acc, Mag) to define sensor position independent from board orientation. "
+    },
+    "configurationMagAlignmentDefault": {
+        "message": "Default"
+    },
+    "configurationMagAlignmentRoll": {
+        "message": "$t(configurationBoardAlignmentRoll.message)"
+    },
+    "configurationMagAlignmentPitch": {
+        "message": "$t(configurationBoardAlignmentPitch.message)"
+    },
+    "configurationMagAlignmentYaw": {
+        "message": "$t(configurationBoardAlignmentYaw.message)"
     },
     "configurationSensorAlignmentGyro": {
         "message": "GYRO Alignment"
@@ -1433,7 +1469,7 @@
         "message": "ACCEL Alignment"
     },
     "configurationSensorAlignmentMag": {
-        "message": "MAG Alignment"
+        "message": "Alignment"
     },
     "configurationSensorAlignmentDefaultOption": {
        "message": "Default"
@@ -4654,9 +4690,6 @@
     },
     "pidTuningIntegratedYawHelp": {
         "message": "Integrated Yaw integrates yaw P, I and D values, allowing yaw P, I and D to be tuned a bit like you'd tune pitch and roll.<br><br>Very little I is required, because the integrated P acts like I, and integrated D acts like P.<br><br>NOTE: Integrated Yaw requires use of Absolute Control, since no I is needed with Integrated Yaw."
-    },
-    "configHelp2": {
-        "message": "Arbitrary board rotation in degrees, to allow mounting it sideways / upside down / rotated etc. When running external sensors, use the sensor alignments (Gyro, Acc, Mag) to define sensor position independent from board orientation. "
     },
     "failsafeFeaturesHelpOld": {
         "message": "Failsafe configuration has changed considerably. Use Betaflight <strong>v1.12.0+</strong> to enable the improved configuration panel."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1396,6 +1396,15 @@
     "configurationMagAlignmentHelp": {
         "message": "The magnetometer alignment is the orientation of the magnetometer sensor on the flight controller board. The default is usually correct, but if you have a custom build or a flight controller with a different magnetometer orientation, you may need to adjust this setting."
     },
+    "configurationMagDeclination": {
+        "message": "Magnetometer Declination"
+    },
+    "configurationMagDeclinationInput": {
+        "message": "Declination Degrees"
+    },
+    "configurationMagDeclinationHelp": {
+        "message": "The magnetic declination is the angle between magnetic north and true north. It is different for every location on earth. You can find the declination for your location on the internet"
+    },
     "configurationBoardAlignment": {
         "message": "Board Alignment"
     },
@@ -1424,7 +1433,7 @@
         "message": "$t(configurationBoardAlignmentYaw.message)"
     },
     "configurationMagAlignment": {
-        "message": "Mag Alignment"
+        "message": "Magnetometer Alignment"
     },
     "configurationBoardAlignmentHelp": {
         "message": "Arbitrary board rotation in degrees, to allow mounting it sideways / upside down / rotated etc. When running external sensors, use the sensor alignments (Gyro, Acc, Mag) to define sensor position independent from board orientation. "
@@ -1468,9 +1477,6 @@
     "configurationSensorAlignmentAcc": {
         "message": "ACCEL Alignment"
     },
-    "configurationSensorAlignmentMag": {
-        "message": "Alignment"
-    },
     "configurationSensorAlignmentDefaultOption": {
        "message": "Default"
     },
@@ -1488,9 +1494,6 @@
     },
     "configurationArmingHelp": {
         "message": "Some Arming options may require accelerometer be enabled"
-    },
-    "configurationMagDeclination": {
-        "message": "Magnetometer Declination [deg]"
     },
     "configurationReverseMotorSwitch": {
         "message": "Motor direction is reversed"

--- a/src/css/tabs/configuration.less
+++ b/src/css/tabs/configuration.less
@@ -19,23 +19,18 @@
         background-repeat: no-repeat;
         background-position: center;
     }
-    .board_align_content {
+    .sensor_align_content {
         display: flex;
         justify-content: space-between;
         width: 100%;
         flex-wrap: wrap;
         gap: 0.5rem;
-        .board_align_inputs {
+        .sensor_align_inputs {
             display: flex;
             label {
                 white-space: nowrap;
             }
         }
-    }
-    .gyro_align_content {
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
     }
     table {
         td {

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -474,6 +474,12 @@ const FC = {
             gyro_to_use: 0,
             gyro_1_align: 0,
             gyro_2_align: 0,
+            gyro_align_roll: 0,
+            gyro_align_pitch: 0,
+            gyro_align_yaw: 0,
+            mag_align_roll: 0,
+            mag_align_pitch: 0,
+            mag_align_yaw: 0,
         };
 
         this.PID_ADVANCED_CONFIG = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -636,13 +636,13 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.SENSOR_ALIGNMENT.gyro_1_align = data.readU8();
                     FC.SENSOR_ALIGNMENT.gyro_2_align = data.readU8();
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
-                        FC.SENSOR_ALIGNMENT.gyro_align_roll = data.readU16() / 10;
-                        FC.SENSOR_ALIGNMENT.gyro_align_pitch = data.readU16() / 10;
-                        FC.SENSOR_ALIGNMENT.gyro_align_yaw = data.readU16() / 10;
+                        FC.SENSOR_ALIGNMENT.gyro_align_roll = data.read16() / 10;
+                        FC.SENSOR_ALIGNMENT.gyro_align_pitch = data.read16() / 10;
+                        FC.SENSOR_ALIGNMENT.gyro_align_yaw = data.read16() / 10;
 
-                        FC.SENSOR_ALIGNMENT.mag_align_roll = data.readU16() / 10;
-                        FC.SENSOR_ALIGNMENT.mag_align_pitch = data.readU16() / 10;
-                        FC.SENSOR_ALIGNMENT.mag_align_yaw = data.readU16() / 10;
+                        FC.SENSOR_ALIGNMENT.mag_align_roll = data.read16() / 10;
+                        FC.SENSOR_ALIGNMENT.mag_align_pitch = data.read16() / 10;
+                        FC.SENSOR_ALIGNMENT.mag_align_yaw = data.read16() / 10;
                     }
                     break;
                 case MSPCodes.MSP_DISPLAYPORT:
@@ -2057,8 +2057,6 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
                 .push8(FC.SENSOR_ALIGNMENT.gyro_1_align)
                 .push8(FC.SENSOR_ALIGNMENT.gyro_2_align);
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
-                // // Use gyro_2_align[RPY] when GYRO_CONFIG_USE_GYRO_2 = 1
-                // if (FC.SENSOR_ALIGNMENT.gyro_to_use === 1) {
                 buffer.push16(FC.SENSOR_ALIGNMENT.gyro_align_roll * 10);
                 buffer.push16(FC.SENSOR_ALIGNMENT.gyro_align_pitch * 10);
                 buffer.push16(FC.SENSOR_ALIGNMENT.gyro_align_yaw * 10);

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -514,7 +514,9 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.MOTOR_CONFIG.use_esc_sensor = data.readU8() != 0;
                     break;
                 case MSPCodes.MSP_COMPASS_CONFIG:
-                    FC.COMPASS_CONFIG.mag_declination = data.read16() / 10;
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                        FC.COMPASS_CONFIG.mag_declination = data.read16() / 10;
+                    }
                     break;
                 case MSPCodes.MSP_GPS_CONFIG:
                     FC.GPS_CONFIG.provider = data.readU8();
@@ -633,6 +635,15 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.SENSOR_ALIGNMENT.gyro_to_use = data.readU8();
                     FC.SENSOR_ALIGNMENT.gyro_1_align = data.readU8();
                     FC.SENSOR_ALIGNMENT.gyro_2_align = data.readU8();
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                        FC.SENSOR_ALIGNMENT.gyro_align_roll = data.readU16() / 10;
+                        FC.SENSOR_ALIGNMENT.gyro_align_pitch = data.readU16() / 10;
+                        FC.SENSOR_ALIGNMENT.gyro_align_yaw = data.readU16() / 10;
+
+                        FC.SENSOR_ALIGNMENT.mag_align_roll = data.readU16() / 10;
+                        FC.SENSOR_ALIGNMENT.mag_align_pitch = data.readU16() / 10;
+                        FC.SENSOR_ALIGNMENT.mag_align_yaw = data.readU16() / 10;
+                    }
                     break;
                 case MSPCodes.MSP_DISPLAYPORT:
                     break;
@@ -773,14 +784,13 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.CONFIG.apiVersion = `${data.readU8()}.${data.readU8()}.0`;
                     break;
 
-                case MSPCodes.MSP_FC_VARIANT: {
+                case MSPCodes.MSP_FC_VARIANT:
                     let fcVariantIdentifier = "";
                     for (let i = 0; i < 4; i++) {
                         fcVariantIdentifier += String.fromCharCode(data.readU8());
                     }
                     FC.CONFIG.flightControllerIdentifier = fcVariantIdentifier;
                     break;
-                }
 
                 case MSPCodes.MSP_FC_VERSION:
                     FC.CONFIG.flightControllerVersion = `${data.readU8()}.${data.readU8()}.${data.readU8()}`;
@@ -899,7 +909,7 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     console.log("Channel forwarding saved");
                     break;
 
-                case MSPCodes.MSP_CF_SERIAL_CONFIG: {
+                case MSPCodes.MSP_CF_SERIAL_CONFIG:
                     FC.SERIAL_CONFIG.ports = [];
                     const bytesPerPort = 1 + 2 + 1 * 4;
 
@@ -917,7 +927,6 @@ MspHelper.prototype.process_data = function (dataHandler) {
                         FC.SERIAL_CONFIG.ports.push(serialPort);
                     }
                     break;
-                }
 
                 case MSPCodes.MSP2_COMMON_SERIAL_CONFIG:
                     FC.SERIAL_CONFIG.ports = [];
@@ -1897,7 +1906,9 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
             buffer.push16(FC.GPS_RESCUE.initialClimbM);
             break;
         case MSPCodes.MSP_SET_COMPASS_CONFIG:
-            buffer.push16(Math.round(10.0 * parseFloat(FC.COMPASS_CONFIG.mag_declination)));
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                buffer.push16(Math.round(10.0 * parseFloat(FC.COMPASS_CONFIG.mag_declination)));
+            }
             break;
         case MSPCodes.MSP_SET_RSSI_CONFIG:
             buffer.push8(FC.RSSI_CONFIG.channel);
@@ -2045,6 +2056,17 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
                 .push8(FC.SENSOR_ALIGNMENT.gyro_to_use)
                 .push8(FC.SENSOR_ALIGNMENT.gyro_1_align)
                 .push8(FC.SENSOR_ALIGNMENT.gyro_2_align);
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                // // Use gyro_2_align[RPY] when GYRO_CONFIG_USE_GYRO_2 = 1
+                // if (FC.SENSOR_ALIGNMENT.gyro_to_use === 1) {
+                buffer.push16(FC.SENSOR_ALIGNMENT.gyro_align_roll * 10);
+                buffer.push16(FC.SENSOR_ALIGNMENT.gyro_align_pitch * 10);
+                buffer.push16(FC.SENSOR_ALIGNMENT.gyro_align_yaw * 10);
+
+                buffer.push16(FC.SENSOR_ALIGNMENT.mag_align_roll * 10);
+                buffer.push16(FC.SENSOR_ALIGNMENT.mag_align_pitch * 10);
+                buffer.push16(FC.SENSOR_ALIGNMENT.mag_align_yaw * 10);
+            }
             break;
         case MSPCodes.MSP_SET_ADVANCED_CONFIG:
             buffer

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -138,21 +138,6 @@ configuration.initialize = function (callback) {
             $("div.mag_declination").parent().parent().hide();
         }
 
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
-            $(".tab-configuration .gyro_align_custom").show();
-            $('input[name="gyro_align_roll"]').val(FC.SENSOR_ALIGNMENT.gyro_align_roll);
-            $('input[name="gyro_align_pitch"]').val(FC.SENSOR_ALIGNMENT.gyro_align_pitch);
-            $('input[name="gyro_align_yaw"]').val(FC.SENSOR_ALIGNMENT.gyro_align_yaw);
-
-            $(".tab-configuration .mag_align_custom").show();
-            $('input[name="mag_align_roll"]').val(FC.SENSOR_ALIGNMENT.mag_align_roll);
-            $('input[name="mag_align_pitch"]').val(FC.SENSOR_ALIGNMENT.mag_align_pitch);
-            $('input[name="mag_align_yaw"]').val(FC.SENSOR_ALIGNMENT.mag_align_yaw);
-        } else {
-            $(".tab-configuration .gyro_align_custom").hide();
-            $(".tab-configuration .mag_align_custom").hide();
-        }
-
         for (let i = 0; i < alignments.length; i++) {
             orientation_gyro_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
             orientation_mag_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
@@ -183,6 +168,8 @@ configuration.initialize = function (callback) {
             self.analyticsChanges["MagAlignment"] = newValue;
 
             FC.SENSOR_ALIGNMENT.align_mag = value;
+
+            toggleMagCustomAlignmentInputs();
         });
 
         // Multi gyro config
@@ -223,6 +210,45 @@ configuration.initialize = function (callback) {
         orientation_gyro_1_align_e.val(FC.SENSOR_ALIGNMENT.gyro_1_align);
         orientation_gyro_2_align_e.val(FC.SENSOR_ALIGNMENT.gyro_2_align);
 
+        function toggleGyroCustomAlignmentInputs() {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                const customEnabled =
+                    orientation_gyro_to_use_e.val() === "1" // 0 = gyro 1, 1 = gyro 2, 2 = both
+                        ? FC.SENSOR_ALIGNMENT.gyro_2_align !== 9
+                        : FC.SENSOR_ALIGNMENT.gyro_1_align !== 9;
+
+                $('input[name="gyro_align_roll"]').attr("disabled", customEnabled);
+                $('input[name="gyro_align_pitch"]').attr("disabled", customEnabled);
+                $('input[name="gyro_align_yaw"]').attr("disabled", customEnabled);
+            }
+        }
+
+        function toggleMagCustomAlignmentInputs() {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                $('input[name="mag_align_roll"]').attr("disabled", FC.SENSOR_ALIGNMENT.align_mag !== 9);
+                $('input[name="mag_align_pitch"]').attr("disabled", FC.SENSOR_ALIGNMENT.align_mag !== 9);
+                $('input[name="mag_align_yaw"]').attr("disabled", FC.SENSOR_ALIGNMENT.align_mag !== 9);
+            }
+        }
+
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+            $(".tab-configuration .gyro_align_custom").show();
+            $('input[name="gyro_align_roll"]').val(FC.SENSOR_ALIGNMENT.gyro_align_roll);
+            $('input[name="gyro_align_pitch"]').val(FC.SENSOR_ALIGNMENT.gyro_align_pitch);
+            $('input[name="gyro_align_yaw"]').val(FC.SENSOR_ALIGNMENT.gyro_align_yaw);
+
+            $(".tab-configuration .mag_align_custom").show();
+            $('input[name="mag_align_roll"]').val(FC.SENSOR_ALIGNMENT.mag_align_roll);
+            $('input[name="mag_align_pitch"]').val(FC.SENSOR_ALIGNMENT.mag_align_pitch);
+            $('input[name="mag_align_yaw"]').val(FC.SENSOR_ALIGNMENT.mag_align_yaw);
+
+            toggleGyroCustomAlignmentInputs();
+            toggleMagCustomAlignmentInputs();
+        } else {
+            $(".tab-configuration .gyro_align_custom").hide();
+            $(".tab-configuration .mag_align_custom").hide();
+        }
+
         $(".gyro_alignment_inputs_first").toggle(detected_gyro_1);
         $(".gyro_alignment_inputs_second").toggle(detected_gyro_2);
         $(".gyro_alignment_inputs_selection").toggle(detected_gyro_1 || detected_gyro_2);
@@ -236,8 +262,9 @@ configuration.initialize = function (callback) {
                 newValue = $(this).find("option:selected").text();
             }
             self.analyticsChanges["Gyro1Alignment"] = newValue;
-
             FC.SENSOR_ALIGNMENT.gyro_1_align = value;
+
+            toggleGyroCustomAlignmentInputs();
         });
 
         orientation_gyro_2_align_e.change(function () {
@@ -248,8 +275,9 @@ configuration.initialize = function (callback) {
                 newValue = $(this).find("option:selected").text();
             }
             self.analyticsChanges["Gyro2Alignment"] = newValue;
-
             FC.SENSOR_ALIGNMENT.gyro_2_align = value;
+
+            toggleGyroCustomAlignmentInputs();
         });
 
         // Gyro and PID update

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -122,8 +122,6 @@ configuration.initialize = function (callback) {
             "Custom",
         ];
 
-        const gyro_align_content_e = $(".tab-configuration .gyro_align_content");
-
         const orientation_gyro_e = $("select.gyroalign");
         const orientation_acc_e = $("select.accalign");
         const orientation_mag_e = $("select.magalign");
@@ -156,7 +154,6 @@ configuration.initialize = function (callback) {
             $(".tab-configuration .mag_align_custom").hide();
         }
 
-        gyro_align_content_e.hide(); // default value
         for (let i = 0; i < alignments.length; i++) {
             orientation_gyro_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
             orientation_acc_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
@@ -204,8 +201,6 @@ configuration.initialize = function (callback) {
         });
 
         // Multi gyro config
-
-        gyro_align_content_e.show();
 
         const GYRO_DETECTION_FLAGS = {
             DETECTED_GYRO_1: 1 << 0,

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -123,7 +123,6 @@ configuration.initialize = function (callback) {
         ];
 
         const gyro_align_content_e = $(".tab-configuration .gyro_align_content");
-        const legacy_accel_alignment_e = $(".tab-configuration .legacy_accel_alignment");
 
         const orientation_gyro_e = $("select.gyroalign");
         const orientation_acc_e = $("select.accalign");
@@ -207,7 +206,6 @@ configuration.initialize = function (callback) {
         // Multi gyro config
 
         gyro_align_content_e.show();
-        legacy_accel_alignment_e.hide();
 
         const GYRO_DETECTION_FLAGS = {
             DETECTED_GYRO_1: 1 << 0,

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -123,7 +123,6 @@ configuration.initialize = function (callback) {
         ];
 
         const orientation_gyro_e = $("select.gyroalign");
-        const orientation_acc_e = $("select.accalign");
         const orientation_mag_e = $("select.magalign");
 
         const orientation_gyro_to_use_e = $("select.gyro_to_use");
@@ -156,12 +155,10 @@ configuration.initialize = function (callback) {
 
         for (let i = 0; i < alignments.length; i++) {
             orientation_gyro_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
-            orientation_acc_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
             orientation_mag_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
         }
 
         orientation_gyro_e.val(FC.SENSOR_ALIGNMENT.align_gyro);
-        orientation_acc_e.val(FC.SENSOR_ALIGNMENT.align_acc);
         orientation_mag_e.val(FC.SENSOR_ALIGNMENT.align_mag);
 
         orientation_gyro_e.change(function () {
@@ -174,18 +171,6 @@ configuration.initialize = function (callback) {
             self.analyticsChanges["GyroAlignment"] = newValue;
 
             FC.SENSOR_ALIGNMENT.align_gyro = value;
-        });
-
-        orientation_acc_e.change(function () {
-            let value = parseInt($(this).val());
-
-            let newValue = undefined;
-            if (value !== FC.SENSOR_ALIGNMENT.align_acc) {
-                newValue = $(this).find("option:selected").text();
-            }
-            self.analyticsChanges["AccAlignment"] = newValue;
-
-            FC.SENSOR_ALIGNMENT.align_acc = value;
         });
 
         orientation_mag_e.change(function () {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -6,7 +6,7 @@ import { mspHelper } from "../msp/MSPHelper";
 import FC from "../fc";
 import MSP from "../msp";
 import MSPCodes from "../msp/MSPCodes";
-import { API_VERSION_1_45, API_VERSION_1_46 } from "../data_storage";
+import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47 } from "../data_storage";
 import { updateTabList } from "../utils/updateTabList";
 import $ from "jquery";
 
@@ -127,6 +127,22 @@ configuration.initialize = function (callback) {
         const orientation_gyro_to_use_e = $("select.gyro_to_use");
         const orientation_gyro_1_align_e = $("select.gyro_1_align");
         const orientation_gyro_2_align_e = $("select.gyro_2_align");
+
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+            $(".tab-configuration .gyro_align_custom").show();
+            $(".tab-configuration .mag_align_custom").show();
+
+            $('input[name="gyro_align_roll"]').val(FC.SENSOR_ALIGNMENT.gyro_align_roll);
+            $('input[name="gyro_align_pitch"]').val(FC.SENSOR_ALIGNMENT.gyro_align_pitch);
+            $('input[name="gyro_align_yaw"]').val(FC.SENSOR_ALIGNMENT.gyro_align_yaw);
+
+            $('input[name="mag_align_roll"]').val(FC.SENSOR_ALIGNMENT.mag_align_roll);
+            $('input[name="mag_align_pitch"]').val(FC.SENSOR_ALIGNMENT.mag_align_pitch);
+            $('input[name="mag_align_yaw"]').val(FC.SENSOR_ALIGNMENT.mag_align_yaw);
+        } else {
+            $(".tab-configuration .gyro_align_custom").hide();
+            $(".tab-configuration .mag_align_custom").hide();
+        }
 
         gyro_align_content_e.hide(); // default value
         for (let i = 0; i < alignments.length; i++) {
@@ -394,6 +410,16 @@ configuration.initialize = function (callback) {
             FC.BOARD_ALIGNMENT_CONFIG.roll = parseInt($('input[name="board_align_roll"]').val());
             FC.BOARD_ALIGNMENT_CONFIG.pitch = parseInt($('input[name="board_align_pitch"]').val());
             FC.BOARD_ALIGNMENT_CONFIG.yaw = parseInt($('input[name="board_align_yaw"]').val());
+
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                FC.SENSOR_ALIGNMENT.gyro_align_roll = parseInt($('input[name="gyro_align_roll"]').val());
+                FC.SENSOR_ALIGNMENT.gyro_align_pitch = parseInt($('input[name="gyro_align_pitch"]').val());
+                FC.SENSOR_ALIGNMENT.gyro_align_yaw = parseInt($('input[name="gyro_align_yaw"]').val());
+
+                FC.SENSOR_ALIGNMENT.mag_align_roll = parseInt($('input[name="mag_align_roll"]').val());
+                FC.SENSOR_ALIGNMENT.mag_align_pitch = parseInt($('input[name="mag_align_pitch"]').val());
+                FC.SENSOR_ALIGNMENT.mag_align_yaw = parseInt($('input[name="mag_align_yaw"]').val());
+            }
 
             FC.CONFIG.accelerometerTrims[1] = parseInt($('input[name="roll"]').val());
             FC.CONFIG.accelerometerTrims[0] = parseInt($('input[name="pitch"]').val());

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -123,7 +123,6 @@ configuration.initialize = function (callback) {
         ];
 
         const gyro_align_content_e = $(".tab-configuration .gyro_align_content");
-        const legacy_gyro_alignment_e = $(".tab-configuration .legacy_gyro_alignment");
         const legacy_accel_alignment_e = $(".tab-configuration .legacy_accel_alignment");
 
         const orientation_gyro_e = $("select.gyroalign");
@@ -208,7 +207,6 @@ configuration.initialize = function (callback) {
         // Multi gyro config
 
         gyro_align_content_e.show();
-        legacy_gyro_alignment_e.hide();
         legacy_accel_alignment_e.hide();
 
         const GYRO_DETECTION_FLAGS = {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -122,7 +122,6 @@ configuration.initialize = function (callback) {
             "Custom",
         ];
 
-        const orientation_gyro_e = $("select.gyroalign");
         const orientation_mag_e = $("select.magalign");
 
         const orientation_gyro_to_use_e = $("select.gyro_to_use");
@@ -139,24 +138,10 @@ configuration.initialize = function (callback) {
         }
 
         for (let i = 0; i < alignments.length; i++) {
-            orientation_gyro_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
             orientation_mag_e.append(`<option value="${i + 1}">${alignments[i]}</option>`);
         }
 
-        orientation_gyro_e.val(FC.SENSOR_ALIGNMENT.align_gyro);
         orientation_mag_e.val(FC.SENSOR_ALIGNMENT.align_mag);
-
-        orientation_gyro_e.change(function () {
-            let value = parseInt($(this).val());
-
-            let newValue = undefined;
-            if (value !== FC.SENSOR_ALIGNMENT.align_gyro) {
-                newValue = $(this).find("option:selected").text();
-            }
-            self.analyticsChanges["GyroAlignment"] = newValue;
-
-            FC.SENSOR_ALIGNMENT.align_gyro = value;
-        });
 
         orientation_mag_e.change(function () {
             let value = parseInt($(this).val());

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -23,10 +23,6 @@ gps.initialize = async function (callback) {
     // mag support added in 1.46
     const hasMag = have_sensor(FC.CONFIG.activeSensors, "mag") && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46);
 
-    if (hasMag) {
-        await MSP.promise(MSPCodes.MSP_COMPASS_CONFIG);
-    }
-
     await MSP.promise(MSPCodes.MSP_GPS_CONFIG);
 
     load_html();
@@ -64,15 +60,7 @@ gps.initialize = async function (callback) {
         }
 
         function get_attitude_data() {
-            MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, load_compass_config);
-        }
-
-        function load_compass_config() {
-            if (hasMag) {
-                MSP.send_message(MSPCodes.MSP_COMPASS_CONFIG, false, false, get_imu_data);
-            } else {
-                get_imu_data();
-            }
+            MSP.send_message(MSPCodes.MSP_ATTITUDE, false, false, get_imu_data);
         }
 
         function get_imu_data() {
@@ -197,13 +185,6 @@ gps.initialize = async function (callback) {
 
         gpsBaudrateElement.prop("disabled", true);
         gpsBaudrateElement.parent().hide();
-
-        // fill magnetometer
-        if (hasMag) {
-            $('input[name="mag_declination"]').val(FC.COMPASS_CONFIG.mag_declination.toFixed(1));
-        } else {
-            $("div.mag_declination").hide();
-        }
 
         if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
             $(".GPS_info td.positionalDop").parent().hide();
@@ -427,12 +408,8 @@ gps.initialize = async function (callback) {
             // fill some data
             FC.GPS_CONFIG.auto_baud = $('input[name="gps_auto_baud"]').is(":checked") ? 1 : 0;
             FC.GPS_CONFIG.auto_config = $('input[name="gps_auto_config"]').is(":checked") ? 1 : 0;
-            FC.COMPASS_CONFIG.mag_declination = $('input[name="mag_declination"]').val();
 
             await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
-            if (hasMag) {
-                await MSP.promise(MSPCodes.MSP_SET_COMPASS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_COMPASS_CONFIG));
-            }
             await MSP.promise(MSPCodes.MSP_SET_GPS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_GPS_CONFIG));
 
             mspHelper.writeConfiguration(true);

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -284,7 +284,6 @@
                     <div class="spacer_box">
                         <div class="select">
                             <label>
-                                <span i18n="configurationSensorAlignmentMag"></span>
                                 <select class="magalign">
                                     <option value="0" i18n="configurationSensorAlignmentDefaultOption"></option>
                                     <!-- list generated here -->
@@ -322,6 +321,22 @@
                     </div>
                 </div>
                 <!-- END MAGNETOMETER ALIGNMENT -->
+
+                <!-- MAGNETIC DECLINATION -->
+                <div class="gui_box grey">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" i18n="configurationMagDeclination"></div>
+                        <div class="helpicon cf_tip" i18n_title="configurationMagDeclinationHelp"></div>
+                    </div>
+                    <div class="spacer_box">
+                        <div class="number mag_declination">
+                            <label> <input type="number" name="mag_declination" step="0.1" min="-30.0" max="30.0" />
+                            <span i18n="configurationMagDeclinationInput"></span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+                <!-- END MAGNETIC DECLINATION -->
 
                 <!-- ACCELEROMETER TRIM -->
                 <div class="gui_box grey accelNeeded">

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -151,28 +151,29 @@
             <div class="col-span-1">
                 <!-- BOARD ORIENTATION -->
                 <div class="board acc">
+                    <!-- BOARD ALIGNMENT -->
                     <div class="gui_box grey">
                         <div class="gui_box_titlebar">
                             <div class="spacer_box_title" i18n="configurationBoardAlignment"></div>
-                            <div class="helpicon cf_tip" i18n_title="configHelp2"></div>
+                            <div class="helpicon cf_tip" i18n_title="configurationBoardAlignmentHelp"></div>
                         </div>
                         <div class="spacer_box">
-                            <div class="board_align_content">
-                                <div class="board_align_inputs">
+                            <div class="sensor_align_content">
+                                <div class="sensor_align_inputs">
                                     <div class="alignicon roll"></div>
                                     <label>
                                         <input type="number" name="board_align_roll" step="1" min="-180" max="360" />
                                         <span i18n="configurationBoardAlignmentRoll"></span>
                                     </label>
                                 </div>
-                                <div class="board_align_inputs">
+                                <div class="sensor_align_inputs">
                                     <div class="alignicon pitch"></div>
                                     <label>
                                         <input type="number" name="board_align_pitch" step="1" min="-180" max="360" />
                                         <span i18n="configurationBoardAlignmentPitch"></span>
                                     </label>
                                 </div>
-                                <div class="board_align_inputs">
+                                <div class="sensor_align_inputs">
                                     <div class="alignicon yaw"></div>
                                     <label>
                                         <input type="number" name="board_align_yaw" step="1" min="-180" max="360" />
@@ -180,71 +181,148 @@
                                     </label>
                                 </div>
                             </div>
-                            <div class="gyro_align_content">
-                                <div class="gyro_alignment_inputs gyro_alignment_inputs_selection">
-                                    <label>
-                                        <select class="gyro_to_use">
-                                            <!-- list generated here -->
-                                        </select>
-                                        <span i18n="configurationSensorGyroToUse"></span>
-                                    </label>
-                                </div>
-                                <div class="gyro_alignment_inputs gyro_alignment_inputs_first">
-                                    <label>
-                                        <span>
-                                            <select class="gyro_1_align">
-                                                <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
-                                                <!-- list generated here -->
-                                            </select>
-                                            <span i18n="configurationSensorAlignmentGyro1"></span>
-                                        </span>
-                                    </label>
-                                </div>
-                                <div class="gyro_alignment_inputs gyro_alignment_inputs_second">
-                                    <label>
-                                        <select class="gyro_2_align">
-                                            <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
-                                            <!-- list generated here -->
-                                        </select>
-                                        <span i18n="configurationSensorAlignmentGyro2"></span>
-                                    </label>
-                                </div>
-                                <div class="gyro_alignment_inputs gyro_alignment_inputs_notfound">
-                                    <span class="message-negative" i18n="configurationSensorGyroToUseNotFound"></span>
-                                </div>
-                            </div>
-                            <div class="sensor_align_content">
-                                <div class="legacy_gyro_alignment select">
-                                    <label>
-                                        <span i18n="configurationSensorAlignmentGyro"></span>
-                                        <select class="gyroalign">
-                                            <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
-                                            <!-- list generated here -->
-                                        </select>
-                                    </label>
-                                </div>
-                                <div class="legacy_accel_alignment select">
-                                    <label>
-                                        <span i18n="configurationSensorAlignmentAcc"></span>
-                                        <select class="accalign">
-                                            <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
-                                            <!-- list generated here -->
-                                        </select>
-                                    </label>
-                                </div>
-                                <div class="select">
-                                    <label>
-                                        <span i18n="configurationSensorAlignmentMag"></span>
-                                        <select class="magalign">
-                                            <option value="0" i18n="configurationSensorAlignmentDefaultOption"></option>
-                                            <!-- list generated here -->
-                                        </select>
-                                    </label>
-                                </div>
-                            </div>
                         </div>
                     </div>
                 </div>
+                <!-- END BOARD ALIGNMENT -->
+                <!-- GYRO ALIGNMENT -->
+                <div class="gui_box grey">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" i18n="configurationGyroAlignment"></div>
+                        <div class="helpicon cf_tip" i18n_title="configurationGyroAlignmentHelp"></div>
+                    </div>
+                    <div class="spacer_box">
+                        <div class="sensor_align_content">
+                            <div class="gyro_alignment_inputs gyro_alignment_inputs_selection">
+                                <label>
+                                    <select class="gyro_to_use">
+                                        <!-- list generated here -->
+                                    </select>
+                                    <span i18n="configurationSensorGyroToUse"></span>
+                                </label>
+                            </div>
+                            <div class="gyro_alignment_inputs gyro_alignment_inputs_first">
+                                <label>
+                                    <span>
+                                        <select class="gyro_1_align">
+                                            <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
+                                            <!-- list generated here -->
+                                        </select>
+                                        <span i18n="configurationSensorAlignmentGyro1"></span>
+                                    </span>
+                                </label>
+                            </div>
+                            <div class="gyro_alignment_inputs gyro_alignment_inputs_second">
+                                <label>
+                                    <select class="gyro_2_align">
+                                        <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
+                                        <!-- list generated here -->
+                                    </select>
+                                    <span i18n="configurationSensorAlignmentGyro2"></span>
+                                </label>
+                            </div>
+                            <div class="gyro_alignment_inputs gyro_alignment_inputs_notfound">
+                                <span class="message-negative" i18n="configurationSensorGyroToUseNotFound"></span>
+                            </div>
+                            <div class="spacer_box">
+                                <div class="sensor_align_content">
+                                    <div class="gyro_align_inputs sensor_align_inputs">
+                                        <div class="alignicon roll"></div>
+                                        <label>
+                                            <input type="number" name="gyro_align_roll" step="1" min="-180" max="360" />
+                                            <span i18n="configurationGyroAlignmentRoll"></span>
+                                        </label>
+                                    </div>
+                                    <div class="gyro_align_inputs sensor_align_inputs">
+                                        <div class="alignicon pitch"></div>
+                                        <label>
+                                            <input type="number" name="gyro_align_pitch" step="1" min="-180" max="360" />
+                                            <span i18n="configurationGyroAlignmentPitch"></span>
+                                        </label>
+                                    </div>
+                                    <div class="gyro_align_inputs sensor_align_inputs">
+                                        <div class="alignicon yaw"></div>
+                                        <label>
+                                            <input type="number" name="gyro_align_yaw" step="1" min="-180" max="360" />
+                                            <span i18n="configurationGyroAlignmentYaw"></span>
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="sensor_align_content">
+                            <div class="legacy_gyro_alignment select">
+                                <label>
+                                    <span i18n="configurationSensorAlignmentGyro"></span>
+                                    <select class="gyroalign">
+                                        <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
+                                        <!-- list generated here -->
+                                    </select>
+                                </label>
+                            </div>
+                            <div class="legacy_accel_alignment select">
+                                <label>
+                                    <span i18n="configurationSensorAlignmentAcc"></span>
+                                    <select class="accalign">
+                                        <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
+                                        <!-- list generated here -->
+                                    </select>
+                                </label>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+                <!-- END GYRO ALIGNMENT -->
+                <!-- MAGNETOMETER ALIGNMENT -->
+                <div class="gui_box grey">
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" i18n="configurationMagAlignment"></div>
+                        <div class="helpicon cf_tip" i18n_title="configurationBoardAlignmentHelp"></div>
+                    </div>
+                    <div class="spacer_box">
+                        <div class="select">
+                            <label>
+                                <span i18n="configurationSensorAlignmentMag"></span>
+                                <select class="magalign">
+                                    <option value="0" i18n="configurationSensorAlignmentDefaultOption"></option>
+                                    <!-- list generated here -->
+                                </select>
+                            </label>
+                        </div>
+
+                        <div class="sensor_align_content">
+                            <div class="mag_align_inputs sensor_align_inputs">
+                                <div class="alignicon roll"></div>
+                                <label>
+                                    <input type="number" name="mag_align_roll" step="1" min="-180" max="360" />
+                                    <span i18n="configurationMagAlignmentRoll"></span>
+                                </label>
+                            </div>
+                            <div class="mag_align_inputs sensor_align_inputs">
+                                <div class="alignicon pitch"></div>
+                                <label>
+                                    <input type="number" name="mag_align_pitch" step="1" min="-180" max="360" />
+                                    <span i18n="configurationMagAlignmentPitch"></span>
+                                </label>
+                            </div>
+                            <div class="mag_align_inputs sensor_align_inputs">
+                                <div class="alignicon yaw"></div>
+                                <label>
+                                    <input type="number" name="mag_align_yaw" step="1" min="-180" max="360" />
+                                    <span i18n="configurationMagAlignmentYaw"></span>
+                                </label>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="gui_box_titlebar">
+                        <div class="spacer_box_title" i18n="configurationMagAlignment"></div>
+                        <div class="helpicon cf_tip" i18n_title="configurationMagAlignmentHelp"></div>
+                    </div>
+                </div>
+                <!-- END MAGNETOMETER ALIGNMENT -->
+
                 <!-- ACCELEROMETER TRIM -->
                 <div class="gui_box grey accelNeeded">
                     <div class="gui_box_titlebar">

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -251,27 +251,6 @@
                             </div>
                         </div>
 
-                        <div class="sensor_align_content">
-                            <div class="legacy_gyro_alignment select">
-                                <label>
-                                    <span i18n="configurationSensorAlignmentGyro"></span>
-                                    <select class="gyroalign">
-                                        <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
-                                        <!-- list generated here -->
-                                    </select>
-                                </label>
-                            </div>
-                            <div class="legacy_accel_alignment select">
-                                <label>
-                                    <span i18n="configurationSensorAlignmentAcc"></span>
-                                    <select class="accalign">
-                                        <option i18n="configurationSensorAlignmentDefaultOption" value="0"></option>
-                                        <!-- list generated here -->
-                                    </select>
-                                </label>
-                            </div>
-                        </div>
-
                     </div>
                 </div>
                 <!-- END GYRO ALIGNMENT -->
@@ -290,7 +269,6 @@
                                 </select>
                             </label>
                         </div>
-
                         <div class="sensor_align_content">
                             <div class="mag_align_inputs sensor_align_inputs">
                                 <div class="alignicon roll"></div>

--- a/src/tabs/gps.html
+++ b/src/tabs/gps.html
@@ -59,11 +59,6 @@
                                     </select>
                                     <span i18n="configurationGPSubxSbas"></span>
                                 </div>
-                                <div class="number mag_declination">
-                                    <label> <input type="number" name="mag_declination" step="0.1" min="0" max="359.9" />
-                                    <span i18n="configurationMagDeclination"></span>
-                                    </label>
-                                </div>
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- keep in sync with https://github.com/betaflight/betaflight/pull/14019
- move magnetic declination setting to configuration tab
- to use custom alignment, CUSTOM must be selected, otherwise basic alignment takes precedence.
- removed `0xDEADC0DE`

BEFORE:

![image](https://github.com/user-attachments/assets/34ab5648-2fc7-4c47-8f43-dc645c04b83a)

AFTER:

![image](https://github.com/user-attachments/assets/93d94cb8-e278-4ce6-8e8f-784a5942a68a)

Two gyro's:

![image](https://github.com/user-attachments/assets/ddccf66c-2a9e-4633-a707-75c5cf62a2b5)

EDIT:

Last commit improves usability by disabling custom fields when preset is used, i.e. Custom is not selected.

![image](https://github.com/user-attachments/assets/b6fe55e2-3a76-4889-8a04-9d9a8515a8f5)

