### PR TITLE
feat(options): add custom theme editor, neon theme, ui scaling

### DIFF
--- a/locales/ca/messages.json
+++ b/locales/ca/messages.json
@@ -7360,6 +7360,78 @@
         "message": "Alt contrast",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "Escala de la interfície",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Ajusta la mida de tota la interfície per millorar la llegibilitat en monitors d'alta resolució.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neó",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Personalitzat",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Colors del tema personalitzat",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Els canvis es mostren a l'instant. Fes clic a Desa per conservar-los al proper inici.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primari",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primari (fosc)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Superfície",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Superfície (fosca)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Text",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Èxit",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Avís",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Error",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Desa el tema personalitzat",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Restableix els valors predeterminats",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Canvis de color sense desar. Fes clic a «Desa» per conservar-los per al proper inici.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Tens canvis de color del tema personalitzat sense desar.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Tipus de Rates"
     },

--- a/locales/da/messages.json
+++ b/locales/da/messages.json
@@ -7353,6 +7353,78 @@
         "message": "Stor kontrast",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "Grænsefladeskalering",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Juster hele grænsefladens størrelse for bedre læsbarhed på skærme med høj opløsning.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Brugerdefineret",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Farver for brugerdefineret tema",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Ændringer vises med det samme. Klik på Gem for at beholde dem til næste opstart.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primær",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primær (mørk)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Overflade",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Overflade (mørk)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Tekst",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Succes",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Advarsel",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Fejl",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Gem brugerdefineret tema",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Nulstil til standard",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Ikke-gemte farveændringer. Klik på Gem for at beholde dem til næste opstart.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Du har ikke-gemte farveændringer i det brugerdefinerede tema.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Hastighed type"
     },

--- a/locales/de/messages.json
+++ b/locales/de/messages.json
@@ -6601,6 +6601,94 @@
     "darkTheme": {
         "message": "Dunkles Design verwenden"
     },
+    "uiScale": {
+        "message": "Oberflächenskalierung",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Passt die gesamte Oberfläche für bessere Lesbarkeit auf hochauflösenden Monitoren an.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorTheme": {
+        "message": "Farbdesign",
+        "description": "Color theme settings"
+    },
+    "colorThemeYellow": {
+        "message": "Gelb (Standard)",
+        "description": "Default yellow color theme"
+    },
+    "colorThemeAmber": {
+        "message": "Amber",
+        "description": "Amber color theme"
+    },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Benutzerdefiniert",
+        "description": "Custom color theme"
+    },
+    "colorThemeContrast": {
+        "message": "Hoher Kontrast",
+        "description": "Contrast color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Benutzerdefinierte Farben",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Änderungen werden sofort angezeigt. Mit Speichern bleiben sie beim nächsten Start erhalten.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primär",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primär (dunkel)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Oberfläche",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Oberfläche (dunkel)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Text",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Erfolg",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Warnung",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Fehler",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Custom-Theme speichern",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Auf Standard zurücksetzen",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Ungespeicherte Farbänderungen. Klicke auf Speichern, damit sie beim nächsten Start erhalten bleiben.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Du hast ungespeicherte Änderungen an den Custom-Theme-Farben.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Drehraten Typ"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7428,6 +7428,14 @@
     "darkTheme": {
         "message": "Enable dark theme"
     },
+    "uiScale": {
+        "message": "UI Scale",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Adjust the whole interface size for better readability on high-resolution monitors.",
+        "description": "Help text for the UI scale setting"
+    },
     "colorTheme": {
         "message": "Color Theme",
         "description": "Color theme settings"
@@ -7440,9 +7448,73 @@
         "message": "Amber",
         "description": "Amber color theme"
     },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Custom",
+        "description": "Custom color theme"
+    },
     "colorThemeContrast": {
         "message": "High Contrast",
         "description": "Contrast color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Custom Theme Colors",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Changes are previewed instantly. Use Save to keep them for next launch.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primary",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primary (dark)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Surface",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Surface (dark)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Text",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Success",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Warning",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Error",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Save Custom Theme",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Reset to Defaults",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Unsaved color changes. Click Save to keep them for next launch.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "You have unsaved custom theme color changes.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
     },
     "pidTuningRatesType": {
         "message": "Rates Type"

--- a/locales/es/messages.json
+++ b/locales/es/messages.json
@@ -7277,6 +7277,78 @@
         "message": "Alto contraste",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "Escala de la interfaz",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Ajusta el tamaño de toda la interfaz para mejorar la legibilidad en monitores de alta resolución.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neón",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Personalizado",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Colores del tema personalizado",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Los cambios se previsualizan al instante. Haz clic en Guardar para conservarlos en el próximo inicio.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primario",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primario (oscuro)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Superficie",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Superficie (oscura)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Texto",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Éxito",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Advertencia",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Error",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Guardar tema personalizado",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Restablecer valores predeterminados",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Cambios de color sin guardar. Haz clic en Guardar para conservarlos en el próximo inicio.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Tienes cambios de color sin guardar en el tema personalizado.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Tipo de Tasas"
     },

--- a/locales/eu/messages.json
+++ b/locales/eu/messages.json
@@ -4590,6 +4590,78 @@
     "darkTheme": {
         "message": "Gai iluna piztu"
     },
+    "uiScale": {
+        "message": "Interfazearen eskala",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Doitu interfazearen tamaina osoa bereizmen handiko monitoreetan irakurgarritasuna hobetzeko.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Pertsonalizatua",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Gai pertsonalizatuaren koloreak",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Aldaketak berehala aurrebistaratzen dira. Sakatu Gorde hurrengo abioan mantentzeko.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Nagusia",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Nagusia (iluna)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Azalera",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Azalera (iluna)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Testua",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Arrakasta",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Abisua",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Errorea",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Gorde gai pertsonalizatua",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Berrezarri lehenetsiak",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Gorde gabeko kolore-aldaketak. Sakatu Gorde hurrengo abioan mantentzeko.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Kolore-aldaketa gorde gabeak dituzu gai pertsonalizatuan.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Rate Mota"
     },

