### PR TITLE
Fix OSD tab dirty state

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5823,7 +5823,7 @@
         "message": "Custom image:"
     },
     "osdSetupCustomLogoInfoImageSize": {
-        "message": "Size must be $t(logoWidthPx)x$t(logoHeightPx) pixels"
+        "message": "Size must be {{logoWidthPx}}x{{logoHeightPx}} pixels"
     },
     "osdSetupCustomLogoInfoColorMap": {
         "message": "Must contain green, black and white pixels"
@@ -5832,7 +5832,7 @@
         "message": "Click <b>$t(osdSetupUploadFont.message)</b> to persist custom logo"
     },
     "osdSetupCustomLogoImageSizeError": {
-        "message": "Invalid image size: {{width}}x{{height}} (expected $t(logoWidthPx)×$t(logoHeightPx))"
+        "message": "Invalid image size: {{width}}x{{height}} (expected {{logoWidthPx}}×{{logoHeightPx}})"
     },
     "osdSetupCustomLogoColorMapError": {
         "message": "The image contains an invalid pixel: rgb({{valueR}}, {{valueG}}, {{valueB}}) at coordinates {{posX}}×{{posY}}"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5853,6 +5853,9 @@
     "osdSetupSave": {
         "message": "Save"
     },
+    "osdSetupRefresh": {
+        "message": "Refresh"
+    },
     "osdSetupFontManager": {
         "message": "Font Manager"
     },

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -505,9 +505,22 @@
                 <UButton :disabled="!osdStore.state.isMax7456FontDeviceDetected" @click="openFontManager()">
                     {{ $t("osdSetupFontManagerTitle") }}
                 </UButton>
-                <UButton @click="saveConfig()" color="primary">
-                    {{ saveButtonText }}
-                </UButton>
+                <UFieldGroup size="sm" orientation="horizontal" class="!flex">
+                    <UButton
+                        @click="saveConfig()"
+                        :disabled="!osdStore.dirty"
+                        :color="osdStore.dirty ? 'success' : 'neutral'"
+                    >
+                        {{ saveButtonText }}
+                    </UButton>
+                    <UDropdownMenu v-slot="{ open }" :items="saveMenuItems" :content="{ align: 'end', side: 'top' }">
+                        <UButton
+                            :color="osdStore.dirty ? 'success' : 'neutral'"
+                            :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
+                            square
+                        />
+                    </UDropdownMenu>
+                </UFieldGroup>
             </div>
         </div>
     </BaseTab>
@@ -562,6 +575,21 @@ const uploadProgressLabel = ref("");
 const isSaving = ref(false);
 const saveButtonTextOverride = ref(null);
 const saveButtonText = computed(() => saveButtonTextOverride.value || i18n.getMessage("osdSetupSave"));
+const saveMenuItems = computed(() => [
+    [
+        {
+            label: i18n.getMessage("osdSetupSave"),
+            icon: "i-lucide-save",
+            disabled: !osdStore.dirty,
+            onSelect: saveConfig,
+        },
+        {
+            label: i18n.getMessage("osdSetupRefresh"),
+            icon: "i-lucide-refresh-cw",
+            onSelect: refreshConfig,
+        },
+    ],
+]);
 const hasLoadedConfig = ref(false);
 // State for popover
 const presetMenuField = ref(null);
@@ -776,70 +804,38 @@ function unhighlightField() {
 function toggleFieldVisibility(fieldIndex, profileIndex, event) {
     osdStore.updateDisplayItemVisibility(fieldIndex, profileIndex, event.target.checked);
     trackChange("displayItem", osdStore.displayItems[fieldIndex].name);
-    osdStore.saveDisplayItem(osdStore.displayItems[fieldIndex]).catch((error) => {
-        console.error("Failed to update display item visibility:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save visibility change" }));
-    });
     updatePreview();
 }
 
 // Handle variant change
 function onVariantChange(field) {
     trackChange("variant", field.name);
-    osdStore.saveDisplayItem(field).catch((error) => {
-        console.error("Failed to update display item variant:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save variant change" }));
-    });
     updatePreview();
 }
 
 // Handle video system change
 function onVideoSystemChange() {
     osdStore.updateDisplaySize();
-    osdStore.saveOtherConfig().catch((error) => {
-        console.error("Failed to update OSD video system:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save OSD video system" }));
-    });
     updatePreview();
 }
 
 function onUnitModeChange() {
-    osdStore.saveOtherConfig().catch((error) => {
-        console.error("Failed to update OSD unit mode:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save OSD unit mode" }));
-    });
     updatePreview();
 }
 
