### PR TITLE
fix: correct servo index display order in Servos tab

### DIFF
--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -94,15 +94,15 @@
                             <div class="servos">
                                 <div class="title2">{{ $t("servosText") }}</div>
                                 <ul class="titles">
-                                    <li v-for="i in 8" :key="i" :title="$t(`servoNumber${9 - i}`)">{{ 9 - i }}</li>
+                                    <li v-for="i in 8" :key="i" :title="$t(`servoNumber${i}`)">{{ i }}</li>
                                 </ul>
                                 <div class="bar-wrapper">
-                                    <div v-for="i in 8" :key="i" :class="`m-block servo-${8 - i}`">
+                                    <div v-for="i in 8" :key="i" :class="`m-block servo-${i - 1}`">
                                         <div class="meter-bar">
-                                            <div class="label">{{ servoData[8 - i] || 1500 }}</div>
-                                            <div class="indicator" :style="getBarStyle(servoData[8 - i] || 1500)">
+                                            <div class="indicator" :style="getBarStyle(servoData[i - 1] || 1500)">
                                                 <div class="label"></div>
                                             </div>
+                                            <div class="label">{{ servoData[i - 1] || 1500 }}</div>
                                         </div>
                                     </div>
                                 </div>

--- a/src/css/tabs/servos.less
+++ b/src/css/tabs/servos.less
@@ -210,15 +210,15 @@
     .servos {
         .titles {
             li {
-                float: right;
+                float: left;
                 width: calc((100% / 8) - 10px);
-                margin: 0 0 0 10px;
+                margin-right: 10px;
             }
         }
         .m-block {
-            float: right;
+            float: left;
             width: calc((100% / 8) - 10px);
-            margin: 0 0 0 10px;
+            margin-right: 10px;
             border-radius: 3px;
         }
     }


### PR DESCRIPTION
When testing the same firmware (SPEEDYBEEF405V5) with both the Desktop app and the Web app, the servo bar chart displayed different index orders:                                                                                                    
  - Desktop app: Servos displayed 1→8 (left to right) ✓
  - Web app: Servos displayed 8→1 (right to left) ✗

Desktop app:
<img width="1645" height="1112" alt="image" src="https://github.com/user-attachments/assets/56a265ee-42aa-481f-986f-92cad5b8cc49" />

Web app:
<img width="1732" height="1148" alt="image" src="https://github.com/user-attachments/assets/666d31d5-6778-4880-a1f0-f3fe6924a492" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Servo indicators now display in correct ascending order (1-8) instead of reversed sequence
* Fixed servo value data binding to align with proper index mapping

## Style
* Adjusted servo control panel layout alignment for improved visual consistency
* Updated spacing of servo blocks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->