### PR TITLE
Fix default_lang message

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -197,8 +197,9 @@
     "language_default": {
         "message": "System Default"
     },
-    "language_default_pretty": {
-        "message": "System Default ($t(detectedLanguage))"
+    "language_DEFAULT": {
+        "message": "$t(language_default.message)",
+        "description": "Don't translate!!!"
     },
     "language_ca": {
         "message": "Catal\u00e0",

--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -108,7 +108,7 @@
                     <div class="userLanguage">
                         <span class="dropdown">
                             <select class="dropdown-select" id="userLanguage" v-model="settings.userLanguage">
-                                <option value="default">{{ $t("language_default") }}</option>
+                                <option value="DEFAULT">{{ $t("language_default") }}</option>
                                 <option disabled>------</option>
                                 <option v-for="lang in availableLanguages" :key="lang" :value="lang">
                                     {{ $t(`language_${lang}`) }}


### PR DESCRIPTION
- missed in previous PR #4736, we need to add uppercase message to match the locale message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated default language option label and selection handling for consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->