### PR TITLE
Refactor: Update StatusBar implementation, bring it back to mobile

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -751,7 +751,7 @@
         "message": "Target"
     },
     "versionLabelFirmware": {
-        "message": "Firmware"
+        "message": "Firmware Version"
     },
     "versionLabelConfigurator": {
         "message": "App Version"

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <UApp>
+    <UApp :tooltip="{ delayDuration: 100 }">
         <div class="app-wrapper">
             <div id="background" v-show="isRevealed" @click="isRevealed = false"></div>
             <div id="side_menu_swipe"></div>
@@ -47,6 +47,8 @@
                 :cycle-time="FC.CONFIG.cycleTime"
                 :cpu-load="FC.CONFIG.cpuload"
                 :configurator-version="CONFIGURATOR.getDisplayVersion()"
+                :firmware-version="FC.CONFIG.flightControllerVersion"
+                :firmware-target="FC.CONFIG.hardwareName"
             ></status-bar>
             <div id="cache">
                 <div class="data-loading">

--- a/src/components/data-flash/DataFlash.vue
+++ b/src/components/data-flash/DataFlash.vue
@@ -10,21 +10,23 @@
                 class="dataflash-icon"
                 :title="$t('sensorDataFlashFreeSpace')"
             />
-            <div class="dataflash-contents_global">
-                <div
-                    class="dataflash-free_global"
-                    :class="usageClass"
-                    :style="{
-                        width: indicatorWidth,
-                    }"
-                >
-                    <span v-if="!compact">
-                        {{ $t("sensorDataFlashFreeSpace") }}
-                        {{ freeSpace }}
-                    </span>
+            <UTooltip :text="$t('sensorDataFlashFreeSpace')">
+                <div class="dataflash-contents_global">
+                    <div
+                        class="dataflash-free_global"
+                        :class="usageClass"
+                        :style="{
+                            width: indicatorWidth,
+                        }"
+                    >
+                        <span v-if="!compact">
+                            {{ $t("sensorDataFlashFreeSpace") }}
+                            {{ freeSpace }}
+                        </span>
+                    </div>
                 </div>
-            </div>
-            <span v-if="compact" class="dataflash-free-label">{{ freeSpace }}</span>
+                <span v-if="compact" class="dataflash-free-label">{{ freeSpace }}</span>
+            </UTooltip>
         </template>
     </div>
 </template>

--- a/src/components/quad-status/BatteryIcon.vue
+++ b/src/components/quad-status/BatteryIcon.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="battery-icon" :class="{ 'battery-icon--compact': compact }">
+    <div class="battery-icon shrink-0" :class="{ 'battery-icon--compact': compact }">
         <div class="quad-status-contents">
             <div class="battery-status" :class="classes" :style="{ width: batteryWidth + '%' }" />
         </div>
