### PR TITLE
Refactor: Nuxt UI conversion cleanup

### DIFF
--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -33,6 +33,7 @@ export default {
         switch: {
             slots: {
                 base: "cursor-pointer",
+                thumb: "bg-white",
             },
             defaultVariants: {
                 size: "sm",

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -1,0 +1,82 @@
+/**
+ * Options for `@nuxt/ui/vite` (see vite.config.js plugins).
+ * light/dark mode is handled elsewhere in the app itself; Nuxt UI would otherwise override it.
+ */
+export default {
+    colorMode: false,
+    ui: {
+        button: {
+            slots: {
+                base: "font-semibold cursor-pointer",
+            },
+            variants: {
+                size: {
+                    "2xl": {
+                        base: "p-2 text-lg gap-2.5",
+                        leadingIcon: "size-8",
+                        leadingAvatarSize: "md",
+                        trailingIcon: "size-8",
+                    },
+                },
+            },
+            defaultVariants: {
+                size: "sm",
+            },
+        },
+        tooltip: {
+            slots: {
+                content: "ring-2 ring-primary max-w-sm lg:max-w-lg h-fit z-99999", // not good, temporary z-index override to fix other extremely high values interfering
+                arrow: "fill-primary",
+                text: "whitespace-normal",
+            },
+        },
+        switch: {
+            slots: {
+                base: "cursor-pointer",
+            },
+            defaultVariants: {
+                size: "sm",
+            },
+        },
+        select: {
+            slots: {
+                base: "cursor-pointer",
+                item: "cursor-pointer",
+                content: "z-99999",
+            },
+            defaultVariants: {
+                size: "sm",
+            },
+        },
+        selectMenu: {
+            slots: {
+                base: "cursor-pointer",
+                item: "cursor-pointer",
+                content: "z-99999",
+            },
+            defaultVariants: {
+                size: "sm",
+            },
+        },
+        input: {
+            defaultVariants: {
+                size: "sm",
+            },
+        },
+        inputNumber: {
+            slots: {
+                root: "min-w-12 w-28",
+                base: "appearance-none",
+            },
+            defaultVariants: {
+                size: "sm",
+            },
+        },
+        colors: {
+            primary: "primary",
+            neutral: "neutral",
+            success: "lime",
+            warning: "orange",
+        },
+    },
+};

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -19,6 +19,13 @@ export default {
                     },
                 },
             },
+            compoundVariants: [
+                {
+                    color: "primary",
+                    variant: "solid",
+                    class: "disabled:bg-accented disabled:text-toned",
+                },
+            ],
             defaultVariants: {
                 size: "sm",
             },

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -25,8 +25,8 @@ export default {
         },
         tooltip: {
             slots: {
-                content: "ring-2 ring-primary max-w-sm lg:max-w-lg h-fit z-99999", // not good, temporary z-index override to fix other extremely high values interfering
-                arrow: "fill-primary",
+                content: "ring-2 ring-primary max-w-sm lg:max-w-lg h-fit",
+                arrow: "fill-primary stroke-primary",
                 text: "whitespace-normal",
             },
         },
@@ -43,7 +43,6 @@ export default {
             slots: {
                 base: "cursor-pointer",
                 item: "cursor-pointer",
-                content: "z-99999",
             },
             defaultVariants: {
                 size: "sm",
@@ -53,7 +52,6 @@ export default {
             slots: {
                 base: "cursor-pointer",
                 item: "cursor-pointer",
-                content: "z-99999",
             },
             defaultVariants: {
                 size: "sm",

--- a/src/components/elements/UiBox.vue
+++ b/src/components/elements/UiBox.vue
@@ -11,7 +11,9 @@
             <slot name="title"></slot>
             <HelpIcon v-if="help" :text="help" />
         </div>
-        <div :class="`flex flex-col ${padding ? 'p-3' : 'rounded-lg overflow-hidden'} gap-2 ${title ? 'pt-6' : ''}`">
+        <div
+            :class="`flex flex-col ${padding ? 'p-3' : 'rounded-lg overflow-hidden p-0!'} gap-2 ${title ? 'pt-6' : ''}`"
+        >
             <slot></slot>
         </div>
     </div>

--- a/src/components/elements/UiBox.vue
+++ b/src/components/elements/UiBox.vue
@@ -11,7 +11,7 @@
             <slot name="title"></slot>
             <HelpIcon v-if="help" :text="help" />
         </div>
-        <div :class="`flex flex-col p-3 gap-2 ${title ? 'pt-6' : ''}`">
+        <div :class="`flex flex-col ${padding ? 'p-3' : 'rounded-lg overflow-hidden'} gap-2 ${title ? 'pt-6' : ''}`">
             <slot></slot>
         </div>
     </div>
@@ -42,6 +42,11 @@ const props = defineProps({
     highlight: {
         type: Boolean,
         default: false,
+        required: false,
+    },
+    padding: {
+        type: Boolean,
+        default: true,
         required: false,
     },
 });

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -5,7 +5,7 @@
         :collapsed="isCompact"
         tooltip
         :ui="navMenuUi"
-        class="sidebar-nav"
+        class="sidebar-nav pb-2"
     />
 </template>
 
@@ -25,7 +25,10 @@ const connectionStore = useConnectionStore();
 const authStore = useAuthStore();
 const sidebarExpanded = inject("sidebarExpanded", ref(true));
 const isCompact = computed(() => !sidebarExpanded.value);
-const navMenuUi = computed(() => (isCompact.value ? { link: "justify-center" } : {}));
+const navMenuUi = computed(() => ({
+    ...(isCompact.value ? { link: "justify-center" } : {}),
+    link: "data-active:before:bg-primary/10 cursor-pointer",
+}));
 const betaflightModel = inject("betaflightModel", null);
 
 const isModeVisible = (mode) => {

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -25,10 +25,12 @@ const connectionStore = useConnectionStore();
 const authStore = useAuthStore();
 const sidebarExpanded = inject("sidebarExpanded", ref(true));
 const isCompact = computed(() => !sidebarExpanded.value);
-const navMenuUi = computed(() => ({
-    ...(isCompact.value ? { link: "justify-center" } : {}),
-    link: "data-active:before:bg-primary/10 cursor-pointer",
-}));
+const navMenuUi = computed(() => {
+    const linkBase = "data-active:before:bg-primary/10 cursor-pointer";
+    return {
+        link: isCompact.value ? `${linkBase} justify-center` : linkBase,
+    };
+});
 const betaflightModel = inject("betaflightModel", null);
 
 const isModeVisible = (mode) => {

--- a/src/components/status-bar/StatusBar.vue
+++ b/src/components/status-bar/StatusBar.vue
@@ -218,9 +218,11 @@ export default defineComponent({
                 return "00:00";
             }
 
-            // Use currentTime.value to make this reactive to time changes
+            // Use currentTime.value to make this reactive to time changes.
+            // Clamp so we never show negative time: currentTime can lag up to ~1s behind
+            // Date.now() used when the connection timestamp was set.
             const elapsedMs = currentTime.value - props.connectionTimestamp;
-            const elapsedSeconds = Math.floor(elapsedMs / 1000);
+            const elapsedSeconds = Math.max(0, Math.floor(elapsedMs / 1000));
 
             const minutes = Math.floor(elapsedSeconds / 60);
             const seconds = elapsedSeconds % 60;
@@ -297,7 +299,7 @@ export default defineComponent({
     display: flex;
     align-items: center;
     white-space: nowrap;
-    gap: 0.5rem;
+    gap: 0.6rem;
     bottom: 0;
     box-sizing: border-box;
     width: 100%;

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -204,8 +204,7 @@ onMounted(async () => {
 }
 
 .adjustments-header {
-    background: var(--surface-700);
-    border-bottom: 2px solid var(--surface-600);
+    background: var(--ui-bg-muted);
     font-weight: 600;
     font-size: 13px;
     color: var(--text-primary);

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -137,12 +137,7 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton
-                :label="$t('adjustmentsSave')"
-                :color="hasChanges ? 'success' : 'neutral'"
-                :disabled="!hasChanges"
-                @click="saveAdjustments"
-            />
+            <UButton :label="$t('adjustmentsSave')" :disabled="!hasChanges" @click="saveAdjustments" />
         </div>
     </BaseTab>
 </template>

--- a/src/components/tabs/AuxiliaryTab.vue
+++ b/src/components/tabs/AuxiliaryTab.vue
@@ -158,9 +158,7 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <div class="btn save_btn">
-                <button type="button" class="save" @click="saveModes">{{ $t("auxiliaryButtonSave") }}</button>
-            </div>
+            <UButton :label="$t('auxiliaryButtonSave')" :disabled="!dirty" @click="saveModes" />
         </div>
     </BaseTab>
 </template>
@@ -234,6 +232,7 @@ export default defineComponent({
 
         // Reactive State
         const modes = reactive([]);
+        const modesDirtyBaseline = ref("");
         const hideUnused = ref(false);
         const auxChannelCount = ref(0);
         const requiredModeRangeCount = ref(0);
@@ -356,6 +355,33 @@ export default defineComponent({
             return [start, end];
         };
 
+        const serializeModesForDirtyCheck = () =>
+            JSON.stringify(
+                modes.map((mode) => ({
+                    id: mode.id,
+                    entries: mode.entries.map((entry) => {
+                        if (entry.kind === "range") {
+                            const [start, end] = normalizeRangeValues(entry.sliderRange);
+                            return {
+                                kind: "range",
+                                auxChannelIndex: entry.auxChannelIndex,
+                                modeLogic: entry.modeLogic,
+                                start,
+                                end,
+                            };
+                        }
+                        return { kind: "link", modeLogic: entry.modeLogic, linkedTo: entry.linkedTo };
+                    }),
+                })),
+            );
+
+        const dirty = computed(() => {
+            if (!modesDirtyBaseline.value) {
+                return false;
+            }
+            return modesDirtyBaseline.value !== serializeModesForDirtyCheck();
+        });
+
         const addRange = (mode, auxChannelIndex = -1, modeLogic = 0, range = DEFAULT_RANGE) => {
             const sliderRange = normalizeRangeValues([range.start, range.end]);
             mode.entries.push({
@@ -468,6 +494,7 @@ export default defineComponent({
             });
 
             updateInfoWidth();
+            modesDirtyBaseline.value = serializeModesForDirtyCheck();
         };
 
         const autoSelectChannel = (rcChannels, activeChannels, rssiChannel) => {
@@ -585,7 +612,9 @@ export default defineComponent({
             fcStore.modeRangesExtra = nextModeRangesExtra;
 
             mspHelper.sendModeRanges(() => {
-                mspHelper.writeConfiguration(false);
+                mspHelper.writeConfiguration(false, () => {
+                    modesDirtyBaseline.value = serializeModesForDirtyCheck();
+                });
             });
         };
 
@@ -645,6 +674,7 @@ export default defineComponent({
             markerStyle,
             pipStyle,
             saveModes,
+            dirty,
         };
     },
 });

--- a/src/components/tabs/AuxiliaryTab.vue
+++ b/src/components/tabs/AuxiliaryTab.vue
@@ -375,6 +375,48 @@ export default defineComponent({
                 })),
             );
 
+        const serializeModesPayloadForDirtyCheck = (modeRanges, modeRangesExtra) => {
+            const byModeId = new Map(
+                modes.map((mode) => [
+                    mode.id,
+                    {
+                        id: mode.id,
+                        entries: [],
+                    },
+                ]),
+            );
+
+            modeRanges.forEach((range, index) => {
+                const target = byModeId.get(range.id);
+                if (!target || range.id === 0) {
+                    return;
+                }
+
+                const extra = modeRangesExtra[index];
+                const modeLogic = extra?.modeLogic ?? 0;
+                const linkedTo = extra?.linkedTo ?? 0;
+
+                if (linkedTo > 0) {
+                    target.entries.push({
+                        kind: "link",
+                        modeLogic,
+                        linkedTo,
+                    });
+                    return;
+                }
+
+                target.entries.push({
+                    kind: "range",
+                    auxChannelIndex: range.auxChannelIndex,
+                    modeLogic,
+                    start: range.range.start,
+                    end: range.range.end,
+                });
+            });
+
+            return JSON.stringify(Array.from(byModeId.values()));
+        };
+
         const dirty = computed(() => {
             if (!modesDirtyBaseline.value) {
                 return false;
@@ -613,7 +655,7 @@ export default defineComponent({
 
             mspHelper.sendModeRanges(() => {
                 mspHelper.writeConfiguration(false, () => {
-                    modesDirtyBaseline.value = serializeModesForDirtyCheck();
+                    modesDirtyBaseline.value = serializeModesPayloadForDirtyCheck(nextModeRanges, nextModeRangesExtra);
                 });
             });
         };

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -79,16 +79,14 @@
 
         <!-- Bottom toolbar -->
         <div class="content_toolbar xs-compressed toolbar_fixed_bottom flex items-center gap-2">
-            <div class="toolbar_expand_btn" nbrow="2">
-                <em class="fas fa-ellipsis-h"></em>
-            </div>
-            <UButton :label="$t('cliSaveToFileBtn')" @click="cli.saveFile" />
-            <UButton :label="$t('cliLoadFromFileBtn')" @click="handleLoadFile" />
-            <UButton :label="$t('cliClearOutputHistoryBtn')" @click="cli.clearHistory" />
+            <UButton :label="$t('cliSaveToFileBtn')" @click="cli.saveFile" variant="soft" />
+            <UButton :label="$t('cliLoadFromFileBtn')" @click="handleLoadFile" variant="soft" />
+            <UButton :label="$t('cliClearOutputHistoryBtn')" @click="cli.clearHistory" variant="soft" />
             <UButton
                 :label="cli.state.copyButtonText"
                 :style="{ minWidth: cli.state.copyButtonWidth }"
                 @click="cli.copyToClipboard"
+                variant="soft"
             />
             <UButton
                 v-if="cli.isSupportRequestAvailable()"

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -106,12 +106,14 @@ import { TABS } from "../../js/gui";
 import CliAutoComplete from "../../js/CliAutoComplete";
 import { EventBus } from "../eventBus";
 import { i18n } from "../../js/localization";
+import UiBox from "../elements/UiBox.vue";
 
 export default defineComponent({
     name: "CliTab",
     components: {
         BaseTab,
         CliAutocompleteDropdown,
+        UiBox,
     },
     setup() {
         const cli = useCli();

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -1,9 +1,9 @@
 <template>
     <BaseTab tab-name="cli" @mounted="onTabMounted" @cleanup="onTabCleanup">
         <div class="content_wrapper flex flex-col overflow-hidden pb-0 max-[1055px]:h-[calc(100%-87px)]">
-            <div class="note">
+            <UiBox highlight class="mb-3">
                 <p v-html="$t('cliInfo')"></p>
-            </div>
+            </UiBox>
 
             <div
                 class="cli-backdrop grow w-full border border-(--surface-500) bg-black/75 bg-no-repeat bg-[position:50%_80%] bg-[size:600px] rounded-[5px] shadow-[inset_0_0_20px_rgba(0,0,0,0.8)] max-[575px]:bg-[size:100%]"

--- a/src/components/tabs/ConfigurationTab.vue
+++ b/src/components/tabs/ConfigurationTab.vue
@@ -534,7 +534,7 @@
             </div>
         </div>
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('configurationButtonSave')" @click="saveConfig" />
+            <UButton :label="$t('configurationButtonSave')" :disabled="!dirty" @click="saveConfig" />
         </div>
     </div>
 </template>
@@ -982,6 +982,55 @@ export default defineComponent({
         const gyroFrequencyDisplay = ref("");
         const pidDenomOptions = ref([]);
 
+        /** Baseline after UI init or successful save; same pattern as Power / Auxiliary */
+        const configurationBaseline = ref("");
+
+        const snapshotSensorAlignmentForDirty = () => ({
+            gyro_to_use: sensorAlignment.gyro_to_use,
+            gyro_1_align: sensorAlignment.gyro_1_align,
+            gyro_2_align: sensorAlignment.gyro_2_align,
+            align_mag: sensorAlignment.align_mag,
+            gyro_1_align_roll: sensorAlignment.gyro_1_align_roll,
+            gyro_1_align_pitch: sensorAlignment.gyro_1_align_pitch,
+            gyro_1_align_yaw: sensorAlignment.gyro_1_align_yaw,
+            gyro_2_align_roll: sensorAlignment.gyro_2_align_roll,
+            gyro_2_align_pitch: sensorAlignment.gyro_2_align_pitch,
+            gyro_2_align_yaw: sensorAlignment.gyro_2_align_yaw,
+            gyro_align: [...(sensorAlignment.gyro_align || [])],
+            gyro_enable_mask: sensorAlignment.gyro_enable_mask,
+            gyro_align_roll: [...(sensorAlignment.gyro_align_roll || [])],
+            gyro_align_pitch: [...(sensorAlignment.gyro_align_pitch || [])],
+            gyro_align_yaw: [...(sensorAlignment.gyro_align_yaw || [])],
+            mag_align_roll: sensorAlignment.mag_align_roll,
+            mag_align_pitch: sensorAlignment.mag_align_pitch,
+            mag_align_yaw: sensorAlignment.mag_align_yaw,
+        });
+
+        const serializeConfigurationState = () =>
+            JSON.stringify({
+                featureMask: fcStore.features?.features?._featureMask ?? 0,
+                beeperDisabledMask: beeperDisabledMask.value,
+                dshotDisabledMask: dshotDisabledMask.value,
+                dshotBeaconTone: dshotBeaconTone.value,
+                pidAdvancedConfig: { ...pidAdvancedConfig },
+                sensorConfig: { ...sensorConfig },
+                boardAlignment: { ...boardAlignment },
+                fpvCamAngleDegrees: fpvCamAngleDegrees.value,
+                craftName: craftName.value,
+                pilotName: pilotName.value,
+                armingConfig: { ...armingConfig },
+                accelTrims: { ...accelTrims },
+                sensorAlignment: snapshotSensorAlignmentForDirty(),
+                magDeclination: magDeclination.value,
+            });
+
+        const dirty = computed(() => {
+            if (!configurationBaseline.value) {
+                return false;
+            }
+            return configurationBaseline.value !== serializeConfigurationState();
+        });
+
         // Loading Logic
         const loadConfig = async () => {
             try {
@@ -1166,6 +1215,8 @@ export default defineComponent({
                 opticalFlowTypesList.value = sensorTypesData.value?.opticalflow.elements || [];
                 showOpticalFlow.value = opticalFlowTypesList.value.length > 0;
             }
+
+            configurationBaseline.value = serializeConfigurationState();
         };
 
         const updateGyroDenom = (gyroFrequency) => {
@@ -1320,6 +1371,8 @@ export default defineComponent({
 
                 gui_log(i18n.getMessage("configurationSaved"));
 
+                configurationBaseline.value = serializeConfigurationState();
+
                 // Save to EEPROM and Reboot
                 await new Promise((resolve) => {
                     mspHelper.writeConfiguration(false, () => {
@@ -1399,6 +1452,7 @@ export default defineComponent({
             toggleGyro,
             updateGyroAlign,
             saveConfig,
+            dirty,
         };
     },
 });

--- a/src/components/tabs/FailsafeTab.vue
+++ b/src/components/tabs/FailsafeTab.vue
@@ -375,12 +375,7 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton
-                :label="$t('configurationButtonSave')"
-                :disabled="!configHasChanged"
-                :color="configHasChanged ? 'success' : 'neutral'"
-                @click="saveConfig"
-            />
+            <UButton :label="$t('configurationButtonSave')" :disabled="!configHasChanged" @click="saveConfig" />
         </div>
     </BaseTab>
 </template>

--- a/src/components/tabs/FailsafeTab.vue
+++ b/src/components/tabs/FailsafeTab.vue
@@ -14,7 +14,7 @@
                 <!-- Left Column -->
                 <div class="flex flex-col gap-4">
                     <!-- Pulse Range Settings -->
-                    <UiBox type="neutral" :title="$t('failsafePulsrangeTitle')" :help="$t('failsafePulsrangeHelp')">
+                    <UiBox :title="$t('failsafePulsrangeTitle')" :help="$t('failsafePulsrangeHelp')">
                         <SettingRow :label="$t('failsafeRxMinUsecItem')">
                             <UInputNumber
                                 v-model="rxConfig.rx_min_usec"
@@ -43,7 +43,6 @@
 
                     <!-- Channel Fallback Settings -->
                     <UiBox
-                        type="neutral"
                         :title="$t('failsafeChannelFallbackSettingsTitle')"
                         :help="$t('failsafeChannelFallbackSettingsHelp')"
                     >
@@ -78,7 +77,7 @@
                 <!-- Right Column -->
                 <div class="flex flex-col gap-4">
                     <!-- Failsafe Switch -->
-                    <UiBox type="neutral" :title="$t('failsafeSwitchTitle')">
+                    <UiBox :title="$t('failsafeSwitchTitle')">
                         <SettingRow :label="$t('failsafeSwitchModeItem')" :help="$t('failsafeSwitchModeHelp')">
                             <USelect
                                 v-model="failsafeConfig.failsafe_switch_mode"
@@ -89,7 +88,7 @@
                     </UiBox>
 
                     <!-- Stage 2 Settings -->
-                    <UiBox type="neutral" :title="$t('failsafeStageTwoSettingsTitle')">
+                    <UiBox :title="$t('failsafeStageTwoSettingsTitle')">
                         <SettingRow :label="$t('failsafeDelayItem')" :help="$t('failsafeDelayHelp')">
                             <UInputNumber
                                 v-model="failsafeDelay"

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -435,7 +435,7 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UFieldGroup size="sm" orientation="horizontal" class="!flex">
+            <UFieldGroup size="sm" orientation="horizontal" class="flex!">
                 <UButton
                     :disabled="state.flashButtonDisabled"
                     :color="state.flashButtonDisabled ? 'neutral' : 'success'"
@@ -451,7 +451,7 @@
                     />
                 </UDropdownMenu>
             </UFieldGroup>
-            <UFieldGroup size="sm" orientation="horizontal" class="!flex">
+            <UFieldGroup size="sm" orientation="horizontal" class="flex!">
                 <UButton :disabled="state.loadRemoteButtonDisabled" @click="handleLoadRemoteFile">{{
                     $t("firmwareFlasherButtonLoadOnline")
                 }}</UButton>

--- a/src/components/tabs/FlightPlan/ElevationProfile.vue
+++ b/src/components/tabs/FlightPlan/ElevationProfile.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('flightPlanElevationProfile')" type="neutral" class="elevation-profile">
+    <UiBox :title="$t('flightPlanElevationProfile')" class="elevation-profile">
         <template v-if="waypoints.length > 0">
             <div class="profile-stats">
                 <span class="stat">

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('flightPlanMap')" type="neutral" class="flight-plan-map">
+    <UiBox :title="$t('flightPlanMap')" class="flight-plan-map">
         <div class="map-container">
             <div ref="mapRef" class="map"></div>
             <div v-if="isLoading" class="map-loading">

--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('flightPlanWaypointList')" type="neutral" class="waypoint-list">
+    <UiBox :title="$t('flightPlanWaypointList')" class="waypoint-list">
         <div class="flex justify-end">
             <UButton
                 icon="i-lucide-plus"

--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -9,9 +9,9 @@
             />
         </div>
 
-        <div v-if="!waypoints.length" class="note">
+        <UiBox highlight class="mb-3" v-if="!waypoints.length">
             <p v-html="$t('flightPlanNoWaypoints')"></p>
-        </div>
+        </UiBox>
         <div v-else class="waypoints">
             <div
                 v-for="waypoint in sortedWaypoints"

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -244,9 +244,10 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <div class="btn save_btn">
+            <!-- <div class="btn save_btn">
                 <button type="button" class="save" @click="saveConfig">{{ $t("configurationButtonSave") }}</button>
-            </div>
+            </div> -->
+            <UButton :label="$t('configurationButtonSave')" :disabled="!dirty" @click="saveConfig" />
         </div>
     </BaseTab>
 </template>
@@ -351,6 +352,27 @@ export default defineComponent({
             ublox_use_galileo: 0,
             ublox_sbas: 0,
             home_point_once: 0,
+        });
+
+        /** Baseline after MSP load or successful save; same pattern as Power/Auxiliary tabs */
+        const gpsTabBaseline = ref("");
+
+        const serializeGpsTabState = () =>
+            JSON.stringify({
+                featureMask: fcStore.features?.features?._featureMask ?? 0,
+                provider: gpsConfig.provider,
+                auto_baud: gpsConfig.auto_baud,
+                auto_config: gpsConfig.auto_config,
+                ublox_use_galileo: gpsConfig.ublox_use_galileo,
+                ublox_sbas: gpsConfig.ublox_sbas,
+                home_point_once: gpsConfig.home_point_once,
+            });
+
+        const dirty = computed(() => {
+            if (!gpsTabBaseline.value) {
+                return false;
+            }
+            return gpsTabBaseline.value !== serializeGpsTabState();
         });
 
         const ubloxIndex = computed(() => gpsProtocols.value.indexOf("UBLOX"));
@@ -705,6 +727,8 @@ export default defineComponent({
 
                 await updateGpsProtocols();
 
+                gpsTabBaseline.value = serializeGpsTabState();
+
                 isOnline.value = ispConnected();
                 isWaiting.value = true;
                 showMap.value = false;
@@ -726,6 +750,7 @@ export default defineComponent({
             await MSP.promise(MSPCodes.MSP_SET_GPS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_GPS_CONFIG));
 
             mspHelper.writeConfiguration(true);
+            gpsTabBaseline.value = serializeGpsTabState();
         };
 
         const initializeMap = () => {
@@ -818,6 +843,7 @@ export default defineComponent({
             toggleFullscreen,
             checkConnectivity,
             saveConfig,
+            dirty,
             onGpsProtocolChange,
             loadingBarsUrl,
         };

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -327,7 +327,7 @@
 
         <!-- Bottom Toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton size="md" color="primary" class="save_btn" :label="saveButtonText" @click="save" />
+            <UButton :label="saveButtonText" @click="save" />
         </div>
     </BaseTab>
 </template>

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -4,9 +4,9 @@
             <div class="tab_title" v-html="$t('tabLedStrip')"></div>
             <WikiButton doc-url="led-strip" />
 
-            <div class="note">
+            <UiBox highlight class="mb-3">
                 <p v-html="$t('ledStripHelp')"></p>
-            </div>
+            </UiBox>
 
             <!-- LED Grid Container -->
             <div class="grid-container">
@@ -345,6 +345,7 @@ import GUI from "@/js/gui";
 import semver from "semver";
 import FC from "@/js/fc";
 import { API_VERSION_1_46 } from "@/js/data_storage";
+import UiBox from "../elements/UiBox.vue";
 
 // Decode HTML entities in translations (some use &amp; etc) so plain-text
 // component props (e.g. USelect item labels) render correctly.

--- a/src/components/tabs/LoggingTab.vue
+++ b/src/components/tabs/LoggingTab.vue
@@ -7,7 +7,7 @@
                 <p v-html="$t('loggingNote')"></p>
             </div>
 
-            <UiBox type="neutral" :title="$t('loggingPropertiesTitle')" class="mt-6">
+            <UiBox :title="$t('loggingPropertiesTitle')" class="mt-6">
                 <div class="flex flex-col gap-1.5">
                     <div v-for="prop in propertyOptions" :key="prop.code" class="flex items-center gap-3">
                         <USwitch
@@ -33,7 +33,7 @@
                 />
             </SettingRow>
 
-            <UiBox type="neutral" class="mt-4">
+            <UiBox class="mt-4">
                 <div class="flex flex-col gap-1">
                     <div class="flex items-center gap-2">
                         <span class="text-sm font-semibold" v-html="$t('loggingSamplesSaved')"></span>

--- a/src/components/tabs/LoggingTab.vue
+++ b/src/components/tabs/LoggingTab.vue
@@ -3,9 +3,9 @@
         <div class="content_wrapper">
             <div class="tab_title" v-html="$t('tabLogging')"></div>
             <WikiButton docUrl="logging" />
-            <div class="note">
+            <UiBox highlight class="mb-3">
                 <p v-html="$t('loggingNote')"></p>
-            </div>
+            </UiBox>
 
             <UiBox :title="$t('loggingPropertiesTitle')" class="mt-6">
                 <div class="flex flex-col gap-1.5">

--- a/src/components/tabs/LoggingTab.vue
+++ b/src/components/tabs/LoggingTab.vue
@@ -48,11 +48,16 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
-            <UButton :label="$t('loggingButtonLogFile')" :disabled="isLogging || isBusy" @click="selectLogFile" />
+            <UButton
+                :label="$t('loggingButtonLogFile')"
+                :disabled="isLogging || isBusy"
+                @click="selectLogFile"
+                variant="soft"
+            />
             <UButton
                 :label="startStopLabel"
                 :disabled="!canToggle"
-                :color="isLogging ? 'error' : selectedProperties.length ? 'success' : 'neutral'"
+                :color="isLogging ? 'error' : selectedProperties.length ? 'success' : 'primary'"
                 @click="toggleLogging"
             />
         </div>

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -487,16 +487,15 @@
         <div class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2">
                 <UButton
-                    :label="$t('configurationButtonSave')"
-                    :disabled="buttonStates.saveDisabled"
-                    :color="buttonStates.saveDisabled ? 'neutral' : 'success'"
-                    @click="saveAndReboot(true)"
-                />
-                <UButton
                     :label="$t('escDshotDirectionDialog-StopWizard')"
                     :disabled="buttonStates.stopDisabled"
                     @click="stopMotors()"
-                    :color="motorsTestingEnabled ? 'error' : 'neutral'"
+                    color="error"
+                />
+                <UButton
+                    :label="$t('configurationButtonSave')"
+                    :disabled="buttonStates.saveDisabled"
+                    @click="saveAndReboot(true)"
                 />
             </div>
         </div>

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -10,7 +10,7 @@
                 <div class="col-span-1">
                     <div class="flex flex-col gap-4">
                         <!-- MIXER -->
-                        <UiBox :title="$t('configurationMixer')" type="neutral">
+                        <UiBox :title="$t('configurationMixer')">
                             <USelect v-model="fcStore.mixerConfig.mixer" :items="sortedMixerListItems" />
                             <SettingRow
                                 :label="$t('configurationReverseMotorSwitch')"
@@ -39,7 +39,7 @@
                             </div>
                         </UiBox>
                         <!-- ESC FEATURES -->
-                        <UiBox :title="$t('configurationEscFeatures')" type="neutral">
+                        <UiBox :title="$t('configurationEscFeatures')">
                             <div v-if="!protocolConfigured" class="text-sm text-orange-500">
                                 <p v-html="$t('configurationEscProtocolDisabled')"></p>
                             </div>
@@ -202,7 +202,7 @@
                             </SettingRow>
                         </UiBox>
                         <!-- 3D -->
-                        <UiBox :title="$t('configuration3d')" type="neutral">
+                        <UiBox :title="$t('configuration3d')">
                             <SettingRow :help="$t('feature3DTip')" full-width>
                                 <USwitch
                                     :model-value="isFeatureEnabled('3D')"
@@ -257,7 +257,7 @@
                     <!-- MOTOR TEST SECTION -->
                     <div class="flex flex-col gap-3">
                         <!-- SENSOR GRAPH SECTION -->
-                        <UiBox type="neutral">
+                        <UiBox>
                             <div class="graph-grid">
                                 <svg ref="graphSvg" id="graph" class="w-full h-full">
                                     <g class="grid x" transform="translate(40, 120)"></g>

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -268,9 +268,6 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <!-- <div class="btn save_btn">
-                <button type="button" class="save" @click="saveSettings">{{ $t("blackboxButtonSave") }}</button>
-            </div> -->
             <UButton :label="$t('blackboxButtonSave')" :disabled="!dirty" @click="saveSettings" />
         </div>
     </BaseTab>

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -268,9 +268,10 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <div class="btn save_btn">
+            <!-- <div class="btn save_btn">
                 <button type="button" class="save" @click="saveSettings">{{ $t("blackboxButtonSave") }}</button>
-            </div>
+            </div> -->
+            <UButton :label="$t('blackboxButtonSave')" :disabled="!dirty" @click="saveSettings" />
         </div>
     </BaseTab>
 </template>
@@ -528,6 +529,24 @@ export default defineComponent({
             );
         });
 
+        /** Baseline after MSP load or successful save; same pattern as Power / Auxiliary */
+        const onboardLoggingBaseline = ref("");
+
+        const serializeOnboardLoggingState = () =>
+            JSON.stringify({
+                blackboxDevice: blackboxDevice.value,
+                blackboxRate: blackboxRate.value,
+                debugMode: debugMode.value,
+                debugFieldsEnabled: [...debugFieldsEnabled.value],
+            });
+
+        const dirty = computed(() => {
+            if (!onboardLoggingBaseline.value) {
+                return false;
+            }
+            return onboardLoggingBaseline.value !== serializeOnboardLoggingState();
+        });
+
         function updateDebugField(index, value) {
             // Use splice to ensure Vue 3 reactivity
             debugFieldsEnabled.value.splice(index, 1, value);
@@ -557,6 +576,7 @@ export default defineComponent({
             await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
 
             mspHelper.writeConfiguration(true);
+            onboardLoggingBaseline.value = serializeOnboardLoggingState();
         }
 
         function askToEraseFlash() {
@@ -855,6 +875,7 @@ export default defineComponent({
                 }
 
                 updateVirtualGyro();
+                onboardLoggingBaseline.value = serializeOnboardLoggingState();
                 updateHtml();
             } catch (error) {
                 console.error("Failed to load onboard logging data", error);
@@ -912,6 +933,7 @@ export default defineComponent({
             formatKilobytes,
             updateDebugField,
             saveSettings,
+            dirty,
             askToEraseFlash,
             flashErase,
             flashEraseCancel,

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -52,7 +52,7 @@
                                         icon: 'i-lucide-search',
                                     }"
                                     class="min-w-64"
-                                    :ui="{ content: 'max-h-72 z-[9999]' }"
+                                    :ui="{ content: 'max-h-72' }"
                                 />
                             </SettingRow>
                         </UiBox>

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -34,7 +34,7 @@
                 <div class="grid-row grid-box col4">
                     <!-- Elements Column -->
                     <div class="col-span-1">
-                        <UiBox :title="$t('osdSetupElementsTitle')" :help="$t('osdSectionHelpElements')" type="neutral">
+                        <UiBox :title="$t('osdSetupElementsTitle')" :help="$t('osdSectionHelpElements')">
                             <template #title>
                                 <HelpIcon :text="$t('osdSetupProfilesTitle')" />
                                 <span
@@ -222,7 +222,7 @@
                     <!-- Settings Column -->
                     <div class="col-span-1">
                         <!-- Active Profile Selector -->
-                        <UiBox :title="$t('osdSetupSelectedProfileTitle')" type="neutral">
+                        <UiBox :title="$t('osdSetupSelectedProfileTitle')">
                             <SettingRow :label="$t('osdSetupSelectedProfileTitle')">
                                 <USelect v-model="activeProfile" :items="profileOptions" size="xs" />
                             </SettingRow>
@@ -236,7 +236,6 @@
                             v-if="osdStore.state.haveMax7456Configured || osdStore.state.isMspDevice"
                             :title="$t('osdSetupVideoFormatTitle')"
                             :help="$t('osdSectionHelpVideoMode')"
-                            type="neutral"
                         >
                             <SettingRow :label="$t('osdSetupVideoFormatTitle')">
                                 <USelect
@@ -258,7 +257,6 @@
                             v-if="osdStore.state.haveOsdFeature"
                             :title="$t('osdSetupUnitsTitle')"
                             :help="$t('osdSectionHelpUnits')"
-                            type="neutral"
                         >
                             <SettingRow :label="$t('osdSetupUnitsTitle')">
                                 <USelect
@@ -280,7 +278,6 @@
                             v-if="osdStore.state.haveOsdFeature && osdStore.timers.length > 0"
                             :title="$t('osdSetupTimersTitle')"
                             :help="$t('osdSectionHelpTimers')"
-                            type="neutral"
                         >
                             <div
                                 v-for="(timer, idx) in osdStore.timers"
@@ -335,7 +332,6 @@
                             v-if="osdStore.state.haveOsdFeature && alarmEntries.length > 0"
                             :title="$t('osdSetupAlarmsTitle')"
                             :help="$t('osdSectionHelpAlarms')"
-                            type="neutral"
                         >
                             <div
                                 v-for="entry in alarmEntries"
@@ -362,7 +358,6 @@
                             v-if="osdStore.state.haveOsdFeature && sortedWarnings.length > 0"
                             :title="$t('osdSetupWarningsTitle')"
                             :help="$t('osdSectionHelpWarnings')"
-                            type="neutral"
                         >
                             <div
                                 v-for="warning in sortedWarnings"
@@ -390,7 +385,6 @@
                             v-if="osdStore.state.haveOsdFeature && sortedStatItems.length > 0"
                             :title="$t('osdSetupStatsTitle')"
                             :help="$t('osdSectionHelpStats')"
-                            type="neutral"
                         >
                             <div
                                 v-for="stat in sortedStatItems"

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -504,23 +504,19 @@
         <!-- Bottom Toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2 items-center">
-                <UButton :disabled="!osdStore.state.isMax7456FontDeviceDetected" @click="openFontManager()">
+                <UButton
+                    :disabled="!osdStore.state.isMax7456FontDeviceDetected"
+                    @click="openFontManager()"
+                    variant="soft"
+                >
                     {{ $t("osdSetupFontManagerTitle") }}
                 </UButton>
                 <UFieldGroup size="sm" orientation="horizontal" class="flex!">
-                    <UButton
-                        @click="saveConfig()"
-                        :disabled="!osdStore.dirty"
-                        :color="osdStore.dirty ? 'success' : 'neutral'"
-                    >
+                    <UButton @click="saveConfig()" :disabled="!osdStore.dirty">
                         {{ saveButtonText }}
                     </UButton>
                     <UDropdownMenu v-slot="{ open }" :items="saveMenuItems" :content="{ align: 'end', side: 'top' }">
-                        <UButton
-                            :color="osdStore.dirty ? 'success' : 'neutral'"
-                            :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
-                            square
-                        />
+                        <UButton :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" square />
                     </UDropdownMenu>
                 </UFieldGroup>
             </div>

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -113,17 +113,12 @@
             <!-- Save/Revert Buttons -->
             <div class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
                 <UButton
-                    :label="$t('pidTuningButtonSave')"
-                    :color="hasChanges ? 'success' : 'primary'"
-                    :disabled="!hasChanges"
-                    @click="save"
-                />
-                <UButton
                     :label="$t('pidTuningButtonRefresh')"
-                    :color="hasChanges ? 'primary' : 'neutral'"
                     :disabled="!hasChanges"
                     @click="refresh"
+                    variant="soft"
                 />
+                <UButton :label="$t('pidTuningButtonSave')" :disabled="!hasChanges" @click="save" />
             </div>
         </div>
     </BaseTab>

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -100,12 +100,7 @@
 
                 <!-- Mobile: card per port -->
                 <div v-else class="flex flex-col gap-3">
-                    <UiBox
-                        v-for="port in ports"
-                        :key="port.identifier"
-                        :title="getPortName(port.identifier)"
-                        type="neutral"
-                    >
+                    <UiBox v-for="port in ports" :key="port.identifier" :title="getPortName(port.identifier)">
                         <!-- MSP -->
                         <div class="flex items-center gap-2">
                             <USwitch v-model="port.msp" :disabled="port.identifier === 20" size="sm" />

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -16,7 +16,7 @@
                     <p v-html="$t('portsVtxTableNotSet')"></p>
                 </UiBox>
 
-                <div v-if="!tabReady || ports.length === 0" class="flex items-center justify-center py-16">
+                <div v-if="!tabReady || isLoading" class="flex items-center justify-center py-16">
                     <UIcon name="i-lucide-loader-circle" class="size-8 animate-spin text-muted" />
                     <span class="ml-2 text-dimmed">{{ $t("dataWaitingForData") }}</span>
                 </div>
@@ -195,7 +195,7 @@ const isDesktop = useMediaQuery("(min-width: 1010px)");
 const { functionRules, mspBaudRates, gpsBaudRates, telemetryBaudRates, blackboxBaudRates, getRules, isRuleDisabled } =
     usePortsRules();
 
-const { ports, analyticsChanges, getPortName, vtxTableNotConfigured, dirty } = usePortsState(getRules);
+const { ports, analyticsChanges, getPortName, vtxTableNotConfigured, dirty, isLoading } = usePortsState(getRules);
 
 const { saveConfig, onTelemetryChange, onPeripheralChange } = usePortsConfiguration(
     ports,

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -16,8 +16,13 @@
                     <p v-html="$t('portsVtxTableNotSet')"></p>
                 </UiBox>
 
-                <!-- Desktop: grid table (hidden below 1010px) -->
-                <div class="max-[1010px]:hidden mt-4">
+                <div v-if="!tabReady || ports.length === 0" class="flex items-center justify-center py-16">
+                    <UIcon name="i-lucide-loader-circle" class="size-8 animate-spin text-muted" />
+                    <span class="ml-2 text-dimmed">{{ $t("dataWaitingForData") }}</span>
+                </div>
+
+                <!-- Desktop: grid table -->
+                <div v-else-if="isDesktop" class="mt-4">
                     <div class="grid grid-cols-[auto_auto_auto_auto_auto_auto] justify-between text-xs">
                         <!-- Header -->
                         <div class="p-2 font-semibold" v-html="$t('portsIdentifier')"></div>
@@ -93,8 +98,8 @@
                     </div>
                 </div>
 
-                <!-- Mobile: card per port (hidden at 1010px+) -->
-                <div class="flex flex-col gap-3 min-[1010px]:hidden">
+                <!-- Mobile: card per port -->
+                <div v-else class="flex flex-col gap-3">
                     <UiBox
                         v-for="port in ports"
                         :key="port.identifier"
@@ -182,7 +187,8 @@
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, onMounted, ref } from "vue";
+import { useMediaQuery } from "@vueuse/core";
 import BaseTab from "./BaseTab.vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
@@ -193,6 +199,8 @@ import { usePortsState } from "../../composables/ports/usePortsState";
 import { usePortsConfiguration } from "../../composables/ports/usePortsConfiguration";
 
 const { t } = useTranslation();
+
+const isDesktop = useMediaQuery("(min-width: 1010px)");
 
 const { functionRules, mspBaudRates, gpsBaudRates, telemetryBaudRates, blackboxBaudRates, getRules, isRuleDisabled } =
     usePortsRules();
@@ -205,11 +213,20 @@ const { saveConfig, onTelemetryChange, onPeripheralChange } = usePortsConfigurat
     functionRules,
 );
 
-// USelect items
-const mspBaudItems = computed(() => mspBaudRates.map((r) => ({ value: r, label: r })));
-const gpsBaudItems = computed(() => gpsBaudRates.map((r) => ({ value: r, label: r })));
-const telemetryBaudItems = computed(() => telemetryBaudRates.map((r) => ({ value: r, label: r })));
-const blackboxBaudItems = computed(() => blackboxBaudRates.map((r) => ({ value: r, label: r })));
+const tabReady = ref(false);
+
+onMounted(() => {
+    requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+            tabReady.value = true;
+        });
+    });
+});
+
+const mspBaudItems = mspBaudRates.map((r) => ({ value: r, label: r }));
+const gpsBaudItems = gpsBaudRates.map((r) => ({ value: r, label: r }));
+const telemetryBaudItems = telemetryBaudRates.map((r) => ({ value: r, label: r }));
+const blackboxBaudItems = blackboxBaudRates.map((r) => ({ value: r, label: r }));
 
 const NONE = "_NONE_";
 const disabledLabel = computed(() => t("portsTelemetryDisabled"));
@@ -229,7 +246,6 @@ const peripheralItems = computed(() => [
     ...getRules("peripherals").map((r) => ({ value: r.name, label: r.displayName, disabled: isRuleDisabled(r) })),
 ]);
 
-// Map between "" in port data and NONE sentinel for USelect
 function portFieldGet(port, field) {
     return port[field] || NONE;
 }

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -175,12 +175,7 @@
 
         <div class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2">
-                <UButton
-                    :label="$t('configurationButtonSave')"
-                    :disabled="!dirty"
-                    :color="dirty ? 'success' : 'neutral'"
-                    @click="saveConfig"
-                />
+                <UButton :label="$t('configurationButtonSave')" :disabled="!dirty" @click="saveConfig" />
             </div>
         </div>
     </BaseTab>

--- a/src/components/tabs/PowerTab.vue
+++ b/src/components/tabs/PowerTab.vue
@@ -253,18 +253,13 @@
 
         <!-- Bottom Toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom">
-            <div class="btn calibration" v-show="showCalibration">
-                <button
-                    type="button"
-                    class="calibrationmanager"
-                    id="calibrationmanager"
-                    @click="openCalibrationManager"
-                    v-html="$t('powerCalibrationManagerButton')"
-                ></button>
-            </div>
-            <div class="btn save_btn">
-                <button type="button" class="save" @click="handleSave" v-html="$t('powerButtonSave')"></button>
-            </div>
+            <UButton
+                :label="$t('powerCalibrationManagerButton')"
+                v-if="showCalibration"
+                @click="openCalibrationManager"
+                variant="soft"
+            />
+            <UButton :label="$t('powerButtonSave')" :disabled="!dirty" @click="handleSave" />
         </div>
 
         <!-- Calibration Manager Dialog -->
@@ -424,6 +419,7 @@ export default defineComponent({
             vbatnewscale,
             amperagenewscale,
             sourceschanged,
+            dirty,
         } = usePower();
 
         const calibrationVisibility = computed(() => getCalibrationVisibility());
@@ -554,6 +550,7 @@ export default defineComponent({
             handleApplyCalibration,
             handleDiscardCalibration,
             handleCalibrationConfirmClose,
+            dirty,
         };
     },
 });

--- a/src/components/tabs/PowerTab.vue
+++ b/src/components/tabs/PowerTab.vue
@@ -108,9 +108,9 @@
 
                     <!-- Voltage Configuration -->
                     <UiBox v-show="showVoltageConfiguration" :title="$t('powerVoltageHead')">
-                        <div class="note">
+                        <UiBox highlight class="mb-3">
                             <div v-html="$t('powerVoltageWarning')"></div>
-                        </div>
+                        </UiBox>
                         <div
                             v-for="(meter, index) in voltageMeters"
                             :key="`voltage-${index}`"
@@ -197,9 +197,9 @@
 
                     <!-- Amperage Configuration -->
                     <UiBox v-show="showAmperageConfiguration" :title="$t('powerAmperageHead')">
-                        <div class="note">
+                        <UiBox highlight class="mb-3">
                             <div v-html="$t('powerAmperageWarning')"></div>
-                        </div>
+                        </UiBox>
                         <div
                             v-for="(meter, index) in currentMeters"
                             :key="`amperage-${index}`"
@@ -246,9 +246,9 @@
                 </div>
             </div>
 
-            <div class="note hidden">
+            <UiBox highlight class="mb-3" hidden>
                 <p v-html="$t('powerFirmwareUpgradeRequired')"></p>
-            </div>
+            </UiBox>
         </div>
 
         <!-- Bottom Toolbar -->
@@ -264,18 +264,18 @@
 
         <!-- Calibration Manager Dialog -->
         <Dialog v-model="showCalibrationManagerDialog" :title="$t('powerCalibrationManagerTitle')">
-            <div class="note">
+            <UiBox highlight class="mb-3">
                 <p v-html="$t('powerCalibrationManagerHelp')"></p>
-            </div>
-            <div class="note">
+            </UiBox>
+            <UiBox highlight class="mb-3">
                 <p v-html="$t('powerCalibrationManagerNote')"></p>
-            </div>
-            <div class="note nocalib" v-show="calibrationVisibility.showNoCalib">
+            </UiBox>
+            <UiBox highlight class="mb-3" v-show="calibrationVisibility.showNoCalib">
                 <p v-html="$t('powerCalibrationManagerWarning')"></p>
-            </div>
-            <div class="note srcchange" v-show="calibrationVisibility.showSrcChange">
+            </UiBox>
+            <UiBox highlight class="mb-3" v-show="calibrationVisibility.showSrcChange">
                 <p v-html="$t('powerCalibrationManagerSourceNote')"></p>
-            </div>
+            </UiBox>
             <div v-show="calibrationVisibility.showVbat">
                 <SettingRow :label="$t('powerVoltageCalibration')">
                     <UInputNumber
@@ -323,9 +323,9 @@
             :title="$t('powerCalibrationManagerConfirmationTitle')"
             @close="handleCalibrationConfirmClose"
         >
-            <div class="note">
+            <UiBox highlight class="mb-3">
                 <p v-html="$t('powerCalibrationConfirmHelp')"></p>
-            </div>
+            </UiBox>
             <div v-show="vbatscalechanged" class="flex justify-between items-center font-semibold">
                 <span v-html="$t('powerVoltageCalibratedScale')"></span>
                 <span>{{ vbatnewscale }}</span>

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -104,17 +104,13 @@
         <div class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2">
                 <UButton
-                    :label="$t('presetsButtonSave')"
-                    :disabled="!store.canApply"
-                    :color="store.canApply ? 'success' : 'neutral'"
-                    @click="applyPickedPresets()"
-                />
-                <UButton
                     :label="$t('presetsButtonCancel')"
                     :disabled="!store.canApply"
-                    :color="store.canApply ? 'primary' : 'neutral'"
                     @click="store.clearPickedPresets()"
+                    color="error"
+                    variant="soft"
                 />
+                <UButton :label="$t('presetsButtonSave')" :disabled="!store.canApply" @click="applyPickedPresets()" />
             </div>
         </div>
 

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -10,7 +10,7 @@
             <div class="grid-row grid-box col5">
                 <!-- Left Column: Model Preview + Channel Bars -->
                 <div class="col-span-2">
-                    <UiBox :title="$t('receiverModelPreview')">
+                    <UiBox :title="$t('receiverModelPreview')" :padding="false" class="bg-muted">
                         <div class="background_paper h-48 w-full" ref="modelPreviewContainer">
                             <canvas ref="modelCanvas"></canvas>
                         </div>

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -476,9 +476,14 @@
 
         <!-- Bottom Toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('receiverButtonSticks')" @click="openSticksWindow" v-if="showSticksButton" />
-            <UButton :label="$t('receiverButtonBind')" @click="sendBind" v-if="showBindButton" />
-            <UButton :label="$t('receiverButtonRefresh')" @click="refreshTab" />
+            <UButton
+                :label="$t('receiverButtonSticks')"
+                @click="openSticksWindow"
+                v-if="showSticksButton"
+                variant="soft"
+            />
+            <UButton :label="$t('receiverButtonBind')" @click="sendBind" v-if="showBindButton" variant="soft" />
+            <UButton :label="$t('receiverButtonRefresh')" @click="refreshTab" variant="soft" />
             <UButton :label="$t('receiverButtonSave')" @click="saveConfig(false)" v-if="!needReboot" />
             <UButton :label="$t('receiverButtonSave')" @click="saveConfig(true)" v-else />
         </div>

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -12,7 +12,7 @@
                 <p v-html="$t('sensorsInfo')"></p>
             </UiBox>
 
-            <UiBox type="neutral">
+            <UiBox>
                 <div class="flex flex-wrap items-center gap-x-5 gap-y-2 p-2">
                     <USwitch
                         v-model="checkboxes[0]"

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -1,6 +1,6 @@
 <template>
     <BaseTab tab-name="sensors">
-        <div class="content_wrapper flex flex-col gap-4">
+        <div class="content_wrapper">
             <div>
                 <div class="tab_title" v-html="$t('tabRawSensorData')"></div>
                 <div class="cf_doc_version_bt">
@@ -8,95 +8,94 @@
                 </div>
             </div>
 
-            <UiBox type="warning" highlight>
-                <p v-html="$t('sensorsInfo')"></p>
-            </UiBox>
-
-            <UiBox>
-                <div class="flex flex-wrap items-center gap-x-5 gap-y-2 p-2">
-                    <USwitch
-                        v-model="checkboxes[0]"
-                        :disabled="!hasGyro"
-                        size="sm"
-                        :label="$t('sensorsGyroSelect')"
-                        @update:model-value="onCheckboxChange"
-                    />
-                    <USwitch
-                        v-model="checkboxes[1]"
-                        :disabled="!hasAccel"
-                        size="sm"
-                        :label="$t('sensorsAccelSelect')"
-                        @update:model-value="onCheckboxChange"
-                    />
-                    <USwitch
-                        v-model="checkboxes[2]"
-                        :disabled="!hasMag"
-                        size="sm"
-                        :label="$t('sensorsMagSelect')"
-                        @update:model-value="onCheckboxChange"
-                    />
-                    <USwitch
-                        v-model="checkboxes[3]"
-                        :disabled="!hasAltitude"
-                        size="sm"
-                        :label="$t('sensorsAltitudeSelect')"
-                        @update:model-value="onCheckboxChange"
-                    />
-                    <USwitch
-                        v-model="checkboxes[4]"
-                        :disabled="!hasSonar"
-                        size="sm"
-                        :label="$t('sensorsSonarSelect')"
-                        @update:model-value="onCheckboxChange"
-                    />
-                    <USwitch
-                        v-model="checkboxes[5]"
-                        :disabled="!hasDebug"
-                        size="sm"
-                        :label="$t('sensorsDebugSelect')"
-                        @update:model-value="onCheckboxChange"
+            <div class="flex flex-col gap-4">
+                <UiBox type="warning" highlight>
+                    <p v-html="$t('sensorsInfo')"></p>
+                </UiBox>
+                <UiBox>
+                    <div class="flex flex-wrap items-center gap-x-5 gap-y-2 p-2">
+                        <USwitch
+                            v-model="checkboxes[0]"
+                            :disabled="!hasGyro"
+                            size="sm"
+                            :label="$t('sensorsGyroSelect')"
+                            @update:model-value="onCheckboxChange"
+                        />
+                        <USwitch
+                            v-model="checkboxes[1]"
+                            :disabled="!hasAccel"
+                            size="sm"
+                            :label="$t('sensorsAccelSelect')"
+                            @update:model-value="onCheckboxChange"
+                        />
+                        <USwitch
+                            v-model="checkboxes[2]"
+                            :disabled="!hasMag"
+                            size="sm"
+                            :label="$t('sensorsMagSelect')"
+                            @update:model-value="onCheckboxChange"
+                        />
+                        <USwitch
+                            v-model="checkboxes[3]"
+                            :disabled="!hasAltitude"
+                            size="sm"
+                            :label="$t('sensorsAltitudeSelect')"
+                            @update:model-value="onCheckboxChange"
+                        />
+                        <USwitch
+                            v-model="checkboxes[4]"
+                            :disabled="!hasSonar"
+                            size="sm"
+                            :label="$t('sensorsSonarSelect')"
+                            @update:model-value="onCheckboxChange"
+                        />
+                        <USwitch
+                            v-model="checkboxes[5]"
+                            :disabled="!hasDebug"
+                            size="sm"
+                            :label="$t('sensorsDebugSelect')"
+                            @update:model-value="onCheckboxChange"
+                        />
+                    </div>
+                </UiBox>
+                <!-- Sensors -->
+                <SensorGraph
+                    v-for="sensor in sensorConfigs"
+                    :key="sensor.type"
+                    :ref="(el) => setSensorRef(sensor.type, el)"
+                    :sensor-type="sensor.type"
+                    :svg-id="sensor.type"
+                    :visible="checkboxes[sensor.checkboxIndex]"
+                    :title="$t(sensor.titleKey)"
+                    :hint="sensor.hintKey ? $t(sensor.hintKey) : null"
+                    :rate="rates[sensor.type]"
+                    @update:rate="updateRate(sensor.type, $event)"
+                    :scale="sensor.hasScale ? scales[sensor.type] : null"
+                    @update:scale="sensor.hasScale ? updateScale(sensor.type, $event) : null"
+                    :scale-options="sensor.scaleOptions"
+                    :display-values="sensor.getDisplayValues()"
+                />
+                <!-- Debug -->
+                <div v-show="checkboxes[5]" class="flex flex-col gap-2.5">
+                    <SensorGraph
+                        v-for="i in debugColumns"
+                        :key="i"
+                        :ref="
+                            (el) => {
+                                if (el) debugSvgs[i - 1] = el;
+                            }
+                        "
+                        sensor-type="debug"
+                        :svg-id="`debug${i - 1}`"
+                        :visible="true"
+                        :title="debugTitles[i - 1]"
+                        :show-refresh-rate="i === 1"
+                        :rate="rates.debug"
+                        @update:rate="updateRate('debug', $event)"
+                        :display-values="[debugDisplay[i - 1]]"
+                        :is-debug="true"
                     />
                 </div>
-            </UiBox>
-
-            <!-- Sensors -->
-            <SensorGraph
-                v-for="sensor in sensorConfigs"
-                :key="sensor.type"
-                :ref="(el) => setSensorRef(sensor.type, el)"
-                :sensor-type="sensor.type"
-                :svg-id="sensor.type"
-                :visible="checkboxes[sensor.checkboxIndex]"
-                :title="$t(sensor.titleKey)"
-                :hint="sensor.hintKey ? $t(sensor.hintKey) : null"
-                :rate="rates[sensor.type]"
-                @update:rate="updateRate(sensor.type, $event)"
-                :scale="sensor.hasScale ? scales[sensor.type] : null"
-                @update:scale="sensor.hasScale ? updateScale(sensor.type, $event) : null"
-                :scale-options="sensor.scaleOptions"
-                :display-values="sensor.getDisplayValues()"
-            />
-
-            <!-- Debug -->
-            <div v-show="checkboxes[5]" class="flex flex-col gap-2.5">
-                <SensorGraph
-                    v-for="i in debugColumns"
-                    :key="i"
-                    :ref="
-                        (el) => {
-                            if (el) debugSvgs[i - 1] = el;
-                        }
-                    "
-                    sensor-type="debug"
-                    :svg-id="`debug${i - 1}`"
-                    :visible="true"
-                    :title="debugTitles[i - 1]"
-                    :show-refresh-rate="i === 1"
-                    :rate="rates.debug"
-                    @update:rate="updateRate('debug', $event)"
-                    :display-values="[debugDisplay[i - 1]]"
-                    :is-debug="true"
-                />
             </div>
         </div>
     </BaseTab>

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -139,12 +139,7 @@
         <!-- Save button toolbar -->
         <div v-if="isSupported" class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2">
-                <UButton
-                    :label="$t('servosButtonSave')"
-                    :disabled="!configHasChanged"
-                    :color="configHasChanged ? 'success' : 'neutral'"
-                    @click="saveServoConfig"
-                />
+                <UButton :label="$t('servosButtonSave')" :disabled="!configHasChanged" @click="saveServoConfig" />
             </div>
         </div>
     </BaseTab>

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -6,7 +6,7 @@
                 <WikiButton docUrl="servos" />
             </div>
 
-            <div v-if="isSupported">
+            <div v-if="isSupported" class="flex flex-col gap-4">
                 <UiBox :title="$t('servosChangeDirection')">
                     <div class="overflow-x-auto">
                         <div

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -7,7 +7,7 @@
             </div>
 
             <div v-if="isSupported">
-                <UiBox :title="$t('servosChangeDirection')" type="neutral">
+                <UiBox :title="$t('servosChangeDirection')">
                     <div class="overflow-x-auto">
                         <div
                             class="grid items-center gap-y-1 min-w-0"
@@ -95,7 +95,7 @@
                 </UiBox>
 
                 <!-- Servo visualization bars -->
-                <UiBox :title="$t('servosText')" type="neutral" class="mt-4">
+                <UiBox :title="$t('servosText')" class="mt-4">
                     <ul class="grid grid-cols-8 gap-2 mb-1">
                         <li
                             v-for="i in 8"

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -5,8 +5,8 @@
             <WikiButton docUrl="setup" />
             <!-- Top: 3D Model + Instruments & Calibration side-by-side -->
             <div class="setup-top">
-                <div class="model-and-info">
-                    <div id="interactive_block">
+                <UiBox :padding="false" class="mt-3">
+                    <div class="relative bg-muted">
                         <div id="canvas_wrapper" class="background_paper" ref="canvasWrapper">
                             <canvas id="canvas" ref="canvasEl"></canvas>
                             <div class="attitude_info">
@@ -21,20 +21,16 @@
                             </div>
                         </div>
                         <UButton
-                            class="reset-zaxis sm-min"
+                            class="absolute top-3 right-3"
                             :label="$t('initialSetupButtonResetZaxisValue', { 1: yaw_fix })"
                             color="neutral"
                             variant="subtle"
                             @click="resetZaxis"
                         />
                     </div>
-                </div>
+                </UiBox>
                 <div class="setup-sidebar">
-                    <UiBox
-                        :title="$t('initialSetupInstrumentsHead')"
-                        :help="$t('initialSetupInstrumentsHeadHelp')"
-                        type="neutral"
-                    >
+                    <UiBox :title="$t('initialSetupInstrumentsHead')" :help="$t('initialSetupInstrumentsHeadHelp')">
                         <div class="flex flex-row justify-center gap-2">
                             <span id="attitude"></span>
                             <span id="heading"></span>
@@ -101,7 +97,7 @@
 
             <!-- Info panels in responsive multi-column grid -->
             <div class="setup-info-grid">
-                <UiBox :title="$t('initialSetupInfoHead')" :help="$t('initialSetupInfoHeadHelp')" type="neutral">
+                <UiBox :title="$t('initialSetupInfoHead')" :help="$t('initialSetupInfoHeadHelp')">
                     <InfoGrid
                         :items="[
                             {
@@ -152,12 +148,7 @@
                         </template>
                     </InfoGrid>
                 </UiBox>
-                <UiBox
-                    :title="$t('initialSensorInfoHead')"
-                    :help="$t('initialSensorInfoHeadHelp')"
-                    type="neutral"
-                    id="sensorInfoBox"
-                >
+                <UiBox :title="$t('initialSensorInfoHead')" :help="$t('initialSensorInfoHeadHelp')" id="sensorInfoBox">
                     <InfoGrid
                         :items="[
                             {
@@ -199,7 +190,7 @@
                         ]"
                     />
                 </UiBox>
-                <UiBox :title="$t('initialSetupGPSHead')" :help="$t('initialSetupGPSHeadHelp')" type="neutral">
+                <UiBox :title="$t('initialSetupGPSHead')" :help="$t('initialSetupGPSHeadHelp')">
                     <InfoGrid
                         :items="[
                             { id: 'gps3dFix', i18n: 'gps3dFix', slotName: 'gps3dFix' },
@@ -221,7 +212,7 @@
                         </template>
                     </InfoGrid>
                 </UiBox>
-                <UiBox :title="$t('initialSetupInfoBuild')" :help="$t('initialSetupInfoFirmwareHelp')" type="neutral">
+                <UiBox :title="$t('initialSetupInfoBuild')" :help="$t('initialSetupInfoFirmwareHelp')">
                     <InfoGrid
                         :items="[
                             {
@@ -291,7 +282,6 @@
                     v-show="state.showSonarBox"
                     :title="$t('initialSetupSonarHead')"
                     :help="$t('initialSetupSonarHeadHelp')"
-                    type="neutral"
                 >
                     <InfoGrid
                         :items="[

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -5,8 +5,8 @@
             <WikiButton docUrl="setup" />
             <!-- Top: 3D Model + Instruments & Calibration side-by-side -->
             <div class="setup-top">
-                <UiBox :padding="false" class="mt-3">
-                    <div class="relative bg-muted">
+                <UiBox :padding="false" class="mt-3 setup-model-box">
+                    <div class="relative bg-muted h-full min-h-0">
                         <div id="canvas_wrapper" class="background_paper" ref="canvasWrapper">
                             <canvas id="canvas" ref="canvasEl"></canvas>
                             <div class="attitude_info">
@@ -1073,16 +1073,18 @@ function openBuildOptionsDialog() {
         gap: 1rem;
         margin-top: 0.75rem;
     }
-    .model-and-info {
-        #canvas_wrapper {
-            position: relative;
-            width: 100%;
-            height: 100%;
-            max-height: 32rem;
-            top: 0;
-            left: 0;
-            border-radius: 1rem;
-        }
+    .setup-model-box :deep(> div) {
+        height: 100%;
+        min-height: 0;
+    }
+    #canvas_wrapper {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        max-height: 32rem;
+        top: 0;
+        left: 0;
+        border-radius: 1rem;
     }
     .setup-sidebar {
         display: flex;

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -355,28 +355,23 @@
 
         <!-- Toolbar -->
         <div class="content_toolbar xs-compressed toolbar_fixed_bottom">
-            <div class="toolbar_expand_btn" nbrow="2">
-                <em class="fas fa-ellipsis-h"></em>
-            </div>
-
+            <UFieldGroup size="sm" orientation="horizontal">
+                <UButton :label="$t('vtxButtonLoadFile')" @click="loadJsonFile" variant="soft" />
+                <UDropdownMenu v-slot="{ open }" :items="loadMenuItems" :content="{ align: 'end', side: 'top' }">
+                    <UButton :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" square variant="soft" />
+                </UDropdownMenu>
+            </UFieldGroup>
+            <UFieldGroup size="sm" orientation="horizontal">
+                <UButton :label="$t('vtxButtonSaveFile')" @click="saveJsonFile" variant="soft" />
+                <UDropdownMenu v-slot="{ open }" :items="saveFileMenuItems" :content="{ align: 'end', side: 'top' }">
+                    <UButton :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" square variant="soft" />
+                </UDropdownMenu>
+            </UFieldGroup>
             <UButton
                 :label="saveButtonOverride || $t('vtxButtonSave')"
                 :disabled="saveButtonDisabled"
-                :color="saveButtonDisabled ? 'neutral' : 'success'"
                 @click="handleSave"
             />
-            <UFieldGroup size="sm" orientation="horizontal" class="!flex">
-                <UButton :label="$t('vtxButtonLoadFile')" @click="loadJsonFile" />
-                <UDropdownMenu v-slot="{ open }" :items="loadMenuItems" :content="{ align: 'end', side: 'top' }">
-                    <UButton :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" square />
-                </UDropdownMenu>
-            </UFieldGroup>
-            <UFieldGroup size="sm" orientation="horizontal" class="!flex">
-                <UButton :label="$t('vtxButtonSaveFile')" @click="saveJsonFile" />
-                <UDropdownMenu v-slot="{ open }" :items="saveFileMenuItems" :content="{ align: 'end', side: 'top' }">
-                    <UButton :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" square />
-                </UDropdownMenu>
-            </UFieldGroup>
         </div>
     </BaseTab>
 </template>

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -8,24 +8,24 @@
             </div>
 
             <!-- Help note -->
-            <div class="note" v-show="vtxSupported">
+            <UiBox highlight class="mb-3" v-show="vtxSupported">
                 <p v-html="$t('vtxHelp')"></p>
-            </div>
+            </UiBox>
 
             <!-- Not supported -->
-            <div class="note" v-show="!vtxSupported">
+            <UiBox highlight class="mb-3" v-show="!vtxSupported">
                 <div v-html="$t('vtxMessageNotSupported')"></div>
-            </div>
+            </UiBox>
 
             <!-- Table not configured -->
-            <div class="note" v-show="vtxTableNotConfigured">
+            <UiBox highlight class="mb-3" v-show="vtxTableNotConfigured">
                 <div v-html="$t('vtxMessageTableNotConfigured')"></div>
-            </div>
+            </UiBox>
 
             <!-- Factory bands not supported -->
-            <div class="note" v-show="factoryBandsNotSupported">
+            <UiBox highlight class="mb-3" v-show="factoryBandsNotSupported">
                 <div v-html="$t('vtxMessageFactoryBandsNotSupported')"></div>
-            </div>
+            </UiBox>
 
             <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
                 <!-- Configuration Panel -->
@@ -348,9 +348,9 @@
             </div>
 
             <!-- Save pending warning -->
-            <div class="note" v-show="savePending">
+            <UiBox highlight class="mb-3" v-show="savePending">
                 <div v-html="$t('vtxMessageVerifyTable')"></div>
-            </div>
+            </UiBox>
         </div>
 
         <!-- Toolbar -->

--- a/src/components/tabs/presets/PresetFilterSelect.vue
+++ b/src/components/tabs/presets/PresetFilterSelect.vue
@@ -9,9 +9,9 @@
             :search-input="{
                 placeholder: $t('dropDownFilterDisabled'),
             }"
-            :ui="{ content: 'max-h-72 z-[9999]' }"
+            :ui="{ content: 'max-h-72' }"
             class="w-full"
-            :class="{ 'ring-2 ring-(--ui-primary) rounded-md': modelValue.length > 0 }"
+            :class="{ 'ring-2 ring-primary rounded-md': modelValue.length > 0 }"
         >
             <template #default>
                 <span v-if="modelValue.length > 0 && modelValue.length === options.length" class="truncate">

--- a/src/components/tabs/sensors/SensorGraph.vue
+++ b/src/components/tabs/sensors/SensorGraph.vue
@@ -1,7 +1,7 @@
 <template>
     <div :class="sensorType" v-show="visible">
         <!-- Normal sensor layout -->
-        <UiBox v-if="!isDebug" type="neutral">
+        <UiBox v-if="!isDebug">
             <div class="grid grid-cols-[1fr_10rem] gap-4 w-full">
                 <svg :id="svgId" ref="svgElement" class="w-full h-full">
                     <g class="grid x" transform="translate(40, 120)"></g>
@@ -61,7 +61,7 @@
             </div>
         </UiBox>
         <!-- Debug layout (own UiBox, same graph-grid as normal sensors) -->
-        <UiBox v-else type="neutral">
+        <UiBox v-else>
             <div class="grid grid-cols-[1fr_10rem] gap-4 w-full">
                 <svg :id="svgId" ref="svgElement" class="w-full h-[140px]">
                     <g class="grid x" transform="translate(40, 120)"></g>

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -228,7 +228,6 @@ export default defineComponent({
     font-size: 13px;
     position: relative;
     margin-top: auto;
-    margin-bottom: 1rem;
 
     #open-login,
     #user-menu-trigger {
@@ -238,7 +237,7 @@ export default defineComponent({
         flex-direction: row;
         align-items: center;
         gap: 8px;
-        padding: 0.5rem;
+        padding: 0.25rem;
         color: var(--text);
         text-decoration: none;
         cursor: pointer;

--- a/src/composables/ports/usePortsState.js
+++ b/src/composables/ports/usePortsState.js
@@ -9,6 +9,7 @@ export function usePortsState(getRules) {
     const ports = reactive([]);
     const analyticsChanges = reactive({});
     const savedSnapshot = ref("");
+    const isLoading = ref(true);
 
     const portIdentifierToNameMapping = {
         0: "UART1",
@@ -71,6 +72,7 @@ export function usePortsState(getRules) {
             ports.push(transformPortData(p));
         });
         savedSnapshot.value = JSON.stringify(ports);
+        isLoading.value = false;
         nextTick(() => {
             GUI.content_ready();
         });
@@ -105,5 +107,6 @@ export function usePortsState(getRules) {
         getPortName,
         vtxTableNotConfigured,
         dirty,
+        isLoading,
     };
 }

--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -43,6 +43,37 @@ export function usePower() {
     const voltageConfigs = reactive([]);
     const currentConfigs = reactive([]);
 
+    /** Serialized baseline after last FC sync; used for save-button dirty detection */
+    const powerConfigBaseline = ref("");
+
+    const buildPowerConfigSnapshot = () => ({
+        voltageMeterSource: batteryConfig.voltageMeterSource,
+        currentMeterSource: batteryConfig.currentMeterSource,
+        vbatmincellvoltage: batteryConfig.vbatmincellvoltage,
+        vbatmaxcellvoltage: batteryConfig.vbatmaxcellvoltage,
+        vbatwarningcellvoltage: batteryConfig.vbatwarningcellvoltage,
+        capacity: batteryConfig.capacity,
+        batteryProfileName: batteryProfileName.value,
+        voltageConfigs: voltageConfigs.map((c) => ({
+            vbatscale: c.vbatscale,
+            vbatresdivval: c.vbatresdivval,
+            vbatresdivmultiplier: c.vbatresdivmultiplier,
+        })),
+        currentConfigs: currentConfigs.map((c) => ({
+            scale: c.scale,
+            offset: c.offset,
+        })),
+    });
+
+    const serializePowerConfig = () => JSON.stringify(buildPowerConfigSnapshot());
+
+    const dirty = computed(() => {
+        if (!powerConfigBaseline.value) {
+            return false;
+        }
+        return powerConfigBaseline.value !== serializePowerConfig();
+    });
+
     // Calibration state
     const sourceschanged = ref(false);
     const vbatscalechanged = ref(false);
@@ -239,6 +270,8 @@ export function usePower() {
         FC.CURRENT_METER_CONFIGS.forEach((config) => {
             currentConfigs.push({ ...config });
         });
+
+        powerConfigBaseline.value = serializePowerConfig();
     };
 
     // Update live data (polling)
@@ -493,5 +526,6 @@ export function usePower() {
         vbatnewscale,
         amperagenewscale,
         sourceschanged,
+        dirty,
     };
 }

--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -477,6 +477,9 @@ export function usePower() {
             await mspHelper.sendVoltageConfig();
             await mspHelper.sendCurrentConfig();
             await mspHelper.writeConfiguration(false);
+            // Refresh the saveConfig() baseline so dirty reflects persisted values.
+            // Equivalent to updateStateFromFC() baseline reset without extra FC reads.
+            powerConfigBaseline.value = serializePowerConfig();
 
             if (callback) {
                 callback();

--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -15,7 +15,11 @@ export function usePower() {
         return FC.CONFIG?.apiVersion && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_44);
     });
     const hasBatteryProfiles = computed(() => {
-        return FC.CONFIG?.apiVersion && semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_48);
+        if (!FC.CONFIG?.apiVersion || !semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_48)) {
+            return false;
+        }
+        // Custom firmware builds may omit multi-profile support while still reporting API 1.48+; hide UI when the FC reports no profiles.
+        return (FC.CONFIG.numberOfBatteryProfiles || 0) > 0;
     });
     const activeBatteryProfile = ref(0);
     const batteryProfileName = ref("");

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -287,6 +287,8 @@ td [role="group"] {
     width: 16rem;
     min-height: 0;
     overflow: auto;
+    /* Match #content: avoid horizontal jump when the sidebar scrollbar appears */
+    scrollbar-gutter: stable;
     padding: 1rem;
     background-color: var(--surface-100);
     display: flex;

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -6,7 +6,7 @@
 
 @import "tailwindcss";
 @import "@nuxt/ui";
-@source "../../vite.config.js";
+@source "../../nuxt-ui.vite.js";
 
 @theme static {
     /* Extending Tailwind colors with Betaflight primary colors */

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ import * as child from "child_process";
 import { VitePWA } from "vite-plugin-pwa";
 import { resolve } from "path";
 import ui from "@nuxt/ui/vite";
+import nuxtUiViteOptions from "./nuxt-ui.vite.js";
 
 const commitHash = child.execSync("git rev-parse --short HEAD").toString().trim();
 
@@ -143,84 +144,7 @@ export default defineConfig({
     },
     plugins: [
         vue(),
-        ui({
-            colorMode: false, // light/dark mode is handled elsewhere in the app itself, Nuxt UI would otherwise override it
-            ui: {
-                button: {
-                    slots: {
-                        base: "font-semibold cursor-pointer",
-                    },
-                    variants: {
-                        size: {
-                            "2xl": {
-                                base: "p-2 text-lg gap-2.5",
-                                leadingIcon: "size-8",
-                                leadingAvatarSize: "md",
-                                trailingIcon: "size-8",
-                            },
-                        },
-                    },
-                    defaultVariants: {
-                        size: "sm",
-                    },
-                },
-                tooltip: {
-                    slots: {
-                        content: "ring-2 ring-primary max-w-sm lg:max-w-lg h-fit z-99999", // not good, temporary z-index override to fix other extremely high values interfering
-                        arrow: "fill-primary",
-                        text: "whitespace-normal",
-                    },
-                },
-                switch: {
-                    slots: {
-                        base: "cursor-pointer",
-                    },
-                    defaultVariants: {
-                        size: "sm",
-                    },
-                },
-                select: {
-                    slots: {
-                        base: "cursor-pointer",
-                        item: "cursor-pointer",
-                        content: "z-99999",
-                    },
-                    defaultVariants: {
-                        size: "sm",
-                    },
-                },
-                selectMenu: {
-                    slots: {
-                        base: "cursor-pointer",
-                        item: "cursor-pointer",
-                        content: "z-99999",
-                    },
-                    defaultVariants: {
-                        size: "sm",
-                    },
-                },
-                input: {
-                    defaultVariants: {
-                        size: "sm",
-                    },
-                },
-                inputNumber: {
-                    slots: {
-                        root: "min-w-12 w-28",
-                        base: "appearance-none",
-                    },
-                    defaultVariants: {
-                        size: "sm",
-                    },
-                },
-                colors: {
-                    primary: "primary",
-                    neutral: "neutral",
-                    success: "lime",
-                    warning: "orange",
-                },
-            },
-        }),
+        ui(nuxtUiViteOptions),
         serveLocalesPlugin(),
         copy({
             targets: [


### PR DESCRIPTION
A lot of relatively small things here and there, but it all stacks up 😅
- Nuxt UI config is in its own file, making it easier to edit and de-clutters the already hefty Vite config
- Switches have white thumbs as requested
- A lot of standardization across note usage, toolbar buttons, UiBox, and layout
- Improve sidebar layout and colors
- Defers ports tab content loading to speed up tab switching. I want to look into what makes it slower, for now this fixes the UX issue of clicking and nothing happening for a while

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized UI theming/options, box padding control, port loading gating, and exposed change-detection ("dirty") flags for power and many tabs.

* **Style**
  * Standardized button appearance (soft/variant), tightened spacing/padding, unified help/warning presentation, consistent panel styling (removed legacy neutral variants), scrollbar stability tweak, and theme source updated to centralized UI config.

* **Bug Fixes**
  * Connection timer now clamps to prevent negative values.

* **Refactor**
  * Simplified toolbar/button markup and consolidated UI configuration into an external module.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->