### PR TITLE
Responsive layout in Adjustments tab

### DIFF
--- a/src/css/tabs/adjustments.less
+++ b/src/css/tabs/adjustments.less
@@ -116,10 +116,6 @@
                 width: 100%;
                 box-sizing: border-box;
 
-                &.info {
-                    padding: 0;
-                }
-
                 &::before {
                     content: attr(data-label);
                     font-weight: bold;
@@ -137,29 +133,27 @@
                 align-items: center;
                 justify-content: center;
                 background-color: var(--surface-300);
-                padding: 2rem;
                 gap: 1rem;
+                padding: 0.75rem;
+
+                &::before {
+                    content: attr(data-label);
+                    font-weight: bold;
+                    display: inline;
+                    margin-bottom: 0;
+                    color: var(--text);
+                    font-size: 0.9em;
+                }
 
                 .enabling {
                     display: flex;
                     align-items: center;
                     justify-content: center;
                     gap: 0.75rem;
-
-                    &::before {
-                        content: "Enable";
-                        font-weight: bold;
-                        color: var(--text);
-                        font-size: 0.9em;
-                    }
                 }
             }
 
             .channelInfo {
-                &::before {
-                    content: "When Channel";
-                }
-
                 > div:first-child {
                     margin-bottom: 0.75rem;
 
@@ -195,10 +189,6 @@
             }
 
             .range {
-                &::before {
-                    content: "Is In Range";
-                }
-
                 padding: 0.75rem;
 
                 .channel-slider {
@@ -214,10 +204,6 @@
             }
 
             .functionSelection {
-                &::before {
-                    content: "Then Apply Function";
-                }
-
                 select {
                     width: 100%;
                     padding: 0.5rem;
@@ -228,10 +214,6 @@
             }
 
             .functionSwitchChannel {
-                &::before {
-                    content: "Via Channel";
-                }
-
                 select {
                     width: 100%;
                     padding: 0.5rem;

--- a/src/js/tabs/adjustments.js
+++ b/src/js/tabs/adjustments.js
@@ -39,6 +39,17 @@ adjustments.initialize = function (callback) {
         $(newAdjustment).attr("id", `adjustment-${adjustmentIndex}`);
         $(newAdjustment).data("index", adjustmentIndex);
 
+        // Set localized data-label attributes for mobile responsive layout
+        $(newAdjustment).find(".info").attr("data-label", i18n.getMessage("adjustmentsColumnEnable"));
+        $(newAdjustment).find(".channelInfo").attr("data-label", i18n.getMessage("adjustmentsColumnWhenChannel"));
+        $(newAdjustment).find(".range").attr("data-label", i18n.getMessage("adjustmentsColumnIsInRange"));
+        $(newAdjustment)
+            .find(".functionSelection")
+            .attr("data-label", i18n.getMessage("adjustmentsColumnThenApplyFunction"));
+        $(newAdjustment)
+            .find(".functionSwitchChannel")
+            .attr("data-label", i18n.getMessage("adjustmentsColumnViaChannel"));
+
         //
         // populate source channel select box
         //


### PR DESCRIPTION
Made the rows of sliders in Adjustments tab responsive and adaptive to mobile.

<img width="250" alt="image" src="https://github.com/user-attachments/assets/d593a9cc-4717-4e3a-9bd5-d74c63503329" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Optimized mobile layout for the Adjustments section into card-like, stacked rows with improved spacing, borders and typography.
  * Improved overflow behavior and responsive rules across breakpoints for smoother mobile scrolling.
  * Added visible per-field labels and reorganized controls for clearer, more readable mobile forms.
* **New Features**
  * Mobile view now includes localized/explicit labels for adjustment fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->