### PR TITLE
Add email-code login as passkey alternative

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8301,6 +8301,9 @@
     "userCreatingPasskey": {
         "message": "Creating passkey..."
     },
+    "userCodeRequired": {
+        "message": "Verification code is required"
+    },
     "userSendingCode": {
         "message": "Sending verification code..."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8235,6 +8235,36 @@
     "labelUsePasskey": {
         "message": "Use Passkey"
     },
+    "labelSignInWithPasskey": {
+        "message": "Sign in with Passkey"
+    },
+    "labelSendVerificationCode": {
+        "message": "Send Verification Code"
+    },
+    "labelSignInWithEmailCode": {
+        "message": "Sign in with email code instead"
+    },
+    "labelBackToPasskey": {
+        "message": "Back to passkey sign in"
+    },
+    "labelBack": {
+        "message": "Back"
+    },
+    "labelNoPasskeyPrompt": {
+        "message": "Don't have a passkey?"
+    },
+    "labelSetOnePasskeyUp": {
+        "message": "Set one up"
+    },
+    "descriptionPasskeyLogin": {
+        "message": "Use your passkey to sign in"
+    },
+    "descriptionCodeRequest": {
+        "message": "We'll email you a verification code"
+    },
+    "descriptionCodeEntered": {
+        "message": "Enter the code we sent to $1"
+    },
     "titleEnterVerificationCode": {
         "message": "Enter Verification Code"
     },
@@ -8270,6 +8300,12 @@
     },
     "userCreatingPasskey": {
         "message": "Creating passkey..."
+    },
+    "userSendingCode": {
+        "message": "Sending verification code..."
+    },
+    "userSendCodeFailed": {
+        "message": "Failed to send verification code"
     },
     "dataWaitingForData": {
         "message": "Waiting for data ..."

--- a/src/components/user-session/UserSession.js
+++ b/src/components/user-session/UserSession.js
@@ -20,6 +20,7 @@ export function useUserSession() {
     const loginError = ref(null);
     const loginSubmitting = ref(false);
     const loginCodeInputRef = ref(null);
+    const codeEmail = ref("");
 
     const dialogLoginRef = ref(null);
     const dialogWaitingRef = ref(null);
@@ -51,7 +52,7 @@ export function useUserSession() {
             return i18n.getMessage("descriptionCodeRequest");
         }
         if (loginMode.value === MODE_CODE_VERIFY) {
-            return i18n.getMessage("descriptionCodeEntered", [loginEmail.value]);
+            return i18n.getMessage("descriptionCodeEntered", [codeEmail.value]);
         }
         return i18n.getMessage("descriptionPasskeyLogin");
     });
