### PR TITLE
Refactor: Enhance Vue tab management, mounting to App directly

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -307,7 +307,14 @@
                     <user-session></user-session>
                     <div class="clear-both"></div>
                 </div>
-                <div id="content"></div>
+                <div id="content">
+                    <component
+                        :is="activeTabComponent"
+                        v-if="activeTabComponent"
+                        :key="vueTabState.activeTabKey"
+                        ref="activeTabInstance"
+                    />
+                </div>
             </div>
             <status-bar
                 :port-usage-down="PortUsage.port_usage_down"
@@ -333,7 +340,7 @@
 </template>
 
 <script setup>
-import { computed, reactive, shallowRef } from "vue";
+import { computed, nextTick, provide, reactive, ref, shallowRef, watch } from "vue";
 import { useConnectionStore } from "./stores/connection";
 import GlobalDialogs from "./components/dialogs/GlobalDialogs.vue";
 import FCModule from "./js/fc.js";
@@ -341,6 +348,14 @@ import MSPModule from "./js/msp.js";
 import PortHandlerModule from "./js/port_handler.js";
 import PortUsageModule from "./js/port_usage.js";
 import CONFIGURATORModule from "./js/data_storage.js";
+import GUI from "./js/gui.js";
+import {
+    completeVueTabMount,
+    tabAdapterRegistration,
+    TAB_ADAPTER_REGISTRATION_KEY,
+    vueTabState,
+} from "./js/vue_tab_mounter.js";
+import { VueTabComponents } from "./js/vue_tab_registry.js";
 
 // Tests or unusual entry points may run without init.js; init.js overwrites this synchronously after its model exists.
 if (!window.vm) {
@@ -378,6 +393,7 @@ const PortUsage = computed(() => currentVm()?.PortUsage ?? PortUsageModule);
 const CONNECTION = computed(() => currentVm()?.CONNECTION ?? connectionFallback);
 
 const connectionStore = useConnectionStore();
+const activeTabInstance = ref(null);
 
 // Read/write current vm via currentVm() so we track the same vm as the globals after window.vm is reassigned.
 const expertMode = computed({
@@ -391,6 +407,27 @@ const expertMode = computed({
 });
 
 const firmwareFlasherActive = computed(() => Boolean(currentVm()?.firmwareFlasherActive));
+const activeTabComponent = computed(() => {
+    const tabName = vueTabState.activeTabName;
+    return tabName ? (VueTabComponents[tabName] ?? null) : null;
+});
+
+provide("betaflightModel", currentVm());
+provide("gui", GUI);
+provide(TAB_ADAPTER_REGISTRATION_KEY, tabAdapterRegistration);
+
+watch(
+    () => vueTabState.activeTabKey,
+    async () => {
+        if (!vueTabState.activeTabName) {
+            return;
+        }
+
+        await nextTick();
+        completeVueTabMount(activeTabInstance.value);
+    },
+    { flush: "post" },
+);
 </script>
 
 <style scoped>

--- a/src/components/init.js
+++ b/src/components/init.js
@@ -45,6 +45,9 @@ const betaflightModel = reactive({
     expertMode: !!getConfig("expertMode").expertMode,
 });
 
+// Keep the legacy global model available while the app finishes moving away from imperative globals.
+globalThis.vm = betaflightModel;
+
 tippy.setDefaultProps({
     allowHTML: true,
     appendTo: () => document.body,

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -96,7 +96,7 @@ function appReady() {
             setConfig({ firstRun: true });
             // Open the options tab after a short delay to ensure UI is ready
             setTimeout(() => {
-                // Use Vue tab mounting directly, no jQuery
+                // Select the root-mounted Vue tab directly, no DOM injection.
                 mountVueTab("options", () => {});
             }, 100);
         }

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -263,16 +263,11 @@ function finishClose(finishedCallback) {
     sensor_status();
 
     if (wasConnected) {
-        // Ensure any mounted Vue tab is unmounted before we remove DOM to avoid Vue runtime errors
+        // Clear the active root-mounted tab before navigation selects the next one.
         try {
             unmountVueTab();
         } catch (e) {
             console.warn("unmountVueTab failed:", e);
-        }
-
-        const content = document.getElementById("content");
-        if (content) {
-            content.innerHTML = "";
         }
 
         // close cliPanel if left open

--- a/src/js/vue_components.js
+++ b/src/js/vue_components.js
@@ -6,71 +6,8 @@ import PortPicker from "../components/port-picker/PortPicker.vue";
 import UserSession from "../components/user-session/UserSession.vue";
 import WikiButton from "../components/elements/WikiButton.vue";
 import Dialog from "../components/elements/Dialog.vue";
-// Tab components
-import HelpTab from "../components/tabs/HelpTab.vue";
-import LandingTab from "../components/tabs/LandingTab.vue";
-import OptionsTab from "../components/tabs/OptionsTab.vue";
-import PortsTab from "../components/tabs/PortsTab.vue";
-import ServosTab from "../components/tabs/ServosTab.vue";
-import ConfigurationTab from "../components/tabs/ConfigurationTab.vue";
-import UserProfileTab from "../components/tabs/UserProfile.vue";
-import BackupsTab from "../components/tabs/Backups.vue";
-import LoggingTab from "../components/tabs/LoggingTab.vue";
-import GpsTab from "../components/tabs/GpsTab.vue";
-import AuxiliaryTab from "../components/tabs/AuxiliaryTab.vue";
-import OnboardLoggingTab from "../components/tabs/OnboardLoggingTab.vue";
-import FirmwareFlasherTab from "../components/tabs/FirmwareFlasherTab.vue";
-import AdjustmentsTab from "../components/tabs/AdjustmentsTab.vue";
-import CliTab from "../components/tabs/CliTab.vue";
-import PowerTab from "../components/tabs/PowerTab.vue";
-import SensorsTab from "../components/tabs/SensorsTab.vue";
-import FlightPlanTab from "../components/tabs/FlightPlanTab.vue";
-import LedStripTab from "../components/tabs/LedStripTab.vue";
-import FailsafeTab from "../components/tabs/FailsafeTab.vue";
-import MotorsTab from "../components/tabs/MotorsTab.vue";
-import ReceiverTab from "../components/tabs/ReceiverTab.vue";
-import OsdTab from "../components/tabs/OsdTab.vue";
-import SetupTab from "../components/tabs/SetupTab.vue";
 import App from "../App.vue";
-import PidTuningTab from "../components/tabs/PidTuningTab.vue";
-import PreflightTab from "../components/tabs/PreflightTab.vue";
-import TransponderTab from "../components/tabs/TransponderTab.vue";
-import VtxTab from "../components/tabs/VtxTab.vue";
-import PresetsTab from "../components/tabs/PresetsTab.vue";
-
-// Registry of Vue tab components - used by main.js for dynamic mounting
-export const VueTabComponents = {
-    help: HelpTab,
-    landing: LandingTab,
-    options: OptionsTab,
-    ports: PortsTab,
-    servos: ServosTab,
-    configuration: ConfigurationTab,
-    user_profile: UserProfileTab,
-    backups: BackupsTab,
-    logging: LoggingTab,
-    gps: GpsTab,
-    auxiliary: AuxiliaryTab,
-    onboard_logging: OnboardLoggingTab,
-    firmware_flasher: FirmwareFlasherTab,
-    adjustments: AdjustmentsTab,
-    cli: CliTab,
-    power: PowerTab,
-    sensors: SensorsTab,
-    flight_plan: FlightPlanTab,
-    led_strip: LedStripTab,
-    failsafe: FailsafeTab,
-    motors: MotorsTab,
-    receiver: ReceiverTab,
-    osd: OsdTab,
-    setup: SetupTab,
-    pid_tuning: PidTuningTab,
-    preflight: PreflightTab,
-    transponder: TransponderTab,
-    vtx: VtxTab,
-    presets: PresetsTab,
-    // Move motors before pid_tuning if present in the future
-};
+import { VueTabComponents } from "./vue_tab_registry.js";
 
 // Create a Vue plugin that registers all components globally
 export const BetaflightComponents = {
@@ -86,30 +23,34 @@ export const BetaflightComponents = {
         app.component("WikiButton", WikiButton);
         app.component("Dialog", Dialog);
         // Register tab components
-        app.component("HelpTab", HelpTab);
-        app.component("LandingTab", LandingTab);
-        app.component("OptionsTab", OptionsTab);
-        app.component("PortsTab", PortsTab);
-        app.component("ServosTab", ServosTab);
-        app.component("ConfigurationTab", ConfigurationTab);
-        app.component("UserProfileTab", UserProfileTab);
-        app.component("BackupsTab", BackupsTab);
-        app.component("LoggingTab", LoggingTab);
-        app.component("GpsTab", GpsTab);
-        app.component("AuxiliaryTab", AuxiliaryTab);
-        app.component("OnboardLoggingTab", OnboardLoggingTab);
-        app.component("SensorsTab", SensorsTab);
-        app.component("FlightPlanTab", FlightPlanTab);
-        app.component("LedStripTab", LedStripTab);
-        app.component("FailsafeTab", FailsafeTab);
-        app.component("MotorsTab", MotorsTab);
-        app.component("ReceiverTab", ReceiverTab);
-        app.component("OsdTab", OsdTab);
-        app.component("SetupTab", SetupTab);
-        app.component("PidTuningTab", PidTuningTab);
-        app.component("PreflightTab", PreflightTab);
-        app.component("TransponderTab", TransponderTab);
-        app.component("VtxTab", VtxTab);
-        app.component("PresetsTab", PresetsTab);
+        app.component("HelpTab", VueTabComponents.help);
+        app.component("LandingTab", VueTabComponents.landing);
+        app.component("OptionsTab", VueTabComponents.options);
+        app.component("PortsTab", VueTabComponents.ports);
+        app.component("ServosTab", VueTabComponents.servos);
+        app.component("ConfigurationTab", VueTabComponents.configuration);
+        app.component("UserProfileTab", VueTabComponents.user_profile);
+        app.component("BackupsTab", VueTabComponents.backups);
+        app.component("LoggingTab", VueTabComponents.logging);
+        app.component("GpsTab", VueTabComponents.gps);
+        app.component("AuxiliaryTab", VueTabComponents.auxiliary);
+        app.component("OnboardLoggingTab", VueTabComponents.onboard_logging);
+        app.component("FirmwareFlasherTab", VueTabComponents.firmware_flasher);
+        app.component("AdjustmentsTab", VueTabComponents.adjustments);
+        app.component("CliTab", VueTabComponents.cli);
+        app.component("PowerTab", VueTabComponents.power);
+        app.component("SensorsTab", VueTabComponents.sensors);
+        app.component("FlightPlanTab", VueTabComponents.flight_plan);
+        app.component("LedStripTab", VueTabComponents.led_strip);
+        app.component("FailsafeTab", VueTabComponents.failsafe);
+        app.component("MotorsTab", VueTabComponents.motors);
+        app.component("ReceiverTab", VueTabComponents.receiver);
+        app.component("OsdTab", VueTabComponents.osd);
+        app.component("SetupTab", VueTabComponents.setup);
+        app.component("PidTuningTab", VueTabComponents.pid_tuning);
+        app.component("PreflightTab", VueTabComponents.preflight);
+        app.component("TransponderTab", VueTabComponents.transponder);
+        app.component("VtxTab", VueTabComponents.vtx);
+        app.component("PresetsTab", VueTabComponents.presets);
     },
 };

--- a/src/js/vue_tab_mounter.js
+++ b/src/js/vue_tab_mounter.js
@@ -1,27 +1,25 @@
-/**
- * Vue Tab Mounting Utility
- *
- * Provides a helper function to mount Vue tab components into the #content area.
- * This bridges the existing jQuery-based tab switching with Vue components.
- */
-import { createApp, effectScope, h } from "vue";
-import { pinia } from "./pinia_instance.js";
-import i18next from "i18next";
-import I18NextVue from "i18next-vue";
-import { VueTabComponents } from "./vue_components.js";
+import { reactive } from "vue";
+import { VueTabComponents } from "./vue_tab_registry.js";
 import GUI, { TABS } from "./gui.js";
 import { useNavigationStore } from "../stores/navigation";
-import { getNuxtUiRouter } from "./nuxt_ui_router.js";
-import ui from "@nuxt/ui/vue-plugin";
-
-// Store the current mounted Vue app instance for cleanup
-let currentTabApp = null;
-let currentTabScope = null;
 export const TAB_ADAPTER_REGISTRATION_KEY = "tabAdapterRegistration";
+export const vueTabState = reactive({
+    activeTabName: null,
+    activeTabKey: 0,
+});
+export const tabAdapterRegistration = reactive({ current: null });
+let pendingContentReadyCallback = null;
+
+function clearTabAdapter(tabName) {
+    if (tabName && TABS[tabName]) {
+        delete TABS[tabName];
+    }
+    tabAdapterRegistration.current = null;
+}
 
 export function buildTabAdapter(tabName, componentInstance, existingAdapter = TABS[tabName]) {
     const fallbackCleanup = (callback) => {
-        if (componentInstance.cleanup) {
+        if (typeof componentInstance?.cleanup === "function") {
             componentInstance.cleanup(callback);
         } else if (callback) {
             callback();
@@ -55,110 +53,54 @@ export function hasVueTab(tabName) {
 }
 
 /**
- * Mount a Vue tab component into the #content container
+ * Select the active Vue tab inside the root app tree.
  * @param {string} tabName - The tab name to mount
  * @param {Function} contentReadyCallback - Callback when tab is ready (for compatibility)
- * @returns {boolean} True if mounted successfully
+ * @returns {boolean} True if the tab exists and was scheduled
  */
 export function mountVueTab(tabName, contentReadyCallback) {
-    const TabComponent = VueTabComponents[tabName];
-    if (!TabComponent) {
+    if (!hasVueTab(tabName)) {
         console.warn(`[Vue Tab] No Vue component found for tab: ${tabName}`);
         return false;
     }
 
-    // Clear any previous content
-    const contentEl = document.getElementById("content");
-    if (!contentEl) {
-        console.error("[Vue Tab] #content element not found");
-        return false;
-    }
+    const previousTab = vueTabState.activeTabName ?? GUI.active_tab;
+    clearTabAdapter(previousTab);
 
-    // Unmount previous Vue tab app if exists
-    unmountVueTab();
-
-    // Clear content
-    contentEl.innerHTML = "";
-
-    // Create new Vue app for this tab
-    currentTabApp = createApp({
-        render() {
-            return h(TabComponent);
-        },
-    });
-
-    // Use i18n plugin
-    currentTabApp.use(I18NextVue, { i18next });
-    currentTabApp.use(pinia);
-    currentTabApp.use(getNuxtUiRouter());
-
-    // Install Nuxt UI inside a dedicated EffectScope so that watchers
-    // created during plugin install (useDark, useMediaQuery, etc.) are
-    // captured and can be stopped when the tab is unmounted.  Without
-    // this, each tab switch leaks orphaned watchers/event-listeners
-    // because plugin install() runs outside the app's component scope.
-    currentTabScope = effectScope();
-    currentTabScope.run(() => currentTabApp.use(ui));
-
-    currentTabApp.provide("gui", GUI);
-    const tabAdapterRegistration = { current: null };
-    currentTabApp.provide(TAB_ADAPTER_REGISTRATION_KEY, tabAdapterRegistration);
-
-    // Provide the global betaflight model
-    if (globalThis.vm) {
-        currentTabApp.provide("betaflightModel", globalThis.vm);
-    }
-
-    // Set active tab for legacy compatibility
+    pendingContentReadyCallback = contentReadyCallback ?? null;
     GUI.active_tab = tabName;
-
-    // Mount to content
-    const componentInstance = currentTabApp.mount(contentEl);
-
-    console.log(`[Vue Tab] Mounted: ${tabName}`);
-    // Preserve any adapter the tab explicitly registered during setup, then add the generic hooks
-    const tabAdapter = buildTabAdapter(tabName, componentInstance, tabAdapterRegistration.current);
-
-    // Merge the adapter into TABS. The adapter provides default handlers
-    // (cleanup, expertModeChanged, etc.). We intentionally spread the
-    // adapter first so that any properties the component itself sets on
-    // `TABS[tabName]` during its mount will override the adapter defaults.
-    //
-    // Note: this ordering is subtle — a component that writes `TABS[tabName].cleanup`
-    // synchronously during its mount will replace the adapter's cleanup. This
-    // is expected: adapter supplies defaults, components supply concrete
-    // implementations. If a component needs to preserve adapter behavior it
-    // should explicitly call or compose with the adapter's methods instead of
-    // relying on the merge ordering.
-    TABS[tabName] = { ...tabAdapter, ...TABS[tabName] };
-
-    // Reset tab switch flag and call content ready callback after next tick
-    setTimeout(() => {
-        GUI.tab_switch_in_progress = false;
-        if (contentReadyCallback) {
-            contentReadyCallback();
-        }
-    }, 0);
-
+    vueTabState.activeTabName = tabName;
+    vueTabState.activeTabKey += 1;
     return true;
 }
 
 /**
- * Unmount the current Vue tab app (cleanup)
+ * Finalize tab registration after the root app renders the selected component.
+ */
+export function completeVueTabMount(componentInstance) {
+    const tabName = vueTabState.activeTabName;
+    if (!tabName) {
+        return;
+    }
+
+    const tabAdapter = buildTabAdapter(tabName, componentInstance, tabAdapterRegistration.current);
+
+    // Spread the generic adapter first so component-defined handlers win.
+    TABS[tabName] = { ...tabAdapter, ...TABS[tabName] };
+
+    GUI.content_ready(() => {
+        GUI.tab_switch_in_progress = false;
+        pendingContentReadyCallback?.();
+        pendingContentReadyCallback = null;
+    });
+}
+
+/**
+ * Clear the active Vue tab so the root app can unmount it naturally.
  */
 export function unmountVueTab() {
-    if (currentTabApp) {
-        currentTabApp.unmount();
-        currentTabApp = null;
-
-        if (currentTabScope) {
-            currentTabScope.stop();
-            currentTabScope = null;
-        }
-
-        // Clean up TABS registry
-        if (GUI.active_tab && TABS[GUI.active_tab]) {
-            delete TABS[GUI.active_tab];
-        }
-    }
+    pendingContentReadyCallback = null;
+    clearTabAdapter(vueTabState.activeTabName ?? GUI.active_tab);
+    vueTabState.activeTabName = null;
+    vueTabState.activeTabKey += 1;
 }

--- a/src/js/vue_tab_registry.js
+++ b/src/js/vue_tab_registry.js
@@ -1,0 +1,61 @@
+import HelpTab from "../components/tabs/HelpTab.vue";
+import LandingTab from "../components/tabs/LandingTab.vue";
+import OptionsTab from "../components/tabs/OptionsTab.vue";
+import PortsTab from "../components/tabs/PortsTab.vue";
+import ServosTab from "../components/tabs/ServosTab.vue";
+import ConfigurationTab from "../components/tabs/ConfigurationTab.vue";
+import UserProfileTab from "../components/tabs/UserProfile.vue";
+import BackupsTab from "../components/tabs/Backups.vue";
+import LoggingTab from "../components/tabs/LoggingTab.vue";
+import GpsTab from "../components/tabs/GpsTab.vue";
+import AuxiliaryTab from "../components/tabs/AuxiliaryTab.vue";
+import OnboardLoggingTab from "../components/tabs/OnboardLoggingTab.vue";
+import FirmwareFlasherTab from "../components/tabs/FirmwareFlasherTab.vue";
+import AdjustmentsTab from "../components/tabs/AdjustmentsTab.vue";
+import CliTab from "../components/tabs/CliTab.vue";
+import PowerTab from "../components/tabs/PowerTab.vue";
+import SensorsTab from "../components/tabs/SensorsTab.vue";
+import FlightPlanTab from "../components/tabs/FlightPlanTab.vue";
+import LedStripTab from "../components/tabs/LedStripTab.vue";
+import FailsafeTab from "../components/tabs/FailsafeTab.vue";
+import MotorsTab from "../components/tabs/MotorsTab.vue";
+import ReceiverTab from "../components/tabs/ReceiverTab.vue";
+import OsdTab from "../components/tabs/OsdTab.vue";
+import SetupTab from "../components/tabs/SetupTab.vue";
+import PidTuningTab from "../components/tabs/PidTuningTab.vue";
+import PreflightTab from "../components/tabs/PreflightTab.vue";
+import TransponderTab from "../components/tabs/TransponderTab.vue";
+import VtxTab from "../components/tabs/VtxTab.vue";
+import PresetsTab from "../components/tabs/PresetsTab.vue";
+
+export const VueTabComponents = {
+    help: HelpTab,
+    landing: LandingTab,
+    options: OptionsTab,
+    ports: PortsTab,
+    servos: ServosTab,
+    configuration: ConfigurationTab,
+    user_profile: UserProfileTab,
+    backups: BackupsTab,
+    logging: LoggingTab,
+    gps: GpsTab,
+    auxiliary: AuxiliaryTab,
+    onboard_logging: OnboardLoggingTab,
+    firmware_flasher: FirmwareFlasherTab,
+    adjustments: AdjustmentsTab,
+    cli: CliTab,
+    power: PowerTab,
+    sensors: SensorsTab,
+    flight_plan: FlightPlanTab,
+    led_strip: LedStripTab,
+    failsafe: FailsafeTab,
+    motors: MotorsTab,
+    receiver: ReceiverTab,
+    osd: OsdTab,
+    setup: SetupTab,
+    pid_tuning: PidTuningTab,
+    preflight: PreflightTab,
+    transponder: TransponderTab,
+    vtx: VtxTab,
+    presets: PresetsTab,
+};


### PR DESCRIPTION
Replaces a majority of the temporary Vue tab mounting that was used during the jQuery conversion with a targeted native approach now that we have all tabs in Vue. The app no longer creates a separate Vue instance/app for the tabs, they now live inside the main `<App/>` shell and share all the important contexts.

I did not want to rewrite everything that still relied on the older implementation, but the separate app approach for tabs was likely going to be an obstacle going forward. Nuxt UI relies on its` <UApp/>` wrapper for things like tooltips and other floating UI, and the lifecycle should generally be a lot cleaner.

@haslinghuis, @Erics1337 and @blckmn - since you did a majority of the actual tab conversion, I'd appreciate a close look to see if I missed anything or if something can be done better 😅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Redesigned internal tab management and mounting system to use reactive state-driven architecture for improved stability and performance.

* **Bug Fixes**
  * Improved tab switching behavior by removing unnecessary cleanup operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->