### PR TITLE
Remove obsolete MSP

### DIFF
--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -532,7 +532,6 @@ configuration.initialize = function (callback) {
                             )
                             : Promise.resolve(true),
                     )
-                    .then(() => MSP.promise(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG)))
                     .then(() =>
                         semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)
                             ? MSP.promise(


### PR DESCRIPTION
This pull request includes a change to the `configuration.initialize` function in `src/js/tabs/configuration.js`. The change removes an unnecessary call to `MSP.promise` with `MSPCodes.MSP_SET_RX_CONFIG`.

Codebase simplification:

* [`src/js/tabs/configuration.js`](diffhunk://#diff-a1f0603f55aa34725fc1b8c9338d0f2bed6e1b5eccd55415147ace42a2376c93L535): Removed the call to `MSP.promise` with `MSPCodes.MSP_SET_RX_CONFIG` in the `configuration.initialize` function.