### PR TITLE
Refactor: Convert Presets tab to Nuxt UI

### DIFF
--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -93,7 +93,7 @@
                         />
                         <div
                             v-if="store.hasTooManyResults"
-                            class="text-2xl"
+                            class="text-2xl col-span-full py-4"
                             v-html="$t('presetsTooManyPresetsFound')"
                         ></div>
                     </div>

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -17,9 +17,14 @@
                     <span v-html="store.failedRepositoriesMessage"></span>
                 </UiBox>
                 <UiBox v-if="store.backupWarningVisible" type="warning" highlight>
-                    <div class="flex items-center gap-4">
-                        <span class="flex-1" v-html="$t('presetsWarningBackup')"></span>
-                        <UButton :label="$t('dontShowAgain')" size="xs" @click="hideBackupWarning" />
+                    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-4">
+                        <span class="flex-1 min-w-0" v-html="$t('presetsWarningBackup')"></span>
+                        <UButton
+                            :label="$t('dontShowAgain')"
+                            size="xs"
+                            class="self-start sm:self-auto"
+                            @click="hideBackupWarning"
+                        />
                     </div>
                 </UiBox>
             </div>

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -76,7 +76,7 @@
 
                 <div class="px-5">
                     <div v-if="store.hasNoResults" class="text-2xl py-4" v-html="$t('presetsNoPresetsFound')"></div>
-                    <div class="grid gap-3 grid-cols-[repeat(auto-fit,minmax(500px,1fr))] pb-5">
+                    <div class="preset-card-grid grid gap-3 pb-5">
                         <PresetCard
                             v-for="entry in store.visiblePresetEntries"
                             :key="entry.key"
@@ -525,6 +525,10 @@ function handleCliErrorsDialogClose() {
 </script>
 
 <style>
+.preset-card-grid {
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 500px), 1fr));
+}
+
 .tab-presets .content_wrapper {
     height: calc(100% - 30px - 3ex);
     overflow-y: scroll;

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -99,12 +99,17 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <div class="btn flex gap-2">
-                <UButton :label="$t('presetsButtonSave')" :disabled="!store.canApply" @click="applyPickedPresets()" />
+            <div class="flex gap-2">
+                <UButton
+                    :label="$t('presetsButtonSave')"
+                    :disabled="!store.canApply"
+                    :color="store.canApply ? 'success' : 'neutral'"
+                    @click="applyPickedPresets()"
+                />
                 <UButton
                     :label="$t('presetsButtonCancel')"
                     :disabled="!store.canApply"
-                    variant="outline"
+                    :color="store.canApply ? 'primary' : 'neutral'"
                     @click="store.clearPickedPresets()"
                 />
             </div>

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -1,73 +1,41 @@
 <template>
     <BaseTab tab-name="presets" @mounted="onTabMounted" @cleanup="onTabCleanup">
         <div class="content_wrapper" id="presets_content_wrapper">
-            <div class="tab_title">
-                <div class="presets_title_text" v-html="$t('tabPresets')"></div>
-                <div class="presets_top_bar_button_pannel">
-                    <a
-                        href="https://betaflight.com/docs/wiki/app/presets-tab"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="presetsWikiButton tool regular-button right"
-                        >{{ $t("presetsWiki") }}</a
-                    >
-                    <div class="top_panel_spacer visible-on-desktop-only"></div>
-                    <a
-                        href="#"
-                        class="presets_sources_show tool regular-button right"
-                        @click.prevent="openSourcesDialog"
-                        >{{ $t("presetSources") }}</a
-                    >
-                    <div class="top_panel_spacer visible-on-desktop-only"></div>
-                    <a
-                        href="#"
-                        class="presets_load_config tool regular-button right"
-                        @click.prevent="loadConfigBackup"
-                        >{{ $t("presetsBackupLoad") }}</a
-                    >
-                    <a
-                        href="#"
-                        class="presets_save_config tool regular-button right"
-                        @click.prevent="saveConfigBackup"
-                        >{{ $t("presetsBackupSave") }}</a
-                    >
+            <div class="tab_title flex items-center flex-wrap gap-2 px-5 pt-5">
+                <div class="text-xl font-semibold" v-html="$t('tabPresets')"></div>
+                <div class="flex items-center gap-2 ml-auto flex-wrap">
+                    <WikiButton docUrl="presets" />
+                    <UButton :label="$t('presetSources')" variant="outline" size="xs" @click="openSourcesDialog" />
+                    <UButton :label="$t('presetsBackupLoad')" variant="outline" size="xs" @click="loadConfigBackup" />
+                    <UButton :label="$t('presetsBackupSave')" variant="outline" size="xs" @click="saveConfigBackup" />
                 </div>
             </div>
 
-            <div class="presets_warnings">
-                <div
-                    v-if="store.isThirdPartyActive"
-                    class="note presets_warning_not_official_source"
-                    v-html="$t('presetsWarningNotOfficialSource')"
-                ></div>
-                <div
-                    v-if="store.failedRepositoryNames.length"
-                    class="note presets_failed_to_load_repositories"
-                    v-html="store.failedRepositoriesMessage"
-                ></div>
-                <div v-if="store.backupWarningVisible" class="note presets_warning_backup">
-                    <div class="presets_warning_backup_text" v-html="$t('presetsWarningBackup')"></div>
-                    <a
-                        href="#"
-                        class="tool regular-button presets_warning_backup_button_hide"
-                        @click.prevent="hideBackupWarning"
-                        >{{ $t("dontShowAgain") }}</a
-                    >
-                </div>
+            <div class="flex flex-col gap-2 px-5">
+                <UiBox v-if="store.isThirdPartyActive" type="warning" highlight>
+                    <span v-html="$t('presetsWarningNotOfficialSource')"></span>
+                </UiBox>
+                <UiBox v-if="store.failedRepositoryNames.length" type="error" highlight>
+                    <span v-html="store.failedRepositoriesMessage"></span>
+                </UiBox>
+                <UiBox v-if="store.backupWarningVisible" type="warning" highlight>
+                    <div class="flex items-center gap-4">
+                        <span class="flex-1" v-html="$t('presetsWarningBackup')"></span>
+                        <UButton :label="$t('dontShowAgain')" variant="outline" size="xs" @click="hideBackupWarning" />
+                    </div>
+                </UiBox>
             </div>
 
-            <div v-if="store.isLoading" id="presets_global_loading" class="data-loading presets_visible_block"></div>
+            <div v-if="store.isLoading" class="data-loading p-5 w-1/2 h-1/2 mx-auto"></div>
 
-            <div v-else-if="store.hasLoadError" id="presets_global_loading_error" class="presets_visible_block">
+            <div v-else-if="store.hasLoadError" class="p-5">
                 <h3 v-html="$t('presetsLoadError')"></h3>
-                <a href="#" id="presets_reload" class="tool regular-button" @click.prevent="reloadPresets">{{
-                    $t("presetsReload")
-                }}</a>
+                <UButton :label="$t('presetsReload')" class="mt-2" @click="reloadPresets" />
             </div>
 
-            <div v-else id="presets_main_content" class="presets_visible_block">
-                <div class="presets_search_settings">
-                    <div class="presets_filter_table_wrapper">
+            <div v-else>
+                <div class="sticky top-0 bg-(--ui-bg) z-10">
+                    <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-1.5 px-5">
                         <PresetFilterSelect
                             v-model="store.filters.categories"
                             label-key="presetsFilterCategory"
@@ -95,26 +63,20 @@
                         />
                     </div>
 
-                    <div id="presets_search_bar_wrapper">
-                        <div id="presets_search_hint"></div>
-                        <input
-                            id="presets_filter_text"
-                            type="text"
-                            class="presets_text_input"
-                            :value="store.filters.searchString"
+                    <div class="flex items-center gap-3 px-5 py-3">
+                        <UInput
+                            :model-value="store.filters.searchString"
                             :placeholder="searchPlaceholder"
-                            @input="store.setSearchString($event.target.value)"
+                            icon="i-lucide-search"
+                            class="flex-1"
+                            @update:model-value="store.setSearchString($event)"
                         />
                     </div>
                 </div>
 
-                <div id="preset_list_wrapper">
-                    <div
-                        v-if="store.hasNoResults"
-                        id="presets_list_no_found"
-                        v-html="$t('presetsNoPresetsFound')"
-                    ></div>
-                    <div id="presets_list">
+                <div class="px-5">
+                    <div v-if="store.hasNoResults" class="text-2xl py-4" v-html="$t('presetsNoPresetsFound')"></div>
+                    <div class="grid gap-3 grid-cols-[repeat(auto-fit,minmax(500px,1fr))] pb-5">
                         <PresetCard
                             v-for="entry in store.visiblePresetEntries"
                             :key="entry.key"
@@ -128,7 +90,7 @@
                         />
                         <div
                             v-if="store.hasTooManyResults"
-                            id="presets_list_too_many_found"
+                            class="text-2xl"
                             v-html="$t('presetsTooManyPresetsFound')"
                         ></div>
                     </div>
@@ -137,23 +99,14 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <div class="btn">
-                <a
-                    href="#"
-                    id="presets_save_button"
-                    class="tool regular-button"
-                    :class="{ disabled: !store.canApply }"
-                    @click.prevent="store.canApply && applyPickedPresets()"
-                    >{{ $t("presetsButtonSave") }}</a
-                >
-                <a
-                    href="#"
-                    id="presets_cancel_button"
-                    class="tool regular-button"
-                    :class="{ disabled: !store.canApply }"
-                    @click.prevent="store.canApply && store.clearPickedPresets()"
-                    >{{ $t("presetsButtonCancel") }}</a
-                >
+            <div class="btn flex gap-2">
+                <UButton :label="$t('presetsButtonSave')" :disabled="!store.canApply" @click="applyPickedPresets()" />
+                <UButton
+                    :label="$t('presetsButtonCancel')"
+                    :disabled="!store.canApply"
+                    variant="outline"
+                    @click="store.clearPickedPresets()"
+                />
             </div>
         </div>
 
@@ -192,54 +145,32 @@
             @deactivate-source="handleDeactivateSource"
         />
 
-        <dialog id="presets_apply_progress_dialog" ref="progressDialogRef" @cancel.prevent>
-            <div class="presets_apply_progress_dialog_label" v-html="$t('presetsApplyingPresets')"></div>
-            <div class="presets_apply_progress_dialog_please_wait" v-html="$t('presetsPleaseWait')"></div>
-            <progress
-                class="presets_apply_progress_dialog_progress_bar"
-                :value="store.applyState.progress"
-                max="100"
-            ></progress>
+        <dialog ref="progressDialogRef" class="w-[300px] h-fit p-6" @cancel.prevent>
+            <div class="text-lg mb-2" v-html="$t('presetsApplyingPresets')"></div>
+            <div class="text-sm text-(--ui-text-muted)" v-html="$t('presetsPleaseWait')"></div>
+            <UProgress :model-value="store.applyState.progress" :max="100" class="mt-3" />
         </dialog>
 
         <dialog
-            id="presets_cli_errors_dialog"
             ref="cliErrorsDialogRef"
+            class="w-[600px] h-fit p-6"
             @close="handleCliErrorsDialogClose"
             @cancel.prevent
         >
-            <div class="presets_cli_errors_dialog_warning" v-html="$t('presetsCliErrorsWarning')"></div>
-            <div id="presets_cli">
-                <div id="presets_cli_background">
-                    <div id="presets_cli_window" ref="cliWindowRef" class="window">
-                        <div id="presets_cli_window_wrapper" ref="windowWrapperRef" class="wrapper"></div>
+            <div class="text-lg mb-2" v-html="$t('presetsCliErrorsWarning')"></div>
+            <div id="presets_cli" class="w-full">
+                <div class="presets_cli_background">
+                    <div ref="cliWindowRef" class="presets_cli_window">
+                        <div ref="windowWrapperRef" class="presets_cli_wrapper"></div>
                     </div>
                 </div>
-                <div class="commandline">
-                    <textarea
-                        id="presets_cli_command"
-                        ref="commandInputRef"
-                        name="commands"
-                        rows="1"
-                        cols="0"
-                    ></textarea>
+                <div class="presets_cli_commandline">
+                    <textarea ref="commandInputRef" name="commands" rows="1" cols="0"></textarea>
                 </div>
             </div>
-            <div class="btn">
-                <a
-                    href="#"
-                    id="presets_cli_errors_save_anyway_button"
-                    class="tool regular-button"
-                    @click.prevent="saveAnywayAfterCliErrors"
-                    >{{ $t("presetsSaveAnyway") }}</a
-                >
-                <a
-                    href="#"
-                    id="presets_cli_errors_exit_no_save_button"
-                    class="tool regular-button"
-                    @click.prevent="closeCliErrorsWithoutSaving"
-                    >{{ $t("presetsButtonCancel") }}</a
-                >
+            <div class="flex gap-2 justify-end mt-3">
+                <UButton :label="$t('presetsButtonCancel')" variant="outline" @click="closeCliErrorsWithoutSaving" />
+                <UButton :label="$t('presetsSaveAnyway')" @click="saveAnywayAfterCliErrors" />
             </div>
         </dialog>
     </BaseTab>
@@ -248,6 +179,8 @@
 <script setup>
 import { inject, nextTick, ref, watch } from "vue";
 import BaseTab from "./BaseTab.vue";
+import UiBox from "@/components/elements/UiBox.vue";
+import WikiButton from "@/components/elements/WikiButton.vue";
 import PresetFilterSelect from "./presets/PresetFilterSelect.vue";
 import PresetCard from "./presets/PresetCard.vue";
 import PresetDetailsDialog from "./presets/PresetDetailsDialog.vue";
@@ -586,339 +519,71 @@ function handleCliErrorsDialogClose() {
 }
 </script>
 
-<style lang="less">
-.tab-presets {
-    height: 100%;
-
-    .content_wrapper {
-        height: calc(100% - 30px - 3ex);
-        overflow-y: scroll;
-        overflow-x: hidden;
-    }
-
-    p {
-        padding: 0;
-        border: 0 dotted var(--surface-500);
-    }
-
-    .presets_warnings {
-        padding-left: 20px;
-        padding-right: 20px;
-    }
-
-    .top_panel_spacer {
-        width: 0;
-        display: inline;
-        border: 1px var(--surface-500);
-        border-style: none none none solid;
-        height: 60%;
-        margin-right: 10px;
-        float: right;
-    }
-
-    .tab_title {
-        padding: 20px 20px 0 20px;
-
-        .presets_top_bar_button_pannel .regular-button {
-            margin-bottom: 0;
-            margin-top: 0;
-            line-height: 17px;
-            font-size: 10px;
-            border-radius: 3px;
-        }
-    }
-
-    .window {
-        height: 100%;
-        width: 100%;
-        padding: 5px;
-        overflow-y: auto;
-        overflow-x: hidden;
-        font-family: monospace;
-        color: white;
-        box-sizing: border-box;
-        -webkit-user-select: text;
-        user-select: text;
-        float: left;
-
-        .wrapper {
-            white-space: pre-wrap;
-            user-select: text;
-        }
-
-        .error_message {
-            color: red;
-            font-weight: bold;
-        }
-    }
-
-    textarea[name="commands"] {
-        -webkit-box-sizing: border-box;
-        box-sizing: border-box;
-        width: 100%;
-        margin-top: 6px;
-        padding: 4px 8px;
-        color: white;
-        border: 1px solid var(--surface-500);
-        background-color: rgba(64, 64, 64, 1);
-        resize: none;
-    }
-
-    .presets_cli_errors_dialog_warning {
-        font-size: 1.2em;
-        margin-bottom: 8px;
-    }
-
-    .presets_apply_progress_dialog_progress_bar {
-        width: 100%;
-        height: 20px;
-        margin-top: 12px;
-        border-radius: 4px;
-        appearance: none;
-        -webkit-appearance: none;
-        overflow: hidden;
-
-        &::-webkit-progress-bar {
-            background-color: var(--surface-500);
-        }
-
-        &::-webkit-progress-value {
-            background-color: var(--primary-500);
-            border-radius: 0 4px 4px 0;
-        }
-    }
-}
-
-#presets_content_wrapper {
+<style>
+.tab-presets .content_wrapper {
+    height: calc(100% - 30px - 3ex);
+    overflow-y: scroll;
+    overflow-x: hidden;
     padding: 0;
     position: relative;
 }
 
-.presets_title_text {
-    display: inline-block;
-}
-
-.presets_top_bar_button_pannel {
-    display: inline;
-}
-
-.presets_warning_backup {
-    display: grid;
-    grid-template-columns: 1fr fit-content(300px);
-}
-
-.presets_warning_backup_text {
-    padding-right: 24px;
-}
-
-.presets_warning_backup_button_hide {
-    margin-top: 0;
-    margin-bottom: 0;
-    margin-right: 0;
-    line-height: 17px;
-    font-size: 10px;
-    height: 17px;
-}
-
-.presetsWikiButton {
-    margin-right: 0;
-}
-
-#preset_list_wrapper {
-    padding-left: 20px;
-    padding-right: 20px;
-}
-
-#presets_list {
-    padding: 0 0 20px 0;
-    height: calc(100% - 180px);
-    display: grid;
-    gap: 12px;
-    grid-template-columns: repeat(auto-fit, minmax(500px, 1fr));
-}
-
-#presets_global_loading {
-    padding: 0 20px 20px 20px;
-    width: 50%;
-    height: 50%;
-    margin: auto;
-}
-
-#presets_global_loading_error {
-    padding: 0 20px 20px 20px;
-}
-
-.presets_visible_block {
-    display: block !important;
-}
-
-.presets_search_settings {
-    position: sticky;
-    top: 0;
-    background-color: var(--surface-100);
-    z-index: 10;
-}
-
-.presets_text_input {
-    border: 1px solid var(--surface-500);
-    border-radius: 3px;
-    background-color: var(--surface-200);
-    color: var(--text);
-}
-
-#presets_filter_text {
-    height: 26px;
-    flex: 1;
-    padding-left: 5px;
-}
-
-#presets_search_hint {
-    float: left;
-    width: 28px;
-    height: 28px;
-    margin-right: 12px;
-    background-repeat: no-repeat;
-    background-image: url(../../images/icons/cf_icon_search_orange.svg);
-}
-
-#presets_search_bar_wrapper {
-    display: flex;
-    padding: 2ex 20px 2ex 20px;
-}
-
-#presets_cli {
-    width: 100%;
-}
-
-#presets_cli_background {
-    border: 1px solid var(--surface-500);
+/* CLI terminal window — runtime-generated DOM, cannot use Tailwind */
+.presets_cli_background {
+    border: 1px solid var(--ui-border);
     background-color: rgba(64, 64, 64, 1);
-    margin-top: 0;
     height: 300px;
     border-radius: 5px;
     box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.8);
 }
 
