### PR TITLE
Fix CLI Copy Paste behaviour

### DIFF
--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -261,8 +261,12 @@ export default defineComponent({
     background-image: url("../../images/light-wide-1.svg");
 }
 
-/* Child selector for runtime-generated content */
-.tab-cli .cli-wrapper > * {
+/* Allow text selection in the CLI output area.
+   The global `* { user-select: none }` in main.less disables selection everywhere,
+   so we re-enable it on the scroll container and all descendants (runtime-generated
+   spans from syntax highlighting, text nodes, etc.). */
+.tab-cli .cli-window,
+.tab-cli .cli-window * {
     user-select: text;
 }
 


### PR DESCRIPTION
- The global * { user-select: none } in main.less makes every element         
  unselectable by default                                                       
  - The old rule only targeted direct children of .cli-wrapper with > *, but:
    - .cli-wrapper has h-0 so all content overflows — mouse clicks land on
  .cli-window which was still user-select: none
    - Text nodes between highlighted <span> elements (like gyro_lpf1_static_hz
  =) inherit from the nearest element ancestor — if that ancestor's user-select
  was unclear due to the overflow, selection broke
    - Nested spans (e.g. labels inside comment lines) weren't matched by > *
  - The new rule makes .cli-window itself and all its descendants selectable, so
   manual text selection works reliably regardless of span nesting or overflow
  layout

Credits to @mituritsyn for reporting the issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text selection behavior in the CLI output window, ensuring users can reliably select text regardless of syntax highlighting or nested content structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->