### PR TITLE
Fix DFU port handler event

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -121,8 +121,8 @@ PortHandler.removedSerialDevice = function (device) {
 PortHandler.addedUsbDevice = function (device) {
     this.updateDeviceList("usb").then(() => {
         const selectedPort = this.selectActivePort(device);
-        if (!device || selectedPort === device.path) {
-            // Send this event when the port handler auto selects a new device
+        if (selectedPort === device?.path) {
+            // Send event when the port handler auto selects a new USB device
             EventBus.$emit("port-handler:auto-select-usb-device", selectedPort);
         }
     });


### PR DESCRIPTION
- fix: event was fired without valid device

This pull request includes a small change to the `PortHandler.removedSerialDevice` function in the `src/js/port_handler.js` file. The change simplifies the conditional check by using optional chaining and updates the comment to clarify the event being sent.

* [`src/js/port_handler.js`](diffhunk://#diff-e7cccb01fb11816d2882c88028695d4ee60691a053ef95077dd6aacb514bc707L124-R125): Simplified the conditional check by using optional chaining and updated the comment to clarify that the event is sent when the port handler auto selects a new USB device.