### PR TITLE
Refactor: Convert PID tuning tab to Nuxt UI

### DIFF
--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -4,64 +4,71 @@
             <div class="tab_title">{{ $t("tabPidTuning") }}</div>
             <WikiButton docUrl="PID-Tuning" />
 
-            <div class="content_wrapper_header">
+            <div class="flex items-start gap-3 flex-wrap mb-2">
                 <!-- Profile Selector -->
-                <div class="profile single-field">
-                    <div class="helpicon cf_tip" :title="$t('pidTuningProfileTip')"></div>
-                    <div class="head">{{ $t("pidTuningProfile") }}</div>
-                    <div>
-                        <select v-model.number="currentProfile" @change="onProfileChange" :disabled="hasChanges">
-                            <option v-for="i in 3" :key="i" :value="i - 1">{{ i }}</option>
-                        </select>
-                    </div>
+                <div class="flex flex-col gap-1 min-w-[130px]">
+                    <SettingRow :label="$t('pidTuningProfile')" :help="$t('pidTuningProfileTip')">
+                        <USelect
+                            v-model="currentProfile"
+                            :items="profileItems"
+                            class="min-w-20"
+                            :disabled="hasChanges"
+                            @update:model-value="onProfileChange"
+                        />
+                    </SettingRow>
                 </div>
 
                 <!-- Rate Profile Selector -->
-                <div class="rate_profile single-field">
-                    <div class="helpicon cf_tip" :title="$t('pidTuningRateProfileTip')"></div>
-                    <div class="head">{{ $t("pidTuningRateProfile") }}</div>
-                    <div>
-                        <select
-                            v-model.number="currentRateProfile"
-                            @change="onRateProfileChange"
+                <div class="flex flex-col gap-1 min-w-[130px]">
+                    <SettingRow :label="$t('pidTuningRateProfile')" :help="$t('pidTuningRateProfileTip')">
+                        <USelect
+                            v-model="currentRateProfile"
+                            :items="rateProfileItems"
+                            class="min-w-20"
                             :disabled="hasChanges"
-                        >
-                            <option v-for="i in numberOfRateProfiles" :key="i" :value="i - 1">{{ i }}</option>
-                        </select>
-                    </div>
+                            @update:model-value="onRateProfileChange"
+                        />
+                    </SettingRow>
                 </div>
 
                 <!-- Header Buttons -->
-                <div class="content_wrapper_header_btns">
-                    <div class="default_btn copyprofilebtn">
-                        <a href="#" @click.prevent="copyProfile">{{ $t("pidTuningCopyProfile") }}</a>
-                    </div>
-                    <div class="default_btn copyrateprofilebtn">
-                        <a href="#" @click.prevent="copyRateProfile">{{ $t("pidTuningCopyRateProfile") }}</a>
-                    </div>
-                    <div class="default_btn resetbt">
-                        <a href="#" @click.prevent="resetProfile">{{ $t("pidTuningResetPidProfile") }}</a>
-                    </div>
-                    <div class="default_btn show showAllPids">
-                        <a href="#" @click.prevent="toggleShowAllPids">{{
-                            showAllPids ? $t("pidTuningHideUnusedPids") : $t("pidTuningShowAllPids")
-                        }}</a>
-                    </div>
+                <div class="flex gap-2 flex-wrap ml-auto">
+                    <UButton
+                        :label="$t('pidTuningCopyProfile')"
+                        color="neutral"
+                        variant="outline"
+                        @click="copyProfile"
+                    />
+                    <UButton
+                        :label="$t('pidTuningCopyRateProfile')"
+                        color="neutral"
+                        variant="outline"
+                        @click="copyRateProfile"
+                    />
+                    <UButton
+                        :label="$t('pidTuningResetPidProfile')"
+                        color="neutral"
+                        variant="outline"
+                        @click="resetProfile"
+                    />
+                    <UButton
+                        :label="showAllPids ? $t('pidTuningHideUnusedPids') : $t('pidTuningShowAllPids')"
+                        color="neutral"
+                        variant="outline"
+                        @click="toggleShowAllPids"
+                    />
                 </div>
             </div>
 
             <!-- Sub-tab Navigation -->
-            <div class="tab-container">
-                <div class="tab pid" :class="{ active: activeSubtab === 'pid' }" @click="activeSubtab = 'pid'">
-                    <a href="#" @click.prevent="activeSubtab = 'pid'">{{ $t("pidTuningSubTabPid") }}</a>
-                </div>
-                <div class="tab rates" :class="{ active: activeSubtab === 'rates' }" @click="activeSubtab = 'rates'">
-                    <a href="#" @click.prevent="activeSubtab = 'rates'">{{ $t("pidTuningSubTabRates") }}</a>
-                </div>
-                <div class="tab filter" :class="{ active: activeSubtab === 'filter' }" @click="activeSubtab = 'filter'">
-                    <a href="#" @click.prevent="activeSubtab = 'filter'">{{ $t("pidTuningSubTabFilter") }}</a>
-                </div>
-            </div>
+            <UTabs
+                :items="subtabItems"
+                :model-value="activeSubtab"
+                :content="false"
+                color="primary"
+                variant="pill"
+                @update:model-value="activeSubtab = $event"
+            />
 
             <!-- Tab Content -->
             <div class="tabarea">
@@ -90,36 +97,28 @@
             </div>
 
             <!-- Save/Revert Buttons -->
-            <div class="content_toolbar toolbar_fixed_bottom">
-                <div class="btn save_btn">
-                    <button
-                        type="button"
-                        class="save"
-                        :class="{ disabled: !hasChanges }"
-                        :disabled="!hasChanges"
-                        @click="save"
-                    >
-                        {{ $t("pidTuningButtonSave") }}
-                    </button>
-                </div>
-                <div class="btn refresh_btn">
-                    <button type="button" class="refresh" @click="refresh">
-                        {{ $t("pidTuningButtonRefresh") }}
-                    </button>
-                </div>
+            <div class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
+                <UButton
+                    :label="$t('pidTuningButtonSave')"
+                    :color="hasChanges ? 'success' : 'primary'"
+                    :disabled="!hasChanges"
+                    @click="save"
+                />
+                <UButton :label="$t('pidTuningButtonRefresh')" color="neutral" variant="outline" @click="refresh" />
             </div>
         </div>
     </BaseTab>
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, nextTick, watch } from "vue";
+import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { usePidTuningStore } from "@/stores/pidTuning";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
 import PidSubTab from "./pid-tuning/PidSubTab.vue";
 import RatesSubTab from "./pid-tuning/RatesSubTab.vue";
 import FilterSubTab from "./pid-tuning/FilterSubTab.vue";
+import SettingRow from "../elements/SettingRow.vue";
 import GUI from "@/js/gui";
 import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
@@ -130,7 +129,6 @@ import { mspHelper } from "@/js/msp/MSPHelper";
 import semver from "semver";
 import { API_VERSION_1_45, API_VERSION_1_47 } from "@/js/data_storage";
 import { isExpertModeEnabled } from "@/js/utils/isExpertModeEnabled";
-import tippy from "tippy.js";
 import { useNavigationStore } from "@/stores/navigation";
 import { useDialog } from "@/composables/useDialog";
 import { useTranslation } from "i18next-vue";
@@ -159,6 +157,29 @@ const numberOfRateProfiles = computed(() => {
     }
     return 4;
 });
+
+// Items arrays for USelect / UTabs
+const profileItems = computed(() => {
+    const items = [];
+    for (let i = 0; i < 3; i++) {
+        items.push({ label: i18n.getMessage("pidTuningProfileOption", [i + 1]), value: i });
+    }
+    return items;
+});
+
+const rateProfileItems = computed(() => {
+    const items = [];
+    for (let i = 0; i < numberOfRateProfiles.value; i++) {
+        items.push({ label: i18n.getMessage("pidTuningRateProfileOption", [i + 1]), value: i });
+    }
+    return items;
+});
+
+const subtabItems = computed(() => [
+    { label: t("pidTuningSubTabPid"), value: "pid" },
+    { label: t("pidTuningSubTabRates"), value: "rates" },
+    { label: t("pidTuningSubTabFilter"), value: "filter" },
+]);
 
 // Profile name state lifted from child components
 const pidProfileName = ref("");
@@ -233,11 +254,7 @@ async function loadData() {
         // Store original values for revert
         storeOriginalValues();
 
-        // Initialize Switchery AFTER data loaded and DOM updated
-        await nextTick();
-        GUI.switchery();
         GUI.content_ready();
-        initToolTips();
         return true;
     } catch (e) {
         console.error("[PidTuning] Failed to load data:", e);
@@ -472,26 +489,6 @@ function onFormChanged() {
     }
     pidTuningStore.checkForChanges(pidProfileName.value, rateProfileName.value);
 }
