### PR TITLE
Fix race condition when compass not available

### DIFF
--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -679,7 +679,7 @@ export default defineComponent({
         };
 
         const getMagData = () => {
-            if (semver.gte(apiVersion.value, API_VERSION_1_46)) {
+            if (hasMag.value) {
                 MSP.send_message(MSPCodes.MSP_COMPASS_CONFIG, false, false, updateUi);
             } else {
                 updateUi();


### PR DESCRIPTION
- The getMagData function now uses the hasMag computed property, which already checks both the API version (>= 1.46) and whether the MAG sensor is actually present in the active sensors.
- Fixes
<img width="423" height="44" alt="image" src="https://github.com/user-attachments/assets/bab97465-851d-44a4-899e-13aaa3772caa" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetometer sensor detection to be based on actual sensor availability rather than API version compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->