### PR TITLE
Remove last references to chrome.app

### DIFF
--- a/src/js/DarkTheme.js
+++ b/src/js/DarkTheme.js
@@ -1,5 +1,3 @@
-import GUI from "./gui";
-import windowWatcherUtil from "./utils/window_watchers";
 import { checkSetupAnalytics } from "./Analytics";
 import $ from "jquery";
 
@@ -28,10 +26,6 @@ DarkTheme.apply = function () {
             self.applyDark();
         } else {
             self.applyNormal();
-        }
-
-        if (chrome.app.window !== undefined) {
-            windowWatcherUtil.passValue(chrome.app.window.get("receiver_msp"), "darkTheme", isEnabled);
         }
     });
 };

--- a/src/js/receiver_msp/receiver_msp.js
+++ b/src/js/receiver_msp/receiver_msp.js
@@ -1,7 +1,6 @@
 import "../jqueryPlugins.js";
 import windowWatcherUtil from "../utils/window_watchers.js";
 import DarkTheme from "../DarkTheme.js";
-import { isWeb } from "../utils/isWeb.js";
 import $ from "jquery";
 
 // This is a hack to get the i18n var of the parent, but the i18n.localizePage not works
@@ -68,7 +67,7 @@ function transmitChannels() {
     // Callback given to us by the window creator so we can have it send data over MSP for us:
     if (!window.setRawRx(channelValues)) {
         // MSP connection has gone away
-        isWeb() ? close() : chrome.app.window.current().close();
+        close();
     }
 }
 
@@ -145,13 +144,7 @@ $(".button-enable .btn").on("click", function () {
     const shrinkHeight = $(".warning").height();
 
     $(".warning").slideUp("short", function () {
-        if (isWeb()) {
-            resizeTo(outerWidth, outerHeight - shrinkHeight);
-        } else {
-            chrome.app.window.current().innerBounds.minHeight -= shrinkHeight;
-            chrome.app.window.current().innerBounds.height -= shrinkHeight;
-            chrome.app.window.current().innerBounds.maxHeight -= shrinkHeight;
-        }
+        resizeTo(outerWidth, outerHeight - shrinkHeight);
     });
 
     enableTX = true;

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -1,7 +1,6 @@
 import semver from "semver";
 import { mixerList } from "../model";
 import CONFIGURATOR from "../data_storage";
-import { gui_log } from "../gui_log";
 import $ from "jquery";
 
 export function millitime() {

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -34,19 +34,6 @@ export function isInt(n) {
     return n % 1 === 0;
 }
 
-/*
- *  checkChromeRuntimeError() has to be called after each chrome API call
- */
-
-export function checkChromeRuntimeError() {
-    if (chrome.runtime.lastError) {
-        console.error(`Chrome API Error: ${chrome.runtime.lastError.message}.\n Traced ${new Error().stack}`);
-        gui_log(`Chrome API Error: ${chrome.runtime.lastError.message}.`);
-        return true;
-    }
-    return false;
-}
-
 const majorFirmwareVersions = {
     1.47: "4.6.*",
     1.46: "4.5.*",

--- a/src/js/utils/window_watchers.js
+++ b/src/js/utils/window_watchers.js
@@ -1,4 +1,3 @@
-import { isWeb } from "../utils/isWeb";
 /*
   This utility is intended to communicate between chrome windows.
   One window could watch passed values from another window and react to them.
@@ -41,7 +40,7 @@ windowWatcherUtil.passValue = function (windows, key, val) {
             return;
         }
 
-        const contentWindow = isWeb() ? win : win.contentWindow;
+        const contentWindow = win;
 
         if (contentWindow.bindings) {
             contentWindow.bindings[key] = val;

--- a/src/js/utils/window_watchers.js
+++ b/src/js/utils/window_watchers.js
@@ -1,5 +1,5 @@
 /*
-  This utility is intended to communicate between chrome windows.
+  This utility is intended to communicate between browser windows.
   One window could watch passed values from another window and react to them.
 */
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified window and environment handling by removing web/Chrome app-specific checks and logic.
  - Removed unused imports and utility functions related to Chrome app APIs.
  - Streamlined theme application and window resizing behavior for a more consistent experience.
- **Chores**
  - Cleaned up legacy code and removed obsolete error-checking and environment detection utilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->