### PR TITLE
Feature: Add modified loader to load arbitrary html as Vue apps

### DIFF
--- a/src/components/init.js
+++ b/src/components/init.js
@@ -7,16 +7,12 @@ import "../js/injected_methods";
 import i18next from "i18next";
 import { createApp, reactive } from "vue";
 import I18NextVue from "i18next-vue";
-import BatteryLegend from "./quad-status/BatteryLegend.vue";
-import BetaflightLogo from "./betaflight-logo/BetaflightLogo.vue";
-import StatusBar from "./status-bar/StatusBar.vue";
-import BatteryIcon from "./quad-status/BatteryIcon.vue";
 import FC from "../js/fc.js";
 import MSP from "../js/msp.js";
 import PortHandler from "../js/port_handler.js";
 import PortUsage from "../js/port_usage.js";
-import PortPicker from "./port-picker/PortPicker.vue";
 import CONFIGURATOR from "../js/data_storage.js";
+import { BetaflightComponents } from "../js/vue_components.js";
 
 /*
  Most of the global objects can go here at first.
@@ -24,7 +20,7 @@ import CONFIGURATOR from "../js/data_storage.js";
  but these instance would eventually have more children
  which would find the use for those extra properties.
 
- FIXME For some reason, some of them (like PortHandler and FC) 
+ FIXME For some reason, some of them (like PortHandler and FC)
  need to be marked as reactive in it's own module, to detect
  changes in arrays so I added the `reactive` wrapper there too.
 */
@@ -45,13 +41,7 @@ i18next.on("initialized", function () {
         },
     });
 
-    app.use(I18NextVue, { i18next })
-        .component("BetaflightLogo", BetaflightLogo)
-        .component("BatteryLegend", BatteryLegend)
-        .component("StatusBar", StatusBar)
-        .component("BatteryIcon", BatteryIcon)
-        .component("PortPicker", PortPicker)
-        .mount("#main-wrapper");
+    app.use(I18NextVue, { i18next }).use(BetaflightComponents).mount("#main-wrapper");
 
     if (process.env.NODE_ENV === "development") {
         console.log("Development mode enabled, installing Vue tools");

--- a/src/js/tab_loader.js
+++ b/src/js/tab_loader.js
@@ -1,0 +1,31 @@
+import { createApp, reactive } from "vue";
+import { BetaflightComponents } from "./vue_components.js";
+import I18NextVue from "i18next-vue";
+import i18next from "i18next";
+
+// Function to load tab content while preserving Vue functionality
+export function loadTabContent(contentElement, htmlPath, callback) {
+    // Load the HTML content
+    contentElement.load(htmlPath, function () {
+        // Find all elements that need Vue functionality
+        const vueElements = contentElement.find("[data-vue]");
+
+        // For each Vue element, create a new Vue app instance
+        vueElements.each(function () {
+            const el = $(this);
+            const app = createApp({});
+
+            // Add the components plugin
+            app.use(BetaflightComponents);
+            app.use(I18NextVue, { i18next });
+
+            // Mount the app to this element
+            app.mount(el[0]);
+        });
+
+        // Call the original callback
+        if (callback) {
+            callback();
+        }
+    });
+}

--- a/src/js/vue_components.js
+++ b/src/js/vue_components.js
@@ -1,0 +1,17 @@
+import BatteryLegend from "../components/quad-status/BatteryLegend.vue";
+import BetaflightLogo from "../components/betaflight-logo/BetaflightLogo.vue";
+import StatusBar from "../components/status-bar/StatusBar.vue";
+import BatteryIcon from "../components/quad-status/BatteryIcon.vue";
+import PortPicker from "../components/port-picker/PortPicker.vue";
+
+// Create a Vue plugin that registers all components globally
+export const BetaflightComponents = {
+    install(app) {
+        // Register all components globally
+        app.component("BetaflightLogo", BetaflightLogo);
+        app.component("BatteryLegend", BatteryLegend);
+        app.component("StatusBar", StatusBar);
+        app.component("BatteryIcon", BatteryIcon);
+        app.component("PortPicker", PortPicker);
+    },
+};

--- a/src/js/vue_loader.js
+++ b/src/js/vue_loader.js
@@ -4,7 +4,7 @@ import I18NextVue from "i18next-vue";
 import i18next from "i18next";
 
 // Function to load tab content while preserving Vue functionality
-export function loadTabContent(contentElement, htmlPath, callback) {
+export function loadContent(contentElement, htmlPath, callback) {
     // Load the HTML content
     contentElement.load(htmlPath, function () {
         // Find all elements that need Vue functionality

--- a/src/js/vue_loader.js
+++ b/src/js/vue_loader.js
@@ -46,7 +46,7 @@ export function loadContent(contentElement, htmlPath, callback) {
             app.use(I18NextVue, { i18next });
 
             // Mount the app to this element and store the instance
-            const mountedApp = app.mount(el[0]);
+            app.mount(el[0]);
             console.log(
                 `${logHead} Mounted Vue app ${index + 1}/${vueElements.length} on element with data-vue attribute`,
             );
@@ -60,7 +60,7 @@ export function loadContent(contentElement, htmlPath, callback) {
 
         // Call the original callback (success case)
         if (callback) {
-            callback();
+            callback(null);
         }
     });
 }
@@ -79,7 +79,7 @@ function unmountVueApps(contentElement) {
             }
         });
         // Clear the stored apps
-        vueAppInstances.set(contentElement[0], []);
+        vueAppInstances.delete(contentElement[0]);
         console.log(`${logHead} Cleared Vue app instances from container`);
     }
 }

