### PR TITLE
Refactor: Backups/UserProfile tables and login modal to Nuxt UI

### DIFF
--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -22,37 +22,20 @@
                     <template v-for="(groupBackups, craft) in groupedBackups" :key="craft">
                         <div class="mb-4">
                             <div class="text-sm font-bold text-[var(--color-primary-500)] mb-1">{{ craft }}</div>
-                            <div class="grid grid-cols-[auto_auto_1fr_auto] text-sm">
-                                <div class="col-span-4 grid grid-cols-subgrid border-b border-[var(--surface-300)]">
-                                    <div class="py-1.5 px-2 text-dimmed font-semibold">
-                                        {{ $t("labelDate") }}
-                                    </div>
-                                    <div class="py-1.5 px-2 text-dimmed font-semibold">
-                                        {{ $t("labelName") }}
-                                    </div>
-                                    <div class="py-1.5 px-2 text-dimmed font-semibold">
-                                        {{ $t("labelDescription") }}
-                                    </div>
-                                    <div class="py-1.5 px-2 text-dimmed font-semibold">
-                                        {{ $t("labelActions") }}
-                                    </div>
-                                </div>
-                                <div
-                                    v-for="backup in groupBackups"
-                                    :key="backup.id"
-                                    class="col-span-4 grid grid-cols-subgrid items-center border-b border-[var(--surface-200)] hover:bg-[var(--surface-100)]"
-                                >
-                                    <div class="py-1.5 px-2">{{ formatDate(backup.created) }}</div>
-                                    <div class="py-1.5 px-2">{{ backup.name }}</div>
-                                    <div class="py-1.5 px-2 text-dimmed">
-                                        {{ backup.description || "" }}
-                                    </div>
-                                    <div class="py-1.5 px-2 flex gap-2">
+                            <UTable :data="groupBackups" :columns="columns" class="text-sm">
+                                <template #created-cell="{ row }">
+                                    {{ formatDate(row.original.created) }}
+                                </template>
+                                <template #description-cell="{ row }">
+                                    <span class="text-dimmed">{{ row.original.description || "" }}</span>
+                                </template>
+                                <template #actions-cell="{ row }">
+                                    <div class="flex gap-2">
                                         <UButton
                                             size="xs"
                                             variant="soft"
                                             icon="i-lucide-download"
-                                            @click="downloadBackup(backup)"
+                                            @click="downloadBackup(row.original)"
                                         >
                                             {{ $t("actionDownload") }}
                                         </UButton>
@@ -60,7 +43,7 @@
                                             size="xs"
                                             variant="soft"
                                             icon="i-lucide-pencil"
-                                            @click="startEdit(backup)"
+                                            @click="startEdit(row.original)"
                                         >
                                             {{ $t("actionEdit") }}
                                         </UButton>
@@ -69,13 +52,13 @@
                                             variant="soft"
                                             color="error"
                                             icon="i-lucide-trash-2"
-                                            @click="deleteBackup(backup.id)"
+                                            @click="deleteBackup(row.original.id)"
                                         >
                                             {{ $t("actionDelete") }}
                                         </UButton>
                                     </div>
-                                </div>
-                            </div>
+                                </template>
+                            </UTable>
                         </div>
                     </template>
                 </UiBox>
@@ -137,6 +120,13 @@ const editForm = ref({ id: null, name: "", description: "", created: null });
 let userApi = null;
 let unsubscribeLogin = null;
 let unsubscribeLogout = null;
