### PR TITLE
FIX: Html Rendering for note on PreviewDialog

### DIFF
--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -27,7 +27,7 @@
         <dialog ref="snippetPreviewDialogRef" closedby="any" id="snippetpreviewdialog" class="html-dialog">
             <div id="snippetpreviewcontent" class="html-dialog-content">
                 <div class="note">
-                    <p>{{ $t("cliConfirmSnippetNote") }}</p>
+                    <p v-html="$t('cliConfirmSnippetNote')"></p>
                 </div>
                 <textarea id="preview" v-model="cli.state.snippetPreview" rows="20"></textarea>
                 <div class="default_btn">


### PR DESCRIPTION
This pull request makes a small change to the `CliTab.vue` component, updating how the `cliConfirmSnippetNote` translation is rendered in the snippet preview dialog. The change ensures that any HTML content in the translation string is rendered correctly by using the `v-html` directive instead of string interpolation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated how translated messages are displayed in snippet preview dialogs to support richer content formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->