### PR TITLE
 rearrange PID tab, move profile names in header

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -312,7 +312,6 @@
         "message": "\u7e41\u9ad4\u4e2d\u6587",
         "description": "Don't translate!!!"
     },
-
     "sensorDataFlashNotFound": {
         "message": "No dataflash <br>chip found",
         "description": "Text of the dataflash image in the header of the page."
@@ -477,7 +476,6 @@
     "tabAuxiliary": {
         "message": "Modes"
     },
-
     "logActionHide": {
         "message": "Hide Log"
     },
@@ -510,7 +508,6 @@
     "serialErrorParityError": {
         "message": "Serial connection error: bad parity"
     },
-
     "serialPortOpened": {
         "message": "Serial port <span class=\"message-positive\">successfully</span> opened with ID: $1"
     },
@@ -523,10 +520,10 @@
     "serialPortClosedFail": {
         "message": "<span class=\"message-negative\">Failed</span> to close serial port"
     },
-    "serialUnrecoverable" : {
+    "serialUnrecoverable": {
         "message": "Unrecoverable <span class=\"message-negative\">failure</span> of serial connection, disconnecting..."
     },
-    "serialPortLoading" : {
+    "serialPortLoading": {
         "message": "Loading ..."
     },
     "usbDeviceOpened": {
@@ -662,21 +659,21 @@
         "message": "<strong>the accelerometer is enabled but it is not calibrated</strong>.<br>If you plan to use the accelerometer, please follow the instructions for '$t(initialSetupButtonCalibrateAccel.message)' on the '$t(tabSetup.message)' tab. If any function that requires the accelerometer (auto level modes, GPS rescue, ...) is enabled, arming of the aircraft will be disabled until the accelerometer has been calibrated.<br>If you are not planning on using the accelerometer it is recommended that you disable it in '$t(configurationSystem.message)' on the '$t(tabConfiguration.message)' tab."
     },
     "infoVersionOs": {
-        "message" : "OS: <strong>{{operatingSystem}}</strong>",
+        "message": "OS: <strong>{{operatingSystem}}</strong>",
         "description": "Message that appears in the GUI log panel indicating operating system"
     },
     "infoVersionConfigurator": {
-        "message" : "App Version: <strong>{{configuratorVersion}}</strong>",
+        "message": "App Version: <strong>{{configuratorVersion}}</strong>",
         "description": "Message that appears in the GUI log panel indicating application version"
     },
     "buildServerSuccess": {
-        "message" : "Success: $1"
+        "message": "Success: $1"
     },
     "buildServerFailure": {
-        "message" : "<b>Build server failure: $1 <code>$2</code></b>"
+        "message": "<b>Build server failure: $1 <code>$2</code></b>"
     },
     "buildServerUsingCached": {
-        "message" : "Using cached builds information for $1."
+        "message": "Using cached builds information for $1."
     },
     "buildServerSupportRequestSubmission": {
         "message": "<br>*** Support data submitted *** <br>ID: $1<br><br><br># copy ID and provide to the betaflight team."
@@ -694,16 +691,16 @@
         "message": "Describe the problem"
     },
     "releaseCheckLoaded": {
-        "message" : "Loaded release information for $1 from GitHub."
+        "message": "Loaded release information for $1 from GitHub."
     },
     "releaseCheckFailed": {
-        "message" : "<b>GitHub query for $1 releases failed, using cached information. Reason: <code>$2</code></b>"
+        "message": "<b>GitHub query for $1 releases failed, using cached information. Reason: <code>$2</code></b>"
     },
     "releaseCheckCached": {
-        "message" : "Using cached release information for $1 releases."
+        "message": "Using cached release information for $1 releases."
     },
     "releaseCheckNoInfo": {
-        "message" : "No release information available for $1."
+        "message": "No release information available for $1."
     },
     "tabSwitchConnectionRequired": {
         "message": "You need to <strong>connect</strong> before you can view any of the tabs."
@@ -1675,12 +1672,11 @@
         "message": "ACCEL Alignment"
     },
     "configurationSensorAlignmentDefaultOption": {
-       "message": "Default"
+        "message": "Default"
     },
     "configurationSensorAlignmentCustom": {
         "message": "Custom"
     },
-
     "configurationAccelTrims": {
         "message": "Accelerometer Trim"
     },
@@ -1699,7 +1695,7 @@
     "configurationReverseMotorSwitch": {
         "message": "Motor direction is reversed"
     },
-       "configurationReverseMotorSwitchHelp": {
+    "configurationReverseMotorSwitchHelp": {
         "message": "This option configures the mixer to expect the motor direction to be reversed and the propellers to be on accordingly. <strong>Warning:</strong> This does not reverse the motor direction. Use the configuration tool for your ESCs or switch the ESC - motor wiring order to achieve this. Also, make sure to check with propellers off that your motors are rotating in the directions shown in the diagram above before attempting to arm."
     },
     "configurationAutoDisarmDelay": {
@@ -1732,7 +1728,7 @@
         "message": "The pole count is the number of magnets on the bell of the motor. Do NOT count the stators where the windings are located. 5\" motors usually have 14 magnets, 3\" or smaller often have 12 magnets.",
         "description": "Help text for the Motor poles field of the ESC/Motor configuration"
     },
-    "configurationMotorIdleRpmHelp" : {
+    "configurationMotorIdleRpmHelp": {
         "message": "This is the dynamic idle value from the active PID profile. When Dynamic Idle is set to zero, only static motor idle will apply. Change the Dynamic Idle settings on the PID tuning tab.",
         "description": "Help text for dynamic idle setting"
     },
@@ -2093,7 +2089,6 @@
     "pidTuningNonProfilePidSettings": {
         "message": "Profile independent PID Controller Settings"
     },
-
     "pidTuningAntiGravity": {
         "message": "Anti Gravity"
     },
@@ -2376,6 +2371,9 @@
     "pidTuningRcExpo": {
         "message": "RC Expo"
     },
+    "pidTuningTpaGroup": {
+        "message": "TPA"
+    },
     "pidTuningTPAMode": {
         "message": "TPA Mode"
     },
@@ -2500,6 +2498,9 @@
     },
     "filterWarning": {
         "message": "<span class=\"message-negative\"><b>Warning:</b></span> The amount of filtering you are using is dangerously low. This is likely to make the aircraft hard to control, and can result in flyaways. It is highly recommended that you <b>enable at least one of Gyro Dynamic Lowpass or Gyro Lowpass 1 and at least one of D-Term Dynamic Lowpass or D Term Lowpass 1</b>."
+    },
+    "pidTuningSliders": {
+        "message": "PID Tuning Sliders"
     },
     "pidTuningSliderPidsMode": {
         "message": "Mode:",
@@ -2666,16 +2667,16 @@
         "message": "Save"
     },
     "auxiliaryAutoChannelSelect": {
-      "message": "AUTO"
+        "message": "AUTO"
     },
     "auxiliaryLinkNone": {
         "message": "None"
     },
     "auxiliaryModeLogicOR": {
-      "message": "OR"
+        "message": "OR"
     },
     "auxiliaryModeLogicAND": {
-      "message": "AND"
+        "message": "AND"
     },
     "auxiliaryHelpMode_3DDISABLE": {
         "message": "Enables reversible motor direction to provide negative thrust and allow inverted flight. Throttle becomes -100 to +100 instead of 0 to 100",
@@ -3035,7 +3036,7 @@
     "adjustmentsFunction30": {
         "message": "LED Profile Selection"
     },
-	"adjustmentsFunction31": {
+    "adjustmentsFunction31": {
         "message": "LED Brightness Adjust"
     },
     "adjustmentsFunction32": {
@@ -3437,71 +3438,71 @@
     "motorsmAhDrawnValue": {
         "message": "$1 mAh"
     },
-    "motorsText":{
+    "motorsText": {
         "message": "Motors"
     },
-    "motorNumber1":{
+    "motorNumber1": {
         "message": "Motor - 1"
     },
-    "motorNumber2":{
+    "motorNumber2": {
         "message": "Motor - 2"
     },
-    "motorNumber3":{
+    "motorNumber3": {
         "message": "Motor - 3"
     },
-    "motorNumber4":{
+    "motorNumber4": {
         "message": "Motor - 4"
     },
-    "motorNumber5":{
+    "motorNumber5": {
         "message": "Motor - 5"
     },
-    "motorNumber6":{
+    "motorNumber6": {
         "message": "Motor - 6"
     },
-    "motorNumber7":{
+    "motorNumber7": {
         "message": "Motor - 7"
     },
-    "motorNumber8":{
+    "motorNumber8": {
         "message": "Motor - 8"
     },
-    "servosText":{
+    "servosText": {
         "message": "Servos"
     },
-    "servoNumber1":{
+    "servoNumber1": {
         "message": "Servo - 1"
     },
-    "servoNumber2":{
+    "servoNumber2": {
         "message": "Servo - 2"
     },
-    "servoNumber3":{
+    "servoNumber3": {
         "message": "Servo - 3"
     },
-    "servoNumber4":{
+    "servoNumber4": {
         "message": "Servo - 4"
     },
-    "servoNumber5":{
+    "servoNumber5": {
         "message": "Servo - 5"
     },
-    "servoNumber6":{
+    "servoNumber6": {
         "message": "Servo - 6"
     },
-    "servoNumber7":{
+    "servoNumber7": {
         "message": "Servo - 7"
     },
-    "servoNumber8":{
+    "servoNumber8": {
         "message": "Servo - 8"
     },
-    "motorsResetMaximumButton":{
+    "motorsResetMaximumButton": {
         "message": "Reset"
     },
-    "motorsResetMaximum":{
+    "motorsResetMaximum": {
         "message": "Reset overtime maximum"
     },
-    "motorsSensorGyroSelect":{
+    "motorsSensorGyroSelect": {
         "message": "$t(sensorStatusGyroShort.message)",
         "description": "Don't translate!!!"
     },
-    "motorsSensorAccelSelect":{
+    "motorsSensorAccelSelect": {
         "message": "accel"
     },
     "motorsTelemetryHelp": {
@@ -3915,7 +3916,7 @@
         "message": "Please wait"
     },
     "firmwareFlasherBoardSelectionHead": {
-    "message": "Board Selection"
+        "message": "Board Selection"
     },
     "firmwareFlasherBranch": {
         "message": "Select Pull Request or Commit"
@@ -4056,10 +4057,10 @@
     "firmwareFlasherBaudRate": {
         "message": "Baud Rate"
     },
-    "firmwareFlasherShowDevelopmentReleases":{
+    "firmwareFlasherShowDevelopmentReleases": {
         "message": "Show release candidates"
     },
-    "firmwareFlasherShowDevelopmentReleasesDescription":{
+    "firmwareFlasherShowDevelopmentReleasesDescription": {
         "message": "Show release candidates in addition to stable releases"
     },
     "firmwareFlasherOptionLoading": {
@@ -5087,7 +5088,7 @@
         "message": "Increases the PID values to compensate when Vbat gets lower. This will give more constant flight characteristics throughout the flight. The amount of compensation that is applied is calculated from the $t(powerBatteryMaximum.message) set in the $t(tabPower.message) page, so make sure that is set to something appropriate."
     },
     "pidTuningVbatSagCompensation": {
-        "message": "Vbat Sag Compensation"
+        "message": "Vbat Sag Compensation %"
     },
     "pidTuningVbatSagCompensationHelp": {
         "message": "Gives consistent throttle and PID performance over the usable battery voltage range by increasing motor output as battery voltage falls.<br /><br />The amount of compensation can be varied between 0 and 100%. Full compensation (100%) is recommended.<br /><br />Visit <a href=\"https://betaflight.com/docs/wiki/tuning/4-2-tuning-notes#dynamic-battery-sag-compensation\" target=\"_blank\" rel=\"noopener noreferrer\">this wiki entry</a> for more info."
@@ -5096,7 +5097,7 @@
         "message": "%"
     },
     "pidTuningThrustLinearization": {
-        "message": "Thrust Linearization"
+        "message": "Thrust Linearization %"
     },
     "pidTuningThrustLinearizationHelp": {
         "message": "Improves low throttle authority and responsiveness. <br><br> Especially useful for whoops and 48k ESCs.  Has no effect at higher throttle.<br><br>The amount of compensation can be varied between 0 and 150%. Usually 30-40% is enough."
@@ -5309,7 +5310,7 @@
     "failsafeGpsRescueDescendRateHelp": {
         "message": "The initial descent rate is set to 3 times this value, decreasing to the set value at the landing altitude."
     },
-    "failsafeGpsRescueItemMinStartDistHelp" : {
+    "failsafeGpsRescueItemMinStartDistHelp": {
         "message": "If the rescue starts too close to home (within this minimum distance), the aircraft will fly away, on its current heading, until at least this distance from home, and then start normal rescue behaviour",
         "description": "Updated help text for the minimum start distance needed for GPS rescue to activate"
     },
@@ -5872,7 +5873,6 @@
     "osdSetupUploadingFontFailed": {
         "message": "Upload failed"
     },
-
     "osdSetupSave": {
         "message": "Save"
     },
@@ -6413,7 +6413,7 @@
         "message": "Timer: remaining time estimate",
         "description": "One of the elements of the OSD"
     },
-    "osdDescElementRemainingTimeEstimate" : {
+    "osdDescElementRemainingTimeEstimate": {
         "message": "Estimate of flight time remaining"
     },
     "osdTextElementRtcDateTime": {
@@ -6446,14 +6446,14 @@
         "message": "Timer 1",
         "description": "One of the elements of the OSD"
     },
-    "osdDescElementTimer1" : {
+    "osdDescElementTimer1": {
         "message": "Shows the value of timer 1"
     },
     "osdTextElementTimer2": {
         "message": "Timer 2",
         "description": "One of the elements of the OSD"
     },
-    "osdDescElementTimer2" : {
+    "osdDescElementTimer2": {
         "message": "Shows the value of timer 2"
     },
     "osdTextElementCoreTemperature": {
@@ -6635,7 +6635,7 @@
         "message": "Unknown $1",
         "description": "One of the elements of the OSD"
     },
-    "osdDescElementUnknown" : {
+    "osdDescElementUnknown": {
         "message": "Unknown element (details to be added in a future release)"
     },
     "osdTextStatMaxSpeed": {
@@ -6886,72 +6886,71 @@
         "message": "Font version: user provided"
     },
     "osdTimerSource": {
-      "message": "Source:"
+        "message": "Source:"
     },
     "osdTimerSourceTooltip": {
         "message": "Select the timer source, this controls the duration/event that the timer measures"
     },
     "osdTimerSourceOptionOnTime": {
-      "message": "On time",
-      "description": "One of the options for the source timer. This options shows the amount of time has passed since the battery was plugged"
+        "message": "On time",
+        "description": "One of the options for the source timer. This options shows the amount of time has passed since the battery was plugged"
     },
     "osdTimerSourceOptionTotalArmedTime": {
-      "message": "Total armed time",
-      "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed since the battery was plugged"
+        "message": "Total armed time",
+        "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed since the battery was plugged"
     },
     "osdTimerSourceOptionLastArmedTime": {
-      "message": "Last armed time",
-      "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed the latest time"
+        "message": "Last armed time",
+        "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed the latest time"
     },
     "osdTimerSourceOptionOnArmTime": {
-      "message": "On/Armed time",
-      "description": "One of the options for the source timer. This option shows On time when aircraft is disarmed, and Armed time when armed"
+        "message": "On/Armed time",
+        "description": "One of the options for the source timer. This option shows On time when aircraft is disarmed, and Armed time when armed"
     },
     "osdTimerPrecision": {
-      "message": "Precision:"
+        "message": "Precision:"
     },
     "osdTimerPrecisionTooltip": {
         "message": "Select the timer precision, this controls to what precision the time is reported in"
     },
     "osdTimerPrecisionOptionSecond": {
-      "message": "Second",
-      "description": "Selectable option for the precision of the timer in the OSD"
+        "message": "Second",
+        "description": "Selectable option for the precision of the timer in the OSD"
     },
     "osdTimerPrecisionOptionHundredth": {
-      "message": "Hundredth",
-      "description": "Selectable option for the precision of the timer in the OSD"
+        "message": "Hundredth",
+        "description": "Selectable option for the precision of the timer in the OSD"
     },
     "osdTimerPrecisionOptionTenth": {
-      "message": "Tenth",
-      "description": "Selectable option for the precision of the timer in the OSD"
+        "message": "Tenth",
+        "description": "Selectable option for the precision of the timer in the OSD"
     },
     "osdTimerAlarm": {
-      "message": "Alarm:"
+        "message": "Alarm:"
     },
     "osdTimerAlarmTooltip": {
         "message": "Select the timer alarm threshold in minutes, when the time exceeds this value the OSD element will blink, setting this to 0 disables the alarm"
     },
     "osdTimerAlarmOptionRssi": {
-      "message": "RSSI",
-      "description": "Text of the RSSI alarm"
+        "message": "RSSI",
+        "description": "Text of the RSSI alarm"
     },
     "osdTimerAlarmOptionCapacity": {
-      "message": "Capacity",
-      "description": "Text of the capacity alarm"
+        "message": "Capacity",
+        "description": "Text of the capacity alarm"
     },
     "osdTimerAlarmOptionAltitude": {
-      "message": "Altitude",
-      "description": "Text of the altitude alarm"
+        "message": "Altitude",
+        "description": "Text of the altitude alarm"
     },
     "osdTimerAlarmOptionLinkQuality": {
         "message": "Link Quality",
         "description": "Text of the link quality alarm"
-      },
-      "osdTimerAlarmOptionRssiDbm": {
+    },
+    "osdTimerAlarmOptionRssiDbm": {
         "message": "RSSI dBm",
         "description": "Text of the RSSI dBm alarm"
-      },
-
+    },
     "osdWarningTextArmingDisabled": {
         "message": "Arming disabled",
         "description": "One of the warnings that can be selected to be shown in the OSD"
@@ -7107,7 +7106,6 @@
     "osdWarningUnknown": {
         "message": "Unknown warning (details to be added in a future release)"
     },
-
     "osdSectionHelpElements": {
         "message": "Enable or disable OSD elements."
     },
@@ -7402,7 +7400,7 @@
         "message": "Save Lua Script",
         "description": "Save Lua script button in the VTX tab"
     },
-    "vtxLuaFileHelp" :{
+    "vtxLuaFileHelp": {
         "message": "The '$t(vtxButtonSaveLua.message)' button will allow you to save a <i>mcuid</i>.lua file containing the VTX table configuration that can be used with the <a href=\"https://github.com/betaflight/betaflight-tx-lua-scripts/\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight TX Lua Scripts</a>.<br><br>Version 1.6.0 and above can use the file as is, but for older versions of the scripts it should be renamed to match the modelname on the TX.",
         "description": "Tooltip message for the Save Lua script button in the VTX tab"
     },
@@ -7459,7 +7457,6 @@
         "message": "Sends ESC data to the FC via DShot telemetry.  Required by RPM Filtering and dynamic idle. <br> <br>Note: Requires a compatible ESC with appropriate firmware, eg JESC, Jazzmac, BLHeli-32.",
         "description": "Description of the Bidirectional DShot feature of the ESC/Motor"
     },
-
     "configurationGyroFrequency": {
         "message": "Gyro update frequency"
     },

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -6,7 +6,7 @@
 
             <div class="flex items-start gap-3 flex-wrap mb-2">
                 <!-- Profile Selector -->
-                <div class="flex flex-col gap-1 min-w-[130px]">
+                <div v-if="['pid', 'filter'].includes(activeSubtab)" class="flex flex-col gap-1 min-w-[130px]">
                     <SettingRow :label="$t('pidTuningProfile')" :help="$t('pidTuningProfileTip')">
                         <USelect
                             v-model="currentProfile"
@@ -19,7 +19,7 @@
                 </div>
 
                 <!-- Rate Profile Selector -->
-                <div class="flex flex-col gap-1 min-w-[130px]">
+                <div v-if="activeSubtab === 'rates'" class="flex flex-col gap-1 min-w-[130px]">
                     <SettingRow :label="$t('pidTuningRateProfile')" :help="$t('pidTuningRateProfileTip')">
                         <USelect
                             v-model="currentRateProfile"
@@ -28,6 +28,20 @@
                             :disabled="hasChanges"
                             @update:model-value="onRateProfileChange"
                         />
+                    </SettingRow>
+                </div>
+                <div>
+                    <!-- Profile Name (API 1.45+) -->
+                    <SettingRow v-if="showProfileName" :label="$t('pidProfileName')" :help="$t('pidProfileNameHelp')">
+                        <UInput v-model="localProfileName" maxlength="8" class="w-28" />
+                    </SettingRow>
+                    <!-- Rate Profile Name (API 1.45+) -->
+                    <SettingRow
+                        v-if="showRateProfileName"
+                        :label="$t('rateProfileName')"
+                        :help="$t('rateProfileNameHelp')"
+                    >
+                        <UInput v-model="localRateProfileName" maxlength="8" class="w-28" />
                     </SettingRow>
                 </div>
 
@@ -195,6 +209,27 @@ const subtabItems = computed(() => [
 // Profile name state lifted from child components
 const pidProfileName = ref("");
 const rateProfileName = ref("");
+
+const showProfileName = computed(
+    () => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45) && ["pid", "filter"].includes(activeSubtab.value),
+);
+const showRateProfileName = computed(
+    () => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45) && activeSubtab.value === "rates",
+);
+
+const localProfileName = computed({
+    get: () => pidProfileName.value,
+    set: (val) => {
+        pidProfileName.value = val;
+    },
+});
+
+const localRateProfileName = computed({
+    get: () => rateProfileName.value,
+    set: (val) => {
+        rateProfileName.value = val;
+    },
+});
 
 // hasChanges is owned by the Pinia store
 const hasChanges = computed(() => pidTuningStore.hasChanges);

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -98,15 +98,9 @@
                         v-if="activeSubtab === 'pid'"
                         :expert-mode="expertModeEnabled"
                         :show-all-pids="showAllPids"
-                        v-model:profile-name="pidProfileName"
                         @change="onFormChanged"
                     />
-                    <RatesSubTab
-                        ref="ratesSubTab"
-                        v-if="activeSubtab === 'rates'"
-                        v-model:rate-profile-name="rateProfileName"
-                        @change="onFormChanged"
-                    />
+                    <RatesSubTab ref="ratesSubTab" v-if="activeSubtab === 'rates'" @change="onFormChanged" />
                     <FilterSubTab
                         ref="filterSubTab"
                         v-if="activeSubtab === 'filter'"

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -2,10 +2,201 @@
     <div class="p-5 grid grid-cols-1 xl:grid-cols-2 gap-4">
         <!-- LEFT COLUMN: PID Table and Sliders -->
         <div class="flex flex-col gap-4">
-            <!-- Profile Name (API 1.45+) -->
-            <SettingRow v-if="showProfileName" :label="$t('pidProfileName')" :help="$t('pidProfileNameHelp')">
-                <UInput v-model="localProfileName" maxlength="8" class="w-28" />
-            </SettingRow>
+            <!-- Tuning Sliders Section -->
+            <UiBox :title="$t('pidTuningSliders')" type="neutral">
+                <!-- Slider Header: Mode select + range labels -->
+                <div class="flex items-center gap-3 mb-2">
+                    <div class="flex items-center gap-2 min-w-44 shrink-0">
+                        <span class="text-xs whitespace-nowrap">{{ $t("pidTuningSliderPidsMode") }}</span>
+                        <USelect
+                            v-model="sliderPidsMode"
+                            :items="pidsModeItems"
+                            size="xs"
+                            class="w-24"
+                            @update:model-value="onSliderModeChange"
+                        />
+                        <HelpIcon :text="$t('pidTuningSliderModeHelp')" />
+                    </div>
+                    <div class="flex justify-between flex-1 text-xs text-dimmed">
+                        <span>{{ $t("pidTuningSliderLow") }}</span>
+                        <span>{{ $t("pidTuningSliderDefault") }}</span>
+                        <span>{{ $t("pidTuningSliderHigh") }}</span>
+                    </div>
+                    <HelpIcon :text="$t('pidTuningPidSlidersHelp')" />
+                </div>
+
+                <!-- Basic Sliders -->
+                <div
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': sliderDGainDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderDGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderDGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="sliderDGainDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange('sliderDGain')"
+                    />
+                    <HelpIcon :text="$t('pidTuningDGainSliderHelp')" />
+                </div>
+
+                <div
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': sliderPIGainDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningPIGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderPIGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderPIGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="sliderPIGainDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange('sliderPIGain')"
+                    />
+                    <HelpIcon :text="$t('pidTuningPIGainSliderHelp')" />
+                </div>
+
+                <div
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': sliderFFGainDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningResponseSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderFFGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderFeedforwardGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="sliderFFGainDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange('sliderFeedforwardGain')"
+                    />
+                    <HelpIcon :text="$t('pidTuningResponseSliderHelp')" />
+                </div>
+
+                <!-- Divider before advanced sliders -->
+                <hr v-show="showAdvancedSliders" class="border-default my-2" />
+
+                <!-- Advanced Sliders -->
+                <div
+                    v-show="showDMaxSlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': dMaxSliderDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDMaxGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderDMaxGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderDMaxGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="dMaxSliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningDMaxGainSliderHelp')" />
+                </div>
+
+                <div
+                    v-show="showIGainSlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': iGainSliderDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningIGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderIGainDisplay }}</span>
+                    <USlider
+                        v-model="sliderIGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="iGainSliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningIGainSliderHelp')" />
+                </div>
+
+                <div
+                    v-show="showRPRatioSlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': rpRatioSliderDisabled }"
+                >
+                    <div
+                        class="min-w-32 text-right text-xs shrink-0"
+                        v-html="$t('pidTuningRollPitchRatioSlider')"
+                    ></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderRPRatioDisplay }}</span>
+                    <USlider
+                        v-model="sliderRollPitchRatio"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="rpRatioSliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningRollPitchRatioSliderHelp')" />
+                </div>
+
+                <div
+                    v-show="showPitchPISlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': pitchPISliderDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningPitchPIGainSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderPitchPIDisplay }}</span>
+                    <USlider
+                        v-model="sliderPitchPIGain"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="pitchPISliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningPitchPIGainSliderHelp')" />
+                </div>
+
+                <div
+                    v-show="showMasterSlider"
+                    class="flex items-center gap-3 py-1"
+                    :class="{ 'opacity-50 pointer-events-none': masterSliderDisabled }"
+                >
+                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningMasterSlider')"></div>
+                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderMasterDisplay }}</span>
+                    <USlider
+                        v-model="sliderMasterMultiplier"
+                        :min="0"
+                        :max="2.0"
+                        :step="0.05"
+                        :disabled="masterSliderDisabled"
+                        class="flex-1"
+                        @update:model-value="onSliderChange()"
+                    />
+                    <HelpIcon :text="$t('pidTuningMasterSliderHelp')" />
+                </div>
+
+                <!-- Danger Zone Warning -->
+                <UiBox v-if="slidersInDangerZone" type="error" highlight>
+                    <p v-html="$t('pidTuningSliderWarning')"></p>
+                </UiBox>
+
+                <!-- Non-Expert Mode Warning -->
+                <UiBox v-if="!props.expertMode && sliderPidsMode > 0" type="warning" highlight>
+                    <p v-html="$t('pidTuningPidSlidersNonExpertMode')"></p>
+                </UiBox>
+
+                <!-- Expert Settings Detected Warning -->
+                <UiBox v-if="showExpertSettingsWarning" type="warning" highlight>
+                    <p v-html="$t('pidTuningSlidersExpertSettingsDetectedNote')"></p>
+                </UiBox>
+            </UiBox>
 
             <!-- PID Table -->
             <UiBox type="neutral">
@@ -198,201 +389,6 @@
                         class="w-full"
                     />
                 </div>
-            </UiBox>
-
-            <!-- Tuning Sliders Section -->
-            <UiBox type="neutral">
-                <!-- Slider Header: Mode select + range labels -->
-                <div class="flex items-center gap-3 mb-2">
-                    <div class="flex items-center gap-2 min-w-44 shrink-0">
-                        <span class="text-xs whitespace-nowrap">{{ $t("pidTuningSliderPidsMode") }}</span>
-                        <USelect
-                            v-model="sliderPidsMode"
-                            :items="pidsModeItems"
-                            class="w-24"
-                            @update:model-value="onSliderModeChange"
-                        />
-                        <HelpIcon :text="$t('pidTuningSliderModeHelp')" />
-                    </div>
-                    <div class="flex justify-between flex-1 text-xs text-dimmed">
-                        <span>{{ $t("pidTuningSliderLow") }}</span>
-                        <span>{{ $t("pidTuningSliderDefault") }}</span>
-                        <span>{{ $t("pidTuningSliderHigh") }}</span>
-                    </div>
-                    <HelpIcon :text="$t('pidTuningPidSlidersHelp')" />
-                </div>
-
-                <!-- Basic Sliders -->
-                <div
-                    class="flex items-center gap-3 py-1"
-                    :class="{ 'opacity-50 pointer-events-none': sliderDGainDisabled }"
-                >
-                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDGainSlider')"></div>
-                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderDGainDisplay }}</span>
-                    <USlider
-                        v-model="sliderDGain"
-                        :min="0"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="sliderDGainDisabled"
-                        class="flex-1"
-                        @update:model-value="onSliderChange('sliderDGain')"
-                    />
-                    <HelpIcon :text="$t('pidTuningDGainSliderHelp')" />
-                </div>
-
-                <div
-                    class="flex items-center gap-3 py-1"
-                    :class="{ 'opacity-50 pointer-events-none': sliderPIGainDisabled }"
-                >
-                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningPIGainSlider')"></div>
-                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderPIGainDisplay }}</span>
-                    <USlider
-                        v-model="sliderPIGain"
-                        :min="0"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="sliderPIGainDisabled"
-                        class="flex-1"
-                        @update:model-value="onSliderChange('sliderPIGain')"
-                    />
-                    <HelpIcon :text="$t('pidTuningPIGainSliderHelp')" />
-                </div>
-
-                <div
-                    class="flex items-center gap-3 py-1"
-                    :class="{ 'opacity-50 pointer-events-none': sliderFFGainDisabled }"
-                >
-                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningResponseSlider')"></div>
-                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderFFGainDisplay }}</span>
-                    <USlider
-                        v-model="sliderFeedforwardGain"
-                        :min="0"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="sliderFFGainDisabled"
-                        class="flex-1"
-                        @update:model-value="onSliderChange('sliderFeedforwardGain')"
-                    />
-                    <HelpIcon :text="$t('pidTuningResponseSliderHelp')" />
-                </div>
-
-                <!-- Divider before advanced sliders -->
-                <hr v-show="showAdvancedSliders" class="border-default my-2" />
-
-                <!-- Advanced Sliders -->
-                <div
-                    v-show="showDMaxSlider"
-                    class="flex items-center gap-3 py-1"
-                    :class="{ 'opacity-50 pointer-events-none': dMaxSliderDisabled }"
-                >
-                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningDMaxGainSlider')"></div>
-                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderDMaxGainDisplay }}</span>
-                    <USlider
-                        v-model="sliderDMaxGain"
-                        :min="0"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="dMaxSliderDisabled"
-                        class="flex-1"
-                        @update:model-value="onSliderChange()"
-                    />
-                    <HelpIcon :text="$t('pidTuningDMaxGainSliderHelp')" />
-                </div>
-
-                <div
-                    v-show="showIGainSlider"
-                    class="flex items-center gap-3 py-1"
-                    :class="{ 'opacity-50 pointer-events-none': iGainSliderDisabled }"
-                >
-                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningIGainSlider')"></div>
-                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderIGainDisplay }}</span>
-                    <USlider
-                        v-model="sliderIGain"
-                        :min="0"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="iGainSliderDisabled"
-                        class="flex-1"
-                        @update:model-value="onSliderChange()"
-                    />
-                    <HelpIcon :text="$t('pidTuningIGainSliderHelp')" />
-                </div>
-
-                <div
-                    v-show="showRPRatioSlider"
-                    class="flex items-center gap-3 py-1"
-                    :class="{ 'opacity-50 pointer-events-none': rpRatioSliderDisabled }"
-                >
-                    <div
-                        class="min-w-32 text-right text-xs shrink-0"
-                        v-html="$t('pidTuningRollPitchRatioSlider')"
-                    ></div>
-                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderRPRatioDisplay }}</span>
-                    <USlider
-                        v-model="sliderRollPitchRatio"
-                        :min="0"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="rpRatioSliderDisabled"
-                        class="flex-1"
-                        @update:model-value="onSliderChange()"
-                    />
-                    <HelpIcon :text="$t('pidTuningRollPitchRatioSliderHelp')" />
-                </div>
-
-                <div
-                    v-show="showPitchPISlider"
-                    class="flex items-center gap-3 py-1"
-                    :class="{ 'opacity-50 pointer-events-none': pitchPISliderDisabled }"
-                >
-                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningPitchPIGainSlider')"></div>
-                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderPitchPIDisplay }}</span>
-                    <USlider
-                        v-model="sliderPitchPIGain"
-                        :min="0"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="pitchPISliderDisabled"
-                        class="flex-1"
-                        @update:model-value="onSliderChange()"
-                    />
-                    <HelpIcon :text="$t('pidTuningPitchPIGainSliderHelp')" />
-                </div>
-
-                <div
-                    v-show="showMasterSlider"
-                    class="flex items-center gap-3 py-1"
-                    :class="{ 'opacity-50 pointer-events-none': masterSliderDisabled }"
-                >
-                    <div class="min-w-32 text-right text-xs shrink-0" v-html="$t('pidTuningMasterSlider')"></div>
-                    <span class="min-w-10 text-center text-sm font-semibold">{{ sliderMasterDisplay }}</span>
-                    <USlider
-                        v-model="sliderMasterMultiplier"
-                        :min="0"
-                        :max="2.0"
-                        :step="0.05"
-                        :disabled="masterSliderDisabled"
-                        class="flex-1"
-                        @update:model-value="onSliderChange()"
-                    />
-                    <HelpIcon :text="$t('pidTuningMasterSliderHelp')" />
-                </div>
-
-                <!-- Danger Zone Warning -->
-                <UiBox v-if="slidersInDangerZone" type="error" highlight>
-                    <p v-html="$t('pidTuningSliderWarning')"></p>
-                </UiBox>
-
-                <!-- Non-Expert Mode Warning -->
-                <UiBox v-if="!props.expertMode && sliderPidsMode > 0" type="warning" highlight>
-                    <p v-html="$t('pidTuningPidSlidersNonExpertMode')"></p>
-                </UiBox>
-
-                <!-- Expert Settings Detected Warning -->
-                <UiBox v-if="showExpertSettingsWarning" type="warning" highlight>
-                    <p v-html="$t('pidTuningSlidersExpertSettingsDetectedNote')"></p>
-                </UiBox>
             </UiBox>
 
             <!-- BARO, MAG, GPS Optional PIDs -->
@@ -678,7 +674,8 @@
                             <USelect
                                 v-model="advancedTuning.feedforward_averaging"
                                 :items="feedforwardAveragingItems"
-                                class="w-28"
+                                size="xs"
+                                class="w-24"
                             />
                         </div>
                         <div class="flex flex-col gap-1">
@@ -732,23 +729,64 @@
                         </div>
                     </div>
                 </div>
+                <!-- TPA Settings -->
+                <div class="flex flex-col gap-2">
+                    <span class="text-sm font-semibold" v-html="$t('pidTuningTpaGroup')"></span>
+                    <div class="flex flex-wrap items-end gap-3 pl-4">
+                        <div v-if="usesAdvancedTpa" class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningTPAMode") }}</span>
+                            <USelect v-model="tpaMode" :items="tpaModeItems" size="xs" class="w-24" />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningTPARate") }}</span>
+                            <UInputNumber
+                                v-model="tpaRate"
+                                :step="1"
+                                :min="0"
+                                :max="100"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-16"
+                            />
+                        </div>
+                        <div class="flex flex-col gap-1">
+                            <span class="text-xs text-dimmed">{{ $t("pidTuningTPABreakPoint") }}</span>
+                            <UInputNumber
+                                v-model="tpaBreakpoint"
+                                :step="10"
+                                :min="750"
+                                :max="2250"
+                                size="xs"
+                                orientation="vertical"
+                                :format-options="{ useGrouping: false }"
+                                class="w-16"
+                            />
+                        </div>
+                    </div>
+                </div>
 
                 <!-- I-term Relax -->
                 <div class="flex flex-col gap-2">
                     <SettingRow :label="$t('pidTuningItermRelax')" :help="$t('pidTuningItermRelaxHelp')">
                         <USwitch v-model="itermRelaxEnabled" size="sm" />
                     </SettingRow>
-                    <div v-if="itermRelaxEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                    <div v-if="itermRelaxEnabled" class="flex flex-wrap items-end gap-3 pl-4">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed" v-html="$t('pidTuningItermRelaxAxes')"></span>
-                            <USelect v-model="advancedTuning.itermRelax" :items="itermRelaxAxesItems" class="w-28" />
+                            <USelect
+                                v-model="advancedTuning.itermRelax"
+                                :items="itermRelaxAxesItems"
+                                size="xs"
+                                class="w-24"
+                            />
                         </div>
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed" v-html="$t('pidTuningItermRelaxType')"></span>
                             <USelect
                                 v-model="advancedTuning.itermRelaxType"
                                 :items="itermRelaxTypeItems"
-                                class="w-28"
+                                size="xs"
+                                class="w-24"
                             />
                         </div>
                         <div class="flex flex-col gap-1">
@@ -774,13 +812,14 @@
                     <SettingRow :label="$t('pidTuningAntiGravity')" :help="$t('pidTuningAntiGravityHelp')">
                         <USwitch v-model="antiGravityEnabled" size="sm" />
                     </SettingRow>
-                    <div v-if="antiGravityEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                    <div v-if="antiGravityEnabled" class="flex flex-wrap items-end gap-3 pl-4">
                         <div class="flex flex-col gap-1">
                             <span class="text-xs text-dimmed" v-html="$t('pidTuningAntiGravityMode')"></span>
                             <USelect
                                 v-model="advancedTuning.antiGravityMode"
                                 :items="antiGravityModeItems"
-                                class="w-28"
+                                size="xs"
+                                class="w-24"
                             />
                         </div>
                         <div class="flex flex-col gap-1">
@@ -908,9 +947,8 @@
                     >
                         <USwitch v-model="vbatSagEnabled" size="sm" />
                     </SettingRow>
-                    <div v-if="vbatSagEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                    <div v-if="vbatSagEnabled" class="flex flex-wrap items-end gap-3 pl-4">
                         <div class="flex flex-col gap-1">
-                            <span class="text-xs text-dimmed" v-html="$t('pidTuningVbatSagValue')"></span>
                             <UInputNumber
                                 v-model="advancedTuning.vbat_sag_compensation"
                                 :step="1"
@@ -932,9 +970,8 @@
                     >
                         <USwitch v-model="thrustLinearEnabled" size="sm" />
                     </SettingRow>
-                    <div v-if="thrustLinearEnabled" class="flex flex-wrap items-end gap-3 pl-8">
+                    <div v-if="thrustLinearEnabled" class="flex flex-wrap items-end gap-3 pl-4">
                         <div class="flex flex-col gap-1">
-                            <span class="text-xs text-dimmed" v-html="$t('pidTuningThrustLinearValue')"></span>
                             <UInputNumber
                                 v-model="advancedTuning.thrustLinearization"
                                 :step="1"
@@ -949,45 +986,15 @@
                 </div>
             </UiBox>
 
-            <!-- TPA Settings -->
-            <UiBox type="neutral">
-                <div class="flex flex-wrap items-end gap-3">
-                    <div v-if="usesAdvancedTpa" class="flex flex-col gap-1">
-                        <span class="text-xs text-dimmed">{{ $t("pidTuningTPAMode") }}</span>
-                        <USelect v-model="tpaMode" :items="tpaModeItems" class="w-24" />
-                    </div>
-                    <div class="flex flex-col gap-1">
-                        <span class="text-xs text-dimmed">{{ $t("pidTuningTPARate") }}</span>
-                        <UInputNumber
-                            v-model="tpaRate"
-                            :step="1"
-                            :min="0"
-                            :max="100"
-                            size="xs"
-                            orientation="vertical"
-                            class="w-16"
-                        />
-                    </div>
-                    <div class="flex flex-col gap-1">
-                        <span class="text-xs text-dimmed">{{ $t("pidTuningTPABreakPoint") }}</span>
-                        <UInputNumber
-                            v-model="tpaBreakpoint"
-                            :step="10"
-                            :min="750"
-                            :max="2250"
-                            size="xs"
-                            orientation="vertical"
-                            :format-options="{ useGrouping: false }"
-                            class="w-16"
-                        />
-                    </div>
-                </div>
-            </UiBox>
-
             <!-- Misc Settings -->
             <UiBox :title="$t('pidTuningMiscSettings')" type="neutral">
                 <SettingRow :label="$t('pidTuningCellCount')" :help="$t('pidTuningCellCountHelp')">
-                    <USelect v-model="advancedTuning.autoProfileCellCount" :items="cellCountItems" class="w-32" />
+                    <USelect
+                        v-model="advancedTuning.autoProfileCellCount"
+                        :items="cellCountItems"
+                        size="xs"
+                        class="w-24"
+                    />
                 </SettingRow>
 
                 <SettingRow
@@ -1011,7 +1018,7 @@
                     </SettingRow>
                     <span
                         v-if="integratedYawEnabled"
-                        class="text-xs text-warning pl-8"
+                        class="text-xs text-warning pl-4"
                         v-html="$t('pidTuningIntegratedYawCaution')"
                     ></span>
                 </div>
@@ -1059,13 +1066,9 @@ const props = defineProps({
         type: Boolean,
         default: false,
     },
-    profileName: {
-        type: String,
-        default: "",
-    },
 });
 
-const emit = defineEmits(["update:profileName", "change"]);
+const emit = defineEmits(["change"]);
 
 // USelect item arrays
 const pidsModeItems = computed(() => [
@@ -1115,15 +1118,6 @@ const cellCountItems = computed(() => [
     { value: 7, label: t("pidTuningCellCount7S") },
     { value: 8, label: t("pidTuningCellCount8S") },
 ]);
-
-// Profile name (local writable computed to avoid duplicate key with prop)
-const localProfileName = computed({
-    get: () => props.profileName,
-    set: (value) => emit("update:profileName", value),
-});
-const showProfileName = computed(() => {
-    return semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45);
-});
 
 // For API < 1.47, derivative and dmax column headers are swapped (PR #4173)
 const isPreApi147 = computed(() => semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_47));

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -2,11 +2,6 @@
     <div class="p-5 grid grid-cols-1 xl:grid-cols-2 gap-4">
         <!-- LEFT COLUMN -->
         <div class="flex flex-col gap-4">
-            <!-- Rate Profile Name (API 1.45+) -->
-            <SettingRow v-if="hasProfileNames" :label="$t('rateProfileName')" :help="$t('rateProfileNameHelp')">
-                <UInput v-model="rateProfileNameModel" maxlength="8" class="w-28" />
-            </SettingRow>
-
             <!-- Rates Type Selector -->
             <UiBox type="neutral">
                 <div class="flex items-center gap-3">
@@ -326,14 +321,7 @@ import kissLogo from "@/images/rate_logos/kiss.svg";
 import actualLogo from "@/images/rate_logos/actual.svg";
 import quickratesLogo from "@/images/rate_logos/quickrates.svg";
 
-const props = defineProps({
-    rateProfileName: {
-        type: String,
-        default: "",
-    },
-});
-
-const emit = defineEmits(["update:rateProfileName", "change"]);
+const emit = defineEmits(["change"]);
 
 const { t } = useTranslation();
 
@@ -372,12 +360,6 @@ let keepRendering = true;
 // API Version helpers
 const hasProfileNames = computed(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45));
 const hasThrottleHover = computed(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47));
-
-// Rate Profile Name
-const rateProfileNameModel = computed({
-    get: () => props.rateProfileName,
-    set: (value) => emit("update:rateProfileName", value),
-});
 
 // Rates Type
 const dialog = useDialog();

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -314,7 +314,7 @@ import MSPCodes from "@/js/msp/MSPCodes";
 import RateCurve from "@/js/RateCurve";
 import Model from "@/js/model";
 import semver from "semver";
-import { API_VERSION_1_45, API_VERSION_1_47 } from "@/js/data_storage";
+import { API_VERSION_1_47 } from "@/js/data_storage";
 import betaflightLogo from "@/images/rate_logos/betaflight.svg";
 import raceflightLogo from "@/images/rate_logos/raceflight.svg";
 import kissLogo from "@/images/rate_logos/kiss.svg";


### PR DESCRIPTION
refactor(pid-tuning tab): 
- move profile names to header
- move TPA in PID config group
- move PID sliders to the top
- slightly polish the UI 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional editable Profile Name and Rate Profile Name fields surfaced in the PID Tuning header.

* **Improvements**
  * Reorganized PID Tuning layout; TPA settings embedded into PID settings.
  * Tightened control sizing/spacing, added slider titles, and clarified labels to include "%" for Vbat Sag Compensation and Thrust Linearization; removed redundant enable-state labels.

* **Localization**
  * Cleaned English translations and added "TPA" and "PID Tuning Sliders".
<!-- end of auto-generated comment: release notes by coderabbit.ai -->