### PR TITLE
Do not use OSD selection for 4.3.x

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -857,6 +857,13 @@ firmware_flasher.initialize = function (callback) {
         });
 
         async function enforceOSDSelection() {
+            const firmwareVersion = $('select[name="firmware_version"] option:selected').text();
+
+            // Skip OSD selection enforcement for firmware versions 4.3.x
+            if (firmwareVersion.startsWith("4.3.")) {
+                return true;
+            }
+
             if ($('select[name="osdProtocols"] option:selected').val() === "") {
                 return new Promise((resolve) => {
                     GUI.showYesNoDialog({


### PR DESCRIPTION
This pull request introduces a small but important change to the `firmware_flasher.js` file. The change ensures that the OSD selection enforcement is skipped for firmware versions starting with "4.3.".

* [`src/js/tabs/firmware_flasher.js`](diffhunk://#diff-1b3c28c855b29bc06cfb60162cffb5635dbcc23931adf8705969ccac5c48c48dR860-R866): Added a condition in the `enforceOSDSelection` function to bypass OSD selection enforcement for firmware versions 4.3.x.