-
-// Watch for sub-tab changes to re-initialize Switchery for new DOM elements
-function initToolTips() {
-    document.querySelectorAll("#pid-tuning .cf_tip").forEach((el) => {
-        const title = el.getAttribute("title");
-        if (title && !el._tippy) {
-            tippy(el, { content: title, allowHTML: true });
-            el.removeAttribute("title");
-        }
-    });
-}
-
-watch(
-    () => activeSubtab.value,
-    async () => {
-        await nextTick();
-        GUI.switchery();
-        initToolTips();
-    },
-);
 
 // Watch profile name changes: sync to FC.CONFIG and re-check for changes
 watch(
@@ -806,58 +803,6 @@ onUnmounted(() => {
     text-align-last: left;
 }
 
-/* ── Tab container ────────────────────────────────────────────────── */
-.tab-pid_tuning .tab-container {
-    border-bottom: 3px solid var(--primary-500);
-    border-right-width: 0;
-    display: flex;
-    flex-direction: row;
-    flex-wrap: nowrap;
-    justify-content: start;
-    width: 100%;
-}
-.tab-pid_tuning .tab-container > div {
-    background-color: var(--surface-200);
-    padding: 6px 12px;
-    border-right: 1px solid var(--surface-500);
-    box-sizing: border-box;
-    text-align: center;
-}
-.tab-pid_tuning .tab-container > div:first-child {
-    border-top-left-radius: 4px;
-}
-.tab-pid_tuning .tab-container > div:last-child {
-    border-top-right-radius: 4px;
-}
-.tab-pid_tuning .tab-container > div a {
-    display: block;
-    color: var(--text);
-}
-.tab-pid_tuning .tab-container > div.active {
-    background-color: var(--primary-500);
-    color: #000;
-    transition: none;
-}
-.tab-pid_tuning .tab-container > div.active a {
-    background-color: var(--primary-500);
-    color: #000;
-    transition: none;
-}
-
-/* ── Single-field selectors ───────────────────────────────────────── */
-.tab-pid_tuning .single-field {
-    display: inline-table;
-    margin-bottom: 10px;
-    margin-right: 5px;
-}
-.tab-pid_tuning .single-field .head {
-    text-align: left;
-    border-radius: 4px;
-    color: var(--text);
-    font-weight: normal;
-    padding-bottom: 0.5rem;
-}
-
 /* ── New rates ────────────────────────────────────────────────────── */
 .tab-pid_tuning .new_rates {
     text-align: center;
@@ -871,9 +816,6 @@ onUnmounted(() => {
 }
 
 /* ── Misc helpers ─────────────────────────────────────────────────── */
-.tab-pid_tuning .top-buttons {
-    float: right;
-}
 .tab-pid_tuning .fixed_band {
     position: absolute;
     width: 100%;
@@ -925,18 +867,6 @@ onUnmounted(() => {
     width: 65px;
     height: 21px;
 }
-.tab-pid_tuning .resetbt {
-    width: 200px;
-    margin-right: 10px;
-}
-.tab-pid_tuning .copyprofilebtn {
-    width: 150px;
-    margin-right: 10px;
-}
-.tab-pid_tuning .copyrateprofilebtn {
-    width: 150px;
-    margin-right: 10px;
-}
 .tab-pid_tuning .right {
     float: right;
 }
@@ -961,32 +891,6 @@ onUnmounted(() => {
 }
 .tab-pid_tuning .topspacer {
     margin-top: 5px;
-}
-
-/* ── Profile / rate profile selectors ─────────────────────────────── */
-.tab-pid_tuning .profile,
-.tab-pid_tuning .rate_profile {
-    min-width: 130px;
-}
-.tab-pid_tuning .profile select,
-.tab-pid_tuning .rate_profile select {
-    width: 100%;
-}
-.tab-pid_tuning .profile .helpicon,
-.tab-pid_tuning .rate_profile .helpicon {
-    margin: 0;
-}
-.tab-pid_tuning .controller {
-    width: 150px;
-}
-.tab-pid_tuning .controller select,
-.tab-pid_tuning .delta select {
-    border: 1px solid var(--surface-500);
-    margin-left: 5px;
-    width: calc(100% - 10px);
-}
-.tab-pid_tuning .delta {
-    width: 150px;
 }
 
 /* ── Bracket icon ─────────────────────────────────────────────────── */
@@ -1257,14 +1161,6 @@ onUnmounted(() => {
     float: left;
 }
 
-/* ── Content header ───────────────────────────────────────────────── */
-.tab-pid_tuning .content_wrapper_header {
-    display: flex;
-}
-.tab-pid_tuning .content_wrapper_header_btns {
-    margin-left: auto;
-}
-
 /* ── Fancy header (not under .tab-pid_tuning) ─────────────────────── */
 .fancy.header {
     background-color: #d6d6d6;
@@ -1357,12 +1253,6 @@ onUnmounted(() => {
     color: black;
 }
 
-/* ── Show all pids button ─────────────────────────────────────────── */
-.show {
-    width: 130px;
-    margin-right: 3px;
-}
-
 /* ── Filter two-columns ───────────────────────────────────────────── */
 .subtab-filter table tr td:first-child {
     text-align: right;
@@ -1398,42 +1288,6 @@ onUnmounted(() => {
     .tab-pid_tuning dialog {
         width: calc(100% - 2em);
         border-radius: unset;
-    }
-    .tab-pid_tuning .content_wrapper_header {
-        flex-wrap: wrap;
-    }
-    .tab-pid_tuning .profile {
-        width: calc(50% - 5px);
-    }
-    .tab-pid_tuning .rate_profile {
-        width: calc(50% - 5px);
-        margin-left: 5px;
-        margin-right: 0;
-    }
-    .tab-pid_tuning .copyprofilebtn {
-        width: calc(50% - 5px);
-    }
-    .tab-pid_tuning .copyrateprofilebtn {
-        width: calc(50% - 5px);
-        margin-right: 0;
-    }
-    .tab-pid_tuning .resetbt {
-        width: calc(50% - 5px);
-    }
-    .tab-pid_tuning .show {
-        width: calc(50% - 5px);
-        margin-right: 0;
-    }
-    .tab-pid_tuning .controller {
-        margin-right: 0;
-        width: 100%;
-    }
-    .tab-pid_tuning .content_wrapper_header_btns {
-        display: flex;
-        flex-wrap: wrap;
-    }
-    .tab-pid_tuning .tab-container > div {
-        width: calc(100% / 3);
     }
     .tab-pid_tuning .subtab-pid .cf_column {
         min-width: 100%;

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -31,27 +31,31 @@
                     </SettingRow>
                 </div>
 
-                <!-- Header Buttons -->
+                <!-- Header Buttons (scoped per subtab) -->
                 <div class="flex gap-2 flex-wrap ml-auto">
                     <UButton
+                        v-if="activeSubtab === 'pid'"
                         :label="$t('pidTuningCopyProfile')"
                         color="neutral"
                         variant="outline"
                         @click="copyProfile"
                     />
                     <UButton
+                        v-if="activeSubtab === 'rates'"
                         :label="$t('pidTuningCopyRateProfile')"
                         color="neutral"
                         variant="outline"
                         @click="copyRateProfile"
                     />
                     <UButton
+                        v-if="activeSubtab === 'pid'"
                         :label="$t('pidTuningResetPidProfile')"
                         color="neutral"
                         variant="outline"
                         @click="resetProfile"
                     />
                     <UButton
+                        v-if="activeSubtab === 'pid'"
                         :label="showAllPids ? $t('pidTuningHideUnusedPids') : $t('pidTuningShowAllPids')"
                         color="neutral"
                         variant="outline"
@@ -61,14 +65,16 @@
             </div>
 
             <!-- Sub-tab Navigation -->
-            <UTabs
-                :items="subtabItems"
-                :model-value="activeSubtab"
-                :content="false"
-                color="primary"
-                variant="pill"
-                @update:model-value="activeSubtab = $event"
-            />
+            <div class="subtab-nav">
+                <UTabs
+                    :items="subtabItems"
+                    :model-value="activeSubtab"
+                    :content="false"
+                    color="primary"
+                    variant="pill"
+                    @update:model-value="activeSubtab = $event"
+                />
+            </div>
 
             <!-- Tab Content -->
             <div class="tabarea">
@@ -111,7 +117,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch } from "vue";
+import { ref, computed, onMounted, onUnmounted, watch, nextTick } from "vue";
 import { usePidTuningStore } from "@/stores/pidTuning";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
@@ -510,6 +516,12 @@ watch(
         onFormChanged();
     },
 );
+
+// Re-initialize Switchery when switching subtabs (subtabs use v-if so checkboxes re-mount)
+watch(activeSubtab, async () => {
+    await nextTick();
+    GUI.switchery();
+});
 
 // Cleanup callback - called from gui.js tab_switch_cleanup when switching away from this tab
 function cleanup(callback) {
@@ -1269,6 +1281,11 @@ onUnmounted(() => {
 .subtab-filter .two_columns .two_columns_second {
     margin-left: 10px;
     height: fit-content;
+}
+
+/* ── Sub-tab navigation ───────────────────────────────────────────── */
+.subtab-nav {
+    width: calc(100% - 22px);
 }
 
 /* ── Tab area ─────────────────────────────────────────────────────── */

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -117,7 +117,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch, nextTick } from "vue";
+import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { usePidTuningStore } from "@/stores/pidTuning";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
@@ -516,12 +516,6 @@ watch(
         onFormChanged();
     },
 );
-
-// Re-initialize Switchery when switching subtabs (subtabs use v-if so checkboxes re-mount)
-watch(activeSubtab, async () => {
-    await nextTick();
-    GUI.switchery();
-});
 
 // Cleanup callback - called from gui.js tab_switch_cleanup when switching away from this tab
 function cleanup(callback) {

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -87,6 +87,8 @@
                             <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                             <UInputNumber
                                 size="xs"
+                                orientation="vertical"
+                                class="w-16"
                                 v-model="gyro_lowpass_hz"
                                 :step="1"
                                 :min="1"
@@ -98,6 +100,8 @@
                             <span class="text-xs text-dimmed">{{ $t("pidTuningMinCutoffFrequency") }}</span>
                             <UInputNumber
                                 size="xs"
+                                orientation="vertical"
+                                class="w-16"
                                 v-model="gyro_lowpass_dyn_min_hz"
                                 :step="1"
                                 :min="1"
@@ -109,6 +113,8 @@
                             <span class="text-xs text-dimmed">{{ $t("pidTuningMaxCutoffFrequency") }}</span>
                             <UInputNumber
                                 size="xs"
+                                orientation="vertical"
+                                class="w-16"
                                 v-model="gyro_lowpass_dyn_max_hz"
                                 :step="1"
                                 :min="1"
@@ -133,6 +139,8 @@
                             <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                             <UInputNumber
                                 size="xs"
+                                orientation="vertical"
+                                class="w-16"
                                 v-model="gyro_lowpass2_hz"
                                 :step="1"
                                 :min="1"
@@ -161,11 +169,27 @@
                     <div v-if="gyroNotch1Enabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
-                            <UInputNumber size="xs" v-model="gyro_notch_hz" :step="1" :min="1" :max="16000" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="gyro_notch_hz"
+                                :step="1"
+                                :min="1"
+                                :max="16000"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
-                            <UInputNumber size="xs" v-model="gyro_notch_cutoff" :step="1" :min="0" :max="16000" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="gyro_notch_cutoff"
+                                :step="1"
+                                :min="0"
+                                :max="16000"
+                            />
                         </div>
                     </div>
                 </div>
@@ -178,11 +202,27 @@
                     <div v-if="gyroNotch2Enabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
-                            <UInputNumber size="xs" v-model="gyro_notch2_hz" :step="1" :min="1" :max="16000" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="gyro_notch2_hz"
+                                :step="1"
+                                :min="1"
+                                :max="16000"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
-                            <UInputNumber size="xs" v-model="gyro_notch2_cutoff" :step="1" :min="0" :max="16000" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="gyro_notch2_cutoff"
+                                :step="1"
+                                :min="0"
+                                :max="16000"
+                            />
                         </div>
                     </div>
                 </div>
@@ -203,6 +243,8 @@
                                 <span class="text-xs text-dimmed">{{ $t("pidTuningRpmHarmonics") }}</span>
                                 <UInputNumber
                                     size="xs"
+                                    orientation="vertical"
+                                    class="w-16"
                                     v-model="gyro_rpm_notch_harmonics"
                                     :step="1"
                                     :min="1"
@@ -213,6 +255,8 @@
                                 <span class="text-xs text-dimmed">{{ $t("pidTuningRpmMinHz") }}</span>
                                 <UInputNumber
                                     size="xs"
+                                    orientation="vertical"
+                                    class="w-16"
                                     v-model="gyro_rpm_notch_min_hz"
                                     :step="1"
                                     :min="50"
@@ -239,19 +283,51 @@
                     <div v-if="dynamicNotchEnabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchCount") }}</span>
-                            <UInputNumber size="xs" v-model="dyn_notch_count" :step="1" :min="1" :max="5" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="dyn_notch_count"
+                                :step="1"
+                                :min="1"
+                                :max="5"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchQ") }}</span>
-                            <UInputNumber size="xs" v-model="dyn_notch_q" :step="1" :min="1" :max="1000" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="dyn_notch_q"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchMinHz") }}</span>
-                            <UInputNumber size="xs" v-model="dyn_notch_min_hz" :step="1" :min="60" :max="250" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="dyn_notch_min_hz"
+                                :step="1"
+                                :min="60"
+                                :max="250"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchMaxHz") }}</span>
-                            <UInputNumber size="xs" v-model="dyn_notch_max_hz" :step="1" :min="200" :max="1000" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="dyn_notch_max_hz"
+                                :step="1"
+                                :min="200"
+                                :max="1000"
+                            />
                         </div>
                     </div>
                 </div>
@@ -284,6 +360,8 @@
                             <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                             <UInputNumber
                                 size="xs"
+                                orientation="vertical"
+                                class="w-16"
                                 v-model="dterm_lowpass_hz"
                                 :step="1"
                                 :min="1"
@@ -295,6 +373,8 @@
                             <span class="text-xs text-dimmed">{{ $t("pidTuningMinCutoffFrequency") }}</span>
                             <UInputNumber
                                 size="xs"
+                                orientation="vertical"
+                                class="w-16"
                                 v-model="dterm_lowpass_dyn_min_hz"
                                 :step="1"
                                 :min="1"
@@ -306,6 +386,8 @@
                             <span class="text-xs text-dimmed">{{ $t("pidTuningMaxCutoffFrequency") }}</span>
                             <UInputNumber
                                 size="xs"
+                                orientation="vertical"
+                                class="w-16"
                                 v-model="dterm_lowpass_dyn_max_hz"
                                 :step="10"
                                 :min="200"
@@ -315,7 +397,15 @@
                         </div>
                         <div v-if="dtermLowpassMode === 1" class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDTermLowpassDynExpo") }}</span>
-                            <UInputNumber size="xs" v-model="dyn_lpf_curve_expo" :step="1" :min="0" :max="10" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="dyn_lpf_curve_expo"
+                                :step="1"
+                                :min="0"
+                                :max="10"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningLowpassFilterType") }}</span>
@@ -334,6 +424,8 @@
                             <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                             <UInputNumber
                                 size="xs"
+                                orientation="vertical"
+                                class="w-16"
                                 v-model="dterm_lowpass2_hz"
                                 :step="1"
                                 :min="1"
@@ -364,11 +456,27 @@
                     <div v-if="dtermNotchEnabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
-                            <UInputNumber size="xs" v-model="dterm_notch_hz" :step="1" :min="1" :max="16000" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="dterm_notch_hz"
+                                :step="1"
+                                :min="1"
+                                :max="16000"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
-                            <UInputNumber size="xs" v-model="dterm_notch_cutoff" :step="1" :min="0" :max="16000" />
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="dterm_notch_cutoff"
+                                :step="1"
+                                :min="0"
+                                :max="16000"
+                            />
                         </div>
                     </div>
                 </div>
@@ -382,7 +490,15 @@
                 <div class="flex flex-wrap items-end gap-3">
                     <div class="flex flex-col gap-1">
                         <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
-                        <UInputNumber size="xs" v-model="yaw_lowpass_hz" :step="1" :min="0" :max="500" />
+                        <UInputNumber
+                            size="xs"
+                            orientation="vertical"
+                            class="w-16"
+                            v-model="yaw_lowpass_hz"
+                            :step="1"
+                            :min="0"
+                            :max="500"
+                        />
                     </div>
                 </div>
             </UiBox>

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -1,672 +1,383 @@
 <template>
-    <div class="subtab-filter">
-        <div class="clear-both"></div>
-
+    <div class="p-5 flex flex-col gap-5">
         <!-- Filter Sliders -->
-        <div id="slidersFilterBox" class="gui_box grey tuningFilterSliders">
-            <table class="pid_titlebar">
-                <thead>
-                    <tr>
-                        <th scope="col" class="sm-min"></th>
-                        <th></th>
-                        <th>{{ $t("pidTuningSliderHighFiltering") }}</th>
-                        <th>{{ $t("pidTuningSliderDefaultFiltering") }}</th>
-                        <th>{{ $t("pidTuningSliderLowFiltering") }}</th>
-                        <th></th>
-                    </tr>
-                </thead>
-            </table>
+        <UiBox type="neutral">
+            <!-- Scale labels above sliders -->
+            <div class="flex justify-between text-xs text-dimmed mb-2">
+                <span>{{ $t("pidTuningSliderHighFiltering") }}</span>
+                <span>{{ $t("pidTuningSliderDefaultFiltering") }}</span>
+                <span>{{ $t("pidTuningSliderLowFiltering") }}</span>
+            </div>
 
-            <table class="sliderLabels">
-                <tbody>
-                    <tr class="xs sliderHeaders">
-                        <td colspan="5">
-                            <span>{{ $t("pidTuningGyroFilterSlider") }}</span>
-                            <div class="helpicon cf_tip" :title="$t('pidTuningGyroFilterSliderHelp')"></div>
-                        </td>
-                    </tr>
-                    <tr class="sliderGyroFilter" :class="{ disabledSliders: gyroSliderDisabled }">
-                        <td class="sm-min">
-                            <span>{{ $t("pidTuningGyroFilterSlider") }}</span>
-                        </td>
-                        <td>
-                            <output>{{ gyroFilterMultiplier.toFixed(2) }}</output>
-                        </td>
-                        <td colspan="3">
-                            <input
-                                type="range"
-                                v-model.number="gyroFilterMultiplier"
-                                min="0.1"
-                                max="2.0"
-                                step="0.05"
-                                class="tuningSlider"
-                                :disabled="gyroSliderDisabled"
-                            />
-                        </td>
-                        <td></td>
-                    </tr>
-                    <tr class="xs sliderHeaders">
-                        <td colspan="5">
-                            <span>{{ $t("pidTuningDTermFilterSlider") }}</span>
-                            <div class="helpicon cf_tip" :title="$t('pidTuningDTermFilterSliderHelp')"></div>
-                        </td>
-                    </tr>
-                    <tr class="sliderDTermFilter" :class="{ disabledSliders: dtermSliderDisabled }">
-                        <td class="sm-min">
-                            <span>{{ $t("pidTuningDTermFilterSlider") }}</span>
-                        </td>
-                        <td>
-                            <output>{{ dtermFilterMultiplier.toFixed(2) }}</output>
-                        </td>
-                        <td colspan="3">
-                            <input
-                                type="range"
-                                v-model.number="dtermFilterMultiplier"
-                                min="0.1"
-                                max="2.0"
-                                step="0.05"
-                                class="tuningSlider"
-                                :disabled="dtermSliderDisabled"
-                            />
-                        </td>
-                        <td></td>
-                    </tr>
-                </tbody>
-            </table>
+            <!-- Gyro Filter Slider -->
+            <div :class="{ 'opacity-50 pointer-events-none': gyroSliderDisabled }">
+                <div class="flex items-center gap-1 mb-1">
+                    <span class="text-sm font-medium">{{ $t("pidTuningGyroFilterSlider") }}</span>
+                    <HelpIcon :text="$t('pidTuningGyroFilterSliderHelp')" />
+                </div>
+                <div class="flex items-center gap-3">
+                    <span class="min-w-10 text-sm font-semibold">{{ gyroFilterMultiplier.toFixed(2) }}</span>
+                    <USlider
+                        v-model="gyroFilterMultiplier"
+                        :min="0.1"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="gyroSliderDisabled"
+                        class="flex-1"
+                    />
+                </div>
+            </div>
+
+            <!-- DTerm Filter Slider -->
+            <div :class="{ 'opacity-50 pointer-events-none': dtermSliderDisabled }">
+                <div class="flex items-center gap-1 mb-1">
+                    <span class="text-sm font-medium">{{ $t("pidTuningDTermFilterSlider") }}</span>
+                    <HelpIcon :text="$t('pidTuningDTermFilterSliderHelp')" />
+                </div>
+                <div class="flex items-center gap-3">
+                    <span class="min-w-10 text-sm font-semibold">{{ dtermFilterMultiplier.toFixed(2) }}</span>
+                    <USlider
+                        v-model="dtermFilterMultiplier"
+                        :min="0.1"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="dtermSliderDisabled"
+                        class="flex-1"
+                    />
+                </div>
+            </div>
 
             <!-- Danger Zone Warning -->
-            <div v-if="filterSlidersInDangerZone" class="danger slidersWarning">
+            <UiBox v-if="filterSlidersInDangerZone" type="error" highlight>
                 <p v-html="$t('pidTuningSliderWarning')"></p>
-            </div>
+            </UiBox>
 
             <!-- Non-expert mode range restriction note -->
-            <div
-                v-if="!props.expertMode && (gyroSliderMode || dtermSliderMode)"
-                class="note expertSettingsDetectedNote nonExpertModeSlidersNote"
-            >
+            <UiBox v-if="!props.expertMode && (gyroSliderMode || dtermSliderMode)" type="warning" highlight>
                 <p v-html="$t('pidTuningFilterSlidersNonExpertMode')"></p>
-            </div>
+            </UiBox>
 
             <!-- Expert settings detected warning -->
-            <div
-                v-if="showGyroExpertSettingsWarning || showDtermExpertSettingsWarning"
-                class="note expertSettingsDetectedNote"
-            >
+            <UiBox v-if="showGyroExpertSettingsWarning || showDtermExpertSettingsWarning" type="warning" highlight>
                 <p v-html="$t('pidTuningSlidersExpertSettingsDetectedNote')"></p>
-            </div>
-        </div>
+            </UiBox>
+        </UiBox>
 
         <!-- Two Column Layout -->
-        <div class="cf_column two_columns">
-            <!-- LEFT COLUMN: Profile independent Filter Settings -->
-            <div class="gui_box grey pid_filter two_columns_first">
-                <table class="pid_titlebar new_rates">
-                    <thead>
-                        <tr>
-                            <th>{{ $t("pidTuningNonProfileFilterSettings") }}</th>
-                            <td>
-                                <span>{{ $t("pidTuningGyroFilterSlider") }}</span>
-                                <select v-model.number="gyroSliderMode" class="sliderMode">
-                                    <option :value="0">{{ $t("pidTuningOptionOff") }}</option>
-                                    <option :value="1">{{ $t("pidTuningOptionOn") }}</option>
-                                </select>
-                            </td>
-                        </tr>
-                    </thead>
-                </table>
+        <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <!-- LEFT COLUMN: Non-Profile Filter Settings -->
+            <UiBox :title="$t('pidTuningNonProfileFilterSettings')" type="neutral">
+                <!-- Gyro Filter Slider On/Off -->
+                <SettingRow :label="$t('pidTuningGyroFilterSlider')">
+                    <USelect v-model="gyroSliderMode" :items="sliderModeItems" class="w-20" />
+                </SettingRow>
 
-                <table class="filterTable compensation">
-                    <tbody>
-                        <!-- Gyro Lowpass Filters Header -->
-                        <tr>
-                            <th colspan="2">
-                                <div class="pid_mode">
-                                    <div class="float-left" v-text="$t('pidTuningGyroLowpassFiltersGroup')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningGyroLowpassFilterHelp')"></div>
-                                </div>
-                            </th>
-                        </tr>
+                <!-- Gyro Lowpass Filters Section -->
+                <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
+                    <span>{{ $t("pidTuningGyroLowpassFiltersGroup") }}</span>
+                    <HelpIcon :text="$t('pidTuningGyroLowpassFilterHelp')" />
+                </div>
 
-                        <!-- Gyro Lowpass 1 -->
-                        <tr class="gyroLowpass">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="gyroLowpassEnabled"
-                                        v-model="gyroLowpassEnabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningGyroLowpass") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningGyroLowpassHelp')"></div>
+                <!-- Gyro Lowpass 1 -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('pidTuningGyroLowpass')" :help="$t('pidTuningGyroLowpassHelp')">
+                        <USwitch v-model="gyroLowpassEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="gyroLowpassEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningGyroLowpassMode") }}</span>
+                            <USelect v-model="gyroLowpassMode" :items="lowpassModeItems" class="w-28" />
+                        </div>
+                        <div v-if="gyroLowpassMode === 0" class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
+                            <UInputNumber
+                                v-model="gyro_lowpass_hz"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
+                                :disabled="gyroInputsDisabled"
+                            />
+                        </div>
+                        <div v-if="gyroLowpassMode === 1" class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningMinCutoffFrequency") }}</span>
+                            <UInputNumber
+                                v-model="gyro_lowpass_dyn_min_hz"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
+                                :disabled="gyroInputsDisabled"
+                            />
+                        </div>
+                        <div v-if="gyroLowpassMode === 1" class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningMaxCutoffFrequency") }}</span>
+                            <UInputNumber
+                                v-model="gyro_lowpass_dyn_max_hz"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
+                                :disabled="gyroInputsDisabled"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningLowpassFilterType") }}</span>
+                            <USelect v-model="gyro_lowpass_type" :items="filterTypeItems" class="w-24" />
+                        </div>
+                    </div>
+                </div>
 
-                                <span v-if="gyroLowpassEnabled" class="suboption gyroLowpassFilterModeGroup">
-                                    <span class="inputValue">
-                                        <select v-model.number="gyroLowpassMode">
-                                            <option :value="0">{{ $t("pidTuningLowpassStatic") }}</option>
-                                            <option :value="1">{{ $t("pidTuningLowpassDynamic") }}</option>
-                                        </select>
-                                    </span>
-                                    <label>
-                                        <span>{{ $t("pidTuningGyroLowpassMode") }}</span>
-                                    </label>
-                                </span>
+                <!-- Gyro Lowpass 2 -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('pidTuningGyroLowpass2')" :help="$t('pidTuningGyroLowpass2Help')">
+                        <USwitch v-model="gyroLowpass2Enabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="gyroLowpass2Enabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
+                            <UInputNumber
+                                v-model="gyro_lowpass2_hz"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
+                                :disabled="gyroInputsDisabled"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningLowpassFilterType") }}</span>
+                            <USelect v-model="gyro_lowpass2_type" :items="filterTypeItems" class="w-24" />
+                        </div>
+                    </div>
+                </div>
 
-                                <span v-if="gyroLowpassEnabled && gyroLowpassMode === 0" class="suboption static">
-                                    <UInputNumber
-                                        v-model="gyro_lowpass_hz"
-                                        :step="1"
-                                        :min="1"
-                                        :max="1000"
-                                        :disabled="gyroInputsDisabled"
-                                    />
-                                    <label>
-                                        <span>{{ $t("pidTuningStaticCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
+                <!-- Gyro Notch Filters Section -->
+                <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
+                    <span>{{ $t("pidTuningGyroNotchFiltersGroup") }}</span>
+                    <HelpIcon :text="$t('pidTuningNotchFilterHelp')" />
+                </div>
 
-                                <span v-if="gyroLowpassEnabled && gyroLowpassMode === 1" class="suboption dynamic">
-                                    <UInputNumber
-                                        v-model="gyro_lowpass_dyn_min_hz"
-                                        :step="1"
-                                        :min="1"
-                                        :max="1000"
-                                        :disabled="gyroInputsDisabled"
-                                    />
-                                    <label>
-                                        <span>{{ $t("pidTuningMinCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
+                <!-- Gyro Notch Filter 1 -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('pidTuningGyroNotchFilter')" :help="$t('pidTuningGyroNotchFilterHelp')">
+                        <USwitch v-model="gyroNotch1Enabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="gyroNotch1Enabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
+                            <UInputNumber v-model="gyro_notch_hz" :step="1" :min="1" :max="16000" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
+                            <UInputNumber v-model="gyro_notch_cutoff" :step="1" :min="0" :max="16000" />
+                        </div>
+                    </div>
+                </div>
 
-                                <span v-if="gyroLowpassEnabled && gyroLowpassMode === 1" class="suboption dynamic">
-                                    <UInputNumber
-                                        v-model="gyro_lowpass_dyn_max_hz"
-                                        :step="1"
-                                        :min="1"
-                                        :max="1000"
-                                        :disabled="gyroInputsDisabled"
-                                    />
-                                    <label>
-                                        <span>{{ $t("pidTuningMaxCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
+                <!-- Gyro Notch Filter 2 -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('pidTuningGyroNotchFilter2')" :help="$t('pidTuningGyroNotchFilter2Help')">
+                        <USwitch v-model="gyroNotch2Enabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="gyroNotch2Enabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
+                            <UInputNumber v-model="gyro_notch2_hz" :step="1" :min="1" :max="16000" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
+                            <UInputNumber v-model="gyro_notch2_cutoff" :step="1" :min="0" :max="16000" />
+                        </div>
+                    </div>
+                </div>
 
-                                <span v-if="gyroLowpassEnabled" class="suboption">
-                                    <select v-model.number="gyro_lowpass_type">
-                                        <option :value="0">PT1</option>
-                                        <option :value="1">BIQUAD</option>
-                                        <option :value="2">PT2</option>
-                                        <option :value="3">PT3</option>
-                                    </select>
-                                    <label>
-                                        <span>{{ $t("pidTuningLowpassFilterType") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
+                <!-- RPM Filter Section -->
+                <template v-if="dshotTelemetryEnabled">
+                    <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
+                        <span>{{ $t("pidTuningRpmFilterGroup") }}</span>
+                        <HelpIcon :text="$t('pidTuningRpmFilterHelp')" />
+                    </div>
 
-                        <!-- Gyro Lowpass 2 -->
-                        <tr class="gyroLowpass2">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="gyroLowpass2Enabled"
-                                        v-model="gyroLowpass2Enabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningGyroLowpass2") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningGyroLowpass2Help')"></div>
+                    <div class="flex flex-col gap-2">
+                        <SettingRow :label="$t('pidTuningRpmFilterGroup')" :help="$t('pidTuningRpmFilterHelp')">
+                            <USwitch v-model="rpmFilterEnabled" size="sm" />
+                        </SettingRow>
+                        <div v-if="rpmFilterEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                            <div class="flex flex-col gap-1">
+                                <span class="text-xs text-dimmed">{{ $t("pidTuningRpmHarmonics") }}</span>
+                                <UInputNumber v-model="gyro_rpm_notch_harmonics" :step="1" :min="1" :max="3" />
+                            </div>
+                            <div class="flex flex-col gap-1">
+                                <span class="text-xs text-dimmed">{{ $t("pidTuningRpmMinHz") }}</span>
+                                <UInputNumber v-model="gyro_rpm_notch_min_hz" :step="1" :min="50" :max="200" />
+                            </div>
+                        </div>
+                    </div>
+                </template>
 
-                                <span v-if="gyroLowpass2Enabled" class="suboption">
-                                    <UInputNumber
-                                        v-model="gyro_lowpass2_hz"
-                                        :step="1"
-                                        :min="1"
-                                        :max="1000"
-                                        :disabled="gyroInputsDisabled"
-                                    />
-                                    <label>
-                                        <span>{{ $t("pidTuningStaticCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
+                <!-- Dynamic Notch Filter Section -->
+                <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
+                    <span>{{ $t("pidTuningDynamicNotchFilterGroup") }}</span>
+                    <HelpIcon :text="$t('pidTuningDynamicNotchFilterHelp')" />
+                </div>
 
-                                <span v-if="gyroLowpass2Enabled" class="suboption">
-                                    <select v-model.number="gyro_lowpass2_type">
-                                        <option :value="0">PT1</option>
-                                        <option :value="1">BIQUAD</option>
-                                        <option :value="2">PT2</option>
-                                        <option :value="3">PT3</option>
-                                    </select>
-                                    <label>
-                                        <span>{{ $t("pidTuningLowpassFilterType") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
+                <div class="flex flex-col gap-2">
+                    <SettingRow
+                        :label="$t('pidTuningDynamicNotchFilterGroup')"
+                        :help="$t('pidTuningDynamicNotchFilterHelp')"
+                    >
+                        <USwitch v-model="dynamicNotchEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="dynamicNotchEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchCount") }}</span>
+                            <UInputNumber v-model="dyn_notch_count" :step="1" :min="1" :max="5" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchQ") }}</span>
+                            <UInputNumber v-model="dyn_notch_q" :step="1" :min="1" :max="1000" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchMinHz") }}</span>
+                            <UInputNumber v-model="dyn_notch_min_hz" :step="1" :min="60" :max="250" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchMaxHz") }}</span>
+                            <UInputNumber v-model="dyn_notch_max_hz" :step="1" :min="200" :max="1000" />
+                        </div>
+                    </div>
+                </div>
+            </UiBox>
 
-                        <!-- Gyro Notch Filters Header -->
-                        <tr>
-                            <th colspan="2">
-                                <div class="pid_mode">
-                                    <div class="float-left" v-text="$t('pidTuningGyroNotchFiltersGroup')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningNotchFilterHelp')"></div>
-                                </div>
-                            </th>
-                        </tr>
+            <!-- RIGHT COLUMN: Profile-dependent Filter Settings -->
+            <UiBox :title="$t('pidTuningFilterSettings')" type="neutral">
+                <!-- DTerm Filter Slider On/Off -->
+                <SettingRow :label="$t('pidTuningDTermFilterSlider')">
+                    <USelect v-model="dtermSliderMode" :items="sliderModeItems" class="w-20" />
+                </SettingRow>
 
-                        <!-- Gyro Notch Filter 1 -->
-                        <tr class="newFilter gyroNotch1">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="gyroNotch1Enabled"
-                                        v-model="gyroNotch1Enabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningGyroNotchFilter") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningGyroNotchFilterHelp')"></div>
+                <!-- D-Term Lowpass Filters Section -->
+                <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
+                    <span>{{ $t("pidTuningDTermLowpassFiltersGroup") }}</span>
+                    <HelpIcon :text="$t('pidTuningDTermLowpassFilterHelp')" />
+                </div>
 
-                                <span v-if="gyroNotch1Enabled" class="suboption">
-                                    <UInputNumber v-model="gyro_notch_hz" :step="1" :min="1" :max="16000" />
-                                    <label>
-                                        <span>{{ $t("pidTuningCenterFrequency") }}</span>
-                                    </label>
-                                </span>
+                <!-- DTerm Lowpass 1 -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('pidTuningDTermLowpass')" :help="$t('pidTuningDTermLowpassHelp')">
+                        <USwitch v-model="dtermLowpassEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="dtermLowpassEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningGyroLowpassMode") }}</span>
+                            <USelect v-model="dtermLowpassMode" :items="lowpassModeItems" class="w-28" />
+                        </div>
+                        <div v-if="dtermLowpassMode === 0" class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
+                            <UInputNumber
+                                v-model="dterm_lowpass_hz"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
+                                :disabled="dtermInputsDisabled"
+                            />
+                        </div>
+                        <div v-if="dtermLowpassMode === 1" class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningMinCutoffFrequency") }}</span>
+                            <UInputNumber
+                                v-model="dterm_lowpass_dyn_min_hz"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
+                                :disabled="dtermInputsDisabled"
+                            />
+                        </div>
+                        <div v-if="dtermLowpassMode === 1" class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningMaxCutoffFrequency") }}</span>
+                            <UInputNumber
+                                v-model="dterm_lowpass_dyn_max_hz"
+                                :step="10"
+                                :min="200"
+                                :max="2000"
+                                :disabled="dtermInputsDisabled"
+                            />
+                        </div>
+                        <div v-if="dtermLowpassMode === 1" class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningDTermLowpassDynExpo") }}</span>
+                            <UInputNumber v-model="dyn_lpf_curve_expo" :step="1" :min="0" :max="10" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningLowpassFilterType") }}</span>
+                            <USelect v-model="dterm_lowpass_type" :items="filterTypeItems" class="w-24" />
+                        </div>
+                    </div>
+                </div>
 
-                                <span v-if="gyroNotch1Enabled" class="suboption">
-                                    <UInputNumber v-model="gyro_notch_cutoff" :step="1" :min="0" :max="16000" />
-                                    <label>
-                                        <span>{{ $t("pidTuningCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
+                <!-- DTerm Lowpass 2 -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('pidTuningDTermLowpass2')" :help="$t('pidTuningDTermLowpass2Help')">
+                        <USwitch v-model="dtermLowpass2Enabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="dtermLowpass2Enabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
+                            <UInputNumber
+                                v-model="dterm_lowpass2_hz"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
+                                :disabled="dtermInputsDisabled"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningLowpassFilterType") }}</span>
+                            <USelect v-model="dterm_lowpass2_type" :items="filterTypeItems" class="w-24" />
+                        </div>
+                    </div>
+                </div>
 
-                        <!-- Gyro Notch Filter 2 -->
-                        <tr class="newFilter gyroNotch2">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="gyroNotch2Enabled"
-                                        v-model="gyroNotch2Enabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningGyroNotchFilter2") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningGyroNotchFilter2Help')"></div>
+                <!-- D-Term Notch Filter Section -->
+                <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
+                    <span>{{ $t("pidTuningDTermNotchFiltersGroup") }}</span>
+                    <HelpIcon :text="$t('pidTuningDTermNotchFiltersGroupHelp')" />
+                </div>
 
-                                <span v-if="gyroNotch2Enabled" class="suboption">
-                                    <UInputNumber v-model="gyro_notch2_hz" :step="1" :min="1" :max="16000" />
-                                    <label>
-                                        <span>{{ $t("pidTuningCenterFrequency") }}</span>
-                                    </label>
-                                </span>
+                <div class="flex flex-col gap-2">
+                    <SettingRow
+                        :label="$t('pidTuningDTermNotchFiltersGroup')"
+                        :help="$t('pidTuningDTermNotchFiltersGroupHelp')"
+                    >
+                        <USwitch v-model="dtermNotchEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="dtermNotchEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
+                            <UInputNumber v-model="dterm_notch_hz" :step="1" :min="1" :max="16000" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
+                            <UInputNumber v-model="dterm_notch_cutoff" :step="1" :min="0" :max="16000" />
+                        </div>
+                    </div>
+                </div>
 
-                                <span v-if="gyroNotch2Enabled" class="suboption">
-                                    <UInputNumber v-model="gyro_notch2_cutoff" :step="1" :min="0" :max="16000" />
-                                    <label>
-                                        <span>{{ $t("pidTuningCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
+                <!-- Yaw Lowpass Filter Section -->
+                <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
+                    <span>{{ $t("pidTuningYawLowpassFiltersGroup") }}</span>
+                    <HelpIcon :text="$t('pidTuningYawLowpassFiltersGroupHelp')" />
+                </div>
 
-                        <!-- RPM Filter Header -->
-                        <tr v-if="dshotTelemetryEnabled" class="newFilter rpmFilter">
-                            <th class="rpmFilter" colspan="2">
-                                <div class="pid_mode rpmFilter">
-                                    <div class="float-left" v-text="$t('pidTuningRpmFilterGroup')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningRpmFilterHelp')"></div>
-                                </div>
-                            </th>
-                        </tr>
-
-                        <!-- RPM Filter -->
-                        <tr v-if="dshotTelemetryEnabled" class="newFilter rpmFilter">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="rpmFilterEnabled"
-                                        v-model="rpmFilterEnabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningRpmFilterGroup") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningRpmFilterHelp')"></div>
-
-                                <span v-if="rpmFilterEnabled" class="suboption">
-                                    <UInputNumber v-model="gyro_rpm_notch_harmonics" :step="1" :min="1" :max="3" />
-                                    <label>
-                                        <span>{{ $t("pidTuningRpmHarmonics") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="rpmFilterEnabled" class="suboption">
-                                    <UInputNumber v-model="gyro_rpm_notch_min_hz" :step="1" :min="50" :max="200" />
-                                    <label>
-                                        <span>{{ $t("pidTuningRpmMinHz") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-
-                        <!-- Dynamic Notch Filter Header -->
-                        <tr class="newFilter dynamicNotch">
-                            <th class="dynamicNotch" colspan="2">
-                                <div class="pid_mode dynamicNotch">
-                                    <div class="float-left" v-text="$t('pidTuningDynamicNotchFilterGroup')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningDynamicNotchFilterHelp')"></div>
-                                </div>
-                            </th>
-                        </tr>
-
-                        <!-- Dynamic Notch Filter -->
-                        <tr class="newFilter dynamicNotch">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="dynamicNotchEnabled"
-                                        v-model="dynamicNotchEnabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningDynamicNotchFilterGroup") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningDynamicNotchFilterHelp')"></div>
-
-                                <span v-if="dynamicNotchEnabled" class="suboption">
-                                    <UInputNumber v-model="dyn_notch_count" :step="1" :min="1" :max="5" />
-                                    <label>
-                                        <span>{{ $t("pidTuningDynamicNotchCount") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dynamicNotchEnabled" class="suboption">
-                                    <UInputNumber v-model="dyn_notch_q" :step="1" :min="1" :max="1000" />
-                                    <label>
-                                        <span>{{ $t("pidTuningDynamicNotchQ") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dynamicNotchEnabled" class="suboption">
-                                    <UInputNumber v-model="dyn_notch_min_hz" :step="1" :min="60" :max="250" />
-                                    <label>
-                                        <span>{{ $t("pidTuningDynamicNotchMinHz") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dynamicNotchEnabled" class="suboption">
-                                    <UInputNumber v-model="dyn_notch_max_hz" :step="1" :min="200" :max="1000" />
-                                    <label>
-                                        <span>{{ $t("pidTuningDynamicNotchMaxHz") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-
-            <!-- RIGHT COLUMN: Profile dependent Filter Settings -->
-            <div class="gui_box grey pid_filter two_columns_second">
-                <table class="pid_titlebar new_rates">
-                    <thead>
-                        <tr>
-                            <th>{{ $t("pidTuningFilterSettings") }}</th>
-                            <td>
-                                <span>{{ $t("pidTuningDTermFilterSlider") }}</span>
-                                <select v-model.number="dtermSliderMode" class="sliderMode">
-                                    <option :value="0">{{ $t("pidTuningOptionOff") }}</option>
-                                    <option :value="1">{{ $t("pidTuningOptionOn") }}</option>
-                                </select>
-                            </td>
-                        </tr>
-                    </thead>
-                </table>
-
-                <table class="filterTable compensation">
-                    <tbody>
-                        <!-- D Term Lowpass Filters Header -->
-                        <tr>
-                            <th colspan="2">
-                                <div class="pid_mode">
-                                    <div class="float-left" v-text="$t('pidTuningDTermLowpassFiltersGroup')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningDTermLowpassFilterHelp')"></div>
-                                </div>
-                            </th>
-                        </tr>
-
-                        <!-- D Term Lowpass 1 -->
-                        <tr class="dtermLowpass">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="dtermLowpassEnabled"
-                                        v-model="dtermLowpassEnabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningDTermLowpass") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningDTermLowpassHelp')"></div>
-
-                                <span v-if="dtermLowpassEnabled" class="suboption dtermLowpassFilterModeGroup">
-                                    <span class="inputValue">
-                                        <select v-model.number="dtermLowpassMode">
-                                            <option :value="0">{{ $t("pidTuningLowpassStatic") }}</option>
-                                            <option :value="1">{{ $t("pidTuningLowpassDynamic") }}</option>
-                                        </select>
-                                    </span>
-                                    <label>
-                                        <span>{{ $t("pidTuningGyroLowpassMode") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dtermLowpassEnabled && dtermLowpassMode === 0" class="suboption static">
-                                    <UInputNumber
-                                        v-model="dterm_lowpass_hz"
-                                        :step="1"
-                                        :min="1"
-                                        :max="1000"
-                                        :disabled="dtermInputsDisabled"
-                                    />
-                                    <label>
-                                        <span>{{ $t("pidTuningStaticCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dtermLowpassEnabled && dtermLowpassMode === 1" class="suboption dynamic">
-                                    <UInputNumber
-                                        v-model="dterm_lowpass_dyn_min_hz"
-                                        :step="1"
-                                        :min="1"
-                                        :max="1000"
-                                        :disabled="dtermInputsDisabled"
-                                    />
-                                    <label>
-                                        <span>{{ $t("pidTuningMinCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dtermLowpassEnabled && dtermLowpassMode === 1" class="suboption dynamic">
-                                    <UInputNumber
-                                        v-model="dterm_lowpass_dyn_max_hz"
-                                        :step="10"
-                                        :min="200"
-                                        :max="2000"
-                                        :disabled="dtermInputsDisabled"
-                                    />
-                                    <label>
-                                        <span>{{ $t("pidTuningMaxCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dtermLowpassEnabled && dtermLowpassMode === 1" class="suboption dynamic">
-                                    <UInputNumber v-model="dyn_lpf_curve_expo" :step="1" :min="0" :max="10" />
-                                    <label>
-                                        <span>{{ $t("pidTuningDTermLowpassDynExpo") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dtermLowpassEnabled" class="suboption">
-                                    <select v-model.number="dterm_lowpass_type">
-                                        <option :value="0">PT1</option>
-                                        <option :value="1">BIQUAD</option>
-                                        <option :value="2">PT2</option>
-                                        <option :value="3">PT3</option>
-                                    </select>
-                                    <label>
-                                        <span>{{ $t("pidTuningLowpassFilterType") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-
-                        <!-- D Term Lowpass 2 -->
-                        <tr class="dtermLowpass2">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="dtermLowpass2Enabled"
-                                        v-model="dtermLowpass2Enabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningDTermLowpass2") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningDTermLowpass2Help')"></div>
-
-                                <span v-if="dtermLowpass2Enabled" class="suboption">
-                                    <UInputNumber
-                                        v-model="dterm_lowpass2_hz"
-                                        :step="1"
-                                        :min="1"
-                                        :max="1000"
-                                        :disabled="dtermInputsDisabled"
-                                    />
-                                    <label>
-                                        <span>{{ $t("pidTuningStaticCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dtermLowpass2Enabled" class="suboption">
-                                    <select v-model.number="dterm_lowpass2_type">
-                                        <option :value="0">PT1</option>
-                                        <option :value="1">BIQUAD</option>
-                                        <option :value="2">PT2</option>
-                                        <option :value="3">PT3</option>
-                                    </select>
-                                    <label>
-                                        <span>{{ $t("pidTuningLowpassFilterType") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-
-                        <!-- D Term Notch Filter Header -->
-                        <tr>
-                            <th colspan="2">
-                                <div class="pid_mode">
-                                    <div class="float-left" v-text="$t('pidTuningDTermNotchFiltersGroup')"></div>
-                                    <div
-                                        class="helpicon cf_tip"
-                                        :title="$t('pidTuningDTermNotchFiltersGroupHelp')"
-                                    ></div>
-                                </div>
-                            </th>
-                        </tr>
-
-                        <!-- D Term Notch Filter -->
-                        <tr class="newFilter dtermNotch">
-                            <td>
-                                <span class="inputSwitch">
-                                    <input
-                                        type="checkbox"
-                                        id="dtermNotchEnabled"
-                                        v-model="dtermNotchEnabled"
-                                        class="toggle"
-                                    />
-                                </span>
-                            </td>
-                            <td colspan="2">
-                                <span>{{ $t("pidTuningDTermNotchFiltersGroup") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningDTermNotchFiltersGroupHelp')"></div>
-
-                                <span v-if="dtermNotchEnabled" class="suboption">
-                                    <UInputNumber v-model="dterm_notch_hz" :step="1" :min="1" :max="16000" />
-                                    <label>
-                                        <span>{{ $t("pidTuningCenterFrequency") }}</span>
-                                    </label>
-                                </span>
-
-                                <span v-if="dtermNotchEnabled" class="suboption">
-                                    <UInputNumber v-model="dterm_notch_cutoff" :step="1" :min="0" :max="16000" />
-                                    <label>
-                                        <span>{{ $t("pidTuningCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-
-                        <!-- Yaw Lowpass Filter Header -->
-                        <tr>
-                            <th colspan="2">
-                                <div class="pid_mode">
-                                    <div class="float-left" v-text="$t('pidTuningYawLowpassFiltersGroup')"></div>
-                                    <div
-                                        class="helpicon cf_tip"
-                                        :title="$t('pidTuningYawLowpassFiltersGroupHelp')"
-                                    ></div>
-                                </div>
-                            </th>
-                        </tr>
-
-                        <!-- Yaw Lowpass Filter -->
-                        <tr class="yawLowpass">
-                            <td colspan="3">
-                                <span>{{ $t("pidTuningYawLowpassFiltersGroup") }}</span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningYawLowpassFiltersGroupHelp')"></div>
-
-                                <span class="suboption">
-                                    <UInputNumber v-model="yaw_lowpass_hz" :step="1" :min="0" :max="500" />
-                                    <label>
-                                        <span>{{ $t("pidTuningStaticCutoffFrequency") }}</span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                <div class="flex flex-wrap items-end gap-3">
+                    <div class="flex flex-col gap-1">
+                        <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
+                        <UInputNumber v-model="yaw_lowpass_hz" :step="1" :min="0" :max="500" />
+                    </div>
+                </div>
+            </UiBox>
         </div>
     </div>
 </template>
 
 <script setup>
 import { computed, ref, watch } from "vue";
+import { useTranslation } from "i18next-vue";
 import FC from "@/js/fc";
 import {
     NON_EXPERT_SLIDER_MIN_GYRO,
@@ -677,6 +388,11 @@ import {
 import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
 import { mspHelper } from "@/js/msp/MSPHelper";
+import UiBox from "@/components/elements/UiBox.vue";
+import HelpIcon from "@/components/elements/HelpIcon.vue";
+import SettingRow from "@/components/elements/SettingRow.vue";
+
+const { t } = useTranslation();
 
 const props = defineProps({
     expertMode: {
@@ -686,6 +402,24 @@ const props = defineProps({
 });
 
 const emit = defineEmits(["change"]);
+
+// USelect item arrays
+const sliderModeItems = computed(() => [
+    { value: 0, label: t("pidTuningOptionOff") },
+    { value: 1, label: t("pidTuningOptionOn") },
+]);
+
+const lowpassModeItems = computed(() => [
+    { value: 0, label: t("pidTuningLowpassStatic") },
+    { value: 1, label: t("pidTuningLowpassDynamic") },
+]);
+
+const filterTypeItems = [
+    { value: 0, label: "PT1" },
+    { value: 1, label: "BIQUAD" },
+    { value: 2, label: "PT2" },
+    { value: 3, label: "PT3" },
+];
 
 // Store previous non-zero values AND mode to restore when re-enabling filters
 const previousValues = ref({
@@ -1272,96 +1006,3 @@ defineExpose({
     forceUpdateSliders,
 });
 </script>
-
-<style scoped>
-.subtab-filter {
-    padding: 20px;
-    display: flex;
-    flex-direction: column;
-    gap: 20px;
-}
-
-.gui_box.grey {
-    border: 1px solid var(--surface-300);
-    border-radius: 4px;
-    padding: 15px;
-    background: var(--surface-50);
-}
-
-.gui_box.grey h3 {
-    margin-top: 0;
-    margin-bottom: 15px;
-    color: var(--text-primary);
-    font-size: 16px;
-}
-
-.checkbox {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 12px;
-}
-
-.checkbox input[type="checkbox"] {
-    width: 16px;
-    height: 16px;
-}
-
-.suboption {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding-left: 24px;
-}
-
-.suboption label {
-    font-weight: 500;
-    color: var(--text-primary);
-    margin-top: 8px;
-}
-
-.suboption :deep(input),
-.suboption select {
-    padding: 6px 10px;
-    border: 1px solid var(--surface-300);
-    border-radius: 4px;
-    background: var(--surface-0);
-    color: var(--text-primary);
-    min-width: fit-content;
-    width: auto;
-    max-width: none;
-}
-
-.slider-container {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin-bottom: 12px;
-}
-
-.slider-container label {
-    min-width: 200px;
-    font-weight: 500;
-}
-
-.tuningSlider {
-    width: 100%;
-    max-width: none;
-}
-
-.slider-container span {
-    min-width: 50px;
-    font-weight: bold;
-    color: var(--accent-color);
-}
-
-.notch-filter {
-    border-left: 2px solid var(--surface-300);
-    padding-left: 12px;
-    margin-bottom: 12px;
-}
-
-.notch-filter:last-child {
-    margin-bottom: 0;
-}
-</style>

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -10,41 +10,36 @@
             </div>
 
             <!-- Gyro Filter Slider -->
-            <div :class="{ 'opacity-50 pointer-events-none': gyroSliderDisabled }">
-                <div class="flex items-center gap-1 mb-1">
-                    <span class="text-sm font-medium">{{ $t("pidTuningGyroFilterSlider") }}</span>
-                    <HelpIcon :text="$t('pidTuningGyroFilterSliderHelp')" />
-                </div>
-                <div class="flex items-center gap-3">
-                    <span class="min-w-10 text-sm font-semibold">{{ gyroFilterMultiplier.toFixed(2) }}</span>
-                    <USlider
-                        v-model="gyroFilterMultiplier"
-                        :min="0.1"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="gyroSliderDisabled"
-                        class="flex-1"
-                    />
-                </div>
+            <div class="flex items-center gap-3 py-1" :class="{ 'opacity-50 pointer-events-none': gyroSliderDisabled }">
+                <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningGyroFilterSlider')"></div>
+                <span class="min-w-10 text-center text-sm font-semibold">{{ gyroFilterMultiplier.toFixed(2) }}</span>
+                <USlider
+                    v-model="gyroFilterMultiplier"
+                    :min="0.1"
+                    :max="2.0"
+                    :step="0.05"
+                    :disabled="gyroSliderDisabled"
+                    class="flex-1"
+                />
+                <HelpIcon :text="$t('pidTuningGyroFilterSliderHelp')" />
             </div>
 
             <!-- DTerm Filter Slider -->
-            <div :class="{ 'opacity-50 pointer-events-none': dtermSliderDisabled }">
-                <div class="flex items-center gap-1 mb-1">
-                    <span class="text-sm font-medium">{{ $t("pidTuningDTermFilterSlider") }}</span>
-                    <HelpIcon :text="$t('pidTuningDTermFilterSliderHelp')" />
-                </div>
-                <div class="flex items-center gap-3">
-                    <span class="min-w-10 text-sm font-semibold">{{ dtermFilterMultiplier.toFixed(2) }}</span>
-                    <USlider
-                        v-model="dtermFilterMultiplier"
-                        :min="0.1"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="dtermSliderDisabled"
-                        class="flex-1"
-                    />
-                </div>
+            <div
+                class="flex items-center gap-3 py-1"
+                :class="{ 'opacity-50 pointer-events-none': dtermSliderDisabled }"
+            >
+                <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDTermFilterSlider')"></div>
+                <span class="min-w-10 text-center text-sm font-semibold">{{ dtermFilterMultiplier.toFixed(2) }}</span>
+                <USlider
+                    v-model="dtermFilterMultiplier"
+                    :min="0.1"
+                    :max="2.0"
+                    :step="0.05"
+                    :disabled="dtermSliderDisabled"
+                    class="flex-1"
+                />
+                <HelpIcon :text="$t('pidTuningDTermFilterSliderHelp')" />
             </div>
 
             <!-- Danger Zone Warning -->
@@ -91,6 +86,7 @@
                         <div v-if="gyroLowpassMode === 0" class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                             <UInputNumber
+                                size="xs"
                                 v-model="gyro_lowpass_hz"
                                 :step="1"
                                 :min="1"
@@ -101,6 +97,7 @@
                         <div v-if="gyroLowpassMode === 1" class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningMinCutoffFrequency") }}</span>
                             <UInputNumber
+                                size="xs"
                                 v-model="gyro_lowpass_dyn_min_hz"
                                 :step="1"
                                 :min="1"
@@ -111,6 +108,7 @@
                         <div v-if="gyroLowpassMode === 1" class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningMaxCutoffFrequency") }}</span>
                             <UInputNumber
+                                size="xs"
                                 v-model="gyro_lowpass_dyn_max_hz"
                                 :step="1"
                                 :min="1"
@@ -134,6 +132,7 @@
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                             <UInputNumber
+                                size="xs"
                                 v-model="gyro_lowpass2_hz"
                                 :step="1"
                                 :min="1"
@@ -162,11 +161,11 @@
                     <div v-if="gyroNotch1Enabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
-                            <UInputNumber v-model="gyro_notch_hz" :step="1" :min="1" :max="16000" />
+                            <UInputNumber size="xs" v-model="gyro_notch_hz" :step="1" :min="1" :max="16000" />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
-                            <UInputNumber v-model="gyro_notch_cutoff" :step="1" :min="0" :max="16000" />
+                            <UInputNumber size="xs" v-model="gyro_notch_cutoff" :step="1" :min="0" :max="16000" />
                         </div>
                     </div>
                 </div>
@@ -179,11 +178,11 @@
                     <div v-if="gyroNotch2Enabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
-                            <UInputNumber v-model="gyro_notch2_hz" :step="1" :min="1" :max="16000" />
+                            <UInputNumber size="xs" v-model="gyro_notch2_hz" :step="1" :min="1" :max="16000" />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
-                            <UInputNumber v-model="gyro_notch2_cutoff" :step="1" :min="0" :max="16000" />
+                            <UInputNumber size="xs" v-model="gyro_notch2_cutoff" :step="1" :min="0" :max="16000" />
                         </div>
                     </div>
                 </div>
@@ -202,11 +201,23 @@
                         <div v-if="rpmFilterEnabled" class="flex flex-wrap items-end gap-3 pl-8">
                             <div class="flex flex-col gap-1">
                                 <span class="text-xs text-dimmed">{{ $t("pidTuningRpmHarmonics") }}</span>
-                                <UInputNumber v-model="gyro_rpm_notch_harmonics" :step="1" :min="1" :max="3" />
+                                <UInputNumber
+                                    size="xs"
+                                    v-model="gyro_rpm_notch_harmonics"
+                                    :step="1"
+                                    :min="1"
+                                    :max="3"
+                                />
                             </div>
                             <div class="flex flex-col gap-1">
                                 <span class="text-xs text-dimmed">{{ $t("pidTuningRpmMinHz") }}</span>
-                                <UInputNumber v-model="gyro_rpm_notch_min_hz" :step="1" :min="50" :max="200" />
+                                <UInputNumber
+                                    size="xs"
+                                    v-model="gyro_rpm_notch_min_hz"
+                                    :step="1"
+                                    :min="50"
+                                    :max="200"
+                                />
                             </div>
                         </div>
                     </div>
@@ -228,19 +239,19 @@
                     <div v-if="dynamicNotchEnabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchCount") }}</span>
-                            <UInputNumber v-model="dyn_notch_count" :step="1" :min="1" :max="5" />
+                            <UInputNumber size="xs" v-model="dyn_notch_count" :step="1" :min="1" :max="5" />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchQ") }}</span>
-                            <UInputNumber v-model="dyn_notch_q" :step="1" :min="1" :max="1000" />
+                            <UInputNumber size="xs" v-model="dyn_notch_q" :step="1" :min="1" :max="1000" />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchMinHz") }}</span>
-                            <UInputNumber v-model="dyn_notch_min_hz" :step="1" :min="60" :max="250" />
+                            <UInputNumber size="xs" v-model="dyn_notch_min_hz" :step="1" :min="60" :max="250" />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDynamicNotchMaxHz") }}</span>
-                            <UInputNumber v-model="dyn_notch_max_hz" :step="1" :min="200" :max="1000" />
+                            <UInputNumber size="xs" v-model="dyn_notch_max_hz" :step="1" :min="200" :max="1000" />
                         </div>
                     </div>
                 </div>
@@ -272,6 +283,7 @@
                         <div v-if="dtermLowpassMode === 0" class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                             <UInputNumber
+                                size="xs"
                                 v-model="dterm_lowpass_hz"
                                 :step="1"
                                 :min="1"
@@ -282,6 +294,7 @@
                         <div v-if="dtermLowpassMode === 1" class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningMinCutoffFrequency") }}</span>
                             <UInputNumber
+                                size="xs"
                                 v-model="dterm_lowpass_dyn_min_hz"
                                 :step="1"
                                 :min="1"
@@ -292,6 +305,7 @@
                         <div v-if="dtermLowpassMode === 1" class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningMaxCutoffFrequency") }}</span>
                             <UInputNumber
+                                size="xs"
                                 v-model="dterm_lowpass_dyn_max_hz"
                                 :step="10"
                                 :min="200"
@@ -301,7 +315,7 @@
                         </div>
                         <div v-if="dtermLowpassMode === 1" class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningDTermLowpassDynExpo") }}</span>
-                            <UInputNumber v-model="dyn_lpf_curve_expo" :step="1" :min="0" :max="10" />
+                            <UInputNumber size="xs" v-model="dyn_lpf_curve_expo" :step="1" :min="0" :max="10" />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningLowpassFilterType") }}</span>
@@ -319,6 +333,7 @@
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
                             <UInputNumber
+                                size="xs"
                                 v-model="dterm_lowpass2_hz"
                                 :step="1"
                                 :min="1"
@@ -349,11 +364,11 @@
                     <div v-if="dtermNotchEnabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCenterFrequency") }}</span>
-                            <UInputNumber v-model="dterm_notch_hz" :step="1" :min="1" :max="16000" />
+                            <UInputNumber size="xs" v-model="dterm_notch_hz" :step="1" :min="1" :max="16000" />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed">{{ $t("pidTuningCutoffFrequency") }}</span>
-                            <UInputNumber v-model="dterm_notch_cutoff" :step="1" :min="0" :max="16000" />
+                            <UInputNumber size="xs" v-model="dterm_notch_cutoff" :step="1" :min="0" :max="16000" />
                         </div>
                     </div>
                 </div>
@@ -367,7 +382,7 @@
                 <div class="flex flex-wrap items-end gap-3">
                     <div class="flex flex-col gap-1">
                         <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
-                        <UInputNumber v-model="yaw_lowpass_hz" :step="1" :min="0" :max="500" />
+                        <UInputNumber size="xs" v-model="yaw_lowpass_hz" :step="1" :min="0" :max="500" />
                     </div>
                 </div>
             </UiBox>

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -9,7 +9,7 @@
 
             <!-- PID Table -->
             <UiBox type="neutral">
-                <div class="grid grid-cols-[3.5rem_repeat(5,1fr)] gap-x-1 gap-y-1 items-center">
+                <div class="grid grid-cols-[3rem_repeat(5,1fr)] gap-x-1 gap-y-1 items-center min-w-0">
                     <!-- Header -->
                     <div></div>
                     <div class="flex items-center justify-center gap-0.5 text-xs">
@@ -45,6 +45,8 @@
                         :max="250"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="pidRollI"
@@ -53,6 +55,8 @@
                         :max="250"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="pidRollD"
@@ -61,6 +65,8 @@
                         :max="250"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="advancedTuning.dMaxRoll"
@@ -69,6 +75,8 @@
                         :max="250"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="advancedTuning.feedforwardRoll"
@@ -77,6 +85,8 @@
                         :max="2000"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
 
                     <!-- PITCH -->
@@ -88,6 +98,8 @@
                         :max="250"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="pidPitchI"
@@ -96,6 +108,8 @@
                         :max="250"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="pidPitchD"
@@ -104,6 +118,8 @@
                         :max="250"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="advancedTuning.dMaxPitch"
@@ -112,6 +128,8 @@
                         :max="250"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="advancedTuning.feedforwardPitch"
@@ -120,13 +138,42 @@
                         :max="2000"
                         :disabled="rollPitchDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
 
                     <!-- YAW -->
                     <div class="font-bold text-white text-center py-0.5 px-1 bg-[#477ac7] rounded text-xs">YAW</div>
-                    <UInputNumber v-model="pidYawP" :step="1" :min="0" :max="250" :disabled="yawDisabled" size="xs" />
-                    <UInputNumber v-model="pidYawI" :step="1" :min="0" :max="250" :disabled="yawDisabled" size="xs" />
-                    <UInputNumber v-model="pidYawD" :step="1" :min="0" :max="250" :disabled="yawDisabled" size="xs" />
+                    <UInputNumber
+                        v-model="pidYawP"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="yawDisabled"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        v-model="pidYawI"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="yawDisabled"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        v-model="pidYawD"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="yawDisabled"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
                     <UInputNumber
                         v-model="advancedTuning.dMaxYaw"
                         :step="1"
@@ -134,6 +181,8 @@
                         :max="250"
                         :disabled="yawDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                     <UInputNumber
                         v-model="advancedTuning.feedforwardYaw"
@@ -142,6 +191,8 @@
                         :max="2000"
                         :disabled="yawDisabled"
                         size="xs"
+                        orientation="vertical"
+                        class="w-full"
                     />
                 </div>
             </UiBox>
@@ -343,7 +394,7 @@
 
             <!-- BARO, MAG, GPS Optional PIDs -->
             <UiBox v-if="showAllLocal && hasBaroMagGpsPids" type="neutral">
-                <div class="grid grid-cols-[3.5rem_repeat(3,1fr)] gap-x-1 gap-y-1 items-center">
+                <div class="grid grid-cols-[3rem_repeat(3,1fr)] gap-x-1 gap-y-1 items-center min-w-0">
                     <!-- Header -->
                     <div></div>
                     <div class="text-xs text-center" v-html="$t('pidTuningProportional')"></div>
@@ -355,15 +406,63 @@
                         <div class="col-span-4 text-xs text-dimmed">{{ $t("pidTuningAltitude") }}</div>
                         <template v-if="hasPidName('ALT')">
                             <div></div>
-                            <UInputNumber v-model="pidAltP" :step="1" :min="0" :max="255" size="xs" />
-                            <UInputNumber v-model="pidAltI" :step="1" :min="0" :max="255" size="xs" />
-                            <UInputNumber v-model="pidAltD" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber
+                                v-model="pidAltP"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
+                            <UInputNumber
+                                v-model="pidAltI"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
+                            <UInputNumber
+                                v-model="pidAltD"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
                         </template>
                         <template v-if="hasPidName('VEL')">
                             <div></div>
-                            <UInputNumber v-model="pidVelP" :step="1" :min="0" :max="255" size="xs" />
-                            <UInputNumber v-model="pidVelI" :step="1" :min="0" :max="255" size="xs" />
-                            <UInputNumber v-model="pidVelD" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber
+                                v-model="pidVelP"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
+                            <UInputNumber
+                                v-model="pidVelI"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
+                            <UInputNumber
+                                v-model="pidVelD"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
                         </template>
                     </template>
 
@@ -371,7 +470,15 @@
                     <template v-if="hasPidName('MAG')">
                         <div class="col-span-4 text-xs text-dimmed">{{ $t("pidTuningMag") }}</div>
                         <div></div>
-                        <UInputNumber v-model="pidMagP" :step="1" :min="0" :max="255" size="xs" />
+                        <UInputNumber
+                            v-model="pidMagP"
+                            :step="1"
+                            :min="0"
+                            :max="255"
+                            size="xs"
+                            orientation="vertical"
+                            class="w-full"
+                        />
                         <div></div>
                         <div></div>
                     </template>
@@ -381,21 +488,77 @@
                         <div class="col-span-4 text-xs text-dimmed">{{ $t("pidTuningGps") }}</div>
                         <template v-if="hasPidName('Pos')">
                             <div></div>
-                            <UInputNumber v-model="pidPosP" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber
+                                v-model="pidPosP"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
                             <div></div>
                             <div></div>
                         </template>
                         <template v-if="hasPidName('PosR')">
                             <div></div>
-                            <UInputNumber v-model="pidPosRP" :step="1" :min="0" :max="255" size="xs" />
-                            <UInputNumber v-model="pidPosRI" :step="1" :min="0" :max="255" size="xs" />
-                            <UInputNumber v-model="pidPosRD" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber
+                                v-model="pidPosRP"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
+                            <UInputNumber
+                                v-model="pidPosRI"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
+                            <UInputNumber
+                                v-model="pidPosRD"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
                         </template>
                         <template v-if="hasPidName('NavR')">
                             <div></div>
-                            <UInputNumber v-model="pidNavRP" :step="1" :min="0" :max="255" size="xs" />
-                            <UInputNumber v-model="pidNavRI" :step="1" :min="0" :max="255" size="xs" />
-                            <UInputNumber v-model="pidNavRD" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber
+                                v-model="pidNavRP"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
+                            <UInputNumber
+                                v-model="pidNavRI"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
+                            <UInputNumber
+                                v-model="pidNavRD"
+                                :step="1"
+                                :min="0"
+                                :max="255"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-full"
+                            />
                         </template>
                     </template>
                 </div>
@@ -403,7 +566,7 @@
 
             <!-- Angle/Horizon Section -->
             <UiBox type="neutral">
-                <div class="grid grid-cols-3 gap-x-1 gap-y-1 items-center">
+                <div class="grid grid-cols-3 gap-x-1 gap-y-1 items-center min-w-0">
                     <!-- Header -->
                     <div></div>
                     <div class="text-xs text-center">{{ $t("pidTuningStrength") }}</div>
@@ -411,13 +574,37 @@
 
                     <!-- Angle -->
                     <div class="text-xs">{{ $t("pidTuningAngle") }}</div>
-                    <UInputNumber v-model="pidLevelAngle" :step="1" :min="0" :max="255" size="xs" />
+                    <UInputNumber
+                        v-model="pidLevelAngle"
+                        :step="1"
+                        :min="0"
+                        :max="255"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
                     <div></div>
 
                     <!-- Horizon -->
                     <div class="text-xs">{{ $t("pidTuningHorizon") }}</div>
-                    <UInputNumber v-model="pidLevelHorizon" :step="1" :min="0" :max="255" size="xs" />
-                    <UInputNumber v-model="pidLevelTransition" :step="1" :min="0" :max="255" size="xs" />
+                    <UInputNumber
+                        v-model="pidLevelHorizon"
+                        :step="1"
+                        :min="0"
+                        :max="255"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        v-model="pidLevelTransition"
+                        :step="1"
+                        :min="0"
+                        :max="255"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
 
                     <!-- Level Angle Limit -->
                     <div></div>
@@ -425,7 +612,15 @@
                     <div></div>
 
                     <div></div>
-                    <UInputNumber v-model="advancedTuning.levelAngleLimit" :step="1" :min="10" :max="200" size="xs" />
+                    <UInputNumber
+                        v-model="advancedTuning.levelAngleLimit"
+                        :step="1"
+                        :min="10"
+                        :max="200"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
                     <div></div>
                 </div>
             </UiBox>

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -1,1143 +1,728 @@
 <template>
-    <div class="subtab-pid">
-        <div class="clear-both"></div>
-
+    <div class="p-5 grid grid-cols-1 xl:grid-cols-2 gap-4">
         <!-- LEFT COLUMN: PID Table and Sliders -->
-        <div class="cf_column">
+        <div class="flex flex-col gap-4">
             <!-- Profile Name (API 1.45+) -->
-            <div class="profile_name" v-if="showProfileName">
-                <div class="number">
-                    <label>
-                        <input type="text" v-model="localProfileName" maxlength="8" style="width: 100px" />
-                        <span>{{ $t("pidProfileName") }}</span>
-                    </label>
-                    <div class="helpicon cf_tip" :title="$t('pidProfileNameHelp')"></div>
-                </div>
-            </div>
+            <SettingRow v-if="showProfileName" :label="$t('pidProfileName')" :help="$t('pidProfileNameHelp')">
+                <UInput v-model="localProfileName" maxlength="8" class="w-28" />
+            </SettingRow>
 
             <!-- PID Table -->
-            <div class="gui_box grey">
-                <table id="pid_main" class="pid_tuning">
-                    <tbody>
-                        <tr class="pid_titlebar">
-                            <th class="name"></th>
-                            <th class="proportional">
-                                <div class="name-helpicon-flex">
-                                    <div class="xs" v-html="$t('pidTuningProportional')"></div>
-                                    <div
-                                        class="cf_tip sm-min"
-                                        :title="$t('pidTuningProportionalHelp')"
-                                        v-html="$t('pidTuningProportional')"
-                                    ></div>
-                                </div>
-                            </th>
-                            <th class="integral">
-                                <div class="name-helpicon-flex">
-                                    <div class="xs" v-html="$t('pidTuningIntegral')"></div>
-                                    <div
-                                        class="cf_tip sm-min"
-                                        :title="$t('pidTuningIntegralHelp')"
-                                        v-html="$t('pidTuningIntegral')"
-                                    ></div>
-                                </div>
-                            </th>
-                            <th class="derivative">
-                                <div class="name-helpicon-flex">
-                                    <div class="xs" v-html="$t(derivativeLabel)"></div>
-                                    <div
-                                        class="cf_tip sm-min"
-                                        :title="$t(derivativeHelp)"
-                                        v-html="$t(derivativeLabel)"
-                                    ></div>
-                                </div>
-                            </th>
-                            <th class="dmax">
-                                <div class="name-helpicon-flex">
-                                    <div class="xs" v-html="$t(dMaxLabel)"></div>
-                                    <div class="cf_tip sm-min" :title="$t(dMaxHelp)" v-html="$t(dMaxLabel)"></div>
-                                </div>
-                            </th>
-                            <th class="feedforward">
-                                <div class="name-helpicon-flex">
-                                    <div class="xs" v-html="$t('pidTuningFeedforward')"></div>
-                                    <div
-                                        class="cf_tip sm-min"
-                                        :title="$t('pidTuningFeedforwardHelp')"
-                                        v-html="$t('pidTuningFeedforward')"
-                                    ></div>
-                                </div>
-                            </th>
-                        </tr>
-                        <tr class="pid_titlebar2">
-                            <th colspan="6">
-                                <div class="pid_mode">
-                                    <div class="float-left">{{ $t("pidTuningBasic") }}</div>
-                                </div>
-                            </th>
-                        </tr>
+            <UiBox type="neutral">
+                <div class="grid grid-cols-[3.5rem_repeat(5,1fr)] gap-x-1 gap-y-1 items-center">
+                    <!-- Header -->
+                    <div></div>
+                    <div class="flex items-center justify-center gap-0.5 text-xs">
+                        <span v-html="$t('pidTuningProportional')"></span>
+                        <HelpIcon :text="$t('pidTuningProportionalHelp')" />
+                    </div>
+                    <div class="flex items-center justify-center gap-0.5 text-xs">
+                        <span v-html="$t('pidTuningIntegral')"></span>
+                        <HelpIcon :text="$t('pidTuningIntegralHelp')" />
+                    </div>
+                    <div class="flex items-center justify-center gap-0.5 text-xs">
+                        <span v-html="$t(derivativeLabel)"></span>
+                        <HelpIcon :text="$t(derivativeHelp)" />
+                    </div>
+                    <div class="flex items-center justify-center gap-0.5 text-xs">
+                        <span v-html="$t(dMaxLabel)"></span>
+                        <HelpIcon :text="$t(dMaxHelp)" />
+                    </div>
+                    <div class="flex items-center justify-center gap-0.5 text-xs">
+                        <span v-html="$t('pidTuningFeedforward')"></span>
+                        <HelpIcon :text="$t('pidTuningFeedforwardHelp')" />
+                    </div>
 
-                        <!-- ROLL -->
-                        <tr class="ROLL">
-                            <td class="pid_roll" style="background-color: #e24761">ROLL</td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="pidRollP"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="pidRollI"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="pidRollD"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="advancedTuning.dMaxRoll"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="advancedTuning.feedforwardRoll"
-                                    :step="1"
-                                    :min="0"
-                                    :max="2000"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                        </tr>
+                    <!-- Section label -->
+                    <div class="col-span-6 text-xs text-dimmed">{{ $t("pidTuningBasic") }}</div>
 
-                        <!-- PITCH -->
-                        <tr class="PITCH">
-                            <td class="pid_pitch" style="background-color: #49c747">PITCH</td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="pidPitchP"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="pidPitchI"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="pidPitchD"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="advancedTuning.dMaxPitch"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="advancedTuning.feedforwardPitch"
-                                    :step="1"
-                                    :min="0"
-                                    :max="2000"
-                                    :disabled="rollPitchDisabled"
-                                />
-                            </td>
-                        </tr>
+                    <!-- ROLL -->
+                    <div class="font-bold text-white text-center py-0.5 px-1 bg-[#e24761] rounded text-xs">ROLL</div>
+                    <UInputNumber
+                        v-model="pidRollP"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="pidRollI"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="pidRollD"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="advancedTuning.dMaxRoll"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="advancedTuning.feedforwardRoll"
+                        :step="1"
+                        :min="0"
+                        :max="2000"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
 
-                        <!-- YAW -->
-                        <tr class="YAW">
-                            <td class="pid_yaw" style="background-color: #477ac7">YAW</td>
-                            <td class="pid_data">
-                                <UInputNumber v-model="pidYawP" :step="1" :min="0" :max="250" :disabled="yawDisabled" />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber v-model="pidYawI" :step="1" :min="0" :max="250" :disabled="yawDisabled" />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber v-model="pidYawD" :step="1" :min="0" :max="250" :disabled="yawDisabled" />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="advancedTuning.dMaxYaw"
-                                    :step="1"
-                                    :min="0"
-                                    :max="250"
-                                    :disabled="yawDisabled"
-                                />
-                            </td>
-                            <td class="pid_data">
-                                <UInputNumber
-                                    v-model="advancedTuning.feedforwardYaw"
-                                    :step="1"
-                                    :min="0"
-                                    :max="2000"
-                                    :disabled="yawDisabled"
-                                />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                    <!-- PITCH -->
+                    <div class="font-bold text-white text-center py-0.5 px-1 bg-[#49c747] rounded text-xs">PITCH</div>
+                    <UInputNumber
+                        v-model="pidPitchP"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="pidPitchI"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="pidPitchD"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="advancedTuning.dMaxPitch"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="advancedTuning.feedforwardPitch"
+                        :step="1"
+                        :min="0"
+                        :max="2000"
+                        :disabled="rollPitchDisabled"
+                        size="xs"
+                    />
+
+                    <!-- YAW -->
+                    <div class="font-bold text-white text-center py-0.5 px-1 bg-[#477ac7] rounded text-xs">YAW</div>
+                    <UInputNumber v-model="pidYawP" :step="1" :min="0" :max="250" :disabled="yawDisabled" size="xs" />
+                    <UInputNumber v-model="pidYawI" :step="1" :min="0" :max="250" :disabled="yawDisabled" size="xs" />
+                    <UInputNumber v-model="pidYawD" :step="1" :min="0" :max="250" :disabled="yawDisabled" size="xs" />
+                    <UInputNumber
+                        v-model="advancedTuning.dMaxYaw"
+                        :step="1"
+                        :min="0"
+                        :max="250"
+                        :disabled="yawDisabled"
+                        size="xs"
+                    />
+                    <UInputNumber
+                        v-model="advancedTuning.feedforwardYaw"
+                        :step="1"
+                        :min="0"
+                        :max="2000"
+                        :disabled="yawDisabled"
+                        size="xs"
+                    />
+                </div>
+            </UiBox>
 
             <!-- Tuning Sliders Section -->
-            <div id="slidersPidsBox" class="gui_box grey tuningPIDSliders">
-                <div class="slider-header">
-                    <div class="slider-mode-section">
-                        <div class="sm-min">{{ $t("pidTuningSliderPidsMode") }}</div>
-                        <select
-                            id="sliderPidsModeSelect"
-                            class="sliderMode"
-                            v-model.number="sliderPidsMode"
-                            @change="onSliderModeChange"
-                        >
-                            <option :value="0">{{ $t("pidTuningOptionOff") }}</option>
-                            <option :value="1">{{ $t("pidTuningOptionRP") }}</option>
-                            <option :value="2">{{ $t("pidTuningOptionRPY") }}</option>
-                        </select>
-                        <div class="helpicon cf_tip" :title="$t('pidTuningSliderModeHelp')"></div>
+            <UiBox type="neutral">
+                <!-- Slider Header: Mode select + range labels -->
+                <div class="flex items-center gap-3 mb-2">
+                    <div class="flex items-center gap-2 min-w-44 shrink-0">
+                        <span class="text-xs whitespace-nowrap">{{ $t("pidTuningSliderPidsMode") }}</span>
+                        <USelect
+                            v-model="sliderPidsMode"
+                            :items="pidsModeItems"
+                            class="w-24"
+                            @update:model-value="onSliderModeChange"
+                        />
+                        <HelpIcon :text="$t('pidTuningSliderModeHelp')" />
                     </div>
-                    <div class="slider-range-labels">
+                    <div class="flex justify-between flex-1 text-xs text-dimmed">
                         <span>{{ $t("pidTuningSliderLow") }}</span>
                         <span>{{ $t("pidTuningSliderDefault") }}</span>
                         <span>{{ $t("pidTuningSliderHigh") }}</span>
                     </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningPidSlidersHelp')"></div>
+                    <HelpIcon :text="$t('pidTuningPidSlidersHelp')" />
                 </div>
 
                 <!-- Basic Sliders -->
-                <div class="slider-row baseSlider" :class="{ disabledSliders: sliderDGainDisabled }">
-                    <div class="slider-label" v-html="$t('pidTuningDGainSlider')"></div>
-                    <div class="slider-value">{{ sliderDGainDisplay }}</div>
-                    <div class="slider-control">
-                        <input
-                            type="range"
-                            class="tuningSlider"
-                            id="sliderDGain"
-                            min="0.0"
-                            max="2.0"
-                            step="0.05"
-                            v-model.number="sliderDGain"
-                            @input="onSliderChange"
-                            :disabled="sliderDGainDisabled"
-                        />
-                    </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningDGainSliderHelp')"></div>
+                <div
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': sliderDGainDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderDGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderDGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="sliderDGainDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange('sliderDGain')"
+                    />
+                    <HelpIcon :text="$t('pidTuningDGainSliderHelp')" />
                 </div>
 
-                <div class="slider-row baseSlider" :class="{ disabledSliders: sliderPIGainDisabled }">
-                    <div class="slider-label" v-html="$t('pidTuningPIGainSlider')"></div>
-                    <div class="slider-value">{{ sliderPIGainDisplay }}</div>
-                    <div class="slider-control">
-                        <input
-                            type="range"
-                            class="tuningSlider"
-                            id="sliderPIGain"
-                            min="0.0"
-                            max="2.0"
-                            step="0.05"
-                            v-model.number="sliderPIGain"
-                            @input="onSliderChange"
-                            :disabled="sliderPIGainDisabled"
-                        />
-                    </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningPIGainSliderHelp')"></div>
+                <div
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': sliderPIGainDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningPIGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderPIGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderPIGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="sliderPIGainDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange('sliderPIGain')"
+                    />
+                    <HelpIcon :text="$t('pidTuningPIGainSliderHelp')" />
                 </div>
 
-                <div class="slider-row baseSlider" :class="{ disabledSliders: sliderFFGainDisabled }">
-                    <div class="slider-label" v-html="$t('pidTuningResponseSlider')"></div>
-                    <div class="slider-value">{{ sliderFFGainDisplay }}</div>
-                    <div class="slider-control">
-                        <input
-                            type="range"
-                            class="tuningSlider"
-                            id="sliderFeedforwardGain"
-                            min="0.0"
-                            max="2.0"
-                            step="0.05"
-                            v-model.number="sliderFeedforwardGain"
-                            @input="onSliderChange"
-                            :disabled="sliderFFGainDisabled"
-                        />
-                    </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningResponseSliderHelp')"></div>
+                <div
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': sliderFFGainDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningResponseSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderFFGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderFeedforwardGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="sliderFFGainDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange('sliderFeedforwardGain')"
+                    />
+                    <HelpIcon :text="$t('pidTuningResponseSliderHelp')" />
                 </div>
 
                 <!-- Divider before advanced sliders -->
-                <div class="sliderDivider" v-show="showAdvancedSliders">
-                    <hr />
-                </div>
+                <hr v-show="showAdvancedSliders" class="border-default my-2" />
 
                 <!-- Advanced Sliders -->
                 <div
-                    class="slider-row advancedSlider"
-                    :class="{ disabledSliders: dMaxSliderDisabled }"
                     v-show="showDMaxSlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': dMaxSliderDisabled }"
                 >
-                    <div class="slider-label" v-html="$t('pidTuningDMaxGainSlider')"></div>
-                    <div class="slider-value">{{ sliderDMaxGainDisplay }}</div>
-                    <div class="slider-control">
-                        <input
-                            type="range"
-                            class="tuningSlider"
-                            id="sliderDMaxGain"
-                            min="0.0"
-                            max="2.0"
-                            step="0.05"
-                            v-model.number="sliderDMaxGain"
-                            @input="onSliderChange"
-                            :disabled="dMaxSliderDisabled"
-                        />
-                    </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningDMaxGainSliderHelp')"></div>
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDMaxGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderDMaxGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderDMaxGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="dMaxSliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningDMaxGainSliderHelp')" />
                 </div>
 
                 <div
-                    class="slider-row advancedSlider"
-                    :class="{ disabledSliders: iGainSliderDisabled }"
                     v-show="showIGainSlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': iGainSliderDisabled }"
                 >
-                    <div class="slider-label" v-html="$t('pidTuningIGainSlider')"></div>
-                    <div class="slider-value">{{ sliderIGainDisplay }}</div>
-                    <div class="slider-control">
-                        <input
-                            type="range"
-                            class="tuningSlider"
-                            id="sliderIGain"
-                            min="0.0"
-                            max="2.0"
-                            step="0.05"
-                            v-model.number="sliderIGain"
-                            @input="onSliderChange"
-                            :disabled="iGainSliderDisabled"
-                        />
-                    </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningIGainSliderHelp')"></div>
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningIGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderIGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderIGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="iGainSliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningIGainSliderHelp')" />
                 </div>
 
                 <div
-                    class="slider-row advancedSlider"
-                    :class="{ disabledSliders: rpRatioSliderDisabled }"
                     v-show="showRPRatioSlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': rpRatioSliderDisabled }"
                 >
-                    <div class="slider-label" v-html="$t('pidTuningRollPitchRatioSlider')"></div>
-                    <div class="slider-value">{{ sliderRPRatioDisplay }}</div>
-                    <div class="slider-control">
-                        <input
-                            type="range"
-                            class="tuningSlider"
-                            id="sliderRollPitchRatio"
-                            min="0.0"
-                            max="2.0"
-                            step="0.05"
-                            v-model.number="sliderRollPitchRatio"
-                            @input="onSliderChange"
-                            :disabled="rpRatioSliderDisabled"
-                        />
-                    </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningRollPitchRatioSliderHelp')"></div>
+                    <div
+                        class="min-w-32 text-right text-xs shrink-0"
+                        v-html="$t('pidTuningRollPitchRatioSlider')"
+                    ></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderRPRatioDisplay }}</span>
+                    <USlider
+                        v-model="sliderRollPitchRatio"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="rpRatioSliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningRollPitchRatioSliderHelp')" />
                 </div>
 
                 <div
-                    class="slider-row advancedSlider"
-                    :class="{ disabledSliders: pitchPISliderDisabled }"
                     v-show="showPitchPISlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': pitchPISliderDisabled }"
                 >
-                    <div class="slider-label" v-html="$t('pidTuningPitchPIGainSlider')"></div>
-                    <div class="slider-value">{{ sliderPitchPIDisplay }}</div>
-                    <div class="slider-control">
-                        <input
-                            type="range"
-                            class="tuningSlider"
-                            id="sliderPitchPIGain"
-                            min="0.0"
-                            max="2.0"
-                            step="0.05"
-                            v-model.number="sliderPitchPIGain"
-                            @input="onSliderChange"
-                            :disabled="pitchPISliderDisabled"
-                        />
-                    </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningPitchPIGainSliderHelp')"></div>
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningPitchPIGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderPitchPIDisplay }}</span>
+                    <USlider
+                        v-model="sliderPitchPIGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="pitchPISliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningPitchPIGainSliderHelp')" />
                 </div>
 
                 <div
-                    class="slider-row advancedSlider"
-                    :class="{ disabledSliders: masterSliderDisabled }"
                     v-show="showMasterSlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': masterSliderDisabled }"
                 >
-                    <div class="slider-label" v-html="$t('pidTuningMasterSlider')"></div>
-                    <div class="slider-value">{{ sliderMasterDisplay }}</div>
-                    <div class="slider-control">
-                        <input
-                            type="range"
-                            class="tuningSlider"
-                            id="sliderMasterMultiplier"
-                            min="0.0"
-                            max="2.0"
-                            step="0.05"
-                            v-model.number="sliderMasterMultiplier"
-                            @input="onSliderChange"
-                            :disabled="masterSliderDisabled"
-                        />
-                    </div>
-                    <div class="helpicon cf_tip" :title="$t('pidTuningMasterSliderHelp')"></div>
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningMasterSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderMasterDisplay }}</span>
+                    <USlider
+                        v-model="sliderMasterMultiplier"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="masterSliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningMasterSliderHelp')" />
                 </div>
 
                 <!-- Danger Zone Warning -->
-                <div v-if="slidersInDangerZone" class="danger slidersWarning">
+                <UiBox v-if="slidersInDangerZone" type="error" highlight>
                     <p v-html="$t('pidTuningSliderWarning')"></p>
-                </div>
+                </UiBox>
 
-                <!-- Warning Messages (Non-Expert Mode) -->
-                <!-- Always show range restriction note when not in expert mode and sliders are on -->
-                <div v-if="!props.expertMode && sliderPidsMode > 0" class="note expertSettingsDetectedNote">
+                <!-- Non-Expert Mode Warning -->
+                <UiBox v-if="!props.expertMode && sliderPidsMode > 0" type="warning" highlight>
                     <p v-html="$t('pidTuningPidSlidersNonExpertMode')"></p>
-                </div>
+                </UiBox>
 
-                <!-- Show disabled warning when values are outside basic range -->
-                <div v-if="showExpertSettingsWarning" class="note expertSettingsDetectedNote">
+                <!-- Expert Settings Detected Warning -->
+                <UiBox v-if="showExpertSettingsWarning" type="warning" highlight>
                     <p v-html="$t('pidTuningSlidersExpertSettingsDetectedNote')"></p>
-                </div>
-            </div>
+                </UiBox>
+            </UiBox>
 
             <!-- BARO, MAG, GPS Optional PIDs -->
-            <div
-                v-if="showAllLocal && hasBaroMagGpsPids"
-                id="pid_baro_mag_gps"
-                class="pid_optional gui_box grey pid_tuning"
-            >
-                <table class="pid_titlebar">
-                    <tbody>
-                        <tr>
-                            <th class="name"></th>
-                            <th class="proportional" v-html="$t('pidTuningProportional')"></th>
-                            <th class="integral" v-html="$t('pidTuningIntegral')"></th>
-                            <th class="derivative" v-html="$t('pidTuningDerivative')"></th>
-                        </tr>
-                    </tbody>
-                </table>
+            <UiBox v-if="showAllLocal && hasBaroMagGpsPids" type="neutral">
+                <div class="grid grid-cols-[3.5rem_repeat(3,1fr)] gap-x-1 gap-y-1 items-center">
+                    <!-- Header -->
+                    <div></div>
+                    <div class="text-xs text-center" v-html="$t('pidTuningProportional')"></div>
+                    <div class="text-xs text-center" v-html="$t('pidTuningIntegral')"></div>
+                    <div class="text-xs text-center" v-html="$t('pidTuningDerivative')"></div>
 
-                <!-- Altitude (Baro) PIDs -->
-                <template v-if="hasPidName('ALT') || hasPidName('VEL')">
-                    <table class="pid_tuning">
-                        <tbody>
-                            <tr>
-                                <th colspan="4">
-                                    <div class="pid_mode">{{ $t("pidTuningAltitude") }}</div>
-                                </th>
-                            </tr>
-                            <tr v-if="hasPidName('ALT')" class="ALT">
-                                <td></td>
-                                <td><UInputNumber v-model="pidAltP" :step="1" :min="0" :max="255" /></td>
-                                <td><UInputNumber v-model="pidAltI" :step="1" :min="0" :max="255" /></td>
-                                <td><UInputNumber v-model="pidAltD" :step="1" :min="0" :max="255" /></td>
-                            </tr>
-                            <tr v-if="hasPidName('VEL')" class="VEL">
-                                <td></td>
-                                <td><UInputNumber v-model="pidVelP" :step="1" :min="0" :max="255" /></td>
-                                <td><UInputNumber v-model="pidVelI" :step="1" :min="0" :max="255" /></td>
-                                <td><UInputNumber v-model="pidVelD" :step="1" :min="0" :max="255" /></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </template>
+                    <!-- Altitude (Baro) PIDs -->
+                    <template v-if="hasPidName('ALT') || hasPidName('VEL')">
+                        <div class="col-span-4 text-xs text-dimmed">{{ $t("pidTuningAltitude") }}</div>
+                        <template v-if="hasPidName('ALT')">
+                            <div></div>
+                            <UInputNumber v-model="pidAltP" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber v-model="pidAltI" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber v-model="pidAltD" :step="1" :min="0" :max="255" size="xs" />
+                        </template>
+                        <template v-if="hasPidName('VEL')">
+                            <div></div>
+                            <UInputNumber v-model="pidVelP" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber v-model="pidVelI" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber v-model="pidVelD" :step="1" :min="0" :max="255" size="xs" />
+                        </template>
+                    </template>
 
-                <!-- Mag PIDs -->
-                <template v-if="hasPidName('MAG')">
-                    <table class="pid_tuning">
-                        <tbody>
-                            <tr>
-                                <th colspan="4">
-                                    <div class="pid_mode">{{ $t("pidTuningMag") }}</div>
-                                </th>
-                            </tr>
-                            <tr class="MAG">
-                                <td></td>
-                                <td><UInputNumber v-model="pidMagP" :step="1" :min="0" :max="255" /></td>
-                                <td></td>
-                                <td></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </template>
+                    <!-- Mag PIDs -->
+                    <template v-if="hasPidName('MAG')">
+                        <div class="col-span-4 text-xs text-dimmed">{{ $t("pidTuningMag") }}</div>
+                        <div></div>
+                        <UInputNumber v-model="pidMagP" :step="1" :min="0" :max="255" size="xs" />
+                        <div></div>
+                        <div></div>
+                    </template>
 
-                <!-- GPS PIDs -->
-                <template v-if="hasPidName('Pos') || hasPidName('PosR') || hasPidName('NavR')">
-                    <table class="pid_tuning">
-                        <tbody>
-                            <tr>
-                                <th colspan="4">
-                                    <div class="pid_mode">{{ $t("pidTuningGps") }}</div>
-                                </th>
-                            </tr>
-                            <tr v-if="hasPidName('Pos')" class="Pos">
-                                <td></td>
-                                <td><UInputNumber v-model="pidPosP" :step="1" :min="0" :max="255" /></td>
-                                <td></td>
-                                <td></td>
-                            </tr>
-                            <tr v-if="hasPidName('PosR')" class="PosR">
-                                <td></td>
-                                <td><UInputNumber v-model="pidPosRP" :step="1" :min="0" :max="255" /></td>
-                                <td><UInputNumber v-model="pidPosRI" :step="1" :min="0" :max="255" /></td>
-                                <td><UInputNumber v-model="pidPosRD" :step="1" :min="0" :max="255" /></td>
-                            </tr>
-                            <tr v-if="hasPidName('NavR')" class="NavR">
-                                <td></td>
-                                <td><UInputNumber v-model="pidNavRP" :step="1" :min="0" :max="255" /></td>
-                                <td><UInputNumber v-model="pidNavRI" :step="1" :min="0" :max="255" /></td>
-                                <td><UInputNumber v-model="pidNavRD" :step="1" :min="0" :max="255" /></td>
-                            </tr>
-                        </tbody>
-                    </table>
-                </template>
-            </div>
+                    <!-- GPS PIDs -->
+                    <template v-if="hasPidName('Pos') || hasPidName('PosR') || hasPidName('NavR')">
+                        <div class="col-span-4 text-xs text-dimmed">{{ $t("pidTuningGps") }}</div>
+                        <template v-if="hasPidName('Pos')">
+                            <div></div>
+                            <UInputNumber v-model="pidPosP" :step="1" :min="0" :max="255" size="xs" />
+                            <div></div>
+                            <div></div>
+                        </template>
+                        <template v-if="hasPidName('PosR')">
+                            <div></div>
+                            <UInputNumber v-model="pidPosRP" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber v-model="pidPosRI" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber v-model="pidPosRD" :step="1" :min="0" :max="255" size="xs" />
+                        </template>
+                        <template v-if="hasPidName('NavR')">
+                            <div></div>
+                            <UInputNumber v-model="pidNavRP" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber v-model="pidNavRI" :step="1" :min="0" :max="255" size="xs" />
+                            <UInputNumber v-model="pidNavRD" :step="1" :min="0" :max="255" size="xs" />
+                        </template>
+                    </template>
+                </div>
+            </UiBox>
 
             <!-- Angle/Horizon Section -->
-            <div class="gui_box grey">
-                <table class="pid_titlebar">
-                    <tbody>
-                        <tr>
-                            <th class="third"></th>
-                            <th class="third" style="width: 33%">{{ $t("pidTuningStrength") }}</th>
-                            <th class="third" style="width: 33%">{{ $t("pidTuningTransition") }}</th>
-                        </tr>
-                    </tbody>
-                </table>
-                <table class="pid_tuning">
-                    <tbody>
-                        <tr>
-                            <td class="third">{{ $t("pidTuningAngle") }}</td>
-                            <td class="third">
-                                <UInputNumber v-model="pidLevelAngle" :step="1" :min="0" :max="255" />
-                            </td>
-                            <td class="third"></td>
-                        </tr>
-                        <tr>
-                            <td class="third">{{ $t("pidTuningHorizon") }}</td>
-                            <td class="third">
-                                <UInputNumber v-model="pidLevelHorizon" :step="1" :min="0" :max="255" />
-                            </td>
-                            <td class="third">
-                                <UInputNumber v-model="pidLevelTransition" :step="1" :min="0" :max="255" />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-                <table class="pid_titlebar pid_titlebar_extended pid_sensitivity">
-                    <tbody>
-                        <tr>
-                            <th class="third"></th>
-                            <th class="third" style="width: 33%">{{ $t("pidTuningLevelAngleLimit") }}</th>
-                            <th class="third" style="width: 33%"></th>
-                        </tr>
-                    </tbody>
-                </table>
-                <table class="pid_tuning pid_sensitivity">
-                    <tbody>
-                        <tr>
-                            <td class="third"></td>
-                            <td class="third">
-                                <UInputNumber v-model="advancedTuning.levelAngleLimit" :step="1" :min="10" :max="200" />
-                            </td>
-                            <td class="third"></td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <!-- END Angle/Horizon Settings-->
+            <UiBox type="neutral">
+                <div class="grid grid-cols-3 gap-x-1 gap-y-1 items-center">
+                    <!-- Header -->
+                    <div></div>
+                    <div class="text-xs text-center">{{ $t("pidTuningStrength") }}</div>
+                    <div class="text-xs text-center">{{ $t("pidTuningTransition") }}</div>
+
+                    <!-- Angle -->
+                    <div class="text-xs">{{ $t("pidTuningAngle") }}</div>
+                    <UInputNumber v-model="pidLevelAngle" :step="1" :min="0" :max="255" size="xs" />
+                    <div></div>
+
+                    <!-- Horizon -->
+                    <div class="text-xs">{{ $t("pidTuningHorizon") }}</div>
+                    <UInputNumber v-model="pidLevelHorizon" :step="1" :min="0" :max="255" size="xs" />
+                    <UInputNumber v-model="pidLevelTransition" :step="1" :min="0" :max="255" size="xs" />
+
+                    <!-- Level Angle Limit -->
+                    <div></div>
+                    <div class="text-xs text-center">{{ $t("pidTuningLevelAngleLimit") }}</div>
+                    <div></div>
+
+                    <div></div>
+                    <UInputNumber v-model="advancedTuning.levelAngleLimit" :step="1" :min="10" :max="200" size="xs" />
+                    <div></div>
+                </div>
+            </UiBox>
         </div>
-        <!-- END LEFT COLUMN -->
 
         <!-- RIGHT COLUMN: PID Controller Settings -->
-        <div class="cf_column_right">
-            <div class="gui_box grey pidControllerAdvancedSettings spacer_left">
-                <table class="pid_titlebar new_rates">
-                    <thead>
-                        <tr>
-                            <th>{{ $t("pidTuningPidSettings") }}</th>
-                        </tr>
-                    </thead>
-                </table>
-                <table class="compensation">
-                    <tbody>
-                        <!-- Feedforward Group -->
-                        <tr class="feedforwardGroup">
-                            <td><span v-html="$t('pidTuningFeedforwardGroup')"></span></td>
-                            <td colspan="2">
-                                <span class="feedforwardOption feedforwardJitterFactor suboption">
-                                    <UInputNumber
-                                        name="feedforwardJitterFactor"
-                                        v-model="advancedTuning.feedforward_jitter_factor"
-                                        :step="1"
-                                        :min="0"
-                                        :max="20"
-                                    />
-                                    <label>
-                                        <span v-html="$t('pidTuningFeedforwardJitter')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningFeedforwardJitterHelp')"></div>
-                                </span>
+        <div class="flex flex-col gap-4">
+            <!-- PID Settings -->
+            <UiBox :title="$t('pidTuningPidSettings')" type="neutral">
+                <!-- Feedforward Group -->
+                <div class="flex flex-col gap-2">
+                    <span class="text-sm font-semibold" v-html="$t('pidTuningFeedforwardGroup')"></span>
+                    <div class="flex flex-wrap items-end gap-3 pl-4">
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span class="text-xs text-dimmed" v-html="$t('pidTuningFeedforwardJitter')"></span>
+                                <HelpIcon :text="$t('pidTuningFeedforwardJitterHelp')" />
+                            </div>
+                            <UInputNumber
+                                v-model="advancedTuning.feedforward_jitter_factor"
+                                :step="1"
+                                :min="0"
+                                :max="20"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span
+                                    class="text-xs text-dimmed"
+                                    v-html="$t('pidTuningFeedforwardSmoothFactor')"
+                                ></span>
+                                <HelpIcon :text="$t('pidTuningFeedforwardSmoothnessHelp')" />
+                            </div>
+                            <UInputNumber
+                                v-model="advancedTuning.feedforward_smooth_factor"
+                                :step="1"
+                                :min="0"
+                                :max="95"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span class="text-xs text-dimmed" v-html="$t('pidTuningFeedforwardAveraging')"></span>
+                                <HelpIcon :text="$t('pidTuningFeedforwardAveragingHelp')" />
+                            </div>
+                            <USelect
+                                v-model="advancedTuning.feedforward_averaging"
+                                :items="feedforwardAveragingItems"
+                                class="w-28"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span class="text-xs text-dimmed" v-html="$t('pidTuningFeedforwardBoost')"></span>
+                                <HelpIcon :text="$t('pidTuningFeedforwardBoostHelp')" />
+                            </div>
+                            <UInputNumber v-model="advancedTuning.feedforward_boost" :step="1" :min="0" :max="50" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span
+                                    class="text-xs text-dimmed"
+                                    v-html="$t('pidTuningFeedforwardMaxRateLimit')"
+                                ></span>
+                                <HelpIcon :text="$t('pidTuningFeedforwardMaxRateLimitHelp')" />
+                            </div>
+                            <UInputNumber
+                                v-model="advancedTuning.feedforward_max_rate_limit"
+                                :step="1"
+                                :min="0"
+                                :max="150"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span class="text-xs text-dimmed" v-html="$t('pidTuningFeedforwardTransition')"></span>
+                                <HelpIcon :text="$t('pidTuningFeedforwardTransitionHelp')" />
+                            </div>
+                            <UInputNumber
+                                v-model="feedforwardTransitionValue"
+                                :step="0.01"
+                                :min="0"
+                                :max="1"
+                                :format-options="{ minimumFractionDigits: 2, maximumFractionDigits: 2 }"
+                            />
+                        </div>
+                    </div>
+                </div>
 
-                                <span class="feedforwardOption feedforwardSmoothFactor suboption">
-                                    <UInputNumber
-                                        name="feedforwardSmoothFactor"
-                                        v-model="advancedTuning.feedforward_smooth_factor"
-                                        :step="1"
-                                        :min="0"
-                                        :max="95"
-                                    />
-                                    <label for="feedforwardSmoothFactor">
-                                        <span v-html="$t('pidTuningFeedforwardSmoothFactor')"></span>
-                                    </label>
-                                    <div
-                                        class="helpicon cf_tip"
-                                        :title="$t('pidTuningFeedforwardSmoothnessHelp')"
-                                    ></div>
-                                </span>
+                <!-- I-term Relax -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('pidTuningItermRelax')" :help="$t('pidTuningItermRelaxHelp')">
+                        <USwitch v-model="itermRelaxEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="itermRelaxEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed" v-html="$t('pidTuningItermRelaxAxes')"></span>
+                            <USelect v-model="advancedTuning.itermRelax" :items="itermRelaxAxesItems" class="w-28" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed" v-html="$t('pidTuningItermRelaxType')"></span>
+                            <USelect
+                                v-model="advancedTuning.itermRelaxType"
+                                :items="itermRelaxTypeItems"
+                                class="w-28"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span class="text-xs text-dimmed" v-html="$t('pidTuningItermRelaxCutoff')"></span>
+                                <HelpIcon :text="$t('pidTuningItermRelaxCutoffHelp')" />
+                            </div>
+                            <UInputNumber v-model="advancedTuning.itermRelaxCutoff" :step="1" :min="1" :max="50" />
+                        </div>
+                    </div>
+                </div>
 
-                                <span class="feedforwardOption feedforwardAveraging suboption">
-                                    <select
-                                        id="feedforwardAveraging"
-                                        v-model.number="advancedTuning.feedforward_averaging"
-                                    >
-                                        <option :value="0">{{ $t("pidTuningOptionOff") }}</option>
-                                        <option :value="1">
-                                            {{ $t("pidTuningFeedforwardAveragingOption2Point") }}
-                                        </option>
-                                        <option :value="2">
-                                            {{ $t("pidTuningFeedforwardAveragingOption3Point") }}
-                                        </option>
-                                        <option :value="3">
-                                            {{ $t("pidTuningFeedforwardAveragingOption4Point") }}
-                                        </option>
-                                    </select>
-                                    <label for="feedforwardAveraging">
-                                        <span v-html="$t('pidTuningFeedforwardAveraging')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningFeedforwardAveragingHelp')"></div>
-                                </span>
+                <!-- Anti Gravity -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('pidTuningAntiGravity')" :help="$t('pidTuningAntiGravityHelp')">
+                        <USwitch v-model="antiGravityEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="antiGravityEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed" v-html="$t('pidTuningAntiGravityMode')"></span>
+                            <USelect
+                                v-model="advancedTuning.antiGravityMode"
+                                :items="antiGravityModeItems"
+                                class="w-28"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span class="text-xs text-dimmed" v-html="$t('pidTuningAntiGravityGain')"></span>
+                                <HelpIcon :text="$t('pidTuningAntiGravityGainHelp')" />
+                            </div>
+                            <UInputNumber
+                                v-model="antiGravityGainValue"
+                                :step="0.1"
+                                :min="0.1"
+                                :max="30"
+                                :format-options="{ minimumFractionDigits: 1, maximumFractionDigits: 1 }"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed" v-html="$t('pidTuningAntiGravityThres')"></span>
+                            <UInputNumber
+                                v-model="advancedTuning.itermThrottleThreshold"
+                                :step="10"
+                                :min="20"
+                                :max="1000"
+                            />
+                        </div>
+                    </div>
+                </div>
 
-                                <span class="feedforwardOption feedforwardBoost suboption">
-                                    <UInputNumber
-                                        name="feedforwardBoost"
-                                        v-model="advancedTuning.feedforward_boost"
-                                        :step="1"
-                                        :min="0"
-                                        :max="50"
-                                    />
-                                    <label for="feedforwardBoost">
-                                        <span v-html="$t('pidTuningFeedforwardBoost')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningFeedforwardBoostHelp')"></div>
-                                </span>
+                <!-- I-term Rotation -->
+                <SettingRow :label="$t('pidTuningItermRotation')" :help="$t('pidTuningItermRotationHelp')">
+                    <USwitch v-model="itermRotationEnabled" size="sm" />
+                </SettingRow>
 
-                                <span class="feedforwardOption feedforwardMaxRateLimit suboption">
-                                    <UInputNumber
-                                        name="feedforwardMaxRateLimit"
-                                        v-model="advancedTuning.feedforward_max_rate_limit"
-                                        :step="1"
-                                        :min="0"
-                                        :max="150"
-                                    />
-                                    <label>
-                                        <span v-html="$t('pidTuningFeedforwardMaxRateLimit')"></span>
-                                    </label>
-                                    <div
-                                        class="helpicon cf_tip"
-                                        :title="$t('pidTuningFeedforwardMaxRateLimitHelp')"
-                                    ></div>
-                                </span>
-
-                                <span class="feedforwardTransition suboption">
-                                    <UInputNumber
-                                        name="feedforwardTransition-number"
-                                        v-model="feedforwardTransitionValue"
-                                        :step="0.01"
-                                        :min="0"
-                                        :max="1"
-                                        :format-options="{ minimumFractionDigits: 2, maximumFractionDigits: 2 }"
-                                    />
-                                    <label>
-                                        <span v-html="$t('pidTuningFeedforwardTransition')"></span>
-                                    </label>
-                                    <div
-                                        class="helpicon cf_tip"
-                                        :title="$t('pidTuningFeedforwardTransitionHelp')"
-                                    ></div>
-                                </span>
-                            </td>
-                        </tr>
-
-                        <!-- I-term Relax -->
-                        <tr class="itermrelax">
-                            <td>
-                                <input type="checkbox" id="itermrelax" class="toggle" v-model="itermRelaxEnabled" />
-                            </td>
-                            <td colspan="2">
-                                <div class="helpicon cf_tip" :title="$t('pidTuningItermRelaxHelp')"></div>
-                                <span v-html="$t('pidTuningItermRelax')"></span>
-
-                                <span class="suboption" v-if="itermRelaxEnabled">
-                                    <select id="itermrelaxAxes" v-model.number="advancedTuning.itermRelax">
-                                        <option :value="1">{{ $t("pidTuningOptionRP") }}</option>
-                                        <option :value="2">{{ $t("pidTuningOptionRPY") }}</option>
-                                        <option :value="3">{{ $t("pidTuningItermRelaxAxesOptionRPInc") }}</option>
-                                        <option :value="4">{{ $t("pidTuningItermRelaxAxesOptionRPYInc") }}</option>
-                                    </select>
-                                    <label for="itermrelaxAxes">
-                                        <span v-html="$t('pidTuningItermRelaxAxes')"></span>
-                                    </label>
-                                </span>
-
-                                <span class="suboption" v-if="itermRelaxEnabled">
-                                    <select id="itermrelaxType" v-model.number="advancedTuning.itermRelaxType">
-                                        <option :value="0">{{ $t("pidTuningItermRelaxTypeOptionGyro") }}</option>
-                                        <option :value="1">{{ $t("pidTuningItermRelaxTypeOptionSetpoint") }}</option>
-                                    </select>
-                                    <label for="itermrelaxType">
-                                        <span v-html="$t('pidTuningItermRelaxType')"></span>
-                                    </label>
-                                </span>
-
-                                <span class="itermRelaxCutoff suboption" v-if="itermRelaxEnabled">
-                                    <UInputNumber
-                                        name="itermRelaxCutoff"
-                                        v-model="advancedTuning.itermRelaxCutoff"
-                                        :step="1"
-                                        :min="1"
-                                        :max="50"
-                                    />
-                                    <label for="itermRelaxCutoff">
-                                        <span v-html="$t('pidTuningItermRelaxCutoff')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningItermRelaxCutoffHelp')"></div>
-                                </span>
-                            </td>
-                        </tr>
-
-                        <!-- Anti Gravity -->
-                        <tr class="antigravity">
-                            <td>
-                                <input
-                                    type="checkbox"
-                                    id="antiGravitySwitch"
-                                    class="toggle"
-                                    v-model="antiGravityEnabled"
-                                />
-                            </td>
-                            <td colspan="3">
-                                <div class="helpicon cf_tip" :title="$t('pidTuningAntiGravityHelp')"></div>
-                                <span v-html="$t('pidTuningAntiGravity')"></span>
-
-                                <span class="suboption antiGravityMode" v-if="antiGravityEnabled">
-                                    <select id="antiGravityMode" v-model.number="advancedTuning.antiGravityMode">
-                                        <option :value="0">{{ $t("pidTuningAntiGravityModeOptionSmooth") }}</option>
-                                        <option :value="1">{{ $t("pidTuningAntiGravityModeOptionStep") }}</option>
-                                    </select>
-                                    <label for="antiGravityMode">
-                                        <span v-html="$t('pidTuningAntiGravityMode')"></span>
-                                    </label>
-                                </span>
-
-                                <span class="suboption" v-if="antiGravityEnabled">
-                                    <UInputNumber
-                                        name="itermAcceleratorGain"
-                                        v-model="antiGravityGainValue"
-                                        :step="0.1"
-                                        :min="0.1"
-                                        :max="30"
-                                        :format-options="{ minimumFractionDigits: 1, maximumFractionDigits: 1 }"
-                                    />
-                                    <label for="antiGravityGain">
-                                        <span v-html="$t('pidTuningAntiGravityGain')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningAntiGravityGainHelp')"></div>
-                                </span>
-
-                                <span class="suboption antiGravityThres" v-if="antiGravityEnabled">
-                                    <UInputNumber
-                                        name="itermThrottleThreshold"
-                                        v-model="advancedTuning.itermThrottleThreshold"
-                                        :step="10"
-                                        :min="20"
-                                        :max="1000"
-                                    />
-                                    <label for="antiGravityThres">
-                                        <span v-html="$t('pidTuningAntiGravityThres')"></span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-
-                        <!-- I-term Rotation -->
-                        <tr class="itermrotation">
-                            <td>
-                                <input
-                                    type="checkbox"
-                                    id="itermrotation"
-                                    class="toggle"
-                                    v-model="itermRotationEnabled"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <span v-html="$t('pidTuningItermRotation')"></span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningItermRotationHelp')"></div>
-                            </td>
-                        </tr>
-
-                        <!-- D-Max Group -->
-                        <tr class="dMaxGroup">
-                            <td>
-                                <span v-html="$t('pidTuningDMaxSettingTitle')"></span>
-                            </td>
-                            <td colspan="3">
-                                <span class="suboption">
-                                    <UInputNumber
-                                        name="dMaxGain"
-                                        v-model="advancedTuning.dMaxGain"
-                                        :step="1"
-                                        :min="0"
-                                        :max="100"
-                                    />
-                                    <label for="dMaxGain">
-                                        <span v-html="$t('pidTuningDMaxGain')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningDMaxGainHelp')"></div>
-                                </span>
-                                <span class="suboption">
-                                    <UInputNumber
-                                        name="dMaxAdvance"
-                                        v-model="advancedTuning.dMaxAdvance"
-                                        :step="1"
-                                        :min="0"
-                                        :max="200"
-                                    />
-                                    <label for="dMaxAdvance">
-                                        <span v-html="$t('pidTuningDMaxAdvance')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningDMaxAdvanceHelp')"></div>
-                                </span>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                <!-- D-Max Group -->
+                <div class="flex flex-col gap-2">
+                    <span class="text-sm font-semibold" v-html="$t('pidTuningDMaxSettingTitle')"></span>
+                    <div class="flex flex-wrap items-end gap-3 pl-4">
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span class="text-xs text-dimmed" v-html="$t('pidTuningDMaxGain')"></span>
+                                <HelpIcon :text="$t('pidTuningDMaxGainHelp')" />
+                            </div>
+                            <UInputNumber v-model="advancedTuning.dMaxGain" :step="1" :min="0" :max="100" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <div class="flex items-center gap-1">
+                                <span class="text-xs text-dimmed" v-html="$t('pidTuningDMaxAdvance')"></span>
+                                <HelpIcon :text="$t('pidTuningDMaxAdvanceHelp')" />
+                            </div>
+                            <UInputNumber v-model="advancedTuning.dMaxAdvance" :step="1" :min="0" :max="200" />
+                        </div>
+                    </div>
+                </div>
+            </UiBox>
 
             <!-- Motor Settings -->
-            <div class="gui_box grey pidControllerAdvancedSettings spacer_left">
-                <table class="pid_titlebar new_rates">
-                    <tbody>
-                        <tr>
-                            <th>{{ $t("pidTuningMotorSettings") }}</th>
-                        </tr>
-                    </tbody>
-                </table>
-                <table class="compensation">
-                    <tbody>
-                        <!-- Throttle Boost -->
-                        <tr class="throttleBoost">
-                            <td>
-                                <UInputNumber
-                                    name="throttleBoost-number"
-                                    v-model="advancedTuning.throttleBoost"
-                                    :step="1"
-                                    :min="0"
-                                    :max="100"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <div>
-                                    <label>
-                                        <span v-html="$t('pidTuningThrottleBoost')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningThrottleBoostHelp')"></div>
-                                </div>
-                            </td>
-                        </tr>
+            <UiBox :title="$t('pidTuningMotorSettings')" type="neutral">
+                <SettingRow :label="$t('pidTuningThrottleBoost')" :help="$t('pidTuningThrottleBoostHelp')">
+                    <UInputNumber v-model="advancedTuning.throttleBoost" :step="1" :min="0" :max="100" />
+                </SettingRow>
 
-                        <!-- Motor Output Limit -->
-                        <tr class="motorOutputLimit">
-                            <td>
-                                <UInputNumber
-                                    name="motorLimit"
-                                    v-model="advancedTuning.motorOutputLimit"
-                                    :step="1"
-                                    :min="1"
-                                    :max="100"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <div>
-                                    <label>
-                                        <span v-html="$t('pidTuningMotorOutputLimit')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningMotorLimitHelp')"></div>
-                                </div>
-                            </td>
-                        </tr>
+                <SettingRow :label="$t('pidTuningMotorOutputLimit')" :help="$t('pidTuningMotorLimitHelp')">
+                    <UInputNumber v-model="advancedTuning.motorOutputLimit" :step="1" :min="1" :max="100" />
+                </SettingRow>
 
-                        <!-- Dynamic Idle Min RPM -->
-                        <tr class="idleMinRpm">
-                            <td>
-                                <UInputNumber
-                                    name="idleMinRpm-number"
-                                    v-model="advancedTuning.idleMinRpm"
-                                    :step="1"
-                                    :min="0"
-                                    :max="idleMinRpmMax"
-                                    :disabled="!dshotTelemetryEnabled"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <div>
-                                    <label>
-                                        <span v-if="dshotTelemetryEnabled" v-html="$t('pidTuningIdleMinRpm')"></span>
-                                        <span v-else v-html="$t('pidTuningIdleMinRpmDisabled')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningIdleMinRpmHelp')"></div>
-                                </div>
-                            </td>
-                        </tr>
+                <SettingRow
+                    :label="dshotTelemetryEnabled ? $t('pidTuningIdleMinRpm') : $t('pidTuningIdleMinRpmDisabled')"
+                    :help="$t('pidTuningIdleMinRpmHelp')"
+                >
+                    <UInputNumber
+                        v-model="advancedTuning.idleMinRpm"
+                        :step="1"
+                        :min="0"
+                        :max="idleMinRpmMax"
+                        :disabled="!dshotTelemetryEnabled"
+                    />
+                </SettingRow>
 
-                        <!-- VBat Sag Compensation -->
-                        <tr class="vbatSagCompensation">
-                            <td>
-                                <input
-                                    type="checkbox"
-                                    id="vbatSagCompensation"
-                                    class="toggle"
-                                    v-model="vbatSagEnabled"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <span v-html="$t('pidTuningVbatSagCompensation')"></span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningVbatSagCompensationHelp')"></div>
+                <!-- VBat Sag Compensation -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow
+                        :label="$t('pidTuningVbatSagCompensation')"
+                        :help="$t('pidTuningVbatSagCompensationHelp')"
+                    >
+                        <USwitch v-model="vbatSagEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="vbatSagEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed" v-html="$t('pidTuningVbatSagValue')"></span>
+                            <UInputNumber
+                                v-model="advancedTuning.vbat_sag_compensation"
+                                :step="1"
+                                :min="1"
+                                :max="150"
+                            />
+                        </div>
+                    </div>
+                </div>
 
-                                <span class="vbatSagValue suboption" v-if="vbatSagEnabled">
-                                    <UInputNumber
-                                        name="vbatSagValue"
-                                        v-model="advancedTuning.vbat_sag_compensation"
-                                        :step="1"
-                                        :min="1"
-                                        :max="150"
-                                    />
-                                    <label for="vbatSagValue">
-                                        <span v-html="$t('pidTuningVbatSagValue')"></span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-
-                        <!-- Thrust Linearization -->
-                        <tr class="thrustLinearization">
-                            <td>
-                                <input
-                                    type="checkbox"
-                                    id="thrustLinearization"
-                                    class="toggle"
-                                    v-model="thrustLinearEnabled"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <span v-html="$t('pidTuningThrustLinearization')"></span>
-                                <div class="helpicon cf_tip" :title="$t('pidTuningThrustLinearizationHelp')"></div>
-
-                                <span class="thrustLinearValue suboption" v-if="thrustLinearEnabled">
-                                    <UInputNumber
-                                        name="thrustLinearValue"
-                                        v-model="advancedTuning.thrustLinearization"
-                                        :step="1"
-                                        :min="1"
-                                        :max="150"
-                                    />
-                                    <label for="thrustLinearValue">
-                                        <span v-html="$t('pidTuningThrustLinearValue')"></span>
-                                    </label>
-                                </span>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                <!-- Thrust Linearization -->
+                <div class="flex flex-col gap-2">
+                    <SettingRow
+                        :label="$t('pidTuningThrustLinearization')"
+                        :help="$t('pidTuningThrustLinearizationHelp')"
+                    >
+                        <USwitch v-model="thrustLinearEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="thrustLinearEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed" v-html="$t('pidTuningThrustLinearValue')"></span>
+                            <UInputNumber v-model="advancedTuning.thrustLinearization" :step="1" :min="1" :max="150" />
+                        </div>
+                    </div>
+                </div>
+            </UiBox>
 
             <!-- TPA Settings -->
-            <div class="gui_box grey tpa pidControllerAdvancedSettings spacer_left">
-                <table class="pid_titlebar tpa-header" aria-labelledby="tpa-header">
-                    <tbody>
-                        <tr>
-                            <th v-if="usesAdvancedTpa">{{ $t("pidTuningTPAMode") }}</th>
-                            <th>{{ $t("pidTuningTPARate") }}</th>
-                            <th>{{ $t("pidTuningTPABreakPoint") }}</th>
-                        </tr>
-                    </tbody>
-                </table>
-                <table class="tpa-settings" aria-labelledby="tpa-settings" role="presentation">
-                    <tbody>
-                        <tr>
-                            <td v-if="usesAdvancedTpa">
-                                <select id="tpaMode" v-model.number="tpaMode">
-                                    <option :value="0">{{ $t("pidTuningTPAPD") }}</option>
-                                    <option :value="1">{{ $t("pidTuningTPAD") }}</option>
-                                </select>
-                            </td>
-                            <td>
-                                <UInputNumber id="tpaRate" v-model="tpaRate" :step="1" :min="0" :max="100" />
-                            </td>
-                            <td class="tpa-breakpoint">
-                                <UInputNumber
-                                    id="tpaBreakpoint"
-                                    v-model="tpaBreakpoint"
-                                    :step="10"
-                                    :min="750"
-                                    :max="2250"
-                                />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            <UiBox type="neutral">
+                <div class="flex flex-wrap items-end gap-3">
+                    <div v-if="usesAdvancedTpa" class="flex flex-col gap-1">
+                        <span class="text-xs text-dimmed">{{ $t("pidTuningTPAMode") }}</span>
+                        <USelect v-model="tpaMode" :items="tpaModeItems" class="w-24" />
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <span class="text-xs text-dimmed">{{ $t("pidTuningTPARate") }}</span>
+                        <UInputNumber v-model="tpaRate" :step="1" :min="0" :max="100" />
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <span class="text-xs text-dimmed">{{ $t("pidTuningTPABreakPoint") }}</span>
+                        <UInputNumber v-model="tpaBreakpoint" :step="10" :min="750" :max="2250" />
+                    </div>
+                </div>
+            </UiBox>
 
             <!-- Misc Settings -->
-            <div class="gui_box grey pidControllerAdvancedSettings spacer_left">
-                <table class="pid_titlebar new_rates">
-                    <tbody>
-                        <tr>
-                            <th>{{ $t("pidTuningMiscSettings") }}</th>
-                        </tr>
-                    </tbody>
-                </table>
-                <table class="compensation">
-                    <tbody>
-                        <!-- Cell Count -->
-                        <tr class="cellCount">
-                            <td>
-                                <select name="cellCount" v-model.number="advancedTuning.autoProfileCellCount">
-                                    <option :value="-1">{{ $t("pidTuningCellCountChange") }}</option>
-                                    <option :value="0">{{ $t("pidTuningCellCountStay") }}</option>
-                                    <option :value="1">{{ $t("pidTuningCellCount1S") }}</option>
-                                    <option :value="2">{{ $t("pidTuningCellCount2S") }}</option>
-                                    <option :value="3">{{ $t("pidTuningCellCount3S") }}</option>
-                                    <option :value="4">{{ $t("pidTuningCellCount4S") }}</option>
-                                    <option :value="5">{{ $t("pidTuningCellCount5S") }}</option>
-                                    <option :value="6">{{ $t("pidTuningCellCount6S") }}</option>
-                                    <option :value="7">{{ $t("pidTuningCellCount7S") }}</option>
-                                    <option :value="8">{{ $t("pidTuningCellCount8S") }}</option>
-                                </select>
-                            </td>
-                            <td colspan="2">
-                                <div>
-                                    <label>
-                                        <span v-html="$t('pidTuningCellCount')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningCellCountHelp')"></div>
-                                </div>
-                            </td>
-                        </tr>
+            <UiBox :title="$t('pidTuningMiscSettings')" type="neutral">
+                <SettingRow :label="$t('pidTuningCellCount')" :help="$t('pidTuningCellCountHelp')">
+                    <USelect v-model="advancedTuning.autoProfileCellCount" :items="cellCountItems" class="w-32" />
+                </SettingRow>
 
-                        <!-- Acro Trainer Angle Limit -->
-                        <tr class="acroTrainerAngleLimit">
-                            <td>
-                                <UInputNumber
-                                    name="acroTrainerAngleLimit-number"
-                                    v-model="advancedTuning.acroTrainerAngleLimit"
-                                    :step="1"
-                                    :min="10"
-                                    :max="80"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <div>
-                                    <label>
-                                        <span v-html="$t('pidTuningAcroTrainerAngleLimit')"></span>
-                                    </label>
-                                    <div
-                                        class="helpicon cf_tip"
-                                        :title="$t('pidTuningAcroTrainerAngleLimitHelp')"
-                                    ></div>
-                                </div>
-                            </td>
-                        </tr>
+                <SettingRow
+                    :label="$t('pidTuningAcroTrainerAngleLimit')"
+                    :help="$t('pidTuningAcroTrainerAngleLimitHelp')"
+                >
+                    <UInputNumber v-model="advancedTuning.acroTrainerAngleLimit" :step="1" :min="10" :max="80" />
+                </SettingRow>
 
-                        <!-- Integrated Yaw -->
-                        <tr class="integratedYaw">
-                            <td>
-                                <input
-                                    type="checkbox"
-                                    id="useIntegratedYaw"
-                                    class="toggle"
-                                    v-model="integratedYawEnabled"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <div class="helpicon cf_tip" :title="$t('pidTuningIntegratedYawHelp')"></div>
-                                <span v-html="$t('pidTuningIntegratedYaw')"></span>
-                                <span class="spacer_left" v-html="$t('pidTuningIntegratedYawCaution')"></span>
-                            </td>
-                        </tr>
+                <div class="flex flex-col gap-1">
+                    <SettingRow :label="$t('pidTuningIntegratedYaw')" :help="$t('pidTuningIntegratedYawHelp')">
+                        <USwitch v-model="integratedYawEnabled" size="sm" />
+                    </SettingRow>
+                    <span
+                        v-if="integratedYawEnabled"
+                        class="text-xs text-warning pl-8"
+                        v-html="$t('pidTuningIntegratedYawCaution')"
+                    ></span>
+                </div>
 
-                        <!-- Absolute Control -->
-                        <tr class="absoluteControlGain">
-                            <td>
-                                <UInputNumber
-                                    name="absoluteControlGain-number"
-                                    v-model="advancedTuning.absoluteControlGain"
-                                    :step="1"
-                                    :min="0"
-                                    :max="20"
-                                />
-                            </td>
-                            <td colspan="2">
-                                <div>
-                                    <label>
-                                        <span v-html="$t('pidTuningAbsoluteControlGain')"></span>
-                                    </label>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningAbsoluteControlGainHelp')"></div>
-                                </div>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                <SettingRow :label="$t('pidTuningAbsoluteControlGain')" :help="$t('pidTuningAbsoluteControlGainHelp')">
+                    <UInputNumber v-model="advancedTuning.absoluteControlGain" :step="1" :min="0" :max="20" />
+                </SettingRow>
+            </UiBox>
         </div>
-        <!-- END RIGHT COLUMN -->
     </div>
 </template>
 
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { useTranslation } from "i18next-vue";
 import FC from "@/js/fc";
 import {
     NON_EXPERT_SLIDER_MIN,
@@ -1147,6 +732,11 @@ import {
 } from "@/composables/useTuningSliders";
 import semver from "semver";
 import { API_VERSION_1_45, API_VERSION_1_47 } from "@/js/data_storage";
+import UiBox from "@/components/elements/UiBox.vue";
+import HelpIcon from "@/components/elements/HelpIcon.vue";
+import SettingRow from "@/components/elements/SettingRow.vue";
+
+const { t } = useTranslation();
 
 const props = defineProps({
     expertMode: {
@@ -1164,6 +754,55 @@ const props = defineProps({
 });
 
 const emit = defineEmits(["update:profileName", "change"]);
+
+// USelect item arrays
+const pidsModeItems = computed(() => [
+    { value: 0, label: t("pidTuningOptionOff") },
+    { value: 1, label: t("pidTuningOptionRP") },
+    { value: 2, label: t("pidTuningOptionRPY") },
+]);
+
+const feedforwardAveragingItems = computed(() => [
+    { value: 0, label: t("pidTuningOptionOff") },
+    { value: 1, label: t("pidTuningFeedforwardAveragingOption2Point") },
+    { value: 2, label: t("pidTuningFeedforwardAveragingOption3Point") },
+    { value: 3, label: t("pidTuningFeedforwardAveragingOption4Point") },
+]);
+
+const itermRelaxAxesItems = computed(() => [
+    { value: 1, label: t("pidTuningOptionRP") },
+    { value: 2, label: t("pidTuningOptionRPY") },
+    { value: 3, label: t("pidTuningItermRelaxAxesOptionRPInc") },
+    { value: 4, label: t("pidTuningItermRelaxAxesOptionRPYInc") },
+]);
+
+const itermRelaxTypeItems = computed(() => [
+    { value: 0, label: t("pidTuningItermRelaxTypeOptionGyro") },
+    { value: 1, label: t("pidTuningItermRelaxTypeOptionSetpoint") },
+]);
+
+const antiGravityModeItems = computed(() => [
+    { value: 0, label: t("pidTuningAntiGravityModeOptionSmooth") },
+    { value: 1, label: t("pidTuningAntiGravityModeOptionStep") },
+]);
+
+const tpaModeItems = computed(() => [
+    { value: 0, label: t("pidTuningTPAPD") },
+    { value: 1, label: t("pidTuningTPAD") },
+]);
+
+const cellCountItems = computed(() => [
+    { value: -1, label: t("pidTuningCellCountChange") },
+    { value: 0, label: t("pidTuningCellCountStay") },
+    { value: 1, label: t("pidTuningCellCount1S") },
+    { value: 2, label: t("pidTuningCellCount2S") },
+    { value: 3, label: t("pidTuningCellCount3S") },
+    { value: 4, label: t("pidTuningCellCount4S") },
+    { value: 5, label: t("pidTuningCellCount5S") },
+    { value: 6, label: t("pidTuningCellCount6S") },
+    { value: 7, label: t("pidTuningCellCount7S") },
+    { value: 8, label: t("pidTuningCellCount8S") },
+]);
 
 // Profile name (local writable computed to avoid duplicate key with prop)
 const localProfileName = computed({
@@ -1634,20 +1273,20 @@ function collectSliderValues() {
     };
 }
 
-// Slider change handler
-async function onSliderChange(event) {
+// Slider change handler — accepts optional slider key for non-expert clamping
+async function onSliderChange(activeSliderKey) {
     isUserInteracting.value = true;
 
     // Clamp the slider the user is actually dragging to the non-expert range.
     // We only clamp the active slider — other sliders may legitimately be
     // outside range (loaded from FC via CLI) and must not be silently reset.
-    if (!props.expertMode && event?.target?.id) {
+    if (!props.expertMode && activeSliderKey) {
         const refMap = {
             sliderDGain,
             sliderPIGain,
             sliderFeedforwardGain,
         };
-        const active = refMap[event.target.id];
+        const active = refMap[activeSliderKey];
         if (active) {
             if (active.value > NON_EXPERT_MAX) {
                 active.value = NON_EXPERT_MAX;
@@ -1695,6 +1334,16 @@ watch(
     () => emit("change"),
 );
 
+watch(
+    () => JSON.stringify(FC.ADVANCED_TUNING),
+    () => emit("change"),
+);
+
+watch(
+    () => JSON.stringify(FC.RC_TUNING),
+    () => emit("change"),
+);
+
 // Expose method to parent component to force slider update after save
 function forceUpdateSliders() {
     isUserInteracting.value = false; // Allow watcher to work
@@ -1718,129 +1367,3 @@ onUnmounted(() => {
     }
 });
 </script>
-
-<style scoped>
-/* Component-specific styles */
-.disabledSliders {
-    opacity: 0.5;
-}
-
-.pid_roll,
-.pid_pitch,
-.pid_yaw {
-    font-weight: bold;
-    color: white;
-    text-align: center;
-    padding: 5px;
-}
-
-.expertSettingsDetectedNote {
-    margin: 10px;
-    padding: 10px;
-    background-color: #ffe4b5;
-    border: 1px solid #ff8c00;
-    border-radius: 3px;
-    color: #333;
-}
-
-.expertSettingsDetectedNote p {
-    margin: 0;
-    color: #333;
-}
-
-.gui_box.grey {
-    margin-bottom: 10px;
-}
-
-/* Slider Header */
-.slider-header {
-    display: grid;
-    grid-template-columns: 20% 60px 1fr 30px;
-    align-items: center;
-    padding: 0.5rem 10px;
-    background-color: var(--surface-300);
-    color: #fff;
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
-    gap: 10px;
-}
-
-.slider-mode-section {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    grid-column: 1 / 3;
-}
-
-.slider-mode-section .sm-min {
-    white-space: nowrap;
-    font-size: 12px;
-}
-
-.slider-range-labels {
-    display: flex;
-    justify-content: space-around;
-    align-items: center;
-    text-align: center;
-    font-size: 12px;
-}
-
-.slider-range-labels span {
-    flex: 1;
-}
-
-/* Slider Rows */
-.slider-row {
-    display: grid;
-    grid-template-columns: 20% 60px 1fr 30px;
-    align-items: center;
-    padding: 8px 10px;
-    border-bottom: 1px solid var(--surface-500);
-    gap: 10px;
-}
-
-.slider-row:last-child {
-    border-bottom: none;
-}
-
-.slider-label {
-    text-align: right;
-    font-size: 12px;
-    line-height: 1.3;
-    padding-right: 10px;
-}
-
-.slider-value {
-    text-align: center;
-    font-weight: bold;
-    font-size: 13px;
-}
-
-.slider-control {
-    display: flex;
-    align-items: center;
-}
-
-.slider-control input[type="range"] {
-    width: 100%;
-}
-
-.slider-row .helpicon {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-/* Divider */
-.sliderDivider {
-    padding: 8px 0;
-}
-
-.sliderDivider hr {
-    border: none;
-    border-top: 1px solid var(--surface-500);
-    border-bottom: 1px solid var(--surface-500);
-    height: 2px;
-    margin: 0;
-}
-</style>

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -9,7 +9,7 @@
 
             <!-- PID Table -->
             <UiBox type="neutral">
-                <div class="grid grid-cols-[3rem_repeat(5,1fr)] gap-x-1 gap-y-1 items-center min-w-0">
+                <div class="grid grid-cols-[3rem_repeat(5,minmax(4rem,auto))] gap-x-3 gap-y-1 items-center min-w-0">
                     <!-- Header -->
                     <div></div>
                     <div class="flex items-center justify-center gap-0.5 text-xs">
@@ -394,7 +394,7 @@
 
             <!-- BARO, MAG, GPS Optional PIDs -->
             <UiBox v-if="showAllLocal && hasBaroMagGpsPids" type="neutral">
-                <div class="grid grid-cols-[3rem_repeat(3,1fr)] gap-x-1 gap-y-1 items-center min-w-0">
+                <div class="grid grid-cols-[3rem_repeat(3,4rem)] gap-x-2 gap-y-1 items-center min-w-0">
                     <!-- Header -->
                     <div></div>
                     <div class="text-xs text-center" v-html="$t('pidTuningProportional')"></div>
@@ -566,7 +566,7 @@
 
             <!-- Angle/Horizon Section -->
             <UiBox type="neutral">
-                <div class="grid grid-cols-3 gap-x-1 gap-y-1 items-center min-w-0">
+                <div class="grid grid-cols-[4rem_repeat(2,4rem)] gap-x-2 gap-y-1 items-center min-w-0">
                     <!-- Header -->
                     <div></div>
                     <div class="text-xs text-center">{{ $t("pidTuningStrength") }}</div>
@@ -644,6 +644,9 @@
                                 :step="1"
                                 :min="0"
                                 :max="20"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
                             />
                         </div>
                         <div class="flex flex-col gap-1">
@@ -659,6 +662,9 @@
                                 :step="1"
                                 :min="0"
                                 :max="95"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
                             />
                         </div>
                         <div class="flex flex-col gap-1">
@@ -677,7 +683,15 @@
                                 <span class="text-xs text-dimmed" v-html="$t('pidTuningFeedforwardBoost')"></span>
                                 <HelpIcon :text="$t('pidTuningFeedforwardBoostHelp')" />
                             </div>
-                            <UInputNumber v-model="advancedTuning.feedforward_boost" :step="1" :min="0" :max="50" />
+                            <UInputNumber
+                                v-model="advancedTuning.feedforward_boost"
+                                :step="1"
+                                :min="0"
+                                :max="50"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <div class="flex items-center gap-1">
@@ -692,6 +706,9 @@
                                 :step="1"
                                 :min="0"
                                 :max="150"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
                             />
                         </div>
                         <div class="flex flex-col gap-1">
@@ -705,6 +722,9 @@
                                 :min="0"
                                 :max="1"
                                 :format-options="{ minimumFractionDigits: 2, maximumFractionDigits: 2 }"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
                             />
                         </div>
                     </div>
@@ -733,7 +753,15 @@
                                 <span class="text-xs text-dimmed" v-html="$t('pidTuningItermRelaxCutoff')"></span>
                                 <HelpIcon :text="$t('pidTuningItermRelaxCutoffHelp')" />
                             </div>
-                            <UInputNumber v-model="advancedTuning.itermRelaxCutoff" :step="1" :min="1" :max="50" />
+                            <UInputNumber
+                                v-model="advancedTuning.itermRelaxCutoff"
+                                :step="1"
+                                :min="1"
+                                :max="50"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                            />
                         </div>
                     </div>
                 </div>
@@ -763,6 +791,9 @@
                                 :min="0.1"
                                 :max="30"
                                 :format-options="{ minimumFractionDigits: 1, maximumFractionDigits: 1 }"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
                             />
                         </div>
                         <div class="flex flex-col gap-1">
@@ -772,6 +803,9 @@
                                 :step="10"
                                 :min="20"
                                 :max="1000"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
                             />
                         </div>
                     </div>
@@ -791,14 +825,30 @@
                                 <span class="text-xs text-dimmed" v-html="$t('pidTuningDMaxGain')"></span>
                                 <HelpIcon :text="$t('pidTuningDMaxGainHelp')" />
                             </div>
-                            <UInputNumber v-model="advancedTuning.dMaxGain" :step="1" :min="0" :max="100" />
+                            <UInputNumber
+                                v-model="advancedTuning.dMaxGain"
+                                :step="1"
+                                :min="0"
+                                :max="100"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <div class="flex items-center gap-1">
                                 <span class="text-xs text-dimmed" v-html="$t('pidTuningDMaxAdvance')"></span>
                                 <HelpIcon :text="$t('pidTuningDMaxAdvanceHelp')" />
                             </div>
-                            <UInputNumber v-model="advancedTuning.dMaxAdvance" :step="1" :min="0" :max="200" />
+                            <UInputNumber
+                                v-model="advancedTuning.dMaxAdvance"
+                                :step="1"
+                                :min="0"
+                                :max="200"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                            />
                         </div>
                     </div>
                 </div>
@@ -807,11 +857,27 @@
             <!-- Motor Settings -->
             <UiBox :title="$t('pidTuningMotorSettings')" type="neutral">
                 <SettingRow :label="$t('pidTuningThrottleBoost')" :help="$t('pidTuningThrottleBoostHelp')">
-                    <UInputNumber v-model="advancedTuning.throttleBoost" :step="1" :min="0" :max="100" />
+                    <UInputNumber
+                        v-model="advancedTuning.throttleBoost"
+                        :step="1"
+                        :min="0"
+                        :max="100"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-16"
+                    />
                 </SettingRow>
 
                 <SettingRow :label="$t('pidTuningMotorOutputLimit')" :help="$t('pidTuningMotorLimitHelp')">
-                    <UInputNumber v-model="advancedTuning.motorOutputLimit" :step="1" :min="1" :max="100" />
+                    <UInputNumber
+                        v-model="advancedTuning.motorOutputLimit"
+                        :step="1"
+                        :min="1"
+                        :max="100"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-16"
+                    />
                 </SettingRow>
 
                 <SettingRow
@@ -824,6 +890,9 @@
                         :min="0"
                         :max="idleMinRpmMax"
                         :disabled="!dshotTelemetryEnabled"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-16"
                     />
                 </SettingRow>
 
@@ -843,6 +912,9 @@
                                 :step="1"
                                 :min="1"
                                 :max="150"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
                             />
                         </div>
                     </div>
@@ -859,7 +931,15 @@
                     <div v-if="thrustLinearEnabled" class="flex flex-wrap items-end gap-3 pl-8">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed" v-html="$t('pidTuningThrustLinearValue')"></span>
-                            <UInputNumber v-model="advancedTuning.thrustLinearization" :step="1" :min="1" :max="150" />
+                            <UInputNumber
+                                v-model="advancedTuning.thrustLinearization"
+                                :step="1"
+                                :min="1"
+                                :max="150"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                            />
                         </div>
                     </div>
                 </div>
@@ -874,11 +954,27 @@
                     </div>
                     <div class="flex flex-col gap-1">
                         <span class="text-xs text-dimmed">{{ $t("pidTuningTPARate") }}</span>
-                        <UInputNumber v-model="tpaRate" :step="1" :min="0" :max="100" />
+                        <UInputNumber
+                            v-model="tpaRate"
+                            :step="1"
+                            :min="0"
+                            :max="100"
+                            size="xs"
+                            orientation="vertical"
+                            class="w-16"
+                        />
                     </div>
                     <div class="flex flex-col gap-1">
                         <span class="text-xs text-dimmed">{{ $t("pidTuningTPABreakPoint") }}</span>
-                        <UInputNumber v-model="tpaBreakpoint" :step="10" :min="750" :max="2250" />
+                        <UInputNumber
+                            v-model="tpaBreakpoint"
+                            :step="10"
+                            :min="750"
+                            :max="2250"
+                            size="xs"
+                            orientation="vertical"
+                            class="w-16"
+                        />
                     </div>
                 </div>
             </UiBox>
@@ -893,7 +989,15 @@
                     :label="$t('pidTuningAcroTrainerAngleLimit')"
                     :help="$t('pidTuningAcroTrainerAngleLimitHelp')"
                 >
-                    <UInputNumber v-model="advancedTuning.acroTrainerAngleLimit" :step="1" :min="10" :max="80" />
+                    <UInputNumber
+                        v-model="advancedTuning.acroTrainerAngleLimit"
+                        :step="1"
+                        :min="10"
+                        :max="80"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-16"
+                    />
                 </SettingRow>
 
                 <div class="flex flex-col gap-1">
@@ -908,7 +1012,15 @@
                 </div>
 
                 <SettingRow :label="$t('pidTuningAbsoluteControlGain')" :help="$t('pidTuningAbsoluteControlGainHelp')">
-                    <UInputNumber v-model="advancedTuning.absoluteControlGain" :step="1" :min="0" :max="20" />
+                    <UInputNumber
+                        v-model="advancedTuning.absoluteControlGain"
+                        :step="1"
+                        :min="0"
+                        :max="20"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-16"
+                    />
                 </SettingRow>
             </UiBox>
         </div>

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -1,424 +1,291 @@
 <template>
-    <div class="subtab-rates">
+    <div class="p-5 grid grid-cols-1 xl:grid-cols-2 gap-4">
         <!-- LEFT COLUMN -->
-        <div class="cf_column">
+        <div class="flex flex-col gap-4">
             <!-- Rate Profile Name (API 1.45+) -->
-            <div v-if="hasProfileNames" class="gui_box grey profile_name">
-                <table class="cf">
-                    <thead>
-                        <tr>
-                            <th>
-                                <div>
-                                    <div class="float-left" v-text="$t('rateProfileName')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('rateProfileNameHelp')"></div>
-                                </div>
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <input type="text" v-model="rateProfileNameModel" maxlength="8" />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            <SettingRow v-if="hasProfileNames" :label="$t('rateProfileName')" :help="$t('rateProfileNameHelp')">
+                <UInput v-model="rateProfileNameModel" maxlength="8" class="w-28" />
+            </SettingRow>
 
             <!-- Rates Type Selector -->
-            <div class="gui_box grey">
-                <table class="cf">
-                    <thead>
-                        <tr>
-                            <th>
-                                <div>
-                                    <div class="float-left" v-text="$t('pidTuningRatesType')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningRatesTypeTip')"></div>
-                                </div>
-                            </th>
-                            <th class="rates_logo_bg"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <select v-model.number="ratesType">
-                                    <option :value="0">Betaflight</option>
-                                    <option :value="1">Raceflight</option>
-                                    <option :value="2">KISS</option>
-                                    <option :value="3">Actual</option>
-                                    <option :value="4">Quick</option>
-                                </select>
-                            </td>
-                            <td class="rates_logo_bg">
-                                <div class="rates_logo_div">
-                                    <img :src="ratesLogoSrc" class="rates_logo" alt="Rates logo" />
-                                </div>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            <UiBox type="neutral">
+                <div class="flex items-center gap-3">
+                    <SettingRow :label="$t('pidTuningRatesType')" :help="$t('pidTuningRatesTypeTip')">
+                        <USelect v-model="ratesType" :items="ratesTypeItems" class="w-32" />
+                    </SettingRow>
+                    <img :src="ratesLogoSrc" class="h-8" alt="Rates logo" />
+                </div>
+            </UiBox>
 
             <!-- Max Rate Warning -->
-            <div v-if="showMaxRateWarning" class="danger rates-tab-warning maxRateWarning">
+            <UiBox v-if="showMaxRateWarning" type="error" highlight>
                 <p v-html="$t('pidTuningMaxRateWarning')"></p>
-            </div>
+            </UiBox>
 
             <!-- Rate Setup Table -->
-            <div class="gui_box grey rateSetup">
-                <table id="rateSetup" class="pid_tuning">
-                    <tbody>
-                        <tr class="pid_titlebar">
-                            <th class="name"></th>
-                            <th class="rc_rate" v-text="rcRateLabel"></th>
-                            <th class="rate" v-text="rateLabel"></th>
-                            <th class="rc_expo" v-text="rcExpoLabel"></th>
-                            <th
-                                v-if="isBetaflightRates"
-                                class="new_rates centerSensitivity"
-                                v-text="fourthColumnLabel"
-                            ></th>
-                            <th v-else class="new_rates maxVel" v-text="fourthColumnLabel"></th>
-                        </tr>
-                        <tr class="pid_titlebar2">
-                            <th colspan="5">
-                                <div class="pid_mode">
-                                    <div class="float-left" v-text="$t('pidTuningRateSetup')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningRatesTuningHelp')"></div>
-                                </div>
-                            </th>
-                        </tr>
+            <UiBox type="neutral">
+                <div class="grid grid-cols-[4rem_repeat(3,4rem)_4rem] gap-x-1 gap-y-1 items-center min-w-0">
+                    <!-- Header -->
+                    <div></div>
+                    <div class="text-xs text-center">{{ rcRateLabel }}</div>
+                    <div class="text-xs text-center">{{ rateLabel }}</div>
+                    <div class="text-xs text-center">{{ rcExpoLabel }}</div>
+                    <div class="text-xs text-center">{{ fourthColumnLabel }}</div>
 
-                        <!-- Roll -->
-                        <tr class="ROLL">
-                            <td class="pid_roll" v-text="$t('controlAxisRoll')"></td>
-                            <td class="rc_rate">
-                                <UInputNumber
-                                    :model-value="rcRate"
-                                    @update:model-value="rcRate = $event"
-                                    :step="rcRateLimits.step"
-                                    :min="rcRateLimits.min"
-                                    :max="rcRateLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: rcRatePrecision,
-                                        maximumFractionDigits: rcRatePrecision,
-                                    }"
-                                />
-                            </td>
-                            <td class="roll_rate">
-                                <UInputNumber
-                                    :model-value="rollRate"
-                                    @update:model-value="rollRate = $event"
-                                    :step="rateLimits.step"
-                                    :min="rateLimits.min"
-                                    :max="rateLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: ratePrecision,
-                                        maximumFractionDigits: ratePrecision,
-                                    }"
-                                />
-                            </td>
-                            <td>
-                                <UInputNumber
-                                    :model-value="rcExpo"
-                                    @update:model-value="rcExpo = $event"
-                                    :step="expoLimits.step"
-                                    :min="expoLimits.min"
-                                    :max="expoLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: expoPrecision,
-                                        maximumFractionDigits: expoPrecision,
-                                    }"
-                                />
-                            </td>
-                            <td v-if="isBetaflightRates" class="new_rates acroCenterSensitivityRoll">
-                                {{ centerSensitivityRoll }}
-                            </td>
-                            <td v-else class="new_rates maxAngularVelRoll">
-                                {{ maxAngularVelRoll }}
-                            </td>
-                        </tr>
+                    <!-- Section label -->
+                    <div class="col-span-5 text-xs text-dimmed">
+                        <div class="flex items-center gap-1">
+                            <span>{{ $t("pidTuningRateSetup") }}</span>
+                            <HelpIcon :text="$t('pidTuningRatesTuningHelp')" />
+                        </div>
+                    </div>
 
-                        <!-- Pitch -->
-                        <tr class="PITCH">
-                            <td class="pid_pitch" v-text="$t('controlAxisPitch')"></td>
-                            <td>
-                                <UInputNumber
-                                    :model-value="rcRatePitch"
-                                    @update:model-value="rcRatePitch = $event"
-                                    :step="rcRateLimits.step"
-                                    :min="rcRateLimits.min"
-                                    :max="rcRateLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: rcRatePrecision,
-                                        maximumFractionDigits: rcRatePrecision,
-                                    }"
-                                />
-                            </td>
-                            <td class="pitch_rate">
-                                <UInputNumber
-                                    :model-value="pitchRate"
-                                    @update:model-value="pitchRate = $event"
-                                    :step="rateLimits.step"
-                                    :min="rateLimits.min"
-                                    :max="rateLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: ratePrecision,
-                                        maximumFractionDigits: ratePrecision,
-                                    }"
-                                />
-                            </td>
-                            <td>
-                                <UInputNumber
-                                    :model-value="rcPitchExpo"
-                                    @update:model-value="rcPitchExpo = $event"
-                                    :step="expoLimits.step"
-                                    :min="expoLimits.min"
-                                    :max="expoLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: expoPrecision,
-                                        maximumFractionDigits: expoPrecision,
-                                    }"
-                                />
-                            </td>
-                            <td v-if="isBetaflightRates" class="new_rates acroCenterSensitivityPitch">
-                                {{ centerSensitivityPitch }}
-                            </td>
-                            <td v-else class="new_rates maxAngularVelPitch">
-                                {{ maxAngularVelPitch }}
-                            </td>
-                        </tr>
+                    <!-- Roll -->
+                    <div class="font-bold text-white text-center py-0.5 px-1 bg-[#e24761] rounded text-xs">
+                        {{ $t("controlAxisRoll") }}
+                    </div>
+                    <UInputNumber
+                        :model-value="rcRate"
+                        @update:model-value="rcRate = $event"
+                        :step="rcRateLimits.step"
+                        :min="rcRateLimits.min"
+                        :max="rcRateLimits.max"
+                        :format-options="{
+                            minimumFractionDigits: rcRatePrecision,
+                            maximumFractionDigits: rcRatePrecision,
+                        }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        :model-value="rollRate"
+                        @update:model-value="rollRate = $event"
+                        :step="rateLimits.step"
+                        :min="rateLimits.min"
+                        :max="rateLimits.max"
+                        :format-options="{ minimumFractionDigits: ratePrecision, maximumFractionDigits: ratePrecision }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        :model-value="rcExpo"
+                        @update:model-value="rcExpo = $event"
+                        :step="expoLimits.step"
+                        :min="expoLimits.min"
+                        :max="expoLimits.max"
+                        :format-options="{ minimumFractionDigits: expoPrecision, maximumFractionDigits: expoPrecision }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <div class="text-xs text-center whitespace-nowrap">
+                        {{ isBetaflightRates ? centerSensitivityRoll : maxAngularVelRoll }}
+                    </div>
 
-                        <!-- Yaw -->
-                        <tr class="YAW">
-                            <td class="pid_yaw" v-text="$t('controlAxisYaw')"></td>
-                            <td>
-                                <UInputNumber
-                                    :model-value="rcRateYaw"
-                                    @update:model-value="rcRateYaw = $event"
-                                    :step="rcRateLimits.step"
-                                    :min="rcRateLimits.min"
-                                    :max="rcRateLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: rcRatePrecision,
-                                        maximumFractionDigits: rcRatePrecision,
-                                    }"
-                                />
-                            </td>
-                            <td>
-                                <UInputNumber
-                                    :model-value="yawRate"
-                                    @update:model-value="yawRate = $event"
-                                    :step="rateLimits.step"
-                                    :min="rateLimits.min"
-                                    :max="rateLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: ratePrecision,
-                                        maximumFractionDigits: ratePrecision,
-                                    }"
-                                />
-                            </td>
-                            <td>
-                                <UInputNumber
-                                    :model-value="rcYawExpo"
-                                    @update:model-value="rcYawExpo = $event"
-                                    :step="expoLimits.step"
-                                    :min="expoLimits.min"
-                                    :max="expoLimits.max"
-                                    :format-options="{
-                                        minimumFractionDigits: expoPrecision,
-                                        maximumFractionDigits: expoPrecision,
-                                    }"
-                                />
-                            </td>
-                            <td v-if="isBetaflightRates" class="new_rates acroCenterSensitivityYaw">
-                                {{ centerSensitivityYaw }}
-                            </td>
-                            <td v-else class="new_rates maxAngularVelYaw">
-                                {{ maxAngularVelYaw }}
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+                    <!-- Pitch -->
+                    <div class="font-bold text-white text-center py-0.5 px-1 bg-[#49c747] rounded text-xs">
+                        {{ $t("controlAxisPitch") }}
+                    </div>
+                    <UInputNumber
+                        :model-value="rcRatePitch"
+                        @update:model-value="rcRatePitch = $event"
+                        :step="rcRateLimits.step"
+                        :min="rcRateLimits.min"
+                        :max="rcRateLimits.max"
+                        :format-options="{
+                            minimumFractionDigits: rcRatePrecision,
+                            maximumFractionDigits: rcRatePrecision,
+                        }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        :model-value="pitchRate"
+                        @update:model-value="pitchRate = $event"
+                        :step="rateLimits.step"
+                        :min="rateLimits.min"
+                        :max="rateLimits.max"
+                        :format-options="{ minimumFractionDigits: ratePrecision, maximumFractionDigits: ratePrecision }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        :model-value="rcPitchExpo"
+                        @update:model-value="rcPitchExpo = $event"
+                        :step="expoLimits.step"
+                        :min="expoLimits.min"
+                        :max="expoLimits.max"
+                        :format-options="{ minimumFractionDigits: expoPrecision, maximumFractionDigits: expoPrecision }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <div class="text-xs text-center whitespace-nowrap">
+                        {{ isBetaflightRates ? centerSensitivityPitch : maxAngularVelPitch }}
+                    </div>
+
+                    <!-- Yaw -->
+                    <div class="font-bold text-white text-center py-0.5 px-1 bg-[#477ac7] rounded text-xs">
+                        {{ $t("controlAxisYaw") }}
+                    </div>
+                    <UInputNumber
+                        :model-value="rcRateYaw"
+                        @update:model-value="rcRateYaw = $event"
+                        :step="rcRateLimits.step"
+                        :min="rcRateLimits.min"
+                        :max="rcRateLimits.max"
+                        :format-options="{
+                            minimumFractionDigits: rcRatePrecision,
+                            maximumFractionDigits: rcRatePrecision,
+                        }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        :model-value="yawRate"
+                        @update:model-value="yawRate = $event"
+                        :step="rateLimits.step"
+                        :min="rateLimits.min"
+                        :max="rateLimits.max"
+                        :format-options="{ minimumFractionDigits: ratePrecision, maximumFractionDigits: ratePrecision }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <UInputNumber
+                        :model-value="rcYawExpo"
+                        @update:model-value="rcYawExpo = $event"
+                        :step="expoLimits.step"
+                        :min="expoLimits.min"
+                        :max="expoLimits.max"
+                        :format-options="{ minimumFractionDigits: expoPrecision, maximumFractionDigits: expoPrecision }"
+                        size="xs"
+                        orientation="vertical"
+                        class="w-full"
+                    />
+                    <div class="text-xs text-center whitespace-nowrap">
+                        {{ isBetaflightRates ? centerSensitivityYaw : maxAngularVelYaw }}
+                    </div>
+                </div>
+            </UiBox>
 
             <!-- Rate Curve -->
-            <div class="gui_box rc_curve">
-                <div class="rc_curve_bg">
-                    <table class="cf rc_curve">
-                        <thead>
-                            <tr>
-                                <th colspan="2">
-                                    <div>
-                                        <div class="float-left" v-text="$t('pidTuningRatesCurve')"></div>
-                                        <div class="helpicon cf_tip" :title="$t('pidTuningRatesTip')"></div>
-                                    </div>
-                                </th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                            <tr>
-                                <td colspan="2">
-                                    <div class="rate_curve background_paper" style="position: relative">
-                                        <canvas
-                                            ref="rateCurveLayer0"
-                                            style="
-                                                position: absolute;
-                                                top: 0;
-                                                left: 0;
-                                                z-index: 0;
-                                                height: 100%;
-                                                width: 100%;
-                                            "
-                                        ></canvas>
-                                        <canvas
-                                            ref="rateCurveLayer1"
-                                            style="
-                                                position: absolute;
-                                                top: 0;
-                                                left: 0;
-                                                z-index: 1;
-                                                height: 100%;
-                                                width: 100%;
-                                            "
-                                        ></canvas>
-                                    </div>
-                                </td>
-                            </tr>
-                        </tbody>
-                    </table>
+            <UiBox :title="$t('pidTuningRatesCurve')" :help="$t('pidTuningRatesTip')" type="neutral">
+                <div
+                    class="relative bg-white dark:bg-neutral-900 border border-default p-1"
+                    style="height: 362px; min-width: 200px"
+                >
+                    <canvas ref="rateCurveLayer0" class="absolute inset-0 w-full h-full" style="z-index: 0"></canvas>
+                    <canvas ref="rateCurveLayer1" class="absolute inset-0 w-full h-full" style="z-index: 1"></canvas>
                 </div>
-            </div>
+            </UiBox>
         </div>
 
         <!-- RIGHT COLUMN -->
-        <div class="cf_column">
+        <div class="flex flex-col gap-4">
             <!-- Throttle Limit -->
-            <div class="gui_box throttle_limit spacer_left">
-                <table class="cf">
-                    <thead>
-                        <tr>
-                            <th>
-                                <div>
-                                    <div class="float-left" v-text="$t('pidTuningThrottleLimitType')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningThrottleLimitTypeTip')"></div>
-                                </div>
-                            </th>
-                            <th>
-                                <div>
-                                    <div class="float-left" v-text="$t('pidTuningThrottleLimitPercent')"></div>
-                                    <div class="helpicon cf_tip" :title="$t('pidTuningThrottleLimitPercentTip')"></div>
-                                </div>
-                            </th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <select v-model.number="throttleLimitType">
-                                    <option :value="0" v-text="$t('pidTuningThrottleLimitTypeOff')"></option>
-                                    <option :value="1" v-text="$t('pidTuningThrottleLimitTypeScale')"></option>
-                                    <option :value="2" v-text="$t('pidTuningThrottleLimitTypeClip')"></option>
-                                </select>
-                            </td>
-                            <td>
-                                <UInputNumber v-model="throttleLimitPercent" :step="1" :min="25" :max="100" />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            <UiBox type="neutral">
+                <div class="flex flex-wrap items-end gap-3">
+                    <div class="flex flex-col gap-1">
+                        <div class="flex items-center gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningThrottleLimitType") }}</span>
+                            <HelpIcon :text="$t('pidTuningThrottleLimitTypeTip')" />
+                        </div>
+                        <USelect v-model="throttleLimitType" :items="throttleLimitTypeItems" class="w-28" />
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <div class="flex items-center gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningThrottleLimitPercent") }}</span>
+                            <HelpIcon :text="$t('pidTuningThrottleLimitPercentTip')" />
+                        </div>
+                        <UInputNumber
+                            v-model="throttleLimitPercent"
+                            :step="1"
+                            :min="25"
+                            :max="100"
+                            size="xs"
+                            orientation="vertical"
+                            class="w-16"
+                        />
+                    </div>
+                </div>
+            </UiBox>
 
             <!-- Throttle Settings -->
-            <div class="gui_box throttle spacer_left">
-                <table class="cf">
-                    <thead>
-                        <tr>
-                            <th v-text="$t('receiverThrottleMid')"></th>
-                            <th v-if="hasThrottleHover" v-text="$t('receiverThrottleHover')"></th>
-                            <th v-text="$t('receiverThrottleExpo')"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td>
-                                <UInputNumber
-                                    :model-value="throttleMid ?? 0"
-                                    @update:model-value="throttleMid = $event"
-                                    :step="0.01"
-                                    :min="0"
-                                    :max="1"
-                                />
-                            </td>
-                            <td v-if="hasThrottleHover">
-                                <UInputNumber
-                                    :model-value="throttleHover ?? 0.5"
-                                    @update:model-value="throttleHover = $event"
-                                    :step="0.01"
-                                    :min="0"
-                                    :max="1"
-                                />
-                            </td>
-                            <td>
-                                <UInputNumber
-                                    :model-value="throttleExpo ?? 0"
-                                    @update:model-value="throttleExpo = $event"
-                                    :step="0.01"
-                                    :min="0"
-                                    :max="1"
-                                />
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            <UiBox type="neutral">
+                <div class="flex flex-wrap items-end gap-3">
+                    <div class="flex flex-col gap-1">
+                        <span class="text-xs text-dimmed">{{ $t("receiverThrottleMid") }}</span>
+                        <UInputNumber
+                            :model-value="throttleMid ?? 0"
+                            @update:model-value="throttleMid = $event"
+                            :step="0.01"
+                            :min="0"
+                            :max="1"
+                            size="xs"
+                            orientation="vertical"
+                            class="w-16"
+                        />
+                    </div>
+                    <div v-if="hasThrottleHover" class="flex flex-col gap-1">
+                        <span class="text-xs text-dimmed">{{ $t("receiverThrottleHover") }}</span>
+                        <UInputNumber
+                            :model-value="throttleHover ?? 0.5"
+                            @update:model-value="throttleHover = $event"
+                            :step="0.01"
+                            :min="0"
+                            :max="1"
+                            size="xs"
+                            orientation="vertical"
+                            class="w-16"
+                        />
+                    </div>
+                    <div class="flex flex-col gap-1">
+                        <span class="text-xs text-dimmed">{{ $t("receiverThrottleExpo") }}</span>
+                        <UInputNumber
+                            :model-value="throttleExpo ?? 0"
+                            @update:model-value="throttleExpo = $event"
+                            :step="0.01"
+                            :min="0"
+                            :max="1"
+                            size="xs"
+                            orientation="vertical"
+                            class="w-16"
+                        />
+                    </div>
+                </div>
+            </UiBox>
 
             <!-- Throttle Curve Preview -->
-            <div class="gui_box throttle spacer_left">
-                <table class="cf">
-                    <thead>
-                        <tr>
-                            <th v-text="$t('pidTuningThrottleCurvePreview')" colspan="2"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td colspan="2" class="throttleCurvePreview">
-                                <div class="throttle_curve background_paper" style="height: 164px">
-                                    <canvas ref="throttleCurveCanvas" style="width: 100%; height: 100%"></canvas>
-                                </div>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
-            <div class="gui_box ratePreview grey spacer_left">
-                <table class="pid_titlebar">
-                    <thead>
-                        <tr>
-                            <th v-text="$t('pidTuningRatesPreview')"></th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <tr>
-                            <td class="rates_preview_cell">
-                                <div class="rates_preview background_paper" ref="ratesPreviewContainer">
-                                    <canvas ref="ratesPreviewCanvas"></canvas>
-                                </div>
-                            </td>
-                        </tr>
-                    </tbody>
-                </table>
-            </div>
+            <UiBox :title="$t('pidTuningThrottleCurvePreview')" type="neutral">
+                <div class="bg-white dark:bg-neutral-900 border border-default p-1" style="height: 164px">
+                    <canvas ref="throttleCurveCanvas" class="w-full h-full block"></canvas>
+                </div>
+            </UiBox>
+
+            <!-- Rates 3D Preview -->
+            <UiBox :title="$t('pidTuningRatesPreview')" type="neutral">
+                <div class="bg-white dark:bg-neutral-900 border border-default p-1 w-full" ref="ratesPreviewContainer">
+                    <canvas ref="ratesPreviewCanvas" class="block"></canvas>
+                </div>
+            </UiBox>
         </div>
     </div>
 </template>
 
 <script setup>
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { useTranslation } from "i18next-vue";
 import { i18n } from "@/js/localization";
 import { useDialog } from "@/composables/useDialog";
+import UiBox from "@/components/elements/UiBox.vue";
+import HelpIcon from "@/components/elements/HelpIcon.vue";
+import SettingRow from "@/components/elements/SettingRow.vue";
 import FC from "@/js/fc";
 import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
@@ -440,6 +307,23 @@ const props = defineProps({
 });
 
 const emit = defineEmits(["update:rateProfileName", "change"]);
+
+const { t } = useTranslation();
+
+// USelect item arrays
+const ratesTypeItems = [
+    { value: 0, label: "Betaflight" },
+    { value: 1, label: "Raceflight" },
+    { value: 2, label: "KISS" },
+    { value: 3, label: "Actual" },
+    { value: 4, label: "Quick" },
+];
+
+const throttleLimitTypeItems = computed(() => [
+    { value: 0, label: t("pidTuningThrottleLimitTypeOff") },
+    { value: 1, label: t("pidTuningThrottleLimitTypeScale") },
+    { value: 2, label: t("pidTuningThrottleLimitTypeClip") },
+]);
 
 // Canvas refs
 const rateCurveLayer0 = ref(null);
@@ -1980,49 +1864,3 @@ onUnmounted(() => {
     }
 });
 </script>
-
-<style scoped>
-.subtab-rates {
-    display: flex;
-    gap: 10px;
-}
-
-.cf_column {
-    flex: 1;
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.gui_box {
-    padding: 10px;
-}
-
-.background_paper {
-    background: var(--surface-50, #fff);
-    border: 1px solid var(--surface-400, #ccc);
-    padding: 5px;
-}
-
-.rate_curve {
-    position: relative;
-}
-
-.throttle_curve {
-    width: 100%;
-}
-
-.rates_preview {
-    width: 100%;
-}
-
-canvas {
-    display: block;
-}
-
-@media all and (max-width: 900px) {
-    .subtab-rates {
-        flex-direction: column;
-    }
-}
-</style>

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -14,6 +14,14 @@
                         <USelect v-model="ratesType" :items="ratesTypeItems" class="w-32" />
                     </SettingRow>
                     <img :src="ratesLogoSrc" class="h-8" alt="Rates logo" />
+                    <a
+                        href="https://rates.metamarc.com"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="text-xs text-primary hover:underline"
+                    >
+                        rates.metamarc.com
+                    </a>
                 </div>
             </UiBox>
 


### PR DESCRIPTION
- initial commit for conversion.

Tasks

- [x] PidTuningTab
- [x] FilterSubTab
- [x] PidSubTab
- [x] RatesSubTab

    

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Redesigned PID tuning UI with modern controls, refreshed sub-tab navigation, and updated styling for clearer layout and responsiveness
  * Reworked filter and rates layouts into cleaner two-column and grid presentations
* **New Features**
  * Sliders show live multiplier/readouts and clearer disabled states; selects and inputs use unified styled controls
  * Header actions and toolbar buttons update contextually and visually when changes are pending
* **Bug Fixes**
  * Improved content readiness and reduced re-initializations for more stable tab switching
<!-- end of auto-generated comment: release notes by coderabbit.ai -->