--- a/locales/fr/messages.json
+++ b/locales/fr/messages.json
@@ -5975,6 +5975,78 @@
     "darkTheme": {
         "message": "Activer le thème sombre"
     },
+    "uiScale": {
+        "message": "Échelle de l'interface",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Ajuste la taille de toute l'interface pour améliorer la lisibilité sur les écrans haute résolution.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Néon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Personnalisé",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Couleurs du thème personnalisé",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Les changements sont prévisualisés instantanément. Cliquez sur Enregistrer pour les conserver au prochain démarrage.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primaire",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primaire (foncé)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Surface",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Surface (foncée)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Texte",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Succès",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Avertissement",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Erreur",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Enregistrer le thème personnalisé",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Réinitialiser par défaut",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Modifications de couleur non enregistrées. Cliquez sur Enregistrer pour les conserver au prochain démarrage.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Vous avez des modifications de couleur non enregistrées dans le thème personnalisé.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Type de rates"
     },

--- a/locales/gl/messages.json
+++ b/locales/gl/messages.json
@@ -6269,6 +6269,78 @@
     "darkTheme": {
         "message": "Activa o tema escuro"
     },
+    "uiScale": {
+        "message": "Escala da interface",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Axusta o tamaño de toda a interface para mellorar a lexibilidade en monitores de alta resolución.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Personalizado",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Cores do tema personalizado",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Os cambios amósanse ao instante. Fai clic en Gardar para conservalos no próximo inicio.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primario",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primario (escuro)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Superficie",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Superficie (escura)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Texto",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Éxito",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Aviso",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Erro",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Gardar tema personalizado",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Restablecer por defecto",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Cambios de cor sen gardar. Fai clic en Gardar para conservalos no próximo inicio.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Tes cambios de cor sen gardar no tema personalizado.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Tipo de Rates"
     },

--- a/locales/it/messages.json
+++ b/locales/it/messages.json
@@ -7348,6 +7348,78 @@
         "message": "Alto Contrasto",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "Scala interfaccia",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Regola la dimensione dell'intera interfaccia per una migliore leggibilità su monitor ad alta risoluzione.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Personalizzato",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Colori del tema personalizzato",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Le modifiche sono visualizzate immediatamente. Fai clic su Salva per mantenerle al prossimo avvio.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primario",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primario (scuro)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Superficie",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Superficie (scura)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Testo",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Successo",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Avviso",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Errore",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Salva tema personalizzato",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Ripristina predefiniti",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Modifiche colore non salvate. Fai clic su Salva per mantenerle al prossimo avvio.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Hai modifiche colore non salvate nel tema personalizzato.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Tipo di rates"
     },

--- a/locales/ja/messages.json
+++ b/locales/ja/messages.json
@@ -7278,6 +7278,78 @@
         "message": "ハイコントラスト",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "UI スケール",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "高解像度モニターでの可読性向上のため、インターフェース全体のサイズを調整します。",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "ネオン",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "カスタム",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "カスタムテーマの色",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "変更はすぐにプレビューされます。次回起動時にも保持するには［保存］をクリックしてください。",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "プライマリ",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "プライマリ（濃）",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "サーフェス",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "サーフェス（濃）",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "テキスト",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "成功",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "警告",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "エラー",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "カスタムテーマを保存",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "デフォルトにリセット",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "未保存の色変更があります。次回起動時にも保持するには［保存］をクリックしてください。",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "カスタムテーマの色変更が保存されていません。",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "レートタイプ"
     },

--- a/locales/ko/messages.json
+++ b/locales/ko/messages.json
@@ -7317,6 +7317,78 @@
         "message": "고대비",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "UI 배율",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "고해상도 모니터에서 가독성을 높이기 위해 전체 인터페이스 크기를 조정합니다.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "네온",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "사용자 지정",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "사용자 지정 테마 색상",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "변경 사항이 즉시 미리보기로 표시됩니다. 다음 실행에도 유지하려면 저장을 클릭하세요.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "기본 색상",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "기본 색상(진하게)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "배경",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "배경(진하게)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "텍스트",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "성공",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "경고",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "오류",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "사용자 지정 테마 저장",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "기본값으로 재설정",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "저장되지 않은 색상 변경이 있습니다. 다음 실행에도 유지하려면 저장을 클릭하세요.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "사용자 지정 테마 색상 변경이 저장되지 않았습니다.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "레이트 형식"
     },

--- a/locales/nl/messages.json
+++ b/locales/nl/messages.json
@@ -4818,6 +4818,78 @@
     "darkTheme": {
         "message": "Donker thema gebruiken"
     },
+    "uiScale": {
+        "message": "UI-schaal",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Pas de grootte van de hele interface aan voor betere leesbaarheid op monitoren met hoge resolutie.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Aangepast",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Kleuren van aangepast thema",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Wijzigingen worden direct weergegeven. Klik op Opslaan om ze voor de volgende start te bewaren.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primair",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primair (donker)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Oppervlak",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Oppervlak (donker)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Tekst",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Succes",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Waarschuwing",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Fout",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Aangepast thema opslaan",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Standaardwaarden herstellen",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Niet-opgeslagen kleurwijzigingen. Klik op Opslaan om ze voor de volgende start te bewaren.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Je hebt niet-opgeslagen kleurwijzigingen in het aangepaste thema.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Rates Type"
     },

--- a/locales/pl/messages.json
+++ b/locales/pl/messages.json
@@ -7328,6 +7328,78 @@
         "message": "Wysoki Kontrast",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "Skalowanie interfejsu",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Dostosuj rozmiar całego interfejsu, aby poprawić czytelność na monitorach o wysokiej rozdzielczości.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Niestandardowy",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Kolory motywu niestandardowego",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Zmiany są podglądane natychmiast. Kliknij Zapisz, aby zachować je przy następnym uruchomieniu.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Główny",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Główny (ciemny)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Powierzchnia",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Powierzchnia (ciemna)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Tekst",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Sukces",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Ostrzeżenie",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Błąd",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Zapisz motyw niestandardowy",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Przywróć domyślne",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Niezapisane zmiany kolorów. Kliknij Zapisz, aby zachować je przy następnym uruchomieniu.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Masz niezapisane zmiany kolorów w motywie niestandardowym.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Rodzaj Rate"
     },

