### PR TITLE
fix: hide RX_PPM option when firmware lacks USE_RX_PPM support

### DIFF
--- a/src/js/Features.js
+++ b/src/js/Features.js
@@ -8,7 +8,7 @@ const Features = function (config) {
     const self = this;
 
     const features = [
-        { bit: 0, group: "rxMode", mode: "select", name: "RX_PPM" },
+        { bit: 0, group: "rxMode", mode: "select", name: "RX_PPM", dependsOn: "RX_PPM" },
         { bit: 2, group: "other", name: "INFLIGHT_ACC_CAL" },
         { bit: 3, group: "rxMode", mode: "select", name: "RX_SERIAL" },
         { bit: 4, group: "escMotorStop", name: "MOTOR_STOP", haveTip: true },
@@ -67,10 +67,7 @@ const Features = function (config) {
             if (
                 config.buildOptions.some(
                     (opt) =>
-                        opt.includes("CRSF") ||
-                        opt.includes("GHST") ||
-                        opt.includes("FPORT") ||
-                        opt.includes("JETI"),
+                        opt.includes("CRSF") || opt.includes("GHST") || opt.includes("FPORT") || opt.includes("JETI"),
                 )
             ) {
                 enableTelemetry = true;


### PR DESCRIPTION
If the firmware was built without USE_RX_PPM, setting the receiver mode to PPM will not work; it will revert to the default protocol.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced feature configuration with improved dependency management capabilities.

* **Refactor**
  * Streamlined code structure for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->