@@ -113,13 +114,18 @@ export function useUserSession() {
         loginCode.value = "";
         loginError.value = null;
         loginSubmitting.value = false;
+        codeEmail.value = "";
+    };
+
+    const showLoginDialog = () => {
+        if (dialogLoginRef.value && !dialogLoginRef.value.open) {
+            dialogLoginRef.value.showModal();
+        }
     };
 
     const openLoginDialog = () => {
         resetLoginDialog();
-        if (dialogLoginRef.value) {
-            dialogLoginRef.value.showModal();
-        }
+        showLoginDialog();
     };
 
     const closeLoginDialog = () => {
@@ -190,13 +196,19 @@ export function useUserSession() {
 
     const handleUsePasskey = async () => {
         const email = loginEmail.value.trim();
+
+        if (!email) {
+            loginError.value = i18n.getMessage("userEmailRequired");
+            return;
+        }
+
         loginError.value = null;
 
         try {
             closeLoginDialog();
             await loginManager.loginWithPasskey(email);
         } catch (error) {
-            openLoginDialog();
+            showLoginDialog();
             loginError.value = i18n.getMessage("userLoginFailed");
             console.error("Login with passkey error:", error);
         }
@@ -215,13 +227,17 @@ export function useUserSession() {
             await loginManager.createPasskey(email);
             openVerificationDialog(email);
         } catch (error) {
-            openLoginDialog();
+            showLoginDialog();
             loginError.value = i18n.getMessage("userCreatePasskeyFailed");
             console.error("Create passkey error:", error);
         }
     };
 
     const handleRequestCode = async () => {
+        if (loginSubmitting.value) {
+            return;
+        }
+
         const email = loginEmail.value.trim();
 
         if (!email) {
@@ -234,6 +250,7 @@ export function useUserSession() {
 
         try {
             await loginManager.requestVerificationCode(email);
+            codeEmail.value = email;
             loginMode.value = MODE_CODE_VERIFY;
             loginCode.value = "";
             focusCodeInput();
@@ -245,11 +262,14 @@ export function useUserSession() {
     };
 
     const handleVerifyCode = async () => {
+        if (loginSubmitting.value) {
+            return;
+        }
+
         const code = loginCode.value.trim();
-        const email = loginEmail.value.trim();
 
         if (!code) {
-            loginError.value = i18n.getMessage("userEmailRequired");
+            loginError.value = i18n.getMessage("userCodeRequired");
             return;
         }
 
@@ -257,7 +277,7 @@ export function useUserSession() {
         loginSubmitting.value = true;
 
         try {
-            await loginManager.loginWithEmailCode(email, code);
+            await loginManager.loginWithEmailCode(codeEmail.value, code);
             closeLoginDialog();
         } catch (error) {
             loginError.value = error?.message || i18n.getMessage("userLoginFailed");

--- a/src/components/user-session/UserSession.js
+++ b/src/components/user-session/UserSession.js
@@ -148,7 +148,7 @@ export function useUserSession() {
 
     const focusCodeInput = () => {
         nextTick(() => {
-            loginCodeInputRef.value?.focus();
+            loginCodeInputRef.value?.inputRef?.focus();
         });
     };
 
@@ -165,7 +165,7 @@ export function useUserSession() {
         if (dialogVerificationRef.value) {
             dialogVerificationRef.value.showModal();
             nextTick(() => {
-                verificationInputRef.value?.focus();
+                verificationInputRef.value?.inputRef?.focus();
             });
         }
     };

--- a/src/components/user-session/UserSession.js
+++ b/src/components/user-session/UserSession.js
@@ -2,20 +2,34 @@ import { ref, computed, onMounted, onUnmounted, nextTick } from "vue";
 import loginManager from "../../js/LoginManager";
 import { i18n } from "../../js/localization";
 
+// Login dialog modes
+const MODE_PASSKEY = "passkey";
+const MODE_CODE_REQUEST = "code-request";
+const MODE_CODE_VERIFY = "code-verify";
+
 export function useUserSession() {
     const isLoggedIn = ref(false);
     const profile = ref(null);
     const menuOpen = ref(false);
     const menuStyle = ref({});
+
+    // Unified login dialog state
+    const loginMode = ref(MODE_PASSKEY);
     const loginEmail = ref("");
+    const loginCode = ref("");
     const loginError = ref(null);
+    const loginSubmitting = ref(false);
+    const loginCodeInputRef = ref(null);
+
+    const dialogLoginRef = ref(null);
+    const dialogWaitingRef = ref(null);
+    const waitingMessage = ref("");
+
+    // Legacy passkey-creation verification dialog
     const verificationError = ref(null);
     const verificationCode = ref("");
     const verificationInputRef = ref(null);
-    const dialogLoginRef = ref(null);
     const dialogVerificationRef = ref(null);
-    const dialogWaitingRef = ref(null);
-    const waitingMessage = ref("");
     const currentVerificationEmail = ref("");
 
     const displayName = computed(() => {
@@ -24,6 +38,22 @@ export function useUserSession() {
 
     const avatarUrl = computed(() => {
         return profile.value?.avatar || null;
+    });
+
+    const loginTitle = computed(() => {
+        return loginMode.value === MODE_CODE_VERIFY
+            ? i18n.getMessage("titleEnterVerificationCode")
+            : i18n.getMessage("titleLogin");
+    });
+
+    const loginDescription = computed(() => {
+        if (loginMode.value === MODE_CODE_REQUEST) {
+            return i18n.getMessage("descriptionCodeRequest");
+        }
+        if (loginMode.value === MODE_CODE_VERIFY) {
+            return i18n.getMessage("descriptionCodeEntered", [loginEmail.value]);
+        }
+        return i18n.getMessage("descriptionPasskeyLogin");
     });
 
     const handleLoginClick = () => {
@@ -77,9 +107,16 @@ export function useUserSession() {
         }
     };
 
-    const openLoginDialog = () => {
+    const resetLoginDialog = () => {
+        loginMode.value = MODE_PASSKEY;
         loginEmail.value = "";
+        loginCode.value = "";
         loginError.value = null;
+        loginSubmitting.value = false;
+    };
+
+    const openLoginDialog = () => {
+        resetLoginDialog();
         if (dialogLoginRef.value) {
             dialogLoginRef.value.showModal();
         }
@@ -89,6 +126,24 @@ export function useUserSession() {
         if (dialogLoginRef.value?.open) {
             dialogLoginRef.value.close();
         }
+    };
+
+    const switchToCodeRequest = () => {
+        loginMode.value = MODE_CODE_REQUEST;
+        loginError.value = null;
+        loginCode.value = "";
+    };
+
+    const switchToPasskey = () => {
+        loginMode.value = MODE_PASSKEY;
+        loginError.value = null;
+        loginCode.value = "";
+    };
+
+    const focusCodeInput = () => {
+        nextTick(() => {
+            loginCodeInputRef.value?.focus();
+        });
     };
 
     const closeVerificationDialog = () => {
@@ -103,11 +158,8 @@ export function useUserSession() {
         verificationError.value = null;
         if (dialogVerificationRef.value) {
             dialogVerificationRef.value.showModal();
-            // Focus input after dialog opens
             nextTick(() => {
-                if (verificationInputRef.value) {
-                    verificationInputRef.value.focus();
-                }
+                verificationInputRef.value?.focus();
             });
         }
     };
@@ -136,6 +188,20 @@ export function useUserSession() {
         dlg.removeAttribute("inert");
     };
 
+    const handleUsePasskey = async () => {
+        const email = loginEmail.value.trim();
+        loginError.value = null;
+
+        try {
+            closeLoginDialog();
+            await loginManager.loginWithPasskey(email);
+        } catch (error) {
+            openLoginDialog();
+            loginError.value = i18n.getMessage("userLoginFailed");
+            console.error("Login with passkey error:", error);
+        }
+    };
+
     const handleCreatePasskey = async () => {
         const email = loginEmail.value.trim();
 
@@ -155,16 +221,48 @@ export function useUserSession() {
         }
     };
 
-    const handleUsePasskey = async () => {
+    const handleRequestCode = async () => {
         const email = loginEmail.value.trim();
 
+        if (!email) {
+            loginError.value = i18n.getMessage("userEmailRequired");
+            return;
+        }
+
+        loginError.value = null;
+        loginSubmitting.value = true;
+
         try {
-            closeLoginDialog();
-            await loginManager.loginWithPasskey(email);
+            await loginManager.requestVerificationCode(email);
+            loginMode.value = MODE_CODE_VERIFY;
+            loginCode.value = "";
+            focusCodeInput();
         } catch (error) {
-            openLoginDialog();
-            loginError.value = i18n.getMessage("userLoginFailed");
-            console.error("Login with passkey error:", error);
+            loginError.value = error?.message || i18n.getMessage("userSendCodeFailed");
+        } finally {
+            loginSubmitting.value = false;
+        }
+    };
+
+    const handleVerifyCode = async () => {
+        const code = loginCode.value.trim();
+        const email = loginEmail.value.trim();
+
+        if (!code) {
+            loginError.value = i18n.getMessage("userEmailRequired");
+            return;
+        }
+
+        loginError.value = null;
+        loginSubmitting.value = true;
+
+        try {
+            await loginManager.loginWithEmailCode(email, code);
+            closeLoginDialog();
+        } catch (error) {
+            loginError.value = error?.message || i18n.getMessage("userLoginFailed");
+        } finally {
+            loginSubmitting.value = false;
         }
     };
 
@@ -203,20 +301,16 @@ export function useUserSession() {
     });
 
     onUnmounted(() => {
-        // Cleanup callbacks
         if (unsubscribeLogin) {
             unsubscribeLogin();
         }
-
         if (unsubscribeLogout) {
             unsubscribeLogout();
         }
 
-        // Clear dialog opener
         loginManager.setDialogOpener(null);
         loginManager.setWaitingDialogController(null);
 
-        // Remove click outside listener
         document.removeEventListener("click", handleClickOutside);
     });
 
@@ -227,24 +321,34 @@ export function useUserSession() {
         avatarUrl,
         menuOpen,
         menuStyle,
+        loginMode,
         loginEmail,
+        loginCode,
         loginError,
+        loginSubmitting,
+        loginTitle,
+        loginDescription,
+        loginCodeInputRef,
+        dialogLoginRef,
+        dialogWaitingRef,
+        waitingMessage,
         verificationError,
         verificationCode,
         verificationInputRef,
-        dialogLoginRef,
         dialogVerificationRef,
-        dialogWaitingRef,
-        waitingMessage,
         handleLoginClick,
         toggleMenu,
         handleSignOut,
         showWaitingDialog,
         hideWaitingDialog,
         closeLoginDialog,
-        closeVerificationDialog,
-        handleCreatePasskey,
+        switchToCodeRequest,
+        switchToPasskey,
         handleUsePasskey,
+        handleCreatePasskey,
+        handleRequestCode,
+        handleVerifyCode,
+        closeVerificationDialog,
         handleVerificationSubmit,
     };
 }

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -38,28 +38,124 @@
                     <button class="dialog-close-button" aria-label="Close" @click.prevent="closeLoginDialog">
                         &times;
                     </button>
-                    <h3 class="dialog-title">{{ $t("titleLogin") }}</h3>
+                    <div class="dialog-logo" aria-hidden="true"></div>
+                    <h3 class="dialog-title">{{ loginTitle }}</h3>
+                    <p class="dialog-description">{{ loginDescription }}</p>
+
                     <div class="dialog-content">
-                        <div class="dialog-input-group">
-                            <label for="login-email" class="dialog-label">{{ $t("labelEmail") }}</label>
-                            <input
-                                v-model="loginEmail"
-                                type="email"
-                                id="login-email"
-                                :placeholder="$t('placeholderEmailAddress')"
-                                class="dialog-input"
-                            />
-                        </div>
-                        <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
-                    </div>
-                    <div class="dialog-buttons dialog-buttons-split">
-                        <a href="#" class="regular-button dialog-passkey-button" @click.prevent="handleCreatePasskey">{{
-                            $t("labelCreatePasskey")
-                        }}</a>
-                        <span class="dialog-separator">OR</span>
-                        <a href="#" class="regular-button dialog-passkey-button" @click.prevent="handleUsePasskey">{{
-                            $t("labelUsePasskey")
-                        }}</a>
+                        <!-- Passkey mode -->
+                        <template v-if="loginMode === 'passkey'">
+                            <div class="dialog-input-group">
+                                <label for="login-email" class="dialog-label">{{ $t("labelEmail") }}</label>
+                                <input
+                                    v-model="loginEmail"
+                                    type="email"
+                                    id="login-email"
+                                    :placeholder="$t('placeholderEmailAddress')"
+                                    class="dialog-input"
+                                    @keypress.enter="handleUsePasskey"
+                                />
+                            </div>
+                            <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
+
+                            <div class="dialog-buttons">
+                                <a
+                                    href="#"
+                                    class="regular-button dialog-primary-button"
+                                    @click.prevent="handleUsePasskey"
+                                >
+                                    <i class="fas fa-key dialog-button-icon"></i>
+                                    <span>{{ $t("labelSignInWithPasskey") }}</span>
+                                </a>
+                            </div>
+
+                            <div class="dialog-footer">
+                                <p class="dialog-hint">
+                                    {{ $t("labelNoPasskeyPrompt") }}
+                                    <a href="#" class="dialog-link" @click.prevent="handleCreatePasskey">{{
+                                        $t("labelSetOnePasskeyUp")
+                                    }}</a>
+                                </p>
+                                <a
+                                    href="#"
+                                    class="dialog-link dialog-link-muted"
+                                    @click.prevent="switchToCodeRequest"
+                                    >{{ $t("labelSignInWithEmailCode") }}</a
+                                >
+                            </div>
+                        </template>
+
+                        <!-- Email-code request mode -->
+                        <template v-else-if="loginMode === 'code-request'">
+                            <div class="dialog-input-group">
+                                <label for="login-email-code" class="dialog-label">{{ $t("labelEmail") }}</label>
+                                <input
+                                    v-model="loginEmail"
+                                    type="email"
+                                    id="login-email-code"
+                                    :placeholder="$t('placeholderEmailAddress')"
+                                    class="dialog-input"
+                                    @keypress.enter="handleRequestCode"
+                                />
+                            </div>
+                            <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
+
+                            <div class="dialog-buttons">
+                                <a
+                                    href="#"
+                                    class="regular-button dialog-primary-button"
+                                    :class="{ 'button-disabled': loginSubmitting }"
+                                    @click.prevent="handleRequestCode"
+                                >
+                                    {{ $t("labelSendVerificationCode") }}
+                                </a>
+                            </div>
+
+                            <div class="dialog-footer">
+                                <a href="#" class="dialog-link dialog-link-muted" @click.prevent="switchToPasskey">{{
+                                    $t("labelBackToPasskey")
+                                }}</a>
+                            </div>
+                        </template>
+
+                        <!-- Email-code verify mode -->
+                        <template v-else-if="loginMode === 'code-verify'">
+                            <div class="dialog-input-group">
+                                <label for="login-code-input" class="dialog-label">{{
+                                    $t("labelVerificationCode")
+                                }}</label>
+                                <input
+                                    v-model="loginCode"
+                                    ref="loginCodeInputRef"
+                                    type="text"
+                                    id="login-code-input"
+                                    maxlength="8"
+                                    class="dialog-input dialog-input-code"
+                                    @keypress.enter="handleVerifyCode"
+                                />
+                            </div>
+                            <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
+
+                            <div class="dialog-buttons">
+                                <a
+                                    href="#"
+                                    class="regular-button dialog-primary-button"
+                                    :class="{ 'button-disabled': loginSubmitting }"
+                                    @click.prevent="handleVerifyCode"
+                                >
+                                    {{ $t("submit") }}
+                                </a>
+                            </div>
+
+                            <div class="dialog-footer">
+                                <a
+                                    href="#"
+                                    class="dialog-link dialog-link-muted"
+                                    @click.prevent="switchToCodeRequest"
+                                    >{{ $t("labelBack") }}</a
+                                >
+                            </div>
+                        </template>
                     </div>
                 </div>
             </dialog>
@@ -258,16 +354,39 @@ export default defineComponent({
 /* Login dialogs */
 .login-dialog {
     width: 360px;
-    aspect-ratio: 16 / 9;
-    padding: 20px;
+    padding: 24px;
     border: 1px solid var(--surface-600);
     border-radius: 8px;
+    background-color: var(--surface-100);
+    color: var(--text);
 }
 
 .dialog-container {
     display: flex;
     flex-direction: column;
-    height: 100%;
+    gap: 4px;
+}
+
+.dialog-logo {
+    width: 180px;
+    height: 36px;
+    margin: 0 auto 12px;
+    background-image: url(../../images/dark-wide-2.svg);
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-size: contain;
+}
+
+.dark .dialog-logo {
+    background-image: url(../../images/light-wide-2.svg);
+}
+
+.dialog-description {
+    margin: 0 0 16px 0;
+    text-align: center;
+    font-size: 12px;
+    color: var(--text);
+    opacity: 0.7;
 }
 
 .dialog-close-button {
@@ -328,29 +447,65 @@ export default defineComponent({
 .dialog-buttons {
     display: flex;
     justify-content: center;
+    margin-top: 4px;
 }
 
-.dialog-buttons-split {
-    flex-direction: row;
-    gap: 10px;
+.dialog-primary-button {
+    display: inline-flex;
     align-items: center;
+    justify-content: center;
+    gap: 8px;
+    width: 100%;
+    padding: 10px 16px;
+    text-decoration: none;
+    font-size: 13px;
+    text-align: center;
+    box-sizing: border-box;
+}
+
+.dialog-button-icon {
+    font-size: 12px;
+}
+
+.button-disabled {
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.dialog-footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    margin-top: 16px;
     text-align: center;
 }
 
-.dialog-passkey-button {
-    padding: 6px 12px;
-    text-decoration: none;
+.dialog-hint {
+    margin: 0;
     font-size: 12px;
-    width: 120px;
-    margin-left: 10px;
+    color: var(--text);
+    opacity: 0.75;
 }
 
-.dialog-separator {
+.dialog-link {
+    color: var(--primary-500);
     font-size: 12px;
-    color: var(--text-secondary);
-    display: flex;
-    align-items: center;
-    flex-shrink: 0;
+    text-decoration: none;
+}
+
+.dialog-link:hover {
+    text-decoration: underline;
+}
+
+.dialog-link-muted {
+    color: var(--text);
+    opacity: 0.7;
+}
+
+.dialog-input-code {
+    text-align: center;
+    letter-spacing: 0.15em;
 }
 
 .dialog-submit-button {

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -35,9 +35,14 @@
             <!-- Login Dialog -->
             <dialog ref="dialogLoginRef" class="login-dialog">
                 <div class="dialog-container">
-                    <button class="dialog-close-button" aria-label="Close" @click.prevent="closeLoginDialog">
-                        &times;
-                    </button>
+                    <UButton
+                        variant="ghost"
+                        icon="i-lucide-x"
+                        size="sm"
+                        class="dialog-close-button"
+                        aria-label="Close"
+                        @click="closeLoginDialog"
+                    />
                     <div class="dialog-logo" aria-hidden="true"></div>
                     <h3 class="dialog-title">{{ loginTitle }}</h3>
                     <p class="dialog-description">{{ loginDescription }}</p>
@@ -45,115 +50,104 @@
                     <div class="dialog-content">
                         <!-- Passkey mode -->
                         <template v-if="loginMode === 'passkey'">
-                            <div class="dialog-input-group">
+                            <div class="dialog-field">
                                 <label for="login-email" class="dialog-label">{{ $t("labelEmail") }}</label>
-                                <input
+                                <UInput
                                     v-model="loginEmail"
                                     type="email"
                                     id="login-email"
                                     :placeholder="$t('placeholderEmailAddress')"
-                                    class="dialog-input"
                                     @keyup.enter="handleUsePasskey"
                                 />
                             </div>
                             <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
 
-                            <div class="dialog-buttons">
-                                <a
-                                    href="#"
-                                    class="regular-button dialog-primary-button"
-                                    @click.prevent="handleUsePasskey"
-                                >
-                                    <i class="fas fa-key dialog-button-icon"></i>
-                                    <span>{{ $t("labelSignInWithPasskey") }}</span>
-                                </a>
-                            </div>
+                            <UButton
+                                block
+                                icon="i-lucide-key-round"
+                                :label="$t('labelSignInWithPasskey')"
+                                @click="handleUsePasskey"
+                            />
 
                             <div class="dialog-footer">
                                 <p class="dialog-hint">
                                     {{ $t("labelNoPasskeyPrompt") }}
-                                    <a href="#" class="dialog-link" @click.prevent="handleCreatePasskey">{{
-                                        $t("labelSetOnePasskeyUp")
-                                    }}</a>
+                                    <UButton
+                                        variant="link"
+                                        size="xs"
+                                        :label="$t('labelSetOnePasskeyUp')"
+                                        @click="handleCreatePasskey"
+                                    />
                                 </p>
-                                <a
-                                    href="#"
-                                    class="dialog-link dialog-link-muted"
-                                    @click.prevent="switchToCodeRequest"
-                                    >{{ $t("labelSignInWithEmailCode") }}</a
-                                >
+                                <UButton
+                                    variant="link"
+                                    size="xs"
+                                    color="neutral"
+                                    :label="$t('labelSignInWithEmailCode')"
+                                    @click="switchToCodeRequest"
+                                />
                             </div>
                         </template>
 
                         <!-- Email-code request mode -->
                         <template v-else-if="loginMode === 'code-request'">
-                            <div class="dialog-input-group">
+                            <div class="dialog-field">
                                 <label for="login-email-code" class="dialog-label">{{ $t("labelEmail") }}</label>
-                                <input
+                                <UInput
                                     v-model="loginEmail"
                                     type="email"
                                     id="login-email-code"
                                     :placeholder="$t('placeholderEmailAddress')"
-                                    class="dialog-input"
                                     @keyup.enter="handleRequestCode"
                                 />
                             </div>
                             <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
 
-                            <div class="dialog-buttons">
-                                <a
-                                    href="#"
-                                    class="regular-button dialog-primary-button"
-                                    :class="{ 'button-disabled': loginSubmitting }"
-                                    @click.prevent="handleRequestCode"
-                                >
-                                    {{ $t("labelSendVerificationCode") }}
-                                </a>
-                            </div>
+                            <UButton
+                                block
+                                :label="$t('labelSendVerificationCode')"
+                                :loading="loginSubmitting"
+                                @click="handleRequestCode"
+                            />
 
                             <div class="dialog-footer">
-                                <a href="#" class="dialog-link dialog-link-muted" @click.prevent="switchToPasskey">{{
-                                    $t("labelBackToPasskey")
-                                }}</a>
+                                <UButton
+                                    variant="link"
+                                    size="xs"
+                                    color="neutral"
+                                    :label="$t('labelBackToPasskey')"
+                                    @click="switchToPasskey"
+                                />
                             </div>
                         </template>
 
                         <!-- Email-code verify mode -->
                         <template v-else-if="loginMode === 'code-verify'">
-                            <div class="dialog-input-group">
+                            <div class="dialog-field">
                                 <label for="login-code-input" class="dialog-label">{{
                                     $t("labelVerificationCode")
                                 }}</label>
-                                <input
+                                <UInput
                                     v-model="loginCode"
                                     ref="loginCodeInputRef"
-                                    type="text"
                                     id="login-code-input"
                                     maxlength="8"
-                                    class="dialog-input dialog-input-code"
+                                    class="dialog-input-code"
                                     @keyup.enter="handleVerifyCode"
                                 />
                             </div>
                             <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
 
-                            <div class="dialog-buttons">
-                                <a
-                                    href="#"
-                                    class="regular-button dialog-primary-button"
-                                    :class="{ 'button-disabled': loginSubmitting }"
-                                    @click.prevent="handleVerifyCode"
-                                >
-                                    {{ $t("submit") }}
-                                </a>
-                            </div>
+                            <UButton block :label="$t('submit')" :loading="loginSubmitting" @click="handleVerifyCode" />
 
                             <div class="dialog-footer">
-                                <a
-                                    href="#"
-                                    class="dialog-link dialog-link-muted"
-                                    @click.prevent="switchToCodeRequest"
-                                    >{{ $t("labelBack") }}</a
-                                >
+                                <UButton
+                                    variant="link"
+                                    size="xs"
+                                    color="neutral"
+                                    :label="$t('labelBack')"
+                                    @click="switchToCodeRequest"
+                                />
                             </div>
                         </template>
                     </div>
@@ -163,35 +157,30 @@
             <!-- Verification Code Dialog -->
             <dialog ref="dialogVerificationRef" class="login-dialog">
                 <div class="dialog-container">
-                    <button class="dialog-close-button" aria-label="Close" @click.prevent="closeVerificationDialog">
-                        &times;
-                    </button>
+                    <UButton
+                        variant="ghost"
+                        icon="i-lucide-x"
+                        size="sm"
+                        class="dialog-close-button"
+                        aria-label="Close"
+                        @click="closeVerificationDialog"
+                    />
                     <h3 class="dialog-title">{{ $t("titleEnterVerificationCode") }}</h3>
                     <div class="dialog-content">
-                        <div class="dialog-input-group">
+                        <div class="dialog-field">
                             <label for="verification-code-input" class="dialog-label">{{
                                 $t("labelVerificationCode")
                             }}</label>
-                            <input
+                            <UInput
                                 v-model="verificationCode"
                                 ref="verificationInputRef"
-                                type="text"
                                 id="verification-code-input"
-                                placeholder=""
-                                class="dialog-input"
                                 @keyup.enter="handleVerificationSubmit"
                             />
                         </div>
                         <p v-if="verificationError" class="dialog-error">{{ verificationError }}</p>
                     </div>
-                    <div class="dialog-buttons">
-                        <a
-                            href="#"
-                            class="regular-button dialog-submit-button"
-                            @click.prevent="handleVerificationSubmit"
-                            >{{ $t("submit") }}</a
-                        >
-                    </div>
+                    <UButton block :label="$t('submit')" @click="handleVerificationSubmit" />
                 </div>
             </dialog>
 
@@ -393,17 +382,6 @@ export default defineComponent({
     position: absolute;
     top: 10px;
     right: 10px;
-    background: none;
-    border: none;
-    font-size: 24px;
-    cursor: pointer;
-    padding: 0;
-    width: 30px;
-    height: 30px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text);
 }
 
 .dialog-title {
@@ -418,8 +396,8 @@ export default defineComponent({
     justify-content: center;
 }
 
-.dialog-input-group {
-    margin-bottom: 15px;
+.dialog-field {
+    margin-bottom: 12px;
 }
 
 .dialog-error {
@@ -434,50 +412,12 @@ export default defineComponent({
     font-size: 12px;
 }
 
-.dialog-input {
-    width: 100%;
-    padding: 8px;
-    border: 1px solid var(--surface-500);
-    border-radius: 4px;
-    background-color: var(--surface-100);
-    color: var(--text);
-    box-sizing: border-box;
-}
-
-.dialog-buttons {
-    display: flex;
-    justify-content: center;
-    margin-top: 4px;
-}
-
-.dialog-primary-button {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    gap: 8px;
-    width: 100%;
-    padding: 10px 16px;
-    text-decoration: none;
-    font-size: 13px;
-    text-align: center;
-    box-sizing: border-box;
-}
-
-.dialog-button-icon {
-    font-size: 12px;
-}
-
-.button-disabled {
-    opacity: 0.6;
-    pointer-events: none;
-}
-
 .dialog-footer {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 8px;
-    margin-top: 16px;
+    gap: 4px;
+    margin-top: 12px;
     text-align: center;
 }
 
@@ -488,29 +428,9 @@ export default defineComponent({
     opacity: 0.75;
 }
 
-.dialog-link {
-    color: var(--primary-500);
-    font-size: 12px;
-    text-decoration: none;
-}
-
-.dialog-link:hover {
-    text-decoration: underline;
-}
-
-.dialog-link-muted {
-    color: var(--text);
-    opacity: 0.7;
-}
-
-.dialog-input-code {
+.dialog-input-code :deep(input) {
     text-align: center;
     letter-spacing: 0.15em;
-}
-
-.dialog-submit-button {
-    padding: 8px 24px;
-    text-decoration: none;
 }
 </style>
 

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -53,7 +53,7 @@
                                     id="login-email"
                                     :placeholder="$t('placeholderEmailAddress')"
                                     class="dialog-input"
-                                    @keypress.enter="handleUsePasskey"
+                                    @keyup.enter="handleUsePasskey"
                                 />
                             </div>
                             <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
@@ -95,7 +95,7 @@
                                     id="login-email-code"
                                     :placeholder="$t('placeholderEmailAddress')"
                                     class="dialog-input"
-                                    @keypress.enter="handleRequestCode"
+                                    @keyup.enter="handleRequestCode"
                                 />
                             </div>
                             <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
@@ -131,7 +131,7 @@
                                     id="login-code-input"
                                     maxlength="8"
                                     class="dialog-input dialog-input-code"
-                                    @keypress.enter="handleVerifyCode"
+                                    @keyup.enter="handleVerifyCode"
                                 />
                             </div>
                             <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
@@ -179,7 +179,7 @@
                                 id="verification-code-input"
                                 placeholder=""
                                 class="dialog-input"
-                                @keypress.enter="handleVerificationSubmit"
+                                @keyup.enter="handleVerificationSubmit"
                             />
                         </div>
                         <p v-if="verificationError" class="dialog-error">{{ verificationError }}</p>

--- a/src/js/LoginApi.js
+++ b/src/js/LoginApi.js
@@ -274,6 +274,42 @@ export default class LoginApi {
         }
     }
 
+    /**
+     * Verify an emailed code and obtain a refresh token without using a passkey.
+     * Intended for browsers where passkey authentication is unreliable.
+     */
+    async verifyLogin(email, code) {
+        const response = await fetch(`${this._url}/api/user/verify/${encodeURIComponent(email)}/login`, {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({ email, key: code }),
+        });
+
+        if (!response.ok) {
+            const text = await response.text();
+            let errorMsg = text || response.statusText;
+            try {
+                const body = JSON.parse(text);
+                if (body?.error) {
+                    errorMsg = body.error;
+                }
+            } catch {
+                // not JSON — use text as-is
+            }
+            throw new Error(errorMsg);
+        }
+
+        const result = await response.json();
+        if (!result.token) {
+            throw new Error("Server did not return a valid token");
+        }
+
+        setConfig({ userToken: result.token });
+        await this.checkToken();
+    }
+
     async isSignedIn() {
         try {
             return await this.checkToken();

--- a/src/js/LoginManager.js
+++ b/src/js/LoginManager.js
@@ -94,6 +94,7 @@ class LoginManager {
             this.hideWaitingDialog();
             gui_log(`${i18n.getMessage("userCreatePasskeyFailed")}: ${error}`);
             console.error("Create passkey error:", error);
+            throw error;
         }
     }
 
@@ -120,6 +121,7 @@ class LoginManager {
             this.hideWaitingDialog();
             gui_log(`${i18n.getMessage("userCreatePasskeyFailed")}: ${error}`);
             console.error("Verify and create passkey error:", error);
+            throw error;
         }
     }
 
@@ -198,6 +200,7 @@ class LoginManager {
             this.hideWaitingDialog();
             gui_log(`${i18n.getMessage("userLoginFailed")}: ${error}`);
             console.error("Login error:", error);
+            throw error;
         }
     }
 

--- a/src/js/LoginManager.js
+++ b/src/js/LoginManager.js
@@ -134,6 +134,48 @@ class LoginManager {
     }
 
     /**
+     * Request a verification code to be emailed to the user.
+     * Throws on failure so the caller can present a specific error.
+     */
+    async requestVerificationCode(email) {
+        try {
+            this.showWaitingDialog(i18n.getMessage("userSendingCode"));
+            await this._loginApi.requestTemporaryPassword(email);
+            this.hideWaitingDialog();
+        } catch (error) {
+            this.hideWaitingDialog();
+            gui_log(`${i18n.getMessage("userSendCodeFailed")}: ${error}`);
+            console.error("Request verification code error:", error);
+            throw error;
+        }
+    }
+
+    /**
+     * Login with an emailed verification code (no passkey).
+     * Used for browsers (e.g. Safari) where passkeys are unreliable.
+     * Throws on failure so the caller can present a specific error.
+     */
+    async loginWithEmailCode(email, code) {
+        try {
+            this.showWaitingDialog(i18n.getMessage("userVerifyingCode"));
+
+            await this._loginApi.verifyLogin(email, code);
+
+            await this.fetchUserProfile();
+            await this.updateTabVisibility();
+            this.notifyLoginCallbacks();
+
+            this.hideWaitingDialog();
+            gui_log(i18n.getMessage("userLoginSuccess"));
+        } catch (error) {
+            this.hideWaitingDialog();
+            gui_log(`${i18n.getMessage("userLoginFailed")}: ${error}`);
+            console.error("Email code login error:", error);
+            throw error;
+        }
+    }
+
+    /**
      * Login with existing passkey
      */
     async loginWithPasskey(email) {


### PR DESCRIPTION
## Summary
- Adds an email-code sign-in path alongside the existing passkey flow, for browsers (e.g. Safari) where passkey authentication is unreliable. Uses the new `POST /api/user/verify/{email}/login` endpoint.
- Redesigns the login dialog: Betaflight logo header, **Sign in with Passkey** primary button with key icon, "Don't have a passkey? Set one up" link for passkey creation, and a "Sign in with email code instead" toggle that switches the dialog into request/verify steps.
- Adds `LoginApi.verifyLogin`, `LoginManager.requestVerificationCode`, and `LoginManager.loginWithEmailCode`; parses structured `{ error }` responses from the Login API.

## Test plan
- [ ] Sign in with an existing passkey — dialog shows logo, email field, **Sign in with Passkey** button; login succeeds.
- [ ] Create a passkey — "Set one up" link triggers the existing create-passkey flow + verification dialog.
- [ ] Sign in with email code — toggle link switches to request step, send code, enter code, login succeeds.
- [ ] Invalid / expired code returns the structured error message from the API.
- [ ] Verify the dialog renders correctly in both light and dark themes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email verification code sign-in flow and passkey sign-in option.
  * New API-backed verification for email+code sign-in.

* **Improvements**
  * Multi-step, mode-driven login dialog with dynamic titles/descriptions and focused inputs.
  * New English UI labels and status messages for passkey and email-code flows.
  * Better Enter-key handling and focus behavior.

* **Refactor**
  * Unified login state and clearer handlers; errors now propagate to calling flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->