### PR TITLE
Add support for 460K8 telemetry baudrate

### DIFF
--- a/src/js/tabs/ports.js
+++ b/src/js/tabs/ports.js
@@ -98,6 +98,7 @@ ports.initialize = function (callback) {
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
         gpsBaudRates.push("230400");
+        telemetryBaudRates.push("230400", "460800");
     }
 
     const columns = ["configuration", "peripherals", "sensors", "telemetry", "rx"];


### PR DESCRIPTION
- depends on https://github.com/betaflight/betaflight/pull/14697

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded telemetry baud rate options. When connected to devices with API v1.47 or higher, users can now select 230400 and 460800 for telemetry configurations, enabling higher-speed communication where supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->