### PR TITLE
Add IMM42652

### DIFF
--- a/src/js/sensor_types.js
+++ b/src/js/sensor_types.js
@@ -111,13 +111,13 @@ export function sensorTypes() {
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
         removeArrayElement(gyroElements, "L3G4200D");
         removeArrayElement(gyroElements, "MPU3050");
-        addArrayElementsAfter(gyroElements, "LSM6DSV16X", ["IIM42653", "ICM45605", "ICM45686", "ICM40609D"]);
+        addArrayElementsAfter(gyroElements, "LSM6DSV16X", ["IIM42653", "ICM45605", "ICM45686", "ICM40609D", "IIM42652"]);
 
         removeArrayElement(accElements, "ADXL345");
         removeArrayElement(accElements, "MMA8452");
         removeArrayElement(accElements, "BMA280");
         removeArrayElement(accElements, "LSM303DLHC");
-        addArrayElementsAfter(accElements, "LSM6DSV16X", ["IIM42653", "ICM45605", "ICM45686", "ICM40609D"]);
+        addArrayElementsAfter(accElements, "LSM6DSV16X", ["IIM42653", "ICM45605", "ICM45686", "ICM40609D", "IIM42652"]);
 
         addArrayElement(gpsElements, "VIRTUAL");
     }


### PR DESCRIPTION
- complements https://github.com/betaflight/betaflight/pull/14424

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for the "IIM42652" sensor type for gyroscope and accelerometer sensors in API versions 1.47 and above.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->