### PR TITLE
Slider grammatical fixes

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4535,7 +4535,7 @@
         "description": "Pitch-Roll Ratio tuning slider helpicon message"
     },
     "pidTuningPitchPIGainSlider": {
-        "message": "Pitch Tracking:<br><i><small>Pitch: P, I & FF</small></i>",
+        "message": "Pitch Tracking:<br><i><small>Pitch:Roll P, I & FF</small></i>",
         "description": "Pitch P & I slider label"
     },
     "pidTuningPitchPIGainSliderHelp": {


### PR DESCRIPTION
Removed the word  "Roll" from the Pitch Sliders wich had confusing some Users. Issue: #4574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PID tuning help text to improve clarity, punctuation, and phrasing; aligns help copy with UI labels.

* **Style**
  * Fixed typos ("Enchances" → "Enhances", "strenght" → "strength") and standardized capitalization and punctuation for clearer UI copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->