### PR TITLE
Refactor: Convert Options tab to Nuxt UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@capacitor/android": "8.0.2",
     "@capacitor/core": "8.0.2",
     "@fortawesome/fontawesome-free": "^6.5.2",
+    "@iconify-json/lucide": "^1.2.101",
     "@nuxt/ui": "^4.4.0",
     "@simplewebauthn/browser": "^13.2.2",
     "@vitejs/plugin-vue": "^6.0.1",

--- a/src/components/elements/HelpIcon.vue
+++ b/src/components/elements/HelpIcon.vue
@@ -1,0 +1,16 @@
+<template>
+    <UTooltip :text="text" :delayDuration="0" arrow>
+        <div class="p-0.5 rounded-full hover:bg-neutral-100/30 cursor-pointer duration-100 w-fit">
+            <UIcon name="i-lucide-circle-question-mark" class="size-4" />
+        </div>
+    </UTooltip>
+</template>
+
+<script setup>
+defineProps({
+    text: {
+        type: String,
+        required: true,
+    },
+});
+</script>

--- a/src/components/elements/SettingRow.vue
+++ b/src/components/elements/SettingRow.vue
@@ -1,0 +1,32 @@
+<template>
+    <div class="flex items-center gap-2">
+        <slot name="default"></slot>
+        <div class="flex" :class="{ 'flex-1': fullWidth }">
+            <slot name="label"></slot>
+            <span v-if="label">{{ label }}</span>
+        </div>
+        <HelpIcon v-if="help" :text="help" class="text-dimmed" />
+    </div>
+</template>
+
+<script setup>
+import HelpIcon from "./HelpIcon.vue";
+
+const props = defineProps({
+    label: {
+        type: String,
+        default: "",
+        required: false,
+    },
+    help: {
+        type: String,
+        default: "",
+        required: false,
+    },
+    fullWidth: {
+        type: Boolean,
+        default: false,
+        required: false,
+    },
+});
+</script>

--- a/src/components/elements/SettingRow.vue
+++ b/src/components/elements/SettingRow.vue
@@ -3,7 +3,7 @@
         <slot name="default"></slot>
         <div class="flex" :class="{ 'flex-1': fullWidth }">
             <slot name="label"></slot>
-            <span v-if="label">{{ label }}</span>
+            <span v-if="label" v-html="label"></span>
         </div>
         <HelpIcon v-if="help" :text="help" class="text-dimmed" />
     </div>
@@ -12,7 +12,7 @@
 <script setup>
 import HelpIcon from "./HelpIcon.vue";
 
