### PR TITLE
Bump src-tauri toolchain pin to 1.95

### DIFF
--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,7 +1,8 @@
 [toolchain]
-# Rust 1.85 is the first release that stabilised the 2024 edition used by
-# Cargo.toml. Pinning keeps CI runners and contributors on a compatible
-# channel without forcing an exact patch version.
-channel = "1.85"
+# Cargo.lock contains transitive dependencies (icu_*, darling, time, etc.)
+# whose latest releases require rustc 1.86+ / 1.88+. Pin to 1.95 so CI
+# runners and contributors stay on a channel that can resolve them without
+# forcing an exact patch version.
+channel = "1.95"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
\`src-tauri/rust-toolchain.toml\` pins Cargo to channel 1.85, which overrides whatever rustup default a workflow installs. The current Cargo.lock has transitive deps (\`icu_*\`, \`darling\`, \`time\`, etc.) that need rustc 1.86+ / 1.88+, so the nightly desktop matrix keeps failing with "rustc 1.85.1 is not supported by the following packages" even after the workflow installs 1.95.0. Bumping the channel to 1.95.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal build tooling to support development improvements.

**Note:** This release contains no user-facing changes. The update is an internal infrastructure improvement with no impact on application functionality or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->