-function onTimerChange(timer) {
-    osdStore.saveTimerConfig(timer).catch((error) => {
-        console.error("Failed to update OSD timer:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save OSD timer" }));
-    });
+function onTimerChange() {
     updatePreview();
 }
 
 function onAlarmChange() {
-    osdStore.saveOtherConfig().catch((error) => {
-        console.error("Failed to update OSD alarms:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save OSD alarms" }));
-    });
     updatePreview();
 }
 
 function onWarningChange() {
-    osdStore.saveOtherConfig().catch((error) => {
-        console.error("Failed to update OSD warnings:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save OSD warnings" }));
-    });
     updatePreview();
 }
 
-function onStatChange(stat) {
-    osdStore.saveStatisticItem(stat).catch((error) => {
-        console.error("Failed to update OSD statistic:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save OSD statistic" }));
-    });
+function onStatChange() {
     updatePreview();
 }
 
@@ -1025,10 +1021,6 @@ function onDropCell(event) {
     // Update display item position
     displayItem.position = position;
     trackChange("position", displayItem.name);
-    osdStore.saveDisplayItem(displayItem).catch((error) => {
-        console.error("Failed to update display item position:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save display item position" }));
-    });
     updatePreview();
 
     dragState.value.field = null;
@@ -1123,10 +1115,6 @@ function applyPresetPosition(field, positionKey) {
 
     field.position = finalPosition;
     trackChange("position", field.name);
-    osdStore.saveDisplayItem(field).catch((error) => {
-        console.error("Failed to apply preset position:", error);
-        gui_log(i18n.getMessage("error", { errorMessage: "Failed to save preset position" }));
-    });
     updatePreview();
 
     closePresetMenu();
@@ -1235,7 +1223,10 @@ async function loadConfig() {
     }
 }
 
