### PR TITLE
Fix custom defines sometimes not applying in firmware flasher

### DIFF
--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -988,7 +988,7 @@ firmware_flasher.initialize = async function (callback) {
                         request.options.push($(this).val());
                     });
 
-                    if ($('input[name="expertModeCheckbox"]').is(":checked")) {
+                    if (expertMode_e.is(":checked")) {
                         if (targetDetail.releaseType === "Unstable") {
                             request.commit = $('select[name="commits"] option:selected').val();
                         }


### PR DESCRIPTION
Custom defines were occasionally not applied because they were conditional based on the wrong Expert Mode checkbox (the one visible when Connected, not the one in Firmware Flasher). 

Applied minimal fix to bring it in line with other places in firmware flasher that test  for this checkbox. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the Firmware Flasher’s expert mode handling by caching the UI state, reducing redundant lookups.
  * Improves responsiveness when expert mode is enabled, especially during Unstable release selection and applying custom options.
  * No changes to visible behavior or settings; users should experience slightly smoother interactions in the flasher workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->