### PR TITLE
Adding version output using text via MSP

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -817,7 +817,7 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.CONFIG.flightControllerIdentifier = fcVariantIdentifier;
                     break;
 
-                case MSPCodes.MSP_FC_VERSION:
+                case MSPCodes.MSP_FC_VERSION: {
                     const major = data.readU8();
                     if (major < 10) {
                         // use the old method (the 3 bytes)
@@ -829,6 +829,7 @@ MspHelper.prototype.process_data = function (dataHandler) {
                         FC.CONFIG.flightControllerVersion = this.getText(data);
                     }
                     break;
+                }
 
                 case MSPCodes.MSP_BUILD_INFO: {
                     const dateLength = 11;


### PR DESCRIPTION
Using text based version (rather than numbers)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added support for newer flight controller version formats so text-based versions (major 10+) display correctly.

- Bug Fixes
  - Preserved legacy numeric version handling for older controllers to ensure accurate version display.
  - Prevents misreported or truncated version information when connecting to latest firmware.

- Chores
  - Improved compatibility with evolving versioning while keeping the user interface and public APIs unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->