### PR TITLE
Refactor: Convert OSD tab to Nuxt UI

### DIFF
--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -34,7 +34,7 @@
                 <div class="grid-row grid-box col4">
                     <!-- Elements Column -->
                     <div class="col-span-1">
-                        <UiBox :title="$t('osdSetupElementsTitle')" :help="$t('osdSectionHelpElements')">
+                        <UiBox :title="$t('osdSetupElementsTitle')" :help="$t('osdSectionHelpElements')" type="neutral">
                             <template #title>
                                 <HelpIcon :text="$t('osdSetupProfilesTitle')" />
                                 <span
@@ -95,7 +95,10 @@
                                     />
 
                                     <!-- Preset button -->
-                                    <div v-if="field.positionable" class="tab-osd-position-controls">
+                                    <div
+                                        v-if="field.positionable"
+                                        class="relative flex items-center justify-center ml-auto shrink-0"
+                                    >
                                         <div
                                             class="tab-osd-preset-btn"
                                             @click="openPresetMenu(field, $event)"
@@ -161,12 +164,8 @@
                         <div class="tab-osd-preview-parent sticky top-6">
                             <!-- Controls bar -->
                             <div
-                                class="flex items-center gap-2 flex-wrap bg-primary rounded-full px-4 py-1.5 mb-2.5 text-[13px] font-bold text-black"
+                                class="flex items-center gap-2 flex-wrap bg-elevated rounded-full px-4 py-1.5 mb-2.5 text-[13px] font-bold text-highlighted"
                             >
-                                <label>{{ $t("osdSetupPreviewSelectProfileTitle") }}</label>
-                                <USelect v-model="previewProfile" :items="profileOptions" size="xs" class="w-36" />
-                                <label>{{ $t("osdSetupPreviewSelectFont") }}</label>
-                                <USelect v-model="selectedFont" :items="fontSelectOptions" size="xs" class="w-36" />
                                 <span class="ml-auto flex items-center gap-1.5">
                                     <USwitch v-model="showRulers" size="xs" />
                                     <label>{{ $t("osdSetupPreviewCheckRulers") }}</label>
@@ -188,7 +187,7 @@
                                     @mouseleave="onPreviewMouseUp"
                                 >
                                     <!-- Preview elements rendered as rows/cells -->
-                                    <div class="flex" v-for="(row, rIdx) in previewRows" :key="rIdx">
+                                    <div class="flex tab-osd-row" v-for="(row, rIdx) in previewRows" :key="rIdx">
                                         <div
                                             v-for="(cell, cIdx) in row"
                                             :key="cIdx"
@@ -229,9 +228,15 @@
                     <!-- Settings Column -->
                     <div class="col-span-1">
                         <!-- Active Profile Selector -->
-                        <UiBox :title="$t('osdSetupSelectedProfileTitle')">
+                        <UiBox :title="$t('osdSetupSelectedProfileTitle')" type="neutral">
                             <SettingRow :label="$t('osdSetupSelectedProfileLabel')">
-                                <USelect v-model="activeProfile" :items="profileOptions" size="sm" class="min-w-40" />
+                                <USelect v-model="activeProfile" :items="profileOptions" size="sm" class="w-full" />
+                            </SettingRow>
+                            <SettingRow :label="$t('osdSetupPreviewSelectProfileTitle')">
+                                <USelect v-model="previewProfile" :items="profileOptions" size="sm" class="w-full" />
+                            </SettingRow>
+                            <SettingRow :label="$t('osdSetupPreviewSelectFont')">
+                                <USelect v-model="selectedFont" :items="fontSelectOptions" size="sm" class="w-full" />
                             </SettingRow>
                         </UiBox>
 
@@ -240,6 +245,7 @@
                             v-if="osdStore.state.haveMax7456Configured || osdStore.state.isMspDevice"
                             :title="$t('osdSetupVideoFormatTitle')"
                             :help="$t('osdSectionHelpVideoMode')"
+                            type="neutral"
                         >
                             <SettingRow :label="$t('osdSetupVideoFormatTitle')">
                                 <USelect
@@ -252,7 +258,7 @@
                                     "
                                     :items="videoTypeSelectItems"
                                     size="sm"
-                                    class="min-w-40"
+                                    class="w-full"
                                 />
                             </SettingRow>
                         </UiBox>
@@ -262,6 +268,7 @@
                             v-if="osdStore.state.haveOsdFeature"
                             :title="$t('osdSetupUnitsTitle')"
                             :help="$t('osdSectionHelpUnits')"
+                            type="neutral"
                         >
                             <SettingRow :label="$t('osdSetupUnitsTitle')">
                                 <USelect
@@ -274,7 +281,7 @@
                                     "
                                     :items="unitTypeSelectItems"
                                     size="sm"
-                                    class="min-w-40"
+                                    class="w-full"
                                 />
                             </SettingRow>
                         </UiBox>
@@ -284,6 +291,7 @@
                             v-if="osdStore.state.haveOsdFeature && osdStore.timers.length > 0"
                             :title="$t('osdSetupTimersTitle')"
                             :help="$t('osdSectionHelpTimers')"
+                            type="neutral"
                         >
                             <div
                                 v-for="(timer, idx) in osdStore.timers"
@@ -302,7 +310,7 @@
                                         "
                                         :items="timerSourceItems"
                                         size="sm"
-                                        class="min-w-36"
+                                        class="w-full"
                                     />
                                 </SettingRow>
                                 <SettingRow :label="$t('osdTimerPrecision')" :help="$t('osdTimerPrecisionTooltip')">
@@ -316,7 +324,7 @@
                                         "
                                         :items="timerPrecisionItems"
                                         size="sm"
-                                        class="min-w-36"
+                                        class="w-full"
                                     />
                                 </SettingRow>
                                 <SettingRow :label="$t('osdTimerAlarm')" :help="$t('osdTimerAlarmTooltip')">
@@ -325,6 +333,7 @@
                                         :min="0"
                                         :max="600"
                                         :step="1"
+                                        :format-options="{ useGrouping: false }"
                                         size="xs"
                                         orientation="vertical"
                                         class="w-16"
@@ -339,6 +348,7 @@
                             v-if="osdStore.state.haveOsdFeature && alarmEntries.length > 0"
                             :title="$t('osdSetupAlarmsTitle')"
                             :help="$t('osdSectionHelpAlarms')"
+                            type="neutral"
                         >
                             <div
                                 v-for="entry in alarmEntries"
@@ -350,6 +360,7 @@
                                     :min="entry.alarm.min || 0"
                                     :max="entry.alarm.max || 9999"
                                     :step="1"
+                                    :format-options="{ useGrouping: false }"
                                     size="xs"
                                     orientation="vertical"
                                     class="w-16"
@@ -364,6 +375,7 @@
                             v-if="osdStore.state.haveOsdFeature && sortedWarnings.length > 0"
                             :title="$t('osdSetupWarningsTitle')"
                             :help="$t('osdSectionHelpWarnings')"
+                            type="neutral"
                         >
                             <div
                                 v-for="warning in sortedWarnings"
@@ -391,6 +403,7 @@
                             v-if="osdStore.state.haveOsdFeature && sortedStatItems.length > 0"
                             :title="$t('osdSetupStatsTitle')"
                             :help="$t('osdSectionHelpStats')"
+                            type="neutral"
                         >
                             <div
                                 v-for="stat in sortedStatItems"
@@ -416,7 +429,7 @@
                 </div>
 
                 <!-- Font Manager Dialog -->
-                <dialog ref="fontManagerDialog" class="w-[750px] h-fit">
+                <dialog ref="fontManagerDialog" class="html-dialog w-[750px] h-fit">
                     <div class="flex h-12 bg-elevated border-b border-default">
                         <div class="flex-1 flex items-center px-4 font-semibold">
                             {{ $t("osdSetupFontManagerTitle") }}
@@ -432,7 +445,6 @@
                     </div>
                     <div class="p-5">
                         <h1 class="text-lg font-bold mb-1">{{ $t("osdSetupFontPresets") }}</h1>
-                        <span class="text-sm opacity-60">{{ fontVersionInfo }}</span>
                         <div class="flex flex-wrap gap-0 my-3" ref="fontPreviewContainer">
                             <img
                                 v-for="(url, charIdx) in fontCharacterUrls"
@@ -448,11 +460,12 @@
                             <USelect
                                 v-model="selectedFontPreset"
                                 :items="fontPresetSelectItems"
+                                :portal="false"
                                 size="sm"
                                 class="min-w-40"
                             />
                             <span>{{ $t("osdSetupFontPresetsSelectorOr") }}</span>
-                            <UButton @click="loadCustomFontFile()" variant="outline" size="sm">
+                            <UButton @click="loadCustomFontFile()" size="sm">
                                 {{ $t("osdSetupOpenFont") }}
                             </UButton>
                             <span class="text-sm opacity-60">(.mcm)</span>
@@ -481,8 +494,8 @@
                         </div>
 
                         <div class="mb-3">
-                            <UButton @click="replaceLogoImage()" variant="outline" size="sm">
-                                {{ $t("osdSetupCustomLogoOpenImageButton") }}
+                            <UButton @click="replaceLogoImage()" size="sm">
+                                <span v-html="$t('osdSetupCustomLogoOpenImageButton')"></span>
                             </UButton>
                         </div>
 
@@ -505,7 +518,6 @@
                 <UButton
                     :disabled="!osdStore.state.isMax7456FontDeviceDetected"
                     @click="osdStore.state.isMax7456FontDeviceDetected && openFontManager()"
-                    variant="outline"
                 >
                     {{ $t("osdSetupFontManagerTitle") }}
                 </UButton>
@@ -565,7 +577,6 @@ const activeProfile = ref(0);
 const selectedFontPreset = ref(selectedFont.value);
 const uploadProgress = ref(0);
 const uploadProgressLabel = ref("");
-const fontVersionInfo = ref("");
 const isSaving = ref(false);
 const saveButtonTextOverride = ref(null);
 const saveButtonText = computed(() => saveButtonTextOverride.value || i18n.getMessage("osdSetupSave"));
@@ -1317,19 +1328,25 @@ function loadCustomFontFile() {
             LogoManager.drawPreview();
             fontDataVersion.value++;
             updatePreviewBuffer();
-            fontVersionInfo.value = i18n.getMessage("osdDescribeFontVersionCUSTOM");
+
             selectedFontPreset.value = -1;
         })
         .catch((err) => console.error("Failed to load custom font file:", err));
 }
 
