### PR TITLE
[10.10.1] macos-13 github runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
             releaseArgs: --linux64
 
           - name: macOS
-            os: macos-12
+            os: macos-13
             releaseArgs: --osx64
 
           - name: Windows


### PR DESCRIPTION
- if it works, prerequisite to https://github.com/betaflight/betaflight-configurator/pull/4384