### PR TITLE
Add Firmware/Download to Setup tab, add ':', formatting (#4444)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1183,11 +1183,20 @@
     "initialSetupInfoBuildConfig": {
         "message": "Config"
     },
+    "initialSetupInfoBuildDownload": {
+        "message": "Download"
+    },
+    "initialSetupInfoBuildFirmware": {
+        "message": "Firmware:"
+    },
     "initialSetupInfoBuildLog": {
         "message": "Log"
     },
     "initialSetupInfoBuildOptions": {
         "message": "Options"
+    },
+    "initialSetupInfoBuildOptionsLabel": {
+        "message": "Options:"
     },
     "initialSetupInfoBuildOptionList": {
         "message": "Options defined in firmware build"
@@ -1196,7 +1205,7 @@
         "message": "Local Build - no Cloud information"
     },
     "initialSetupInfoBuildType": {
-        "message": "Build type"
+        "message": "Build type:"
     },
     "initialSetupInfoBuildLocal": {
         "message": "Local Build"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1195,9 +1195,6 @@
     "initialSetupInfoBuildOptions": {
         "message": "Options"
     },
-    "initialSetupInfoBuildOptionsLabel": {
-        "message": "Options:"
-    },
     "initialSetupInfoBuildOptionList": {
         "message": "Options defined in firmware build"
     },

--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -212,6 +212,7 @@ setup.initialize = function (callback) {
             build_date_e = $(".build-date"),
             build_type_e = $(".build-type"),
             build_info_e = $(".build-info"),
+            build_firmware_e = $(".build-firmware"),
             build_options_e = $(".build-options");
 
         // DISARM FLAGS
@@ -369,27 +370,37 @@ setup.initialize = function (callback) {
 
             if (supported && ispConnected()) {
                 const buildRoot = `https://build.betaflight.com/api/builds/${FC.CONFIG.buildKey}`;
+
                 const buildConfig = `<span class="buildInfoBtn" title="${i18n.getMessage(
                     "initialSetupInfoBuildConfig",
                 )}: ${buildRoot}/json">
-                                    <a href="${buildRoot}/json" target="_blank"><strong>${i18n.getMessage(
+                    <a href="${buildRoot}/json" target="_blank"><strong>${i18n.getMessage(
     "initialSetupInfoBuildConfig",
 )}</strong></a></span>`;
+
                 const buildLog = `<span class="buildInfoBtn" title="${i18n.getMessage(
                     "initialSetupInfoBuildLog",
                 )}: ${buildRoot}/log">
-                                    <a href="${buildRoot}/log" target="_blank"><strong>${i18n.getMessage(
+                    <a href="${buildRoot}/log" target="_blank"><strong>${i18n.getMessage(
     "initialSetupInfoBuildLog",
 )}</strong></a></span>`;
-                build_info_e.html(`<span class="buildInfoBtn" title="${i18n.getMessage(
-                    "initialSetupInfoBuildOptions",
-                )}">
-                    <a class="buildOptions" href=#"><strong>${i18n.getMessage(
-        "initialSetupInfoBuildOptionList",
-    )}</strong></a></span>`);
+
                 build_info_e.html(`${buildConfig} ${buildLog}`);
+
+                const buildDownload = `<span class="buildInfoBtn" title="${i18n.getMessage(
+                    "initialSetupInfoBuildDownload",
+                )}: ${buildRoot}/hex">
+                    <a href="${buildRoot}/hex" target="_blank"><strong>${i18n.getMessage(
+    "initialSetupInfoBuildDownload",
+)}</strong></a></span>`;
+
+                build_firmware_e.html(buildDownload);
             } else {
                 build_info_e.html(
+                    supported ? i18n.getMessage("initialSetupNotOnline") : i18n.getMessage("initialSetupNoBuildInfo"),
+                );
+
+                build_firmware_e.html(
                     supported ? i18n.getMessage("initialSetupNotOnline") : i18n.getMessage("initialSetupNoBuildInfo"),
                 );
             }
@@ -418,7 +429,7 @@ setup.initialize = function (callback) {
                 const buildOptions = `<span class="buildInfoBtn" title="${i18n.getMessage(
                     "initialSetupInfoBuildOptionList",
                 )}">
-                                      <a class="buildOptions" href=#"><strong>${i18n.getMessage(
+                    <a class="buildOptions" href=#"><strong>${i18n.getMessage(
         "initialSetupInfoBuildOptions",
     )}</strong></a></span>`;
 

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -242,10 +242,6 @@
                                     <td id="build-firmware" i18n="initialSetupInfoBuildFirmware"></td>
                                     <td class="build-firmware"></td>
                                 </tr>
-                                <tr>
-                                    <td id="build-options" i18n="initialSetupInfoBuildOptionsLabel"></td>
-                                    <td class="build-options"></td>
-                                </tr>
                             </tbody>
                         </table>
                     </div>

--- a/src/tabs/setup.html
+++ b/src/tabs/setup.html
@@ -226,7 +226,7 @@
                                     <td id="api-version" i18n="initialSetupInfoAPIversion"></td>
                                     <td class="api-version"></td>
                                 </tr>
-                                    <tr>
+                                <tr>
                                     <td id="build-date" i18n="initialSetupInfoBuildDate"></td>
                                     <td class="build-date"></td>
                                 </tr>
@@ -234,13 +234,16 @@
                                     <td id="build-type" i18n="initialSetupInfoBuildType"></td>
                                     <td class="build-type"></td>
                                 </tr>
-                                </tr>
-                                    <tr>
+                                <tr>
                                     <td id="build-info" i18n="initialSetupInfoBuildInfo"></td>
                                     <td class="build-info"></td>
                                 </tr>
                                 <tr>
-                                    <td id="build-options" i18n="initialSetupInfoBuildOptions"></td>
+                                    <td id="build-firmware" i18n="initialSetupInfoBuildFirmware"></td>
+                                    <td class="build-firmware"></td>
+                                </tr>
+                                <tr>
+                                    <td id="build-options" i18n="initialSetupInfoBuildOptionsLabel"></td>
                                     <td class="build-options"></td>
                                 </tr>
                             </tbody>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a "Download" button and improved display of firmware build information in the setup tab.
  - Firmware build options are now presented in a dialog for easier viewing.

- **Bug Fixes**
  - Corrected table structure in the build information section for better display consistency.

- **Style**
  - Updated labels and headings for firmware build information to include colons for clarity.

- **Refactor**
  - Unified and clarified how firmware build information and options are displayed in the setup tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->