### PR TITLE
Clarify dyn_notch_q tooltip: value is scaled by 100

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4992,7 +4992,7 @@
         "message": "The dynamic notch has three frequency ranges in which it can operate: LOW(80-330hz) for lower revving aircraft like 6+ inches, MEDIUM(140-550hz) for a normal 5 inch aircraft, HIGH(230-800hz) for very high revving 2.5-3 inch aircraft. AUTO option selects the range depending on the value of the Gyro Dynamic Lowpass 1 Filter's max cutoff frequency."
     },
     "pidTuningDynamicNotchQHelp": {
-        "message": "Q factor adjust how narrow or wide the dynamic notch filters are. The stored value is Q factor × 100 (e.g., 300 = Q 3.0). Higher value makes it narrower and more precise and lower value makes it wider and broader. Having a really low value will greatly increase filter delay."
+        "message": "Q factor adjusts how narrow or wide the dynamic notch filters are. The stored value is Q factor × 100 (e.g., 300 = Q 3.0). Higher value makes it narrower and more precise, and lower value makes it wider and broader. Having a really low value will greatly increase filter delay."
     },
     "pidTuningDynamicNotchMinHzHelp": {
         "message": "Set this to the lowest incoming noise frequency that is needed to be controlled by the dynamic notch."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4977,7 +4977,7 @@
         "message": "Dynamic Notch Filter Range"
     },
     "pidTuningDynamicNotchQ": {
-        "message": "Q factor"
+        "message": "Q factor (x100)"
     },
     "pidTuningDynamicNotchMinHz": {
         "message": "Min Frequency [Hz]"
@@ -4992,7 +4992,7 @@
         "message": "The dynamic notch has three frequency ranges in which it can operate: LOW(80-330hz) for lower revving aircraft like 6+ inches, MEDIUM(140-550hz) for a normal 5 inch aircraft, HIGH(230-800hz) for very high revving 2.5-3 inch aircraft. AUTO option selects the range depending on the value of the Gyro Dynamic Lowpass 1 Filter's max cutoff frequency."
     },
     "pidTuningDynamicNotchQHelp": {
-        "message": "Q factor adjust how narrow or wide the dynamic notch filters are. Higher value makes it narrower and more precise and lower value makes it wider and broader. Having a really low value will greatly increase filter delay."
+        "message": "Q factor adjust how narrow or wide the dynamic notch filters are. The stored value is Q factor × 100 (e.g., 300 = Q 3.0). Higher value makes it narrower and more precise and lower value makes it wider and broader. Having a really low value will greatly increase filter delay."
     },
     "pidTuningDynamicNotchMinHzHelp": {
         "message": "Set this to the lowest incoming noise frequency that is needed to be controlled by the dynamic notch."


### PR DESCRIPTION
- Label: 'Q factor' → 'Q factor (x100)'
- Help text: Add note that stored value is Q factor × 100 (e.g., 300 = Q 3.0)

A small useful clarification for calculation of Q factors. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Dynamic Notch filter UI: label now shows Q factor scaled by ×100 and help tooltip explains the stored value equals Q × 100 (example mapping included, e.g., stored 300 → Q 3.0). Qualitative behavior notes (higher Q = narrower/more precise; lower Q = wider/broader; very low Q increases filter delay) updated to reflect the scaled storage format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->