-#presets_cli_errors_dialog {
-    width: 600px;
-    padding: 24px;
+.presets_cli_window {
+    height: 100%;
+    width: 100%;
+    padding: 5px;
+    overflow-y: auto;
+    overflow-x: hidden;
+    font-family: monospace;
+    color: white;
+    box-sizing: border-box;
+    user-select: text;
+    float: left;
+}
 
-    .regular-button {
-        margin-bottom: 0;
-        margin-left: 12px;
-        margin-right: 0;
-        float: right;
+.presets_cli_wrapper {
+    white-space: pre-wrap;
+    user-select: text;
+}
+
+.presets_cli_window .error_message {
+    color: red;
+    font-weight: bold;
+}
+
+.presets_cli_commandline textarea {
+    box-sizing: border-box;
+    width: 100%;
+    margin-top: 6px;
+    padding: 4px 8px;
+    color: white;
+    border: 1px solid var(--ui-border);
+    background-color: rgba(64, 64, 64, 1);
+    resize: none;
+}
+
+@media only screen and (max-width: 1055px) {
+    .tab-presets .content_wrapper {
+        height: calc(100% - 87px);
     }
-}
 
-#presets_apply_progress_dialog {
-    width: 300px;
-    padding: 24px;
-}
-
-.presets_filter_table_wrapper {
-    display: grid;
-    gap: 5px;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
-    padding: 0 20px 0 20px;
-}
-
-#presets_list_no_found,
-#presets_list_too_many_found {
-    font-size: 1.5em;
-}
-
-@media only screen and (max-width: 1055px), only screen and (max-device-width: 1055px) {
-    .tab-presets {
-        .content_wrapper {
-            height: calc(100% - 87px);
-        }
-
-        .content_toolbar {
-            margin-top: 5px;
-        }
-    }
-
-    .presets_search_settings {
-        position: static;
-        top: unset;
+    .tab-presets .content_toolbar {
+        margin-top: 5px;
     }
 }
 
 @media all and (max-width: 575px) {
-    .tab-presets {
-        .content_wrapper {
-            height: calc(100% - 51px);
-        }
-
-        .tab_title {
-            padding: 20px 10px 10px 10px;
-        }
-
-        .presets_warnings {
-            padding-left: 8px;
-            padding-right: 8px;
-        }
-    }
-
-    #presets_list {
-        grid-template-columns: 100%;
-    }
-
-    #preset_list_wrapper {
-        padding-left: 8px;
-        padding-right: 8px;
-    }
-
-    .presets_search_settings {
-        padding-left: 8px;
-        padding-right: 8px;
-    }
-
-    .presets_filter_table_wrapper {
-        display: table;
-        border-spacing: 6px;
-        margin-right: -6px;
-        margin-left: -6px;
-        padding-left: 0;
-        padding-right: 0;
-    }
-
-    #presets_search_bar_wrapper {
-        padding-left: 0;
-        padding-right: 0;
-        padding-top: 1ex;
-    }
-
-    #presets_cli_errors_dialog {
-        padding: 12px;
-
-        .btn {
-            position: fixed;
-            right: 12px;
-            bottom: 12px;
-        }
-    }
-
-    #presets_apply_progress_dialog {
-        padding: 12px;
-    }
-
-    #presets_cli {
-        height: calc(100% - 121px);
-    }
-
-    #presets_cli_background {
-        height: 100%;
-    }
-
-    .presets_warning_backup {
-        display: block;
-    }
-
-    .presets_warning_backup_text {
-        padding-right: 24px;
-        margin-bottom: 6px;
+    .tab-presets .content_wrapper {
+        height: calc(100% - 51px);
     }
 }
 </style>

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -1,17 +1,15 @@
 <template>
     <BaseTab tab-name="presets" @mounted="onTabMounted" @cleanup="onTabCleanup">
         <div class="content_wrapper" id="presets_content_wrapper">
