### PR TITLE
Add POSHOLD_FAILED OSD warning

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7050,7 +7050,21 @@
         "message": "Warns if the CPU LOAD of the flight controller is too high",
         "description": "Description of one of the warnings that can be selected to be shown in the OSD"
     },
-
+    "osdTextElementPosHoldFailed": {
+        "message": "Position hold failed",
+        "description": "One of the elements of the OSD that can be enabled to show a warning when position hold fails (e.g. in GPS mode)"
+    },
+    "osdDescElementPosHoldFailed": {
+        "message": "Shows a warning when position hold fails (e.g. in GPS mode)"
+    },
+    "osdWarningTextPosHoldFailed": {
+        "message": "Position hold failed",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningPosHoldFailed": {
+        "message": "Position hold failed",
+        "description": "Warns when the position hold fails (e.g. in GPS mode)"
+    },
     "osdWarningTextUnknown": {
         "message": "Unknown $1"
     },

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -1563,6 +1563,7 @@ OSD.chooseFields = function () {
     }
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.filter((w) => w.name !== "RC_SMOOTHING_FAILURE");
+        OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([F.POSHOLD_FAILED]);
     }
 };
 

--- a/src/components/tabs/osd/osd_constants.js
+++ b/src/components/tabs/osd/osd_constants.js
@@ -267,6 +267,11 @@ export const OSD_CONSTANTS = {
             text: "osdWarningTextLoad",
             desc: "osdWarningLoad",
         },
+        POSHOLD_FAILED: {
+            name: "POSHOLD_FAILED",
+            text: "osdWarningTextPosHoldFailed",
+            desc: "osdWarningPosHoldFailed",
+        },
     },
     FONT_TYPES: [
         { file: "default", name: "osdSetupFontTypeDefault" },


### PR DESCRIPTION
- follow up on https://github.com/betaflight/betaflight/pull/13975

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Position hold failed" warning indicator to the OSD, selectable for newer firmware/API versions and configurable display positioning (applies in GPS/poshold contexts).
  * Included English localization strings for the new warning text, element label, and descriptive copy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->