### PR TITLE
Make backup on flash an option

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3824,6 +3824,31 @@
     "unstableFirmwareAcknowledgementFlash": {
         "message": "Flash"
     },
+    "firmwareFlasherRemindBackupTitle": {
+        "message": "Wipe out settings",
+        "description": "Warning message title before actual flashing takes place"
+    },
+    "firmwareFlasherRemindBackup": {
+        "message": "Flashing new firmware will wipe out all settings. We strongly recommend to save a backup before continuing.",
+        "description": "Warning message before actual flashing takes place"
+    },
+    "firmwareFlasherBackup": {
+        "message": "Create Backup",
+        "description": "Create a backup before actual flashing takes place"
+    },
+    "firmwareFlasherBackupIgnore": {
+        "message": "Ignore the risk",
+        "description": "Ignore creating a backup before actual flashing takes place"
+    },
+    "firmwareBackupEnabled": {
+        "message": "Backup enabled"
+    },
+    "firmwareBackupDisabled": {
+        "message": "Backup disabled"
+    },
+    "firmwareBackupAsk": {
+        "message": "Ask before backup"
+    },
     "ledStripHelp": {
         "message": "The flight controller can control colors and effects of individual LEDs on a strip.<br />Configure LEDs on the grid, configure wiring order then attach LEDs on your aircraft according to grid positions. LEDs without wire ordering number will not be saved.<br />Double-click on a color to edit the HSV values."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -56,9 +56,6 @@
     "storageDeviceNotReady": {
         "message": "The storage device is not ready. In the case of a microSD card, make sure it is properly recognised by your flight controller."
     },
-    "options_title": {
-        "message": "Application Options"
-    },
     "connect": {
         "message": "Connect"
     },
@@ -3827,25 +3824,6 @@
     "unstableFirmwareAcknowledgementFlash": {
         "message": "Flash"
     },
-    "firmwareFlasherPreviousDevice": {
-        "message": "Detected: <strong>$1</strong> - previous device still flashing, please replug to try again"
-    },
-    "firmwareFlasherRemindBackupTitle": {
-        "message": "Wipe out settings",
-        "description": "Warning message title before actual flashing takes place"
-    },
-    "firmwareFlasherRemindBackup": {
-        "message": "Flashing new firmware will wipe out all settings. We strongly recommend to save a backup before continuing.",
-        "description": "Warning message before actual flashing takes place"
-    },
-    "firmwareFlasherBackup": {
-        "message": "Create Backup",
-        "description": "Create a backup before actual flashing takes place"
-    },
-    "firmwareFlasherBackupIgnore": {
-        "message": "Ignore the risk",
-        "description": "Ignore creating a backup before actual flashing takes place"
-    },
     "ledStripHelp": {
         "message": "The flight controller can control colors and effects of individual LEDs on a strip.<br />Configure LEDs on the grid, configure wiring order then attach LEDs on your aircraft according to grid positions. LEDs without wire ordering number will not be saved.<br />Double-click on a color to edit the HSV values."
     },
@@ -7169,6 +7147,9 @@
     },
     "cliAutoComplete": {
         "message": "Advanced CLI AutoComplete"
+    },
+    "firmwareBackupOnFlash": {
+        "message": "Create a backup before flashing new target"
     },
     "darkTheme": {
         "message": "Enable dark theme"

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -19,6 +19,10 @@ class FileSystem {
             ],
         });
 
+        if (!fileHandle) {
+            return null;
+        }
+
         const file = this._createFile(fileHandle);
 
         if (await this.verifyPermission(file, true)) {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -62,7 +62,9 @@ function cleanupLocalStorage() {
     }
 
     setConfig({ erase_chip: true }); // force erase chip on first run
-    setConfig({ backupOnFlash: true }); // force backup on flash on first run
+    if (getConfig("backupOnFlash") === undefined) {
+        setConfig({ backupOnFlash: "1" }); // force backup on flash on first run
+    }
 }
 
 function appReady() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -62,9 +62,6 @@ function cleanupLocalStorage() {
     }
 
     setConfig({ erase_chip: true }); // force erase chip on first run