-const props = defineProps({
+defineProps({
     label: {
         type: String,
         default: "",

--- a/src/components/elements/UiBox.vue
+++ b/src/components/elements/UiBox.vue
@@ -1,0 +1,83 @@
+<template>
+    <div
+        class="relative border-2 rounded-lg mt-3"
+        :class="highlight ? [typeClass.border, typeClass.borderColor, typeClass.softBg] : 'border-neutral-500/30'"
+    >
+        <div
+            v-if="title"
+            :class="`flex gap-2 items-center absolute top-0 left-4 translate-y-[-50%] p-1 px-3 rounded-full text-black text-[13px] font-semibold ${typeClass.bg}`"
+        >
+            {{ title }}
+            <HelpIcon v-if="help" :text="help" />
+        </div>
+        <div :class="`flex flex-col p-3 gap-2 ${title ? 'pt-6' : ''}`">
+            <slot></slot>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import HelpIcon from "./HelpIcon.vue";
+
+const props = defineProps({
+    title: {
+        type: String,
+        required: true,
+    },
+    help: {
+        type: String,
+        default: null,
+        required: false,
+    },
+    type: {
+        type: String,
+        default: "default",
+        required: false,
+        validator: (value) => {
+            return ["default", "info", "warning", "error"].includes(value);
+        },
+    },
+    highlight: {
+        type: Boolean,
+        default: false,
+        required: false,
+    },
+});
+
+const typeClass = computed(() => {
+    return (
+        {
+            default: {
+                bg: "bg-primary",
+                border: "border-primary",
+                softBg: "bg-primary/15",
+                borderColor: "border-primary",
+            },
+            info: {
+                bg: "bg-success",
+                border: "border-success",
+                softBg: "bg-success/15",
+                borderColor: "border-success",
+            },
+            warning: {
+                bg: "bg-warning",
+                border: "border-warning",
+                softBg: "bg-warning/15",
+                borderColor: "border-warning",
+            },
+            error: {
+                bg: "bg-error",
+                border: "border-error",
+                softBg: "bg-error/15",
+                borderColor: "border-error",
+            },
+        }[props.type] || {
+            bg: "bg-primary",
+            border: "border-primary",
+            softBg: "bg-primary/15",
+            borderColor: "border-primary",
+        }
+    );
+});
+</script>

--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -1,209 +1,119 @@
 <template>
     <BaseTab tab-name="options">
         <div class="content_wrapper grid-box col1">
-            <!-- Main Options Box -->
-            <div class="gui_box">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" v-html="$t('tabOptions')"></div>
-                </div>
-                <div class="spacer">
-                    <!-- Expert Mode -->
-                    <div class="expertMode margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.expertMode" />
-                        </div>
-                        <span class="freelabel" v-html="$t('expertMode')"></span>
-                    </div>
+            <UiBox :title="$t('tabOptions')">
+                <SettingRow :label="$t('expertMode')">
+                    <USwitch v-model="settings.expertMode" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('rememberLastTab')">
+                    <USwitch v-model="settings.rememberLastTab" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('meteredConnection')">
+                    <USwitch v-model="settings.meteredConnection" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('analyticsOptOut')">
+                    <USwitch v-model="settings.analyticsOptOut" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('cliAutoComplete')">
+                    <USwitch v-model="settings.cliAutoComplete" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('showManualMode')">
+                    <USwitch v-model="settings.showManualMode" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('showVirtualMode')">
+                    <USwitch v-model="settings.showVirtualMode" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('showDevToolsOnStartup')">
+                    <USwitch v-model="settings.showDevToolsOnStartup" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('showNotifications')">
+                    <USwitch v-model="settings.showNotifications" @change="handleNotificationsChange" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('firmwareBackupOnFlash')">
+                    <USelect
+                        :items="[
+                            { label: $t('firmwareBackupDisabled'), value: 0 },
+                            { label: $t('firmwareBackupEnabled'), value: 1 },
+                            { label: $t('firmwareBackupAsk'), value: 2 },
+                        ]"
+                        size="sm"
+                        v-model="settings.backupOnFlash"
+                        class="min-w-40"
+                    />
+                </SettingRow>
+            </UiBox>
 
-                    <!-- Remember Last Tab -->
-                    <div class="rememberLastTab margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.rememberLastTab" />
-                        </div>
-                        <span class="freelabel" v-html="$t('rememberLastTab')"></span>
-                    </div>
+            <UiBox :title="$t('languageAndAppearanceSettings')">
+                <SettingRow :label="$t('useLegacyRenderingModel')">
+                    <USwitch v-model="settings.useLegacyRenderingModel" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('darkTheme')">
+                    <USelect
+                        :items="[
+                            { label: $t('on'), value: 0 },
+                            { label: $t('off'), value: 1 },
+                            { label: $t('auto'), value: 2 },
+                        ]"
+                        size="sm"
+                        v-model="settings.darkTheme"
+                        class="min-w-40"
+                    />
+                </SettingRow>
+                <SettingRow :label="$t('colorTheme')">
+                    <USelect
+                        :items="[
+                            { label: $t('colorThemeYellow'), value: 'yellow' },
+                            { label: $t('colorThemeAmber'), value: 'amber' },
+                            { label: $t('colorThemeContrast'), value: 'contrast' },
+                        ]"
+                        size="sm"
+                        v-model="settings.colorTheme"
+                        class="min-w-40"
+                    />
+                </SettingRow>
+                <!-- Includes "languages" icon to be noticeable even if the language is set incorrectly for the user -->
+                <!-- Other input elements are unlikely to need an icon -->
+                <SettingRow :label="$t('userLanguageSelect')">
+                    <USelectMenu
+                        v-model="settings.userLanguage"
+                        value-key="value"
+                        :items="[
+                            { label: $t('language_default'), value: 'DEFAULT' },
+                            { type: 'separator' },
+                            ...availableLanguages.map((lang) => ({
+                                label: $t(`language_${lang}`),
+                                value: lang,
+                            })),
+                        ]"
+                        size="sm"
+                        leading-icon="i-lucide-languages"
+                        :search-input="{
+                            placeholder: $t('search'),
+                            icon: 'i-lucide-search',
+                        }"
+                        class="min-w-48"
+                        :ui="{ content: 'max-h-72' }"
+                    />
+                </SettingRow>
+            </UiBox>
 
