### PR TITLE
Solve tooltips racing issue

### DIFF
--- a/src/components/tabs/AuxiliaryTab.vue
+++ b/src/components/tabs/AuxiliaryTab.vue
@@ -191,7 +191,7 @@
 </template>
 
 <script>
-import { defineComponent, reactive, ref, computed, onMounted, onUnmounted, watch } from "vue";
+import { defineComponent, reactive, ref, computed, onMounted, onUnmounted, watch, nextTick } from "vue";
 import { useFlightControllerStore } from "@/stores/fc";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "../elements/WikiButton.vue";
@@ -664,6 +664,7 @@ export default defineComponent({
             } catch (error) {
                 console.error("Failed to load auxiliary data", error);
             } finally {
+                await nextTick();
                 GUI.content_ready();
             }
         };


### PR DESCRIPTION
# Fix: HTML Tooltips Not Rendered in AuxiliaryTab.vue

## Problem

In `src/components/tabs/AuxiliaryTab.vue`, mode help tooltips containing HTML tags display raw HTML text instead of rendered HTML. For example, the tooltip for ARM mode shows:

```
Enables motor output and allows the aircraft to fly.  <span class="message-negative">Attention:</span> Pilot may wish to configure <b>BOXPREARM</b> (2-stage arming) for safety reasons.
```

Instead of rendering "Attention:" in red and "BOXPREARM" in bold.

## Affected Locale Entries

Three `auxiliaryHelpMode_*` entries in `locales/en/messages.json` contain HTML:

| Key | HTML Elements |
|-----|--------------|
| `auxiliaryHelpMode_ARM` (line 2637) | `<span class="message-negative">`, `<b>` |
| `auxiliaryHelpMode_AIRMODE` (line 2649) | `<a href="..." target="_blank">` |
| `auxiliaryHelpMode_ALTHOLD` (line 2653) | `<a href="..." target="_blank">` |

The same entries exist across all 13 locale files.

## Root Cause Analysis

### How the tooltip pipeline works

1. **Translation**: `$t(mode.helpKey)` resolves to a string containing raw HTML
2. **Binding**: `:title="$t(mode.helpKey)"` sets the DOM `title` attribute (line 27)
3. **Tippy initialization**: `GUI.content_ready()` (line 667) queries `.cf_tip` elements, reads their `title` attribute, and creates tippy instances with `allowHTML: true`

### The timing bug

In `loadData()` (lines 650-669):

```javascript
buildModesFromFC();      // line 662 — updates reactive `modes` array
updateMarkers();         // line 663
// ...
GUI.content_ready();     // line 667 — queries DOM for .cf_tip elements
```

`buildModesFromFC()` populates the reactive `modes` array, which triggers Vue's `v-for` rendering loop. However, **Vue batches DOM updates asynchronously** (processed on `nextTick`). `GUI.content_ready()` runs synchronously right after, **before Vue has rendered the mode elements into the DOM**. Therefore, the `.cf_tip` query finds no mode help elements, and tippy is never attached to them.

Without tippy, the browser falls back to the native `title` tooltip, which always displays content as **plain text** — so HTML tags appear literally.

### Confirmation via working pattern

`PidTuningTab.vue` has a working implementation (lines 477-494):

```javascript
function initToolTips() {
    document.querySelectorAll("#pid-tuning .cf_tip").forEach((el) => {
        const title = el.getAttribute("title");
        if (title && !el._tippy) {
            tippy(el, { content: title, allowHTML: true });
            el.removeAttribute("title");
        }
    });
}

watch(
    () => activeSubtab.value,
    async () => {
        await nextTick();  // <-- waits for Vue DOM update
        GUI.switchery();
        initToolTips();
    },
);
```

The key difference: PidTuningTab waits for `nextTick()` before querying the DOM for `.cf_tip` elements.

## Proposed Fix

### Option A: Add `nextTick` before `GUI.content_ready()` (Minimal fix)

In `AuxiliaryTab.vue`, await `nextTick()` after updating reactive state so the DOM is ready when `GUI.content_ready()` queries for `.cf_tip` elements.

**File**: `src/components/tabs/AuxiliaryTab.vue`

```javascript
// Change loadData() from:
buildModesFromFC();
updateMarkers();
// ...
GUI.content_ready();

// To:
buildModesFromFC();
updateMarkers();
await nextTick();       // <-- wait for Vue to render mode elements
// ...
GUI.content_ready();
```

**Pros**: Minimal change, consistent with existing codebase patterns.
**Cons**: `GUI.content_ready()` is a global DOM sweep; if other cf_tip elements exist earlier, this is fine since tippy skips already-initialized elements (`!element._tippy` check).

### Option B: Add a local `initToolTips()` (Targeted fix, follows PidTuningTab pattern)

Add a dedicated function to initialize tooltips specifically for auxiliary mode elements, called after `nextTick`.

**File**: `src/components/tabs/AuxiliaryTab.vue`

```javascript
import tippy from "tippy.js";

function initToolTips() {
    document.querySelectorAll(".modes .cf_tip").forEach((el) => {
        const title = el.getAttribute("title");
        if (title && !el._tippy) {
            tippy(el, { content: title, allowHTML: true });
            el.removeAttribute("title");
        }
    });
}
```

Call it after `nextTick` in `loadData()`:

```javascript
buildModesFromFC();
updateMarkers();
await nextTick();
initToolTips();
GUI.content_ready();
```

**Pros**: More explicit, won't break if `GUI.content_ready()` changes. Follows PidTuningTab's proven pattern.
**Cons**: Slight code duplication with `gui.js`.

### Option C: Vue directive approach (Modern, but larger change)

Create a `v-tippy` directive that initializes tippy directly when elements mount, removing the need for manual DOM queries entirely.

**Pros**: Reactive, no timing issues, idiomatic Vue.
**Cons**: Larger scope change; would need adoption across many tabs. Better as a separate refactoring effort.

## Recommended Approach

**Option A** — the `nextTick` insertion is the simplest fix with the smallest diff. It directly addresses the root cause (timing) and is safe because `GUI.content_ready()` already guards against duplicate initialization.

If the team prefers more robustness, **Option B** is a good middle ground — it matches `PidTuningTab.vue`'s existing pattern and adds resilience against future changes to `GUI.content_ready()`.

## Files to Modify

| File | Change |
|------|--------|
| `src/components/tabs/AuxiliaryTab.vue` | Add `await nextTick()` before `GUI.content_ready()` in `loadData()` (+ import `nextTick` if not already imported) |

## Testing

1. Connect to a flight controller (or use a simulated one)
2. Navigate to the Auxiliary/Modes tab
3. Hover over the help icon (?) next to **ARM** mode — verify "Attention:" appears styled in red and "BOXPREARM" appears bold
4. Hover over the help icon next to **AIRMODE** — verify the "AirMode" link is clickable
5. Hover over the help icon next to **ALTHOLD** — verify the "Altitude Hold" link is clickable
6. Verify all other mode tooltips still display correctly (plain text entries unaffected)
7. Toggle "Hide unused modes" and verify tooltips still work after the list re-renders


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the timing of DOM update cycles to ensure the interface properly renders before proceeding with subsequent operations, enhancing the reliability of UI state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->