### PR TITLE
Adds support for Airbot Theia OSD

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -2365,6 +2365,7 @@ OSD.msp = {
         d.state.haveMax7456Configured = bit_check(d.flags, 4);
         d.state.haveFrSkyOSDConfigured = bit_check(d.flags, 3);
         d.state.haveMax7456FontDeviceConfigured = d.state.haveMax7456Configured || d.state.haveFrSkyOSDConfigured;
+        d.state.haveAirbotTheiaOsdDevice = bit_check(d.flags, 7) && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45);
         d.state.isMax7456FontDeviceDetected = bit_check(d.flags, 5);
         d.state.haveOsdFeature = bit_check(d.flags, 0);
         d.state.isOsdSlave = bit_check(d.flags, 1);
@@ -2817,7 +2818,7 @@ osd.initialize = function (callback) {
                     OSD.msp.decode(info);
                 }
 
-                if (OSD.data.state.haveMax7456FontDeviceConfigured && !OSD.data.state.isMax7456FontDeviceDetected) {
+                if (OSD.data.state.haveMax7456FontDeviceConfigured && !OSD.data.state.isMax7456FontDeviceDetected && !OSD.data.state.haveAirbotTheiaOsdDevice) {
                     $(".noOsdChipDetect").show();
                 }
 
@@ -3093,7 +3094,7 @@ osd.initialize = function (callback) {
                     $(".requires-max7456").hide();
                 }
 
-                if (!OSD.data.state.isMax7456FontDeviceDetected || !OSD.data.state.haveMax7456FontDeviceConfigured) {
+                if (!OSD.data.state.isMax7456FontDeviceDetected || (!OSD.data.state.haveMax7456FontDeviceConfigured && !OSD.data.state.haveAirbotTheiaOsdDevice)) {
                     $(".requires-max7456-font-device-detected").addClass("disabled");
                 }
 


### PR DESCRIPTION
Adds support for the new Airbot Theia OSD chip.

- Prevents incorrect display of "no OSD chip detected" message when using Theia OSD.
- Disables features requiring Max7456 font device when using Theia OSD.

Airbot will release a new OSD chip "Theia" - it is a replacement for the MAX IC.

Requires:
[#14391](https://github.com/betaflight/betaflight/pull/14391)