### PR TITLE
Add RC smoothing throttle configuration to UI

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2057,16 +2057,24 @@
         "message": "Manual"
     },
     "receiverRcSmoothingAutoFactor": {
-        "message": "Auto Factor",
-        "description": "Auto Factor parameter for RC smoothing"
+        "message": "SetPoint Auto Factor",
+        "description": "SetPoint Auto Factor parameter for RC smoothing"
     },
     "receiverRcSmoothingAutoFactorHelp": {
-        "message": "Adjusts the Auto factor calculation, 10 is the default factor to delay ratio. Increasing the number will smooth RC inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs.",
-        "description": "Auto Factor parameter help message"
+        "message": "Adjusts the SetPoint Auto factor calculation, 10 is the default factor to delay ratio. Increasing the number will smooth RC inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs.",
+        "description": "SetPoint Auto Factor parameter help message"
     },
     "receiverRcSmoothingAutoFactorHelp2": {
-        "message": "Adjusts auto RC smoothing. 30 is the default. Higher values smooth RC inputs more - e.g. 60 for HD freestyle or 90-120 for cinematic flying. Note: Values over 50 will cause appreciable stick delay. Lower values, eg 20-25, will transfer some of the RC control steps into the motor signals, slightly increasing motor heat, but will reduce RC delay slightly. This may be useful for racing.",
-        "description": "Auto Factor parameter help message"
+        "message": "Adjusts SetPoint RC smoothing. 30 is the default. Higher values smooth RC inputs more - e.g. 60 for HD freestyle or 90-120 for cinematic flying. Note: Values over 50 will cause appreciable stick delay. Lower values, eg 20-25, will transfer some of the RC control steps into the motor signals, slightly increasing motor heat, but will reduce RC delay slightly. This may be useful for racing.",
+        "description": "SetPoint Auto Factor parameter help message"
+    },
+    "receiverRcSmoothingAutoFactorThrottle": {
+        "message": "Throttle Auto Factor",
+        "description": "Throttle Auto Factor parameter for RC smoothing"
+    },
+    "receiverRcSmoothingAutoFactorThrottleHelp": {
+        "message": "Adjusts the Throttle factor calculation, 10 is the default factor to delay ratio. Increasing the number will smooth throttle inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs.",
+        "description": "Throttle Auto Factor parameter help message"
     },
     "receiverRcFeedforwardTypeSelect": {
         "message": "Feedforward Cutoff Type"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -632,6 +632,7 @@ const FC = {
             rcSmoothingInputType: 0,
             rcSmoothingDerivativeType: 0,
             rcSmoothingAutoFactor: 0,
+            rcSmoothingAutoFactorThrottle: 0,
             usbCdcHidType: 0,
             rcSmoothing: 0,
             elrsUid: [0, 0, 0, 0, 0, 0],

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1050,10 +1050,11 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.RX_CONFIG.rcSmoothingSetpointCutoff = data.readU8();
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
                         FC.RX_CONFIG.rcSmoothingThrottleCutoff = data.readU8();
+                        FC.RX_CONFIG.rcSmoothingAutoFactorThrottle = data.readU8();
                     } else {
                         FC.RX_CONFIG.rcSmoothingFeedforwardCutoff = data.readU8(); // deprecated in 1.47
+                        data.readU8(); // was FC.RX_CONFIG.rcSmoothingDerivativeCutoff
                     }
-                    data.readU8(); // was FC.RX_CONFIG.rcSmoothingInputType
                     data.readU8(); // was FC.RX_CONFIG.rcSmoothingDerivativeType
                     FC.RX_CONFIG.usbCdcHidType = data.readU8();
                     FC.RX_CONFIG.rcSmoothingAutoFactor = data.readU8();
@@ -2002,10 +2003,12 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
                 .push8(FC.RX_CONFIG.rcSmoothingSetpointCutoff);
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
                 buffer.push8(FC.RX_CONFIG.rcSmoothingThrottleCutoff);
+                buffer.push8(FC.RX_CONFIG.rcSmoothingAutoFactorThrottle);
             } else {
                 buffer.push8(FC.RX_CONFIG.rcSmoothingFeedforwardCutoff);
+                buffer.push8(FC.RX_CONFIG.rcSmoothingInputType);
             }
-            buffer.push8(FC.RX_CONFIG.rcSmoothingInputType).push8(FC.RX_CONFIG.rcSmoothingDerivativeType);
+            buffer.push8(FC.RX_CONFIG.rcSmoothingDerivativeType);
 
             // Introduced in 1.42
             buffer.push8(FC.RX_CONFIG.usbCdcHidType).push8(FC.RX_CONFIG.rcSmoothingAutoFactor);

