### PR TITLE
Fix TPA breakpoint range

### DIFF
--- a/src/js/tabs/pid_tuning.js
+++ b/src/js/tabs/pid_tuning.js
@@ -10,7 +10,7 @@ import TuningSliders from "../TuningSliders";
 import Model from "../model";
 import RateCurve from "../RateCurve";
 import MSPCodes from "../msp/MSPCodes";
-import { API_VERSION_1_45, API_VERSION_1_47 } from "../data_storage";
+import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47 } from "../data_storage";
 import { gui_log } from "../gui_log";
 import { degToRad, isInt } from "../utils/common";
 import semver from "semver";
@@ -912,6 +912,10 @@ pid_tuning.initialize = function (callback) {
         } else {
             FC.RC_TUNING.dynamic_THR_PID = parseFloat($('.tpa-old input[name="tpa"]').val());
             FC.RC_TUNING.dynamic_THR_breakpoint = parseInt($('.tpa-old input[name="tpa-breakpoint"]').val());
+        }
+
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+            $('input[id="tpaBreakpoint"]').attr({ max: 2000, min: 1000 });
         }
 
         FC.FILTER_CONFIG.gyro_lowpass_hz = parseInt($('.pid_filter input[name="gyroLowpassFrequency"]').val());


### PR DESCRIPTION
- follow up on https://github.com/betaflight/betaflight/pull/12721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The TPA Breakpoint input field now enforces a minimum value of 1000 and a maximum value of 2000 for supported flight controller versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->