### PR TITLE
Enhancement: Add MSP 1.48 API to the virtual mode selection list

### DIFF
--- a/src/components/port-picker/FirmwareVirtualOption.vue
+++ b/src/components/port-picker/FirmwareVirtualOption.vue
@@ -37,6 +37,7 @@ export default defineComponent({
         };
 
         const firmwareVersions = ref([
+            { value: "1.48.0", label: "MSP: 1.48 | Firmware: 2026.06.*" },
             { value: "1.47.0", label: "MSP: 1.47 | Firmware: 2025.12.*" },
             { value: "1.46.0", label: "MSP: 1.46 | Firmware: 4.5.*" },
             { value: "1.45.0", label: "MSP: 1.45 | Firmware: 4.4.*" },


### PR DESCRIPTION
MSP was bumped to 1.48 in https://github.com/betaflight/betaflight/pull/14761, certain Configurator PRs already call for it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MSP 1.48 firmware option (Firmware 2026.06.*) to the available firmware version selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->