### PR TITLE
Post migration fixes

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,15 +1,9 @@
-module.exports = {
-  "stories": [
-    "../src/**/*.stories.mdx",
-    "../src/**/*.stories.@(js|jsx|ts|tsx)"
-  ],
-  "addons": [
-    "@storybook/addon-links",
-    "@storybook/addon-essentials"
-  ],
-  "framework": "@storybook/vue",
-  "staticDirs": [
-    { from: "../locales", to: "/locales" },
-    { from: "../src/css", to: "/css" },
-  ]
-}
+export default {
+    stories: ["../src/**/*.stories.mdx", "../src/**/*.stories.@(js|jsx|ts|tsx)"],
+    addons: ["@storybook/addon-links", "@storybook/addon-essentials"],
+    framework: "@storybook/vue3",
+    staticDirs: [
+        { from: "../locales", to: "/locales" },
+        { from: "../src/css", to: "/css" },
+    ],
+};

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,68 +1,66 @@
-import Vue from "vue";
-import VueI18Next from "@panter/vue-i18next";
+import { setup } from "@storybook/vue3";
 import i18next from "i18next";
-import i18nextXHRBackend from "i18next-xhr-backend";
+import HttpBackend from "i18next-http-backend";
+import I18NextVue from "i18next-vue";
 
 /**
  * Logic from ../src/js/localization.js
  */
 function parseInputFile(data) {
-  // Remove the $n interpolate of Chrome $1, $2, ... -> {{1}}, {{2}}, ...
-  const REGEXP_CHROME = /\$([1-9])/g;
-  const dataChrome = data.replace(REGEXP_CHROME, "{{$1}}");
+    // Remove the $n interpolate of Chrome $1, $2, ... -> {{1}}, {{2}}, ...
+    const REGEXP_CHROME = /\$([1-9])/g;
+    const dataChrome = data.replace(REGEXP_CHROME, "{{$1}}");
 
-  // Remove the .message of the nesting $t(xxxxx.message) -> $t(xxxxx)
-  const REGEXP_NESTING = /\$t\(([^\)]*).message\)/g;
-  const dataNesting = dataChrome.replace(REGEXP_NESTING, "$t($1)");
+    // Remove the .message of the nesting $t(xxxxx.message) -> $t(xxxxx)
+    const REGEXP_NESTING = /\$t\(([^\)]*).message\)/g;
+    const dataNesting = dataChrome.replace(REGEXP_NESTING, "$t($1)");
 
-  // Move the .message of the json object to root xxxxx.message -> xxxxx
-  const jsonData = JSON.parse(dataNesting);
-  Object.entries(jsonData).forEach(([key, value]) => {
-    jsonData[key] = value.message;
-  });
+    // Move the .message of the json object to root xxxxx.message -> xxxxx
+    const jsonData = JSON.parse(dataNesting);
+    Object.entries(jsonData).forEach(([key, value]) => {
+        jsonData[key] = value.message;
+    });
 
-  return jsonData;
+    return jsonData;
 }
 
