### PR TITLE
TARGET: Implement simple ability to flash UF2 for PICO

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3812,6 +3812,9 @@
     "firmwareFlasherFirmwareOnlineLoaded": {
         "message": "Loaded Online Firmware: {{filename}} ({{bytes}} bytes)"
     },
+    "firmwareFlasherTooltipSaveFirmware": {
+        "message": "Save Firmware"
+    },
     "firmwareFlasherHexCorrupted": {
         "message": "HEX file appears to be corrupted"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -446,7 +446,7 @@
         "message": "{{typeof}} files",
         "description": "Text for the file picker dialog, showing the type of files selected. The parameter can be HEX, TXT, etc."
     },
-    "fileSystemPickFirmwareFiles": {
+    "fileSystemPickerFirmwareFiles": {
         "message": "Firmware files"
     },
     "serialErrorFrameError": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -446,6 +446,9 @@
         "message": "{{typeof}} files",
         "description": "Text for the file picker dialog, showing the type of files selected. The parameter can be HEX, TXT, etc."
     },
+    "fileSystemPickFirmwareFiles": {
+        "message": "Firmware files"
+    },
     "serialErrorFrameError": {
         "message": "Serial connection error: bad framing"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3815,6 +3815,12 @@
     "firmwareFlasherTooltipSaveFirmware": {
         "message": "Save Firmware"
     },
+    "firmwareFlasherInvalidFileFormat": {
+        "message": "Invalid file format"
+    },
+    "firmwareFlasherUf2Corrupted": {
+        "message": "UF2 file appears to be corrupted"
+    },
     "firmwareFlasherHexCorrupted": {
         "message": "HEX file appears to be corrupted"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3824,6 +3824,12 @@
     "firmwareFlasherHexCorrupted": {
         "message": "HEX file appears to be corrupted"
     },
+    "firmwareFlasherUF2SaveSuccess": {
+        "message": "Saved (flashed) UF2 successfully"
+    },
+    "firmwareFlasherUF2SaveFailed": {
+        "message": "Failed to save (flash) UF2"
+    },
     "firmwareFlasherConfigCorrupted": {
         "message": "Config file appears to be corrupted, ASCII accepted (chars 0-255)",
         "description": "shown in the progress bar at the bottom, be brief"

--- a/src/js/BuildApi.js
+++ b/src/js/BuildApi.js
@@ -13,6 +13,23 @@ export default class BuildApi {
         return code === 200 || code === 201 || code === 202;
     }
 
+    async fetchBytes(url) {
+        const response = await fetch(url, {
+            method: "GET",
+            headers: {
+                "User-Agent": navigator.userAgent,
+                "X-CFG-VER": `${CONFIGURATOR.version}`,
+            },
+        });
+
+        if (this.isSuccessCode(response.status)) {
+            return await response.bytes();
+        }
+
+        gui_log(i18n.getMessage("buildServerFailure", [url, `HTTP ${response.status}`]));
+        return null;
+    }
+
     async fetchText(url) {
         const response = await fetch(url, {
             method: "GET",
@@ -101,9 +118,9 @@ export default class BuildApi {
         return await this.fetchCachedJson(url);
     }
 
-    async loadTargetHex(path) {
+    async loadTargetFirmware(path) {
         const url = `${this._url}${path}`;
-        return await this.fetchText(url);
+        return await this.fetchBytes(url);
     }
 
     async getSupportCommands() {

--- a/src/js/BuildApi.js
+++ b/src/js/BuildApi.js
@@ -23,7 +23,7 @@ export default class BuildApi {
         });
 
         if (this.isSuccessCode(response.status)) {
-            return await response.bytes();
+            return new Uint8Array(await response.arrayBuffer());
         }
 
         gui_log(i18n.getMessage("buildServerFailure", [url, `HTTP ${response.status}`]));

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -70,6 +70,7 @@ export const usbDevices = {
         { vendorId: 10473, productId: 393 }, // GD32 DFU Bootloader
         { vendorId: 11836, productId: 57105 }, // AT32F435 DFU Bootloader
         { vendorId: 12619, productId: 262 }, // APM32 DFU Bootloader
+        { vendorId: 11914, productId: 15 }, // Raspberry Pi Pico in Bootloader mode
     ],
 };
 

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -162,12 +162,15 @@ firmware_flasher.initialize = async function (callback) {
 
         function processHex(data, key) {
             self.firmware_type = "HEX";
-            if (!data || data.length === 0) {
+            const bytes = data instanceof Uint8Array ? data : data instanceof ArrayBuffer ? new Uint8Array(data) : null;
+
+            if (!bytes || bytes.byteLength === 0) {
                 loadFailed();
                 return;
             }
-            const decoder = new TextDecoder();
-            self.intel_hex = decoder.decode(data);
+
+            const decoder = new TextDecoder("utf-8");
+            self.intel_hex = decoder.decode(bytes);
 
             parseHex(self.intel_hex, function (data) {
                 self.parsed_hex = data;

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -153,7 +153,8 @@ firmware_flasher.initialize = async function (callback) {
         function processHex(data, key) {
             self.firmware_type = "HEX";
             self.localFirmwareLoaded = false;
-            self.intel_hex = String.fromCharCode().apply(null, data);
+            const decoder = new TextDecoder();
+            self.intel_hex = decoder.decode(data);
 
             parseHex(self.intel_hex, function (data) {
                 self.parsed_hex = data;
@@ -1352,7 +1353,11 @@ firmware_flasher.initialize = async function (callback) {
             self.enableLoadRemoteFileButton(false);
             self.enableLoadFileButton(false);
 
-            if (self.uf2_binary) {
+            if (self.firmware_type === "UF2") {
+                // due to save dialoque security requirements
+                // we need to do this within proximity to the
+                // user action hence here.
+
                 tracking.sendEvent(tracking.EVENT_CATEGORIES.FLASHING, "UF2 Flashing", {
                     filename: self.filename || null,
                 });

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -1393,12 +1393,19 @@ firmware_flasher.initialize = async function (callback) {
                 tracking.sendEvent(tracking.EVENT_CATEGORIES.FLASHING, "UF2 Flashing", {
                     filename: self.filename || null,
                 });
-                await saveFirmware();
+                const saved = await saveFirmware();
+                self.flashingMessage(
+                    saved
+                        ? i18n.getMessage("firmwareFlasherUF2SaveSuccess")
+                        : i18n.getMessage("firmwareFlasherUF2SaveFailed"),
+                    saved ? self.FLASH_MESSAGE_TYPES.VALID : self.FLASH_MESSAGE_TYPES.INVALID,
+                );
                 self.isFlashing = false;
                 GUI.interval_resume("sponsor");
                 self.enableFlashButton(true);
                 self.enableLoadRemoteFileButton(true);
                 self.enableLoadFileButton(true);
+                self.enableDfuExitButton(PortHandler.dfuAvailable);
                 return;
             }
 
@@ -1470,7 +1477,7 @@ firmware_flasher.cleanup = function (callback) {
 
 firmware_flasher.enableCancelBuildButton = function (enabled) {
     $("a.cloud_build_cancel").toggleClass("disabled", !enabled);
-    self.cancelBuild = false; // remove the semaphore
+    firmware_flasher.cancelBuild = false; // remove the semaphore
 };
 
 firmware_flasher.enableFlashButton = function (enabled) {

--- a/src/js/tabs/firmware_flasher.js
+++ b/src/js/tabs/firmware_flasher.js
@@ -900,7 +900,7 @@ firmware_flasher.initialize = async function (callback) {
             self.developmentFirmwareLoaded = false;
 
             try {
-                const file = await FileSystem.pickOpenFile(i18n.getMessage("fileSystemPickFirmwareFiles"), [
+                const file = await FileSystem.pickOpenFile(i18n.getMessage("fileSystemPickerFirmwareFiles"), [
                     ".hex",
                     ".uf2",
                 ]);
@@ -952,7 +952,10 @@ firmware_flasher.initialize = async function (callback) {
                             ) {
                                 self.enableFlashButton(true);
                                 self.flashingMessage(
-                                    i18n.getMessage("firmwareFlasherFirmwareLocalLoaded", self.parsed_hex.bytes_total),
+                                    i18n.getMessage("firmwareFlasherFirmwareLocalLoaded", {
+                                        filename: file.name,
+                                        bytes: self.parsed_hex.bytes_total,
+                                    }),
                                     self.FLASH_MESSAGE_TYPES.NEUTRAL,
                                 );
                             }
@@ -962,6 +965,7 @@ firmware_flasher.initialize = async function (callback) {
             } catch (error) {
                 console.error("Error reading file:", error);
                 self.enableLoadRemoteFileButton(true);
+                self.enableLoadFileButton(true);
             }
         });
         /**


### PR DESCRIPTION
Simple mechanism for flashing the UF2 file for the PICO.

At the minute it is simply to save the file to the device
TODO: 

1. (maybe in another PR) add detection to make sure the USB device is plugged in and is in BOOTSEL mode (not the different product ID we can use to check).
2. Modify the split out the webusbdfu and webusb and consolidate to one line in the USB request permissions (handle independent for all of BOOTSEL, DFU and CDC).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UF2 firmware support: load, save, and UF2-aware flashing.
  * Device detection now includes Raspberry Pi Pico in bootloader mode.

* **Improvements**
  * Binary-safe firmware loading from cloud and local sources; consistent firmware size/messaging.
  * Public API surface updated; firmware load events now include release info.

* **Bug Fixes**
  * Invalid or corrupted firmware files are rejected with clear feedback.

* **Localization**
  * Added strings for firmware picker, save action, invalid format, UF2 corrupted, UF2 save success/failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->