### PR TITLE
Update vite-plugin-pwa to version 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "switchery-latest": "^0.8.2",
     "three": "~0.97.0",
     "tiny-emitter": "^2.1.0",
-    "vite-plugin-pwa": "^0.21.1",
+    "vite-plugin-pwa": "^1.0.0",
     "vue": "^3.5.13"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10165,10 +10165,10 @@ vite-node@3.0.7:
     pathe "^2.0.3"
     vite "^5.0.0 || ^6.0.0"
 
-vite-plugin-pwa@^0.21.1:
-  version "0.21.1"
-  resolved "https://registry.yarnpkg.com/vite-plugin-pwa/-/vite-plugin-pwa-0.21.1.tgz#2fb718ce6c7e62729d51e91bce739232e4a8e792"
-  integrity sha512-rkTbKFbd232WdiRJ9R3u+hZmf5SfQljX1b45NF6oLA6DSktEKpYllgTo1l2lkiZWMWV78pABJtFjNXfBef3/3Q==
+vite-plugin-pwa@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vite-plugin-pwa/-/vite-plugin-pwa-1.0.0.tgz#bd0ee81e71851bd45cae2f4aec90e52e9833152d"
+  integrity sha512-X77jo0AOd5OcxmWj3WnVti8n7Kw2tBgV1c8MCXFclrSlDV23ePzv2eTDIALXI2Qo6nJ5pZJeZAuX0AawvRfoeA==
   dependencies:
     debug "^4.3.6"
     pretty-bytes "^6.1.1"


### PR DESCRIPTION
This simply upgrades an outdated plugin to latest version.

