### PR TITLE
Replace nonexistent action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,13 +43,36 @@ jobs:
       - name: Sync Capacitor Android Project
         run: npx cap sync android
 
-      - name: Build and Sign Android APK
-        uses: Narottam04/action-capacitor-android@v1
+      - name: Set up Java
+        uses: actions/setup-java@v4
         with:
-          build-type: 'release'
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Build and Sign Android APK
         env:
-          RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
+        run: |
+          : "${RELEASE_KEYSTORE_BASE64:?Set the RELEASE_KEYSTORE secret with your base64-encoded keystore}"
+          : "${RELEASE_KEYSTORE_PASSWORD:?Set the RELEASE_KEYSTORE_PASSWORD secret with your keystore password}"
+          : "${RELEASE_KEY_ALIAS:?Set the RELEASE_KEY_ALIAS secret with your key alias}"
+          : "${RELEASE_KEY_ALIAS_PASSWORD:?Set the RELEASE_KEY_ALIAS_PASSWORD secret with your key alias password}"
+
+          mkdir -p android/keystore
+          echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > android/keystore/release.jks
+
+          pushd android >/dev/null
+          ./gradlew clean
+          ./gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file="$PWD/keystore/release.jks" \
+            -Pandroid.injected.signing.store.password="$RELEASE_KEYSTORE_PASSWORD" \
+            -Pandroid.injected.signing.key.alias="$RELEASE_KEY_ALIAS" \
+            -Pandroid.injected.signing.key.password="$RELEASE_KEY_ALIAS_PASSWORD"
+          popd >/dev/null
 
       - name: Upload APK as Artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
- Replaced the nonexistent Narottam04/action-capacitor-android@v1 call in [deploy.yml](vscode-file://vscode-app/snap/code/215/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) with first-party steps: install Temurin JDK 21 via actions/setup-java@v4, decode the keystore, and run ./gradlew assembleRelease while injecting the signing parameters so we still produce a signed APK.
- Added guard clauses to surface missing keystore secrets early and documented the expected inputs (RELEASE_KEYSTORE, RELEASE_KEYSTORE_PASSWORD, RELEASE_KEY_ALIAS, RELEASE_KEY_ALIAS_PASSWORD) so the Gradle build can sign correctly.
- Left the artifact upload steps untouched so the generated APK continues to be stored under [android/app/build/outputs/apk/release/](vscode-file://vscode-app/snap/code/215/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Android build and deployment process for improved reliability and security.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->