### PR TITLE
Fix alignment of filter type select elements

### DIFF
--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -678,7 +678,6 @@ onUnmounted(() => {
 }
 .tab-pid_tuning .subtab-filter table select {
     display: inline-block;
-    margin-left: auto;
 }
 .tab-pid_tuning .subtab-filter .newFilter .helpicon {
     margin-top: 2px;


### PR DESCRIPTION
### Description
Fix alignment of filter type dropdowns in filter settings UI.

### Changes
- Fixed incorrect alignment of filter type selectors
- Removed layout behavior causing elements to shift right
- Unified positioning across Gyro and D-Term sections
- Improved overall UI consistency

### Before
<img width="1502" height="428" alt="image" src="https://github.com/user-attachments/assets/4089f2de-aa64-45ed-a750-1c193cfd0a44" />

### After
<img width="1502" height="428" alt="image" src="https://github.com/user-attachments/assets/9ce3bf7c-8ecb-40dd-af15-0037beefc3c9" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted select dropdown positioning in the PID tuning filter interface. Dropdowns now display with consistent spacing and alignment instead of being pushed to the right.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->