### PR TITLE
Add FLASH_TEST_PRBS debug mode

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -788,6 +788,13 @@ const DEBUG = {
             "debug[all]": "Chirp",
             "debug[0]": "Chirp sinarg",
         },
+        FLASH_TEST_PRBS: {
+            "debug[all]": "Flash Test PRBS",
+            "debug[0]": "State",
+            "debug[1]": "Flash Length",
+            "debug[6]": "FlashLength / Pagesize",
+            "debug[7]": "Errors",
+        },
     },
 
     enableFields: [
@@ -829,6 +836,7 @@ function update() {
         addArrayElementAfter(DEBUG.modes, "RANGEFINDER_QUALITY", "OPTICALFLOW");
         addArrayElement(DEBUG.modes, "AUTOPILOT_POSITION");
         addArrayElement(DEBUG.modes, "CHIRP");
+        addArrayElement(DEBUG.modes, "FLASH_TEST_PRBS");
         replaceArrayElement(DEBUG.modes, "DUAL_GYRO_RAW", "MULTI_GYRO_RAW");
         replaceArrayElement(DEBUG.modes, "DUAL_GYRO_DIFF", "MULTI_GYRO_DIFF");
         replaceArrayElement(DEBUG.modes, "DUAL_GYRO_SCALED", "MULTI_GYRO_SCALED");


### PR DESCRIPTION
- Added in https://github.com/betaflight/betaflight/pull/14607

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a new “Flash Test PRBS” debug mode, now selectable in the debug view.
  - Provides clear labels for key diagnostics: State, Flash Length, FlashLength/PageSize, Errors, and an overall summary.
  - Appears in the mode list after CHIRP for easy discovery.
  - Enhances visibility into flash testing metrics and error counts, improving troubleshooting and monitoring during diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->