### PR TITLE
docs (motorsTelemetryHelp): spelling fix and add of denomination info…

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3163,7 +3163,7 @@
         "message": "accel"
     },
     "motorsTelemetryHelp": {
-        "message": "This numbers show the telemetry info received from the ESCs if available. It can show the actual speed of motors (in RPM), the error rate of the telemetry link and the temperature of the ESCs.",
+        "message": "These numbers show the telemetry info received from the ESCs if available. It can show the actual speed of motors (R, in RPM), the error rate (E) of the telemetry link and the temperature (T) of the ESCs.",
         "description": "Help text for the telemetry values in the motors tab."
     },
     "motorsRPM": {


### PR DESCRIPTION
Closes #4545

### Describe the bug

In line [3166 of `messages.json`, there is a typo](https://github.com/betaflight/betaflight-configurator/blob/be45ddf05e433b012055302b524e18c8e469687d/locales/en/messages.json#L3166), and also the explanation is lacking to explain what each of the letters is standing for. Thus, I will propose an MR to correct that.


```json
        "message": "This numbers show the telemetry info received from the ESCs if available. It can show the actual speed of motors (in RPM), the error rate of the telemetry link and the temperature of the ESCs.",
```


Thank you for taking the time to review this Issue and the associated PR.

### To Reproduce

N/A

### Expected behavior

N/A

### Configurator version

10.10.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved the help text in the motors tab by clarifying telemetry information and labeling values with abbreviations for easier understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->