-function openFontManager() {
+async function openFontManager() {
     if (!osdStore.state.isMax7456FontDeviceDetected) {
         return;
     }
     FONT.initData();
-    // Initialize LogoManager if not already
+
+    // Show the dialog first so DOM elements are available for LogoManager
+    fontManagerDialog.value?.showModal?.();
+    await nextTick();
+
+    // Initialize LogoManager (caches DOM elements via querySelector)
     LogoManager.init(FONT, SYM.LOGO);
+
     // Load selected/default preset on first open if no font is loaded yet.
     if (!FONT.data.character_image_urls.length && fontTypes.value.length > 0) {
         const presetToLoad = Math.max(0, selectedFontPreset.value);
@@ -1339,11 +1356,7 @@ function openFontManager() {
         // Keep dialog previews in sync when font data was loaded earlier (e.g. during tab init).
         LogoManager.drawPreview();
         fontDataVersion.value++;
-        if (selectedFontPreset.value >= 0) {
-            fontVersionInfo.value = i18n.getMessage("osdDescribeFontVersion2");
-        }
     }
-    fontManagerDialog.value?.showModal?.();
 }
 
 function loadFontPreset(index) {
@@ -1353,7 +1366,6 @@ function loadFontPreset(index) {
     }
 
     const fontVer = 2;
-    fontVersionInfo.value = i18n.getMessage(`osdDescribeFontVersion${fontVer}`);
 
     // If this font is already loaded in memory, just trigger reactivity
     if (FONT.data?.loaded_font_file === font.file && FONT.data?.characters?.length > 0) {
@@ -1406,7 +1418,7 @@ function replaceLogoImage() {
             lastFontPresetRequestId++;
             LogoManager.drawPreview();
             LogoManager.showUploadHint();
-            fontVersionInfo.value = i18n.getMessage("osdDescribeFontVersionCUSTOM");
+
             selectedFontPreset.value = -1;
             fontDataVersion.value++;
             updatePreviewBuffer();
@@ -1432,7 +1444,6 @@ async function flashFont() {
             LogoManager.drawPreview();
             fontDataVersion.value++;
             updatePreviewBuffer();
-            fontVersionInfo.value = i18n.getMessage("osdDescribeFontVersionCUSTOM");
         } catch (err) {
             console.error("User cancelled custom font selection or error occurred", err);
             GUI.connect_lock = false;
@@ -1584,15 +1595,6 @@ onUnmounted(() => {
 }
 
 /* Preset position button */
-.tab-osd-position-controls {
-    position: relative;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-left: auto;
-    flex-shrink: 0;
-}
-
 .tab-osd-preset-btn {
     width: 20px;
     height: 20px;

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -464,6 +464,7 @@
                             <div class="p-2.5" style="background: rgba(0, 255, 0, 0.4)">
                                 <div
                                     ref="logoPreview"
+                                    id="font-logo-preview"
                                     style="background: rgba(0, 255, 0, 1); line-height: 0; margin: auto"
                                 ></div>
                             </div>
@@ -472,10 +473,10 @@
                                     {{ $t("osdSetupCustomLogoInfoTitle") }}
                                 </h3>
                                 <ul class="tab-osd-logo-info-list">
-                                    <li>{{ $t("osdSetupCustomLogoInfoImageSize") }}</li>
-                                    <li>{{ $t("osdSetupCustomLogoInfoColorMap") }}</li>
+                                    <li id="font-logo-info-size">{{ $t("osdSetupCustomLogoInfoImageSize") }}</li>
+                                    <li id="font-logo-info-colors">{{ $t("osdSetupCustomLogoInfoColorMap") }}</li>
                                 </ul>
-                                <p v-html="$t('osdSetupCustomLogoInfoUploadHint')"></p>
+                                <p id="font-logo-info-upload-hint" v-html="$t('osdSetupCustomLogoInfoUploadHint')"></p>
                             </div>
                         </div>
 
@@ -673,12 +674,20 @@ const profileOptions = computed(() =>
     })),
 );
 
-const fontSelectOptions = computed(() =>
-    fontTypes.value.map((font, idx) => ({
-        value: idx,
-        label: i18n.getMessage(font.name),
-    })),
-);
+const fontSelectOptions = computed(() => {
+    const items = [];
+    if (selectedFont.value === -1) {
+        items.push({
+            value: -1,
+            label: i18n.getMessage("osdSetupFontPresetsSelectorCustomOption"),
+            disabled: true,
+        });
+    }
+    fontTypes.value.forEach((font, idx) => {
+        items.push({ value: idx, label: i18n.getMessage(font.name) });
+    });
+    return items;
+});
 
 const fontPresetSelectItems = computed(() => {
     const items = [];

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -1501,13 +1501,12 @@ const handleClickOutside = () => closePresetMenu();
 onMounted(async () => {
     document.addEventListener("click", handleClickOutside);
     SYM.loadSymbols();
-    // Inject logo-size i18n resources (logoWidthPx / logoHeightPx) needed by
-    // translation strings before the font manager dialog is opened.  The DOM
-    // element cache will be stale (dialog is not yet mounted), but
-    // openFontManager() re-runs init() after showModal() to fix that.
-    LogoManager.init(FONT, SYM.LOGO);
     await loadConfig();
     await nextTick();
+    if (osdStore.isSupported) {
+        // Dialog markup is mounted now; openFontManager() will re-run this after showModal().
+        LogoManager.init(FONT, SYM.LOGO);
+    }
     applyLegacyMobilePreviewZoom();
     GUI.content_ready();
 });

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -1,631 +1,516 @@
 <template>
     <BaseTab tab-name="osd">
-        <div class="content_wrapper">
+        <div class="content_wrapper pb-15">
             <div class="tab_title">{{ $t("osdSetupTitle") }}</div>
             <WikiButton docUrl="OSD" />
 
             <!-- Warning: No OSD Chip Detected -->
-            <div
+            <UiBox
                 v-if="
                     hasLoadedConfig &&
                     osdStore.state.haveMax7456FontDeviceConfigured &&
                     !osdStore.state.isMax7456FontDeviceDetected &&
                     !osdStore.state.haveAirbotTheiaOsdDevice
                 "
-                class="noOsdChipDetect"
+                type="warning"
+                highlight
+                class="mb-3"
             >
-                <p class="note">{{ $t("osdSetupNoOsdChipDetectWarning") }}</p>
-            </div>
+                <p>{{ $t("osdSetupNoOsdChipDetectWarning") }}</p>
+            </UiBox>
 
             <!-- Warning: Unsupported -->
-            <div v-if="hasLoadedConfig && !osdStore.isSupported" class="unsupported">
-                <p class="note">{{ $t("osdSetupUnsupportedNote1") }}</p>
-                <p class="note" v-html="$t('osdSetupUnsupportedNote2')"></p>
-            </div>
+            <UiBox v-if="hasLoadedConfig && !osdStore.isSupported" type="error" highlight class="mb-3">
+                <p>{{ $t("osdSetupUnsupportedNote1") }}</p>
+                <p v-html="$t('osdSetupUnsupportedNote2')"></p>
+            </UiBox>
 
             <!-- Supported OSD Content -->
-            <div v-if="hasLoadedConfig && osdStore.isSupported" class="supported">
-                <div style="margin-bottom: 10px">
-                    <p class="note" v-html="$t('osdSetupPreviewHelp')"></p>
-                </div>
+            <div v-if="hasLoadedConfig && osdStore.isSupported">
+                <UiBox highlight class="mb-3">
+                    <p v-html="$t('osdSetupPreviewHelp')"></p>
+                </UiBox>
 
                 <div class="grid-row grid-box col4">
                     <!-- Elements Column -->
-                    <div class="col-span-1 elements requires-osd-feature osd-feature">
-                        <div class="gui_box grey">
-                            <div
-                                class="gui_box_titlebar cf_tip"
-                                style="margin-bottom: 0px"
-                                :title="$t('osdSectionHelpElements')"
-                            >
-                                <div class="spacer_box_title">
-                                    <span class="osd-profiles-header cf_tip" :title="$t('osdSetupProfilesTitle')">
+                    <div class="col-span-1">
+                        <UiBox :title="$t('osdSetupElementsTitle')" :help="$t('osdSectionHelpElements')">
+                            <template #title>
+                                <HelpIcon :text="$t('osdSetupProfilesTitle')" />
+                                <span
+                                    v-for="profileIdx in osdStore.numberOfProfiles"
+                                    :key="profileIdx"
+                                    class="inline-block w-5 text-center font-bold"
+                                    >{{ profileIdx }}</span
+                                >
+                            </template>
+                            <!-- Search box -->
+                            <UInput
+                                v-model="elementSearchQuery"
+                                :placeholder="$t('search') + '...'"
+                                icon="i-lucide-search"
+                                size="sm"
+                                class="mb-2"
+                            />
+                            <!-- Element list -->
+                            <div class="flex flex-col">
+                                <div
+                                    v-for="field in filteredDisplayItems"
+                                    :key="field.index"
+                                    class="flex items-center gap-1 py-0.5 border-b border-neutral-500/30 last:border-b-0"
+                                    :class="{ 'bg-neutral-500/15': isFieldHighlighted(field) }"
+                                    @mouseenter="highlightField(field)"
+                                    @mouseleave="unhighlightField(field)"
+                                >
+                                    <!-- Profile checkboxes -->
+                                    <div class="flex gap-1 shrink-0">
                                         <template v-for="profileIdx in osdStore.numberOfProfiles" :key="profileIdx">
-                                            <span class="profile-label">{{ profileIdx }}</span>
+                                            <input
+                                                type="checkbox"
+                                                :checked="field.isVisible[profileIdx - 1]"
+                                                @change="toggleFieldVisibility(field.index, profileIdx - 1, $event)"
+                                                class="size-4"
+                                            />
                                         </template>
-                                    </span>
-                                    <span>{{ $t("osdSetupElementsTitle") }}</span>
-                                </div>
-                            </div>
-                            <div class="spacer_box">
-                                <!-- Search box -->
-                                <div class="element-search">
-                                    <input
-                                        type="text"
-                                        v-model="elementSearchQuery"
-                                        :placeholder="$t('search') + '...'"
-                                        class="search-input"
+                                    </div>
+
+                                    <!-- Field label -->
+                                    <span class="flex-1 ml-1 text-xs truncate cursor-default" :title="$t(field.desc)">{{
+                                        $t(field.text, field.textParams)
+                                    }}</span>
+
+                                    <!-- Variant selector -->
+                                    <USelect
+                                        v-if="field.variants && field.variants.length > 1"
+                                        :model-value="field.variant"
+                                        @update:model-value="
+                                            (v) => {
+                                                field.variant = v;
+                                                onVariantChange(field);
+                                            }
+                                        "
+                                        :items="field.variants.map((v, i) => ({ value: i, label: $t(v) }))"
+                                        size="xs"
+                                        class="w-24 shrink-0"
                                     />
-                                </div>
-                                <div id="element-fields" class="switchable-fields">
-                                    <div
-                                        v-for="field in filteredDisplayItems"
-                                        :key="field.index"
-                                        class="switchable-field display-field"
-                                        :class="{ highlighted: isFieldHighlighted(field) }"
-                                        @mouseenter="highlightField(field)"
-                                        @mouseleave="unhighlightField(field)"
-                                    >
-                                        <div class="profile-checkboxes">
-                                            <template v-for="profileIdx in osdStore.numberOfProfiles" :key="profileIdx">
-                                                <input
-                                                    type="checkbox"
-                                                    :checked="field.isVisible[profileIdx - 1]"
-                                                    @change="toggleFieldVisibility(field.index, profileIdx - 1, $event)"
-                                                    class="profile-checkbox"
-                                                />
-                                            </template>
-                                        </div>
 
-                                        <!-- Field label -->
-                                        <span class="field-label cf_tip" :title="$t(field.desc)">{{
-                                            $t(field.text, field.textParams)
-                                        }}</span>
-
-                                        <!-- Variant selector -->
-                                        <select
-                                            v-if="field.variants && field.variants.length > 1"
-                                            v-model="field.variant"
-                                            @change="onVariantChange(field)"
-                                            class="variant-selector"
+                                    <!-- Preset button -->
+                                    <div v-if="field.positionable" class="tab-osd-position-controls">
+                                        <div
+                                            class="tab-osd-preset-btn"
+                                            @click="openPresetMenu(field, $event)"
+                                            :title="$t('presetsOptions')"
                                         >
-                                            <option v-for="(variant, vIdx) in field.variants" :key="vIdx" :value="vIdx">
-                                                {{ $t(variant) }}
-                                            </option>
-                                        </select>
-
-                                        <!-- Preset button only (position input removed to match legacy) -->
-                                        <div v-if="field.positionable" class="position-controls">
-                                            <div
-                                                class="preset-pos-btn"
-                                                @click="openPresetMenu(field, $event)"
-                                                :title="$t('presetsOptions')"
-                                            >
-                                                ...
-                                            </div>
-                                            <!-- Context Menu (Level 1) -->
-                                            <div v-if="presetMenuField === field" class="context-menu show" @click.stop>
-                                                <div class="context-menu-item">
-                                                    <div
-                                                        class="context-menu-item-display"
-                                                        @click="showPresetSubmenu = !showPresetSubmenu"
-                                                    >
-                                                        <span>{{ $t("osdPresetPositionAlignTitle") }}</span>
-                                                        <span>
-                                                            ▶
-                                                            <span class="context-menu-item-content-wrapper">
-                                                                <!-- Submenu (Level 2 - Grid) -->
-                                                                <div
-                                                                    class="context-menu-item-content"
-                                                                    :class="{ show: showPresetSubmenu }"
-                                                                    @click.stop
-                                                                >
-                                                                    <div id="preset-pos-grid-wrapper">
-                                                                        <div class="preset-popover-title">
-                                                                            {{ $t("osdPresetPositionChooseTitle") }}
-                                                                        </div>
-                                                                        <div class="preset-grid">
-                                                                            <div
-                                                                                v-for="cell in presetGridCells"
-                                                                                :key="`${cell.col}-${cell.row}`"
-                                                                                class="preset-grid-cell"
-                                                                                :style="{
-                                                                                    gridColumn: cell.col + 1,
-                                                                                    gridRow: cell.row + 1,
-                                                                                }"
-                                                                                :title="cell.label"
-                                                                                @click="
-                                                                                    applyPresetPosition(field, cell.key)
-                                                                                "
-                                                                            >
-                                                                                <span class="preset-cell-dot"></span>
-                                                                            </div>
+                                            ...
+                                        </div>
+                                        <!-- Context Menu (Level 1) -->
+                                        <div v-if="presetMenuField === field" class="tab-osd-context-menu" @click.stop>
+                                            <div class="tab-osd-context-menu-item">
+                                                <div
+                                                    class="tab-osd-context-menu-display"
+                                                    @click="showPresetSubmenu = !showPresetSubmenu"
+                                                >
+                                                    <span>{{ $t("osdPresetPositionAlignTitle") }}</span>
+                                                    <span>
+                                                        ▶
+                                                        <span class="tab-osd-context-menu-content-wrapper">
+                                                            <!-- Submenu (Level 2 - Grid) -->
+                                                            <div
+                                                                class="tab-osd-context-menu-content"
+                                                                :class="{ show: showPresetSubmenu }"
+                                                                @click.stop
+                                                            >
+                                                                <div class="tab-osd-preset-grid-wrapper">
+                                                                    <div class="font-semibold text-center mb-1.5">
+                                                                        {{ $t("osdPresetPositionChooseTitle") }}
+                                                                    </div>
+                                                                    <div class="tab-osd-preset-grid">
+                                                                        <div
+                                                                            v-for="cell in presetGridCells"
+                                                                            :key="`${cell.col}-${cell.row}`"
+                                                                            class="tab-osd-preset-grid-cell"
+                                                                            :style="{
+                                                                                gridColumn: cell.col + 1,
+                                                                                gridRow: cell.row + 1,
+                                                                            }"
+                                                                            :title="cell.label"
+                                                                            @click="
+                                                                                applyPresetPosition(field, cell.key)
+                                                                            "
+                                                                        >
+                                                                            <span
+                                                                                class="tab-osd-preset-cell-dot"
+                                                                            ></span>
                                                                         </div>
                                                                     </div>
                                                                 </div>
-                                                            </span>
+                                                            </div>
                                                         </span>
-                                                    </div>
+                                                    </span>
                                                 </div>
                                             </div>
                                         </div>
                                     </div>
                                 </div>
                             </div>
-                        </div>
+                        </UiBox>
                     </div>
 
                     <!-- Preview Column -->
-                    <div class="col-span-2 osd-preview">
-                        <div class="gui_box grey preview-parent requires-osd-feature">
-                            <div class="gui_box_titlebar image preview-controls-bar">
-                                <div class="spacer_box_title">
-                                    <span class="preview-controls-wrapper" :title="$t('osdSetupPreviewForTitle')">
-                                        <label for="osd-preview-profile">{{
-                                            $t("osdSetupPreviewSelectProfileTitle")
-                                        }}</label>
-                                        <select
-                                            id="osd-preview-profile"
-                                            v-model.number="previewProfile"
-                                            class="osdprofile-selector small"
-                                        >
-                                            <option
-                                                v-for="idx in osdStore.numberOfProfiles"
-                                                :key="idx"
-                                                :value="idx - 1"
-                                            >
-                                                {{ $t("osdSetupPreviewSelectProfileElement", { profileNumber: idx }) }}
-                                            </option>
-                                        </select>
-
-                                        <label for="osd-preview-font">{{ $t("osdSetupPreviewSelectFont") }}</label>
-                                        <select
-                                            id="osd-preview-font"
-                                            v-model.number="selectedFont"
-                                            class="osdfont-selector small"
-                                        >
-                                            <option v-for="(font, idx) in fontTypes" :key="idx" :value="idx">
-                                                {{ $t(font.name) }}
-                                            </option>
-                                        </select>
-
-                                        <span class="osd-preview-rulers-group">
-                                            <input
-                                                type="checkbox"
-                                                id="osd-preview-rulers-selector"
-                                                v-model="showRulers"
-                                            />
-                                            <label for="osd-preview-rulers-selector">{{
-                                                $t("osdSetupPreviewCheckRulers")
-                                            }}</label>
-                                        </span>
-                                    </span>
-                                </div>
+                    <div class="col-span-2">
+                        <div class="tab-osd-preview-parent sticky top-6">
+                            <!-- Controls bar -->
+                            <div
+                                class="flex items-center gap-2 flex-wrap bg-primary rounded-full px-4 py-1.5 mb-2.5 text-[13px] font-bold text-black"
+                            >
+                                <label>{{ $t("osdSetupPreviewSelectProfileTitle") }}</label>
+                                <USelect v-model="previewProfile" :items="profileOptions" size="xs" class="w-36" />
+                                <label>{{ $t("osdSetupPreviewSelectFont") }}</label>
+                                <USelect v-model="selectedFont" :items="fontSelectOptions" size="xs" class="w-36" />
+                                <span class="ml-auto flex items-center gap-1.5">
+                                    <USwitch v-model="showRulers" size="xs" />
+                                    <label>{{ $t("osdSetupPreviewCheckRulers") }}</label>
+                                </span>
                             </div>
 
-                            <div class="display-layout">
-                                <div ref="previewContainerOuter" class="preview-container">
-                                    <canvas
-                                        ref="rulerCanvas"
-                                        class="ruler-overlay"
-                                        v-show="effectiveShowRulers"
-                                    ></canvas>
-                                    <div
-                                        ref="previewContainer"
-                                        class="preview"
-                                        @mousedown="onPreviewMouseDown"
-                                        @mouseup="onPreviewMouseUp"
-                                        @mouseleave="onPreviewMouseUp"
-                                    >
-                                        <!-- Preview elements rendered as rows/cells -->
-                                        <div class="row" v-for="(row, rIdx) in previewRows" :key="rIdx">
-                                            <div
-                                                v-for="(cell, cIdx) in row"
-                                                :key="cIdx"
-                                                class="char"
-                                                :class="getPreviewCellClass(cell)"
-                                                :data-x="cIdx"
-                                                :data-y="rIdx"
-                                                :data-position="rIdx * osdStore.displaySize.x + cIdx"
-                                                :draggable="cell.field?.positionable"
-                                                @dragstart="onDragStart($event, cell)"
-                                                @dragover.prevent="onDragOverCell($event)"
-                                                @dragleave="onDragLeaveCell($event)"
-                                                @drop.prevent="onDropCell($event)"
-                                                @dragend="onPreviewMouseUp"
-                                                @mouseenter="onCellMouseEnter(cell)"
-                                                @mouseleave="onCellMouseLeave(cell)"
-                                            >
-                                                <img
-                                                    :src="
-                                                        cell.img ||
-                                                        'data:image/svg+xml;utf8,<svg width=\'12\' height=\'18\' xmlns=\'http://www.w3.org/2000/svg\'></svg>'
-                                                    "
-                                                    draggable="false"
-                                                    alt="Preview Element"
-                                                />
-                                            </div>
+                            <!-- Preview area -->
+                            <div ref="previewContainerOuter" class="relative">
+                                <canvas
+                                    ref="rulerCanvas"
+                                    class="absolute inset-0 w-full h-full z-10 pointer-events-none"
+                                    v-show="effectiveShowRulers"
+                                ></canvas>
+                                <div
+                                    ref="previewContainer"
+                                    class="tab-osd-preview"
+                                    @mousedown="onPreviewMouseDown"
+                                    @mouseup="onPreviewMouseUp"
+                                    @mouseleave="onPreviewMouseUp"
+                                >
+                                    <!-- Preview elements rendered as rows/cells -->
+                                    <div class="flex" v-for="(row, rIdx) in previewRows" :key="rIdx">
+                                        <div
+                                            v-for="(cell, cIdx) in row"
+                                            :key="cIdx"
+                                            class="tab-osd-char"
+                                            :class="getPreviewCellClass(cell)"
+                                            :data-x="cIdx"
+                                            :data-y="rIdx"
+                                            :data-position="rIdx * osdStore.displaySize.x + cIdx"
+                                            :draggable="cell.field?.positionable"
+                                            @dragstart="onDragStart($event, cell)"
+                                            @dragover.prevent="onDragOverCell($event)"
+                                            @dragleave="onDragLeaveCell($event)"
+                                            @drop.prevent="onDropCell($event)"
+                                            @dragend="onPreviewMouseUp"
+                                            @mouseenter="onCellMouseEnter(cell)"
+                                            @mouseleave="onCellMouseLeave(cell)"
+                                        >
+                                            <img
+                                                :src="
+                                                    cell.img ||
+                                                    'data:image/svg+xml;utf8,<svg width=\'12\' height=\'18\' xmlns=\'http://www.w3.org/2000/svg\'></svg>'
+                                                "
+                                                draggable="false"
+                                                alt=""
+                                                aria-hidden="true"
+                                            />
                                         </div>
                                     </div>
                                 </div>
                             </div>
 
-                            <div class="gui_box_bottombar">
-                                <div class="spacer_box_title">{{ $t("osdSetupPreviewTitle") }}</div>
+                            <div class="text-center mt-6 text-sm font-semibold">
+                                {{ $t("osdSetupPreviewTitle") }}
                             </div>
                         </div>
                     </div>
 
                     <!-- Settings Column -->
-                    <div class="col-span-1 osd-profile">
+                    <div class="col-span-1">
                         <!-- Active Profile Selector -->
-                        <div class="gui_box osdprofile-selected-container grey">
-                            <div class="gui_box_titlebar cf_tip">
-                                <div class="spacer_box_title">{{ $t("osdSetupSelectedProfileTitle") }}</div>
-                            </div>
-                            <div class="spacer_box">
-                                <label for="osd-active-profile">{{ $t("osdSetupSelectedProfileLabel") }}</label>
-                                <select
-                                    id="osd-active-profile"
-                                    v-model.number="activeProfile"
-                                    class="osdprofile-active"
-                                >
-                                    <option v-for="idx in osdStore.numberOfProfiles" :key="idx" :value="idx - 1">
-                                        {{ $t("osdSetupPreviewSelectProfileElement", { profileNumber: idx }) }}
-                                    </option>
-                                </select>
-                            </div>
-                        </div>
+                        <UiBox :title="$t('osdSetupSelectedProfileTitle')">
+                            <SettingRow :label="$t('osdSetupSelectedProfileLabel')">
+                                <USelect v-model="activeProfile" :items="profileOptions" size="sm" class="min-w-40" />
+                            </SettingRow>
+                        </UiBox>
 
                         <!-- Video Format (MAX7456 only) -->
-                        <div
+                        <UiBox
                             v-if="osdStore.state.haveMax7456Configured || osdStore.state.isMspDevice"
-                            class="gui_box videomode-container grey requires-max7456"
+                            :title="$t('osdSetupVideoFormatTitle')"
+                            :help="$t('osdSectionHelpVideoMode')"
                         >
-                            <div class="gui_box_titlebar cf_tip" :title="$t('osdSectionHelpVideoMode')">
-                                <div class="spacer_box_title">{{ $t("osdSetupVideoFormatTitle") }}</div>
-                            </div>
-                            <div class="spacer_box">
-                                <div class="video-types">
-                                    <label
-                                        v-for="option in videoTypeOptions"
-                                        :key="option.value"
-                                        class="video-type-option"
-                                        :class="{ disabled: option.disabled }"
-                                    >
-                                        <input
-                                            type="radio"
-                                            :value="option.value"
-                                            :disabled="option.disabled"
-                                            v-model.number="osdStore.videoSystem"
-                                            @change="onVideoSystemChange"
-                                        />
-                                        <span>{{ $t(option.label) }}</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
+                            <SettingRow :label="$t('osdSetupVideoFormatTitle')">
+                                <USelect
+                                    :model-value="osdStore.videoSystem"
+                                    @update:model-value="
+                                        (v) => {
+                                            osdStore.videoSystem = v;
+                                            onVideoSystemChange();
+                                        }
+                                    "
+                                    :items="videoTypeSelectItems"
+                                    size="sm"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                        </UiBox>
 
                         <!-- Units -->
-                        <div
+                        <UiBox
                             v-if="osdStore.state.haveOsdFeature"
-                            class="gui_box grey units-container requires-osd-feature"
+                            :title="$t('osdSetupUnitsTitle')"
+                            :help="$t('osdSectionHelpUnits')"
                         >
-                            <div class="gui_box_titlebar cf_tip" :title="$t('osdSectionHelpUnits')">
-                                <div class="spacer_box_title">{{ $t("osdSetupUnitsTitle") }}</div>
-                            </div>
-                            <div class="spacer_box">
-                                <div class="units">
-                                    <label v-for="unit in unitTypeOptions" :key="unit.value" class="unit-option">
-                                        <input
-                                            type="radio"
-                                            :value="unit.value"
-                                            v-model.number="osdStore.unitMode"
-                                            @change="onUnitModeChange"
-                                        />
-                                        <span>{{ $t(unit.label) }}</span>
-                                    </label>
-                                </div>
-                            </div>
-                        </div>
+                            <SettingRow :label="$t('osdSetupUnitsTitle')">
+                                <USelect
+                                    :model-value="osdStore.unitMode"
+                                    @update:model-value="
+                                        (v) => {
+                                            osdStore.unitMode = v;
+                                            onUnitModeChange();
+                                        }
+                                    "
+                                    :items="unitTypeSelectItems"
+                                    size="sm"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                        </UiBox>
 
                         <!-- Timers -->
-                        <div
+                        <UiBox
                             v-if="osdStore.state.haveOsdFeature && osdStore.timers.length > 0"
-                            class="gui_box grey timers-container requires-osd-feature"
+                            :title="$t('osdSetupTimersTitle')"
+                            :help="$t('osdSectionHelpTimers')"
                         >
                             <div
-                                class="gui_box_titlebar cf_tip"
-                                style="margin-bottom: 0px"
-                                :title="$t('osdSectionHelpTimers')"
+                                v-for="(timer, idx) in osdStore.timers"
+                                :key="idx"
+                                class="flex flex-col gap-2 pb-3 mb-3 border-b border-neutral-500/30 last:border-b-0 last:mb-0 last:pb-0"
                             >
-                                <div class="spacer_box_title">{{ $t("osdSetupTimersTitle") }}</div>
+                                <div class="font-bold text-sm">{{ idx + 1 }}</div>
+                                <SettingRow :label="$t('osdTimerSource')" :help="$t('osdTimerSourceTooltip')">
+                                    <USelect
+                                        :model-value="timer.src"
+                                        @update:model-value="
+                                            (v) => {
+                                                timer.src = v;
+                                                onTimerChange(timer);
+                                            }
+                                        "
+                                        :items="timerSourceItems"
+                                        size="sm"
+                                        class="min-w-36"
+                                    />
+                                </SettingRow>
+                                <SettingRow :label="$t('osdTimerPrecision')" :help="$t('osdTimerPrecisionTooltip')">
+                                    <USelect
+                                        :model-value="timer.precision"
+                                        @update:model-value="
+                                            (v) => {
+                                                timer.precision = v;
+                                                onTimerChange(timer);
+                                            }
+                                        "
+                                        :items="timerPrecisionItems"
+                                        size="sm"
+                                        class="min-w-36"
+                                    />
+                                </SettingRow>
+                                <SettingRow :label="$t('osdTimerAlarm')" :help="$t('osdTimerAlarmTooltip')">
+                                    <UInputNumber
+                                        v-model="timer.alarm"
+                                        :min="0"
+                                        :max="600"
+                                        :step="1"
+                                        size="xs"
+                                        orientation="vertical"
+                                        class="w-16"
+                                        @update:model-value="onTimerChange(timer)"
+                                    />
+                                </SettingRow>
                             </div>
-                            <div class="spacer_box">
-                                <div id="timer-fields" class="switchable-fields">
-                                    <div v-for="(timer, idx) in osdStore.timers" :key="idx" class="timer-config">
-                                        <div class="timer-index">{{ idx + 1 }}</div>
-                                        <div class="timer-fields">
-                                            <div class="timer-row osd_tip" :title="$t('osdTimerSourceTooltip')">
-                                                <label :for="'osd-timer-src-' + idx">{{ $t("osdTimerSource") }}</label>
-                                                <select
-                                                    :id="'osd-timer-src-' + idx"
-                                                    v-model.number="timer.src"
-                                                    @change="onTimerChange(timer)"
-                                                >
-                                                    <option
-                                                        v-for="(src, sIdx) in timerSources"
-                                                        :key="sIdx"
-                                                        :value="sIdx"
-                                                    >
-                                                        {{ $t(src) }}
-                                                    </option>
-                                                </select>
-                                            </div>
-                                            <div class="timer-row osd_tip" :title="$t('osdTimerPrecisionTooltip')">
-                                                <label :for="'osd-timer-prec-' + idx">{{
-                                                    $t("osdTimerPrecision")
-                                                }}</label>
-                                                <select
-                                                    :id="'osd-timer-prec-' + idx"
-                                                    v-model.number="timer.precision"
-                                                    @change="onTimerChange(timer)"
-                                                >
-                                                    <option
-                                                        v-for="(prec, pIdx) in timerPrecisions"
-                                                        :key="pIdx"
-                                                        :value="pIdx"
-                                                    >
-                                                        {{ $t(prec) }}
-                                                    </option>
-                                                </select>
-                                            </div>
-                                            <div class="timer-row osd_tip" :title="$t('osdTimerAlarmTooltip')">
-                                                <label :for="'osd-timer-alarm-' + idx">{{ $t("osdTimerAlarm") }}</label>
-                                                <UInputNumber
-                                                    :id="'osd-timer-alarm-' + idx"
-                                                    v-model="timer.alarm"
-                                                    :min="0"
-                                                    :max="600"
-                                                    :step="1"
-                                                    @change="onTimerChange(timer)"
-                                                />
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </UiBox>
 
                         <!-- Alarms -->
-                        <div
+                        <UiBox
                             v-if="osdStore.state.haveOsdFeature && alarmEntries.length > 0"
-                            class="gui_box grey alarms-container requires-osd-feature"
+                            :title="$t('osdSetupAlarmsTitle')"
+                            :help="$t('osdSectionHelpAlarms')"
                         >
-                            <div class="gui_box_titlebar cf_tip" :title="$t('osdSectionHelpAlarms')">
-                                <div class="spacer_box_title">{{ $t("osdSetupAlarmsTitle") }}</div>
+                            <div
+                                v-for="entry in alarmEntries"
+                                :key="entry.key"
+                                class="flex items-center gap-2.5 py-1.5 border-b border-neutral-500/30 last:border-b-0"
+                            >
+                                <UInputNumber
+                                    v-model="entry.alarm.value"
+                                    :min="entry.alarm.min || 0"
+                                    :max="entry.alarm.max || 9999"
+                                    :step="1"
+                                    size="xs"
+                                    orientation="vertical"
+                                    class="w-16"
+                                    @update:model-value="onAlarmChange"
+                                />
+                                <span class="text-sm">{{ entry.alarm.display_name }}</span>
                             </div>
-                            <div class="spacer_box">
-                                <div class="alarms">
-                                    <div v-for="entry in alarmEntries" :key="entry.key" class="alarm-config">
-                                        <label :for="'osd-alarm-' + entry.key">
-                                            <UInputNumber
-                                                :id="'osd-alarm-' + entry.key"
-                                                v-model="entry.alarm.value"
-                                                :min="entry.alarm.min || 0"
-                                                :max="entry.alarm.max || 9999"
-                                                :step="1"
-                                                @change="onAlarmChange"
-                                            />
-                                            <span>{{ entry.alarm.display_name }}</span>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </UiBox>
 
                         <!-- Warnings -->
-                        <div
+                        <UiBox
                             v-if="osdStore.state.haveOsdFeature && sortedWarnings.length > 0"
-                            class="gui_box grey warnings-container requires-osd-feature"
+                            :title="$t('osdSetupWarningsTitle')"
+                            :help="$t('osdSectionHelpWarnings')"
                         >
                             <div
-                                class="gui_box_titlebar cf_tip"
-                                style="margin-bottom: 0px"
-                                :title="$t('osdSectionHelpWarnings')"
+                                v-for="warning in sortedWarnings"
+                                :key="warning.index"
+                                class="flex items-center gap-2 py-0.5"
                             >
-                                <div class="spacer_box_title">{{ $t("osdSetupWarningsTitle") }}</div>
+                                <USwitch
+                                    :model-value="warning.enabled"
+                                    @update:model-value="
+                                        (v) => {
+                                            warning.enabled = v;
+                                            onWarningChange();
+                                        }
+                                    "
+                                    size="sm"
+                                />
+                                <span class="text-xs" :title="warning.desc ? $t(warning.desc) : undefined">{{
+                                    $t(warning.text, warning.textParams)
+                                }}</span>
                             </div>
-                            <div class="spacer_box">
-                                <div id="warnings-fields" class="switchable-fields">
-                                    <div
-                                        v-for="warning in sortedWarnings"
-                                        :key="warning.index"
-                                        class="switchable-field"
-                                        :class="[`field-${warning.index}`, { osd_tip: warning.desc }]"
-                                        :title="warning.desc ? $t(warning.desc) : undefined"
-                                    >
-                                        <input
-                                            type="checkbox"
-                                            :id="warning.name"
-                                            :name="warning.name"
-                                            class="togglesmall"
-                                            v-model="warning.enabled"
-                                            @change="onWarningChange"
-                                        />
-                                        <label :for="warning.name" class="char-label">{{
-                                            $t(warning.text, warning.textParams)
-                                        }}</label>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </UiBox>
 
                         <!-- Post-flight Stats -->
-                        <div
+                        <UiBox
                             v-if="osdStore.state.haveOsdFeature && sortedStatItems.length > 0"
-                            class="gui_box grey stats-container requires-osd-feature"
+                            :title="$t('osdSetupStatsTitle')"
+                            :help="$t('osdSectionHelpStats')"
                         >
                             <div
-                                class="gui_box_titlebar cf_tip"
-                                style="margin-bottom: 0px"
-                                :title="$t('osdSectionHelpStats')"
+                                v-for="stat in sortedStatItems"
+                                :key="stat.index"
+                                class="flex items-center gap-2 py-0.5"
                             >
-                                <div class="spacer_box_title">{{ $t("osdSetupStatsTitle") }}</div>
+                                <USwitch
+                                    :model-value="stat.enabled"
+                                    @update:model-value="
+                                        (v) => {
+                                            stat.enabled = v;
+                                            onStatChange(stat);
+                                        }
+                                    "
+                                    size="sm"
+                                />
+                                <span class="text-xs" :title="stat.desc ? $t(stat.desc) : undefined">{{
+                                    $t(stat.text, stat.textParams)
+                                }}</span>
                             </div>
-                            <div class="spacer_box">
-                                <div id="post-flight-stat-fields" class="switchable-fields">
-                                    <div
-                                        v-for="stat in sortedStatItems"
-                                        :key="stat.index"
-                                        class="switchable-field"
-                                        :class="[`field-${stat.index}`, { osd_tip: stat.desc }]"
-                                        :title="stat.desc ? $t(stat.desc) : undefined"
-                                    >
-                                        <input
-                                            type="checkbox"
-                                            :id="stat.name"
-                                            :name="stat.name"
-                                            class="togglesmall"
-                                            v-model="stat.enabled"
-                                            @change="onStatChange(stat)"
-                                        />
-                                        <label :for="stat.name" class="char-label">{{
-                                            $t(stat.text, stat.textParams)
-                                        }}</label>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
+                        </UiBox>
                     </div>
                 </div>
 
                 <!-- Font Manager Dialog -->
-                <dialog ref="fontManagerDialog" id="fontmanagerdialog" class="html-dialog" style="width: 750px">
-                    <div
-                        style="
-                            display: flex;
-                            height: 47px;
-                            background: var(--surface-300);
-                            border-bottom: 1px solid var(--surface-950);
-                        "
-                    >
-                        <div style="flex: 1; display: flex; align-items: center">
-                            <div style="padding: 15px">{{ $t("osdSetupFontManagerTitle") }}</div>
+                <dialog ref="fontManagerDialog" class="w-[750px] h-fit">
+                    <div class="flex h-12 bg-elevated border-b border-default">
+                        <div class="flex-1 flex items-center px-4 font-semibold">
+                            {{ $t("osdSetupFontManagerTitle") }}
                         </div>
-                        <div
+                        <UButton
                             @click="closeFontManager"
-                            style="
-                                flex: 0 0 47px;
-                                display: flex;
-                                align-items: center;
-                                justify-content: center;
-                                cursor: pointer;
-                            "
-                        >
-                            <svg width="10" height="10" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                                <line x1="0" y1="0" x2="10" y2="10" stroke="var(--surface-950)" stroke-width="2" />
-                                <line x1="0" y1="10" x2="10" y2="0" stroke="var(--surface-950)" stroke-width="2" />
-                            </svg>
-                        </div>
+                            icon="i-lucide-x"
+                            variant="ghost"
+                            color="neutral"
+                            size="sm"
+                            class="my-auto mr-2"
+                        />
                     </div>
-                    <div class="html-dialog-content">
-                        <div class="font-picker">
-                            <h1 class="tab_title">{{ $t("osdSetupFontPresets") }}</h1>
-                            <span class="font-manager-version-info">{{ fontVersionInfo }}</span>
-                            <div class="content_wrapper font-preview" ref="fontPreviewContainer">
-                                <img
-                                    v-for="(url, charIdx) in fontCharacterUrls"
-                                    :key="charIdx"
-                                    :src="url"
-                                    :title="'0x' + charIdx.toString(16)"
-                                    alt="Font Character"
-                                />
-                            </div>
-                            <div class="fontpresets_wrapper">
-                                <label for="osd-font-preset">{{ $t("osdSetupFontPresetsSelector") }}</label>
-                                <select id="osd-font-preset" v-model.number="selectedFontPreset" class="fontpresets">
-                                    <option v-show="selectedFontPreset === -1" :value="-1" disabled>
-                                        {{ $t("osdSetupFontPresetsSelectorCustomOption") }}
-                                    </option>
-                                    <option v-for="(font, idx) in fontTypes" :key="idx" :value="idx">
-                                        {{ $t(font.name) }}
-                                    </option>
-                                </select>
-                                <span>{{ $t("osdSetupFontPresetsSelectorOr") }}</span>
-                                <button type="button" class="load_font_file" @click="loadCustomFontFile()">
-                                    {{ $t("osdSetupOpenFont") }}
-                                </button>
-                                <span class="font-format-hint">(.mcm)</span>
-                            </div>
+                    <div class="p-5">
+                        <h1 class="text-lg font-bold mb-1">{{ $t("osdSetupFontPresets") }}</h1>
+                        <span class="text-sm opacity-60">{{ fontVersionInfo }}</span>
+                        <div class="flex flex-wrap gap-0 my-3" ref="fontPreviewContainer">
+                            <img
+                                v-for="(url, charIdx) in fontCharacterUrls"
+                                :key="charIdx"
+                                :src="url"
+                                :title="'0x' + charIdx.toString(16)"
+                                alt=""
+                                aria-hidden="true"
+                            />
+                        </div>
+                        <div class="flex items-center gap-2 py-4">
+                            <label>{{ $t("osdSetupFontPresetsSelector") }}</label>
+                            <USelect
+                                v-model="selectedFontPreset"
+                                :items="fontPresetSelectItems"
+                                size="sm"
+                                class="min-w-40"
+                            />
+                            <span>{{ $t("osdSetupFontPresetsSelectorOr") }}</span>
+                            <UButton @click="loadCustomFontFile()" variant="outline" size="sm">
+                                {{ $t("osdSetupOpenFont") }}
+                            </UButton>
+                            <span class="text-sm opacity-60">(.mcm)</span>
+                        </div>
 
-                            <!-- Logo customization -->
-                            <h1 class="tab_title">{{ $t("osdSetupCustomLogoTitle") }}</h1>
-                            <div id="font-logo">
-                                <div id="font-logo-preview-container">
-                                    <div id="font-logo-preview" ref="logoPreview"></div>
-                                </div>
-                                <div id="font-logo-info">
-                                    <h3>{{ $t("osdSetupCustomLogoInfoTitle") }}</h3>
-                                    <ul>
-                                        <li>{{ $t("osdSetupCustomLogoInfoImageSize") }}</li>
-                                        <li>{{ $t("osdSetupCustomLogoInfoColorMap") }}</li>
-                                    </ul>
-                                    <p v-html="$t('osdSetupCustomLogoInfoUploadHint')"></p>
-                                </div>
+                        <!-- Logo customization -->
+                        <h1 class="text-lg font-bold mb-1">{{ $t("osdSetupCustomLogoTitle") }}</h1>
+                        <div class="flex mb-8">
+                            <div class="p-2.5" style="background: rgba(0, 255, 0, 0.4)">
+                                <div
+                                    ref="logoPreview"
+                                    style="background: rgba(0, 255, 0, 1); line-height: 0; margin: auto"
+                                ></div>
                             </div>
-
-                            <div class="default_btn">
-                                <button
-                                    type="button"
-                                    class="replace_logo"
-                                    @click="replaceLogoImage()"
-                                    @keydown.enter.prevent="replaceLogoImage()"
-                                    @keydown.space.prevent="replaceLogoImage()"
-                                >
-                                    {{ $t("osdSetupCustomLogoOpenImageButton") }}
-                                </button>
-                            </div>
-
-                            <div class="info">
-                                <progress class="progress" :value="uploadProgress" min="0" max="100"></progress>
-                                <div class="progressLabel">{{ uploadProgressLabel }}</div>
-                            </div>
-
-                            <div class="default_btn green">
-                                <button
-                                    type="button"
-                                    class="flash_font active"
-                                    @click="flashFont()"
-                                    @keydown.enter.prevent="flashFont()"
-                                    @keydown.space.prevent="flashFont()"
-                                >
-                                    {{ $t("osdSetupUploadFont") }}
-                                </button>
+                            <div class="flex-1 ml-8 leading-relaxed">
+                                <h3 class="font-semibold mb-1">
+                                    {{ $t("osdSetupCustomLogoInfoTitle") }}
+                                </h3>
+                                <ul class="tab-osd-logo-info-list">
+                                    <li>{{ $t("osdSetupCustomLogoInfoImageSize") }}</li>
+                                    <li>{{ $t("osdSetupCustomLogoInfoColorMap") }}</li>
+                                </ul>
+                                <p v-html="$t('osdSetupCustomLogoInfoUploadHint')"></p>
                             </div>
                         </div>
+
+                        <div class="mb-3">
+                            <UButton @click="replaceLogoImage()" variant="outline" size="sm">
+                                {{ $t("osdSetupCustomLogoOpenImageButton") }}
+                            </UButton>
+                        </div>
+
+                        <div class="tab-osd-upload-progress mb-3">
+                            <progress class="tab-osd-progress-bar" :value="uploadProgress" min="0" max="100"></progress>
+                            <div class="tab-osd-progress-label">{{ uploadProgressLabel }}</div>
+                        </div>
+
+                        <UButton @click="flashFont()" color="success" size="sm">
+                            {{ $t("osdSetupUploadFont") }}
+                        </UButton>
                     </div>
                 </dialog>
             </div>
         </div>
 
         <!-- Bottom Toolbar -->
-        <div class="content_toolbar toolbar_fixed_bottom supported">
-            <div class="btn">
-                <button
-                    type="button"
-                    class="fonts"
-                    :class="{ disabled: !osdStore.state.isMax7456FontDeviceDetected }"
+        <div class="content_toolbar toolbar_fixed_bottom">
+            <div class="flex gap-2 items-center">
+                <UButton
                     :disabled="!osdStore.state.isMax7456FontDeviceDetected"
                     @click="osdStore.state.isMax7456FontDeviceDetected && openFontManager()"
+                    variant="outline"
                 >
                     {{ $t("osdSetupFontManagerTitle") }}
-                </button>
-            </div>
-            <div class="btn save_btn">
-                <button type="button" class="save" @click="saveConfig()">
+                </UButton>
+                <UButton @click="saveConfig()" color="primary">
                     {{ saveButtonText }}
-                </button>
+                </UButton>
             </div>
         </div>
     </BaseTab>
@@ -641,6 +526,9 @@ import { useOsdPreview } from "@/composables/useOsdPreview";
 import { useOsdRuler } from "@/composables/useOsdRuler";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
+import UiBox from "@/components/elements/UiBox.vue";
+import HelpIcon from "@/components/elements/HelpIcon.vue";
+import SettingRow from "@/components/elements/SettingRow.vue";
 import { i18n } from "@/js/localization";
 
 import { FONT, SYM } from "@/js/utils/osdFont";
@@ -776,6 +664,65 @@ const timerSources = [
 
 // Font types from OSD constants
 const fontTypes = computed(() => OSD_CONSTANTS.FONT_TYPES || []);
+
+// USelect computed items
+const profileOptions = computed(() =>
+    Array.from({ length: osdStore.numberOfProfiles }, (_, i) => ({
+        value: i,
+        label: i18n.getMessage("osdSetupPreviewSelectProfileElement", { profileNumber: i + 1 }),
+    })),
+);
+
+const fontSelectOptions = computed(() =>
+    fontTypes.value.map((font, idx) => ({
+        value: idx,
+        label: i18n.getMessage(font.name),
+    })),
+);
+
+const fontPresetSelectItems = computed(() => {
+    const items = [];
+    if (selectedFontPreset.value === -1) {
+        items.push({
+            value: -1,
+            label: i18n.getMessage("osdSetupFontPresetsSelectorCustomOption"),
+            disabled: true,
+        });
+    }
+    fontTypes.value.forEach((font, idx) => {
+        items.push({ value: idx, label: i18n.getMessage(font.name) });
+    });
+    return items;
+});
+
+const videoTypeSelectItems = computed(() =>
+    videoTypeOptions.value.map((opt) => ({
+        value: opt.value,
+        label: i18n.getMessage(opt.label),
+        disabled: opt.disabled,
+    })),
+);
+
+const unitTypeSelectItems = computed(() =>
+    unitTypeOptions.map((opt) => ({
+        value: opt.value,
+        label: i18n.getMessage(opt.label),
+    })),
+);
+
+const timerSourceItems = computed(() =>
+    timerSources.map((src, idx) => ({
+        value: idx,
+        label: i18n.getMessage(src),
+    })),
+);
+
+const timerPrecisionItems = computed(() =>
+    timerPrecisions.map((prec, idx) => ({
+        value: idx,
+        label: i18n.getMessage(prec),
+    })),
+);
 
 function getLocalizedFieldText(field) {
     return i18n.getMessage(field.text, field.textParams) || "";
@@ -1564,263 +1511,9 @@ onUnmounted(() => {
 });
 </script>
 
-<style scoped>
-.content_wrapper {
-    padding-bottom: 60px;
-}
-
-/* Base styles */
-:deep(input[type="checkbox"]) {
-    width: 18px;
-    height: 18px;
-}
-
-:deep(select) {
-    background: var(--surface-200);
-    color: var(--text);
-    border: 1px solid var(--surface-500);
-    border-radius: 3px;
-    padding: 2px;
-}
-
-:deep(input) {
-    background: var(--surface-200);
-    color: var(--text);
-    border: 1px solid var(--surface-500);
-    border-radius: 3px;
-}
-
-/* Info Progress Bars */
-.info {
-    display: grid;
-    grid-template-areas: "area";
-    width: 100%;
-    margin-bottom: 10px;
-}
-
-.info .progressLabel {
-    grid-area: area;
-    width: 100%;
-    height: 26px;
-    line-height: 26px;
-    text-align: center;
-    color: white;
-    font-weight: bold;
-}
-
-.info .progressLabel a {
-    color: white;
-}
-
-.info .progressLabel a:hover {
-    text-decoration: underline;
-}
-
-.info .progress {
-    grid-area: area;
-    width: 100%;
-    height: 26px;
-    border-radius: 5px;
-    border: 1px solid var(--surface-500);
-    -webkit-appearance: none;
-    appearance: none;
-}
-
-.info .progress::-webkit-progress-bar {
-    background-color: var(--text);
-    border-radius: 4px;
-    box-shadow: inset 0 0 5px #2f2f2f;
-}
-
-.info .progress::-webkit-progress-value {
-    background-color: #f86008;
-    border-radius: 4px;
-}
-
-.info .progress.valid::-webkit-progress-bar,
-.info .progress.valid::-webkit-progress-value {
-    background-color: #56ac1d;
-    border-radius: 4px;
-}
-
-.info .progress.invalid::-webkit-progress-bar,
-.info .progress.invalid::-webkit-progress-value {
-    background-color: #a62e32;
-    border-radius: 4px;
-}
-
-/* Options */
-.options {
-    position: relative;
-    margin-bottom: 10px;
-    line-height: 18px;
-    text-align: left;
-}
-
-.options label input {
-    margin-top: 2px;
-}
-
-.options label span {
-    font-weight: bold;
-    margin-left: 6px;
-}
-
-.options select {
-    width: 300px;
-    height: 20px;
-    border: 1px solid var(--surface-500);
-}
-
-.options .releases select {
-    width: 280px;
-}
-
-.options .description {
-    position: relative;
-    left: 0;
-    font-style: italic;
-    color: #818181;
-}
-
-.options .flash_on_connect_wrapper {
-    display: none;
-}
-
-.options .manual_baud_rate select {
-    width: 75px;
-    margin-left: 19px;
-}
-
-.option.releases {
-    margin: 0 0 2px 0;
-    line-height: 20px;
-}
-
-/* Display Layout / Elements */
-.display-layout {
-    height: 100%;
-}
-
-.display-layout label {
-    margin: 0.25em 0.1em;
-    display: inline-block;
-}
-
-.display-layout input {
-    margin: 0.1em 1em;
-}
-
-.display-layout input.position {
-    width: 5em;
-    border-bottom: 1px solid var(--surface-500);
-}
-
-.video-type-option.disabled span {
-    color: #afafaf;
-}
-
-/* Switchable Fields (Core Element List) */
-.switchable-fields {
-    margin-top: 5px;
-    margin-bottom: 8px;
-    width: 100%;
-    /* Removed overflow/height constraints to allow absolute position popups to overflow */
-}
-
-.switchable-fields .elements-search-field,
-.element-search {
-    margin: 0 0 5px 0.5rem;
-}
-
-.switchable-field,
-.display-field {
-    /* Keep compatibility with template class */
-    flex: 1;
-    display: flex; /* Added for alignment */
-    align-items: center; /* Added for alignment */
-    padding: 3px;
-    border: 1px solid transparent;
-    border-bottom: 1px solid var(--surface-500);
-}
-
-.switchable-field input,
-.display-field input {
-    border-radius: 3px;
-    border: 1px solid var(--surface-500);
-    padding: 2px;
-}
-
-.switchable-field label,
-.display-field .field-label {
-    margin-left: 5px;
-    flex: 1;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.switchable-field:last-child,
-.display-field:last-child {
-    border-bottom: 0;
-}
-
-.switchable-field.mouseover,
-.switchable-field.highlighted,
-.display-field.mouseover,
-.display-field.highlighted {
-    background: var(--surface-200);
-    /* border: 1px solid var(--surface-500); Removed per user request */
-    /* font-weight: 800; Removed per user request */
-}
-
-/* Profile Checkboxes */
-.profile-checkboxes {
-    display: flex;
-    gap: 4px;
-}
-
-.profile-checkbox {
-    width: 16px;
-    height: 16px;
-}
-
-.profile-label {
-    display: inline-block;
-    width: 20px;
-    text-align: center;
-    font-weight: bold;
-}
-
-/* Variant Selector */
-.variant-selector {
-    width: 100px;
-}
-
-/* Preview Area */
-.preview-parent {
-    position: sticky;
-    top: 1.5rem;
-}
-
-.preview-container {
-    position: relative;
-    display: block;
-    width: 100%;
-    height: 100%;
-}
-
-.ruler-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-    pointer-events: none;
-}
-
-.preview {
+<style>
+/* OSD Preview — unscoped for runtime-generated elements */
+.tab-osd-preview {
     background: url(../../images/osd-bg-1.jpg);
     background-size: cover;
     background-repeat: no-repeat;
@@ -1828,25 +1521,7 @@ onUnmounted(() => {
     margin-left: 20px;
 }
 
-.gui_box_titlebar label {
-    max-width: 100px;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: inline-block;
-    white-space: nowrap;
-    vertical-align: text-bottom;
-}
-
-.gui_box_bottombar {
-    text-align: center;
-    margin-top: 30px;
-}
-
-.preview-parent .row {
-    display: flex;
-}
-
-.char {
+.tab-osd-char {
     display: flex;
     padding: 0;
     margin: 0;
@@ -1855,31 +1530,25 @@ onUnmounted(() => {
     border: 1px solid transparent;
 }
 
-.char[draggable="true"] {
+.tab-osd-char[draggable="true"] {
     cursor: move;
 }
 
-.char img {
+.tab-osd-char img {
     flex: 1 1 auto;
     max-width: 100%;
     height: auto;
     image-rendering: pixelated;
 }
 
-.char.mouseover {
+.tab-osd-char.mouseover,
+.tab-osd-char.highlighted,
+.tab-osd-char.dragging {
     background: rgba(255, 255, 255, 0.4);
 }
 
-.char.highlighted {
-    background: rgba(255, 255, 255, 0.4);
-}
-
-.char.dragging {
-    background: rgba(255, 255, 255, 0.4);
-}
-
-/* Crosshair and grid lines on mouse-down (legacy :active behavior) */
-.preview-parent:active::before {
+/* Crosshair and grid lines on mouse-down */
+.tab-osd-preview-parent:active::before {
     content: "";
     position: absolute;
     top: 50%;
@@ -1890,7 +1559,7 @@ onUnmounted(() => {
     pointer-events: none;
 }
 
-.preview-parent:active::after {
+.tab-osd-preview-parent:active::after {
     content: "";
     position: absolute;
     top: 50%;
@@ -1901,84 +1570,21 @@ onUnmounted(() => {
     pointer-events: none;
 }
 
-.preview-parent:active .char {
+.tab-osd-preview-parent:active .tab-osd-char {
     border: 1px dashed rgba(55, 55, 55, 0.5);
 }
 
-.osd-feature .gui_box_titlebar {
-    left: 0;
-}
-
-/* Preview Controls Bar */
-.preview-controls-bar {
-    background-color: var(--primary-500) !important;
-    border-radius: 20px;
-    padding: 5px 15px !important;
-    margin-bottom: 10px;
-    height: auto !important;
-    border: none !important;
+/* Preset position button */
+.tab-osd-position-controls {
+    position: relative;
     display: flex;
     align-items: center;
+    justify-content: center;
+    margin-left: auto;
+    flex-shrink: 0;
 }
 
-.preview-controls-bar .spacer_box_title {
-    width: 100%;
-}
-
-.preview-controls-wrapper {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    flex-wrap: wrap;
-    width: 100%;
-    color: #141414;
-    font-weight: 700;
-}
-
-.preview-controls-wrapper label {
-    color: #141414;
-    margin-right: 0;
-    white-space: nowrap;
-    max-width: none;
-    overflow: visible;
-    text-overflow: clip;
-}
-
-.preview-controls-wrapper select,
-.preview-controls-wrapper select.dark-select {
-    background-color: #262626 !important;
-    color: #f8f8f8 !important;
-    border: 1px solid #1b1b1b !important;
-    border-radius: 4px;
-    padding: 2px 5px;
-    margin-right: 0;
-    height: 24px;
-    font-weight: 600;
-}
-
-.preview-controls-wrapper select option {
-    background-color: #262626;
-    color: #f8f8f8;
-}
-
-.osd-preview-rulers-group {
-    margin-left: auto; /* Push to right */
-    display: flex;
-    align-items: center;
-    gap: 6px;
-}
-
-.osd-preview-rulers-group input {
-    margin-right: 0;
-}
-
-/* Fix specificity for legacy overrides */
-.gui_box_titlebar.image.preview-controls-bar {
-    line-height: normal;
-}
-
-/* Preset Button - Explicitly Legacy */
-.preset-pos-btn {
+.tab-osd-preset-btn {
     width: 20px;
     height: 20px;
     cursor: pointer;
@@ -1997,91 +1603,74 @@ onUnmounted(() => {
     margin-left: 4px;
 }
 
-.preset-pos-btn:hover {
+.tab-osd-preset-btn:hover {
     background-color: var(--surface-700, #666);
     transform: scale(1.1);
 }
 
-.preset-pos-btn:active {
+.tab-osd-preset-btn:active {
     transform: scale(0.9);
 }
 
-/* Position Controls Container - Anchor for absolute menu */
-.position-controls {
-    position: relative;
-    display: flex; /* Ensure button aligns */
-    align-items: center;
-    justify-content: center;
-    margin-left: auto; /* Push to right of flex container */
-    flex-shrink: 0;
-}
-
-/* Context Menu Structure (Matches Legacy osd.less) */
-.context-menu {
+/* Context menu */
+.tab-osd-context-menu {
     position: absolute;
     display: inline-block;
-    min-width: 140px; /* Legacy width */
-    top: -5px; /* Slight offset up to align nicely with button center */
-    left: 100%; /* Align to right of button container */
-    margin-left: 5px; /* Space from button */
+    min-width: 140px;
+    top: -5px;
+    left: 100%;
+    margin-left: 5px;
     padding: 2px;
-    background-color: var(--surface-50); /* Legacy background */
+    background-color: var(--surface-50);
     border: 1px solid var(--surface-500);
     border-radius: 3px;
-    z-index: 10001; /* Legacy z-index */
+    z-index: 10001;
     transition: opacity 0.2s;
     opacity: 1;
     box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.5);
 }
 
-.context-menu-item {
+.tab-osd-context-menu-item {
     position: relative;
 }
 
-/* The list "item" */
-.context-menu-item-display {
+.tab-osd-context-menu-display {
     position: relative;
     padding: 4px 8px;
     display: flex;
     align-items: center;
     justify-content: space-between;
     cursor: pointer;
-    font-size: 11px; /* Legacy font size match */
+    font-size: 11px;
     transition: all 0.15s;
     border-radius: 2px;
     color: var(--text);
     white-space: nowrap;
 }
 
-.context-menu-item-display:hover {
+.tab-osd-context-menu-display:hover {
     background-color: var(--surface-700);
     color: #fff;
 }
 
-/* Submenu Content (The Grid) */
-.context-menu-item-content {
+.tab-osd-context-menu-content {
     position: absolute;
-    /* Position relative to the .context-menu-item-display (parent of this tree) */
-    /* Since it's nested deep in spans, we need to ensure it breaks out correctly */
     left: 100%;
     top: -5px;
     margin-left: 5px;
     display: none;
     opacity: 0;
-    /* pointer-events handled by show class */
     z-index: 10002;
 }
 
-.context-menu-item-content.show {
+.tab-osd-context-menu-content.show {
     display: block;
     opacity: 1;
     pointer-events: all;
 }
 
-/* Preset Button - Explicitly Legacy */
-
-/* Preset Popover Grid Container */
-#preset-pos-grid-wrapper {
+/* Preset grid */
+.tab-osd-preset-grid-wrapper {
     background-color: var(--surface-50);
     border-radius: 5px;
     padding: 10px;
@@ -2092,15 +1681,7 @@ onUnmounted(() => {
     align-items: center;
 }
 
-.preset-popover-title {
-    font-weight: 600;
-    text-align: center;
-    margin-bottom: 6px;
-    color: var(--text);
-    /* Legacy didn't have specific title class in this context but keeping for structure */
-}
-
-.preset-grid {
+.tab-osd-preset-grid {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     grid-template-rows: repeat(5, 1fr);
@@ -2113,7 +1694,7 @@ onUnmounted(() => {
     border: 2px solid var(--surface-700);
 }
 
-.preset-grid-cell {
+.tab-osd-preset-grid-cell {
     position: relative;
     display: flex;
     align-items: center;
@@ -2128,29 +1709,7 @@ onUnmounted(() => {
     color: var(--text);
 }
 
-/* Hover transform removed per user request */
-
-/* Tooltip for cell */
-.preset-grid-cell .preset-pos-cell-tooltip {
-    position: absolute;
-    top: -25px;
-    font-size: 8px;
-    white-space: nowrap;
-    color: var(--text);
-    background-color: color-mix(in srgb, var(--surface-300) 70%, var(--primary-500) 30%);
-    opacity: 0;
-    transition: opacity 0.25s;
-    pointer-events: none;
-    padding: 5px;
-    border-radius: 5px;
-}
-
-.preset-grid-cell:hover .preset-pos-cell-tooltip {
-    opacity: 1;
-}
-
-.preset-cell-dot {
-    content: "";
+.tab-osd-preset-cell-dot {
     position: absolute;
     width: 4px;
     height: 4px;
@@ -2159,193 +1718,80 @@ onUnmounted(() => {
     opacity: 0.8;
 }
 
-/* Timers */
-.timer-config {
-    margin-bottom: 10px;
-    padding-bottom: 10px;
-    border-bottom: 1px solid var(--surface-500);
-}
-
-.timer-config:last-child {
-    border-bottom: none;
-    margin-bottom: 0;
-    padding-bottom: 0;
-}
-
-.timer-row {
-    margin-bottom: 5px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-}
-
-.timer-row label {
-    flex: 1;
-}
-
-.timer-row select,
-.timer-row :deep(input) {
-    width: 140px;
-}
-
-/* Alarms */
-.alarms label {
-    display: flex;
-    align-items: center;
-    gap: 10px;
+/* Upload progress bar */
+.tab-osd-upload-progress {
+    display: grid;
+    grid-template-areas: "area";
     width: 100%;
-    border-bottom: 1px solid var(--surface-500);
-    margin-top: 0;
-    padding: 5px 0;
 }
 
-.alarms label:last-child {
-    border-bottom: none;
-    padding-bottom: 0;
-}
-
-.alarms :deep(input) {
-    height: 18px;
-    line-height: 20px;
-    border-radius: 3px;
-    font-size: 11px;
-    font-weight: normal;
-}
-
-.warning-field,
-.stat-field {
-    margin-bottom: 4px;
-}
-
-/* Font Manager */
-.font-picker {
-    padding: 20px;
-}
-
-.fontpresets_wrapper {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin: 16px 0;
-    padding: 1rem 0;
-}
-
-.font-format-hint {
-    font-size: 0.85em;
-    opacity: 0.6;
-}
-
-.fontpresets {
-    background: var(--surface-200);
-    color: var(--text);
+.tab-osd-progress-bar {
+    grid-area: area;
+    width: 100%;
+    height: 26px;
+    border-radius: 5px;
     border: 1px solid var(--surface-500);
-    border-radius: 3px;
+    appearance: none;
 }
 
-#font-logo {
-    display: flex;
-    margin-bottom: 2em;
+.tab-osd-progress-bar::-webkit-progress-bar {
+    background-color: var(--text);
+    border-radius: 4px;
+    box-shadow: inset 0 0 5px #2f2f2f;
 }
 
-#font-logo-preview-container {
-    background: rgba(0, 255, 0, 0.4);
-    margin-bottom: 10px;
-    padding: 10px;
+.tab-osd-progress-bar::-webkit-progress-value {
+    background-color: #f86008;
+    border-radius: 4px;
 }
 
-#font-logo-preview {
-    background: rgba(0, 255, 0, 1);
-    line-height: 0;
-    margin: auto;
+.tab-osd-progress-label {
+    grid-area: area;
+    width: 100%;
+    height: 26px;
+    line-height: 26px;
+    text-align: center;
+    color: white;
+    font-weight: bold;
 }
 
-#font-logo-info {
-    flex: 1;
-    margin-left: 2em;
-    line-height: 150%;
-}
-
-#font-logo-info h3 {
-    margin-bottom: 0.2em;
-}
-
-#font-logo-info ul li:before {
+/* Logo info list (validation markers) */
+.tab-osd-logo-info-list li::before {
     content: "\2022\20";
 }
-
-#font-logo-info ul li.valid {
+.tab-osd-logo-info-list li.valid {
     color: #00a011;
 }
-
-#font-logo-info ul li.valid:before {
+.tab-osd-logo-info-list li.valid::before {
     content: "\2714\20";
 }
-
-#font-logo-info ul li.invalid {
+.tab-osd-logo-info-list li.invalid {
     color: #a01100;
 }
-
-#font-logo-info ul li.invalid:before {
+.tab-osd-logo-info-list li.invalid::before {
     content: "\2715\20";
 }
 
-button {
-    padding: 4px 10px !important;
-    font-weight: 600;
-    font-size: 9pt !important;
-    cursor: pointer;
-}
-
-/* Spacers */
-.spacer_box div label {
-    display: inline-flex;
-    gap: 3px;
-    margin-right: 10px;
-}
-
-/* Timers */
-.timer-option {
-    padding: 2px;
-    display: inline !important;
-}
-
-.timers-container .timer-detail {
-    padding-left: 15px;
-    padding-top: 3px;
-    padding-bottom: 3px;
-}
-
-.timers-container label {
-    margin-right: 5px !important;
-    display: inline-block;
-    width: 80px;
-}
-
-.timers-container input,
-.timers-container select {
-    width: 150px;
-}
-
-/* Media Queries */
+/* Responsive layout for OSD grid */
 @media all and (max-width: 1455px) {
-    .grid-box .col-span-2 {
+    .tab-osd .grid-box .col-span-2 {
         grid-column: span 4;
         grid-row-start: 1;
         grid-row-end: 1;
     }
-    .grid-box .col-span-1 {
+    .tab-osd .grid-box .col-span-1 {
         grid-column: span 2;
     }
 }
 
 @media all and (max-width: 575px) {
-    .grid-box.col4 {
+    .tab-osd .grid-box.col4 {
         grid-template-columns: 1fr;
     }
-    .grid-box.col4 .col-span-2 {
+    .tab-osd .grid-box.col4 .col-span-2 {
         grid-column: span 1;
     }
-    .grid-box.col4 .col-span-1 {
+    .tab-osd .grid-box.col4 .col-span-1 {
         grid-column: span 1;
     }
 }

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -517,8 +517,6 @@
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from "vue";
 import { useOsdStore } from "@/stores/osd";
 import { useFlightControllerStore } from "@/stores/fc";
-import { useNavigationStore } from "@/stores/navigation";
-import { useReboot } from "@/composables/useReboot";
 import { useOsdPreview } from "@/composables/useOsdPreview";
 import { useOsdRuler } from "@/composables/useOsdRuler";
 import BaseTab from "./BaseTab.vue";
@@ -540,9 +538,7 @@ import semver from "semver";
 import { API_VERSION_1_45 } from "@/js/data_storage";
 
 const osdStore = useOsdStore();
-const _fcStore = useFlightControllerStore();
-const _navigationStore = useNavigationStore();
-const { reboot: _reboot } = useReboot();
+const fcStore = useFlightControllerStore();
 
 // Refs for DOM elements
 const previewContainer = ref(null);
@@ -618,8 +614,8 @@ const videoTypeOptions = computed(() => {
         NTSC: "osdSetupVideoFormatOptionNtsc",
         HD: "osdSetupVideoFormatOptionHd",
     };
-    const buildOptions = _fcStore.config?.buildOptions || [];
-    const apiVersion = _fcStore.config?.apiVersion;
+    const buildOptions = fcStore.config?.buildOptions || [];
+    const apiVersion = fcStore.config?.apiVersion;
     const hasBuildOptionGating = apiVersion && semver.gte(apiVersion, API_VERSION_1_45) && buildOptions.length > 0;
 
     return types.map((type, value) => {
@@ -1770,6 +1766,11 @@ onUnmounted(() => {
     display: inline;
 }
 
+#font-logo-info-upload-hint {
+    margin-top: 1em;
+    display: none;
+}
+
 /* Responsive layout for OSD grid */
 @media all and (max-width: 1455px) {
     .tab-osd .grid-box .col-span-2 {
@@ -1792,10 +1793,5 @@ onUnmounted(() => {
     .tab-osd .grid-box.col4 .col-span-1 {
         grid-column: span 1;
     }
-}
-
-#font-logo-info-upload-hint {
-    margin-top: 1em;
-    display: none;
 }
 </style>

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -531,6 +531,7 @@ import { OSD_CONSTANTS } from "./osd/osd_constants";
 import { positionConfigs, getPresetGridCells } from "./osd/osd_positions";
 import LogoManager from "@/js/LogoManager";
 import GUI from "@/js/gui";
+import MSP from "@/js/msp";
 import { reinitializeConnection } from "@/js/serial_backend";
 import { gui_log } from "@/js/gui_log";
 import { tracking } from "@/js/Analytics";
@@ -1444,14 +1445,13 @@ async function flashFont() {
         // Close the dialog before rebooting so the user isn't left with
         // a stale modal over a disconnected UI.
         closeFontManager();
-        // Flush any pending MSP callbacks from the char-write burst to
-        // avoid CRC errors when the reboot command goes out.
-        GUI.tab_switch_cleanup(() => {
-            // Reboot FC to apply the new font — reinitializeConnection sends
-            // MSP_SET_REBOOT (fire-and-forget) and sets rebootTimestamp so the
-            // serial backend auto-reconnects after the device comes back.
-            reinitializeConnection();
-        });
+        // Reset MSP parser state and flush pending callbacks to prevent
+        // CRC errors from residual serial data before the reboot command.
+        MSP.disconnect_cleanup();
+        // Reboot FC to apply the new font — reinitializeConnection sends
+        // MSP_SET_REBOOT (fire-and-forget) and sets rebootTimestamp so the
+        // serial backend auto-reconnects after the device comes back.
+        reinitializeConnection();
     } catch (err) {
         console.error("Font upload failed:", err);
         uploadProgressLabel.value = i18n.getMessage("osdSetupUploadingFontFailed");

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -502,10 +502,7 @@
         <!-- Bottom Toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2 items-center">
-                <UButton
-                    :disabled="!osdStore.state.isMax7456FontDeviceDetected"
-                    @click="osdStore.state.isMax7456FontDeviceDetected && openFontManager()"
-                >
+                <UButton :disabled="!osdStore.state.isMax7456FontDeviceDetected" @click="openFontManager()">
                     {{ $t("osdSetupFontManagerTitle") }}
                 </UButton>
                 <UButton @click="saveConfig()" color="primary">
@@ -536,6 +533,7 @@ import { OSD_CONSTANTS } from "./osd/osd_constants";
 import { positionConfigs, getPresetGridCells } from "./osd/osd_positions";
 import LogoManager from "@/js/LogoManager";
 import GUI from "@/js/gui";
+import { reinitializeConnection } from "@/js/serial_backend";
 import { gui_log } from "@/js/gui_log";
 import { tracking } from "@/js/Analytics";
 import semver from "semver";
@@ -672,9 +670,9 @@ const profileOptions = computed(() =>
     })),
 );
 
-const fontSelectOptions = computed(() => {
+function buildFontItems(selectedValue) {
     const items = [];
-    if (selectedFont.value === -1) {
+    if (selectedValue === -1) {
         items.push({
             value: -1,
             label: i18n.getMessage("osdSetupFontPresetsSelectorCustomOption"),
@@ -685,22 +683,11 @@ const fontSelectOptions = computed(() => {
         items.push({ value: idx, label: i18n.getMessage(font.name) });
     });
     return items;
-});
+}
 
-const fontPresetSelectItems = computed(() => {
-    const items = [];
-    if (selectedFontPreset.value === -1) {
-        items.push({
-            value: -1,
-            label: i18n.getMessage("osdSetupFontPresetsSelectorCustomOption"),
-            disabled: true,
-        });
-    }
-    fontTypes.value.forEach((font, idx) => {
-        items.push({ value: idx, label: i18n.getMessage(font.name) });
-    });
-    return items;
-});
+const fontSelectOptions = computed(() => buildFontItems(selectedFont.value));
+
+const fontPresetSelectItems = computed(() => buildFontItems(selectedFontPreset.value));
 
 const videoTypeSelectItems = computed(() =>
     videoTypeOptions.value.map((opt) => ({
@@ -1458,6 +1445,10 @@ async function flashFont() {
         uploadProgressLabel.value = i18n.getMessage("osdSetupUploadingFontEnd", {
             length: FONT.data.characters.length,
         });
+        // Reboot FC to apply the new font — reinitializeConnection sends
+        // MSP_SET_REBOOT (fire-and-forget) and sets rebootTimestamp so the
+        // serial backend auto-reconnects after the device comes back.
+        reinitializeConnection();
     } catch (err) {
         console.error("Font upload failed:", err);
         uploadProgressLabel.value = i18n.getMessage("osdSetupUploadingFontFailed");
@@ -1505,7 +1496,10 @@ const handleClickOutside = () => closePresetMenu();
 onMounted(async () => {
     document.addEventListener("click", handleClickOutside);
     SYM.loadSymbols();
-    // Initialize LogoManager to inject logo size i18n resources
+    // Inject logo-size i18n resources (logoWidthPx / logoHeightPx) needed by
+    // translation strings before the font manager dialog is opened.  The DOM
+    // element cache will be stale (dialog is not yet mounted), but
+    // openFontManager() re-runs init() after showModal() to fix that.
     LogoManager.init(FONT, SYM.LOGO);
     await loadConfig();
     await nextTick();

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -1441,10 +1441,17 @@ async function flashFont() {
         uploadProgressLabel.value = i18n.getMessage("osdSetupUploadingFontEnd", {
             length: FONT.data.characters.length,
         });
-        // Reboot FC to apply the new font — reinitializeConnection sends
-        // MSP_SET_REBOOT (fire-and-forget) and sets rebootTimestamp so the
-        // serial backend auto-reconnects after the device comes back.
-        reinitializeConnection();
+        // Close the dialog before rebooting so the user isn't left with
+        // a stale modal over a disconnected UI.
+        closeFontManager();
+        // Flush any pending MSP callbacks from the char-write burst to
+        // avoid CRC errors when the reboot command goes out.
+        GUI.tab_switch_cleanup(() => {
+            // Reboot FC to apply the new font — reinitializeConnection sends
+            // MSP_SET_REBOOT (fire-and-forget) and sets rebootTimestamp so the
+            // serial backend auto-reconnects after the device comes back.
+            reinitializeConnection();
+        });
     } catch (err) {
         console.error("Font upload failed:", err);
         uploadProgressLabel.value = i18n.getMessage("osdSetupUploadingFontFailed");
@@ -1477,7 +1484,9 @@ watch(selectedFont, (newVal) => {
 
 watch(activeProfile, (newVal) => {
     osdStore.osdProfiles.selected = newVal;
-    previewProfile.value = newVal;
+    if (previewProfile.value !== newVal) {
+        previewProfile.value = newVal;
+    }
     if (hasLoadedConfig.value) {
         osdStore.saveOtherConfig().catch((error) => {
             console.error("Failed to update active OSD profile:", error);

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -16,7 +16,7 @@
                 highlight
                 class="mb-3"
             >
-                <p>{{ $t("osdSetupNoOsdChipDetectWarning") }}</p>
+                <p v-html="$t('osdSetupNoOsdChipDetectWarning')"></p>
             </UiBox>
 
             <!-- Warning: Unsupported -->

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -1783,6 +1783,11 @@ onUnmounted(() => {
     content: "\2715\20";
 }
 
+/* Boot logo preview — override Tailwind preflight img { display: block } */
+#font-logo-preview img {
+    display: inline;
+}
+
 /* Responsive layout for OSD grid */
 @media all and (max-width: 1455px) {
     .tab-osd .grid-box .col-span-2 {

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -1761,7 +1761,6 @@ onUnmounted(() => {
     content: "\2715\20";
 }
 
-/* Boot logo preview — override Tailwind preflight img { display: block } */
 #font-logo-preview img {
     display: inline;
 }

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -91,7 +91,7 @@
                                         "
                                         :items="field.variants.map((v, i) => ({ value: i, label: $t(v) }))"
                                         size="xs"
-                                        class="w-24 shrink-0"
+                                        class="shrink-0"
                                     />
 
                                     <!-- Preset button -->
@@ -162,16 +162,6 @@
                     <!-- Preview Column -->
                     <div class="col-span-2">
                         <div class="tab-osd-preview-parent sticky top-6">
-                            <!-- Controls bar -->
-                            <div
-                                class="flex items-center gap-2 flex-wrap bg-elevated rounded-full px-4 py-1.5 mb-2.5 text-[13px] font-bold text-highlighted"
-                            >
-                                <span class="ml-auto flex items-center gap-1.5">
-                                    <USwitch v-model="showRulers" size="xs" />
-                                    <label>{{ $t("osdSetupPreviewCheckRulers") }}</label>
-                                </span>
-                            </div>
-
                             <!-- Preview area -->
                             <div ref="previewContainerOuter" class="relative">
                                 <canvas
@@ -219,8 +209,12 @@
                                 </div>
                             </div>
 
-                            <div class="text-center mt-6 text-sm font-semibold">
-                                {{ $t("osdSetupPreviewTitle") }}
+                            <div class="flex items-center justify-center gap-3 mt-6 text-sm font-semibold">
+                                <span>{{ $t("osdSetupPreviewTitle") }}</span>
+                                <span class="flex items-center gap-1.5">
+                                    <USwitch v-model="showRulers" size="xs" />
+                                    <label>{{ $t("osdSetupPreviewCheckRulers") }}</label>
+                                </span>
                             </div>
                         </div>
                     </div>
@@ -229,14 +223,11 @@
                     <div class="col-span-1">
                         <!-- Active Profile Selector -->
                         <UiBox :title="$t('osdSetupSelectedProfileTitle')" type="neutral">
-                            <SettingRow :label="$t('osdSetupSelectedProfileLabel')">
-                                <USelect v-model="activeProfile" :items="profileOptions" size="sm" class="w-full" />
-                            </SettingRow>
-                            <SettingRow :label="$t('osdSetupPreviewSelectProfileTitle')">
-                                <USelect v-model="previewProfile" :items="profileOptions" size="sm" class="w-full" />
+                            <SettingRow :label="$t('osdSetupSelectedProfileTitle')">
+                                <USelect v-model="activeProfile" :items="profileOptions" size="xs" />
                             </SettingRow>
                             <SettingRow :label="$t('osdSetupPreviewSelectFont')">
-                                <USelect v-model="selectedFont" :items="fontSelectOptions" size="sm" class="w-full" />
+                                <USelect v-model="selectedFont" :items="fontSelectOptions" size="xs" />
                             </SettingRow>
                         </UiBox>
 
@@ -257,8 +248,7 @@
                                         }
                                     "
                                     :items="videoTypeSelectItems"
-                                    size="sm"
-                                    class="w-full"
+                                    size="xs"
                                 />
                             </SettingRow>
                         </UiBox>
@@ -280,8 +270,7 @@
                                         }
                                     "
                                     :items="unitTypeSelectItems"
-                                    size="sm"
-                                    class="w-full"
+                                    size="xs"
                                 />
                             </SettingRow>
                         </UiBox>
@@ -309,8 +298,7 @@
                                             }
                                         "
                                         :items="timerSourceItems"
-                                        size="sm"
-                                        class="w-full"
+                                        size="xs"
                                     />
                                 </SettingRow>
                                 <SettingRow :label="$t('osdTimerPrecision')" :help="$t('osdTimerPrecisionTooltip')">
@@ -323,8 +311,7 @@
                                             }
                                         "
                                         :items="timerPrecisionItems"
-                                        size="sm"
-                                        class="w-full"
+                                        size="xs"
                                     />
                                 </SettingRow>
                                 <SettingRow :label="$t('osdTimerAlarm')" :help="$t('osdTimerAlarmTooltip')">
@@ -1503,6 +1490,7 @@ watch(selectedFont, (newVal) => {
 
 watch(activeProfile, (newVal) => {
     osdStore.osdProfiles.selected = newVal;
+    previewProfile.value = newVal;
     if (hasLoadedConfig.value) {
         osdStore.saveOtherConfig().catch((error) => {
             console.error("Failed to update active OSD profile:", error);

--- a/src/composables/useOsdRuler.js
+++ b/src/composables/useOsdRuler.js
@@ -27,7 +27,7 @@ function applyRulerMargins(containerRef, enabled) {
         return;
     }
 
-    const preview = container.querySelector(".preview");
+    const preview = container.querySelector(".tab-osd-preview");
     if (!preview) {
         return;
     }
@@ -79,17 +79,17 @@ function getContext(canvas, container) {
     ctx.textAlign = "center";
     ctx.textBaseline = "middle";
 
-    const rows = container.querySelectorAll(".row");
+    const rows = container.querySelectorAll(".tab-osd-row");
     if (!rows.length) {
         return null;
     }
 
-    const colsInRow = rows[0].querySelectorAll(".char");
+    const colsInRow = rows[0].querySelectorAll(".tab-osd-char");
     if (!colsInRow.length) {
         return null;
     }
 
-    const preview = container.querySelector(".preview");
+    const preview = container.querySelector(".tab-osd-preview");
     if (!preview) {
         return null;
     }

--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -304,7 +304,10 @@ LogoManager.drawPreview = function () {
     el.innerHTML = "";
     for (let i = this.logoStartIndex, I = this.font.constants.MAX_CHAR_COUNT; i < I; i++) {
         const url = this.font.data.character_image_urls[i];
-        el.insertAdjacentHTML("beforeend", `<img src="${url}" title="0x${i.toString(16)}">`);
+        const img = document.createElement("img");
+        img.src = url;
+        img.title = `0x${i.toString(16)}`;
+        el.appendChild(img);
     }
 };
 

--- a/src/js/utils/osdFont.js
+++ b/src/js/utils/osdFont.js
@@ -278,8 +278,6 @@ FONT.upload = function ($progress) {
         .then(function () {
             console.log(`Uploaded all ${FONT.data.characters.length} characters`);
             gui_log(i18n.getMessage("osdSetupUploadingFontEnd", { length: FONT.data.characters.length }));
-
-            return MSP.promise(MSPCodes.MSP_SET_REBOOT);
         });
 };
 


### PR DESCRIPTION
## Todo

- [x] Select Font Presets only shows Default value in OSD Font Manager
- [x] Boot logo does not show the image in OSD Font Manager
- [x] Select Custom Image button is using html in OSD Font Manager
- [x] Remove the reference to Font Version in OSD Font Manager
- [x] Fix rulers (works in master) and remove remaining css selectors to use TailWind
- [x] Fix the OSD Font Manager button styling (remove variant)
- [x] Remove thousand separator from input(s)
- [x] Fix alternative OSD options selection width
- [x] Preview for selection is already covered in active OSD profile - font selection could move here too
- [x] Remove yellow group headers - this is for buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized the OSD tab UI with component-driven controls, rebuilt the Elements list and Font Manager dialog, and switched preview images to DOM-based creation.
* **Bug Fixes**
  * Preview/profile selection stays in sync; dialog now closes and device connection is reset after a successful font flash; font uploads no longer trigger an automatic reboot.
* **Style**
  * Updated preview DOM structure and runtime styling to improve ruler/preview sizing, interaction, and warning display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->