### PR TITLE
Only use semver, no need for semver.min dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "multiple-select": "^2.0.9",
     "ol": "^10.4.0",
     "select2": "^4.0.13",
-    "semver-min": "^0.7.2",
     "short-unique-id": "^5.2.0",
     "switchery-latest": "^0.8.2",
     "three": "^0.176.0",

--- a/src/js/tabs/motors.js
+++ b/src/js/tabs/motors.js
@@ -17,7 +17,7 @@ import { updateTabList } from "../utils/updateTabList";
 import { isInt, getMixerImageSrc } from "../utils/common";
 import * as d3 from "d3";
 import $ from "jquery";
-import semver from "semver-min";
+import semver from "semver";
 import { API_VERSION_1_47 } from "../data_storage.js";
 
 const motors = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2274,11 +2274,6 @@
   resolved "https://registry.yarnpkg.com/@types/resolve/-/resolve-1.20.2.tgz#97d26e00cd4a0423b4af620abecf3e6f442b7975"
   integrity sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==
 
-"@types/semver@^7.3.4":
-  version "7.5.8"
-  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.5.8.tgz#8268a8c57a3e4abd25c165ecd36237db7948a55e"
-  integrity sha512-I8EUhyrgfLrcTkzV3TSsGyl1tSuPrEDzr0yd5m90UgNxQkyDXULk3b6MlQqTCpZpNtWe1K0hzclnZkTcLBe2UQ==
-
 "@types/slice-ansi@^4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/slice-ansi/-/slice-ansi-4.0.0.tgz#eb40dfbe3ac5c1de61f6bcb9ed471f54baa989d6"
@@ -9054,13 +9049,6 @@ semver-greatest-satisfied-range@^1.1.0:
   integrity sha512-Ny/iyOzSSa8M5ML46IAx3iXc6tfOsYU2R4AXi2UpHk60Zrgyq6eqPj/xiOfS0rRl/iiQ/rdJkVjw/5cdUyCntQ==
   dependencies:
     sver-compat "^1.5.0"
-
-semver-min@^0.7.2:
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/semver-min/-/semver-min-0.7.2.tgz#32d14fd568203e489375481bec2c597e701f7ea9"
-  integrity sha512-TtfGG+PA/vPuTF2/XsXl54EKlRTH4KjswvwugoLJKFY6IciYl0JgC0LZPW0ENGbiqOXR1OzhD/oZsXGbsb8fnA==
-  dependencies:
-    "@types/semver" "^7.3.4"
 
 "semver@2 || 3 || 4 || 5", semver@^5.6.0:
   version "5.7.2"


### PR DESCRIPTION
- fixes #4741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package dependencies

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->