-    if (getConfig("backupOnFlash") === undefined) {
-        setConfig({ backupOnFlash: 1 }); // no dialog by default
-    }
 }
 
 function appReady() {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -63,7 +63,7 @@ function cleanupLocalStorage() {
 
     setConfig({ erase_chip: true }); // force erase chip on first run
     if (getConfig("backupOnFlash") === undefined) {
-        setConfig({ backupOnFlash: "1" }); // force backup on flash on first run
+        setConfig({ backupOnFlash: 2 }); // use dialog by default
     }
 }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -63,7 +63,7 @@ function cleanupLocalStorage() {
 
     setConfig({ erase_chip: true }); // force erase chip on first run
     if (getConfig("backupOnFlash") === undefined) {
-        setConfig({ backupOnFlash: 2 }); // use dialog by default
+        setConfig({ backupOnFlash: 1 }); // no dialog by default
     }
 }
 

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -62,6 +62,7 @@ function cleanupLocalStorage() {
     }
 
     setConfig({ erase_chip: true }); // force erase chip on first run
+    setConfig({ backupOnFlash: true }); // force backup on flash on first run
 }
 
 function appReady() {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1107,26 +1107,17 @@ firmware_flasher.initialize = function (callback) {
                 }
             }
 
-            // Backup not available in DFU, manual or virtual mode.
-            // When flash on connect is enabled, the backup dialog is not shown.
-            if (isFlashOnConnect || !(PortHandler.portAvailable || GUI.connect_lock)) {
+            // Backup not available in DFU, manual, virtual mode or when using flash on connect            const backupOnFlash = getConfig("backupOnFlash");
+            const noPortOrLock = !PortHandler.portAvailable && !GUI.connect_lock;
+            const backupOnFlash = getConfig("backupOnFlash").backupOnFlash;
+            if (isFlashOnConnect || !backupOnFlash || noPortOrLock) {
                 initiateFlashing();
             } else {
-                GUI.showYesNoDialog({
-                    title: i18n.getMessage("firmwareFlasherRemindBackupTitle"),
-                    text: i18n.getMessage("firmwareFlasherRemindBackup"),
-                    buttonYesText: i18n.getMessage("firmwareFlasherBackup"),
-                    buttonNoText: i18n.getMessage("firmwareFlasherBackupIgnore"),
-                    buttonYesCallback: () => {
-                        // prevent connection while backup is in progress
-                        GUI.connect_lock = true;
-                        AutoBackup.execute(() => {
-                            GUI.connect_lock = false;
-                            initiateFlashing();
-                        });
-                    },
-
-                    buttonNoCallback: initiateFlashing,
+                // prevent connection while backup is in progress
+                GUI.connect_lock = true;
+                AutoBackup.execute(() => {
+                    GUI.connect_lock = false;
+                    initiateFlashing();
                 });
             }
         });

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1124,7 +1124,7 @@ firmware_flasher.initialize = function (callback) {
             // 1: backup without dialog
             // 2: backup with dialog
 
-            const backupOnFlash = getConfig("backupOnFlash").backupOnFlash;
+            const backupOnFlash = getConfig("backupOnFlash", 1).backupOnFlash;
 
             switch (backupOnFlash) {
                 case 1:

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1089,83 +1089,33 @@ firmware_flasher.initialize = function (callback) {
             setTimeout(() => detectBoardElement.toggleClass("disabled", false), 2000);
         });
 
-        $("a.flash_firmware").on("click", function () {
-            if (GUI.connect_lock) {
-                return;
-            }
-
-            self.isFlashing = true;
-            GUI.interval_pause("sponsor");
-
-            self.enableFlashButton(false);
-            self.enableDfuExitButton(false);
-            self.enableLoadRemoteFileButton(false);
-            self.enableLoadFileButton(false);
-
-            const isFlashOnConnect = $("input.flash_on_connect").is(":checked");
-
-            if (isFlashOnConnect || !PortHandler.portAvailable) {
+        function initiateFlashing() {
+            if (self.developmentFirmwareLoaded) {
+                checkShowAcknowledgementDialog();
+            } else {
                 startFlashing();
-                return;
             }
+        }
 
-            function initiateFlashing() {
-                if (self.developmentFirmwareLoaded) {
-                    checkShowAcknowledgementDialog();
+        // Backup not available in DFU, manual, virtual mode or when using flash on connect
+
+        function startBackup(callback) {
+            // prevent connection while backup is in progress
+            GUI.connect_lock = true;
+            AutoBackup.execute((result) => {
+                GUI.connect_lock = false;
+                if (result) {
+                    callback();
                 } else {
-                    startFlashing();
+                    self.isFlashing = false;
+                    self.enableFlashButton(true);
+                    self.enableLoadRemoteFileButton(true);
+                    self.enableLoadFileButton(true);
+                    GUI.interval_resume("sponsor");
+                    console.log(`${self.logHead} Backup failed, skipping flashing`);
                 }
-            }
-
-            // Backup not available in DFU, manual, virtual mode or when using flash on connect
-
-            function startBackup(callback) {
-                // prevent connection while backup is in progress
-                GUI.connect_lock = true;
-                AutoBackup.execute((result) => {
-                    GUI.connect_lock = false;
-                    if (result === false) {
-                        self.isFlashing = false;
-                        self.enableFlashButton(true);
-                        self.enableLoadRemoteFileButton(true);
-                        self.enableLoadFileButton(true);
-                        GUI.interval_resume("sponsor");
-                        console.log(`${self.logHead} Backup failed, skipping flashing`);
-                    } else {
-                        callback();
-                    }
-                });
-            }
-
-            // backupOnFlash:
-            // 0: disabled (default)
-            // 1: backup without dialog
-            // 2: backup with dialog
-
-            const backupOnFlash = getConfig("backupOnFlash", 1).backupOnFlash;
-
-            switch (backupOnFlash) {
-                case 1:
-                    // prevent connection while backup is in progress
-                    startBackup(initiateFlashing);
-                    break;
-                case 2:
-                    GUI.showYesNoDialog({
-                        title: i18n.getMessage("firmwareFlasherRemindBackupTitle"),
-                        text: i18n.getMessage("firmwareFlasherRemindBackup"),
-                        buttonYesText: i18n.getMessage("firmwareFlasherBackup"),
-                        buttonNoText: i18n.getMessage("firmwareFlasherBackupIgnore"),
-                        buttonYesCallback: () => {
-                            startBackup(initiateFlashing);
-                        },
-                        buttonNoCallback: initiateFlashing,
-                    });
-                    break;
-                default:
-                    initiateFlashing();
-                    break;
-            }
-        });
+            });
+        }
 
         function checkShowAcknowledgementDialog() {
             const DAY_MS = 86400 * 1000;
@@ -1251,6 +1201,56 @@ firmware_flasher.initialize = function (callback) {
                 }
             }
         }
+
+        $("a.flash_firmware").on("click", function () {
+            if (GUI.connect_lock) {
+                return;
+            }
+
+            self.isFlashing = true;
+            GUI.interval_pause("sponsor");
+
+            self.enableFlashButton(false);
+            self.enableDfuExitButton(false);
+            self.enableLoadRemoteFileButton(false);
+            self.enableLoadFileButton(false);
+
+            const isFlashOnConnect = $("input.flash_on_connect").is(":checked");
+
+            if (isFlashOnConnect || !PortHandler.portAvailable) {
+                startFlashing();
+                return;
+            }
+
+            // backupOnFlash:
+            // 0: disabled (default)
+            // 1: backup without dialog
+            // 2: backup with dialog
+
+            const backupOnFlash = getConfig("backupOnFlash", 1).backupOnFlash;
+
+            switch (backupOnFlash) {
+                case 1:
+                    // prevent connection while backup is in progress
+                    startBackup(initiateFlashing);
+                    break;
+                case 2:
+                    GUI.showYesNoDialog({
+                        title: i18n.getMessage("firmwareFlasherRemindBackupTitle"),
+                        text: i18n.getMessage("firmwareFlasherRemindBackup"),
+                        buttonYesText: i18n.getMessage("firmwareFlasherBackup"),
+                        buttonNoText: i18n.getMessage("firmwareFlasherBackupIgnore"),
+                        buttonYesCallback: () => {
+                            startBackup(initiateFlashing);
+                        },
+                        buttonNoCallback: initiateFlashing,
+                    });
+                    break;
+                default:
+                    initiateFlashing();
+                    break;
+            }
+        });
 
         $("span.progressLabel").on("click", "a.save_firmware", function () {
             FileSystem.pickSaveFile(

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -258,7 +258,8 @@ options.initMeteredConnection = function () {
 };
 
 options.initBackupOnFlash = function () {
-    const result = getConfig("backupOnFlash");
+    // default to always backup on flash
+    const result = getConfig("backupOnFlash", 1);
     $("#backupOnFlashSelect").val(result.backupOnFlash);
     $("#backupOnFlashSelect")
         .on("change", function () {

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -259,10 +259,13 @@ options.initMeteredConnection = function () {
 
 options.initBackupOnFlash = function () {
     const result = getConfig("backupOnFlash");
-    $("div.backupOnFlash input")
-        .prop("checked", !!result.backupOnFlash)
+    console.log(result.backupOnFlash);
+    $("#backupOnFlashSelect")
+        .val(result.backupOnFlash)
         .on("change", function () {
-            setConfig({ backupOnFlash: $(this).is(":checked") });
+            const value = parseInt($(this).val());
+
+            setConfig({ backupOnFlash: value });
         })
         .trigger("change");
 };

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -258,7 +258,7 @@ options.initMeteredConnection = function () {
 };
 
 options.initBackupOnFlash = function () {
-    const result = getConfig("backupOnFlash", true);
+    const result = getConfig("backupOnFlash");
     $("div.backupOnFlash input")
         .prop("checked", !!result.backupOnFlash)
         .on("change", function () {

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -259,7 +259,6 @@ options.initMeteredConnection = function () {
 
 options.initBackupOnFlash = function () {
     const result = getConfig("backupOnFlash");
-    console.log(result.backupOnFlash);
     $("#backupOnFlashSelect").val(result.backupOnFlash);
     $("#backupOnFlashSelect")
         .on("change", function () {

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -34,6 +34,7 @@ options.initialize = function (callback) {
         TABS.options.initUserLanguage();
         TABS.options.initShowWarnings();
         TABS.options.initMeteredConnection();
+        TABS.options.initBackupOnFlash();
 
         GUI.content_ready(callback);
     });
@@ -252,6 +253,16 @@ options.initMeteredConnection = function () {
             setConfig({ meteredConnection: $(this).is(":checked") });
             // update network status
             ispConnected();
+        })
+        .trigger("change");
+};
+
+options.initBackupOnFlash = function () {
+    const result = getConfig("backupOnFlash", true);
+    $("div.backupOnFlash input")
+        .prop("checked", !!result.backupOnFlash)
+        .on("change", function () {
+            setConfig({ backupOnFlash: $(this).is(":checked") });
         })
         .trigger("change");
 };

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -260,8 +260,8 @@ options.initMeteredConnection = function () {
 options.initBackupOnFlash = function () {
     const result = getConfig("backupOnFlash");
     console.log(result.backupOnFlash);
+    $("#backupOnFlashSelect").val(result.backupOnFlash);
     $("#backupOnFlashSelect")
-        .val(result.backupOnFlash)
         .on("change", function () {
             const value = parseInt($(this).val());
 

--- a/src/js/utils/AutoBackup.js
+++ b/src/js/utils/AutoBackup.js
@@ -105,7 +105,7 @@ class AutoBackup {
             setTimeout(() => {
                 this.outputHistory = "";
                 resolve();
-            }, 500);
+            }, 1000);
         });
     }
 

--- a/src/js/utils/AutoBackup.js
+++ b/src/js/utils/AutoBackup.js
@@ -58,26 +58,25 @@ class AutoBackup {
         const filename = generateFilename(prefix, suffix);
         let result = false;
 
-        FileSystem.pickSaveFile(
-            filename,
-            i18n.getMessage("fileSystemPickerFiles", { typeof: suffix.toUpperCase() }),
-            `.${suffix}`,
-        )
-            .then((file) => {
-                if (file) {
-                    console.log("Saving config to:", file.name);
-                    FileSystem.writeFile(file, data);
-                    result = true;
-                }
-            })
-            .catch((error) => {
-                console.error("Error saving config:", error);
-            })
-            .finally(() => {
-                if (this.callback) {
-                    this.callback(result);
-                }
-            });
+        try {
+            const file = await FileSystem.pickSaveFile(
+                filename,
+                i18n.getMessage("fileSystemPickerFiles", { typeof: suffix.toUpperCase() }),
+                `.${suffix}`,
+            );
+
+            if (file) {
+                console.log("Saving config to:", file.name);
+                await FileSystem.writeFile(file, data);
+                result = true;
+            }
+        } catch (error) {
+            console.error("Error saving config:", error);
+        } finally {
+            if (this.callback) {
+                this.callback(result);
+            }
+        }
     }
 
     async run() {

--- a/src/js/utils/AutoBackup.js
+++ b/src/js/utils/AutoBackup.js
@@ -56,6 +56,7 @@ class AutoBackup {
         const prefix = "cli_backup";
         const suffix = "txt";
         const filename = generateFilename(prefix, suffix);
+        let result = false;
 
         FileSystem.pickSaveFile(
             filename,
@@ -63,15 +64,18 @@ class AutoBackup {
             `.${suffix}`,
         )
             .then((file) => {
-                console.log("Saving config to:", file.name);
-                FileSystem.writeFile(file, data);
+                if (file) {
+                    console.log("Saving config to:", file.name);
+                    FileSystem.writeFile(file, data);
+                    result = true;
+                }
             })
             .catch((error) => {
                 console.error("Error saving config:", error);
             })
             .finally(() => {
                 if (this.callback) {
-                    this.callback();
+                    this.callback(result);
                 }
             });
     }

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -36,12 +36,6 @@
                     </div>
                     <span class="freelabel" i18n="cliAutoComplete"></span>
                 </div>
-                <div class="backupOnFlash margin-bottom">
-                    <div>
-                        <input type="checkbox" class="toggle" />
-                    </div>
-                    <span class="freelabel" i18n="firmwareBackupOnFlash"></span>
-                </div>
                 <div class="showAllSerialDevices margin-bottom">
                     <div>
                         <input type="checkbox" class="toggle" />
@@ -93,6 +87,14 @@
                         <input type="checkbox" class="toggle" />
                     </div>
                     <span class="freelabel" i18n="showNotifications"></span>
+                </div>
+                <div class="backupOnFlash margin-bottom">
+                    <select id="backupOnFlashSelect">
+                        <option value="0" i18n="firmwareBackupDisabled"></option>
+                        <option value="1" i18n="firmwareBackupEnabled"></option>
+                        <option value="2" i18n="firmwareBackupAsk"></option>
+                    </select>
+                    <span class="freelabel" i18n="firmwareBackupOnFlash"></span>
                 </div>
                 <div class="userLanguage">
                     <span class="dropdown">

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -36,6 +36,12 @@
                     </div>
                     <span class="freelabel" i18n="cliAutoComplete"></span>
                 </div>
+                <div class="backupOnFlash margin-bottom">
+                    <div>
+                        <input type="checkbox" class="toggle" />
+                    </div>
+                    <span class="freelabel" i18n="firmwareBackupOnFlash"></span>
+                </div>
                 <div class="showAllSerialDevices margin-bottom">
                     <div>
                         <input type="checkbox" class="toggle" />


### PR DESCRIPTION
- adds option for backup during flashing (disabled, enabled, ask)
- enabled is default
- add error handling in filesystem API if there is no file handler available
- add error handling for backup process
- increase timeout to enter cli for backup command to reduce corruption of resulting config
- remove some unused messages
- fix parameter for i18n message
- refactor to make sonar happy

![image](https://github.com/user-attachments/assets/5686720f-3951-45d6-9080-3e03076579e4)