@@ -97,23 +97,15 @@ export default defineComponent({
 
 <style scoped>
 .quad-status-contents {
-    display: inline-block;
-    margin-top: 10px;
-    margin-left: 14px;
+    position: absolute;
+    top: 10px;
+    left: 14px;
     height: 10px;
     width: 31px;
 }
 
-.quad-status-contents progress::-webkit-progress-bar {
-    height: 12px;
-    background-color: var(--surface-300);
-}
-
-.quad-status-contents progress::-webkit-progress-value {
-    background-color: #bcf;
-}
-
 .battery-icon {
+    position: relative;
     background-image: url(../../images/icons/cf_icon_bat_grey.svg);
     background-size: contain;
     background-position: center;
@@ -159,8 +151,8 @@ export default defineComponent({
 }
 
 .battery-icon--compact .quad-status-contents {
-    margin-top: 8px;
-    margin-left: 10px;
+    top: 8px;
+    left: 11px;
     width: 26px;
     height: 8px;
 }

--- a/src/components/quad-status/BottomStatusIcons.vue
+++ b/src/components/quad-status/BottomStatusIcons.vue
@@ -1,13 +1,21 @@
 <template>
     <div class="bottomStatusIcons" :class="{ 'bottomStatusIcons--compact': compact }">
         <UTooltip :text="$t('mainHelpArmed')">
-            <div class="armedicon" :class="{ active: setActiveArmed }" />
+            <UIcon
+                name="i-lucide-triangle-alert"
+                class="size-4"
+                :class="setActiveArmed ? 'text-primary' : 'text-muted'"
+            />
         </UTooltip>
         <UTooltip :text="$t('mainHelpFailsafe')">
-            <div class="failsafeicon" :class="{ active: setFailsafeActive }" />
+            <UIcon
+                name="i-lucide-shield-alert"
+                class="size-4"
+                :class="setFailsafeActive ? 'text-primary' : 'text-muted'"
+            />
         </UTooltip>
         <UTooltip :text="$t('mainHelpLink')">
-            <div class="linkicon" :class="{ active: setActiveLink }" />
+            <UIcon name="i-lucide-link" class="size-4" :class="setActiveLink ? 'text-primary' : 'text-muted'" />
         </UTooltip>
     </div>
 </template>
@@ -51,66 +59,6 @@ const setActiveLink = computed(() => performance.now() - props.lastReceivedTimes
     border-bottom-left-radius: 5px;
     border-bottom-right-radius: 5px;
 }
-button {
-    padding: 0.5em 0.75em;
-    border-radius: 4px;
-    background-color: #ccc;
-    color: #666;
-    border: 1px solid var(--surface-500);
-    font-weight: 600;
-    font-size: 10pt;
-    cursor: pointer;
-}
-button.active {
-    background-color: var(--primary-500);
-    border: 1px solid #dba718;
-    color: #000;
-}
-.armedicon {
-    margin-left: 8px;
-    margin-right: 8px;
-    margin-top: 6px;
-    height: 18px;
-    width: 18px;
-    opacity: 0.8;
-    background-size: contain;
-    background-position: center;
-    transition: none;
-    background-image: url(../../images/icons/cf_icon_armed_grey.svg);
-}
-.failsafeicon {
-    margin-left: 8px;
-    margin-right: 8px;
-    margin-top: 6px;
-    height: 18px;
-    width: 18px;
-    opacity: 0.8;
-    background-size: contain;
-    background-position: center;
-    transition: none;
-    background-image: url(../../images/icons/cf_icon_failsafe_grey.svg);
-}
-.linkicon {
-    margin-left: 8px;
-    margin-right: 8px;
-    margin-top: 6px;
-    height: 18px;
-    width: 18px;
-    opacity: 0.8;
-    background-size: contain;
-    background-position: center;
-    transition: none;
-    background-image: url(../../images/icons/cf_icon_link_grey.svg);
-}
-.armedicon.active {
-    background-image: url(../../images/icons/cf_icon_armed_active.svg);
-}
-.failsafeicon.active {
-    background-image: url(../../images/icons/cf_icon_failsafe_active.svg);
-}
-.linkicon.active {
-    background-image: url(../../images/icons/cf_icon_link_active.svg);
-}
 
 .bottomStatusIcons--compact {
     height: auto;
@@ -122,13 +70,5 @@ button.active {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-}
-
-.bottomStatusIcons--compact .armedicon,
-.bottomStatusIcons--compact .failsafeicon,
-.bottomStatusIcons--compact .linkicon {
-    margin: 0;
-    height: 16px;
-    width: 16px;
 }
 </style>

--- a/src/components/sensor-status/SensorStatus.vue
+++ b/src/components/sensor-status/SensorStatus.vue
@@ -1,44 +1,44 @@
 <template>
-    <div class="sensor-status" :class="{ 'sensor-status--compact': compact }">
-        <ul>
-            <li class="gyro" :title="$t('sensorStatusGyro')" :class="{ on: setGyroActive }">
-                <div class="gyroicon" :class="{ active: setGyroActive }">
-                    {{ $t("sensorStatusGyroShort") }}
-                </div>
-            </li>
-            <li class="accel" :title="$t('sensorStatusAccel')" :class="{ on: setAccActive }">
-                <div class="accicon" :class="{ active: setAccActive }">
-                    {{ $t("sensorStatusAccelShort") }}
-                </div>
-            </li>
-            <li class="mag" :title="$t('sensorStatusMag')" :class="{ on: setMagActive }">
-                <div class="magicon" :class="{ active: setMagActive }">
-                    {{ $t("sensorStatusMagShort") }}
-                </div>
-            </li>
-            <li class="baro" :title="$t('sensorStatusBaro')" :class="{ on: setBaroActive }">
-                <div class="baroicon" :class="{ active: setBaroActive }">
-                    {{ $t("sensorStatusBaroShort") }}
-                </div>
-            </li>
-            <li class="gps" :class="{ on: gpsOn }" :title="$t('sensorStatusGPS')">
-                <div
-                    class="gpsicon"
-                    :class="{
-                        active: gpsActiveNoFix,
-                        active_fix: gpsActiveWithFix,
-                    }"
-                >
-                    {{ $t("sensorStatusGPSShort") }}
-                </div>
-            </li>
-            <li class="sonar" :title="$t('sensorStatusSonar')" :class="{ on: setSonarActive }">
-                <div class="sonaricon" :class="{ active: setSonarActive }">
-                    {{ $t("sensorStatusSonarShort") }}
-                </div>
-            </li>
-        </ul>
-    </div>
+    <ul class="flex gap-4">
+        <li>
+            <UTooltip :text="$t('sensorStatusGyro')">
+                <UIcon
+                    name="i-lucide-rotate-3d"
+                    class="size-4"
+                    :class="setGyroActive ? 'text-primary' : 'text-muted'"
+                />
+            </UTooltip>
+        </li>
+        <li>
+            <UTooltip :text="$t('sensorStatusAccel')">
+                <UIcon name="i-lucide-move-3d" class="size-4" :class="setAccActive ? 'text-primary' : 'text-muted'" />
+            </UTooltip>
+        </li>
+        <li>
+            <UTooltip :text="$t('sensorStatusMag')">
+                <UIcon name="i-lucide-compass" class="size-4" :class="setMagActive ? 'text-primary' : 'text-muted'" />
+            </UTooltip>
+        </li>
+        <li>
+            <UTooltip :text="$t('sensorStatusBaro')">
+                <UIcon
+                    name="i-lucide-thermometer"
+                    class="size-4"
+                    :class="setBaroActive ? 'text-primary' : 'text-muted'"
+                />
+            </UTooltip>
+        </li>
+        <li>
+            <UTooltip :text="$t('sensorStatusGPS')">
+                <UIcon name="i-lucide-satellite" class="size-4" :class="gpsColor" />
+            </UTooltip>
+        </li>
+        <li>
+            <UTooltip :text="$t('sensorStatusSonar')">
+                <UIcon name="i-lucide-ruler" class="size-4" :class="setSonarActive ? 'text-primary' : 'text-muted'" />
+            </UTooltip>
+        </li>
+    </ul>
 </template>
 
 <script setup>
@@ -48,7 +48,6 @@ import { bit_check } from "../../js/bit";
 const props = defineProps({
     sensorsDetected: { type: Number, default: 0 },
     gpsFixState: { type: Number, default: 0 },
-    compact: { type: Boolean, default: false },
 });
 
 function haveSensor(sensorsDetected, sensorCode) {
@@ -79,175 +78,14 @@ const hasFix = computed(() => props.gpsFixState > 0);
 const gpsOn = computed(() => gpsDetected.value || hasFix.value);
 const gpsActiveNoFix = computed(() => gpsOn.value && gpsDetected.value && !hasFix.value);
 const gpsActiveWithFix = computed(() => gpsOn.value && gpsDetected.value && hasFix.value);
+
+const gpsColor = computed(() => {
+    if (gpsActiveNoFix.value) {
+        return "text-error";
+    }
+    if (gpsActiveWithFix.value) {
+        return "text-primary";
+    }
+    return "text-muted";
+});
 </script>
-
-<style scoped lang="less">
-#sensor-status ul {
-    font-family: "Open Sans", "Segoe UI", Tahoma, sans-serif;
-    font-size: 12px;
-    list-style: none;
-    display: flex;
-}
-li {
-    float: left;
-    height: 67px;
-    width: 33px;
-    line-height: 18px;
-    text-align: center;
-    border-top: 1px solid #373737;
-    border-bottom: 1px solid #1a1a1a;
-    border-left: 1px solid #373737;
-    border-right: 1px solid #222222;
-    background-color: #434343;
-    background-image: -webkit-linear-gradient(top, transparent, rgba(0, 0, 0, 0.45));
-    padding-left: 5px;
-    padding-right: 5px;
-    &:last-child {
-        border-right: 0 solid #c0c0c0;
-        border-top-right-radius: 5px;
-        border-bottom-right-radius: 5px;
-    }
-    &:first-child {
-        border-left: 0 solid #c0c0c0;
-        border-top-left-radius: 5px;
-        border-bottom-left-radius: 5px;
-    }
-}
-div {
-    white-space: nowrap;
-    overflow: hidden;
-}
-.on {
-    background-color: #434343;
-    background-image: -webkit-linear-gradient(top, transparent, rgba(0, 0, 0, 0.45));
-}
-
-.gyroicon {
-    background-repeat: no-repeat;
-    height: 30px;
-    margin-top: 3px;
-    width: 100%;
-    padding-top: 40px;
-    color: var(--text);
-    text-align: center;
-    background-image: url(../../images/icons/sensor_gyro_off.png);
-    background-size: 43px;
-    background-position: top;
-}
-.accicon {
-    background-repeat: no-repeat;
-    height: 30px;
-    margin-top: 3px;
-    width: 100%;
-    padding-top: 40px;
-    color: var(--text);
-    text-align: center;
-    background-image: url(../../images/icons/sensor_acc_off.png);
-    background-size: 40px;
-    background-position: -5px 2px;
-}
-.magicon {
-    background-repeat: no-repeat;
-    height: 30px;
-    margin-top: 3px;
-    width: 100%;
-    padding-top: 40px;
-    color: var(--text);
-    text-align: center;
-    background-image: url(../../images/icons/sensor_mag_off.png);
-    background-size: 42px;
-    background-position: -5px 2px;
-}
-.gpsicon {
-    background-repeat: no-repeat;
-    height: 30px;
-    margin-top: 3px;
-    width: 100%;
-    padding-top: 40px;
-    color: var(--text);
-    text-align: center;
-    background-image: url(../../images/icons/sensor_sat_off.png);
-    background-size: 42px;
-    background-position: -5px 2px;
-}
-.baroicon {
-    background-repeat: no-repeat;
-    height: 30px;
-    margin-top: 3px;
-    width: 100%;
-    padding-top: 40px;
-    color: var(--text);
-    text-align: center;
-    background-image: url(../../images/icons/sensor_baro_off.png);
-    background-size: 40px;
-    background-position: -5px 2px;
-}
-.sonaricon {
-    background-repeat: no-repeat;
-    height: 30px;
-    margin-top: 3px;
-    width: 100%;
-    padding-top: 40px;
-    color: var(--text);
-    text-align: center;
-    background-image: url(../../images/icons/sensor_sonar_off.png);
-    background-size: 41px;
-    background-position: -4px 1px;
-}
-.gyroicon.active {
-    color: #818181;
-    background-image: url(../../images/icons/sensor_gyro_on.png);
-}
-.accicon.active {
-    color: #818181;
-    background-image: url(../../images/icons/sensor_acc_on.png);
-}
-.magicon.active {
-    color: #818181;
-    background-image: url(../../images/icons/sensor_mag_on.png);
-}
-.gpsicon.active {
-    color: #818181;
-    background-image: url(../../images/icons/sensor_sat_on_no_fix.png);
-}
-.gpsicon.active_fix {
-    color: #818181;
-    background-image: url(../../images/icons/sensor_sat_on_with_fix.png);
-}
-.baroicon.active {
-    color: #818181;
-    background-image: url(../../images/icons/sensor_baro_on.png);
-}
-.sonaricon.active {
-    color: #818181;
-    background-image: url(../../images/icons/sensor_sonar_on.png);
-}
-
-.sensor-status--compact {
-    background-color: transparent;
-    display: inline-block;
-}
-
-.sensor-status--compact li {
-    width: 2rem;
-    height: auto;
-    background: none;
-    border: 0;
-    padding: 0;
-    margin-right: 0.25rem;
-}
-
-.sensor-status--compact .gyroicon,
-.sensor-status--compact .accicon,
-.sensor-status--compact .magicon,
-.sensor-status--compact .baroicon,
-.sensor-status--compact .gpsicon,
-.sensor-status--compact .sonaricon {
-    padding-top: 1.4rem;
-    height: 0;
-    background-size: 22px;
-    background-position: center 0;
-    font-size: 9px;
-    margin-top: 0;
-}
-</style>

--- a/src/components/status-bar/PortUtilization.vue
+++ b/src/components/status-bar/PortUtilization.vue
@@ -1,13 +1,12 @@
 <template>
-    <div
-        class="port-utilization"
-        :title="`${$t('statusbar_port_utilization')}  \u2193 ${usageDown}%  \u2191 ${usageUp}%`"
-    >
-        <UIcon name="i-lucide-arrow-down" class="port-utilization__icon" />
-        <span class="value">{{ usageDown }}%</span>
-        <UIcon name="i-lucide-arrow-up" class="port-utilization__icon" />
-        <span class="value">{{ usageUp }}%</span>
-    </div>
+    <UTooltip :text="$t('statusbar_port_utilization')">
+        <div class="port-utilization">
+            <UIcon name="i-lucide-arrow-down" class="port-utilization__icon" />
+            <span class="value w-8">{{ usageDown }}%</span>
+            <UIcon name="i-lucide-arrow-up" class="port-utilization__icon" />
+            <span class="value w-8">{{ usageUp }}%</span>
+        </div>
+    </UTooltip>
 </template>
 
 <script>
@@ -32,11 +31,6 @@ export default defineComponent({
     display: inline-flex;
     align-items: center;
     gap: 0.25rem;
-}
-
-.port-utilization__icon {
-    width: 14px;
-    height: 14px;
 }
 
 .value {

--- a/src/components/status-bar/StatusBar.vue
+++ b/src/components/status-bar/StatusBar.vue
@@ -1,61 +1,101 @@
 <template>
     <div id="status-bar">
         <template v-if="connectionTimestamp">
-            <PortUtilization :usage-down="portUsageDown" :usage-up="portUsageUp" />
-            <span class="stat-group" :title="$t('statusbar_connection_time')">
-                <UIcon name="i-lucide-clock" class="stat-icon" />
-                <span class="value">{{ formattedConnectionTime }}</span>
-            </span>
-            <span class="stat-group" :title="$t('statusbar_packet_error')">
-                <UIcon name="i-lucide-triangle-alert" class="stat-icon" />
-                <span class="value">{{ packetError }}</span>
-            </span>
-            <span class="stat-group" :title="$t('statusbar_cycle_time')">
-                <UIcon name="i-lucide-timer" class="stat-icon" />
-                <span class="value">{{ cycleTime }}</span>
-            </span>
-            <span class="stat-group cpu-load" :title="`${$t('statusbar_cpu_load')}: ${cpuLoad}%`">
-                <UIcon name="i-lucide-cpu" class="stat-icon" />
-                <span class="cpu-bar" :class="cpuLoadClass">
-                    <span class="cpu-bar__fill" :style="{ width: `${clampedCpuLoad}%` }"></span>
+            <template v-if="expertMode">
+                <PortUtilization :usage-down="portUsageDown" :usage-up="portUsageUp" />
+
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+
+                <UTooltip :text="$t('statusbar_connection_time')">
+                    <span class="stat-group">
+                        <UIcon name="i-lucide-clock" class="stat-icon" />
+                        <span class="value">{{ formattedConnectionTime }}</span>
+                    </span>
+                </UTooltip>
+
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+
+                <UTooltip :text="$t('statusbar_packet_error')">
+                    <span class="stat-group">
+                        <UIcon name="i-lucide-triangle-alert" class="stat-icon" />
+                        <span class="value">{{ packetError }}</span>
+                    </span>
+                </UTooltip>
+
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+
+                <UTooltip :text="$t('statusbar_cycle_time')">
+                    <span class="stat-group">
+                        <UIcon name="i-lucide-timer" class="stat-icon" />
+                        <span class="value">{{ cycleTime }}</span>
+                    </span>
+                </UTooltip>
+
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+            </template>
+
+            <UTooltip :text="`${$t('statusbar_cpu_load')} ${cpuLoad}%`">
+                <span class="stat-group cpu-load">
+                    <UIcon name="i-lucide-cpu" class="stat-icon" />
+                    <span class="cpu-bar" :class="cpuLoadClass">
+                        <span class="cpu-bar__fill" :style="{ width: `${clampedCpuLoad}%` }"></span>
+                    </span>
                 </span>
-            </span>
-            <div class="status-indicators">
-                <SensorStatus
-                    class="status-indicators__sensors"
-                    compact
-                    :sensors-detected="fcConfig.activeSensors ?? 0"
-                    :gps-fix-state="gps.fix ?? 0"
-                />
-                <BatteryIcon
-                    compact
-                    :voltage="analog.voltage ?? 0"
-                    :vbatmaxcellvoltage="batteryConfig.vbatmaxcellvoltage ?? 1"
-                    :vbatwarningcellvoltage="batteryConfig.vbatwarningcellvoltage ?? 1"
-                    :battery-state="batteryState.batteryState"
-                />
-                <BatteryLegend
-                    compact
-                    :voltage="analog.voltage ?? 0"
-                    :vbatmaxcellvoltage="batteryConfig.vbatmaxcellvoltage ?? 1"
-                />
-                <BottomStatusIcons
-                    compact
-                    :last-received-timestamp="analog.last_received_timestamp ?? 0"
-                    :mode="fcConfig.mode ?? 0"
-                    :aux-config="auxConfig"
-                />
-                <DataFlash
-                    v-if="dataflashSupported"
-                    compact
-                    :fc-total-size="dataflash.totalSize"
-                    :fc-used-size="dataflash.usedSize"
-                />
-            </div>
+            </UTooltip>
+
+            <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+
+            <SensorStatus :sensors-detected="fcConfig.activeSensors ?? 0" :gps-fix-state="gps.fix ?? 0" />
+
+            <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+
+            <BatteryIcon
+                compact
+                :voltage="analog.voltage ?? 0"
+                :vbatmaxcellvoltage="batteryConfig.vbatmaxcellvoltage ?? 1"
+                :vbatwarningcellvoltage="batteryConfig.vbatwarningcellvoltage ?? 1"
+                :battery-state="batteryState.batteryState"
+            />
+            <BatteryLegend
+                compact
+                :voltage="analog.voltage ?? 0"
+                :vbatmaxcellvoltage="batteryConfig.vbatmaxcellvoltage ?? 1"
+            />
+
+            <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+
+            <BottomStatusIcons
+                compact
+                :last-received-timestamp="analog.last_received_timestamp ?? 0"
+                :mode="fcConfig.mode ?? 0"
+                :aux-config="auxConfig"
+            />
+
+            <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+
+            <DataFlash
+                v-if="dataflashSupported"
+                compact
+                :fc-total-size="dataflash.totalSize"
+                :fc-used-size="dataflash.usedSize"
+            />
         </template>
-        <span class="stat-group status-version" :title="$t('versionLabelConfigurator')">
-            <span class="value">{{ configuratorVersion }}</span>
-        </span>
+        <div class="flex gap-2 text-xs text-muted ml-auto items-center h-full">
+            <template v-if="firmwareTarget && firmwareVersion">
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+                <UIcon name="i-lucide-cpu" class="size-4" />
+                <UTooltip :text="$t('versionLabelFirmware')">
+                    <span>{{ displayedFirmwareTarget }} {{ displayedFirmwareVersion }}</span>
+                </UTooltip>
+            </template>
+
+            <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+
+            <UIcon name="i-lucide-monitor" class="size-4" />
+            <UTooltip :text="$t('versionLabelConfigurator')">
+                <span>{{ displayedConfiguratorVersion }}</span>
+            </UTooltip>
+        </div>
     </div>
 </template>
 
@@ -67,7 +107,43 @@ import BatteryLegend from "../quad-status/BatteryLegend.vue";
 import BottomStatusIcons from "../quad-status/BottomStatusIcons.vue";
 import DataFlash from "../data-flash/DataFlash.vue";
 import SensorStatus from "../sensor-status/SensorStatus.vue";
+import { EventBus } from "../eventBus";
 import FC from "../../js/fc";
+import { isExpertModeEnabled } from "../../js/utils/isExpertModeEnabled";
+
+/**
+ * Shorter target for the status bar when not in expert mode, e.g.
+ * "MFGID/TARGETNAME(MCUNAME)" -> "TARGETNAME"
+ */
+function shortenTargetDisplay(name) {
+    if (!name || typeof name !== "string") {
+        return "";
+    }
+    let s = name.trim();
+    const i = s.indexOf("/");
+    if (i >= 0) {
+        s = s.slice(i + 1);
+    }
+    s = s.replace(/\([^)]*\)\s*$/, "").trim();
+    return s;
+}
+
+/**
+ * Drop trailing (git/revision) segments from a display version string, e.g.
+ * "25.1.0 (a1b2c3d)" or "4.5.0 (a1b2c3d)" for non–expert status text.
+ */
+function stripVersionDisplay(version) {
+    if (!version || typeof version !== "string") {
+        return "";
+    }
+    let s = version.trim();
+    let prev;
+    do {
+        prev = s;
+        s = s.replace(/\s+\([^)]*\)\s*$/, "").trim();
+    } while (s !== prev);
+    return s;
+}
 
 export default defineComponent({
     components: {
@@ -107,22 +183,38 @@ export default defineComponent({
             type: String,
             default: "",
         },
+        firmwareVersion: {
+            type: String,
+            default: "",
+        },
+        firmwareTarget: {
+            type: String,
+            default: "",
+        },
     },
     setup(props) {
         const currentTime = ref(Date.now());
+        const expertMode = ref(isExpertModeEnabled());
         let interval = null;
+
+        const onExpertModeChange = (enabled) => {
+            expertMode.value = enabled;
+        };
 
         onMounted(() => {
             // Update current time every second for the connection timer
             interval = setInterval(() => {
                 currentTime.value = Date.now();
             }, 1000);
+            expertMode.value = isExpertModeEnabled();
+            EventBus.$on("expert-mode-change", onExpertModeChange);
         });
 
         onUnmounted(() => {
             if (interval) {
                 clearInterval(interval);
             }
+            EventBus.$off("expert-mode-change", onExpertModeChange);
         });
 
         const formattedConnectionTime = computed(() => {
@@ -161,7 +253,37 @@ export default defineComponent({
             return "cpu-bar--ok";
         });
 
+        const displayedFirmwareTarget = computed(() => {
+            if (expertMode.value) {
+                return props.firmwareTarget;
+            }
+            return shortenTargetDisplay(props.firmwareTarget);
+        });
+
+        const displayedConfiguratorVersion = computed(() => {
+            if (expertMode.value) {
+                return props.configuratorVersion;
+            }
+            return stripVersionDisplay(props.configuratorVersion);
+        });
+
+        const displayedFirmwareVersion = computed(() => {
+            if (expertMode.value) {
+                return props.firmwareVersion;
+            }
+            return stripVersionDisplay(props.firmwareVersion);
+        });
+
+        const fullFirmwareStatusTooltip = computed(() =>
+            [props.firmwareTarget, props.firmwareVersion].filter(Boolean).join(" ").trim(),
+        );
+
         return {
+            expertMode,
+            fullFirmwareStatusTooltip,
+            displayedFirmwareTarget,
+            displayedConfiguratorVersion,
+            displayedFirmwareVersion,
             formattedConnectionTime,
             analog,
             batteryConfig,
@@ -188,13 +310,10 @@ export default defineComponent({
     bottom: 0;
     box-sizing: border-box;
     width: 100%;
-    min-height: 2.5rem;
+    height: 2.5rem;
     padding: 0.25rem 1rem;
     background-color: var(--surface-300);
     line-height: 1.2;
-    .message {
-        margin-right: 0.25rem;
-    }
     overflow-x: auto;
     scrollbar-width: none;
     -ms-overflow-style: none;
@@ -256,36 +375,5 @@ export default defineComponent({
 
 .cpu-bar--critical .cpu-bar__fill {
     background-color: var(--error-500);
-}
-
-.status-indicators {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-}
-
-.status-version {
-    margin-left: auto;
-    opacity: 0.75;
-    font-variant-numeric: tabular-nums;
-}
-
-/* Hide the sensor-icon row on narrower viewports so the status bar does not crowd. */
-@media all and (max-width: 1100px) {
-    .status-indicators__sensors {
-        display: none;
-    }
-}
-
-#status-bar > * ~ * {
-    padding-left: 10px;
-    border-left: 1px solid var(--surface-400);
-}
-
-/** Status bar (phones) **/
-@media all and (max-width: 575px) {
-    #status-bar {
-        display: none;
-    }
 }
 </style>

--- a/src/components/status-bar/StatusBar.vue
+++ b/src/components/status-bar/StatusBar.vue
@@ -71,14 +71,11 @@
                 :aux-config="auxConfig"
             />
 
-            <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+            <template v-if="dataflashSupported">
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
 
-            <DataFlash
-                v-if="dataflashSupported"
-                compact
-                :fc-total-size="dataflash.totalSize"
-                :fc-used-size="dataflash.usedSize"
-            />
+                <DataFlash compact :fc-total-size="dataflash.totalSize" :fc-used-size="dataflash.usedSize" />
+            </template>
         </template>
         <div class="flex gap-2 text-xs text-muted ml-auto items-center h-full">
             <template v-if="firmwareTarget && firmwareVersion">
@@ -87,9 +84,8 @@
                 <UTooltip :text="$t('versionLabelFirmware')">
                     <span>{{ displayedFirmwareTarget }} {{ displayedFirmwareVersion }}</span>
                 </UTooltip>
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
             </template>
-
-            <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
 
             <UIcon name="i-lucide-monitor" class="size-4" />
             <UTooltip :text="$t('versionLabelConfigurator')">
@@ -273,10 +269,6 @@ export default defineComponent({
             }
             return stripVersionDisplay(props.firmwareVersion);
         });
-
-        const fullFirmwareStatusTooltip = computed(() =>
-            [props.firmwareTarget, props.firmwareVersion].filter(Boolean).join(" ").trim(),
-        );
 
         return {
             expertMode,

--- a/src/components/status-bar/StatusBar.vue
+++ b/src/components/status-bar/StatusBar.vue
@@ -272,7 +272,6 @@ export default defineComponent({
 
         return {
             expertMode,
-            fullFirmwareStatusTooltip,
             displayedFirmwareTarget,
             displayedConfiguratorVersion,
             displayedFirmwareVersion,

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -593,7 +593,7 @@ dialog {
     align-items: center;
     justify-content: end;
     gap: 0.5rem;
-    padding: 0.75rem 1rem 0.75rem 1rem;
+    padding: 0.75rem 1rem 0.25rem 1rem;
     border-top-left-radius: 1.5rem;
     &::before {
         width: 1.5rem;
@@ -662,7 +662,7 @@ dialog {
         display: flex;
         flex-wrap: wrap;
         position: fixed;
-        bottom: 34px;
+        bottom: 2.5rem;
         right: 0;
     }
 }
@@ -1431,9 +1431,6 @@ each(range(12), {
             overflow-y: auto;
             position: initial;
         }
-        &.content_toolbar {
-            bottom: 0;
-        }
     }
 }
 @media (max-width: 1055px) {
@@ -1452,7 +1449,9 @@ each(range(12), {
         width: calc(100% - 42px);
     }
     .content_wrapper {
-        padding: 15px 15px 15px 14px;
+        padding: 1rem 0.5rem;
+        // 3rem to clear the status bar + buttons
+        padding-bottom: 3rem;
     }
     .tab_title {
         font-size: 16px;


### PR DESCRIPTION
- Replace old background-image icons with dedicated Lucide NuxtUI icon elements where applicable
- Use consistent dedicated Nuxt UI separators
- Use Nuxt UI tooltips instead of html titles
- Gate expert data points (port util, packet error, cycle time, firmware/app commit hash) behind expert mode
- Realign button toolbar

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Status area now shows firmware target and an explicit "Firmware Version" label
  * Expert mode reveals additional metrics in the status bar

* **UI/UX Improvements**
  * Broader use of tooltips for status indicators and utility displays
  * Simplified sensor and status icons with clearer active/inactive coloring (including GPS)
  * Refined battery visuals and improved dialog/small-screen spacing
<!-- end of auto-generated comment: release notes by coderabbit.ai -->