### PR TITLE
Add QMC5883P

### DIFF
--- a/src/js/sensor_types.js
+++ b/src/js/sensor_types.js
@@ -87,6 +87,7 @@ export function sensorTypes() {
                 "LIS3MDL",
                 "MPU925X_AK8963",
                 "IST8310",
+                "QMC5883P",
             ],
         },
         gps: {


### PR DESCRIPTION
- keep in sync with https://github.com/betaflight/betaflight/pull/14680

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the QMC5883P magnetometer, allowing users to configure and use this sensor alongside existing magnetometer options.
  * The new sensor is available in selection menus and works with existing data display and calibration flows without additional steps.
  * Expands hardware compatibility, improving coverage for devices relying on magnetic heading, orientation, and navigation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->