### PR TITLE
Add DroneBridge Bluetooth LE device definition

### DIFF
--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -41,6 +41,12 @@ export const bluetoothDevices = [
         writeCharacteristic: "0000abf1-0000-1000-8000-00805f9b34fb",
         readCharacteristic: "0000abf2-0000-1000-8000-00805f9b34fb",
     },
+    {
+        name: "DroneBridge",
+        serviceUuid: "0000db32-0000-1000-8000-00805f9b34fb",
+        writeCharacteristic: "0000db33-0000-1000-8000-00805f9b34fb",
+        readCharacteristic: "0000db34-0000-1000-8000-00805f9b34fb",
+    },
 ];
 
 export const serialDevices = [


### PR DESCRIPTION
Added DroneBridge for ESP32 Bluetooth LE device definition.
BLE will be available soon with the next release of DroneBridge for ESP32. The device definition is necessary so that the configurator can recognize the ESP32 device.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for connecting to the "DroneBridge" Bluetooth device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->