### PR TITLE
Refactor: Convert Blackbox tab to Nuxt UI

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3828,9 +3828,6 @@
     "dataflashNotPresentNote": {
         "message": "Your flight controller does not have a compatible dataflash chip available."
     },
-    "dataflashFirmwareUpgradeRequired": {
-        "message": "Dataflash requires firmware &gt;= 1.8.0."
-    },
     "dataflashButtonSaveFile": {
         "message": "Save flash to file..."
     },

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -212,10 +212,6 @@
                             </div>
 
                             <p class="require-dataflash-not-present">{{ $t("dataflashNotPresentNote") }}</p>
-                            <p
-                                class="require-dataflash-unsupported"
-                                v-html="$t('dataflashFirmwareUpgradeRequired')"
-                            ></p>
                         </UiBox>
 
                         <UiBox :title="$t('onboardLoggingOnboardSDCard')" class="require-sdcard-supported">

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -78,7 +78,7 @@
                             <p>{{ $t("serialLoggingSupportedNote") }}</p>
                         </UiBox>
 
-                        <UiBox :title="$t('onboardLoggingFlashLogger')" class="require-dataflash-supported">
+                        <UiBox :title="$t('onboardLoggingFlashLogger')">
                             <div class="require-dataflash-supported">
                                 <p>{{ $t("dataflashNote") }}</p>
 

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -207,10 +207,7 @@
                                         @click.prevent="flashSaveBegin(false)"
                                     >
                                         <span>{{ $t("dataflashButtonSaveFile") }}</span>
-                                        <span
-                                            class="helpicon cf_tip"
-                                            :title="$t('dataflashSaveFileDepreciationHint')"
-                                        ></span>
+                                        <HelpIcon :text="$t('dataflashSaveFileDepreciationHint')" />
                                     </a>
                                     <p v-html="$t('dataflashSavetoFileNote')"></p>
                                 </div>
@@ -292,6 +289,7 @@ import BaseTab from "./BaseTab.vue";
 import WikiButton from "../elements/WikiButton.vue";
 import UiBox from "../elements/UiBox.vue";
 import SettingRow from "../elements/SettingRow.vue";
+import HelpIcon from "../elements/HelpIcon.vue";
 import GUI from "../../js/gui";
 import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