-            <div class="tab_title" v-html="$t('tabPresets')"></div>
-            <div class="cf_doc_version_bt">
-                <WikiButton docUrl="presets" />
-            </div>
-            <div class="flex items-center gap-2 flex-wrap mb-2 px-5 justify-end">
+            <div class="tab_title">{{ $t("tabPresets") }}</div>
+            <WikiButton docUrl="presets" />
+            <div class="flex items-center gap-2 flex-wrap mb-2 justify-end">
                 <UButton :label="$t('presetSources')" size="xs" @click="openSourcesDialog" />
                 <UButton :label="$t('presetsBackupLoad')" size="xs" @click="loadConfigBackup" />
                 <UButton :label="$t('presetsBackupSave')" size="xs" @click="saveConfigBackup" />
             </div>
 
-            <div class="flex flex-col gap-2 px-5 mb-3">
+            <div class="flex flex-col gap-2 mb-3">
                 <UiBox v-if="store.isThirdPartyActive" type="warning" highlight>
                     <span v-html="$t('presetsWarningNotOfficialSource')"></span>
                 </UiBox>
@@ -35,7 +33,7 @@
 
             <div v-else>
                 <div class="sticky top-0 bg-(--ui-bg) z-10">
-                    <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-1.5 px-5">
+                    <div class="grid grid-cols-[repeat(auto-fit,minmax(150px,1fr))] gap-1.5">
                         <PresetFilterSelect
                             v-model="store.filters.categories"
                             label-key="presetsFilterCategory"
@@ -63,7 +61,7 @@
                         />
                     </div>
 
-                    <div class="flex items-center gap-3 px-5 py-3">
+                    <div class="flex items-center gap-3 py-3">
                         <UInput
                             :model-value="store.filters.searchString"
                             :placeholder="searchPlaceholder"
@@ -74,7 +72,7 @@
                     </div>
                 </div>
 
-                <div class="px-5">
+                <div>
                     <div v-if="store.hasNoResults" class="text-2xl py-4" v-html="$t('presetsNoPresetsFound')"></div>
                     <div class="preset-card-grid grid gap-3 pb-5">
                         <PresetCard
@@ -530,11 +528,8 @@ function handleCliErrorsDialogClose() {
 }
 
 .tab-presets .content_wrapper {
-    height: calc(100% - 30px - 3ex);
     overflow-y: scroll;
     overflow-x: hidden;
-    padding: 0;
-    position: relative;
 }
 
 /* CLI terminal window — runtime-generated DOM, cannot use Tailwind */

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -1,17 +1,17 @@
 <template>
     <BaseTab tab-name="presets" @mounted="onTabMounted" @cleanup="onTabCleanup">
         <div class="content_wrapper" id="presets_content_wrapper">
-            <div class="tab_title flex items-center flex-wrap gap-2 px-5 pt-5">
-                <div class="text-xl font-semibold" v-html="$t('tabPresets')"></div>
-                <div class="flex items-center gap-2 ml-auto flex-wrap">
-                    <WikiButton docUrl="presets" />
-                    <UButton :label="$t('presetSources')" variant="outline" size="xs" @click="openSourcesDialog" />
-                    <UButton :label="$t('presetsBackupLoad')" variant="outline" size="xs" @click="loadConfigBackup" />
-                    <UButton :label="$t('presetsBackupSave')" variant="outline" size="xs" @click="saveConfigBackup" />
-                </div>
+            <div class="tab_title" v-html="$t('tabPresets')"></div>
+            <div class="cf_doc_version_bt">
+                <WikiButton docUrl="presets" />
+            </div>
+            <div class="flex items-center gap-2 flex-wrap mb-2 px-5 justify-end">
+                <UButton :label="$t('presetSources')" size="xs" @click="openSourcesDialog" />
+                <UButton :label="$t('presetsBackupLoad')" size="xs" @click="loadConfigBackup" />
+                <UButton :label="$t('presetsBackupSave')" size="xs" @click="saveConfigBackup" />
             </div>
 
-            <div class="flex flex-col gap-2 px-5">
+            <div class="flex flex-col gap-2 px-5 mb-3">
                 <UiBox v-if="store.isThirdPartyActive" type="warning" highlight>
                     <span v-html="$t('presetsWarningNotOfficialSource')"></span>
                 </UiBox>
@@ -21,7 +21,7 @@
                 <UiBox v-if="store.backupWarningVisible" type="warning" highlight>
                     <div class="flex items-center gap-4">
                         <span class="flex-1" v-html="$t('presetsWarningBackup')"></span>
-                        <UButton :label="$t('dontShowAgain')" variant="outline" size="xs" @click="hideBackupWarning" />
+                        <UButton :label="$t('dontShowAgain')" size="xs" @click="hideBackupWarning" />
                     </div>
                 </UiBox>
             </div>

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -161,7 +161,7 @@
 
         <dialog
             ref="cliErrorsDialogRef"
-            class="w-[600px] h-fit p-6"
+            class="w-[600px] max-w-[calc(100vw-2rem)] h-fit p-6"
             @close="handleCliErrorsDialogClose"
             @cancel.prevent
         >

--- a/src/components/tabs/presets/PresetCard.vue
+++ b/src/components/tabs/presets/PresetCard.vue
@@ -37,7 +37,7 @@
             </button>
             <div>
                 <span
-                    class="text-2xl font-bold inline-block mb-2 overflow-hidden whitespace-nowrap text-ellipsis w-[calc(100%-60px)]"
+                    class="text-lg font-bold inline-block mb-2 overflow-hidden whitespace-nowrap text-ellipsis w-[calc(100%-60px)]"
                 >
                     {{ preset.title }}
                 </span>

--- a/src/components/tabs/presets/PresetCard.vue
+++ b/src/components/tabs/presets/PresetCard.vue
@@ -52,7 +52,7 @@
                         >
                         <span
                             v-show="preset.status === 'COMMUNITY'"
-                            class="px-1 py-0.5 inline-block text-white font-bold rounded bg-(--ui-primary)"
+                            class="px-1 py-0.5 inline-block text-black font-bold rounded bg-(--ui-primary)"
                             >{{ $t("presetsCommunity") }}</span
                         >
                         <span

--- a/src/components/tabs/presets/PresetCard.vue
+++ b/src/components/tabs/presets/PresetCard.vue
@@ -1,7 +1,13 @@
 <template>
     <div
-        :class="wrapperClasses"
-        :style="wrapperStyle"
+        :class="[
+            'rounded p-4 shadow-sm',
+            clickable
+                ? 'cursor-pointer focus-visible:outline-2 focus-visible:outline-(--ui-primary) focus-visible:outline-offset-[-2px]'
+                : '',
+            isPicked ? 'border-2 border-green-500' : 'border border-(--ui-border)',
+            clickable && mouseOnPanel && !mouseOnStar ? 'bg-(--ui-bg-elevated)' : 'bg-(--ui-bg-muted)',
+        ]"
         :role="clickable ? 'button' : undefined"
         :tabindex="clickable ? 0 : undefined"
         @click="handleOpen"
@@ -9,16 +15,17 @@
         @mouseenter="mouseOnPanel = true"
         @mouseleave="mouseOnPanel = false"
     >
-        <div class="preset_title_panel">
+        <div class="relative text-(--ui-text-highlighted)">
             <img
                 v-if="repository?.official"
-                class="preset_title_panel_betaflight_official"
+                class="w-[25px] h-[25px] rounded-[5px] p-[5px] bg-origin-content bg-no-repeat absolute right-[26px] top-[-5px]"
                 :src="officialIcon"
                 alt=""
+                aria-hidden="true"
             />
             <button
                 type="button"
-                class="preset_title_panel_star"
+                class="w-[35px] h-[35px] rounded-[5px] p-[5px] absolute right-[-6px] top-[-5px] border-0 flex items-center justify-center cursor-pointer focus-visible:outline-2 focus-visible:outline-(--ui-primary) focus-visible:outline-offset-1"
                 :style="{ backgroundColor: starBackgroundColor }"
                 :aria-pressed="isFavorite"
                 :aria-label="favoriteAriaLabel"
@@ -26,76 +33,68 @@
                 @mouseenter="mouseOnStar = true"
                 @mouseleave="mouseOnStar = false"
             >
-                <img :src="starImage" alt="" class="preset_title_panel_star_img" />
+                <img :src="starImage" alt="" class="w-[25px] h-[25px] pointer-events-none" />
             </button>
             <div>
-                <span class="preset_title_panel_title">{{ preset.title }}</span>
+                <span
+                    class="text-2xl font-bold inline-block mb-2 overflow-hidden whitespace-nowrap text-ellipsis w-[calc(100%-60px)]"
+                >
+                    {{ preset.title }}
+                </span>
             </div>
-            <div class="presets_title_panel_meta">
-                <div class="presets_title_panel_row">
-                    <div class="presets_title_panel_key">
+            <div class="grid gap-0">
+                <div class="grid grid-cols-[100px_minmax(0,1fr)] items-center min-h-6">
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
                         <span
-                            class="preset_title_panel_official preset_title_panel_status_experimental"
                             v-show="preset.status === 'EXPERIMENTAL'"
+                            class="px-1 py-0.5 inline-block text-white font-bold rounded bg-(--ui-error)"
                             >{{ $t("presetsExperimental") }}</span
                         >
                         <span
-                            class="preset_title_panel_official preset_title_panel_status_community"
                             v-show="preset.status === 'COMMUNITY'"
+                            class="px-1 py-0.5 inline-block text-white font-bold rounded bg-(--ui-primary)"
                             >{{ $t("presetsCommunity") }}</span
                         >
                         <span