--- a/locales/pt/messages.json
+++ b/locales/pt/messages.json
@@ -7352,6 +7352,78 @@
         "message": "Alto Contraste",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "Escala da interface",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Ajusta o tamanho de toda a interface para melhor legibilidade em monitores de alta resolução.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Néon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Personalizado",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Cores do tema personalizado",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "As alterações são pré-visualizadas instantaneamente. Clique em Guardar para as manter no próximo arranque.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primário",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primário (escuro)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Superfície",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Superfície (escura)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Texto",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Sucesso",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Aviso",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Erro",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Guardar tema personalizado",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Repor predefinições",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Alterações de cor não guardadas. Clique em Guardar para as manter no próximo arranque.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Tem alterações de cor não guardadas no tema personalizado.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Tipo de Rates"
     },

--- a/locales/pt_BR/messages.json
+++ b/locales/pt_BR/messages.json
@@ -6461,6 +6461,78 @@
     "darkTheme": {
         "message": "Ativar tema escuro"
     },
+    "uiScale": {
+        "message": "Escala da interface",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Ajuste o tamanho de toda a interface para melhor legibilidade em monitores de alta resolução.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Neon",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Personalizado",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Cores do tema personalizado",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "As alterações são exibidas instantaneamente. Clique em Salvar para mantê-las na próxima inicialização.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Primário",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Primário (escuro)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Superfície",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Superfície (escura)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Texto",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Sucesso",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Aviso",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Erro",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Salvar tema personalizado",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Restaurar padrões",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Alterações de cor não salvas. Clique em Salvar para mantê-las na próxima inicialização.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "Você tem alterações de cor não salvas no tema personalizado.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Tipos de taxas"
     },

--- a/locales/ru/messages.json
+++ b/locales/ru/messages.json
@@ -7301,6 +7301,78 @@
         "message": "Высокий контраст",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "Масштаб интерфейса",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Настраивает размер всего интерфейса для лучшей читаемости на мониторах высокого разрешения.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Неон",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Пользовательская",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Цвета пользовательской темы",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Изменения отображаются сразу. Нажмите «Сохранить», чтобы сохранить их для следующего запуска.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Основной",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Основной (тёмный)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Поверхность",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Поверхность (тёмная)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Текст",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Успех",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Предупреждение",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Ошибка",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Сохранить пользовательскую тему",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Сбросить по умолчанию",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Есть несохранённые изменения цветов. Нажмите «Сохранить», чтобы сохранить их для следующего запуска.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "У вас есть несохранённые изменения цветов в пользовательской теме.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Тип коэффициентов"
     },

--- a/locales/uk/messages.json
+++ b/locales/uk/messages.json
@@ -7298,6 +7298,78 @@
         "message": "Висококонтрастна",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "Масштаб інтерфейсу",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "Налаштовує розмір усього інтерфейсу для кращої читабельності на моніторах високої роздільної здатності.",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "Неон",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "Користувацька",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "Кольори користувацької теми",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "Зміни відображаються миттєво. Натисніть «Зберегти», щоб зберегти їх для наступного запуску.",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "Основний",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "Основний (темний)",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "Поверхня",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "Поверхня (темна)",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "Текст",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "Успіх",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "Попередження",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "Помилка",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "Зберегти користувацьку тему",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "Скинути до типових",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "Є незбережені зміни кольорів. Натисніть «Зберегти», щоб зберегти їх для наступного запуску.",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "У вас є незбережені зміни кольорів у користувацькій темі.",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Тип коефіцієнтів"
     },

--- a/locales/zh_CN/messages.json
+++ b/locales/zh_CN/messages.json
@@ -6562,6 +6562,78 @@
     "darkTheme": {
         "message": "使用暗色主题"
     },
+    "uiScale": {
+        "message": "界面缩放",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "调整整个界面的大小，以提高高分辨率显示器上的可读性。",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "霓虹",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "自定义",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "自定义主题颜色",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "更改会立即预览。点击“保存”以在下次启动时保留。",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "主色",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "主色（深）",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "表面",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "表面（深）",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "文本",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "成功",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "警告",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "错误",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "保存自定义主题",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "恢复默认",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "有未保存的颜色更改。点击“保存”以在下次启动时保留。",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "你有未保存的自定义主题颜色更改。",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Rate 类型"
     },

--- a/locales/zh_TW/messages.json
+++ b/locales/zh_TW/messages.json
@@ -4513,6 +4513,78 @@
     "darkTheme": {
         "message": "使用深色主題"
     },
