### PR TITLE
Fix flasher stylesheet hierarchy

### DIFF
--- a/src/css/tabs/firmware_flasher.less
+++ b/src/css/tabs/firmware_flasher.less
@@ -8,38 +8,6 @@
             margin-top: 8px;
         }
     }
-    .info {
-        position: relative;
-        flex-grow: 100;
-        .progressLabel.valid {
-            background-color: var(--success-500);
-            border-radius: 5px;
-        }
-        .progressLabel.invalid {
-            background-color: var(--error-500);
-            border-radius: 5px;
-        }
-        .progressLabel.actionRequired {
-            background-color: var(--warning-500);
-            border-radius: 5px;
-        }
-        .progress {
-            width: 100%;
-            height: 26px;
-            border-radius: 5px;
-            border: 1px solid var(--surface-500);
-            -webkit-appearance: none;
-            &::-webkit-progress-bar {
-                background-color: var(--text);
-                border-radius: 4px;
-                box-shadow: inset 0px 0px 5px #2f2f2f;
-            }
-            &::-webkit-progress-value {
-                background-color: #f86008;
-                border-radius: 4px;
-            }
-        }
-    }
     .buildProgress {
         border-radius: 4px;
         appearance: none;
@@ -71,6 +39,9 @@
         }
         .flash_on_connect_wrapper {
             display: none;
+        }
+        #flash_manual_baud_rate {
+            margin-left: 0.5rem;
         }
     }
     .cf_table {
@@ -113,7 +84,9 @@
                 color: var(--surface-50);
                 font-size: 10px;
                 border-radius: 999px;
-                transition: color 200ms, background-color 200ms;
+                transition:
+                    color 200ms,
+                    background-color 200ms;
                 display: flex;
                 align-items: center;
                 gap: 0.5rem;
@@ -139,6 +112,9 @@
             display: flex;
             flex-direction: row-reverse;
             gap: 1rem;
+        }
+        #customDefines {
+            width: calc(100% - 2rem) !important;
         }
     }
     .release_info,
@@ -193,9 +169,33 @@
         }
     }
 }
-#customDefines {
-    width: calc(100% - 2rem) !important;
-}
-#flash_manual_baud_rate {
-    margin-left: 0.5rem;
+
+.content_toolbar {
+    .info {
+        .progressLabel {
+            &.valid {
+                background-color: var(--success-600);
+                border-radius: 5px;
+            }
+            &.invalid {
+                background-color: var(--error-500);
+                border-radius: 5px;
+            }
+            &.actionRequired {
+                background-color: var(--warning-500);
+                border-radius: 5px;
+            }
+        }
+        .progress {
+            width: 100%;
+            height: 26px;
+            border-radius: 5px;
+            border: 1px solid var(--surface-500);
+            -webkit-appearance: none;
+            &::-webkit-progress-value {
+                background-color: var(--success-600);
+                border-radius: 4px;
+            }
+        }
+    }
 }


### PR DESCRIPTION
Fixes styling issues for the flasher progress bar introduced in eecc858.
- `TABS.firmware_flasher.FLASH_MESSAGE_TYPES` now once again properly style the progress bar, and some one-off styles are now moved to the correct scope. 
- Slightly darkens the success variant to maintain readability in both light and dark mode - contrast in dark mode between the background and the text when flashing finished was too little.

<img width="1039" alt="image" src="https://github.com/user-attachments/assets/a7675b13-6b56-4aa7-92b4-f6e9627126a3" />
<img width="1037" alt="image" src="https://github.com/user-attachments/assets/1bd1f447-38cc-4d7a-bfb1-a2d71a950873" />
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/8d843702-9426-4a16-9d62-2792c4b31862" />
