### PR TITLE
Fix GNSS status when fix is attained without sat info

### DIFF
--- a/src/js/sensor_helpers.js
+++ b/src/js/sensor_helpers.js
@@ -76,19 +76,17 @@ export function sensor_status(sensors_detected = 0, gps_fix_state = 0) {
         $(".magicon", eSensorStatus).removeClass("active");
     }
 
-    if (have_sensor(sensors_detected, "gps")) {
+    const gnssSensorDetected = have_sensor(sensors_detected, "gps");
+    const hasGnssFix = gps_fix_state > 0;
+
+    if (gnssSensorDetected || hasGnssFix) {
         $(".gps", eSensorStatus).addClass("on");
-        if (gps_fix_state) {
-            $(".gpsicon", eSensorStatus).removeClass("active");
-            $(".gpsicon", eSensorStatus).addClass("active_fix");
-        } else {
-            $(".gpsicon", eSensorStatus).removeClass("active_fix");
-            $(".gpsicon", eSensorStatus).addClass("active");
-        }
+        $(".gpsicon", eSensorStatus)
+            .toggleClass("active", gnssSensorDetected && !hasGnssFix)
+            .toggleClass("active_fix", gnssSensorDetected && hasGnssFix);
     } else {
         $(".gps", eSensorStatus).removeClass("on");
-        $(".gpsicon", eSensorStatus).removeClass("active");
-        $(".gpsicon", eSensorStatus).removeClass("active_fix");
+        $(".gpsicon", eSensorStatus).removeClass("active active_fix");
     }
 
     if (have_sensor(sensors_detected, "sonar")) {


### PR DESCRIPTION
- fixes: https://github.com/betaflight/betaflight/issues/13919

Some GNSS modules won't send sat info, but could attain a fix.

This pull request refactors the `sensor_status` function in `src/js/sensor_helpers.js` to improve readability and reduce redundant code. The most important change consolidates the logic for toggling GPS icon classes based on sensor detection and GPS fix state.

### Code refactoring for readability and maintainability:
* Introduced `gnssSensorDetected` and `hasGnssFix` constants to clarify the conditions for GPS sensor detection and fix state.
* Simplified the logic for toggling GPS icon classes (`active` and `active_fix`) by using the `toggleClass` method, reducing redundancy in class manipulation.
* Streamlined the removal of multiple classes (`active` and `active_fix`) into a single `removeClass` call for better readability.