### PR TITLE
Fix filter settings' caution message visibility in light theme

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -973,7 +973,7 @@ dialog {
 .danger {
     background-color: var(--error-transparent-1);
     border: 1px solid var(--error-600);
-    color: #fff;
+    color: var(--text);
     margin-bottom: 0.5rem;
     margin-top: 0.5rem;
     border-radius: 0.5rem;


### PR DESCRIPTION
Hi, the current filter settings warning is barely visible on the light theme:

<img width="886" height="142" alt="image" src="https://github.com/user-attachments/assets/9f8b10b7-c644-4c35-bd14-0cb99097519c" />

I've un-hardcoded the white text color and used the `text` variable so it's readable across all themes now

<img width="944" height="135" alt="image" src="https://github.com/user-attachments/assets/38ac9ce8-9663-4799-b368-2a91148f8021" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced theme compatibility for danger indicators to respect application theme colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->