### PR TITLE
Remove cordova remnants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,12 +9,10 @@ yarn-error.log*
 cache/
 apps/
 dist/
-dist_cordova/
 debug/
 release/
 testresults/
 .eslintcache
-cordova/bundle.keystore
 
 # OSX
 .DS_store

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,12 +9,10 @@ yarn-error.log*
 cache/
 apps/
 dist/
-dist_cordova/
 debug/
 release/
 testresults/
 .eslintcache
-cordova/bundle.keystore
 
 # OSX
 .DS_store

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,20 +10,9 @@ export default defineConfig([
             ecmaVersion: "latest",
             sourceType: "module",
             globals: {
-                cordova: "readonly",
-                cordovaUI: "readonly",
                 ol: "readonly",
                 wNumb: "readonly",
                 ConfigStorage: "readonly",
-                // start cordova bindings, remove after cordova is removed/replace/modularized
-                cordova_serial: "readonly",
-                fileChooser: "readonly",
-                i18n: "readonly",
-                appReady: "readonly",
-                cordovaChromeapi: "readonly",
-                appAvailability: "readonly",
-                // end cordova bindings
-
                 // globals for vite
                 __APP_PRODUCTNAME__: "readonly",
                 __APP_VERSION__: "readonly",

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -7,8 +7,6 @@ import $ from "jquery";
 const TABS = {};
 
 const GUI_MODES = {
-    NWJS: "NW.js",
-    Cordova: "Cordova",
     Other: "Other",
 };
 

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -6,10 +6,6 @@ import $ from "jquery";
 
 const TABS = {};
 
-const GUI_MODES = {
-    Other: "Other",
-};
-
 class GuiControl {
     constructor() {
         this.connecting_to = false;
@@ -52,9 +48,6 @@ class GuiControl {
 
         // check which operating system is user running
         this.operating_system = GUI_checkOperatingSystem();
-
-        // Check the method of execution
-        this.nwGui = GUI_MODES.Other;
     }
     // Timer managing methods
     // name = string
@@ -341,9 +334,6 @@ class GuiControl {
                 : "tab_setup";
 
         $(`#tabs ul.mode-connected .${tab} a`).trigger("click");
-    }
-    isOther() {
-        return this.Mode === GUI_MODES.Other;
     }
     showYesNoDialog(yesNoDialogSettings) {
         // yesNoDialogSettings:

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -103,9 +103,7 @@ function startProcess() {
     // our view is reactive to model changes
     // updateTopBarVersion();
 
-    if (!GUI.isOther()) {
-        checkForConfiguratorUpdates();
-    }
+    checkForConfiguratorUpdates();
 
     // log webgl capability
     // it would seem the webgl "enabling" through advanced settings will be ignored in the future

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -27,15 +27,11 @@ if (typeof String.prototype.replaceAll === "undefined") {
 }
 
 $(document).ready(function () {
-    if (typeof cordovaApp === "undefined") {
-        appReady();
-    }
+    appReady();
 });
 
 function readConfiguratorVersionMetadata() {
-    // These are injected by vite. If not checking
-    // for undefined occasionally there is a race
-    // condition where this fails the nwjs and cordova builds
+    // These are injected by vite. Check for undefined is needed to prevent race conditions
     CONFIGURATOR.productName =
         typeof __APP_PRODUCTNAME__ !== "undefined" ? __APP_PRODUCTNAME__ : "Betaflight Configurator";
     CONFIGURATOR.version = typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "0.0.0";
@@ -132,7 +128,10 @@ function startProcess() {
     });
 
     $("a.firmware_flasher_button__link").on("click", function () {
-        if ($("a.firmware_flasher_button__label").hasClass("active") && $("a.firmware_flasher_button__link").hasClass("active")) {
+        if (
+            $("a.firmware_flasher_button__label").hasClass("active") &&
+            $("a.firmware_flasher_button__link").hasClass("active")
+        ) {
             $("a.firmware_flasher_button__label").removeClass("active");
             $("a.firmware_flasher_button__link").removeClass("active");
             $("#tabs ul.mode-disconnected .tab_landing a").click();

--- a/src/js/tabs/options.js
+++ b/src/js/tabs/options.js
@@ -27,7 +27,6 @@ options.initialize = function (callback) {
         TABS.options.initShowVirtualMode();
         TABS.options.initUseManualConnection();
         TABS.options.initLegacyRendering3DModel();
-        TABS.options.initCordovaForceComputerUI();
         TABS.options.initDarkTheme();
         TABS.options.initShowDevToolsOnStartup();
         TABS.options.initShowNotifications();
@@ -163,10 +162,6 @@ options.initUseManualConnection = function () {
         setConfig({ showManualMode: checked });
         PortHandler.setShowManualMode(checked);
     });
-};
-
-options.initCordovaForceComputerUI = function () {
-    $("div.cordovaForceComputerUI").hide();
 };
 
 options.initLegacyRendering3DModel = function () {

--- a/src/tabs/options.html
+++ b/src/tabs/options.html
@@ -61,13 +61,6 @@
                     <span class="freelabel"
                         i18n="useLegacyRenderingModel"></span>
                 </div>
-                <div class="cordovaForceComputerUI margin-bottom">
-                    <div>
-                        <input type="checkbox" class="toggle" />
-                    </div>
-                    <span class="freelabel"
-                        i18n="cordovaForceComputerUI"></span>
-                </div>
                 <div class="darkTheme margin-bottom">
                     <select id="darkThemeSelect">
                         <option value="0" i18n="on"></option>


### PR DESCRIPTION
Should we remove cordova localization messages too ?

This pull request includes several changes aimed at removing Cordova-related code and improving code readability. The most important changes include updates to configuration files, JavaScript files, and HTML files.

Removal of Cordova-related code:

* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98L12-L17): Removed `dist_cordova/` and `cordova/bundle.keystore` entries.
* [`eslint.config.js`](diffhunk://#diff-a32a0887ed9d1d707bbb3b845b7df7fd40e673c47e7b60a3ebd896b68d3b8839L13-L26): Removed Cordova-related global variables such as `cordova`, `cordovaUI`, `cordova_serial`, and others.
* [`src/js/gui.js`](diffhunk://#diff-7a4ca28a30284ff6e369b0bb76be6070b9d652fe473df60673ce76e31967c1c7L10-L11): Removed Cordova from `GUI_MODES`.
* [`src/js/main.js`](diffhunk://#diff-81d502d98dcad00826ed219fc0c5e3dc3abf3ccd9a28206d01c2eb334bc9421bL30-R34): Removed checks and references to `cordovaApp`.
* [`src/js/tabs/options.js`](diffhunk://#diff-70a13634e14782f68d675ee39cd9e01856b9acf1bc5fd133cdbe8da241631021L30): Removed the `initCordovaForceComputerUI` function and its call. [[1]](diffhunk://#diff-70a13634e14782f68d675ee39cd9e01856b9acf1bc5fd133cdbe8da241631021L30) [[2]](diffhunk://#diff-70a13634e14782f68d675ee39cd9e01856b9acf1bc5fd133cdbe8da241631021L168-L171)
* [`src/tabs/options.html`](diffhunk://#diff-04632c1a0b39237f3cb27d22d303db802495ddd6dc3349f4cad7c326e154c226L64-L70): Removed the Cordova-related HTML section.

Code readability improvements:

* [`src/js/main.js`](diffhunk://#diff-81d502d98dcad00826ed219fc0c5e3dc3abf3ccd9a28206d01c2eb334bc9421bL135-R134): Reformatted an `if` statement for better readability.