### PR TITLE
Shorten UA 🇺🇦 sensor status labels to prevent overlap

### DIFF
--- a/locales/uk/messages.json
+++ b/locales/uk/messages.json
@@ -213,14 +213,14 @@
         "message": "Щонайменше один гіроскоп повинен бути увімкнений"
     },
     "sensorStatusGyroShort": {
-        "message": "Гіроскоп",
+        "message": "Гіро",
         "description": "Text of the image in the top sensors icons. Please keep it short."
     },
     "sensorStatusAccel": {
         "message": "Акселерометр"
     },
     "sensorStatusAccelShort": {
-        "message": "акселерометр",
+        "message": "Аксель",
         "description": "Text of the image in the top sensors icons. Please keep it short."
     },
     "sensorStatusMag": {
@@ -234,7 +234,7 @@
         "message": "Барометр"
     },
     "sensorStatusBaroShort": {
-        "message": "Барометер",
+        "message": "Баро",
         "description": "Text of the image in the top sensors icons. Please keep it short."
     },
     "sensorStatusGPS": {


### PR DESCRIPTION
Hi, in ukrainian translations the sensor labels are overlapping + the accelerometer is all lowercase.

<img width="423" height="136" alt="image" src="https://github.com/user-attachments/assets/63e3df1e-107e-4348-9277-876a378a4669" />

I've edited them to use shortened versions, like in English locale (I'm a UA native speaker).

<img width="416" height="116" alt="image" src="https://github.com/user-attachments/assets/1a79da1c-99a6-4e7c-b6c3-57621d5b6639" />

EDIT: fixed it in CrowdIn, pls approve if you can :pray:  

Accel: https://crowdin.com/editor/betaflight-configurator/6/en-uk?view=side-by-side&filter=basic&value=0&search_scope=everything&search_strict=0&search_full_match=0&case_sensitive=0#q=sensorStatusAccelShort

Gyro: https://crowdin.com/editor/betaflight-configurator/6/en-uk?view=side-by-side&filter=basic&value=0#q=sensorStatusGyroShort

Baro: https://crowdin.com/editor/betaflight-configurator/6/en-uk?view=side-by-side&filter=basic&value=0#q=sensorStatusBaroShort


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Ukrainian language sensor indicator labels to shortened abbreviations for improved interface display and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->