### PR TITLE
Gate virtual and manual connect options behind expert mode

### DIFF
--- a/src/components/port-picker/ConnectButton.vue
+++ b/src/components/port-picker/ConnectButton.vue
@@ -125,10 +125,8 @@ export default defineComponent({
             dialogOpen.value = true;
         }
 
-        const menuItems = computed(() => {
-            const items = [];
+        function buildDeviceItems(expertMode) {
             const devices = [];
-
             if (PortHandler.showSerialOption) {
                 for (const d of serialPorts.value) {
                     devices.push({
@@ -156,8 +154,6 @@ export default defineComponent({
                     });
                 }
             }
-
-            const expertMode = isExpertModeEnabled();
             if (expertMode && PortHandler.showVirtualMode) {
                 devices.push({
                     label: i18n.getMessage("portsSelectVirtual"),
@@ -172,11 +168,11 @@ export default defineComponent({
                     onSelect: () => openConnectDialog("manual"),
                 });
             }
+            return devices;
+        }
 
-            if (devices.length) {
-                items.push(...devices, { type: "separator" });
-            }
-
+        function buildPermissionItems() {
+            const items = [];
             if (PortHandler.showSerialOption) {
                 items.push({
                     label: i18n.getMessage("portsSelectPermission"),
@@ -198,8 +194,14 @@ export default defineComponent({
                     onSelect: () => PortHandler.requestDevicePermission("usb"),
                 });
             }
+            return items;
+        }
 
+        const menuItems = computed(() => {
+            const devices = buildDeviceItems(isExpertModeEnabled());
+            const items = devices.length ? [...devices, { type: "separator" }] : [];
             items.push(
+                ...buildPermissionItems(),
                 { type: "separator" },
                 {
                     type: "checkbox",
@@ -209,13 +211,18 @@ export default defineComponent({
                     onSelect: (e) => e.preventDefault(),
                 },
             );
-
             return items;
         });
 
         async function onConnectClick() {
             if (portPickerDisabled.value) {
                 return;
+            }
+
+            // Guard against a persisted virtual/manual selection when expert mode is off.
+            const gatedModes = ["virtual", "manual"];
+            if (!isExpertModeEnabled() && gatedModes.includes(selectedPort.value)) {
+                PortHandler.portPicker.selectedPort = "noselection";
             }
 
             if (selectedPort.value === "noselection") {

--- a/src/components/port-picker/ConnectButton.vue
+++ b/src/components/port-picker/ConnectButton.vue
@@ -60,6 +60,7 @@ import PortHandler from "../../js/port_handler";
 import { connectDisconnect, disconnect } from "../../js/serial_backend";
 import { i18n } from "../../js/localization";
 import { set as setConfig } from "../../js/ConfigStorage";
+import { isExpertModeEnabled } from "../../js/utils/isExpertModeEnabled";
 import ConnectOptionsDialog from "./ConnectOptionsDialog.vue";
 
 function selectAndConnect(path) {
@@ -156,14 +157,15 @@ export default defineComponent({
                 }
             }
 
-            if (PortHandler.showVirtualMode) {
+            const expertMode = isExpertModeEnabled();
+            if (expertMode && PortHandler.showVirtualMode) {
                 devices.push({
                     label: i18n.getMessage("portsSelectVirtual"),
                     icon: "i-lucide-flask-conical",
                     onSelect: () => openConnectDialog("virtual"),
                 });
             }
-            if (PortHandler.showManualMode) {
+            if (expertMode && PortHandler.showManualMode) {
                 devices.push({
                     label: i18n.getMessage("portsSelectManual"),
                     icon: "i-lucide-keyboard",

--- a/src/components/port-picker/ConnectButton.vue
+++ b/src/components/port-picker/ConnectButton.vue
@@ -125,7 +125,8 @@ export default defineComponent({
             dialogOpen.value = true;
         }
 
-        function buildDeviceItems(expertMode) {
+        function buildDeviceItems() {
+            const expertMode = isExpertModeEnabled();
             const devices = [];
             if (PortHandler.showSerialOption) {
                 for (const d of serialPorts.value) {
@@ -198,7 +199,7 @@ export default defineComponent({
         }
 
         const menuItems = computed(() => {
-            const devices = buildDeviceItems(isExpertModeEnabled());
+            const devices = buildDeviceItems();
             const items = devices.length ? [...devices, { type: "separator" }] : [];
             items.push(
                 ...buildPermissionItems(),

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -3,6 +3,7 @@ import { EventBus } from "../components/eventBus";
 import { serial } from "./serial.js";
 import defaultDfu, { UsbDfuProtocol } from "./protocols/usbdfu";
 import CapacitorDfuTransport from "./protocols/CapacitorDfuTransport";
+import { isExpertModeEnabled } from "./utils/isExpertModeEnabled";
 import { reactive } from "vue";
 import {
     checkCompatibility,
@@ -283,13 +284,14 @@ PortHandler.selectActivePort = function (suggestedDevice = false) {
         }
     }
 
-    // Return the virtual port
-    if (!selectedPort && this.showVirtualMode) {
+    // Expert-only fallbacks: only surface virtual/manual when expert mode is on.
+    const expertMode = isExpertModeEnabled();
+
+    if (!selectedPort && expertMode && this.showVirtualMode) {
         selectedPort = "virtual";
     }
 
-    // Return the manual port
-    if (!selectedPort && this.showManualMode) {
+    if (!selectedPort && expertMode && this.showManualMode) {
         selectedPort = "manual";
     }
 


### PR DESCRIPTION
The Virtual and Manual entries in the sidebar connect menu now require expert mode in addition to the existing `showVirtualMode` / `showManualMode` toggles, keeping the casual connect flow free of dev-only options.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual and manual connection options are only shown when expert mode is enabled; menu and permission items are rebuilt to reflect this and include a separator only when devices exist.

* **Bug Fixes**
  * Connect flow now clears hidden/unsupported saved selections when expert mode is off, preventing accidental attempts to use unavailable connection types.
* **Notes**
  * Auto-connect checkbox behavior is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->