### PR TITLE
PICO: Add new PIOUART range

### DIFF
--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -149,6 +149,16 @@ ports.initialize = function (callback) {
             58: "UART8",
             59: "UART9",
             60: "UART10",
+            70: "PIOUART0",
+            71: "PIOUART1",
+            72: "PIOUART2",
+            73: "PIOUART3",
+            74: "PIOUART4",
+            75: "PIOUART5",
+            76: "PIOUART6",
+            77: "PIOUART7",
+            78: "PIOUART8",
+            79: "PIOUART9",
         };
 
         let gpsBaudrateElement = $("select.gps_baudrate");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The UI now recognizes and displays PIO UART ports: IDs 70–79 are labeled as PIOUART0–PIOUART9 wherever port names are shown in the interface.
  * Labels are applied consistently across relevant UI elements (e.g., selectors, lists, and summaries), providing clearer, human-readable identification of these ports. No behavioral changes to port handling—only display naming is updated for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->