### PR TITLE
Fix: update GNSS provider for API 1.47+

### DIFF
--- a/src/js/sensor_types.js
+++ b/src/js/sensor_types.js
@@ -196,7 +196,7 @@ function sensorTypesLegacy() {
     }
 
     // Update GNSS Provider
-    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47) {
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
         addArrayElement(gpsElements, "VIRTUAL");
     }
 


### PR DESCRIPTION
GNSS provider was not updated due to API comparison and is not retrieved using cli over msp when using virtual mode.

IMO this is currently not correct solution but can only able to test in 6 days. Purpose is to be able to use Virtual GPS provider when serial port is not configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added five new sensor types for API 1.47.

* **Bug Fixes**
  * Broadened removal of deprecated legacy sensors to apply for API >= 1.47.
  * Ensured deprecated accelerometer entries are removed once (no duplicates) and additions do not perform removals.
  * Updated GNSS provider behavior for API >= 1.47 to append VIRTUAL consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->