### PR TITLE
Revert "Add info overlay about gyro status over model view"

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7618,17 +7618,5 @@
     "programmingFailedNotification": {
         "message": "FC programming failed",
         "description": "Notification message when programming is unsuccessful"
-    },
-    "accCalibratingMessageText": {
-        "message": "Calibrating accelerometer"
-    },
-    "accCalibratingDescriptionText": {
-        "message": "Place the drone on a flat surface and wait for the calibration to complete."
-    },
-    "gyroErroredText": {
-        "message": "No Gyro"
-    },
-    "gyroErroredDescriptionText": {
-        "message": "Gyro has not been detected."
     }
 }

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1832,9 +1832,6 @@ each(range(12), {
         shape-rendering: crispEdges;
     }
 }
-.blur {
-    filter: blur(3px);
-}
 @media not all and (max-width: 575px) {
     .visible-on-phone-only {
         display: none !important;

--- a/src/css/tabs/setup.less
+++ b/src/css/tabs/setup.less
@@ -167,21 +167,3 @@
 .disarm-flag {
     padding-left: 5px;
 }
-
-#model-and-info-container {
-    position: relative;
-
-    .overlay-status {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        z-index: 1;
-        text-align: center;
-
-        .status-message {
-            font-weight: bold;
-            font-size: 2.1rem;
-        }
-    }
-}

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -497,8 +497,6 @@ setup.initialize = function (callback) {
                 );
             }
 
-            setup.updateGyroStatus(FC.CONFIG.armingDisableFlags);
-
             // System info is acquired in the background using update_live_status() in serial_backend.js
 
             bat_voltage_e.text(i18n.getMessage("initialSetupBatteryValue", [FC.ANALOG.voltage]));
@@ -604,34 +602,6 @@ setup.refresh = function () {
     GUI.tab_switch_cleanup(function () {
         self.initialize();
     });
-};
-
-setup.updateGyroStatus = function (armingDisableFlags) {
-    const NO_GYRO_BIT = 0; // Position of NO_GYRO flag
-    const CALIBRATING_BIT = 12; // Position of CALIBRATING flag
-    const ACC_CALIBRATION_BIT = 23; // Position of ACC_CALIBRATION flag
-
-    const hasNoGyro = armingDisableFlags & (1 << NO_GYRO_BIT);
-    const isCalibrating =
-        armingDisableFlags & (1 << CALIBRATING_BIT) || armingDisableFlags & (1 << ACC_CALIBRATION_BIT);
-
-    const hasGyroIssue = hasNoGyro || isCalibrating;
-
-    if (hasGyroIssue) {
-        // Show appropriate text based on the issue
-        $(".overlay-status .status-message").text(
-            i18n.getMessage(hasNoGyro ? "gyroErroredText" : "accCalibratingMessageText"),
-        );
-        $(".overlay-status .status-description").text(
-            i18n.getMessage(hasNoGyro ? "gyroErroredDescriptionText" : "accCalibratingDescriptionText"),
-        );
-
-        $("#interactive_block").addClass("blur");
-        $(".overlay-status").show();
-    } else {
-        $(".overlay-status").hide();
-        $("#interactive_block").removeClass("blur");
-    }
 };
 
 TABS.setup = setup;

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -70,29 +70,21 @@
         <div class="modelwrapper"></div>
         <div class="grid-row grid-box col4">
             <div class="col-span-3 model-and-info">
-                <div id="model-and-info-container">
-                    <div class="overlay-status">
-                        <p class="status-message"
-                            i18n="accCalibratingMessageText"></p>
-                        <p class="status-description"
-                            i18n="accCalibratingDescriptionText"></p>
-                    </div>
-                    <div id="interactive_block">
-                        <div id="canvas_wrapper" class="background_paper">
-                            <canvas id="canvas"></canvas>
-                            <div class="attitude_info">
-                                <dl>
-                                    <dt i18n="initialSetupHeading"></dt>
-                                    <dd class="heading">&nbsp;</dd>
-                                    <dt i18n="initialSetupPitch"></dt>
-                                    <dd class="pitch">&nbsp;</dd>
-                                    <dt i18n="initialSetupRoll"></dt>
-                                    <dd class="roll">&nbsp;</dd>
-                                </dl>
-                            </div>
+                <div id="interactive_block">
+                    <div id="canvas_wrapper" class="background_paper">
+                        <canvas id="canvas"></canvas>
+                        <div class="attitude_info">
+                            <dl>
+                                <dt i18n="initialSetupHeading"></dt>
+                                <dd class="heading">&nbsp;</dd>
+                                <dt i18n="initialSetupPitch"></dt>
+                                <dd class="pitch">&nbsp;</dd>
+                                <dt i18n="initialSetupRoll"></dt>
+                                <dd class="roll">&nbsp;</dd>
+                            </dl>
                         </div>
-                        <a class="reset sm-min" href="#" i18n="initialSetupButtonResetZaxis"></a>
                     </div>
+                    <a class="reset sm-min" href="#" i18n="initialSetupButtonResetZaxis"></a>
                 </div>
             </div>
             <div class="col-span-1 grid-box col1">


### PR DESCRIPTION
- Reverts betaflight/betaflight-configurator#4358
- reason for reversion: it was found that "calibrating accelerometer" displays after reboots and connections until sensors are initialized. this is not the intent of such a message. intent is to only display "calibrating" when the "calibrate accelerometer" is clicked.