### PR TITLE
Fix AT32 Configuration can't be saved on MacOS

### DIFF
--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -182,6 +182,9 @@ class WebSerial extends EventTarget {
             const connectionInfo = this.port.getInfo();
             this.connectionInfo = connectionInfo;
             this.isNeedBatchWrite = this.checkIsNeedBatchWrite();
+            if (this.isNeedBatchWrite) {
+                console.log(`${this.logHead} Enabling batch write mode for AT32 on macOS`);
+            }
             this.writer = this.port.writable.getWriter();
             this.reader = this.port.readable.getReader();
 

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -1,5 +1,6 @@
 import { webSerialDevices, vendorIdNames } from "./devices";
 import { checkBrowserCompatibility } from "../utils/checkBrowserCompatibilty";
+import { GUI } from "../gui";
 
 const logHead = "[SERIAL]";
 
@@ -333,7 +334,7 @@ class WebSerial extends EventTarget {
     }
 
     checkIsNeedBatchWrite() {
-        const isMac = /macintosh|mac os x/i.test(navigator.userAgent);
+        const isMac = GUI.operating_system === "MacOS";
         return isMac && vendorIdNames[this.connectionInfo.usbVendorId] === "AT32";
     }
 

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -1,6 +1,6 @@
 import { webSerialDevices, vendorIdNames } from "./devices";
 import { checkBrowserCompatibility } from "../utils/checkBrowserCompatibilty";
-import { GUI } from "../gui";
+import GUI from "../gui";
 
 const logHead = "[SERIAL]";
 

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -184,7 +184,7 @@ class WebSerial extends EventTarget {
             this.connectionInfo = connectionInfo;
             this.isNeedBatchWrite = this.checkIsNeedBatchWrite();
             if (this.isNeedBatchWrite) {
-                console.log(`${this.logHead} Enabling batch write mode for AT32 on macOS`);
+                console.log(`${logHead} Enabling batch write mode for AT32 on macOS`);
             }
             this.writer = this.port.writable.getWriter();
             this.reader = this.port.readable.getReader();
@@ -349,7 +349,7 @@ class WebSerial extends EventTarget {
             try {
                 await this.writer.write(sliceData);
             } catch (error) {
-                console.error(`${this.logHead} Error writing batch chunk:`, error);
+                console.error(`${logHead} Error writing batch chunk:`, error);
                 throw error; // Re-throw to be caught by the send method
             }
         }

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -69,7 +69,6 @@ class WebSerial extends EventTarget {
             navigator.serial.addEventListener("connect", (e) => this.handleNewDevice(e.target));
             navigator.serial.addEventListener("disconnect", (e) => this.handleRemovedDevice(e.target));
         }
-        this.isMac = /macintosh|mac os x/i.test(navigator.userAgent);
         this.isNeedBatchWrite = false;
         this.loadDevices();
     }
@@ -331,11 +330,12 @@ class WebSerial extends EventTarget {
     }
 
     checkIsNeedBatchWrite() {
-        return this.isMac && vendorIdNames[this.connectionInfo.usbVendorId] === "AT32";
+        const isMac = /macintosh|mac os x/i.test(navigator.userAgent);
+        return isMac && vendorIdNames[this.connectionInfo.usbVendorId] === "AT32";
     }
 
     async batchWrite(data) {
-        // AT32 on macOS requires smaller chunks (63 bytes) to work correctly due to 
+        // AT32 on macOS requires smaller chunks (63 bytes) to work correctly due to
         // USB buffer size limitations in the macOS implementation
         const batchWriteSize = 63;
         let remainingData = data;

--- a/src/js/utils/checkBrowserCompatibilty.js
+++ b/src/js/utils/checkBrowserCompatibilty.js
@@ -6,7 +6,7 @@ export function getOS() {
     let os = "unknown";
     const userAgent = window.navigator.userAgent;
     const platform = window.navigator?.userAgentData?.platform || window.navigator.platform;
-    const macosPlatforms = ["Macintosh", "MacIntel", "MacPPC", "Mac68K", "MacOS"];
+    const macosPlatforms = ["Macintosh", "MacIntel", "MacPPC", "Mac68K", "macOS"];
     const windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"];
     const iosPlatforms = ["iPhone", "iPad", "iPod"];
 


### PR DESCRIPTION
Can fix #3514, but not good.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved compatibility for macOS users when connecting to certain USB devices by automatically adjusting how data is sent.
- **Bug Fixes**
  - Enhanced data transmission reliability for specific devices on macOS platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->