### PR TITLE
Prevent multiple calls to handleDisconnect

### DIFF
--- a/src/js/protocols/webstm32.js
+++ b/src/js/protocols/webstm32.js
@@ -150,7 +150,6 @@ class STM32Protocol {
                 // if firmware doesn't flush MSP/serial send buffers and gracefully shutdown VCP connections we won't get a reply, so don't wait for it.
                 this.mspConnector.disconnect((disconnectionResult) => {
                     console.log(`${this.logHead} Disconnecting from MSP`, disconnectionResult);
-                    this.handleDisconnect(disconnectionResult);
                 });
             });
             console.log(`${this.logHead} Reboot request received by device`);


### PR DESCRIPTION
Using PWA to flash the AT32 firmware will result in it getting stuck at the 'Initiating reboot to bootloader ...' state.

AT32 calls 'handleDisconnect' two times, which causes the flash operation to fail:
[AT32F435_LOG.TXT](https://github.com/user-attachments/files/19779089/AT32F435_LOG.TXT)

However, STM32 has no such issue:
[stm32F405_LOG.TXT](https://github.com/user-attachments/files/19779090/stm32F405_LOG.TXT)

After sending `MSPCodes.MSP_SET_REBOOT`, STM32's web serial closes immediately, and no MSP data is returned. However, for AT32, it successfully receives the MSP response and calls `this.mspConnector.disconnect`.
The issue is that `this.mspConnector.disconnect` will send a `disconnect` event, and webstm32 is listening to this event and calls `handleDisconnect`. After the callback, it calls the `handleDisconnect` function again.