### PR TITLE
Pin nightly Tauri Rust toolchain to 1.95.0

### DIFF
--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -107,7 +107,7 @@ jobs:
             rpm
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: ${{ matrix.target }}
 


### PR DESCRIPTION
The \`dtolnay/rust-toolchain@stable\` branch is parked on rustc 1.85.1, but the current \`Cargo.lock\` has dependencies that require 1.86+ / 1.88+, so the desktop matrix in \`tauri-nightly.yml\` fails on every runner. Pin to the action's \`1.95.0\` branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rust toolchain for desktop builds to use a pinned version targeting Rust 1.95.0, replacing the previous stable toolchain reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->