### PR TITLE
Add binary sub protocol to allow communication with websockify.

### DIFF
--- a/src/js/protocols/websocket.js
+++ b/src/js/protocols/websocket.js
@@ -61,7 +61,7 @@ class WebsocketSerial extends EventTarget {
         this.address = path;
         console.log(`${this.logHead} Connecting to ${this.address}`);
 
-        this.ws = new WebSocket(this.address);
+        this.ws = new WebSocket(this.address, ["binary", "wsSerial"]);
         let socket = this;
 
         this.ws.onopen = function (e) {

--- a/src/js/protocols/websocket.js
+++ b/src/js/protocols/websocket.js
@@ -61,7 +61,7 @@ class WebsocketSerial extends EventTarget {
         this.address = path;
         console.log(`${this.logHead} Connecting to ${this.address}`);
 
-        this.ws = new WebSocket(this.address, "wsSerial");
+        this.ws = new WebSocket(this.address);
         let socket = this;
 
         this.ws.onopen = function (e) {


### PR DESCRIPTION
~~This removes the protocol definition when opening an WebSocket for connecting to the FC boards in the configurator.~~ Currently we require using Websockify to proxy requests from localhost to the FC on the network, Websockify does not support (at least on the latest branch) this protocol, nor is it specified by IANA.

This has been tested on two boards and works for connecting to it - it does not however work for flashing (specifically detecting at the very least).

EDIT: 

Added `binary` as a subprotocol as well since that is at least one of the ones accepted by websockify.

See:

- https://websockets.spec.whatwg.org/#the-websocket-interface
- https://medium.com/@lancers/websocket-api-sec-websocket-protocol-subprotocol-header-support-277e34164537
- https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.2