### PR TITLE
Fix: Handle BT-11 BLE boards

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -829,9 +829,20 @@ function update() {
         addArrayElementAfter(DEBUG.modes, "RANGEFINDER_QUALITY", "OPTICALFLOW");
         addArrayElement(DEBUG.modes, "AUTOPILOT_POSITION");
         addArrayElement(DEBUG.modes, "CHIRP");
+        replaceArrayElement(DEBUG.modes, "DUAL_GYRO_RAW", "MULTI_GYRO_RAW");
+        replaceArrayElement(DEBUG.modes, "DUAL_GYRO_DIFF", "MULTI_GYRO_DIFF");
+        replaceArrayElement(DEBUG.modes, "DUAL_GYRO_SCALED", "MULTI_GYRO_SCALED");
 
         delete DEBUG.fieldNames.GPS_RESCUE_THROTTLE_PID;
         delete DEBUG.fieldNames.GYRO_SCALED;
+        
+        DEBUG.fieldNames["MULTI_GYRO_RAW"] = DEBUG.fieldNames.DUAL_GYRO_RAW;
+        DEBUG.fieldNames["MULTI_GYRO_DIFF"] = DEBUG.fieldNames.DUAL_GYRO_DIFF;
+        DEBUG.fieldNames["MULTI_GYRO_SCALED"] = DEBUG.fieldNames.DUAL_GYRO_SCALED;
+
+        delete DEBUG.fieldNames.DUAL_GYRO_RAW;
+        delete DEBUG.fieldNames.DUAL_GYRO_DIFF;
+        delete DEBUG.fieldNames.DUAL_GYRO_SCALED;
 
         DEBUG.fieldNames.FFT_FREQ = {
             "debug[all]": "Debug FFT FREQ",

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -271,7 +271,7 @@ const MSP = {
             // Special handling for BT-11/Bluetooth checksum corruption
             // Common pattern: received checksum is 0xff but calculated is correct
             if (expectedChecksum === 0xff && this.message_checksum !== 0xff) {
-                console.log("Detected potential Bluetooth checksum corruption (0xff), attempting recovery...");
+                // console.log("Detected potential Bluetooth checksum corruption (0xff), attempting recovery...");
                 // Use the calculated checksum instead of the received one
                 this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
                 this.crcError = false; // Override the CRC error for this specific case

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -53,7 +53,6 @@ const MSP = {
     message_checksum: 0,
     messageIsJumboFrame: false,
     crcError: false,
-    bt11_crc_corruption_logged: false,
 
     callbacks: [],
     packet_error: 0,
@@ -462,7 +461,6 @@ const MSP = {
     disconnect_cleanup() {
         this.state = 0; // reset packet state for "clean" initial entry (this is only required if user hot-disconnects)
         this.packet_error = 0; // reset CRC packet error counter for next session
-        this.bt11_crc_corruption_logged = false;
 
         this.callbacks_cleanup();
     },

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -278,8 +278,7 @@ const MSP = {
             return false;
         }
 
-        const problematicDevices = ["BT-11", "CC2541"];
-        return problematicDevices.includes(deviceDescription.name);
+        return deviceDescription?.susceptibleToCrcCorruption ?? false;
     },
     _dispatch_message(expectedChecksum) {
         if (this.message_checksum === expectedChecksum) {

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -291,8 +291,7 @@ const MSP = {
             const isBT11Device = this._isBT11CorruptionPattern(expectedChecksum);
             if (isBT11Device) {
                 if (!this.bt11_crc_corruption_logged) {
-                    const logHead = "[MSP/BLUETOOTH]";
-                    console.log(`${logHead} Detected BT-11/CC2541 checksum corruption (0xff), skipping CRC check`);
+                    console.log(`Detected BT-11/CC2541 checksum corruption (0xff), skipping CRC check`);
                     this.bt11_crc_corruption_logged = true;
                 }
                 // Use the calculated checksum instead of the received one

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -269,7 +269,7 @@ const MSP = {
         if (this.message_checksum === expectedChecksum) {
             // message received, store dataview
             this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
-        } else if (this._shouldBypassCrc(expectedChecksum)) {
+        } else if (serial._webBluetooth.shouldBypassCrc(expectedChecksum)) {
             this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
             this.crcError = false; // Override the CRC error for this specific case
         } else {
@@ -283,20 +283,6 @@ const MSP = {
         this.state = 0;
         this.messageIsJumboFrame = false;
         this.crcError = false;
-    },
-
-    _shouldBypassCrc(expectedChecksum) {
-        // Special handling for specific BT-11/CC2541 checksum corruption
-        // Only apply workaround for known problematic devices
-        const isBT11Device = serial._webBluetooth.isBT11CorruptionPattern(expectedChecksum);
-        if (isBT11Device) {
-            if (!this.bt11_crc_corruption_logged) {
-                console.log(`Detected BT-11/CC2541 CRC corruption (0xff), skipping CRC check`);
-                this.bt11_crc_corruption_logged = true;
-            }
-            return true;
-        }
-        return false;
     },
     notify() {
         this.listeners.forEach((listener) => {

--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -105,6 +105,20 @@ class WebBluetooth extends EventTarget {
         return deviceDescription?.susceptibleToCrcCorruption ?? false;
     }
 
+    shouldBypassCrc(expectedChecksum) {
+        // Special handling for specific BT-11/CC2541 checksum corruption
+        // Only apply workaround for known problematic devices
+        const isBT11Device = this.isBT11CorruptionPattern(expectedChecksum);
+        if (isBT11Device) {
+            if (!this.bt11_crc_corruption_logged) {
+                console.log(`Detected BT-11/CC2541 CRC corruption (0xff), skipping CRC check`);
+                this.bt11_crc_corruption_logged = true;
+            }
+            return true;
+        }
+        return false;
+    }
+
     async loadDevices() {
         try {
             const devices = await this.getDevices();

--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -88,6 +88,23 @@ class WebBluetooth extends EventTarget {
         };
     }
 
+    isBT11CorruptionPattern(expectedChecksum) {
+        if (expectedChecksum !== 0xff || this.message_checksum === 0xff) {
+            return false;
+        }
+
+        if (!this.connected) {
+            return false;
+        }
+
+        const deviceDescription = this.deviceDescription;
+        if (!deviceDescription) {
+            return false;
+        }
+
+        return deviceDescription?.susceptibleToCrcCorruption ?? false;
+    }
+
     async loadDevices() {
         try {
             const devices = await this.getDevices();

--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -163,7 +163,7 @@ class WebBluetooth extends EventTarget {
 
         if (connectionInfo && !this.openCanceled) {
             this.connected = true;
-            this.connectionId = this.device.port;
+            this.connectionId = path;
             this.bitrate = options.baudRate;
             this.bytesReceived = 0;
             this.bytesSent = 0;
@@ -177,11 +177,9 @@ class WebBluetooth extends EventTarget {
 
             this.dispatchEvent(new CustomEvent("connect", { detail: connectionInfo }));
         } else if (connectionInfo && this.openCanceled) {
-            this.connectionId = this.device.port;
+            this.connectionId = path;
 
-            console.log(
-                `${this.logHead} Connection opened with ID: ${connectionInfo.connectionId}, but request was canceled, disconnecting`,
-            );
+            console.log(`${this.logHead} Connection opened with ID: ${path}, but request was canceled, disconnecting`);
             // some bluetooth dongles/dongle drivers really doesn't like to be closed instantly, adding a small delay
             setTimeout(() => {
                 this.openRequested = false;
@@ -260,11 +258,11 @@ class WebBluetooth extends EventTarget {
     }
 
     handleNotification(event) {
-        const buffer = new Uint8Array(event.target.value.byteLength);
-
-        for (let i = 0; i < event.target.value.byteLength; i++) {
-            buffer[i] = event.target.value.getUint8(i);
-        }
+        // Create a proper Uint8Array directly from the DataView buffer
+        const dataView = event.target.value;
+        const buffer = new Uint8Array(
+            dataView.buffer.slice(dataView.byteOffset, dataView.byteOffset + dataView.byteLength),
+        );
 
         // Dispatch immediately instead of using setTimeout to avoid race conditions
         this.dispatchEvent(new CustomEvent("receive", { detail: buffer }));

--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -337,14 +337,24 @@ class WebBluetooth extends EventTarget {
     }
 
     async send(data, cb) {
-        if (!this.writeCharacteristic) {
+        if (!this.writeCharacteristic || typeof this.writeCharacteristic.writeValue !== "function") {
             if (cb) {
                 cb({
-                    error: "No write characteristic available",
+                    error: "No write characteristic available or characteristic is invalid",
                     bytesSent: 0,
                 });
             }
-            console.error(`${this.logHead} No write characteristic available`);
+            console.error(`${this.logHead} No write characteristic available or characteristic is invalid`);
+            return;
+        }
+        if (!this.device?.gatt?.connected) {
+            if (cb) {
+                cb({
+                    error: "GATT Server is disconnected. Cannot perform GATT operations.",
+                    bytesSent: 0,
+                });
+            }
+            console.error(`${this.logHead} GATT Server is disconnected. Cannot perform GATT operations.`);
             return;
         }
 

--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -113,7 +113,7 @@ class WebBluetooth extends EventTarget {
         const isBT11Device = this.isBT11CorruptionPattern(expectedChecksum);
         if (isBT11Device) {
             if (!this.bt11_crc_corruption_logged) {
-                console.log(`Detected BT-11/CC2541 CRC corruption (0xff), skipping CRC check`);
+                console.log(`${this.logHead} Detected BT-11/CC2541 CRC corruption (0xff), skipping CRC check`);
                 this.bt11_crc_corruption_logged = true;
             }
             return true;

--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -35,6 +35,8 @@ class WebBluetooth extends EventTarget {
 
         this.bluetooth = navigator?.bluetooth;
 
+        this.bt11_crc_corruption_logged = false;
+
         if (!this.bluetooth) {
             console.error(`${this.logHead} Web Bluetooth API not supported`);
             return;
@@ -341,6 +343,7 @@ class WebBluetooth extends EventTarget {
                 this.readCharacteristic = false;
                 this.deviceDescription = false;
                 this.device = null;
+                this.bt11_crc_corruption_logged = false;
             }
         };
 

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -3,7 +3,7 @@ export const bluetoothDevices = [
         name: "CC2541",
         serviceUuid: "0000ffe0-0000-1000-8000-00805f9b34fb",
         writeCharacteristic: "0000ffe1-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "0000ffe1-0000-1000-8000-00805f9b34fb",
+        readCharacteristic: "0000ffe2-0000-1000-8000-00805f9b34fb",
     },
     {
         name: "HC-05",

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -4,6 +4,7 @@ export const bluetoothDevices = [
         serviceUuid: "0000ffe0-0000-1000-8000-00805f9b34fb",
         writeCharacteristic: "0000ffe1-0000-1000-8000-00805f9b34fb",
         readCharacteristic: "0000ffe2-0000-1000-8000-00805f9b34fb",
+        susceptibleToCrcCorruption: true,
     },
     {
         name: "HC-05",


### PR DESCRIPTION
Fixes connection over BLE using BT-11 modules, provided by Airbot. I only found few public resources on these, but I assume that most similar/generic boards like these should also now work (unverified)

Had to pass 0xff CRC errors through, otherwise the connection would hang. Apart from this, they now work like other Bluetooth-enabled FCs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of a specific Bluetooth checksum error to prevent unnecessary message rejection.
  * Enhanced error validation and messaging for Bluetooth device connections and data transmission.
  * Corrected the read characteristic UUID for the "CC2541" Bluetooth device to ensure proper communication.

* **Refactor**
  * Optimized buffer handling for Bluetooth notifications to improve efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->