### PR TITLE
Fix Throttle Curve Preview

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2045,7 +2045,7 @@
         "message": "PID Profile Settings"
     },
     "pidTuningSubTabRates": {
-        "message": "Rateprofile Settings"
+        "message": "Rate Profile Settings"
     },
     "pidTuningSubTabFilter": {
         "message": "Filter Settings"
@@ -2111,7 +2111,7 @@
         "description": "Title for the options panel for the D Max feature"
     },
     "pidTuningDMaxSettingTitle": {
-        "message": "Dynamic<br>Damping",
+        "message": "Dynamic Damping",
         "description": "Sidebar title for the options panel for the D Max feature"
     },
     "pidTuningDMaxGain": {
@@ -2239,7 +2239,7 @@
         "message": "<span class=\"message-negative\"><strong>$t(warningTitle.message):<\/strong> The use of a D Setpoint transition greater than 0 and less than 0.1 is highly discouraged. Doing so may lead instability and reduced stick responsiveness as the sticks cross the centre point.<\/span>"
     },
     "pidTuningFeedforwardGroup": {
-        "message": "Feed-<br>forward"
+        "message": "Feedforward"
     },
     "pidTuningFeedforwardGroupHelp": {
         "message": "Feedforward adjusts stick responsiveness.<br /><br /> These options let you adjust it to provide anything from crisp, immediate stick responses for racing, or soft smooth responses for cinematic / HD purposes."
@@ -2344,6 +2344,9 @@
     },
     "pidTuningRatesPreview": {
         "message": "Rates Preview"
+    },
+    "pidTuningRatesModelPreview": {
+        "message": "Rates Model Preview"
     },
     "pidTuningRatesTuningHelp": {
         "message": "<b>Rates and Expo</b>: Determine your stick feel based on these parameters. Use the graph and live 3D model to find your favourite rate setting."
@@ -7679,7 +7682,7 @@
         "message": "Rates Type"
     },
     "pidTuningRatesTypeTip": {
-        "message": "Changing rates type will change the rates curve and the way you can set it"
+        "message": "Changing rates type will change the rates curve and the way you can set it<br><br><a href='https://rates.metamarc.com' target='_blank' rel='noopener noreferrer'>rates.metamarc.com</a>"
     },
     "pidTuningRcRateRaceflight": {
         "message": "Rate"

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -71,7 +71,7 @@
                     :model-value="activeSubtab"
                     :content="false"
                     color="primary"
-                    variant="pill"
+                    variant="link"
                     @update:model-value="activeSubtab = $event"
                 />
             </div>
@@ -182,9 +182,9 @@ const rateProfileItems = computed(() => {
 });
 
 const subtabItems = computed(() => [
-    { label: t("pidTuningSubTabPid"), value: "pid" },
-    { label: t("pidTuningSubTabRates"), value: "rates" },
-    { label: t("pidTuningSubTabFilter"), value: "filter" },
+    { label: t("pidTuningSubTabPid"), value: "pid", icon: "i-lucide-sliders-horizontal" },
+    { label: t("pidTuningSubTabRates"), value: "rates", icon: "i-lucide-gauge" },
+    { label: t("pidTuningSubTabFilter"), value: "filter", icon: "i-lucide-filter" },
 ]);
 
 // Profile name state lifted from child components
@@ -1280,6 +1280,7 @@ onUnmounted(() => {
 /* ── Sub-tab navigation ───────────────────────────────────────────── */
 .subtab-nav {
     width: calc(100% - 22px);
+    margin-bottom: 6px;
 }
 
 /* ── Tab area ─────────────────────────────────────────────────────── */
@@ -1291,7 +1292,7 @@ onUnmounted(() => {
     border-bottom-right-radius: 8px;
     border-bottom-left-radius: 8px;
     border-top: 0 solid var(--surface-500);
-    background: var(--surface-200);
+    background: transparent;
 }
 
 /* ── Responsive: 575px ────────────────────────────────────────────── */

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -110,7 +110,12 @@
                     :disabled="!hasChanges"
                     @click="save"
                 />
-                <UButton :label="$t('pidTuningButtonRefresh')" color="neutral" variant="outline" @click="refresh" />
+                <UButton
+                    :label="$t('pidTuningButtonRefresh')"
+                    :color="hasChanges ? 'primary' : 'neutral'"
+                    :disabled="!hasChanges"
+                    @click="refresh"
+                />
             </div>
         </div>
     </BaseTab>

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -14,14 +14,6 @@
                         <USelect v-model="ratesType" :items="ratesTypeItems" class="w-32" />
                     </SettingRow>
                     <img :src="ratesLogoSrc" class="h-8" alt="Rates logo" />
-                    <a
-                        href="https://rates.metamarc.com"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-xs text-primary hover:underline"
-                    >
-                        rates.metamarc.com
-                    </a>
                 </div>
             </UiBox>
 
@@ -277,7 +269,7 @@
             </UiBox>
 
             <!-- Rates 3D Preview -->
-            <UiBox :title="$t('pidTuningRatesPreview')" type="neutral">
+            <UiBox :title="$t('pidTuningRatesModelPreview')" type="neutral">
                 <div class="bg-white dark:bg-neutral-900 border border-default p-1 w-full" ref="ratesPreviewContainer">
                     <canvas ref="ratesPreviewCanvas" class="block"></canvas>
                 </div>

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -1762,12 +1762,13 @@ onMounted(() => {
         updateRatesLabels();
     });
 
-    // Poll MSP_RC for live stick data and update rate curve labels
+    // Poll MSP_RC for live stick data and update rate curve labels + throttle curve
     rcUpdateInterval = setInterval(() => {
         MSP.send_message(MSPCodes.MSP_RC, false, false, () => {
             if (rateCurveLayer1.value) {
                 updateRatesLabels();
             }
+            drawThrottleCurve();
         });
     }, 100); // Update 10 times per second
 });


### PR DESCRIPTION
The fix adds drawThrottleCurve() to the MSP_RC polling callback.
                                                                              
  Root cause: The original jQuery version had a dedicated                       
  setInterval(redrawThrottleCurve, 100) that continuously redraws the throttle
  curve, picking up the latest FC.RC.channels[3] value. When the tab was        
  migrated to Vue 3, this dedicated interval was not carried over. The RC
  polling callback only called updateRatesLabels() (which updates rate curve    
  stick positions for roll/pitch/yaw) but never drawThrottleCurve(), so the     
  throttle position indicator on the throttle curve canvas never updated with
  live stick data.

  Note: This bug was technically introduced during the Vue 3 migration          
  (d2192774), not PR #5007 specifically, but it may have become more noticeable
  after the Nuxt UI refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added icons to PID tuning sub-tabs for improved visual clarity.

* **UI/Styling**
  * Updated PID tuning tab navigation and spacing for cleaner presentation.
  * Refresh button now reflects unsaved changes and is disabled when no changes exist.
  * Cleaned up UI text formatting and renamed "Rates 3D Preview" to "Rates Model Preview."
  * Throttle curve preview now updates more consistently.

* **Documentation**
  * Moved rates reference link into the tooltip for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->