### PR TITLE
Adding 'Slider Master Multiplier' to the Adjustment Dropdown List

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2965,6 +2965,9 @@
 	"adjustmentsFunction31": {
         "message": "LED Brightness Adjust"
     },
+    "adjustmentsFunction32": {
+        "message": "Slider Master Multiplier"
+    },
     "adjustmentsSave": {
         "message": "Save"
     },

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -154,10 +154,10 @@ export default defineComponent({
 
         const pipValues = computed(() => PIP_VALUES);
 
-        // Generate function options (0-31, 'LED Dimmer' is the last)
+        // Generate function options (0-32, 'Slider Master Multiplier' is the last)
         const functionOptions = computed(() => {
             const options = [];
-            for (let i = 0; i < 32; i++) {
+            for (let i = 0; i < 33; i++) {
                 options.push({
                     value: i,
                     label: i18n.getMessage(`adjustmentsFunction${i}`),


### PR DESCRIPTION
Adding 'Slider Master Multipler' to the Adjustments dropdown list in coordination with [#14371](https://github.com/betaflight/betaflight/pull/14371)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one additional adjustment option in the Adjustments tab, expanding available controls.
  * Added a new localization string to support the new UI option.

* **Improvements**
  * Updated the final adjustment option label to "Slider Master Multiplier" for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->