### PR TITLE
FIX: Backup and User Profile tabs not available when FC connected

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -191,17 +191,17 @@ async function startProcess() {
             const isTabAllowed = GUI.allowedTabs.includes(tab) || isLoginSectionTab;
 
             if (!isTabAllowed) {
-                if (tab === "firmware_flasher") {
-                    // Special handling for firmware flasher tab
-                    if (GUI.connected_to || GUI.connecting_to) {
-                        $("a.connection_button__link").trigger("click");
-                    }
-                    // This line is required but it triggers opening the firmware flasher tab again
-                    $("a.firmware_flasher_button__link").trigger("click");
-                } else {
+                if (tab !== "firmware_flasher") {
                     gui_log(i18n.getMessage("tabSwitchUpgradeRequired", [tabName]));
                     return;
                 }
+
+                // Special handling for firmware flasher tab
+                if (GUI.connected_to || GUI.connecting_to) {
+                    $("a.connection_button__link").trigger("click");
+                }
+                // This line is required but it triggers opening the firmware flasher tab again
+                $("a.firmware_flasher_button__link").trigger("click");
             }
 
             GUI.tab_switch_in_progress = true;


### PR DESCRIPTION
Small bug where the tabs were not working (version issue) when FC is connected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Tab switching now enforces allowed-tab rules tied to authenticated sections, and logs an upgrade-required message when switching to disallowed tabs.
  * Firmware flasher tab behavior preserved: it checks connection state and initiates/connects as needed before activating that tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->