### PR TITLE
PICO: Adding USB serial filter for PICO boards

### DIFF
--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -146,6 +146,7 @@ class WebSerial extends EventTarget {
     }
 
     async getDevices() {
+        await this.loadDevices();
         return this.ports;
     }
 

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -57,9 +57,10 @@ export const serialDevices = [
     { vendorId: 4292, productId: 60000 }, // CP210x
     { vendorId: 4292, productId: 60001 }, // CP210x
     { vendorId: 4292, productId: 60002 }, // CP210x
-    { vendorId: 10473, productId: 394 },  // GD32 VCP
+    { vendorId: 10473, productId: 394 }, // GD32 VCP
     { vendorId: 11836, productId: 22336 }, // AT32 VCP
     { vendorId: 12619, productId: 22336 }, // APM32 VCP
+    { vendorId: 11914, productId: 9 }, // Raspberry Pi Pico VCP
 ];
 
 export const usbDevices = {
@@ -72,11 +73,12 @@ export const usbDevices = {
 };
 
 export const vendorIdNames = {
-    1027: "FTDI",
-    1155: "STM Electronics",
-    4292: "Silicon Labs",
+    0x0403: "FTDI",
+    0x0483: "STM Electronics",
+    0x10c4: "Silicon Labs",
     0x2e3c: "AT32",
     0x314b: "Geehy Semiconductor",
+    0x2e8a: "Raspberry Pi Pico",
 };
 
 export const webSerialDevices = serialDevices.map(({ vendorId, productId }) => ({

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -67,18 +67,18 @@ export const usbDevices = {
     filters: [
         { vendorId: 1155, productId: 57105 }, // STM Device in DFU Mode || Digital Radio in USB mode
         { vendorId: 10473, productId: 393 }, // GD32 DFU Bootloader
-        { vendorId: 0x2e3c, productId: 0xdf11 }, // AT32F435 DFU Bootloader
+        { vendorId: 11836, productId: 57105 }, // AT32F435 DFU Bootloader
         { vendorId: 12619, productId: 262 }, // APM32 DFU Bootloader
     ],
 };
 
 export const vendorIdNames = {
-    0x0403: "FTDI",
-    0x0483: "STM Electronics",
-    0x10c4: "Silicon Labs",
-    0x2e3c: "AT32",
-    0x314b: "Geehy Semiconductor",
-    0x2e8a: "Raspberry Pi Pico",
+    1027: "FTDI",
+    1155: "STM Electronics",
+    4292: "Silicon Labs",
+    11836: "AT32",
+    12619: "Geehy Semiconductor",
+    11914: "Raspberry Pi Pico",
 };
 
 export const webSerialDevices = serialDevices.map(({ vendorId, productId }) => ({


### PR DESCRIPTION
Merely adding the additional details for Raspberry Pi Pico


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for detecting Raspberry Pi Pico VCP devices.

- **Improvements**
  - Updated device vendor names for improved clarity.
  - Refined device identification for AT32F435 DFU Bootloader.
  - Enhanced device detection by refreshing the serial device list only when necessary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->