### PR TITLE
Dynamic “return altitude” field in GPS Rescue tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4794,7 +4794,7 @@
         "message": "The distance the aircraft will climb, above the current altitude, when a rescue is initiated and the altitude mode is set to CURRENT Altitude; also added when in MAX Altitude mode."
     },
     "failsafeGpsRescueItemReturnAltitude": {
-        "message": "Return altitude (meters) - <strong>only applies in Fixed Altitude mode</strong>"
+        "message": "Return altitude (meters)"
     },
     "failsafeGpsRescueItemAscendRate": {
         "message": "Ascend rate (meters/second)"

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -314,6 +314,18 @@ failsafe.initialize = function (callback) {
         // Sort the element, if need to group, do it by lexical sort, ie. by naming of (the translated) selection text
         $("#failsafeGpsRescueItemAltitudeSelect").sortSelect();
 
+        // Show the return altitude input if the alt mode equals to FixedAlt
+        function showReturnAlt() {
+            let altitude_number_field = $('input[name="gps_rescue_return_altitude"]').closest(".number");
+            if ($("#failsafeGpsRescueItemAltitudeSelect").val() === "1") {
+                altitude_number_field.show();
+            } else {
+                altitude_number_field.hide();
+            }
+        }
+        showReturnAlt();
+        $("#failsafeGpsRescueItemAltitudeSelect").on("change", showReturnAlt);
+
         // Introduced in 1.43
         $('input[name="gps_rescue_ascend_rate"]').val((FC.GPS_RESCUE.ascendRate / 100).toFixed(1));
         $('input[name="gps_rescue_descend_rate"]').val((FC.GPS_RESCUE.descendRate / 100).toFixed(1));


### PR DESCRIPTION
Made “return altitude” visible only when GPS rescue mode “fixed altitude” is selected. 

Removed unnecessary warning string

<img width="886" alt="alt" src="https://github.com/user-attachments/assets/39defeeb-f34b-4c32-bf8e-bca7eac6b507" />