### PR TITLE
Update deploy-preview.yml for short sha

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -72,7 +72,7 @@ jobs:
         uses: thollander/actions-comment-pull-request@v3
         with:
           message: |
-             Preview URL: ${{ steps.deploy.outputs.deployment-url }}
+             Preview URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
           reactions: eyes, rocket
           comment-tag: 'Preview URL'
           mode: recreate

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -54,13 +54,19 @@ jobs:
           name: dist-files
           path: src/dist
 
+      - name: Set short git commit SHA
+        id: vars
+        run: |
+          calculatedSha=$(echo ${{ github.event.pull_request.head.sha }} | head -c 8)
+          echo "COMMIT_SHORT_SHA=$calculatedSha" >> $GITHUB_ENV
+
       - name: Deploy to Cloudflare
         id: deploy
         uses: cloudflare/wrangler-action@v3
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy src/dist --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --branch ${{ github.head_ref }} --commit-dirty=true
+          command: pages deploy src/dist --project-name=${{ vars.CLOUDFLARE_PROJECT_NAME }} --branch=${{ env.COMMIT_SHORT_SHA }} --commit-dirty=true
 
       - name: Add deployment comment
         uses: thollander/actions-comment-pull-request@v3


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy-preview.yml` to improve branch naming consistency during deployments by introducing a short git commit SHA.

### Workflow improvements:

* Added a step to calculate and set a short git commit SHA (`COMMIT_SHORT_SHA`) as an environment variable for use in subsequent steps.
* Updated the Cloudflare deployment command to use the short git commit SHA (`COMMIT_SHORT_SHA`) as the branch name, replacing the previous `github.head_ref`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated deployment process to use a shortened commit hash as the branch identifier for preview deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->