### PR TITLE
[10.10.1] backport #3923 (Fix dual telemetry in receiver tab for local builds)

### DIFF
--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -40,26 +40,29 @@ const Features = function (config) {
 
     self._features = features;
 
-    // Filter features based on build options
-    if (semver.gte(config.apiVersion, API_VERSION_1_45) && config.buildOptions.length) {
-        self._features = [];
+    if (config.buildOptions?.length) {
+        // Filter features based on build options
+        if (semver.gte(config.apiVersion, API_VERSION_1_45)) {
+            self._features = [];
 
-        for (const feature of features) {
-            if (config.buildOptions.some(opt => opt.includes(feature.dependsOn)) || feature.dependsOn === undefined) {
-                self._features.push(feature);
+            for (const feature of features) {
+                if (config.buildOptions.some(opt => opt.includes(feature.dependsOn)) || feature.dependsOn === undefined) {
+                    self._features.push(feature);
+                }
             }
         }
-    }
 
-    // Add TELEMETRY feature if any of the following protocols are used: CRSF, GHST, FPORT
-    if (semver.gte(config.apiVersion, API_VERSION_1_46)) {
-        let enableTelemetry = false;
-        if (config.buildOptions.some(opt => opt.includes('CRSF') || opt.includes('GHST') || opt.includes('FPORT'))) {
-            enableTelemetry = true;
-        }
+        // Add TELEMETRY feature if any of the following protocols are used: CRSF, GHST, FPORT
+        if (semver.gte(config.apiVersion, API_VERSION_1_46)) {
+            let enableTelemetry = false;
+            if (config.buildOptions.some(opt => opt.includes('CRSF') || opt.includes('GHST') || opt.includes('FPORT'))) {
+                enableTelemetry = true;
+            }
 
-        if (enableTelemetry) {
-            self._features.push({bit: 10, group: 'telemetry', name: 'TELEMETRY', haveTip: true, dependsOn: 'TELEMETRY'});
+            const telemetryFeature = self._features.filter(f => f.name === 'TELEMETRY')?.[0];
+            if (enableTelemetry && !telemetryFeature) {
+                self._features.push({bit: 10, group: 'telemetry', name: 'TELEMETRY', haveTip: true, dependsOn: 'TELEMETRY'});
+            }
         }
     }
 


### PR DESCRIPTION
backport https://github.com/betaflight/betaflight-configurator/pull/3923
* Fix dual telemetry in receiver tab
* Do not add telemetry twice