-                            class="preset_title_panel_official preset_title_panel_status_official"
                             v-show="preset.status === 'OFFICIAL'"
+                            class="px-1 py-0.5 inline-block text-white font-bold rounded bg-(--ui-success)"
                             >{{ $t("presetsOfficial") }}</span
                         >
                     </div>
-                    <div class="presets_title_panel_value">
-                        <span class="preset_title_panel_category">{{ preset.category }}</span>
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span class="text-(--ui-text-highlighted) font-bold">{{ preset.category }}</span>
                     </div>
                 </div>
-                <div class="presets_title_panel_row">
-                    <div class="presets_title_panel_key">
-                        <span
-                            class="preset_title_panel_label preset_title_panel_author_label"
-                            v-html="$t('presetsAuthor')"
-                        ></span>
+                <div class="grid grid-cols-[100px_minmax(0,1fr)] items-center min-h-6">
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span class="text-(--ui-text-muted)" v-html="$t('presetsAuthor')"></span>
                     </div>
-                    <div class="presets_title_panel_value">
-                        <span class="preset_title_panel_author_text">{{ preset.author }}</span>
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span>{{ preset.author }}</span>
                     </div>
                 </div>
-                <div class="presets_title_panel_row">
-                    <div class="presets_title_panel_key">
-                        <span
-                            class="preset_title_panel_label preset_title_panel_versions_label"
-                            v-html="$t('presetsVersions')"
-                        ></span>
+                <div class="grid grid-cols-[100px_minmax(0,1fr)] items-center min-h-6">
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span class="text-(--ui-text-muted)" v-html="$t('presetsVersions')"></span>
                     </div>
-                    <div class="presets_title_panel_value">
-                        <span class="preset_title_panel_versions_text">{{ firmwareVersions }}</span>
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span class="font-bold">{{ firmwareVersions }}</span>
                     </div>
                 </div>
-                <div class="presets_title_panel_row">
-                    <div class="presets_title_panel_key">
-                        <span
-                            class="preset_title_panel_label preset_title_panel_keywords_label"
-                            v-html="$t('presetsKeywords')"
-                        ></span>
+                <div class="grid grid-cols-[100px_minmax(0,1fr)] items-center min-h-6">
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span class="text-(--ui-text-muted)" v-html="$t('presetsKeywords')"></span>
                     </div>
-                    <div class="presets_title_panel_value">
-                        <span class="preset_title_panel_keywords_text" :title="keywords">{{ keywords }}</span>
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span :title="keywords">{{ keywords }}</span>
                     </div>
                 </div>
-                <div v-if="showRepositoryName" class="presets_title_panel_row preset_title_panel_repository_row">
-                    <div class="presets_title_panel_key">
-                        <span
-                            class="preset_title_panel_label preset_title_panel_repository_label"
-                            v-html="$t('presetsSourceRepository')"
-                        ></span>
+                <div v-if="showRepositoryName" class="grid grid-cols-[100px_minmax(0,1fr)] items-center min-h-6">
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span class="text-(--ui-text-muted)" v-html="$t('presetsSourceRepository')"></span>
                     </div>
-                    <div class="presets_title_panel_value">
-                        <span class="preset_title_panel_repository_text">{{ repository?.name }}</span>
+                    <div class="overflow-hidden text-ellipsis whitespace-nowrap">
+                        <span>{{ repository?.name }}</span>
                     </div>
                 </div>
             </div>
@@ -149,20 +148,8 @@ const favoriteAriaLabel = computed(() =>
     i18n.getMessage(props.isFavorite ? "presetsFavoriteRemoveAriaLabel" : "presetsFavoriteAddAriaLabel"),
 );
 
