### PR TITLE
Fix OSD selection in firmware flasher

### DIFF
--- a/src/js/utils/AutoDetect.js
+++ b/src/js/utils/AutoDetect.js
@@ -116,7 +116,6 @@ class AutoDetect {
     async getBoardInfo() {
         await MSP.promise(MSPCodes.MSP_BOARD_INFO);
         if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
-            FC.processBuildOptions();
             TABS.firmware_flasher.cloudBuildOptions = FC.CONFIG.buildOptions;
         }
         this.onFinishClose();


### PR DESCRIPTION
This pull request includes a small change to the `src/js/utils/AutoDetect.js` file. The change removes the call to `FC.processBuildOptions()` within the `getBoardInfo` method.

* [`src/js/utils/AutoDetect.js`](diffhunk://#diff-8f294e4e362f82942702bc4abdcb5b667c585587e5070de673ad42e53a09127bL119): Removed the call to `FC.processBuildOptions()` in the `getBoardInfo` method.