### PR TITLE
Fix nightly publish job: releases fetch returned a 422

### DIFF
--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -377,10 +377,12 @@ jobs:
           cat manifest.json
 
       - name: Fetch GitHub releases
+        shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh api --paginate --slurp -f per_page=100 repos/${{ github.repository }}/releases | jq 'add' > releases.json
+          set -o pipefail
+          gh api --paginate --slurp "repos/${{ github.repository }}/releases?per_page=100" | jq 'add' > releases.json
 
       - name: Generate index
         env:

--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -383,6 +383,7 @@ jobs:
         run: |
           set -o pipefail
           gh api --paginate --slurp "repos/${{ github.repository }}/releases?per_page=100" | jq 'add' > releases.json
+          jq -e 'type == "array" and (length == 0 or all(.[]; has("tag_name") and has("html_url")))' releases.json > /dev/null
 
       - name: Generate index
         env:

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -255,6 +255,9 @@ try {
 
     const manifest = args.manifest ? JSON.parse(readFileSync(args.manifest, "utf8")) : { nightly: null };
     const releases = args.releases ? JSON.parse(readFileSync(args.releases, "utf8")) : [];
+    if (!Array.isArray(releases)) {
+        throw new Error(`Releases payload at ${args.releases} is not an array`);
+    }
 
     const publicReleases = releases.filter((r) => !r.draft);
     const latestStable = publicReleases.find((r) => !r.prerelease) || null;


### PR DESCRIPTION
\`gh api -f per_page=100 ...\` flips \`gh\` into POST mode, which made the GitHub API reject the request as a release create with HTTP 422 (\"tag_name wasn't supplied\"). Without \`pipefail\`, the failure leaked through \`jq\` and wrote junk into \`releases.json\`, which then crashed the index generator.

Move \`per_page\` into the URL so the call stays a GET, and enable \`pipefail\` so any future gh failure aborts the step instead of masking itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved nightly pipeline reliability by running steps more safely and validating release data before processing.
* **Bug Fixes**
  * Prevented downstream failures by ensuring fetched release data is well-formed (array with required fields), aborting on invalid input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->