@@ -357,6 +355,7 @@ export default defineComponent({
         WikiButton,
         UiBox,
         SettingRow,
+        HelpIcon,
     },
     setup() {
         const fcStore = useFlightControllerStore();
@@ -1117,12 +1116,6 @@ export default defineComponent({
         }
         h3 {
             margin-bottom: 0.5em;
-        }
-    }
-    .save-flash {
-        .helpicon {
-            margin: 4px 0 0 7px;
-            display: inline-block;
         }
     }
     .require-msc-supported {

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -64,14 +64,12 @@
                         >
                             <div class="blackboxDebugFieldsTable">
                                 <div v-for="(field, index) in debugFields" :key="index" class="debug-field-row">
-                                    <input
-                                        :id="`blackboxDebugField${index}`"
-                                        :checked="debugFieldsEnabled[index]"
-                                        type="checkbox"
-                                        class="toggle"
-                                        @change="updateDebugField(index, $event)"
+                                    <USwitch
+                                        :model-value="debugFieldsEnabled[index]"
+                                        size="sm"
+                                        @update:model-value="updateDebugField(index, $event)"
                                     />
-                                    <label :for="`blackboxDebugField${index}`">{{ field }}</label>
+                                    <span>{{ field }}</span>
                                 </div>
                             </div>
                         </UiBox>
@@ -534,9 +532,9 @@ export default defineComponent({
             );
         });
 
-        function updateDebugField(index, event) {
+        function updateDebugField(index, value) {
             // Use splice to ensure Vue 3 reactivity
-            debugFieldsEnabled.value.splice(index, 1, event.target.checked);
+            debugFieldsEnabled.value.splice(index, 1, value);
         }
 
         async function saveSettings() {
@@ -858,26 +856,6 @@ export default defineComponent({
                     debugFieldsEnabled.value = debugStore.enableFields.map((_, index) => {
                         return (disabledMask & (1 << index)) === 0;
                     });
-
-                    // Destroy existing Switchery instances and recreate with loaded state
-                    nextTick(() => {
-                        debugFieldsEnabled.value.forEach((_, index) => {
-                            const checkbox = document.getElementById(`blackboxDebugField${index}`);
-                            if (checkbox) {
-                                // Remove existing Switchery element
-                                const switcheryElement = checkbox.nextElementSibling;
-                                if (switcheryElement && switcheryElement.classList.contains("switchery")) {
-                                    switcheryElement.remove();
-                                }
-                                // Add the toggle class back so GUI.switchery() will reinitialize
-                                if (!checkbox.classList.contains("toggle")) {
-                                    checkbox.classList.add("toggle");
-                                }
-                            }
-                        });
-                        // Reinitialize Switchery with correct state
-                        GUI.switchery();
-                    });
                 }
 
                 updateVirtualGyro();
@@ -957,14 +935,7 @@ export default defineComponent({
             margin-bottom: 8px;
             display: flex;
             align-items: center;
-
-            .switchery {
-                margin-right: 15px;
-            }
-
-            label {
-                margin-left: 0;
-            }
+            gap: 8px;
         }
     }
 

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -28,288 +28,249 @@
 
                 <div class="grid-box col1">
                     <div class="require-blackbox-supported grid-box col1">
-                        <div class="gui_box grey require-blackbox-config-supported">
-                            <div class="gui_box_titlebar">
-                                <div class="spacer_box_title">{{ $t("blackboxConfiguration") }}</div>
+                        <UiBox :title="$t('blackboxConfiguration')" v-show="blackboxConfigSupported">
+                            <SettingRow :label="$t('onboardLoggingBlackbox')">
+                                <USelect
+                                    v-model="blackboxDevice"
+                                    :items="blackboxDeviceOptions"
+                                    size="sm"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                            <SettingRow v-show="blackboxDevice !== 0" :label="$t('onboardLoggingRateOfLogging')">
+                                <USelect v-model="blackboxRate" :items="loggingRates" size="sm" class="min-w-40" />
+                            </SettingRow>
+                            <SettingRow :label="$t('onboardLoggingDebugMode')">
+                                <USelectMenu
+                                    v-model="debugMode"
+                                    value-key="value"
+                                    :items="debugModes"
+                                    size="sm"
+                                    leading-icon="i-lucide-bug"
+                                    :search-input="{
+                                        placeholder: $t('search'),
+                                        icon: 'i-lucide-search',
+                                    }"
+                                    class="min-w-64"
+                                    :ui="{ content: 'max-h-72 z-[9999]' }"
+                                />
+                            </SettingRow>
+                        </UiBox>
+
+                        <UiBox
+                            v-if="showDebugFields"
+                            :title="$t('onboardLoggingDebugFields')"
+                            v-show="blackboxConfigSupported"
+                        >
+                            <div class="blackboxDebugFieldsTable">
+                                <div v-for="(field, index) in debugFields" :key="index" class="debug-field-row">
+                                    <input
+                                        :id="`blackboxDebugField${index}`"
+                                        :checked="debugFieldsEnabled[index]"
+                                        type="checkbox"
+                                        class="toggle"
+                                        @change="updateDebugField(index, $event)"
+                                    />
+                                    <label :for="`blackboxDebugField${index}`">{{ field }}</label>
+                                </div>
                             </div>
-                            <div class="spacer_box">
-                                <div class="line blackboxDevice">
-                                    <select v-model.number="blackboxDevice" name="blackbox_device">
-                                        <option :value="0">{{ $t("blackboxLoggingNone") }}</option>
-                                        <option v-if="dataflashSupported" :value="1">
-                                            {{ $t("blackboxLoggingFlash") }}
-                                        </option>
-                                        <option v-if="sdcardSupported" :value="2">
-                                            {{ $t("blackboxLoggingSdCard") }}
-                                        </option>
-                                        <option :value="3">{{ $t("blackboxLoggingSerial") }}</option>
-                                        <option v-if="virtualGyro" :value="4">
-                                            {{ $t("blackboxLoggingVirtual") }}
-                                        </option>
-                                    </select>
-                                    <span>{{ $t("onboardLoggingBlackbox") }}</span>
-                                </div>
-                                <div v-show="blackboxDevice !== 0" class="line blackboxRate">
-                                    <select v-model.number="blackboxRate" name="blackbox_rate">
-                                        <option v-for="rate in loggingRates" :key="rate.value" :value="rate.value">
-                                            {{ rate.label }}
-                                        </option>
-                                    </select>
-                                    <span>{{ $t("onboardLoggingRateOfLogging") }}</span>
-                                </div>
-                                <div class="line blackboxDebugMode">
-                                    <select v-model.number="debugMode" name="blackboxDebugMode">
-                                        <option v-for="(mode, index) in debugModes" :key="index" :value="index">
-                                            {{ mode }}
-                                        </option>
-                                    </select>
-                                    <span class="blackboxDebugModeText">{{ $t("onboardLoggingDebugMode") }}</span>
-                                </div>
-                                <div v-if="showDebugFields" class="gui_box grey">
-                                    <div class="gui_box_titlebar">
-                                        <div class="spacer_box_title">{{ $t("onboardLoggingDebugFields") }}</div>
+                        </UiBox>
+
+                        <UiBox :title="$t('onboardLoggingSerialLogger')">
+                            <p>{{ $t("serialLoggingSupportedNote") }}</p>
+                        </UiBox>
+
+                        <UiBox :title="$t('onboardLoggingFlashLogger')" class="require-dataflash-supported">
+                            <div class="require-dataflash-supported">
+                                <p>{{ $t("dataflashNote") }}</p>
+
+                                <dialog
+                                    ref="eraseDialog"
+                                    class="dataflash-confirm-erase"
+                                    :class="{ erasing: isErasing }"
+                                >
+                                    <h3>{{ $t("dataflashConfirmEraseTitle") }}</h3>
+                                    <div class="dataflash-confirm-erase-note">
+                                        {{ $t("dataflashConfirmEraseNote") }}
                                     </div>
-                                    <div class="blackboxDebugFieldsTable">
-                                        <div v-for="(field, index) in debugFields" :key="index" class="debug-field-row">
-                                            <input
-                                                :id="`blackboxDebugField${index}`"
-                                                :checked="debugFieldsEnabled[index]"
-                                                type="checkbox"
-                                                class="toggle"
-                                                @change="updateDebugField(index, $event)"
-                                            />
-                                            <label :for="`blackboxDebugField${index}`">{{ field }}</label>
+                                    <div class="dataflash-erase-progress">
+                                        <div class="data-loading">
+                                            <p>{{ $t("onboardLoggingEraseInProgress") }}</p>
                                         </div>
                                     </div>
-                                </div>
-                            </div>
-                        </div>
+                                    <div class="buttons">
+                                        <a
+                                            href="#"
+                                            class="erase-flash-confirm regular-button"
+                                            @click.prevent="flashErase"
+                                        >
+                                            {{ $t("dataflashButtonEraseConfirm") }}
+                                        </a>
+                                        <a
+                                            href="#"
+                                            class="erase-flash-cancel regular-button"
+                                            @click.prevent="flashEraseCancel"
+                                        >
+                                            {{ $t("dataflashButtonEraseCancel") }}
+                                        </a>
+                                    </div>
+                                </dialog>
 
-                        <div class="gui_box grey">
-                            <div class="gui_box_titlebar">
-                                <div class="spacer_box_title">{{ $t("onboardLoggingSerialLogger") }}</div>
-                            </div>
-                            <div class="spacer_box">
-                                <p>{{ $t("serialLoggingSupportedNote") }}</p>
-                            </div>
-                        </div>
-
-                        <div class="gui_box grey require-dataflash-supported">
-                            <div class="gui_box_titlebar">
-                                <div class="spacer_box_title">{{ $t("onboardLoggingFlashLogger") }}</div>
-                            </div>
-                            <div class="spacer_box">
-                                <div class="require-dataflash-supported">
-                                    <p>{{ $t("dataflashNote") }}</p>
-
-                                    <dialog
-                                        ref="eraseDialog"
-                                        class="dataflash-confirm-erase"
-                                        :class="{ erasing: isErasing }"
-                                    >
-                                        <h3>{{ $t("dataflashConfirmEraseTitle") }}</h3>
-                                        <div class="dataflash-confirm-erase-note">
-                                            {{ $t("dataflashConfirmEraseNote") }}
-                                        </div>
-                                        <div class="dataflash-erase-progress">
-                                            <div class="data-loading">
-                                                <p>{{ $t("onboardLoggingEraseInProgress") }}</p>
-                                            </div>
-                                        </div>
+                                <dialog ref="savingDialog" class="dataflash-saving">
+                                    <h3>{{ $t("dataflashSavingTitle") }}</h3>
+                                    <div class="dataflash-saving-before">
+                                        <div>{{ $t("dataflashSavingNote") }}</div>
+                                        <progress :value="saveProgress" min="0" max="100"></progress>
                                         <div class="buttons">
                                             <a
                                                 href="#"
-                                                class="erase-flash-confirm regular-button"
-                                                @click.prevent="flashErase"
+                                                class="save-flash-cancel regular-button"
+                                                @click.prevent="flashSaveCancel"
                                             >
-                                                {{ $t("dataflashButtonEraseConfirm") }}
+                                                {{ $t("dataflashButtonSaveCancel") }}
                                             </a>
+                                        </div>
+                                    </div>
+                                    <div class="dataflash-saving-after">
+                                        <div>{{ $t("dataflashSavingNoteAfter") }}</div>
+                                        <div class="buttons">
                                             <a
                                                 href="#"
-                                                class="erase-flash-cancel regular-button"
-                                                @click.prevent="flashEraseCancel"
+                                                class="save-flash-dismiss regular-button"
+                                                @click.prevent="dismissSavingDialog"
                                             >
-                                                {{ $t("dataflashButtonEraseCancel") }}
+                                                {{ $t("dataflashButtonSaveDismiss") }}
                                             </a>
                                         </div>
-                                    </dialog>
-
-                                    <dialog ref="savingDialog" class="dataflash-saving">
-                                        <h3>{{ $t("dataflashSavingTitle") }}</h3>
-                                        <div class="dataflash-saving-before">
-                                            <div>{{ $t("dataflashSavingNote") }}</div>
-                                            <progress :value="saveProgress" min="0" max="100"></progress>
-                                            <div class="buttons">
-                                                <a
-                                                    href="#"
-                                                    class="save-flash-cancel regular-button"
-                                                    @click.prevent="flashSaveCancel"
-                                                >
-                                                    {{ $t("dataflashButtonSaveCancel") }}
-                                                </a>
-                                            </div>
-                                        </div>
-                                        <div class="dataflash-saving-after">
-                                            <div>{{ $t("dataflashSavingNoteAfter") }}</div>
-                                            <div class="buttons">
-                                                <a
-                                                    href="#"
-                                                    class="save-flash-dismiss regular-button"
-                                                    @click.prevent="dismissSavingDialog"
-                                                >
-                                                    {{ $t("dataflashButtonSaveDismiss") }}
-                                                </a>
-                                            </div>
-                                        </div>
-                                    </dialog>
-
-                                    <ul class="dataflash-contents">
-                                        <li
-                                            class="dataflash-used"
-                                            :style="{
-                                                width: dataflashUsedPercent + '%',
-                                                display: dataflashUsedSize > 0 ? 'block' : 'none',
-                                            }"
-                                        >
-                                            <div>
-                                                {{ $t("dataflashUsedSpace") }} {{ formatBytes(dataflashUsedSize) }}
-                                            </div>
-                                        </li>
-                                        <li
-                                            class="dataflash-free"
-                                            :style="{
-                                                width: dataflashFreePercent + '%',
-                                                display: dataflashFreeSize > 0 ? 'block' : 'none',
-                                            }"
-                                        >
-                                            <div>
-                                                {{ $t("dataflashFreeSpace") }} {{ formatBytes(dataflashFreeSize) }}
-                                            </div>
-                                        </li>
-                                    </ul>
-
-                                    <div class="dataflash-buttons">
-                                        <a
-                                            class="regular-button erase-flash"
-                                            :class="{ disabled: dataflashUsedSize === 0 }"
-                                            href="#"
-                                            @click.prevent="askToEraseFlash"
-                                        >
-                                            {{ $t("dataflashButtonErase") }}
-                                        </a>
-                                        <a
-                                            class="regular-button require-msc-not-supported save-flash-erase"
-                                            :class="{ disabled: dataflashUsedSize === 0 }"
-                                            href="#"
-                                            @click.prevent="flashSaveBegin(true)"
-                                        >
-                                            {{ $t("dataflashButtonSaveAndErase") }}
-                                        </a>
-                                        <a
-                                            class="regular-button require-msc-not-supported save-flash"
-                                            :class="{ disabled: dataflashUsedSize === 0 }"
-                                            href="#"
-                                            @click.prevent="flashSaveBegin(false)"
-                                        >
-                                            {{ $t("dataflashButtonSaveFile") }}
-                                        </a>
-                                        <a
-                                            v-if="isExpertMode"
-                                            class="regular-button require-msc-supported save-flash-erase"
-                                            :class="{ disabled: dataflashUsedSize === 0 }"
-                                            href="#"
-                                            @click.prevent="flashSaveBegin(true)"
-                                        >
-                                            {{ $t("dataflashButtonSaveAndErase") }}
-                                        </a>
-                                        <a
-                                            class="regular-button require-msc-supported save-flash"
-                                            :class="{ disabled: dataflashUsedSize === 0 }"
-                                            href="#"
-                                            @click.prevent="flashSaveBegin(false)"
-                                        >
-                                            <span>{{ $t("dataflashButtonSaveFile") }}</span>
-                                            <span
-                                                class="helpicon cf_tip"
-                                                :title="$t('dataflashSaveFileDepreciationHint')"
-                                            ></span>
-                                        </a>
-                                        <p v-html="$t('dataflashSavetoFileNote')"></p>
                                     </div>
-                                </div>
+                                </dialog>
 
-                                <p class="require-dataflash-not-present">{{ $t("dataflashNotPresentNote") }}</p>
-                                <p
-                                    class="require-dataflash-unsupported"
-                                    v-html="$t('dataflashFirmwareUpgradeRequired')"
-                                ></p>
-                            </div>
-                        </div>
-
-                        <div class="require-sdcard-supported">
-                            <div class="gui_box grey">
-                                <div class="gui_box_titlebar">
-                                    <div class="spacer_box_title">{{ $t("onboardLoggingOnboardSDCard") }}</div>
-                                </div>
-                                <div class="spacer_box">
-                                    <div class="sdcard">
-                                        <div class="sdcard-icon"></div>
-                                        <div class="sdcard-status" v-html="sdcardStatusText"></div>
-                                    </div>
-                                    <p>{{ $t("sdcardNote") }}</p>
-
-                                    <div class="require-sdcard-ready">
-                                        <ul class="sdcard-contents">
-                                            <li
-                                                class="sdcard-other"
-                                                :style="{
-                                                    width: sdcardUsedPercent + '%',
-                                                    display: sdcardUsedKB > 0 ? 'block' : 'none',
-                                                }"
-                                            >
-                                                <div>
-                                                    {{ $t("dataflashUnavSpace") }} {{ formatKilobytes(sdcardUsedKB) }}
-                                                </div>
-                                            </li>
-                                            <li
-                                                class="sdcard-free"
-                                                :style="{
-                                                    width: sdcardFreePercent + '%',
-                                                    display: sdcardFreeKB > 0 ? 'block' : 'none',
-                                                }"
-                                            >
-                                                <div>
-                                                    {{ $t("dataflashLogsSpace") }} {{ formatKilobytes(sdcardFreeKB) }}
-                                                </div>
-                                            </li>
-                                        </ul>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div class="gui_box grey require-msc-supported">
-                        <div class="gui_box_titlebar">
-                            <div class="spacer_box_title">{{ $t("onboardLoggingMsc") }}</div>
-                        </div>
-                        <div class="spacer_box">
-                            <div class="require-msc-supported">
-                                <div>
-                                    <a
-                                        class="require-msc-ready regular-button onboardLoggingRebootMsc"
-                                        :class="{ disabled: !mscReady }"
-                                        href="#"
-                                        @click.prevent="rebootToMsc"
+                                <ul class="dataflash-contents">
+                                    <li
+                                        class="dataflash-used"
+                                        :style="{
+                                            width: dataflashUsedPercent + '%',
+                                            display: dataflashUsedSize > 0 ? 'block' : 'none',
+                                        }"
                                     >
