### PR TITLE
Move desktop bundle rename to workflow

### DIFF
--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -160,7 +160,8 @@ jobs:
           NIGHTLY_VERSION="${PKG_VERSION}-${SHA_SHORT}"
           for f in staging/*; do
             base=$(basename "$f")
-            new=${base/${STRIPPED}/${NIGHTLY_VERSION}}
+            new=${base//Betaflight App/betaflight-app}
+            new=${new/${STRIPPED}/${NIGHTLY_VERSION}}
             if [[ "$new" != "$base" ]]; then
               mv -- "$f" "staging/${new}"
             fi

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -30,7 +30,6 @@
     },
     "bundle": {
         "active": true,
-        "fileName": "betaflight-app",
         "targets": [
             "deb",
             "rpm",


### PR DESCRIPTION
\`bundle.fileName\` isn't a valid Tauri 2 schema key, so the desktop matrix has been hard-failing on \"Additional properties are not allowed ('fileName' was unexpected)\" since #5071. Drop it from \`tauri.conf.json\` and do the lowercase + SHA rewrite in the workflow staging step.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved desktop bundle artifact naming for nightly releases with enhanced filename normalization to ensure consistent, predictable build artifact names across nightly release cycles
  * Streamlined build configuration by removing manual bundle filename specifications and relying on Tauri's default naming behavior for improved configuration maintainability and consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->