### PR TITLE
Fix dynamic notch filter setting when switching bidirectional dshot

### DIFF
--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -684,6 +684,7 @@ import DshotCommand from "@/js/utils/DshotCommand";
 import { mspHelper } from "@/js/msp/MSPHelper";
 import { tracking } from "@/js/Analytics";
 import GUI from "@/js/gui";
+import FC from "@/js/fc";
 
 // Import composables for proper state management
 import { useMotorsState } from "@/composables/motors/useMotorsState";
@@ -728,12 +729,7 @@ const closeDynFiltersDialog = () => {
 };
 
 const applyDynFiltersChange = () => {
-    const FILTER_DEFAULT = {
-        dyn_notch_count_rpm: 1,
-        dyn_notch_q_rpm: 500,
-        dyn_notch_count: 3,
-        dyn_notch_q: 120,
-    };
+    const FILTER_DEFAULT = FC.getFilterDefaults();
 
     if (fcStore.motorConfig.use_dshot_telemetry && !previousDshotBidir.value) {
         fcStore.filterConfig.dyn_notch_count = FILTER_DEFAULT.dyn_notch_count_rpm;
@@ -884,21 +880,14 @@ watch(
 
         const rpmFilterIsDisabled = fcStore.filterConfig.gyro_rpm_notch_harmonics === 0;
 
-        // Store previous values for potential restore
-        if (previousFilterDynQ.value === null) {
-            previousFilterDynQ.value = fcStore.filterConfig.dyn_notch_q;
-            previousFilterDynCount.value = fcStore.filterConfig.dyn_notch_count;
-        }
+        // Always restore filter values to original firmware state first
+        fcStore.filterConfig.dyn_notch_count = previousFilterDynCount.value;
+        fcStore.filterConfig.dyn_notch_q = previousFilterDynQ.value;
 
-        // Show dialog when dshotBidir changes and RPM filter is enabled
-        if (newValue !== oldValue && !rpmFilterIsDisabled) {
+        // Show dialog when dshotBidir differs from original firmware value and RPM filter is enabled
+        if (newValue !== previousDshotBidir.value && !rpmFilterIsDisabled) {
             showDynFiltersDialog();
-        } else {
-            // Restore values if dialog not shown
-            fcStore.filterConfig.dyn_notch_count = previousFilterDynCount.value;
-            fcStore.filterConfig.dyn_notch_q = previousFilterDynQ.value;
         }
-        previousDshotBidir.value = newValue;
     },
 );
 


### PR DESCRIPTION
# Fix: Bidirectional DShot Dynamic Notch Filter Settings

## Problem

After the Vue 3 migration, enabling/disabling bidirectional DShot in the Motors tab no longer correctly applies dynamic notch filter settings. The dialog appears but clicking "Yes" has no effect.

## Root Cause

Three bugs were introduced during the migration from jQuery (`motors.js`) to Vue 3 (`MotorsTab.vue`):

### Bug 1: `previousDshotBidir` updated on every toggle (critical)

The watcher set `previousDshotBidir.value = newValue` at the end of every invocation. Since the dialog is non-blocking, by the time the user clicks "Yes", `previousDshotBidir` already holds the *new* value. This makes both conditions in `applyDynFiltersChange` always evaluate to `false`:

```javascript
// Both are false because previousDshotBidir was already updated to match use_dshot_telemetry
if (fcStore.motorConfig.use_dshot_telemetry && !previousDshotBidir.value) { ... }
else if (!fcStore.motorConfig.use_dshot_telemetry && previousDshotBidir.value) { ... }
```

The old jQuery code never updated `self.previousDshotBidir` in the change handler -- it stayed as the original firmware value for the entire session.

**Fix:** Removed the `previousDshotBidir.value = newValue` line from the watcher.

### Bug 2: Filter values not restored before showing dialog

The old code always restored `dyn_notch_count` and `dyn_notch_q` to their original firmware values *before* the dialog check. This ensures that if the user clicks "No" (cancel), values revert to the firmware state. The Vue code only restored in the `else` branch (when the dialog was *not* shown).

**Fix:** Moved the restore to happen unconditionally before the dialog check.

### Bug 3: Hardcoded filter defaults instead of `FC.getFilterDefaults()`

The Vue code hardcoded:
```javascript
const FILTER_DEFAULT = {
    dyn_notch_count_rpm: 1,
    dyn_notch_q_rpm: 500,
    dyn_notch_count: 3,
    dyn_notch_q: 120,  // Wrong for API >= 1.44 (should be 300)
};
```

The old code used `FC.getFilterDefaults()` which returns API version-aware defaults. For API >= 1.44, `dyn_notch_q` defaults to `300`, not `120`.

**Fix:** Added `import FC from "@/js/fc"` and replaced hardcoded object with `FC.getFilterDefaults()`.

## Expected Behavior (restored)

| Action | `dyn_notch_count` | `dyn_notch_q` |
|---|---|---|
| Enable bidirectional DShot (user confirms) | 1 | 500 |
| Disable bidirectional DShot (user confirms) | firmware default (3) | firmware default (300 for API >= 1.44) |
| Toggle back to original state | restored to firmware values | restored to firmware values |
| User clicks "No" on dialog | restored to firmware values | restored to firmware values |
| RPM filter disabled (`gyro_rpm_notch_harmonics === 0`) | no change | no change |

## Files Changed

- `src/components/tabs/MotorsTab.vue` -- watcher logic, `applyDynFiltersChange`, added FC import

## Reference

- Old implementation: `src/js/tabs/motors.js` (2025.12-maintenance branch)
- Filter defaults: `src/js/fc.js` (`FC.DEFAULT`, `FC.getFilterDefaults()`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated filter default retrieval to use shared configuration logic
  * Improved dshot telemetry filter value restoration behavior for more consistent settings management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->