### PR TITLE
Fix: Add null checks for search parameters, allowing proper functiona…

### DIFF
--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -690,8 +690,8 @@ presets.isPresetFitSearchFirmwareVersions = function (preset, searchParams) {
 
 presets.isPresetFitSearchString = function (preset, searchParams) {
     if (searchParams.searchString) {
-        const allKeywords = preset.keywords ? preset.keywords.join(" ") : "";
-        const allVersions = preset.firmware_version ? preset.firmware_version.join(" ") : "";
+        const allKeywords = Array.isArray(preset.keywords) ? preset.keywords.join(" ") : "";
+        const allVersions = Array.isArray(preset.firmware_version) ? preset.firmware_version.join(" ") : "";
         const totalLine = [preset.description, allKeywords, preset.title, preset.author, allVersions, preset.category]
             .join("\n")
             .toLowerCase()

--- a/src/tabs/presets/presets.js
+++ b/src/tabs/presets/presets.js
@@ -690,8 +690,8 @@ presets.isPresetFitSearchFirmwareVersions = function (preset, searchParams) {
 
 presets.isPresetFitSearchString = function (preset, searchParams) {
     if (searchParams.searchString) {
-        const allKeywords = preset.keywords.join(" ");
-        const allVersions = preset.firmware_version.join(" ");
+        const allKeywords = preset.keywords ? preset.keywords.join(" ") : "";
+        const allVersions = preset.firmware_version ? preset.firmware_version.join(" ") : "";
         const totalLine = [preset.description, allKeywords, preset.title, preset.author, allVersions, preset.category]
             .join("\n")
             .toLowerCase()


### PR DESCRIPTION
This pull request addresses a potential issue in the `isPresetFitSearchString` function by adding null checks to prevent errors when `preset.keywords` or `preset.firmware_version` are undefined.

### Changes to error prevention:

* [`src/tabs/presets/presets.js`](diffhunk://#diff-d040557f390136c535dc0111888f5634335f6a3f9e6081c6b6ade5705b976a63L693-R694): Updated the `isPresetFitSearchString` function to include null checks for `preset.keywords` and `preset.firmware_version` to ensure they default to empty strings if undefined. This prevents potential runtime errors during the `join` operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability when searching presets by ensuring the app handles missing or undefined keywords and firmware version fields without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->