+    "uiScale": {
+        "message": "介面縮放",
+        "description": "User interface scale setting"
+    },
+    "uiScaleHelp": {
+        "message": "調整整個介面的大小，以提升高解析度螢幕上的可讀性。",
+        "description": "Help text for the UI scale setting"
+    },
+    "colorThemeNeon": {
+        "message": "霓虹",
+        "description": "Neon color theme"
+    },
+    "colorThemeCustom": {
+        "message": "自訂",
+        "description": "Custom color theme"
+    },
+    "customThemeEditorTitle": {
+        "message": "自訂主題色彩",
+        "description": "Custom theme editor section title"
+    },
+    "customThemeLivePreviewHint": {
+        "message": "變更會立即預覽。按一下「儲存」可在下次啟動時保留。",
+        "description": "Hint shown in custom theme editor"
+    },
+    "customThemePrimary": {
+        "message": "主要",
+        "description": "Custom theme primary color label"
+    },
+    "customThemePrimaryDark": {
+        "message": "主要（深）",
+        "description": "Custom theme primary dark color label"
+    },
+    "customThemeSurface": {
+        "message": "表面",
+        "description": "Custom theme surface color label"
+    },
+    "customThemeSurfaceDark": {
+        "message": "表面（深）",
+        "description": "Custom theme dark surface color label"
+    },
+    "customThemeText": {
+        "message": "文字",
+        "description": "Custom theme text color label"
+    },
+    "customThemeSuccess": {
+        "message": "成功",
+        "description": "Custom theme success color label"
+    },
+    "customThemeWarning": {
+        "message": "警告",
+        "description": "Custom theme warning color label"
+    },
+    "customThemeError": {
+        "message": "錯誤",
+        "description": "Custom theme error color label"
+    },
+    "customThemeSave": {
+        "message": "儲存自訂主題",
+        "description": "Save custom theme button label"
+    },
+    "customThemeReset": {
+        "message": "恢復預設",
+        "description": "Reset custom theme button label"
+    },
+    "customThemeUnsavedWarning": {
+        "message": "有尚未儲存的色彩變更。按一下「儲存」可在下次啟動時保留。",
+        "description": "Warning shown when custom theme changes are not saved"
+    },
+    "customThemeUnsavedBrowserWarning": {
+        "message": "你的自訂主題色彩變更尚未儲存。",
+        "description": "Browser unload warning when custom theme changes are unsaved"
+    },
     "pidTuningRatesType": {
         "message": "Rate 類型"
     },

--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -122,14 +122,168 @@
                         <span class="freelabel" v-html="$t('darkTheme')"></span>
                     </div>
 
+                    <!-- UI Scale -->
+                    <div class="uiScale margin-bottom">
+                        <span class="freelabel uiScaleLabel" v-html="$t('uiScale')"></span>
+                        <div class="uiScaleHint" v-html="$t('uiScaleHelp')"></div>
+                        <div class="uiScalePresets">
+                            <button
+                                type="button"
+                                class="regular-button uiScalePresetButton"
+                                :class="{ active: settings.uiScale === 0.9 }"
+                                @click="applyUiScalePreset(0.9)"
+                            >
+                                90%
+                            </button>
+                            <button
+                                type="button"
+                                class="regular-button uiScalePresetButton"
+                                :class="{ active: settings.uiScale === 1 }"
+                                @click="applyUiScalePreset(1)"
+                            >
+                                100%
+                            </button>
+                            <button
+                                type="button"
+                                class="regular-button uiScalePresetButton"
+                                :class="{ active: settings.uiScale === 1.1 }"
+                                @click="applyUiScalePreset(1.1)"
+                            >
+                                110%
+                            </button>
+                            <button
+                                type="button"
+                                class="regular-button uiScalePresetButton"
+                                :class="{ active: settings.uiScale === 1.25 }"
+                                @click="applyUiScalePreset(1.25)"
+                            >
+                                125%
+                            </button>
+                            <button
+                                type="button"
+                                class="regular-button uiScalePresetButton"
+                                :class="{ active: settings.uiScale === 1.4 }"
+                                @click="applyUiScalePreset(1.4)"
+                            >
+                                140%
+                            </button>
+                        </div>
+
+                        <div class="uiScaleControls">
+                            <input
+                                id="uiScaleRange"
+                                type="range"
+                                v-model.number="settings.uiScale"
+                                min="0.85"
+                                max="1.5"
+                                step="0.01"
+                            />
+                            <input
+                                id="uiScaleNumber"
+                                type="number"
+                                v-model.number="settings.uiScale"
+                                min="0.85"
+                                max="1.5"
+                                step="0.01"
+                            />
+                            <span class="uiScaleValue">{{ Math.round(settings.uiScale * 100) }}%</span>
+                        </div>
+                    </div>
+
                     <!-- Color Theme -->
                     <div class="colorTheme margin-bottom">
                         <select id="colorThemeSelect" v-model="settings.colorTheme">
                             <option value="yellow">{{ $t("colorThemeYellow") }}</option>
                             <option value="amber">{{ $t("colorThemeAmber") }}</option>
+                            <option value="neon">{{ $t("colorThemeNeon") }}</option>
                             <option value="contrast">{{ $t("colorThemeContrast") }}</option>
+                            <option disabled>────────</option>
+                            <option value="custom">{{ $t("colorThemeCustom") }}</option>
                         </select>
                         <span class="freelabel" v-html="$t('colorTheme')"></span>
+                    </div>
+
+                    <div v-if="settings.colorTheme === 'custom'" class="customThemeEditor margin-bottom">
+                        <div class="customThemeTitle" v-html="$t('customThemeEditorTitle')"></div>
+                        <div class="customThemeHint" v-html="$t('customThemeLivePreviewHint')"></div>
+
+                        <div class="customThemePresets">
+                            <button
+                                type="button"
+                                class="regular-button customThemePresetButton"
+                                @click="applyCustomThemePreset('graphite')"
+                            >
+                                Graphite
+                            </button>
+                            <button
+                                type="button"
+                                class="regular-button customThemePresetButton"
+                                @click="applyCustomThemePreset('ocean')"
+                            >
+                                Ocean
+                            </button>
+                            <button
+                                type="button"
+                                class="regular-button customThemePresetButton"
+                                @click="applyCustomThemePreset('emerald')"
+                            >
+                                Emerald
+                            </button>
+                        </div>
+
+                        <div class="customThemeGrid">
+                            <label class="customThemeField">
+                                <span class="customThemeFieldLabel">{{ $t("customThemePrimary") }}</span>
+                                <input type="color" v-model="settings.customTheme.primary500" />
+                            </label>
+                            <label class="customThemeField">
+                                <span class="customThemeFieldLabel">{{ $t("customThemePrimaryDark") }}</span>
+                                <input type="color" v-model="settings.customTheme.primary700" />
+                            </label>
+                            <label class="customThemeField">
+                                <span class="customThemeFieldLabel">{{ $t("customThemeSurface") }}</span>
+                                <input type="color" v-model="settings.customTheme.surface100" />
+                            </label>
+                            <label class="customThemeField">
+                                <span class="customThemeFieldLabel">{{ $t("customThemeSurfaceDark") }}</span>
+                                <input type="color" v-model="settings.customTheme.surface300" />
+                            </label>
+                            <label class="customThemeField">
+                                <span class="customThemeFieldLabel">{{ $t("customThemeText") }}</span>
+                                <input type="color" v-model="settings.customTheme.text" />
+                            </label>
+                            <label class="customThemeField">
+                                <span class="customThemeFieldLabel">{{ $t("customThemeSuccess") }}</span>
+                                <input type="color" v-model="settings.customTheme.success500" />
+                            </label>
+                            <label class="customThemeField">
+                                <span class="customThemeFieldLabel">{{ $t("customThemeWarning") }}</span>
+                                <input type="color" v-model="settings.customTheme.warning500" />
+                            </label>
+                            <label class="customThemeField">
+                                <span class="customThemeFieldLabel">{{ $t("customThemeError") }}</span>
+                                <input type="color" v-model="settings.customTheme.error500" />
+                            </label>
+                        </div>
+
+                        <div class="customThemeActions">
+                            <button type="button" class="regular-button" @click="saveCustomTheme">
+                                {{ $t("customThemeSave") }}
+                            </button>
+                            <button
+                                type="button"
+                                class="regular-button customThemeResetButton"
+                                @click="resetCustomTheme"
+                            >
+                                {{ $t("customThemeReset") }}
+                            </button>
+                        </div>
+
+                        <div
+                            v-if="isCustomThemeDirty"
+                            class="customThemeUnsavedWarning"
+                            v-html="customThemeUnsavedWarningText"
+                        ></div>
                     </div>
 
                     <!-- User Language -->
