### PR TITLE
Include support ID when saving to file

### DIFF
--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -214,7 +214,7 @@ cli.initialize = function (callback) {
             let content = self.outputHistory;
 
             if (self.lastSupportId) {
-                content = `Support ID: ${self.lastSupportId}\n\n${content}`;
+                content = `# Support ID: ${self.lastSupportId}\n\n${content}`;
             }
 
             saveFile(filename, content);

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -26,6 +26,7 @@ const cli = {
         windowWrapper: null,
     },
     lastArrival: 0,
+    lastSupportId: null,
 };
 
 function removePromptHash(promptText) {
@@ -210,7 +211,13 @@ cli.initialize = function (callback) {
         $("a.save").on("click", function () {
             const filename = generateFilename("cli", "txt");
 
-            saveFile(filename, self.outputHistory);
+            let content = self.outputHistory;
+
+            if (self.lastSupportId) {
+                content = `Support ID: ${self.lastSupportId}\n\n${content}`;
+            }
+
+            saveFile(filename, content);
         });
 
         $("a.clear").click(function () {
@@ -241,6 +248,7 @@ cli.initialize = function (callback) {
                                 clearInterval(delay);
                                 const text = self.outputHistory;
                                 api.submitSupportData(text, (key) => {
+                                    self.lastSupportId = key;
                                     writeToOutput(i18n.getMessage("buildServerSupportRequestSubmission", [key]));
                                 });
                             }


### PR DESCRIPTION
- resolves #4482



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - The support request ID is now displayed in the output window after submitting support data.
  - When saving CLI output, the support request ID (if available) is included at the beginning of the saved file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->