### PR TITLE
Disable motor stop feature when airmode is enabled

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1258,6 +1258,9 @@
     "featureMOTOR_STOP": {
         "message": "Don't spin the motors when armed"
     },
+    "featureMOTOR_STOPTip": {
+        "message": "This feature is disabled when AIRMODE is enabled"
+    },
     "featureSERVO_TILT": {
         "message": "Servo gimbal"
     },

--- a/src/css/switchery_custom.less
+++ b/src/css/switchery_custom.less
@@ -55,7 +55,7 @@
     }
 }
 .switchery-disabled {
-    opacity: 0.5;
+    opacity: 0.25;
     .switchery {
         cursor: not-allowed !important;
     }

--- a/src/css/switchery_custom.less
+++ b/src/css/switchery_custom.less
@@ -55,6 +55,8 @@
     }
 }
 .switchery-disabled {
-    pointer-events: none;
-    opacity: 0.3;
+    opacity: 0.5;
+    .switchery {
+        cursor: not-allowed !important;
+    }
 }

--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -11,7 +11,7 @@ const Features = function (config) {
         { bit: 0, group: "rxMode", mode: "select", name: "RX_PPM" },
         { bit: 2, group: "other", name: "INFLIGHT_ACC_CAL" },
         { bit: 3, group: "rxMode", mode: "select", name: "RX_SERIAL" },
-        { bit: 4, group: "escMotorStop", name: "MOTOR_STOP" },
+        { bit: 4, group: "escMotorStop", name: "MOTOR_STOP", haveTip: true },
         { bit: 5, group: "other", name: "SERVO_TILT", haveTip: true, dependsOn: "SERVOS" },
         { bit: 6, group: "other", name: "SOFTSERIAL", haveTip: true },
         { bit: 7, group: "other", name: "GPS", haveTip: true, dependsOn: "GPS" },

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -812,7 +812,10 @@ motors.initialize = async function (callback) {
             $("div.checkboxDshotBidir").toggle(digitalProtocolConfigured);
             $("div.motorPoles").toggle(protocolConfigured && rpmFeaturesVisible);
 
-            $(".escMotorStop").toggle(protocolConfigured && !FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"));
+            $(".escMotorStop")
+                .toggle(protocolConfigured)
+                .find("input#feature4")
+                .prop("disabled", FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"));
 
             $("#escProtocolDisabled").toggle(!protocolConfigured);
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -815,7 +815,12 @@ motors.initialize = async function (callback) {
             $(".escMotorStop")
                 .toggle(protocolConfigured)
                 .find("input#feature4")
-                .prop("disabled", FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"));
+                .prop(
+                    "checked",
+                    FC.FEATURE_CONFIG.features.isEnabled("MOTOR_STOP") &&
+                        !FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"),
+                )
+                .attr("disabled", FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"));
 
             $("#escProtocolDisabled").toggle(!protocolConfigured);
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -812,7 +812,7 @@ motors.initialize = async function (callback) {
             $("div.checkboxDshotBidir").toggle(digitalProtocolConfigured);
             $("div.motorPoles").toggle(protocolConfigured && rpmFeaturesVisible);
 
-            $(".escMotorStop").toggle(protocolConfigured);
+            $(".escMotorStop").toggle(protocolConfigured && !FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"));
 
             $("#escProtocolDisabled").toggle(!protocolConfigured);
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -820,7 +820,9 @@ motors.initialize = async function (callback) {
                     FC.FEATURE_CONFIG.features.isEnabled("MOTOR_STOP") &&
                         !FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"),
                 )
-                .attr("disabled", FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"));
+                .attr("disabled", FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"))
+                .parent()
+                .toggleClass("switchery-disabled", FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"));
 
             $("#escProtocolDisabled").toggle(!protocolConfigured);
 

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -815,11 +815,6 @@ motors.initialize = async function (callback) {
             $(".escMotorStop")
                 .toggle(protocolConfigured)
                 .find("input#feature4")
-                .prop(
-                    "checked",
-                    FC.FEATURE_CONFIG.features.isEnabled("MOTOR_STOP") &&
-                        !FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"),
-                )
                 .attr("disabled", FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"))
                 .parent()
                 .toggleClass("switchery-disabled", FC.FEATURE_CONFIG.features.isEnabled("AIRMODE"));


### PR DESCRIPTION
- fixes https://github.com/betaflight/betaflight/issues/14231

This pull request includes changes to the `locales/en/messages.json`, `src/js/Features.js`, and `src/js/tabs/motors.js` files to enhance the functionality and user interface related to the MOTOR_STOP feature. The most important changes include adding a tip message for the MOTOR_STOP feature, updating the feature configuration to include the tip, and modifying the motor initialization logic to handle the MOTOR_STOP feature based on the AIRMODE status.

Enhancements to MOTOR_STOP feature:

* [`locales/en/messages.json`](diffhunk://#diff-8aa9190a05814c6894dde1e917c699ad0a2951547c963586a884eefb2d918b84R1261-R1263): Added a new message for the MOTOR_STOP feature tip, indicating that the feature is disabled when AIRMODE is enabled.
* [`src/js/Features.js`](diffhunk://#diff-900c7ee221bebe38a3012205241f850d9a0c6d96d52a8f589a139dc9207e71bdL14-R14): Updated the MOTOR_STOP feature configuration to include a `haveTip` attribute, enabling the display of the tip message.
* [`src/js/tabs/motors.js`](diffhunk://#diff-bb58ef056b2205384458af9eed983bab38a4c25cb0d7fa4a5fe00091030f7b1dL815-R823): Modified the motor initialization logic to check the status of MOTOR_STOP and AIRMODE, ensuring the MOTOR_STOP feature is only enabled when AIRMODE is disabled.