### PR TITLE
modify ALTITUDE_HOLD mode verbiage

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2454,7 +2454,7 @@
         "description": "Help text to AIRMODE mode"
     },
     "auxiliaryHelpMode_ALTHOLD": {
-        "message": "<a href=\"https://betaflight.com/docs/wiki/guides/current/position-hold-v4-6#altitude-hold\">Altitude Hold</a> actively regulates the aircraft's altitude using external sensors combined with Angle Mode (Stable Mode).",
+        "message": "<a href=\"https://betaflight.com/docs/wiki/guides/current/position-hold-v4-6#altitude-hold\" target=\"_blank\" rel=\"noopener noreferrer\">Altitude Hold</a> actively regulates the aircraft's altitude using external sensors combined with Angle Mode (Stable Mode).",
         "description": "Help text for ALTITUDE HOLD mode"
     },
     "auxiliaryHelpMode_BEEPER": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2454,7 +2454,7 @@
         "description": "Help text to AIRMODE mode"
     },
     "auxiliaryHelpMode_ALTHOLD": {
-        "message": "Altitude mode is the safest non-GPS manual mode for new fliers. It is just like Stabilized mode but additionally locks the vehicle altitude when the sticks are released",
+        "message": "<a href=\"https://betaflight.com/docs/wiki/guides/current/position-hold-v4-6#altitude-hold\">Altitude Hold</a> actively regulates the aircraft's altitude using external sensors combined with Angle Mode (Stable Mode).",
         "description": "Help text for ALTITUDE HOLD mode"
     },
     "auxiliaryHelpMode_BEEPER": {


### PR DESCRIPTION
- Initially for removal of the word `vehicle` but, upon using A.I. along with personal opinions, decided to rewrite entire message including linking to the wiki.
- ![image](https://github.com/user-attachments/assets/339e0d8c-b046-4774-9423-37573b857b1c)
- "active regulation" infers rather continuous adjustments in attempt to maintain altitude rather than "locked".
