### PR TITLE
Fix custom defines

### DIFF
--- a/src/composables/useCloudBuild.js
+++ b/src/composables/useCloudBuild.js
@@ -193,7 +193,7 @@ export function useCloudBuild(params) {
 
             // Parse custom defines from input
             if (customDefinesInput?.value) {
-                const customDefinesText = customDefinesInput.value.value || "";
+                const customDefinesText = customDefinesInput.value || "";
                 customDefinesText
                     .split(" ")
                     .map((element) => element.trim())


### PR DESCRIPTION
# Custom Defines Not Respected During Cloud Build

## Summary

Custom defines entered by the user in expert mode are silently ignored when requesting a cloud build. The build request is sent with an empty options list for custom defines, so the resulting firmware never includes them.

## Root Cause

A double `.value` dereference bug in `src/composables/useCloudBuild.js` line 196 inside `buildRequestConfig()`.

### Data flow trace

1. **Template** (`FirmwareFlasherTab.vue:385`): A plain `<input>` element with a Vue template ref:
   ```html
   <input ref="customDefinesInput" id="customDefines" name="customDefines" />
   ```

2. **Component ref** (`FirmwareFlasherTab.vue:792`): The template ref is a standard Vue `ref(null)`:
   ```js
   const customDefinesInput = ref(null);
   ```
   At runtime, `customDefinesInput.value` is the DOM `<input>` element.

3. **Caller** (`FirmwareFlasherTab.vue:1754`): Passes the unwrapped DOM element to the composable:
   ```js
   customDefinesInput: customDefinesInput.value,  // DOM <input> element
   ```

4. **Composable** (`useCloudBuild.js:194-202`): Reads the value with a double dereference:
   ```js
   if (customDefinesInput?.value) {                          // DOM.value = "MY_DEFINE FOO" (string) -- OK
       const customDefinesText = customDefinesInput.value.value || "";  // string.value = undefined -- BUG
       customDefinesText
           .split(" ")
           .map((element) => element.trim())
           .filter(Boolean)
           .forEach((v) => request.options.push(v));
   }
   ```

   - `customDefinesInput` = DOM `<input>` element
   - `customDefinesInput.value` = `"MY_DEFINE FOO"` (the input's text) -- the `if` check passes correctly
   - `customDefinesInput.value.value` = `"MY_DEFINE FOO".value` = `undefined` -- **strings don't have a `.value` property**
   - `customDefinesText` = `undefined || ""` = `""` -- always empty
   - Result: no custom defines are ever added to `request.options`

### Comparison with original implementation

The original jQuery code (`firmware_flasher.js:1158-1164`) works correctly:
```js
$('input[name="customDefines"]')
    .val()                           // gets the input text directly
    .split(" ")
    .map((element) => element.trim())
    .forEach((v) => {
        request.options.push(v);
    });
```

## Fix

**File**: `src/composables/useCloudBuild.js`

Change line 196 from:
```js
const customDefinesText = customDefinesInput.value.value || "";
```
to:
```js
const customDefinesText = customDefinesInput.value || "";
```

This is a one-line fix. `customDefinesInput` is already the DOM element, so `.value` gives the text string directly. The second `.value` was an erroneous extra dereference, likely a confusion between Vue ref semantics (`ref.value.value` for a template ref's input value) and the already-unwrapped DOM element that is actually passed.

## Impact

- All cloud builds in expert mode with custom defines are affected
- Custom defines are silently dropped -- the build succeeds but without the requested defines
- No error is logged because `"".split(" ").filter(Boolean)` produces an empty array gracefully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed custom input handling to ensure custom definitions are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->