### PR TITLE
Add 230K4 baudrate support for GPS

### DIFF
--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -6,7 +6,7 @@ import { mspHelper } from "../msp/MSPHelper";
 import FC from "../fc";
 import MSP from "../msp";
 import MSPCodes from "../msp/MSPCodes";
-import { API_VERSION_1_45 } from "../data_storage";
+import { API_VERSION_1_45, API_VERSION_1_47 } from "../data_storage";
 import $ from "jquery";
 
 const ports = {
@@ -91,6 +91,10 @@ ports.initialize = function (callback) {
         "2000000",
         "2470000",
     ];
+
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+        gpsBaudRates.push("230400");
+    }
 
     const columns = ["configuration", "peripherals", "sensors", "telemetry", "rx"];
 


### PR DESCRIPTION
- depends on https://github.com/betaflight/betaflight/pull/14192

This pull request includes an update to the `src/js/tabs/ports.js` file to support a new API version and add a new GPS baud rate if the API version is 1.47 or higher.

Key changes:

* [`src/js/tabs/ports.js`](diffhunk://#diff-836136f202be28c9ec8026e845e10a43184d86616bd3475af3ca1e4d386301a9L9-R9): Imported `API_VERSION_1_47` from `data_storage`.
* [`src/js/tabs/ports.js`](diffhunk://#diff-836136f202be28c9ec8026e845e10a43184d86616bd3475af3ca1e4d386301a9R95-R98): Added a condition to include "230400" in `gpsBaudRates` if the API version is 1.47 or higher.

![image](https://github.com/user-attachments/assets/5f2ab612-76ef-45b5-b171-73a85cc69a25)

```
GPS: connected, UART57 230400 (set to 230400), configured, version =  M10
```

- Q: Why does it show UART57 - see https://github.com/betaflight/betaflight/pull/14094
- A: Output fixed in https://github.com/betaflight/betaflight/pull/14193