--- a/src/js/vue_loader.js
+++ b/src/js/vue_loader.js
@@ -1,4 +1,4 @@
-import { createApp, reactive } from "vue";
+import { createApp } from "vue";
 import { BetaflightComponents } from "./vue_components.js";
 import I18NextVue from "i18next-vue";
 import i18next from "i18next";

--- a/src/js/vue_loader.js
+++ b/src/js/vue_loader.js
@@ -3,15 +3,41 @@ import { BetaflightComponents } from "./vue_components.js";
 import I18NextVue from "i18next-vue";
 import i18next from "i18next";
 
+const logHead = "[VUE_LOADER]";
+
+// Store Vue app instances for proper cleanup
+const vueAppInstances = new WeakMap();
+
 // Function to load tab content while preserving Vue functionality
 export function loadContent(contentElement, htmlPath, callback) {
+    console.log(logHead, "vueAppInstances", vueAppInstances);
+    // Unmount any existing Vue apps before loading new content
+    unmountVueApps(contentElement);
+
     // Load the HTML content
-    contentElement.load(htmlPath, function () {
+    contentElement.load(htmlPath, function (responseText, textStatus, xhr) {
+        // Check if the load was successful
+        if (textStatus !== "success") {
+            console.error(`${logHead} Failed to load content from ${htmlPath}:`, textStatus, xhr?.status);
+
+            // Call the callback with error information if provided
+            if (callback) {
+                callback(new Error(`Failed to load content: ${textStatus}`));
+            }
+            return;
+        }
+
+        console.log(`${logHead} Successfully loaded content from ${htmlPath}`);
+
         // Find all elements that need Vue functionality
         const vueElements = contentElement.find("[data-vue]");
 
+        if (vueElements.length > 0) {
+            console.log(`${logHead} Found ${vueElements.length} Vue element(s) to mount`);
+        }
+
         // For each Vue element, create a new Vue app instance
-        vueElements.each(function () {
+        vueElements.each(function (index) {
             const el = $(this);
             const app = createApp({});
 
@@ -19,13 +45,41 @@ export function loadContent(contentElement, htmlPath, callback) {
             app.use(BetaflightComponents);
             app.use(I18NextVue, { i18next });
 
-            // Mount the app to this element
-            app.mount(el[0]);
+            // Mount the app to this element and store the instance
+            const mountedApp = app.mount(el[0]);
+            console.log(
+                `${logHead} Mounted Vue app ${index + 1}/${vueElements.length} on element with data-vue attribute`,
+            );
+
+            // Store the app instance for later cleanup
+            if (!vueAppInstances.has(contentElement[0])) {
+                vueAppInstances.set(contentElement[0], []);
+            }
+            vueAppInstances.get(contentElement[0]).push(app);
         });
 
-        // Call the original callback
+        // Call the original callback (success case)
         if (callback) {
             callback();
         }
     });
+}
+
+// Helper function to unmount existing Vue apps
+function unmountVueApps(contentElement) {
+    const apps = vueAppInstances.get(contentElement[0]);
+    if (apps && apps.length > 0) {
+        console.log(`${logHead} Unmounting ${apps.length} existing Vue app(s)`);
+        apps.forEach((app, index) => {
+            try {
+                app.unmount();
+                console.log(`${logHead} Successfully unmounted Vue app ${index + 1}/${apps.length}`);
+            } catch (error) {
+                console.warn(`${logHead} Error unmounting Vue app ${index + 1}:`, error);
+            }
+        });
+        // Clear the stored apps
+        vueAppInstances.set(contentElement[0], []);
+        console.log(`${logHead} Cleared Vue app instances from container`);
+    }
 }


### PR DESCRIPTION
The existing way that (for example) tab content was loaded went directly through jQuery, not allowing Vue components to be loaded outside of the main app context.

The `loadContent` function replicates the existing jQuery `load` functionality to be used as a drop-in replacement that allows Vue components to be used within tabs. This should allow future work in Vue with minimal disruption to existing html/js code. 

This PR only contains the functionality and a centralized place to register components without touching any other app code. I hope to follow it up by creating dedicated Vue components that replace/replicate the existing common UI elements such as UI boxes, buttons, inputs, and really anything else that's re-used often across the app in order to standardize and simplify the existing elements. But it should help lead more functional Vue development as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for dynamically loading HTML content with embedded Vue components, which are automatically initialized and internationalized.

- **Refactor**
  - Streamlined Vue component registration by consolidating multiple components into a single plugin, allowing for easier use of components throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->