### PR TITLE
Experimental Fix: Add reported non-workig VID/PID

### DIFF
--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -55,6 +55,7 @@ export const serialDevices = [
     { vendorId: 1155, productId: 12886 }, // STM32 in HID mode
     { vendorId: 1155, productId: 14158 }, // 0483:374e STM Electronics STLink Virtual COM Port (NUCLEO boards)
     { vendorId: 1155, productId: 22336 }, // STM Electronics Virtual COM Port
+    { vendorId: 1161, productId: 57549 }, // Experimental VID/PID reproducing user issue (iFlight F745 AIO)
     { vendorId: 4292, productId: 60000 }, // CP210x
     { vendorId: 4292, productId: 60001 }, // CP210x
     { vendorId: 4292, productId: 60002 }, // CP210x


### PR DESCRIPTION
Please don't review yet, just a basic implementation of user-reported VID/PID on an iFlight F745 AIO. Need working build to try

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new serial USB device, expanding device compatibility for the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->