### PR TITLE
Add 5s and 10s average of ampere to help calibrate ampere sensor.

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3130,6 +3130,12 @@
     "motorsmAhDrawn": {
         "message": "Amp. drawn:"
     },
+    "motorsAmperageAverage5s": {
+        "message": "Amperage (5s avg):"
+    },
+    "motorsAmperageAverage10s": {
+        "message": "Amperage (10s avg):"
+    },
     "motorsVoltageValue": {
         "message": "$1 V"
     },
@@ -3138,6 +3144,12 @@
     },
     "motorsmAhDrawnValue": {
         "message": "$1 mAh"
+    },
+    "motorsAmperageAverage5sValue": {
+        "message": "$1 A"
+    },
+    "motorsAmperageAverage10sValue": {
+        "message": "$1 A"
     },
     "motorsText":{
         "message": "Motors"
@@ -5332,6 +5344,12 @@
     },
     "powerBatteryAmperage": {
         "message": "Amperage"
+    },
+    "powerBatteryAmperageAverage5s": {
+        "message": "Amperage (5s average)"
+    },
+    "powerBatteryAmperageAverage10s": {
+        "message": "Amperage (10s average)"
     },
     "powerBatteryCapacity": {
         "message": "Capacity (mAh)"

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -2239,6 +2239,12 @@
     "motorsmAhDrawn": {
         "message": "已消耗电流："
     },
+    "motorsAmperageAverage5s": {
+        "message": "电流 (5秒平均)："
+    },
+    "motorsAmperageAverage10s": {
+        "message": "电流 (10秒平均)："
+    },
     "motorsVoltageValue": {
         "message": "$1 V"
     },
@@ -2247,6 +2253,12 @@
     },
     "motorsmAhDrawnValue": {
         "message": "$1 mAh"
+    },
+    "motorsAmperageAverage5sValue": {
+        "message": "$1 A"
+    },
+    "motorsAmperageAverage10sValue": {
+        "message": "$1 A"
     },
     "motorsText": {
         "message": "电机"
@@ -3999,6 +4011,12 @@
     },
     "powerBatteryAmperage": {
         "message": "电流"
+    },
+    "powerBatteryAmperageAverage5s": {
+        "message": "电流 (5秒平均)"
+    },
+    "powerBatteryAmperageAverage10s": {
+        "message": "电流 (10秒平均)"
     },
     "powerBatteryCapacity": {
         "message": "容量 (mAh)"

--- a/src/tabs/motors.html
+++ b/src/tabs/motors.html
@@ -279,6 +279,8 @@
                             <span i18n="motorsVoltage" class="power_text"></span><span class="motors-bat-voltage power_value"></span>
                             <span i18n="motorsADrawing" class="power_text"></span><span class="motors-bat-mah-drawing power_value"></span>
                             <span i18n="motorsmAhDrawn" class="power_text"></span><span class="motors-bat-mah-drawn power_value"></span>
+                            <span i18n="motorsAmperageAverage5s" class="power_text"></span><span class="motors-bat-amperage-average-5s power_value"></span>
+                            <span i18n="motorsAmperageAverage10s" class="power_text"></span><span class="motors-bat-amperage-average-10s power_value"></span>
                         </div>
                     </div>
                         <div class="motors">

--- a/src/tabs/power.html
+++ b/src/tabs/power.html
@@ -123,6 +123,14 @@
             <td i18n="powerBatteryAmperage"></td>
             <td class="value"></td>
         </tr>
+        <tr class="amperage-average-5s">
+            <td i18n="powerBatteryAmperageAverage5s"></td>
+            <td class="value"></td>
+        </tr>
+        <tr class="amperage-average-10s">
+            <td i18n="powerBatteryAmperageAverage10s"></td>
+            <td class="value"></td>
+        </tr>
         </tbody>
     </table>
 


### PR DESCRIPTION
Why?

My ampere values is jumping fast and that makes me very hard to know the current ampere to calibrate battery.

So having 5s and 10s average makes everything easier.