### PR TITLE
Improve Dataflash Save To File

### DIFF
--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -98,12 +98,12 @@ class FileSystem {
         return await fileHandle.createWritable(options);
     }
 
-    async writeChunck(writable, chunk) {
-        await writable.write(chunk);
+    async writeChunk(writable, chunk) {
+        writable.write(chunk);
     }
 
     async closeFile(writable) {
-        await writable.close();
+        writable.close();
     }
 }
 

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -122,7 +122,8 @@ const MSP = {
                             this.state = this.decoder_states.DIRECTION_V2;
                             break;
                         default:
-                            console.log(`Unknown protocol char ${String.fromCharCode(chunk)}`);
+                            // Removed logging of unknown protocol characters because the log itself is binary.
+                            // console.log(`Unknown protocol char ${String.fromCharCode(chunk)}`);
                             this.state = this.decoder_states.IDLE;
                     }
                     break;

--- a/src/js/tabs/logging.js
+++ b/src/js/tabs/logging.js
@@ -257,7 +257,7 @@ logging.initialize = function (callback) {
     }
 
     function append_to_file(data) {
-        FileSystem.writeChunck(logging.fileWriter, new Blob([data], { type: "text/plain" })).catch((error) => {
+        FileSystem.writeChunk(logging.fileWriter, new Blob([data], { type: "text/plain" })).catch((error) => {
             console.error("Error appending to file: ", error);
         });
     }

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -492,7 +492,7 @@ onboard_logging.initialize = function (callback) {
                     show_saving_dialog();
 
                     // START PATCH: minimal retry for null/missing blocks
-                    const MAX_SIMPLE_RETRIES = 1;
+                    const MAX_SIMPLE_RETRIES = 5;
                     let simpleRetryCount = 0;
 
                     function onChunkRead(chunkAddress, chunkDataView, bytesCompressed) {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -488,8 +488,8 @@ onboard_logging.initialize = function (callback) {
             show_saving_dialog();
 
             const MAX_SIMPLE_RETRIES = 5;
-            const BASE_RETRY_BACKOFF_MS = 30; // starting backoff
-            const INTER_BLOCK_DELAY_MS = 2; // small delay between successful blocks
+            const BASE_RETRY_BACKOFF_MS = 50; // starting backoff
+            const INTER_BLOCK_DELAY_MS = 10; // small delay between successful blocks
             const startTime = new Date().getTime();
 
             prepare_file(async (fileWriter) => {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -537,7 +537,7 @@ onboard_logging.initialize = function (callback) {
                                 nextAddress += self.blockSize; // Move to next block
                                 simpleRetryCount = 0; // reset counter for next block
 
-                                if (nextAddress >= maxBytes) {
+                                if (saveCancelled || nextAddress >= maxBytes) {
                                     mark_saving_dialog_done(startTime, nextAddress, totalBytesCompressed);
                                     FileSystem.closeFile(openedFile);
                                 } else {

--- a/src/js/tabs/onboard_logging.js
+++ b/src/js/tabs/onboard_logging.js
@@ -502,7 +502,7 @@ onboard_logging.initialize = function (callback) {
 
                             // --- ORIGINAL BLOCK WRITE LOGIC ---
                             const blob = new Blob([chunkDataView]);
-                            FileSystem.writeChunck(openedFile, blob);
+                            FileSystem.writeChunk(openedFile, blob);
 
                             nextAddress += chunkDataView.byteLength;
 


### PR DESCRIPTION
For a very long time, the 'unsupported' 'Save Flash to File button in the Blackbox tab would randomly stall while saving.

This PR, with help from chat GPT, doesn't stall nearly as often.  By saving all blocks even if the CRC fails, and not attempting retries, the download progresses quickly and without hanging, although the data may contain some errors, the logs appear the same in blackbox log viewer.

The main end-user  benefits include a standard file dialog, in whichthe the file can be pre-named, at save time, the resulting file is not locked and can easily be re-named, there is no need to exit Mass storage Mode, sothe Configurator sessioncan  remain active, hence there is no need to  re-connect the FC to continue working in Configurator.


If we ca retry on CRC errors, without locking up the save process, that would be worth looking into.

It may be possible to improve the 'retry' logic, but most logs made this way appear to contain the same data as those copied by the Mass Storage method, when reviewed in Blackbox log viewer.

I removed the  console logging of the protocol character errors, which seemed generally unhelpful, but am happy to reverse that if recommended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for reading and decoding compressed onboard logs (Huffman) and reporting compressed byte counts.

* **Bug Fixes**
  * Robust retry/backoff for missing/NULL blocks with skip-after-fail to avoid stalls.
  * Returns available data on CRC/address mismatches and updates progress per valid chunk.
  * More reliable file write/close behavior to ensure logging is saved.

* **Style**
  * Reduced noisy protocol warnings and standardized progress / kB / s formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->