### PR TITLE
Feature: Basic Firefox compatibility

### DIFF
--- a/src/js/tabs/setup.js
+++ b/src/js/tabs/setup.js
@@ -14,6 +14,7 @@ import $ from "jquery";
 import { ispConnected } from "../utils/connection";
 import { sensorTypes } from "../sensor_types";
 import { addArrayElementsAfter, replaceArrayElement } from "../utils/array";
+import { isFirefoxBrowser } from "../utils/checkBrowserCompatibility";
 
 const setup = {
     yaw_fix: 0.0,
@@ -387,17 +388,19 @@ setup.initialize = function (callback) {
                 const buildConfig = `<span class="buildInfoBtn" title="${i18n.getMessage(
                     "initialSetupInfoBuildConfig",
                 )}: ${buildRoot}/json">
-                    <a href="${buildRoot}/json" target="_blank"><strong>${i18n.getMessage(
-    "initialSetupInfoBuildConfig",
-)}</strong></a></span>`;
+                    <a href="${buildRoot}/json" target="_blank">
+                        <strong>${i18n.getMessage("initialSetupInfoBuildConfig")}</strong>
+                    </a>
+                </span>`;
 
                 // Creates the "Log" button
                 const buildLog = `<span class="buildInfoBtn" title="${i18n.getMessage(
                     "initialSetupInfoBuildLog",
                 )}: ${buildRoot}/log">
-                    <a href="${buildRoot}/log" target="_blank"><strong>${i18n.getMessage(
-    "initialSetupInfoBuildLog",
-)}</strong></a></span>`;
+                    <a href="${buildRoot}/log" target="_blank">
+                        <strong>${i18n.getMessage("initialSetupInfoBuildLog")}</strong>
+                    </a>
+                </span>`;
 
                 // Shows the "Config" and "Log" buttons
                 build_info_e.html(`${buildConfig} ${buildLog}`);
