### PR TITLE
fix local en craft_name

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5764,7 +5764,7 @@
         "description": "One of the elements of the OSD"
     },
     "osdDescElementCraftName": {
-        "message": "Aircraft name as set in the Configuration tab.</br>Can also be set via the \"aircraft_name\" CLI variable."
+        "message": "Aircraft name as set in the Configuration tab.</br>Can also be set via the \"craft_name\" CLI variable."
     },
     "osdTextElementAltitude": {
         "message": "Altitude",


### PR DESCRIPTION
resolves #4607



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None.

- Bug Fixes
  - Corrected the on-screen display description for the aircraft name to reference the “craft_name” CLI variable.

- Documentation
  - Updated English locale text for the aircraft name OSD description to improve clarity and consistency.
  - Ensures the help text accurately reflects current CLI terminology across the interface.
  - No functional behavior changes; this is a text-only update visible in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->