### PR TITLE
Fix Nuxt number inputs for PidTuning tab

### DIFF
--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -1255,6 +1255,11 @@ watch(dtermFilterMultiplier, (newValue, oldValue) => {
         });
 });
 
+watch(
+    () => JSON.stringify(FC.FILTER_CONFIG),
+    () => emit("change"),
+);
+
 // Re-sync local slider refs from FC state (called by parent after loadData/refresh)
 function forceUpdateSliders() {
     isUpdatingSliders = true;

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -1689,7 +1689,11 @@ watch(
     { deep: true },
 );
 
-watch([() => JSON.stringify(FC.PIDS), () => JSON.stringify(FC.ADVANCED_TUNING)], () => emit("change"));
+// Watch for changes to mark tab dirty state in parent component
+watch(
+    () => JSON.stringify(FC.PIDS),
+    () => emit("change"),
+);
 
 // Expose method to parent component to force slider update after save
 function forceUpdateSliders() {

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -688,6 +688,7 @@
                                         :step="0.01"
                                         :min="0"
                                         :max="1"
+                                        :format-options="{ minimumFractionDigits: 2, maximumFractionDigits: 2 }"
                                     />
                                     <label>
                                         <span v-html="$t('pidTuningFeedforwardTransition')"></span>
@@ -778,6 +779,7 @@
                                         :step="0.1"
                                         :min="0.1"
                                         :max="30"
+                                        :format-options="{ minimumFractionDigits: 1, maximumFractionDigits: 1 }"
                                     />
                                     <label for="antiGravityGain">
                                         <span v-html="$t('pidTuningAntiGravityGain')"></span>
@@ -1399,7 +1401,7 @@ const tpaBreakpoint = computed({
 
 // Feedforward transition display value (divided by 100 for display)
 const feedforwardTransitionValue = computed({
-    get: () => (FC.ADVANCED_TUNING.feedforwardTransition / 100).toFixed(2),
+    get: () => FC.ADVANCED_TUNING.feedforwardTransition / 100,
     set: (val) => (FC.ADVANCED_TUNING.feedforwardTransition = Math.round(Number.parseFloat(val) * 100)),
 });
 
@@ -1416,7 +1418,7 @@ const antiGravityEnabled = computed({
 
 // Anti-gravity gain display value (divided by 10 for display)
 const antiGravityGainValue = computed({
-    get: () => (FC.ADVANCED_TUNING.antiGravityGain / 10).toFixed(1),
+    get: () => FC.ADVANCED_TUNING.antiGravityGain / 10,
     set: (val) => (FC.ADVANCED_TUNING.antiGravityGain = Math.round(Number.parseFloat(val) * 10)),
 });
 
@@ -1686,6 +1688,8 @@ watch(
     },
     { deep: true },
 );
+
+watch([() => JSON.stringify(FC.PIDS), () => JSON.stringify(FC.ADVANCED_TUNING)], () => emit("change"));
 
 // Expose method to parent component to force slider update after save
 function forceUpdateSliders() {

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -1787,6 +1787,11 @@ watch(
     { immediate: true },
 );
 
+watch(
+    () => JSON.stringify(FC.RC_TUNING),
+    () => emit("change"),
+);
+
 onMounted(() => {
     // Initialize 3D Model for rates preview
     // Wait for MIXER_CONFIG to be available before initializing model


### PR DESCRIPTION
## TL;DR

- add watchers for each tab to emit change to update Save 
- remove toFixed and use :format-options={ minimumFractionDigits: 2, maximumFractionDigits: 2 }

# Fix: PID Tuning Save Button Not Updating After PR #4982

## Problem

PR #4982 replaced all `<input type="number">` with Nuxt UI's `<UInputNumber>` across 13 tabs.
After this change, editing any `UInputNumber` field on the **PidSubTab**, **RatesSubTab**, and
**FilterSubTab** no longer activates the **Save** button.

**Confirmed broken:** PidSubTab, RatesSubTab, FilterSubTab.
**Confirmed working:** MotorsTab (uses a different change-detection architecture).

## Root Cause: Timing Mismatch Between Native Events and Model Commit

### How PidTuningTab detects changes

`PidTuningTab.vue` wires change detection via:

```html
<form @input="onFormChanged" @change="onFormChanged">
    <PidSubTab    @change="onFormChanged" />
    <RatesSubTab  @change="onFormChanged" />
    <FilterSubTab @change="onFormChanged" />
</form>
```

`onFormChanged()` calls `pidTuningStore.checkForChanges()`, which compares current FC data
against stored originals via `JSON.stringify`.

### How reka-ui's NumberField handles events

From `NumberFieldInput.js` (reka-ui), the inner `<input type="text">` has these handlers:

| Event         | Handler                                    | Effect                          |
|---------------|--------------------------------------------|---------------------------------|
| `onInput`     | `inputValue.value = target.value`          | Local display only, NO model    |
| `onChange`     | `requestAnimationFrame(sync display)`      | Display sync only, NO model     |
| `onBlur`      | `rootContext.applyInputValue(target.value)` | **COMMITS model value**         |
| `onKeydown↵`  | `rootContext.applyInputValue(target.value)` | **COMMITS model value**         |

The model value is only committed on **blur** or **Enter key** via `applyInputValue()`, which
calls `modelValue.value = clampInputValue(parsedValue)` in `NumberFieldRoot.js` (line 153).

### The timing bug

When a user leaves a `UInputNumber` field, the browser fires native events in this order:

1. **Native `change`** fires → bubbles to `<form>` → `onFormChanged()` →
   `checkForChanges()` → **FC data NOT yet updated** → `hasChanges = false`
2. **Native `blur`** fires → `applyInputValue()` → `NumberFieldRoot` emits
   `update:model-value` → chain propagates → **FC data updated**

By the time FC data is updated (step 2), `checkForChanges()` has already run (step 1) and
found no changes. No subsequent event triggers a re-check.

### UInputNumber's Vue "change" event fires at the right time

After `applyInputValue()` commits the model, UInputNumber's `onUpdate()` runs
(`InputNumber.vue` line 77) and emits a **Vue custom `"change"` event**. At this point:

1. The forwarded emit has already updated the consumer's `v-model` / computed setter
2. FC data IS up-to-date

But this Vue custom event does NOT bubble through the DOM — it's only catchable by an explicit
`@change` listener on the `<UInputNumber>` element in the parent template, which none of the
subtabs currently have.

### Why MotorsTab works

MotorsTab uses **Vue watchers on reactive store properties** (`useMotorConfiguration` →
`setupConfigWatchers`), not DOM event bubbling. Watchers fire synchronously after the reactive
data mutates, so there's no timing gap.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed decimal display and input behavior for PID tuning fields so values show consistent fractional digits and edit correctly.

* **Improvements**
  * Improved responsiveness across Filter, PID, and Rates tuning tabs so configuration changes are detected and reflected more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->