### PR TITLE
Fix broken link to wiki for ports-tab

### DIFF
--- a/src/components/tabs/ConfigurationTab.vue
+++ b/src/components/tabs/ConfigurationTab.vue
@@ -5,7 +5,7 @@
             <div class="cf_doc_version_bt">
                 <a
                     id="button-documentation"
-                    href="https://betaflight.com/docs/wiki/configurator/configuration-tab"
+                    href="https://betaflight.com/docs/wiki/app/configuration-tab"
                     target="_blank"
                     rel="noopener noreferrer"
                     :aria-label="$t('betaflightSupportButton')"

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -5,7 +5,7 @@
             <div class="cf_doc_version_bt">
                 <a
                     id="button-documentation"
-                    href="https://betaflight.com/docs/wiki/configurator/ports-tab"
+                    href="https://betaflight.com/docs/wiki/app/ports-tab"
                     target="_blank"
                     rel="noopener noreferrer"
                     :aria-label="$t('betaflightSupportButton')"

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -5,7 +5,7 @@
             <div class="cf_doc_version_bt">
                 <a
                     id="button-documentation"
-                    href="https://betaflight.com/docs/wiki/configurator/servos-tab"
+                    href="https://betaflight.com/docs/wiki/app/servos-tab"
                     target="_blank"
                     rel="noopener noreferrer"
                     :aria-label="$t('betaflightSupportButton')"

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -299,7 +299,7 @@ class GuiControl {
 
         $("div#content #button-documentation")
             .html(i18n.getMessage("betaflightSupportButton"))
-            .attr("href", `https://betaflight.com/docs/wiki/configurator/${tRex}-tab`);
+            .attr("href", `https://betaflight.com/docs/wiki/app/${tRex}-tab`);
 
         // Create tooltips once page is "ready"
         $(function () {

--- a/src/tabs/presets/presets.html
+++ b/src/tabs/presets/presets.html
@@ -3,7 +3,7 @@
         <div class="tab_title">
             <div i18n="tabPresets" class="presets_title_text"></div>
             <div class="presets_top_bar_button_pannel">
-                <a i18n="presetsWiki" class="presetsWikiButton tool regular-button right" href="https://betaflight.com/docs/wiki/configurator/presets-tab" target="_blank" rel="noopener noreferrer">Presets Wiki</a>
+                <a i18n="presetsWiki" class="presetsWikiButton tool regular-button right" href="https://betaflight.com/docs/wiki/app/presets-tab" target="_blank" rel="noopener noreferrer">Presets Wiki</a>
                 <div class = "top_panel_spacer visible-on-desktop-only"></div>
                 <a href="#" class="presets_sources_show tool regular-button right" i18n="presetSources"></a>
                 <div class = "top_panel_spacer visible-on-desktop-only"></div>


### PR DESCRIPTION
At some point, the url structure to the wiki must've changed and the old urls do not rewrite to the new ones.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links to point to the app section of the Betaflight wiki instead of the configurator section.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->