### PR TITLE
Add assistance for OSD selection

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7585,16 +7585,16 @@
         "message": "Custom Defines"
     },
     "firmwareFlasherOSDProtocolNotSelected": {
-        "message": "OSD Protocol not selected"
+        "message": "OSD protocol not selected"
     },
     "firmwareFlasherOSDProtocolNotSelectedDescription": {
         "message": "You must select an OSD protocol to build a firmware."
     },
     "firmwareFlasherOSDProtocolSelect": {
-        "message": "Select OSD Protocol"
+        "message": "Select OSD protocol"
     },
     "firmwareFlasherOSDProtocolNotSelectedContinue": {
-        "message": "Continue without OSD Protocol"
+        "message": "Continue without OSD protocol"
     },
     "coreBuild": {
         "message": "Core Only"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7584,6 +7584,18 @@
     "firmwareFlasherBuildCustomDefines": {
         "message": "Custom Defines"
     },
+    "firmwareFlasherOSDProtocolNotSelected": {
+        "message": "OSD Protocol not selected"
+    },
+    "firmwareFlasherOSDProtocolNotSelectedDescription": {
+        "message": "You must select an OSD protocol to build a firmware."
+    },
+    "firmwareFlasherOSDProtocolSelect": {
+        "message": "Select OSD Protocol"
+    },
+    "firmwareFlasherOSDProtocolNotSelectedContinue": {
+        "message": "Continue without OSD Protocol"
+    },
     "coreBuild": {
         "message": "Core Only"
     },

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -869,15 +869,8 @@ firmware_flasher.initialize = function (callback) {
                         text: i18n.getMessage("firmwareFlasherOSDProtocolNotSelectedDescription"),
                         buttonYesText: i18n.getMessage("firmwareFlasherOSDProtocolNotSelectedContinue"),
                         buttonNoText: i18n.getMessage("firmwareFlasherOSDProtocolSelect"),
-
-                        buttonYesCallback: () => {
-                            console.log(`${self.logHead} User confirmed no OSD`);
-                            resolve(true);
-                        },
-                        buttonNoCallback: () => {
-                            console.log(`${self.logHead} User wants to select OSD`);
-                            resolve(false);
-                        },
+                        buttonYesCallback: () => resolve(true),
+                        buttonNoCallback: () => resolve(false),
                     });
                 });
             } else {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -861,12 +861,6 @@ firmware_flasher.initialize = function (callback) {
 
         async function enforceOSDSelection() {
             const selectedOSDProtocol = $('select[name="osdProtocols"] option:selected').val();
-            console.log(`${self.logHead} selectedOSDProtocol:`, selectedOSDProtocol);
-
-            // Log the options available in the dropdown
-            $('select[name="osdProtocols"] option').each(function () {
-                console.log(`Option value: ${$(this).val()}, text: ${$(this).text()}`);
-            });
 
             if (selectedOSDProtocol === "") {
                 return new Promise((resolve) => {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -242,18 +242,11 @@ firmware_flasher.initialize = function (callback) {
         }
 
         function updateOsdProtocolColor() {
-            if ($('select[name="osdProtocols"] option:selected').val() === "") {
-                // Apply the color to Select2's rendered element using !important to override Select2's styles
-                $('select[name="osdProtocols"]')
-                    .next(".select2-container")
-                    .find(".select2-selection__rendered")
-                    .attr("style", "color: red !important");
-            } else {
-                $('select[name="osdProtocols"]')
-                    .next(".select2-container")
-                    .find(".select2-selection__rendered")
-                    .attr("style", "");
-            }
+            const osdProtocol = $('select[name="osdProtocols"] option:selected').val();
+            $('select[name="osdProtocols"]')
+                .next(".select2-container")
+                .find(".select2-selection__rendered")
+                .attr("style", osdProtocol === "" ? "color: red !important" : "");
         }
 
         function buildOptions(data) {
@@ -860,9 +853,7 @@ firmware_flasher.initialize = function (callback) {
         });
 
         async function enforceOSDSelection() {
-            const selectedOSDProtocol = $('select[name="osdProtocols"] option:selected').val();
-
-            if (selectedOSDProtocol === "") {
+            if ($('select[name="osdProtocols"] option:selected').val() === "") {
                 return new Promise((resolve) => {
                     GUI.showYesNoDialog({
                         title: i18n.getMessage("firmwareFlasherOSDProtocolNotSelected"),


### PR DESCRIPTION
This pull request introduces new functionality to enforce the selection of an OSD protocol before proceeding with firmware flashing. The changes include updates to the user interface and logic to handle OSD protocol selection.

### User Interface Enhancements:
* Added new messages to `locales/en/messages.json` for OSD protocol selection prompts and descriptions.

### Logic and Functionality Updates:
* Introduced the `updateOsdProtocolColor` function to change the color of the OSD protocol dropdown based on selection status in `src/js/tabs/firmware_flasher.js`.
* Added logic to call `updateOsdProtocolColor` after the Select2 dropdown initializes and when the selection changes in `src/js/tabs/firmware_flasher.js`.
* Implemented the `enforceOSDSelection` function to prompt the user to select an OSD protocol if none is selected, with options to continue without selection or to select a protocol in `src/js/tabs/firmware_flasher.js`.