### PR TITLE
Add missing dyn-idle setting after Vue migration

### DIFF
--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -958,6 +958,30 @@
                             </td>
                         </tr>
 
+                        <!-- Dynamic Idle Min RPM -->
+                        <tr class="idleMinRpm">
+                            <td>
+                                <input
+                                    type="number"
+                                    name="idleMinRpm-number"
+                                    v-model.number="advancedTuning.idleMinRpm"
+                                    step="1"
+                                    min="0"
+                                    :max="idleMinRpmMax"
+                                    :disabled="!dshotTelemetryEnabled"
+                                />
+                            </td>
+                            <td colspan="2">
+                                <div>
+                                    <label>
+                                        <span v-if="dshotTelemetryEnabled" v-html="$t('pidTuningIdleMinRpm')"></span>
+                                        <span v-else v-html="$t('pidTuningIdleMinRpmDisabled')"></span>
+                                    </label>
+                                    <div class="helpicon cf_tip" :title="$t('pidTuningIdleMinRpmHelp')"></div>
+                                </div>
+                            </td>
+                        </tr>
+
                         <!-- VBat Sag Compensation -->
                         <tr class="vbatSagCompensation">
                             <td>
@@ -1365,6 +1389,10 @@ const pidNavRD = createPidComputed("NavR", 2);
 // Advanced tuning - reactive reference
 const advancedTuning = computed(() => FC.ADVANCED_TUNING);
 
+// Dynamic Idle visibility and state
+const dshotTelemetryEnabled = computed(() => FC.MOTOR_CONFIG.use_dshot_telemetry ?? false);
+const idleMinRpmMax = computed(() => (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45) ? 200 : 100));
+
 // TPA settings with API version gating
 // API >= 1.45: Use ADVANCED_TUNING (tpaMode, tpaRate, tpaBreakpoint)
 // API < 1.45: Use RC_TUNING (dynamic_THR_PID, dynamic_THR_breakpoint)
@@ -1456,7 +1484,8 @@ const itermRotationEnabled = computed({
 
 const vbatSagEnabled = computed({
     get: () => FC.ADVANCED_TUNING.vbat_sag_compensation !== 0,
-    set: (val) => (FC.ADVANCED_TUNING.vbat_sag_compensation = val ? FC.ADVANCED_TUNING.vbat_sag_compensation || 100 : 0),
+    set: (val) =>
+        (FC.ADVANCED_TUNING.vbat_sag_compensation = val ? FC.ADVANCED_TUNING.vbat_sag_compensation || 100 : 0),
 });
 
 const thrustLinearEnabled = computed({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Dynamic Idle Min RPM setting to Motor Settings in PID Tuning. This new control enables idle RPM configuration and is available only when DSHOT telemetry is enabled, with constraints based on firmware capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->