### PR TITLE
macos-13 github runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
             releaseArgs: --linux64
 
           - name: macOS
-            os: macos-11
+            os: macos-12
             releaseArgs: --osx64
 
           - name: Windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,7 @@ jobs:
     needs: test
     runs-on:  ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - name: Android

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             releaseArgs: --linux64
 
           - name: macOS
-            os: macos-12
+            os: macos-13
             releaseArgs: --osx64
 
           - name: Windows

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6422,6 +6422,15 @@
     "osdWarningRSNR": {
         "message": "Warns when RSNR value is below alarm setting"
     },
+    "osdWarningTextLoad": {
+        "message": "LOAD",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLoad": {
+        "message": "Warns if the CPU LOAD of the flight controller is too high",
+        "description": "Description of one of the warnings that can be selected to be shown in the OSD"
+    },
+
     "osdWarningTextUnknown": {
         "message": "Unknown $1"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "betaflight-configurator",
   "productName": "Betaflight Configurator",
   "description": "Crossplatform configuration tool for Betaflight flight control system.",
-  "version": "11.0.0",
+  "version": "10.10.1",
   "main": "main.html",
   "chromium-args": "--disable-features=nw2",
   "scripts": {

--- a/src/css/tabs/auxiliary.less
+++ b/src/css/tabs/auxiliary.less
@@ -63,39 +63,6 @@
 			border-radius: 3px;
 		}
 	}
-	.mode.on {
-		.info {
-			background: var(--accent);
-			color: black;
-		}
-		&:nth-child(odd) {
-			.info {
-				background: var(--accent);
-			}
-		}
-	}
-	.mode.off {
-		.info {
-			background: #828885;
-			color: white;
-		}
-		&:nth-child(odd) {
-			.info {
-				background: #828885;
-			}
-		}
-	}
-	.mode.disabled {
-		.info {
-			background: var(--error);
-			color: var(--quietText);
-		}
-		&:nth-child(odd) {
-			.info {
-				background: var(--error);
-			}
-		}
-	}
 	.modes {
 		width: 100%;
 	}
@@ -103,6 +70,40 @@
 		background-color: #f9f9f9;
 		vertical-align: top;
 		display: flex;
+
+		&.on {
+			.info {
+				background: var(--accent) !important;
+				color: black;
+			}
+			&:nth-child(odd) {
+				.info {
+					background: var(--accent) !important;
+				}
+			}
+		}
+		&.off {
+			.info {
+				background: #828885 !important;
+				color: white;
+			}
+			&:nth-child(odd) {
+				.info {
+					background: #828885 !important;
+				}
+			}
+		}
+		&.disabled {
+			.info {
+				background: var(--error) !important;
+				color: var(--quietText);
+			}
+			&:nth-child(odd) {
+				.info {
+					background: var(--error) !important;
+				}
+			}
+		}	
 		.name {
 			min-height: 80px;
 			padding: 5px 0;

--- a/src/js/Analytics.js
+++ b/src/js/Analytics.js
@@ -1,5 +1,4 @@
 import ShortUniqueId from 'short-unique-id';
-import BuildApi from './BuildApi';
 import { set as setConfig, get as getConfig } from './ConfigStorage';
 import GUI from './gui';
 import CONFIGURATOR from './data_storage';
@@ -74,7 +73,7 @@ class Analytics {
         this.setOptOut(settings.optOut);
 
         this._settings = settings;
-        this._api = new BuildApi();
+        this._url = 'https://analytics.betaflight.com';
 
         this.EVENT_CATEGORIES = {
             APPLICATION: 'Application',
@@ -90,11 +89,19 @@ class Analytics {
             return;
         }
 
-        this._api.sendAnalytics(name, {
-            sessionId: this._settings.sessionId,
-            userId: this._settings.userId,
-            [name]: properties,
+        const url = `${this._url}/analytics/${name}`;
+        $.ajax({
+            url: url,
+            type: "POST",
+            data: JSON.stringify({
+                sessionId: this._settings.sessionId,
+                userId: this._settings.userId,
+                [name]: properties,
+            }),
+            contentType: "application/json",
+            dataType: "json",
         });
+
     }
 
     sendSettings() {

--- a/src/js/BuildApi.js
+++ b/src/js/BuildApi.js
@@ -182,15 +182,4 @@ export default class BuildApi {
             }
         });
     }
-
-    sendAnalytics(type, parcel) {
-        const url = `${this._url}/analytics/${type}`;
-        $.ajax({
-            url: url,
-            type: "POST",
-            data: JSON.stringify(parcel),
-            contentType: "application/json",
-            dataType: "json",
-        });
-    }
 }

--- a/src/js/data_storage.js
+++ b/src/js/data_storage.js
@@ -13,7 +13,7 @@ const CONFIGURATOR = {
     // all versions are specified and compared using semantic versioning http://semver.org/
     API_VERSION_ACCEPTED: API_VERSION_1_41,
     API_VERSION_MIN_SUPPORTED_BACKUP_RESTORE: API_VERSION_1_41,
-    API_VERSION_MAX_SUPPORTED: API_VERSION_1_47,
+    API_VERSION_MAX_SUPPORTED: API_VERSION_1_46,
 
     connectionValid: false,
     connectionValidCliOnly: false,

--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -1827,6 +1827,11 @@ OSD.constants = {
             text: 'osdWarningTextRSNR',
             desc: 'osdWarningRSNR',
         },
+        LOAD: {
+            name: 'LOAD',
+            text: 'osdWarningTextLoad',
+            desc: 'osdWarningLoad',
+        },
 
     },
     FONT_TYPES: [
@@ -2094,6 +2099,11 @@ OSD.chooseFields = function() {
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
             F.RSNR,
+        ]);
+    }
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+        OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([
+            F.LOAD,
         ]);
     }
 };

--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -490,6 +490,7 @@ pid_tuning.initialize = function (callback) {
             $('.dtermLowpassDynLegacy').hide();
 
             $('.pid_filter input[name="dtermLowpassExpo"]').val(FC.FILTER_CONFIG.dyn_lpf_curve_expo);
+            $('input[name="feedforwardSmoothFactor"]').attr("max", "95");
         } else {
             // hide firmware filter switches
             $('.gyroLowpass').hide();

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -270,7 +270,7 @@ setup.initialize = function (callback) {
             }
 
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
-                disarmFlagElements.splice(disarmFlagElements.indexOf('RPMFILTER'), 0, 'DSHOT_TELEM');
+                disarmFlagElements.splice(disarmFlagElements.indexOf('RPMFILTER'), 1, 'DSHOT_TELEM');
             }
 
             // Always the latest element


### PR DESCRIPTION
- **10.10-maintenance update - including background colour activation cherry pick (#3966)**
- **Add CPU LOAD warning to the OSD tab (#4021) (#4022)**
- **10.10-maintenance: Move analytics to its own domain and capture host (#4036)**
- **[10.10-MAINT] Fix feedforward smooth factor range (#4099)**
- **[10.10-MAINT] update macos build (#4100)**
- **[10.10.1] fast-fail false; do not abort other builds (#4153)**
- **[10.10.1] Fix arming flag (#4152)**
- **[10.10.1] macos-13 github runner**
