### PR TITLE
Centre text in verification code input

### DIFF
--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -185,7 +185,7 @@
                             ref="verificationInputRef"
                             id="verification-code-input"
                             type="password"
-                            class="w-full"
+                            class="dialog-input-code w-full"
                             @keyup.enter="handleVerificationSubmit"
                         />
                     </div>


### PR DESCRIPTION
The second verification dialog was missing the `dialog-input-code` class, so its password-type input rendered flush-left while the email-code variant centred and letter-spaced correctly. Apply the same class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated verification code input field styling in the user session dialog for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->