### PR TITLE
Style Fix: Re-implement headerbar expanding for mobile

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -334,6 +334,10 @@ function startProcess() {
         $("#background").hide();
     });
 
+    $("#reveal_btn").on("click", function () {
+        $(".headerbar").toggleClass("expand");
+    });
+
     $(window).on("resize", function () {
         // 575px is the mobile breakpoint defined in CSS
         if (window.innerWidth > 575) {


### PR DESCRIPTION
The headerbar expanding function was un-intentionally removed in the move to the CSS-native approach to Mobile UI handling. The change accidentally broke certain UI functionality in vertical oriented screens.

The PR adds back simple toggle functionality to expand the headerbar again. Does not require a mobile phone for testing, simply open the app in a window and resize it until the UI hits the mobile breakpoint. The 3 vertical dots in the top right (curiously called a kebab menu) would expand the headerbar in 10.10.0, in `master` it doesn't do anything, in this PR it works as intended again.