### PR TITLE
Fix - disable disabled sensors

### DIFF
--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -420,36 +420,15 @@ onMounted(async () => {
         sensorsStore.debugColumns = 4;
     }
 
-    // Force-disable checkboxes for unavailable sensors
-    if (!hasGyro.value) {
-        checkboxes.value[0] = false;
-    }
-    if (!hasAccel.value) {
-        checkboxes.value[1] = false;
-    }
-    if (!hasMag.value) {
-        checkboxes.value[2] = false;
-    }
-    if (!hasAltitude.value) {
-        checkboxes.value[3] = false;
-    }
-    if (!hasSonar.value) {
-        checkboxes.value[4] = false;
+    // Disable checkboxes for unavailable sensors; if none remain, enable all available as defaults
+    const sensorAvailability = [hasGyro.value, hasAccel.value, hasMag.value, hasAltitude.value, hasSonar.value];
+    for (let i = 0; i < sensorAvailability.length; i++) {
+        checkboxes.value[i] = checkboxes.value[i] && sensorAvailability[i];
     }
 
-    // If no saved checkbox states, set defaults based on available sensors
     if (!checkboxes.value.some(Boolean)) {
-        if (hasGyro.value) {
-            checkboxes.value[0] = true;
-        }
-        if (hasAccel.value) {
-            checkboxes.value[1] = true;
-        }
-        if (hasMag.value) {
-            checkboxes.value[2] = true;
-        }
-        if (hasAltitude.value) {
-            checkboxes.value[3] = true;
+        for (let i = 0; i < sensorAvailability.length; i++) {
+            checkboxes.value[i] = sensorAvailability[i];
         }
     }
 

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -439,7 +439,7 @@ onMounted(async () => {
         hasDebug.value,
     ];
     for (let i = 0; i < sensorAvailability.length; i++) {
-        checkboxes.value[i] = checkboxes.value[i] && sensorAvailability[i];
+        checkboxes.value[i] = Boolean(checkboxes.value[i]) && sensorAvailability[i];
     }
 
     if (!checkboxes.value.some(Boolean)) {

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -41,7 +41,12 @@
                             @change="onCheckboxChange"
                         />
                         <span v-html="$t('sensorsSonarSelect')"></span>
-                        <input type="checkbox" v-model="checkboxes[5]" @change="onCheckboxChange" />
+                        <input
+                            type="checkbox"
+                            v-model="checkboxes[5]"
+                            :disabled="!hasDebug"
+                            @change="onCheckboxChange"
+                        />
                         <span v-html="$t('sensorsDebugSelect')"></span>
                     </div>
                 </div>
@@ -246,6 +251,10 @@ const hasSonar = computed(() => {
     );
 });
 
+const hasDebug = computed(() => {
+    return fcStore.pidAdvancedConfig.debugMode !== 0;
+});
+
 // Debug titles
 const debugTitles = ref(new Array(8).fill("").map((_, i) => `Debug ${i}`));
 
@@ -421,7 +430,14 @@ onMounted(async () => {
     }
 
     // Disable checkboxes for unavailable sensors; if none remain, enable all available as defaults
-    const sensorAvailability = [hasGyro.value, hasAccel.value, hasMag.value, hasAltitude.value, hasSonar.value];
+    const sensorAvailability = [
+        hasGyro.value,
+        hasAccel.value,
+        hasMag.value,
+        hasAltitude.value,
+        hasSonar.value,
+        hasDebug.value,
+    ];
     for (let i = 0; i < sensorAvailability.length; i++) {
         checkboxes.value[i] = checkboxes.value[i] && sensorAvailability[i];
     }

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -420,6 +420,23 @@ onMounted(async () => {
         sensorsStore.debugColumns = 4;
     }
 
+    // Force-disable checkboxes for unavailable sensors
+    if (!hasGyro.value) {
+        checkboxes.value[0] = false;
+    }
+    if (!hasAccel.value) {
+        checkboxes.value[1] = false;
+    }
+    if (!hasMag.value) {
+        checkboxes.value[2] = false;
+    }
+    if (!hasAltitude.value) {
+        checkboxes.value[3] = false;
+    }
+    if (!hasSonar.value) {
+        checkboxes.value[4] = false;
+    }
+
     // If no saved checkbox states, set defaults based on available sensors
     if (!checkboxes.value.some(Boolean)) {
         if (hasGyro.value) {


### PR DESCRIPTION
Previously, if you had a sensor enabled and it was saved to localStorage, then disabled the sensor on the FC, the checkbox would be disabled (greyed out) but still checked — meaning the graph would still render and potentially poll for data. Now the checkbox is forced to false when the sensor isn't available, which hides the graph and prevents unnecessary MSP polling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unavailable sensors are no longer shown as enabled on startup; stored sensor choices are clipped to device capability.
  * If no sensors are selected, the app now defaults to enabling available primary sensors on first load.
  * The Debug option is disabled when debug capability/mode is not available, preventing it from being toggled.
  * Initialization now uses a unified fallback so saved states won't re-enable unavailable sensors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->