### PR TITLE
Fix defineExpose

### DIFF
--- a/src/components/dialogs/InformationDialog.vue
+++ b/src/components/dialogs/InformationDialog.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script setup>
-import { ref, defineExpose } from "vue";
+import { ref } from "vue";
 
 defineProps({
     title: String,


### PR DESCRIPTION
[@vue/compiler-sfc] defineExpose is a compiler macro and no longer needs to be imported.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a potential runtime error in the Information Dialog component.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->