### PR TITLE
Disable motor protocols not included in build

### DIFF
--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -705,7 +705,7 @@ motors.initialize = async function (callback) {
         const escProtocolElement = $("select.escprotocol");
 
         escProtocols.forEach((protocol, index) => {
-            const isDisabled = protocol !== "DISABLED" && FC.CONFIG.buildOptions && !FC.CONFIG.buildOptions.some(option => protocol.includes(option.substring(4))) ? "disabled" : "";
+            const isDisabled = protocol !== "DISABLED" && FC.CONFIG.buildOptions.length && !FC.CONFIG.buildOptions.some(option => protocol.includes(option.substring(4))) ? "disabled" : "";
             const option = `<option value="${index + 1}" ${isDisabled}>${protocol}</option>`;
             escProtocolElement.append(option);
         });

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -704,9 +704,11 @@ motors.initialize = async function (callback) {
         const escProtocols = EscProtocols.GetAvailableProtocols(FC.CONFIG.apiVersion);
         const escProtocolElement = $("select.escprotocol");
 
-        for (let j = 0; j < escProtocols.length; j++) {
-            escProtocolElement.append(`<option value="${j + 1}">${escProtocols[j]}</option>`);
-        }
+        escProtocols.forEach((protocol, index) => {
+            const isDisabled = protocol !== "DISABLED" && FC.CONFIG.buildOptions && !FC.CONFIG.buildOptions.some(option => protocol.includes(option.substring(4))) ? "disabled" : "";
+            const option = `<option value="${index + 1}" ${isDisabled}>${protocol}</option>`;
+            escProtocolElement.append(option);
+        });
 
         escProtocolElement.sortSelect("DISABLED");
 

--- a/src/js/utils/EscProtocols.js
+++ b/src/js/utils/EscProtocols.js
@@ -1,6 +1,6 @@
 class EscProtocols {
     static get PROTOCOL_PWM() {
-        return "PWM";
+        return "PWM_OUTPUT";
     }
     static get PROTOCOL_ONESHOT125() {
         return "ONESHOT125";


### PR DESCRIPTION
This pull request includes changes to the `motors.js` and `EscProtocols.js` files to improve the handling of ESC protocols and their display in the UI. The most important changes include modifying the way ESC protocol options are appended to the select element and updating the protocol constants.

Improvements to ESC protocol handling:

* [`src/js/tabs/motors.js`](diffhunk://#diff-bb58ef056b2205384458af9eed983bab38a4c25cb0d7fa4a5fe00091030f7b1dL707-R714): Changed the loop to use `forEach` for appending ESC protocol options to the select element. Added logic to disable options based on `buildOptions` from the configuration.

Updates to protocol constants:

* [`src/js/utils/EscProtocols.js`](diffhunk://#diff-ea84b296f27a4d237155e6dd5898a33ada4b5a0e3b7995c37dad5f6a988ba10eL3-R3): Updated the `PROTOCOL_PWM` constant to return "PWM_OUTPUT" instead of "PWM".