### PR TITLE
Fix number input fields constrain issue

### DIFF
--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -638,8 +638,8 @@ export default defineComponent({
     gap: 8px;
 }
 
-.adjustment-center input,
-.adjustment-scale input {
+.adjustment-center :deep(input),
+.adjustment-scale :deep(input) {
     width: 100%;
     background: var(--surface-700);
     border: 1px solid var(--surface-600);
@@ -648,8 +648,8 @@ export default defineComponent({
     border-radius: 4px;
 }
 
-.adjustment-center input:disabled,
-.adjustment-scale input:disabled {
+.adjustment-center :deep(input:disabled),
+.adjustment-scale :deep(input:disabled) {
     opacity: 0.5;
     cursor: not-allowed;
 }

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -562,7 +562,7 @@ export default defineComponent({
 
 .adjustments-header {
     display: grid;
-    grid-template-columns: 80px 80px 1fr 200px 80px 60px 60px;
+    grid-template-columns: 80px 80px 1fr 200px 80px 120px 120px;
     gap: 16px;
     padding: 12px 16px;
     background: var(--surface-700);
@@ -584,7 +584,7 @@ export default defineComponent({
 
 .adjustment {
     display: grid;
-    grid-template-columns: 80px 80px 1fr 200px 80px 60px 60px;
+    grid-template-columns: 80px 80px 1fr 200px 80px 120px 120px;
     gap: 16px;
     padding: 16px;
     background: var(--surface-200);

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -118,24 +118,24 @@
                         </div>
 
                         <div class="adjustment-center" :data-label="$t('adjustmentsColumnAdjustmentCenter')">
-                            <input
-                                type="number"
-                                v-model.number="adjustment.adjustmentCenter"
+                            <UInputNumber
+                                v-model="adjustment.adjustmentCenter"
                                 class="center-input"
                                 :disabled="!adjustment.enabled"
-                                min="0"
-                                max="2000"
+                                :min="0"
+                                :max="2000"
+                                :step="1"
                             />
                         </div>
 
                         <div class="adjustment-scale" :data-label="$t('adjustmentsColumnAdjustmentScale')">
-                            <input
-                                type="number"
-                                v-model.number="adjustment.adjustmentScale"
+                            <UInputNumber
+                                v-model="adjustment.adjustmentScale"
                                 class="scale-input"
                                 :disabled="!adjustment.enabled"
-                                min="0"
-                                max="2000"
+                                :min="0"
+                                :max="2000"
+                                :step="1"
                             />
                         </div>
                     </div>

--- a/src/components/tabs/ConfigurationTab.vue
+++ b/src/components/tabs/ConfigurationTab.vue
@@ -119,13 +119,12 @@
                         <div class="spacer_box">
                             <div class="number fpvCamAngleDegrees">
                                 <label>
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="fpvCamAngleDegrees"
-                                        v-model.number="fpvCamAngleDegrees"
-                                        step="1"
-                                        min="0"
-                                        max="90"
+                                        v-model="fpvCamAngleDegrees"
+                                        :step="1"
+                                        :min="0"
+                                        :max="90"
                                     />
                                     <span>{{ $t("configurationFpvCamAngleDegrees") }}</span>
                                 </label>
@@ -142,12 +141,12 @@
                         <div class="spacer_box">
                             <div class="number">
                                 <label>
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="small_angle"
-                                        v-model.number="armingConfig.small_angle"
-                                        min="0"
-                                        max="180"
+                                        v-model="armingConfig.small_angle"
+                                        :step="1"
+                                        :min="0"
+                                        :max="180"
                                     />
                                     <span>{{ $t("configurationSmallAngle") }}</span>
                                 </label>
@@ -169,12 +168,12 @@
 
                             <div class="number" v-if="showAutoDisarmDelay">
                                 <label>
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="auto_disarm_delay"
-                                        v-model.number="armingConfig.auto_disarm_delay"
-                                        min="0"
-                                        max="60"
+                                        v-model="armingConfig.auto_disarm_delay"
+                                        :step="1"
+                                        :min="0"
+                                        :max="60"
                                     />
                                     <span>{{ $t("configurationAutoDisarmDelay") }}</span>
                                 </label>
@@ -244,12 +243,11 @@
                                     <div class="sensor_align_inputs">
                                         <div class="alignicon roll"></div>
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="boardAlignment.roll"
-                                                step="1"
-                                                min="-180"
-                                                max="360"
+                                            <UInputNumber
+                                                v-model="boardAlignment.roll"
+                                                :step="1"
+                                                :min="-180"
+                                                :max="360"
                                                 :aria-label="$t('configurationBoardAlignmentRoll')"
                                             />
                                             <span>{{ $t("configurationBoardAlignmentRoll") }}</span>
@@ -258,12 +256,11 @@
                                     <div class="sensor_align_inputs">
                                         <div class="alignicon pitch"></div>
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="boardAlignment.pitch"
-                                                step="1"
-                                                min="-180"
-                                                max="360"
+                                            <UInputNumber
+                                                v-model="boardAlignment.pitch"
+                                                :step="1"
+                                                :min="-180"
+                                                :max="360"
                                                 :aria-label="$t('configurationBoardAlignmentPitch')"
                                             />
                                             <span>{{ $t("configurationBoardAlignmentPitch") }}</span>
@@ -272,12 +269,11 @@
                                     <div class="sensor_align_inputs">
                                         <div class="alignicon yaw"></div>
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="boardAlignment.yaw"
-                                                step="1"
-                                                min="-180"
-                                                max="360"
+                                            <UInputNumber
+                                                v-model="boardAlignment.yaw"
+                                                :step="1"
+                                                :min="-180"
+                                                :max="360"
                                                 :aria-label="$t('configurationBoardAlignmentYaw')"
                                             />
                                             <span>{{ $t("configurationBoardAlignmentYaw") }}</span>
@@ -369,12 +365,11 @@
                                         <div class="sensor_align_inputs">
                                             <div class="alignicon roll"></div>
                                             <label>
-                                                <input
-                                                    type="number"
-                                                    v-model.number="sensorAlignment.gyro_1_align_roll"
-                                                    step="0.1"
-                                                    min="-180"
-                                                    max="360"
+                                                <UInputNumber
+                                                    v-model="sensorAlignment.gyro_1_align_roll"
+                                                    :step="0.1"
+                                                    :min="-180"
+                                                    :max="360"
                                                     :aria-label="$t('configurationGyro1AlignmentRoll')"
                                                 />
                                                 <span>{{ $t("configurationGyro1AlignmentRoll") }}</span>
@@ -383,12 +378,11 @@
                                         <div class="sensor_align_inputs">
                                             <div class="alignicon pitch"></div>
                                             <label>
-                                                <input
-                                                    type="number"
-                                                    v-model.number="sensorAlignment.gyro_1_align_pitch"
-                                                    step="0.1"
-                                                    min="-180"
-                                                    max="360"
+                                                <UInputNumber
+                                                    v-model="sensorAlignment.gyro_1_align_pitch"
+                                                    :step="0.1"
+                                                    :min="-180"
+                                                    :max="360"
                                                     :aria-label="$t('configurationGyro1AlignmentPitch')"
                                                 />
                                                 <span>{{ $t("configurationGyro1AlignmentPitch") }}</span>
@@ -397,12 +391,11 @@
                                         <div class="sensor_align_inputs">
                                             <div class="alignicon yaw"></div>
                                             <label>
-                                                <input
-                                                    type="number"
-                                                    v-model.number="sensorAlignment.gyro_1_align_yaw"
-                                                    step="0.1"
-                                                    min="-180"
-                                                    max="360"
+                                                <UInputNumber
+                                                    v-model="sensorAlignment.gyro_1_align_yaw"
+                                                    :step="0.1"
+                                                    :min="-180"
+                                                    :max="360"
                                                     :aria-label="$t('configurationGyro1AlignmentYaw')"
                                                 />
                                                 <span>{{ $t("configurationGyro1AlignmentYaw") }}</span>
@@ -430,12 +423,11 @@
                                         <div class="sensor_align_inputs">
                                             <div class="alignicon roll"></div>
                                             <label>
-                                                <input
-                                                    type="number"
-                                                    v-model.number="sensorAlignment.gyro_2_align_roll"
-                                                    step="0.1"
-                                                    min="-180"
-                                                    max="360"
+                                                <UInputNumber
+                                                    v-model="sensorAlignment.gyro_2_align_roll"
+                                                    :step="0.1"
+                                                    :min="-180"
+                                                    :max="360"
                                                     :aria-label="$t('configurationGyro2AlignmentRoll')"
                                                 />
                                                 <span>{{ $t("configurationGyro2AlignmentRoll") }}</span>
@@ -444,12 +436,11 @@
                                         <div class="sensor_align_inputs">
                                             <div class="alignicon pitch"></div>
                                             <label>
-                                                <input
-                                                    type="number"
-                                                    v-model.number="sensorAlignment.gyro_2_align_pitch"
-                                                    step="0.1"
-                                                    min="-180"
-                                                    max="360"
+                                                <UInputNumber
+                                                    v-model="sensorAlignment.gyro_2_align_pitch"
+                                                    :step="0.1"
+                                                    :min="-180"
+                                                    :max="360"
                                                     :aria-label="$t('configurationGyro2AlignmentPitch')"
                                                 />
                                                 <span>{{ $t("configurationGyro2AlignmentPitch") }}</span>
@@ -458,12 +449,11 @@
                                         <div class="sensor_align_inputs">
                                             <div class="alignicon yaw"></div>
                                             <label>
-                                                <input
-                                                    type="number"
-                                                    v-model.number="sensorAlignment.gyro_2_align_yaw"
-                                                    step="0.1"
-                                                    min="-180"
-                                                    max="360"
+                                                <UInputNumber
+                                                    v-model="sensorAlignment.gyro_2_align_yaw"
+                                                    :step="0.1"
+                                                    :min="-180"
+                                                    :max="360"
                                                     :aria-label="$t('configurationGyro2AlignmentYaw')"
                                                 />
                                                 <span>{{ $t("configurationGyro2AlignmentYaw") }}</span>
@@ -497,12 +487,11 @@
                                 <div class="sensor_align_inputs">
                                     <div class="alignicon roll"></div>
                                     <label>
-                                        <input
-                                            type="number"
-                                            v-model.number="sensorAlignment.mag_align_roll"
-                                            step="0.1"
-                                            min="-180"
-                                            max="360"
+                                        <UInputNumber
+                                            v-model="sensorAlignment.mag_align_roll"
+                                            :step="0.1"
+                                            :min="-180"
+                                            :max="360"
                                             :aria-label="$t('configurationMagAlignmentRoll')"
                                         />
                                         <span>{{ $t("configurationMagAlignmentRoll") }}</span>
@@ -511,12 +500,11 @@
                                 <div class="sensor_align_inputs">
                                     <div class="alignicon pitch"></div>
                                     <label>
-                                        <input
-                                            type="number"
-                                            v-model.number="sensorAlignment.mag_align_pitch"
-                                            step="0.1"
-                                            min="-180"
-                                            max="360"
+                                        <UInputNumber
+                                            v-model="sensorAlignment.mag_align_pitch"
+                                            :step="0.1"
+                                            :min="-180"
+                                            :max="360"
                                             :aria-label="$t('configurationMagAlignmentPitch')"
                                         />
                                         <span>{{ $t("configurationMagAlignmentPitch") }}</span>
@@ -525,12 +513,11 @@
                                 <div class="sensor_align_inputs">
                                     <div class="alignicon yaw"></div>
                                     <label>
-                                        <input
-                                            type="number"
-                                            v-model.number="sensorAlignment.mag_align_yaw"
-                                            step="0.1"
-                                            min="-180"
-                                            max="360"
+                                        <UInputNumber
+                                            v-model="sensorAlignment.mag_align_yaw"
+                                            :step="0.1"
+                                            :min="-180"
+                                            :max="360"
                                             :aria-label="$t('configurationMagAlignmentYaw')"
                                         />
                                         <span>{{ $t("configurationMagAlignmentYaw") }}</span>
@@ -550,7 +537,7 @@
                             <!-- MAG DECLINATION -->
                             <div class="number" v-if="showMagDeclination">
                                 <label>
-                                    <input type="number" step="0.1" v-model.number="magDeclination" />
+                                    <UInputNumber :step="0.1" :min="-180" :max="180" v-model="magDeclination" />
                                     <span>{{ $t("configurationMagDeclination") }}</span>
                                 </label>
                             </div>
@@ -585,13 +572,25 @@
                         <div class="spacer_box">
                             <div class="number">
                                 <label>
-                                    <input type="number" name="acc_trim_roll" v-model.number="accelTrims.roll" />
+                                    <UInputNumber
+                                        name="acc_trim_roll"
+                                        :step="1"
+                                        :min="-300"
+                                        :max="300"
+                                        v-model="accelTrims.roll"
+                                    />
                                     <span>{{ $t("configurationAccelTrimRoll") }}</span>
                                 </label>
                             </div>
                             <div class="number">
                                 <label>
-                                    <input type="number" name="acc_trim_pitch" v-model.number="accelTrims.pitch" />
+                                    <UInputNumber
+                                        name="acc_trim_pitch"
+                                        :step="1"
+                                        :min="-300"
+                                        :max="300"
+                                        v-model="accelTrims.pitch"
+                                    />
                                     <span>{{ $t("configurationAccelTrimPitch") }}</span>
                                 </label>
                             </div>

--- a/src/components/tabs/FailsafeTab.vue
+++ b/src/components/tabs/FailsafeTab.vue
@@ -627,34 +627,34 @@ const isGpsSettingsDisabled = computed(() => {
 
 // Computed properties for conversions (values stored as x10 or x100 in config)
 const failsafeDelay = computed({
-    get: () => (failsafeConfig.value.failsafe_delay / 10.0).toFixed(1),
-    set: (val) => (failsafeConfig.value.failsafe_delay = Math.round(parseFloat(val) * 10.0)),
+    get: () => failsafeConfig.value.failsafe_delay / 10,
+    set: (val) => (failsafeConfig.value.failsafe_delay = Math.round(Number(val) * 10)),
 });
 
 const failsafeThrottleLowDelay = computed({
-    get: () => (failsafeConfig.value.failsafe_throttle_low_delay / 10.0).toFixed(1),
-    set: (val) => (failsafeConfig.value.failsafe_throttle_low_delay = Math.round(parseFloat(val) * 10.0)),
+    get: () => failsafeConfig.value.failsafe_throttle_low_delay / 10,
+    set: (val) => (failsafeConfig.value.failsafe_throttle_low_delay = Math.round(Number(val) * 10)),
 });
 
 const failsafeOffDelay = computed({
-    get: () => (failsafeConfig.value.failsafe_off_delay / 10.0).toFixed(1),
-    set: (val) => (failsafeConfig.value.failsafe_off_delay = Math.round(parseFloat(val) * 10.0)),
+    get: () => failsafeConfig.value.failsafe_off_delay / 10,
+    set: (val) => (failsafeConfig.value.failsafe_off_delay = Math.round(Number(val) * 10)),
 });
 
 // GPS Rescue Conversions
 const gpsRescueGroundSpeed = computed({
-    get: () => (gpsRescue.value.groundSpeed / 100).toFixed(1),
-    set: (val) => (gpsRescue.value.groundSpeed = Math.round(parseFloat(val) * 100)),
+    get: () => gpsRescue.value.groundSpeed / 100,
+    set: (val) => (gpsRescue.value.groundSpeed = Math.round(Number(val) * 100)),
 });
 
 const gpsRescueAscendRate = computed({
-    get: () => (gpsRescue.value.ascendRate / 100).toFixed(1),
-    set: (val) => (gpsRescue.value.ascendRate = Math.round(parseFloat(val) * 100)),
+    get: () => gpsRescue.value.ascendRate / 100,
+    set: (val) => (gpsRescue.value.ascendRate = Math.round(Number(val) * 100)),
 });
 
 const gpsRescueDescendRate = computed({
-    get: () => (gpsRescue.value.descendRate / 100).toFixed(1),
-    set: (val) => (gpsRescue.value.descendRate = Math.round(parseFloat(val) * 100)),
+    get: () => gpsRescue.value.descendRate / 100,
+    set: (val) => (gpsRescue.value.descendRate = Math.round(Number(val) * 100)),
 });
 
 const gpsRescueAllowArmingWithoutFix = computed({

--- a/src/components/tabs/FailsafeTab.vue
+++ b/src/components/tabs/FailsafeTab.vue
@@ -19,13 +19,13 @@
                         <div class="spacer_box">
                             <div class="number">
                                 <label>
-                                    <input type="number" v-model.number="rxConfig.rx_min_usec" min="750" max="2250" />
+                                    <UInputNumber v-model="rxConfig.rx_min_usec" :min="750" :max="2250" :step="1" />
                                     <span v-html="$t('failsafeRxMinUsecItem')"></span>
                                 </label>
                             </div>
                             <div class="number">
                                 <label>
-                                    <input type="number" v-model.number="rxConfig.rx_max_usec" min="750" max="2250" />
+                                    <UInputNumber v-model="rxConfig.rx_max_usec" :min="750" :max="2250" :step="1" />
                                     <span v-html="$t('failsafeRxMaxUsecItem')"></span>
                                 </label>
                             </div>
@@ -76,12 +76,11 @@
                                         </select>
                                     </div>
                                     <div class="auxiliary">
-                                        <input
-                                            type="number"
-                                            v-model.number="rxFailConfig[index].value"
-                                            min="750"
-                                            max="2250"
-                                            step="25"
+                                        <UInputNumber
+                                            v-model="rxFailConfig[index].value"
+                                            :min="750"
+                                            :max="2250"
+                                            :step="25"
                                             :disabled="rxFailConfig[index].mode !== 2"
                                             v-show="rxFailConfig[index].mode === 2"
                                         />
@@ -133,7 +132,7 @@
 
                             <div class="number stage2">
                                 <label>
-                                    <input type="number" v-model.number="failsafeDelay" min="1" max="20" step="0.1" />
+                                    <UInputNumber v-model="failsafeDelay" :min="1" :max="20" :step="0.1" />
                                     <span v-html="$t('failsafeDelayItem')"></span>
                                 </label>
                                 <div class="helpicon cf_tip" :title="$t('failsafeDelayHelp')"></div>
@@ -141,13 +140,7 @@
 
                             <div class="number stage2">
                                 <label>
-                                    <input
-                                        type="number"
-                                        v-model.number="failsafeThrottleLowDelay"
-                                        min="0"
-                                        max="30"
-                                        step="0.1"
-                                    />
+                                    <UInputNumber v-model="failsafeThrottleLowDelay" :min="0" :max="30" :step="0.1" />
                                     <span v-html="$t('failsafeThrottleLowItem')"></span>
                                 </label>
                                 <div class="helpicon cf_tip" :title="$t('failsafeThrottleLowHelp')"></div>
@@ -186,11 +179,11 @@
                                 >
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="failsafeConfig.failsafe_throttle"
-                                                min="0"
-                                                max="2000"
+                                            <UInputNumber
+                                                v-model="failsafeConfig.failsafe_throttle"
+                                                :min="0"
+                                                :max="2000"
+                                                :step="1"
                                                 :disabled="failsafeConfig.failsafe_procedure !== 0"
                                             />
                                             <span v-html="$t('failsafeThrottleItem')"></span>
@@ -198,12 +191,11 @@
                                     </div>
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="failsafeOffDelay"
-                                                min="0"
-                                                max="250"
-                                                step="0.1"
+                                            <UInputNumber
+                                                v-model="failsafeOffDelay"
+                                                :min="0"
+                                                :max="250"
+                                                :step="0.1"
                                                 :disabled="failsafeConfig.failsafe_procedure !== 0"
                                             />
                                             <span v-html="$t('failsafeOffDelayItem')"></span>
@@ -259,11 +251,11 @@
                                     <div class="number" v-if="gpsRescue.altitudeMode === 1">
                                         <!-- showReturnAlt logic -->
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.returnAltitudeM"
-                                                min="20"
-                                                max="100"
+                                            <UInputNumber
+                                                v-model="gpsRescue.returnAltitudeM"
+                                                :min="20"
+                                                :max="100"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemReturnAltitude')"></span>
@@ -272,11 +264,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.initialClimbM"
-                                                min="0"
-                                                max="100"
+                                            <UInputNumber
+                                                v-model="gpsRescue.initialClimbM"
+                                                :min="0"
+                                                :max="100"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueInitialClimb')"></span>
@@ -289,12 +281,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescueAscendRate"
-                                                min="1.00"
-                                                max="25.00"
-                                                step="0.1"
+                                            <UInputNumber
+                                                v-model="gpsRescueAscendRate"
+                                                :min="1"
+                                                :max="25"
+                                                :step="0.1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemAscendRate')"></span>
@@ -303,12 +294,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescueGroundSpeed"
-                                                min="3.00"
-                                                max="30.00"
-                                                step="0.1"
+                                            <UInputNumber
+                                                v-model="gpsRescueGroundSpeed"
+                                                :min="3"
+                                                :max="30"
+                                                :step="0.1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemGroundSpeed')"></span>
@@ -317,11 +307,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.angle"
-                                                min="0"
-                                                max="200"
+                                            <UInputNumber
+                                                v-model="gpsRescue.angle"
+                                                :min="0"
+                                                :max="200"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemAngle')"></span>
@@ -334,11 +324,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.descentDistanceM"
-                                                min="30"
-                                                max="500"
+                                            <UInputNumber
+                                                v-model="gpsRescue.descentDistanceM"
+                                                :min="30"
+                                                :max="500"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemDescentDistance')"></span>
@@ -347,12 +337,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescueDescendRate"
-                                                min="1.00"
-                                                max="5.00"
-                                                step="0.1"
+                                            <UInputNumber
+                                                v-model="gpsRescueDescendRate"
+                                                :min="1"
+                                                :max="5"
+                                                :step="0.1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemDescendRate')"></span>
@@ -365,11 +354,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.throttleMin"
-                                                min="1000"
-                                                max="2000"
+                                            <UInputNumber
+                                                v-model="gpsRescue.throttleMin"
+                                                :min="1000"
+                                                :max="2000"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemThrottleMin')"></span>
@@ -378,11 +367,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.throttleMax"
-                                                min="1000"
-                                                max="2000"
+                                            <UInputNumber
+                                                v-model="gpsRescue.throttleMax"
+                                                :min="1000"
+                                                :max="2000"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemThrottleMax')"></span>
@@ -395,11 +384,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.throttleHover"
-                                                min="1000"
-                                                max="2000"
+                                            <UInputNumber
+                                                v-model="gpsRescue.throttleHover"
+                                                :min="1000"
+                                                :max="2000"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemThrottleHover')"></span>
@@ -412,11 +401,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.minStartDistM"
-                                                min="50"
-                                                max="1000"
+                                            <UInputNumber
+                                                v-model="gpsRescue.minStartDistM"
+                                                :min="50"
+                                                :max="1000"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemMinDth')"></span>
@@ -429,11 +418,11 @@
 
                                     <div class="number">
                                         <label>
-                                            <input
-                                                type="number"
-                                                v-model.number="gpsRescue.minSats"
-                                                min="5"
-                                                max="50"
+                                            <UInputNumber
+                                                v-model="gpsRescue.minSats"
+                                                :min="5"
+                                                :max="50"
+                                                :step="1"
                                                 :disabled="isGpsSettingsDisabled"
                                             />
                                             <span v-html="$t('failsafeGpsRescueItemMinSats')"></span>

--- a/src/components/tabs/FlightPlan/WaypointEditor.vue
+++ b/src/components/tabs/FlightPlan/WaypointEditor.vue
@@ -4,12 +4,11 @@
             <!-- Latitude -->
             <div class="form-row">
                 <div class="input-column">
-                    <input
-                        type="number"
-                        v-model.number="form.latitude"
-                        step="0.000001"
-                        min="-90"
-                        max="90"
+                    <UInputNumber
+                        v-model="form.latitude"
+                        :step="0.000001"
+                        :min="-90"
+                        :max="90"
                         required
                         :aria-label="$t('flightPlanLatitude')"
                     />
@@ -23,12 +22,11 @@
             <!-- Longitude -->
             <div class="form-row">
                 <div class="input-column">
-                    <input
-                        type="number"
-                        v-model.number="form.longitude"
-                        step="0.000001"
-                        min="-180"
-                        max="180"
+                    <UInputNumber
+                        v-model="form.longitude"
+                        :step="0.000001"
+                        :min="-180"
+                        :max="180"
                         required
                         :aria-label="$t('flightPlanLongitude')"
                     />
@@ -42,12 +40,11 @@
             <!-- Altitude -->
             <div class="form-row">
                 <div class="input-column">
-                    <input
-                        type="number"
-                        v-model.number="form.altitude"
-                        step="1"
-                        min="0"
-                        max="50000"
+                    <UInputNumber
+                        v-model="form.altitude"
+                        :step="1"
+                        :min="0"
+                        :max="50000"
                         required
                         :aria-label="$t('flightPlanAltitude')"
                     />
@@ -61,12 +58,11 @@
             <!-- Speed -->
             <div class="form-row">
                 <div class="input-column">
-                    <input
-                        type="number"
-                        v-model.number="form.speed"
-                        step="0.1"
-                        min="0"
-                        max="500"
+                    <UInputNumber
+                        v-model="form.speed"
+                        :step="0.1"
+                        :min="0"
+                        :max="500"
                         required
                         :aria-label="$t('flightPlanSpeed')"
                     />
@@ -96,12 +92,11 @@
             <!-- Duration (conditional - only for hold) -->
             <div v-if="form.type === 'hold'" class="form-row">
                 <div class="input-column">
-                    <input
-                        type="number"
-                        v-model.number="form.duration"
-                        step="0.1"
-                        min="0"
-                        max="60"
+                    <UInputNumber
+                        v-model="form.duration"
+                        :step="0.1"
+                        :min="0"
+                        :max="60"
                         :aria-label="$t('flightPlanDuration')"
                     />
                 </div>

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -1823,13 +1823,9 @@ onUnmounted(() => {
     }
     .number {
         input {
-            width: 55px;
-            padding-left: 3px;
             height: 20px;
             line-height: 20px;
-            text-align: left;
             border-radius: 3px;
-            margin-right: 11px;
             font-size: 12px;
             font-weight: normal;
         }

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -125,14 +125,13 @@
                                     <div class="number unsyncedpwmfreq" v-if="showAnalogSettings && useUnsyncedPwm">
                                         <label for="unsyncedpwmfreq">
                                             <div class="numberspacer">
-                                                <input
+                                                <UInputNumber
                                                     id="unsyncedpwmfreq"
-                                                    type="number"
                                                     name="unsyncedpwmfreq"
-                                                    min="200"
-                                                    max="32000"
-                                                    step="100"
-                                                    v-model.number="fcStore.pidAdvancedConfig.motor_pwm_rate"
+                                                    :min="200"
+                                                    :max="32000"
+                                                    :step="100"
+                                                    v-model="fcStore.pidAdvancedConfig.motor_pwm_rate"
                                                 />
                                             </div>
                                             <span v-html="$t('configurationUnsyncedPWMFreq')"></span>
@@ -205,14 +204,13 @@
                                     <div class="number motorPoles" v-if="protocolConfigured && rpmFeaturesVisible">
                                         <label for="motorPoles">
                                             <div class="numberspacer">
-                                                <input
+                                                <UInputNumber
                                                     id="motorPoles"
-                                                    type="number"
                                                     name="motorPoles"
-                                                    min="4"
-                                                    max="255"
-                                                    step="1"
-                                                    v-model.number="fcStore.motorConfig.motor_poles"
+                                                    :min="4"
+                                                    :max="255"
+                                                    :step="1"
+                                                    v-model="fcStore.motorConfig.motor_poles"
                                                 />
                                             </div>
                                             <span v-html="$t('configurationMotorPolesLong')"></span>
@@ -225,14 +223,13 @@
                                     <div class="number motorIdle" v-if="showMotorIdle">
                                         <label for="motorIdle">
                                             <div class="numberspacer">
-                                                <input
+                                                <UInputNumber
                                                     id="motorIdle"
-                                                    type="number"
                                                     name="motorIdle"
-                                                    min="0.0"
-                                                    max="20.0"
-                                                    step="0.1"
-                                                    v-model.number="fcStore.pidAdvancedConfig.motorIdle"
+                                                    :min="0"
+                                                    :max="20"
+                                                    :step="0.1"
+                                                    v-model="fcStore.pidAdvancedConfig.motorIdle"
                                                 />
                                             </div>
                                             <span v-html="$t('configurationMotorIdle')"></span>
@@ -245,15 +242,14 @@
                                     <div class="number idleMinRpm" v-if="showIdleMinRpm">
                                         <label for="idleMinRpm">
                                             <div class="numberspacer noarrows">
-                                                <input
+                                                <UInputNumber
                                                     id="idleMinRpm"
-                                                    type="number"
                                                     name="idleMinRpm"
-                                                    min="0"
-                                                    max="100"
-                                                    step="1"
-                                                    readonly
-                                                    v-model.number="fcStore.advancedTuning.idleMinRpm"
+                                                    :min="0"
+                                                    :max="100"
+                                                    :step="1"
+                                                    :readonly="true"
+                                                    v-model="fcStore.advancedTuning.idleMinRpm"
                                                 />
                                             </div>
                                             <span v-html="$t('pidTuningIdleMinRpm')"></span>
@@ -266,13 +262,13 @@
                                     <div class="number mincommand" v-if="showAnalogSettings">
                                         <label for="mincommand">
                                             <div class="numberspacer">
-                                                <input
+                                                <UInputNumber
                                                     id="mincommand"
-                                                    type="number"
                                                     name="mincommand"
-                                                    min="0"
-                                                    max="2000"
-                                                    v-model.number="fcStore.motorConfig.mincommand"
+                                                    :min="0"
+                                                    :max="2000"
+                                                    :step="1"
+                                                    v-model="fcStore.motorConfig.mincommand"
                                                 />
                                             </div>
                                             <span v-html="$t('configurationThrottleMinimumCommand')"></span>
@@ -285,13 +281,13 @@
                                     <div class="number minthrottle" v-if="showMinThrottle">
                                         <label for="minthrottle">
                                             <div class="numberspacer">
-                                                <input
+                                                <UInputNumber
                                                     id="minthrottle"
-                                                    type="number"
                                                     name="minthrottle"
-                                                    min="0"
-                                                    max="2000"
-                                                    v-model.number="fcStore.motorConfig.minthrottle"
+                                                    :min="0"
+                                                    :max="2000"
+                                                    :step="1"
+                                                    v-model="fcStore.motorConfig.minthrottle"
                                                 />
                                             </div>
                                             <span v-html="$t('configurationThrottleMinimum')"></span>
@@ -304,13 +300,13 @@
                                     <div class="number maxthrottle" v-if="showAnalogSettings">
                                         <label for="maxthrottle">
                                             <div class="numberspacer">
-                                                <input
+                                                <UInputNumber
                                                     id="maxthrottle"
-                                                    type="number"
                                                     name="maxthrottle"
-                                                    min="0"
-                                                    max="2000"
-                                                    v-model.number="fcStore.motorConfig.maxthrottle"
+                                                    :min="0"
+                                                    :max="2000"
+                                                    :step="1"
+                                                    v-model="fcStore.motorConfig.maxthrottle"
                                                 />
                                             </div>
                                             <span v-html="$t('configurationThrottleMaximum')"></span>
@@ -358,42 +354,39 @@
                                     <div class="_3dSettings" v-if="isFeatureEnabled('3D')">
                                         <div class="number">
                                             <label for="_3ddeadbandlow">
-                                                <input
+                                                <UInputNumber
                                                     id="_3ddeadbandlow"
-                                                    type="number"
                                                     name="_3ddeadbandlow"
-                                                    step="1"
-                                                    min="1250"
-                                                    max="1600"
-                                                    v-model.number="fcStore.motor3dConfig.deadband3d_low"
+                                                    :step="1"
+                                                    :min="1250"
+                                                    :max="1600"
+                                                    v-model="fcStore.motor3dConfig.deadband3d_low"
                                                 />
                                                 <span v-html="$t('configuration3dDeadbandLow')"></span>
                                             </label>
                                         </div>
                                         <div class="number">
                                             <label for="_3ddeadbandhigh">
-                                                <input
+                                                <UInputNumber
                                                     id="_3ddeadbandhigh"
-                                                    type="number"
                                                     name="_3ddeadbandhigh"
-                                                    step="1"
-                                                    min="1400"
-                                                    max="1750"
-                                                    v-model.number="fcStore.motor3dConfig.deadband3d_high"
+                                                    :step="1"
+                                                    :min="1400"
+                                                    :max="1750"
+                                                    v-model="fcStore.motor3dConfig.deadband3d_high"
                                                 />
                                                 <span v-html="$t('configuration3dDeadbandHigh')"></span>
                                             </label>
                                         </div>
                                         <div class="number">
                                             <label for="_3dneutral">
-                                                <input
+                                                <UInputNumber
                                                     id="_3dneutral"
-                                                    type="number"
                                                     name="_3dneutral"
-                                                    step="1"
-                                                    min="1400"
-                                                    max="1600"
-                                                    v-model.number="fcStore.motor3dConfig.neutral"
+                                                    :step="1"
+                                                    :min="1400"
+                                                    :max="1600"
+                                                    v-model="fcStore.motor3dConfig.neutral"
                                                 />
                                                 <span v-html="$t('configuration3dNeutral')"></span>
                                             </label>

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -382,12 +382,12 @@
                                             </div>
                                             <div class="timer-row osd_tip" :title="$t('osdTimerAlarmTooltip')">
                                                 <label :for="'osd-timer-alarm-' + idx">{{ $t("osdTimerAlarm") }}</label>
-                                                <input
-                                                    type="number"
+                                                <UInputNumber
                                                     :id="'osd-timer-alarm-' + idx"
-                                                    v-model.number="timer.alarm"
-                                                    min="0"
-                                                    max="600"
+                                                    v-model="timer.alarm"
+                                                    :min="0"
+                                                    :max="600"
+                                                    :step="1"
                                                     @change="onTimerChange(timer)"
                                                 />
                                             </div>
@@ -409,12 +409,12 @@
                                 <div class="alarms">
                                     <div v-for="entry in alarmEntries" :key="entry.key" class="alarm-config">
                                         <label :for="'osd-alarm-' + entry.key">
-                                            <input
-                                                type="number"
+                                            <UInputNumber
                                                 :id="'osd-alarm-' + entry.key"
-                                                v-model.number="entry.alarm.value"
+                                                v-model="entry.alarm.value"
                                                 :min="entry.alarm.min || 0"
                                                 :max="entry.alarm.max || 9999"
+                                                :step="1"
                                                 @change="onAlarmChange"
                                             />
                                             <span>{{ entry.alarm.display_name }}</span>

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -2205,13 +2205,9 @@ onUnmounted(() => {
 }
 
 .alarms :deep(input) {
-    width: 55px;
-    padding-left: 3px;
     height: 18px;
     line-height: 20px;
-    text-align: left;
     border-radius: 3px;
-    margin-right: 0;
     font-size: 11px;
     font-weight: normal;
 }

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -2184,7 +2184,7 @@ onUnmounted(() => {
 }
 
 .timer-row select,
-.timer-row input {
+.timer-row :deep(input) {
     width: 140px;
 }
 
@@ -2204,7 +2204,7 @@ onUnmounted(() => {
     padding-bottom: 0;
 }
 
-.alarms input {
+.alarms :deep(input) {
     width: 55px;
     padding-left: 3px;
     height: 18px;

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -645,7 +645,6 @@ onUnmounted(() => {
     width: calc(100% - 0px);
     height: 20px;
     line-height: 20px;
-    text-align: right;
     border: 1px solid var(--surface-500);
     border-radius: 3px;
 }
@@ -744,7 +743,7 @@ onUnmounted(() => {
     padding: 0 0.5rem;
 }
 .tab-pid_tuning table.compensation td:first-child:not(.filterTable) {
-    width: 75px;
+    width: 110px;
     text-align: center;
     vertical-align: top;
     padding-top: 4px;
@@ -906,14 +905,10 @@ onUnmounted(() => {
     border-bottom: 0;
 }
 .tab-pid_tuning .number input {
-    width: 50px;
-    padding-left: 3px;
     height: 20px;
     line-height: 20px;
-    text-align: left;
     border: 1px solid var(--surface-500);
     border-radius: 3px;
-    margin-right: 11px;
     font-weight: normal;
 }
 .tab-pid_tuning .gui_box_titlebar .helpicon {

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -611,11 +611,6 @@ onUnmounted(() => {
     min-width: 200px;
 }
 
-/* ── Inputs ───────────────────────────────────────────────────────── */
-.tab-pid_tuning input[type="number"]::-webkit-inner-spin-button {
-    border: 0;
-}
-
 .tab-pid_tuning table .inputBackground {
     background: white;
 }

--- a/src/components/tabs/PowerTab.vue
+++ b/src/components/tabs/PowerTab.vue
@@ -106,15 +106,14 @@
 
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             id="mincellvoltage"
-                                                            type="number"
                                                             name="mincellvoltage"
-                                                            step="0.01"
-                                                            min="1"
-                                                            max="5"
+                                                            :step="0.01"
+                                                            :min="1"
+                                                            :max="5"
                                                             :aria-label="$t('powerBatteryMinimum')"
-                                                            v-model.number="batteryConfig.vbatmincellvoltage"
+                                                            v-model="batteryConfig.vbatmincellvoltage"
                                                         />
                                                         <span v-html="$t('powerBatteryMinimum')"></span>
                                                     </label>
@@ -125,15 +124,14 @@
                                                 </div>
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             id="maxcellvoltage"
-                                                            type="number"
                                                             name="maxcellvoltage"
-                                                            step="0.01"
-                                                            min="1"
-                                                            max="5"
+                                                            :step="0.01"
+                                                            :min="1"
+                                                            :max="5"
                                                             :aria-label="$t('powerBatteryMaximum')"
-                                                            v-model.number="batteryConfig.vbatmaxcellvoltage"
+                                                            v-model="batteryConfig.vbatmaxcellvoltage"
                                                         />
                                                         <span v-html="$t('powerBatteryMaximum')"></span>
                                                     </label>
@@ -144,15 +142,14 @@
                                                 </div>
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             id="warningcellvoltage"
-                                                            type="number"
                                                             name="warningcellvoltage"
-                                                            step="0.01"
-                                                            min="1"
-                                                            max="5"
+                                                            :step="0.01"
+                                                            :min="1"
+                                                            :max="5"
                                                             :aria-label="$t('powerBatteryWarning')"
-                                                            v-model.number="batteryConfig.vbatwarningcellvoltage"
+                                                            v-model="batteryConfig.vbatwarningcellvoltage"
                                                         />
                                                         <span v-html="$t('powerBatteryWarning')"></span>
                                                     </label>
@@ -163,15 +160,14 @@
                                                 </div>
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             id="capacity"
-                                                            type="number"
                                                             name="capacity"
-                                                            step="1"
-                                                            min="0"
-                                                            max="20000"
+                                                            :step="1"
+                                                            :min="0"
+                                                            :max="20000"
                                                             :aria-label="$t('powerBatteryCapacity')"
-                                                            v-model.number="batteryConfig.capacity"
+                                                            v-model="batteryConfig.capacity"
                                                         />
                                                         <span v-html="$t('powerBatteryCapacity')"></span>
                                                     </label>
@@ -218,51 +214,43 @@
                                             <div class="voltage-configuration">
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             :id="`vbatscale-${index}`"
-                                                            type="number"
                                                             :name="`vbatscale-${index}`"
-                                                            step="1"
-                                                            min="10"
-                                                            max="255"
+                                                            :step="1"
+                                                            :min="10"
+                                                            :max="255"
                                                             :aria-label="$t('powerVoltageScale')"
-                                                            v-model.number="voltageConfigs[index].vbatscale"
-                                                            @change="
-                                                                onVoltageScaleChange(
-                                                                    index,
-                                                                    voltageConfigs[index].vbatscale,
-                                                                )
-                                                            "
+                                                            v-model="voltageConfigs[index].vbatscale"
+                                                            @update:model-value="onVoltageScaleChange(index, $event)"
                                                         />
                                                         <span v-html="$t('powerVoltageScale')"></span>
                                                     </label>
                                                 </div>
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             :id="`vbatresdivval-${index}`"
-                                                            type="number"
                                                             :name="`vbatresdivval-${index}`"
-                                                            step="1"
-                                                            min="1"
-                                                            max="255"
+                                                            :step="1"
+                                                            :min="1"
+                                                            :max="255"
                                                             :aria-label="$t('powerVoltageDivider')"
-                                                            v-model.number="voltageConfigs[index].vbatresdivval"
+                                                            v-model="voltageConfigs[index].vbatresdivval"
                                                         />
                                                         <span v-html="$t('powerVoltageDivider')"></span>
                                                     </label>
                                                 </div>
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             :id="`vbatresdivmultiplier-${index}`"
-                                                            type="number"
                                                             :name="`vbatresdivmultiplier-${index}`"
-                                                            step="1"
-                                                            min="1"
-                                                            max="255"
+                                                            :step="1"
+                                                            :min="1"
+                                                            :max="255"
                                                             :aria-label="$t('powerVoltageMultiplier')"
-                                                            v-model.number="voltageConfigs[index].vbatresdivmultiplier"
+                                                            v-model="voltageConfigs[index].vbatresdivmultiplier"
                                                         />
                                                         <span v-html="$t('powerVoltageMultiplier')"></span>
                                                     </label>
@@ -357,36 +345,29 @@
                                             <div class="amperage-configuration">
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             :id="`amperagescale-${index}`"
-                                                            type="number"
                                                             :name="`amperagescale-${index}`"
-                                                            step="1"
-                                                            min="-16000"
-                                                            max="16000"
+                                                            :step="1"
+                                                            :min="-16000"
+                                                            :max="16000"
                                                             :aria-label="$t('powerAmperageScale')"
-                                                            v-model.number="currentConfigs[index].scale"
-                                                            @change="
-                                                                onAmperageScaleChange(
-                                                                    index,
-                                                                    currentConfigs[index].scale,
-                                                                )
-                                                            "
+                                                            v-model="currentConfigs[index].scale"
+                                                            @update:model-value="onAmperageScaleChange(index, $event)"
                                                         />
                                                         <span v-html="$t('powerAmperageScale')"></span>
                                                     </label>
                                                 </div>
                                                 <div class="number">
                                                     <label>
-                                                        <input
+                                                        <UInputNumber
                                                             :id="`amperageoffset-${index}`"
-                                                            type="number"
                                                             :name="`amperageoffset-${index}`"
-                                                            step="1"
-                                                            min="-32000"
-                                                            max="32000"
+                                                            :step="1"
+                                                            :min="-32000"
+                                                            :max="32000"
                                                             :aria-label="$t('powerAmperageOffset')"
-                                                            v-model.number="currentConfigs[index].offset"
+                                                            v-model="currentConfigs[index].offset"
                                                         />
                                                         <span v-html="$t('powerAmperageOffset')"></span>
                                                     </label>
@@ -444,15 +425,14 @@
                     <label for="vbatcalibration">
                         <span v-html="$t('powerVoltageCalibration')"></span>
                     </label>
-                    <input
+                    <UInputNumber
                         id="vbatcalibration"
-                        type="number"
                         name="vbatcalibration"
-                        step="0.01"
-                        min="0"
-                        max="255"
+                        :step="0.01"
+                        :min="0"
+                        :max="255"
                         :aria-label="$t('powerVoltageCalibration')"
-                        v-model.number="vbatcalibrationValue"
+                        v-model="vbatcalibrationValue"
                     />
                 </div>
             </div>
@@ -461,15 +441,14 @@
                     <label for="amperagecalibration">
                         <span v-html="$t('powerAmperageCalibration')"></span>
                     </label>
-                    <input
+                    <UInputNumber
                         id="amperagecalibration"
-                        type="number"
                         name="amperagecalibration"
-                        step="0.01"
-                        min="0"
-                        max="255"
+                        :step="0.01"
+                        :min="0"
+                        :max="255"
                         :aria-label="$t('powerAmperageCalibration')"
-                        v-model.number="amperagecalibrationValue"
+                        v-model="amperagecalibrationValue"
                     />
                 </div>
             </div>

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1470,7 +1470,7 @@ onUnmounted(() => {
         select {
             width: 90%;
         }
-        input {
+        :deep(input) {
             width: 90%;
         }
         .helpicon {

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -110,12 +110,12 @@
                                     <span class="elrsUid">{{ elrsUidDisplay }}</span>
                                 </div>
                                 <div class="number" v-if="showElrsModelId">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="elrsModelId-number"
-                                        min="0"
-                                        max="255"
-                                        v-model.number="rxConfig.elrsModelId"
+                                        :min="0"
+                                        :max="255"
+                                        :step="1"
+                                        v-model="rxConfig.elrsModelId"
                                     />
                                     <span v-html="$t('receiverModelId')"></span>
                                     <div class="helpicon cf_tip" :title="$t('receiverHelpModelId')"></div>
@@ -218,12 +218,12 @@
                                 <div class="spacer_box_title" v-html="$t('receiverStickMin')"></div>
                             </div>
                             <div class="input-helpicon-flex">
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="stick_min"
-                                    min="1000"
-                                    max="1200"
-                                    v-model.number="rxConfig.stick_min"
+                                    :min="1000"
+                                    :max="1200"
+                                    :step="1"
+                                    v-model="rxConfig.stick_min"
                                 />
                                 <div class="helpicon cf_tip" :title="$t('receiverHelpStickMin')"></div>
                             </div>
@@ -233,12 +233,12 @@
                                 <div class="spacer_box_title" v-html="$t('receiverStickCenter')"></div>
                             </div>
                             <div class="input-helpicon-flex">
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="stick_center"
-                                    min="1401"
-                                    max="1599"
-                                    v-model.number="rxConfig.stick_center"
+                                    :min="1401"
+                                    :max="1599"
+                                    :step="1"
+                                    v-model="rxConfig.stick_center"
                                 />
                                 <div class="helpicon cf_tip" :title="$t('receiverHelpStickCenter')"></div>
                             </div>
@@ -248,12 +248,12 @@
                                 <div class="spacer_box_title" v-html="$t('receiverStickMax')"></div>
                             </div>
                             <div class="input-helpicon-flex">
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="stick_max"
-                                    min="1800"
-                                    max="2000"
-                                    v-model.number="rxConfig.stick_max"
+                                    :min="1800"
+                                    :max="2000"
+                                    :step="1"
+                                    v-model="rxConfig.stick_max"
                                 />
                                 <div class="helpicon cf_tip" :title="$t('receiverHelpStickMax')"></div>
                             </div>
@@ -265,12 +265,12 @@
                                 <div class="spacer_box_title" v-html="$t('receiverDeadband')"></div>
                             </div>
                             <div class="input-helpicon-flex">
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="deadband"
-                                    min="0"
-                                    max="32"
-                                    v-model.number="rcDeadbandConfig.deadband"
+                                    :min="0"
+                                    :max="32"
+                                    :step="1"
+                                    v-model="rcDeadbandConfig.deadband"
                                 />
                                 <div class="helpicon cf_tip" :title="$t('receiverHelpDeadband')"></div>
                             </div>
@@ -280,12 +280,12 @@
                                 <div class="spacer_box_title" v-html="$t('receiverYawDeadband')"></div>
                             </div>
                             <div class="input-helpicon-flex">
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="yaw_deadband"
-                                    min="0"
-                                    max="100"
-                                    v-model.number="rcDeadbandConfig.yaw_deadband"
+                                    :min="0"
+                                    :max="100"
+                                    :step="1"
+                                    v-model="rcDeadbandConfig.yaw_deadband"
                                 />
                                 <div class="helpicon cf_tip" :title="$t('receiverHelpYawDeadband')"></div>
                             </div>
@@ -295,12 +295,12 @@
                                 <div class="spacer_box_title" v-html="$t('recevier3dDeadbandThrottle')"></div>
                             </div>
                             <div class="input-helpicon-flex">
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="3ddeadbandthrottle"
-                                    min="0"
-                                    max="100"
-                                    v-model.number="rcDeadbandConfig.deadband3d_throttle"
+                                    :min="0"
+                                    :max="100"
+                                    :step="1"
+                                    v-model="rcDeadbandConfig.deadband3d_throttle"
                                 />
                                 <div class="helpicon cf_tip" :title="$t('receiverHelp3dDeadbandThrottle')"></div>
                             </div>
@@ -353,13 +353,12 @@
                                     </tr>
                                     <tr class="rcSmoothing-setpoint-manual" v-if="setpointManualMode === '1'">
                                         <td class="rcSmoothing-setpoint-cutoff">
-                                            <input
-                                                type="number"
+                                            <UInputNumber
                                                 name="rcSmoothingSetpointHz-number"
-                                                step="1"
-                                                min="0"
-                                                max="255"
-                                                v-model.number="rxConfig.rcSmoothingSetpointCutoff"
+                                                :step="1"
+                                                :min="0"
+                                                :max="255"
+                                                v-model="rxConfig.rcSmoothingSetpointCutoff"
                                             />
                                         </td>
                                         <td class="rcSmoothing-setpoint-cutoff" colspan="2">
@@ -376,13 +375,12 @@
                                     <!-- Auto Factor -->
                                     <tr class="rcSmoothing-auto-factor" v-if="showAutoFactor">
                                         <td>
-                                            <input
-                                                type="number"
+                                            <UInputNumber
                                                 name="rcSmoothingAutoFactor-number"
-                                                step="1"
-                                                min="0"
-                                                max="250"
-                                                v-model.number="rxConfig.rcSmoothingAutoFactor"
+                                                :step="1"
+                                                :min="0"
+                                                :max="250"
+                                                v-model="rxConfig.rcSmoothingAutoFactor"
                                             />
                                         </td>
                                         <td>
@@ -424,13 +422,12 @@
                                         </tr>
                                         <tr class="rcSmoothing-throttle-manual" v-if="throttleManualMode === '1'">
                                             <td class="rcSmoothing-throttle-cutoff">
-                                                <input
-                                                    type="number"
+                                                <UInputNumber
                                                     name="rcSmoothingThrottleCutoffHz-number"
-                                                    step="1"
-                                                    min="0"
-                                                    max="255"
-                                                    v-model.number="rxConfig.rcSmoothingThrottleCutoff"
+                                                    :step="1"
+                                                    :min="0"
+                                                    :max="255"
+                                                    v-model="rxConfig.rcSmoothingThrottleCutoff"
                                                 />
                                             </td>
                                             <td class="rcSmoothing-throttle-cutoff" colspan="2">
@@ -445,13 +442,12 @@
                                         </tr>
                                         <tr class="rcSmoothing-auto-factor-throttle" v-if="showThrottleAutoFactor">
                                             <td>
-                                                <input
-                                                    type="number"
+                                                <UInputNumber
                                                     name="rcSmoothingAutoFactorThrottle-number"
-                                                    step="1"
-                                                    min="0"
-                                                    max="250"
-                                                    v-model.number="rxConfig.rcSmoothingAutoFactorThrottle"
+                                                    :step="1"
+                                                    :min="0"
+                                                    :max="250"
+                                                    v-model="rxConfig.rcSmoothingAutoFactorThrottle"
                                                 />
                                             </td>
                                             <td>
@@ -494,13 +490,12 @@
                                         </tr>
                                         <tr class="rcSmoothing-feedforward-manual" v-if="feedforwardManualMode === '1'">
                                             <td class="rcSmoothing-feedforward-cutoff">
-                                                <input
-                                                    type="number"
+                                                <UInputNumber
                                                     name="rcSmoothingFeedforwardCutoff-number"
-                                                    step="1"
-                                                    min="1"
-                                                    max="255"
-                                                    v-model.number="rxConfig.rcSmoothingFeedforwardCutoff"
+                                                    :step="1"
+                                                    :min="1"
+                                                    :max="255"
+                                                    v-model="rxConfig.rcSmoothingFeedforwardCutoff"
                                                 />
                                             </td>
                                             <td colspan="2" class="rcSmoothing-feedforward-cutoff">

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -417,7 +417,7 @@ export default defineComponent({
             border: 1px solid var(--surface-500);
             border-radius: 3px;
         }
-        input[type="number"] {
+        :deep(input) {
             display: block;
             width: 100%;
             height: 20px;
@@ -427,11 +427,6 @@ export default defineComponent({
         input[type="checkbox"] {
             width: 16px;
             height: 16px;
-        }
-    }
-    input[type="number"] {
-        &::-webkit-inner-spin-button {
-            border: 0;
         }
     }
     .directions {

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -417,7 +417,7 @@ export default defineComponent({
             border: 1px solid var(--surface-500);
             border-radius: 3px;
         }
-        :deep(input) {
+        :deep(input:not([type="checkbox"])) {
             display: block;
             width: 100%;
             height: 20px;

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -27,29 +27,29 @@
                                 <tr v-for="(servo, index) in servoConfigs" :key="index">
                                     <td style="text-align: center">Servo {{ index + 1 }}</td>
                                     <td class="min">
-                                        <input
-                                            type="number"
-                                            min="500"
-                                            max="2500"
-                                            v-model.number="servo.min"
+                                        <UInputNumber
+                                            :min="500"
+                                            :max="2500"
+                                            :step="1"
+                                            v-model="servo.min"
                                             @change="onServoChange"
                                         />
                                     </td>
                                     <td class="middle">
-                                        <input
-                                            type="number"
-                                            min="500"
-                                            max="2500"
-                                            v-model.number="servo.middle"
+                                        <UInputNumber
+                                            :min="500"
+                                            :max="2500"
+                                            :step="1"
+                                            v-model="servo.middle"
                                             @change="onServoChange"
                                         />
                                     </td>
                                     <td class="max">
-                                        <input
-                                            type="number"
-                                            min="500"
-                                            max="2500"
-                                            v-model.number="servo.max"
+                                        <UInputNumber
+                                            :min="500"
+                                            :max="2500"
+                                            :step="1"
+                                            v-model="servo.max"
                                             @change="onServoChange"
                                         />
                                     </td>

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -797,11 +797,11 @@ export default defineComponent({
 }
 
 .one_digit_input {
-    width: 28px;
+    width: 80px;
 }
 
 .frequency_input {
-    width: 64px;
+    width: 120px;
 }
 
 .vtx_table_box {

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -84,13 +84,13 @@
                         <!-- Frequency input -->
                         <div class="field number vtx_frequency" v-show="frequencyMode">
                             <span class="numberspacer">
-                                <input
+                                <UInputNumber
                                     class="frequency_input"
-                                    type="number"
                                     id="vtx_frequency"
-                                    min="64"
-                                    max="5999"
-                                    v-model.number="vtxConfig.vtx_frequency"
+                                    :min="64"
+                                    :max="5999"
+                                    :step="1"
+                                    v-model="vtxConfig.vtx_frequency"
                                 />
                             </span>
                             <label>
@@ -133,13 +133,13 @@
                         <!-- Pit mode frequency -->
                         <div class="field number vtx_pit_mode_frequency">
                             <span class="numberspacer">
-                                <input
+                                <UInputNumber
                                     class="frequency_input"
-                                    type="number"
                                     id="vtx_pit_mode_frequency"
-                                    min="0"
-                                    max="5999"
-                                    v-model.number="vtxConfig.vtx_pit_mode_frequency"
+                                    :min="0"
+                                    :max="5999"
+                                    :step="1"
+                                    v-model="vtxConfig.vtx_pit_mode_frequency"
                                 />
                             </span>
                             <label>
@@ -235,13 +235,13 @@
                             <!-- Bands count -->
                             <div class="field number vtx_table_bands_channels">
                                 <span class="numberspacer">
-                                    <input
+                                    <UInputNumber
                                         class="one_digit_input"
-                                        type="number"
                                         id="vtx_table_bands"
-                                        min="0"
-                                        max="8"
-                                        v-model.number="vtxConfig.vtx_table_bands"
+                                        :min="0"
+                                        :max="8"
+                                        :step="1"
+                                        v-model="vtxConfig.vtx_table_bands"
                                     />
                                 </span>
                                 <label>
@@ -253,13 +253,13 @@
                             <!-- Channels count -->
                             <div class="field number vtx_table_channels">
                                 <span class="numberspacer">
-                                    <input
+                                    <UInputNumber
                                         class="one_digit_input"
-                                        type="number"
                                         id="vtx_table_channels"
-                                        min="0"
-                                        max="8"
-                                        v-model.number="vtxConfig.vtx_table_channels"
+                                        :min="0"
+                                        :max="8"
+                                        :step="1"
+                                        v-model="vtxConfig.vtx_table_channels"
                                     />
                                 </span>
                                 <label>
@@ -346,14 +346,14 @@
                                                     v-show="chIdx <= vtxConfig.vtx_table_channels"
                                                 >
                                                     <span class="numberspacer field_band_channel">
-                                                        <input
+                                                        <UInputNumber
                                                             class="frequency_input"
-                                                            type="number"
-                                                            min="0"
-                                                            max="5999"
-                                                            :value="getBandChannelFreq(bandIdx, chIdx)"
-                                                            @input="
-                                                                setBandChannelFreq(bandIdx, chIdx, $event.target.value)
+                                                            :min="0"
+                                                            :max="5999"
+                                                            :step="1"
+                                                            :model-value="getBandChannelFreq(bandIdx, chIdx)"
+                                                            @update:model-value="
+                                                                setBandChannelFreq(bandIdx, chIdx, $event)
                                                             "
                                                         />
                                                     </span>
@@ -373,13 +373,13 @@
                             <!-- Power levels count -->
                             <div class="field number vtx_table_powerlevels">
                                 <span class="numberspacer">
-                                    <input
+                                    <UInputNumber
                                         class="one_digit_input"
-                                        type="number"
                                         id="vtx_table_powerlevels"
-                                        min="0"
-                                        max="8"
-                                        v-model.number="vtxConfig.vtx_table_powerlevels"
+                                        :min="0"
+                                        :max="8"
+                                        :step="1"
+                                        v-model="vtxConfig.vtx_table_powerlevels"
                                     />
                                 </span>
                                 <label>
@@ -412,12 +412,12 @@
                                                     v-show="i <= vtxConfig.vtx_table_powerlevels"
                                                 >
                                                     <span class="numberspacer field_powerlevel_value">
-                                                        <input
-                                                            type="number"
-                                                            min="0"
-                                                            max="65535"
-                                                            :value="getPowerLevelValue(i)"
-                                                            @input="setPowerLevelValue(i, $event.target.value)"
+                                                        <UInputNumber
+                                                            :min="0"
+                                                            :max="65535"
+                                                            :step="1"
+                                                            :model-value="getPowerLevelValue(i)"
+                                                            @update:model-value="setPowerLevelValue(i, $event)"
                                                         />
                                                     </span>
                                                 </td>

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -796,11 +796,11 @@ export default defineComponent({
     align-items: center;
 }
 
-input.one_digit_input {
+.one_digit_input {
     width: 28px;
 }
 
-input.frequency_input {
+.frequency_input {
     width: 64px;
 }
 
@@ -825,7 +825,7 @@ input.frequency_input {
     text-align: center;
 }
 
-.table_vtx_bands input {
+.table_vtx_bands :deep(input) {
     min-width: 0;
     padding-right: 0.25rem;
 }
@@ -839,7 +839,7 @@ input.frequency_input {
     text-align: center;
 }
 
-.table_vtx_powerlevels input {
+.table_vtx_powerlevels :deep(input) {
     display: block;
     min-width: 5rem;
 }

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -1315,7 +1315,7 @@ defineExpose({
     margin-top: 8px;
 }
 
-.suboption input[type="number"],
+.suboption :deep(input),
 .suboption select {
     padding: 6px 10px;
     border: 1px solid var(--surface-300);

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -156,12 +156,11 @@
                                 </span>
 
                                 <span v-if="gyroLowpassEnabled && gyroLowpassMode === 0" class="suboption static">
-                                    <input
-                                        type="number"
-                                        v-model.number="gyro_lowpass_hz"
-                                        step="1"
-                                        min="1"
-                                        max="1000"
+                                    <UInputNumber
+                                        v-model="gyro_lowpass_hz"
+                                        :step="1"
+                                        :min="1"
+                                        :max="1000"
                                         :disabled="gyroInputsDisabled"
                                     />
                                     <label>
@@ -170,12 +169,11 @@
                                 </span>
 
                                 <span v-if="gyroLowpassEnabled && gyroLowpassMode === 1" class="suboption dynamic">
-                                    <input
-                                        type="number"
-                                        v-model.number="gyro_lowpass_dyn_min_hz"
-                                        step="1"
-                                        min="1"
-                                        max="1000"
+                                    <UInputNumber
+                                        v-model="gyro_lowpass_dyn_min_hz"
+                                        :step="1"
+                                        :min="1"
+                                        :max="1000"
                                         :disabled="gyroInputsDisabled"
                                     />
                                     <label>
@@ -184,12 +182,11 @@
                                 </span>
 
                                 <span v-if="gyroLowpassEnabled && gyroLowpassMode === 1" class="suboption dynamic">
-                                    <input
-                                        type="number"
-                                        v-model.number="gyro_lowpass_dyn_max_hz"
-                                        step="1"
-                                        min="1"
-                                        max="1000"
+                                    <UInputNumber
+                                        v-model="gyro_lowpass_dyn_max_hz"
+                                        :step="1"
+                                        :min="1"
+                                        :max="1000"
                                         :disabled="gyroInputsDisabled"
                                     />
                                     <label>
@@ -228,12 +225,11 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningGyroLowpass2Help')"></div>
 
                                 <span v-if="gyroLowpass2Enabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="gyro_lowpass2_hz"
-                                        step="1"
-                                        min="1"
-                                        max="1000"
+                                    <UInputNumber
+                                        v-model="gyro_lowpass2_hz"
+                                        :step="1"
+                                        :min="1"
+                                        :max="1000"
                                         :disabled="gyroInputsDisabled"
                                     />
                                     <label>
@@ -282,20 +278,14 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningGyroNotchFilterHelp')"></div>
 
                                 <span v-if="gyroNotch1Enabled" class="suboption">
-                                    <input type="number" v-model.number="gyro_notch_hz" step="1" min="1" max="16000" />
+                                    <UInputNumber v-model="gyro_notch_hz" :step="1" :min="1" :max="16000" />
                                     <label>
                                         <span>{{ $t("pidTuningCenterFrequency") }}</span>
                                     </label>
                                 </span>
 
                                 <span v-if="gyroNotch1Enabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="gyro_notch_cutoff"
-                                        step="1"
-                                        min="0"
-                                        max="16000"
-                                    />
+                                    <UInputNumber v-model="gyro_notch_cutoff" :step="1" :min="0" :max="16000" />
                                     <label>
                                         <span>{{ $t("pidTuningCutoffFrequency") }}</span>
                                     </label>
@@ -320,20 +310,14 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningGyroNotchFilter2Help')"></div>
 
                                 <span v-if="gyroNotch2Enabled" class="suboption">
-                                    <input type="number" v-model.number="gyro_notch2_hz" step="1" min="1" max="16000" />
+                                    <UInputNumber v-model="gyro_notch2_hz" :step="1" :min="1" :max="16000" />
                                     <label>
                                         <span>{{ $t("pidTuningCenterFrequency") }}</span>
                                     </label>
                                 </span>
 
                                 <span v-if="gyroNotch2Enabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="gyro_notch2_cutoff"
-                                        step="1"
-                                        min="0"
-                                        max="16000"
-                                    />
+                                    <UInputNumber v-model="gyro_notch2_cutoff" :step="1" :min="0" :max="16000" />
                                     <label>
                                         <span>{{ $t("pidTuningCutoffFrequency") }}</span>
                                     </label>
@@ -368,26 +352,14 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningRpmFilterHelp')"></div>
 
                                 <span v-if="rpmFilterEnabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="gyro_rpm_notch_harmonics"
-                                        step="1"
-                                        min="1"
-                                        max="3"
-                                    />
+                                    <UInputNumber v-model="gyro_rpm_notch_harmonics" :step="1" :min="1" :max="3" />
                                     <label>
                                         <span>{{ $t("pidTuningRpmHarmonics") }}</span>
                                     </label>
                                 </span>
 
                                 <span v-if="rpmFilterEnabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="gyro_rpm_notch_min_hz"
-                                        step="1"
-                                        min="50"
-                                        max="200"
-                                    />
+                                    <UInputNumber v-model="gyro_rpm_notch_min_hz" :step="1" :min="50" :max="200" />
                                     <label>
                                         <span>{{ $t("pidTuningRpmMinHz") }}</span>
                                     </label>
@@ -422,40 +394,28 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningDynamicNotchFilterHelp')"></div>
 
                                 <span v-if="dynamicNotchEnabled" class="suboption">
-                                    <input type="number" v-model.number="dyn_notch_count" step="1" min="1" max="5" />
+                                    <UInputNumber v-model="dyn_notch_count" :step="1" :min="1" :max="5" />
                                     <label>
                                         <span>{{ $t("pidTuningDynamicNotchCount") }}</span>
                                     </label>
                                 </span>
 
                                 <span v-if="dynamicNotchEnabled" class="suboption">
-                                    <input type="number" v-model.number="dyn_notch_q" step="1" min="1" max="1000" />
+                                    <UInputNumber v-model="dyn_notch_q" :step="1" :min="1" :max="1000" />
                                     <label>
                                         <span>{{ $t("pidTuningDynamicNotchQ") }}</span>
                                     </label>
                                 </span>
 
                                 <span v-if="dynamicNotchEnabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="dyn_notch_min_hz"
-                                        step="1"
-                                        min="60"
-                                        max="250"
-                                    />
+                                    <UInputNumber v-model="dyn_notch_min_hz" :step="1" :min="60" :max="250" />
                                     <label>
                                         <span>{{ $t("pidTuningDynamicNotchMinHz") }}</span>
                                     </label>
                                 </span>
 
                                 <span v-if="dynamicNotchEnabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="dyn_notch_max_hz"
-                                        step="1"
-                                        min="200"
-                                        max="1000"
-                                    />
+                                    <UInputNumber v-model="dyn_notch_max_hz" :step="1" :min="200" :max="1000" />
                                     <label>
                                         <span>{{ $t("pidTuningDynamicNotchMaxHz") }}</span>
                                     </label>
@@ -524,12 +484,11 @@
                                 </span>
 
                                 <span v-if="dtermLowpassEnabled && dtermLowpassMode === 0" class="suboption static">
-                                    <input
-                                        type="number"
-                                        v-model.number="dterm_lowpass_hz"
-                                        step="1"
-                                        min="1"
-                                        max="1000"
+                                    <UInputNumber
+                                        v-model="dterm_lowpass_hz"
+                                        :step="1"
+                                        :min="1"
+                                        :max="1000"
                                         :disabled="dtermInputsDisabled"
                                     />
                                     <label>
@@ -538,12 +497,11 @@
                                 </span>
 
                                 <span v-if="dtermLowpassEnabled && dtermLowpassMode === 1" class="suboption dynamic">
-                                    <input
-                                        type="number"
-                                        v-model.number="dterm_lowpass_dyn_min_hz"
-                                        step="1"
-                                        min="1"
-                                        max="1000"
+                                    <UInputNumber
+                                        v-model="dterm_lowpass_dyn_min_hz"
+                                        :step="1"
+                                        :min="1"
+                                        :max="1000"
                                         :disabled="dtermInputsDisabled"
                                     />
                                     <label>
@@ -552,12 +510,11 @@
                                 </span>
 
                                 <span v-if="dtermLowpassEnabled && dtermLowpassMode === 1" class="suboption dynamic">
-                                    <input
-                                        type="number"
-                                        v-model.number="dterm_lowpass_dyn_max_hz"
-                                        step="10"
-                                        min="200"
-                                        max="2000"
+                                    <UInputNumber
+                                        v-model="dterm_lowpass_dyn_max_hz"
+                                        :step="10"
+                                        :min="200"
+                                        :max="2000"
                                         :disabled="dtermInputsDisabled"
                                     />
                                     <label>
@@ -566,13 +523,7 @@
                                 </span>
 
                                 <span v-if="dtermLowpassEnabled && dtermLowpassMode === 1" class="suboption dynamic">
-                                    <input
-                                        type="number"
-                                        v-model.number="dyn_lpf_curve_expo"
-                                        step="1"
-                                        min="0"
-                                        max="10"
-                                    />
+                                    <UInputNumber v-model="dyn_lpf_curve_expo" :step="1" :min="0" :max="10" />
                                     <label>
                                         <span>{{ $t("pidTuningDTermLowpassDynExpo") }}</span>
                                     </label>
@@ -609,12 +560,11 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningDTermLowpass2Help')"></div>
 
                                 <span v-if="dtermLowpass2Enabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="dterm_lowpass2_hz"
-                                        step="1"
-                                        min="1"
-                                        max="1000"
+                                    <UInputNumber
+                                        v-model="dterm_lowpass2_hz"
+                                        :step="1"
+                                        :min="1"
+                                        :max="1000"
                                         :disabled="dtermInputsDisabled"
                                     />
                                     <label>
@@ -666,20 +616,14 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningDTermNotchFiltersGroupHelp')"></div>
 
                                 <span v-if="dtermNotchEnabled" class="suboption">
-                                    <input type="number" v-model.number="dterm_notch_hz" step="1" min="1" max="16000" />
+                                    <UInputNumber v-model="dterm_notch_hz" :step="1" :min="1" :max="16000" />
                                     <label>
                                         <span>{{ $t("pidTuningCenterFrequency") }}</span>
                                     </label>
                                 </span>
 
                                 <span v-if="dtermNotchEnabled" class="suboption">
-                                    <input
-                                        type="number"
-                                        v-model.number="dterm_notch_cutoff"
-                                        step="1"
-                                        min="0"
-                                        max="16000"
-                                    />
+                                    <UInputNumber v-model="dterm_notch_cutoff" :step="1" :min="0" :max="16000" />
                                     <label>
                                         <span>{{ $t("pidTuningCutoffFrequency") }}</span>
                                     </label>
@@ -707,7 +651,7 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningYawLowpassFiltersGroupHelp')"></div>
 
                                 <span class="suboption">
-                                    <input type="number" v-model.number="yaw_lowpass_hz" step="1" min="0" max="500" />
+                                    <UInputNumber v-model="yaw_lowpass_hz" :step="1" :min="0" :max="500" />
                                     <label>
                                         <span>{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                                     </label>

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -80,52 +80,47 @@
                         <tr class="ROLL">
                             <td class="pid_roll" style="background-color: #e24761">ROLL</td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidRollP"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber
+                                    v-model="pidRollP"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidRollI"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber
+                                    v-model="pidRollI"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidRollD"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber
+                                    v-model="pidRollD"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="advancedTuning.dMaxRoll"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber
+                                    v-model="advancedTuning.dMaxRoll"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="advancedTuning.feedforwardRoll"
-                                    step="1"
-                                    min="0"
-                                    max="2000"
+                                <UInputNumber
+                                    v-model="advancedTuning.feedforwardRoll"
+                                    :step="1"
+                                    :min="0"
+                                    :max="2000"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
@@ -135,52 +130,47 @@
                         <tr class="PITCH">
                             <td class="pid_pitch" style="background-color: #49c747">PITCH</td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidPitchP"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber
+                                    v-model="pidPitchP"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidPitchI"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber
+                                    v-model="pidPitchI"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidPitchD"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber
+                                    v-model="pidPitchD"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="advancedTuning.dMaxPitch"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber
+                                    v-model="advancedTuning.dMaxPitch"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="advancedTuning.feedforwardPitch"
-                                    step="1"
-                                    min="0"
-                                    max="2000"
+                                <UInputNumber
+                                    v-model="advancedTuning.feedforwardPitch"
+                                    :step="1"
+                                    :min="0"
+                                    :max="2000"
                                     :disabled="rollPitchDisabled"
                                 />
                             </td>
@@ -190,52 +180,29 @@
                         <tr class="YAW">
                             <td class="pid_yaw" style="background-color: #477ac7">YAW</td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidYawP"
-                                    step="1"
-                                    min="0"
-                                    max="250"
+                                <UInputNumber v-model="pidYawP" :step="1" :min="0" :max="250" :disabled="yawDisabled" />
+                            </td>
+                            <td class="pid_data">
+                                <UInputNumber v-model="pidYawI" :step="1" :min="0" :max="250" :disabled="yawDisabled" />
+                            </td>
+                            <td class="pid_data">
+                                <UInputNumber v-model="pidYawD" :step="1" :min="0" :max="250" :disabled="yawDisabled" />
+                            </td>
+                            <td class="pid_data">
+                                <UInputNumber
+                                    v-model="advancedTuning.dMaxYaw"
+                                    :step="1"
+                                    :min="0"
+                                    :max="250"
                                     :disabled="yawDisabled"
                                 />
                             </td>
                             <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidYawI"
-                                    step="1"
-                                    min="0"
-                                    max="250"
-                                    :disabled="yawDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="pidYawD"
-                                    step="1"
-                                    min="0"
-                                    max="250"
-                                    :disabled="yawDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="advancedTuning.dMaxYaw"
-                                    step="1"
-                                    min="0"
-                                    max="250"
-                                    :disabled="yawDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <input
-                                    type="number"
-                                    v-model.number="advancedTuning.feedforwardYaw"
-                                    step="1"
-                                    min="0"
-                                    max="2000"
+                                <UInputNumber
+                                    v-model="advancedTuning.feedforwardYaw"
+                                    :step="1"
+                                    :min="0"
+                                    :max="2000"
                                     :disabled="yawDisabled"
                                 />
                             </td>
@@ -493,15 +460,15 @@
                             </tr>
                             <tr v-if="hasPidName('ALT')" class="ALT">
                                 <td></td>
-                                <td><input type="number" v-model.number="pidAltP" step="1" min="0" max="255" /></td>
-                                <td><input type="number" v-model.number="pidAltI" step="1" min="0" max="255" /></td>
-                                <td><input type="number" v-model.number="pidAltD" step="1" min="0" max="255" /></td>
+                                <td><UInputNumber v-model="pidAltP" :step="1" :min="0" :max="255" /></td>
+                                <td><UInputNumber v-model="pidAltI" :step="1" :min="0" :max="255" /></td>
+                                <td><UInputNumber v-model="pidAltD" :step="1" :min="0" :max="255" /></td>
                             </tr>
                             <tr v-if="hasPidName('VEL')" class="VEL">
                                 <td></td>
-                                <td><input type="number" v-model.number="pidVelP" step="1" min="0" max="255" /></td>
-                                <td><input type="number" v-model.number="pidVelI" step="1" min="0" max="255" /></td>
-                                <td><input type="number" v-model.number="pidVelD" step="1" min="0" max="255" /></td>
+                                <td><UInputNumber v-model="pidVelP" :step="1" :min="0" :max="255" /></td>
+                                <td><UInputNumber v-model="pidVelI" :step="1" :min="0" :max="255" /></td>
+                                <td><UInputNumber v-model="pidVelD" :step="1" :min="0" :max="255" /></td>
                             </tr>
                         </tbody>
                     </table>
@@ -518,7 +485,7 @@
                             </tr>
                             <tr class="MAG">
                                 <td></td>
-                                <td><input type="number" v-model.number="pidMagP" step="1" min="0" max="255" /></td>
+                                <td><UInputNumber v-model="pidMagP" :step="1" :min="0" :max="255" /></td>
                                 <td></td>
                                 <td></td>
                             </tr>
@@ -537,21 +504,21 @@
                             </tr>
                             <tr v-if="hasPidName('Pos')" class="Pos">
                                 <td></td>
-                                <td><input type="number" v-model.number="pidPosP" step="1" min="0" max="255" /></td>
+                                <td><UInputNumber v-model="pidPosP" :step="1" :min="0" :max="255" /></td>
                                 <td></td>
                                 <td></td>
                             </tr>
                             <tr v-if="hasPidName('PosR')" class="PosR">
                                 <td></td>
-                                <td><input type="number" v-model.number="pidPosRP" step="1" min="0" max="255" /></td>
-                                <td><input type="number" v-model.number="pidPosRI" step="1" min="0" max="255" /></td>
-                                <td><input type="number" v-model.number="pidPosRD" step="1" min="0" max="255" /></td>
+                                <td><UInputNumber v-model="pidPosRP" :step="1" :min="0" :max="255" /></td>
+                                <td><UInputNumber v-model="pidPosRI" :step="1" :min="0" :max="255" /></td>
+                                <td><UInputNumber v-model="pidPosRD" :step="1" :min="0" :max="255" /></td>
                             </tr>
                             <tr v-if="hasPidName('NavR')" class="NavR">
                                 <td></td>
-                                <td><input type="number" v-model.number="pidNavRP" step="1" min="0" max="255" /></td>
-                                <td><input type="number" v-model.number="pidNavRI" step="1" min="0" max="255" /></td>
-                                <td><input type="number" v-model.number="pidNavRD" step="1" min="0" max="255" /></td>
+                                <td><UInputNumber v-model="pidNavRP" :step="1" :min="0" :max="255" /></td>
+                                <td><UInputNumber v-model="pidNavRI" :step="1" :min="0" :max="255" /></td>
+                                <td><UInputNumber v-model="pidNavRD" :step="1" :min="0" :max="255" /></td>
                             </tr>
                         </tbody>
                     </table>
@@ -574,17 +541,17 @@
                         <tr>
                             <td class="third">{{ $t("pidTuningAngle") }}</td>
                             <td class="third">
-                                <input type="number" v-model.number="pidLevelAngle" step="1" min="0" max="255" />
+                                <UInputNumber v-model="pidLevelAngle" :step="1" :min="0" :max="255" />
                             </td>
                             <td class="third"></td>
                         </tr>
                         <tr>
                             <td class="third">{{ $t("pidTuningHorizon") }}</td>
                             <td class="third">
-                                <input type="number" v-model.number="pidLevelHorizon" step="1" min="0" max="255" />
+                                <UInputNumber v-model="pidLevelHorizon" :step="1" :min="0" :max="255" />
                             </td>
                             <td class="third">
-                                <input type="number" v-model.number="pidLevelTransition" step="1" min="0" max="255" />
+                                <UInputNumber v-model="pidLevelTransition" :step="1" :min="0" :max="255" />
                             </td>
                         </tr>
                     </tbody>
@@ -603,13 +570,7 @@
                         <tr>
                             <td class="third"></td>
                             <td class="third">
-                                <input
-                                    type="number"
-                                    v-model.number="advancedTuning.levelAngleLimit"
-                                    step="1"
-                                    min="10"
-                                    max="200"
-                                />
+                                <UInputNumber v-model="advancedTuning.levelAngleLimit" :step="1" :min="10" :max="200" />
                             </td>
                             <td class="third"></td>
                         </tr>
@@ -637,13 +598,12 @@
                             <td><span v-html="$t('pidTuningFeedforwardGroup')"></span></td>
                             <td colspan="2">
                                 <span class="feedforwardOption feedforwardJitterFactor suboption">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="feedforwardJitterFactor"
-                                        v-model.number="advancedTuning.feedforward_jitter_factor"
-                                        step="1"
-                                        min="0"
-                                        max="20"
+                                        v-model="advancedTuning.feedforward_jitter_factor"
+                                        :step="1"
+                                        :min="0"
+                                        :max="20"
                                     />
                                     <label>
                                         <span v-html="$t('pidTuningFeedforwardJitter')"></span>
@@ -652,13 +612,12 @@
                                 </span>
 
                                 <span class="feedforwardOption feedforwardSmoothFactor suboption">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="feedforwardSmoothFactor"
-                                        v-model.number="advancedTuning.feedforward_smooth_factor"
-                                        step="1"
-                                        min="0"
-                                        max="95"
+                                        v-model="advancedTuning.feedforward_smooth_factor"
+                                        :step="1"
+                                        :min="0"
+                                        :max="95"
                                     />
                                     <label for="feedforwardSmoothFactor">
                                         <span v-html="$t('pidTuningFeedforwardSmoothFactor')"></span>
@@ -692,13 +651,12 @@
                                 </span>
 
                                 <span class="feedforwardOption feedforwardBoost suboption">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="feedforwardBoost"
-                                        v-model.number="advancedTuning.feedforward_boost"
-                                        step="1"
-                                        min="0"
-                                        max="50"
+                                        v-model="advancedTuning.feedforward_boost"
+                                        :step="1"
+                                        :min="0"
+                                        :max="50"
                                     />
                                     <label for="feedforwardBoost">
                                         <span v-html="$t('pidTuningFeedforwardBoost')"></span>
@@ -707,13 +665,12 @@
                                 </span>
 
                                 <span class="feedforwardOption feedforwardMaxRateLimit suboption">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="feedforwardMaxRateLimit"
-                                        v-model.number="advancedTuning.feedforward_max_rate_limit"
-                                        step="1"
-                                        min="0"
-                                        max="150"
+                                        v-model="advancedTuning.feedforward_max_rate_limit"
+                                        :step="1"
+                                        :min="0"
+                                        :max="150"
                                     />
                                     <label>
                                         <span v-html="$t('pidTuningFeedforwardMaxRateLimit')"></span>
@@ -725,13 +682,12 @@
                                 </span>
 
                                 <span class="feedforwardTransition suboption">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="feedforwardTransition-number"
-                                        v-model.number="feedforwardTransitionValue"
-                                        step="0.01"
-                                        min="0.00"
-                                        max="1.00"
+                                        v-model="feedforwardTransitionValue"
+                                        :step="0.01"
+                                        :min="0"
+                                        :max="1"
                                     />
                                     <label>
                                         <span v-html="$t('pidTuningFeedforwardTransition')"></span>
@@ -776,13 +732,12 @@
                                 </span>
 
                                 <span class="itermRelaxCutoff suboption" v-if="itermRelaxEnabled">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="itermRelaxCutoff"
-                                        v-model.number="advancedTuning.itermRelaxCutoff"
-                                        step="1"
-                                        min="1"
-                                        max="50"
+                                        v-model="advancedTuning.itermRelaxCutoff"
+                                        :step="1"
+                                        :min="1"
+                                        :max="50"
                                     />
                                     <label for="itermRelaxCutoff">
                                         <span v-html="$t('pidTuningItermRelaxCutoff')"></span>
@@ -817,13 +772,12 @@
                                 </span>
 
                                 <span class="suboption" v-if="antiGravityEnabled">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="itermAcceleratorGain"
-                                        v-model.number="antiGravityGainValue"
-                                        step="0.1"
-                                        min="0.1"
-                                        max="30"
+                                        v-model="antiGravityGainValue"
+                                        :step="0.1"
+                                        :min="0.1"
+                                        :max="30"
                                     />
                                     <label for="antiGravityGain">
                                         <span v-html="$t('pidTuningAntiGravityGain')"></span>
@@ -832,13 +786,12 @@
                                 </span>
 
                                 <span class="suboption antiGravityThres" v-if="antiGravityEnabled">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="itermThrottleThreshold"
-                                        v-model.number="advancedTuning.itermThrottleThreshold"
-                                        step="10"
-                                        min="20"
-                                        max="1000"
+                                        v-model="advancedTuning.itermThrottleThreshold"
+                                        :step="10"
+                                        :min="20"
+                                        :max="1000"
                                     />
                                     <label for="antiGravityThres">
                                         <span v-html="$t('pidTuningAntiGravityThres')"></span>
@@ -870,13 +823,12 @@
                             </td>
                             <td colspan="3">
                                 <span class="suboption">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="dMaxGain"
-                                        v-model.number="advancedTuning.dMaxGain"
-                                        step="1"
-                                        min="0"
-                                        max="100"
+                                        v-model="advancedTuning.dMaxGain"
+                                        :step="1"
+                                        :min="0"
+                                        :max="100"
                                     />
                                     <label for="dMaxGain">
                                         <span v-html="$t('pidTuningDMaxGain')"></span>
@@ -884,13 +836,12 @@
                                     <div class="helpicon cf_tip" :title="$t('pidTuningDMaxGainHelp')"></div>
                                 </span>
                                 <span class="suboption">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="dMaxAdvance"
-                                        v-model.number="advancedTuning.dMaxAdvance"
-                                        step="1"
-                                        min="0"
-                                        max="200"
+                                        v-model="advancedTuning.dMaxAdvance"
+                                        :step="1"
+                                        :min="0"
+                                        :max="200"
                                     />
                                     <label for="dMaxAdvance">
                                         <span v-html="$t('pidTuningDMaxAdvance')"></span>
@@ -917,13 +868,12 @@
                         <!-- Throttle Boost -->
                         <tr class="throttleBoost">
                             <td>
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="throttleBoost-number"
-                                    v-model.number="advancedTuning.throttleBoost"
-                                    step="1"
-                                    min="0"
-                                    max="100"
+                                    v-model="advancedTuning.throttleBoost"
+                                    :step="1"
+                                    :min="0"
+                                    :max="100"
                                 />
                             </td>
                             <td colspan="2">
@@ -939,13 +889,12 @@
                         <!-- Motor Output Limit -->
                         <tr class="motorOutputLimit">
                             <td>
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="motorLimit"
-                                    v-model.number="advancedTuning.motorOutputLimit"
-                                    step="1"
-                                    min="1"
-                                    max="100"
+                                    v-model="advancedTuning.motorOutputLimit"
+                                    :step="1"
+                                    :min="1"
+                                    :max="100"
                                 />
                             </td>
                             <td colspan="2">
@@ -961,12 +910,11 @@
                         <!-- Dynamic Idle Min RPM -->
                         <tr class="idleMinRpm">
                             <td>
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="idleMinRpm-number"
-                                    v-model.number="advancedTuning.idleMinRpm"
-                                    step="1"
-                                    min="0"
+                                    v-model="advancedTuning.idleMinRpm"
+                                    :step="1"
+                                    :min="0"
                                     :max="idleMinRpmMax"
                                     :disabled="!dshotTelemetryEnabled"
                                 />
@@ -997,13 +945,12 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningVbatSagCompensationHelp')"></div>
 
                                 <span class="vbatSagValue suboption" v-if="vbatSagEnabled">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="vbatSagValue"
-                                        v-model.number="advancedTuning.vbat_sag_compensation"
-                                        step="1"
-                                        min="1"
-                                        max="150"
+                                        v-model="advancedTuning.vbat_sag_compensation"
+                                        :step="1"
+                                        :min="1"
+                                        :max="150"
                                     />
                                     <label for="vbatSagValue">
                                         <span v-html="$t('pidTuningVbatSagValue')"></span>
@@ -1027,13 +974,12 @@
                                 <div class="helpicon cf_tip" :title="$t('pidTuningThrustLinearizationHelp')"></div>
 
                                 <span class="thrustLinearValue suboption" v-if="thrustLinearEnabled">
-                                    <input
-                                        type="number"
+                                    <UInputNumber
                                         name="thrustLinearValue"
-                                        v-model.number="advancedTuning.thrustLinearization"
-                                        step="1"
-                                        min="1"
-                                        max="150"
+                                        v-model="advancedTuning.thrustLinearization"
+                                        :step="1"
+                                        :min="1"
+                                        :max="150"
                                     />
                                     <label for="thrustLinearValue">
                                         <span v-html="$t('pidTuningThrustLinearValue')"></span>
@@ -1066,16 +1012,15 @@
                                 </select>
                             </td>
                             <td>
-                                <input type="number" id="tpaRate" v-model.number="tpaRate" step="1" min="0" max="100" />
+                                <UInputNumber id="tpaRate" v-model="tpaRate" :step="1" :min="0" :max="100" />
                             </td>
                             <td class="tpa-breakpoint">
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     id="tpaBreakpoint"
-                                    v-model.number="tpaBreakpoint"
-                                    step="10"
-                                    min="750"
-                                    max="2250"
+                                    v-model="tpaBreakpoint"
+                                    :step="10"
+                                    :min="750"
+                                    :max="2250"
                                 />
                             </td>
                         </tr>
@@ -1123,13 +1068,12 @@
                         <!-- Acro Trainer Angle Limit -->
                         <tr class="acroTrainerAngleLimit">
                             <td>
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="acroTrainerAngleLimit-number"
-                                    v-model.number="advancedTuning.acroTrainerAngleLimit"
-                                    step="1"
-                                    min="10"
-                                    max="80"
+                                    v-model="advancedTuning.acroTrainerAngleLimit"
+                                    :step="1"
+                                    :min="10"
+                                    :max="80"
                                 />
                             </td>
                             <td colspan="2">
@@ -1165,13 +1109,12 @@
                         <!-- Absolute Control -->
                         <tr class="absoluteControlGain">
                             <td>
-                                <input
-                                    type="number"
+                                <UInputNumber
                                     name="absoluteControlGain-number"
-                                    v-model.number="advancedTuning.absoluteControlGain"
-                                    step="1"
-                                    min="0"
-                                    max="20"
+                                    v-model="advancedTuning.absoluteControlGain"
+                                    :step="1"
+                                    :min="0"
+                                    :max="20"
                                 />
                             </td>
                             <td colspan="2">

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -100,6 +100,10 @@
                                     :step="rcRateLimits.step"
                                     :min="rcRateLimits.min"
                                     :max="rcRateLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: rcRatePrecision,
+                                        maximumFractionDigits: rcRatePrecision,
+                                    }"
                                 />
                             </td>
                             <td class="roll_rate">
@@ -109,6 +113,10 @@
                                     :step="rateLimits.step"
                                     :min="rateLimits.min"
                                     :max="rateLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: ratePrecision,
+                                        maximumFractionDigits: ratePrecision,
+                                    }"
                                 />
                             </td>
                             <td>
@@ -118,6 +126,10 @@
                                     :step="expoLimits.step"
                                     :min="expoLimits.min"
                                     :max="expoLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: expoPrecision,
+                                        maximumFractionDigits: expoPrecision,
+                                    }"
                                 />
                             </td>
                             <td v-if="isBetaflightRates" class="new_rates acroCenterSensitivityRoll">
@@ -138,6 +150,10 @@
                                     :step="rcRateLimits.step"
                                     :min="rcRateLimits.min"
                                     :max="rcRateLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: rcRatePrecision,
+                                        maximumFractionDigits: rcRatePrecision,
+                                    }"
                                 />
                             </td>
                             <td class="pitch_rate">
@@ -147,6 +163,10 @@
                                     :step="rateLimits.step"
                                     :min="rateLimits.min"
                                     :max="rateLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: ratePrecision,
+                                        maximumFractionDigits: ratePrecision,
+                                    }"
                                 />
                             </td>
                             <td>
@@ -156,6 +176,10 @@
                                     :step="expoLimits.step"
                                     :min="expoLimits.min"
                                     :max="expoLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: expoPrecision,
+                                        maximumFractionDigits: expoPrecision,
+                                    }"
                                 />
                             </td>
                             <td v-if="isBetaflightRates" class="new_rates acroCenterSensitivityPitch">
@@ -176,6 +200,10 @@
                                     :step="rcRateLimits.step"
                                     :min="rcRateLimits.min"
                                     :max="rcRateLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: rcRatePrecision,
+                                        maximumFractionDigits: rcRatePrecision,
+                                    }"
                                 />
                             </td>
                             <td>
@@ -185,6 +213,10 @@
                                     :step="rateLimits.step"
                                     :min="rateLimits.min"
                                     :max="rateLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: ratePrecision,
+                                        maximumFractionDigits: ratePrecision,
+                                    }"
                                 />
                             </td>
                             <td>
@@ -194,6 +226,10 @@
                                     :step="expoLimits.step"
                                     :min="expoLimits.min"
                                     :max="expoLimits.max"
+                                    :format-options="{
+                                        minimumFractionDigits: expoPrecision,
+                                        maximumFractionDigits: expoPrecision,
+                                    }"
                                 />
                             </td>
                             <td v-if="isBetaflightRates" class="new_rates acroCenterSensitivityYaw">
@@ -546,6 +582,32 @@ const fourthColumnLabel = computed(() => {
         return i18n.getMessage("pidTuningRcRateActual");
     } else {
         return i18n.getMessage("pidTuningMaxVel");
+    }
+});
+
+// Precision for expo inputs based on rates type
+const expoPrecision = computed(() => (ratesType.value === RatesType.RACEFLIGHT ? 0 : 2));
+
+// Precision for rate inputs based on rates type
+const ratePrecision = computed(() => {
+    switch (ratesType.value) {
+        case RatesType.BETAFLIGHT:
+        case RatesType.KISS:
+            return 2;
+        default:
+            return 0;
+    }
+});
+
+// Precision for RC rate inputs based on rates type
+const rcRatePrecision = computed(() => {
+    switch (ratesType.value) {
+        case RatesType.BETAFLIGHT:
+        case RatesType.KISS:
+        case RatesType.QUICKRATES:
+            return 2;
+        default:
+            return 0;
     }
 });
 

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -94,30 +94,27 @@
                         <tr class="ROLL">
                             <td class="pid_roll" v-text="$t('controlAxisRoll')"></td>
                             <td class="rc_rate">
-                                <input
-                                    type="number"
-                                    :value="rcRate.toFixed(rcRatePrecision)"
-                                    @change="rcRate = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="rcRate"
+                                    @update:model-value="rcRate = $event"
                                     :step="rcRateLimits.step"
                                     :min="rcRateLimits.min"
                                     :max="rcRateLimits.max"
                                 />
                             </td>
                             <td class="roll_rate">
-                                <input
-                                    type="number"
-                                    :value="rollRate.toFixed(ratePrecision)"
-                                    @change="rollRate = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="rollRate"
+                                    @update:model-value="rollRate = $event"
                                     :step="rateLimits.step"
                                     :min="rateLimits.min"
                                     :max="rateLimits.max"
                                 />
                             </td>
                             <td>
-                                <input
-                                    type="number"
-                                    :value="rcExpo.toFixed(expoPrecision)"
-                                    @change="rcExpo = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="rcExpo"
+                                    @update:model-value="rcExpo = $event"
                                     :step="expoLimits.step"
                                     :min="expoLimits.min"
                                     :max="expoLimits.max"
@@ -135,30 +132,27 @@
                         <tr class="PITCH">
                             <td class="pid_pitch" v-text="$t('controlAxisPitch')"></td>
                             <td>
-                                <input
-                                    type="number"
-                                    :value="rcRatePitch.toFixed(rcRatePrecision)"
-                                    @change="rcRatePitch = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="rcRatePitch"
+                                    @update:model-value="rcRatePitch = $event"
                                     :step="rcRateLimits.step"
                                     :min="rcRateLimits.min"
                                     :max="rcRateLimits.max"
                                 />
                             </td>
                             <td class="pitch_rate">
-                                <input
-                                    type="number"
-                                    :value="pitchRate.toFixed(ratePrecision)"
-                                    @change="pitchRate = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="pitchRate"
+                                    @update:model-value="pitchRate = $event"
                                     :step="rateLimits.step"
                                     :min="rateLimits.min"
                                     :max="rateLimits.max"
                                 />
                             </td>
                             <td>
-                                <input
-                                    type="number"
-                                    :value="rcPitchExpo.toFixed(expoPrecision)"
-                                    @change="rcPitchExpo = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="rcPitchExpo"
+                                    @update:model-value="rcPitchExpo = $event"
                                     :step="expoLimits.step"
                                     :min="expoLimits.min"
                                     :max="expoLimits.max"
@@ -176,30 +170,27 @@
                         <tr class="YAW">
                             <td class="pid_yaw" v-text="$t('controlAxisYaw')"></td>
                             <td>
-                                <input
-                                    type="number"
-                                    :value="rcRateYaw.toFixed(rcRatePrecision)"
-                                    @change="rcRateYaw = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="rcRateYaw"
+                                    @update:model-value="rcRateYaw = $event"
                                     :step="rcRateLimits.step"
                                     :min="rcRateLimits.min"
                                     :max="rcRateLimits.max"
                                 />
                             </td>
                             <td>
-                                <input
-                                    type="number"
-                                    :value="yawRate.toFixed(ratePrecision)"
-                                    @change="yawRate = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="yawRate"
+                                    @update:model-value="yawRate = $event"
                                     :step="rateLimits.step"
                                     :min="rateLimits.min"
                                     :max="rateLimits.max"
                                 />
                             </td>
                             <td>
-                                <input
-                                    type="number"
-                                    :value="rcYawExpo.toFixed(expoPrecision)"
-                                    @change="rcYawExpo = parseFloat($event.target.value)"
+                                <UInputNumber
+                                    :model-value="rcYawExpo"
+                                    @update:model-value="rcYawExpo = $event"
                                     :step="expoLimits.step"
                                     :min="expoLimits.min"
                                     :max="expoLimits.max"
@@ -296,13 +287,7 @@
                                 </select>
                             </td>
                             <td>
-                                <input
-                                    type="number"
-                                    v-model.number="throttleLimitPercent"
-                                    step="1"
-                                    min="25"
-                                    max="100"
-                                />
+                                <UInputNumber v-model="throttleLimitPercent" :step="1" :min="25" :max="100" />
                             </td>
                         </tr>
                     </tbody>
@@ -322,33 +307,30 @@
                     <tbody>
                         <tr>
                             <td>
-                                <input
-                                    type="number"
-                                    :value="(throttleMid ?? 0).toFixed(2)"
-                                    @input="throttleMid = $event.target.value"
-                                    step="0.01"
-                                    min="0"
-                                    max="1"
+                                <UInputNumber
+                                    :model-value="throttleMid ?? 0"
+                                    @update:model-value="throttleMid = $event"
+                                    :step="0.01"
+                                    :min="0"
+                                    :max="1"
                                 />
                             </td>
                             <td v-if="hasThrottleHover">
-                                <input
-                                    type="number"
-                                    :value="(throttleHover ?? 0.5).toFixed(2)"
-                                    @input="throttleHover = $event.target.value"
-                                    step="0.01"
-                                    min="0"
-                                    max="1"
+                                <UInputNumber
+                                    :model-value="throttleHover ?? 0.5"
+                                    @update:model-value="throttleHover = $event"
+                                    :step="0.01"
+                                    :min="0"
+                                    :max="1"
                                 />
                             </td>
                             <td>
-                                <input
-                                    type="number"
-                                    :value="(throttleExpo ?? 0).toFixed(2)"
-                                    @input="throttleExpo = $event.target.value"
-                                    step="0.01"
-                                    min="0"
-                                    max="1"
+                                <UInputNumber
+                                    :model-value="throttleExpo ?? 0"
+                                    @update:model-value="throttleExpo = $event"
+                                    :step="0.01"
+                                    :min="0"
+                                    :max="1"
                                 />
                             </td>
                         </tr>
@@ -564,32 +546,6 @@ const fourthColumnLabel = computed(() => {
         return i18n.getMessage("pidTuningRcRateActual");
     } else {
         return i18n.getMessage("pidTuningMaxVel");
-    }
-});
-
-// Precision for expo inputs based on rates type
-const expoPrecision = computed(() => (ratesType.value === RatesType.RACEFLIGHT ? 0 : 2));
-
-// Precision for rate inputs based on rates type
-const ratePrecision = computed(() => {
-    switch (ratesType.value) {
-        case RatesType.BETAFLIGHT:
-        case RatesType.KISS:
-            return 2;
-        default:
-            return 0;
-    }
-});
-
-// Precision for RC rate inputs based on rates type
-const rcRatePrecision = computed(() => {
-    switch (ratesType.value) {
-        case RatesType.BETAFLIGHT:
-        case RatesType.KISS:
-        case RatesType.QUICKRATES:
-            return 2;
-        default:
-            return 0;
     }
 });
 

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -170,12 +170,6 @@ select,
 input[type="checkbox"] {
     cursor: pointer;
 }
-input[type="number"] {
-    &::-webkit-inner-spin-button {
-        opacity: 1;
-        margin-left: 5px;
-    }
-}
 .noarrows {
     input::-webkit-outer-spin-button,
     input::-webkit-inner-spin-button {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -170,6 +170,10 @@ select,
 input[type="checkbox"] {
     cursor: pointer;
 }
+/* UInputNumber: fill table cells */
+td [role="group"] {
+    display: flex;
+}
 .noarrows {
     input::-webkit-outer-spin-button,
     input::-webkit-inner-spin-button {

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -358,69 +358,6 @@ async function startProcess() {
         }
     });
 
-    // listen to all input change events and adjust the value within limits if necessary
-    // Using event delegation on #content for dynamically added number inputs
-    const contentEl = document.getElementById("content");
-
-    contentEl?.addEventListener(
-        "focus",
-        function (e) {
-            if (e.target.matches('input[type="number"]')) {
-                const val = e.target.value;
-                if (!isNaN(val)) {
-                    e.target.dataset.previousValue = Number.parseFloat(val);
-                }
-            }
-        },
-        true,
-    );
-
-    contentEl?.addEventListener("change", function (e) {
-        if (!e.target.matches('input[type="number"]')) {
-            return;
-        }
-
-        const element = e.target;
-        const min = Number.parseFloat(element.min);
-        const max = Number.parseFloat(element.max);
-        const step = Number.parseFloat(element.step);
-
-        let val = Number.parseFloat(element.value);
-
-        // only adjust minimal end if bound is set
-        if (element.min && val < min) {
-            element.value = min;
-            val = min;
-        }
-
-        // only adjust maximal end if bound is set
-        if (element.max && val > max) {
-            element.value = max;
-            val = max;
-        }
-
-        // if entered value is illegal use previous value instead
-        if (isNaN(val)) {
-            element.value = element.dataset.previousValue;
-            val = Number.parseFloat(element.dataset.previousValue);
-        }
-
-        // if step is not set or step is int and value is float use previous value instead
-        if ((isNaN(step) || step % 1 === 0) && val % 1 !== 0) {
-            element.value = element.dataset.previousValue;
-            val = Number.parseFloat(element.dataset.previousValue);
-        }
-
-        // if step is set and is float and value is int, convert to float, keep decimal places in float according to step *experimental*
-        if (!isNaN(step) && step % 1 !== 0) {
-            const decimal_places = String(step).split(".")[1].length;
-
-            if (val % 1 === 0 || String(val).split(".")[1].length !== decimal_places) {
-                element.value = val.toFixed(decimal_places);
-            }
-        }
-    });
-
     const showlogBtn = document.getElementById("showlog");
     let logState = false;
     showlogBtn?.addEventListener("click", function () {


### PR DESCRIPTION
# Number Input Constraining Analysis

## Problem

After the Vue migration, number inputs do not constrain values to min/max bounds.
Out-of-range values get saved to the flight controller.

## Root Cause

The old jQuery handler in `main.js` clamped `element.value` on `change` via event
delegation on `#content`. This was ported to native DOM APIs (`src/js/main.js:361-422`)
but doesn't work with Vue — `v-model.number` captures the unclamped value on the
earlier `input` event, and programmatic `element.value` changes don't trigger a new
event for Vue to see.

Dialog inputs (`<Teleport to="body">`) are doubly broken — they render outside
`#content`, so the native handler never fires at all.

## Fix

Replaced all `<input type="number">` with Nuxt UI's `<UInputNumber>` component
(from `@nuxt/ui` v4.4, built on reka-ui NumberField). It clamps values to min/max
on blur/Enter and emits already-clamped values via `update:modelValue`. Since it
renders as `type="text" inputmode="decimal"`, the native handler in `main.js`
is bypassed entirely.

Removed the now-dead native handler from `src/js/main.js` (focus/change event
delegation on `#content`) and the `input[type="number"]` spin-button CSS from
`src/css/main.less`.

## Per-Tab Summary

| Tab | Inputs | Notes |
|-----|--------|-------|
| PowerTab | 11 | 2 dialog inputs now properly constrained |
| ConfigurationTab | 18 | Added min/max to magDeclination (-180/180), acc_trim_roll/pitch (-300/300); 12 alignment inputs |
| MotorsTab | 10 | Added step=1 to mincommand, minthrottle, maxthrottle; removed fixed input width/text-align overrides |
| ReceiverTab | 12 | Added step=1 to all; fixed `.rcSmoothing table input` CSS → `:deep(input)` |
| FailsafeTab | 19 | Includes GPS rescue inputs; removed `.toFixed(1)` from 6 computed getters (UInputNumber expects numbers, not strings) |
| VtxTab | 7 | 2 used :value/@input converted; fixed CSS class selectors; `:deep(input)` for table rules; increased `.frequency_input` (120px) and `.one_digit_input` (80px) widths for UInputNumber buttons |
| ServosTab | 3 | Fixed `input[type="number"]` CSS → `:deep(input:not([type="checkbox"]))`; removed dead spin-button rule |
| AdjustmentsTab | 2 | Fixed `.adjustment-center input`/`.adjustment-scale input` CSS → `:deep(input)` |
| OsdTab | 2 | Fixed `.timer-row input` and `.alarms input` CSS → `:deep(input)`; removed fixed width/text-align from alarms |
| PidSubTab | 52 | Removed fixed input width/text-align overrides; widened compensation table first column (75px → 110px) |
| FilterSubTab | 22 | Fixed `.suboption input[type="number"]` CSS → `.suboption :deep(input)` |
| RatesSubTab | 13 | 9 used :value/@change converted; precision computeds preserved via `:format-options` |
| WaypointEditor | 5 | Dialog component — now properly constrained |
| **Total** | **176** | |

## CSS Fix Summary

UInputNumber renders as a wrapper `<div role="group">` (`inline-flex`) with decrement button,
inner `<input type="text">`, and increment button.

**Scoped styles**: Selectors like `.parent input` won't reach the inner input. Fixed with `:deep(input)`.
Use `:deep(input:not([type="checkbox"]))` where the same parent contains both UInputNumber and checkboxes (e.g. ServosTab).

**Width handling**: The old fixed widths (50-75px) targeted single `<input>` elements. UInputNumber
with buttons needs more room. Removed fixed `width`/`text-align` overrides on inner inputs to let
Nuxt UI's flex layout handle sizing. Widened the compensation table first column (75px → 110px).

**Table cells**: Added `td [role="group"] { display: flex; }` in `main.less` so UInputNumber
fills table cells instead of sizing to content.

Removed dead `input[type="number"]::-webkit-inner-spin-button` rules (no spin buttons on `type="text"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced native number inputs with a unified numeric component across many settings, standardizing bindings and constraint props and removing per-input type-casting modifiers and legacy input-clamping logic.

* **Style**
  * Updated scoped styling so sizing, disabled and layout rules target the new numeric component internals and adjusted column widths for several tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->