### PR TITLE
Tauri bundles: rename file output to betaflight-app

### DIFF
--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -131,6 +131,9 @@ jobs:
 
       - name: Stage desktop bundles
         shell: bash
+        env:
+          PKG_VERSION: ${{ needs.prepare.outputs.version }}
+          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
         run: |
           mkdir -p staging
           shopt -s nullglob
@@ -152,6 +155,16 @@ jobs:
             echo "No desktop bundles produced for ${{ matrix.label }}" >&2
             exit 1
           fi
+          STRIPPED="${PKG_VERSION%%-*}"
+          SHA_SHORT="${COMMIT_SHA:0:8}"
+          NIGHTLY_VERSION="${PKG_VERSION}-${SHA_SHORT}"
+          for f in staging/*; do
+            base=$(basename "$f")
+            new=${base/${STRIPPED}/${NIGHTLY_VERSION}}
+            if [[ "$new" != "$base" ]]; then
+              mv -- "$f" "staging/${new}"
+            fi
+          done
           ls -la staging
 
       - name: Sync desktop bundles to R2

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -5,7 +5,7 @@
  * Inputs:
  *   --manifest <path>     JSON manifest of today's nightly artefact URLs (R2)
  *   --releases <path>     JSON file with the GitHub releases payload (output of `gh api releases`)
- *   --output <dir>        Output directory; index.html, logo.svg and favicon.png are written here
+ *   --output <dir>        Output directory; index.html and favicon.png are written here
  *   --master-url <url>    URL to the master branch web app deploy
  *   --release-url <url>   URL to the release web app (default: https://app.betaflight.com)
  *
@@ -282,7 +282,6 @@ try {
     writeFileSync(join(outputDir, "index.html"), html);
 
     const repoRoot = resolve(__dirname, "..");
-    copyFileSync(join(repoRoot, "src/images/dark-wide-2-compact.svg"), join(outputDir, "logo.svg"));
     copyFileSync(join(repoRoot, "src-tauri/icons/bf_icon_128.png"), join(outputDir, "favicon.png"));
 
     console.log(`Wrote ${join(outputDir, "index.html")}`);

--- a/scripts/templates/downloads-index.html
+++ b/scripts/templates/downloads-index.html
@@ -164,7 +164,7 @@
     </head>
     <body>
         <header>
-            <img src="logo.svg" alt="Betaflight" />
+            <img src="https://betaflight.com/img/betaflight/logo_dark.svg" alt="Betaflight" />
             <h1>Downloads</h1>
         </header>
         <main>

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,6 +30,7 @@
     },
     "bundle": {
         "active": true,
+        "fileName": "betaflight-app",
         "targets": [
             "deb",
             "rpm",


### PR DESCRIPTION
Sets \`bundle.fileName\` so the Tauri output bundles ship as \`betaflight-app-<version>-...\` instead of \`Betaflight App-<version>-...\`. Drops the encoded space from the download URLs without touching the OS-level display name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized application bundle base filename so generated installer artifacts use a consistent name.
  * Nightly build artifacts are now versioned with a short commit identifier so nightly uploads reflect the specific commit.
  * Downloads index generation no longer produces a local logo file; the downloads page now loads the dark logo from the public site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->