### PR TITLE
Add beeper-config controls

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1710,6 +1710,12 @@
     "beeperRC_SMOOTHING_INIT_FAIL": {
         "message": "Beep when armed and rc smoothing has not initialized filters"
     },
+    "configurationBeeperEnableAll": {
+        "message": "Enable All"
+    },
+    "configurationBeeperDisableAll": {
+        "message": "Disable All"
+    },
     "configuration3d": {
         "message": "3D ESC/Motor Features"
     },

--- a/src/css/tabs/configuration.less
+++ b/src/css/tabs/configuration.less
@@ -143,8 +143,8 @@
         .btn {
             padding: 0.15rem 0.5rem;
             font-size: 10px;
-            border: 1px solid #ccc;
-            background: #f5f5f5;
+            border: 1px solid var(--surface-400);
+            background: var(--primary-300);
             cursor: pointer;
             border-radius: 999px;
             white-space: nowrap;
@@ -156,12 +156,12 @@
                 background-color 200ms;
 
             &:hover {
-                background: #e9e9e9;
-                border-color: #999;
+                background: var(--primary-500);
+                border-color: var(--surface-500);
             }
 
             &:active {
-                background: #ddd;
+                background: var(--surface-300);
             }
         }
     }

--- a/src/css/tabs/configuration.less
+++ b/src/css/tabs/configuration.less
@@ -134,6 +134,31 @@
     thead {
         display: none;
     }
+
+    .beeper-controls {
+        margin-bottom: 1rem;
+        display: flex;
+        gap: 0.5rem;
+
+        .btn {
+            padding: 0.5rem 1rem;
+            font-size: 0.875rem;
+            border: 1px solid #ccc;
+            background: #f5f5f5;
+            cursor: pointer;
+            border-radius: 3px;
+
+            &:hover {
+                background: #e9e9e9;
+                border-color: #999;
+            }
+
+            &:active {
+                background: #ddd;
+            }
+        }
+    }
+
     @media all and (max-width: 575px) {
         .grid-box {
             &.col2 {

--- a/src/css/tabs/configuration.less
+++ b/src/css/tabs/configuration.less
@@ -136,17 +136,24 @@
     }
 
     .beeper-controls {
-        margin-bottom: 1rem;
+        margin-bottom: 0.5rem;
         display: flex;
-        gap: 0.5rem;
+        gap: 0.25rem;
 
         .btn {
-            padding: 0.5rem 1rem;
-            font-size: 0.875rem;
+            padding: 0.15rem 0.5rem;
+            font-size: 10px;
             border: 1px solid #ccc;
             background: #f5f5f5;
             cursor: pointer;
-            border-radius: 3px;
+            border-radius: 999px;
+            white-space: nowrap;
+            height: 1.4rem;
+            display: flex;
+            align-items: center;
+            transition:
+                color 200ms,
+                background-color 200ms;
 
             &:hover {
                 background: #e9e9e9;

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -117,6 +117,19 @@ configuration.initialize = function (callback) {
             FC.BEEPER_CONFIG.dshotBeaconConditions.updateData(element);
         });
 
+        // DShot Beeper toggle all buttons
+        $(".dshot-beeper-enable-all").click(function () {
+            $("input.condition", dshotBeaconCondition_e).each(function () {
+                $(this).prop("checked", true).trigger("change");
+            });
+        });
+
+        $(".dshot-beeper-disable-all").click(function () {
+            $("input.condition", dshotBeaconCondition_e).each(function () {
+                $(this).prop("checked", false).trigger("change");
+            });
+        });
+
         // Analog Beeper
         const destination = $(".beepers .beeper-configuration");
         const beeper_e = $(".tab-configuration .beepers");
@@ -641,6 +654,19 @@ configuration.initialize = function (callback) {
         $("input.condition", beeper_e).change(function () {
             const element = $(this);
             FC.BEEPER_CONFIG.beepers.updateData(element);
+        });
+
+        // Analog Beeper toggle all buttons
+        $(".beeper-enable-all").click(function () {
+            $("input.condition", beeper_e).each(function () {
+                $(this).prop("checked", true).trigger("change");
+            });
+        });
+
+        $(".beeper-disable-all").click(function () {
+            $("input.condition", beeper_e).each(function () {
+                $(this).prop("checked", false).trigger("change");
+            });
         });
 
         function save_config() {

--- a/src/tabs/configuration.html
+++ b/src/tabs/configuration.html
@@ -403,6 +403,10 @@
                                     </tr>
                                 </tbody>
                             </table>
+                            <div class="beeper-controls">
+                                <button type="button" class="btn dshot-beeper-enable-all" i18n="configurationBeeperEnableAll"></button>
+                                <button type="button" class="btn dshot-beeper-disable-all" i18n="configurationBeeperDisableAll"></button>
+                            </div>
                             <table>
                                 <tbody class="dshotBeaconConditions" id="noline">
                                     <!-- table generated here -->
@@ -419,6 +423,10 @@
                                 <div class="spacer_box_title" i18n="configurationBeeper"></div>
                             </div>
                             <div class="spacer_box">
+                                <div class="beeper-controls">
+                                    <button type="button" class="btn beeper-enable-all" i18n="configurationBeeperEnableAll"></button>
+                                    <button type="button" class="btn beeper-disable-all" i18n="configurationBeeperDisableAll"></button>
+                                </div>
                                 <table>
                                     <tbody class="beeper-configuration" id="noline">
                                         <tr class="beeper-template" style="display:none">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Enable All" and "Disable All" buttons to both DShot and Analog beeper configuration sections, allowing users to quickly toggle all beeper condition checkboxes at once.

* **Style**
  * Introduced new styling for the beeper control buttons to enhance their appearance and usability.

* **Localization**
  * Added new English localization entries for the "Enable All" and "Disable All" button labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->