### PR TITLE
Fix import statement for MSP and isExpertModeEnabled

### DIFF
--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -1,4 +1,4 @@
-eimport MSP from "./msp";
+import MSP from "./msp";
 import FC from "./fc";
 import MSPCodes from "./msp/MSPCodes";
 import semver from "semver";

--- a/src/js/TuningSliders.js
+++ b/src/js/TuningSliders.js
@@ -1,9 +1,9 @@
-import MSP from "./msp";
+eimport MSP from "./msp";
 import FC from "./fc";
 import MSPCodes from "./msp/MSPCodes";
 import semver from "semver";
 import { API_VERSION_1_47 } from "./data_storage";
-import { isExpertModeEnabled } from "./utils/isExportModeEnabled";
+import { isExpertModeEnabled } from "./utils/isExpertModeEnabled";
 import { mspHelper } from "./msp/MSPHelper";
 import $ from "jquery";
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue that prevented Expert Mode from being correctly detected and initialized on load within tuning controls, which could set the wrong default mode for some users. The app now reliably reflects the saved Expert Mode state when opening the page and when toggling the mode, ensuring consistent access to advanced tuning options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->