### PR TITLE
Resolved missing DEBUG modes

### DIFF
--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -101,6 +101,9 @@ const DEBUG = {
         "TASK",
         "GIMBAL",
         "WING_SETPOINT",
+        "DEBUG_AUTOPILOT",
+        "CHIRP",
+        "FLASH_TEST_PRBS",
     ],
 
     fieldNames: {
@@ -854,7 +857,7 @@ function update() {
 
         delete DEBUG.fieldNames.GPS_RESCUE_THROTTLE_PID;
         delete DEBUG.fieldNames.GYRO_SCALED;
-        
+
         DEBUG.fieldNames["MULTI_GYRO_RAW"] = DEBUG.fieldNames.DUAL_GYRO_RAW;
         DEBUG.fieldNames["MULTI_GYRO_DIFF"] = DEBUG.fieldNames.DUAL_GYRO_DIFF;
         DEBUG.fieldNames["MULTI_GYRO_SCALED"] = DEBUG.fieldNames.DUAL_GYRO_SCALED;


### PR DESCRIPTION
Resolved missing DEBUG modes:
"DEBUG_AUTOPILOT",
"CHIRP",
 "FLASH_TEST_PRBS"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added debug modes: Autopilot, Chirp, and Flash Test PRBS.
  - Introduced new debug categories: Autopilot Altitude/Position, Optical Flow, FFT Frequency, and TPA.
  - Added Attitude and Servo to available enable options.

- Changes
  - Migrated dual-gyro debug categories to multi-gyro equivalents.
  - Removed legacy GPS Rescue Throttle PID and Gyro Scaled categories.
  - Expanded FFT frequency labels and adjusted ordering to place Attitude after Gyro.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->