### PR TITLE
wing_tuning: add Wing Tuning tab (MSP, USE_WING gate)

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -576,7 +576,7 @@
         "message": "Yaw Type"
     },
     "wingYawTypeDesc": {
-        "message": "Select how the aircraft yaws. RUDDER uses a rudder servo. DIFF_THRUST uses differential motor thrust; s_yaw is forced to 0 in this mode."
+        "message": "Select how the aircraft yaws. RUDDER uses a rudder servo. DIFF_THRUST uses differential motor thrust; the firmware ignores s_yaw in this mode (your stored value is preserved)."
     },
     "wingAxis": {
         "message": "Axis"
@@ -591,7 +591,7 @@
         "message": "Slider"
     },
     "wingSYawForcedZero": {
-        "message": "Yaw type is DIFF_THRUST, so s_yaw is forced to 0."
+        "message": "Yaw type is DIFF_THRUST — the firmware ignores s_yaw in this mode. Your stored value is preserved for when you switch back to RUDDER."
     },
     "wingAngleModeTitle": {
         "message": "Angle Mode"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -539,6 +539,90 @@
     "tabServos": {
         "message": "Servos"
     },
+    "tabWingTuning": {
+        "message": "Wing Tuning"
+    },
+    "wingTuningStatus": {
+        "message": "Status"
+    },
+    "wingTuningLoading": {
+        "message": "Reading values from FC…"
+    },
+    "wingTuningSaving": {
+        "message": "Saving to FC…"
+    },
+    "wingTuningDirty": {
+        "message": "Unsaved changes. Click Save to write to FC."
+    },
+    "wingTuningClean": {
+        "message": "In sync with FC."
+    },
+    "wingTuningReload": {
+        "message": "Reload from FC"
+    },
+    "wingTuningSave": {
+        "message": "Save to FC"
+    },
+    "wingTuningApiRequired": {
+        "message": "Wing Tuning requires firmware built with USE_WING enabled. Please update or rebuild your flight controller firmware."
+    },
+    "wingSTermTitle": {
+        "message": "S-term (PIDF_S controller)"
+    },
+    "wingSTermDesc": {
+        "message": "S-term translates stick position directly to a servo command. It is the main driver for maneuvers; PID stabilizes the craft around S-term. Recommended start: 50 for all axes. For differential-thrust yaw, set s_yaw to 0."
+    },
+    "wingYawTypeTitle": {
+        "message": "Yaw Type"
+    },
+    "wingYawTypeDesc": {
+        "message": "Select how the aircraft yaws. RUDDER uses a rudder servo. DIFF_THRUST uses differential motor thrust; s_yaw is forced to 0 in this mode."
+    },
+    "wingAxis": {
+        "message": "Axis"
+    },
+    "wingValue": {
+        "message": "Value"
+    },
+    "wingParameter": {
+        "message": "Parameter"
+    },
+    "wingSlider": {
+        "message": "Slider"
+    },
+    "wingSYawForcedZero": {
+        "message": "Yaw type is DIFF_THRUST, so s_yaw is forced to 0."
+    },
+    "wingAngleModeTitle": {
+        "message": "Angle Mode"
+    },
+    "wingAngleModeDesc": {
+        "message": "angle_pitch_offset trims pitch attitude in Angle mode (negative values pitch the nose down). angle_earth_ref controls earth-reference strength; set to 0 to disable axis mixing for wings."
+    },
+    "wingTpaAirspeedTitle": {
+        "message": "TPA Airspeed"
+    },
+    "wingTpaAirspeedDesc": {
+        "message": "Airspeed-based PID attenuation for fixed wings. tpa_mode=PDS enables S-term scaling at low speeds. Set tpa_speed_max_voltage to your battery's full-charge voltage (V × 100) — use the cell-count helper."
+    },
+    "wingTpaAdvancedHint": {
+        "message": "ADVANCED estimation parameters (tpa_speed_adv_*) are CLI-only. Most pilots can use BASIC."
+    },
+    "wingTpaCurveTitle": {
+        "message": "TPA Curve"
+    },
+    "wingTpaCurveDesc": {
+        "message": "TPA curve shape. HYPERBOLIC is recommended for planes. pid_thr0 / pid_thr100 set the PID multiplier at idle and full throttle; stall_throttle is the threshold where PIDs are maxed out."
+    },
+    "wingTpaClassicNoPreview": {
+        "message": "Curve preview only available for HYPERBOLIC type. CLASSIC mode uses tpa_low_rate / tpa_low_breakpoint instead of this curve."
+    },
+    "wingSpaTitle": {
+        "message": "SPA (Setpoint PID Attenuation)"
+    },
+    "wingSpaDesc": {
+        "message": "Reduce PID terms during high-rate maneuvers to prevent bounce-back. I_FREEZE is the recommended starting mode for all axes. Typical start: roll center=200 / width=70, pitch=150/70, yaw=150/70."
+    },
     "tabFailsafe": {
         "message": "Failsafe"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -590,7 +590,7 @@
     "wingSlider": {
         "message": "Slider"
     },
-    "wingSYawForcedZero": {
+    "wingSYawIgnored": {
         "message": "Yaw type is DIFF_THRUST — the firmware ignores s_yaw in this mode. Your stored value is preserved for when you switch back to RUDDER."
     },
     "wingAngleModeTitle": {

--- a/src/components/sidebar/sidebar_items.js
+++ b/src/components/sidebar/sidebar_items.js
@@ -23,6 +23,13 @@ export const sidebarItems = [
         icon: "i-lucide-rotate-ccw",
         buildOptions: ["USE_SERVOS", "USE_WING"],
     },
+    {
+        key: "wing_tuning",
+        mode: "connected",
+        i18n: "tabWingTuning",
+        icon: "i-lucide-plane",
+        buildOptions: ["USE_WING"],
+    },
     { key: "gps", mode: "connected", i18n: "tabGPS", icon: "i-lucide-map-pin", buildOptions: ["USE_GPS"] },
     { key: "motors", mode: "connected", i18n: "tabMotorTesting", icon: "i-lucide-fan" },
     { key: "osd", mode: "connected", i18n: "tabOsd", icon: "i-lucide-monitor", feature: "OSD" },

--- a/src/components/tabs/WingTuningTab.vue
+++ b/src/components/tabs/WingTuningTab.vue
@@ -620,13 +620,12 @@ export default defineComponent({
         const saving = ref(false);
         const error = ref(null);
 
+        // In DIFF_THRUST mode the firmware ignores s_yaw, and the
+        // `s_yaw` input is disabled in the template when this is true.
+        // Don't mutate `fields.s_yaw` here — a user who toggles
+        // RUDDER → DIFF_THRUST → RUDDER would otherwise silently lose
+        // their tuned value.
         const diffThrustMode = computed(() => fields.yaw_type === "DIFF_THRUST");
-
-        watch(diffThrustMode, (isDiff) => {
-            if (isDiff && fields.s_yaw !== 0) {
-                fields.s_yaw = 0;
-            }
-        });
 
         // hasChanges is owned by the Pinia store; mirror it as `dirty`
         // so the template binding stays unchanged.
@@ -637,9 +636,17 @@ export default defineComponent({
         // Capability check — tab requires a USE_WING firmware build.
         // The MSP codes (MSP2_WING_TUNING / MSP2_SET_WING_TUNING) ship
         // in the same firmware PR as USE_WING, so the build-option flag
-        // is sufficient. Per BF convention, API_VERSION_MINOR is bumped
-        // by release maintainers at release-cut time, not per feature
-        // PR — so we don't gate on apiVersion here.
+        // is sufficient at merge time. Per BF convention,
+        // API_VERSION_MINOR is bumped by release maintainers at
+        // release-cut time, not per feature PR — so we don't gate on
+        // apiVersion here yet.
+        //
+        // TODO: once the firmware side (betaflight/betaflight#15124)
+        // allocates a minor API version, tighten this gate with a
+        // `semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_xx)` check so
+        // custom firmware builds that flip USE_WING without picking up
+        // the MSP handlers fall back to the stub instead of hanging on
+        // reload. Suggested by limonspb on PR #5015.
         //
         // Safe-by-default: if FC.CONFIG.buildOptions is undefined/empty
         // (MSP_BUILD_INFO failed or truncated), .includes returns false

--- a/src/components/tabs/WingTuningTab.vue
+++ b/src/components/tabs/WingTuningTab.vue
@@ -44,7 +44,7 @@
                             </div>
                             <div class="grid grid-cols-[180px_100px_1fr] gap-2 items-center">
                                 <span
-                                    title="Trims pitch attitude in Angle mode. Units of 0.1°. Negative pitches the nose down. See BF PR #14009."
+                                    title="Trims pitch attitude in Angle mode. Units of 0.1°. Positive pitches the nose down, negative pitches the nose up. See BF PR #14009."
                                 >
                                     angle_pitch_offset (0.1°)
                                 </span>
@@ -570,11 +570,11 @@
 </template>
 
 <script>
-import { defineComponent, reactive, ref, computed, watch } from "vue";
+import { defineComponent, ref, computed, watch } from "vue";
 import BaseTab from "./BaseTab.vue";
 import UiBox from "../elements/UiBox.vue";
 import SettingRow from "../elements/SettingRow.vue";
-import { useWingTuningStore } from "@/stores/wingTuning";
+import { useWingTuningStore, FIELD_DEFS } from "@/stores/wingTuning";
 import GUI from "../../js/gui";
 import FC from "../../js/fc";
 import MSP from "../../js/msp";
@@ -605,58 +605,16 @@ const ENUM_OPTIONS = Object.fromEntries(
 
 const PID_GAIN_MAX = 200;
 
-// Field definitions: name → parse/format type. "int" and "string" only.
-// Enums (lookup tables) are strings; everything else is int.
-const FIELD_DEFS = [
-    // S-term
-    { name: "s_pitch", type: "int" },
-    { name: "s_roll", type: "int" },
-    { name: "s_yaw", type: "int" },
-    // Yaw type
-    { name: "yaw_type", type: "string" },
-    // Angle mode
-    { name: "angle_pitch_offset", type: "int" },
-    { name: "angle_earth_ref", type: "int" },
-    // TPA mode + airspeed
-    { name: "tpa_mode", type: "string" },
-    { name: "tpa_speed_type", type: "string" },
-    { name: "tpa_speed_basic_delay", type: "int" },
-    { name: "tpa_speed_basic_gravity", type: "int" },
-    { name: "tpa_speed_max_voltage", type: "int" },
-    { name: "tpa_speed_pitch_offset", type: "int" },
-    // TPA curve
-    { name: "tpa_curve_type", type: "string" },
-    { name: "tpa_curve_stall_throttle", type: "int" },
-    { name: "tpa_curve_pid_thr0", type: "int" },
-    { name: "tpa_curve_pid_thr100", type: "int" },
-    { name: "tpa_curve_expo", type: "int" },
-    // SPA
-    { name: "spa_roll_center", type: "int" },
-    { name: "spa_roll_width", type: "int" },
-    { name: "spa_roll_mode", type: "string" },
-    { name: "spa_pitch_center", type: "int" },
-    { name: "spa_pitch_width", type: "int" },
-    { name: "spa_pitch_mode", type: "string" },
-    { name: "spa_yaw_center", type: "int" },
-    { name: "spa_yaw_width", type: "int" },
-    { name: "spa_yaw_mode", type: "string" },
-];
-
-function defaultFields() {
-    const f = {};
-    for (const def of FIELD_DEFS) {
-        f[def.name] = def.type === "string" ? "" : 0;
-    }
-    return f;
-}
-
 export default defineComponent({
     name: "WingTuningTab",
     components: { BaseTab, UiBox, SettingRow },
 
     setup() {
-        const fields = reactive(defaultFields());
         const wingTuningStore = useWingTuningStore();
+        // `fields` is owned by the Pinia store so other code (presets,
+        // wizards, etc.) can read/write through a single SSoT. MSP I/O
+        // remains in this tab.
+        const fields = wingTuningStore.fields;
 
         const loading = ref(false);
         const saving = ref(false);
@@ -674,7 +632,7 @@ export default defineComponent({
         // so the template binding stays unchanged.
         const dirty = computed(() => wingTuningStore.hasChanges);
 
-        watch(fields, () => wingTuningStore.checkForChanges(fields), { deep: true });
+        watch(fields, () => wingTuningStore.checkForChanges(), { deep: true });
 
         // Capability check — tab requires a USE_WING firmware build.
         // The MSP codes (MSP2_WING_TUNING / MSP2_SET_WING_TUNING) ship

--- a/src/components/tabs/WingTuningTab.vue
+++ b/src/components/tabs/WingTuningTab.vue
@@ -572,6 +572,9 @@
 <script>
 import { defineComponent, reactive, ref, computed, watch } from "vue";
 import BaseTab from "./BaseTab.vue";
+import UiBox from "../elements/UiBox.vue";
+import SettingRow from "../elements/SettingRow.vue";
+import { useWingTuningStore } from "@/stores/wingTuning";
 import GUI from "../../js/gui";
 import FC from "../../js/fc";
 import MSP from "../../js/msp";
@@ -653,7 +656,7 @@ export default defineComponent({
 
     setup() {
         const fields = reactive(defaultFields());
-        const initialFields = ref({ ...fields });
+        const wingTuningStore = useWingTuningStore();
 
         const loading = ref(false);
         const saving = ref(false);
@@ -667,7 +670,11 @@ export default defineComponent({
             }
         });
 
-        const dirty = computed(() => FIELD_DEFS.some((def) => fields[def.name] !== initialFields.value[def.name]));
+        // hasChanges is owned by the Pinia store; mirror it as `dirty`
+        // so the template binding stays unchanged.
+        const dirty = computed(() => wingTuningStore.hasChanges);
+
+        watch(fields, () => wingTuningStore.checkForChanges(fields), { deep: true });
 
         // Capability check — tab requires a USE_WING firmware build.
         // The MSP codes (MSP2_WING_TUNING / MSP2_SET_WING_TUNING) ship
@@ -779,7 +786,7 @@ export default defineComponent({
                         fields[def.name] = FC.WING_TUNING[def.name];
                     }
                 }
-                initialFields.value = { ...fields };
+                wingTuningStore.storeOriginals();
             } catch (e) {
                 console.error("[WingTuning] reload failed:", e);
                 error.value = e.message || String(e);
@@ -800,7 +807,7 @@ export default defineComponent({
                 }
                 await MSP.promise(MSPCodes.MSP2_SET_WING_TUNING, mspHelper.crunch(MSPCodes.MSP2_SET_WING_TUNING));
                 await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
-                initialFields.value = { ...fields };
+                wingTuningStore.storeOriginals();
             } catch (e) {
                 console.error("[WingTuning] save failed:", e);
                 error.value = e.message || String(e);

--- a/src/components/tabs/WingTuningTab.vue
+++ b/src/components/tabs/WingTuningTab.vue
@@ -1,0 +1,847 @@
+<template>
+    <BaseTab tab-name="wing_tuning">
+        <div class="content_wrapper">
+            <div class="tab_title">{{ $t("tabWingTuning") }}</div>
+
+            <!-- Firmware too old for MSP path — tab is effectively disabled. -->
+            <UiBox v-if="!apiOk" type="warning" :title="$t('wingTuningStatus')">
+                <p>{{ $t("wingTuningApiRequired") }}</p>
+            </UiBox>
+
+            <template v-else>
+                <!-- Status panel -->
+                <UiBox :title="$t('wingTuningStatus')" :type="error ? 'error' : 'default'">
+                    <p v-if="loading">{{ $t("wingTuningLoading") }}</p>
+                    <p v-else-if="error" class="text-error">{{ error }}</p>
+                    <p v-else-if="saving">{{ $t("wingTuningSaving") }}</p>
+                    <p v-else>
+                        <span v-if="dirty">{{ $t("wingTuningDirty") }}</span>
+                        <span v-else>{{ $t("wingTuningClean") }}</span>
+                    </p>
+                </UiBox>
+
+                <!-- Yaw Type + Angle Mode -->
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                    <UiBox :title="$t('wingYawTypeTitle')">
+                        <p>{{ $t("wingYawTypeDesc") }}</p>
+                        <USelect
+                            v-model="fields.yaw_type"
+                            :items="enumOptions.yaw_type"
+                            size="sm"
+                            :disabled="loading"
+                            class="min-w-40"
+                        />
+                    </UiBox>
+                    <UiBox :title="$t('wingAngleModeTitle')">
+                        <p>{{ $t("wingAngleModeDesc") }}</p>
+                        <div class="flex flex-col gap-2">
+                            <div
+                                class="grid grid-cols-[180px_100px_1fr] gap-2 items-center text-sm font-semibold text-dimmed"
+                            >
+                                <span>{{ $t("wingParameter") }}</span>
+                                <span>{{ $t("wingValue") }}</span>
+                                <span>{{ $t("wingSlider") }}</span>
+                            </div>
+                            <div class="grid grid-cols-[180px_100px_1fr] gap-2 items-center">
+                                <span
+                                    title="Trims pitch attitude in Angle mode. Units of 0.1°. Negative pitches the nose down. See BF PR #14009."
+                                >
+                                    angle_pitch_offset (0.1°)
+                                </span>
+                                <UInputNumber
+                                    v-model="fields.angle_pitch_offset"
+                                    :min="-1000"
+                                    :max="1000"
+                                    size="sm"
+                                    :disabled="loading"
+                                />
+                                <USlider
+                                    v-model="fields.angle_pitch_offset"
+                                    :min="-1000"
+                                    :max="1000"
+                                    :disabled="loading"
+                                />
+                            </div>
+                            <div class="grid grid-cols-[180px_100px_1fr] gap-2 items-center">
+                                <span
+                                    title="Earth-reference strength for Angle mode axis mixing. Set 0 to disable mixing for wings (often preferable)."
+                                >
+                                    angle_earth_ref
+                                </span>
+                                <UInputNumber
+                                    v-model="fields.angle_earth_ref"
+                                    :min="0"
+                                    :max="100"
+                                    size="sm"
+                                    :disabled="loading"
+                                />
+                                <USlider v-model="fields.angle_earth_ref" :min="0" :max="100" :disabled="loading" />
+                            </div>
+                        </div>
+                    </UiBox>
+                </div>
+
+                <!-- S-term -->
+                <UiBox :title="$t('wingSTermTitle')">
+                    <p>{{ $t("wingSTermDesc") }}</p>
+                    <div class="flex flex-col gap-2">
+                        <div
+                            class="grid grid-cols-[80px_120px_1fr] gap-2 items-center text-sm font-semibold text-dimmed"
+                        >
+                            <span>{{ $t("wingAxis") }}</span>
+                            <span>{{ $t("wingValue") }}</span>
+                            <span>{{ $t("wingSlider") }}</span>
+                        </div>
+                        <div
+                            v-for="axis in ['pitch', 'roll', 'yaw']"
+                            :key="axis"
+                            class="grid grid-cols-[80px_120px_1fr] gap-2 items-center"
+                        >
+                            <span class="capitalize">{{ axis }}</span>
+                            <UInputNumber
+                                v-model="fields[`s_${axis}`]"
+                                :min="0"
+                                :max="PID_GAIN_MAX"
+                                size="sm"
+                                :disabled="loading || (axis === 'yaw' && diffThrustMode)"
+                            />
+                            <USlider
+                                v-model="fields[`s_${axis}`]"
+                                :min="0"
+                                :max="PID_GAIN_MAX"
+                                :disabled="loading || (axis === 'yaw' && diffThrustMode)"
+                            />
+                        </div>
+                    </div>
+                    <p v-if="diffThrustMode" class="mt-2 text-warning">{{ $t("wingSYawForcedZero") }}</p>
+                </UiBox>
+
+                <!-- TPA Mode + Airspeed -->
+                <UiBox :title="$t('wingTpaAirspeedTitle')">
+                    <p>{{ $t("wingTpaAirspeedDesc") }}</p>
+                    <div class="flex flex-col gap-2">
+                        <div
+                            class="grid grid-cols-[260px_140px_1fr] gap-2 items-center text-sm font-semibold text-dimmed"
+                        >
+                            <span>{{ $t("wingParameter") }}</span>
+                            <span>{{ $t("wingValue") }}</span>
+                            <span></span>
+                        </div>
+                        <div class="grid grid-cols-[260px_140px_1fr] gap-2 items-center">
+                            <span
+                                title="PID scaling mode. PDS enables S-term scaling at low speeds for wings. See BF PR #14010."
+                            >
+                                tpa_mode
+                            </span>
+                            <USelect
+                                v-model="fields.tpa_mode"
+                                :items="enumOptions.tpa_mode"
+                                size="sm"
+                                :disabled="loading"
+                                class="col-span-2"
+                            />
+                        </div>
+                        <div class="grid grid-cols-[260px_140px_1fr] gap-2 items-center">
+                            <span
+                                title="Airspeed estimation model. BASIC works for most pilots. ADVANCED uses additional params (adv_prop_pitch, adv_mass, adv_drag_k, adv_thrust) that must be set via CLI. See BF PR #13895."
+                            >
+                                tpa_speed_type
+                            </span>
+                            <USelect
+                                v-model="fields.tpa_speed_type"
+                                :items="enumOptions.tpa_speed_type"
+                                size="sm"
+                                :disabled="loading"
+                                class="col-span-2"
+                            />
+                        </div>
+                        <div class="grid grid-cols-[260px_140px_1fr] gap-2 items-center">
+                            <span title="BASIC airspeed model filter delay. See BF PR #13895 for tuning procedure.">
+                                tpa_speed_basic_delay
+                            </span>
+                            <UInputNumber
+                                v-model="fields.tpa_speed_basic_delay"
+                                :min="1"
+                                :max="65535"
+                                size="sm"
+                                :disabled="loading"
+                            />
+                            <span></span>
+                        </div>
+                        <div class="grid grid-cols-[260px_140px_1fr] gap-2 items-center">
+                            <span title="BASIC airspeed model gravity term. See BF PR #13895 for tuning.">
+                                tpa_speed_basic_gravity
+                            </span>
+                            <UInputNumber
+                                v-model="fields.tpa_speed_basic_gravity"
+                                :min="1"
+                                :max="65535"
+                                size="sm"
+                                :disabled="loading"
+                            />
+                            <span></span>
+                        </div>
+                        <div class="grid grid-cols-[260px_140px_1fr] gap-2 items-center">
+                            <span
+                                title="Battery full-charge voltage × 100. Example: 3S = 1260 (12.6V), 6S = 2520 (25.2V). Use the cell-count dropdown to set correctly."
+                            >
+                                tpa_speed_max_voltage <small>(V × 100)</small>
+                            </span>
+                            <UInputNumber
+                                v-model="fields.tpa_speed_max_voltage"
+                                :min="0"
+                                :max="3360"
+                                size="sm"
+                                :disabled="loading"
+                            />
+                            <USelect
+                                :model-value="detectedCellCount"
+                                @update:model-value="onCellCountChange"
+                                :items="cellCountItems"
+                                size="sm"
+                                :disabled="loading"
+                                placeholder="— cells —"
+                                title="Pick your cell count to auto-fill max_voltage."
+                                class="max-w-44"
+                            />
+                        </div>
+                        <div class="grid grid-cols-[260px_140px_1fr] gap-2 items-center">
+                            <span
+                                title="Pitch offset for BASIC airspeed estimation, in units of 0.1° (firmware comment: 'pitch offset in degrees*10 for craft speed estimation'). Compensates for FC mounting angle relative to the wing's aero-zero reference. Default 0."
+                            >
+                                tpa_speed_pitch_offset (0.1°)
+                            </span>
+                            <UInputNumber
+                                v-model="fields.tpa_speed_pitch_offset"
+                                :min="-32768"
+                                :max="32767"
+                                size="sm"
+                                :disabled="loading"
+                            />
+                            <span></span>
+                        </div>
+                    </div>
+                    <p v-if="fields.tpa_speed_type === 'ADVANCED'" class="mt-2 text-warning">
+                        {{ $t("wingTpaAdvancedHint") }}
+                    </p>
+                </UiBox>
+
+                <!-- TPA Curve -->
+                <UiBox :title="$t('wingTpaCurveTitle')">
+                    <p>{{ $t("wingTpaCurveDesc") }}</p>
+                    <div class="flex flex-col gap-2">
+                        <div
+                            class="grid grid-cols-[220px_120px_1fr] gap-2 items-center text-sm font-semibold text-dimmed"
+                        >
+                            <span>{{ $t("wingParameter") }}</span>
+                            <span>{{ $t("wingValue") }}</span>
+                            <span>{{ $t("wingSlider") }}</span>
+                        </div>
+                        <div class="grid grid-cols-[220px_120px_1fr] gap-2 items-center">
+                            <span
+                                title="Curve shape. HYPERBOLIC is recommended for planes. CLASSIC uses tpa_low_* params (CLI only) instead of this curve. See BF PR #13805."
+                            >
+                                tpa_curve_type
+                            </span>
+                            <USelect
+                                v-model="fields.tpa_curve_type"
+                                :items="enumOptions.tpa_curve_type"
+                                size="sm"
+                                :disabled="loading"
+                                class="col-span-2"
+                            />
+                        </div>
+                        <div class="grid grid-cols-[220px_120px_1fr] gap-2 items-center">
+                            <span
+                                title="Throttle % below which PID multiplier stays at pid_thr0. Dashed yellow line on the curve."
+                            >
+                                tpa_curve_stall_throttle
+                            </span>
+                            <UInputNumber
+                                v-model="fields.tpa_curve_stall_throttle"
+                                :min="0"
+                                :max="100"
+                                size="sm"
+                                :disabled="loading"
+                            />
+                            <USlider
+                                v-model="fields.tpa_curve_stall_throttle"
+                                :min="0"
+                                :max="100"
+                                :disabled="loading"
+                            />
+                        </div>
+                        <div class="grid grid-cols-[220px_120px_1fr] gap-2 items-center">
+                            <span title="PID multiplier % at zero throttle / stall. Typical: 200 (2.0×) for planes.">
+                                tpa_curve_pid_thr0
+                            </span>
+                            <UInputNumber
+                                v-model="fields.tpa_curve_pid_thr0"
+                                :min="0"
+                                :max="1000"
+                                size="sm"
+                                :disabled="loading"
+                            />
+                            <USlider v-model="fields.tpa_curve_pid_thr0" :min="0" :max="1000" :disabled="loading" />
+                        </div>
+                        <div class="grid grid-cols-[220px_120px_1fr] gap-2 items-center">
+                            <span title="PID multiplier % at full throttle. Typical: 70 (0.7×) for planes.">
+                                tpa_curve_pid_thr100
+                            </span>
+                            <UInputNumber
+                                v-model="fields.tpa_curve_pid_thr100"
+                                :min="0"
+                                :max="1000"
+                                size="sm"
+                                :disabled="loading"
+                            />
+                            <USlider v-model="fields.tpa_curve_pid_thr100" :min="0" :max="1000" :disabled="loading" />
+                        </div>
+                        <div class="grid grid-cols-[220px_120px_1fr] gap-2 items-center">
+                            <span
+                                title="Curve slope parameter. Divided by 10 in the formula. Values near 10 approach a step; negative values invert curvature."
+                            >
+                                tpa_curve_expo
+                            </span>
+                            <UInputNumber
+                                v-model="fields.tpa_curve_expo"
+                                :min="-100"
+                                :max="100"
+                                size="sm"
+                                :disabled="loading"
+                            />
+                            <USlider v-model="fields.tpa_curve_expo" :min="-100" :max="100" :disabled="loading" />
+                        </div>
+                    </div>
+                    <!-- TPA curve live preview (HYPERBOLIC math from Limon's PR #13805) -->
+                    <div v-if="fields.tpa_curve_type === 'HYPERBOLIC'" class="flex justify-center mt-3">
+                        <svg :width="tpaChart.width" :height="tpaChart.height" class="rounded bg-neutral-800/40">
+                            <!-- axes -->
+                            <line
+                                :x1="tpaChart.padLeft"
+                                :y1="tpaChart.padTop"
+                                :x2="tpaChart.padLeft"
+                                :y2="tpaChart.height - tpaChart.padBottom"
+                                stroke="#888"
+                                stroke-width="1"
+                            />
+                            <line
+                                :x1="tpaChart.padLeft"
+                                :y1="tpaChart.height - tpaChart.padBottom"
+                                :x2="tpaChart.width - tpaChart.padRight"
+                                :y2="tpaChart.height - tpaChart.padBottom"
+                                stroke="#888"
+                                stroke-width="1"
+                            />
+                            <!-- stall threshold vertical line -->
+                            <line
+                                :x1="tpaChart.stallX"
+                                :y1="tpaChart.padTop"
+                                :x2="tpaChart.stallX"
+                                :y2="tpaChart.height - tpaChart.padBottom"
+                                stroke="#c80"
+                                stroke-width="1"
+                                stroke-dasharray="4 3"
+                            />
+                            <text :x="tpaChart.stallX + 3" :y="tpaChart.padTop + 10" fill="#c80" font-size="10">
+                                stall
+                            </text>
+                            <!-- curve -->
+                            <path :d="tpaChart.pathD" fill="none" stroke="#ffb800" stroke-width="2" />
+                            <!-- labels -->
+                            <text
+                                :x="tpaChart.padLeft - 4"
+                                :y="tpaChart.padTop + 4"
+                                text-anchor="end"
+                                fill="#aaa"
+                                font-size="10"
+                            >
+                                {{ tpaChart.yMax }}
+                            </text>
+                            <text
+                                :x="tpaChart.padLeft - 4"
+                                :y="tpaChart.height - tpaChart.padBottom"
+                                text-anchor="end"
+                                fill="#aaa"
+                                font-size="10"
+                            >
+                                {{ tpaChart.yMin }}
+                            </text>
+                            <text :x="tpaChart.padLeft" :y="tpaChart.height - 4" fill="#aaa" font-size="10">0%</text>
+                            <text
+                                :x="tpaChart.width - tpaChart.padRight"
+                                :y="tpaChart.height - 4"
+                                text-anchor="end"
+                                fill="#aaa"
+                                font-size="10"
+                            >
+                                100% throttle
+                            </text>
+                        </svg>
+                    </div>
+                    <p v-else class="text-sm text-neutral-500 italic mt-2">
+                        {{ $t("wingTpaClassicNoPreview") }}
+                    </p>
+                </UiBox>
+
+                <!-- SPA -->
+                <UiBox :title="$t('wingSpaTitle')">
+                    <p>{{ $t("wingSpaDesc") }}</p>
+                    <div class="flex flex-col gap-3">
+                        <div
+                            class="grid grid-cols-[60px_100px_1fr_100px_1fr_140px] gap-2 items-center text-sm font-semibold text-dimmed"
+                        >
+                            <span>{{ $t("wingAxis") }}</span>
+                            <span>Center</span>
+                            <span></span>
+                            <span>Width</span>
+                            <span></span>
+                            <span>Mode</span>
+                        </div>
+                        <template v-for="axis in ['roll', 'pitch', 'yaw']" :key="axis">
+                            <div class="grid grid-cols-[60px_100px_1fr_100px_1fr_140px] gap-2 items-center">
+                                <span class="capitalize">{{ axis }}</span>
+                                <UInputNumber
+                                    v-model="fields[`spa_${axis}_center`]"
+                                    :min="0"
+                                    :max="65535"
+                                    size="sm"
+                                    :disabled="loading"
+                                />
+                                <USlider
+                                    v-model="fields[`spa_${axis}_center`]"
+                                    :min="0"
+                                    :max="SPA_SETPOINT_MAX"
+                                    :disabled="loading"
+                                />
+                                <UInputNumber
+                                    v-model="fields[`spa_${axis}_width`]"
+                                    :min="0"
+                                    :max="65535"
+                                    size="sm"
+                                    :disabled="loading"
+                                />
+                                <USlider
+                                    v-model="fields[`spa_${axis}_width`]"
+                                    :min="0"
+                                    :max="SPA_WIDTH_SLIDER_MAX"
+                                    :disabled="loading"
+                                />
+                                <USelect
+                                    v-model="fields[`spa_${axis}_mode`]"
+                                    :items="enumOptions.spa_mode"
+                                    size="sm"
+                                    :disabled="loading"
+                                />
+                            </div>
+                            <div v-if="fields[`spa_${axis}_mode`] !== 'OFF'" class="flex justify-center">
+                                <svg
+                                    :width="spaChart(axis).width"
+                                    :height="spaChart(axis).height"
+                                    class="rounded bg-neutral-800/40"
+                                >
+                                    <!-- gridlines at 0.5 PID -->
+                                    <line
+                                        :x1="spaChart(axis).padLeft"
+                                        :y1="spaChart(axis).midY"
+                                        :x2="spaChart(axis).width - spaChart(axis).padRight"
+                                        :y2="spaChart(axis).midY"
+                                        stroke="#444"
+                                        stroke-width="1"
+                                        stroke-dasharray="2 3"
+                                    />
+                                    <!-- axes -->
+                                    <line
+                                        :x1="spaChart(axis).padLeft"
+                                        :y1="spaChart(axis).padTop"
+                                        :x2="spaChart(axis).padLeft"
+                                        :y2="spaChart(axis).height - spaChart(axis).padBottom"
+                                        stroke="#888"
+                                        stroke-width="1"
+                                    />
+                                    <line
+                                        :x1="spaChart(axis).padLeft"
+                                        :y1="spaChart(axis).height - spaChart(axis).padBottom"
+                                        :x2="spaChart(axis).width - spaChart(axis).padRight"
+                                        :y2="spaChart(axis).height - spaChart(axis).padBottom"
+                                        stroke="#888"
+                                        stroke-width="1"
+                                    />
+                                    <!-- left limit (green dashed) -->
+                                    <line
+                                        :x1="spaChart(axis).leftLimitX"
+                                        :y1="spaChart(axis).padTop"
+                                        :x2="spaChart(axis).leftLimitX"
+                                        :y2="spaChart(axis).height - spaChart(axis).padBottom"
+                                        stroke="#3c3"
+                                        stroke-width="1"
+                                        stroke-dasharray="4 3"
+                                    />
+                                    <!-- right limit (green dashed) -->
+                                    <line
+                                        :x1="spaChart(axis).rightLimitX"
+                                        :y1="spaChart(axis).padTop"
+                                        :x2="spaChart(axis).rightLimitX"
+                                        :y2="spaChart(axis).height - spaChart(axis).padBottom"
+                                        stroke="#3c3"
+                                        stroke-width="1"
+                                        stroke-dasharray="4 3"
+                                    />
+                                    <!-- center (red dashed) -->
+                                    <line
+                                        :x1="spaChart(axis).centerX"
+                                        :y1="spaChart(axis).padTop"
+                                        :x2="spaChart(axis).centerX"
+                                        :y2="spaChart(axis).height - spaChart(axis).padBottom"
+                                        stroke="#e44"
+                                        stroke-width="1"
+                                        stroke-dasharray="4 3"
+                                    />
+                                    <!-- curve -->
+                                    <path :d="spaChart(axis).pathD" fill="none" stroke="#3af" stroke-width="2" />
+                                    <!-- labels -->
+                                    <text
+                                        :x="spaChart(axis).padLeft - 4"
+                                        :y="spaChart(axis).padTop + 4"
+                                        text-anchor="end"
+                                        fill="#aaa"
+                                        font-size="10"
+                                    >
+                                        1.0
+                                    </text>
+                                    <text
+                                        :x="spaChart(axis).padLeft - 4"
+                                        :y="spaChart(axis).height - spaChart(axis).padBottom"
+                                        text-anchor="end"
+                                        fill="#aaa"
+                                        font-size="10"
+                                    >
+                                        0.0
+                                    </text>
+                                    <text
+                                        :x="spaChart(axis).padLeft"
+                                        :y="spaChart(axis).height - 4"
+                                        fill="#aaa"
+                                        font-size="10"
+                                    >
+                                        0
+                                    </text>
+                                    <text
+                                        :x="spaChart(axis).width - spaChart(axis).padRight"
+                                        :y="spaChart(axis).height - 4"
+                                        text-anchor="end"
+                                        fill="#aaa"
+                                        font-size="10"
+                                    >
+                                        {{ SPA_SETPOINT_MAX }} setpoint
+                                    </text>
+                                    <text
+                                        :x="spaChart(axis).centerX + 3"
+                                        :y="spaChart(axis).padTop + 10"
+                                        fill="#e44"
+                                        font-size="10"
+                                    >
+                                        center
+                                    </text>
+                                </svg>
+                            </div>
+                        </template>
+                    </div>
+                </UiBox>
+            </template>
+        </div>
+
+        <!-- Sticky bottom-right toolbar, matching ServosTab / PortsTab / etc.
+             Global `a.disabled` CSS (main.less:47) greys out + disables
+             pointer-events, so click is blocked automatically. -->
+        <div class="content_toolbar toolbar_fixed_bottom" v-if="apiOk">
+            <div class="btn save_btn">
+                <a class="update" href="#" :class="{ disabled: loading || saving || !dirty }" @click.prevent="save">{{
+                    $t("wingTuningSave")
+                }}</a>
+            </div>
+            <div class="btn save_btn">
+                <a class="update" href="#" :class="{ disabled: loading || saving }" @click.prevent="reload">{{
+                    $t("wingTuningReload")
+                }}</a>
+            </div>
+        </div>
+    </BaseTab>
+</template>
+
+<script>
+import { defineComponent, reactive, ref, computed, watch } from "vue";
+import BaseTab from "./BaseTab.vue";
+import GUI from "../../js/gui";
+import FC from "../../js/fc";
+import MSP from "../../js/msp";
+import MSPCodes from "../../js/msp/MSPCodes";
+import { mspHelper } from "../../js/msp/MSPHelper";
+import { computeTpaCurve, computeSpaCurve, SPA_SETPOINT_MAX } from "../../js/utils/wing_math.js";
+import { WING_ENUM_TABLES } from "../../js/utils/wingEnumLookups.js";
+
+// Friendly labels for a few enum values where the raw firmware string
+// alone is ambiguous in the UI. Anything not listed here renders the
+// raw string from WING_ENUM_TABLES.
+const ENUM_LABEL_OVERRIDES = {
+    tpa_mode: { PDS: "PDS (wing)" },
+    tpa_speed_type: { ADVANCED: "ADVANCED (CLI only)" },
+};
+
+// Pre-built {value, label} arrays per enum table. Driving the dropdowns
+// from this avoids drift between the UI options and what the MSP crunch
+// path (`enumStringToIndex`) accepts — a firmware enum reorder shows up
+// in one source-of-truth file (`wingEnumLookups.js`) and fixes both at
+// once.
+const ENUM_OPTIONS = Object.fromEntries(
+    Object.entries(WING_ENUM_TABLES).map(([table, values]) => [
+        table,
+        values.map((value) => ({ value, label: ENUM_LABEL_OVERRIDES[table]?.[value] ?? value })),
+    ]),
+);
+
+const PID_GAIN_MAX = 200;
+
+// Field definitions: name → parse/format type. "int" and "string" only.
+// Enums (lookup tables) are strings; everything else is int.
+const FIELD_DEFS = [
+    // S-term
+    { name: "s_pitch", type: "int" },
+    { name: "s_roll", type: "int" },
+    { name: "s_yaw", type: "int" },
+    // Yaw type
+    { name: "yaw_type", type: "string" },
+    // Angle mode
+    { name: "angle_pitch_offset", type: "int" },
+    { name: "angle_earth_ref", type: "int" },
+    // TPA mode + airspeed
+    { name: "tpa_mode", type: "string" },
+    { name: "tpa_speed_type", type: "string" },
+    { name: "tpa_speed_basic_delay", type: "int" },
+    { name: "tpa_speed_basic_gravity", type: "int" },
+    { name: "tpa_speed_max_voltage", type: "int" },
+    { name: "tpa_speed_pitch_offset", type: "int" },
+    // TPA curve
+    { name: "tpa_curve_type", type: "string" },
+    { name: "tpa_curve_stall_throttle", type: "int" },
+    { name: "tpa_curve_pid_thr0", type: "int" },
+    { name: "tpa_curve_pid_thr100", type: "int" },
+    { name: "tpa_curve_expo", type: "int" },
+    // SPA
+    { name: "spa_roll_center", type: "int" },
+    { name: "spa_roll_width", type: "int" },
+    { name: "spa_roll_mode", type: "string" },
+    { name: "spa_pitch_center", type: "int" },
+    { name: "spa_pitch_width", type: "int" },
+    { name: "spa_pitch_mode", type: "string" },
+    { name: "spa_yaw_center", type: "int" },
+    { name: "spa_yaw_width", type: "int" },
+    { name: "spa_yaw_mode", type: "string" },
+];
+
+function defaultFields() {
+    const f = {};
+    for (const def of FIELD_DEFS) {
+        f[def.name] = def.type === "string" ? "" : 0;
+    }
+    return f;
+}
+
+export default defineComponent({
+    name: "WingTuningTab",
+    components: { BaseTab, UiBox, SettingRow },
+
+    setup() {
+        const fields = reactive(defaultFields());
+        const initialFields = ref({ ...fields });
+
+        const loading = ref(false);
+        const saving = ref(false);
+        const error = ref(null);
+
+        const diffThrustMode = computed(() => fields.yaw_type === "DIFF_THRUST");
+
+        watch(diffThrustMode, (isDiff) => {
+            if (isDiff && fields.s_yaw !== 0) {
+                fields.s_yaw = 0;
+            }
+        });
+
+        const dirty = computed(() => FIELD_DEFS.some((def) => fields[def.name] !== initialFields.value[def.name]));
+
+        // Capability check — tab requires a USE_WING firmware build.
+        // The MSP codes (MSP2_WING_TUNING / MSP2_SET_WING_TUNING) ship
+        // in the same firmware PR as USE_WING, so the build-option flag
+        // is sufficient. Per BF convention, API_VERSION_MINOR is bumped
+        // by release maintainers at release-cut time, not per feature
+        // PR — so we don't gate on apiVersion here.
+        //
+        // Safe-by-default: if FC.CONFIG.buildOptions is undefined/empty
+        // (MSP_BUILD_INFO failed or truncated), .includes returns false
+        // → stub shown, no crash.
+        const apiOk = computed(() => {
+            const opts = FC.CONFIG?.buildOptions;
+            return Array.isArray(opts) && opts.includes("USE_WING");
+        });
+
+        // Cell-count helper: derive S-count from tpa_speed_max_voltage (V×100).
+        // Full charge per cell = 4.2V → V×100 / 420 ≈ cell count.
+        const detectedCellCount = computed(() => {
+            const v = fields.tpa_speed_max_voltage;
+            if (!v) {
+                return "";
+            }
+            const n = Math.round(v / 420);
+            return n >= 2 && n <= 8 ? n : "";
+        });
+
+        const cellCountItems = [2, 3, 4, 5, 6, 7, 8].map((n) => ({
+            label: `${n}S (${(n * 4.2).toFixed(1)}V)`,
+            value: n,
+        }));
+
+        function onCellCountChange(value) {
+            const n = Number.parseInt(value, 10);
+            if (!Number.isNaN(n)) {
+                fields.tpa_speed_max_voltage = n * 420;
+            }
+        }
+
+        // TPA curve chart geometry (reactive).
+        const tpaChart = computed(() => {
+            const stall = fields.tpa_curve_stall_throttle;
+            const thr0 = fields.tpa_curve_pid_thr0;
+            const thr100 = fields.tpa_curve_pid_thr100;
+            const expo = fields.tpa_curve_expo;
+            const points = computeTpaCurve(stall, thr0, thr100, expo);
+
+            const width = 480,
+                height = 200;
+            const padLeft = 40,
+                padRight = 16,
+                padTop = 16,
+                padBottom = 28;
+            const plotW = width - padLeft - padRight;
+            const plotH = height - padTop - padBottom;
+            const yMin = Math.min(thr0, thr100, 50) - 10;
+            const yMax = Math.max(thr0, thr100, 100) + 10;
+            const yRange = yMax - yMin || 1;
+            const toX = (t) => padLeft + (t / 100) * plotW;
+            const toY = (m) => padTop + plotH - ((m - yMin) / yRange) * plotH;
+            const pathD = points
+                .map((p, i) => `${i === 0 ? "M" : "L"}${toX(p.throttle).toFixed(1)},${toY(p.multiplier).toFixed(1)}`)
+                .join(" ");
+            const stallX = toX(stall);
+            return { width, height, padLeft, padRight, padTop, padBottom, pathD, stallX, yMin, yMax };
+        });
+
+        function spaChart(axis) {
+            const center = fields[`spa_${axis}_center`] || 0;
+            const width = fields[`spa_${axis}_width`] || 0;
+            const points = computeSpaCurve(center, width);
+            const chartW = 420,
+                chartH = 140;
+            const padLeft = 34,
+                padRight = 16,
+                padTop = 12,
+                padBottom = 22;
+            const plotW = chartW - padLeft - padRight;
+            const plotH = chartH - padTop - padBottom;
+            const toX = (s) => padLeft + (s / SPA_SETPOINT_MAX) * plotW;
+            const toY = (m) => padTop + plotH - m * plotH;
+            const pathD = points
+                .map((p, i) => `${i === 0 ? "M" : "L"}${toX(p.setpoint).toFixed(1)},${toY(p.multiplier).toFixed(1)}`)
+                .join(" ");
+            const leftLimit = Math.max(0, center - width / 2);
+            const rightLimit = Math.min(SPA_SETPOINT_MAX, center + width / 2);
+            return {
+                width: chartW,
+                height: chartH,
+                padLeft,
+                padRight,
+                padTop,
+                padBottom,
+                pathD,
+                centerX: toX(Math.min(SPA_SETPOINT_MAX, center)),
+                leftLimitX: toX(leftLimit),
+                rightLimitX: toX(rightLimit),
+                midY: padTop + plotH / 2,
+            };
+        }
+
+        async function reload() {
+            loading.value = true;
+            error.value = null;
+            try {
+                await MSP.promise(MSPCodes.MSP2_WING_TUNING);
+                for (const def of FIELD_DEFS) {
+                    if (FC.WING_TUNING[def.name] !== undefined) {
+                        fields[def.name] = FC.WING_TUNING[def.name];
+                    }
+                }
+                initialFields.value = { ...fields };
+            } catch (e) {
+                console.error("[WingTuning] reload failed:", e);
+                error.value = e.message || String(e);
+            } finally {
+                loading.value = false;
+            }
+        }
+
+        async function save() {
+            saving.value = true;
+            error.value = null;
+            try {
+                // Copy form state into FC.WING_TUNING so crunch reads the
+                // correct values. Enum strings pass through; crunch maps
+                // them to indices via wingEnumLookups.
+                for (const def of FIELD_DEFS) {
+                    FC.WING_TUNING[def.name] = fields[def.name];
+                }
+                await MSP.promise(MSPCodes.MSP2_SET_WING_TUNING, mspHelper.crunch(MSPCodes.MSP2_SET_WING_TUNING));
+                await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
+                initialFields.value = { ...fields };
+            } catch (e) {
+                console.error("[WingTuning] save failed:", e);
+                error.value = e.message || String(e);
+            } finally {
+                saving.value = false;
+            }
+        }
+
+        function onTabReady() {
+            GUI.content_ready();
+            if (apiOk.value) {
+                reload();
+            }
+        }
+
+        return {
+            PID_GAIN_MAX,
+            SPA_SETPOINT_MAX,
+            SPA_WIDTH_SLIDER_MAX: 500,
+            enumOptions: ENUM_OPTIONS,
+            fields,
+            loading,
+            saving,
+            error,
+            apiOk,
+            FC,
+            dirty,
+            diffThrustMode,
+            detectedCellCount,
+            cellCountItems,
+            onCellCountChange,
+            tpaChart,
+            spaChart,
+            reload,
+            save,
+            onTabReady,
+        };
+    },
+
+    mounted() {
+        this.onTabReady();
+    },
+});
+</script>

--- a/src/components/tabs/WingTuningTab.vue
+++ b/src/components/tabs/WingTuningTab.vue
@@ -113,7 +113,7 @@
                             />
                         </div>
                     </div>
-                    <p v-if="diffThrustMode" class="mt-2 text-warning">{{ $t("wingSYawForcedZero") }}</p>
+                    <p v-if="diffThrustMode" class="mt-2 text-warning">{{ $t("wingSYawIgnored") }}</p>
                 </UiBox>
 
                 <!-- TPA Mode + Airspeed -->

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -143,6 +143,12 @@ const FC = {
     ADJUSTMENT_RANGES: null,
     ADVANCED_TUNING: null,
     ADVANCED_TUNING_ACTIVE: null,
+    // Wing tuning config (26 fields from pidProfile_t). Populated via
+    // MSP2_WING_TUNING decode (firmware USE_WING build, BF PR #15124).
+    // WING_TUNING_ACTIVE is the post-Reload snapshot used for dirty-
+    // checking in WingTuningTab.vue.
+    WING_TUNING: null,
+    WING_TUNING_ACTIVE: null,
     ANALOG: { ...INITIAL_ANALOG },
     ARMING_CONFIG: null,
     AUX_CONFIG: null,
@@ -593,6 +599,39 @@ const FC = {
             tpaBreakpoint: 0,
         };
         this.ADVANCED_TUNING_ACTIVE = { ...this.ADVANCED_TUNING };
+
+        // Wing tuning — field order matches firmware .plan/WIRE_FORMAT.md
+        // (MSP2_WING_TUNING payload, 39 bytes). Enum fields store string
+        // labels; MSPHelper crunch maps to int indices via wingEnumLookups.
+        this.WING_TUNING = {
+            s_roll: 0,
+            s_pitch: 0,
+            s_yaw: 0,
+            yaw_type: "RUDDER",
+            angle_pitch_offset: 0,
+            angle_earth_ref: 0,
+            tpa_mode: "PD",
+            tpa_speed_type: "BASIC",
+            tpa_speed_basic_delay: 0,
+            tpa_speed_basic_gravity: 0,
+            tpa_speed_max_voltage: 0,
+            tpa_speed_pitch_offset: 0,
+            tpa_curve_type: "CLASSIC",
+            tpa_curve_stall_throttle: 0,
+            tpa_curve_pid_thr0: 0,
+            tpa_curve_pid_thr100: 0,
+            tpa_curve_expo: 0,
+            spa_roll_center: 0,
+            spa_roll_width: 0,
+            spa_roll_mode: "OFF",
+            spa_pitch_center: 0,
+            spa_pitch_width: 0,
+            spa_pitch_mode: "OFF",
+            spa_yaw_center: 0,
+            spa_yaw_width: 0,
+            spa_yaw_mode: "OFF",
+        };
+        this.WING_TUNING_ACTIVE = { ...this.WING_TUNING };
 
         this.SENSOR_CONFIG = {
             acc_hardware: 0,

--- a/src/js/msp/MSPCodes.js
+++ b/src/js/msp/MSPCodes.js
@@ -199,6 +199,14 @@ const MSPCodes = {
     MSP2_SENSOR_CONFIG_ACTIVE: 0x300a,
     MSP2_MCU_INFO: 0x300c,
     MSP2_GYRO_SENSOR: 0x300d,
+    // Wing tuning (firmware `#ifdef USE_WING`, see betaflight/betaflight
+    // PR #15124). Shared golden-vector test with firmware
+    // `wing_msp_unittest.cc` for cross-repo wire agreement. Runtime
+    // state (TPA attenuation, SPA scaling, applied S-term) is
+    // intentionally NOT exposed over MSP — blackbox DEBUG_SET covers
+    // that use case at 8 kHz, which is strictly better than polling.
+    MSP2_WING_TUNING: 0x3012,
+    MSP2_SET_WING_TUNING: 0x3013,
     // MSP2_GET_TEXT and MSP2_SET_TEXT variable types
     PILOT_NAME: 1,
     CRAFT_NAME: 2,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -8,6 +8,7 @@ import vtxDeviceStatusFactory from "../utils/VtxDeviceStatus/VtxDeviceStatusFact
 import MSP from "../msp";
 import MSPCodes from "./MSPCodes";
 import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48 } from "../data_storage";
+import { decodeWingTuning, crunchWingTuning } from "./wingTuningSchema.js";
 import EscProtocols from "../utils/EscProtocols";
 import huffmanDecodeBuf from "../huffman";
 import { defaultHuffmanTree, defaultHuffmanLenIndex } from "../default_huffman_tree";
@@ -1201,6 +1202,28 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     console.log("Advanced PID settings saved");
                     FC.ADVANCED_TUNING_ACTIVE = { ...FC.ADVANCED_TUNING };
                     break;
+                case MSPCodes.MSP2_SET_WING_TUNING:
+                    console.log("Wing tuning saved");
+                    FC.WING_TUNING_ACTIVE = { ...FC.WING_TUNING };
+                    break;
+                case MSPCodes.MSP2_WING_TUNING: {
+                    // Atomic decode: populate a local snapshot first; only
+                    // copy to FC.WING_TUNING / _ACTIVE after the full 39
+                    // bytes parse without error. try/catch so a truncated
+                    // payload can't short-circuit callback dispatch after
+                    // the switch — leaves the tab responsive with prior
+                    // values intact.
+                    // Wire format is defined by WING_TUNING_SCHEMA in
+                    // wingTuningSchema.js; see firmware PR #15124.
+                    try {
+                        const snap = decodeWingTuning(data);
+                        FC.WING_TUNING = snap;
+                        FC.WING_TUNING_ACTIVE = { ...snap };
+                    } catch (error) {
+                        console.warn("Failed to decode wing tuning payload:", error);
+                    }
+                    break;
+                }
                 case MSPCodes.MSP_PID_ADVANCED:
                     FC.ADVANCED_TUNING.rollPitchItermIgnoreRate = data.readU16();
                     FC.ADVANCED_TUNING.yawItermIgnoreRate = data.readU16();
@@ -2276,6 +2299,14 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
             buffer.push8(FC.ADVANCED_TUNING.tpaMode);
             buffer.push8(Math.round(FC.ADVANCED_TUNING.tpaRate * 100));
             buffer.push16(FC.ADVANCED_TUNING.tpaBreakpoint);
+            break;
+        case MSPCodes.MSP2_SET_WING_TUNING:
+            // 39-byte payload driven by WING_TUNING_SCHEMA. Field order
+            // is part of the MSP wire contract — extend the schema with
+            // new fields appended at the end (never reordered); type
+            // change or removal requires MSP2_SET_WING_TUNING_V2 at a
+            // new code slot.
+            crunchWingTuning(buffer, FC.WING_TUNING);
             break;
         case MSPCodes.MSP_SET_SENSOR_CONFIG:
             buffer.push8(FC.SENSOR_CONFIG.acc_hardware);

--- a/src/js/msp/wingTuningSchema.js
+++ b/src/js/msp/wingTuningSchema.js
@@ -1,0 +1,86 @@
+// Single source of truth for the MSP2_WING_TUNING / MSP2_SET_WING_TUNING
+// wire format. Field order is part of the MSP wire contract and must
+// match firmware `.plan/WIRE_FORMAT.md`. Append-only: new fields may
+// only be added at the end; type change or removal requires a new
+// MSP2 code slot (e.g. MSP2_WING_TUNING_V2).
+import { enumIndexToString, enumStringToIndex } from "../utils/wingEnumLookups.js";
+
+export const WING_TUNING_SCHEMA = [
+    { name: "s_roll", type: "u8" },
+    { name: "s_pitch", type: "u8" },
+    { name: "s_yaw", type: "u8" },
+    { name: "yaw_type", type: "enum", table: "yaw_type" },
+    { name: "angle_pitch_offset", type: "i16" },
+    { name: "angle_earth_ref", type: "u8" },
+    { name: "tpa_mode", type: "enum", table: "tpa_mode" },
+    { name: "tpa_speed_type", type: "enum", table: "tpa_speed_type" },
+    { name: "tpa_speed_basic_delay", type: "u16" },
+    { name: "tpa_speed_basic_gravity", type: "u16" },
+    { name: "tpa_speed_max_voltage", type: "u16" },
+    { name: "tpa_speed_pitch_offset", type: "i16" },
+    { name: "tpa_curve_type", type: "enum", table: "tpa_curve_type" },
+    { name: "tpa_curve_stall_throttle", type: "u8" },
+    { name: "tpa_curve_pid_thr0", type: "u16" },
+    { name: "tpa_curve_pid_thr100", type: "u16" },
+    { name: "tpa_curve_expo", type: "i8" },
+    { name: "spa_roll_center", type: "u16" },
+    { name: "spa_roll_width", type: "u16" },
+    { name: "spa_roll_mode", type: "enum", table: "spa_mode" },
+    { name: "spa_pitch_center", type: "u16" },
+    { name: "spa_pitch_width", type: "u16" },
+    { name: "spa_pitch_mode", type: "enum", table: "spa_mode" },
+    { name: "spa_yaw_center", type: "u16" },
+    { name: "spa_yaw_width", type: "u16" },
+    { name: "spa_yaw_mode", type: "enum", table: "spa_mode" },
+];
+
+export function decodeWingTuning(data) {
+    const out = {};
+    for (const f of WING_TUNING_SCHEMA) {
+        switch (f.type) {
+            case "u8":
+                out[f.name] = data.readU8();
+                break;
+            case "u16":
+                out[f.name] = data.readU16();
+                break;
+            case "i8":
+                out[f.name] = data.read8();
+                break;
+            case "i16":
+                out[f.name] = data.read16();
+                break;
+            case "enum":
+                out[f.name] = enumIndexToString(f.table, data.readU8());
+                break;
+        }
+    }
+    return out;
+}
+
+// Push signed int16/int8 via unsigned mask so negative values serialize
+// to the correct two's-complement byte sequence; the Array-based push16
+// in injected_methods otherwise emits raw negative values that only get
+// masked later at frame-assembly time.
+export function crunchWingTuning(buffer, t) {
+    for (const f of WING_TUNING_SCHEMA) {
+        switch (f.type) {
+            case "u8":
+                buffer.push8(t[f.name]);
+                break;
+            case "u16":
+                buffer.push16(t[f.name]);
+                break;
+            case "i8":
+                buffer.push8(t[f.name] & 0xff);
+                break;
+            case "i16":
+                buffer.push16(t[f.name] & 0xffff);
+                break;
+            case "enum":
+                buffer.push8(enumStringToIndex(f.table, t[f.name]));
+                break;
+        }
+    }
+    return buffer;
+}

--- a/src/js/msp/wingTuningSchema.js
+++ b/src/js/msp/wingTuningSchema.js
@@ -3,7 +3,7 @@
 // match firmware `.plan/WIRE_FORMAT.md`. Append-only: new fields may
 // only be added at the end; type change or removal requires a new
 // MSP2 code slot (e.g. MSP2_WING_TUNING_V2).
-import { enumIndexToString, enumStringToIndex } from "../utils/wingEnumLookups.js";
+import { enumIndexToString, enumStringToIndex } from "../utils/wingEnumLookups";
 
 export const WING_TUNING_SCHEMA = [
     { name: "s_roll", type: "u8" },

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -624,6 +624,15 @@ function setRtc() {
     MSP.send_message(MSPCodes.MSP_SET_RTC, mspHelper.crunch(MSPCodes.MSP_SET_RTC), false, finishOpen);
 }
 
+// USE_WING build: enables servos implicitly AND adds the Wing Tuning tab.
+function applyWingBuildOption() {
+    for (const tab of ["servos", "wing_tuning"]) {
+        if (!GUI.allowedTabs.includes(tab)) {
+            GUI.allowedTabs.push(tab);
+        }
+    }
+}
+
 function finishOpen() {
     CONFIGURATOR.connectionValid = true;
 
@@ -641,9 +650,8 @@ function finishOpen() {
             }
         }
 
-        // Special case: USE_WING includes servo functionality but doesn't expose USE_SERVOS in build options
-        if (FC.CONFIG.buildOptions.some((opt) => opt.includes("USE_WING")) && !GUI.allowedTabs.includes("servos")) {
-            GUI.allowedTabs.push("servos");
+        if (FC.CONFIG.buildOptions.some((opt) => opt.includes("USE_WING"))) {
+            applyWingBuildOption();
         }
     } else {
         GUI.allowedTabs = Array.from(GUI.defaultAllowedFCTabsWhenConnected);

--- a/src/js/utils/wingEnumLookups.js
+++ b/src/js/utils/wingEnumLookups.js
@@ -1,0 +1,82 @@
+// Shared enum lookup tables for Wing Tuning MSP <-> UI translation.
+//
+// Array indices MUST match firmware's lookupTable* ordering exactly —
+// these are part of the MSP wire contract (see firmware
+// `.plan/WIRE_FORMAT.md`, "Append-only rule"). Reordering any entry within
+// a minor API version is a wire-format break.
+//
+// This module is the single source of truth for:
+//   - MSPHelper decode (int -> string for FC.WING_TUNING.*)
+//   - MSPHelper crunch (string -> int for MSP2_SET_WING_TUNING)
+//   - WingTuningTab.vue dropdown options
+//
+// A firmware enum reorder caught here fixes all three call sites.
+
+export const WING_ENUM_TABLES = {
+    // firmware: lookupTableYawType (`cli/settings.c`, #ifdef USE_WING)
+    yaw_type: ["RUDDER", "DIFF_THRUST"],
+
+    // firmware: lookupTableTpaMode. "PDS" is appended when USE_WING.
+    // Index ordering stays stable across multirotor/wing builds.
+    tpa_mode: ["PD", "D", "PDS"],
+
+    // firmware: lookupTableTpaSpeedType (#ifdef USE_WING)
+    tpa_speed_type: ["BASIC", "ADVANCED"],
+
+    // firmware: lookupTableTpaCurveType (#ifdef USE_ADVANCED_TPA)
+    tpa_curve_type: ["CLASSIC", "HYPERBOLIC"],
+
+    // firmware: lookupTableSpaMode (#ifdef USE_WING).
+    // Shared across all three axes (spa_{roll,pitch,yaw}_mode).
+    spa_mode: ["OFF", "I_FREEZE", "I", "PID", "PD_I_FREEZE"],
+};
+
+/**
+ * Decode an enum index to its string label.
+ * Unknown indices (e.g. firmware introduced a new value we don't know
+ * yet) return "Unknown (N)" rather than throwing — forward-compat.
+ *
+ * @param {string} table - key into WING_ENUM_TABLES
+ * @param {number} index - uint8 from MSP payload
+ * @returns {string}
+ */
+export function enumIndexToString(table, index) {
+    const values = WING_ENUM_TABLES[table];
+    if (!values) {
+        throw new Error(`wingEnumLookups: unknown table "${table}"`);
+    }
+    if (index >= 0 && index < values.length) {
+        return values[index];
+    }
+    return `Unknown (${index})`;
+}
+
+/**
+ * Encode a string label to its enum index for crunching into MSP payload.
+ * Forward-compat: accepts `Unknown (N)` labels produced by
+ * `enumIndexToString` for enum values added in newer firmware, so a user
+ * editing other fields can still save without the unknown value blocking
+ * the round-trip.
+ *
+ * @param {string} table - key into WING_ENUM_TABLES
+ * @param {string} label - string value from FC.WING_TUNING.*
+ * @returns {number} uint8 index
+ */
+export function enumStringToIndex(table, label) {
+    const values = WING_ENUM_TABLES[table];
+    if (!values) {
+        throw new Error(`wingEnumLookups: unknown table "${table}"`);
+    }
+    const idx = values.indexOf(label);
+    if (idx >= 0) {
+        return idx;
+    }
+    const unknownMatch = /^Unknown \((\d+)\)$/.exec(label);
+    if (unknownMatch) {
+        const unknownIndex = Number(unknownMatch[1]);
+        if (Number.isInteger(unknownIndex) && unknownIndex >= 0 && unknownIndex <= 0xff) {
+            return unknownIndex;
+        }
+    }
+    throw new Error(`wingEnumLookups: "${label}" is not a valid ${table} value ` + `(valid: ${values.join(", ")})`);
+}

--- a/src/js/utils/wing_math.js
+++ b/src/js/utils/wing_math.js
@@ -1,0 +1,86 @@
+// Pure math utilities for wing tuning visualizations.
+// Ported from bf-wing-mixer/src/components/TpaCurvePanel.jsx and SpaPanel.jsx.
+// No framework dependencies — safe to use from any Vue/JS context.
+
+/**
+ * Hyperbolic TPA curve from Limon's PR #13805.
+ *
+ * @param {number} x - normalized throttle 0.0–1.0
+ * @param {number} stallThrottle - tpa_curve_stall_throttle (0–100, stored as %)
+ * @param {number} pidThr0 - tpa_curve_pid_thr0 (uint16, e.g. 200 = 2.0×)
+ * @param {number} pidThr100 - tpa_curve_pid_thr100 (uint16, e.g. 70 = 0.7×)
+ * @param {number} expoParam - tpa_curve_expo (int8, divided by 10 in formula)
+ * @returns {number} PID multiplier factor (e.g. 2.0 at stall, 0.7 at max)
+ */
+export function tpaCurveHyperbolic(x, stallThrottle, pidThr0, pidThr100, expoParam) {
+    const thrStall = stallThrottle / 100;
+    const pThr0 = pidThr0 / 100;
+
+    if (x <= thrStall) {
+        return pThr0;
+    }
+
+    const expoDivider = expoParam / 10 - 1;
+    const expo = Math.abs(expoDivider) > 1e-3 ? 1 / expoDivider : 1e3;
+
+    const pThr100 = pidThr100 / 100;
+    const xShifted = (x - thrStall) / (1 - thrStall);
+
+    // Guard: UI allows pidThr0 / pidThr100 = 0, which would drive the
+    // hyperbolic formula into 0/0 → NaN → invalid SVG path. Fall back
+    // to a straight-line interpolation when either endpoint is zero.
+    if (pThr0 <= 0 || pThr100 <= 0) {
+        return pThr0 + (pThr100 - pThr0) * xShifted;
+    }
+
+    const base = 1 + (Math.pow(pThr0 / pThr100, 1 / expo) - 1) * xShifted;
+    const divisor = Math.pow(base, expo);
+
+    return pThr0 / divisor;
+}
+
+/**
+ * Build an array of `(throttle%, pidMultiplier%)` points for the TPA curve.
+ */
+export function computeTpaCurve(stallThrottle, pidThr0, pidThr100, expo, points = 100) {
+    const result = [];
+    for (let i = 0; i <= points; i++) {
+        const x = i / points;
+        const multiplier = tpaCurveHyperbolic(x, stallThrottle, pidThr0, pidThr100, expo);
+        result.push({ throttle: x * 100, multiplier: multiplier * 100 });
+    }
+    return result;
+}
+
+/**
+ * SPA smooth step-down transition curve, matching Limon's PR #13719.
+ *
+ * Returns y ∈ [0, 1]:
+ *   1.0 (full PID) when setpoint < leftLimit (center - width/2)
+ *   0.0 (attenuated) when setpoint > rightLimit (center + width/2)
+ *   Smooth cubic transition (3t² - 2t³) between the two.
+ */
+export const SPA_SETPOINT_MAX = 1000;
+
+export function spaSmoothStepDown(setpoint, center, width) {
+    const leftLimit = center - width / 2;
+    const rightLimit = center + width / 2;
+    if (setpoint <= leftLimit) {
+        return 1;
+    }
+    if (setpoint >= rightLimit) {
+        return 0;
+    }
+    const t = (setpoint - leftLimit) / Math.max(1e-6, width);
+    const smooth = t * t * (3 - 2 * t);
+    return 1 - smooth;
+}
+
+export function computeSpaCurve(center, width, points = 100, maxSetpoint = SPA_SETPOINT_MAX) {
+    const result = [];
+    for (let i = 0; i <= points; i++) {
+        const setpoint = (i / points) * maxSetpoint;
+        result.push({ setpoint, multiplier: spaSmoothStepDown(setpoint, center, width) });
+    }
+    return result;
+}

--- a/src/js/vue_components.js
+++ b/src/js/vue_components.js
@@ -56,5 +56,7 @@ export const BetaflightComponents = {
         app.component("PreflightTab", VueTabComponents.preflight);
         app.component("VtxTab", VueTabComponents.vtx);
         app.component("PresetsTab", VueTabComponents.presets);
+        app.component("LogTab", VueTabComponents.log);
+        app.component("WingTuningTab", VueTabComponents.wing_tuning);
     },
 };

--- a/src/js/vue_tab_registry.js
+++ b/src/js/vue_tab_registry.js
@@ -26,6 +26,8 @@ import PreflightTab from "../components/tabs/PreflightTab.vue";
 import VtxTab from "../components/tabs/VtxTab.vue";
 import PresetsTab from "../components/tabs/PresetsTab.vue";
 import AutotuneTab from "../components/tabs/AutotuneTab.vue";
+import LogTab from "../components/tabs/LogTab.vue";
+import WingTuningTab from "../components/tabs/WingTuningTab.vue";
 
 export const VueTabComponents = {
     help: HelpTab,
@@ -56,4 +58,6 @@ export const VueTabComponents = {
     vtx: VtxTab,
     presets: PresetsTab,
     autotune: AutotuneTab,
+    log: LogTab,
+    wing_tuning: WingTuningTab,
 };

--- a/src/stores/wingTuning.js
+++ b/src/stores/wingTuning.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { reactive, ref } from "vue";
+import { reactive, ref, toRaw } from "vue";
 
 /**
  * Field definitions for the Wing Tuning tab. Type "int" defaults to 0,

--- a/src/stores/wingTuning.js
+++ b/src/stores/wingTuning.js
@@ -75,7 +75,11 @@ export const useWingTuningStore = defineStore("wingTuning", () => {
      * MSP load (reload) and after every successful save.
      */
     function storeOriginals() {
-        originalWingTuning.value = JSON.parse(JSON.stringify(fields));
+        // structuredClone over a toRaw'd snapshot — bypasses the reactive
+        // proxy and avoids the JSON.parse(JSON.stringify(...)) Sonar smell
+        // (javascript:S7784). All fields are primitives so structuredClone
+        // is a strict superset of the prior behavior.
+        originalWingTuning.value = structuredClone(toRaw(fields));
         originalsReady.value = true;
         hasChanges.value = false;
     }

--- a/src/stores/wingTuning.js
+++ b/src/stores/wingTuning.js
@@ -1,45 +1,99 @@
 import { defineStore } from "pinia";
-import { ref } from "vue";
-import FC from "@/js/fc";
+import { reactive, ref } from "vue";
 
 /**
- * Pinia store for Wing Tuning tab change tracking.
+ * Field definitions for the Wing Tuning tab. Type "int" defaults to 0,
+ * "string" to "" (enum types collapse to "string" since their JS default
+ * is an empty string). Mirrors the wire schema in `wingTuningSchema.js`
+ * at JS-default granularity.
  *
- * Mirrors the pattern in `pidTuning.js`: keeps a plain-object snapshot of the
- * field values at load time, and exposes `hasChanges` + `checkForChanges()` so
- * the tab has a single source of truth for its dirty state. FC.WING_TUNING
- * itself remains the wire-facing data — this store only owns dirty tracking.
+ * Exported so the tab can iterate the same field set when copying values
+ * between `wingTuningStore.fields` and the legacy `FC.WING_TUNING` global
+ * during MSP load / save.
+ */
+export const FIELD_DEFS = [
+    // S-term
+    { name: "s_pitch", type: "int" },
+    { name: "s_roll", type: "int" },
+    { name: "s_yaw", type: "int" },
+    // Yaw type
+    { name: "yaw_type", type: "string" },
+    // Angle mode
+    { name: "angle_pitch_offset", type: "int" },
+    { name: "angle_earth_ref", type: "int" },
+    // TPA mode + airspeed
+    { name: "tpa_mode", type: "string" },
+    { name: "tpa_speed_type", type: "string" },
+    { name: "tpa_speed_basic_delay", type: "int" },
+    { name: "tpa_speed_basic_gravity", type: "int" },
+    { name: "tpa_speed_max_voltage", type: "int" },
+    { name: "tpa_speed_pitch_offset", type: "int" },
+    // TPA curve
+    { name: "tpa_curve_type", type: "string" },
+    { name: "tpa_curve_stall_throttle", type: "int" },
+    { name: "tpa_curve_pid_thr0", type: "int" },
+    { name: "tpa_curve_pid_thr100", type: "int" },
+    { name: "tpa_curve_expo", type: "int" },
+    // SPA
+    { name: "spa_roll_center", type: "int" },
+    { name: "spa_roll_width", type: "int" },
+    { name: "spa_roll_mode", type: "string" },
+    { name: "spa_pitch_center", type: "int" },
+    { name: "spa_pitch_width", type: "int" },
+    { name: "spa_pitch_mode", type: "string" },
+    { name: "spa_yaw_center", type: "int" },
+    { name: "spa_yaw_width", type: "int" },
+    { name: "spa_yaw_mode", type: "string" },
+];
+
+function defaultFields() {
+    const f = {};
+    for (const def of FIELD_DEFS) {
+        f[def.name] = def.type === "string" ? "" : 0;
+    }
+    return f;
+}
+
+/**
+ * Pinia store for the Wing Tuning tab.
+ *
+ * Owns the 26-field reactive (`fields`) bound by the tab's USelect /
+ * UInputNumber / USlider inputs, plus a plain-object snapshot of those
+ * values at load time so `hasChanges` can be computed without a deep
+ * watcher tree across the form. MSP I/O remains in the tab — the store
+ * is a pure state holder, mirroring the pattern in
+ * betaflight/blackbox-log-viewer#913 (`src/stores/log.js`).
  */
 export const useWingTuningStore = defineStore("wingTuning", () => {
+    const fields = reactive(defaultFields());
     const hasChanges = ref(false);
     const originalsReady = ref(false);
-
     const originalWingTuning = ref({});
 
     /**
-     * Snapshot the current FC.WING_TUNING values. Call after every successful
+     * Snapshot the current `fields` values. Call after every successful
      * MSP load (reload) and after every successful save.
      */
     function storeOriginals() {
-        originalWingTuning.value = JSON.parse(JSON.stringify(FC.WING_TUNING));
+        originalWingTuning.value = JSON.parse(JSON.stringify(fields));
         originalsReady.value = true;
         hasChanges.value = false;
     }
 
     /**
-     * Compare the tab's current field values against the stored originals
-     * and update `hasChanges`. The tab passes its local working copy because
-     * fields are bound to a local reactive (not FC.WING_TUNING directly).
+     * Compare current `fields` against the stored originals and update
+     * `hasChanges`.
      */
-    function checkForChanges(currentFields) {
+    function checkForChanges() {
         if (!originalsReady.value) {
             hasChanges.value = false;
             return;
         }
-        hasChanges.value = JSON.stringify(currentFields) !== JSON.stringify(originalWingTuning.value);
+        hasChanges.value = JSON.stringify(fields) !== JSON.stringify(originalWingTuning.value);
     }
 
     return {
+        fields,
         hasChanges,
         storeOriginals,
         checkForChanges,

--- a/src/stores/wingTuning.js
+++ b/src/stores/wingTuning.js
@@ -1,0 +1,47 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import FC from "@/js/fc";
+
+/**
+ * Pinia store for Wing Tuning tab change tracking.
+ *
+ * Mirrors the pattern in `pidTuning.js`: keeps a plain-object snapshot of the
+ * field values at load time, and exposes `hasChanges` + `checkForChanges()` so
+ * the tab has a single source of truth for its dirty state. FC.WING_TUNING
+ * itself remains the wire-facing data — this store only owns dirty tracking.
+ */
+export const useWingTuningStore = defineStore("wingTuning", () => {
+    const hasChanges = ref(false);
+    const originalsReady = ref(false);
+
+    const originalWingTuning = ref({});
+
+    /**
+     * Snapshot the current FC.WING_TUNING values. Call after every successful
+     * MSP load (reload) and after every successful save.
+     */
+    function storeOriginals() {
+        originalWingTuning.value = JSON.parse(JSON.stringify(FC.WING_TUNING));
+        originalsReady.value = true;
+        hasChanges.value = false;
+    }
+
+    /**
+     * Compare the tab's current field values against the stored originals
+     * and update `hasChanges`. The tab passes its local working copy because
+     * fields are bound to a local reactive (not FC.WING_TUNING directly).
+     */
+    function checkForChanges(currentFields) {
+        if (!originalsReady.value) {
+            hasChanges.value = false;
+            return;
+        }
+        hasChanges.value = JSON.stringify(currentFields) !== JSON.stringify(originalWingTuning.value);
+    }
+
+    return {
+        hasChanges,
+        storeOriginals,
+        checkForChanges,
+    };
+});

--- a/test/js/msp/wing_msp.test.js
+++ b/test/js/msp/wing_msp.test.js
@@ -1,0 +1,170 @@
+// Cross-repo wire contract test for Wing Tuning MSP2 messages.
+//
+// This file shares the golden byte vector with the firmware unit test
+// `src/test/unit/wing_msp_unittest.cc`. When either side reorders a
+// field, flips a signed/unsigned reader, or shifts an enum index, BOTH
+// tests fail in sync — proving the wire contract is stable.
+//
+// Reference: firmware repo `.plan/WIRE_FORMAT.md` and `.plan/GOLDEN_VECTOR.md`.
+
+import { describe, it, expect } from "vitest";
+import "../../../src/js/injected_methods";
+import { enumIndexToString, enumStringToIndex, WING_ENUM_TABLES } from "../../../src/js/utils/wingEnumLookups.js";
+import { decodeWingTuning, crunchWingTuning } from "../../../src/js/msp/wingTuningSchema.js";
+
+// ---------------------------------------------------------------------------
+// Golden vector — MUST match firmware `.plan/GOLDEN_VECTOR.md` byte-for-byte
+// ---------------------------------------------------------------------------
+
+const WING_TUNING_GOLDEN = new Uint8Array([
+    0x1e, 0x28, 0x00, 0x01, 0x88, 0xff, 0x64, 0x00, 0x01, 0x20, 0x03, 0x96, 0x00, 0x60, 0x09, 0xce, 0xff, 0x01, 0x23,
+    0x96, 0x00, 0x50, 0x00, 0xfb, 0x90, 0x01, 0xfa, 0x00, 0x02, 0x5e, 0x01, 0xc8, 0x00, 0x01, 0x2c, 0x01, 0x96, 0x00,
+    0x00,
+]);
+
+// Canonical values corresponding to WING_TUNING_GOLDEN. Field order follows
+// the wire — only enum fields have string labels (via wingEnumLookups).
+const WING_TUNING_CANONICAL = {
+    s_roll: 30,
+    s_pitch: 40,
+    s_yaw: 0,
+    yaw_type: "DIFF_THRUST", // index 1
+    angle_pitch_offset: -120,
+    angle_earth_ref: 100,
+    tpa_mode: "PD", // index 0
+    tpa_speed_type: "ADVANCED", // index 1
+    tpa_speed_basic_delay: 800,
+    tpa_speed_basic_gravity: 150,
+    tpa_speed_max_voltage: 2400,
+    tpa_speed_pitch_offset: -50,
+    tpa_curve_type: "HYPERBOLIC", // index 1
+    tpa_curve_stall_throttle: 35,
+    tpa_curve_pid_thr0: 150,
+    tpa_curve_pid_thr100: 80,
+    tpa_curve_expo: -5,
+    spa_roll_center: 400,
+    spa_roll_width: 250,
+    spa_roll_mode: "I", // index 2
+    spa_pitch_center: 350,
+    spa_pitch_width: 200,
+    spa_pitch_mode: "I_FREEZE", // index 1
+    spa_yaw_center: 300,
+    spa_yaw_width: 150,
+    spa_yaw_mode: "OFF", // index 0
+};
+
+// ---------------------------------------------------------------------------
+// Test-local helpers. Decode/crunch logic lives in wingTuningSchema.js and is
+// shared with MSPHelper; the golden vector below is the cross-repo fixture
+// that cross-checks the schema against the firmware side byte-for-byte.
+// ---------------------------------------------------------------------------
+
+function makeDataView(uint8Array) {
+    // DataView.offset = 0 prototype extension is installed by injected_methods;
+    // fresh DataView picks it up but we explicitly reset per-test.
+    const view = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
+    view.offset = 0;
+    return view;
+}
+
+function crunchToUnsignedBytes(t) {
+    // push16/push8 may emit Array elements outside the 0-255 range for
+    // negative values (e.g. push16 high byte of -1 is raw -1). Normalize
+    // to unsigned bytes so the comparison against the golden Uint8Array
+    // works. Production code path (MSP.send_message) does this same
+    // coercion when assembling the frame.
+    return crunchWingTuning([], t).map((b) => b & 0xff);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("wingEnumLookups", () => {
+    it("has the five expected tables", () => {
+        expect(Object.keys(WING_ENUM_TABLES).sort((a, b) => a.localeCompare(b))).toEqual([
+            "spa_mode",
+            "tpa_curve_type",
+            "tpa_mode",
+            "tpa_speed_type",
+            "yaw_type",
+        ]);
+    });
+
+    it("yaw_type: RUDDER=0, DIFF_THRUST=1", () => {
+        expect(enumStringToIndex("yaw_type", "RUDDER")).toBe(0);
+        expect(enumStringToIndex("yaw_type", "DIFF_THRUST")).toBe(1);
+        expect(enumIndexToString("yaw_type", 0)).toBe("RUDDER");
+        expect(enumIndexToString("yaw_type", 1)).toBe("DIFF_THRUST");
+    });
+
+    it("spa_mode: full ordering OFF,I_FREEZE,I,PID,PD_I_FREEZE", () => {
+        expect(enumIndexToString("spa_mode", 0)).toBe("OFF");
+        expect(enumIndexToString("spa_mode", 1)).toBe("I_FREEZE");
+        expect(enumIndexToString("spa_mode", 2)).toBe("I");
+        expect(enumIndexToString("spa_mode", 3)).toBe("PID");
+        expect(enumIndexToString("spa_mode", 4)).toBe("PD_I_FREEZE");
+    });
+
+    it("unknown index returns Unknown (N) without throwing (forward-compat)", () => {
+        expect(enumIndexToString("spa_mode", 99)).toBe("Unknown (99)");
+        expect(enumIndexToString("tpa_curve_type", 2)).toBe("Unknown (2)");
+    });
+
+    it("unknown string throws on encode (UI validation required upstream)", () => {
+        expect(() => enumStringToIndex("yaw_type", "NOT_A_MODE")).toThrow();
+    });
+
+    it("unknown table throws", () => {
+        expect(() => enumIndexToString("not_a_table", 0)).toThrow();
+        expect(() => enumStringToIndex("not_a_table", "x")).toThrow();
+    });
+});
+
+describe("MSP2_WING_TUNING — golden vector round-trip", () => {
+    it("decodes golden bytes to canonical values", () => {
+        const view = makeDataView(WING_TUNING_GOLDEN);
+        const decoded = decodeWingTuning(view);
+        expect(decoded).toEqual(WING_TUNING_CANONICAL);
+    });
+
+    it("crunches canonical values to golden bytes", () => {
+        const crunched = crunchToUnsignedBytes(WING_TUNING_CANONICAL);
+        expect(new Uint8Array(crunched)).toEqual(WING_TUNING_GOLDEN);
+    });
+
+    it("payload is exactly 39 bytes", () => {
+        expect(WING_TUNING_GOLDEN.byteLength).toBe(39);
+        expect(crunchToUnsignedBytes(WING_TUNING_CANONICAL).length).toBe(39);
+    });
+
+    it("preserves negative int16 values (angle_pitch_offset = -120)", () => {
+        const view = makeDataView(WING_TUNING_GOLDEN);
+        const decoded = decodeWingTuning(view);
+        expect(decoded.angle_pitch_offset).toBe(-120);
+        expect(decoded.tpa_speed_pitch_offset).toBe(-50);
+    });
+
+    it("preserves negative int8 values (tpa_curve_expo = -5)", () => {
+        const view = makeDataView(WING_TUNING_GOLDEN);
+        const decoded = decodeWingTuning(view);
+        expect(decoded.tpa_curve_expo).toBe(-5);
+    });
+
+    it("reverses enum indices correctly (spa_roll_mode index 2 = 'I')", () => {
+        const view = makeDataView(WING_TUNING_GOLDEN);
+        const decoded = decodeWingTuning(view);
+        expect(decoded.spa_roll_mode).toBe("I");
+        expect(decoded.spa_pitch_mode).toBe("I_FREEZE");
+        expect(decoded.spa_yaw_mode).toBe("OFF");
+    });
+
+    it("round-trips Unknown (N) enum labels from future firmware", () => {
+        // Forward-compat: if a newer firmware adds a yaw_type = 2, the
+        // configurator decodes it as "Unknown (2)". Saving unrelated
+        // fields must not throw — the raw index should round-trip back.
+        const snapshot = { ...WING_TUNING_CANONICAL, yaw_type: "Unknown (7)" };
+        const bytes = crunchToUnsignedBytes(snapshot);
+        expect(bytes[3]).toBe(7);
+    });
+});

--- a/test/js/utils/wing_math.test.js
+++ b/test/js/utils/wing_math.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import {
+    tpaCurveHyperbolic,
+    computeTpaCurve,
+    spaSmoothStepDown,
+    computeSpaCurve,
+    SPA_SETPOINT_MAX,
+} from "../../../src/js/utils/wing_math.js";
+
+describe("tpaCurveHyperbolic", () => {
+    it("returns pidThr0 / 100 when throttle is below stall threshold", () => {
+        expect(tpaCurveHyperbolic(0, 20, 200, 70, -10)).toBeCloseTo(2, 5);
+        expect(tpaCurveHyperbolic(0.1, 20, 200, 70, -10)).toBeCloseTo(2, 5);
+        expect(tpaCurveHyperbolic(0.2, 20, 200, 70, -10)).toBeCloseTo(2, 5);
+    });
+
+    it("monotonically decreases from stall to full throttle", () => {
+        const stall = 20,
+            thr0 = 200,
+            thr100 = 70,
+            expo = -10;
+        let prev = Infinity;
+        for (let x = 0.21; x <= 1; x += 0.05) {
+            const v = tpaCurveHyperbolic(x, stall, thr0, thr100, expo);
+            expect(v).toBeLessThanOrEqual(prev + 1e-9);
+            prev = v;
+        }
+    });
+
+    it("approaches pidThr100 / 100 near x=1", () => {
+        const v = tpaCurveHyperbolic(1, 20, 200, 70, -10);
+        expect(v).toBeCloseTo(0.7, 1);
+    });
+
+    it("handles expoParam near the singularity (expoDivider ≈ 0)", () => {
+        // expo=10 → expoDivider = 10/10 - 1 = 0 → code uses large fallback
+        const v = tpaCurveHyperbolic(0.5, 20, 200, 70, 10);
+        expect(Number.isFinite(v)).toBe(true);
+    });
+
+    it("does not return NaN when pidThr0 or pidThr100 is zero", () => {
+        // UI min for both is 0 — prevents NaN from polluting the SVG path.
+        expect(Number.isFinite(tpaCurveHyperbolic(0.5, 20, 0, 70, -10))).toBe(true);
+        expect(Number.isFinite(tpaCurveHyperbolic(0.5, 20, 200, 0, -10))).toBe(true);
+        expect(Number.isFinite(tpaCurveHyperbolic(0.5, 20, 0, 0, -10))).toBe(true);
+    });
+});
+
+describe("computeTpaCurve", () => {
+    it("returns points+1 samples from throttle 0..100", () => {
+        const points = computeTpaCurve(20, 200, 70, -10, 50);
+        expect(points.length).toBe(51);
+        expect(points[0].throttle).toBe(0);
+        expect(points.at(-1).throttle).toBe(100);
+    });
+
+    it("first point matches tpaCurveHyperbolic(0, ...) * 100", () => {
+        const points = computeTpaCurve(20, 200, 70, -10, 100);
+        const expected = tpaCurveHyperbolic(0, 20, 200, 70, -10) * 100;
+        expect(points[0].multiplier).toBeCloseTo(expected, 5);
+    });
+});
+
+describe("spaSmoothStepDown", () => {
+    it("returns 1.0 for setpoint below left limit", () => {
+        // center=500, width=200 → leftLimit=400, rightLimit=600
+        expect(spaSmoothStepDown(0, 500, 200)).toBe(1);
+        expect(spaSmoothStepDown(399, 500, 200)).toBe(1);
+        expect(spaSmoothStepDown(400, 500, 200)).toBe(1);
+    });
+
+    it("returns 0.0 for setpoint above right limit", () => {
+        expect(spaSmoothStepDown(600, 500, 200)).toBe(0);
+        expect(spaSmoothStepDown(601, 500, 200)).toBe(0);
+        expect(spaSmoothStepDown(1000, 500, 200)).toBe(0);
+    });
+
+    it("returns ~0.5 at the center of the transition", () => {
+        // At center, t = 0.5, smooth = 0.5 * 0.5 * (3 - 1) = 0.5 → y = 1 - 0.5 = 0.5
+        expect(spaSmoothStepDown(500, 500, 200)).toBeCloseTo(0.5, 5);
+    });
+
+    it("is monotonically non-increasing", () => {
+        let prev = Infinity;
+        for (let s = 0; s <= 1000; s += 10) {
+            const v = spaSmoothStepDown(s, 500, 200);
+            expect(v).toBeLessThanOrEqual(prev + 1e-9);
+            prev = v;
+        }
+    });
+
+    it("handles zero width without dividing by zero", () => {
+        const v = spaSmoothStepDown(500, 500, 0);
+        expect(Number.isFinite(v)).toBe(true);
+    });
+});
+
+describe("computeSpaCurve", () => {
+    it("returns points+1 samples over 0..SPA_SETPOINT_MAX", () => {
+        const points = computeSpaCurve(500, 200, 100);
+        expect(points.length).toBe(101);
+        expect(points[0].setpoint).toBe(0);
+        expect(points.at(-1).setpoint).toBe(SPA_SETPOINT_MAX);
+    });
+
+    it("first point equals 1.0 when center is above 0", () => {
+        const points = computeSpaCurve(500, 200);
+        expect(points[0].multiplier).toBe(1);
+    });
+
+    it("last point equals 0.0 when center is well below max", () => {
+        const points = computeSpaCurve(300, 100);
+        expect(points.at(-1).multiplier).toBe(0);
+    });
+});


### PR DESCRIPTION
edit; 
Rebased onto current master and ported the tab to Nuxt UI per https://github.com/betaflight/betaflight-configurator/issues/4995 (mirrors patterns from https://github.com/betaflight/betaflight-configurator/pull/4985 / https://github.com/betaflight/betaflight-configurator/pull/4987). All checks pass locally; hardware re-tested on SPEEDYBEEF405WING and FLYWOOF405NANO

The idea  - https://youtu.be/JOVxj9ci__U

Adds a new **Wing Tuning** tab that exposes fixed-wing-specific
`pidProfile_t` fields over MSP. Consumes the two new MSP2 codes added
by firmware PR [betaflight/betaflight#15124](https://github.com/betaflight/betaflight/pull/15124).

Compared to a CLI-based approach this gives:

- **Reload in ~30 ms** (single MSP round-trip) vs ~2–3 s for a 26-field
  CLI `get` chain.
- **Save without FC reboot.** `MSP_EEPROM_WRITE` persists to flash
  without the USB CDC re-init that leaving CLI mode triggers.
- **No "other tabs freeze" side effect.** Other tabs' MSP polling
  continues normally because the tab doesn't hold the FC in CLI.
- **Auto-load on tab activation**, matching PID Tuning / Servos etc.

## Changes

- `src/js/msp/MSPCodes.js` — register `MSP2_WING_TUNING` (0x3012) and
  `MSP2_SET_WING_TUNING` (0x3013). No `API_VERSION_MINOR` bump per BF
  convention — release maintainers handle that at release-cut time
  covering all MSP additions for that cycle.
- `src/js/utils/wingEnumLookups.js` (new) — single source of truth for
  the five enum `int↔string` lookup tables (`yaw_type`, `tpa_mode`,
  `tpa_speed_type`, `tpa_curve_type`, `spa_mode`). Consumed by both
  MSPHelper decode/crunch AND the tab's dropdowns, so a firmware enum
  reorder is caught in one file.
- `src/js/fc.js` — add `FC.WING_TUNING` + `FC.WING_TUNING_ACTIVE`
  (mirrors `ADVANCED_TUNING` / `_ACTIVE` dirty-check pattern).
- `src/js/msp/MSPHelper.js`:
  - Decode `MSP2_WING_TUNING`. Atomic: local snapshot first, commit to
    `FC.*` only on full parse success so a truncated payload leaves
    prior values intact.
  - Crunch `MSP2_SET_WING_TUNING`.
  - Signed-aware readers/writers (`read8` / `read16`,
    `push8(val & 0xFF)` / `push16(val & 0xFFFF)`) for the int8 / int16
    fields per the wire contract.
  - Unknown-enum decode returns `"Unknown (N)"` rather than throwing —
    forward-compat with future firmware enum additions.
- `src/components/tabs/WingTuningTab.vue` (new) — the tab. MSP-only
  reload/save, auto-load on activation, `apiOk` computed gate:
  - `apiOk = FC.CONFIG.buildOptions.includes('USE_WING')`
  - When false, sidebar entry is hidden; tab renders a "firmware update
    required" stub if somehow reached.
  - Sticky bottom-right Save/Reload toolbar matching every other tab.
- `src/js/vue_tab_registry.js` / `src/js/vue_components.js` — register
  `WingTuningTab`. `main.js` needs zero changes because upstream's
  `mountVueTab(tab, content_ready)` auto-dispatches from the registry.
- `src/App.vue` — sidebar `<li>` gated on `USE_WING` in `buildOptions`
  (matches the existing Servos tab pattern).
- `src/js/serial_backend.js` — expand the existing USE_WING special
  case to also push `wing_tuning` into `GUI.allowedTabs`.
- `src/js/utils/wing_math.js` (new) + `test/js/utils/wing_math.test.js`
  (new) — TPA curve (hyperbolic, firmware PR
  [#13805](https://github.com/betaflight/betaflight/pull/13805)) and SPA
  smooth step-down transition (firmware PR
  [#13719](https://github.com/betaflight/betaflight/pull/13719)) for the
  tab's live curve visualizations.
- `locales/en/messages.json` — wing i18n keys (tab label, status,
  section titles/descriptions, firmware-required stub message).
- `test/js/msp/wing_msp.test.js` (new) — round-trip test against the
  shared golden vector (details below).
- `src/images/icons/cf_icon_wing_grey.svg` + `src/css/main.less` +
  `src/css/theme.css` — sidebar icon.

## Wire format

Full byte-offset / C-type / signed tables live in firmware PR
[#15124](https://github.com/betaflight/betaflight/pull/15124).
Configurator-side summary:

- `MSP2_WING_TUNING` — **39 bytes, little-endian.** 26 fields: S-term
  × 3, yaw_type, angle_pitch_offset (int16), angle_earth_ref,
  tpa_mode, tpa_speed_type, tpa_speed_basic_delay,
  tpa_speed_basic_gravity, tpa_speed_max_voltage,
  tpa_speed_pitch_offset (int16), tpa_curve_type,
  tpa_curve_stall_throttle, tpa_curve_pid_thr0, tpa_curve_pid_thr100,
  tpa_curve_expo (int8), spa_{roll,pitch,yaw}_{center,width,mode}.
- `MSP2_SET_WING_TUNING` — same 39-byte layout, SET direction.

### Append-only contract

- Fields may only be appended, never reordered or type-changed.
- Enum indices are part of the wire contract — new values may only be
  appended, never renumbered within a minor API version.
- Type changes require a new MSP2 code at a new slot (e.g.
  `MSP2_WING_TUNING_V2`), not in-place modification.

## Golden vector

The firmware unit test and the configurator vitest consume the **same
hex byte array**. When either side reorders a field or flips a
signed/unsigned reader, both tests fail in sync.

Vector defined inline in `test/js/msp/wing_msp.test.js`:

```js
const WING_TUNING_GOLDEN = new Uint8Array([
    0x1e, 0x28, 0x00, 0x01,
    0x88, 0xff,
    0x64,
    0x00, 0x01,
    0x20, 0x03, 0x96, 0x00,
    0x60, 0x09,
    0xce, 0xff,
    0x01, 0x23,
    0x96, 0x00, 0x50, 0x00,
    0xfb,
    0x90, 0x01, 0xfa, 0x00, 0x02,
    0x5e, 0x01, 0xc8, 0x00, 0x01,
    0x2c, 0x01, 0x96, 0x00, 0x00,
]);
```

Canonical values are designed to include negative int16 / int8 values
and non-zero enum indices to flush out signed-reader and
lookup-reorder bugs.

## Testing

- `yarn test test/js/msp/wing_msp.test.js` — passes. Assertions cover
  golden-vector round-trip, negative value preservation, unknown-enum
  forward-compat, enum index correctness.
- `yarn test` — full suite passes, no existing tests regressed.
- `yarn lint`, `yarn build` — both pass.
- Manual hardware round-trip on `SPEEDYBEEF405WING`:
  - Tab auto-loads on activation (~30 ms perceived).
  - All 26 fields load correctly including signed fields
    (`angle_pitch_offset`, `tpa_speed_pitch_offset`, `tpa_curve_expo`)
    with both positive and negative values.
  - Save: values persist across disconnect/reconnect. No FC reboot.
  - SPA per-axis curve + TPA hyperbolic curve visualizations update
    live against loaded values.
  - Setup / Receiver / Power tabs continue showing live sensor data
    with Wing Tuning open.

## Companion firmware PR

[betaflight/betaflight#15124](https://github.com/betaflight/betaflight/pull/15124).

Merge order: firmware PR merges first so the MSP codes exist on FCs
running master builds before this configurator change lands. Users on
stable releases get the tab once the next firmware + configurator
release cycle ships together.

## Scope boundaries

- `wing_launch_*` fields are out of scope. They're not on this tab and
  remain on their existing CLI-based path (firmware PR
  [#15121](https://github.com/betaflight/betaflight/pull/15121)).
- Live runtime state (TPA attenuation, SPA scaling, effective S-term
  contribution) is intentionally not exposed over MSP. Firmware PR
  #15124 covers the rationale: blackbox `DEBUG_SET(DEBUG_TPA)` /
  `DEBUG_SET(DEBUG_SPA)` already records this data at 8 kHz for
  post-flight analysis, which is strictly more useful than a
  configurator panel polling at 4 Hz on a craft nobody's watching.
- Profile-change mid-tab reload hook is deferred. Tab auto-loads on
  activation which covers the common case; mid-tab profile switches
  are rare and can land in a follow-up.
- `tabBusy` operation mutex is deferred — `loading` / `saving` refs
  are sufficient for button gating until the tab ever gains live
  polling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Wing Tuning tab for advanced wing flight-control settings (yaw type, angle-mode trimming/mixing, S-term, TPA/SPA) with save/reload and unsaved-change indicators plus live TPA/SPA visual previews.

* **UI / Sidebar**
  * Sidebar entry for Wing Tuning gated by a firmware build-option; shows prerequisite warning when unavailable.

* **Localization**
  * Complete English UI strings and help texts for the new tab (no existing keys removed).

* **Tests**
  * Added wire-contract and math unit tests for wing-tuning serialization and curve math.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5015)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->