-                                        {{ $t("onboardLoggingRebootMscText") }}
+                                        <div>{{ $t("dataflashUsedSpace") }} {{ formatBytes(dataflashUsedSize) }}</div>
+                                    </li>
+                                    <li
+                                        class="dataflash-free"
+                                        :style="{
+                                            width: dataflashFreePercent + '%',
+                                            display: dataflashFreeSize > 0 ? 'block' : 'none',
+                                        }"
+                                    >
+                                        <div>{{ $t("dataflashFreeSpace") }} {{ formatBytes(dataflashFreeSize) }}</div>
+                                    </li>
+                                </ul>
+
+                                <div class="dataflash-buttons">
+                                    <a
+                                        class="regular-button erase-flash"
+                                        :class="{ disabled: dataflashUsedSize === 0 }"
+                                        href="#"
+                                        @click.prevent="askToEraseFlash"
+                                    >
+                                        {{ $t("dataflashButtonErase") }}
                                     </a>
+                                    <a
+                                        class="regular-button require-msc-not-supported save-flash-erase"
+                                        :class="{ disabled: dataflashUsedSize === 0 }"
+                                        href="#"
+                                        @click.prevent="flashSaveBegin(true)"
+                                    >
+                                        {{ $t("dataflashButtonSaveAndErase") }}
+                                    </a>
+                                    <a
+                                        class="regular-button require-msc-not-supported save-flash"
+                                        :class="{ disabled: dataflashUsedSize === 0 }"
+                                        href="#"
+                                        @click.prevent="flashSaveBegin(false)"
+                                    >
+                                        {{ $t("dataflashButtonSaveFile") }}
+                                    </a>
+                                    <a
+                                        v-if="isExpertMode"
+                                        class="regular-button require-msc-supported save-flash-erase"
+                                        :class="{ disabled: dataflashUsedSize === 0 }"
+                                        href="#"
+                                        @click.prevent="flashSaveBegin(true)"
+                                    >
+                                        {{ $t("dataflashButtonSaveAndErase") }}
+                                    </a>
+                                    <a
+                                        class="regular-button require-msc-supported save-flash"
+                                        :class="{ disabled: dataflashUsedSize === 0 }"
+                                        href="#"
+                                        @click.prevent="flashSaveBegin(false)"
+                                    >
+                                        <span>{{ $t("dataflashButtonSaveFile") }}</span>
+                                        <span
+                                            class="helpicon cf_tip"
+                                            :title="$t('dataflashSaveFileDepreciationHint')"
+                                        ></span>
+                                    </a>
+                                    <p v-html="$t('dataflashSavetoFileNote')"></p>
                                 </div>
                             </div>
