### PR TITLE
Clarify cli (dev only) mode

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3391,6 +3391,9 @@
     "cliEnter": {
         "message": "CLI mode detected"
     },
+    "cliDevEnter": {
+        "message": "CLI only developer mode detected"
+    },
     "cliReboot": {
         "message": "CLI reboot detected"
     },

--- a/src/js/tabs/cli.js
+++ b/src/js/tabs/cli.js
@@ -12,6 +12,7 @@ import { serial } from "../serial";
 import FileSystem from "../FileSystem";
 import { ispConnected } from "../utils/connection";
 import { initializeModalDialog } from "../utils/initializeModalDialog";
+import { get as getConfig } from "../ConfigStorage";
 
 const cli = {
     lineDelayMs: 5,
@@ -477,7 +478,7 @@ cli.read = function (readInfo) {
     this.lastArrival = new Date().getTime();
 
     if (!CONFIGURATOR.cliValid && validateText.indexOf("CLI") !== -1) {
-        gui_log(i18n.getMessage("cliEnter"));
+        gui_log(i18n.getMessage(getConfig("cliOnlyMode")?.cliOnlyMode ? "cliDevEnter" : "cliEnter"));
         CONFIGURATOR.cliValid = true;
         // begin output history with the prompt (last line of welcome message)
         // this is to match the content of the history with what the user sees on this tab


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CLI now shows a context-aware startup message distinguishing developer vs. regular CLI-only mode.

- **Chores**
  - Added an English translation string for the developer-mode CLI message.
  - Expanded localization catalog with a new key to support the developer-mode message and future translations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->