### PR TITLE
Add missing tooltips (ALTHOLD, POSHOLD)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1111,6 +1111,14 @@
         "message": "Crash Flip Switch is active",
         "description": "Message that pops to describe the CRASHFLIP arming disable flag"
     },
+    "initialSetupArmingDisableFlagsTooltipALTHOLD": {
+        "message": "Altitude Hold is active",
+        "description": "Message that pops up to describe the ALTHOLD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipPOSHOLD": {
+        "message": "Position Hold is active",
+        "description": "Message that pops up to describe the POSHOLD arming disable flag"
+    },
     "initialSetupArmingDisableFlagsTooltipARM_SWITCH": {
         "message": "One of the others disarm flags is active when arming",
         "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"


### PR DESCRIPTION
This pull request includes changes to the `locales/en/messages.json` file to add new messages for arming disable flags. The most important changes include adding tooltips for Altitude Hold and Position Hold.

Localization updates:

* [`locales/en/messages.json`](diffhunk://#diff-8aa9190a05814c6894dde1e917c699ad0a2951547c963586a884eefb2d918b84R1114-R1121): Added new messages and descriptions for `initialSetupArmingDisableFlagsTooltipALTHOLD` and `initialSetupArmingDisableFlagsTooltipPOSHOLD` to describe the Altitude Hold and Position Hold arming disable flags.