### PR TITLE
FIX: Move backups to diff all

### DIFF
--- a/src/components/tabs/Backups.vue
+++ b/src/components/tabs/Backups.vue
@@ -177,7 +177,7 @@ export default defineComponent({
                 }
 
                 const output = await new Promise((resolve, reject) => {
-                    MSP.send_cli_command("dump all", (data) => {
+                    MSP.send_cli_command("diff all", (data) => {
                         if (data && Array.isArray(data) && data.length > 0) {
                             // Create a copy of the data since the original array gets cleared after callback
                             resolve([...data]);


### PR DESCRIPTION
Simply using `diff all` now instead.

Future PR will be remove the `download` button (if connected) and have a `restore` option instead (for matching compatible boards - i.e. same board name).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the CLI command used during backup creation to ensure proper backup operation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->