### PR TITLE
Motor direction is saved upon selection

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3264,6 +3264,9 @@
     "escDshotDirectionDialog-SetDirectionHintSafety": {
         "message": "Motors will spin when setting the direction!"
     },
+    "escDshotDirectionDialog-SettingsAutoSaved": {
+        "message": "Motor direction is saved after selection"
+    },
     "escDshotDirectionDialog-WrongProtocolText": {
         "message": "Feature works with DSHOT ESCs only.<br />Verify that your ESC (electric speed controller) supports DSHOT protocol and change it on $t(tabMotorTesting.message) tab."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3265,7 +3265,7 @@
         "message": "Motors will spin when setting the direction!"
     },
     "escDshotDirectionDialog-SettingsAutoSaved": {
-        "message": "Motor direction is saved after selection"
+        "message": "Motor direction is saved upon selection"
     },
     "escDshotDirectionDialog-WrongProtocolText": {
         "message": "Feature works with DSHOT ESCs only.<br />Verify that your ESC (electric speed controller) supports DSHOT protocol and change it on $t(tabMotorTesting.message) tab."

--- a/src/components/EscDshotDirection/Body.html
+++ b/src/components/EscDshotDirection/Body.html
@@ -21,6 +21,7 @@
                     <a href="#" id="escDshotDirectionDialog-RotationNormal" class="regular-button" i18n="escDshotDirectionDialog-CommandNormal"></a>
                     <a href="#" id="escDshotDirectionDialog-RotationReverse" class="regular-button" i18n="escDshotDirectionDialog-CommandReverse"></a>
                 </div>
+                <h4 id="escDshotDirectionDialog-SettingsAutoSaved" i18n="escDshotDirectionDialog-SettingsAutoSaved"></h4>
             </div>
         </div>
         <div id="escDshotDirectionDialog-WizardDialog" class="display-contents">
@@ -31,6 +32,7 @@
                 <div id="escDshotDirectionDialog-WizardMotorButtons">
                 </div>
                 <a href="#" id="escDshotDirectionDialog-StopWizard" class="regular-button" i18n="escDshotDirectionDialog-StopWizard"></a>
+                <h4 id="escDshotDirectionDialog-SettingsAutoSaved" i18n="escDshotDirectionDialog-SettingsAutoSaved"></h4>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This pull request includes changes to the `locales/en/messages.json` file and the `src/components/EscDshotDirection/Body.html` file to add a new message indicating that motor direction settings are automatically saved after selection.

Localization updates:

* [`locales/en/messages.json`](diffhunk://#diff-8aa9190a05814c6894dde1e917c699ad0a2951547c963586a884eefb2d918b84R3267-R3269): Added a new message `"escDshotDirectionDialog-SettingsAutoSaved"` with the text "Motor direction is saved after selection".

UI updates:

* [`src/components/EscDshotDirection/Body.html`](diffhunk://#diff-05cb088a7f5b61df87be73f98a907b301425a66b944222dfaa7146aa2386459aR24): Added a new `<h4>` element with the id `escDshotDirectionDialog-SettingsAutoSaved` to display the message about motor direction settings being automatically saved. This element was added in two places within the file. [[1]](diffhunk://#diff-05cb088a7f5b61df87be73f98a907b301425a66b944222dfaa7146aa2386459aR24) [[2]](diffhunk://#diff-05cb088a7f5b61df87be73f98a907b301425a66b944222dfaa7146aa2386459aR35)

![image](https://github.com/user-attachments/assets/4fc4e59d-f64f-4b08-9452-0137e482598d)
