### PR TITLE
Nightly Tauri + APK builds, downloads.betaflight.com index

### DIFF
--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -74,7 +74,7 @@ jobs:
           - os: macos-latest
             label: macos-arm64
             target: aarch64-apple-darwin
-          - os: macos-13
+          - os: macos-15-intel
             label: macos-x64
             target: x86_64-apple-darwin
           - os: windows-latest
@@ -148,6 +148,10 @@ jobs:
           do
             cp "$path" staging/
           done
+          if ! compgen -G 'staging/*' > /dev/null; then
+            echo "No desktop bundles produced for ${{ matrix.label }}" >&2
+            exit 1
+          fi
           ls -la staging
 
       - name: Upload to R2
@@ -207,7 +211,7 @@ jobs:
                   group,
                   entry: {
                       label,
-                      url: `${base}/${prefix}/${file}`,
+                      url: `${base}/${prefix}/${encodeURIComponent(file)}`,
                       size: stat.size,
                   },
               };
@@ -320,6 +324,7 @@ jobs:
 
   publish:
     name: Publish downloads index
+    if: github.ref == 'refs/heads/master'
     needs: [prepare, desktop, android]
     runs-on: ubuntu-latest
     permissions:
@@ -383,7 +388,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api 'repos/${{ github.repository }}/releases?per_page=30' > releases.json
+          gh api --paginate --slurp -f per_page=100 repos/${{ github.repository }}/releases | jq 'add' > releases.json
 
       - name: Generate index
         env:
@@ -404,4 +409,4 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy dist-downloads --project-name=${{ vars.CLOUDFLARE_DOWNLOADS_PROJECT_NAME }} --branch=main --commit-dirty=true
+          command: pages deploy dist-downloads --project-name=${{ vars.CLOUDFLARE_DOWNLOADS_PROJECT_NAME }} --branch=master --commit-dirty=true

