### PR TITLE
Reducing the minumum mmix number of motors for the warning to appear in the "Custom Airplane" mixer

### DIFF
--- a/src/js/model.js
+++ b/src/js/model.js
@@ -26,7 +26,7 @@ export const mixerList = [
     { name: "Singlecopter", pos: 20, model: "custom", image: "custom", motors: 1, servos: true },
     { name: "A-tail Quad", pos: 21, model: "quad_atail", image: "atail_quad", motors: 4, servos: false },
     { name: "Custom", pos: 22, model: "custom", image: "custom", motors: 0, servos: false },
-    { name: "Custom Airplane", pos: 23, model: "custom", image: "custom", motors: 2, servos: true },
+    { name: "Custom Airplane", pos: 23, model: "custom", image: "custom", motors: 0, servos: true },
     { name: "Custom Tricopter", pos: 24, model: "custom", image: "custom", motors: 3, servos: true },
     { name: "Quad X 1234", pos: 25, model: "quad_x", image: "quad_x_1234", motors: 4, servos: false },
     { name: "Octo X8 +", pos: 26, model: "custom", image: "custom", motors: 8, servos: false },

--- a/src/js/model.js
+++ b/src/js/model.js
@@ -26,7 +26,7 @@ export const mixerList = [
     { name: "Singlecopter", pos: 20, model: "custom", image: "custom", motors: 1, servos: true },
     { name: "A-tail Quad", pos: 21, model: "quad_atail", image: "atail_quad", motors: 4, servos: false },
     { name: "Custom", pos: 22, model: "custom", image: "custom", motors: 0, servos: false },
-    { name: "Custom Airplane", pos: 23, model: "custom", image: "custom", motors: 0, servos: true },
+    { name: "Custom Airplane", pos: 23, model: "custom", image: "custom", motors: 1, servos: true },
     { name: "Custom Tricopter", pos: 24, model: "custom", image: "custom", motors: 3, servos: true },
     { name: "Quad X 1234", pos: 25, model: "quad_x", image: "quad_x_1234", motors: 4, servos: false },
     { name: "Octo X8 +", pos: 26, model: "custom", image: "custom", motors: 8, servos: false },


### PR DESCRIPTION
<img width="400" alt="image" src="https://github.com/user-attachments/assets/23f8512f-2b4b-4d93-9f90-a702c3a02d7a" />

I have discovered that the betaflight configurator gives a warning that I need to define 2+ motors in the “Custom Airplane” mixer mode. 

I don't think this is expected behavior, because “Custom Airplane” can sometimes have no motors at all (gliders). Given that this case is very rare, it seems to me that the number of expected motors for this mode should be set to 1, not 2.

(perhaps 0 would even be a better choice, given the fact that in “Custom Airplane” you have to define mmix/smix yourself anyway)

The earliest commit defining 2 minimum motors can be found here: https://github.com/betaflight/betaflight-configurator/commit/6b3db9e8d53762b1508f404bc77514ce251c8e31