-                    <!-- Metered Connection -->
-                    <div class="meteredConnection margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.meteredConnection" />
-                        </div>
-                        <span class="freelabel" v-html="$t('meteredConnection')"></span>
-                    </div>
+            <UiBox :title="$t('developmentSettings')">
+                <SettingRow :label="$t('showAllSerialDevices')">
+                    <USwitch v-model="settings.showAllSerialDevices" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('cliOnlyMode')">
+                    <USwitch v-model="settings.cliOnlyMode" size="sm" />
+                </SettingRow>
+                <SettingRow :label="$t('automaticDevOptions')">
+                    <USwitch v-model="settings.automaticDevOptions" size="sm" />
+                </SettingRow>
+            </UiBox>
 
-                    <!-- Analytics Opt Out -->
-                    <div class="analyticsOptOut margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.analyticsOptOut" />
-                        </div>
-                        <span class="freelabel" v-html="$t('analyticsOptOut')"></span>
-                    </div>
-
-                    <!-- CLI Auto Complete -->
-                    <div class="cliAutoComplete margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.cliAutoComplete" />
-                        </div>
-                        <span class="freelabel" v-html="$t('cliAutoComplete')"></span>
-                    </div>
-
-                    <!-- Show Manual Mode -->
-                    <div class="showManualMode margin-bottom">
-                        <div>
-                            <input
-                                type="checkbox"
-                                class="toggle"
-                                v-model="settings.showManualMode"
-                                data-setting="showManualMode"
-                            />
-                        </div>
-                        <span class="freelabel" v-html="$t('showManualMode')"></span>
-                    </div>
-
-                    <!-- Show Virtual Mode -->
-                    <div class="showVirtualMode margin-bottom">
-                        <div>
-                            <input
-                                type="checkbox"
-                                class="toggle"
-                                v-model="settings.showVirtualMode"
-                                data-setting="showVirtualMode"
-                            />
-                        </div>
-                        <span class="freelabel" v-html="$t('showVirtualMode')"></span>
-                    </div>
-
-                    <!-- Show Dev Tools On Startup -->
-                    <div class="showDevToolsOnStartup margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.showDevToolsOnStartup" />
-                        </div>
-                        <span class="freelabel" v-html="$t('showDevToolsOnStartup')"></span>
-                    </div>
-
-                    <!-- Show Notifications -->
-                    <div class="showNotifications margin-bottom">
-                        <div>
-                            <input
-                                type="checkbox"
-                                class="toggle"
-                                v-model="settings.showNotifications"
-                                @change="handleNotificationsChange"
-                            />
-                        </div>
-                        <span class="freelabel" v-html="$t('showNotifications')"></span>
-                    </div>
-
-                    <!-- Backup On Flash -->
-                    <div class="backupOnFlash margin-bottom">
-                        <select id="backupOnFlashSelect" v-model.number="settings.backupOnFlash">
-                            <option value="0">{{ $t("firmwareBackupDisabled") }}</option>
-                            <option value="1">{{ $t("firmwareBackupEnabled") }}</option>
-                            <option value="2">{{ $t("firmwareBackupAsk") }}</option>
-                        </select>
-                        <span class="freelabel" v-html="$t('firmwareBackupOnFlash')"></span>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Language and Appearance Box -->
-            <div class="gui_box">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" v-html="$t('languageAndAppearanceSettings')"></div>
-                </div>
-                <div class="spacer">
-                    <!-- Use Legacy Rendering Model -->
-                    <div class="useLegacyRenderingModel margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.useLegacyRenderingModel" />
-                        </div>
-                        <span class="freelabel" v-html="$t('useLegacyRenderingModel')"></span>
-                    </div>
-
-                    <!-- Dark Theme -->
-                    <div class="darkTheme margin-bottom">
-                        <select id="darkThemeSelect" v-model.number="settings.darkTheme">
-                            <option value="0">{{ $t("on") }}</option>
-                            <option value="1">{{ $t("off") }}</option>
-                            <option value="2">{{ $t("auto") }}</option>
-                        </select>
-                        <span class="freelabel" v-html="$t('darkTheme')"></span>
-                    </div>
-
-                    <!-- Color Theme -->
-                    <div class="colorTheme margin-bottom">
-                        <select id="colorThemeSelect" v-model="settings.colorTheme">
-                            <option value="yellow">{{ $t("colorThemeYellow") }}</option>
-                            <option value="amber">{{ $t("colorThemeAmber") }}</option>
-                            <option value="contrast">{{ $t("colorThemeContrast") }}</option>
-                        </select>
-                        <span class="freelabel" v-html="$t('colorTheme')"></span>
-                    </div>
-
-                    <!-- User Language -->
-                    <div class="userLanguage">
-                        <span class="dropdown">
-                            <select class="dropdown-select" id="userLanguage" v-model="settings.userLanguage">
-                                <option value="DEFAULT">{{ $t("language_default") }}</option>
-                                <option disabled>------</option>
-                                <option v-for="lang in availableLanguages" :key="lang" :value="lang">
-                                    {{ $t(`language_${lang}`) }}
-                                </option>
-                            </select>
-                        </span>
-                        <span v-html="$t('userLanguageSelect')" class="freelabel"></span>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Development Settings Box -->
-            <div class="gui_box">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" v-html="$t('developmentSettings')"></div>
-                </div>
-                <div class="spacer">
-                    <div class="showAllSerialDevices margin-bottom">
-                        <div>
-                            <input
-                                type="checkbox"
-                                class="toggle"
-                                v-model="settings.showAllSerialDevices"
-                                data-setting="showAllSerialDevices"
-                            />
-                        </div>
-                        <span class="freelabel" v-html="$t('showAllSerialDevices')"></span>
-                    </div>
-
-                    <div class="cliOnlyMode margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.cliOnlyMode" />
-                        </div>
-                        <span class="freelabel" v-html="$t('cliOnlyMode')"></span>
-                    </div>
-
-                    <div class="automaticDevOptions margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.automaticDevOptions" />
-                        </div>
-                        <span class="freelabel" v-html="$t('automaticDevOptions')"></span>
-                    </div>
-                </div>
-            </div>
-
-            <!-- Warning Settings Box -->
-            <div class="gui_box">
-                <div class="gui_box_titlebar">
-                    <div class="spacer_box_title" v-html="$t('warningSettings')"></div>
-                </div>
-                <div class="spacer">
-                    <div class="presetsWarningBackup margin-bottom">
-                        <div>
-                            <input type="checkbox" class="toggle" v-model="settings.showPresetsWarningBackup" />
-                        </div>
-                        <span class="freelabel" v-html="$t('presetsWarningBackup')"></span>
-                    </div>
-                </div>
-            </div>
+            <UiBox :title="$t('warningSettings')">
+                <SettingRow :label="$t('presetsWarningBackup')">
+                    <USwitch v-model="settings.showPresetsWarningBackup" size="sm" />
+                </SettingRow>
+            </UiBox>
         </div>
     </BaseTab>
 </template>