-// Save OSD configuration to FC
+async function refreshConfig() {
+    await loadConfig();
+}
+
 // Save OSD configuration to FC
 async function saveConfig() {
     if (isSaving.value) {
@@ -1247,8 +1238,8 @@ async function saveConfig() {
         // Sync store state to the shared OSD.data bridge used by legacy helpers.
         osdStore.syncToLegacy();
 
-        // Legacy parity: Save button commits pending in-memory config to EEPROM.
-        await osdStore.saveToEeprom();
+        // Send all OSD config to FC and write EEPROM.
+        await osdStore.saveAllConfig();
 
         // Track analytics
         const changes = analyticsChanges.value;
@@ -1486,12 +1477,6 @@ watch(activeProfile, (newVal) => {
     osdStore.osdProfiles.selected = newVal;
     if (previewProfile.value !== newVal) {
         previewProfile.value = newVal;
-    }
-    if (hasLoadedConfig.value) {
-        osdStore.saveOtherConfig().catch((error) => {
-            console.error("Failed to update active OSD profile:", error);
-            gui_log(i18n.getMessage("error", { errorMessage: "Failed to save active OSD profile" }));
-        });
     }
 });
 

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -505,7 +505,7 @@
                 <UButton :disabled="!osdStore.state.isMax7456FontDeviceDetected" @click="openFontManager()">
                     {{ $t("osdSetupFontManagerTitle") }}
                 </UButton>
-                <UFieldGroup size="sm" orientation="horizontal" class="!flex">
+                <UFieldGroup size="sm" orientation="horizontal" class="flex!">
                     <UButton
                         @click="saveConfig()"
                         :disabled="!osdStore.dirty"

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -580,12 +580,13 @@ const saveMenuItems = computed(() => [
         {
             label: i18n.getMessage("osdSetupSave"),
             icon: "i-lucide-save",
-            disabled: !osdStore.dirty,
+            disabled: !osdStore.dirty || isSaving.value,
             onSelect: saveConfig,
         },
         {
             label: i18n.getMessage("osdSetupRefresh"),
             icon: "i-lucide-refresh-cw",
+            disabled: isSaving.value,
             onSelect: refreshConfig,
         },
     ],
@@ -1224,7 +1225,11 @@ async function loadConfig() {
 }
 
 async function refreshConfig() {
+    if (isSaving.value) {
+        return;
+    }
     await loadConfig();
+    analyticsChanges.value = {};
 }
 
 // Save OSD configuration to FC

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -473,7 +473,9 @@
                                     {{ $t("osdSetupCustomLogoInfoTitle") }}
                                 </h3>
                                 <ul class="tab-osd-logo-info-list">
-                                    <li id="font-logo-info-size">{{ $t("osdSetupCustomLogoInfoImageSize") }}</li>
+                                    <li id="font-logo-info-size">
+                                        {{ $t("osdSetupCustomLogoInfoImageSize", logoImageSizeParams) }}
+                                    </li>
                                     <li id="font-logo-info-colors">{{ $t("osdSetupCustomLogoInfoColorMap") }}</li>
                                 </ul>
                                 <p id="font-logo-info-upload-hint" v-html="$t('osdSetupCustomLogoInfoUploadHint')"></p>
@@ -573,6 +575,10 @@ const selectedFontPreset = ref(selectedFont.value);
 const uploadProgress = ref(0);
 const uploadProgressLabel = ref("");
 const isSaving = ref(false);
+const logoImageSizeParams = {
+    logoWidthPx: FONT.constants.SIZES.CHAR_WIDTH * 24,
+    logoHeightPx: FONT.constants.SIZES.CHAR_HEIGHT * 4,
+};
 const saveButtonTextOverride = ref(null);
 const saveButtonText = computed(() => saveButtonTextOverride.value || i18n.getMessage("osdSetupSave"));
 const saveMenuItems = computed(() => [

--- a/src/js/LogoManager.js
+++ b/src/js/LogoManager.js
@@ -130,6 +130,8 @@ LogoManager.init = function (font, logoStartIndex) {
                         i18n.getMessage("osdSetupCustomLogoImageSizeError", {
                             width: img.width,
                             height: img.height,
+                            logoWidthPx: constraint.expectedWidth,
+                            logoHeightPx: constraint.expectedHeight,
                         }),
                     );
                     return false;
@@ -175,11 +177,6 @@ LogoManager.init = function (font, logoStartIndex) {
     // deps from osd.js
     this.font = font;
     this.logoStartIndex = logoStartIndex;
-    // inject logo size variables for dynamic translation strings
-    i18n.addResources({
-        logoWidthPx: `${this.constraints.imageSize.expectedWidth}`, // NOSONAR
-        logoHeightPx: `${this.constraints.imageSize.expectedHeight}`, // NOSONAR
-    });
     // find/cache DOM elements (skip _-prefixed keys from previous init calls)
     Object.keys(this.elements).forEach((key) => {
         if (key.startsWith("_")) {

--- a/src/stores/osd.js
+++ b/src/stores/osd.js
@@ -115,12 +115,27 @@ export const useOsdStore = defineStore("osd", () => {
         return JSON.stringify({
             videoSystem: videoSystem.value,
             unitMode: unitMode.value,
-            alarms: alarms.value,
-            statItems: statItems.value,
-            warnings: warnings.value,
-            displayItems: displayItems.value,
-            timers: timers.value,
-            osdProfiles: osdProfiles.value,
+            parameters: {
+                cameraFrameWidth: parameters.cameraFrameWidth,
+                cameraFrameHeight: parameters.cameraFrameHeight,
+                overlayRadioMode: parameters.overlayRadioMode,
+            },
+            alarms: Object.fromEntries(
+                Object.entries(alarms.value).map(([key, alarm]) => [key, { value: alarm.value }]),
+            ),
+            statItems: statItems.value.map(({ index, enabled }) => ({ index, enabled })),
+            warnings: warnings.value.map(({ index, enabled }) => ({ index, enabled })),
+            displayItems: displayItems.value.map(({ index, position, variant, isVisible }) => ({
+                index,
+                position,
+                variant,
+                isVisible: [...isVisible],
+            })),
+            timers: timers.value.map(({ index, src, precision, alarm }) => ({ index, src, precision, alarm })),
+            osdProfiles: {
+                number: osdProfiles.value.number,
+                selected: osdProfiles.value.selected,
+            },
         });
     }
 

--- a/src/stores/osd.js
+++ b/src/stores/osd.js
@@ -108,6 +108,30 @@ export const useOsdStore = defineStore("osd", () => {
     // Currently selected preview profile
     const selectedPreviewProfile = ref(0);
 
+    // Dirty state tracking
+    const savedSnapshot = ref("");
+
+    function takeSnapshot() {
+        return JSON.stringify({
+            videoSystem: videoSystem.value,
+            unitMode: unitMode.value,
+            alarms: alarms.value,
+            statItems: statItems.value,
+            warnings: warnings.value,
+            displayItems: displayItems.value,
+            timers: timers.value,
+            osdProfiles: osdProfiles.value,
+        });
+    }
+
+    function captureSnapshot() {
+        savedSnapshot.value = takeSnapshot();
+    }
+
+    const dirty = computed(() => {
+        return savedSnapshot.value !== "" && takeSnapshot() !== savedSnapshot.value;
+    });
+
     // Video system constants
     const VIDEO_COLS = {
         PAL: 30,
@@ -215,6 +239,7 @@ export const useOsdStore = defineStore("osd", () => {
             await decodeOsdData(info);
             syncStoreFromDecodedOsdData();
             await ensureDefaultFontLoaded();
+            captureSnapshot();
         } catch (e) {
             console.error("Failed to fetch OSD config", e);
             throw e;
@@ -355,6 +380,28 @@ export const useOsdStore = defineStore("osd", () => {
         return MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
     };
 
+    const saveAllConfig = async () => {
+        await MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, encodeOther());
+
+        for (const item of displayItems.value) {
+            await MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, encodeLayout(item));
+        }
+
+        for (const timer of timers.value) {
+            await MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, encodeTimer(timer));
+        }
+
+        for (const stat of statItems.value) {
+            await MSP.promise(
+                MSPCodes.MSP_SET_OSD_CONFIG,
+                encodeStatisticsPayload(stat, CONFIGURATOR.virtualMode, OSD.virtualMode),
+            );
+        }
+
+        await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
+        captureSnapshot();
+    };
+
     return {
         // State
         videoSystem,
@@ -374,6 +421,7 @@ export const useOsdStore = defineStore("osd", () => {
         numberOfProfiles,
         currentPreviewProfile,
         isSupported,
+        dirty,
 
         // Actions
         initData,
@@ -387,5 +435,6 @@ export const useOsdStore = defineStore("osd", () => {
         saveTimerConfig,
         saveStatisticItem,
         saveToEeprom,
+        saveAllConfig,
     };
 });


### PR DESCRIPTION
# Plan: OSD Tab Dirty State, Deferred Save & Legacy Bridge Removal

**Issue:** [#4995](https://github.com/betaflight/betaflight-configurator/issues/4995)

Two phases:
- **Phase 1** — Fix dirty state: defer MSP sends, add save/refresh buttons.
- **Phase 2** — Remove the `OSD.data` legacy bridge so the Pinia store is the
  single source of truth.

---

## Problem

The OSD tab sends MSP commands to the flight controller **immediately** on every UI
interaction (checkbox toggle, variant change, drag-and-drop, alarm edit, etc.).
The "Save" button only writes EEPROM (`MSP_EEPROM_WRITE`), not the config itself.

This means:
1. Changes are applied to FC RAM instantly — there is no way to discard them.
2. Switching tabs loses the ability to revert because the FC already has the new
   values in memory.
3. There is no dirty-state indicator — the save button is always enabled.
4. There is no refresh/revert mechanism.

Other tabs (e.g. Ports) follow a correct pattern: edit locally, track dirty state
via snapshot comparison, batch-save on button click.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual save flow introduced with explicit Save action and a Save+Refresh dropdown.
  * Added a Refresh action to reload configuration from the device.
  * UI now shows save state (dirty) and disables actions appropriately.

* **Bug Fixes / UX**
  * Improved custom logo size messaging and validation to display correct dimensions.
  * Stopped persisting on every minor UI change to prevent unintended writes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->