### PR TITLE
Fix intermittent leak of listeners in firmware flasher tab.

### DIFF
--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -1496,6 +1496,8 @@ export default defineComponent({
             }
         };
 
+        let eventListenerRefs = null;
+
         const setupEventBusListeners = () => {
             const { detectedUsbDevice, onDeviceRemoved } = firmwareFlashing.setupFlashingEventListeners({
                 getFlashOnConnect: () => state.flashOnConnect,
@@ -1510,7 +1512,7 @@ export default defineComponent({
             EventBus.$on("port-handler:auto-select-usb-device", detectedUsbDevice);
             EventBus.$on("port-handler:device-removed", onDeviceRemoved);
 
-            return { detectedUsbDevice, onDeviceRemoved };
+            eventListenerRefs = { detectedUsbDevice, onDeviceRemoved };
         };
 
         onMounted(async () => {
@@ -1560,11 +1562,11 @@ export default defineComponent({
         });
 
         onBeforeUnmount(() => {
-            // Unsubscribe from EventBus
-            const eventListeners = setupEventBusListeners();
-            if (eventListeners) {
-                EventBus.$off("port-handler:auto-select-usb-device", eventListeners.detectedUsbDevice);
-                EventBus.$off("port-handler:device-removed", eventListeners.onDeviceRemoved);
+            // Unsubscribe from EventBus using the original handler references
+            if (eventListenerRefs) {
+                EventBus.$off("port-handler:auto-select-usb-device", eventListenerRefs.detectedUsbDevice);
+                EventBus.$off("port-handler:device-removed", eventListenerRefs.onDeviceRemoved);
+                eventListenerRefs = null;
             }
 
             if (dfuMonitorInterval) {


### PR DESCRIPTION
### Intermittent Issue

[FIRMWARE_FLASHER] processHex called with data type: object
main-YSl56jcz.js:3981 HEX_PARSER - File parsed in: 36.301025390625 ms
main-YSl56jcz.js:3981 [FIRMWARE_FLASHER] processHex called with data type: object
main-YSl56jcz.js:3981 HEX_PARSER - File parsed in: 23.760986328125 ms
main-YSl56jcz.js:3981 [FIRMWARE_FLASHER] processHex called with data type: object
main-YSl56jcz.js:3981 HEX_PARSER - File parsed in: 28.748046875 ms
main-YSl56jcz.js:3981 [FIRMWARE_FLASHER] processHex called with data type: object
main-YSl56jcz.js:3981 HEX_PARSER - File parsed in: 26.765869140625 ms

### Root cause

onBeforeUnmount at line 1564 was calling setupEventBusListeners() to get handler references for removal. But setupEventBusListeners() also registers new listeners as a side effect. This means:

1. On mount: 2 listeners registered (correct)                          
2. On unmount: 2 new listeners registered, then immediately removed. The original listeners from mount are never removed (they're different function references)
3. On re-mount: 2 more listeners added on top of the leaked ones from step 1

- Each tab re-entry added 2 more listener registrations, causing processHex to fire once per accumulated entry.                                              
                                                                                
### Fix

Store the handler references returned during setup and reuse them for cleanup, instead of calling the setup function again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal event handling and cleanup logic in the firmware flashing module for better stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->