### PR TITLE
Fix missing right padding in status bar

### DIFF
--- a/src/components/status-bar/StatusBar.vue
+++ b/src/components/status-bar/StatusBar.vue
@@ -122,9 +122,8 @@ export default defineComponent({
     white-space: nowrap;
     gap: 0.5rem;
     bottom: 0;
-    width: calc(100% - 20px);
-    height: 20px;
-    line-height: 20px;
+    box-sizing: border-box;
+    width: 100%;
     padding: 0.5rem 1rem;
     background-color: var(--surface-300);
     .message {


### PR DESCRIPTION
The `calc(100% - 20px)` does not correctly
amount for the `1rem` padding on _both right and left_. And since `calc(100% - 2 * 1 rem)` is not legal (can't mix the units) and it would still duplicate the `1rem` between the padding and the width calculation, instead switch to a box sizing model where we don't have to account for the padding. this makes it equal again on left and right. The height and line-height is unnecessary, it's just fine without.

## Before

Note the inconsistent padding left and right of the page.
<img width="815" height="89" alt="Bildschirmfoto 2026-01-12 um 19 45 07" src="https://github.com/user-attachments/assets/9a71f8cf-bb6f-43dc-8d73-5e79849aa415" />


## After
<img width="817" height="88" alt="Bildschirmfoto 2026-01-12 um 19 42 42" src="https://github.com/user-attachments/assets/788d6031-0fcb-4fe4-ba00-1469b50d5f88" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced status bar styling with improved layout calculations. The status bar now properly occupies full width with padding included in sizing, while removing fixed height constraints. This enables more flexible responsive behavior and better layout consistency across different screen sizes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->