### PR TITLE
Restore yaw lp filter switch and replace modes with switches

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4750,7 +4750,7 @@
         "description": "Filter tuning slider high header"
     },
     "pidTuningGyroFilterSlider": {
-        "message": "Gyro Filter Multiplier:",
+        "message": "Gyro Filter Multiplier",
         "description": "Gyro filter tuning slider label"
     },
     "pidTuningGyroFilterSliderHelp": {
@@ -4758,11 +4758,11 @@
         "description": "Gyro filter tuning slider helpicon message"
     },
     "pidTuningGyroSliderEnabled": {
-        "message": "Use Gyro Slider",
+        "message": "Use Gyro Filter Multiplier",
         "description": "Disable or enable Gyro Filter Tuning Slider"
     },
     "pidTuningDTermFilterSlider": {
-        "message": "D Term Filter Multiplier:",
+        "message": "D Term Filter Multiplier",
         "description": "D Term filter tuning slider label"
     },
     "pidTuningDTermFilterSliderHelp": {
@@ -4770,7 +4770,7 @@
         "description": "D Term filter tuning slider helpicon message"
     },
     "pidTuningDTermSliderEnabled": {
-        "message": "Use D Term Slider",
+        "message": "Use D Term Filter Multiplier",
         "description": "Disable or enable D Term Filter Tuning Slider"
     },
     "pidTuningPidSlidersHelp": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4757,10 +4757,6 @@
         "message": "Changes the Gyro Lowpass filter cutoffs.<br /><br />Moving the slider to the left gives stronger Gyro filtering (lower cutoff frequency).<br /><br />Moving the slider to the right gives less Gyro filtering (higher cutoff frequency).<br /><br />When moving the slider to the right to improve propwash handling, BE CAREFUL to not get too radical.  You will allow more noise into both P and D and may get fly-aways or burnt out motors.<br /><br />You may need  to move the slider to left if you have frame resonance issues, bad bearings, beat up props, hot motors, etc.<br /><br />Gyro filtering is applied before, and in addition to, D filtering.",
         "description": "Gyro filter tuning slider helpicon message"
     },
