### PR TITLE
Add message for flashing not continuing after backup cancelled

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3765,6 +3765,9 @@
     "firmwareFlasherFailedToLoadUnifiedConfig": {
         "message": "Failed to load remote config for {{remote_file}}"
     },
+    "firmwareFlasherCanceledBackup": {
+        "message": "Backup cancelled, flashing aborted"
+    },
     "firmwareFlasherLegacyLabel": {
         "message": "{{target}} (Legacy)",
         "description": "If we have a Unified target and a old style target available, we are labeling the older one"

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1153,7 +1153,7 @@ firmware_flasher.initialize = function (callback) {
                     console.log(`${self.logHead} Backup failed, skipping flashing`);
                     self.flashingMessage(
                         i18n.getMessage("firmwareFlasherCanceledBackup"),
-                        TABS.firmware_flasher.FLASH_MESSAGE_TYPES.CANCELED,
+                        self.FLASH_MESSAGE_TYPES.INVALID,
                     );
                 }
             });
@@ -1400,7 +1400,6 @@ firmware_flasher.FLASH_MESSAGE_TYPES = {
     VALID: "VALID",
     INVALID: "INVALID",
     ACTION: "ACTION",
-    CANCEL: "CANCELED",
 };
 
 firmware_flasher.flashingMessage = function (message, type) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1151,6 +1151,10 @@ firmware_flasher.initialize = function (callback) {
                     self.enableLoadFileButton(true);
                     GUI.interval_resume("sponsor");
                     console.log(`${self.logHead} Backup failed, skipping flashing`);
+                    self.flashingMessage(
+                        i18n.getMessage("firmwareFlasherCanceledBackup"),
+                        TABS.firmware_flasher.FLASH_MESSAGE_TYPES.CANCELED,
+                    );
                 }
             });
         }
@@ -1396,6 +1400,7 @@ firmware_flasher.FLASH_MESSAGE_TYPES = {
     VALID: "VALID",
     INVALID: "INVALID",
     ACTION: "ACTION",
+    CANCEL: "CANCELED",
 };
 
 firmware_flasher.flashingMessage = function (message, type) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1140,21 +1140,38 @@ firmware_flasher.initialize = function (callback) {
         function startBackup(callback) {
             // prevent connection while backup is in progress
             GUI.connect_lock = true;
+
+            const aborted = function (message) {
+                GUI.connect_lock = false;
+                self.isFlashing = false;
+                self.enableFlashButton(true);
+                self.enableLoadRemoteFileButton(true);
+                self.enableLoadFileButton(true);
+                GUI.interval_resume("sponsor");
+                self.flashingMessage(i18n.getMessage(message), self.FLASH_MESSAGE_TYPES.INVALID);
+            };
+
+            const callBackWhenPortAvailable = function () {
+                const startTime = Date.now();
+                const interval = setInterval(() => {
+                    if (PortHandler.portAvailable) {
+                        clearInterval(interval);
+                        callback();
+                    } else if (Date.now() - startTime > 5000) {
+                        clearInterval(interval);
+                        // failed to connect
+                        aborted("portsSelectNone");
+                    }
+                }, 100);
+            };
+
             AutoBackup.execute((result) => {
                 GUI.connect_lock = false;
                 if (result) {
-                    callback();
+                    // wait for the port to be available again - timeout after 5 seconds
+                    callBackWhenPortAvailable();
                 } else {
-                    self.isFlashing = false;
-                    self.enableFlashButton(true);
-                    self.enableLoadRemoteFileButton(true);
-                    self.enableLoadFileButton(true);
-                    GUI.interval_resume("sponsor");
-                    console.log(`${self.logHead} Backup failed, skipping flashing`);
-                    self.flashingMessage(
-                        i18n.getMessage("firmwareFlasherCanceledBackup"),
-                        self.FLASH_MESSAGE_TYPES.INVALID,
-                    );
+                    aborted("firmwareFlasherCanceledBackup");
                 }
             });
         }


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/23ffe35a-21ad-4c1c-849f-1ce5e297c565)

This pull request includes changes to improve the firmware flashing process and enhance user feedback. The most important changes include adding a new message for backup cancellation and modifying the firmware flasher initialization to handle backup and port availability more robustly.

Improvements to user feedback:

* [`locales/en/messages.json`](diffhunk://#diff-8aa9190a05814c6894dde1e917c699ad0a2951547c963586a884eefb2d918b84R3768-R3770): Added a new message for when the backup is cancelled, informing the user that flashing has been aborted.

Enhancements to firmware flashing process:

* [`src/js/tabs/firmware_flasher.js`](diffhunk://#diff-1b3c28c855b29bc06cfb60162cffb5635dbcc23931adf8705969ccac5c48c48dL1143-R1174): Modified the `startBackup` function to include a new `aborted` function for handling backup cancellation and a `callBackWhenPortAvailable` function to wait for the port to be available before proceeding with flashing.