-                            <p v-html="$t('onboardLoggingMscNote')"></p>
-                            <p class="require-msc-not-ready">{{ $t("onboardLoggingMscNotReady") }}</p>
-                        </div>
+
+                            <p class="require-dataflash-not-present">{{ $t("dataflashNotPresentNote") }}</p>
+                            <p
+                                class="require-dataflash-unsupported"
+                                v-html="$t('dataflashFirmwareUpgradeRequired')"
+                            ></p>
+                        </UiBox>
+
+                        <UiBox :title="$t('onboardLoggingOnboardSDCard')" class="require-sdcard-supported">
+                            <div class="sdcard">
+                                <div class="sdcard-icon"></div>
+                                <div class="sdcard-status" v-html="sdcardStatusText"></div>
+                            </div>
+                            <p>{{ $t("sdcardNote") }}</p>
+
+                            <div class="require-sdcard-ready">
+                                <ul class="sdcard-contents">
+                                    <li
+                                        class="sdcard-other"
+                                        :style="{
+                                            width: sdcardUsedPercent + '%',
+                                            display: sdcardUsedKB > 0 ? 'block' : 'none',
+                                        }"
+                                    >
+                                        <div>{{ $t("dataflashUnavSpace") }} {{ formatKilobytes(sdcardUsedKB) }}</div>
+                                    </li>
+                                    <li
+                                        class="sdcard-free"
+                                        :style="{
+                                            width: sdcardFreePercent + '%',
+                                            display: sdcardFreeKB > 0 ? 'block' : 'none',
+                                        }"
+                                    >
+                                        <div>{{ $t("dataflashLogsSpace") }} {{ formatKilobytes(sdcardFreeKB) }}</div>
+                                    </li>
+                                </ul>
+                            </div>
+                        </UiBox>
                     </div>
