### PR TITLE
Fix capitalization in SETpoINT Auto Factor messages

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2057,16 +2057,16 @@
         "message": "Manual"
     },
     "receiverRcSmoothingAutoFactor": {
-        "message": "SetPoint Auto Factor",
+        "message": "Setpoint Auto Factor",
         "description": "SetPoint Auto Factor parameter for RC smoothing"
     },
     "receiverRcSmoothingAutoFactorHelp": {
-        "message": "Adjusts the SetPoint Auto factor calculation, 10 is the default factor to delay ratio. Increasing the number will smooth RC inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs.",
-        "description": "SetPoint Auto Factor parameter help message"
+        "message": "Adjusts the Setpoint Auto factor calculation, 10 is the default factor to delay ratio. Increasing the number will smooth RC inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs.",
+        "description": "Setpoint Auto Factor parameter help message"
     },
     "receiverRcSmoothingAutoFactorHelp2": {
-        "message": "Adjusts SetPoint RC smoothing. 30 is the default. Higher values smooth RC inputs more - e.g. 60 for HD freestyle or 90-120 for cinematic flying. Note: Values over 50 will cause appreciable stick delay. Lower values, eg 20-25, will transfer some of the RC control steps into the motor signals, slightly increasing motor heat, but will reduce RC delay slightly. This may be useful for racing.",
-        "description": "SetPoint Auto Factor parameter help message"
+        "message": "Adjusts Setpoint RC smoothing. 30 is the default. Higher values smooth RC inputs more - e.g. 60 for HD freestyle or 90-120 for cinematic flying. Note: Values over 50 will cause appreciable stick delay. Lower values, eg 20-25, will transfer some of the RC control steps into the motor signals, slightly increasing motor heat, but will reduce RC delay slightly. This may be useful for racing.",
+        "description": "Setpoint Auto Factor parameter help message"
     },
     "receiverRcSmoothingAutoFactorThrottle": {
         "message": "Throttle Auto Factor",

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2058,7 +2058,7 @@
     },
     "receiverRcSmoothingAutoFactor": {
         "message": "Setpoint Auto Factor",
-        "description": "SetPoint Auto Factor parameter for RC smoothing"
+        "description": "Setpoint Auto Factor parameter for RC smoothing"
     },
     "receiverRcSmoothingAutoFactorHelp": {
         "message": "Adjusts the Setpoint Auto factor calculation, 10 is the default factor to delay ratio. Increasing the number will smooth RC inputs more, while also adding delay. This may be useful for unreliable RC connections or for cinematic flying.<br>Be careful with numbers approaching 50, input delay will become noticeable.<br>Use the CLI command rc_smoothing_info while TX and RX are powered to see the automatically calculated RC smoothing cutoffs.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized capitalization from “SetPoint” to “Setpoint” for the RC Smoothing Auto Factor label in the UI.

* **Documentation**
  * Updated English help text and descriptions to use “Setpoint” consistently across RC Smoothing Auto Factor entries, improving clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->