### PR TITLE
Move CLI history to module scope

### DIFF
--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -54,6 +54,28 @@ function getCliCommand(command, cliBuffer) {
     return commandWithBackSpaces(command, buffer, noOfCharsToDelete);
 }
 
+// History management — module scope so it survives tab switches
+const history = reactive({
+    items: [],
+    index: 0,
+    add(str) {
+        this.items.push(str);
+        this.index = this.items.length;
+    },
+    prev() {
+        if (this.index > 0) {
+            this.index -= 1;
+        }
+        return this.items[this.index];
+    },
+    next() {
+        if (this.index < this.items.length) {
+            this.index += 1;
+        }
+        return this.items[this.index - 1];
+    },
+});
+
 function onCopyFailed(ex) {
     console.warn(ex);
 }
@@ -115,28 +137,6 @@ export function useCli() {
 
     // Support dialog callback
     let supportDialogCallback = null;
-
-    // History management
-    const history = reactive({
-        items: [],
-        index: 0,
-        add(str) {
-            this.items.push(str);
-            this.index = this.items.length;
-        },
-        prev() {
-            if (this.index > 0) {
-                this.index -= 1;
-            }
-            return this.items[this.index];
-        },
-        next() {
-            if (this.index < this.items.length) {
-                this.index += 1;
-            }
-            return this.items[this.index - 1];
-        },
-    });
 
     let outputBuffer = "";
     let outputFlushRaf = null;


### PR DESCRIPTION
TL;DR: The root cause is in src/composables/useCli.js:120-139. The history reactive object is created inside useCli(), which CliTab.vue calls fresh on every mount. In the old jQuery code, cli.history was a module-level singleton that survived tab switches.

# CLI Tab Command History Not Retained Between Sessions

## Problem

After the Vue migration (PR #4824, commit `bbb0dbb6`), CLI command history was lost every time the user navigated away from the CLI tab and back. Previously, history survived tab switches within the same application session.

## Root Cause

The Vue migration changed the history lifecycle from a **persistent module singleton** to a **per-mount composable instance**.

In the old jQuery code (`src/js/tabs/cli.js`), `cli` was a single object at module scope. When the user switched tabs, `cli.cleanup()` ran but did not reset `cli.history`. Returning to the CLI tab reused the same history array.

In the Vue code (`src/composables/useCli.js`), `CliTab.vue` calls `useCli()` inside `setup()`. Every time the component mounts, `useCli()` constructed a brand-new `history` reactive object with an empty items array. The previous history was garbage-collected.

## Fix Applied (Option A)

Moved the `history` reactive object from inside `useCli()` to **module scope** in `src/composables/useCli.js` (lines 57–77). The object is now created once when the module loads and shared across all calls to `useCli()`, restoring parity with the old jQuery singleton behavior.

## Future Enhancement Options

### Option B: Persist to `localStorage` via `ConfigStorage` (full cross-session persistence)

Save `history.items` to `localStorage` on every `add()`, and restore on module load. Cap at a max number of items to prevent unbounded growth.

**Pros:** History survives app restarts. Capped size prevents unbounded growth.
**Cons:** Slightly more code. Needs a max-items cap to avoid localStorage bloat.

### Option C: Pinia store (Vue-idiomatic, enables future features)

Create a dedicated `useCliHistoryStore` Pinia store. The store lives for the app lifetime (like Option A) and can optionally persist via a Pinia plugin.

**Pros:** Vue-idiomatic, easily extensible (e.g. per-port history, search).
**Cons:** More boilerplate than needed for this fix alone.

## Note on "Cross-Session" History

The old jQuery implementation also **never** persisted command history to storage. History only survived within a single page session (tab switches). If the user closed and reopened the Configurator, history was gone. The Vue migration made this worse by also losing history on tab switches. True cross-session persistence (Options B/C) would be a new feature, not a regression fix.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Command history is now preserved when switching between tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->