+
+                    <UiBox :title="$t('onboardLoggingMsc')" class="require-msc-supported">
+                        <div class="require-msc-supported">
+                            <div>
+                                <a
+                                    class="require-msc-ready regular-button onboardLoggingRebootMsc"
+                                    :class="{ disabled: !mscReady }"
+                                    href="#"
+                                    @click.prevent="rebootToMsc"
+                                >
+                                    {{ $t("onboardLoggingRebootMscText") }}
+                                </a>
+                            </div>
+                        </div>
+                        <p v-html="$t('onboardLoggingMscNote')"></p>
+                        <p class="require-msc-not-ready">{{ $t("onboardLoggingMscNotReady") }}</p>
+                    </UiBox>
                 </div>
                 <div class="clear-both"></div>
             </div>
@@ -329,6 +290,8 @@ import { useFlightControllerStore } from "@/stores/fc";
 import { useConnectionStore } from "@/stores/connection";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "../elements/WikiButton.vue";
+import UiBox from "../elements/UiBox.vue";
+import SettingRow from "../elements/SettingRow.vue";
 import GUI from "../../js/gui";
 import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
@@ -392,6 +355,8 @@ export default defineComponent({
     components: {
         BaseTab,
         WikiButton,
+        UiBox,
+        SettingRow,
     },
     setup() {
         const fcStore = useFlightControllerStore();
@@ -436,6 +401,21 @@ export default defineComponent({
             virtualGyro.value = fcStore.sensorConfigActive?.gyro_hardware === index;
         };
 
+        const blackboxDeviceOptions = computed(() => {
+            const options = [{ label: i18n.getMessage("blackboxLoggingNone"), value: 0 }];
+            if (dataflashSupported.value) {
+                options.push({ label: i18n.getMessage("blackboxLoggingFlash"), value: 1 });
+            }
+            if (sdcardSupported.value) {
+                options.push({ label: i18n.getMessage("blackboxLoggingSdCard"), value: 2 });
+            }
+            options.push({ label: i18n.getMessage("blackboxLoggingSerial"), value: 3 });
+            if (virtualGyro.value) {
+                options.push({ label: i18n.getMessage("blackboxLoggingVirtual"), value: 4 });
+            }
+            return options;
+        });
+
         const blackboxSupport = computed(() => {
             if (
                 fcStore.blackbox?.supported ||
@@ -477,12 +457,13 @@ export default defineComponent({
             const modes = [];
             const debugModeCount = fcStore.pidAdvancedConfig?.debugModeCount || 0;
             for (let i = 0; i < debugModeCount; i++) {
-                if (i < debugStore.modes.length) {
-                    modes.push(debugStore.modes[i]);
-                } else {
-                    modes.push(i18n.getMessage("onboardLoggingDebugModeUnknown"));
-                }
+                const label =
+                    i < debugStore.modes.length
+                        ? debugStore.modes[i]
+                        : i18n.getMessage("onboardLoggingDebugModeUnknown");
+                modes.push({ label, value: i });
             }
+            modes.sort((a, b) => a.label.localeCompare(b.label));
             return modes;
         });
 
@@ -936,6 +917,7 @@ export default defineComponent({
             blackboxConfigSupported,
             isExpertMode,
             virtualGyro,
+            blackboxDeviceOptions,
             blackboxSupport,
             loggingRates,
             debugModes,


### PR DESCRIPTION
# Plan: Searchable Debug Mode Selector & Nuxt UI Conversion for Onboard Logging Tab

## PR Summary

**Title:** Add searchable debug mode dropdown and convert Onboard Logging tab to Nuxt UI

Replace the plain HTML `<select>` for blackbox debug mode selection with a Nuxt UI `USelectMenu` component featuring built-in search. With 100+ debug modes available, users currently must scroll through a massive unsearchable dropdown to find modes like `CRSF_LINK_STATISTICS_UPLINK` or `RX_EXPRESSLRS_SPI`. The new searchable dropdown lets users type to instantly filter modes (e.g. typing "gyro" shows all gyro-related modes). Debug modes are also sorted alphabetically for easier browsing.

Additionally, convert all legacy `gui_box`/`spacer_box` HTML throughout the tab to the new `UiBox`/`SettingRow`/`USelect` component pattern established in PR #4985, and replace switchery checkboxes with `USwitch` components.

---

## Problem

- Plain `<select>` renders all ~120 debug modes in an unsearchable dropdown
- Users must manually scroll through the entire list to find a specific debug mode
- No type-ahead, no filtering, no search — a poor UX for a list this large
- Legacy `gui_box`/`spacer_box` HTML pattern throughout the tab is inconsistent with the new Nuxt UI direction
- The project is adopting Nuxt UI (PR #4985 converted Options tab) — this tab should follow suit

## Solution

1. Replace the debug mode `<select>` with `<USelectMenu>` (searchable dropdown with filtering)
2. Convert all blackbox config controls to `UiBox`/`SettingRow`/`USelect` components
3. Replace debug field switchery checkboxes with `USwitch` components
4. Convert all remaining `gui_box` sections (Serial Logger, Flash Logger, SD Card, MSC) to `UiBox`
5. Sort debug modes alphabetically

---

## Changes Made

### 1. Searchable debug mode dropdown

Replaced the plain `<select>` with `<USelectMenu>` including:
- `:search-input` prop for type-to-filter functionality
- `value-key="value"` to keep `debugMode` as a numeric ref
- Alphabetical sorting of mode names
- `leading-icon="i-lucide-bug"` for visual consistency with OptionsTab pattern
- `min-w-64` trigger width / `max-h-72` content sizing for long mode names

### 2. Blackbox Configuration box → UiBox + SettingRow + USelect

Converted:
- Blackbox device selector → `<USelect>` inside `<SettingRow>`
- Logging rate selector → `<USelect>` inside `<SettingRow>`
- Debug mode selector → `<USelectMenu>` inside `<SettingRow>`
- All wrapped in `<UiBox :title="$t('blackboxConfiguration')">`

### 3. Debug Fields → separate UiBox with USwitch toggles

Moved debug field toggles into their own `<UiBox :title="$t('onboardLoggingDebugFields')">`. Replaced legacy switchery checkboxes (`<input type="checkbox" class="toggle">`) with `<USwitch>` components. Removed all Switchery DOM manipulation code (`GUI.switchery()`, manual destroy/recreate in `nextTick`) — USwitch is fully reactive and requires no imperative lifecycle management.

### 4. All remaining gui_box → UiBox

Converted all legacy sections:
- **Serial Logger** — simple `<UiBox>` with note text
- **Flash Logger** — `<UiBox>` preserving dialogs, progress bars, dataflash buttons
- **SD Card** — `<UiBox>` with status display and contents bar
- **MSC** — `<UiBox>` with reboot button and notes

### 5. Visibility toggling fix

Replaced CSS class-based visibility (`require-blackbox-config-supported` → `display: none/block`) with Vue `v-show` for the Blackbox Configuration and Debug Fields boxes. The CSS `display: block` override was interfering with Reka UI's ComboboxAnchor positioning, preventing the USelectMenu dropdown from appearing as a floating popover.

### 6. Legacy `cf_tip` tooltip → HelpIcon

Replaced the old `<span class="helpicon cf_tip" :title="...">` on the flash save button with the new `<HelpIcon :text="...">` component (uses `UTooltip` with arrow and zero delay). Removed associated `.helpicon` CSS.

### 7. Added `blackboxDeviceOptions` computed

New computed property returning `{ label, value }[]` for the blackbox device `USelect`.

### 7. Updated `debugModes` computed

Changed from returning `string[]` to `{ label, value }[]` with alphabetical sort.

---

## Key Design Decisions

| Decision | Choice | Rationale |
|----------|--------|-----------|
| Component | `USelectMenu` (not `USelect`) | `USelectMenu` supports `:search-input` for filtering; `USelect` does not |
| Search icon | `i-lucide-search` | Consistent with OptionsTab language selector pattern |
| Size | `sm` | Matches all other Nuxt UI components in the project |
| Max height | `max-h-72` | Prevents dropdown from covering the entire screen with 120+ items |
| Trigger width | `min-w-64` | Debug mode names are long (e.g. `CRSF_LINK_STATISTICS_UPLINK`) |
| Content z-index | `z-[9999]` | Ensures dropdown floats above all page content |
| Value binding | `value-key="value"` | Keeps `debugMode` as a numeric ref, no save/load refactoring needed |
| Visibility | `v-show` (not CSS class toggle) | CSS `display: block` override conflicted with Reka UI portal positioning |
| Sorting | Alphabetical by label | Easier to find modes in the long list |
| Debug field toggles | `USwitch` (not switchery `<input class="toggle">`) | Eliminates imperative Switchery DOM manipulation; fully reactive with `v-model` |

## Bug Fix: Dropdown popover not floating

The USelectMenu dropdown was rendering but not appearing as a floating popover (unlike the identical component in OptionsTab). Root cause: the legacy CSS visibility pattern (`.require-blackbox-config-supported { display: none }` overridden to `display: block`) was interfering with Reka UI's ComboboxAnchor bounding rect calculations used by Floating UI for portal positioning. Fix: switched to Vue's `v-show` directive and added explicit `z-[9999]` on the dropdown content.

## Files Modified

| File | Change |
|------|--------|
| `src/components/tabs/OnboardLoggingTab.vue` | Full Nuxt UI conversion: USelectMenu, USelect, USwitch, UiBox, SettingRow; visibility fix |

## Testing Plan

- [ ] Open Onboard Logging tab with a connected flight controller
- [ ] Verify all boxes render correctly (Blackbox Config, Debug Fields, Serial Logger, Flash Logger, SD Card, MSC)
- [ ] Verify debug mode dropdown renders with all modes sorted alphabetically
- [ ] Type in the search box — confirm modes filter in real-time (e.g. "gyro" → GYRO_FILTERED, GYRO_RAW, GYRO_SCALED)
- [ ] Select a mode — confirm `debugMode` value updates correctly
- [ ] Confirm debug fields section updates when mode changes (API >= 1.45)
- [ ] Verify debug field USwitch toggles render with correct on/off state from saved `blackboxDisabledMask`
- [ ] Toggle a debug field off, save, re-open tab — confirm it remains off
- [ ] Verify blackbox device and logging rate selectors work correctly
- [ ] Save configuration — confirm the correct debug mode index is sent to the FC
- [ ] Re-open tab — confirm the previously saved mode is correctly pre-selected
- [ ] Test visibility toggling: boxes show/hide correctly based on hardware support
- [ ] Test flash erase/save dialogs still function within the new UiBox
- [ ] Test SD card status display
- [ ] Test MSC reboot button


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Modernized blackbox configuration UI with standardized controls and improved alignment
  * Enhanced debug mode selector and more reliable debug-field toggles with cleaner layout
  * Refined flash/serial logger presentation and updated help hints

* **Chores**
  * Removed an obsolete English localization entry for a dataflash firmware notice
<!-- end of auto-generated comment: release notes by coderabbit.ai -->