### PR TITLE
Guard MSP messages not included in build

### DIFF
--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -813,7 +813,7 @@ const FC = {
             serialRxTypes[0] = "NONE";
             serialRxTypes.push("SPEKTRUM1024");
         }
-        
+
         if (semver.gte(apiVersion, API_VERSION_1_47)) {
             serialRxTypes.push("MAVLINK");
         }
@@ -871,6 +871,13 @@ const FC = {
         }
 
         return FC.getSerialRxTypes();
+    },
+
+    checkBuildOption(option) {
+        if (this.CONFIG.buildOptions?.length) {
+            return this.CONFIG.buildOptions.includes(option);
+        }
+        return true; // assume all options are available if build options are not known
     },
 
     calculateHardwareName() {

--- a/src/js/tabs/configuration.js
+++ b/src/js/tabs/configuration.js
@@ -71,7 +71,7 @@ configuration.initialize = function (callback) {
             )
             .then(() => MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG))
             .then(() =>
-                semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)
+                semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46) && FC.checkBuildOption("USE_MAG")
                     ? MSP.promise(MSPCodes.MSP_COMPASS_CONFIG)
                     : Promise.resolve(true),
             )

--- a/src/js/tabs/failsafe.js
+++ b/src/js/tabs/failsafe.js
@@ -29,7 +29,11 @@ failsafe.initialize = function (callback) {
     }
 
     function load_gps_rescue() {
-        MSP.send_message(MSPCodes.MSP_GPS_RESCUE, false, false, get_box_names);
+        if (FC.checkBuildOption("USE_GPS")) {
+            MSP.send_message(MSPCodes.MSP_GPS_RESCUE, false, false, get_box_names);
+        } else {
+            get_box_names();
+        }
     }
 
     function get_box_names() {
@@ -65,7 +69,7 @@ failsafe.initialize = function (callback) {
     }
 
     function load_compass_config() {
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46) && FC.checkBuildOption("USE_MAG")) {
             MSP.send_message(MSPCodes.MSP_COMPASS_CONFIG, false, false, load_gps_config);
         } else {
             load_gps_config();


### PR DESCRIPTION
Added `checkBuildOption` helper to test if provided build option is included in the build to prevent unsupported MSP requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Added runtime checks so certain features are enabled only when corresponding build-time options are present.
  * Compass configuration is now shown only when the required build option and a minimum API version are met.
  * GPS rescue flow now respects build-time configuration, altering whether a rescue command is sent or skipped.
  * Feature availability may vary depending on build-time options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->