### PR TITLE
Fix motors tab esc_sensor, dirty state and formatting

### DIFF
--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -70,6 +70,7 @@
                                     :step="100"
                                     size="xs"
                                     orientation="vertical"
+                                    :format-options="{ useGrouping: false }"
                                     class="w-16"
                                 />
                             </SettingRow>
@@ -166,6 +167,7 @@
                                     :step="1"
                                     size="xs"
                                     orientation="vertical"
+                                    :format-options="{ useGrouping: false }"
                                     class="w-16"
                                 />
                             </SettingRow>
@@ -182,6 +184,7 @@
                                     :step="1"
                                     size="xs"
                                     orientation="vertical"
+                                    :format-options="{ useGrouping: false }"
                                     class="w-16"
                                 />
                             </SettingRow>
@@ -197,6 +200,7 @@
                                     :step="1"
                                     size="xs"
                                     orientation="vertical"
+                                    :format-options="{ useGrouping: false }"
                                     class="w-16"
                                 />
                             </SettingRow>
@@ -211,7 +215,6 @@
                                 />
                                 <template #label>
                                     <span v-html="$t('feature3D')"></span>
-                                    <span class="ml-2 font-semibold">3D</span>
                                 </template>
                             </SettingRow>
                             <template v-if="isFeatureEnabled('3D')">
@@ -223,6 +226,7 @@
                                         :step="1"
                                         size="xs"
                                         orientation="vertical"
+                                        :format-options="{ useGrouping: false }"
                                         class="w-16"
                                     />
                                 </SettingRow>
@@ -234,6 +238,7 @@
                                         :step="1"
                                         size="xs"
                                         orientation="vertical"
+                                        :format-options="{ useGrouping: false }"
                                         class="w-16"
                                     />
                                 </SettingRow>
@@ -245,6 +250,7 @@
                                         :step="1"
                                         size="xs"
                                         orientation="vertical"
+                                        :format-options="{ useGrouping: false }"
                                         class="w-16"
                                     />
                                 </SettingRow>
@@ -534,7 +540,7 @@ const dialog = useDialog();
 
 // Initialize motors state management
 const motorsState = useMotorsState();
-const { configHasChanged, trackChange, resetChanges } = motorsState;
+const { configHasChanged, resetChanges } = motorsState;
 
 // Warning dialog
 const dialogSettingsChanged = ref(null);
@@ -1402,15 +1408,7 @@ const toggleFeature = (featureName, checked) => {
     } else {
         featuresHelper.disable(featureName);
     }
-    // Track the change for config change detection
-    trackChange(featureName, checked);
-    // We might need to trigger an update to make sure Vue detects change if the helper modifies internal state but not the ref directly in a way Vue sees?
-    // Pinia store `features` refers to `FC.FEATURE_CONFIG`.
-    // The `featureMask` is inside.
-    // To ensure reactivity, we might need to re-assign or trigger update.
-    // `fcStore.features = { ...fcStore.features }` might be too heavy.
-    // But since `FC.FEATURE_CONFIG` is reactive in `fc.js` (proxy), it should work?
-    // Let's assume it works for now.
+    // Change tracking is handled by watchers in useMotorConfiguration
 };
 
 const numberOfValidOutputs = computed(() => {

--- a/src/composables/motors/useMotorConfiguration.js
+++ b/src/composables/motors/useMotorConfiguration.js
@@ -102,9 +102,9 @@ export function useMotorConfiguration(motorsState, motorsTestingEnabled, stopMot
             (newVal, oldVal) => handleChange("dshotbidir", newVal, oldVal),
         );
 
-        // ESC Sensor
+        // ESC Sensor feature
         watch(
-            () => fcStore.motorConfig.use_esc_sensor,
+            () => fcStore.features?.features?.isEnabled?.("ESC_SENSOR") ?? false,
             (newVal, oldVal) => handleChange("ESC_SENSOR", newVal, oldVal),
         );
 

--- a/src/composables/motors/useMotorsState.js
+++ b/src/composables/motors/useMotorsState.js
@@ -47,7 +47,7 @@ export function useMotorsState() {
             mincommand: fcStore.motorConfig.mincommand,
             motorPoles: fcStore.motorConfig.motor_poles,
             dshotbidir: fcStore.motorConfig.use_dshot_telemetry,
-            ESC_SENSOR: fcStore.motorConfig.use_esc_sensor,
+            ESC_SENSOR: fcStore.features.features.isEnabled("ESC_SENSOR"),
             use_unsyncedPwm: fcStore.pidAdvancedConfig.use_unsyncedPwm,
             motor_pwm_rate: fcStore.pidAdvancedConfig.motor_pwm_rate,
             motorIdle: fcStore.pidAdvancedConfig.motorIdle,


### PR DESCRIPTION
### Summary

Root cause: toggleFeature() in MotorsTab.vue called trackChange(featureName,  
  checked) using the raw feature name (e.g., "3D", "MOTOR_STOP") as the key. But
   defaultConfiguration and the watchers in useMotorConfiguration.js use        
  different keys ("feature12", "feature4"). This meant:
                                                                                
  1. Toggling 3D added two entries: "3D" (from toggleFeature) and "feature12"   
  (from watcher)                                                                
  2. Toggling back only removed "feature12" — the "3D" entry could never be
  cleared because it didn't match any key in defaultConfiguration
  3. configHasChanged stayed true permanently

  Changes made (3 files):

  1. src/components/tabs/MotorsTab.vue — Removed the trackChange call from
  toggleFeature and its unused destructured import. The watchers in
  useMotorConfiguration.js already handle tracking feature changes with the
  correct keys.
  2. src/composables/motors/useMotorConfiguration.js — Changed the ESC_SENSOR
  watcher from fcStore.motorConfig.use_esc_sensor to
  fcStore.features?.features?.isEnabled?.("ESC_SENSOR") so it actually fires
  when the feature is toggled (consistent with how MOTOR_STOP and 3D are
  watched).
  3. src/composables/motors/useMotorsState.js — Changed the ESC_SENSOR default
  snapshot from fcStore.motorConfig.use_esc_sensor to
  fcStore.features.features.isEnabled("ESC_SENSOR") to match the watcher.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Removed thousands separators from numeric input fields for PWM frequency, throttle, and deadband settings for clearer input values.
  * Simplified 3D feature label display by removing redundant text.

* **Refactor**
  * Updated motor configuration change tracking to integrate with feature flag system for ESC Sensor settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->