### PR TITLE
Fix: Virtual callback is handled in serial.js already

### DIFF
--- a/src/js/protocols/VirtualSerial.js
+++ b/src/js/protocols/VirtualSerial.js
@@ -21,18 +21,18 @@ class VirtualSerial {
         this.connected = true;
         this.connectionId = VIRTUAL;
         this.bitrate = 115200;
+        return true;
     }
-    disconnect(callback) {
+    disconnect() {
         this.connected = false;
         this.outputBuffer = [];
         this.transmitting = false;
         if (this.connectionId) {
             this.connectionId = false;
             this.bitrate = 0;
-            if (callback) {
-                callback(true);
-            }
+            return true;
         }
+        return false;
     }
     getConnectedPort() {
         return this.connectionId;


### PR DESCRIPTION
- Callback for virtual connection already handled in serial.js is no longer used in virtualSerial protocol
- Removed unused `openCanceled` parameter
- Removed unused callback for disconnect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Connection API simplified: connect now takes only port and options; callback-based signature removed.
  * Connection behavior changed: connections are immediately marked active and configured, and disconnect now returns a boolean result instead of using a callback.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->