### PR TITLE
Deprecate feedforward cutoff

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1055,7 +1055,7 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     data.readU8(); // was FC.RX_CONFIG.rcInterpolationChannels
                     data.readU8(); // was FC.RX_CONFIG.rcSmoothingType
                     FC.RX_CONFIG.rcSmoothingSetpointCutoff = data.readU8();
-                    FC.RX_CONFIG.rcSmoothingFeedforwardCutoff = data.readU8();
+                    FC.RX_CONFIG.rcSmoothingFeedforwardCutoff = data.readU8(); // deprecated in 1.47
                     data.readU8(); // was FC.RX_CONFIG.rcSmoothingInputType
                     data.readU8(); // was FC.RX_CONFIG.rcSmoothingDerivativeType
                     FC.RX_CONFIG.usbCdcHidType = data.readU8();
@@ -1996,7 +1996,7 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
                 .push8(FC.RX_CONFIG.rcInterpolationChannels)
                 .push8(FC.RX_CONFIG.rcSmoothingType)
                 .push8(FC.RX_CONFIG.rcSmoothingSetpointCutoff)
-                .push8(FC.RX_CONFIG.rcSmoothingFeedforwardCutoff)
+                .push8(FC.RX_CONFIG.rcSmoothingFeedforwardCutoff) // deprecated in 1.47
                 .push8(FC.RX_CONFIG.rcSmoothingInputType)
                 .push8(FC.RX_CONFIG.rcSmoothingDerivativeType);
 


### PR DESCRIPTION
- add changes for https://github.com/betaflight/betaflight/pull/14411/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * RC smoothing UI is now version-aware: for API 1.47+, the feedforward cutoff control is hidden; for older versions, it remains available.
  * Added a manual/automatic toggle for the setpoint cutoff, with dynamic show/hide of the input.
  * Initialization now derives mode directly from the configuration, improving accuracy and responsiveness of UI updates.
  * Maintains compatibility with older API versions while streamlining the interface for newer ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->