### PR TITLE
Fix custom mag_alignment

### DIFF
--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -643,9 +643,9 @@ MspHelper.prototype.process_data = function (dataHandler) {
 
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
                         FC.SENSOR_ALIGNMENT.gyro_enable_mask = data.readU8(); // replacing gyro_to_use
-                        FC.SENSOR_ALIGNMENT.mag_align_roll = data.readU16();
-                        FC.SENSOR_ALIGNMENT.mag_align_pitch = data.readU16();
-                        FC.SENSOR_ALIGNMENT.mag_align_yaw = data.readU16();
+                        FC.SENSOR_ALIGNMENT.mag_align_roll = data.read16();
+                        FC.SENSOR_ALIGNMENT.mag_align_pitch = data.read16();
+                        FC.SENSOR_ALIGNMENT.mag_align_yaw = data.read16();
                     } else {
                         FC.SENSOR_ALIGNMENT.gyro_to_use = data.readU8();
                         FC.SENSOR_ALIGNMENT.gyro_1_align = data.readU8();

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -643,6 +643,9 @@ MspHelper.prototype.process_data = function (dataHandler) {
 
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
                         FC.SENSOR_ALIGNMENT.gyro_enable_mask = data.readU8(); // replacing gyro_to_use
+                        FC.SENSOR_ALIGNMENT.mag_align_roll = data.readU16();
+                        FC.SENSOR_ALIGNMENT.mag_align_pitch = data.readU16();
+                        FC.SENSOR_ALIGNMENT.mag_align_yaw = data.readU16();
                     } else {
                         FC.SENSOR_ALIGNMENT.gyro_to_use = data.readU8();
                         FC.SENSOR_ALIGNMENT.gyro_1_align = data.readU8();
@@ -2091,7 +2094,11 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
                 .push8(FC.SENSOR_ALIGNMENT.align_mag);
 
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
-                buffer.push8(FC.SENSOR_ALIGNMENT.gyro_enable_mask); // replacing gyro_to_use
+                buffer
+                    .push8(FC.SENSOR_ALIGNMENT.gyro_enable_mask) // replacing gyro_to_use
+                    .push16(FC.SENSOR_ALIGNMENT.mag_align_roll)
+                    .push16(FC.SENSOR_ALIGNMENT.mag_align_pitch)
+                    .push16(FC.SENSOR_ALIGNMENT.mag_align_yaw);
             } else {
                 buffer
                     .push8(FC.SENSOR_ALIGNMENT.gyro_to_use)

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -643,9 +643,9 @@ MspHelper.prototype.process_data = function (dataHandler) {
 
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
                         FC.SENSOR_ALIGNMENT.gyro_enable_mask = data.readU8(); // replacing gyro_to_use
-                        FC.SENSOR_ALIGNMENT.mag_align_roll = data.read16();
-                        FC.SENSOR_ALIGNMENT.mag_align_pitch = data.read16();
-                        FC.SENSOR_ALIGNMENT.mag_align_yaw = data.read16();
+                        FC.SENSOR_ALIGNMENT.mag_align_roll = data.read16() / 10;
+                        FC.SENSOR_ALIGNMENT.mag_align_pitch = data.read16() / 10;
+                        FC.SENSOR_ALIGNMENT.mag_align_yaw = data.read16() / 10;
                     } else {
                         FC.SENSOR_ALIGNMENT.gyro_to_use = data.readU8();
                         FC.SENSOR_ALIGNMENT.gyro_1_align = data.readU8();
@@ -2096,9 +2096,9 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
                 buffer
                     .push8(FC.SENSOR_ALIGNMENT.gyro_enable_mask) // replacing gyro_to_use
-                    .push16(FC.SENSOR_ALIGNMENT.mag_align_roll)
-                    .push16(FC.SENSOR_ALIGNMENT.mag_align_pitch)
-                    .push16(FC.SENSOR_ALIGNMENT.mag_align_yaw);
+                    .push16(FC.SENSOR_ALIGNMENT.mag_align_roll * 10)
+                    .push16(FC.SENSOR_ALIGNMENT.mag_align_pitch * 10)
+                    .push16(FC.SENSOR_ALIGNMENT.mag_align_yaw * 10);
             } else {
                 buffer
                     .push8(FC.SENSOR_ALIGNMENT.gyro_to_use)


### PR DESCRIPTION
- fixes #4623
- unintentional removed in https://github.com/betaflight/betaflight-configurator/commit/04d4255cefad632d77f67ae8bd305eb09e0fed45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added magnetometer alignment support for API v1.47+: the app now reads and saves mag alignment (roll, pitch, yaw) alongside gyro settings, improving compatibility with newer firmware and preserving magnetometer alignment during configuration syncs. Older API behavior is unchanged for backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->