### PR TITLE
feat: open options-tab on first visit

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -111,8 +111,8 @@ function startProcess() {
     console.log(`Libraries: jQuery - ${$.fn.jquery}, three.js - ${THREE.REVISION}`);
 
     // Check if this is the first visit
-    if (!localStorage.getItem('hasVisited')) {
-        localStorage.setItem('hasVisited', 'true');
+    if (getConfig('hasVisited')) {
+        setConfig('hasVisited', 'true');
         import('./tabs/static_tab.js').then(({ staticTab }) => {
             staticTab.initialize('options', () => {
                 console.log('Options tab opened on first visit.');

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -111,7 +111,7 @@ function startProcess() {
     console.log(`Libraries: jQuery - ${$.fn.jquery}, three.js - ${THREE.REVISION}`);
 
     // Check if this is the first visit
-    if (getConfig('firstRun').firstRun === undefined) {  
+    if (getConfig('firstRun').firstRun === undefined) {
         setConfig({ firstRun: true });
         import('./tabs/static_tab.js').then(({ staticTab }) => {
             staticTab.initialize('options', () => {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -110,6 +110,16 @@ function startProcess() {
     // log library versions in console to make version tracking easier
     console.log(`Libraries: jQuery - ${$.fn.jquery}, three.js - ${THREE.REVISION}`);
 
+    // Check if this is the first visit
+    if (!localStorage.getItem('hasVisited')) {
+        localStorage.setItem('hasVisited', 'true');
+        import('./tabs/static_tab.js').then(({ staticTab }) => {
+            staticTab.initialize('options', () => {
+                console.log('Options tab opened on first visit.');
+            });
+        });
+    }
+
     // Tabs
     $("#tabs ul.mode-connected li").click(function () {
         // store the first class of the current tab (omit things like ".active")

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -111,11 +111,14 @@ function startProcess() {
     console.log(`Libraries: jQuery - ${$.fn.jquery}, three.js - ${THREE.REVISION}`);
 
     // Check if this is the first visit
-    if (getConfig('hasVisited')) {
-        setConfig('hasVisited', 'true');
+    if (getConfig('firstRun').firstRun === undefined) {  
+        setConfig({ firstRun: true });
         import('./tabs/static_tab.js').then(({ staticTab }) => {
             staticTab.initialize('options', () => {
-                console.log('Options tab opened on first visit.');
+                setTimeout(() => {
+                    // Open the options tab after a delay
+                    $("#tabs .tab_options a").click();
+                }, 100);
             });
         });
     }


### PR DESCRIPTION
- fixes #4394

This pull request includes an enhancement to the `startProcess` function in `src/js/main.js`. The main change is the addition of a check for the first visit, which initializes the options tab if it is the user's first time running the application.

Enhancements to user experience:

* [`src/js/main.js`](diffhunk://#diff-81d502d98dcad00826ed219fc0c5e3dc3abf3ccd9a28206d01c2eb334bc9421bR113-R125): Added a check for the first visit by verifying the `firstRun` configuration. If it is the first visit, the code sets the `firstRun` flag to true and initializes the options tab with a delay to open it automatically.