### PR TITLE
Firmware flasher facelift

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4122,6 +4122,12 @@
     "firmwareFlasherFirmwareNotLoaded": {
         "message": "Firmware not loaded"
     },
+    "firmwareFlasherFirmwareLoaded": {
+        "message": "Firmware"
+    },
+    "firmwareFlasherFirmwareSize": {
+        "message": "File Size"
+    },
     "firmwareFlasherFirmwareLocalLoaded": {
         "message": "Loaded Local Firmware: {{filename}} ({{bytes}} bytes)"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4126,7 +4126,7 @@
         "message": "Firmware"
     },
     "firmwareFlasherFirmwareSize": {
-        "message": "File Size"
+        "message": "{{bytes}} bytes"
     },
     "firmwareFlasherFirmwareLocalLoaded": {
         "message": "Loaded Local Firmware: {{filename}} ({{bytes}} bytes)"

--- a/src/components/ProgressRing.vue
+++ b/src/components/ProgressRing.vue
@@ -32,7 +32,9 @@
         </svg>
         <div class="progress-ring__content">
             <slot>
-                <span v-if="!indeterminate && value > 0" class="progress-ring__pct"> {{ Math.round(value) }}% </span>
+                <span v-if="!indeterminate && progressPercent > 0" class="progress-ring__pct">
+                    {{ progressPercent }}%
+                </span>
             </slot>
         </div>
     </div>
@@ -73,13 +75,20 @@ const centre = computed(() => props.size / 2);
 const radius = computed(() => (props.size - props.strokeWidth) / 2);
 const circumference = computed(() => 2 * Math.PI * radius.value);
 
+const effectiveMax = computed(() => (Number.isFinite(props.max) && props.max > 0 ? props.max : 100));
+const clampedValue = computed(() => {
+    const v = Number.isFinite(props.value) ? props.value : 0;
+    return Math.min(Math.max(v, 0), effectiveMax.value);
+});
+const progressRatio = computed(() => clampedValue.value / effectiveMax.value);
+const progressPercent = computed(() => Math.round(progressRatio.value * 100));
+
 const dashOffset = computed(() => {
     if (props.indeterminate) {
         // show ~75% arc that spins
         return circumference.value * 0.25;
     }
-    const pct = Math.min(props.value, props.max) / props.max;
-    return circumference.value * (1 - pct);
+    return circumference.value * (1 - progressRatio.value);
 });
 
 const colorMap = {

--- a/src/components/ProgressRing.vue
+++ b/src/components/ProgressRing.vue
@@ -1,0 +1,142 @@
+<template>
+    <div class="progress-ring" :style="{ width: `${size}px`, height: `${size}px` }">
+        <svg
+            :width="size"
+            :height="size"
+            :viewBox="`0 0 ${size} ${size}`"
+            class="progress-ring__svg"
+            :class="{ 'progress-ring__svg--spin': indeterminate }"
+        >
+            <!-- background track -->
+            <circle
+                class="progress-ring__track"
+                :cx="centre"
+                :cy="centre"
+                :r="radius"
+                fill="none"
+                :stroke-width="strokeWidth"
+            />
+            <!-- progress arc -->
+            <circle
+                class="progress-ring__fill"
+                :cx="centre"
+                :cy="centre"
+                :r="radius"
+                fill="none"
+                :stroke-width="strokeWidth"
+                :stroke-dasharray="circumference"
+                :stroke-dashoffset="dashOffset"
+                stroke-linecap="round"
+                :style="{ stroke: strokeColor }"
+            />
+        </svg>
+        <div class="progress-ring__content">
+            <slot>
+                <span v-if="!indeterminate && value > 0" class="progress-ring__pct"> {{ Math.round(value) }}% </span>
+            </slot>
+        </div>
+    </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+    value: {
+        type: Number,
+        default: 0,
+    },
+    max: {
+        type: Number,
+        default: 100,
+    },
+    color: {
+        type: String,
+        default: "primary",
+        validator: (v) => ["primary", "success", "error"].includes(v),
+    },
+    size: {
+        type: Number,
+        default: 40,
+    },
+    strokeWidth: {
+        type: Number,
+        default: 4,
+    },
+    indeterminate: {
+        type: Boolean,
+        default: false,
+    },
+});
+
+const centre = computed(() => props.size / 2);
+const radius = computed(() => (props.size - props.strokeWidth) / 2);
+const circumference = computed(() => 2 * Math.PI * radius.value);
+
+const dashOffset = computed(() => {
+    if (props.indeterminate) {
+        // show ~75% arc that spins
+        return circumference.value * 0.25;
+    }
+    const pct = Math.min(props.value, props.max) / props.max;
+    return circumference.value * (1 - pct);
+});
+
+const colorMap = {
+    primary: "var(--primary-500)",
+    success: "var(--success-500)",
+    error: "var(--error-500)",
+};
+
+const strokeColor = computed(() => colorMap[props.color] ?? colorMap.primary);
+</script>
+
+<style scoped>
+.progress-ring {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+.progress-ring__svg {
+    transform: rotate(-90deg);
+}
+
+.progress-ring__svg--spin {
+    animation: ring-spin 0.8s linear infinite;
+}
+
+.progress-ring__track {
+    stroke: var(--surface-400);
+}
+
+.progress-ring__fill {
+    transition:
+        stroke-dashoffset 0.35s ease,
+        stroke 0.35s ease;
+}
+
+.progress-ring__content {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    pointer-events: none;
+}
+
+.progress-ring__pct {
+    font-size: 1.1em;
+    font-weight: 600;
+    color: var(--text);
+    line-height: 1;
+}
+
+@keyframes ring-spin {
+    to {
+        transform: rotate(270deg);
+    }
+}
+</style>

--- a/src/components/dialogs/WaitDialog.vue
+++ b/src/components/dialogs/WaitDialog.vue
@@ -1,6 +1,6 @@
 <template>
     <dialog ref="dialogRef" class="dialogWait" @cancel.prevent>
-        <div class="data-loading"></div>
+        <ProgressRing indeterminate :size="80" :stroke-width="6" color="primary" class="dialogWait-spinner" />
         <h3 class="dialogWaitTitle">{{ title }}</h3>
         <div class="buttons" v-if="showCancel">
             <button type="button" class="dialogWait-cancelButton regular-button" @click="$emit('cancel')">
@@ -13,6 +13,7 @@
 <script setup>
 import { ref } from "vue";
 import { i18n } from "@/js/localization";
+import ProgressRing from "../ProgressRing.vue";
 
 defineProps({
     title: String,
@@ -51,13 +52,19 @@ defineExpose({
 }
 
 .dialogWait {
-    display: block;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     z-index: 1000;
     position: fixed;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
     margin: 0;
+}
+
+.dialogWait-spinner {
+    margin: 1rem auto;
 }
 
 .dialogWait::backdrop {

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -10,7 +10,7 @@
                     :indeterminate="state.flashProgressValue === 0"
                     :size="80"
                     :stroke-width="6"
-                    color="primary"
+                    :color="flashRingColor"
                 />
                 <p>{{ state.progressLabelText }} {{ $t("firmwareFlasherPleaseWait") }}</p>
             </div>
@@ -536,7 +536,7 @@
 </template>
 
 <script>
-import { defineComponent, reactive, ref, onMounted, onBeforeUnmount, inject, nextTick } from "vue";
+import { computed, defineComponent, reactive, ref, onMounted, onBeforeUnmount, inject, nextTick } from "vue";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "../elements/WikiButton.vue";
 import Multiselect from "vue-multiselect";
@@ -715,6 +715,9 @@ export default defineComponent({
             VALID: "VALID",
             INVALID: "INVALID",
             ACTION: "ACTION",
+            ERASING: "ERASING",
+            FLASHING: "FLASHING",
+            VERIFYING: "VERIFYING",
         };
 
         // Helper functions
@@ -767,6 +770,15 @@ export default defineComponent({
                     break;
                 case FLASH_MESSAGE_TYPES.ACTION:
                     state.progressLabelClass = "actionRequired";
+                    break;
+                case FLASH_MESSAGE_TYPES.ERASING:
+                    state.progressLabelClass = "erasing";
+                    break;
+                case FLASH_MESSAGE_TYPES.FLASHING:
+                    state.progressLabelClass = "flashing";
+                    break;
+                case FLASH_MESSAGE_TYPES.VERIFYING:
+                    state.progressLabelClass = "verifying";
                     break;
                 case FLASH_MESSAGE_TYPES.NEUTRAL:
                 default:
@@ -2145,9 +2157,23 @@ export default defineComponent({
             }
         };
 
+        const flashRingColor = computed(() => {
+            switch (state.progressLabelClass) {
+                case "erasing":
+                    return "error";
+                case "flashing":
+                    return "success";
+                case "verifying":
+                    return "primary";
+                default:
+                    return "primary";
+            }
+        });
+
         // Return all public methods and state
         return {
             state,
+            flashRingColor,
             cloudBuild,
             boardSelection,
             FLASH_MESSAGE_TYPES,

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -2892,7 +2892,7 @@ export default defineComponent({
         }
     }
     & + .content_toolbar {
-        width: calc(100% - 18rem) !important;
+        width: fit-content;
     }
     @media all and (max-width: 575px) {
         .grid-box {
@@ -2913,7 +2913,7 @@ export default defineComponent({
 }
 
 :deep(.toolbar_fixed_bottom.content_toolbar) {
-    width: calc(100% - 18rem) !important;
+    width: fit-content;
 }
 
 :deep(.content_toolbar) {

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -435,20 +435,22 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton
-                :disabled="state.dfuExitButtonDisabled"
-                :color="state.dfuExitButtonDisabled ? 'neutral' : 'error'"
-                @click="handleExitDfu"
-            >
-                {{ $t("firmwareFlasherExitDfu") }}
-            </UButton>
-            <UButton
-                :disabled="state.flashButtonDisabled"
-                :color="state.flashButtonDisabled ? 'neutral' : 'success'"
-                @click="handleFlashFirmware"
-            >
-                {{ $t("firmwareFlasherFlashFirmware") }}
-            </UButton>
+            <UFieldGroup size="sm" orientation="horizontal" class="!flex">
+                <UButton
+                    :disabled="state.flashButtonDisabled"
+                    :color="state.flashButtonDisabled ? 'neutral' : 'success'"
+                    @click="handleFlashFirmware"
+                >
+                    {{ $t("firmwareFlasherFlashFirmware") }}
+                </UButton>
+                <UDropdownMenu v-slot="{ open }" :items="flashActionMenuItems" :content="{ align: 'end', side: 'top' }">
+                    <UButton
+                        :color="state.flashButtonDisabled ? 'neutral' : 'success'"
+                        :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+                        square
+                    />
+                </UDropdownMenu>
+            </UFieldGroup>
             <UFieldGroup size="sm" orientation="horizontal" class="!flex">
                 <UButton :disabled="state.loadRemoteButtonDisabled" @click="handleLoadRemoteFile">{{
                     $t("firmwareFlasherButtonLoadOnline")
@@ -2170,6 +2172,23 @@ export default defineComponent({
             ],
         ]);
 
+        const flashActionMenuItems = computed(() => [
+            [
+                {
+                    label: $t("firmwareFlasherFlashFirmware"),
+                    icon: "i-lucide-zap",
+                    disabled: state.flashButtonDisabled,
+                    onSelect: handleFlashFirmware,
+                },
+                {
+                    label: $t("firmwareFlasherExitDfu"),
+                    icon: "i-lucide-usb",
+                    disabled: state.dfuExitButtonDisabled,
+                    onSelect: handleExitDfu,
+                },
+            ],
+        ]);
+
         const flashRingColor = computed(() => {
             switch (state.progressLabelClass) {
                 case "invalid":
@@ -2189,6 +2208,7 @@ export default defineComponent({
         return {
             state,
             flashRingColor,
+            flashActionMenuItems,
             loadFirmwareMenuItems,
             cloudBuild,
             boardSelection,

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -395,46 +395,30 @@
                                     min="0"
                                     max="100"
                                 ></progress>
-                                <span ref="cloudTargetStatusSpan" id="cloudTargetStatus">
-                                    {{ cloudBuild.state.cloudTargetStatusText }}</span
-                                >
                             </div>
                             <div>
                                 <UButton
+                                    v-if="!cloudBuild.state.cancelBuildButtonDisabled"
                                     ref="cloudBuildCancelButton"
                                     size="xs"
                                     variant="soft"
-                                    :disabled="cloudBuild.state.cancelBuildButtonDisabled"
                                     @click="cloudBuild.handleCancelBuild"
                                     >{{ $t("cancel") }}</UButton
                                 >
+                                <span v-else ref="cloudTargetStatusSpan" id="cloudTargetStatus">
+                                    {{ cloudBuild.state.cloudTargetStatusText }}
+                                </span>
                             </div>
                         </div>
-                        <!-- Firmware Loaded Rows -->
-                        <div v-if="state.firmwareLoadedName" class="info_row">
+                        <!-- Firmware Loaded Rows (online only) -->
+                        <div v-if="state.firmwareLoadedName && !state.firmwareLoadedIsLocal" class="info_row">
                             <strong>{{ $t("firmwareFlasherFirmwareLoaded") }}</strong>
-                            <span>{{ state.firmwareLoadedName }}</span>
-                            <div v-if="!state.firmwareLoadedIsLocal">
+                            <span>{{ state.firmwareLoadedSize }}</span>
+                            <div>
                                 <UButton size="xs" variant="soft" @click="saveFirmware">{{ $t("save") }}</UButton>
                             </div>
                         </div>
-                        <div v-if="state.firmwareLoadedSize" class="info_row">
-                            <strong>{{ $t("firmwareFlasherFirmwareSize") }}</strong>
-                            <span>{{ state.firmwareLoadedSize }}</span>
-                            <div></div>
-                        </div>
                     </div>
-                </UiBox>
-
-                <!-- Standalone firmware-loaded banner for local loads (no release info) -->
-                <UiBox
-                    v-if="!state.releaseInfoVisible && state.firmwareLoadedName && state.firmwareLoadedIsLocal"
-                    :title="$t('firmwareFlasherFirmwareLoaded')"
-                    type="neutral"
-                    class="col-span-1"
-                >
-                    <div>{{ state.firmwareLoadedName }}</div>
-                    <div>{{ state.firmwareLoadedSize }}</div>
                 </UiBox>
             </div>
             <div class="grid-box-spacer"></div>
@@ -2257,6 +2241,7 @@ export default defineComponent({
             handleVerifyBoardContinue,
             handleVerifyBoardDialogClose,
             handleProgressLabelClick,
+            saveFirmware,
         };
     },
 });

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -667,13 +667,7 @@ export default defineComponent({
         const corebuildModeCheckbox = ref(null);
 
         // Buttons
-        const exitDfuButton = ref(null);
-        const flashFirmwareButton = ref(null);
-        const loadRemoteFileButton = ref(null);
-        const loadFileButton = ref(null);
         const cloudBuildCancelButton = ref(null);
-
-        // Progress elements (progressLabel ref removed — using reactive state instead)
 
         // Release info elements
         const releaseInfoContainer = ref(null);
@@ -867,7 +861,7 @@ export default defineComponent({
         const showLoadedFirmware = (filename, bytes) => {
             state.filename = filename;
             state.firmwareLoadedName = filename;
-            state.firmwareLoadedSize = `${bytes} bytes`;
+            state.firmwareLoadedSize = $t("firmwareFlasherFirmwareSize", { bytes });
             state.firmwareLoadedIsLocal = state.localFirmwareLoaded;
 
             if (state.localFirmwareLoaded) {
@@ -980,10 +974,6 @@ export default defineComponent({
             state.progressLabelClass = "invalid";
             gui_log(message);
             enableLoadRemoteFileButton(true);
-            if (loadRemoteFileButton.value) {
-                loadRemoteFileButton.value.textContent = $t("firmwareFlasherButtonLoadOnline");
-            }
-            i18n.localizePage();
         };
 
         const normalizeSelectValue = (value) => (value === "" ? null : value);
@@ -2215,10 +2205,6 @@ export default defineComponent({
             FLASH_MESSAGE_TYPES,
             // Template refs
             sponsorTile,
-            exitDfuButton,
-            flashFirmwareButton,
-            loadRemoteFileButton,
-            loadFileButton,
             cloudBuildCancelButton,
             releaseInfoContainer,
             targetSpan,

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -869,10 +869,7 @@ export default defineComponent({
                 );
             } else {
                 flashingMessage(
-                    `<a class="save_firmware" href="#" title="${$t("firmwareFlasherTooltipSaveFirmware")}">${$t(
-                        "firmwareFlasherFirmwareOnlineLoaded",
-                        { filename, bytes },
-                    )}</a>`,
+                    $t("firmwareFlasherFirmwareOnlineLoaded", { filename, bytes }),
                     FLASH_MESSAGE_TYPES.NEUTRAL,
                 );
             }
@@ -2150,12 +2147,6 @@ export default defineComponent({
             }
         };
 
-        const handleProgressLabelClick = (event) => {
-            if (event.target?.classList.contains("save_firmware")) {
-                saveFirmware();
-            }
-        };
-
         const flashRingColor = computed(() => {
             switch (state.progressLabelClass) {
                 case "invalid":
@@ -2240,7 +2231,6 @@ export default defineComponent({
             handleVerifyBoardAbort,
             handleVerifyBoardContinue,
             handleVerifyBoardDialogClose,
-            handleProgressLabelClick,
             saveFirmware,
         };
     },

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -449,12 +449,18 @@
             >
                 {{ $t("firmwareFlasherFlashFirmware") }}
             </UButton>
-            <UButton :disabled="state.loadRemoteButtonDisabled" @click="handleLoadRemoteFile">
-                {{ $t("firmwareFlasherButtonLoadOnline") }}
-            </UButton>
-            <UButton :disabled="state.loadFileButtonDisabled" @click="handleLoadFile" variant="soft">
-                {{ $t("firmwareFlasherButtonLoadLocal") }}
-            </UButton>
+            <UFieldGroup size="sm" orientation="horizontal" class="!flex">
+                <UButton :disabled="state.loadRemoteButtonDisabled" @click="handleLoadRemoteFile">{{
+                    $t("firmwareFlasherButtonLoadOnline")
+                }}</UButton>
+                <UDropdownMenu
+                    v-slot="{ open }"
+                    :items="loadFirmwareMenuItems"
+                    :content="{ align: 'end', side: 'top' }"
+                >
+                    <UButton :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" square />
+                </UDropdownMenu>
+            </UFieldGroup>
         </div>
 
         <dialog
@@ -2147,6 +2153,23 @@ export default defineComponent({
             }
         };
 
+        const loadFirmwareMenuItems = computed(() => [
+            [
+                {
+                    label: $t("firmwareFlasherButtonLoadOnline"),
+                    icon: "i-lucide-cloud-download",
+                    disabled: state.loadRemoteButtonDisabled,
+                    onSelect: handleLoadRemoteFile,
+                },
+                {
+                    label: $t("firmwareFlasherButtonLoadLocal"),
+                    icon: "i-lucide-hard-drive-download",
+                    disabled: state.loadFileButtonDisabled,
+                    onSelect: handleLoadFile,
+                },
+            ],
+        ]);
+
         const flashRingColor = computed(() => {
             switch (state.progressLabelClass) {
                 case "invalid":
@@ -2166,6 +2189,7 @@ export default defineComponent({
         return {
             state,
             flashRingColor,
+            loadFirmwareMenuItems,
             cloudBuild,
             boardSelection,
             FLASH_MESSAGE_TYPES,

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -428,7 +428,7 @@
 
                 <!-- Standalone firmware-loaded banner for local loads (no release info) -->
                 <UiBox
-                    v-if="!state.releaseInfoVisible && state.firmwareLoadedName"
+                    v-if="!state.releaseInfoVisible && state.firmwareLoadedName && state.firmwareLoadedIsLocal"
                     :title="$t('firmwareFlasherFirmwareLoaded')"
                     type="neutral"
                     class="col-span-1"
@@ -857,15 +857,19 @@ export default defineComponent({
             state.configFilename = hasFilename ? filename : null;
         };
 
+        const clearLoadedFirmwareInfo = () => {
+            state.firmwareLoadedName = "";
+            state.firmwareLoadedSize = "";
+            state.firmwareLoadedIsLocal = false;
+        };
+
         const clearBufferedFirmware = () => {
             clearBoardConfig();
             firmwareFlashing.clearFirmwareState();
             state.firmware_type = undefined;
             state.localFirmwareLoaded = false;
             state.filename = null;
-            state.firmwareLoadedName = "";
-            state.firmwareLoadedSize = "";
-            state.firmwareLoadedIsLocal = false;
+            clearLoadedFirmwareInfo();
         };
 
         const showLoadedFirmware = (filename, bytes) => {
@@ -1269,6 +1273,7 @@ export default defineComponent({
 
             if (!state.localFirmwareLoaded) {
                 enableFlashButton(false);
+                clearLoadedFirmwareInfo();
                 flashingMessage($t("firmwareFlasherLoadFirmwareFile"), FLASH_MESSAGE_TYPES.NEUTRAL);
                 if (firmwareFlashing.getParsedHex() && firmwareFlashing.getParsedHex().bytes_total) {
                     // Changing the board triggers a version change, so we need only dump it here.
@@ -1988,6 +1993,7 @@ export default defineComponent({
             enableLoadRemoteFileButton(false);
 
             state.localFirmwareLoaded = false;
+            clearLoadedFirmwareInfo();
             const buildType = state.selectedBuildType;
             state.developmentFirmwareLoaded = buildType > 1;
 
@@ -2012,6 +2018,7 @@ export default defineComponent({
 
         const processFirmwareFile = async (file, extension, data) => {
             state.localFirmwareLoaded = true;
+            state.releaseInfoVisible = false;
             const result = await firmwareFlashing.processFirmware(data, extension, {
                 flashingMessage,
                 enableFlashButton,

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -14,6 +14,12 @@
                 />
                 <p>{{ state.progressLabelText }} {{ $t("firmwareFlasherPleaseWait") }}</p>
             </div>
+            <div
+                v-else-if="state.progressLabelText && state.progressLabelClass === 'invalid'"
+                class="flash-status-message flash-status-error"
+            >
+                {{ state.progressLabelText }}
+            </div>
             <div class="grid-box-spacer"></div>
             <div class="grid-box col2">
                 <UiBox
@@ -976,8 +982,10 @@ export default defineComponent({
         };
 
         const loadFailed = () => {
-            state.progressLabelText = $t("firmwareFlasherFailedToLoadOnlineFirmware");
+            const message = $t("firmwareFlasherFailedToLoadOnlineFirmware");
+            state.progressLabelText = message;
             state.progressLabelClass = "invalid";
+            gui_log(message);
             enableLoadRemoteFileButton(true);
             if (loadRemoteFileButton.value) {
                 loadRemoteFileButton.value.textContent = $t("firmwareFlasherButtonLoadOnline");
@@ -2159,8 +2167,10 @@ export default defineComponent({
 
         const flashRingColor = computed(() => {
             switch (state.progressLabelClass) {
+                case "invalid":
                 case "erasing":
                     return "error";
+                case "valid":
                 case "flashing":
                     return "success";
                 case "verifying":
@@ -2257,6 +2267,15 @@ export default defineComponent({
         align-items: center;
         justify-content: center;
         gap: 1rem;
+    }
+    .flash-status-message {
+        padding: 0.5rem 1rem;
+        border-radius: 0.25rem;
+        font-size: 0.85rem;
+    }
+    .flash-status-error {
+        background-color: var(--error-500);
+        color: #fff;
     }
     .grid-box-spacer {
         height: 1rem;

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -4,7 +4,14 @@
             <div class="tab_title">{{ $t("tabFirmwareFlasher") }}</div>
             <WikiButton docUrl="firmware_flasher" />
             <SponsorTile ref="sponsorTile" sponsor-type="flash" />
-            <div v-if="state.flashingInProgress" class="data-loading flashing-wait">
+            <div v-if="state.flashingInProgress" class="flashing-wait">
+                <ProgressRing
+                    :value="state.flashProgressValue"
+                    :indeterminate="state.flashProgressValue === 0"
+                    :size="80"
+                    :stroke-width="6"
+                    color="primary"
+                />
                 <p>{{ state.progressLabelText }} {{ $t("firmwareFlasherPleaseWait") }}</p>
             </div>
             <div class="grid-box-spacer"></div>
@@ -309,10 +316,9 @@
                             <strong>{{ $t("firmwareFlasherReleaseTarget") }}</strong>
                             <span ref="targetSpan" class="target">{{ state.targetSpanText }}</span>
                             <div class="board_support">
-                                <a id="targetSupportInfoUrl" :href="state.targetSupportUrl" target="_blank">{{
+                                <UButton size="xs" variant="soft" :to="state.targetSupportUrl" target="_blank">{{
                                     $t("betaflightSupportButton")
-                                }}</a>
-                                <div class="helpicon cf_tip_wide" :title="$t('firmwareFlasherTargetWikiUrlInfo')"></div>
+                                }}</UButton>
                             </div>
                         </div>
 
@@ -387,20 +393,42 @@
                                     {{ cloudBuild.state.cloudTargetStatusText }}</span
                                 >
                             </div>
-                            <div class="btn default_btn">
-                                <a
+                            <div>
+                                <UButton
                                     ref="cloudBuildCancelButton"
-                                    :class="[
-                                        'cloud_build_cancel',
-                                        { disabled: cloudBuild.state.cancelBuildButtonDisabled },
-                                    ]"
-                                    href="#"
-                                    @click.prevent="cloudBuild.handleCancelBuild"
-                                    >{{ $t("cancel") }}</a
+                                    size="xs"
+                                    variant="soft"
+                                    :disabled="cloudBuild.state.cancelBuildButtonDisabled"
+                                    @click="cloudBuild.handleCancelBuild"
+                                    >{{ $t("cancel") }}</UButton
                                 >
                             </div>
                         </div>
+                        <!-- Firmware Loaded Rows -->
+                        <div v-if="state.firmwareLoadedName" class="info_row">
+                            <strong>{{ $t("firmwareFlasherFirmwareLoaded") }}</strong>
+                            <span>{{ state.firmwareLoadedName }}</span>
+                            <div v-if="!state.firmwareLoadedIsLocal">
+                                <UButton size="xs" variant="soft" @click="saveFirmware">{{ $t("save") }}</UButton>
+                            </div>
+                        </div>
+                        <div v-if="state.firmwareLoadedSize" class="info_row">
+                            <strong>{{ $t("firmwareFlasherFirmwareSize") }}</strong>
+                            <span>{{ state.firmwareLoadedSize }}</span>
+                            <div></div>
+                        </div>
                     </div>
+                </UiBox>
+
+                <!-- Standalone firmware-loaded banner for local loads (no release info) -->
+                <UiBox
+                    v-if="!state.releaseInfoVisible && state.firmwareLoadedName"
+                    :title="$t('firmwareFlasherFirmwareLoaded')"
+                    type="neutral"
+                    class="col-span-1"
+                >
+                    <div>{{ state.firmwareLoadedName }}</div>
+                    <div>{{ state.firmwareLoadedSize }}</div>
                 </UiBox>
             </div>
             <div class="grid-box-spacer"></div>
@@ -416,33 +444,19 @@
             </div>
         </div>
 
-        <div class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
-            <div class="flex flex-1 relative items-center">
-                <UProgress
-                    v-model="state.flashProgressValue"
-                    :max="100"
-                    :color="
-                        state.progressLabelClass === 'valid'
-                            ? 'success'
-                            : state.progressLabelClass === 'invalid'
-                              ? 'error'
-                              : 'primary'
-                    "
-                    :ui="{
-                        base: 'border border-default h-7 rounded-md',
-                    }"
-                />
-                <span
-                    ref="progressLabel"
-                    class="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 text-center text-xs text-default w-fit h-fit whitespace-nowrap"
-                    v-html="state.progressLabelText"
-                    @click="handleProgressLabelClick"
-                ></span>
-            </div>
-            <UButton :disabled="state.dfuExitButtonDisabled" @click="handleExitDfu" variant="soft">
+        <div class="content_toolbar toolbar_fixed_bottom">
+            <UButton
+                :disabled="state.dfuExitButtonDisabled"
+                :color="state.dfuExitButtonDisabled ? 'neutral' : 'error'"
+                @click="handleExitDfu"
+            >
                 {{ $t("firmwareFlasherExitDfu") }}
             </UButton>
-            <UButton :disabled="state.flashButtonDisabled" @click="handleFlashFirmware">
+            <UButton
+                :disabled="state.flashButtonDisabled"
+                :color="state.flashButtonDisabled ? 'neutral' : 'success'"
+                @click="handleFlashFirmware"
+            >
                 {{ $t("firmwareFlasherFlashFirmware") }}
             </UButton>
             <UButton :disabled="state.loadRemoteButtonDisabled" @click="handleLoadRemoteFile">
@@ -548,6 +562,7 @@ import { ispConnected } from "../../js/utils/connection.js";
 import FC from "../../js/fc";
 import SponsorTile from "../sponsor/SponsorTile.vue";
 import UiBox from "../elements/UiBox.vue";
+import ProgressRing from "../ProgressRing.vue";
 import SettingRow from "../elements/SettingRow.vue";
 import SettingColumn from "../elements/SettingColumn.vue";
 
@@ -559,6 +574,7 @@ export default defineComponent({
         Multiselect,
         SponsorTile,
         UiBox,
+        ProgressRing,
         SettingRow,
         SettingColumn,
     },
@@ -635,6 +651,9 @@ export default defineComponent({
             targetSupportUrl: "https://betaflight.com/docs/wiki/boards/archive/Missing",
             progressLabelText: "",
             progressLabelClass: "", // "valid", "invalid", "actionRequired"
+            firmwareLoadedName: "",
+            firmwareLoadedSize: "",
+            firmwareLoadedIsLocal: false,
             /** 0–100; drives firmware flash UProgress (replaces native progress element). */
             flashProgressValue: 0,
             osdProtocolNeedsAttention: false, // True if OSD protocol is empty (shows red)
@@ -656,8 +675,7 @@ export default defineComponent({
         const loadFileButton = ref(null);
         const cloudBuildCancelButton = ref(null);
 
-        // Progress elements
-        const progressLabel = ref(null);
+        // Progress elements (progressLabel ref removed — using reactive state instead)
 
         // Release info elements
         const releaseInfoContainer = ref(null);
@@ -827,24 +845,27 @@ export default defineComponent({
             state.firmware_type = undefined;
             state.localFirmwareLoaded = false;
             state.filename = null;
+            state.firmwareLoadedName = "";
+            state.firmwareLoadedSize = "";
+            state.firmwareLoadedIsLocal = false;
         };
 
         const showLoadedFirmware = (filename, bytes) => {
             state.filename = filename;
+            state.firmwareLoadedName = filename;
+            state.firmwareLoadedSize = `${bytes} bytes`;
+            state.firmwareLoadedIsLocal = state.localFirmwareLoaded;
 
             if (state.localFirmwareLoaded) {
                 flashingMessage(
-                    $t("firmwareFlasherFirmwareLocalLoaded", {
-                        filename: filename,
-                        bytes: bytes,
-                    }),
+                    $t("firmwareFlasherFirmwareLocalLoaded", { filename, bytes }),
                     FLASH_MESSAGE_TYPES.NEUTRAL,
                 );
             } else {
                 flashingMessage(
                     `<a class="save_firmware" href="#" title="${$t("firmwareFlasherTooltipSaveFirmware")}">${$t(
                         "firmwareFlasherFirmwareOnlineLoaded",
-                        { filename: filename, bytes: bytes },
+                        { filename, bytes },
                     )}</a>`,
                     FLASH_MESSAGE_TYPES.NEUTRAL,
                 );
@@ -943,10 +964,8 @@ export default defineComponent({
         };
 
         const loadFailed = () => {
-            if (progressLabel.value) {
-                progressLabel.value.setAttribute("i18n", "firmwareFlasherFailedToLoadOnlineFirmware");
-                progressLabel.value.classList.remove("i18n-replaced");
-            }
+            state.progressLabelText = $t("firmwareFlasherFailedToLoadOnlineFirmware");
+            state.progressLabelClass = "invalid";
             enableLoadRemoteFileButton(true);
             if (loadRemoteFileButton.value) {
                 loadRemoteFileButton.value.textContent = $t("firmwareFlasherButtonLoadOnline");
@@ -2139,7 +2158,6 @@ export default defineComponent({
             loadRemoteFileButton,
             loadFileButton,
             cloudBuildCancelButton,
-            progressLabel,
             releaseInfoContainer,
             targetSpan,
             manufacturerInfoDiv,
@@ -2205,14 +2223,14 @@ export default defineComponent({
 .tab-firmware_flasher {
     min-height: 100%;
 
-    .content_wrapper .data-loading {
+    .content_wrapper .flashing-wait {
         min-height: 150px;
         height: 50%;
-        p {
-            text-align: center;
-            margin-top: 100px;
-            padding-top: 1rem;
-        }
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 1rem;
     }
     .grid-box-spacer {
         height: 1rem;
@@ -2730,9 +2748,9 @@ export default defineComponent({
     }
 
     /* Waiting overlay shown during flashing */
-    .flashing-wait {
+    .flashing-wait p {
         text-align: center;
-        padding: 2rem 1rem;
+        padding: 0 1rem;
         font-size: 14px;
     }
 
@@ -2866,40 +2884,6 @@ export default defineComponent({
         position: absolute;
         left: -1.5rem;
         bottom: 0;
-    }
-    .info {
-        flex: 100;
-        position: relative;
-        .progress {
-            width: 100%;
-            height: 30px;
-            border-radius: 0.25rem;
-            overflow: hidden;
-            &::-webkit-progress-bar {
-                background-color: var(--surface-400);
-            }
-        }
-        .progressLabel {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            text-align: center;
-            font-size: 0.75rem;
-            line-height: 1.75rem;
-            &.valid {
-                background-color: var(--success-600);
-                border-radius: 5px;
-            }
-            &.invalid {
-                background-color: var(--error-500);
-                border-radius: 5px;
-            }
-            &.actionRequired {
-                background-color: var(--warning-500);
-                border-radius: 5px;
-            }
-        }
     }
     .btn {
         a {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -513,14 +513,6 @@ dialog {
     width: fit-content;
     max-width: 500px;
     min-width: 300px;
-    .data-loading {
-        margin-top: 16px;
-        margin-bottom: 16px;
-        margin-left: auto;
-        margin-right: auto;
-        width: 100px;
-        height: 100px;
-    }
     .dialogWaitTitle {
         margin-left: auto;
         margin-right: auto;

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -605,28 +605,6 @@ dialog {
         left: -1.5rem;
         bottom: 0;
     }
-    .info {
-        flex: 100;
-        position: relative;
-        .progress {
-            width: 100%;
-            height: 30px;
-            border-radius: 0.25rem;
-            overflow: hidden;
-            &::-webkit-progress-bar {
-                background-color: var(--surface-400);
-            }
-        }
-        .progressLabel {
-            position: absolute;
-            top: 0;
-            left: 0;
-            width: 100%;
-            text-align: center;
-            font-size: 0.75rem;
-            line-height: 1.75rem;
-        }
-    }
     .btn {
         a,
         button {

--- a/src/js/protocols/usbdfu.js
+++ b/src/js/protocols/usbdfu.js
@@ -905,7 +905,7 @@ export class UsbDfuProtocol extends EventTarget {
                     break;
                 }
 
-                this.flashingMessage(i18n.getMessage("stm32Erase"), this.options?.flashMessageTypes?.NEUTRAL);
+                this.flashingMessage(i18n.getMessage("stm32Erase"), this.options?.flashMessageTypes?.ERASING);
                 console.log(`${this.logHead} Executing local chip erase`, erase_pages);
 
                 let page = 0;
@@ -1019,7 +1019,7 @@ export class UsbDfuProtocol extends EventTarget {
                 // upload
                 // we dont need to clear the state as we are already using DFU_DNLOAD
                 console.log(`${this.logHead} Writing data ...`);
-                this.flashingMessage(i18n.getMessage("stm32Flashing"), this.options?.flashMessageTypes?.NEUTRAL);
+                this.flashingMessage(i18n.getMessage("stm32Flashing"), this.options?.flashMessageTypes?.FLASHING);
 
                 blocks = this.hex.data.length - 1;
                 let flashing_block = 0;
@@ -1113,7 +1113,7 @@ export class UsbDfuProtocol extends EventTarget {
             case 5: {
                 // verify
                 console.log(`${this.logHead} Verifying data ...`);
-                this.flashingMessage(i18n.getMessage("stm32Verifying"), this.options?.flashMessageTypes?.NEUTRAL);
+                this.flashingMessage(i18n.getMessage("stm32Verifying"), this.options?.flashMessageTypes?.VERIFYING);
 
                 blocks = this.hex.data.length - 1;
                 let reading_block = 0;

--- a/src/js/protocols/webstm32.js
+++ b/src/js/protocols/webstm32.js
@@ -619,7 +619,7 @@ class STM32Protocol {
                         console.log(`${this.logHead} Executing global chip erase (via extended erase)`);
                         TABS.firmware_flasher.flashingMessage(
                             i18n.getMessage("stm32GlobalEraseExtended"),
-                            TABS.firmware_flasher.FLASH_MESSAGE_TYPES.NEUTRAL,
+                            TABS.firmware_flasher.FLASH_MESSAGE_TYPES.ERASING,
                         );
 
                         this.send([this.command.extended_erase, 0xbb], 1, (reply) => {
@@ -636,7 +636,7 @@ class STM32Protocol {
                         console.log(`${this.logHead} Executing local erase (via extended erase)`);
                         TABS.firmware_flasher.flashingMessage(
                             i18n.getMessage("stm32LocalEraseExtended"),
-                            TABS.firmware_flasher.FLASH_MESSAGE_TYPES.NEUTRAL,
+                            TABS.firmware_flasher.FLASH_MESSAGE_TYPES.ERASING,
                         );
 
                         this.send([this.command.extended_erase, 0xbb], 1, (reply) => {
@@ -751,7 +751,7 @@ class STM32Protocol {
                 console.log(`${this.logHead} Writing data ...`);
                 TABS.firmware_flasher.flashingMessage(
                     i18n.getMessage("stm32Flashing"),
-                    TABS.firmware_flasher.FLASH_MESSAGE_TYPES.NEUTRAL,
+                    TABS.firmware_flasher.FLASH_MESSAGE_TYPES.FLASHING,
                 );
 
                 let blocks = this.hex.data.length - 1,
@@ -844,7 +844,7 @@ class STM32Protocol {
                 console.log(`${this.logHead} Verifying data ...`);
                 TABS.firmware_flasher.flashingMessage(
                     i18n.getMessage("stm32Verifying"),
-                    TABS.firmware_flasher.FLASH_MESSAGE_TYPES.NEUTRAL,
+                    TABS.firmware_flasher.FLASH_MESSAGE_TYPES.VERIFYING,
                 );
 
                 const blocks = this.hex.data.length - 1;


### PR DESCRIPTION
- initial commit to improve firmware flasher layout for AX12

<img width="1038" height="1092" alt="image" src="https://github.com/user-attachments/assets/ac2a4052-26fb-4380-9e90-c42a468e9ded" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shows loaded firmware name and file size for online firmware, with a Save action and clearer loaded-state display
  * Adds a circular progress ring component used across dialogs and flashing flows

* **UI/UX Improvements**
  * Replaces linear loader with a centered circular indeterminate spinner
  * Reworks flashing controls into a toolbar with grouped actions and step-specific status/colors; improved invalid-state messaging and button behavior

* **Localization**
  * Added English labels: "Firmware" and a parameterized file-size string (e.g., "123 bytes")
<!-- end of auto-generated comment: release notes by coderabbit.ai -->