@@ -222,11 +132,15 @@ import { checkSetupAnalytics } from "../../js/Analytics";
 import NotificationManager from "../../js/utils/notifications";
 import { ispConnected } from "../../js/utils/connection";
 import { DEFAULT_DEVELOPMENT_OPTIONS, resetDevelopmentOptions } from "../../js/utils/developmentOptions";
+import UiBox from "../elements/UiBox.vue";
+import SettingRow from "../elements/SettingRow.vue";
 
 export default defineComponent({
     name: "OptionsTab",
     components: {
         BaseTab,
+        UiBox,
+        SettingRow,
     },
     setup() {
         const dialog = useDialog();
@@ -478,26 +392,3 @@ export default defineComponent({
     },
 });
 </script>
-
-<style lang="less">
-.tab-options {
-    .freelabel {
-        margin-left: 10px;
-        position: relative;
-    }
-    .switchery {
-        float: left;
-    }
-    .margin-bottom {
-        margin-bottom: 10px;
-        grid-template-columns: fit-content(300px) 1fr;
-    }
-    select {
-        background: var(--surface-200);
-        color: var(--text);
-        border: 1px solid var(--surface-500);
-        border-radius: 3px;
-        width: fit-content;
-    }
-}
-</style>

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -6,6 +6,7 @@
 
 @import "tailwindcss";
 @import "@nuxt/ui";
+@source "../../vite.config.js";
 
 @theme static {
     /* Extending Tailwind colors with Betaflight primary colors */
@@ -102,6 +103,7 @@ html {
     /* The default ui bg is neutral-900, it will stand out for the duration of the conversion to Nuxt UI */
     /* When the conversion is complete, the color will be matched to the existing theme colors */
     /* --ui-bg: var(--ui-color-neutral-800); */
+    --ui-primary: var(--primary-500);
     --ui-error: var(--ui-color-error-500);
     --ui-radius: 0.35rem;
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -155,10 +155,17 @@ export default defineConfig({
                         },
                     },
                 },
+                tooltip: {
+                    slots: {
+                        content: "ring-2 ring-primary",
+                        arrow: "fill-primary",
+                    },
+                },
                 colors: {
                     primary: "primary",
                     neutral: "neutral",
                     success: "lime",
+                    warning: "orange",
                 },
             },
         }),

