### PR TITLE
Fix OSD elements search

### DIFF
--- a/src/js/tabs/osd.js
+++ b/src/js/tabs/osd.js
@@ -4019,10 +4019,12 @@ osd.initialize = function (callback) {
                 );
                 $(".elements-search-field").on("input", function () {
                     const searchTerm = $(this).val().toLowerCase();
-                    $(".switchable-field").each(function () {
+                    $("#element-fields .switchable-field").each(function () {
                         const fieldName = $(this).find("label").text().toLowerCase();
                         $(this).toggle(fieldName.includes(searchTerm));
-                        $(this).closest(".switchable-field-wrapper").toggle(fieldName.includes(searchTerm));
+                        $(this)
+                            .closest("#element-fields .switchable-field-wrapper")
+                            .toggle(fieldName.includes(searchTerm));
                     });
                 });
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search filtering now applies only within the Element Fields section, preventing unrelated fields elsewhere from being affected.
  * Toggling of field wrappers is limited to the Element Fields section for more predictable behavior.
  * Improves accuracy and consistency when searching or switching fields within the element editor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->