@@ -429,19 +432,19 @@ setup.initialize = function (callback) {
                 // Creates the "Options" button (if possible)
                 const buildOptions = buildOptionsValid
                     ? `<span class="buildInfoBtn" title="${i18n.getMessage("initialSetupInfoBuildOptionList")}">
-                    <a class="buildOptions" href="#"><strong>${i18n.getMessage(
-        "initialSetupInfoBuildOptions",
-    )}</strong></a></span>`
+                        <a class="buildOptions" href="#">
+                            <strong>${i18n.getMessage("initialSetupInfoBuildOptions")}</strong>
+                        </a>
+                    </span>`
                     : "";
 
                 // Creates the "Download" button (if possible)
                 const buildDownload = buildKeyValid
-                    ? `<span class="buildInfoBtn" title="${i18n.getMessage(
-                        "initialSetupInfoBuildDownload",
-                    )}: ${buildRoot}/hex">
-                    <a href="${buildRoot}/hex" target="_blank"><strong>${i18n.getMessage(
-    "initialSetupInfoBuildDownload",
-)}</strong></a></span>`
+                    ? `<span class="buildInfoBtn" title="${i18n.getMessage("initialSetupInfoBuildDownload")}: ${buildRoot}/hex">
+                        <a href="${buildRoot}/hex" target="_blank">
+                            <strong>${i18n.getMessage("initialSetupInfoBuildDownload")}</strong>
+                        </a>
+                    </span>`
                     : "";
 
                 // Shows the "Options" and/or "Download" buttons
@@ -493,13 +496,14 @@ setup.initialize = function (callback) {
         }
 
         function showNetworkStatus() {
+            const isFirefox = isFirefoxBrowser();
             const networkStatus = ispConnected();
 
             let statusText = "";
 
-            const type = navigator.connection.effectiveType;
-            const downlink = navigator.connection.downlink;
-            const rtt = navigator.connection.rtt;
+            const type = isFirefox ? "NA" : navigator.connection.effectiveType;
+            const downlink = isFirefox ? "NA" : navigator.connection.downlink;
+            const rtt = isFirefox ? "NA" : navigator.connection.rtt;
 
             if (!networkStatus || !navigator.onLine || type === "none") {
                 statusText = i18n.getMessage("initialSetupNetworkInfoStatusOffline");
@@ -510,9 +514,9 @@ setup.initialize = function (callback) {
             }
 
             $(".network-status").text(statusText);
-            $(".network-type").text(navigator.connection.effectiveType);
-            $(".network-downlink").text(`${navigator.connection.downlink} Mbps`);
-            $(".network-rtt").text(navigator.connection.rtt);
+            $(".network-type").text(type);
+            $(".network-downlink").text(`${downlink} Mbps`);
+            $(".network-rtt").text(rtt);
         }
 
         prepareDisarmFlags();

--- a/src/js/utils/checkBrowserCompatibility.js
+++ b/src/js/utils/checkBrowserCompatibility.js
@@ -28,15 +28,26 @@ export function getOS() {
 }
 
 export function isChromiumBrowser() {
-    if (navigator.userAgentData) {
-        return navigator.userAgentData.brands.some((brand) => {
-            return brand.brand == "Chromium";
-        });
+    // https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
+    if (!navigator.userAgentData) {
+        // Fallback to traditional userAgent string check
+        return /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
     }
 
-    // Fallback for older browsers/Android
-    const ua = navigator.userAgent.toLowerCase();
-    return ua.includes("chrom") || ua.includes("edg");
+    // https://learn.microsoft.com/en-us/microsoft-edge/web-platform/user-agent-guidance
+    return navigator.userAgentData.brands.some((brand) => {
+        return brand.brand == "Chromium";
+    });
+}
+
+export function isFirefoxBrowser() {
+    if (navigator.userAgentData) {
+        return navigator.userAgentData.brands.some((brand) => {
+            return brand.brand == "Firefox";
+        });
+    }
+    // Fallback to traditional userAgent string check
+    return navigator.userAgent.includes("Firefox");
 }
 
 export function isAndroid() {
@@ -65,15 +76,18 @@ export function checkBrowserCompatibility() {
     const isWebBluetooth = checkWebBluetoothSupport();
     const isWebUSB = checkWebUSBSupport();
     const isChromium = isChromiumBrowser();
-
+    const isFirefox = isFirefoxBrowser();
     const isNative = Capacitor.isNativePlatform();
 
-    const compatible = isNative || (isChromium && (isWebSerial || isWebBluetooth || isWebUSB));
+    const compatible = isNative || ((isChromium || isFirefox) && (isWebSerial || isWebBluetooth || isWebUSB));
 
     console.log("User Agent: ", navigator.userAgentData);
     console.log("Native: ", isNative);
     console.log("Chromium: ", isChromium);
+    console.log("Firefox: ", isFirefox);
     console.log("Web Serial: ", isWebSerial);
+    console.log("Web Bluetooth: ", isWebBluetooth);
+    console.log("Web USB: ", isWebUSB);
     console.log("OS: ", getOS());
 
     console.log("Android: ", isAndroid());

--- a/src/js/utils/checkBrowserCompatibility.js
+++ b/src/js/utils/checkBrowserCompatibility.js
@@ -100,7 +100,8 @@ export function checkBrowserCompatibility() {
 
     let errorMessage = "";
     if (!isChromium) {
-        errorMessage = "Betaflight app requires a Chromium based browser (Chrome, Chromium, Edge).<br/>";
+        errorMessage =
+            "Betaflight app requires a Chromium based browser (Chrome, Chromium, Edge),<br> or Firefox based browser running the <a href='https://addons.mozilla.org/cs/firefox/addon/webserial-for-firefox/'>WebSerial extension</a>.<br/>";
     }
 
     if (!isWebBluetooth) {


### PR DESCRIPTION
### Intro:

Using an extension (and native local bridge) available for Firefox that practically acts as a WebSerial polyfill, it is possible to connect and perform basic functionality even if Firefox doesn't support WebSerial on its own

- https://addons.mozilla.org/en-US/firefox/addon/webserial-for-firefox/
- https://github.com/kuba2k2/firefox-webserial

### TLDR of the main changes made:

- Change compatibility checks to include Firefox, yet still throw an error if WebSerial isn't available through the extension
- Firefox doesn't support `navigator.connection`, that metering data has been patched out if FF is used
- The polyfill extension seemingly has stricter data communication requirements, using `ArrayBuffer` helps everything go through

### What does (not) work:

- [x] Port selection
- [x] Connection
- [x] CLI Communication (both ways)
- [x] MSP Communication (both ways)
- [x] Save to EEPROM
- [x] Save add Reboot (saves, but it doesn't like the MCU rebooting, that may have to be cleaned up)
- [ ] Connection to DFU device
- [ ] Flashing
- [ ] Bluetooth
- [ ] PWA (though there seems to be an extension for this too - but I haven't tried it)

### Closing:

If Firefox does change stance on the WebUSB/WebSerial/WebBluetooth APIs in their current or slightly changed forms, this should work too. Otherwise the polyfill achieves basic functionality for those who use Firefox-based browsers and want to use them for setup/development.

I'm not sure if DFU over regular serial is a worthwhile effort, I don't know all the requirements for it, and haven't messed with anything in those parts.