--- a/src/js/tabs/receiver.js
+++ b/src/js/tabs/receiver.js
@@ -496,6 +496,9 @@ receiver.initialize = function (callback) {
                 if (FC.RX_CONFIG.rcSmoothingThrottleCutoff === 0) {
                     $('select[name="rcSmoothing-throttle-manual-select"]').val(0).trigger("change");
                 }
+                FC.RX_CONFIG.rcSmoothingAutoFactorThrottle = Number.parseInt(
+                    $('input[name="rcSmoothingAutoFactorThrottle-number"]').val(),
+                );
             } else {
                 FC.RX_CONFIG.rcSmoothingFeedforwardCutoff = parseInt(
                     $('input[name="rcSmoothingFeedforwardCutoff-number"]').val(),
@@ -724,6 +727,12 @@ receiver.initialize = function (callback) {
         rcSmoothingAutoFactor.val(FC.RX_CONFIG.rcSmoothingAutoFactor);
 
         $(".receiverRcSmoothingAutoFactorHelp").attr("title", i18n.getMessage("receiverRcSmoothingAutoFactorHelp2"));
+
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+            $('input[name="rcSmoothingAutoFactorThrottle-number"]').val(FC.RX_CONFIG.rcSmoothingAutoFactorThrottle);
+        } else {
+            $(".tab-receiver .rcSmoothing-auto-factor-throttle").hide();
+        }
 
         updateInterpolationView();
 
@@ -987,15 +996,19 @@ function updateInterpolationView() {
     $(".tab-receiver .rcSmoothing-feedforward-cutoff").show();
     $(".tab-receiver .rcSmoothing-setpoint-cutoff").show();
 
-    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+        $(".tab-receiver .rcSmoothing-throttle-manual").show();
+    } else {
         $(".tab-receiver .rcSmoothing-feedforward-manual").show();
     }
 
     $(".tab-receiver .rcSmoothing-setpoint-manual").show();
-    $(".tab-receiver .rcSmoothing-throttle-cutoff").show();
 
     if (FC.RX_CONFIG.rcSmoothingFeedforwardCutoff === 0 || FC.RX_CONFIG.rcSmoothingSetpointCutoff === 0) {
         $(".tab-receiver .rcSmoothing-auto-factor").show();
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+            $(".tab-receiver .rcSmoothing-auto-factor-throttle").show();
+        }
     }
 
     $(".tab-receiver .rcSmoothingOff").text(i18n.getMessage("off"));
@@ -1007,7 +1020,9 @@ function updateInterpolationView() {
         $(".tab-receiver .rcSmoothing-throttle-cutoff").hide();
         $(".tab-receiver .rcSmoothing-feedforward-manual").hide();
         $(".tab-receiver .rcSmoothing-setpoint-manual").hide();
+        $(".tab-receiver .rcSmoothing-throttle-manual").hide();
         $(".tab-receiver .rcSmoothing-auto-factor").hide();
+        $(".tab-receiver .rcSmoothing-auto-factor-throttle").hide();
     }
 
     if (FC.RX_CONFIG.rcSmoothingFeedforwardCutoff === 0) {

--- a/src/tabs/receiver.html
+++ b/src/tabs/receiver.html
@@ -227,6 +227,22 @@
                             </td>
                         </tr>
 
+                        <tr class="rcSmoothing-auto-factor">
+                            <td>
+                                <input type="number" name="rcSmoothingAutoFactor-number" step="1" min="0" max="250">
+                            </td>
+                            <td>
+                                <div>
+                                    <label>
+                                        <span i18n="receiverRcSmoothingAutoFactor"></span>
+                                    </label>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="helpicon cf_tip receiverRcSmoothingAutoFactorHelp" i18n_title="receiverRcSmoothingAutoFactorHelp"></div>
+                            </td>
+                        </tr>
+
                         <tr class="rcSmoothing-throttle-manual">
                             <td>
                                 <select name="rcSmoothing-throttle-manual-select">
@@ -257,6 +273,22 @@
                             </td>
                         </tr>
 
+                        <tr class="rcSmoothing-auto-factor-throttle">
+                            <td>
+                                <input type="number" name="rcSmoothingAutoFactorThrottle-number" step="1" min="0" max="250">
+                            </td>
+                            <td>
+                                <div>
+                                    <label>
+                                        <span i18n="receiverRcSmoothingAutoFactorThrottle"></span>
+                                    </label>
+                                </div>
+                            </td>
+                            <td>
+                                <div class="helpicon cf_tip receiverRcSmoothingAutoFactorThrottleHelp" i18n_title="receiverRcSmoothingAutoFactorThrottleHelp"></div>
+                            </td>
+                        </tr>
+
                         <tr class="rcSmoothing-feedforward-manual">
                             <td>
                                 <select name="rcSmoothing-feedforward-select">
@@ -284,21 +316,6 @@
                                     </label>
                                     <div class="helpicon cf_tip" i18n_title="rcSmoothingFeedforwardCutoffHelp"></div>
                                 </div>
-                            </td>
-                        </tr>
-                        <tr class="rcSmoothing-auto-factor">
-                            <td>
-                                <input type="number" name="rcSmoothingAutoFactor-number" step="1" min="0" max="250">
-                            </td>
-                            <td>
-                                <div>
-                                    <label>
-                                        <span i18n="receiverRcSmoothingAutoFactor"></span>
-                                    </label>
-                                </div>
-                            </td>
-                            <td>
-                                <div class="helpicon cf_tip receiverRcSmoothingAutoFactorHelp" i18n_title="receiverRcSmoothingAutoFactorHelp"></div>
                             </td>
                         </tr>
                     </table>


### PR DESCRIPTION
- depends on https://github.com/betaflight/betaflight/pull/14683

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added throttle-smoothing controls in Receiver: Throttle Auto/Manual selector and Throttle Cutoff Frequency input with contextual help; UI shows/hides controls based on selection and firmware version.

* **Localization**
  * Added and updated English labels/help: "Throttle Cutoff Type", "Throttle Cutoff Frequency", throttle-specific Auto Factor text and help, and renamed "Auto Factor" to "SetPoint Auto Factor".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->