### PR TITLE
Fix initialization of build options when MSP timeout occurs

### DIFF
--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -409,20 +409,20 @@ const MSP = {
             start: performance.now(),
         };
 
-        if (!requestExists) {
-            obj.timer = setTimeout(() => {
-                console.warn(
-                    `MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} TIMEOUT: ${
-                        this.timeout
-                    } QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`,
-                );
-                serial.send(bufferOut, (_sendInfo) => {
-                    obj.stop = performance.now();
-                    const executionTime = Math.round(obj.stop - obj.start);
-                    this.timeout = Math.max(this.MIN_TIMEOUT, Math.min(executionTime, this.MAX_TIMEOUT));
-                });
-            }, this.timeout);
-        }
+        // if (!requestExists) {
+        //     obj.timer = setTimeout(() => {
+        //         console.warn(
+        //             `MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} TIMEOUT: ${
+        //                 this.timeout
+        //             } QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`,
+        //         );
+        //         serial.send(bufferOut, (_sendInfo) => {
+        //             obj.stop = performance.now();
+        //             const executionTime = Math.round(obj.stop - obj.start);
+        //             this.timeout = Math.max(this.MIN_TIMEOUT, Math.min(executionTime, this.MAX_TIMEOUT));
+        //         });
+        //     }, this.timeout);
+        // }
 
         this.callbacks.push(obj);
 

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -409,20 +409,20 @@ const MSP = {
             start: performance.now(),
         };
 
-        // if (!requestExists) {
-        //     obj.timer = setTimeout(() => {
-        //         console.warn(
-        //             `MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} TIMEOUT: ${
-        //                 this.timeout
-        //             } QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`,
-        //         );
-        //         serial.send(bufferOut, (_sendInfo) => {
-        //             obj.stop = performance.now();
-        //             const executionTime = Math.round(obj.stop - obj.start);
-        //             this.timeout = Math.max(this.MIN_TIMEOUT, Math.min(executionTime, this.MAX_TIMEOUT));
-        //         });
-        //     }, this.timeout);
-        // }
+        if (!requestExists) {
+            obj.timer = setTimeout(() => {
+                console.warn(
+                    `MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} TIMEOUT: ${
+                        this.timeout
+                    } QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`,
+                );
+                serial.send(bufferOut, (_sendInfo) => {
+                    obj.stop = performance.now();
+                    const executionTime = Math.round(obj.stop - obj.start);
+                    this.timeout = Math.max(this.MIN_TIMEOUT, Math.min(executionTime, this.MAX_TIMEOUT));
+                });
+            }, this.timeout);
+        }
 
         this.callbacks.push(obj);
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -830,6 +830,8 @@ MspHelper.prototype.process_data = function (dataHandler) {
                             FC.CONFIG.buildOptions.push(option);
                             option = data.readU16();
                         }
+                        // Humanize the build options
+                        FC.processBuildOptions();
                     }
 
                     break;

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -824,6 +824,7 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     console.log("Fw git rev:", FC.CONFIG.gitRevision);
 
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                        FC.CONFIG.buildOptions = [];
                         let option = data.readU16();
                         while (option) {
                             FC.CONFIG.buildOptions.push(option);

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -825,10 +825,9 @@ MspHelper.prototype.process_data = function (dataHandler) {
 
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
                         FC.CONFIG.buildOptions = [];
-                        let option = data.readU16();
-                        while (option) {
+                        let option;
+                        while ((option = data.readU16())) {
                             FC.CONFIG.buildOptions.push(option);
-                            option = data.readU16();
                         }
                         // Humanize the build options
                         FC.processBuildOptions();

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -323,11 +323,6 @@ function onOpen(openInfo) {
                             MSP.send_message(MSPCodes.MSP_BUILD_INFO, false, false, function () {
                                 gui_log(i18n.getMessage("buildInfoReceived", [FC.CONFIG.buildInfo]));
 
-                                // retrieve build options from the flight controller
-                                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
-                                    FC.processBuildOptions();
-                                }
-
                                 MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, processBoardInfo);
                             });
                         });
@@ -634,7 +629,10 @@ function connectCli() {
 }
 
 function onConnect() {
-    if ($("a.firmware_flasher_button__label").hasClass("active") || $("a.firmware_flasher_button__link").hasClass("active")) {
+    if (
+        $("a.firmware_flasher_button__label").hasClass("active") ||
+        $("a.firmware_flasher_button__link").hasClass("active")
+    ) {
         $("a.firmware_flasher_button__label").removeClass("active");
         $("a.firmware_flasher_button__link").removeClass("active");
     }


### PR DESCRIPTION
- fixes the issue when a MSP timeout occurs 
    - the command `MSP_BUILD_INFO` is called again
    - function processBuildOptions is not executed.
- reported on discord and tested with SITL

![image](https://github.com/user-attachments/assets/1acae29e-00c0-46ae-b543-535afac170bd)