-    "pidTuningGyroSliderEnabled": {
-        "message": "Use Gyro Filter Multiplier",
-        "description": "Disable or enable Gyro Filter Tuning Slider"
-    },
     "pidTuningDTermFilterSlider": {
         "message": "D Term Filter Multiplier",
         "description": "D Term filter tuning slider label"
@@ -4768,10 +4764,6 @@
     "pidTuningDTermFilterSliderHelp": {
         "message": "Changes the D-term Lowpass Filter cutoffs.<br /><br />Moving the slider to the left gives stronger D filtering (lower cutoff frequency).<br /><br />Moving the slider to the right gives less filtering (higher cutoff frequency).<br /><br />D-term is the most sensitive PID element to noise and resonance. It can amplify high frequency noise by 10x to 100x. That's why D filter cutoffs are much lower than the gyro filters.<br /><br />D-term filtering is applied after, and in addition to, the gyro filtering. The default D filtering is optimal for most aircraft and rarely needs changing.<br /><br />Moving this slider to the left reduces motor heat in noisy aircraft and with high PID 'D' tunes, but we may see more propwash and lower frequency D resonances.<br /><br />Moving the slider to the right is not recommended, but may improve propwash on clean builds.  It may cause motor grinding on arming, sudden resonances in-flight, and serious motor overheating.",
         "description": "D Term filter tuning slider helpicon message"
-    },
-    "pidTuningDTermSliderEnabled": {
-        "message": "Use D Term Filter Multiplier",
-        "description": "Disable or enable D Term Filter Tuning Slider"
     },
     "pidTuningPidSlidersHelp": {
         "message": "Sliders to adjust the aircraft flight characteristics (PID gains)<br /><br />Damping (D gain): Resists fast movement, minimises P oscillation.<br /><br />Tracking (P and I gain): Enhances the responsiveness of the aircraft; if too high, may cause trilling or oscillation.<br /><br />Stick Response (Feedforward): Increases the responsiveness of the aircraft to faster stick movements.<br /><br />Drift - Wobble (I gain, expert):  Fine adjustment of I.<br /><br />Dynamic D (D Max, expert):  Sets the maximum amount that D can be boosted to during fast movements.<br /><br />Pitch Damping (Pitch:Roll D ratio, expert): Increases the amount of damping on pitch relative to roll.<br /><br />Pitch Tracking (Pitch:Roll P, I and F ratio, expert): Increases stabilising strength on pitch relative to roll.<br /><br />Master Multiplier (all gains, expert): Raises or lowers all the PID gains, keeping their proportions constant.",

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -10,7 +10,8 @@
             </div>
 
             <!-- Gyro Filter Slider -->
-            <div class="flex items-center gap-3 py-1" :class="{ 'opacity-50 pointer-events-none': gyroSliderDisabled }">
+            <div class="flex items-center gap-3 py-1">
+                <USwitch v-model="gyroSliderEnabled" size="sm" />
                 <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningGyroFilterSlider')"></div>
                 <span class="min-w-10 text-center text-sm font-semibold">{{ gyroFilterMultiplier.toFixed(2) }}</span>
                 <USlider
@@ -25,10 +26,8 @@
             </div>
 
             <!-- DTerm Filter Slider -->
-            <div
-                class="flex items-center gap-3 py-1"
-                :class="{ 'opacity-50 pointer-events-none': dtermSliderDisabled }"
-            >
+            <div class="flex items-center gap-3 py-1">
+                <USwitch v-model="dtermSliderEnabled" size="sm" />
                 <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDTermFilterSlider')"></div>
                 <span class="min-w-10 text-center text-sm font-semibold">{{ dtermFilterMultiplier.toFixed(2) }}</span>
                 <USlider
@@ -62,11 +61,6 @@
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <!-- LEFT COLUMN: Non-Profile Filter Settings -->
             <UiBox :title="$t('pidTuningNonProfileFilterSettings')" type="neutral">
-                <!-- Gyro Filter Slider On/Off -->
-                <SettingRow :label="$t('pidTuningGyroSliderEnabled')">
-                    <USwitch v-model="gyroSliderEnabled" size="sm" />
-                </SettingRow>
-
                 <!-- Gyro Lowpass Filters Section -->
                 <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
                     <span>{{ $t("pidTuningGyroLowpassFiltersGroup") }}</span>
@@ -345,11 +339,6 @@
 
             <!-- RIGHT COLUMN: Profile-dependent Filter Settings -->
             <UiBox :title="$t('pidTuningFilterSettings')" type="neutral">
-                <!-- DTerm Filter Slider On/Off -->
-                <SettingRow :label="$t('pidTuningDTermSliderEnabled')">
-                    <USwitch v-model="dtermSliderEnabled" size="sm" />
-                </SettingRow>
-
                 <!-- D-Term Lowpass Filters Section -->
                 <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
                     <span>{{ $t("pidTuningDTermLowpassFiltersGroup") }}</span>

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -18,7 +18,7 @@
             <!-- Gyro Filter Slider -->
             <div class="flex items-center gap-3 py-1">
                 <USwitch v-model="gyroSliderEnabled" size="sm" />
-                <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningGyroFilterSlider')"></div>
+                <div class="min-w-32 text-xs shrink-0" v-html="$t('pidTuningGyroFilterSlider')"></div>
                 <span class="min-w-10 text-center text-sm font-semibold">{{ gyroFilterMultiplier.toFixed(2) }}</span>
                 <USlider
                     v-model="gyroFilterMultiplier"
@@ -34,7 +34,7 @@
             <!-- DTerm Filter Slider -->
             <div class="flex items-center gap-3 py-1">
                 <USwitch v-model="dtermSliderEnabled" size="sm" />
-                <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDTermFilterSlider')"></div>
+                <div class="min-w-32 text-xs shrink-0" v-html="$t('pidTuningDTermFilterSlider')"></div>
                 <span class="min-w-10 text-center text-sm font-semibold">{{ dtermFilterMultiplier.toFixed(2) }}</span>
                 <USlider
                     v-model="dtermFilterMultiplier"

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -2,11 +2,17 @@
     <div class="p-5 flex flex-col gap-5">
         <!-- Filter Sliders -->
         <UiBox type="neutral">
-            <!-- Scale labels above sliders -->
-            <div class="flex justify-between text-xs text-dimmed mb-2">
-                <span>{{ $t("pidTuningSliderHighFiltering") }}</span>
-                <span>{{ $t("pidTuningSliderDefaultFiltering") }}</span>
-                <span>{{ $t("pidTuningSliderLowFiltering") }}</span>
+            <!-- Scale labels above sliders — aligned with the slider column -->
+            <div class="flex items-center gap-3">
+                <div class="shrink-0 invisible" style="width: 40px"></div>
+                <div class="min-w-32 shrink-0"></div>
+                <span class="min-w-10"></span>
+                <div class="flex-1 flex justify-between text-xs text-dimmed">
+                    <span>{{ $t("pidTuningSliderHighFiltering") }}</span>
+                    <span>{{ $t("pidTuningSliderDefaultFiltering") }}</span>
+                    <span>{{ $t("pidTuningSliderLowFiltering") }}</span>
+                </div>
+                <div class="invisible"><HelpIcon text="" /></div>
             </div>
 
             <!-- Gyro Filter Slider -->

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -63,8 +63,8 @@
             <!-- LEFT COLUMN: Non-Profile Filter Settings -->
             <UiBox :title="$t('pidTuningNonProfileFilterSettings')" type="neutral">
                 <!-- Gyro Filter Slider On/Off -->
-                <SettingRow :label="$t('pidTuningGyroFilterSlider')">
-                    <USelect v-model="gyroSliderMode" :items="sliderModeItems" class="w-20" />
+                <SettingRow :label="$t('pidTuningGyroSliderEnabled')">
+                    <USwitch v-model="gyroSliderEnabled" size="sm" />
                 </SettingRow>
 
                 <!-- Gyro Lowpass Filters Section -->
@@ -346,8 +346,8 @@
             <!-- RIGHT COLUMN: Profile-dependent Filter Settings -->
             <UiBox :title="$t('pidTuningFilterSettings')" type="neutral">
                 <!-- DTerm Filter Slider On/Off -->
-                <SettingRow :label="$t('pidTuningDTermFilterSlider')">
-                    <USelect v-model="dtermSliderMode" :items="sliderModeItems" class="w-20" />
+                <SettingRow :label="$t('pidTuningDTermSliderEnabled')">
+                    <USwitch v-model="dtermSliderEnabled" size="sm" />
                 </SettingRow>
 
                 <!-- D-Term Lowpass Filters Section -->
@@ -503,18 +503,26 @@
                     <HelpIcon :text="$t('pidTuningYawLowpassFiltersGroupHelp')" />
                 </div>
 
-                <div class="flex flex-wrap items-end gap-3">
-                    <div class="flex flex-col gap-1">
-                        <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
-                        <UInputNumber
-                            size="xs"
-                            orientation="vertical"
-                            class="w-16"
-                            v-model="yaw_lowpass_hz"
-                            :step="1"
-                            :min="0"
-                            :max="500"
-                        />
+                <div class="flex flex-col gap-2">
+                    <SettingRow
+                        :label="$t('pidTuningYawLowpassFiltersGroup')"
+                        :help="$t('pidTuningYawLowpassFiltersGroupHelp')"
+                    >
+                        <USwitch v-model="yawLowpassEnabled" size="sm" />
+                    </SettingRow>
+                    <div v-if="yawLowpassEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningStaticCutoffFrequency") }}</span>
+                            <UInputNumber
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                                v-model="yaw_lowpass_hz"
+                                :step="1"
+                                :min="1"
+                                :max="500"
+                            />
+                        </div>
                     </div>
                 </div>
             </UiBox>
