### PR TITLE
Update the DNS name for firmware presets

### DIFF
--- a/src/tabs/presets/SourcesDialog/SourcesDialog.js
+++ b/src/tabs/presets/SourcesDialog/SourcesDialog.js
@@ -74,7 +74,7 @@ export default class PresetsSourcesDialog {
     _createOfficialSource() {
         const officialSource = new PresetSource(
             "Betaflight Official Presets",
-            "https://api.betaflight.com/firmware-presets/",
+            "https://presets.betaflight.com/firmware-presets/",
             "",
         );
         officialSource.official = true;


### PR DESCRIPTION
The use of the location: https://api.betaflight.com/firmware-presets/ will remain, however in the future it may be served by a proxy for backwards compatibility, and the use of api.betaflight.com for more purposes other than presets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the official presets source URL to a new endpoint for improved service delivery.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->