### PR TITLE
update virtualFC version and accompanying modes for modes-tab

### DIFF
--- a/src/components/port-picker/FirmwareVirtualOption.vue
+++ b/src/components/port-picker/FirmwareVirtualOption.vue
@@ -25,9 +25,6 @@ export default {
                 { value: "1.46.0", label: "MSP: 1.46 | Firmware: 4.5.*" },
                 { value: "1.45.0", label: "MSP: 1.45 | Firmware: 4.4.*" },
                 { value: "1.44.0", label: "MSP: 1.44 | Firmware: 4.3.*" },
-                { value: "1.43.0", label: "MSP: 1.43 | Firmware: 4.2.*" },
-                { value: "1.42.0", label: "MSP: 1.42 | Firmware: 4.1.*" },
-                { value: "1.41.0", label: "MSP: 1.41 | Firmware: 4.0.*" },
             ],
         };
     },

--- a/src/components/port-picker/FirmwareVirtualOption.vue
+++ b/src/components/port-picker/FirmwareVirtualOption.vue
@@ -21,6 +21,7 @@ export default {
     data() {
         return {
             firmwareVersions: [
+                { value: "1.47.0", label: "MSP: 1.47 | Firmware: 4.6.*" },
                 { value: "1.46.0", label: "MSP: 1.46 | Firmware: 4.5.*" },
                 { value: "1.45.0", label: "MSP: 1.45 | Firmware: 4.4.*" },
                 { value: "1.44.0", label: "MSP: 1.44 | Firmware: 4.3.*" },

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -2,10 +2,9 @@ import Features from "./Features";
 import { i18n } from "./localization";
 import Beepers from "./Beepers";
 import FC from "./fc";
-import CONFIGURATOR from "./data_storage";
+import CONFIGURATOR, { API_VERSION_1_47 } from "./data_storage";
 import { OSD } from "./tabs/osd";
 import semver from "semver";
-import { API_VERSION_1_47 } from "./data_storage";
 
 const VirtualFC = {
     // these values are manufactured to unlock all the functionality of the configurator, they dont represent actual hardware

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -224,6 +224,11 @@ const VirtualFC = {
             "LAP TIMER RESET",
             "CHIRP",
         ];
+    if (semver.gte(virtualFC.CONFIG.apiVersion, API_VERSION_1_47)) {
+        virtualFC.AUX_CONFIG.splice(virtualFC.AUX_CONFIG.indexOf("HORIZON") + 1, 0, "ALT_HOLD");
+        virtualFC.AUX_CONFIG.splice(virtualFC.AUX_CONFIG.indexOf("CAMSTAB") + 1, 0, "POS_HOLD");
+        virtualFC.AUX_CONFIG.push("CHIRP");
+    }
         FC.AUX_CONFIG_IDS = [
             0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 15, 17, 19, 20, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
             36, 37, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -15,7 +15,7 @@ const VirtualFC = {
         virtualFC.resetState();
         virtualFC.CONFIG.deviceIdentifier = 0;
 
-        virtualFC.CONFIG.flightControllerVersion = "4.5.0";
+        virtualFC.CONFIG.flightControllerVersion = "4.6.0";
         virtualFC.CONFIG.apiVersion = CONFIGURATOR.virtualApiVersion;
 
         virtualFC.CONFIG.cpuTemp = 48;

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -4,6 +4,8 @@ import Beepers from "./Beepers";
 import FC from "./fc";
 import CONFIGURATOR from "./data_storage";
 import { OSD } from "./tabs/osd";
+import semver from "semver";
+import { API_VERSION_1_47 } from "./data_storage";
 
 const VirtualFC = {
     // these values are manufactured to unlock all the functionality of the configurator, they dont represent actual hardware
@@ -178,13 +180,11 @@ const VirtualFC = {
             "ARM",
             "ANGLE",
             "HORIZON",
-            "ALTHOLD",
             "ANTI GRAVITY",
             "MAG",
             "HEADFREE",
             "HEADADJ",
             "CAMSTAB",
-            "POS HOLD",
             "PASSTHRU",
             "BEEPERON",
             "LEDLOW",
@@ -222,13 +222,14 @@ const VirtualFC = {
             "BEEPER MUTE",
             "READY",
             "LAP TIMER RESET",
-            "CHIRP",
         ];
-    if (semver.gte(virtualFC.CONFIG.apiVersion, API_VERSION_1_47)) {
-        virtualFC.AUX_CONFIG.splice(virtualFC.AUX_CONFIG.indexOf("HORIZON") + 1, 0, "ALT_HOLD");
-        virtualFC.AUX_CONFIG.splice(virtualFC.AUX_CONFIG.indexOf("CAMSTAB") + 1, 0, "POS_HOLD");
-        virtualFC.AUX_CONFIG.push("CHIRP");
-    }
+
+        if (semver.gte(virtualFC.CONFIG.apiVersion, API_VERSION_1_47)) {
+            virtualFC.AUX_CONFIG.splice(virtualFC.AUX_CONFIG.indexOf("HORIZON") + 1, 0, "ALT_HOLD");
+            virtualFC.AUX_CONFIG.splice(virtualFC.AUX_CONFIG.indexOf("CAMSTAB") + 1, 0, "POS_HOLD");
+            virtualFC.AUX_CONFIG.push("CHIRP");
+        }
+
         FC.AUX_CONFIG_IDS = [
             0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 15, 17, 19, 20, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
             36, 37, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -178,11 +178,13 @@ const VirtualFC = {
             "ARM",
             "ANGLE",
             "HORIZON",
+            "ALTHOLD",
             "ANTI GRAVITY",
             "MAG",
             "HEADFREE",
             "HEADADJ",
             "CAMSTAB",
+            "POS HOLD",
             "PASSTHRU",
             "BEEPERON",
             "LEDLOW",
@@ -220,10 +222,11 @@ const VirtualFC = {
             "BEEPER MUTE",
             "READY",
             "LAP TIMER RESET",
+            "CHIRP",
         ];
         FC.AUX_CONFIG_IDS = [
-            0, 1, 2, 4, 5, 6, 7, 8, 12, 13, 15, 17, 19, 20, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37,
-            39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 11, 12, 13, 15, 17, 19, 20, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35,
+            36, 37, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55,
         ];
 
         for (let i = 0; i < 16; i++) {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -16,7 +16,7 @@ const PortHandler = new (function () {
         selectedPort: DEFAULT_PORT,
         selectedBauds: DEFAULT_BAUDS,
         portOverride: getConfig("portOverride", "/dev/rfcomm0").portOverride,
-        virtualMspVersion: "1.46.0",
+        virtualMspVersion: "1.47.0",
         autoConnect: getConfig("autoConnect", false).autoConnect,
     };
 

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -48,6 +48,7 @@ export function checkChromeRuntimeError() {
 }
 
 const majorFirmwareVersions = {
+    1.47: "4.6.*",
     1.46: "4.5.*",
     1.45: "4.4.*",
     1.44: "4.3.*",

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -52,9 +52,6 @@ const majorFirmwareVersions = {
     1.46: "4.5.*",
     1.45: "4.4.*",
     1.44: "4.3.*",
-    1.43: "4.2.*",
-    1.42: "4.1.*",
-    1.41: "4.0.*",
 };
 
 export function generateVirtualApiVersions() {


### PR DESCRIPTION
This pull request introduces support for firmware version 4.6 and makes several related updates across multiple files. The key changes include adding the new firmware version to relevant lists, updating version checks, and modifying configurations.

### Firmware Version Updates:

* [`src/components/port-picker/FirmwareVirtualOption.vue`](diffhunk://#diff-cfc799aa7bfd8227eb344ce25123498ddaefac9e645fa3b71d2c868879b54d59R24): Added firmware version "1.47.0" to the `firmwareVersions` list.
* [`src/js/VirtualFC.js`](diffhunk://#diff-d1f9cc52247d9056ec75904fd55fa821d07821673f6bfc864a22f2d9c7c33242L16-R18): Updated the `flightControllerVersion` to "4.6.0" and added a check to include new AUX_CONFIG options if the API version is 1.47 or higher. [[1]](diffhunk://#diff-d1f9cc52247d9056ec75904fd55fa821d07821673f6bfc864a22f2d9c7c33242L16-R18) [[2]](diffhunk://#diff-d1f9cc52247d9056ec75904fd55fa821d07821673f6bfc864a22f2d9c7c33242R226-R235) (`ALT_HOLD`,`POS_HOLD`,`CHIRP`)
* [`src/js/port_handler.js`](diffhunk://#diff-e7cccb01fb11816d2882c88028695d4ee60691a053ef95077dd6aacb514bc707L19-R19): Updated the `virtualMspVersion` to "1.47.0".
* [`src/js/utils/common.js`](diffhunk://#diff-5953960187b347119975a18fac197a9932b5a40a2048bf5803b370814195bcedR51): Added major firmware version 1.47 with corresponding firmware "4.6.*" to the `majorFirmwareVersions` object.

### Dependency and Import Updates:

* [`src/js/VirtualFC.js`](diffhunk://#diff-d1f9cc52247d9056ec75904fd55fa821d07821673f6bfc864a22f2d9c7c33242R7-R8): Imported `semver` and `API_VERSION_1_47` to handle version checks.