### PR TITLE
Fix vbat_sag_compensation default

### DIFF
--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -1456,7 +1456,7 @@ const itermRotationEnabled = computed({
 
 const vbatSagEnabled = computed({
     get: () => FC.ADVANCED_TUNING.vbat_sag_compensation !== 0,
-    set: (val) => (FC.ADVANCED_TUNING.vbat_sag_compensation = val ? FC.ADVANCED_TUNING.vbat_sag_compensation || 75 : 0),
+    set: (val) => (FC.ADVANCED_TUNING.vbat_sag_compensation = val ? FC.ADVANCED_TUNING.vbat_sag_compensation || 100 : 0),
 });
 
 const thrustLinearEnabled = computed({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated the default value for VBat sag compensation in PID tuning settings to 100 when enabling the feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->