### PR TITLE
Fix spacing in display of arming disable flags

### DIFF
--- a/src/css/tabs/setup.less
+++ b/src/css/tabs/setup.less
@@ -165,5 +165,5 @@
     bottom: 20px;
 }
 .disarm-flag {
-    padding-left: 5px;
+    padding-right: 5px;
 }


### PR DESCRIPTION
This pull request includes a small change to the `src/css/tabs/setup.less` file. The change modifies the padding of the `.disarm-flag` class to use `padding-right` instead of `padding-left`.