@@ -201,7 +355,7 @@
 </template>
 
 <script>
-import { defineComponent, reactive, watch, onMounted, nextTick } from "vue";
+import { computed, defineComponent, reactive, ref, watch, onBeforeUnmount, onMounted, nextTick } from "vue";
 import BaseTab from "./BaseTab.vue";
 import { useDialog } from "@/composables/useDialog";
 import GUI from "../../js/gui";
@@ -210,10 +364,51 @@ import { i18n } from "../../js/localization";
 import PortHandler from "../../js/port_handler";
 import CliAutoComplete from "../../js/CliAutoComplete";
 import DarkTheme, { setDarkTheme } from "../../js/DarkTheme";
+import {
+    DEFAULT_CUSTOM_THEME,
+    applyCustomTheme,
+    clearCustomTheme,
+    isDefaultCustomTheme,
+    sanitizeCustomTheme,
+} from "../../js/ColorTheme";
+import { DEFAULT_UI_SCALE, applyUiScale, sanitizeUiScale } from "../../js/UiScale";
 import { checkSetupAnalytics } from "../../js/Analytics";
 import NotificationManager from "../../js/utils/notifications";
 import { ispConnected } from "../../js/utils/connection";
 import { DEFAULT_DEVELOPMENT_OPTIONS, resetDevelopmentOptions } from "../../js/utils/developmentOptions";