+
+const columns = computed(() => [
+    { accessorKey: "created", header: t("labelDate") },
+    { accessorKey: "name", header: t("labelName") },
+    { accessorKey: "description", header: t("labelDescription") },
+    { accessorKey: "actions", header: t("labelActions") },
+]);
 
 const groupedBackups = computed(() => {
     const grouped = {};

--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -125,7 +125,7 @@ const columns = computed(() => [
     { accessorKey: "created", header: t("labelDate") },
     { accessorKey: "name", header: t("labelName") },
     { accessorKey: "description", header: t("labelDescription") },
-    { accessorKey: "actions", header: t("labelActions") },
+    { id: "actions", header: t("labelActions") },
 ]);
 
 const groupedBackups = computed(() => {

--- a/src/components/tabs/UserProfileTab.vue
+++ b/src/components/tabs/UserProfileTab.vue
@@ -4,8 +4,9 @@
             <div class="tab_title">{{ $t("tabUserProfile") }}</div>
 
             <!-- Loading State -->
-            <div v-if="isLoading" class="data-loading">
-                <p>{{ $t("dataWaitingForData") }}</p>
+            <div v-if="isLoading" class="flex items-center justify-center py-16">
+                <UIcon name="i-lucide-loader-circle" class="size-5 animate-spin text-[var(--color-primary-500)]" />
+                <span class="ml-2 text-dimmed">{{ $t("dataWaitingForData") }}</span>
             </div>
 
             <!-- Not Logged In State -->
@@ -97,78 +98,61 @@
 
                 <!-- Token Section -->
                 <UiBox class="options col-span-3" :title="$t('sectionUserTokens')">
-                    <div class="grid grid-cols-[auto_auto_auto_1fr_auto] text-sm">
-                        <div class="col-span-5 grid grid-cols-subgrid border-b border-[var(--surface-300)]">
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelId") }}</div>
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelCreated") }}</div>
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelExpiry") }}</div>
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelDetails") }}</div>
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelActions") }}</div>
-                        </div>
-                        <div v-if="tokens.length === 0" class="col-span-5 py-1.5 px-2 text-dimmed">
-                            {{ $t("userTokenNoTokens") }}
-                        </div>
-                        <div
-                            v-for="token in tokens"
-                            :key="token.id"
-                            class="col-span-5 grid grid-cols-subgrid items-center border-b border-[var(--surface-200)] hover:bg-[var(--surface-100)]"
-                        >
-                            <div class="py-1.5 px-2">{{ token.id }}</div>
-                            <div class="py-1.5 px-2">{{ formatDate(token.created) }}</div>
-                            <div class="py-1.5 px-2">{{ formatDate(token.expiry) }}</div>
-                            <div class="py-1.5 px-2 text-dimmed">
-                                {{ token.details || token.client?.address || "-" }}
-                            </div>
-                            <div class="py-1.5 px-2">
-                                <UButton
-                                    size="xs"
-                                    variant="soft"
-                                    color="error"
-                                    icon="i-lucide-trash-2"
-                                    @click="deleteToken(token.id)"
-                                >
-                                    {{ $t("actionDelete") }}
-                                </UButton>
-                            </div>
-                        </div>
-                    </div>
+                    <UTable :data="tokens" :columns="tokenColumns" :empty="$t('userTokenNoTokens')" class="text-sm">
+                        <template #created-cell="{ row }">
+                            {{ formatDate(row.original.created) }}
+                        </template>
+                        <template #expiry-cell="{ row }">
+                            {{ formatDate(row.original.expiry) }}
+                        </template>
+                        <template #details-cell="{ row }">
+                            <span class="text-dimmed">
+                                {{ row.original.details || row.original.client?.address || "-" }}
+                            </span>
+                        </template>
+                        <template #actions-cell="{ row }">
+                            <UButton
+                                size="xs"
+                                variant="soft"
+                                color="error"
+                                icon="i-lucide-trash-2"
+                                @click="deleteToken(row.original.id)"
+                            >
+                                {{ $t("actionDelete") }}
+                            </UButton>
+                        </template>
+                    </UTable>
                 </UiBox>
 
                 <!-- Passkeys Section -->
                 <UiBox class="options col-span-3" :title="$t('sectionUserPasskeys')">
-                    <div class="grid grid-cols-[auto_auto_auto_1fr_auto] text-sm">
-                        <div class="col-span-5 grid grid-cols-subgrid border-b border-[var(--surface-300)]">
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelId") }}</div>
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelCreated") }}</div>
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelLastUsed") }}</div>
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelDetails") }}</div>
-                            <div class="py-1.5 px-2 text-dimmed font-semibold">{{ $t("labelActions") }}</div>
-                        </div>
-                        <div v-if="passkeys.length === 0" class="col-span-5 py-1.5 px-2 text-dimmed">
-                            {{ $t("userPasskeyNoPasskeys") }}
-                        </div>
-                        <div
-                            v-for="passkey in passkeys"
-                            :key="passkey.id"
-                            class="col-span-5 grid grid-cols-subgrid items-center border-b border-[var(--surface-200)] hover:bg-[var(--surface-100)]"
-                        >
-                            <div class="py-1.5 px-2">{{ passkey.id }}</div>
-                            <div class="py-1.5 px-2">{{ formatDate(passkey.createdAtUtc) }}</div>
-                            <div class="py-1.5 px-2">{{ formatDate(passkey.updatedAtUtc) }}</div>
-                            <div class="py-1.5 px-2 text-dimmed">{{ passkey.client?.address || "-" }}</div>
-                            <div class="py-1.5 px-2">
-                                <UButton
-                                    size="xs"
-                                    variant="soft"
-                                    color="error"
-                                    icon="i-lucide-trash-2"
-                                    @click="deletePasskey(passkey.id)"
-                                >
-                                    {{ $t("actionDelete") }}
-                                </UButton>
-                            </div>
-                        </div>
-                    </div>
+                    <UTable
+                        :data="passkeys"
+                        :columns="passkeyColumns"
+                        :empty="$t('userPasskeyNoPasskeys')"
+                        class="text-sm"
+                    >
+                        <template #createdAtUtc-cell="{ row }">
+                            {{ formatDate(row.original.createdAtUtc) }}
+                        </template>
+                        <template #updatedAtUtc-cell="{ row }">
+                            {{ formatDate(row.original.updatedAtUtc) }}
+                        </template>
+                        <template #details-cell="{ row }">
+                            <span class="text-dimmed">{{ row.original.client?.address || "-" }}</span>
+                        </template>
+                        <template #actions-cell="{ row }">
+                            <UButton
+                                size="xs"
+                                variant="soft"
+                                color="error"
+                                icon="i-lucide-trash-2"
+                                @click="deletePasskey(row.original.id)"
+                            >
+                                {{ $t("actionDelete") }}
+                            </UButton>
+                        </template>
+                    </UTable>
                 </UiBox>
             </div>
         </div>
@@ -198,6 +182,22 @@ const editDialogRef = ref(null);
 let userApi = null;
 let unsubscribeLogin = null;
 let unsubscribeLogout = null;
+
+const tokenColumns = computed(() => [
+    { accessorKey: "id", header: t("labelId") },
+    { accessorKey: "created", header: t("labelCreated") },
+    { accessorKey: "expiry", header: t("labelExpiry") },
+    { accessorKey: "details", header: t("labelDetails") },
+    { accessorKey: "actions", header: t("labelActions") },
+]);
+
+const passkeyColumns = computed(() => [
+    { accessorKey: "id", header: t("labelId") },
+    { accessorKey: "createdAtUtc", header: t("labelCreated") },
+    { accessorKey: "updatedAtUtc", header: t("labelLastUsed") },
+    { accessorKey: "details", header: t("labelDetails") },
+    { accessorKey: "actions", header: t("labelActions") },
+]);
 
 const profilePhoto = computed(() => {
     if (profile.value?.avatar) {

--- a/src/components/tabs/UserProfileTab.vue
+++ b/src/components/tabs/UserProfileTab.vue
@@ -188,7 +188,7 @@ const tokenColumns = computed(() => [
     { accessorKey: "created", header: t("labelCreated") },
     { accessorKey: "expiry", header: t("labelExpiry") },
     { accessorKey: "details", header: t("labelDetails") },
-    { accessorKey: "actions", header: t("labelActions") },
+    { id: "actions", header: t("labelActions") },
 ]);
 
 const passkeyColumns = computed(() => [
@@ -196,7 +196,7 @@ const passkeyColumns = computed(() => [
     { accessorKey: "createdAtUtc", header: t("labelCreated") },
     { accessorKey: "updatedAtUtc", header: t("labelLastUsed") },
     { accessorKey: "details", header: t("labelDetails") },
-    { accessorKey: "actions", header: t("labelActions") },
+    { id: "actions", header: t("labelActions") },
 ]);
 
 const profilePhoto = computed(() => {

--- a/src/components/user-session/UserSession.js
+++ b/src/components/user-session/UserSession.js
@@ -22,15 +22,15 @@ export function useUserSession() {
     const loginCodeInputRef = ref(null);
     const codeEmail = ref("");
 
-    const dialogLoginRef = ref(null);
-    const dialogWaitingRef = ref(null);
+    const loginDialogOpen = ref(false);
+    const waitingDialogOpen = ref(false);
     const waitingMessage = ref("");
 
     // Legacy passkey-creation verification dialog
     const verificationError = ref(null);
     const verificationCode = ref("");
     const verificationInputRef = ref(null);
-    const dialogVerificationRef = ref(null);
+    const verificationDialogOpen = ref(false);
     const currentVerificationEmail = ref("");
 
     const displayName = computed(() => {
@@ -118,9 +118,7 @@ export function useUserSession() {
     };
 
     const showLoginDialog = () => {
-        if (dialogLoginRef.value && !dialogLoginRef.value.open) {
-            dialogLoginRef.value.showModal();
-        }
+        loginDialogOpen.value = true;
     };
 
     const openLoginDialog = () => {
@@ -129,9 +127,7 @@ export function useUserSession() {
     };
 
     const closeLoginDialog = () => {
-        if (dialogLoginRef.value?.open) {
-            dialogLoginRef.value.close();
-        }
+        loginDialogOpen.value = false;
     };
 
     const switchToCodeRequest = () => {
@@ -153,45 +149,26 @@ export function useUserSession() {
     };
 
     const closeVerificationDialog = () => {
-        if (dialogVerificationRef.value?.open) {
-            dialogVerificationRef.value.close();
-        }
+        verificationDialogOpen.value = false;
     };
 
     const openVerificationDialog = (email) => {
         currentVerificationEmail.value = email;
         verificationCode.value = "";
         verificationError.value = null;
-        if (dialogVerificationRef.value) {
-            dialogVerificationRef.value.showModal();
-            nextTick(() => {
-                verificationInputRef.value?.inputRef?.focus();
-            });
-        }
+        verificationDialogOpen.value = true;
+        nextTick(() => {
+            verificationInputRef.value?.inputRef?.focus();
+        });
     };
 
-    // Waiting dialog controls (component-managed)
     const showWaitingDialog = (message = i18n.getMessage("userLoggingIn")) => {
         waitingMessage.value = message || i18n.getMessage("userLoggingIn");
-        const dlg = dialogWaitingRef.value;
-        if (!dlg) return;
-        try {
-            dlg.showModal();
-        } catch {
-            if (!dlg.open) dlg.setAttribute("open", "open");
-        }
+        waitingDialogOpen.value = true;
     };
 
     const hideWaitingDialog = () => {
-        const dlg = dialogWaitingRef.value;
-        if (!dlg) return;
-        if (dlg.open) {
-            try {
-                dlg.close();
-            } catch {}
-        }
-        dlg.classList.remove("non-blocking");
-        dlg.removeAttribute("inert");
+        waitingDialogOpen.value = false;
     };
 
     const handleUsePasskey = async () => {
@@ -349,13 +326,13 @@ export function useUserSession() {
         loginTitle,
         loginDescription,
         loginCodeInputRef,
-        dialogLoginRef,
-        dialogWaitingRef,
+        loginDialogOpen,
+        waitingDialogOpen,
         waitingMessage,
         verificationError,
         verificationCode,
         verificationInputRef,
-        dialogVerificationRef,
+        verificationDialogOpen,
         handleLoginClick,
         toggleMenu,
         handleSignOut,

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -33,17 +33,22 @@
             </div>
 
             <!-- Login Dialog -->
-            <UModal
-                v-model:open="loginDialogOpen"
-                :title="loginTitle"
-                :description="loginDescription"
-                :ui="{ content: 'max-w-sm' }"
-            >
-                <template #header>
-                    <div class="dialog-header-stack">
-                        <div class="dialog-logo" aria-hidden="true"></div>
-                        <h3 class="dialog-title">{{ loginTitle }}</h3>
-                        <p class="dialog-description">{{ loginDescription }}</p>
+            <UModal v-model:open="loginDialogOpen" :ui="{ content: 'max-w-sm' }">
+                <template #header="{ close }">
+                    <div class="flex items-start justify-between gap-2 w-full">
+                        <div class="dialog-header-stack">
+                            <div class="dialog-logo" aria-hidden="true"></div>
+                            <h3 class="dialog-title">{{ loginTitle }}</h3>
+                            <p class="dialog-description">{{ loginDescription }}</p>
+                        </div>
+                        <UButton
+                            color="neutral"
+                            variant="ghost"
+                            icon="i-lucide-x"
+                            size="sm"
+                            :aria-label="$t('dialogClose')"
+                            @click="close"
+                        />
                     </div>
                 </template>
                 <template #body>
@@ -154,14 +159,20 @@
             </UModal>
 
             <!-- Verification Code Dialog -->
-            <UModal
-                v-model:open="verificationDialogOpen"
-                :title="$t('titleEnterVerificationCode')"
-                :ui="{ content: 'max-w-sm' }"
-            >
-                <template #header>
-                    <div class="dialog-header-stack">
-                        <h3 class="dialog-title">{{ $t("titleEnterVerificationCode") }}</h3>
+            <UModal v-model:open="verificationDialogOpen" :ui="{ content: 'max-w-sm' }">
+                <template #header="{ close }">
+                    <div class="flex items-start justify-between gap-2 w-full">
+                        <div class="dialog-header-stack">
+                            <h3 class="dialog-title">{{ $t("titleEnterVerificationCode") }}</h3>
+                        </div>
+                        <UButton
+                            color="neutral"
+                            variant="ghost"
+                            icon="i-lucide-x"
+                            size="sm"
+                            :aria-label="$t('dialogClose')"
+                            @click="close"
+                        />
                     </div>
                 </template>
                 <template #body>

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -33,164 +33,165 @@
             </div>
 
             <!-- Login Dialog -->
-            <dialog ref="dialogLoginRef" class="login-dialog">
-                <div class="dialog-container">
-                    <UButton
-                        variant="ghost"
-                        icon="i-lucide-x"
-                        size="sm"
-                        class="dialog-close-button"
-                        aria-label="Close"
-                        @click="closeLoginDialog"
-                    />
-                    <div class="dialog-logo" aria-hidden="true"></div>
-                    <h3 class="dialog-title">{{ loginTitle }}</h3>
-                    <p class="dialog-description">{{ loginDescription }}</p>
-
-                    <div class="dialog-content">
-                        <!-- Passkey mode -->
-                        <template v-if="loginMode === 'passkey'">
-                            <div class="dialog-field">
-                                <label for="login-email" class="dialog-label">{{ $t("labelEmail") }}</label>
-                                <UInput
-                                    v-model="loginEmail"
-                                    type="email"
-                                    id="login-email"
-                                    :placeholder="$t('placeholderEmailAddress')"
-                                    @keyup.enter="handleUsePasskey"
-                                />
-                            </div>
-                            <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
-
-                            <UButton
-                                block
-                                icon="i-lucide-key-round"
-                                :label="$t('labelSignInWithPasskey')"
-                                @click="handleUsePasskey"
-                            />
-
-                            <div class="dialog-footer">
-                                <p class="dialog-hint">
-                                    {{ $t("labelNoPasskeyPrompt") }}
-                                    <UButton
-                                        variant="link"
-                                        size="xs"
-                                        :label="$t('labelSetOnePasskeyUp')"
-                                        @click="handleCreatePasskey"
-                                    />
-                                </p>
-                                <UButton
-                                    variant="link"
-                                    size="xs"
-                                    color="neutral"
-                                    :label="$t('labelSignInWithEmailCode')"
-                                    @click="switchToCodeRequest"
-                                />
-                            </div>
-                        </template>
-
-                        <!-- Email-code request mode -->
-                        <template v-else-if="loginMode === 'code-request'">
-                            <div class="dialog-field">
-                                <label for="login-email-code" class="dialog-label">{{ $t("labelEmail") }}</label>
-                                <UInput
-                                    v-model="loginEmail"
-                                    type="email"
-                                    id="login-email-code"
-                                    :placeholder="$t('placeholderEmailAddress')"
-                                    @keyup.enter="handleRequestCode"
-                                />
-                            </div>
-                            <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
-
-                            <UButton
-                                block
-                                :label="$t('labelSendVerificationCode')"
-                                :loading="loginSubmitting"
-                                @click="handleRequestCode"
-                            />
-
-                            <div class="dialog-footer">
-                                <UButton
-                                    variant="link"
-                                    size="xs"
-                                    color="neutral"
-                                    :label="$t('labelBackToPasskey')"
-                                    @click="switchToPasskey"
-                                />
-                            </div>
-                        </template>
-
-                        <!-- Email-code verify mode -->
-                        <template v-else-if="loginMode === 'code-verify'">
-                            <div class="dialog-field">
-                                <label for="login-code-input" class="dialog-label">{{
-                                    $t("labelVerificationCode")
-                                }}</label>
-                                <UInput
-                                    v-model="loginCode"
-                                    ref="loginCodeInputRef"
-                                    id="login-code-input"
-                                    maxlength="8"
-                                    class="dialog-input-code"
-                                    @keyup.enter="handleVerifyCode"
-                                />
-                            </div>
-                            <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
-
-                            <UButton block :label="$t('submit')" :loading="loginSubmitting" @click="handleVerifyCode" />
-
-                            <div class="dialog-footer">
-                                <UButton
-                                    variant="link"
-                                    size="xs"
-                                    color="neutral"
-                                    :label="$t('labelBack')"
-                                    @click="switchToCodeRequest"
-                                />
-                            </div>
-                        </template>
+            <UModal
+                v-model:open="loginDialogOpen"
+                :title="loginTitle"
+                :description="loginDescription"
+                :ui="{ content: 'max-w-sm' }"
+            >
+                <template #header>
+                    <div class="dialog-header-stack">
+                        <div class="dialog-logo" aria-hidden="true"></div>
+                        <h3 class="dialog-title">{{ loginTitle }}</h3>
+                        <p class="dialog-description">{{ loginDescription }}</p>
                     </div>
-                </div>
-            </dialog>
-
-            <!-- Verification Code Dialog -->
-            <dialog ref="dialogVerificationRef" class="login-dialog">
-                <div class="dialog-container">
-                    <UButton
-                        variant="ghost"
-                        icon="i-lucide-x"
-                        size="sm"
-                        class="dialog-close-button"
-                        aria-label="Close"
-                        @click="closeVerificationDialog"
-                    />
-                    <h3 class="dialog-title">{{ $t("titleEnterVerificationCode") }}</h3>
-                    <div class="dialog-content">
+                </template>
+                <template #body>
+                    <!-- Passkey mode -->
+                    <template v-if="loginMode === 'passkey'">
                         <div class="dialog-field">
-                            <label for="verification-code-input" class="dialog-label">{{
-                                $t("labelVerificationCode")
-                            }}</label>
+                            <label for="login-email" class="dialog-label">{{ $t("labelEmail") }}</label>
                             <UInput
-                                v-model="verificationCode"
-                                ref="verificationInputRef"
-                                id="verification-code-input"
-                                @keyup.enter="handleVerificationSubmit"
+                                v-model="loginEmail"
+                                type="email"
+                                id="login-email"
+                                class="w-full"
+                                :placeholder="$t('placeholderEmailAddress')"
+                                @keyup.enter="handleUsePasskey"
                             />
                         </div>
-                        <p v-if="verificationError" class="dialog-error">{{ verificationError }}</p>
-                    </div>
-                    <UButton block :label="$t('submit')" @click="handleVerificationSubmit" />
-                </div>
-            </dialog>
+                        <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
 
-            <!-- Waiting Dialog (component-managed, non-blocking capable) -->
-            <dialog ref="dialogWaitingRef" class="login-dialog waiting-dialog">
-                <div class="dialog-container waiting-container">
-                    <div class="waiting-spinner" aria-hidden="true"></div>
-                    <p class="waiting-message">{{ waitingMessage }}</p>
-                </div>
-            </dialog>
+                        <UButton
+                            block
+                            icon="i-lucide-key-round"
+                            :label="$t('labelSignInWithPasskey')"
+                            @click="handleUsePasskey"
+                        />
+
+                        <div class="dialog-footer">
+                            <p class="dialog-hint">
+                                {{ $t("labelNoPasskeyPrompt") }}
+                                <UButton
+                                    variant="link"
+                                    size="xs"
+                                    :label="$t('labelSetOnePasskeyUp')"
+                                    @click="handleCreatePasskey"
+                                />
+                            </p>
+                            <UButton
+                                variant="link"
+                                size="xs"
+                                color="neutral"
+                                :label="$t('labelSignInWithEmailCode')"
+                                @click="switchToCodeRequest"
+                            />
+                        </div>
+                    </template>
+
+                    <!-- Email-code request mode -->
+                    <template v-else-if="loginMode === 'code-request'">
+                        <div class="dialog-field">
+                            <label for="login-email-code" class="dialog-label">{{ $t("labelEmail") }}</label>
+                            <UInput
+                                v-model="loginEmail"
+                                type="email"
+                                id="login-email-code"
+                                class="w-full"
+                                :placeholder="$t('placeholderEmailAddress')"
+                                @keyup.enter="handleRequestCode"
+                            />
+                        </div>
+                        <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
+
+                        <UButton
+                            block
+                            :label="$t('labelSendVerificationCode')"
+                            :loading="loginSubmitting"
+                            @click="handleRequestCode"
+                        />
+
+                        <div class="dialog-footer">
+                            <UButton
+                                variant="link"
+                                size="xs"
+                                color="neutral"
+                                :label="$t('labelBackToPasskey')"
+                                @click="switchToPasskey"
+                            />
+                        </div>
+                    </template>
+
+                    <!-- Email-code verify mode -->
+                    <template v-else-if="loginMode === 'code-verify'">
+                        <div class="dialog-field">
+                            <label for="login-code-input" class="dialog-label">{{ $t("labelVerificationCode") }}</label>
+                            <UInput
+                                v-model="loginCode"
+                                ref="loginCodeInputRef"
+                                id="login-code-input"
+                                type="password"
+                                maxlength="8"
+                                class="dialog-input-code w-full"
+                                @keyup.enter="handleVerifyCode"
+                            />
+                        </div>
+                        <p v-if="loginError" class="dialog-error">{{ loginError }}</p>
+
+                        <UButton block :label="$t('submit')" :loading="loginSubmitting" @click="handleVerifyCode" />
+
+                        <div class="dialog-footer">
+                            <UButton
+                                variant="link"
+                                size="xs"
+                                color="neutral"
+                                :label="$t('labelBack')"
+                                @click="switchToCodeRequest"
+                            />
+                        </div>
+                    </template>
+                </template>
+            </UModal>
+
+            <!-- Verification Code Dialog -->
+            <UModal
+                v-model:open="verificationDialogOpen"
+                :title="$t('titleEnterVerificationCode')"
+                :ui="{ content: 'max-w-sm' }"
+            >
+                <template #header>
+                    <div class="dialog-header-stack">
+                        <h3 class="dialog-title">{{ $t("titleEnterVerificationCode") }}</h3>
+                    </div>
+                </template>
+                <template #body>
+                    <div class="dialog-field">
+                        <label for="verification-code-input" class="dialog-label">{{
+                            $t("labelVerificationCode")
+                        }}</label>
+                        <UInput
+                            v-model="verificationCode"
+                            ref="verificationInputRef"
+                            id="verification-code-input"
+                            type="password"
+                            class="w-full"
+                            @keyup.enter="handleVerificationSubmit"
+                        />
+                    </div>
+                    <p v-if="verificationError" class="dialog-error">{{ verificationError }}</p>
+                    <UButton block :label="$t('submit')" @click="handleVerificationSubmit" />
+                </template>
+            </UModal>
+
+            <!-- Waiting Dialog -->
+            <UModal v-model:open="waitingDialogOpen" :close="false" :dismissible="false" title="">
+                <template #body>
+                    <div class="waiting-container">
+                        <div class="waiting-spinner" aria-hidden="true"></div>
+                        <p class="waiting-message">{{ waitingMessage }}</p>
+                    </div>
+                </template>
+            </UModal>
         </Teleport>
     </div>
 </template>
@@ -353,6 +354,14 @@ export default defineComponent({
 .dialog-container {
     display: flex;
     flex-direction: column;
+    gap: 4px;
+}
+
+.dialog-header-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 100%;
     gap: 4px;
 }
 


### PR DESCRIPTION
Backups, user tokens and passkeys now render via `UTable`. Login and verification dialogs use `UModal` with a stacked header, narrower width, full-width email input and masked verification code entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Replaced several manual lists with unified, structured tables for backups, tokens, and passkeys for clearer layout and actions.
  * Redesigned authentication dialogs (login, verification, waiting) with modern modal styling and consistent header/body layout.
  * Loading states now show a centered spinner and dimmed label instead of plain text.
  * Waiting modal made non-dismissible and simplified to a focused spinner/message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->