--- a/yarn.lock
+++ b/yarn.lock
@@ -1315,6 +1315,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/retry/-/retry-0.4.3.tgz#c2b9d2e374ee62c586d3adbea87199b1d7a7a6ba"
   integrity sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==
 
+"@iconify-json/lucide@^1.2.101":
+  version "1.2.101"
+  resolved "https://registry.yarnpkg.com/@iconify-json/lucide/-/lucide-1.2.101.tgz#088a7aa6570275261afa0eba07585ca99d2e04de"
+  integrity sha512-JUN7uuSLRG3GK/9c5b8cK9e7sL6EAWDaASIwBOd0zUeKS0ACcokJubo2RMQHyVUVpd8mYkrR3Zd2mkH9ghhw1Q==
+  dependencies:
+    "@iconify/types" "*"
+
 "@iconify/collections@^1.0.641":
   version "1.0.671"
   resolved "https://registry.yarnpkg.com/@iconify/collections/-/collections-1.0.671.tgz#62b64c2c4ae60c89a7755c0436e40a8becd7b6c3"


### PR DESCRIPTION
A continuation of #4967, this PR converts the UI elements of the Options tab with custom components and Nuxt UI elements.

Outside of the existing `Select` and `Switch` elements introduced in #4967, there's also `SelectMenu` for the language selection, which offers a dedicated search field to filter the specific languages. I also added reusable components that follow common UI patterns:
- `UiBox` - A customizable alternative to the existing verbose html implementation. It offers different color variations, an option to highlight the entire box, and a dedicated help icon element in the title
- `HelpIcon` - A reusable consistent implementation of the existing implementation. It uses Nuxt UI's icon and tooltip functionality, and its color can be arbitrarily changed to work across all kinds of surfaces unlike the static SVG file that was used as a background image
- `SettingRow` - A layout container that matches the "input, text, help icon" row layout. Its default slot can take any input element, and it has attributes for a title and help text that conditionally render only if provided

Lastly I also changed a few theme options, and installed the lucide icon pack to be served locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added help icon tooltips providing contextual guidance on settings options with improved usability.
  * Redesigned settings interface with enhanced visual organization, container styling, improved layout structure, and better information hierarchy.

* **UI/Style**
  * Enhanced tooltip styling and improved visual appearance across the interface.
  * Added warning color option to the UI component palette for better visual feedback.
  * Improved overall theme customization with additional CSS variables and styling support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->