### PR TITLE
Add visual info about pdop quality

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2962,6 +2962,10 @@
     "gpsPositionalDop": {
         "message": "Positional DOP:"
     },
+    "gpsMagneticDeclination": {
+        "message": "$t(configurationMagDeclination):",
+        "description": "Do not translate"
+    },
     "gpsSignalStrHead": {
         "message": "GPS Signal Strength"
     },

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1512,6 +1512,31 @@ table {
     &.ready {
         background-color: var(--success-500);
     }
+    &.ideal {
+        // should be blue
+        background-color: blue;
+    }
+    &.excellent {
+        // should be green
+        background-color: var(--success-500);
+    }
+    &.good {
+        // should be orange
+        background-color: var(--warning-500);
+    }
+    &.moderate {
+        // should be yellow
+        background-color: var(--primary-500);
+        color: black;
+    }
+    &.fair {
+        // should be red
+        background-color: var(--error-500);
+    }
+    &.poor {
+        // should be gray
+        background-color: var(--surface-500);
+    }
 }
 .buildInfoBtn {
     position: relative;

--- a/src/tabs/gps.html
+++ b/src/tabs/gps.html
@@ -103,7 +103,7 @@
                             </tr>
                             <tr>
                                 <td i18n="gpsHeading"></td>
-                                <td class="heading"><a href="#" target="_blank">0.0000 deg</a></td>
+                                <td class="heading"></td>
                             </tr>
                             <tr>
                                 <td i18n="gpsLatLon"></td>
@@ -118,7 +118,7 @@
                                 <td class="positionalDop"></td>
                             </tr>
                             <tr>
-                                <td i18n="configurationMagDeclination"></td>
+                                <td i18n="gpsMagneticDeclination"></td>
                                 <td class="magDeclination"></td>
                             </tr>
                         </table>


### PR DESCRIPTION
- resolves #4342
- fixes declination label to include `:`
- removes unused href from gpsheading

![image](https://github.com/user-attachments/assets/b2f9bd56-da0c-476c-bac3-5686397bc801)

| pdop | status | color | stars |
| ---: | --- |--- |--- |
| 0 - 1 | ideal | blue | ★★★★★ |
| 1 - 2 | excellent | green | ★★★★☆ |
| 2 - 5 | good | orange | ★★★☆☆ |
| 5 - 10 | moderate | yellow | ★★☆☆☆ |
| 10 - 20 | fair | red | ★☆☆☆☆ |
| 20 - 100 | poor | gray | ☆☆☆☆☆ |

- reference: https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)

![image](https://github.com/user-attachments/assets/d591d942-479e-411b-8ed8-bfad5b07798f)
