### PR TITLE
Fixed collapsed sidebar

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1921,21 +1921,13 @@ each(range(12), {
     #tabs {
         li {
             a {
-                font-weight: normal;
-                font-size: 12px;
-                padding-left: 60px;
                 padding-top: 6px;
-                padding-bottom: 2px;
-                content: "";
-                transition: none;
-                text-overflow: clip;
-                white-space: nowrap;
-                overflow: hidden;
+                padding-bottom: 6px;
+            }
+            ::before {
+                padding-left: 22px;
             }
         }
-    }
-    .tab_container {
-        width: 42px;
     }
     #content {
         width: calc(100% - 42px);

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -655,7 +655,16 @@ input[type="number"] {
     padding: 1rem;
     padding-right: 0.5rem;
     background-color: var(--surface-100);
+
+    &::-webkit-scrollbar {
+        width: 0.3rem;
+        height: 2em;
+    }
+    &::-webkit-scrollbar-thumb {
+        background: var(--surface-600);
+    }
 }
+
 #content {
     transition: all 0.2s;
     overflow-x: hidden;
@@ -760,8 +769,8 @@ each(@tabIcons, {
     .ic_@{key} {
         &::before {
             content: " ";
-            width: 1rem;
-            height: 1rem;
+            min-width: 1rem;
+            min-height: 1rem;
             mask: @value no-repeat center center;
             -webkit-mask: @value no-repeat center center;
             background-color: var(--surface-700);
@@ -1834,13 +1843,13 @@ each(range(12), {
         overflow-y: auto;
     }
 }
-@media only screen and (max-device-height: 750px) {
+@media (max-height: 750px) {
     .tab_container {
         overflow-x: hidden;
         overflow-y: auto;
     }
 }
-@media only screen and (max-width: 1055px) {
+@media (max-width: 1055px) {
     #tabs {
         li {
             a {
@@ -1917,7 +1926,7 @@ each(range(12), {
         }
     }
 }
-@media only screen and (max-device-width: 1055px) {
+@media (max-width: 1055px) {
     #tabs {
         li {
             a {
@@ -1925,7 +1934,7 @@ each(range(12), {
                 padding-bottom: 6px;
             }
             ::before {
-                padding-left: 22px;
+                padding-left: 3px;
             }
         }
     }


### PR DESCRIPTION
Fixed the icons not properly displaying when the sidebar is collapsed (when viewed on a smaller screen).

**Before:**
<img src="https://github.com/user-attachments/assets/e9f0ffa2-3f3d-4e59-88a4-40e580b68042" height="400px" />

**After:**
<img src="https://github.com/user-attachments/assets/fc1b460c-2269-4950-b0ec-e228dca1cdc2" height="400px" />