@@ -551,11 +559,6 @@ const props = defineProps({
 const emit = defineEmits(["change"]);
 
 // USelect item arrays
-const sliderModeItems = computed(() => [
-    { value: 0, label: t("pidTuningOptionOff") },
-    { value: 1, label: t("pidTuningOptionOn") },
-]);
-
 const lowpassModeItems = computed(() => [
     { value: 0, label: t("pidTuningLowpassStatic") },
     { value: 1, label: t("pidTuningLowpassDynamic") },
@@ -589,6 +592,7 @@ const previousValues = ref({
     dtermNotchCutoff: 160,
     dynNotchCount: 3, // Default dynamic notch count
     lastDynNotchMode: 1, // Track if dynamic notch was enabled
+    yawLowpassHz: 100,
 });
 
 // Slider Modes (ON/OFF toggles for gyro and dterm sliders)
@@ -601,6 +605,17 @@ const gyroSliderMode = computed({
 const dtermSliderMode = computed({
     get: () => FC.TUNING_SLIDERS.slider_dterm_filter ?? 1,
     set: (value) => (FC.TUNING_SLIDERS.slider_dterm_filter = value),
+});
+
+// Boolean wrappers for USwitch binding
+const gyroSliderEnabled = computed({
+    get: () => gyroSliderMode.value === 1,
+    set: (value) => (gyroSliderMode.value = value ? 1 : 0),
+});
+
+const dtermSliderEnabled = computed({
+    get: () => dtermSliderMode.value === 1,
+    set: (value) => (dtermSliderMode.value = value ? 1 : 0),
 });
 
 // Filter Sliders
@@ -1061,6 +1076,20 @@ const dterm_notch_cutoff = computed({
 });
 
 // Yaw Lowpass Filter
+const yawLowpassEnabled = computed({
+    get: () => FC.FILTER_CONFIG.yaw_lowpass_hz !== 0,
+    set: (value) => {
+        if (value) {
+            FC.FILTER_CONFIG.yaw_lowpass_hz = previousValues.value.yawLowpassHz;
+        } else {
+            if (FC.FILTER_CONFIG.yaw_lowpass_hz > 0) {
+                previousValues.value.yawLowpassHz = FC.FILTER_CONFIG.yaw_lowpass_hz;
+            }
+            FC.FILTER_CONFIG.yaw_lowpass_hz = 0;
+        }
+    },
+});
+
 const yaw_lowpass_hz = computed({
     get: () => FC.FILTER_CONFIG.yaw_lowpass_hz ?? 0,
     set: (value) => (FC.FILTER_CONFIG.yaw_lowpass_hz = value),

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -1159,6 +1159,9 @@ watch(
     () => emit("change"),
 );
 
+watch(gyroSliderMode, () => emit("change"));
+watch(dtermSliderMode, () => emit("change"));
+
 // Re-sync local slider refs from FC state (called by parent after loadData/refresh)
 function forceUpdateSliders() {
     isUpdatingSliders = true;


### PR DESCRIPTION
- Credits for @mituritsyn reporting the issues:

Issue 1 - Gyro/DTerm filter multiplier selects replaced with switches:        
  - USelect (On/Off) → USwitch for both gyro and dterm slider mode toggles    
  - i18n labels updated: removed colon from "Gyro Filter Multiplier:" / "D Term 
  Filter Multiplier:", and updated the SettingRow labels to use "Use Gyro Filter
   Multiplier" / "Use D Term Filter Multiplier" (via pidTuningGyroSliderEnabled 
  / pidTuningDTermSliderEnabled keys)                                           
  - Added gyroSliderEnabled / dtermSliderEnabled boolean computed wrappers      
  around the numeric slider mode
  - Removed unused sliderModeItems

  Issue 2 - Yaw lowpass filter switch restored:
  - Added USwitch with yawLowpassEnabled computed property (matches the pattern
  of all other filter toggles)
  - Cutoff frequency input only shows when the switch is on
  - When disabled, saves the current hz value and sets to 0; when re-enabled,
  restores the previous value (default 100)
  - Min changed from 0 to 1 (since 0 means disabled, controlled by the switch)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced gyro and D-term filter dropdowns with in-row toggle switches for simpler control
  * Added a yaw lowpass enable/disable switch that shows/hides the cutoff input and restores previous value when re-enabled

* **Improvements**
  * Tightened yaw cutoff validation (minimum now 1 Hz)
  * Updated translation text (removed trailing colons) and removed two obsolete toggle translation keys
<!-- end of auto-generated comment: release notes by coderabbit.ai -->