### PR TITLE
Ingore CRC on dataFlash Reads

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2443,147 +2443,74 @@ MspHelper.prototype.setRawRx = function (channels) {
 
 /**
  * Send a request to read a block of data from the dataflash at the given address and pass that address and a dataview
- * of the returned data to the given callback (or null for the data if an error occured).
+ * of the returned data to the given callback (or null for the data if an error occurred).
  */
-MspHelper.prototype.dataflashRead = function (address, blockSize, onDataCallback) {
-    let outData = [address & 0xff, (address >> 8) & 0xff, (address >> 16) & 0xff, (address >> 24) & 0xff];
+MspHelper.prototype.dataflashRead = function(address, blockSize, onDataCallback) {
+    let outData = [
+        address & 0xFF,
+        (address >> 8) & 0xFF,
+        (address >> 16) & 0xFF,
+        (address >> 24) & 0xFF,
+        blockSize & 0xFF,
+        (blockSize >> 8) & 0xFF,
+        1 // allow compression
+    ];
 
-    outData = outData.concat([blockSize & 0xff, (blockSize >> 8) & 0xff]);
+    const mspObj = this.msp || (typeof MSP !== 'undefined' ? MSP : null);
+    if (!mspObj) {
+        console.error('MSP object not found, cannot read dataflash.');
+        onDataCallback(address, null);
+        return;
+    }
 
-    // Allow compression
-    outData = outData.concat([1]);
+    mspObj.send_message(MSPCodes.MSP_DATAFLASH_READ, outData, false, function(response) {
+        let payloadView = null;
 
-    MSP.send_message(
-        MSPCodes.MSP_DATAFLASH_READ,
-        outData,
-        false,
-        function (response) {
-            if (!response.crcError) {
-                const chunkAddress = response.data.readU32();
+        if (response && response.data) {
+            const headerSize = 7;
+            const chunkAddress = response.data.readU32();
+            const dataSize = response.data.readU16();
+            const dataCompressionType = response.data.readU8();
 
-                const headerSize = 7;
-                const dataSize = response.data.readU16();
-                const dataCompressionType = response.data.readU8();
-
-                // Verify that the address of the memory returned matches what the caller asked for and there was not a CRC error
-                if (chunkAddress == address) {
-                    /* Strip that address off the front of the reply and deliver it separately so the caller doesn't have to
-                     * figure out the reply format:
-                     */
-                    if (dataCompressionType == 0) {
-                        onDataCallback(
-                            address,
-                            new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize),
-                        );
-                    } else if (dataCompressionType == 1) {
-                        // Read compressed char count to avoid decoding stray bit sequences as bytes
+            if (chunkAddress === address) {
+                try {
+                    if (dataCompressionType === 0) {
+                        payloadView = new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize);
+                    } else if (dataCompressionType === 1) {
                         const compressedCharCount = response.data.readU16();
-
-                        // Compressed format uses 2 additional bytes as a pseudo-header to denote the number of uncompressed bytes
                         const compressedArray = new Uint8Array(
                             response.data.buffer,
                             response.data.byteOffset + headerSize + 2,
-                            dataSize - 2,
+                            dataSize - 2
                         );
                         const decompressedArray = huffmanDecodeBuf(
                             compressedArray,
                             compressedCharCount,
                             defaultHuffmanTree,
-                            defaultHuffmanLenIndex,
+                            defaultHuffmanLenIndex
                         );
-
-                        onDataCallback(address, new DataView(decompressedArray.buffer), dataSize);
+                        payloadView = new DataView(decompressedArray.buffer);
                     }
-                } else {
-                    // Report address error
-                    console.log(`Expected address ${address} but received ${chunkAddress} - retrying`);
-                    onDataCallback(address, null); // returning null to the callback forces a retry
+                } catch (e) {
+                    console.warn('Decompression or read failed, delivering raw data anyway');
+                    payloadView = new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize);
                 }
             } else {
-                // Report crc error
-                console.log(`CRC error for address ${address} - retrying`);
-                onDataCallback(address, null); // returning null to the callback forces a retry
+                console.log(`Expected address ${address} but received ${chunkAddress}`);
             }
-        },
-        true,
-    );
-};
-
-MspHelper.prototype.sendServoConfigurations = function (onCompleteCallback) {
-    let nextFunction = send_next_servo_configuration;
-
-    let servoIndex = 0;
-
-    if (FC.SERVO_CONFIG.length == 0) {
-        onCompleteCallback();
-    } else {
-        nextFunction();
-    }
-
-    function send_next_servo_configuration() {
-        const buffer = [];
-
-        // send one at a time, with index
-
-        const servoConfiguration = FC.SERVO_CONFIG[servoIndex];
-
-        buffer
-            .push8(servoIndex)
-            .push16(servoConfiguration.min)
-            .push16(servoConfiguration.max)
-            .push16(servoConfiguration.middle)
-            .push8(servoConfiguration.rate);
-
-        let out = servoConfiguration.indexOfChannelToForward;
-        if (out == undefined) {
-            out = 255; // Cleanflight defines "CHANNEL_FORWARDING_DISABLED" as "(uint8_t)0xFF"
-        }
-        buffer.push8(out).push32(servoConfiguration.reversedInputSources);
-
-        // prepare for next iteration
-        servoIndex++;
-        if (servoIndex == FC.SERVO_CONFIG.length) {
-            nextFunction = onCompleteCallback;
         }
 
-        MSP.send_message(MSPCodes.MSP_SET_SERVO_CONFIGURATION, buffer, false, nextFunction);
-    }
-};
+        // Deliver payloadView if defined, otherwise pass null
+        onDataCallback(address, payloadView);
 
-MspHelper.prototype.sendModeRanges = function (onCompleteCallback) {
-    let nextFunction = send_next_mode_range;
-
-    let modeRangeIndex = 0;
-
-    if (FC.MODE_RANGES.length == 0) {
-        onCompleteCallback();
-    } else {
-        send_next_mode_range();
-    }
-
-    function send_next_mode_range() {
-        const modeRange = FC.MODE_RANGES[modeRangeIndex];
-        const buffer = [];
-
-        buffer
-            .push8(modeRangeIndex)
-            .push8(modeRange.id)
-            .push8(modeRange.auxChannelIndex)
-            .push8((modeRange.range.start - 900) / 25)
-            .push8((modeRange.range.end - 900) / 25);
-
-        const modeRangeExtra = FC.MODE_RANGES_EXTRA[modeRangeIndex];
-
-        buffer.push8(modeRangeExtra.modeLogic).push8(modeRangeExtra.linkedTo);
-
-        // prepare for next iteration
-        modeRangeIndex++;
-        if (modeRangeIndex == FC.MODE_RANGES.length) {
-            nextFunction = onCompleteCallback;
+        if (!response || response.crcError) {
+            console.log(`CRC error or missing data at address ${address} - delivering whatever we got`);
+        } else if (payloadView) {
+            console.log(`Block at ${address} received (${payloadView.byteLength} bytes)`);
         }
-        MSP.send_message(MSPCodes.MSP_SET_MODE_RANGE, buffer, false, nextFunction);
-    }
-};
+    }, true); // end of send_message
+}; // end of dataflashRead
+
 
 MspHelper.prototype.sendAdjustmentRanges = function (onCompleteCallback) {
     let nextFunction = send_next_adjustment_range;

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -489,49 +489,50 @@ onboard_logging.initialize = function (callback) {
 
                     show_saving_dialog();
 
-                    function onChunkRead(chunkAddress, chunkDataView, bytesCompressed) {
-                        if (chunkDataView !== null) {
-                            // Did we receive any data?
-                            if (chunkDataView.byteLength > 0) {
-                                nextAddress += chunkDataView.byteLength;
-                                if (isNaN(bytesCompressed) || isNaN(totalBytesCompressed)) {
-                                    totalBytesCompressed = null;
-                                } else {
-                                    totalBytesCompressed += bytesCompressed;
-                                }
+function onChunkRead(chunkAddress, chunkDataView, bytesCompressed) {
+    if (chunkDataView && chunkDataView.byteLength > 0) {
+        // Always write non-empty data, even if CRC mismatch
+        const blob = new Blob([chunkDataView]);
+        FileSystem.writeChunck(openedFile, blob);
 
-                                $(".dataflash-saving progress").attr("value", (nextAddress / maxBytes) * 100);
+        nextAddress += chunkDataView.byteLength;
 
-                                const blob = new Blob([chunkDataView]);
-                                FileSystem.writeChunck(openedFile, blob).then(() => {
-                                    if (saveCancelled || nextAddress >= maxBytes) {
-                                        if (saveCancelled) {
-                                            dismiss_saving_dialog();
-                                        } else {
-                                            mark_saving_dialog_done(startTime, nextAddress, totalBytesCompressed);
-                                        }
-                                        FileSystem.closeFile(openedFile);
-                                    } else {
-                                        if (!self.writeError) {
-                                            mspHelper.dataflashRead(nextAddress, self.blockSize, onChunkRead);
-                                        } else {
-                                            dismiss_saving_dialog();
-                                            FileSystem.closeFile(openedFile);
-                                        }
-                                    }
-                                });
-                            } else {
-                                // A zero-byte block indicates end-of-file, so we're done
-                                mark_saving_dialog_done(startTime, nextAddress, totalBytesCompressed);
-                                FileSystem.closeFile(openedFile);
-                            }
-                        } else {
-                            // There was an error with the received block (address didn't match the one we asked for), retry
-                            mspHelper.dataflashRead(nextAddress, self.blockSize, onChunkRead);
-                        }
-                    }
+        // Track total compressed bytes, if provided
+        if (typeof bytesCompressed === "number") {
+            if (totalBytesCompressed == null) totalBytesCompressed = 0; // initialize if previously unknown
+            totalBytesCompressed += bytesCompressed;
+        }
 
-                    const startTime = new Date().getTime();
+        $(".dataflash-saving progress").attr("value", (nextAddress / maxBytes) * 100);
+
+        if (saveCancelled || nextAddress >= maxBytes) {
+            mark_saving_dialog_done(startTime, nextAddress, totalBytesCompressed);
+            FileSystem.closeFile(openedFile);
+        } else {
+            mspHelper.dataflashRead(nextAddress, self.blockSize, onChunkRead);
+        }
+
+    } else if (chunkDataView && chunkDataView.byteLength === 0) {
+        // Zero-length block → EOF
+        mark_saving_dialog_done(startTime, nextAddress, totalBytesCompressed);
+        FileSystem.closeFile(openedFile);
+
+    } else {
+        // Null block → skip ahead (hard error)
+        console.warn(`Skipping null block at address ${nextAddress}`);
+        nextAddress += self.blockSize;
+
+        if (nextAddress >= maxBytes) {
+            mark_saving_dialog_done(startTime, nextAddress, totalBytesCompressed);
+            FileSystem.closeFile(openedFile);
+        } else {
+            mspHelper.dataflashRead(nextAddress, self.blockSize, onChunkRead);
+        }
+    }
+}
+
+const startTime = new Date().getTime(); // Start timestamp
+
                     // Fetch the initial block
                     FileSystem.openFile(fileWriter).then((file) => {
                         openedFile = file;


### PR DESCRIPTION
Just a quick hack to see if ignoring CRC errors will allow the 'Save Flash to File function to work more reliably.
Currently the binary characters in the logfile seem to generate CRC errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Callbacks now always receive available data; checksum/address mismatches and decompression/read issues are logged without retries, improving robustness.

* **New Features**
  * Automatic handling of compressed flash blocks with on-the-fly decompression, immediate per-block writes, skip-null-block behavior, single-read flow, and improved progress/timing reporting.

* **Chores**
  * Removed two legacy public helper methods; main data-read API remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->