### PR TITLE
Fix preset details bottom bar on mobile

### DIFF
--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.html
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.html
@@ -22,8 +22,11 @@
                 <a id="presets_open_online" i18n="presetsViewOnline" class="tool regular-button" target="_blank" rel="noopener noreferrer"></a>
                 <a id="presets_open_discussion" i18n="presetsOpenDiscussion" class="tool regular-button" target="_blank" rel="noopener noreferrer"></a>
             </div>
-            <a href="#" id="presets_detailed_dialog_applybtn" class="tool regular-button mainButton" i18n="presetsApply"></a>
-            <a href="#" id="presets_detailed_dialog_closebtn" class="tool regular-button mainButton" i18n="close"></a>
+            <div>
+                <a href="#" id="presets_detailed_dialog_applybtn" class="tool regular-button mainButton" i18n="presetsApply"></a>
+                <a href="#" id="presets_detailed_dialog_closebtn" class="tool regular-button mainButton" i18n="close"></a>
+            </div>
+
         </div>
     </div>
 </div>

--- a/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.less
+++ b/src/tabs/presets/DetailedDialog/PresetsDetailedDialog.less
@@ -145,24 +145,39 @@ ol {
     #presets_detailed_dialog {
         .content_toolbar {
             position: fixed;
-            height: 70px;
-            padding-bottom: 8px;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            width: 100vw;
+            height: auto;
+            min-height: 80px;
+            padding: 10px;
+            box-sizing: border-box;
+            border-top: 1px solid var(--primary-500);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 10px;
         }
         .btn {
-            margin-left: 0px;
+            display: flex;
+            flex-direction: column;
             width: 100%;
+            align-items: center;
             .left-panel {
-                margin-left: 12px;
-                margin-bottom: 12px;
-                padding-left: 0px;
-                .regular-button {
-                    float: none;
-                    display: inline-block;
-                }
+                position: relative;
+                left: unset;
+                padding-left: 0;
+                margin: 0;
+                display: flex;
+                flex-wrap: wrap;
+                justify-content: center;
+                gap: 5px;
             }
         }
         .mainButton {
-            margin-top: 40px;
+            margin-top: 5px;
+            display: inline-block;
         }
     }
     #presets_options_panel {


### PR DESCRIPTION
Fixes an issue with the bottom bar of the preset details being unusable on mobile.

| master.app.betaflight.com | This PR (fix) |
| -------- | ------- |
| <img width="200px"  alt="image" src="https://github.com/user-attachments/assets/ffd935de-1242-4800-b078-b7c0e27b855b" /> | <img width="200px" alt="image" src="https://github.com/user-attachments/assets/84ccbf63-fc68-4f79-b9a0-ee00ed06a5ed" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Improved responsive layout of the detailed dialog component on small screens, with optimized button placement and panel arrangement for better mobile usability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->