### PR TITLE
Fix autoconnect

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -36,6 +36,7 @@ let liveDataRefreshTimerId = false;
 let isConnected = false;
 
 const REBOOT_CONNECT_MAX_TIME_MS = 10000;
+const REBOOT_GRACE_PERIOD_MS = 2000;
 let rebootTimestamp = 0;
 
 const toggleStatus = function () {
@@ -110,7 +111,7 @@ function connectDisconnect() {
             }
 
             // When rebooting, adhere to the auto-connect setting
-            if (!PortHandler.portPicker.autoConnect && Date.now() - rebootTimestamp < 2000) {
+            if (!PortHandler.portPicker.autoConnect && Date.now() - rebootTimestamp < REBOOT_GRACE_PERIOD_MS) {
                 console.log(`${logHead} Rebooting, not connecting`);
                 return;
             }


### PR DESCRIPTION
This pull request includes a change to the `connectDisconnect` function in `src/js/serial_backend.js`. The change ensures that the auto-connect setting is respected when rebooting.

* [`src/js/serial_backend.js`](diffhunk://#diff-10a494ca982565d04a22c726709bce1f419e7ee93f3e02977f089b1657162650R112-R117): Added a condition to check the `autoConnect` setting and the reboot timestamp before attempting to connect. If `autoConnect` is disabled and the reboot occurred within the last 2 seconds, the function will log a message and return without connecting.