### PR TITLE
Add info overlay about gyro status over model view

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7618,5 +7618,17 @@
     "programmingFailedNotification": {
         "message": "FC programming failed",
         "description": "Notification message when programming is unsuccessful"
+    },
+    "accCalibratingMessageText": {
+        "message": "Calibrating accelerometer"
+    },
+    "accCalibratingDescriptionText": {
+        "message": "Place the drone on a flat surface and wait for the calibration to complete."
+    },
+    "gyroErroredText": {
+        "message": "No Gyro"
+    },
+    "gyroErroredDescriptionText": {
+        "message": "Gyro has not been detected."
     }
 }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1823,6 +1823,9 @@ each(range(12), {
         shape-rendering: crispEdges;
     }
 }
+.blur {
+    filter: blur(3px);
+}
 @media not all and (max-width: 575px) {
     .visible-on-phone-only {
         display: none !important;

--- a/src/css/tabs/setup.less
+++ b/src/css/tabs/setup.less
@@ -167,3 +167,21 @@
 .disarm-flag {
     padding-left: 5px;
 }
+
+#model-and-info-container {
+    position: relative;
+
+    .overlay-status {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        z-index: 1;
+        text-align: center;
+
+        .status-message {
+            font-weight: bold;
+            font-size: 2.1rem;
+        }
+    }
+}

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -70,21 +70,29 @@
         <div class="modelwrapper"></div>
         <div class="grid-row grid-box col4">
             <div class="col-span-3 model-and-info">
-                <div id="interactive_block">
-                    <div id="canvas_wrapper" class="background_paper">
-                        <canvas id="canvas"></canvas>
-                        <div class="attitude_info">
-                            <dl>
-                                <dt i18n="initialSetupHeading"></dt>
-                                <dd class="heading">&nbsp;</dd>
-                                <dt i18n="initialSetupPitch"></dt>
-                                <dd class="pitch">&nbsp;</dd>
-                                <dt i18n="initialSetupRoll"></dt>
-                                <dd class="roll">&nbsp;</dd>
-                            </dl>
-                        </div>
+                <div id="model-and-info-container">
+                    <div class="overlay-status">
+                        <p class="status-message"
+                            i18n="accCalibratingMessageText"></p>
+                        <p class="status-description"
+                            i18n="accCalibratingDescriptionText"></p>
                     </div>
-                    <a class="reset sm-min" href="#" i18n="initialSetupButtonResetZaxis"></a>
+                    <div id="interactive_block">
+                        <div id="canvas_wrapper" class="background_paper">
+                            <canvas id="canvas"></canvas>
+                            <div class="attitude_info">
+                                <dl>
+                                    <dt i18n="initialSetupHeading"></dt>
+                                    <dd class="heading">&nbsp;</dd>
+                                    <dt i18n="initialSetupPitch"></dt>
+                                    <dd class="pitch">&nbsp;</dd>
+                                    <dt i18n="initialSetupRoll"></dt>
+                                    <dd class="roll">&nbsp;</dd>
+                                </dl>
+                            </div>
+                        </div>
+                        <a class="reset sm-min" href="#" i18n="initialSetupButtonResetZaxis"></a>
+                    </div>
                 </div>
             </div>
             <div class="col-span-1 grid-box col1">


### PR DESCRIPTION
Many people don't realised about the arming flags, this PR aims to make more clear the arming flags related to the gyro status.

It read the arming flag about NO-GYRO and CALIBRATION to overlay on the model view a message informing about the status.

** Please feel free to update or suggest changes about the implementation as FE is not my strongest tech skill.

### Demo
https://github.com/user-attachments/assets/a52dd792-e2a2-49fd-bd35-73cf7e889072


### Gyro calibrating
![calib](https://github.com/user-attachments/assets/1442a229-c3b8-4d9a-8d63-ea784f3e3129)


### No Gyro
![nogyro](https://github.com/user-attachments/assets/5267c59d-adb8-4039-b52c-4f9e8aa3f178)

