### PR TITLE
Don't use registerSW for Android

### DIFF
--- a/src/js/browserMain.js
+++ b/src/js/browserMain.js
@@ -50,25 +50,29 @@ import "./main";
 
 import GUI from "./gui";
 import { registerSW } from "virtual:pwa-register";
+import { isAndroid } from "./utils/checkCompatibility.js";
 
-const updateSW = registerSW({
-    onNeedRefresh() {
-        console.log("Detected onNeedRefresh");
-        GUI.showYesNoDialog({
-            title: i18n.getMessage("pwaOnNeedRefreshTitle"),
-            text: i18n.getMessage("pwaOnNeedRefreshText"),
-            buttonYesText: i18n.getMessage("yes"),
-            buttonNoText: i18n.getMessage("no"),
-            buttonYesCallback: () => updateSW(),
-            buttonNoCallback: null,
-        });
-    },
-    onOfflineReady() {
-        console.log("Detected onOfflineReady");
-        GUI.showInformationDialog({
-            title: i18n.getMessage("pwaOnOffilenReadyTitle"),
-            text: i18n.getMessage("pwaOnOffilenReadyText"),
-            buttonConfirmText: i18n.getMessage("OK"),
-        });
-    },
-});
+// Skip PWA update/offline prompts on Android native builds where they are unnecessary
+if (!isAndroid()) {
+    const updateSW = registerSW({
+        onNeedRefresh() {
+            console.log("Detected onNeedRefresh");
+            GUI.showYesNoDialog({
+                title: i18n.getMessage("pwaOnNeedRefreshTitle"),
+                text: i18n.getMessage("pwaOnNeedRefreshText"),
+                buttonYesText: i18n.getMessage("yes"),
+                buttonNoText: i18n.getMessage("no"),
+                buttonYesCallback: () => updateSW(),
+                buttonNoCallback: null,
+            });
+        },
+        onOfflineReady() {
+            console.log("Detected onOfflineReady");
+            GUI.showInformationDialog({
+                title: i18n.getMessage("pwaOnOffilenReadyTitle"),
+                text: i18n.getMessage("pwaOnOffilenReadyText"),
+                buttonConfirmText: i18n.getMessage("OK"),
+            });
+        },
+    });
+}


### PR DESCRIPTION
- Verified still working for PWA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PWA update and offline prompts are now skipped on Android native builds. These notifications are properly gated and will not appear on native Android installations, improving user experience by eliminating unnecessary prompts.
  * Service Worker registration and callback handling have been adjusted to respect Android-specific platform requirements and native application expectations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->