### PR TITLE
FIX: Firmware Flasher - Restore PR selection functionality, including manual entry

### DIFF
--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -1861,7 +1861,16 @@ export default defineComponent({
 
         const onCommitTag = (searchQuery) => {
             // Handle custom PR number or commit hash input
-            let formattedValue = searchQuery.trim();
+            if (!searchQuery) {
+                return;
+            }
+
+            const formattedValue = searchQuery.trim();
+
+            // Prevent empty/whitespace submissions
+            if (!formattedValue) {
+                return;
+            }
 
             // Check if it's a PR number (with or without #)
             const prMatch = formattedValue.match(/^#?(\d+)$/);


### PR DESCRIPTION
Following migration to vue this multiselect was not behaving as expected i.e. being able to enter custom PR #s and select a PR from the drop down. 

This PR resolves that issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Made the firmware commit selector searchable and taggable.
  * Users can type and add PR numbers (with or without #) or commit hashes directly—these entries become selectable immediately.
  * Selector now returns the chosen commit value consistently when triggering builds or actions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->