### PR TITLE
Fix: Add GLTF models to service worker caching for offline use

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -144,7 +144,7 @@ export default defineConfig({
         VitePWA({
             registerType: "prompt",
             workbox: {
-                globPatterns: ["**/*.{js,css,html,ico,png,svg,json,mcm}"],
+                globPatterns: ["**/*.{js,css,html,ico,png,svg,json,mcm,gltf}"],
                 // 5MB
                 maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
             },


### PR DESCRIPTION
The 3D models were previously relying on an internet connection to load. This change adds them to the files that get cached for offline use.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended service worker caching configuration to include 3D model file formats for improved offline application support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->