### PR TITLE
Add missing VTXPOWER tooltip message

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2727,6 +2727,10 @@
         "message": "Disable the control of VTX settings through the OSD",
         "description": "Help text to VTX CONTROL DISABLE mode"
     },
+    "auxiliaryHelpMode_VTXPOWER": {
+        "message": "Cycle through VTX power levels (if supported by VTX)",
+        "description": "Help text to VTX POWER mode"
+    },
     "auxiliaryHelpMode_VTXPITMODE": {
         "message": "Switch the VTX into pit mode (low output power, if supported)",
         "description": "Help text to VTX PIT MODE mode"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added English help text for the VTX POWER mode, explaining cycling through VTX power levels when supported by the device.
  * Appears with other auxiliary mode help messages in the UI to guide configuration and improve clarity when adjusting VTX settings.
  * Available wherever auxiliary mode help is displayed for the English locale; this is a text addition only and does not change functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->