### PR TITLE
FIX: GNSS feature enabling in PortsTab.vue

### DIFF
--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -463,7 +463,11 @@ export default defineComponent({
 
             blackbox ? featureConfig.enable("BLACKBOX") : featureConfig.disable("BLACKBOX");
             esc ? featureConfig.enable("ESC_SENSOR") : featureConfig.disable("ESC_SENSOR");
-            gps ? featureConfig.enable("GPS") : featureConfig.disable("GPS");
+
+            // GNSS: only enable when port configured, don't disable (allows Virtual GPS)
+            if (gps) {
+                featureConfig.enable("GPS");
+            }
         };
 
         const vtxTableNotConfigured = computed(() => {


### PR DESCRIPTION
Update GPS feature enabling logic to allow Virtual GPS.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * GPS feature can now be enabled independently of port configuration, allowing support for virtual GPS scenarios without requiring a hardware port setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->