### PR TITLE
Fix receiver meter bars

### DIFF
--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1414,6 +1414,7 @@ onUnmounted(() => {
     }
     .meter-bar {
         position: relative;
+        container-type: inline-size;
         width: 100%;
         height: 1rem;
         border: 1px solid var(--surface-500);
@@ -1423,6 +1424,7 @@ onUnmounted(() => {
             position: absolute;
             width: 50px;
             text-align: center;
+            left: calc(50cqi - 25px);
             color: var(--text);
         }
         .fill {


### PR DESCRIPTION
Restored meter bars after Vue migration

<img width="419" height="456" alt="image" src="https://github.com/user-attachments/assets/bd7b509c-b4f8-4269-8bb1-9bbf10481eae" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved channel meter bar label centering with enhanced positioning alignment using responsive container query techniques.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->