### PR TITLE
Refactor: Convert Flight Plan tab to Nuxt UI

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3311,7 +3311,13 @@
         "message": "Please wait..."
     },
     "flightPlanClear": {
-        "message": "Clear Plan"
+        "message": "Clear"
+    },
+    "flightPlanLoad": {
+        "message": "Load"
+    },
+    "flightPlanSaveToFC": {
+        "message": "Save to FC"
     },
     "flightPlanLoaded": {
         "message": "Flight plan loaded successfully"
@@ -3369,6 +3375,15 @@
     },
     "flightPlanClearTitle": {
         "message": "Clear Flight Plan"
+    },
+    "flightPlanLoadPromptTitle": {
+        "message": "Load Flight Plan from Flight Controller?"
+    },
+    "flightPlanLoadPromptBody": {
+        "message": "A flight controller is connected. Do you want to replace the current flight plan with the one stored on the flight controller? Choosing No keeps your current plan so you can save it to the flight controller."
+    },
+    "flightPlanKeepLocal": {
+        "message": "Keep current"
     },
     "flightPlanElevationProfile": {
         "message": "Elevation Profile"

--- a/src/App.vue
+++ b/src/App.vue
@@ -158,6 +158,14 @@
                                     i18n_title="tabPreflight"
                                 ></a>
                             </li>
+                            <li class="tab_flight_plan" v-show="expertMode">
+                                <a
+                                    href="#"
+                                    i18n="tabFlightPlan"
+                                    class="tabicon ic_route"
+                                    i18n_title="tabFlightPlan"
+                                ></a>
+                            </li>
                         </ul>
                         <ul class="mode-connected">
                             <li class="tab_setup">

--- a/src/components/dialogs/ProfileSelectionDialog.vue
+++ b/src/components/dialogs/ProfileSelectionDialog.vue
@@ -29,7 +29,7 @@
 <script setup>
 import { ref } from "vue";
 
-const props = defineProps({
+defineProps({
     title: String,
     message: String,
     options: Array,

--- a/src/components/tabs/FlightPlan/ElevationProfile.vue
+++ b/src/components/tabs/FlightPlan/ElevationProfile.vue
@@ -234,7 +234,6 @@ const getSegmentKey = (fromUid, toUid) => `${fromUid}-${toUid}`;
 // Conversion constants
 const METERS_TO_FEET = 3.28084;
 const METERS_TO_NAUTICAL_MILES = 1 / 1852;
-const NAUTICAL_MILES_TO_METERS = 1852;
 
 // Calculate distance between two points using Haversine formula
 const calculateDistance = (lat1, lon1, lat2, lon2) => {
@@ -540,7 +539,7 @@ const handleMarkerHover = (point, index) => {
     };
 };
 
-const handleMouseMove = (event) => {
+const handleMouseMove = () => {
     // Keep current hover if over a marker
 };
 

--- a/src/components/tabs/FlightPlan/ElevationProfile.vue
+++ b/src/components/tabs/FlightPlan/ElevationProfile.vue
@@ -1,191 +1,193 @@
 <template>
     <UiBox :title="$t('flightPlanElevationProfile')" type="neutral" class="elevation-profile">
-        <div class="profile-stats" v-if="waypoints.length > 0">
-            <span class="stat">
-                <strong>{{ $t("flightPlanDistance") }}:</strong> {{ formatDistance(totalDistance) }}
-            </span>
-            <span class="stat">
-                <strong>{{ $t("flightPlanFlightTime") }}:</strong> {{ totalFlightTime }}
-            </span>
-            <span class="stat">
-                <strong>{{ $t("flightPlanMinAlt") }}:</strong> {{ minAltitude }}ft
-            </span>
-            <span class="stat">
-                <strong>{{ $t("flightPlanMaxAlt") }}:</strong> {{ maxAltitude }}ft
-            </span>
-            <span class="stat">
-                <strong>{{ $t("flightPlanGroundElev") }}:</strong> {{ groundElevation }}ft
-            </span>
-            <span class="stat">
-                <strong>{{ $t("flightPlanMaxGroundElev") }}:</strong> {{ maxGroundElevation }}ft
-            </span>
-        </div>
+        <template v-if="waypoints.length > 0">
+            <div class="profile-stats">
+                <span class="stat">
+                    <strong>{{ $t("flightPlanDistance") }}:</strong> {{ formatDistance(totalDistance) }}
+                </span>
+                <span class="stat">
+                    <strong>{{ $t("flightPlanFlightTime") }}:</strong> {{ totalFlightTime }}
+                </span>
+                <span class="stat">
+                    <strong>{{ $t("flightPlanMinAlt") }}:</strong> {{ minAltitude }}ft
+                </span>
+                <span class="stat">
+                    <strong>{{ $t("flightPlanMaxAlt") }}:</strong> {{ maxAltitude }}ft
+                </span>
+                <span class="stat">
+                    <strong>{{ $t("flightPlanGroundElev") }}:</strong> {{ groundElevation }}ft
+                </span>
+                <span class="stat">
+                    <strong>{{ $t("flightPlanMaxGroundElev") }}:</strong> {{ maxGroundElevation }}ft
+                </span>
+            </div>
 
-        <div class="profile-chart-container" v-if="waypoints.length > 0">
-            <svg
-                ref="chartSvg"
-                :viewBox="`0 0 ${chartWidth} ${chartHeight}`"
-                class="profile-chart"
-                @mousemove="handleMouseMove"
-                @mouseleave="handleMouseLeave"
-            >
-                <!-- Y-axis grid lines and labels -->
-                <g class="y-axis">
+            <div class="profile-chart-container">
+                <svg
+                    ref="chartSvg"
+                    :viewBox="`0 0 ${chartWidth} ${chartHeight}`"
+                    class="profile-chart"
+                    @mousemove="handleMouseMove"
+                    @mouseleave="handleMouseLeave"
+                >
+                    <!-- Y-axis grid lines and labels -->
+                    <g class="y-axis">
+                        <line
+                            v-for="tick in yAxisTicks"
+                            :key="`y-${tick.value}`"
+                            :x1="padding.left"
+                            :y1="tick.y"
+                            :x2="chartWidth - padding.right"
+                            :y2="tick.y"
+                            class="grid-line"
+                        />
+                        <text
+                            v-for="tick in yAxisTicks"
+                            :key="`y-label-${tick.value}`"
+                            :x="padding.left - 9"
+                            :y="tick.y + 3"
+                            class="axis-label"
+                            text-anchor="end"
+                        >
+                            {{ tick.value }}ft
+                        </text>
+                    </g>
+
+                    <!-- X-axis grid lines and labels -->
+                    <g class="x-axis">
+                        <line
+                            v-for="(point, index) in scaledProfilePoints"
+                            :key="`x-${index}`"
+                            :x1="point.x"
+                            :y1="padding.top"
+                            :x2="point.x"
+                            :y2="chartHeight - padding.bottom"
+                            class="grid-line-light"
+                        />
+                        <text
+                            v-for="(point, index) in scaledProfilePoints"
+                            :key="`x-label-${index}`"
+                            :x="point.x"
+                            :y="chartHeight - padding.bottom + 15"
+                            class="axis-label"
+                            text-anchor="middle"
+                        >
+                            {{ formatDistance(point.distance) }}
+                        </text>
+                    </g>
+
+                    <!-- Terrain area fill (ground elevation at each waypoint) -->
+                    <path v-if="terrainAreaPath" :d="terrainAreaPath" class="terrain-area" />
+
+                    <!-- Terrain line (ground elevation profile) -->
+                    <path v-if="terrainLinePath" :d="terrainLinePath" class="terrain-line" />
+
+                    <!-- Average ground elevation reference line -->
                     <line
-                        v-for="tick in yAxisTicks"
-                        :key="`y-${tick.value}`"
+                        v-if="groundElevation > 0"
                         :x1="padding.left"
-                        :y1="tick.y"
+                        :y1="scaleY(groundElevation)"
                         :x2="chartWidth - padding.right"
-                        :y2="tick.y"
-                        class="grid-line"
+                        :y2="scaleY(groundElevation)"
+                        class="ground-line"
                     />
                     <text
-                        v-for="tick in yAxisTicks"
-                        :key="`y-label-${tick.value}`"
-                        :x="padding.left - 9"
-                        :y="tick.y + 3"
-                        class="axis-label"
+                        v-if="groundElevation > 0"
+                        :x="chartWidth - padding.right - 5"
+                        :y="scaleY(groundElevation) - 3"
+                        class="ground-label"
                         text-anchor="end"
                     >
-                        {{ tick.value }}ft
+                        {{ $t("flightPlanAvgGround") }}
                     </text>
-                </g>
 
-                <!-- X-axis grid lines and labels -->
-                <g class="x-axis">
+                    <!-- Maximum ground elevation reference line -->
                     <line
-                        v-for="(point, index) in scaledProfilePoints"
-                        :key="`x-${index}`"
-                        :x1="point.x"
-                        :y1="padding.top"
-                        :x2="point.x"
-                        :y2="chartHeight - padding.bottom"
-                        class="grid-line-light"
+                        v-if="maxGroundElevation > 0"
+                        :x1="padding.left"
+                        :y1="scaleY(maxGroundElevation)"
+                        :x2="chartWidth - padding.right"
+                        :y2="scaleY(maxGroundElevation)"
+                        class="max-ground-line"
                     />
                     <text
-                        v-for="(point, index) in scaledProfilePoints"
-                        :key="`x-label-${index}`"
-                        :x="point.x"
-                        :y="chartHeight - padding.bottom + 15"
-                        class="axis-label"
-                        text-anchor="middle"
+                        v-if="maxGroundElevation > 0"
+                        :x="chartWidth - padding.right - 5"
+                        :y="scaleY(maxGroundElevation) - 3"
+                        class="max-ground-label"
+                        text-anchor="end"
                     >
-                        {{ formatDistance(point.distance) }}
+                        {{ $t("flightPlanMaxGround") }}
                     </text>
-                </g>
 
-                <!-- Terrain area fill (ground elevation at each waypoint) -->
-                <path v-if="terrainAreaPath" :d="terrainAreaPath" class="terrain-area" />
+                    <!-- Elevation area fill -->
+                    <path :d="areaPath" class="elevation-area" />
 
-                <!-- Terrain line (ground elevation profile) -->
-                <path v-if="terrainLinePath" :d="terrainLinePath" class="terrain-line" />
+                    <!-- Elevation line -->
+                    <path :d="linePath" class="elevation-line" />
 
-                <!-- Average ground elevation reference line -->
-                <line
-                    v-if="groundElevation > 0"
-                    :x1="padding.left"
-                    :y1="scaleY(groundElevation)"
-                    :x2="chartWidth - padding.right"
-                    :y2="scaleY(groundElevation)"
-                    class="ground-line"
-                />
-                <text
-                    v-if="groundElevation > 0"
-                    :x="chartWidth - padding.right - 5"
-                    :y="scaleY(groundElevation) - 3"
-                    class="ground-label"
-                    text-anchor="end"
-                >
-                    {{ $t("flightPlanAvgGround") }}
-                </text>
+                    <!-- Waypoint markers -->
+                    <g class="waypoint-markers">
+                        <circle
+                            v-for="(point, index) in scaledProfilePoints"
+                            :key="`marker-${index}`"
+                            :cx="point.x"
+                            :cy="point.y"
+                            :r="point.uid === selectedWaypointUid ? 4 : 3"
+                            :class="['waypoint-marker', { selected: point.uid === selectedWaypointUid }]"
+                            @click="handleWaypointClick(point.uid)"
+                            @mouseenter="handleMarkerHover(point, index)"
+                        />
+                        <text
+                            v-for="(point, index) in scaledProfilePoints"
+                            :key="`label-${index}`"
+                            :x="point.x"
+                            :y="point.y - 8"
+                            class="waypoint-label"
+                            text-anchor="middle"
+                        >
+                            WP{{ index + 1 }}
+                        </text>
+                    </g>
 
-                <!-- Maximum ground elevation reference line -->
-                <line
-                    v-if="maxGroundElevation > 0"
-                    :x1="padding.left"
-                    :y1="scaleY(maxGroundElevation)"
-                    :x2="chartWidth - padding.right"
-                    :y2="scaleY(maxGroundElevation)"
-                    class="max-ground-line"
-                />
-                <text
-                    v-if="maxGroundElevation > 0"
-                    :x="chartWidth - padding.right - 5"
-                    :y="scaleY(maxGroundElevation) - 3"
-                    class="max-ground-label"
-                    text-anchor="end"
-                >
-                    {{ $t("flightPlanMaxGround") }}
-                </text>
-
-                <!-- Elevation area fill -->
-                <path :d="areaPath" class="elevation-area" />
-
-                <!-- Elevation line -->
-                <path :d="linePath" class="elevation-line" />
-
-                <!-- Waypoint markers -->
-                <g class="waypoint-markers">
-                    <circle
-                        v-for="(point, index) in scaledProfilePoints"
-                        :key="`marker-${index}`"
-                        :cx="point.x"
-                        :cy="point.y"
-                        :r="point.uid === selectedWaypointUid ? 4 : 3"
-                        :class="['waypoint-marker', { selected: point.uid === selectedWaypointUid }]"
-                        @click="handleWaypointClick(point.uid)"
-                        @mouseenter="handleMarkerHover(point, index)"
-                    />
-                    <text
-                        v-for="(point, index) in scaledProfilePoints"
-                        :key="`label-${index}`"
-                        :x="point.x"
-                        :y="point.y - 8"
-                        class="waypoint-label"
-                        text-anchor="middle"
-                    >
-                        WP{{ index + 1 }}
-                    </text>
-                </g>
-
-                <!-- Hover tooltip -->
-                <g v-if="hoveredPoint" class="hover-tooltip">
-                    <rect
-                        :x="hoveredPoint.tooltipX - 50"
-                        :y="hoveredPoint.tooltipY - 40"
-                        width="100"
-                        height="38"
-                        class="tooltip-bg"
-                        rx="3"
-                    />
-                    <text
-                        :x="hoveredPoint.tooltipX"
-                        :y="hoveredPoint.tooltipY - 25"
-                        class="tooltip-text"
-                        text-anchor="middle"
-                    >
-                        WP{{ hoveredPoint.index + 1 }}
-                    </text>
-                    <text
-                        :x="hoveredPoint.tooltipX"
-                        :y="hoveredPoint.tooltipY - 12"
-                        class="tooltip-text"
-                        text-anchor="middle"
-                    >
-                        {{ $t("flightPlanAlt") }}: {{ hoveredPoint.altitude }}ft
-                    </text>
-                    <text
-                        :x="hoveredPoint.tooltipX"
-                        :y="hoveredPoint.tooltipY + 1"
-                        class="tooltip-text"
-                        text-anchor="middle"
-                    >
-                        {{ $t("flightPlanDist") }}: {{ formatDistance(hoveredPoint.distance) }}
-                    </text>
-                </g>
-            </svg>
-        </div>
+                    <!-- Hover tooltip -->
+                    <g v-if="hoveredPoint" class="hover-tooltip">
+                        <rect
+                            :x="hoveredPoint.tooltipX - 50"
+                            :y="hoveredPoint.tooltipY - 40"
+                            width="100"
+                            height="38"
+                            class="tooltip-bg"
+                            rx="3"
+                        />
+                        <text
+                            :x="hoveredPoint.tooltipX"
+                            :y="hoveredPoint.tooltipY - 25"
+                            class="tooltip-text"
+                            text-anchor="middle"
+                        >
+                            WP{{ hoveredPoint.index + 1 }}
+                        </text>
+                        <text
+                            :x="hoveredPoint.tooltipX"
+                            :y="hoveredPoint.tooltipY - 12"
+                            class="tooltip-text"
+                            text-anchor="middle"
+                        >
+                            {{ $t("flightPlanAlt") }}: {{ hoveredPoint.altitude }}ft
+                        </text>
+                        <text
+                            :x="hoveredPoint.tooltipX"
+                            :y="hoveredPoint.tooltipY + 1"
+                            class="tooltip-text"
+                            text-anchor="middle"
+                        >
+                            {{ $t("flightPlanDist") }}: {{ formatDistance(hoveredPoint.distance) }}
+                        </text>
+                    </g>
+                </svg>
+            </div>
+        </template>
 
         <div v-else class="no-waypoints">
             <p>{{ $t("flightPlanNoWaypointsForProfile") }}</p>

--- a/src/components/tabs/FlightPlan/ElevationProfile.vue
+++ b/src/components/tabs/FlightPlan/ElevationProfile.vue
@@ -1,205 +1,201 @@
 <template>
-    <div class="gui_box grey elevation-profile">
-        <div class="gui_box_titlebar">
-            <div class="spacer_box_title" v-html="$t('flightPlanElevationProfile')"></div>
+    <UiBox :title="$t('flightPlanElevationProfile')" type="neutral" class="elevation-profile">
+        <div class="profile-stats" v-if="waypoints.length > 0">
+            <span class="stat">
+                <strong>{{ $t("flightPlanDistance") }}:</strong> {{ formatDistance(totalDistance) }}
+            </span>
+            <span class="stat">
+                <strong>{{ $t("flightPlanFlightTime") }}:</strong> {{ totalFlightTime }}
+            </span>
+            <span class="stat">
+                <strong>{{ $t("flightPlanMinAlt") }}:</strong> {{ minAltitude }}ft
+            </span>
+            <span class="stat">
+                <strong>{{ $t("flightPlanMaxAlt") }}:</strong> {{ maxAltitude }}ft
+            </span>
+            <span class="stat">
+                <strong>{{ $t("flightPlanGroundElev") }}:</strong> {{ groundElevation }}ft
+            </span>
+            <span class="stat">
+                <strong>{{ $t("flightPlanMaxGroundElev") }}:</strong> {{ maxGroundElevation }}ft
+            </span>
         </div>
-        <div class="spacer_box">
-            <div class="profile-stats" v-if="waypoints.length > 0">
-                <span class="stat">
-                    <strong>{{ $t("flightPlanDistance") }}:</strong> {{ formatDistance(totalDistance) }}
-                </span>
-                <span class="stat">
-                    <strong>{{ $t("flightPlanFlightTime") }}:</strong> {{ totalFlightTime }}
-                </span>
-                <span class="stat">
-                    <strong>{{ $t("flightPlanMinAlt") }}:</strong> {{ minAltitude }}ft
-                </span>
-                <span class="stat">
-                    <strong>{{ $t("flightPlanMaxAlt") }}:</strong> {{ maxAltitude }}ft
-                </span>
-                <span class="stat">
-                    <strong>{{ $t("flightPlanGroundElev") }}:</strong> {{ groundElevation }}ft
-                </span>
-                <span class="stat">
-                    <strong>{{ $t("flightPlanMaxGroundElev") }}:</strong> {{ maxGroundElevation }}ft
-                </span>
-            </div>
 
-            <div class="profile-chart-container" v-if="waypoints.length > 0">
-                <svg
-                    ref="chartSvg"
-                    :viewBox="`0 0 ${chartWidth} ${chartHeight}`"
-                    class="profile-chart"
-                    @mousemove="handleMouseMove"
-                    @mouseleave="handleMouseLeave"
+        <div class="profile-chart-container" v-if="waypoints.length > 0">
+            <svg
+                ref="chartSvg"
+                :viewBox="`0 0 ${chartWidth} ${chartHeight}`"
+                class="profile-chart"
+                @mousemove="handleMouseMove"
+                @mouseleave="handleMouseLeave"
+            >
+                <!-- Y-axis grid lines and labels -->
+                <g class="y-axis">
+                    <line
+                        v-for="tick in yAxisTicks"
+                        :key="`y-${tick.value}`"
+                        :x1="padding.left"
+                        :y1="tick.y"
+                        :x2="chartWidth - padding.right"
+                        :y2="tick.y"
+                        class="grid-line"
+                    />
+                    <text
+                        v-for="tick in yAxisTicks"
+                        :key="`y-label-${tick.value}`"
+                        :x="padding.left - 9"
+                        :y="tick.y + 3"
+                        class="axis-label"
+                        text-anchor="end"
+                    >
+                        {{ tick.value }}ft
+                    </text>
+                </g>
+
+                <!-- X-axis grid lines and labels -->
+                <g class="x-axis">
+                    <line
+                        v-for="(point, index) in scaledProfilePoints"
+                        :key="`x-${index}`"
+                        :x1="point.x"
+                        :y1="padding.top"
+                        :x2="point.x"
+                        :y2="chartHeight - padding.bottom"
+                        class="grid-line-light"
+                    />
+                    <text
+                        v-for="(point, index) in scaledProfilePoints"
+                        :key="`x-label-${index}`"
+                        :x="point.x"
+                        :y="chartHeight - padding.bottom + 15"
+                        class="axis-label"
+                        text-anchor="middle"
+                    >
+                        {{ formatDistance(point.distance) }}
+                    </text>
+                </g>
+
+                <!-- Terrain area fill (ground elevation at each waypoint) -->
+                <path v-if="terrainAreaPath" :d="terrainAreaPath" class="terrain-area" />
+
+                <!-- Terrain line (ground elevation profile) -->
+                <path v-if="terrainLinePath" :d="terrainLinePath" class="terrain-line" />
+
+                <!-- Average ground elevation reference line -->
+                <line
+                    v-if="groundElevation > 0"
+                    :x1="padding.left"
+                    :y1="scaleY(groundElevation)"
+                    :x2="chartWidth - padding.right"
+                    :y2="scaleY(groundElevation)"
+                    class="ground-line"
+                />
+                <text
+                    v-if="groundElevation > 0"
+                    :x="chartWidth - padding.right - 5"
+                    :y="scaleY(groundElevation) - 3"
+                    class="ground-label"
+                    text-anchor="end"
                 >
-                    <!-- Y-axis grid lines and labels -->
-                    <g class="y-axis">
-                        <line
-                            v-for="tick in yAxisTicks"
-                            :key="`y-${tick.value}`"
-                            :x1="padding.left"
-                            :y1="tick.y"
-                            :x2="chartWidth - padding.right"
-                            :y2="tick.y"
-                            class="grid-line"
-                        />
-                        <text
-                            v-for="tick in yAxisTicks"
-                            :key="`y-label-${tick.value}`"
-                            :x="padding.left - 9"
-                            :y="tick.y + 3"
-                            class="axis-label"
-                            text-anchor="end"
-                        >
-                            {{ tick.value }}ft
-                        </text>
-                    </g>
+                    {{ $t("flightPlanAvgGround") }}
+                </text>
 
-                    <!-- X-axis grid lines and labels -->
-                    <g class="x-axis">
-                        <line
-                            v-for="(point, index) in scaledProfilePoints"
-                            :key="`x-${index}`"
-                            :x1="point.x"
-                            :y1="padding.top"
-                            :x2="point.x"
-                            :y2="chartHeight - padding.bottom"
-                            class="grid-line-light"
-                        />
-                        <text
-                            v-for="(point, index) in scaledProfilePoints"
-                            :key="`x-label-${index}`"
-                            :x="point.x"
-                            :y="chartHeight - padding.bottom + 15"
-                            class="axis-label"
-                            text-anchor="middle"
-                        >
-                            {{ formatDistance(point.distance) }}
-                        </text>
-                    </g>
+                <!-- Maximum ground elevation reference line -->
+                <line
+                    v-if="maxGroundElevation > 0"
+                    :x1="padding.left"
+                    :y1="scaleY(maxGroundElevation)"
+                    :x2="chartWidth - padding.right"
+                    :y2="scaleY(maxGroundElevation)"
+                    class="max-ground-line"
+                />
+                <text
+                    v-if="maxGroundElevation > 0"
+                    :x="chartWidth - padding.right - 5"
+                    :y="scaleY(maxGroundElevation) - 3"
+                    class="max-ground-label"
+                    text-anchor="end"
+                >
+                    {{ $t("flightPlanMaxGround") }}
+                </text>
 
-                    <!-- Terrain area fill (ground elevation at each waypoint) -->
-                    <path v-if="terrainAreaPath" :d="terrainAreaPath" class="terrain-area" />
+                <!-- Elevation area fill -->
+                <path :d="areaPath" class="elevation-area" />
 
-                    <!-- Terrain line (ground elevation profile) -->
-                    <path v-if="terrainLinePath" :d="terrainLinePath" class="terrain-line" />
+                <!-- Elevation line -->
+                <path :d="linePath" class="elevation-line" />
 
-                    <!-- Average ground elevation reference line -->
-                    <line
-                        v-if="groundElevation > 0"
-                        :x1="padding.left"
-                        :y1="scaleY(groundElevation)"
-                        :x2="chartWidth - padding.right"
-                        :y2="scaleY(groundElevation)"
-                        class="ground-line"
+                <!-- Waypoint markers -->
+                <g class="waypoint-markers">
+                    <circle
+                        v-for="(point, index) in scaledProfilePoints"
+                        :key="`marker-${index}`"
+                        :cx="point.x"
+                        :cy="point.y"
+                        :r="point.uid === selectedWaypointUid ? 4 : 3"
+                        :class="['waypoint-marker', { selected: point.uid === selectedWaypointUid }]"
+                        @click="handleWaypointClick(point.uid)"
+                        @mouseenter="handleMarkerHover(point, index)"
                     />
                     <text
-                        v-if="groundElevation > 0"
-                        :x="chartWidth - padding.right - 5"
-                        :y="scaleY(groundElevation) - 3"
-                        class="ground-label"
-                        text-anchor="end"
+                        v-for="(point, index) in scaledProfilePoints"
+                        :key="`label-${index}`"
+                        :x="point.x"
+                        :y="point.y - 8"
+                        class="waypoint-label"
+                        text-anchor="middle"
                     >
-                        {{ $t("flightPlanAvgGround") }}
+                        WP{{ index + 1 }}
                     </text>
+                </g>
 
-                    <!-- Maximum ground elevation reference line -->
-                    <line
-                        v-if="maxGroundElevation > 0"
-                        :x1="padding.left"
-                        :y1="scaleY(maxGroundElevation)"
-                        :x2="chartWidth - padding.right"
-                        :y2="scaleY(maxGroundElevation)"
-                        class="max-ground-line"
+                <!-- Hover tooltip -->
+                <g v-if="hoveredPoint" class="hover-tooltip">
+                    <rect
+                        :x="hoveredPoint.tooltipX - 50"
+                        :y="hoveredPoint.tooltipY - 40"
+                        width="100"
+                        height="38"
+                        class="tooltip-bg"
+                        rx="3"
                     />
                     <text
-                        v-if="maxGroundElevation > 0"
-                        :x="chartWidth - padding.right - 5"
-                        :y="scaleY(maxGroundElevation) - 3"
-                        class="max-ground-label"
-                        text-anchor="end"
+                        :x="hoveredPoint.tooltipX"
+                        :y="hoveredPoint.tooltipY - 25"
+                        class="tooltip-text"
+                        text-anchor="middle"
                     >
-                        {{ $t("flightPlanMaxGround") }}
+                        WP{{ hoveredPoint.index + 1 }}
                     </text>
-
-                    <!-- Elevation area fill -->
-                    <path :d="areaPath" class="elevation-area" />
-
-                    <!-- Elevation line -->
-                    <path :d="linePath" class="elevation-line" />
-
-                    <!-- Waypoint markers -->
-                    <g class="waypoint-markers">
-                        <circle
-                            v-for="(point, index) in scaledProfilePoints"
-                            :key="`marker-${index}`"
-                            :cx="point.x"
-                            :cy="point.y"
-                            :r="point.uid === selectedWaypointUid ? 4 : 3"
-                            :class="['waypoint-marker', { selected: point.uid === selectedWaypointUid }]"
-                            @click="handleWaypointClick(point.uid)"
-                            @mouseenter="handleMarkerHover(point, index)"
-                        />
-                        <text
-                            v-for="(point, index) in scaledProfilePoints"
-                            :key="`label-${index}`"
-                            :x="point.x"
-                            :y="point.y - 8"
-                            class="waypoint-label"
-                            text-anchor="middle"
-                        >
-                            WP{{ index + 1 }}
-                        </text>
-                    </g>
-
-                    <!-- Hover tooltip -->
-                    <g v-if="hoveredPoint" class="hover-tooltip">
-                        <rect
-                            :x="hoveredPoint.tooltipX - 50"
-                            :y="hoveredPoint.tooltipY - 40"
-                            width="100"
-                            height="38"
-                            class="tooltip-bg"
-                            rx="3"
-                        />
-                        <text
-                            :x="hoveredPoint.tooltipX"
-                            :y="hoveredPoint.tooltipY - 25"
-                            class="tooltip-text"
-                            text-anchor="middle"
-                        >
-                            WP{{ hoveredPoint.index + 1 }}
-                        </text>
-                        <text
-                            :x="hoveredPoint.tooltipX"
-                            :y="hoveredPoint.tooltipY - 12"
-                            class="tooltip-text"
-                            text-anchor="middle"
-                        >
-                            {{ $t("flightPlanAlt") }}: {{ hoveredPoint.altitude }}ft
-                        </text>
-                        <text
-                            :x="hoveredPoint.tooltipX"
-                            :y="hoveredPoint.tooltipY + 1"
-                            class="tooltip-text"
-                            text-anchor="middle"
-                        >
-                            {{ $t("flightPlanDist") }}: {{ formatDistance(hoveredPoint.distance) }}
-                        </text>
-                    </g>
-                </svg>
-            </div>
-
-            <div v-else class="no-waypoints">
-                <p>{{ $t("flightPlanNoWaypointsForProfile") }}</p>
-            </div>
+                    <text
+                        :x="hoveredPoint.tooltipX"
+                        :y="hoveredPoint.tooltipY - 12"
+                        class="tooltip-text"
+                        text-anchor="middle"
+                    >
+                        {{ $t("flightPlanAlt") }}: {{ hoveredPoint.altitude }}ft
+                    </text>
+                    <text
+                        :x="hoveredPoint.tooltipX"
+                        :y="hoveredPoint.tooltipY + 1"
+                        class="tooltip-text"
+                        text-anchor="middle"
+                    >
+                        {{ $t("flightPlanDist") }}: {{ formatDistance(hoveredPoint.distance) }}
+                    </text>
+                </g>
+            </svg>
         </div>
-    </div>
+
+        <div v-else class="no-waypoints">
+            <p>{{ $t("flightPlanNoWaypointsForProfile") }}</p>
+        </div>
+    </UiBox>
 </template>
 
 <script setup>
 import { ref, computed, watch } from "vue";
+import UiBox from "@/components/elements/UiBox.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
 
 const { sortedWaypoints, selectedWaypointUid, selectWaypoint } = useFlightPlan();
@@ -774,10 +770,6 @@ watch(
 </script>
 
 <style scoped>
-.elevation-profile {
-    margin-top: 1rem;
-}
-
 .profile-stats {
     display: flex;
     gap: 1rem;

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -1,26 +1,22 @@
 <template>
-    <div class="gui_box grey flight-plan-map">
-        <div class="gui_box_titlebar">
-            <div class="spacer_box_title" v-html="$t('flightPlanMap')"></div>
-        </div>
-        <div class="spacer_box">
-            <div class="map-container">
-                <div ref="mapRef" class="map"></div>
-                <div v-if="isLoading" class="map-loading">
-                    <div class="loading-message">
-                        {{ $t("flightPlanLoading") }}
-                    </div>
+    <UiBox :title="$t('flightPlanMap')" type="neutral" class="flight-plan-map">
+        <div class="map-container">
+            <div ref="mapRef" class="map"></div>
+            <div v-if="isLoading" class="map-loading">
+                <div class="loading-message">
+                    {{ $t("flightPlanLoading") }}
                 </div>
             </div>
-            <div class="map-instructions">
-                <p v-html="$t('flightPlanMapInstructions')"></p>
-            </div>
         </div>
-    </div>
+        <div class="map-instructions">
+            <p v-html="$t('flightPlanMapInstructions')"></p>
+        </div>
+    </UiBox>
 </template>
 
 <script setup>
 import { ref, watch, onMounted, onUnmounted } from "vue";
+import UiBox from "@/components/elements/UiBox.vue";
 import { initMap } from "@/js/utils/map";
 import { fromLonLat, toLonLat } from "ol/proj";
 import { Feature } from "ol";
@@ -491,10 +487,6 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
-.flight-plan-map {
-    /* Inherits standard gui_box styling */
-}
-
 .map-container {
     height: 480px;
     border-radius: 4px;

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -487,8 +487,20 @@ onUnmounted(() => {
 </script>
 
 <style scoped>
+.flight-plan-map {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.flight-plan-map :deep(> div:last-child) {
+    flex: 1;
+    min-height: 0;
+}
+
 .map-container {
-    height: 480px;
+    flex: 1;
+    min-height: 480px;
     border-radius: 4px;
     overflow: hidden;
     border: 1px solid var(--surface-500);
@@ -536,7 +548,7 @@ onUnmounted(() => {
 
 @media (max-width: 1055px) {
     .map-container {
-        height: 320px;
+        min-height: 320px;
     }
 }
 </style>

--- a/src/components/tabs/FlightPlan/WaypointEditor.vue
+++ b/src/components/tabs/FlightPlan/WaypointEditor.vue
@@ -1,135 +1,87 @@
 <template>
     <Dialog v-model="showEditorDialog" :title="editMode ? $t('flightPlanEditWaypoint') : $t('flightPlanAddWaypoint')">
-        <form ref="formElement" @submit.prevent="handleSave">
-            <!-- Latitude -->
-            <div class="form-row">
-                <div class="input-column">
-                    <UInputNumber
-                        v-model="form.latitude"
-                        :step="0.000001"
-                        :min="-90"
-                        :max="90"
-                        required
-                        :aria-label="$t('flightPlanLatitude')"
-                    />
-                </div>
-                <div class="label-column" v-html="$t('flightPlanLatitude')"></div>
-                <div class="separator"></div>
-                <div class="extra-column-1"></div>
-                <div class="extra-column-2"></div>
-            </div>
+        <form ref="formElement" class="editor-form flex flex-col gap-3" @submit.prevent="handleSave">
+            <SettingRow :label="$t('flightPlanLatitude')" full-width>
+                <UInputNumber
+                    v-model="form.latitude"
+                    :step="0.000001"
+                    :min="-90"
+                    :max="90"
+                    required
+                    :aria-label="$t('flightPlanLatitude')"
+                    class="w-48"
+                />
+            </SettingRow>
 
-            <!-- Longitude -->
-            <div class="form-row">
-                <div class="input-column">
-                    <UInputNumber
-                        v-model="form.longitude"
-                        :step="0.000001"
-                        :min="-180"
-                        :max="180"
-                        required
-                        :aria-label="$t('flightPlanLongitude')"
-                    />
-                </div>
-                <div class="label-column" v-html="$t('flightPlanLongitude')"></div>
-                <div class="separator"></div>
-                <div class="extra-column-1"></div>
-                <div class="extra-column-2"></div>
-            </div>
+            <SettingRow :label="$t('flightPlanLongitude')" full-width>
+                <UInputNumber
+                    v-model="form.longitude"
+                    :step="0.000001"
+                    :min="-180"
+                    :max="180"
+                    required
+                    :aria-label="$t('flightPlanLongitude')"
+                    class="w-48"
+                />
+            </SettingRow>
 
-            <!-- Altitude -->
-            <div class="form-row">
-                <div class="input-column">
-                    <UInputNumber
-                        v-model="form.altitude"
-                        :step="1"
-                        :min="0"
-                        :max="50000"
-                        required
-                        :aria-label="$t('flightPlanAltitude')"
-                    />
-                </div>
-                <div class="label-column" v-html="$t('flightPlanAltitude')"></div>
-                <div class="separator"></div>
-                <div class="extra-column-1"></div>
-                <div class="extra-column-2"></div>
-            </div>
+            <SettingRow :label="$t('flightPlanAltitude')" full-width>
+                <UInputNumber
+                    v-model="form.altitude"
+                    :step="1"
+                    :min="0"
+                    :max="50000"
+                    required
+                    :aria-label="$t('flightPlanAltitude')"
+                    class="w-48"
+                />
+            </SettingRow>
 
-            <!-- Speed -->
-            <div class="form-row">
-                <div class="input-column">
-                    <UInputNumber
-                        v-model="form.speed"
-                        :step="0.1"
-                        :min="0"
-                        :max="500"
-                        required
-                        :aria-label="$t('flightPlanSpeed')"
-                    />
-                </div>
-                <div class="label-column" v-html="$t('flightPlanSpeed')"></div>
-                <div class="separator"></div>
-                <div class="extra-column-1"></div>
-                <div class="extra-column-2"></div>
-            </div>
+            <SettingRow :label="$t('flightPlanSpeed')" full-width>
+                <UInputNumber
+                    v-model="form.speed"
+                    :step="0.1"
+                    :min="0"
+                    :max="500"
+                    required
+                    :aria-label="$t('flightPlanSpeed')"
+                    class="w-48"
+                />
+            </SettingRow>
 
-            <!-- Type -->
-            <div class="form-row">
-                <div class="input-column">
-                    <select v-model="form.type" :aria-label="$t('flightPlanType')">
-                        <option value="flyover">{{ $t("flightPlanTypeFlyover") }}</option>
-                        <option value="flyby">{{ $t("flightPlanTypeFlyby") }}</option>
-                        <option value="hold">{{ $t("flightPlanTypeHold") }}</option>
-                        <option value="land">{{ $t("flightPlanTypeLand") }}</option>
-                    </select>
-                </div>
-                <div class="label-column" v-html="$t('flightPlanType')"></div>
-                <div class="separator"></div>
-                <div class="extra-column-1"></div>
-                <div class="extra-column-2"></div>
-            </div>
+            <SettingRow :label="$t('flightPlanType')" full-width>
+                <USelect v-model="form.type" :items="typeItems" :aria-label="$t('flightPlanType')" class="w-48" />
+            </SettingRow>
 
-            <!-- Duration (conditional - only for hold) -->
-            <div v-if="form.type === 'hold'" class="form-row">
-                <div class="input-column">
-                    <UInputNumber
-                        v-model="form.duration"
-                        :step="0.1"
-                        :min="0"
-                        :max="60"
-                        :aria-label="$t('flightPlanDuration')"
-                    />
-                </div>
-                <div class="label-column" v-html="$t('flightPlanDuration')"></div>
-                <div class="separator"></div>
-                <div class="extra-column-1"></div>
-                <div class="extra-column-2"></div>
-            </div>
+            <SettingRow v-if="form.type === 'hold'" :label="$t('flightPlanDuration')" full-width>
+                <UInputNumber
+                    v-model="form.duration"
+                    :step="0.1"
+                    :min="0"
+                    :max="60"
+                    :aria-label="$t('flightPlanDuration')"
+                    class="w-48"
+                />
+            </SettingRow>
 
-            <!-- Pattern (conditional - only for hold) -->
-            <div v-if="form.type === 'hold'" class="form-row">
-                <div class="input-column">
-                    <select v-model="form.pattern" :aria-label="$t('flightPlanPattern')">
-                        <option value="circle">{{ $t("flightPlanPatternCircle") }}</option>
-                        <option value="figure8">{{ $t("flightPlanPatternFigure8") }}</option>
-                        <option value="orbit">{{ $t("flightPlanPatternOrbit") }}</option>
-                    </select>
-                </div>
-                <div class="label-column" v-html="$t('flightPlanPattern')"></div>
-                <div class="separator"></div>
-                <div class="extra-column-1"></div>
-                <div class="extra-column-2"></div>
-            </div>
+            <SettingRow v-if="form.type === 'hold'" :label="$t('flightPlanPattern')" full-width>
+                <USelect
+                    v-model="form.pattern"
+                    :items="patternItems"
+                    :aria-label="$t('flightPlanPattern')"
+                    class="w-48"
+                />
+            </SettingRow>
         </form>
 
         <template #footer>
-            <div class="buttons">
-                <button type="button" @click="handleCancel" class="cancel-btn">
+            <div class="flex gap-2 justify-end">
+                <UButton variant="soft" color="neutral" @click="handleCancel">
                     {{ $t("cancel") }}
-                </button>
-                <button type="button" @click="handleSave" class="primary save-btn">
+                </UButton>
+                <UButton color="primary" @click="handleSave">
                     {{ editMode ? $t("update") : $t("add") }}
-                </button>
+                </UButton>
             </div>
         </template>
     </Dialog>
@@ -138,7 +90,9 @@
 <script setup>
 import { reactive, computed, watch, ref } from "vue";
 import Dialog from "@/components/elements/Dialog.vue";
+import SettingRow from "@/components/elements/SettingRow.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
+import { i18n } from "@/js/localization";
 
 const { editingWaypointUid, editingWaypoint, showEditorDialog, addWaypoint, updateWaypoint, cancelEdit } =
     useFlightPlan();
@@ -162,6 +116,19 @@ const form = reactive({
 
 // Check if we're in edit mode
 const editMode = computed(() => editingWaypointUid.value !== null);
+
+const typeItems = computed(() => [
+    { label: i18n.getMessage("flightPlanTypeFlyover"), value: "flyover" },
+    { label: i18n.getMessage("flightPlanTypeFlyby"), value: "flyby" },
+    { label: i18n.getMessage("flightPlanTypeHold"), value: "hold" },
+    { label: i18n.getMessage("flightPlanTypeLand"), value: "land" },
+]);
+
+const patternItems = computed(() => [
+    { label: i18n.getMessage("flightPlanPatternCircle"), value: "circle" },
+    { label: i18n.getMessage("flightPlanPatternFigure8"), value: "figure8" },
+    { label: i18n.getMessage("flightPlanPatternOrbit"), value: "orbit" },
+]);
 
 // Watch for editing waypoint changes and populate form
 watch(editingWaypoint, (waypoint) => {
@@ -267,91 +234,7 @@ const handleCancel = () => {
 </script>
 
 <style scoped>
-form {
-    min-width: 600px;
-}
-
-.form-row {
-    display: grid;
-    grid-template-columns: 0.575fr 2fr auto 1fr 1fr;
-    gap: 1rem;
-    margin-bottom: 0.75rem;
-    align-items: center;
-}
-
-.separator {
-    width: 1px;
-    height: 100%;
-    background: var(--surface-400);
-    opacity: 0.3;
-    margin: 0 0.5rem;
-}
-
-.extra-column-1,
-.extra-column-2 {
-    /* Placeholder for future options */
-}
-
-.input-column input,
-.input-column select {
-    width: 100%;
-    padding: 0.5rem;
-    border: 1px solid var(--surface-500);
-    border-radius: 4px;
-    background: var(--surface-50);
-    color: var(--text);
-    font-size: 0.9rem;
-}
-
-.input-column input:focus,
-.input-column select:focus {
-    outline: none;
-    border-color: var(--primary-500);
-}
-
-.label-column {
-    text-align: left;
-    color: var(--text);
-    font-size: 0.9rem;
-}
-
-.number,
-.select {
-    margin-bottom: 0.5rem;
-}
-
-.buttons {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: flex-end;
-}
-
-.buttons button {
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    border: 1px solid var(--surface-500);
-    background: var(--surface-200);
-    color: var(--text);
-    cursor: pointer;
-    transition: background 0.2s;
-}
-
-.buttons button:hover {
-    background: var(--surface-300);
-}
-
-.save-btn.primary {
-    background: var(--primary-500);
-    color: var(--surface-50);
-    border-color: var(--primary-500);
-}
-
-.save-btn.primary:hover {
-    background: var(--primary-600);
-    border-color: var(--primary-600);
-}
-
-.cancel-btn:hover {
-    background: var(--surface-400);
+.editor-form {
+    min-width: 400px;
 }
 </style>

--- a/src/components/tabs/FlightPlan/WaypointEditor.vue
+++ b/src/components/tabs/FlightPlan/WaypointEditor.vue
@@ -89,11 +89,12 @@
 
 <script setup>
 import { reactive, computed, watch, ref } from "vue";
+import { useTranslation } from "i18next-vue";
 import Dialog from "@/components/elements/Dialog.vue";
 import SettingRow from "@/components/elements/SettingRow.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
-import { i18n } from "@/js/localization";
 
+const { t } = useTranslation();
 const { editingWaypointUid, editingWaypoint, showEditorDialog, addWaypoint, updateWaypoint, cancelEdit } =
     useFlightPlan();
 
@@ -118,16 +119,16 @@ const form = reactive({
 const editMode = computed(() => editingWaypointUid.value !== null);
 
 const typeItems = computed(() => [
-    { label: i18n.getMessage("flightPlanTypeFlyover"), value: "flyover" },
-    { label: i18n.getMessage("flightPlanTypeFlyby"), value: "flyby" },
-    { label: i18n.getMessage("flightPlanTypeHold"), value: "hold" },
-    { label: i18n.getMessage("flightPlanTypeLand"), value: "land" },
+    { label: t("flightPlanTypeFlyover"), value: "flyover" },
+    { label: t("flightPlanTypeFlyby"), value: "flyby" },
+    { label: t("flightPlanTypeHold"), value: "hold" },
+    { label: t("flightPlanTypeLand"), value: "land" },
 ]);
 
 const patternItems = computed(() => [
-    { label: i18n.getMessage("flightPlanPatternCircle"), value: "circle" },
-    { label: i18n.getMessage("flightPlanPatternFigure8"), value: "figure8" },
-    { label: i18n.getMessage("flightPlanPatternOrbit"), value: "orbit" },
+    { label: t("flightPlanPatternCircle"), value: "circle" },
+    { label: t("flightPlanPatternFigure8"), value: "figure8" },
+    { label: t("flightPlanPatternOrbit"), value: "orbit" },
 ]);
 
 // Watch for editing waypoint changes and populate form

--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -191,24 +191,11 @@ const handleDragEnd = (event) => {
 </script>
 
 <style scoped>
-.waypoint-list {
-    display: flex;
-    flex-direction: column;
-    min-height: 50%;
-}
-
 .note {
     padding: 1rem;
     text-align: center;
     color: var(--surface-700);
     font-style: italic;
-}
-
-.waypoints {
-    flex: 1;
-    min-height: 0;
-    max-height: 60dvh;
-    overflow-y: auto;
 }
 
 .waypoint-item {

--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -1,81 +1,81 @@
 <template>
-    <div class="gui_box grey waypoint-list">
-        <div class="gui_box_titlebar">
-            <div class="spacer_box_title" v-html="$t('flightPlanWaypointList')"></div>
+    <UiBox :title="$t('flightPlanWaypointList')" type="neutral" class="waypoint-list">
+        <div class="flex justify-end">
+            <UButton
+                icon="i-lucide-plus"
+                size="sm"
+                :aria-label="$t('flightPlanAddWaypoint')"
+                @click="handleAddWaypoint"
+            />
         </div>
-        <div class="spacer_box">
-            <div class="add-waypoint-row">
-                <button @click="handleAddWaypoint" class="add-waypoint-btn" :aria-label="$t('flightPlanAddWaypoint')">
-                    <i class="fa fa-plus"></i>
-                </button>
-            </div>
 
-            <div v-if="!waypoints.length" class="note">
-                <p v-html="$t('flightPlanNoWaypoints')"></p>
-            </div>
-            <div v-else>
-                <!-- Add waypoint button row -->
-                <!-- Waypoints list -->
-                <div class="waypoints">
-                    <div
-                        v-for="waypoint in sortedWaypoints"
-                        :key="waypoint.uid"
-                        class="waypoint-item"
-                        :class="{
-                            selected: selectedWaypointUid === waypoint.uid,
-                            'drag-over': dragOverUid === waypoint.uid,
-                        }"
-                        draggable="true"
-                        @click="selectWaypoint(waypoint.uid)"
-                        @dragstart="handleDragStart($event, waypoint.uid)"
-                        @dragover="handleDragOver($event, waypoint.uid)"
-                        @dragleave="handleDragLeave($event)"
-                        @drop="handleDrop($event, waypoint.uid)"
-                        @dragend="handleDragEnd($event)"
-                    >
-                        <div class="waypoint-order">{{ waypoint.order + 1 }}</div>
-                        <div class="waypoint-info">
-                            <div class="waypoint-coords">
-                                {{ waypoint.latitude.toFixed(6) }}°, {{ waypoint.longitude.toFixed(6) }}°
-                            </div>
-                            <div class="waypoint-details">
-                                {{ waypoint.altitude }}ft AMSL - {{ waypoint.speed }}kts -
-                                {{ getWaypointTypeLabel(waypoint.type) }}
-                                <span v-if="waypoint.type === 'hold'" class="hold-details">
-                                    ({{ waypoint.duration }}min, {{ getPatternLabel(waypoint.pattern) }})
-                                </span>
-                            </div>
-                        </div>
-                        <div class="waypoint-actions">
-                            <button @click.stop="handleEdit(waypoint.uid)" :aria-label="$t('edit')" class="edit-btn">
-                                <i class="fa fa-edit"></i>
-                            </button>
-                            <button
-                                @click.stop="handleRemove(waypoint.uid)"
-                                :aria-label="$t('delete')"
-                                class="delete-btn"
-                            >
-                                <i class="fa fa-trash"></i>
-                            </button>
-                        </div>
+        <div v-if="!waypoints.length" class="note">
+            <p v-html="$t('flightPlanNoWaypoints')"></p>
+        </div>
+        <div v-else class="waypoints">
+            <div
+                v-for="waypoint in sortedWaypoints"
+                :key="waypoint.uid"
+                class="waypoint-item"
+                :class="{
+                    selected: selectedWaypointUid === waypoint.uid,
+                    'drag-over': dragOverUid === waypoint.uid,
+                }"
+                draggable="true"
+                @click="selectWaypoint(waypoint.uid)"
+                @dragstart="handleDragStart($event, waypoint.uid)"
+                @dragover="handleDragOver($event, waypoint.uid)"
+                @dragleave="handleDragLeave($event)"
+                @drop="handleDrop($event, waypoint.uid)"
+                @dragend="handleDragEnd($event)"
+            >
+                <div class="waypoint-order">{{ waypoint.order + 1 }}</div>
+                <div class="waypoint-info">
+                    <div class="waypoint-coords">
+                        {{ waypoint.latitude.toFixed(6) }}°, {{ waypoint.longitude.toFixed(6) }}°
                     </div>
+                    <div class="waypoint-details">
+                        {{ waypoint.altitude }}ft AMSL - {{ waypoint.speed }}kts -
+                        {{ getWaypointTypeLabel(waypoint.type) }}
+                        <span v-if="waypoint.type === 'hold'" class="hold-details">
+                            ({{ waypoint.duration }}min, {{ getPatternLabel(waypoint.pattern) }})
+                        </span>
+                    </div>
+                </div>
+                <div class="flex gap-1 flex-shrink-0">
+                    <UButton
+                        icon="i-lucide-pencil"
+                        size="xs"
+                        variant="soft"
+                        color="primary"
+                        :aria-label="$t('edit')"
+                        @click.stop="handleEdit(waypoint.uid)"
+                    />
+                    <UButton
+                        icon="i-lucide-trash-2"
+                        size="xs"
+                        variant="soft"
+                        color="error"
+                        :aria-label="$t('delete')"
+                        @click.stop="handleRemove(waypoint.uid)"
+                    />
                 </div>
             </div>
         </div>
-    </div>
+    </UiBox>
 
     <!-- Delete Confirmation Dialog -->
     <Dialog v-model="showDeleteDialog" :title="$t('flightPlanDeleteWaypointTitle')">
         <p v-html="$t('flightPlanDeleteWaypointConfirm')"></p>
 
         <template #footer>
-            <div class="dialog-buttons">
-                <button @click="showDeleteDialog = false" class="cancel-btn">
+            <div class="flex gap-2 justify-end">
+                <UButton variant="soft" color="neutral" @click="showDeleteDialog = false">
                     {{ $t("cancel") }}
-                </button>
-                <button @click="confirmDelete" class="delete-btn primary">
+                </UButton>
+                <UButton color="error" @click="confirmDelete">
                     {{ $t("delete") }}
-                </button>
+                </UButton>
             </div>
         </template>
     </Dialog>
@@ -84,6 +84,7 @@
 <script setup>
 import { ref } from "vue";
 import Dialog from "@/components/elements/Dialog.vue";
+import UiBox from "@/components/elements/UiBox.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
 import { i18n } from "@/js/localization";
 
@@ -191,45 +192,9 @@ const handleDragEnd = (event) => {
 
 <style scoped>
 .waypoint-list {
-    margin-bottom: 1rem;
     display: flex;
     flex-direction: column;
     min-height: 50%;
-}
-
-.waypoint-list .spacer_box {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
-}
-
-.add-waypoint-row {
-    display: flex;
-    justify-content: flex-end;
-    padding: 0.35rem 0.5rem;
-    flex-shrink: 0;
-}
-
-.add-waypoint-btn {
-    width: 32px;
-    height: 32px;
-    padding: 0;
-    background: var(--primary-500);
-    color: var(--surface-50);
-    border: 1px solid var(--primary-500);
-    border-radius: 4px;
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 16px;
-    transition: background 0.2s;
-}
-
-.add-waypoint-btn:hover {
-    background: var(--primary-600);
-    border-color: var(--primary-600);
 }
 
 .note {
@@ -243,7 +208,7 @@ const handleDragEnd = (event) => {
     flex: 1;
     min-height: 0;
     max-height: 60dvh;
-    overflow-y: scroll;
+    overflow-y: auto;
 }
 
 .waypoint-item {
@@ -303,17 +268,6 @@ const handleDragEnd = (event) => {
     color: var(--surface-50);
 }
 
-.waypoint-item.selected .waypoint-actions button {
-    background: var(--surface-50);
-    border-color: var(--surface-50);
-    color: var(--primary-500);
-}
-
-.waypoint-item.selected .waypoint-actions button:hover {
-    background: var(--surface-100);
-    border-color: var(--surface-100);
-}
-
 .waypoint-order {
     width: 28px;
     height: 28px;
@@ -347,71 +301,5 @@ const handleDragEnd = (event) => {
 
 .hold-details {
     font-style: italic;
-}
-
-.waypoint-actions {
-    display: flex;
-    gap: 0.35rem;
-    flex-shrink: 0;
-}
-
-.waypoint-actions button {
-    padding: 0.4rem;
-    background: var(--surface-200);
-    border: 1px solid var(--surface-500);
-    color: var(--text);
-    cursor: pointer;
-    border-radius: 4px;
-    transition: background 0.2s;
-}
-
-.waypoint-actions button:hover {
-    background: var(--surface-300);
-}
-
-.edit-btn:hover {
-    background: var(--primary-200);
-    border-color: var(--primary-500);
-}
-
-.delete-btn:hover {
-    background: var(--error-200);
-    border-color: var(--error-500);
-    color: var(--error-700);
-}
-
-.dialog-buttons {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: flex-end;
-}
-
-.dialog-buttons button {
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    border: 1px solid var(--surface-500);
-    background: var(--surface-200);
-    color: var(--text);
-    cursor: pointer;
-    transition: background 0.2s;
-}
-
-.dialog-buttons button:hover {
-    background: var(--surface-300);
-}
-
-.dialog-buttons .delete-btn.primary {
-    background: var(--error-500);
-    color: var(--surface-50);
-    border-color: var(--error-500);
-}
-
-.dialog-buttons .delete-btn.primary:hover {
-    background: var(--error-600);
-    border-color: var(--error-600);
-}
-
-.dialog-buttons .cancel-btn:hover {
-    background: var(--surface-400);
 }
 </style>

--- a/src/components/tabs/FlightPlanTab.vue
+++ b/src/components/tabs/FlightPlanTab.vue
@@ -8,15 +8,15 @@
             </div>
 
             <!-- Two-column layout -->
-            <div class="grid-row grid-box col2">
+            <div class="grid grid-cols-1 xl:grid-cols-[1.15fr_1fr] gap-4">
                 <!-- Left Column: Map Display and Elevation Profile -->
-                <div class="col-span-1">
+                <div class="flex flex-col gap-4">
                     <FlightPlanMap />
                     <ElevationProfile />
                 </div>
 
                 <!-- Right Column: Flight Plan List -->
-                <div class="col-span-1">
+                <div class="flex flex-col">
                     <WaypointList />
                 </div>
             </div>
@@ -30,28 +30,28 @@
             <p v-html="$t('flightPlanConfirmClear')"></p>
 
             <template #footer>
-                <div class="dialog-buttons">
-                    <button @click="showClearDialog = false" class="cancel-btn">
+                <div class="flex gap-2 justify-end">
+                    <UButton variant="soft" color="neutral" @click="showClearDialog = false">
                         {{ $t("cancel") }}
-                    </button>
-                    <button @click="confirmClear" class="clear-btn primary">
+                    </UButton>
+                    <UButton color="error" @click="confirmClear">
                         {{ $t("flightPlanClear") }}
-                    </button>
+                    </UButton>
                 </div>
             </template>
         </Dialog>
 
         <!-- Bottom toolbar -->
-        <div class="content_toolbar toolbar_fixed_bottom">
-            <div class="btn clear-button">
-                <button @click="handleClear" v-html="$t('flightPlanClear')"></button>
-            </div>
-            <div class="btn load-button">
-                <button @click="handleLoad" v-html="$t('flightPlanLoadFromFC')"></button>
-            </div>
-            <div class="btn save-button">
-                <button @click="handleSave" v-html="$t('save')"></button>
-            </div>
+        <div class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
+            <UButton variant="soft" color="error" @click="handleClear">
+                {{ $t("flightPlanClear") }}
+            </UButton>
+            <UButton variant="soft" @click="handleLoad">
+                {{ $t("flightPlanLoadFromFC") }}
+            </UButton>
+            <UButton @click="handleSave">
+                {{ $t("save") }}
+            </UButton>
         </div>
     </BaseTab>
 </template>
@@ -103,63 +103,9 @@ const confirmClear = async () => {
 </script>
 
 <style scoped>
-.grid-row.grid-box.col2 {
-    display: grid;
-    grid-template-columns: 1.15fr 1fr;
-    gap: 1rem;
-}
-
 /* Bottom toolbar (CRITICAL: must be exactly 2rem) */
 .content_toolbar.toolbar_fixed_bottom {
     position: fixed;
     bottom: 2rem;
-}
-
-.content_toolbar.toolbar_fixed_bottom .btn a {
-    min-width: 125px;
-    text-align: center;
-}
-
-/* Dialog buttons */
-.dialog-buttons {
-    display: flex;
-    gap: 0.5rem;
-    justify-content: flex-end;
-}
-
-.dialog-buttons button {
-    padding: 0.5rem 1rem;
-    border-radius: 4px;
-    border: 1px solid var(--surface-500);
-    background: var(--surface-200);
-    color: var(--text);
-    cursor: pointer;
-    transition: background 0.2s;
-}
-
-.dialog-buttons button:hover {
-    background: var(--surface-300);
-}
-
-.dialog-buttons .clear-btn.primary {
-    background: var(--error-500);
-    color: var(--surface-50);
-    border-color: var(--error-500);
-}
-
-.dialog-buttons .clear-btn.primary:hover {
-    background: var(--error-600);
-    border-color: var(--error-600);
-}
-
-.dialog-buttons .cancel-btn:hover {
-    background: var(--surface-400);
-}
-
-/* Responsive */
-@media (max-width: 1055px) {
-    .grid-row.grid-box.col2 {
-        grid-template-columns: 1fr;
-    }
 }
 </style>

--- a/src/components/tabs/FlightPlanTab.vue
+++ b/src/components/tabs/FlightPlanTab.vue
@@ -7,7 +7,7 @@
                 <WikiButton docUrl="flight-plan" />
             </div>
 
-            <div class="flex flex-col gap-4">
+            <div class="flex flex-col gap-[25px]">
                 <!-- Top row: Map and Waypoint List (stretch to matching heights) -->
                 <div class="grid grid-cols-1 xl:grid-cols-[1.15fr_1fr] gap-4">
                     <FlightPlanMap />
@@ -38,15 +38,31 @@
             </template>
         </Dialog>
 
+        <!-- Load-from-FC Confirmation Dialog -->
+        <Dialog v-model="showLoadPromptDialog" :title="$t('flightPlanLoadPromptTitle')" :closeable="false">
+            <p v-html="$t('flightPlanLoadPromptBody')"></p>
+
+            <template #footer>
+                <div class="flex gap-2 justify-end">
+                    <UButton variant="soft" color="neutral" @click="declineLoadFromFC">
+                        {{ $t("flightPlanKeepLocal") }}
+                    </UButton>
+                    <UButton @click="confirmLoadFromFC">
+                        {{ $t("flightPlanLoadFromFC") }}
+                    </UButton>
+                </div>
+            </template>
+        </Dialog>
+
         <!-- Bottom toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
             <UButton variant="soft" color="error" @click="handleClear">
                 {{ $t("flightPlanClear") }}
             </UButton>
-            <UButton variant="soft" @click="handleLoad">
-                {{ $t("flightPlanLoadFromFC") }}
+            <UButton variant="soft" :disabled="!canUseFC" :title="$t('flightPlanLoadFromFC')" @click="handleLoad">
+                {{ $t("flightPlanLoad") }}
             </UButton>
-            <UButton @click="handleSave">
+            <UButton :disabled="!canUseFC" :title="$t('flightPlanSaveToFC')" @click="handleSave">
                 {{ $t("save") }}
             </UButton>
         </div>
@@ -54,7 +70,7 @@
 </template>
 
 <script setup>
-import { ref, onMounted } from "vue";
+import { ref, computed, onMounted } from "vue";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
 import Dialog from "@/components/elements/Dialog.vue";
@@ -63,23 +79,46 @@ import WaypointEditor from "./FlightPlan/WaypointEditor.vue";
 import FlightPlanMap from "./FlightPlan/FlightPlanMap.vue";
 import ElevationProfile from "./FlightPlan/ElevationProfile.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
+import { useConnectionStore } from "@/stores/connection";
+import FC from "@/js/fc";
 import GUI from "@/js/gui";
 import { gui_log } from "@/js/gui_log";
 import { i18n } from "@/js/localization";
 
-const { loadFromFC, saveToFC, clearOnFC, clearPlan, waypoints } = useFlightPlan();
+const { loadFromFC, saveToFC, clearOnFC, clearPlan, loadPlan, waypoints } = useFlightPlan();
+const connectionStore = useConnectionStore();
 const showClearDialog = ref(false);
+const showLoadPromptDialog = ref(false);
+
+const isConnected = computed(() => connectionStore.connectionValid);
+const fcHasFlightPlan = computed(() => FC.CONFIG?.buildOptions?.includes("USE_FLIGHT_PLAN") ?? false);
+const canUseFC = computed(() => isConnected.value && fcHasFlightPlan.value);
 
 onMounted(async () => {
-    await loadFromFC();
+    loadPlan();
+
+    if (canUseFC.value) {
+        if (waypoints.value.length === 0) {
+            await loadFromFC();
+        } else {
+            showLoadPromptDialog.value = true;
+        }
+    }
+
     GUI.content_ready();
 });
 
 const handleSave = async () => {
+    if (!canUseFC.value) {
+        return;
+    }
     await saveToFC();
 };
 
 const handleLoad = async () => {
+    if (!canUseFC.value) {
+        return;
+    }
     await loadFromFC();
 };
 
@@ -94,8 +133,19 @@ const handleClear = () => {
 
 const confirmClear = async () => {
     clearPlan();
-    await clearOnFC();
+    if (canUseFC.value) {
+        await clearOnFC();
+    }
     showClearDialog.value = false;
+};
+
+const confirmLoadFromFC = async () => {
+    showLoadPromptDialog.value = false;
+    await loadFromFC();
+};
+
+const declineLoadFromFC = () => {
+    showLoadPromptDialog.value = false;
 };
 </script>
 

--- a/src/components/tabs/FlightPlanTab.vue
+++ b/src/components/tabs/FlightPlanTab.vue
@@ -7,18 +7,15 @@
                 <WikiButton docUrl="flight-plan" />
             </div>
 
-            <!-- Two-column layout -->
-            <div class="grid grid-cols-1 xl:grid-cols-[1.15fr_1fr] gap-4">
-                <!-- Left Column: Map Display and Elevation Profile -->
-                <div class="flex flex-col gap-4">
+            <div class="flex flex-col gap-4">
+                <!-- Top row: Map and Waypoint List (stretch to matching heights) -->
+                <div class="grid grid-cols-1 xl:grid-cols-[1.15fr_1fr] gap-4">
                     <FlightPlanMap />
-                    <ElevationProfile />
-                </div>
-
-                <!-- Right Column: Flight Plan List -->
-                <div class="flex flex-col">
                     <WaypointList />
                 </div>
+
+                <!-- Full-width Elevation Profile -->
+                <ElevationProfile />
             </div>
         </div>
 

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -39,6 +39,7 @@ class GuiControl {
             "help",
             "user_profile",
             "backups",
+            "flight_plan",
         ];
 
         this.defaultAllowedTabs = [


### PR DESCRIPTION
## Summary

- Swap `gui_box` wrappers for `UiBox` across the Flight Plan tab (map, elevation profile, waypoint list) and replace native buttons with `UButton`.
- Convert Waypoint Editor selects to `USelect` and form rows to `SettingRow`; use `UButton` in dialog footers.
- Drop bespoke button/dialog CSS in favour of Tailwind utilities; drag-and-drop, map interactions and SVG chart logic are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized container wrappers and simplified templates across the Flight Plan UI, replacing legacy title/box markup with a unified box component and reorganizing map, elevation profile, waypoint list/editor and dialogs for more consistent structure and interactions.

* **Style**
  * Modernized controls and form layouts (unified selects/buttons and setting rows), improved spacing, responsive sizing and flex/grid layout adjustments, and refreshed list/toolbar/dialog styling for a cleaner, more cohesive flight‑planning experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->