### PR TITLE
Update latlon

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2957,9 +2957,13 @@
     "gpsAltitude": {
         "message": "Altitude:"
     },
-    "gpsLatLon": {
-        "message": "Current Latitude / Longitude:",
-        "description": "Show GPS position - Latitude / Longitude"
+    "gpsLatitude": {
+        "message": "Latitude:",
+        "description": "Show GPS position - Latitude"
+    },
+    "gpsLongitude": {
+        "message": "Longitude:",
+        "description": "Show GPS position - Longitude"
     },
     "gpsHeading": {
         "message": "Heading IMU / GPS:",

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -321,8 +321,8 @@ const VirtualFC = {
 const sampleGpsData = {
     fix: 2,
     numSat: 10,
-    lat: 474919409,
-    lon: 190539766,
+    latitude: 474919409,
+    longitude: 190539766,
     alt: 0,
     speed: 0,
     ground_course: 1337,

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -342,8 +342,8 @@ const FC = {
         this.GPS_DATA = {
             fix: 0,
             numSat: 0,
-            lat: 0,
-            lon: 0,
+            latitude: 0,
+            longitude: 0,
             alt: 0,
             speed: 0,
             ground_course: 0,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -309,8 +309,8 @@ MspHelper.prototype.process_data = function (dataHandler) {
                 case MSPCodes.MSP_RAW_GPS:
                     FC.GPS_DATA.fix = data.readU8();
                     FC.GPS_DATA.numSat = data.readU8();
-                    FC.GPS_DATA.lat = data.read32();
-                    FC.GPS_DATA.lon = data.read32();
+                    FC.GPS_DATA.latitude = data.read32();
+                    FC.GPS_DATA.longitude = data.read32();
                     FC.GPS_DATA.alt = data.readU16();
                     FC.GPS_DATA.speed = data.readU16();
                     FC.GPS_DATA.ground_course = data.readU16();

--- a/src/js/tabs/gps.js
+++ b/src/js/tabs/gps.js
@@ -334,9 +334,9 @@ gps.initialize = async function (callback) {
         }
 
         function update_ui() {
-            const lat = FC.GPS_DATA.lat / 10000000;
-            const lon = FC.GPS_DATA.lon / 10000000;
-            const url = `https://maps.google.com/?q=${lat},${lon}`;
+            const latitude = FC.GPS_DATA.latitude / 10000000;
+            const longitude = FC.GPS_DATA.longitude / 10000000;
+            const url = `https://maps.google.com/?q=${latitude},${longitude}`;
             const imuHeadingDegrees = FC.SENSOR_DATA.kinematics[2];
             // Convert to radians and add 180 degrees to make icon point in the right direction
             const imuHeadingRadians = ((imuHeadingDegrees + 180) * Math.PI) / 180;
@@ -353,9 +353,12 @@ gps.initialize = async function (callback) {
 
             const gpsUnitText = i18n.getMessage("gpsPositionUnit");
             $(".GPS_info td.alt").text(`${alt} m`);
-            $(".GPS_info td.latLon a")
+            $(".GPS_info td.latitude a")
                 .prop("href", url)
-                .text(`${lat.toFixed(6)} / ${lon.toFixed(6)} ${gpsUnitText}`);
+                .text(`${latitude.toFixed(6)} ${gpsUnitText}`);
+            $(".GPS_info td.longitude a")
+                .prop("href", url)
+                .text(`${longitude.toFixed(6)} ${gpsUnitText}`);
             $(".GPS_info td.heading").text(`${imuHeadingDegrees.toFixed(0)} / ${gpsHeading.toFixed(0)} ${gpsUnitText}`);
             $(".GPS_info td.speed").text(`${FC.GPS_DATA.speed} cm/s`);
             $(".GPS_info td.sats").text(FC.GPS_DATA.numSat);
@@ -384,12 +387,12 @@ gps.initialize = async function (callback) {
             if (ispConnected()) {
                 $("#connect").hide();
 
-                gpsFoundPosition = !!(lon && lat);
+                gpsFoundPosition = !!(longitude && latitude);
 
                 if (gpsFoundPosition) {
                     (hasMag ? iconStyleMag : iconStyleGPS).getImage().setRotation(imuHeadingRadians);
                     iconFeature.setStyle(hasMag ? iconStyleMag : iconStyleGPS);
-                    const center = fromLonLat([lon, lat]);
+                    const center = fromLonLat([longitude, latitude]);
                     mapView.setCenter(center);
                     iconGeometry.setCoordinates(center);
                 } else {

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -524,13 +524,16 @@ setup.initialize = function (callback) {
             gpsFix_e.toggleClass("ready", FC.GPS_DATA.fix != 0);
             gpsSats_e.text(FC.GPS_DATA.numSat);
 
-            const lat = FC.GPS_DATA.lat / 10000000;
-            const lon = FC.GPS_DATA.lon / 10000000;
-            const url = `https://maps.google.com/?q=${lat},${lon}`;
+            const latitude = FC.GPS_DATA.latitude / 10000000;
+            const longitude = FC.GPS_DATA.longitude / 10000000;
+            const url = `https://maps.google.com/?q=${latitude},${longitude}`;
             const gpsUnitText = i18n.getMessage("gpsPositionUnit");
-            $(".GPS_info td.latLon a")
+            $(".GPS_info td.latitude a")
                 .prop("href", url)
-                .text(`${lat.toFixed(4)} / ${lon.toFixed(4)} ${gpsUnitText}`);
+                .text(`${latitude.toFixed(4)} ${gpsUnitText}`);
+            $(".GPS_info td.longitude a")
+                .prop("href", url)
+                .text(`${longitude.toFixed(4)} ${gpsUnitText}`);
         }
 
         function get_fast_data() {

--- a/src/tabs/gps.html
+++ b/src/tabs/gps.html
@@ -114,8 +114,12 @@
                                 <td class="heading"></td>
                             </tr>
                             <tr>
-                                <td i18n="gpsLatLon"></td>
-                                <td class="latLon"><a href="#" target="_blank">0.0000 deg</a></td>
+                                <td i18n="gpsLatitude"></td>
+                                <td class="latitude"><a href="#" target="_blank">0.0000 deg</a></td>
+                            </tr>
+                            <tr>
+                                <td i18n="gpsLongitude"></td>
+                                <td class="longitude"><a href="#" target="_blank">0.0000 deg</a></td>
                             </tr>
                             <tr>
                                 <td i18n="gpsDistToHome"></td>

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -112,9 +112,12 @@
                                 <td class="gpsSats"></td>
                             </tr>
                             <tr>
-                                <td i18n="gpsLatLon"></td>
-                                <td class="latLon"><a href="#" target="_blank">0.0000 deg</a></td>
+                                <td i18n="gpsLatitude"></td>
+                                <td class="latitude"><a href="#" target="_blank">0.0000 deg</a></td>
                             </tr>
+                            <tr>
+                                <td i18n="gpsLongitude"></td>
+                                <td class="longitude"><a href="#" target="_blank">0.0000 deg</a></td>
                             </tbody>
                         </table>
                     </div>

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -118,6 +118,7 @@
                             <tr>
                                 <td i18n="gpsLongitude"></td>
                                 <td class="longitude"><a href="#" target="_blank">0.0000 deg</a></td>
+                            </tr>
                             </tbody>
                         </table>
                     </div>


### PR DESCRIPTION
- resolves #4348

This pull request includes changes to the GPS data handling and display, specifically separating the latitude and longitude into distinct fields. The changes are made across multiple files to ensure consistency in the codebase.

Changes to GPS data handling and display:

* [`locales/en/messages.json`](diffhunk://#diff-8aa9190a05814c6894dde1e917c699ad0a2951547c963586a884eefb2d918b84L2956-R2962): Separated the GPS latitude and longitude messages into individual fields.

* [`src/js/fc.js`](diffhunk://#diff-def74802211e42c4104393c1b631cc4a3d0d80697e526f35428e33980dcbabfdL344-R345): Updated the `GPS_DATA` object to use `latitude` and `longitude` instead of `lat` and `lon`.

* [`src/js/msp/MSPHelper.js`](diffhunk://#diff-2a7a24b74c7564918c438782f9a53a977205c0c79fd016a069b6dca546563adfL312-R313): Modified the `process_data` function to read `latitude` and `longitude` instead of `lat` and `lon`.

* [`src/js/tabs/gps.js`](diffhunk://#diff-83e7d8c9c01eecddf9a16b1285ba83ec8bc9754210885ddafb1e62d128fdedb4L337-R339): Updated the `initialize` function to handle `latitude` and `longitude` separately, including changes to the UI updates and map centering logic. [[1]](diffhunk://#diff-83e7d8c9c01eecddf9a16b1285ba83ec8bc9754210885ddafb1e62d128fdedb4L337-R339) [[2]](diffhunk://#diff-83e7d8c9c01eecddf9a16b1285ba83ec8bc9754210885ddafb1e62d128fdedb4L356-R361) [[3]](diffhunk://#diff-83e7d8c9c01eecddf9a16b1285ba83ec8bc9754210885ddafb1e62d128fdedb4L387-R395)

* [`src/js/tabs/setup.js`](diffhunk://#diff-fbcf931acee85a530dc7a58d7e11b809d249b2747c9b7dad5f0eff3db2bf99b5L527-R536): Adjusted the `initialize` function to update the display and URL generation for `latitude` and `longitude` separately.

* [`src/tabs/gps.html`](diffhunk://#diff-8a6c9a1f7ddcd6dabbcbab07b51b106c91da665d29f046ba3ee39c14cf3bd470L117-R122): Split the GPS position display into separate rows for latitude and longitude.

* [`src/tabs/setup.html`](diffhunk://#diff-47913d2805132befd6c52b3d687cf4f9fcf449e9da7a8bb793e9d51f6992550dL115-R120): Similarly, split the GPS position display into separate rows for latitude and longitude.