### PR TITLE
Add fallback for File System Access API

### DIFF
--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -6,51 +6,132 @@ class FileSystem {
         };
     }
 
-    async pickSaveFile(suggestedName, description, extension) {
-        const fileHandle = await window.showSaveFilePicker({
-            suggestedName: suggestedName,
-            types: [
-                {
-                    description: description,
-                    accept: {
-                        "application/unknown": extension,
-                    },
-                },
-            ],
+    // Create a wrapper for legacy File objects (from input element fallback)
+    _createLegacyFile(file) {
+        return {
+            name: file.name,
+            _fileHandle: null,
+            _legacyFile: file,
+        };
+    }
+
+    // Fallback file picker using hidden input element
+    _pickOpenFileFallback(extension) {
+        return new Promise((resolve) => {
+            const input = document.createElement("input");
+            input.type = "file";
+            // Convert extension array or string to accept attribute
+            if (Array.isArray(extension)) {
+                input.accept = extension.join(",");
+            } else {
+                input.accept = extension;
+            }
+            input.style.display = "none";
+            document.body.appendChild(input);
+
+            input.addEventListener("change", () => {
+                const file = input.files[0];
+                document.body.removeChild(input);
+                if (file) {
+                    resolve(this._createLegacyFile(file));
+                } else {
+                    resolve(null);
+                }
+            });
+
+            input.addEventListener("cancel", () => {
+                document.body.removeChild(input);
+                resolve(null);
+            });
+
+            input.click();
         });
+    }
 
-        if (!fileHandle) {
-            return null;
-        }
+    // Fallback save using download link
+    _pickSaveFileFallback(suggestedName, contents) {
+        return new Promise((resolve) => {
+            const blob = new Blob([contents], { type: "application/octet-stream" });
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement("a");
+            a.href = url;
+            a.download = suggestedName;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            URL.revokeObjectURL(url);
+            resolve(true);
+        });
+    }
 
-        const file = this._createFile(fileHandle);
+    async pickSaveFile(suggestedName, description, extension) {
+        // Check if File System Access API is available
+        if (window.showSaveFilePicker) {
+            const fileHandle = await window.showSaveFilePicker({
+                suggestedName: suggestedName,
+                types: [
+                    {
+                        description: description,
+                        accept: {
+                            "application/unknown": extension,
+                        },
+                    },
+                ],
+            });
 
-        if (await this.verifyPermission(file, true)) {
-            return file;
+            if (!fileHandle) {
+                return null;
+            }
+
+            const file = this._createFile(fileHandle);
+
+            if (await this.verifyPermission(file, true)) {
+                return file;
+            }
+        } else {
+            // Fallback: return a pseudo file object for legacy save
+            console.log("File System Access API not available, using fallback for save");
+            return {
+                name: suggestedName,
+                _fileHandle: null,
+                _fallbackSave: true,
+            };
         }
     }
 
     async pickOpenFile(description, extension) {
-        const fileHandle = await window.showOpenFilePicker({
-            multiple: false,
-            types: [
-                {
-                    description: description,
-                    accept: {
-                        "application/unknown": extension,
+        // Check if File System Access API is available
+        if (window.showOpenFilePicker) {
+            const fileHandle = await window.showOpenFilePicker({
+                multiple: false,
+                types: [
+                    {
+                        description: description,
+                        accept: {
+                            "application/unknown": extension,
+                        },
                     },
-                },
-            ],
-        });
+                ],
+            });
 
-        const file = this._createFile(fileHandle[0]);
+            const file = this._createFile(fileHandle[0]);
 
-        if (await this.verifyPermission(file, false)) {
-            return file;
+            if (await this.verifyPermission(file, false)) {
+                return file;
+            }
+        } else {
+            // Fallback to traditional file input
+            console.log("File System Access API not available, using fallback file picker");
+            return await this._pickOpenFileFallback(extension);
         }
     }
 
     async verifyPermission(file, withWrite) {
+        // Legacy files from fallback picker don't need permission verification
+        if (file._legacyFile || file._fallbackSave) {
+            return true;
+        }
+
         const fileHandle = file._fileHandle;
 
         const opts = {};
@@ -71,6 +152,11 @@ class FileSystem {
     }
 
     async writeFile(file, contents) {
+        // Handle fallback save (download)
+        if (file._fallbackSave) {
+            return await this._pickSaveFileFallback(file.name, contents);
+        }
+
         const fileHandle = file._fileHandle;
 
         const writable = await fileHandle.createWritable();
@@ -79,15 +165,23 @@ class FileSystem {
     }
 
     async readFile(file) {
-        const fileHandle = file._fileHandle;
+        // Handle legacy file objects (from fallback picker)
+        if (file._legacyFile) {
+            return await file._legacyFile.text();
+        }
 
+        const fileHandle = file._fileHandle;
         const fileReader = await fileHandle.getFile();
         return await fileReader.text();
     }
 
     async readFileAsBlob(file) {
-        const fileHandle = file._fileHandle;
+        // Handle legacy file objects (from fallback picker)
+        if (file._legacyFile) {
+            return file._legacyFile;
+        }
 
+        const fileHandle = file._fileHandle;
         return await fileHandle.getFile();
     }
 


### PR DESCRIPTION
## Summary
Add fallback file picker using traditional `<input type=\"file\">` for browsers that don't support the File System Access API (`showOpenFilePicker`).

## Problem
The \"Load Firmware [Local]\" button fails silently in browsers without File System Access API support (Firefox, some PWA contexts).

## Solution
- Check if `showOpenFilePicker`/`showSaveFilePicker` are available
- Fall back to hidden file input element for open operations
- Fall back to download link for save operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fallback support for file operations in browsers without File System Access API support, enabling file open and save operations through traditional file dialogs and downloads when modern APIs are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->