-i18next.use(i18nextXHRBackend).init({
-  lng: "en",
-  debug: true,
-  getAsync: false,
-  ns: ["messages"],
-  defaultNS: ["messages"],
-  fallbackLng: {
-    default: ["en"],
-  },
-  backend: {
-    loadPath: "/locales/{{lng}}/{{ns}}.json",
-    parse: parseInputFile,
-  },
+i18next.use(HttpBackend).init({
+    lng: "en",
+    debug: true,
+    ns: ["messages"],
+    defaultNS: ["messages"],
+    fallbackLng: {
+        default: ["en"],
+    },
+    backend: {
+        loadPath: "/locales/{{lng}}/{{ns}}.json",
+        parse: parseInputFile,
+    },
 });
 
-Vue.use(VueI18Next);
-
-const i18n = new VueI18Next(i18next);
+setup((app) => {
+    app.use(I18NextVue, { i18next });
+});
 
 export const decorators = [
-  (story) => ({
-    i18n,
-    components: { story },
-    template: `
+    (story) => ({
+        components: { story },
+        template: `
     <div style="margin: 1rem;">
       <link rel="stylesheet" href="/css/opensans_webfontkit/fonts.css" />
       <link rel="stylesheet" href="/css/theme.css" />
       <story />
     </div>
 `,
-  }),
+    }),
 ];
 
 export const parameters = {
-  actions: { argTypesRegex: "^on[A-Z].*" },
-  controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
+    actions: { argTypesRegex: "^on[A-Z].*" },
+    controls: {
+        matchers: {
+            color: /(background|color)$/i,
+            date: /Date$/,
+        },
     },
-  },
 };

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "android:sync": "vite build && node capacitor.config.generator.mjs && npx cap sync android",
     "android:release": "vite build && node capacitor.config.generator.mjs && npx cap build android --release",
     "format": "prettier --write {src,test}/**/*.{js,vue,css,less}",
-    "storybook": "start-storybook -p 6006",
+    "storybook": "storybook dev -p 6006",
     "prepare": "husky"
   },
   "window": {
@@ -53,7 +53,7 @@
     "geomagnetism": "^0.2.0",
     "i18next": "^24.2.2",
     "i18next-vue": "^5.2.0",
-    "i18next-xhr-backend": "^3.2.2",
+    "i18next-http-backend": "^3.0.1",
     "inflection": "^1.13.4",
 
     "jsdom": "^26.0.0",
@@ -107,14 +107,11 @@
     "prettier": "^3.5.2",
     "rollup": "^4.59.0",
     "rollup-plugin-copy": "^3.5.0",
-    "rollup-plugin-vue": "^6.0.0",
     "rpm-builder": "^1.2.1",
     "run-script-os": "^1.1.6",
     "vite": "^7.1.5",
     "vite-plugin-mkcert": "^1.17.9",
     "vitest": "^3.2.4",
-    "vue-loader": "^17.4.2",
-    "vue-template-compiler": "^2.7.16",
     "yarn": "^1.22.22"
   },
   "resolutions": {

--- a/src/components/data-flash/DataFlash.vue
+++ b/src/components/data-flash/DataFlash.vue
@@ -19,44 +19,42 @@
     </div>
 </template>
 
-<script>
-import { defineComponent } from "vue";
-export default defineComponent({
-    props: {
-        fcTotalSize: { type: Number, default: 100000 },
-        fcUsedSize: { type: Number, default: 82000 },
-    },
-    computed: {
-        supportDataflash() {
-            return this.fcTotalSize > 0;
-        },
-        freeSpace() {
-            if (!this.supportDataflash) {
-                return;
-            }
-            const bytes = this.fcTotalSize - this.fcUsedSize;
-            if (this.fcUsedSize >= this.fcTotalSize) {
-                return "0B";
-            }
-            if (bytes < 1024) {
-                return `${bytes}B`;
-            }
-            const kilobytes = bytes / 1024;
-            if (kilobytes < 1024) {
-                return `${Math.round(kilobytes)}KB`;
-            }
-            const megabytes = kilobytes / 1024;
-            if (megabytes < 1024) {
-                return `${megabytes.toFixed(1)}MB`;
-            }
-            const gigabytes = megabytes / 1024;
-            return `${gigabytes.toFixed(1)}GB`;
-        },
-        indicatorWidth() {
-            return this.supportDataflash ? `${Math.min((this.fcUsedSize / this.fcTotalSize) * 100, 100)}%` : "0%";
-        },
-    },
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+    fcTotalSize: { type: Number, default: 100000 },
+    fcUsedSize: { type: Number, default: 82000 },
 });
+
+const supportDataflash = computed(() => props.fcTotalSize > 0);
+
+const freeSpace = computed(() => {
+    if (!supportDataflash.value) {
+        return;
+    }
+    const bytes = props.fcTotalSize - props.fcUsedSize;
+    if (props.fcUsedSize >= props.fcTotalSize) {
+        return "0B";
+    }
+    if (bytes < 1024) {
+        return `${bytes}B`;
+    }
+    const kilobytes = bytes / 1024;
+    if (kilobytes < 1024) {
+        return `${Math.round(kilobytes)}KB`;
+    }
+    const megabytes = kilobytes / 1024;
+    if (megabytes < 1024) {
+        return `${megabytes.toFixed(1)}MB`;
+    }
+    const gigabytes = megabytes / 1024;
+    return `${gigabytes.toFixed(1)}GB`;
+});
+
+const indicatorWidth = computed(() =>
+    supportDataflash.value ? `${Math.min((props.fcUsedSize / props.fcTotalSize) * 100, 100)}%` : "0%",
+);
 </script>
 
 <style scoped>

--- a/src/components/init.js
+++ b/src/components/init.js
@@ -1,7 +1,5 @@
-// This modules is imported and has side effect of attaching the
-// `i18n` helper to window and setting up `i18next`
-// in the future it should be pure. This means it should
-// explicitly export things used by other parts of the app.
+// This module is imported for its side effects: setting up i18next
+// and initializing the Vue app with plugins and global model.
 import "../js/localization.js";
 import "../js/injected_methods";
 import i18next from "i18next";
@@ -72,7 +70,4 @@ i18next.on("initialized", function () {
     }
 });
 
-// Not strictly necessary here, but if needed
-// it's always possible to modify this model in
-// jquery land to trigger updates in vue
-window.vm = betaflightModel;
+export { betaflightModel };

--- a/src/components/quad-status/BatteryLegend.vue
+++ b/src/components/quad-status/BatteryLegend.vue
@@ -3,41 +3,23 @@
         {{ reading }}
     </div>
 </template>
-<script>
-const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8;
-import { defineComponent } from "vue";
+<script setup>
+import { computed } from "vue";
 
-export default defineComponent({
-    props: {
-        voltage: {
-            type: Number,
-            default: 0,
-        },
-        vbatmaxcellvoltage: {
-            type: Number,
-            default: 1,
-        },
-        computed: {
-            reading() {
-                let nbCells = Math.floor(this.voltage / this.vbatmaxcellvoltage) + 1;
-                if (this.voltage === 0) {
-                    nbCells = 1;
-                }
-                const cellsText = this.voltage > NO_BATTERY_VOLTAGE_MAXIMUM ? `${nbCells}S` : "USB";
-                return `${this.voltage.toFixed(2)}V (${cellsText})`;
-            },
-        },
-    },
-    computed: {
-        reading() {
-            let nbCells = Math.floor(this.voltage / this.vbatmaxcellvoltage) + 1;
-            if (this.voltage === 0) {
-                nbCells = 1;
-            }
-            const cellsText = this.voltage > NO_BATTERY_VOLTAGE_MAXIMUM ? `${nbCells}S` : "USB";
-            return `${this.voltage.toFixed(2)}V (${cellsText})`;
-        },
-    },
+const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8;
+
+const props = defineProps({
+    voltage: { type: Number, default: 0 },
+    vbatmaxcellvoltage: { type: Number, default: 1 },
+});
+
+const reading = computed(() => {
+    let nbCells = Math.floor(props.voltage / props.vbatmaxcellvoltage) + 1;
+    if (props.voltage === 0) {
+        nbCells = 1;
+    }
+    const cellsText = props.voltage > NO_BATTERY_VOLTAGE_MAXIMUM ? `${nbCells}S` : "USB";
+    return `${props.voltage.toFixed(2)}V (${cellsText})`;
 });
 </script>
 

--- a/src/components/quad-status/BottomStatusIcons.vue
+++ b/src/components/quad-status/BottomStatusIcons.vue
@@ -6,36 +6,31 @@
     </div>
 </template>
 
-<script>
-import { defineComponent } from "vue";
+<script setup>
+import { computed } from "vue";
 import { bit_check } from "../../js/bit";
 
-export default defineComponent({
-    props: {
-        lastReceivedTimestamp: { type: Number, default: 0 },
-        mode: { type: Number, default: 0 },
-        auxConfig: { type: Array, default: null },
-    },
-    computed: {
-        setActiveArmed() {
-            return (
-                this.auxConfig?.length &&
-                this.auxConfig?.includes("ARM") &&
-                bit_check(this.mode, this.auxConfig?.indexOf("ARM"))
-            );
-        },
-        setFailsafeActive() {
-            return (
-                this.auxConfig?.length &&
-                this.auxConfig?.includes("FAILSAFE") &&
-                bit_check(this.mode, this.auxConfig?.indexOf("FAILSAFE"))
-            );
-        },
-        setActiveLink() {
-            return performance.now() - this.lastReceivedTimestamp < 300;
-        },
-    },
+const props = defineProps({
+    lastReceivedTimestamp: { type: Number, default: 0 },
+    mode: { type: Number, default: 0 },
+    auxConfig: { type: Array, default: null },
 });
+
+const setActiveArmed = computed(
+    () =>
+        props.auxConfig?.length &&
+        props.auxConfig?.includes("ARM") &&
+        bit_check(props.mode, props.auxConfig?.indexOf("ARM")),
+);
+
+const setFailsafeActive = computed(
+    () =>
+        props.auxConfig?.length &&
+        props.auxConfig?.includes("FAILSAFE") &&
+        bit_check(props.mode, props.auxConfig?.indexOf("FAILSAFE")),
+);
+
+const setActiveLink = computed(() => performance.now() - props.lastReceivedTimestamp < 300);
 </script>
 
 <style scoped>

--- a/src/components/sensor-status/SensorStatus.vue
+++ b/src/components/sensor-status/SensorStatus.vue
@@ -41,64 +41,40 @@
     </div>
 </template>
 
-<script>
-import { defineComponent } from "vue";
+<script setup>
+import { computed } from "vue";
 import { bit_check } from "../../js/bit";
 
-export default defineComponent({
-    props: {
-        sensorsDetected: {
-            type: Number,
-            default: 0,
-        },
-        gpsFixState: {
-            type: Number,
-            default: 0,
-        },
-    },
-    computed: {
-        setAccActive() {
-            return this.haveSensor(this.sensorsDetected, "acc");
-        },
-        setGyroActive() {
-            return this.haveSensor(this.sensorsDetected, "gyro");
-        },
-        setBaroActive() {
-            return this.haveSensor(this.sensorsDetected, "baro");
-        },
-        setMagActive() {
-            return this.haveSensor(this.sensorsDetected, "mag");
-        },
-        setGpsActive() {
-            return this.haveSensor(this.sensorsDetected, "gps");
-        },
-        setGpsFixState() {
-            return this.gpsFixState !== 0;
-        },
-        setSonarActive() {
-            return this.haveSensor(this.sensorsDetected, "sonar");
-        },
-    },
-    methods: {
-        haveSensor(sensorsDetected, sensorCode) {
-            switch (sensorCode) {
-                case "acc":
-                    return bit_check(sensorsDetected, 0);
-                case "baro":
-                    return bit_check(sensorsDetected, 1);
-                case "mag":
-                    return bit_check(sensorsDetected, 2);
-                case "gps":
-                    return bit_check(sensorsDetected, 3);
-                case "sonar":
-                    return bit_check(sensorsDetected, 4);
-                case "gyro":
-                    return bit_check(sensorsDetected, 5);
-            }
-            return false;
-        },
-    },
+const props = defineProps({
+    sensorsDetected: { type: Number, default: 0 },
+    gpsFixState: { type: Number, default: 0 },
 });
+
+function haveSensor(sensorsDetected, sensorCode) {
+    switch (sensorCode) {
+        case "acc":
+            return bit_check(sensorsDetected, 0);
+        case "baro":
+            return bit_check(sensorsDetected, 1);
+        case "mag":
+            return bit_check(sensorsDetected, 2);
+        case "gps":
+            return bit_check(sensorsDetected, 3);
+        case "sonar":
+            return bit_check(sensorsDetected, 4);
+        case "gyro":
+            return bit_check(sensorsDetected, 5);
+    }
+    return false;
+}
+
+const setAccActive = computed(() => haveSensor(props.sensorsDetected, "acc"));
+const setGyroActive = computed(() => haveSensor(props.sensorsDetected, "gyro"));
+const setBaroActive = computed(() => haveSensor(props.sensorsDetected, "baro"));
+const setMagActive = computed(() => haveSensor(props.sensorsDetected, "mag"));
+const setGpsActive = computed(() => haveSensor(props.sensorsDetected, "gps"));
+const setGpsFixState = computed(() => props.gpsFixState !== 0);
+const setSonarActive = computed(() => haveSensor(props.sensorsDetected, "sonar"));
 </script>
 
 <style scoped lang="less">

--- a/src/components/tabs/Backups.vue
+++ b/src/components/tabs/Backups.vue
@@ -106,209 +106,187 @@
     </div>
 </template>
 
-<script>
-import { defineComponent } from "vue";
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import { useTranslation } from "i18next-vue";
 import loginManager from "../../js/LoginManager";
 import { gui_log } from "../../js/gui_log";
 import MSP from "../../js/msp";
 import { useConnectionStore } from "../../stores/connection";
 
-export default defineComponent({
-    name: "Backups",
-    data() {
-        return {
-            isLoading: true,
-            backups: [],
-            isEditing: false,
-            unsubscribeLogin: null,
-            unsubscribeLogout: null,
-            editForm: {
-                id: null,
-                name: "",
-                description: "",
-                created: null,
-            },
-            userApi: null,
-            currentCraft: null,
-        };
-    },
-    computed: {
-        groupedBackups() {
-            const grouped = {};
-            this.backups.forEach((backup) => {
-                const key = backup.key || "Unknown";
-                if (!grouped[key]) {
-                    grouped[key] = [];
+const { t } = useTranslation();
+const connectionStore = useConnectionStore();
+
+const isLoading = ref(true);
+const backups = ref([]);
+const isEditing = ref(false);
+const editForm = ref({ id: null, name: "", description: "", created: null });
+let userApi = null;
+let unsubscribeLogin = null;
+let unsubscribeLogout = null;
+
+const groupedBackups = computed(() => {
+    const grouped = {};
+    backups.value.forEach((backup) => {
+        const key = backup.key || "Unknown";
+        if (!grouped[key]) {
+            grouped[key] = [];
+        }
+        grouped[key].push(backup);
+    });
+    return grouped;
+});
+
+const isConnected = computed(() => connectionStore.connectionValid);
+
+async function loadBackups() {
+    isLoading.value = true;
+
+    try {
+        const loggedIn = await loginManager.isUserLoggedIn();
+        if (!loggedIn) {
+            backups.value = [];
+            isLoading.value = false;
+            return;
+        }
+
+        userApi = loginManager.getUserApi();
+        backups.value = await userApi.getBackups();
+    } catch (error) {
+        gui_log(`${t("userBackupsLoadFailed")}: ${error}`);
+    }
+
+    isLoading.value = false;
+}
+
+async function createBackup() {
+    try {
+        if (!userApi) {
+            throw new Error(t("notLoggedIn"));
+        }
+
+        const output = await new Promise((resolve, reject) => {
+            MSP.send_cli_command("diff all", (data) => {
+                if (data && Array.isArray(data) && data.length > 0) {
+                    resolve([...data]);
+                } else {
+                    reject(new Error(t("profileBackupEmptyResult") || "Empty backup result"));
                 }
-                grouped[key].push(backup);
             });
-            return grouped;
-        },
-        isConnected() {
-            return useConnectionStore().connectionValid;
-        },
-    },
-    methods: {
-        async loadBackups() {
-            this.isLoading = true;
-
-            try {
-                const isLoggedIn = await loginManager.isUserLoggedIn();
-                if (!isLoggedIn) {
-                    this.backups = [];
-                    this.isLoading = false;
-                    return;
-                }
-
-                this.userApi = loginManager.getUserApi();
-
-                const backups = await this.userApi.getBackups();
-                this.backups = backups;
-            } catch (error) {
-                gui_log(`${this.$t("userBackupsLoadFailed")}: ${error}`);
-            }
-
-            this.isLoading = false;
-        },
-        async createBackup() {
-            try {
-                if (!this.userApi) {
-                    throw new Error(this.$t("notLoggedIn"));
-                }
-
-                const output = await new Promise((resolve, reject) => {
-                    MSP.send_cli_command("diff all", (data) => {
-                        if (data && Array.isArray(data) && data.length > 0) {
-                            // Create a copy of the data since the original array gets cleared after callback
-                            resolve([...data]);
-                        } else {
-                            reject(new Error(this.$t("profileBackupEmptyResult") || "Empty backup result"));
-                        }
-                    });
-                });
-
-                gui_log(this.$t("profileBackupSuccess"));
-                const text = output.join("\n");
-
-                // Upload to API
-                await this.userApi.uploadBackup(text);
-
-                gui_log(this.$t("profileBackupApiSuccess"));
-                await this.loadBackups();
-            } catch (error) {
-                gui_log(`${this.$t("profileBackupApiFail")}: ${error.message || error}`);
-            }
-        },
-        async downloadBackup(backup) {
-            try {
-                if (!this.userApi) {
-                    throw new Error(this.$t("notLoggedIn"));
-                }
-
-                const response = await this.userApi.downloadBackupFile(backup.id);
-                // response is an object { name, file } where file is JSON string
-
-                // Parse the JSON and extract fileContents
-                let fileContent = response.file;
-                if (!fileContent || fileContent.length === 0) {
-                    throw new Error("Backup file is empty");
-                }
-
-                const filename = response.name || backup.name || "backup.txt";
-                // Create a blob from the decoded text for download
-                const blob = new Blob([fileContent], { type: "text/plain" });
-                const url = globalThis.URL.createObjectURL(blob);
-                const link = document.createElement("a");
-                link.href = url;
-                link.setAttribute("download", filename);
-                document.body.appendChild(link);
-                link.click();
-                link.remove();
-                // Clean up the object URL to avoid memory leaks
-                globalThis.URL.revokeObjectURL(url);
-            } catch (error) {
-                gui_log(`${this.$t("userBackupDownloadFailed")}: ${error}`);
-            }
-        },
-        startEdit(backup) {
-            this.editForm.id = backup.id;
-            this.editForm.name = backup.name;
-            this.editForm.description = backup.description || "";
-            this.editForm.created = backup.created;
-            this.isEditing = true;
-        },
-        cancelEdit() {
-            this.isEditing = false;
-        },
-        async saveBackupChanges() {
-            if (!this.userApi) {
-                return;
-            }
-
-            try {
-                await this.userApi.updateBackup({
-                    Id: this.editForm.id,
-                    name: this.editForm.name,
-                    description: this.editForm.description,
-                });
-                gui_log(this.$t("userBackupUpdateSuccess"));
-                await this.loadBackups();
-                this.isEditing = false;
-            } catch (error) {
-                gui_log(`${this.$t("userBackupUpdateFailed")}: ${error}`);
-            }
-        },
-        async deleteBackup(backupId) {
-            const confirmed = globalThis.confirm(this.$t("confirmDelete", { item: this.$t("itemBackup") }));
-            if (!confirmed) {
-                return;
-            }
-
-            if (!this.userApi) {
-                return;
-            }
-
-            try {
-                await this.userApi.deleteBackup(backupId);
-                gui_log(this.$t("userBackupDeleteSuccess"));
-                await this.loadBackups();
-            } catch (error) {
-                gui_log(`${this.$t("userBackupDeleteFailed")}: ${error}`);
-            }
-        },
-        formatDate(dateString) {
-            if (!dateString) {
-                return "";
-            }
-            return new Date(dateString).toLocaleString();
-        },
-        getSerialForCraft(craft) {
-            const backup = this.backups.find((b) => b.key === craft);
-            return backup ? backup.serial || this.$t("backupMcuUnknown") : "";
-        },
-    },
-    async mounted() {
-        // Load backups on mount
-        await this.loadBackups();
-
-        // Register callbacks for login/logout and store unsubscribe functions
-        this.unsubscribeLogin = loginManager.onLogin(async () => {
-            await this.loadBackups();
         });
 
-        this.unsubscribeLogout = loginManager.onLogout(async () => {
-            await this.loadBackups();
+        gui_log(t("profileBackupSuccess"));
+        const text = output.join("\n");
+
+        await userApi.uploadBackup(text);
+
+        gui_log(t("profileBackupApiSuccess"));
+        await loadBackups();
+    } catch (error) {
+        gui_log(`${t("profileBackupApiFail")}: ${error.message || error}`);
+    }
+}
+
+async function downloadBackup(backup) {
+    try {
+        if (!userApi) {
+            throw new Error(t("notLoggedIn"));
+        }
+
+        const response = await userApi.downloadBackupFile(backup.id);
+
+        let fileContent = response.file;
+        if (!fileContent || fileContent.length === 0) {
+            throw new Error("Backup file is empty");
+        }
+
+        const filename = response.name || backup.name || "backup.txt";
+        const blob = new Blob([fileContent], { type: "text/plain" });
+        const url = globalThis.URL.createObjectURL(blob);
+        const link = document.createElement("a");
+        link.href = url;
+        link.setAttribute("download", filename);
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        globalThis.URL.revokeObjectURL(url);
+    } catch (error) {
+        gui_log(`${t("userBackupDownloadFailed")}: ${error}`);
+    }
+}
+
+function startEdit(backup) {
+    editForm.value.id = backup.id;
+    editForm.value.name = backup.name;
+    editForm.value.description = backup.description || "";
+    editForm.value.created = backup.created;
+    isEditing.value = true;
+}
+
+function cancelEdit() {
+    isEditing.value = false;
+}
+
+async function saveBackupChanges() {
+    if (!userApi) {
+        return;
+    }
+
+    try {
+        await userApi.updateBackup({
+            Id: editForm.value.id,
+            name: editForm.value.name,
+            description: editForm.value.description,
         });
-    },
-    unmounted() {
-        // Clean up callbacks on unmount
-        if (this.unsubscribeLogin) {
-            this.unsubscribeLogin();
-        }
-        if (this.unsubscribeLogout) {
-            this.unsubscribeLogout();
-        }
-    },
+        gui_log(t("userBackupUpdateSuccess"));
+        await loadBackups();
+        isEditing.value = false;
+    } catch (error) {
+        gui_log(`${t("userBackupUpdateFailed")}: ${error}`);
+    }
+}
+
+async function deleteBackup(backupId) {
+    const confirmed = globalThis.confirm(t("confirmDelete", { item: t("itemBackup") }));
+    if (!confirmed || !userApi) {
+        return;
+    }
+
+    try {
+        await userApi.deleteBackup(backupId);
+        gui_log(t("userBackupDeleteSuccess"));
+        await loadBackups();
+    } catch (error) {
+        gui_log(`${t("userBackupDeleteFailed")}: ${error}`);
+    }
+}
+
+function formatDate(dateString) {
+    if (!dateString) {
+        return "";
+    }
+    return new Date(dateString).toLocaleString();
+}
+
+onMounted(async () => {
+    await loadBackups();
+
+    unsubscribeLogin = loginManager.onLogin(async () => {
+        await loadBackups();
+    });
+
+    unsubscribeLogout = loginManager.onLogout(async () => {
+        await loadBackups();
+    });
+});
+
+onUnmounted(() => {
+    if (unsubscribeLogin) {
+        unsubscribeLogin();
+    }
+    if (unsubscribeLogout) {
+        unsubscribeLogout();
+    }
 });
 </script>
 

--- a/src/components/tabs/UserProfile.vue
+++ b/src/components/tabs/UserProfile.vue
@@ -189,198 +189,184 @@
     </div>
 </template>
 
-<script>
-import { defineComponent } from "vue";
+<script setup>
+import { ref, computed, onMounted, onUnmounted } from "vue";
+import { useTranslation } from "i18next-vue";
 import loginManager from "../../js/LoginManager";
 import { gui_log } from "../../js/gui_log";
 
-export default defineComponent({
-    name: "UserProfile",
-    data() {
-        return {
-            isLoading: true,
-            isLoggedIn: false,
-            isEditing: false,
-            editError: null,
-            profile: null,
-            unsubscribeLogin: null,
-            unsubscribeLogout: null,
-            editForm: {
-                name: "",
-                address: "",
-                country: "",
-                avatar: "",
-            },
-            tokens: [],
-            passkeys: [],
-            userApi: null,
-        };
-    },
-    computed: {
-        profilePhoto() {
-            if (this.profile?.avatar) {
-                return this.profile.avatar;
-            }
-            return "/images/default-user-avatar-loggedin.png";
-        },
-    },
-    methods: {
-        async loadProfile() {
-            this.isLoading = true;
+const { t } = useTranslation();
 
-            try {
-                const isLoggedIn = await loginManager.isUserLoggedIn();
-                if (!isLoggedIn) {
-                    this.isLoggedIn = false;
-                    this.tokens = [];
-                    this.passkeys = [];
-                    this.isLoading = false;
-                    return;
-                }
+const isLoading = ref(true);
+const isLoggedIn = ref(false);
+const isEditing = ref(false);
+const editError = ref(null);
+const profile = ref(null);
+const editForm = ref({ name: "", address: "", country: "", avatar: "" });
+const tokens = ref([]);
+const passkeys = ref([]);
+let userApi = null;
+let unsubscribeLogin = null;
+let unsubscribeLogout = null;
 
-                this.isLoggedIn = true;
-                this.userApi = loginManager.getUserApi();
+const profilePhoto = computed(() => {
+    if (profile.value?.avatar) {
+        return profile.value.avatar;
+    }
+    return "/images/default-user-avatar-loggedin.png";
+});
 
-                try {
-                    const data = await this.userApi.profile();
-                    this.profile = data;
-                } catch (error) {
-                    gui_log(`${this.$t("userProfileLoadFailed")}: ${error}`);
-                }
+async function loadProfile() {
+    isLoading.value = true;
 
-                try {
-                    this.tokens = await this.userApi.getTokens();
-                } catch (error) {
-                    gui_log(`${this.$t("userTokenLoadFailed")}: ${error}`);
-                }
-            } catch (error) {
-                console.error("Error checking login state:", error);
-                this.isLoggedIn = false;
-                this.tokens = [];
-                this.passkeys = [];
-                this.isLoading = false;
-                return;
-            }
+    try {
+        const loggedIn = await loginManager.isUserLoggedIn();
+        if (!loggedIn) {
+            isLoggedIn.value = false;
+            tokens.value = [];
+            passkeys.value = [];
+            isLoading.value = false;
+            return;
+        }
 
-            try {
-                this.passkeys = await this.userApi.getPasskeys();
-            } catch (error) {
-                gui_log(`${this.$t("userPasskeyLoadFailed")}: ${error}`);
-            }
+        isLoggedIn.value = true;
+        userApi = loginManager.getUserApi();
 
-            this.isLoading = false;
-        },
-        startEdit() {
-            if (!this.profile) {
-                return;
-            }
-            this.editForm.name = this.profile.name || "";
-            this.editForm.address = this.profile.address || "";
-            this.editForm.country = this.profile.country || "";
-            this.editForm.avatar = this.profile.avatar || "";
-            this.editError = null;
-            this.isEditing = true;
-        },
-        cancelEdit() {
-            this.isEditing = false;
-            this.editError = null;
-        },
-        async saveProfileChanges() {
-            if (!this.userApi) {
-                return;
-            }
+        try {
+            profile.value = await userApi.profile();
+        } catch (error) {
+            gui_log(`${t("userProfileLoadFailed")}: ${error}`);
+        }
 
-            try {
-                this.editError = null;
-                await this.userApi.updateProfile({
-                    name: this.editForm.name,
-                    address: this.editForm.address,
-                    country: this.editForm.country,
-                    avatar: this.editForm.avatar,
-                });
+        try {
+            tokens.value = await userApi.getTokens();
+        } catch (error) {
+            gui_log(`${t("userTokenLoadFailed")}: ${error}`);
+        }
+    } catch (error) {
+        console.error("Error checking login state:", error);
+        isLoggedIn.value = false;
+        tokens.value = [];
+        passkeys.value = [];
+        isLoading.value = false;
+        return;
+    }
 
-                if (!this.profile) {
-                    this.profile = {};
-                }
-                this.profile.name = this.editForm.name;
-                this.profile.address = this.editForm.address;
-                this.profile.country = this.editForm.country;
-                this.profile.avatar = this.editForm.avatar;
-                gui_log(this.$t("userProfileUpdateSuccess"));
-                this.isEditing = false;
-            } catch (error) {
-                this.editError = `${this.$t("userProfileUpdateFailed")}: ${error.message || error}`;
-                gui_log(this.editError);
-            }
-        },
-        async deleteToken(tokenId) {
-            const confirmed = globalThis.confirm(this.$t("confirmDelete", { item: this.$t("itemToken") }));
-            if (!confirmed) {
-                return;
-            }
+    try {
+        passkeys.value = await userApi.getPasskeys();
+    } catch (error) {
+        gui_log(`${t("userPasskeyLoadFailed")}: ${error}`);
+    }
 
-            if (!this.userApi) {
-                return;
-            }
+    isLoading.value = false;
+}
 
-            try {
-                await this.userApi.deleteToken(tokenId);
-                this.tokens = this.tokens.filter((tk) => tk.id !== tokenId);
-                gui_log(this.$t("userTokenDeleteSuccess"));
-            } catch (error) {
-                gui_log(`${this.$t("userTokenDeleteFailed")}: ${error}`);
-            }
-        },
-        async deletePasskey(passkeyId) {
-            const confirmed = globalThis.confirm(this.$t("confirmDelete", { item: this.$t("itemPasskey") }));
-            if (!confirmed) {
-                return;
-            }
+function startEdit() {
+    if (!profile.value) {
+        return;
+    }
+    editForm.value.name = profile.value.name || "";
+    editForm.value.address = profile.value.address || "";
+    editForm.value.country = profile.value.country || "";
+    editForm.value.avatar = profile.value.avatar || "";
+    editError.value = null;
+    isEditing.value = true;
+}
 
-            if (!this.userApi) {
-                return;
-            }
+function cancelEdit() {
+    isEditing.value = false;
+    editError.value = null;
+}
 
-            try {
-                await this.userApi.deletePasskey(passkeyId);
-                this.passkeys = this.passkeys.filter((pk) => pk.id !== passkeyId);
-                gui_log(this.$t("userPasskeyDeleteSuccess"));
-            } catch (error) {
-                gui_log(`${this.$t("userPasskeyDeleteFailed")}: ${error}`);
-            }
-        },
-        formatDate(dateString) {
-            if (!dateString) {
-                return "";
-            }
-            return new Date(dateString).toLocaleString();
-        },
-        showLoginDialog() {
-            loginManager.showLoginDialog();
-        },
-    },
-    async mounted() {
-        // Load profile on mount
-        await this.loadProfile();
+async function saveProfileChanges() {
+    if (!userApi) {
+        return;
+    }
 
-        // Register callbacks for login/logout and store unsubscribe functions
-        this.unsubscribeLogin = loginManager.onLogin(async () => {
-            await this.loadProfile();
+    try {
+        editError.value = null;
+        await userApi.updateProfile({
+            name: editForm.value.name,
+            address: editForm.value.address,
+            country: editForm.value.country,
+            avatar: editForm.value.avatar,
         });
 
-        this.unsubscribeLogout = loginManager.onLogout(async () => {
-            await this.loadProfile();
-        });
-    },
-    unmounted() {
-        // Clean up callbacks on unmount
-        if (this.unsubscribeLogin) {
-            this.unsubscribeLogin();
+        if (!profile.value) {
+            profile.value = {};
         }
-        if (this.unsubscribeLogout) {
-            this.unsubscribeLogout();
-        }
-    },
+        profile.value.name = editForm.value.name;
+        profile.value.address = editForm.value.address;
+        profile.value.country = editForm.value.country;
+        profile.value.avatar = editForm.value.avatar;
+        gui_log(t("userProfileUpdateSuccess"));
+        isEditing.value = false;
+    } catch (error) {
+        editError.value = `${t("userProfileUpdateFailed")}: ${error.message || error}`;
+        gui_log(editError.value);
+    }
+}
+
+async function deleteToken(tokenId) {
+    const confirmed = globalThis.confirm(t("confirmDelete", { item: t("itemToken") }));
+    if (!confirmed || !userApi) {
+        return;
+    }
+
+    try {
+        await userApi.deleteToken(tokenId);
+        tokens.value = tokens.value.filter((tk) => tk.id !== tokenId);
+        gui_log(t("userTokenDeleteSuccess"));
+    } catch (error) {
+        gui_log(`${t("userTokenDeleteFailed")}: ${error}`);
+    }
+}
+
+async function deletePasskey(passkeyId) {
+    const confirmed = globalThis.confirm(t("confirmDelete", { item: t("itemPasskey") }));
+    if (!confirmed || !userApi) {
+        return;
+    }
+
+    try {
+        await userApi.deletePasskey(passkeyId);
+        passkeys.value = passkeys.value.filter((pk) => pk.id !== passkeyId);
+        gui_log(t("userPasskeyDeleteSuccess"));
+    } catch (error) {
+        gui_log(`${t("userPasskeyDeleteFailed")}: ${error}`);
+    }
+}
+
+function formatDate(dateString) {
+    if (!dateString) {
+        return "";
+    }
+    return new Date(dateString).toLocaleString();
+}
+
+function showLoginDialog() {
+    loginManager.showLoginDialog();
+}
+
+onMounted(async () => {
+    await loadProfile();
+
+    unsubscribeLogin = loginManager.onLogin(async () => {
+        await loadProfile();
+    });
+
+    unsubscribeLogout = loginManager.onLogout(async () => {
+        await loadProfile();
+    });
+});
+
+onUnmounted(() => {
+    if (unsubscribeLogin) {
+        unsubscribeLogin();
+    }
+    if (unsubscribeLogout) {
+        unsubscribeLogout();
+    }
 });
 </script>
 

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -1,13 +1,9 @@
 import i18next from "i18next";
-import i18nextXHRBackend from "i18next-xhr-backend";
+import HttpBackend from "i18next-http-backend";
 import { gui_log } from "./gui_log.js";
 import { get as getConfig, set as setConfig } from "./ConfigStorage.js";
 
 const i18n = {};
-/*
- * Wrapper around the i18n system
- */
-window.i18n = i18n;
 
 const languagesAvailables = [
     "ca",
@@ -42,10 +38,9 @@ const languageFallback = {
  */
 i18n.init = function (cb) {
     getStoredUserLocale(function (userLanguage) {
-        i18next.use(i18nextXHRBackend).init(
+        i18next.use(HttpBackend).init(
             {
                 lng: userLanguage,
-                getAsync: false,
                 debug: true,
                 ns: ["messages"],
                 defaultNS: ["messages"],

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -9,7 +9,6 @@ import FC from "./fc.js";
 import CONFIGURATOR from "./data_storage.js";
 import CliAutoComplete from "./CliAutoComplete.js";
 import DarkTheme, { setDarkTheme } from "./DarkTheme.js";
-import { isExpertModeEnabled } from "./utils/isExpertModeEnabled.js";
 import { updateTabList } from "./utils/updateTabList.js";
 import { mountVueTab } from "./vue_tab_mounter.js";
 import * as THREE from "three";
@@ -482,6 +481,3 @@ async function startProcess() {
         DarkTheme.autoSet();
     });
 }
-
-window.isExpertModeEnabled = isExpertModeEnabled;
-window.appReady = appReady;

--- a/src/js/utils/updateTabList.js
+++ b/src/js/utils/updateTabList.js
@@ -1,10 +1,12 @@
+import { betaflightModel } from "../../components/init.js";
+
 // Delegate tab visibility to Vue via template v-show bindings. This function now
 // only syncs the expert mode checkbox state to the global Vue model if present.
 export function updateTabList(_features) {
     try {
         const isExpertModeEnabled = document.querySelector('input[name="expertModeCheckbox"]')?.checked ?? false;
-        if (window.vm && typeof window.vm.expertMode !== "undefined") {
-            window.vm.expertMode = isExpertModeEnabled;
+        if (typeof betaflightModel.expertMode !== "undefined") {
+            betaflightModel.expertMode = isExpertModeEnabled;
         }
     } catch {
         // noop: if Vue model not available, do nothing

--- a/yarn.lock
+++ b/yarn.lock
@@ -891,7 +891,7 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.4.tgz#a70226016fabe25c5783b2f22d3e1c9bc5ca3326"
   integrity sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==
 
-"@babel/runtime@^7.17.8", "@babel/runtime@^7.23.2", "@babel/runtime@^7.5.5":
+"@babel/runtime@^7.17.8", "@babel/runtime@^7.23.2":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.26.10.tgz#a07b4d8fa27af131a633d7b3524db803eb4764c2"
   integrity sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==
@@ -2939,7 +2939,7 @@ chalk@^0.5.1:
     strip-ansi "^0.3.0"
     supports-color "^0.2.0"
 
-chalk@^4.0.0, chalk@^4.1.0:
+chalk@^4.0.0:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -3207,6 +3207,13 @@ crc32-stream@^6.0.0:
   dependencies:
     crc-32 "^1.2.0"
     readable-stream "^4.0.0"
+
+cross-fetch@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-4.0.0.tgz#f037aef1580bb3a1a35164ea2a848ba81b445983"
+  integrity sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==
+  dependencies:
+    node-fetch "^2.6.12"
 
 cross-spawn-windows-exe@^1.1.0:
   version "1.2.0"
@@ -3545,12 +3552,7 @@ dateformat@^2.0.0:
   resolved "https://registry.yarnpkg.com/dateformat/-/dateformat-2.2.0.tgz#4065e2013cf9fb916ddfd82efb506ad4c6769062"
   integrity sha512-GODcnWq3YGoTnygPfi02ygEiRxqUxpJwuRHjdhJYuxpcZmDq4rjBiXYmbCCzStxo176ixfLT6i4NPwQooRySnw==
 
-de-indent@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/de-indent/-/de-indent-1.0.2.tgz#b2038e846dc33baa5796128d0804b455b8c1e21d"
-  integrity sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==
-
-debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
+debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.0.tgz#2b3f2aea2ffeb776477460267377dc8710faba8a"
   integrity sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==
@@ -4074,11 +4076,6 @@ estraverse@^5.1.0, estraverse@^5.2.0:
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
   integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
 
-estree-walker@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.6.1.tgz#53049143f40c6eb918b23671d1fe3219f3a1b362"
-  integrity sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==
-
 estree-walker@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
@@ -4540,11 +4537,6 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob-to-regexp@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz#c75297087c851b9a578bd217dd59a92f59fe546e"
-  integrity sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==
-
 glob@^10.0.0:
   version "10.4.5"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.4.5.tgz#f4d9f0b90ffdbab09c9d77f5f29b4262517b0956"
@@ -4727,22 +4719,12 @@ has-tostringtag@^1.0.2:
   dependencies:
     has-symbols "^1.0.3"
 
-hash-sum@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/hash-sum/-/hash-sum-2.0.0.tgz#81d01bb5de8ea4a214ad5d6ead1b523460b0b45a"
-  integrity sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==
-
 hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
-
-he@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
-  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
 hookable@^5.5.3:
   version "5.5.3"
@@ -4791,17 +4773,17 @@ husky@^9.1.7:
   resolved "https://registry.yarnpkg.com/husky/-/husky-9.1.7.tgz#d46a38035d101b46a70456a850ff4201344c0b2d"
   integrity sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==
 
+i18next-http-backend@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/i18next-http-backend/-/i18next-http-backend-3.0.2.tgz#7c8daa31aa69679e155ec1f96a37846225bdf907"
+  integrity sha512-PdlvPnvIp4E1sYi46Ik4tBYh/v/NbYfFFgTjkwFl0is8A18s7/bx9aXqsrOax9WUbeNS6mD2oix7Z0yGGf6m5g==
+  dependencies:
+    cross-fetch "4.0.0"
+
 i18next-vue@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/i18next-vue/-/i18next-vue-5.2.0.tgz#b1ddd02374e8c1e328f9c239faf15e7f5f580f26"
   integrity sha512-VlP2BoEhBQkjr8v0e/TZ3o+3WCExxEbEDYHTEv3FpGZbr6idnIUBYu0NWKG+Sv7f1Xxp78qAR7fM5vy2pRJ18A==
-
-i18next-xhr-backend@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/i18next-xhr-backend/-/i18next-xhr-backend-3.2.2.tgz#769124441461b085291f539d91864e3691199178"
-  integrity sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
 
 i18next@^24.2.2:
   version "24.2.2"
@@ -5801,6 +5783,13 @@ needle@^3.1.0:
     iconv-lite "^0.6.3"
     sax "^1.2.4"
 
+node-fetch@^2.6.12:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.7.0.tgz#d0f0fa6e3e2dc1d27efcd8ad99d550bda94d187d"
+  integrity sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==
+  dependencies:
+    whatwg-url "^5.0.0"
+
 node-releases@^2.0.19:
   version "2.0.19"
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.19.tgz#9e445a52950951ec4d177d843af370b411caf314"
@@ -6554,22 +6543,6 @@ rollup-plugin-copy@^3.5.0:
     fs-extra "^8.1.0"
     globby "10.0.1"
     is-plain-object "^3.0.0"
-
-rollup-plugin-vue@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-plugin-vue/-/rollup-plugin-vue-6.0.0.tgz#e379e93e5ae9a8648522f698be2e452e8672aaf2"
-  integrity sha512-oVvUd84d5u73M2HYM3XsMDLtZRIA/tw2U0dmHlXU2UWP5JARYHzh/U9vcxaN/x/9MrepY7VH3pHFeOhrWpxs/Q==
-  dependencies:
-    debug "^4.1.1"
-    hash-sum "^2.0.0"
-    rollup-pluginutils "^2.8.2"
-
-rollup-pluginutils@^2.8.2:
-  version "2.8.2"
-  resolved "https://registry.yarnpkg.com/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz#72f2af0748b592364dbd3389e600e5a9444a351e"
-  integrity sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==
-  dependencies:
-    estree-walker "^0.6.1"
 
 rollup@^2.43.1:
   version "2.79.2"
@@ -7391,6 +7364,11 @@ tr46@^5.0.0:
   dependencies:
     punycode "^2.3.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
 tree-kill@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/tree-kill/-/tree-kill-1.2.2.tgz#4ca09a9092c88b73a7cdc5e8a01b507b0790a0cc"
@@ -7704,27 +7682,10 @@ vue-eslint-parser@^9.4.3:
     lodash "^4.17.21"
     semver "^7.3.6"
 
-vue-loader@^17.4.2:
-  version "17.4.2"
-  resolved "https://registry.yarnpkg.com/vue-loader/-/vue-loader-17.4.2.tgz#f87f0d8adfcbbe8623de9eba1979d41ba223c6da"
-  integrity sha512-yTKOA4R/VN4jqjw4y5HrynFL8AK0Z3/Jt7eOJXEitsm0GMRHDBjCfCiuTiLP7OESvsZYo2pATCWhDqxC5ZrM6w==
-  dependencies:
-    chalk "^4.1.0"
-    hash-sum "^2.0.0"
-    watchpack "^2.4.0"
-
 vue-multiselect@^3.0.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/vue-multiselect/-/vue-multiselect-3.4.0.tgz#cabe054c639a1e7475171ee4cb2f0724b86f271f"
   integrity sha512-NtaL1/VOsGsvM+H0EZswy1E+RcA5yeCpCxrhT28CBwKu9D1WbMSXBfIDNDw0v+T4enVRfOD5X7u2gyIJWCFX9w==
-
-vue-template-compiler@^2.7.16:
-  version "2.7.16"
-  resolved "https://registry.yarnpkg.com/vue-template-compiler/-/vue-template-compiler-2.7.16.tgz#c81b2d47753264c77ac03b9966a46637482bb03b"
-  integrity sha512-AYbUWAJHLGGQM7+cNTELw+KsOG9nl2CnSv467WobS5Cv9uk3wFcnr1Etsz2sEIHEZvw1U+o9mRlEO6QbZvUPGQ==
-  dependencies:
-    de-indent "^1.0.2"
-    he "^1.2.0"
 
 vue3-slider@^1.10.1:
   version "1.10.1"
@@ -7749,18 +7710,15 @@ w3c-xmlserializer@^5.0.0:
   dependencies:
     xml-name-validator "^5.0.0"
 
-watchpack@^2.4.0:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-2.4.2.tgz#2feeaed67412e7c33184e5a79ca738fbd38564da"
-  integrity sha512-TnbFSbcOCcDgjZ4piURLCbJ3nJhznVh9kw6F6iokjiFPl8ONxe9A6nMDVXDiNbrSfLILs6vB07F7wLBrwPYzJw==
-  dependencies:
-    glob-to-regexp "^0.4.1"
-    graceful-fs "^4.1.2"
-
 web-worker@^1.2.0:
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/web-worker/-/web-worker-1.5.0.tgz#71b2b0fbcc4293e8f0aa4f6b8a3ffebff733dcc5"
   integrity sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==
+
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
 webidl-conversions@^4.0.2:
   version "4.0.2"
@@ -7796,6 +7754,14 @@ whatwg-url@^14.0.0, whatwg-url@^14.1.0:
   dependencies:
     tr46 "^5.0.0"
     webidl-conversions "^7.0.0"
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
 
 whatwg-url@^7.0.0:
   version "7.1.0"


### PR DESCRIPTION
# Post Vue 3 / Pinia Migration Audit

Audit of remaining legacy code and dependencies after the Vue 3 migration ([#4812](https://github.com/betaflight/betaflight-configurator/issues/4812)).

## Open Items from Issue Tracker

| Item | Status | Reference |
|------|--------|-----------|
| Missing dyn-idle setting | Done | [#4937](https://github.com/betaflight/betaflight-configurator/issues/4937) |
| Remove unused legacy code and dependencies | Done | This branch |
| Manual timer cleanup verification | Done | All 12 tab components verified clean |

## Resolved (this branch)

### Storybook Migrated to Vue 3

- `.storybook/main.js` — converted from CommonJS to ESM, framework changed to `@storybook/vue3`
- `.storybook/preview.js` — rewritten: removed Vue 2 imports (`Vue`, `@panter/vue-i18next`), uses `setup()` from `@storybook/vue3` with `i18next-vue` plugin
- `package.json` — storybook script updated from `start-storybook` to `storybook dev`

### Dead Vue 2 Build Dependencies Removed

| Package | Reason |
|---------|--------|
| `rollup-plugin-vue` | Replaced by Vite's built-in Vue plugin |
| `vue-loader` | Webpack loader, not needed with Vite |
| `vue-template-compiler` | Vue 2 template compiler, incompatible with Vue 3 |

### i18n Backend Modernized

Replaced `i18next-xhr-backend` (XHR-based, deprecated) with `i18next-http-backend` (fetch-based) in:
- `package.json`
- `src/js/localization.js`
- `.storybook/preview.js`

### Options API Components Converted to `<script setup>`

| Component | File |
|-----------|------|
| UserProfile | `src/components/tabs/UserProfile.vue` |
| Backups | `src/components/tabs/Backups.vue` |
| DataFlash | `src/components/data-flash/DataFlash.vue` |
| BatteryLegend | `src/components/quad-status/BatteryLegend.vue` |
| BottomStatusIcons | `src/components/quad-status/BottomStatusIcons.vue` |
| SensorStatus | `src/components/sensor-status/SensorStatus.vue` |

BatteryLegend also had a bug fixed: `computed` block was accidentally nested inside `props`.

### Global `window.*` Assignments Removed

| Removed | File | Replacement |
|---------|------|-------------|
| `window.vm` | `src/components/init.js` | Named export `betaflightModel` |
| `window.i18n` | `src/js/localization.js` | Module already exports `i18n` |
| `window.isExpertModeEnabled` | `src/js/main.js` | Unused externally |
| `window.appReady` | `src/js/main.js` | Unused externally |

`src/js/utils/updateTabList.js` updated to import `betaflightModel` directly instead of using `window.vm`.

## Remaining (Low Priority / Intentional Bridges)

### TABS Registry and Tab Mounter Bridge

The legacy `TABS` object registry is still used as a bridge between the old tab-switching system and Vue components:

- `src/js/gui.js` — defines `const TABS = {}`
- `src/js/vue_tab_mounter.js` — maps tab names to Vue components through the `TABS` object
- `src/js/serial_backend.js` — references `TABS` for tab navigation
- `src/js/protocols/webstm32.js` — references `TABS.firmware_flasher`

This bridge is intentional and functional but could eventually be replaced with Vue Router.

### Switchery Toggle Library

**Package:** `switchery-latest@^0.8.2`

Old toggle switch UI component still used in 16 files. Could be replaced with a native Vue toggle component.

### jQuery in Vendored Library

**File:** `libraries/flightIndicators.js`

This vendored library still uses jQuery internally. Since it's not part of the main source, it's low priority but should be noted if the library is still in active use.

### Migration TODO/FIXME Comments

| File | Note |
|------|------|
| `src/components/init.js:30` | `FIXME` — reactive marking of PortHandler and FC |
| `src/components/init.js:70` | `TODO` — Vue devtools config |
| `src/js/protocols/webstm32.js:241` | `TODO` — update to Web Serial / USB API |
| `src/js/protocols/webstm32.js:277,1000` | `TODO` — UI locking/unlocking needs rework |
| `src/js/serial_backend.js:79` | `TODO` — use gattserverdisconnected event |

## What's Clean

- All 30 tabs fully migrated to Vue 3 SFCs
- All components now use `<script setup>` (Composition API)
- No jQuery in main source code (fully removed via [#4927](https://github.com/betaflight/betaflight-configurator/pull/4927))
- No Handlebars templates remaining
- No Chrome extension API references
- No global `window.*` state leaks
- All tabs use proper Vue 3 lifecycle hooks
- Timer cleanup verified across all tab components
- Pinia stores in place
- CSS/LESS consolidated into SFCs ([#4931](https://github.com/betaflight/betaflight-configurator/pull/4931))
- Tab files relocated from legacy directories ([#4930](https://github.com/betaflight/betaflight-configurator/pull/4930))
- Storybook configured for Vue 3
- i18n backend modernized (fetch-based)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Upgraded Storybook to Vue 3 with updated build tooling and configuration.
  * Updated i18n backend for improved HTTP request handling.

* **Refactor**
  * Migrated Vue components to Composition API for improved maintainability and code organization.
  * Restructured internal module architecture to reduce global dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->