-const wrapperClasses = computed(() => ({
-    preset_title_panel_border: true,
-    preset_title_panel_clickable: props.clickable,
-    preset_title_panel_wrapper: true,
-}));
-
-const wrapperStyle = computed(() => ({
-    border: props.isPicked ? "2px solid green" : "1px solid var(--surface-500)",
-    backgroundColor:
-        props.clickable && mouseOnPanel.value && !mouseOnStar.value ? "var(--surface-500)" : "var(--surface-200)",
-}));
-
 const starBackgroundColor = computed(() =>
-    mouseOnStar.value || (mouseOnPanel.value && props.clickable) ? "var(--surface-500)" : "transparent",
+    mouseOnStar.value || (mouseOnPanel.value && props.clickable) ? "var(--ui-bg-elevated)" : "transparent",
 );
 
 const starImage = computed(() => {
@@ -203,138 +190,3 @@ function handleCardKeydown(event) {
     }
 }
 </script>
-
-<style lang="less">
-.preset_title_panel_wrapper {
-    border-radius: 4px;
-}
-
-.preset_title_panel {
-    color: var(--text);
-    position: relative;
-}
-
-.preset_title_panel_border {
-    padding: 1.5ex;
-    box-shadow: 2px 2px 5px rgba(92, 92, 92, 0.25);
-    border-radius: 4px;
-}
-
-.preset_title_panel_clickable {
-    cursor: pointer;
-
-    &:focus-visible {
-        outline: 2px solid var(--primary-500);
-        outline-offset: -2px;
-    }
-}
-
-.preset_title_panel_title {
-    font-size: 1.5em;
-    font-weight: bold;
-    display: inline-block;
-    margin-bottom: 1ex;
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    width: calc(100% - 60px);
-}
-
-.preset_title_panel_star {
-    width: 35px;
-    height: 35px;
-    border-radius: 5px;
-    padding: 5px;
-    position: absolute;
-    cursor: pointer;
-    right: -6px;
-    top: -5px;
-    border: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    &:focus-visible {
-        outline: 2px solid var(--primary-500);
-        outline-offset: 1px;
-    }
-}
-
-.preset_title_panel_star_img {
-    width: 25px;
-    height: 25px;
-    pointer-events: none;
-}
-
-.preset_title_panel_betaflight_official {
-    width: 25px;
-    height: 25px;
-    background-size: cover;
-    border-radius: 5px;
-    padding: 5px;
-    background-origin: content-box;
-    background-repeat: no-repeat;
-    position: absolute;
-    right: 26px;
-    top: -5px;
-}
-
-.preset_title_panel_category {
-    color: var(--surface-950);
-    font-weight: bold;
-}
-
-.preset_title_panel_official {
-    padding: 3px;
-    display: inline-block;
-    color: white;
-    font-weight: 700;
-    border-radius: 4px;
-}
-
-.preset_title_panel_status_official {
-    background-color: var(--success-500);
-}
-
-.preset_title_panel_status_community {
-    background-color: var(--primary-500);
-}
-
-.preset_title_panel_status_experimental {
-    background-color: var(--error-500);
-}
-
-.preset_title_panel_versions_text {
-    font-weight: bold;
-}
-
-.preset_title_panel_keywords_text,
-.preset_title_panel_repository_text {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-.presets_title_panel_meta {
-    display: grid;
-    gap: 0;
-}
-
-.presets_title_panel_row {
-    display: grid;
-    grid-template-columns: 100px minmax(0, 1fr);
-    align-items: center;
-    min-height: 24px;
-}
-
-.presets_title_panel_key,
-.presets_title_panel_value {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.preset_title_panel_label {
-    color: var(--surface-800);
-}
-</style>

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -105,7 +105,7 @@
                 <div v-if="error" class="p-5 text-(--ui-error)">{{ error }}</div>
             </div>
 
-            <div class="flex items-center justify-between mt-auto mx-[-12px] py-2 px-3">
+            <div class="flex flex-wrap items-center justify-between gap-2 mt-auto mx-[-12px] py-2 px-3">
                 <div class="flex items-center flex-wrap gap-1.5">
                     <UButton
                         v-if="!showCli"
@@ -142,7 +142,7 @@
                         data-testid="preset-discussion-link"
                     />
                 </div>
-                <div class="flex gap-1.5">
+                <div class="flex flex-wrap justify-end gap-1.5 ml-auto">
                     <UButton :label="$t('presetsApply')" :disabled="loading || !!error" @click="handleApply" />
                     <UButton :label="$t('close')" variant="outline" @click="requestClose" />
                 </div>

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -15,20 +15,21 @@
 
                     <details
                         v-if="preset?.options?.length"
-                        class="relative min-h-[26px] h-[26px] overflow-visible mt-1.5"
+                        ref="optionsDetailsRef"
+                        class="relative min-h-[26px] h-[26px] overflow-visible mt-1.5 w-fit min-w-[200px]"
                         :open="optionsExpanded"
                         @toggle="handleOptionsToggle"
                     >
                         <summary
-                            class="grid grid-cols-[100px_minmax(0,1fr)_16px] items-center gap-3 min-h-[38px] px-3 border-2 border-(--ui-primary) rounded cursor-pointer list-none preset-options-summary"
+                            class="flex items-center gap-3 min-h-[38px] px-3 border border-(--ui-primary) rounded cursor-pointer list-none preset-options-summary"
                         >
-                            <span class="w-[100px] inline-block" v-html="$t('presetsOptions')"></span>
+                            <span class="shrink-0" v-html="$t('presetsOptions')"></span>
                             <span class="min-w-0 text-(--ui-text-muted) truncate" :title="optionsSummary">{{
                                 optionsSummary
                             }}</span>
                         </summary>
                         <div
-                            class="absolute top-full left-0 right-0 z-30 grid gap-2.5 max-h-60 mt-0 p-3 overflow-auto border border-(--ui-border) border-t-0 rounded-b bg-(--ui-bg) shadow-lg"
+                            class="absolute top-full left-0 z-30 grid gap-2.5 min-w-full max-h-60 mt-0 p-3 overflow-auto border border-(--ui-border) border-t-0 rounded-b bg-(--ui-bg) shadow-lg w-fit"
                         >
                             <div v-for="(option, optionIndex) in preset.options" :key="`${option.name}-${optionIndex}`">
                                 <template v-if="Array.isArray(option.childs)">
@@ -102,48 +103,46 @@
                 <div v-if="error" class="p-5 text-(--ui-error)">{{ error }}</div>
             </div>
 
-            <div class="content_toolbar mt-auto mx-[-12px]">
-                <div class="flex items-center justify-between w-full">
-                    <div class="flex items-center flex-wrap gap-1.5 pl-5">
-                        <UButton
-                            v-if="!showCli"
-                            :label="showCliLabel"
-                            variant="outline"
-                            size="xs"
-                            @click="emit('toggle-cli-visible', true)"
-                        />
-                        <UButton
-                            v-if="showCli"
-                            :label="hideCliLabel"
-                            variant="outline"
-                            size="xs"
-                            @click="emit('toggle-cli-visible', false)"
-                        />
-                        <UButton
-                            :label="viewOnlineLabel"
-                            variant="outline"
-                            size="xs"
-                            :as="'a'"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            :href="onlineLink"
-                        />
-                        <UButton
-                            :label="discussionLabel"
-                            variant="outline"
-                            size="xs"
-                            :as="'a'"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            :href="discussionHref"
-                            :disabled="!discussionLink"
-                            data-testid="preset-discussion-link"
-                        />
-                    </div>
-                    <div class="flex gap-1.5">
-                        <UButton :label="$t('presetsApply')" :disabled="loading || !!error" @click="handleApply" />
-                        <UButton :label="$t('close')" variant="outline" @click="requestClose" />
-                    </div>
+            <div class="flex items-center justify-between mt-auto mx-[-12px] py-2 px-3">
+                <div class="flex items-center flex-wrap gap-1.5">
+                    <UButton
+                        v-if="!showCli"
+                        :label="showCliLabel"
+                        variant="outline"
+                        size="xs"
+                        @click="emit('toggle-cli-visible', true)"
+                    />
+                    <UButton
+                        v-if="showCli"
+                        :label="hideCliLabel"
+                        variant="outline"
+                        size="xs"
+                        @click="emit('toggle-cli-visible', false)"
+                    />
+                    <UButton
+                        :label="viewOnlineLabel"
+                        variant="outline"
+                        size="xs"
+                        :as="'a'"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        :href="onlineLink"
+                    />
+                    <UButton
+                        :label="discussionLabel"
+                        variant="outline"
+                        size="xs"
+                        :as="'a'"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        :href="discussionHref"
+                        :disabled="!discussionLink"
+                        data-testid="preset-discussion-link"
+                    />
+                </div>
+                <div class="flex gap-1.5">
+                    <UButton :label="$t('presetsApply')" :disabled="loading || !!error" @click="handleApply" />
+                    <UButton :label="$t('close')" variant="outline" @click="requestClose" />
                 </div>
             </div>
         </div>
@@ -151,7 +150,7 @@
 </template>
 
 <script setup>
-import { computed, nextTick, ref, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { i18n } from "@/js/localization";
@@ -223,16 +222,47 @@ const emit = defineEmits([
 ]);
 
 const dialogRef = ref(null);
+const optionsDetailsRef = ref(null);
+
+function handleClickOutside(event) {
+    if (optionsDetailsRef.value?.open && !optionsDetailsRef.value.contains(event.target)) {
+        optionsDetailsRef.value.open = false;
+        emit("options-expanded-change", false);
+    }
+}
+
+onMounted(() => {
+    document.addEventListener("click", handleClickOutside);
+});
+
+onBeforeUnmount(() => {
+    document.removeEventListener("click", handleClickOutside);
+});
 
 const descriptionText = computed(() => props.preset?.description?.join("\n") ?? "");
 const isDescriptionHtml = computed(() => props.preset?.parser === "MARKED");
 const cliText = computed(() => props.cliStrings.join("\n"));
-const optionsSummary = computed(() => {
-    if (props.selectedOptionLabels.length === 0) {
-        return "";
+const totalOptionsCount = computed(() => {
+    if (!props.preset?.options) {
+        return 0;
     }
 
-    return props.selectedOptionLabels.join("; ");
+    return props.preset.options.reduce((count, option) => {
+        if (Array.isArray(option.childs)) {
+            return count + option.childs.length;
+        }
+
+        return count + 1;
+    }, 0);
+});
+const optionsSummary = computed(() => {
+    const selected = props.selectedOptionIds.length;
+
+    if (selected === 0) {
+        return `0 of ${totalOptionsCount.value} selected`;
+    }
+
+    return `${selected} of ${totalOptionsCount.value} selected`;
 });
 const onlineLink = computed(() =>
     props.preset && props.repository ? props.repository.getPresetOnlineLink(props.preset) : "#",

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -91,6 +91,7 @@
                     <div
                         v-if="!showCli && isDescriptionHtml"
                         class="preset-description-text preset-description-html"
+                        data-testid="preset-html-description"
                         v-html="descriptionHtml"
                     ></div>
                     <div v-if="showCli" class="preset-description-text">
@@ -136,6 +137,7 @@
                             rel="noopener noreferrer"
                             :href="discussionHref"
                             :disabled="!discussionLink"
+                            data-testid="preset-discussion-link"
                         />
                     </div>
                     <div class="flex gap-1.5">

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -1,5 +1,10 @@
 <template>
-    <dialog ref="dialogRef" class="w-[600px] h-[520px] p-3 pb-0" @close="emit('close')" @cancel.prevent="requestClose">
+    <dialog
+        ref="dialogRef"
+        class="w-[600px] max-w-[calc(100vw-2rem)] h-[520px] p-3 pb-0"
+        @close="emit('close')"
+        @cancel.prevent="requestClose"
+    >
         <div class="flex flex-col flex-1 min-h-0 h-full">
             <div class="flex flex-col flex-1 min-h-0">
                 <div v-if="!loading && preset" class="flex flex-col flex-1 min-h-0">

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -1,8 +1,8 @@
 <template>
-    <dialog id="presets_detailed_dialog" ref="dialogRef" @close="emit('close')" @cancel.prevent="requestClose">
-        <div id="presets_detailed_dialog_content_wrapper">
-            <div id="presets_detailed_dialog_content">
-                <div v-if="!loading && preset" id="presets_detailed_dialog_properties">
+    <dialog ref="dialogRef" class="w-[600px] h-[520px] p-3 pb-0" @close="emit('close')" @cancel.prevent="requestClose">
+        <div class="flex flex-col flex-1 min-h-0 h-full">
+            <div class="flex flex-col flex-1 min-h-0">
+                <div v-if="!loading && preset" class="flex flex-col flex-1 min-h-0">
                     <PresetCard
                         :preset="preset"
                         :repository="repository"
@@ -15,25 +15,29 @@
 
                     <details
                         v-if="preset?.options?.length"
-                        id="presets_options_panel"
+                        class="relative min-h-[26px] h-[26px] overflow-visible mt-1.5"
                         :open="optionsExpanded"
                         @toggle="handleOptionsToggle"
                     >
-                        <summary>
-                            <span id="preset_options_label" v-html="$t('presetsOptions')"></span>
-                            <span class="preset-options-summary-value" :title="optionsSummary">{{
+                        <summary
+                            class="grid grid-cols-[100px_minmax(0,1fr)_16px] items-center gap-3 min-h-[38px] px-3 border-2 border-(--ui-primary) rounded cursor-pointer list-none preset-options-summary"
+                        >
+                            <span class="w-[100px] inline-block" v-html="$t('presetsOptions')"></span>
+                            <span class="min-w-0 text-(--ui-text-muted) truncate" :title="optionsSummary">{{
                                 optionsSummary
                             }}</span>
                         </summary>
-                        <div class="preset-options-list">
+                        <div
+                            class="absolute top-full left-0 right-0 z-30 grid gap-2.5 max-h-60 mt-0 p-3 overflow-auto border border-(--ui-border) border-t-0 rounded-b bg-(--ui-bg) shadow-lg"
+                        >
                             <div v-for="(option, optionIndex) in preset.options" :key="`${option.name}-${optionIndex}`">
                                 <template v-if="Array.isArray(option.childs)">
-                                    <fieldset class="preset-options-group">
-                                        <legend>{{ option.name }}</legend>
+                                    <fieldset class="m-0 p-0 border-0 min-w-0">
+                                        <legend class="mb-1.5 font-bold">{{ option.name }}</legend>
                                         <label
                                             v-for="(child, childIndex) in option.childs"
                                             :key="`${child.name}-${childIndex}`"
-                                            class="preset-option-label"
+                                            class="flex gap-2 items-center mb-1.5 pl-1"
                                         >
                                             <input
                                                 v-if="option.isExclusive"
@@ -64,7 +68,7 @@
                                         </label>
                                     </fieldset>
                                 </template>
-                                <label v-else class="preset-option-label">
+                                <label v-else class="flex gap-2 items-center mb-1.5 pl-1">
                                     <input
                                         type="checkbox"
                                         :checked="selectedOptionIds.includes(option.id)"
@@ -81,84 +85,62 @@
                         </div>
                     </details>
 
-                    <div
-                        v-if="!showCli && !isDescriptionHtml"
-                        id="presets_detailed_dialog_text_description"
-                        class="presets_detailed_dialog_text"
-                    >
+                    <div v-if="!showCli && !isDescriptionHtml" class="preset-description-text">
                         {{ descriptionText }}
                     </div>
                     <div
                         v-if="!showCli && isDescriptionHtml"
-                        id="presets_detailed_dialog_html_description"
-                        class="presets_detailed_dialog_text"
+                        class="preset-description-text preset-description-html"
                         v-html="descriptionHtml"
                     ></div>
-                    <div v-if="showCli" id="presets_detailed_dialog_text_cli" class="presets_detailed_dialog_text">
+                    <div v-if="showCli" class="preset-description-text">
                         {{ cliText }}
                     </div>
                 </div>
-                <div v-if="loading" id="presets_detailed_dialog_loading" class="data-loading"></div>
-                <div v-if="error" id="presets_detailed_dialog_error">{{ error }}</div>
+                <div v-if="loading" class="data-loading h-[300px]"></div>
+                <div v-if="error" class="p-5 text-(--ui-error)">{{ error }}</div>
             </div>
 
-            <div class="content_toolbar">
-                <div class="btn">
-                    <div class="left-panel">
-                        <a
-                            id="presets_cli_show"
-                            v-show="!showCli"
-                            href="#"
-                            class="tool regular-button"
-                            @click.prevent="emit('toggle-cli-visible', true)"
-                            :aria-label="showCliLabel"
-                            >{{ showCliLabel }}</a
-                        >
-                        <a
-                            id="presets_cli_hide"
-                            v-show="showCli"
-                            href="#"
-                            class="tool regular-button"
-                            @click.prevent="emit('toggle-cli-visible', false)"
-                            :aria-label="hideCliLabel"
-                            >{{ hideCliLabel }}</a
-                        >
-                        <a
-                            id="presets_open_online"
-                            class="tool regular-button"
+            <div class="content_toolbar mt-auto mx-[-12px]">
+                <div class="flex items-center justify-between w-full">
+                    <div class="flex items-center flex-wrap gap-1.5 pl-5">
+                        <UButton
+                            v-if="!showCli"
+                            :label="showCliLabel"
+                            variant="outline"
+                            size="xs"
+                            @click="emit('toggle-cli-visible', true)"
+                        />
+                        <UButton
+                            v-if="showCli"
+                            :label="hideCliLabel"
+                            variant="outline"
+                            size="xs"
+                            @click="emit('toggle-cli-visible', false)"
+                        />
+                        <UButton
+                            :label="viewOnlineLabel"
+                            variant="outline"
+                            size="xs"
+                            :as="'a'"
                             target="_blank"
                             rel="noopener noreferrer"
                             :href="onlineLink"
-                            :aria-label="viewOnlineLabel"
-                            >{{ viewOnlineLabel }}</a
-                        >
-                        <a
-                            id="presets_open_discussion"
-                            class="tool regular-button"
+                        />
+                        <UButton
+                            :label="discussionLabel"
+                            variant="outline"
+                            size="xs"
+                            :as="'a'"
                             target="_blank"
                             rel="noopener noreferrer"
                             :href="discussionHref"
-                            :class="{ disabled: !discussionLink }"
-                            :aria-label="discussionLabel"
-                            >{{ discussionLabel }}</a
-                        >
+                            :disabled="!discussionLink"
+                        />
                     </div>
-                    <div>
-                        <a
-                            href="#"
-                            id="presets_detailed_dialog_applybtn"
-                            class="tool regular-button mainButton"
-                            :class="{ disabled: loading || !!error }"
-                            @click.prevent="handleApply"
-                            >{{ $t("presetsApply") }}</a
-                        >
-                        <a
-                            href="#"
-                            id="presets_detailed_dialog_closebtn"
-                            class="tool regular-button mainButton"
-                            @click.prevent="requestClose"
-                            >{{ $t("close") }}</a
-                        >
+                    <div class="flex gap-1.5">
+                        <UButton :label="$t('presetsApply')" :disabled="loading || !!error" @click="handleApply" />
+                        <UButton :label="$t('close')" variant="outline" @click="requestClose" />
                     </div>
                 </div>
             </div>
@@ -331,184 +313,15 @@ function handleOptionsToggle(event) {
 }
 </script>
 
-<style lang="less">
-#presets_detailed_dialog {
-    width: 600px;
-    height: 520px;
-    padding: 12px 12px 0 12px;
-    flex-direction: column;
-
-    .content_toolbar {
-        width: auto;
-        margin-top: auto;
-        margin-left: -12px;
-        margin-right: -12px;
-        justify-content: space-between;
-
-        .btn {
-            display: contents;
-        }
-    }
-}
-
-#presets_detailed_dialog[open] {
+<style>
+/* Details dialog: show as flex when open */
+dialog[open]:has(.preset-description-text) {
     display: flex;
 }
 
-#presets_detailed_dialog_content_wrapper {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
-    .preset_title_panel_title {
-        padding-bottom: 0.5ex;
-        border-bottom: 1px solid var(--primary-500);
-        margin-bottom: 2ex;
-    }
-
-    .left-panel {
-        display: flex;
-        align-items: center;
-        flex-wrap: wrap;
-        gap: 5px;
-        padding-left: 20px;
-
-        .regular-button {
-            margin-top: 0;
-            margin-bottom: 0;
-        }
-    }
-}
-
-#presets_detailed_dialog_content {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
-}
-
-#presets_detailed_dialog_properties {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    min-height: 0;
-}
-
-#presets_detailed_dialog_loading {
-    height: 300px;
-}
-
-#presets_detailed_dialog_error {
-    padding: 20px 10px;
-    color: var(--error-500);
-}
-
-#presets_options_panel {
-    position: relative;
-    min-height: 26px;
-    margin-top: 6px;
-    height: 26px;
-    overflow: visible;
-}
-
-#presets_options_panel summary {
-    display: grid;
-    grid-template-columns: 100px minmax(0, 1fr) 16px;
-    align-items: center;
-    gap: 12px;
-    min-height: 38px;
-    padding: 0 12px;
-    border: 2px solid var(--primary-500);
-    border-radius: 4px;
-    background: var(--surface-50);
-    cursor: pointer;
-    list-style: none;
-}
-
-#presets_options_panel summary::-webkit-details-marker {
-    display: none;
-}
-
-.preset-options-summary-value {
-    min-width: 0;
-    color: var(--text);
-    opacity: 0.8;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-}
-
-#presets_options_panel summary::after {
-    content: "";
-    width: 0;
-    height: 0;
-    border-left: 5px solid transparent;
-    border-right: 5px solid transparent;
-    border-top: 6px solid var(--text);
-    justify-self: end;
-    opacity: 0.65;
-    transition: transform 0.2s ease;
-}
-
-#presets_options_panel[open] summary {
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-}
-
-#presets_options_panel[open] summary::after {
-    transform: rotate(180deg);
-}
-
-.preset-options-list {
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    z-index: 30;
-    display: grid;
-    gap: 10px;
-    max-height: 240px;
-    margin-top: 0;
-    padding: 12px 14px;
-    overflow: auto;
-    border: 1px solid var(--surface-500);
-    border-top: 0;
-    border-bottom-left-radius: 4px;
-    border-bottom-right-radius: 4px;
-    background: var(--surface-50);
-    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.18);
-}
-
-.preset-options-group {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    min-width: 0;
-}
-
-.preset-options-group legend {
-    margin-bottom: 6px;
-    font-weight: 700;
-}
-
-.preset-option-label {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-    margin-bottom: 6px;
-    padding-left: 4px;
-}
-
-.preset-option-label:last-child {
-    margin-bottom: 0;
-}
-
-#preset_options_label {
-    width: 100px;
-    display: inline-block;
-}
-
-.presets_detailed_dialog_text {
+/* Preset title styling inside the details dialog */
+.tab-presets dialog .preset-description-text + .preset-description-text,
+.tab-presets dialog .preset-description-text {
     padding-top: 6px;
     padding-bottom: 6px;
     margin-top: 12px;
@@ -521,105 +334,80 @@ function handleOptionsToggle(event) {
     user-select: text;
 }
 
-#presets_detailed_dialog_html_description {
+/* Options panel summary arrow */
+.preset-options-summary::-webkit-details-marker {
+    display: none;
+}
+
+.preset-options-summary::after {
+    content: "";
+    width: 0;
+    height: 0;
+    border-left: 5px solid transparent;
+    border-right: 5px solid transparent;
+    border-top: 6px solid var(--ui-text);
+    justify-self: end;
+    opacity: 0.65;
+    transition: transform 0.2s ease;
+}
+
+details[open] > .preset-options-summary {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+details[open] > .preset-options-summary::after {
+    transform: rotate(180deg);
+}
+
+/* Markdown description HTML styling */
+.preset-description-html {
     white-space: normal;
+}
 
-    h1,
-    h2 {
-        padding-top: 10px;
-        padding-bottom: 3px;
-    }
+.preset-description-html h1,
+.preset-description-html h2 {
+    padding-top: 10px;
+    padding-bottom: 3px;
+}
 
-    h3 {
-        padding-top: 5px;
-        padding-bottom: 0;
-    }
+.preset-description-html h3 {
+    padding-top: 5px;
+    padding-bottom: 0;
+}
 
-    h4,
-    h5,
-    h6 {
-        padding-top: 0;
-        padding-bottom: 0;
-    }
+.preset-description-html h4,
+.preset-description-html h5,
+.preset-description-html h6 {
+    padding-top: 0;
+    padding-bottom: 0;
+}
 
-    ul,
-    ol {
-        padding-left: 25px;
-    }
+.preset-description-html ul,
+.preset-description-html ol {
+    padding-left: 25px;
+}
 
-    ul li {
-        padding-left: 12px;
-        list-style-type: disclosure-closed;
-    }
+.preset-description-html ul li {
+    padding-left: 12px;
+    list-style-type: disclosure-closed;
+}
 
-    ol li {
-        padding-left: 12px;
-        list-style-type: decimal;
-    }
+.preset-description-html ol li {
+    padding-left: 12px;
+    list-style-type: decimal;
+}
 
-    img {
-        max-width: 100%;
-        height: auto;
-        border-radius: 4px;
-    }
+.preset-description-html img {
+    max-width: 100%;
+    height: auto;
+    border-radius: 4px;
 }
 
 @media all and (max-width: 575px) {
-    .presets_detailed_dialog_text {
+    .preset-description-text {
         height: unset;
         padding-bottom: 100px;
-    }
-
-    #presets_detailed_dialog {
-        .content_toolbar {
-            position: fixed;
-            left: 0;
-            right: 0;
-            bottom: 0;
-            width: 100vw;
-            height: auto;
-            min-height: 80px;
-            padding: 10px;
-            box-sizing: border-box;
-            border-top: 1px solid var(--primary-500);
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            gap: 10px;
-        }
-
-        .btn {
-            display: flex;
-            flex-direction: column;
-            width: 100%;
-            align-items: center;
-
-            .left-panel {
-                position: relative;
-                left: unset;
-                padding-left: 0;
-                margin: 0;
-                display: flex;
-                flex-wrap: wrap;
-                justify-content: center;
-                gap: 5px;
-            }
-        }
-
-        .mainButton {
-            margin-top: 5px;
-            display: inline-block;
-        }
-    }
-
-    #presets_options_panel {
-        margin-top: 6px;
-        grid-template-columns: 100px 1fr;
-        display: grid;
-    }
-
-    #presets_options_panel summary {
-        grid-template-columns: 100px minmax(0, 1fr) 16px;
     }
 }
 </style>

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -86,11 +86,8 @@
                         </div>
                     </details>
 
-                    <div v-if="!showCli && !isDescriptionHtml" class="preset-description-text">
-                        {{ descriptionText }}
-                    </div>
                     <div
-                        v-if="!showCli && isDescriptionHtml"
+                        v-if="!showCli"
                         class="preset-description-text preset-description-html"
                         data-testid="preset-html-description"
                         v-html="descriptionHtml"
@@ -240,7 +237,6 @@ onBeforeUnmount(() => {
 });
 
 const descriptionText = computed(() => props.preset?.description?.join("\n") ?? "");
-const isDescriptionHtml = computed(() => props.preset?.parser === "MARKED");
 const cliText = computed(() => props.cliStrings.join("\n"));
 const totalOptionsCount = computed(() => {
     if (!props.preset?.options) {
@@ -275,7 +271,7 @@ const viewOnlineLabel = decodeHtmlEntities(i18n.getMessage("presetsViewOnline"))
 const discussionLabel = decodeHtmlEntities(i18n.getMessage("presetsOpenDiscussion"));
 
 const descriptionHtml = computed(() => {
-    if (!isDescriptionHtml.value) {
+    if (!descriptionText.value) {
         return "";
     }
 

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -21,7 +21,7 @@
                     <details
                         v-if="preset?.options?.length"
                         ref="optionsDetailsRef"
-                        class="relative min-h-[26px] h-[26px] overflow-visible mt-1.5 w-fit min-w-[200px]"
+                        class="relative min-h-[38px] overflow-visible mt-1.5 w-fit min-w-[200px]"
                         :open="optionsExpanded"
                         @toggle="handleOptionsToggle"
                     >

--- a/src/components/tabs/presets/PresetFilterSelect.vue
+++ b/src/components/tabs/presets/PresetFilterSelect.vue
@@ -1,38 +1,36 @@
 <template>
-    <div class="presets_filter_row">
-        <div class="presets_filter_table_header" v-html="$t(labelKey)"></div>
-        <div class="presets_filter_table_value">
-            <Multiselect
-                :model-value="modelValue"
-                :options="options"
-                :multiple="true"
-                :searchable="true"
-                :show-labels="false"
-                :close-on-select="false"
-                :clear-on-select="false"
-                :preserve-search="true"
-                :placeholder="$t('dropDownFilterDisabled')"
-                :class="{ presets_filter_select_nonempty: modelValue.length > 0 }"
-                @update:model-value="$emit('update:modelValue', $event)"
-            >
-                <template #selection="{ values }">
-                    <span v-if="values.length > 0 && values.length === options.length" class="multiselect__single">
-                        {{ $t("dropDownAll") }}
-                    </span>
-                    <span v-else-if="values.length > 0" class="multiselect__single" :title="values.join('; ')">
-                        {{ values.join("; ") }}
-                    </span>
-                </template>
-            </Multiselect>
-        </div>
+    <div class="flex flex-col gap-0.5">
+        <div class="text-left font-normal py-0.5" v-html="$t(labelKey)"></div>
+        <USelectMenu
+            v-model="selectedItems"
+            multiple
+            :items="items"
+            :search-input="{
+                placeholder: $t('dropDownFilterDisabled'),
+            }"
+            :ui="{ content: 'max-h-72 z-[9999]' }"
+            class="w-full"
+            :class="{ 'ring-2 ring-(--ui-primary) rounded-md': modelValue.length > 0 }"
+        >
+            <template #default>
+                <span v-if="modelValue.length > 0 && modelValue.length === options.length" class="truncate">
+                    {{ $t("dropDownAll") }}
+                </span>
+                <span v-else-if="modelValue.length > 0" class="truncate" :title="modelValue.join('; ')">
+                    {{ modelValue.join("; ") }}
+                </span>
+                <span v-else class="opacity-70 truncate">
+                    {{ $t("dropDownFilterDisabled") }}
+                </span>
+            </template>
+        </USelectMenu>
     </div>
 </template>
 
 <script setup>
-import Multiselect from "vue-multiselect";
-import "vue-multiselect/dist/vue-multiselect.css";
+import { computed } from "vue";
 
-defineProps({
+const props = defineProps({
     labelKey: {
         type: String,
         required: true,
@@ -47,135 +45,19 @@ defineProps({
     },
 });
 
-defineEmits(["update:modelValue"]);
+const emit = defineEmits(["update:modelValue"]);
+
+const items = computed(() => props.options.map((opt) => ({ value: opt, label: opt })));
+
+const selectedItems = computed({
+    get() {
+        return props.modelValue.map((val) => ({ value: val, label: val }));
+    },
+    set(newItems) {
+        emit(
+            "update:modelValue",
+            newItems.map((item) => item.value),
+        );
+    },
+});
 </script>
-
-<style scoped lang="less">
-.presets_filter_table_header {
-    color: var(--text);
-    border-radius: 4px;
-    font-weight: normal;
-    text-align: left;
-    padding: 0.25rem 0;
-}
-
-.presets_filter_table_value {
-    width: 100%;
-}
-
-:deep(.presets_filter_select_nonempty .multiselect__tags) {
-    border-color: var(--primary-500);
-    border-width: 2px;
-}
-
-.multiselect {
-    width: 100%;
-    min-height: 38px;
-    color: var(--text);
-    font-size: inherit;
-}
-
-.multiselect:deep(.multiselect__tags) {
-    min-height: 38px;
-    display: flex;
-    align-items: center;
-    padding: 0 40px 0 10px;
-    border-color: var(--surface-500);
-    background: var(--surface-50);
-}
-
-.multiselect:deep(.multiselect__input),
-.multiselect:deep(.multiselect__single) {
-    color: var(--text);
-    min-height: 0;
-    min-width: 0;
-    display: block;
-    width: 100%;
-    padding: 0;
-    margin: 0;
-    border: 0 !important;
-    border-radius: 0;
-    background: transparent !important;
-    box-shadow: none;
-    line-height: 22px;
-}
-
-.multiselect:deep(.multiselect__input:hover),
-.multiselect:deep(.multiselect__input:focus),
-.multiselect:deep(.multiselect__single:hover),
-.multiselect:deep(.multiselect__single:focus) {
-    border: 0 !important;
-    box-shadow: none;
-}
-
-.multiselect:deep(.multiselect__input::placeholder),
-.multiselect:deep(.multiselect__placeholder) {
-    color: var(--text);
-    opacity: 0.72;
-}
-
-.multiselect:deep(.multiselect__placeholder) {
-    padding: 0;
-    margin: 0;
-    line-height: 22px;
-}
-
-.multiselect:deep(.multiselect__select) {
-    height: 36px;
-}
-
-.multiselect:deep(.multiselect__select::before) {
-    color: var(--text);
-    opacity: 0.65;
-    border-color: var(--text) transparent transparent transparent;
-}
-
-.multiselect:deep(.multiselect__content) {
-    background: var(--surface-50);
-}
-
-.multiselect:deep(.multiselect__option) {
-    color: var(--text);
-}
-
-.multiselect:deep(.multiselect__option::after) {
-    background: transparent;
-}
-
-.multiselect:deep(.multiselect__option--selected::after) {
-    color: var(--text);
-}
-
-.multiselect:deep(.multiselect__single) {
-    margin-bottom: 0;
-}
-
-.multiselect:deep(.multiselect__content-wrapper) {
-    border-color: var(--surface-500);
-}
-
-.multiselect:deep(.multiselect__option--selected) {
-    background: var(--primary-100);
-    color: var(--text);
-}
-
-.multiselect:deep(.multiselect__option--highlight) {
-    background: var(--primary-500);
-}
-
-@media all and (max-width: 575px) {
-    .presets_filter_row {
-        display: table-row;
-    }
-
-    .presets_filter_table_header {
-        display: table-cell;
-        background-color: unset;
-        border-right: unset;
-    }
-
-    .presets_filter_table_value {
-        display: table-cell;
-    }
-}
-</style>

--- a/src/components/tabs/presets/PresetFilterSelect.vue
+++ b/src/components/tabs/presets/PresetFilterSelect.vue
@@ -4,6 +4,7 @@
         <USelectMenu
             v-model="selectedItems"
             multiple
+            value-key="value"
             :items="items"
             :search-input="{
                 placeholder: $t('dropDownFilterDisabled'),
@@ -51,13 +52,10 @@ const items = computed(() => props.options.map((opt) => ({ value: opt, label: op
 
 const selectedItems = computed({
     get() {
-        return props.modelValue.map((val) => ({ value: val, label: val }));
+        return props.modelValue;
     },
-    set(newItems) {
-        emit(
-            "update:modelValue",
-            newItems.map((item) => item.value),
-        );
+    set(newValues) {
+        emit("update:modelValue", newValues);
     },
 });
 </script>

--- a/src/components/tabs/presets/PresetSourceCard.vue
+++ b/src/components/tabs/presets/PresetSourceCard.vue
@@ -2,96 +2,73 @@
     <div>
         <div
             :class="[
-                'presets_source_panel',
-                selected ? 'presets_source_panel_selected' : 'presets_source_panel_not_selected',
+                'bg-(--ui-bg-muted) border border-(--ui-border) p-4 shadow-sm rounded mb-1.5',
+                selected ? '' : 'cursor-pointer hover:bg-(--ui-bg-elevated) hover:shadow-md',
             ]"
             @click="!selected && emit('select')"
         >
-            <div v-if="!selected" class="presets_source_panel_no_editing">
-                <div v-if="active" class="presets_source_panel_no_editing_selected"></div>
-                <div class="presets_source_panel_no_editing_name">{{ source.name }}</div>
+            <div v-if="!selected" class="flex items-center gap-2">
+                <img v-if="active" :src="checkIcon" alt="" aria-hidden="true" class="w-[30px] h-[30px]" />
+                <span class="text-lg inline-block align-middle">{{ source.name }}</span>
             </div>
 
-            <div v-else class="presets_source_panel_editing">
-                <div class="presets_source_panel_editing_table">
-                    <div class="presets_source_panel_editing_row">
-                        <div class="presets_source_panel_editing_field_label">Name</div>
-                        <div class="presets_source_panel_editing_field_edit">
-                            <input
-                                v-model="draft.name"
-                                type="text"
-                                class="presets_source_panel_editing_name_field standard_input"
-                                :disabled="source.official"
-                            />
-                        </div>
-                    </div>
-                    <div class="presets_source_panel_editing_row">
-                        <div class="presets_source_panel_editing_field_label">Url</div>
-                        <div class="presets_source_panel_editing_field_edit">
-                            <input
-                                v-model="draft.url"
-                                type="text"
-                                class="presets_source_panel_editing_url_field standard_input"
-                                :disabled="source.official"
-                                @input="handleUrlInput"
-                            />
-                        </div>
-                    </div>
-                    <div
-                        v-if="showGithubBranch"
-                        class="presets_source_panel_editing_row presets_source_panel_editing_github_branch"
-                    >
-                        <div class="presets_source_panel_editing_field_label">GitHub branch</div>
-                        <div class="presets_source_panel_editing_field_edit">
-                            <input
-                                v-model="draft.gitHubBranch"
-                                type="text"
-                                class="presets_source_panel_editing_branch_field standard_input"
-                                :disabled="source.official"
-                            />
-                        </div>
-                    </div>
+            <div v-else>
+                <div class="grid grid-cols-[100px_1fr] gap-1.5 items-center">
+                    <span class="whitespace-pre pr-2.5 min-w-[100px]">Name</span>
+                    <UInput v-model="draft.name" :disabled="source.official" class="w-full" />
+                    <span class="whitespace-pre pr-2.5 min-w-[100px]">Url</span>
+                    <UInput
+                        v-model="draft.url"
+                        :disabled="source.official"
+                        class="w-full"
+                        @update:model-value="handleUrlInput"
+                    />
+                    <template v-if="showGithubBranch">
+                        <span class="whitespace-pre pr-2.5 min-w-[100px]">GitHub branch</span>
+                        <UInput v-model="draft.gitHubBranch" :disabled="source.official" class="w-full" />
+                    </template>
                 </div>
 
-                <div>
-                    <div v-if="active" class="presets_source_panel_no_editing_selected"></div>
-                    <a
+                <div class="flex items-center flex-wrap gap-2 mt-3">
+                    <img v-if="active" :src="checkIcon" alt="" aria-hidden="true" class="w-[30px] h-[30px]" />
+                    <UButton
                         v-if="!active"
-                        href="#"
-                        class="tool regular-button presets_source_panel_activate"
-                        @click.prevent="handleActivate"
-                        >{{ $t("presetsSourcesDialogMakeSourceActive") }}</a
-                    >
-                    <a
+                        :label="$t('presetsSourcesDialogMakeSourceActive')"
+                        size="xs"
+                        @click="handleActivate"
+                    />
+                    <UButton
                         v-if="active"
-                        href="#"
-                        class="tool regular-button presets_source_panel_deactivate"
-                        @click.prevent="handleDeactivate"
-                        >{{ $t("presetsSourcesDialogMakeSourceDisable") }}</a
-                    >
-                    <a
-                        v-if="!source.official"
-                        href="#"
-                        class="tool regular-button presets_source_panel_save"
-                        :class="{ disabled: !isDirty }"
-                        @click.prevent="isDirty && handleSave()"
-                        >{{ $t("presetsSourcesDialogSaveSource") }}</a
-                    >
-                    <a
-                        v-if="!source.official"
-                        href="#"
-                        class="tool regular-button presets_source_panel_reset"
-                        :class="{ disabled: !isDirty }"
-                        @click.prevent="isDirty && resetDraft()"
-                        >{{ $t("presetsSourcesDialogResetSource") }}</a
-                    >
-                    <a
-                        v-if="!source.official"
-                        href="#"
-                        class="tool regular-button presets_source_panel_delete"
-                        @click.prevent="emit('delete')"
-                        >{{ $t("presetsSourcesDialogDeleteSource") }}</a
-                    >
+                        :label="$t('presetsSourcesDialogMakeSourceDisable')"
+                        variant="outline"
+                        size="xs"
+                        @click="handleDeactivate"
+                    />
+                    <div class="ml-auto flex gap-1.5">
+                        <UButton
+                            v-if="!source.official"
+                            :label="$t('presetsSourcesDialogSaveSource')"
+                            :disabled="!isDirty"
+                            size="xs"
+                            @click="handleSave"
+                        />
+                        <UButton
+                            v-if="!source.official"
+                            :label="$t('presetsSourcesDialogResetSource')"
+                            :disabled="!isDirty"
+                            variant="outline"
+                            size="xs"
+                            @click="resetDraft"
+                        />
+                        <UButton
+                            v-if="!source.official"
+                            :label="$t('presetsSourcesDialogDeleteSource')"
+                            variant="outline"
+                            color="error"
+                            size="xs"
+                            @click="emit('delete')"
+                        />
+                    </div>
                 </div>
             </div>
         </div>
@@ -101,6 +78,7 @@
 <script setup>
 import { computed, reactive, watch } from "vue";
 import PresetSource from "./SourcesDialog/PresetSource";
+import checkIcon from "@/images/icons/cf_icon_check_orange.svg";
 
 const props = defineProps({
     source: {
@@ -178,7 +156,9 @@ function handleUrlInput() {
 }
 
 function handleSave() {
-    emit("save", normalizedDraft());
+    if (isDirty.value) {
+        emit("save", normalizedDraft());
+    }
 }
 
 function handleActivate() {
@@ -191,74 +171,3 @@ function handleDeactivate() {
     emit("deactivate");
 }
 </script>
-
-<style lang="less">
-.presets_source_panel {
-    background-color: var(--surface-200);
-    border: 1px solid var(--surface-500);
-    padding: 1.5ex;
-    box-shadow: 2px 2px 5px rgba(92, 92, 92, 0.25);
-    border-radius: 4px;
-    margin-bottom: 6px;
-}
-
-.presets_source_panel_not_selected {
-    cursor: pointer;
-}
-
-.presets_source_panel_not_selected:hover {
-    background-color: var(--surface-500);
-    box-shadow: 2px 2px 5px rgba(92, 92, 92, 0.5);
-}
-
-.presets_source_panel_editing_table {
-    display: table;
-    width: 100%;
-    border-spacing: 6px;
-}
-
-.presets_source_panel_editing_row {
-    display: table-row;
-}
-
-.presets_source_panel_editing_field_label {
-    display: table-cell;
-    white-space: pre;
-    padding-right: 10px;
-    min-width: 100px;
-}
-
-.presets_source_panel_editing_field_edit {
-    display: table-cell;
-    width: 100%;
-    padding-right: 10px;
-}
-
-.presets_source_panel_editing_row .standard_input {
-    width: 100%;
-    margin-right: 12px;
-}
-
-.presets_source_panel_no_editing_name {
-    font-size: 130%;
-    display: inline-block;
-    vertical-align: middle;
-}
-
-.presets_source_panel_no_editing_selected {
-    background-image: url(../../../images/icons/cf_icon_check_orange.svg);
-    width: 30px;
-    height: 30px;
-    display: inline-block;
-    margin-top: 8px;
-    margin-bottom: 8px;
-    margin-right: 5px;
-    vertical-align: middle;
-}
-
-.presets_source_panel_reset,
-.presets_source_panel_save,
-.presets_source_panel_delete {
-    float: right;
-}
-</style>

--- a/src/components/tabs/presets/PresetSourcesDialog.vue
+++ b/src/components/tabs/presets/PresetSourcesDialog.vue
@@ -1,43 +1,34 @@
 <template>
-    <dialog id="presets_sources_dialog" ref="dialogRef" @close="emit('close')" @cancel.prevent="emit('close')">
-        <div id="presets_sources_dialog_content_wrapper">
-            <div id="presets_sources_dialog_content">
-                <div class="presets_sources_dialog_title_panel" v-html="$t('presetsSourcesDialogTitle')"></div>
-                <div class="presets_sources_dialog_scrollable">
-                    <div class="note" v-html="$t('presets_sources_dialog_warning')"></div>
-                    <div class="presets_sources_dialog_sources">
-                        <PresetSourceCard
-                            v-for="source in sources"
-                            :key="source.id"
-                            :source="source"
-                            :selected="selectedSourceId === source.id"
-                            :active="activeSourceIds.includes(source.id)"
-                            @select="selectedSourceId = source.id"
-                            @save="emit('save-source', source.id, $event)"
-                            @delete="emit('delete-source', source.id)"
-                            @activate="emit('activate-source', source.id)"
-                            @deactivate="emit('deactivate-source', source.id)"
-                        />
-                    </div>
+    <dialog ref="dialogRef" class="w-[600px] h-[520px] p-3" @close="emit('close')" @cancel.prevent="emit('close')">
+        <div class="flex flex-col h-full">
+            <div
+                class="pb-1 border-b border-(--ui-primary) mb-3 text-2xl font-bold"
+                v-html="$t('presetsSourcesDialogTitle')"
+            ></div>
+            <div class="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
+                <UiBox type="warning" highlight class="mb-3">
+                    <span v-html="$t('presets_sources_dialog_warning')"></span>
+                </UiBox>
+                <div>
+                    <PresetSourceCard
+                        v-for="source in sources"
+                        :key="source.id"
+                        :source="source"
+                        :selected="selectedSourceId === source.id"
+                        :active="activeSourceIds.includes(source.id)"
+                        @select="selectedSourceId = source.id"
+                        @save="emit('save-source', source.id, $event)"
+                        @delete="emit('delete-source', source.id)"
+                        @activate="emit('activate-source', source.id)"
+                        @deactivate="emit('deactivate-source', source.id)"
+                    />
                 </div>
             </div>
 
-            <div class="content_toolbar">
-                <div class="btn">
-                    <a
-                        id="presets_sources_dialog_close"
-                        href="#"
-                        class="tool regular-button"
-                        @click.prevent="emit('close')"
-                        >{{ $t("OK") }}</a
-                    >
-                    <a
-                        id="presets_sources_dialog_add_new"
-                        href="#"
-                        class="tool regular-button"
-                        @click.prevent="handleAddSource"
-                        >{{ $t("presetsSourcesDialogAddNew") }}</a
-                    >
+            <div class="content_toolbar mt-auto">
+                <div class="flex gap-2 justify-end">
+                    <UButton :label="$t('presetsSourcesDialogAddNew')" variant="outline" @click="handleAddSource" />
+                    <UButton :label="$t('OK')" @click="emit('close')" />
                 </div>
             </div>
         </div>
@@ -46,6 +37,7 @@
 
 <script setup>
 import { nextTick, ref, watch } from "vue";
+import UiBox from "@/components/elements/UiBox.vue";
 import PresetSourceCard from "./PresetSourceCard.vue";
 
 const props = defineProps({
@@ -111,38 +103,3 @@ function handleAddSource() {
     emit("add-source");
 }
 </script>
-
-<style lang="less">
-#presets_sources_dialog {
-    width: 600px;
-    height: 520px;
-    padding: 12px;
-}
-
-.presets_sources_dialog_title_panel {
-    padding-bottom: 0.5ex;
-    border-bottom: 1px solid var(--primary-500);
-    margin-bottom: 2ex;
-    font-size: 1.5em;
-    font-weight: bold;
-}
-
-.presets_sources_dialog_scrollable {
-    height: 430px;
-    overflow-y: auto;
-    overflow-x: hidden;
-}
-
-@media all and (max-width: 575px) {
-    #presets_sources_dialog_content_wrapper .content_toolbar {
-        position: fixed;
-    }
-
-    .presets_sources_dialog_scrollable {
-        overflow-y: auto;
-        overflow-x: hidden;
-        padding-bottom: 51px;
-        height: unset;
-    }
-}
-</style>

--- a/test/js/preset_details_dialog.test.js
+++ b/test/js/preset_details_dialog.test.js
@@ -83,11 +83,12 @@ describe("PresetDetailsDialog", () => {
 
         await nextTick();
 
-        const htmlBlock = wrapper.container.querySelector("#presets_detailed_dialog_html_description");
+        const htmlBlock = wrapper.container.querySelector('[data-testid="preset-html-description"]');
         expect(htmlBlock.innerHTML).toContain("<h1");
         expect(htmlBlock.querySelector("a").getAttribute("target")).toBe("_blank");
-        expect(wrapper.container.querySelector("#presets_open_discussion").classList.contains("disabled")).toBe(true);
-        expect(wrapper.container.querySelector("#presets_open_discussion").getAttribute("href")).toBeNull();
+        const discussionBtn = wrapper.container.querySelector('[data-testid="preset-discussion-link"]');
+        expect(discussionBtn).toBeTruthy();
+        expect(discussionBtn.hasAttribute("href")).toBe(false);
 
         const checkbox = wrapper.container.querySelector('input[type="checkbox"]');
         checkbox.checked = false;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized the Presets UI: replaced legacy links and native controls with unified buttons and inputs, refreshed dialogs and progress UI, standardized status pills, introduced a sticky search/header, improved empty/error/loading states, and migrated styling to utility classes and a grid layout for better responsiveness.
  * Streamlined preset cards, filter selector, source editor, and bottom toolbar for clearer actions and improved usability.

* **Tests**
  * Updated UI tests to match the new dialog and discussion link markup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->