### PR TITLE
Ensure single comment is created

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy src/dist --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --commit-dirty=true
+          command: pages deploy src/dist --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --branch ${{ github.head_ref }} --commit-dirty=true
 
       - name: Add deployment comment
         uses: thollander/actions-comment-pull-request@v3

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -46,4 +46,5 @@ jobs:
           message: |
              Preview URL: ${{ steps.deploy.outputs.deployment-url }}
           reactions: eyes, rocket
-          only-update: true
+          comment-tag: 'Preview URL'
+          mode: recreate


### PR DESCRIPTION
This pull request modifies the deployment workflow to improve the handling of preview URLs in comments. The key change is the replacement of the `only-update` property with `comment-tag` and `mode` properties to provide more control over comment behavior.

Deployment workflow updates:

* [`.github/workflows/deploy-preview.yml`](diffhunk://#diff-3239a21dec3186eee83cd0c0db9f3f1e93a8ab7936d93dcabf6a275e022158b0L49-R50): Replaced the `only-update` property with `comment-tag: 'Preview URL'` to tag comments with a specific identifier and added `mode: recreate` to ensure comments are recreated rather than updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the deployment preview comments on pull requests to improve how they are managed and replaced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->