### PR TITLE
Set default port on permission request failure

### DIFF
--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -167,6 +167,7 @@ PortHandler.requestDevicePermission = async function (protocol) {
             this.selectActivePort(port);
         } else {
             console.log(`${this.logHead} Permission request cancelled or failed for ${protocol} device`);
+            this.portPicker.selectedPort = DEFAULT_PORT;
         }
     } catch (error) {
         console.error(`${this.logHead} Error requesting permission for ${protocol} device:`, error);


### PR DESCRIPTION
- when request fails port_handler should fall back to default port selected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling for cancelled or denied device permissions, ensuring the system automatically reverts to default device selection when permission requests fail.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->