### PR TITLE
Responsive GPS tab

### DIFF
--- a/src/css/tabs/gps.less
+++ b/src/css/tabs/gps.less
@@ -294,6 +294,12 @@ meter[value] {
         .gps_map {
             height: 403px;
         }
+        /* Make the grid a column on small devices */
+        .grid-row.grid-box {
+            display: flex;
+            flex-direction: column;
+            width: 100%;
+        }
     }
     .tabs-gps {
         #loadmap {
@@ -301,13 +307,5 @@ meter[value] {
                 height: 343px;
             }
         }
-    }
-}
-@media only screen and (max-width: 768px) {
-    /* Make the grid a column on small devices */
-    .grid-row.grid-box {
-        display: flex;
-        flex-direction: column;
-        width: 100%;
     }
 }


### PR DESCRIPTION
Turned the grid view into a column/list on mobile devices for better UX.

| master.app.betaflight.com | This PR |
| -------- | ------- |
| <img width="200px"  alt="image" src="https://github.com/user-attachments/assets/ecbfffa6-153e-491e-8975-d9de3a4e22ae" /> | <img width="200px" alt="image" src="https://github.com/user-attachments/assets/ee88ace0-8b15-4fc1-86ad-84030ecd399b" /> |

_Tooltips are still not readable (because they appear off-screen on the right), but that's an issue on all pages (on mobile) that should be addressed in a separate PR._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsive layout for the GPS tab: on devices up to 1055px wide the content switches to a single-column layout for better readability and full-width display, enhancing usability on small and mid-sized screens.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->