### PR TITLE
Expose RPM filter settings

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5026,6 +5026,18 @@
         "message": "Minimum frequency that will be used by the RPM Filter.",
         "description": "Help text for one of the parameters of the RPM Filter"
     },
+    "pidTuningRpmFadeRangeHz": {
+        "message": "Fade Range [Hz]",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmQ": {
+        "message": "Q Factor",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmWeight": {
+        "message": "Weight {{index}}",
+        "description": "Text for the per-harmonic weight parameter of the RPM Filter"
+    },
     "pidTuningFilterSettings": {
         "message": "Profile dependent Filter Settings"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5011,7 +5011,7 @@
         "description": "Header text for the RPM Filter group"
     },
     "pidTuningRpmHarmonics": {
-        "message": "Gyro RPM Filter Harmonics Number",
+        "message": "Harmonics",
         "description": "Text for one of the parameters of the RPM Filter"
     },
     "pidTuningRpmHarmonicsHelp": {
@@ -5019,7 +5019,7 @@
         "description": "Help text for one of the parameters of the RPM Filter"
     },
     "pidTuningRpmMinHz": {
-        "message": "Gyro RPM Filter Min Frequency [Hz]",
+        "message": "Min Frequency [Hz]",
         "description": "Text for one of the parameters of the RPM Filter"
     },
     "pidTuningRpmMinHzHelp": {

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -271,6 +271,47 @@
                                     :max="200"
                                 />
                             </div>
+                            <template v-if="hasExtendedRpmFilter">
+                                <div class="flex flex-col gap-1">
+                                    <span class="text-xs text-dimmed">{{ $t("pidTuningRpmFadeRangeHz") }}</span>
+                                    <UInputNumber
+                                        size="xs"
+                                        orientation="vertical"
+                                        class="w-16"
+                                        v-model="gyro_rpm_notch_fade_range_hz"
+                                        :step="1"
+                                        :min="0"
+                                        :max="1000"
+                                    />
+                                </div>
+                                <div class="flex flex-col gap-1">
+                                    <span class="text-xs text-dimmed">{{ $t("pidTuningRpmQ") }}</span>
+                                    <UInputNumber
+                                        size="xs"
+                                        orientation="vertical"
+                                        class="w-16"
+                                        v-model="gyro_rpm_notch_q"
+                                        :step="1"
+                                        :min="1"
+                                        :max="3000"
+                                    />
+                                </div>
+                                <div v-for="i in gyro_rpm_notch_harmonics" :key="i" class="flex flex-col gap-1">
+                                    <span class="text-xs text-dimmed">{{
+                                        $t("pidTuningRpmWeight", { index: i })
+                                    }}</span>
+                                    <UInputNumber
+                                        size="xs"
+                                        orientation="vertical"
+                                        class="w-16"
+                                        :model-value="gyro_rpm_notch_weights[i - 1]"
+                                        @update:model-value="setRpmWeight(i - 1, $event)"
+                                        :step="1"
+                                        :min="0"
+                                        :max="100"
+                                    />
+                                </div>
+                            </template>
                         </div>
                     </div>
                 </template>
@@ -535,6 +576,8 @@ import {
     NON_EXPERT_SLIDER_MIN_DTERM,
     NON_EXPERT_SLIDER_MAX_DTERM,
 } from "@/composables/useTuningSliders";
+import semver from "semver";
+import { API_VERSION_1_48 } from "@/js/data_storage";
 import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
 import { mspHelper } from "@/js/msp/MSPHelper";
@@ -887,6 +930,7 @@ const gyro_notch2_cutoff = computed({
 });
 
 // RPM Filter
+const hasExtendedRpmFilter = computed(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_48));
 const dshotTelemetryEnabled = computed(() => FC.MOTOR_CONFIG.use_dshot_telemetry ?? false);
 
 const rpmFilterEnabled = computed({
@@ -914,6 +958,22 @@ const gyro_rpm_notch_min_hz = computed({
     get: () => FC.FILTER_CONFIG.gyro_rpm_notch_min_hz || 100,
     set: (value) => (FC.FILTER_CONFIG.gyro_rpm_notch_min_hz = value),
 });
+
+const gyro_rpm_notch_fade_range_hz = computed({
+    get: () => FC.FILTER_CONFIG.gyro_rpm_notch_fade_range_hz ?? 0,
+    set: (value) => (FC.FILTER_CONFIG.gyro_rpm_notch_fade_range_hz = value),
+});
+
+const gyro_rpm_notch_q = computed({
+    get: () => FC.FILTER_CONFIG.gyro_rpm_notch_q ?? 0,
+    set: (value) => (FC.FILTER_CONFIG.gyro_rpm_notch_q = value),
+});
+
+const gyro_rpm_notch_weights = computed(() => FC.FILTER_CONFIG.gyro_rpm_notch_weights ?? [0, 0, 0]);
+
+function setRpmWeight(index, value) {
+    FC.FILTER_CONFIG.gyro_rpm_notch_weights[index] = value;
+}
 
 // Dynamic Notch Filter
 const dynamicNotchEnabled = computed({

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -271,47 +271,48 @@
                                     :max="200"
                                 />
                             </div>
-                            <template v-if="hasExtendedRpmFilter">
-                                <div class="flex flex-col gap-1">
-                                    <span class="text-xs text-dimmed">{{ $t("pidTuningRpmFadeRangeHz") }}</span>
-                                    <UInputNumber
-                                        size="xs"
-                                        orientation="vertical"
-                                        class="w-16"
-                                        v-model="gyro_rpm_notch_fade_range_hz"
-                                        :step="1"
-                                        :min="0"
-                                        :max="1000"
-                                    />
-                                </div>
-                                <div class="flex flex-col gap-1">
-                                    <span class="text-xs text-dimmed">{{ $t("pidTuningRpmQ") }}</span>
-                                    <UInputNumber
-                                        size="xs"
-                                        orientation="vertical"
-                                        class="w-16"
-                                        v-model="gyro_rpm_notch_q"
-                                        :step="1"
-                                        :min="1"
-                                        :max="3000"
-                                    />
-                                </div>
-                                <div v-for="i in gyro_rpm_notch_harmonics" :key="i" class="flex flex-col gap-1">
-                                    <span class="text-xs text-dimmed">{{
-                                        $t("pidTuningRpmWeight", { index: i })
-                                    }}</span>
-                                    <UInputNumber
-                                        size="xs"
-                                        orientation="vertical"
-                                        class="w-16"
-                                        :model-value="gyro_rpm_notch_weights[i - 1]"
-                                        @update:model-value="setRpmWeight(i - 1, $event)"
-                                        :step="1"
-                                        :min="0"
-                                        :max="100"
-                                    />
-                                </div>
-                            </template>
+                        </div>
+                        <div
+                            v-if="rpmFilterEnabled && hasExtendedRpmFilter"
+                            class="flex flex-wrap items-end gap-3 pl-8"
+                        >
+                            <div class="flex flex-col gap-1">
+                                <span class="text-xs text-dimmed">{{ $t("pidTuningRpmQ") }}</span>
+                                <UInputNumber
+                                    size="xs"
+                                    orientation="vertical"
+                                    class="w-16"
+                                    v-model="gyro_rpm_notch_q"
+                                    :step="1"
+                                    :min="250"
+                                    :max="3000"
+                                />
+                            </div>
+                            <div v-for="i in gyro_rpm_notch_harmonics" :key="i" class="flex flex-col gap-1">
+                                <span class="text-xs text-dimmed">{{ $t("pidTuningRpmWeight", { index: i }) }}</span>
+                                <UInputNumber
+                                    size="xs"
+                                    orientation="vertical"
+                                    class="w-16"
+                                    :model-value="gyro_rpm_notch_weights[i - 1]"
+                                    @update:model-value="setRpmWeight(i - 1, $event)"
+                                    :step="1"
+                                    :min="0"
+                                    :max="100"
+                                />
+                            </div>
+                            <div class="flex flex-col gap-1">
+                                <span class="text-xs text-dimmed">{{ $t("pidTuningRpmFadeRangeHz") }}</span>
+                                <UInputNumber
+                                    size="xs"
+                                    orientation="vertical"
+                                    class="w-16"
+                                    v-model="gyro_rpm_notch_fade_range_hz"
+                                    :step="1"
+                                    :min="0"
+                                    :max="1000"
+                                />
+                            </div>
                         </div>
                     </div>
                 </template>

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -536,6 +536,9 @@ const FC = {
             dyn_notch_count: 0,
             gyro_rpm_notch_harmonics: 0,
             gyro_rpm_notch_min_hz: 0,
+            gyro_rpm_notch_fade_range_hz: 0,
+            gyro_rpm_notch_q: 0,
+            gyro_rpm_notch_weights: [0, 0, 0],
         };
 
         this.ADVANCED_TUNING = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1187,6 +1187,15 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     // Introduced in 1.44
                     FC.FILTER_CONFIG.dyn_lpf_curve_expo = data.readU8();
                     FC.FILTER_CONFIG.dyn_notch_count = data.readU8();
+                    // Introduced in 1.48
+                    if (data.remaining() >= 7) {
+                        FC.FILTER_CONFIG.gyro_rpm_notch_fade_range_hz = data.readU16();
+                        FC.FILTER_CONFIG.gyro_rpm_notch_q = data.readU16();
+                        FC.FILTER_CONFIG.gyro_rpm_notch_weights = [];
+                        for (let i = 0; i < 3; i++) {
+                            FC.FILTER_CONFIG.gyro_rpm_notch_weights.push(data.readU8());
+                        }
+                    }
                     break;
                 case MSPCodes.MSP_SET_PID_ADVANCED:
                     console.log("Advanced PID settings saved");
@@ -2181,6 +2190,12 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
 
             // Introduced in 1.44
             buffer.push8(FC.FILTER_CONFIG.dyn_lpf_curve_expo).push8(FC.FILTER_CONFIG.dyn_notch_count);
+
+            // Introduced in 1.48
+            buffer.push16(FC.FILTER_CONFIG.gyro_rpm_notch_fade_range_hz).push16(FC.FILTER_CONFIG.gyro_rpm_notch_q);
+            for (let i = 0; i < 3; i++) {
+                buffer.push8(FC.FILTER_CONFIG.gyro_rpm_notch_weights[i]);
+            }
             break;
         case MSPCodes.MSP_SET_PID_ADVANCED:
             buffer

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2192,9 +2192,11 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
             buffer.push8(FC.FILTER_CONFIG.dyn_lpf_curve_expo).push8(FC.FILTER_CONFIG.dyn_notch_count);
 
             // Introduced in 1.48
-            buffer.push16(FC.FILTER_CONFIG.gyro_rpm_notch_fade_range_hz).push16(FC.FILTER_CONFIG.gyro_rpm_notch_q);
-            for (let i = 0; i < 3; i++) {
-                buffer.push8(FC.FILTER_CONFIG.gyro_rpm_notch_weights[i]);
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_48)) {
+                buffer.push16(FC.FILTER_CONFIG.gyro_rpm_notch_fade_range_hz).push16(FC.FILTER_CONFIG.gyro_rpm_notch_q);
+                for (let i = 0; i < 3; i++) {
+                    buffer.push8(FC.FILTER_CONFIG.gyro_rpm_notch_weights[i]);
+                }
             }
             break;
         case MSPCodes.MSP_SET_PID_ADVANCED:


### PR DESCRIPTION
- requires https://github.com/betaflight/betaflight/pull/15144

<img width="460" height="148" alt="image" src="https://github.com/user-attachments/assets/7f12d312-8f40-4b18-9b2f-65b707c29363" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced RPM filter tuning controls: fade range (Hz), Q-factor, and per-harmonic weight inputs; shown when RPM filtering is enabled and firmware API ≥ 1.48.

* **Localization**
  * Shortened two RPM filter labels for clarity.
  * Added localized labels for fade range, Q, and per-harmonic weight (supports indexed label).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->