--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -1,0 +1,407 @@
+name: Nightly downloads
+
+# Builds Tauri desktop bundles + Android APK every day, uploads them to the
+# Cloudflare R2 bucket behind binaries.betaflight.com, regenerates the static
+# downloads index, and deploys it to the betaflight-downloads Cloudflare Pages
+# project (downloads.betaflight.com).
+#
+# Required repository configuration:
+#   Variables:
+#     CLOUDFLARE_R2_BUCKET                 — R2 bucket name (e.g. betaflight-downloads)
+#     CLOUDFLARE_R2_ENDPOINT               — https://<accountid>.r2.cloudflarestorage.com
+#     CLOUDFLARE_R2_PUBLIC_BASE_URL        — https://binaries.betaflight.com
+#     CLOUDFLARE_DOWNLOADS_PROJECT_NAME    — Cloudflare Pages project (e.g. betaflight-downloads)
+#     WEB_APP_MASTER_URL (optional)        — Master web-app URL (defaults to main project preview)
+#     WEB_APP_RELEASE_URL (optional)       — Release web-app URL (defaults to https://app.betaflight.com)
+#   Secrets:
+#     CLOUDFLARE_R2_ACCESS_KEY_ID
+#     CLOUDFLARE_R2_SECRET_ACCESS_KEY
+#     CLOUDFLARE_API_TOKEN                 — already provisioned for the existing PWA deploy
+#     CLOUDFLARE_ACCOUNT_ID                — already provisioned
+#     RELEASE_KEYSTORE / *_PASSWORD / *_ALIAS / *_ALIAS_PASSWORD — already provisioned for APK signing
+#
+# R2 lifecycle: configure a 30-day expiry rule on prefix "nightly/" against the bucket
+# (one-time, in the Cloudflare dashboard or via the R2 API).
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+concurrency:
+  group: nightly-downloads
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  prepare:
+    name: Prepare nightly metadata
+    runs-on: ubuntu-latest
+    outputs:
+      nightly_date: ${{ steps.meta.outputs.nightly_date }}
+      nightly_prefix: ${{ steps.meta.outputs.nightly_prefix }}
+      commit_sha: ${{ steps.meta.outputs.commit_sha }}
+      version: ${{ steps.meta.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Compute metadata
+        id: meta
+        run: |
+          NIGHTLY_DATE=$(date -u +%Y-%m-%d)
+          COMMIT_SHA=$(git rev-parse HEAD)
+          VERSION=$(jq -r '.version' package.json)
+          {
+            echo "nightly_date=${NIGHTLY_DATE}"
+            echo "nightly_prefix=nightly/${NIGHTLY_DATE}"
+            echo "commit_sha=${COMMIT_SHA}"
+            echo "version=${VERSION}"
+          } >> "$GITHUB_OUTPUT"
+
+  desktop:
+    name: Tauri desktop (${{ matrix.label }})
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux
+            target: ''
+          - os: macos-latest
+            label: macos-arm64
+            target: aarch64-apple-darwin
+          - os: macos-13
+            label: macos-x64
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            label: windows
+            target: ''
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install Tauri Linux prereqs
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libudev-dev \
+            rpm
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Cargo registry and target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.label }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Tauri bundle
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.target }}" ]; then
+            npm run tauri:build -- --target ${{ matrix.target }}
+          else
+            npm run tauri:build
+          fi
+
+      - name: Stage desktop bundles
+        shell: bash
+        run: |
+          mkdir -p staging
+          shopt -s nullglob
+          for path in \
+            src-tauri/target/release/bundle/deb/*.deb \
+            src-tauri/target/release/bundle/rpm/*.rpm \
+            src-tauri/target/release/bundle/appimage/*.AppImage \
+            src-tauri/target/release/bundle/dmg/*.dmg \
+            src-tauri/target/release/bundle/nsis/*.exe \
+            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb \
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm \
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage \
+            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg \
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+          do
+            cp "$path" staging/
+          done
+          ls -la staging
+
+      - name: Upload to R2
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          aws-region: auto
+
+      - name: Sync desktop bundles to R2
+        shell: bash
+        env:
+          R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
+          R2_ENDPOINT: ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
+          PREFIX: ${{ needs.prepare.outputs.nightly_prefix }}/desktop
+        run: |
+          aws s3 sync staging/ "s3://${R2_BUCKET}/${PREFIX}/" --endpoint-url "${R2_ENDPOINT}" --no-progress
+
+      - name: Emit per-platform manifest fragment
+        shell: bash
+        env:
+          PUBLIC_BASE: ${{ vars.CLOUDFLARE_R2_PUBLIC_BASE_URL }}
+          PREFIX: ${{ needs.prepare.outputs.nightly_prefix }}/desktop
+          PLATFORM: ${{ matrix.label }}
+        run: |
+          mkdir -p manifest-fragments
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const base = process.env.PUBLIC_BASE.replace(/\/$/, '');
+          const prefix = process.env.PREFIX;
+          const platform = process.env.PLATFORM;
+          const files = fs.readdirSync('staging');
+          const entries = files.map((file) => {
+              const stat = fs.statSync(path.join('staging', file));
+              let group;
+              let label;
+              if (file.endsWith('.exe')) {
+                  group = 'windows';
+                  label = 'Windows installer (x64)';
+              } else if (file.endsWith('.dmg')) {
+                  group = 'macos';
+                  label = platform === 'macos-arm64' ? 'macOS (Apple Silicon)' : 'macOS (Intel)';
+              } else if (file.endsWith('.deb')) {
+                  group = 'linux';
+                  label = 'Linux (.deb)';
+              } else if (file.endsWith('.rpm')) {
+                  group = 'linux';
+                  label = 'Linux (.rpm)';
+              } else if (file.endsWith('.AppImage')) {
+                  group = 'linux';
+                  label = 'Linux (AppImage)';
+              } else {
+                  return null;
+              }
+              return {
+                  group,
+                  entry: {
+                      label,
+                      url: `${base}/${prefix}/${file}`,
+                      size: stat.size,
+                  },
+              };
+          }).filter(Boolean);
+          fs.writeFileSync(`manifest-fragments/${platform}.json`, JSON.stringify(entries));
+          NODE
+
+      - name: Upload manifest fragment
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest-${{ matrix.label }}
+          path: manifest-fragments/${{ matrix.label }}.json
+
+  android:
+    name: Android APK
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+
+      - run: npm install yarn -g
+      - run: yarn install
+      - run: yarn build
+      - run: node capacitor.config.generator.mjs
+      - run: npx cap sync android
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: gradle
+
+      - name: Build and sign APK
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
+        run: |
+          : "${RELEASE_KEYSTORE_BASE64:?Set the RELEASE_KEYSTORE secret with your base64-encoded keystore}"
+          : "${RELEASE_KEYSTORE_PASSWORD:?Set the RELEASE_KEYSTORE_PASSWORD secret with your keystore password}"
+          : "${RELEASE_KEY_ALIAS:?Set the RELEASE_KEY_ALIAS secret with your key alias}"
+          : "${RELEASE_KEY_ALIAS_PASSWORD:?Set the RELEASE_KEY_ALIAS_PASSWORD secret with your key alias password}"
+
+          mkdir -p android/keystore
+          echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > android/keystore/release.jks
+
+          pushd android >/dev/null
+          ./gradlew clean
+          ./gradlew assembleRelease \
+            -Pandroid.injected.signing.store.file="$PWD/keystore/release.jks" \
+            -Pandroid.injected.signing.store.password="$RELEASE_KEYSTORE_PASSWORD" \
+            -Pandroid.injected.signing.key.alias="$RELEASE_KEY_ALIAS" \
+            -Pandroid.injected.signing.key.password="$RELEASE_KEY_ALIAS_PASSWORD"
+          popd >/dev/null
+
+      - name: Stage APK
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
+        run: |
+          mkdir -p staging
+          SHA_SHORT=$(echo "$COMMIT_SHA" | head -c 8)
+          APK_NAME="betaflight-app-${VERSION}-${SHA_SHORT}.apk"
+          cp android/app/build/outputs/apk/release/app-release.apk "staging/${APK_NAME}"
+          echo "APK_NAME=${APK_NAME}" >> "$GITHUB_ENV"
+
+      - name: Configure R2 credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
+          aws-region: auto
+
+      - name: Sync APK to R2
+        env:
+          R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
+          R2_ENDPOINT: ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
+          PREFIX: ${{ needs.prepare.outputs.nightly_prefix }}/android
+        run: |
+          aws s3 sync staging/ "s3://${R2_BUCKET}/${PREFIX}/" --endpoint-url "${R2_ENDPOINT}" --no-progress
+
+      - name: Emit Android manifest fragment
+        env:
+          PUBLIC_BASE: ${{ vars.CLOUDFLARE_R2_PUBLIC_BASE_URL }}
+          PREFIX: ${{ needs.prepare.outputs.nightly_prefix }}/android
+        run: |
+          mkdir -p manifest-fragments
+          BASE="${PUBLIC_BASE%/}"
+          SIZE=$(stat -c %s "staging/${APK_NAME}")
+          jq -n --arg label "Android APK" --arg url "${BASE}/${PREFIX}/${APK_NAME}" --argjson size "$SIZE" \
+            '{label: $label, url: $url, size: $size}' > manifest-fragments/android.json
+
+      - name: Upload manifest fragment
+        uses: actions/upload-artifact@v4
+        with:
+          name: manifest-android
+          path: manifest-fragments/android.json
+
+  publish:
+    name: Publish downloads index
+    needs: [prepare, desktop, android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
+    environment:
+      name: nightly-downloads
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+
+      - name: Download manifest fragments
+        uses: actions/download-artifact@v5
+        with:
+          path: manifest-fragments
+          pattern: manifest-*
+          merge-multiple: true
+
+      - name: Build manifest
+        env:
+          NIGHTLY_DATE: ${{ needs.prepare.outputs.nightly_date }}
+          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          node <<'NODE'
+          const fs = require('node:fs');
+          const path = require('node:path');
+          const fragmentsDir = 'manifest-fragments';
+          const desktop = { windows: [], macos: [], linux: [] };
+          let android = null;
+          for (const file of fs.readdirSync(fragmentsDir)) {
+              const data = JSON.parse(fs.readFileSync(path.join(fragmentsDir, file), 'utf8'));
+              if (file === 'android.json') {
+                  android = data;
+                  continue;
+              }
+              for (const item of data) {
+                  desktop[item.group]?.push(item.entry);
+              }
+          }
+          const manifest = {
+              generatedAt: new Date().toISOString(),
+              nightly: {
+                  date: process.env.NIGHTLY_DATE,
+                  commit: process.env.COMMIT_SHA,
+                  version: process.env.VERSION,
+                  desktop,
+                  android,
+              },
+          };
+          fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2));
+          NODE
+          cat manifest.json
+
+      - name: Fetch GitHub releases
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api 'repos/${{ github.repository }}/releases?per_page=30' > releases.json
+
+      - name: Generate index
+        env:
+          MASTER_URL: ${{ vars.WEB_APP_MASTER_URL }}
+          RELEASE_URL: ${{ vars.WEB_APP_RELEASE_URL }}
+        run: |
+          ARGS=(--manifest manifest.json --releases releases.json --output dist-downloads)
+          if [ -n "${MASTER_URL}" ]; then
+            ARGS+=(--master-url "${MASTER_URL}")
+          fi
+          if [ -n "${RELEASE_URL}" ]; then
+            ARGS+=(--release-url "${RELEASE_URL}")
+          fi
+          node scripts/generate-downloads-index.mjs "${ARGS[@]}"
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3.14.1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy dist-downloads --project-name=${{ vars.CLOUDFLARE_DOWNLOADS_PROJECT_NAME }} --branch=main --commit-dirty=true

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -17,6 +17,8 @@ import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+const ALLOWED_FLAGS = new Set(["manifest", "releases", "output", "master-url", "release-url"]);
+
 function parseArgs(argv) {
     const args = {};
     for (let i = 0; i < argv.length; i += 2) {
@@ -28,7 +30,11 @@ function parseArgs(argv) {
         if (value === undefined || value.startsWith("--")) {
             throw new Error(`Missing value for CLI flag: ${flag}`);
         }
-        args[flag.slice(2)] = value;
+        const key = flag.slice(2);
+        if (!ALLOWED_FLAGS.has(key)) {
+            throw new Error(`Unknown CLI flag: ${flag}`);
+        }
+        args[key] = value;
     }
     return args;
 }
@@ -191,6 +197,18 @@ function renderReleaseHistorySection(releases) {
     cutoff.setFullYear(cutoff.getFullYear() - RECENT_RELEASE_YEARS);
     const recent = releases.filter((r) => r.published_at && new Date(r.published_at) >= cutoff);
     const olderCount = releases.length - recent.length;
+    const olderNote = olderCount
+        ? `<p class="meta">Earlier releases are available on <a href="${RELEASES_INDEX_URL}">GitHub</a>.</p>`
+        : "";
+
+    if (!recent.length) {
+        return `
+            <section>
+                <h2>Recent releases</h2>
+                <p class="empty">No releases in the last ${RECENT_RELEASE_YEARS} years.</p>
+                ${olderNote}
+            </section>`;
+    }
 
     const items = recent
         .map((release) => {
@@ -218,10 +236,6 @@ function renderReleaseHistorySection(releases) {
                 </details>`;
         })
         .join("");
-
-    const olderNote = olderCount
-        ? `<p class="meta">Earlier releases are available on <a href="${RELEASES_INDEX_URL}">GitHub</a>.</p>`
-        : "";
 
     return `
             <section>

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -20,19 +20,26 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 function parseArgs(argv) {
     const args = {};
     for (let i = 0; i < argv.length; i += 2) {
-        const key = argv[i].replace(/^--/, "");
-        args[key] = argv[i + 1];
+        const flag = argv[i];
+        if (!flag?.startsWith("--")) {
+            throw new Error(`Expected a CLI flag starting with --, got: ${flag ?? "<missing>"}`);
+        }
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith("--")) {
+            throw new Error(`Missing value for CLI flag: ${flag}`);
+        }
+        args[flag.slice(2)] = value;
     }
     return args;
 }
 
 function escapeHtml(value) {
     return String(value)
-        .replace(/&/g, "&amp;")
-        .replace(/</g, "&lt;")
-        .replace(/>/g, "&gt;")
-        .replace(/"/g, "&quot;")
-        .replace(/'/g, "&#39;");
+        .replaceAll("&", "&amp;")
+        .replaceAll("<", "&lt;")
+        .replaceAll(">", "&gt;")
+        .replaceAll('"', "&quot;")
+        .replaceAll("'", "&#39;");
 }
 
 function formatBytes(bytes) {
@@ -97,7 +104,16 @@ function renderWebAppSection(masterUrl, releaseUrl) {
 }
 
 function renderNightlySection(nightly) {
-    if (!nightly) {
+    const desktop = nightly?.desktop || {};
+    const platforms = [
+        { key: "windows", title: "Windows" },
+        { key: "macos", title: "macOS" },
+        { key: "linux", title: "Linux" },
+    ];
+    const hasDesktop = platforms.some((p) => Array.isArray(desktop[p.key]) && desktop[p.key].length > 0);
+    const hasAndroid = Boolean(nightly?.android);
+
+    if (!nightly || (!hasDesktop && !hasAndroid)) {
         return `
             <section>
                 <h2>Nightly build</h2>
@@ -105,19 +121,12 @@ function renderNightlySection(nightly) {
             </section>`;
     }
 
-    const desktop = nightly.desktop || {};
-    const platforms = [
-        { key: "windows", title: "Windows" },
-        { key: "macos", title: "macOS" },
-        { key: "linux", title: "Linux" },
-    ];
-
     const platformBlocks = platforms
         .filter((p) => Array.isArray(desktop[p.key]) && desktop[p.key].length > 0)
         .map((p) => `<h3>${escapeHtml(p.title)}</h3>${fileList(desktop[p.key])}`)
         .join("");
 
-    const androidBlock = nightly.android ? `<h3>Android</h3>${fileList([nightly.android])}` : "";
+    const androidBlock = hasAndroid ? `<h3>Android</h3>${fileList([nightly.android])}` : "";
 
     const commitShort = nightly.commit ? nightly.commit.slice(0, 8) : "";
     const metaParts = [];
@@ -166,16 +175,24 @@ function renderLatestStableSection(latest) {
             </section>`;
 }
 
+const RECENT_RELEASE_YEARS = 4;
+const RELEASES_INDEX_URL = "https://github.com/betaflight/betaflight-configurator/releases";
+
 function renderReleaseHistorySection(releases) {
     if (!releases?.length) {
         return `
             <section>
-                <h2>All releases</h2>
+                <h2>Recent releases</h2>
                 <p class="empty">No releases found.</p>
             </section>`;
     }
 
-    const items = releases
+    const cutoff = new Date();
+    cutoff.setFullYear(cutoff.getFullYear() - RECENT_RELEASE_YEARS);
+    const recent = releases.filter((r) => r.published_at && new Date(r.published_at) >= cutoff);
+    const olderCount = releases.length - recent.length;
+
+    const items = recent
         .map((release) => {
             const assets = (release.assets || []).filter((a) => !a.name.endsWith(".sha256"));
             const assetItems = assets.length
@@ -202,14 +219,19 @@ function renderReleaseHistorySection(releases) {
         })
         .join("");
 
+    const olderNote = olderCount
+        ? `<p class="meta">Earlier releases are available on <a href="${RELEASES_INDEX_URL}">GitHub</a>.</p>`
+        : "";
+
     return `
             <section>
-                <h2>All releases</h2>
+                <h2>Recent releases</h2>
                 ${items}
+                ${olderNote}
             </section>`;
 }
 
-async function main() {
+try {
     const args = parseArgs(process.argv.slice(2));
     if (!args.output) {
         throw new Error("--output is required");
@@ -220,8 +242,8 @@ async function main() {
     const manifest = args.manifest ? JSON.parse(readFileSync(args.manifest, "utf8")) : { nightly: null };
     const releases = args.releases ? JSON.parse(readFileSync(args.releases, "utf8")) : [];
 
-    const stableReleases = releases.filter((r) => !r.draft && !r.prerelease);
-    const latestStable = stableReleases[0] || null;
+    const publicReleases = releases.filter((r) => !r.draft);
+    const latestStable = publicReleases.find((r) => !r.prerelease) || null;
 
     const masterUrl = args["master-url"] || "https://master.betaflight-app.pages.dev";
     const releaseUrl = args["release-url"] || "https://app.betaflight.com";
@@ -230,7 +252,7 @@ async function main() {
         renderWebAppSection(masterUrl, releaseUrl),
         renderNightlySection(manifest.nightly),
         renderLatestStableSection(latestStable),
-        renderReleaseHistorySection(releases),
+        renderReleaseHistorySection(publicReleases),
     ].join("\n");
 
     const templatePath = join(__dirname, "templates", "downloads-index.html");
@@ -247,9 +269,7 @@ async function main() {
     copyFileSync(join(repoRoot, "src-tauri/icons/bf_icon_128.png"), join(outputDir, "favicon.png"));
 
     console.log(`Wrote ${join(outputDir, "index.html")}`);
-}
-
-main().catch((error) => {
+} catch (error) {
     console.error(error);
     process.exit(1);
-});
+}

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/*
+ * Generate the static downloads index for downloads.betaflight.com.
+ *
+ * Inputs:
+ *   --manifest <path>     JSON manifest of today's nightly artefact URLs (R2)
+ *   --releases <path>     JSON file with the GitHub releases payload (output of `gh api releases`)
+ *   --output <dir>        Output directory; index.html, logo.svg and favicon.png are written here
+ *   --master-url <url>    URL to the master branch web app deploy
+ *   --release-url <url>   URL to the release web app (default: https://app.betaflight.com)
+ *
+ * The manifest schema is documented in the workflow that calls this script.
+ */
+import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 0; i < argv.length; i += 2) {
+        const key = argv[i].replace(/^--/, "");
+        args[key] = argv[i + 1];
+    }
+    return args;
+}
+
+function escapeHtml(value) {
+    return String(value)
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#39;");
+}
+
+function formatBytes(bytes) {
+    if (!bytes && bytes !== 0) {
+        return "";
+    }
+    const units = ["B", "KB", "MB", "GB"];
+    let value = Number(bytes);
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+        value /= 1024;
+        unit++;
+    }
+    return `${value.toFixed(unit === 0 ? 0 : 1)} ${units[unit]}`;
+}
+
+function formatDate(value) {
+    if (!value) {
+        return "";
+    }
+    const date = new Date(value);
+    if (Number.isNaN(date.valueOf())) {
+        return "";
+    }
+    return date.toISOString().slice(0, 10);
+}
+
+function downloadCard({ label, sub, url }) {
+    const subLine = sub ? `<div class="sub">${escapeHtml(sub)}</div>` : "";
+    return `
+                <div class="card">
+                    <div class="label">${escapeHtml(label)}</div>
+                    ${subLine}
+                    <a class="download-btn" href="${escapeHtml(url)}">Download</a>
+                </div>`;
+}
+
+function renderWebAppSection(masterUrl, releaseUrl) {
+    return `
+            <section>
+                <h2>Web app</h2>
+                <div class="card-grid">
+                    ${downloadCard({
+                        label: "Latest release",
+                        sub: "Stable, runs in your browser",
+                        url: releaseUrl,
+                    })}
+                    ${downloadCard({
+                        label: "Master (development)",
+                        sub: "Latest commit on master",
+                        url: masterUrl,
+                    })}
+                </div>
+            </section>`;
+}
+
+function renderNightlySection(nightly) {
+    if (!nightly) {
+        return `
+            <section>
+                <h2>Nightly build</h2>
+                <p class="empty">Nightly artefacts unavailable.</p>
+            </section>`;
+    }
+
+    const desktop = nightly.desktop || {};
+    const platforms = [
+        { key: "windows", title: "Windows" },
+        { key: "macos", title: "macOS" },
+        { key: "linux", title: "Linux" },
+    ];
+
+    const desktopHtml = platforms
+        .filter((p) => Array.isArray(desktop[p.key]) && desktop[p.key].length > 0)
+        .map((p) => {
+            const cards = desktop[p.key]
+                .map((entry) =>
+                    downloadCard({
+                        label: entry.label,
+                        sub: formatBytes(entry.size),
+                        url: entry.url,
+                    }),
+                )
+                .join("");
+            return `
+                <h3>${escapeHtml(p.title)}</h3>
+                <div class="card-grid">${cards}
+                </div>`;
+        })
+        .join("");
+
+    const androidHtml = nightly.android
+        ? `
+                <h3>Android</h3>
+                <div class="card-grid">${downloadCard({
+                    label: nightly.android.label || "Android APK",
+                    sub: formatBytes(nightly.android.size),
+                    url: nightly.android.url,
+                })}
+                </div>`
+        : "";
+
+    const commitShort = nightly.commit ? nightly.commit.slice(0, 8) : "";
+    const metaParts = [];
+    if (nightly.date) {
+        metaParts.push(`Built ${escapeHtml(nightly.date)}`);
+    }
+    if (commitShort) {
+        metaParts.push(
+            `commit <a href="https://github.com/betaflight/betaflight-configurator/commit/${escapeHtml(nightly.commit)}">${escapeHtml(commitShort)}</a>`,
+        );
+    }
+    if (nightly.version) {
+        metaParts.push(`version ${escapeHtml(nightly.version)}`);
+    }
+    const meta = metaParts.length ? `<p class="meta">${metaParts.join(" &middot; ")}</p>` : "";
+
+    return `
+            <section>
+                <h2>Nightly build</h2>
+                ${meta}
+                ${desktopHtml}
+                ${androidHtml}
+            </section>`;
+}
+
+function renderLatestStableSection(latest) {
+    if (!latest) {
+        return `
+            <section>
+                <h2>Latest stable release</h2>
+                <p class="empty">No stable releases found.</p>
+            </section>`;
+    }
+
+    const assets = (latest.assets || []).filter((a) => !a.name.endsWith(".sha256"));
+    const cards = assets
+        .map((asset) =>
+            downloadCard({
+                label: asset.name,
+                sub: formatBytes(asset.size),
+                url: asset.browser_download_url,
+            }),
+        )
+        .join("");
+
+    const meta = `Released ${escapeHtml(formatDate(latest.published_at))} &middot; tag <a href="${escapeHtml(latest.html_url)}">${escapeHtml(latest.tag_name)}</a>`;
+
+    return `
+            <section>
+                <h2>Latest stable release</h2>
+                <p class="meta">${meta}</p>
+                <div class="card-grid">${cards || `<p class="empty">No assets attached.</p>`}
+                </div>
+            </section>`;
+}
+
+function renderReleaseHistorySection(releases) {
+    if (!releases?.length) {
+        return `
+            <section>
+                <h2>All releases</h2>
+                <p class="empty">No releases found.</p>
+            </section>`;
+    }
+
+    const items = releases
+        .map((release) => {
+            const assets = (release.assets || []).filter((a) => !a.name.endsWith(".sha256"));
+            const assetItems = assets.length
+                ? assets
+                      .map(
+                          (asset) =>
+                              `<li><a href="${escapeHtml(asset.browser_download_url)}">${escapeHtml(asset.name)}</a> <span class="sub">${formatBytes(asset.size)}</span></li>`,
+                      )
+                      .join("")
+                : `<li class="empty">No assets attached.</li>`;
+            const tag = escapeHtml(release.tag_name);
+            const meta = [formatDate(release.published_at), release.prerelease ? "pre-release" : null]
+                .filter(Boolean)
+                .map((s) => escapeHtml(s))
+                .join(" &middot; ");
+            return `
+                <details>
+                    <summary>
+                        <a href="${escapeHtml(release.html_url)}">${tag}</a>
+                        <span class="release-meta">${meta}</span>
+                    </summary>
+                    <ul>${assetItems}</ul>
+                </details>`;
+        })
+        .join("");
+
+    return `
+            <section>
+                <h2>All releases</h2>
+                ${items}
+            </section>`;
+}
+
+async function main() {
+    const args = parseArgs(process.argv.slice(2));
+    if (!args.output) {
+        throw new Error("--output is required");
+    }
+    const outputDir = resolve(args.output);
+    mkdirSync(outputDir, { recursive: true });
+
+    const manifest = args.manifest ? JSON.parse(readFileSync(args.manifest, "utf8")) : { nightly: null };
+    const releases = args.releases ? JSON.parse(readFileSync(args.releases, "utf8")) : [];
+
+    const stableReleases = releases.filter((r) => !r.draft && !r.prerelease);
+    const latestStable = stableReleases[0] || null;
+
+    const masterUrl = args["master-url"] || "https://master.betaflight-app.pages.dev";
+    const releaseUrl = args["release-url"] || "https://app.betaflight.com";
+
+    const sections = [
+        renderWebAppSection(masterUrl, releaseUrl),
+        renderNightlySection(manifest.nightly),
+        renderLatestStableSection(latestStable),
+        renderReleaseHistorySection(releases),
+    ].join("\n");
+
+    const templatePath = join(__dirname, "templates", "downloads-index.html");
+    const template = readFileSync(templatePath, "utf8");
+    const generatedAt = manifest.generatedAt || new Date().toISOString();
+    const html = template
+        .replace("<!--SECTIONS-->", sections)
+        .replace("<!--GENERATED_AT-->", escapeHtml(generatedAt));
+
+    writeFileSync(join(outputDir, "index.html"), html);
+
+    const repoRoot = resolve(__dirname, "..");
+    copyFileSync(join(repoRoot, "src/images/dark-wide-2-compact.svg"), join(outputDir, "logo.svg"));
+    copyFileSync(join(repoRoot, "src-tauri/icons/bf_icon_128.png"), join(outputDir, "favicon.png"));
+
+    console.log(`Wrote ${join(outputDir, "index.html")}`);
+}
+
+main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+});

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -12,7 +12,7 @@
  * The manifest schema is documented in the workflow that calls this script.
  */
 import { readFileSync, writeFileSync, copyFileSync, mkdirSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
+import { dirname, join, resolve, basename } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -60,32 +60,39 @@ function formatDate(value) {
     return date.toISOString().slice(0, 10);
 }
 
-function downloadCard({ label, sub, url }) {
-    const subLine = sub ? `<div class="sub">${escapeHtml(sub)}</div>` : "";
-    return `
-                <div class="card">
-                    <div class="label">${escapeHtml(label)}</div>
-                    ${subLine}
-                    <a class="download-btn" href="${escapeHtml(url)}">Download</a>
-                </div>`;
+function filenameFrom(entry) {
+    if (entry.filename) {
+        return entry.filename;
+    }
+    try {
+        return basename(new URL(entry.url).pathname);
+    } catch {
+        return entry.url;
+    }
+}
+
+function fileListItem(entry) {
+    const filename = filenameFrom(entry);
+    const size = formatBytes(entry.size);
+    const sizeHtml = size ? `<span class="size">${escapeHtml(size)}</span>` : "";
+    return `<li><a href="${escapeHtml(entry.url)}">${escapeHtml(filename)}</a> ${sizeHtml}</li>`;
+}
+
+function fileList(entries) {
+    if (!entries.length) {
+        return `<p class="empty">No files available.</p>`;
+    }
+    return `<ul class="file-list">${entries.map(fileListItem).join("")}</ul>`;
 }
 
 function renderWebAppSection(masterUrl, releaseUrl) {
     return `
             <section>
                 <h2>Web app</h2>
-                <div class="card-grid">
-                    ${downloadCard({
-                        label: "Latest release",
-                        sub: "Stable, runs in your browser",
-                        url: releaseUrl,
-                    })}
-                    ${downloadCard({
-                        label: "Master (development)",
-                        sub: "Latest commit on master",
-                        url: masterUrl,
-                    })}
-                </div>
+                <ul class="link-list">
+                    <li><a href="${escapeHtml(releaseUrl)}">Latest release</a> — stable, runs in your browser</li>
+                    <li><a href="${escapeHtml(masterUrl)}">Master (development)</a> — latest commit on master</li>
+                </ul>
             </section>`;
 }
 
@@ -105,35 +112,12 @@ function renderNightlySection(nightly) {
         { key: "linux", title: "Linux" },
     ];
 
-    const desktopHtml = platforms
+    const platformBlocks = platforms
         .filter((p) => Array.isArray(desktop[p.key]) && desktop[p.key].length > 0)
-        .map((p) => {
-            const cards = desktop[p.key]
-                .map((entry) =>
-                    downloadCard({
-                        label: entry.label,
-                        sub: formatBytes(entry.size),
-                        url: entry.url,
-                    }),
-                )
-                .join("");
-            return `
-                <h3>${escapeHtml(p.title)}</h3>
-                <div class="card-grid">${cards}
-                </div>`;
-        })
+        .map((p) => `<h3>${escapeHtml(p.title)}</h3>${fileList(desktop[p.key])}`)
         .join("");
 
-    const androidHtml = nightly.android
-        ? `
-                <h3>Android</h3>
-                <div class="card-grid">${downloadCard({
-                    label: nightly.android.label || "Android APK",
-                    sub: formatBytes(nightly.android.size),
-                    url: nightly.android.url,
-                })}
-                </div>`
-        : "";
+    const androidBlock = nightly.android ? `<h3>Android</h3>${fileList([nightly.android])}` : "";
 
     const commitShort = nightly.commit ? nightly.commit.slice(0, 8) : "";
     const metaParts = [];
@@ -154,8 +138,8 @@ function renderNightlySection(nightly) {
             <section>
                 <h2>Nightly build</h2>
                 ${meta}
-                ${desktopHtml}
-                ${androidHtml}
+                ${platformBlocks}
+                ${androidBlock}
             </section>`;
 }
 
@@ -168,16 +152,9 @@ function renderLatestStableSection(latest) {
             </section>`;
     }
 
-    const assets = (latest.assets || []).filter((a) => !a.name.endsWith(".sha256"));
-    const cards = assets
-        .map((asset) =>
-            downloadCard({
-                label: asset.name,
-                sub: formatBytes(asset.size),
-                url: asset.browser_download_url,
-            }),
-        )
-        .join("");
+    const assets = (latest.assets || [])
+        .filter((a) => !a.name.endsWith(".sha256"))
+        .map((a) => ({ filename: a.name, url: a.browser_download_url, size: a.size }));
 
     const meta = `Released ${escapeHtml(formatDate(latest.published_at))} &middot; tag <a href="${escapeHtml(latest.html_url)}">${escapeHtml(latest.tag_name)}</a>`;
 
@@ -185,8 +162,7 @@ function renderLatestStableSection(latest) {
             <section>
                 <h2>Latest stable release</h2>
                 <p class="meta">${meta}</p>
-                <div class="card-grid">${cards || `<p class="empty">No assets attached.</p>`}
-                </div>
+                ${fileList(assets)}
             </section>`;
 }
 
@@ -206,7 +182,7 @@ function renderReleaseHistorySection(releases) {
                 ? assets
                       .map(
                           (asset) =>
-                              `<li><a href="${escapeHtml(asset.browser_download_url)}">${escapeHtml(asset.name)}</a> <span class="sub">${formatBytes(asset.size)}</span></li>`,
+                              `<li><a href="${escapeHtml(asset.browser_download_url)}">${escapeHtml(asset.name)}</a> <span class="size">${formatBytes(asset.size)}</span></li>`,
                       )
                       .join("")
                 : `<li class="empty">No assets attached.</li>`;

--- a/scripts/templates/downloads-index.html
+++ b/scripts/templates/downloads-index.html
@@ -1,0 +1,215 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <title>Betaflight downloads</title>
+        <meta name="description" content="Download Betaflight Configurator nightly builds, stable releases, and the web app." />
+        <link rel="icon" type="image/png" href="favicon.png" />
+        <style>
+            :root {
+                --primary-500: #ffbb00;
+                --primary-700: #bb6502;
+                --surface-50: #000000;
+                --surface-100: #0a0a0a;
+                --surface-200: #141414;
+                --surface-300: #1f1f1f;
+                --surface-400: #2a2a2a;
+                --surface-500: #404040;
+                --surface-700: #6b6b6b;
+                --text: hsl(0, 0%, 95%);
+                --text-dim: hsl(0, 0%, 65%);
+                --link: var(--primary-500);
+            }
+
+            * {
+                box-sizing: border-box;
+            }
+
+            html,
+            body {
+                margin: 0;
+                padding: 0;
+                background: var(--surface-100);
+                color: var(--text);
+                font-family:
+                    system-ui,
+                    -apple-system,
+                    "Segoe UI",
+                    Roboto,
+                    sans-serif;
+                font-size: 16px;
+                line-height: 1.5;
+            }
+
+            a {
+                color: var(--link);
+                text-decoration: none;
+            }
+            a:hover {
+                text-decoration: underline;
+            }
+
+            header {
+                background: var(--surface-200);
+                border-bottom: 1px solid var(--surface-400);
+                padding: 1.5rem 2rem;
+                display: flex;
+                align-items: center;
+                gap: 1rem;
+            }
+            header img {
+                height: 40px;
+            }
+            header h1 {
+                font-size: 1.5rem;
+                margin: 0;
+                color: var(--primary-500);
+            }
+
+            main {
+                max-width: 960px;
+                margin: 0 auto;
+                padding: 2rem 1.5rem 4rem;
+            }
+
+            section {
+                margin-bottom: 3rem;
+            }
+
+            h2 {
+                font-size: 1.25rem;
+                color: var(--primary-500);
+                border-bottom: 1px solid var(--surface-400);
+                padding-bottom: 0.5rem;
+                margin: 0 0 1rem;
+            }
+
+            h3 {
+                font-size: 1rem;
+                color: var(--text);
+                margin: 1.25rem 0 0.5rem;
+            }
+
+            .meta {
+                color: var(--text-dim);
+                font-size: 0.875rem;
+                margin: -0.5rem 0 1rem;
+            }
+
+            .card-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+                gap: 0.75rem;
+            }
+
+            .card {
+                background: var(--surface-200);
+                border: 1px solid var(--surface-400);
+                border-radius: 6px;
+                padding: 1rem;
+                display: flex;
+                flex-direction: column;
+                gap: 0.25rem;
+            }
+            .card .label {
+                font-weight: 600;
+            }
+            .card .sub {
+                color: var(--text-dim);
+                font-size: 0.875rem;
+            }
+
+            .download-btn {
+                display: inline-block;
+                margin-top: 0.5rem;
+                padding: 0.4rem 0.9rem;
+                background: var(--primary-500);
+                color: #000;
+                font-weight: 600;
+                border-radius: 4px;
+                text-align: center;
+            }
+            .download-btn:hover {
+                text-decoration: none;
+                background: #ffd03d;
+            }
+
+            table {
+                width: 100%;
+                border-collapse: collapse;
+                margin-top: 0.5rem;
+            }
+            th,
+            td {
+                text-align: left;
+                padding: 0.5rem 0.75rem;
+                border-bottom: 1px solid var(--surface-400);
+                font-size: 0.9rem;
+            }
+            th {
+                color: var(--text-dim);
+                font-weight: 600;
+                font-size: 0.8rem;
+                text-transform: uppercase;
+                letter-spacing: 0.05em;
+            }
+            td a {
+                white-space: nowrap;
+            }
+            details {
+                background: var(--surface-200);
+                border: 1px solid var(--surface-400);
+                border-radius: 6px;
+                padding: 0.5rem 1rem;
+                margin-bottom: 0.5rem;
+            }
+            details summary {
+                cursor: pointer;
+                font-weight: 600;
+                padding: 0.25rem 0;
+            }
+            details summary .release-meta {
+                color: var(--text-dim);
+                font-weight: 400;
+                margin-left: 0.5rem;
+                font-size: 0.875rem;
+            }
+            details ul {
+                list-style: none;
+                padding: 0;
+                margin: 0.5rem 0;
+            }
+            details li {
+                padding: 0.25rem 0;
+                font-size: 0.9rem;
+            }
+
+            footer {
+                color: var(--text-dim);
+                font-size: 0.85rem;
+                text-align: center;
+                padding: 2rem 1rem;
+                border-top: 1px solid var(--surface-400);
+            }
+
+            .empty {
+                color: var(--text-dim);
+                font-style: italic;
+            }
+        </style>
+    </head>
+    <body>
+        <header>
+            <img src="logo.svg" alt="Betaflight" />
+            <h1>Downloads</h1>
+        </header>
+        <main>
+            <!--SECTIONS-->
+        </main>
+        <footer>
+            Generated <!--GENERATED_AT-->. Source:
+            <a href="https://github.com/betaflight/betaflight-configurator">betaflight/betaflight-configurator</a>.
+        </footer>
+    </body>
+</html>

--- a/scripts/templates/downloads-index.html
+++ b/scripts/templates/downloads-index.html
@@ -10,15 +10,11 @@
             :root {
                 --primary-500: #ffbb00;
                 --primary-700: #bb6502;
-                --surface-50: #000000;
                 --surface-100: #0a0a0a;
                 --surface-200: #141414;
-                --surface-300: #1f1f1f;
                 --surface-400: #2a2a2a;
-                --surface-500: #404040;
-                --surface-700: #6b6b6b;
                 --text: hsl(0, 0%, 95%);
-                --text-dim: hsl(0, 0%, 65%);
+                --text-dim: hsl(0, 0%, 60%);
                 --link: var(--primary-500);
             }
 
@@ -39,7 +35,7 @@
                     Roboto,
                     sans-serif;
                 font-size: 16px;
-                line-height: 1.5;
+                line-height: 1.55;
             }
 
             a {
@@ -68,106 +64,69 @@
             }
 
             main {
-                max-width: 960px;
+                max-width: 880px;
                 margin: 0 auto;
                 padding: 2rem 1.5rem 4rem;
             }
 
             section {
-                margin-bottom: 3rem;
+                margin-bottom: 2.5rem;
             }
 
             h2 {
-                font-size: 1.25rem;
+                font-size: 1.2rem;
                 color: var(--primary-500);
                 border-bottom: 1px solid var(--surface-400);
-                padding-bottom: 0.5rem;
-                margin: 0 0 1rem;
+                padding-bottom: 0.4rem;
+                margin: 0 0 0.75rem;
             }
 
             h3 {
-                font-size: 1rem;
+                font-size: 0.95rem;
                 color: var(--text);
-                margin: 1.25rem 0 0.5rem;
+                margin: 1rem 0 0.25rem;
+                font-weight: 600;
             }
 
+            .meta,
+            .size {
+                color: var(--text-dim);
+                font-size: 0.875rem;
+            }
             .meta {
-                color: var(--text-dim);
-                font-size: 0.875rem;
-                margin: -0.5rem 0 1rem;
+                margin: -0.25rem 0 0.75rem;
             }
 
-            .card-grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-                gap: 0.75rem;
+            ul.file-list,
+            ul.link-list {
+                list-style: none;
+                padding: 0;
+                margin: 0;
+            }
+            ul.file-list li,
+            ul.link-list li {
+                padding: 0.2rem 0;
+                font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+                font-size: 0.92rem;
+            }
+            ul.link-list li {
+                font-family: inherit;
+            }
+            ul.file-list .size {
+                margin-left: 0.5rem;
             }
 
-            .card {
-                background: var(--surface-200);
-                border: 1px solid var(--surface-400);
-                border-radius: 6px;
-                padding: 1rem;
-                display: flex;
-                flex-direction: column;
-                gap: 0.25rem;
-            }
-            .card .label {
-                font-weight: 600;
-            }
-            .card .sub {
-                color: var(--text-dim);
-                font-size: 0.875rem;
-            }
-
-            .download-btn {
-                display: inline-block;
-                margin-top: 0.5rem;
-                padding: 0.4rem 0.9rem;
-                background: var(--primary-500);
-                color: #000;
-                font-weight: 600;
-                border-radius: 4px;
-                text-align: center;
-            }
-            .download-btn:hover {
-                text-decoration: none;
-                background: #ffd03d;
-            }
-
-            table {
-                width: 100%;
-                border-collapse: collapse;
-                margin-top: 0.5rem;
-            }
-            th,
-            td {
-                text-align: left;
-                padding: 0.5rem 0.75rem;
-                border-bottom: 1px solid var(--surface-400);
-                font-size: 0.9rem;
-            }
-            th {
-                color: var(--text-dim);
-                font-weight: 600;
-                font-size: 0.8rem;
-                text-transform: uppercase;
-                letter-spacing: 0.05em;
-            }
-            td a {
-                white-space: nowrap;
-            }
             details {
-                background: var(--surface-200);
-                border: 1px solid var(--surface-400);
-                border-radius: 6px;
-                padding: 0.5rem 1rem;
-                margin-bottom: 0.5rem;
+                border-top: 1px solid var(--surface-400);
+                padding: 0.5rem 0;
+            }
+            details:last-of-type {
+                border-bottom: 1px solid var(--surface-400);
             }
             details summary {
                 cursor: pointer;
                 font-weight: 600;
-                padding: 0.25rem 0;
+                padding: 0.15rem 0;
             }
             details summary .release-meta {
                 color: var(--text-dim);
@@ -178,11 +137,15 @@
             details ul {
                 list-style: none;
                 padding: 0;
-                margin: 0.5rem 0;
+                margin: 0.5rem 0 0.25rem 1rem;
             }
             details li {
-                padding: 0.25rem 0;
+                padding: 0.15rem 0;
+                font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
                 font-size: 0.9rem;
+            }
+            details li .size {
+                margin-left: 0.5rem;
             }
 
             footer {


### PR DESCRIPTION
Adds a daily workflow that builds Tauri desktop bundles (Linux, macOS arm64/x64, Windows) and a signed APK, uploads them to the Cloudflare R2 bucket behind `binaries.betaflight.com`, then regenerates the static `downloads.betaflight.com` index page (linking to nightlies, latest stable, the full release history via the GitHub API, and the web app).

R2 lifecycle (30-day expiry on the `nightly/` prefix) is configured once on the bucket. Required vars/secrets listed at the top of `.github/workflows/tauri-nightly.yml`.

![Downloads page preview](https://raw.githubusercontent.com/betaflight/betaflight-configurator/assets/pr-5065-preview/nightly-downloads-preview.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automated nightly builds published for Linux, macOS (arm64/x64), Windows, and Android APK with per-build metadata (date, commit, version, sizes).
  * A static downloads index page that lists nightly artifacts, the latest stable release, and recent release history with platform-organized entries.
  * A generator that assembles manifests/releases into the downloads site and deploys the resulting page automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->