+
+const CUSTOM_THEME_PRESETS = {
+    graphite: {
+        primary500: "#94a3b8",
+        primary700: "#64748b",
+        surface100: "#141922",
+        surface300: "#2a3140",
+        text: "#e5e7eb",
+        success500: "#34d399",
+        warning500: "#fbbf24",
+        error500: "#fb7185",
+    },
+    ocean: {
+        primary500: "#0284c7",
+        primary700: "#075985",
+        surface100: "#f0f9ff",
+        surface300: "#bae6fd",
+        text: "#0c4a6e",
+        success500: "#16a34a",
+        warning500: "#f59e0b",
+        error500: "#dc2626",
+    },
+    emerald: {
+        primary500: "#22c55e",
+        primary700: "#15803d",
+        surface100: "#101915",
+        surface300: "#1f2e27",
+        text: "#e7f5ec",
+        success500: "#34d399",
+        warning500: "#fbbf24",
+        error500: "#fb7185",
+    },
+};
 
 export default defineComponent({
     name: "OptionsTab",
@@ -233,7 +428,9 @@ export default defineComponent({
             showVirtualMode: !!getConfig("showVirtualMode").showVirtualMode,
             useLegacyRenderingModel: !!getConfig("useLegacyRenderingModel").useLegacyRenderingModel,
             darkTheme: DarkTheme.configSetting,
+            uiScale: sanitizeUiScale(getConfig("uiScale", DEFAULT_UI_SCALE).uiScale),
             colorTheme: getConfig("colorTheme", "yellow").colorTheme ?? "yellow",
+            customTheme: sanitizeCustomTheme(getConfig("customTheme", DEFAULT_CUSTOM_THEME).customTheme),
             showDevToolsOnStartup: !!getConfig("showDevToolsOnStartup").showDevToolsOnStartup,
             showNotifications: !!getConfig("showNotifications").showNotifications,
             backupOnFlash: getConfig("backupOnFlash", 1).backupOnFlash ?? 1,
@@ -244,7 +441,63 @@ export default defineComponent({
             automaticDevOptions: !!getConfig("automaticDevOptions", true).automaticDevOptions,
         });
 
+        settings.customTheme = sanitizeCustomTheme(settings.customTheme);
+
+        const savedCustomTheme = ref(sanitizeCustomTheme(settings.customTheme));
+
+        function serializeCustomTheme(theme) {
+            const normalizedTheme = sanitizeCustomTheme(theme);
+            return [
+                normalizedTheme.primary500,
+                normalizedTheme.primary700,
+                normalizedTheme.surface100,
+                normalizedTheme.surface300,
+                normalizedTheme.text,
+                normalizedTheme.success500,
+                normalizedTheme.warning500,
+                normalizedTheme.error500,
+            ].join("|");
+        }
+
+        const isCustomThemeDirty = computed(
+            () => serializeCustomTheme(settings.customTheme) !== serializeCustomTheme(savedCustomTheme.value),
+        );
+
+        function getLocaleMessageOrFallback(key, fallbackMessage) {
+            const localizedMessage = i18n.getMessage(key);
+            return localizedMessage && localizedMessage !== key ? localizedMessage : fallbackMessage;
+        }
+
+        const customThemeUnsavedWarningText = computed(() =>
+            getLocaleMessageOrFallback(
+                "customThemeUnsavedWarning",
+                "Unsaved color changes. Click Save to keep them for next launch.",
+            ),
+        );
+
+        const customThemeUnsavedBrowserWarningText = computed(() =>
+            getLocaleMessageOrFallback(
+                "customThemeUnsavedBrowserWarning",
+                "You have unsaved custom theme color changes.",
+            ),
+        );
+
+        function applyOrClearCustomTheme(themeInput = settings.customTheme) {
+            const customTheme = sanitizeCustomTheme(themeInput);
+            if (isDefaultCustomTheme(customTheme)) {
+                clearCustomTheme();
+            } else {
+                applyCustomTheme(customTheme);
+            }
+
+            return customTheme;
+        }
+
         const availableLanguages = i18n.getLanguagesAvailables();
+
+        if (settings.colorTheme === "custom") {
+            settings.customTheme = applyOrClearCustomTheme(settings.customTheme);
+        }
 
         // switchery workaround to refresh the toggles
         const refreshDevelopmentToggles = () => {
@@ -317,6 +570,16 @@ export default defineComponent({
         );
 
         watch(
+            () => settings.uiScale,
+            (value) => {
+                const uiScale = sanitizeUiScale(value);
+                settings.uiScale = uiScale;
+                setConfig({ uiScale });
+                applyUiScale(uiScale);
+            },
+        );
+
+        watch(
             () => settings.darkTheme,
             (value) => {
                 // Contrast theme requires dark mode - prevent user from changing it
@@ -344,8 +607,54 @@ export default defineComponent({
                     setConfig({ darkTheme: 0 });
                     setDarkTheme(0);
                 }
+
+                if (value === "custom") {
+                    settings.customTheme = applyOrClearCustomTheme(settings.customTheme);
+                } else {
+                    clearCustomTheme();
+                }
             },
         );
+
+        watch(
+            () => settings.customTheme,
+            (value) => {
+                if (settings.colorTheme === "custom") {
+                    applyOrClearCustomTheme(value);
+                }
+            },
+            { deep: true },
+        );
+
+        function saveCustomTheme() {
+            const customTheme = applyOrClearCustomTheme(settings.customTheme);
+            settings.customTheme = customTheme;
+            savedCustomTheme.value = customTheme;
+            setConfig({ customTheme });
+        }
+
+        function resetCustomTheme() {
+            settings.customTheme = { ...DEFAULT_CUSTOM_THEME };
+            savedCustomTheme.value = sanitizeCustomTheme(settings.customTheme);
+            setConfig({ customTheme: settings.customTheme });
+
+            if (settings.colorTheme === "custom") {
+                clearCustomTheme();
+            }
+        }
+
+        function applyCustomThemePreset(presetName) {
+            const preset = CUSTOM_THEME_PRESETS[presetName];
+            if (!preset) {
+                return;
+            }
+
+            settings.customTheme = sanitizeCustomTheme(preset);
+        }
+
+        function applyUiScalePreset(value) {
+            settings.uiScale = sanitizeUiScale(value);
+        }
 
         watch(
             () => settings.showDevToolsOnStartup,
@@ -443,13 +752,33 @@ export default defineComponent({
         }
 
         onMounted(() => {
+            window.addEventListener("beforeunload", handleBeforeUnload);
             GUI.content_ready();
         });
+
+        onBeforeUnmount(() => {
+            window.removeEventListener("beforeunload", handleBeforeUnload);
+        });
+
+        function handleBeforeUnload(event) {
+            if (!isCustomThemeDirty.value) {
+                return;
+            }
+
+            event.preventDefault();
+            event.returnValue = customThemeUnsavedBrowserWarningText.value;
+        }
 
         return {
             settings,
             availableLanguages,
             handleNotificationsChange,
+            saveCustomTheme,
+            resetCustomTheme,
+            applyCustomThemePreset,
+            applyUiScalePreset,
+            isCustomThemeDirty,
+            customThemeUnsavedWarningText,
         };
     },
 });
@@ -474,6 +803,188 @@ export default defineComponent({
         border: 1px solid var(--surface-500);
         border-radius: 3px;
         width: fit-content;
+    }
+
+    .customThemeEditor {
+        display: grid;
+        gap: 10px;
+        padding: 12px;
+        border: 1px solid var(--surface-300);
+        border-radius: 6px;
+        background: var(--surface-100);
+        color: var(--text);
+    }
+
+    .customThemeTitle {
+        font-weight: 600;
+    }
+
+    .customThemeHint {
+        color: var(--text);
+        opacity: 0.75;
+        font-size: 12px;
+    }
+
+    .customThemeGrid {
+        display: grid;
+        gap: 10px;
+        grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    }
+
+    .customThemeField {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+        padding: 8px 10px;
+        border: 1px solid var(--surface-300);
+        border-radius: 4px;
+        background: var(--surface-100);
+    }
+
+    .customThemeFieldLabel {
+        font-size: 12px;
+        font-weight: 600;
+        color: var(--text);
+    }
+
+    .customThemeField input[type="color"] {
+        width: 34px;
+        height: 24px;
+        padding: 0;
+        border: 1px solid var(--surface-500);
+        border-radius: 4px;
+        background: var(--surface-100);
+        cursor: pointer;
+    }
+
+    .customThemeActions {
+        display: flex;
+        gap: 8px;
+        align-items: center;
+    }
+
+    .customThemeUnsavedWarning {
+        color: var(--warning-500);
+        font-size: 12px;
+        font-weight: 600;
+    }
+
+    .customThemeActions .regular-button {
+        margin-top: 0;
+        margin-bottom: 0;
+        line-height: 24px;
+        padding: 0 8px;
+        font-size: 11px;
+    }
+
+    .customThemeActions .regular-button.customThemeResetButton {
+        background-color: var(--primary-200);
+        border: 1px solid var(--primary-600);
+        color: #000;
+    }
+
+    .customThemeActions .regular-button.customThemeResetButton:hover {
+        background-color: var(--primary-300);
+    }
+
+    .customThemePresets {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+    }
+
+    .customThemePresets .customThemePresetButton.regular-button {
+        margin: 0;
+        padding: 0 10px;
+        line-height: 24px;
+        font-size: 11px;
+        border-radius: 999px;
+        background-color: var(--primary-100);
+        border-color: var(--primary-600);
+        color: #000;
+    }
+
+    .customThemePresets .customThemePresetButton.regular-button:hover {
+        background-color: var(--primary-200);
+    }
+
+    .uiScaleControls {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+        margin-top: 4px;
+    }
+
+    .uiScaleControls input[type="range"] {
+        min-width: 240px;
+        flex: 1 1 240px;
+        accent-color: var(--primary-500);
+    }
+
+    .uiScaleControls input[type="number"] {
+        width: 90px;
+        min-width: 90px;
+    }
+
+    .uiScalePresets {
+        display: flex;
+        gap: 6px;
+        flex-wrap: wrap;
+        margin: 2px 0 4px;
+    }
+
+    .uiScalePresetButton.regular-button {
+        margin: 0;
+        padding: 0 10px;
+        line-height: 26px;
+        font-size: 11px;
+        border-radius: 999px;
+        background-color: var(--primary-100);
+        border-color: var(--primary-600);
+        color: #000;
+        opacity: 0.92;
+    }
+
+    .uiScalePresetButton.regular-button:hover {
+        background-color: var(--primary-200);
+        opacity: 1;
+    }
+
+    .uiScalePresetButton.regular-button.active {
+        background-color: var(--primary-500);
+        border-color: var(--primary-600);
+        color: #000;
+        opacity: 1;
+    }
+
+    .uiScaleValue {
+        min-width: 50px;
+        font-weight: 600;
+        color: var(--text);
+    }
+
+    .uiScale {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 6px;
+        padding: 12px;
+        border: 1px solid var(--surface-300);
+        border-radius: 6px;
+        background: var(--surface-100);
+    }
+
+    .uiScale .freelabel.uiScaleLabel {
+        margin-left: 0;
+        font-weight: 600;
+    }
+
+    .uiScaleHint {
+        margin-top: 0;
+        color: var(--text);
+        opacity: 0.75;
+        font-size: 12px;
     }
 }
 </style>

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -19,6 +19,7 @@ body {
     margin: 0;
     padding: 0;
     overflow: hidden;
+    --ui-scale: 1;
 
     ::-webkit-scrollbar {
         width: 0.3rem;
@@ -235,10 +236,13 @@ input[type="number"] {
     font-style: italic;
 }
 #main-wrapper {
-    height: 100vh;
+    width: calc(100vw / var(--ui-scale));
+    height: calc(100vh / var(--ui-scale));
     background-color: var(--surface-100);
     display: flex;
     flex-direction: column;
+    transform: scale(var(--ui-scale));
+    transform-origin: top left;
 }
 #background {
     background: rgba(0, 0, 0, 0.5);

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -99,6 +99,25 @@ body[data-theme="amber"] {
     --primary-transparent-4: rgba(255, 167, 36, 0.4);
 }
 
+body[data-theme="neon"] {
+    --primary-50: #f2f3ff;
+    --primary-100: #e8e9ff;
+    --primary-200: #d4d7ff;
+    --primary-300: #b7bbff;
+    --primary-400: #9397ff;
+    --primary-500: #6f6dff;
+    --primary-600: #6056f5;
+    --primary-700: #4f43dc;
+    --primary-800: #4035b4;
+    --primary-900: #332c8c;
+    --primary-950: #1f1b5c;
+
+    --primary-transparent-1: rgba(111, 109, 255, 0.1);
+    --primary-transparent-2: rgba(111, 109, 255, 0.2);
+    --primary-transparent-3: rgba(111, 109, 255, 0.3);
+    --primary-transparent-4: rgba(111, 109, 255, 0.4);
+}
+
 body[data-theme="contrast"] {
     --surface-50: #000000;
     --surface-100: #000000;

--- a/src/js/ColorTheme.js
+++ b/src/js/ColorTheme.js
@@ -1,0 +1,100 @@
+const HEX_COLOR_REGEX = /^#([0-9a-f]{6})$/i;
+
+const COLOR_THEME_VARIABLES = {
+    "--primary-500": "primary500",
+    "--primary-700": "primary700",
+    "--primary-action": "primary500",
+    "--primary-action-border": "primary700",
+    "--primary-action-hover": "primary500",
+    "--surface-100": "surface100",
+    "--surface-300": "surface300",
+    "--text": "text",
+    "--success-500": "success500",
+    "--warning-500": "warning500",
+    "--error-500": "error500",
+};
+
+const CLEARABLE_CUSTOM_VARIABLES = [
+    ...Object.keys(COLOR_THEME_VARIABLES),
+    "--primary-600",
+    "--surface-200",
+    "--primary-transparent-1",
+    "--primary-transparent-2",
+    "--primary-transparent-3",
+    "--primary-transparent-4",
+];
+
+export const DEFAULT_CUSTOM_THEME = {
+    primary500: "#4f46e5",
+    primary700: "#3730a3",
+    surface100: "#f8fafc",
+    surface300: "#e2e8f0",
+    text: "#0f172a",
+    success500: "#22c55e",
+    warning500: "#f59e0b",
+    error500: "#ef4444",
+};
+
+export function sanitizeCustomTheme(themeInput) {
+    const input = themeInput && typeof themeInput === "object" ? themeInput : {};
+
+    return Object.keys(DEFAULT_CUSTOM_THEME).reduce((acc, key) => {
+        const candidateValue = input[key];
+        const normalizedCandidate =
+            typeof candidateValue === "string" ? candidateValue.trim().toLowerCase() : candidateValue;
+        acc[key] = HEX_COLOR_REGEX.test(normalizedCandidate) ? normalizedCandidate : DEFAULT_CUSTOM_THEME[key];
+        return acc;
+    }, {});
+}
+
+export function isDefaultCustomTheme(themeInput) {
+    const theme = sanitizeCustomTheme(themeInput);
+    return Object.keys(DEFAULT_CUSTOM_THEME).every((key) => theme[key] === DEFAULT_CUSTOM_THEME[key]);
+}
+
+function hexToRgb(hex) {
+    const normalizedHex = hex.replace("#", "");
+    const numericHex = Number.parseInt(normalizedHex, 16);
+
+    return {
+        r: (numericHex >> 16) & 255,
+        g: (numericHex >> 8) & 255,
+        b: numericHex & 255,
+    };
+}
+
+function rgbToHex({ r, g, b }) {
+    const toHex = (value) => value.toString(16).padStart(2, "0");
+    return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+function blendHex(baseHex, targetHex, ratio) {
+    const base = hexToRgb(baseHex);
+    const target = hexToRgb(targetHex);
+    const blend = {
+        r: Math.round(base.r + (target.r - base.r) * ratio),
+        g: Math.round(base.g + (target.g - base.g) * ratio),
+        b: Math.round(base.b + (target.b - base.b) * ratio),
+    };
+
+    return rgbToHex(blend);
+}
+
+export function applyCustomTheme(themeInput) {
+    const theme = sanitizeCustomTheme(themeInput);
+    const surface200 = blendHex(theme.surface100, theme.surface300, 0.5);
+    const primary600 = blendHex(theme.primary500, theme.primary700, 0.5);
+
+    Object.entries(COLOR_THEME_VARIABLES).forEach(([cssVariable, themeKey]) => {
+        document.body.style.setProperty(cssVariable, theme[themeKey]);
+    });
+
+    document.body.style.setProperty("--primary-600", primary600);
+    document.body.style.setProperty("--surface-200", surface200);
+}
+
+export function clearCustomTheme() {
+    CLEARABLE_CUSTOM_VARIABLES.forEach((cssVariable) => {
+        document.body.style.removeProperty(cssVariable);
+    });
+}

--- a/src/js/UiScale.js
+++ b/src/js/UiScale.js
@@ -1,0 +1,22 @@
+const DEFAULT_UI_SCALE = 1;
+const MIN_UI_SCALE = 0.85;
+const MAX_UI_SCALE = 1.5;
+const UI_SCALE_PRECISION = 2;
+
+export function sanitizeUiScale(value) {
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+        return DEFAULT_UI_SCALE;
+    }
+
+    const clampedValue = Math.min(MAX_UI_SCALE, Math.max(MIN_UI_SCALE, numericValue));
+    return Number(clampedValue.toFixed(UI_SCALE_PRECISION));
+}
+
+export function applyUiScale(value) {
+    const scale = sanitizeUiScale(value);
+    document.body.style.setProperty("--ui-scale", scale);
+    return scale;
+}
+
+export { DEFAULT_UI_SCALE };

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -9,6 +9,8 @@ import FC from "./fc.js";
 import CONFIGURATOR from "./data_storage.js";
 import CliAutoComplete from "./CliAutoComplete.js";
 import DarkTheme, { setDarkTheme } from "./DarkTheme.js";
+import { applyCustomTheme, clearCustomTheme, isDefaultCustomTheme, sanitizeCustomTheme } from "./ColorTheme.js";
+import { applyUiScale, DEFAULT_UI_SCALE, sanitizeUiScale } from "./UiScale.js";
 import { updateTabList } from "./utils/updateTabList.js";
 import { mountVueTab } from "./vue_tab_mounter.js";
 import * as THREE from "three";
@@ -112,6 +114,8 @@ function appReady() {
 async function startProcess() {
     // translate to user-selected language
     i18n.localizePage();
+
+    applyUiScale(sanitizeUiScale(getConfig("uiScale", DEFAULT_UI_SCALE).uiScale));
 
     // Initialize login manager
     await loginManager.initialize();
@@ -469,6 +473,17 @@ async function startProcess() {
     result = getConfig("colorTheme");
     const colorTheme = result.colorTheme ?? "yellow";
     document.body.dataset.theme = colorTheme;
+
+    if (colorTheme === "custom") {
+        const customTheme = sanitizeCustomTheme(getConfig("customTheme", {}).customTheme);
+        if (isDefaultCustomTheme(customTheme)) {
+            clearCustomTheme();
+        } else {
+            applyCustomTheme(customTheme);
+        }
+    } else {
+        clearCustomTheme();
+    }
 
     // Contrast theme requires dark mode
     if (colorTheme === "contrast") {


### PR DESCRIPTION
## Appearance Update – Options Tab

This PR introduces a complete appearance customization flow in the **Options** tab.

---

### New Features

- **Neon Theme**
  - Adds a new built-in neon color theme.

- **Custom Theme**
  - Live preview while editing
  - Presets for quick selection
  - Save & reset actions
  - Unsaved-change warnings

- **Runtime Theme Application**
  - Custom theme variables are applied dynamically:
    - `primary`
    - `action`
    - `surface`
    - `text`
    - `status`

---

### UI Scaling (Related to issue #2959)

- Slider for fine control
- Preset scaling options
- Persistent settings (saved across sessions)
- Applied automatically on startup

---

### Localization

- Extended localization keys
- Updated across all locale files to support new UI elements

---

### Validation

- `npm run lint` passes  
  *(Note: an existing unrelated warning may still appear in `ProfileSelectionDialog.vue`)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added adjustable UI scale with presets (90%, 100%, 110%, 125%, 140%) for interface sizing
  * Introduced "Neon" and "Custom" color theme options
  * Added custom theme editor with color pickers to personalize theme colors
  * Unsaved changes warning when editing custom themes; browser unload protection included
  * Multi-language support added across all interface customization features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->