### PR TITLE
Fix triggering firmware flasher tab twice

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -188,8 +188,6 @@ function startProcess() {
                 if (GUI.connected_to || GUI.connecting_to) {
                     $("a.connection_button__link").click();
                 }
-                // this line is required but it triggers opening the firmware flasher tab again
-                $("a.firmware_flasher_button__link").click();
             } else if (GUI.allowedTabs.indexOf(tab) < 0) {
                 gui_log(i18n.getMessage("tabSwitchUpgradeRequired", [tabName]));
                 return;


### PR DESCRIPTION
- isolated fix from https://github.com/betaflight/betaflight-configurator/pull/4661

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stopped automatic redirect to the firmware flasher tab when attempting to open restricted tabs during an active connection. Navigation now remains on your current tab until you choose to switch, preventing surprise tab changes and preserving ongoing workflows.
  * Improves stability of the connection flow by relying on user-driven navigation, reducing accidental flasher launches and unintended context switches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->