### PR TITLE
Fix 4K resolution

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7664,6 +7664,10 @@
         "message": "High Contrast",
         "description": "Contrast color theme"
     },
+    "uiScale": {
+        "message": "UI Scale",
+        "description": "Scale the entire user interface up or down"
+    },
     "pidTuningRatesType": {
         "message": "Rates Type"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7668,6 +7668,18 @@
         "message": "UI Scale",
         "description": "Scale the entire user interface up or down"
     },
+    "uiScaleKeepTitle": {
+        "message": "Keep this UI scale?"
+    },
+    "uiScaleKeepMessage": {
+        "message": "If the screen is unusable, the previous scale will be restored automatically."
+    },
+    "uiScaleKeep": {
+        "message": "Keep"
+    },
+    "uiScaleRevert": {
+        "message": "Revert"
+    },
     "pidTuningRatesType": {
         "message": "Rates Type"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7668,18 +7668,6 @@
         "message": "UI Scale",
         "description": "Scale the entire user interface up or down"
     },
-    "uiScaleKeepTitle": {
-        "message": "Keep this UI scale?"
-    },
-    "uiScaleKeepMessage": {
-        "message": "If the screen is unusable, the previous scale will be restored automatically."
-    },
-    "uiScaleKeep": {
-        "message": "Keep"
-    },
-    "uiScaleRevert": {
-        "message": "Revert"
-    },
     "pidTuningRatesType": {
         "message": "Rates Type"
     },

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-    <UApp :tooltip="{ delayDuration: 100 }">
+    <UApp :tooltip="{ delayDuration: 100 }" portal="#main-wrapper">
         <div class="app-wrapper">
             <div id="background" v-show="isRevealed" @click="isRevealed = false"></div>
             <div id="side_menu_swipe"></div>
@@ -210,7 +210,7 @@ watch(
 .app-wrapper {
     display: flex;
     flex-direction: column;
-    height: 100vh;
+    height: 100%;
     min-height: 0; /* Allow flex children to shrink below content size */
 }
 

--- a/src/components/elements/Dialog.vue
+++ b/src/components/elements/Dialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <Teleport to="body">
+    <Teleport to="#main-wrapper">
         <dialog v-if="modelValue" ref="dialogRef" class="dialog-modal" @close="handleClose">
             <div class="dialog-title-bar">
                 <div class="dialog-title">

--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -73,7 +73,7 @@
                     />
                 </SettingRow>
                 <div class="flex flex-col gap-2 py-2">
-                    <span class="text-sm font-semibold">{{ $t("uiScale") }}</span>
+                    <label for="ui-scale-slider" class="text-sm font-semibold">{{ $t("uiScale") }}</label>
                     <div class="flex gap-1.5 flex-wrap">
                         <button
                             v-for="preset in [0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.25, 1.5]"
@@ -92,6 +92,7 @@
                     </div>
                     <div class="flex items-center gap-2">
                         <input
+                            id="ui-scale-slider"
                             type="range"
                             v-model.number="settings.uiScale"
                             :min="minUiScale"

--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -152,7 +152,7 @@
 </template>
 
 <script>
-import { defineComponent, reactive, watch, onMounted } from "vue";
+import { defineComponent, reactive, watch, onMounted, onUnmounted } from "vue";
 import BaseTab from "./BaseTab.vue";
 import { useDialog } from "@/composables/useDialog";
 import GUI from "../../js/gui";
@@ -296,15 +296,25 @@ export default defineComponent({
             },
         );
 
+        let uiScalePersistTimer = null;
+
         watch(
             () => settings.uiScale,
             (value) => {
                 const uiScale = sanitizeUiScale(value);
-                settings.uiScale = uiScale;
-                setConfig({ uiScale });
+                if (settings.uiScale !== uiScale) {
+                    settings.uiScale = uiScale;
+                    return;
+                }
                 applyUiScale(uiScale);
+                clearTimeout(uiScalePersistTimer);
+                uiScalePersistTimer = setTimeout(() => {
+                    setConfig({ uiScale });
+                }, 150);
             },
         );
+
+        onUnmounted(() => clearTimeout(uiScalePersistTimer));
 
         watch(
             () => settings.showDevToolsOnStartup,

--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -72,6 +72,25 @@
                         class="min-w-40"
                     />
                 </SettingRow>
+                <SettingRow :label="$t('uiScale')">
+                    <USelect
+                        :items="[
+                            { label: '50%', value: 50 },
+                            { label: '60%', value: 60 },
+                            { label: '70%', value: 70 },
+                            { label: '75%', value: 75 },
+                            { label: '80%', value: 80 },
+                            { label: '90%', value: 90 },
+                            { label: '100%', value: 100 },
+                            { label: '110%', value: 110 },
+                            { label: '125%', value: 125 },
+                            { label: '150%', value: 150 },
+                        ]"
+                        size="sm"
+                        v-model="settings.uiScale"
+                        class="min-w-40"
+                    />
+                </SettingRow>
                 <!-- Includes "languages" icon to be noticeable even if the language is set incorrectly for the user -->
                 <!-- Other input elements are unlikely to need an icon -->
                 <SettingRow :label="$t('userLanguageSelect')">
@@ -134,6 +153,7 @@ import NotificationManager from "../../js/utils/notifications";
 import { ispConnected } from "../../js/utils/connection";
 import { DEFAULT_DEVELOPMENT_OPTIONS, resetDevelopmentOptions } from "../../js/utils/developmentOptions";
 import { applyExpertMode } from "../../js/utils/applyExpertMode";
+import { applyUiScale } from "../../js/UiScale";
 import UiBox from "../elements/UiBox.vue";
 import SettingRow from "../elements/SettingRow.vue";
 
@@ -167,6 +187,7 @@ export default defineComponent({
             cliOnlyMode: !!getConfig("cliOnlyMode", false).cliOnlyMode,
             showPresetsWarningBackup: !!getConfig("showPresetsWarningBackup").showPresetsWarningBackup,
             automaticDevOptions: !!getConfig("automaticDevOptions", true).automaticDevOptions,
+            uiScale: getConfig("uiScale", 100).uiScale ?? 100,
         });
 
         const availableLanguages = i18n.getLanguagesAvailables();
@@ -259,6 +280,14 @@ export default defineComponent({
                     setConfig({ darkTheme: 0 });
                     setDarkTheme(0);
                 }
+            },
+        );
+
+        watch(
+            () => settings.uiScale,
+            (value) => {
+                setConfig({ uiScale: value });
+                applyUiScale(value);
             },
         );
 

--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -72,25 +72,38 @@
                         class="min-w-40"
                     />
                 </SettingRow>
-                <SettingRow :label="$t('uiScale')">
-                    <USelect
-                        :items="[
-                            { label: '50%', value: 50 },
-                            { label: '60%', value: 60 },
-                            { label: '70%', value: 70 },
-                            { label: '75%', value: 75 },
-                            { label: '80%', value: 80 },
-                            { label: '90%', value: 90 },
-                            { label: '100%', value: 100 },
-                            { label: '110%', value: 110 },
-                            { label: '125%', value: 125 },
-                            { label: '150%', value: 150 },
-                        ]"
-                        size="sm"
-                        v-model="settings.uiScale"
-                        class="min-w-40"
-                    />
-                </SettingRow>
+                <div class="flex flex-col gap-2 py-2">
+                    <span class="text-sm font-semibold">{{ $t("uiScale") }}</span>
+                    <div class="flex gap-1.5 flex-wrap">
+                        <button
+                            v-for="preset in [0.5, 0.6, 0.7, 0.8, 0.9, 1, 1.1, 1.25, 1.5]"
+                            :key="preset"
+                            type="button"
+                            class="px-2.5 py-1 text-xs rounded-full border cursor-pointer transition-colors"
+                            :class="
+                                settings.uiScale === preset
+                                    ? 'bg-(--primary-500) border-(--primary-600) text-black font-semibold'
+                                    : 'bg-(--surface-200) border-(--surface-400) text-(--text) hover:bg-(--surface-300)'
+                            "
+                            @click="settings.uiScale = preset"
+                        >
+                            {{ Math.round(preset * 100) }}%
+                        </button>
+                    </div>
+                    <div class="flex items-center gap-2">
+                        <input
+                            type="range"
+                            v-model.number="settings.uiScale"
+                            :min="minUiScale"
+                            :max="maxUiScale"
+                            step="0.01"
+                            class="flex-1 accent-(--primary-500)"
+                        />
+                        <span class="text-sm font-semibold min-w-12 text-right"
+                            >{{ Math.round(settings.uiScale * 100) }}%</span
+                        >
+                    </div>
+                </div>
                 <!-- Includes "languages" icon to be noticeable even if the language is set incorrectly for the user -->
                 <!-- Other input elements are unlikely to need an icon -->
                 <SettingRow :label="$t('userLanguageSelect')">
@@ -139,7 +152,7 @@
 </template>
 
 <script>
-import { defineComponent, reactive, watch, ref, onBeforeUnmount, onMounted } from "vue";
+import { defineComponent, reactive, watch, onMounted } from "vue";
 import BaseTab from "./BaseTab.vue";
 import { useDialog } from "@/composables/useDialog";
 import GUI from "../../js/gui";
@@ -153,8 +166,7 @@ import NotificationManager from "../../js/utils/notifications";
 import { ispConnected } from "../../js/utils/connection";
 import { DEFAULT_DEVELOPMENT_OPTIONS, resetDevelopmentOptions } from "../../js/utils/developmentOptions";
 import { applyExpertMode } from "../../js/utils/applyExpertMode";
-import { applyUiScale } from "../../js/UiScale";
-import { useDialogStore } from "@/stores/dialog";
+import { applyUiScale, sanitizeUiScale, DEFAULT_UI_SCALE, MIN_UI_SCALE, MAX_UI_SCALE } from "../../js/UiScale";
 import UiBox from "../elements/UiBox.vue";
 import SettingRow from "../elements/SettingRow.vue";
 
@@ -167,7 +179,6 @@ export default defineComponent({
     },
     setup() {
         const dialog = useDialog();
-        const dialogStore = useDialogStore();
 
         // Load initial settings from config storage
         const settings = reactive({
@@ -189,7 +200,7 @@ export default defineComponent({
             cliOnlyMode: !!getConfig("cliOnlyMode", false).cliOnlyMode,
             showPresetsWarningBackup: !!getConfig("showPresetsWarningBackup").showPresetsWarningBackup,
             automaticDevOptions: !!getConfig("automaticDevOptions", true).automaticDevOptions,
-            uiScale: getConfig("uiScale", 100).uiScale ?? 100,
+            uiScale: sanitizeUiScale(getConfig("uiScale", DEFAULT_UI_SCALE).uiScale),
         });
 
         const availableLanguages = i18n.getLanguagesAvailables();
@@ -285,74 +296,13 @@ export default defineComponent({
             },
         );
 
-        const SCALE_REVERT_SECONDS = 10;
-        let scaleRevertTimer = null;
-        let scaleCountdownTimer = null;
-        const previousScale = ref(settings.uiScale);
-
-        function clearScaleTimers() {
-            clearTimeout(scaleRevertTimer);
-            clearInterval(scaleCountdownTimer);
-            scaleRevertTimer = null;
-            scaleCountdownTimer = null;
-        }
-
-        onBeforeUnmount(() => clearScaleTimers());
-
         watch(
             () => settings.uiScale,
             (value) => {
-                clearScaleTimers();
-                const oldScale = previousScale.value;
-
-                if (value === oldScale) {
-                    return;
-                }
-
-                applyUiScale(value);
-
-                let remaining = SCALE_REVERT_SECONDS;
-                const revert = () => {
-                    clearScaleTimers();
-                    settings.uiScale = oldScale;
-                    setConfig({ uiScale: oldScale });
-                    applyUiScale(oldScale);
-                    dialog.close();
-                };
-
-                const updateTitle = () => `${i18n.getMessage("uiScaleKeepTitle")  } (${remaining}s)`;
-
-                dialog.openYesNo(
-                    updateTitle(),
-                    i18n.getMessage("uiScaleKeepMessage"),
-                    () => {
-                        // Yes — keep
-                        clearScaleTimers();
-                        previousScale.value = value;
-                        setConfig({ uiScale: value });
-                    },
-                    () => {
-                        // No — revert
-                        revert();
-                    },
-                    {
-                        yesText: i18n.getMessage("uiScaleKeep"),
-                        noText: i18n.getMessage("uiScaleRevert"),
-                    },
-                );
-
-                scaleCountdownTimer = setInterval(() => {
-                    remaining--;
-                    if (remaining <= 0) {
-                        revert();
-                    } else {
-                        dialogStore.updateProps({ title: updateTitle() });
-                    }
-                }, 1000);
-
-                scaleRevertTimer = setTimeout(() => {
-                    revert();
-                }, SCALE_REVERT_SECONDS * 1000);
+                const uiScale = sanitizeUiScale(value);
+                settings.uiScale = uiScale;
+                setConfig({ uiScale });
+                applyUiScale(uiScale);
             },
         );
 
@@ -462,6 +412,8 @@ export default defineComponent({
             settings,
             availableLanguages,
             handleNotificationsChange,
+            minUiScale: MIN_UI_SCALE,
+            maxUiScale: MAX_UI_SCALE,
         };
     },
 });

--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -139,7 +139,7 @@
 </template>
 
 <script>
-import { defineComponent, reactive, watch, onMounted } from "vue";
+import { defineComponent, reactive, watch, ref, onBeforeUnmount, onMounted } from "vue";
 import BaseTab from "./BaseTab.vue";
 import { useDialog } from "@/composables/useDialog";
 import GUI from "../../js/gui";
@@ -154,6 +154,7 @@ import { ispConnected } from "../../js/utils/connection";
 import { DEFAULT_DEVELOPMENT_OPTIONS, resetDevelopmentOptions } from "../../js/utils/developmentOptions";
 import { applyExpertMode } from "../../js/utils/applyExpertMode";
 import { applyUiScale } from "../../js/UiScale";
+import { useDialogStore } from "@/stores/dialog";
 import UiBox from "../elements/UiBox.vue";
 import SettingRow from "../elements/SettingRow.vue";
 
@@ -166,6 +167,7 @@ export default defineComponent({
     },
     setup() {
         const dialog = useDialog();
+        const dialogStore = useDialogStore();
 
         // Load initial settings from config storage
         const settings = reactive({
@@ -283,11 +285,74 @@ export default defineComponent({
             },
         );
 
+        const SCALE_REVERT_SECONDS = 10;
+        let scaleRevertTimer = null;
+        let scaleCountdownTimer = null;
+        const previousScale = ref(settings.uiScale);
+
+        function clearScaleTimers() {
+            clearTimeout(scaleRevertTimer);
+            clearInterval(scaleCountdownTimer);
+            scaleRevertTimer = null;
+            scaleCountdownTimer = null;
+        }
+
+        onBeforeUnmount(() => clearScaleTimers());
+
         watch(
             () => settings.uiScale,
             (value) => {
-                setConfig({ uiScale: value });
+                clearScaleTimers();
+                const oldScale = previousScale.value;
+
+                if (value === oldScale) {
+                    return;
+                }
+
                 applyUiScale(value);
+
+                let remaining = SCALE_REVERT_SECONDS;
+                const revert = () => {
+                    clearScaleTimers();
+                    settings.uiScale = oldScale;
+                    setConfig({ uiScale: oldScale });
+                    applyUiScale(oldScale);
+                    dialog.close();
+                };
+
+                const updateTitle = () => `${i18n.getMessage("uiScaleKeepTitle")  } (${remaining}s)`;
+
+                dialog.openYesNo(
+                    updateTitle(),
+                    i18n.getMessage("uiScaleKeepMessage"),
+                    () => {
+                        // Yes — keep
+                        clearScaleTimers();
+                        previousScale.value = value;
+                        setConfig({ uiScale: value });
+                    },
+                    () => {
+                        // No — revert
+                        revert();
+                    },
+                    {
+                        yesText: i18n.getMessage("uiScaleKeep"),
+                        noText: i18n.getMessage("uiScaleRevert"),
+                    },
+                );
+
+                scaleCountdownTimer = setInterval(() => {
+                    remaining--;
+                    if (remaining <= 0) {
+                        revert();
+                    } else {
+                        dialogStore.updateProps({ title: updateTitle() });
+                    }
+                }, 1000);
+
+                scaleRevertTimer = setTimeout(() => {
+                    revert();
+                }, SCALE_REVERT_SECONDS * 1000);
             },
         );
 

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -23,7 +23,7 @@
                 <span id="username-display" class="username">{{ displayName }}</span>
             </a>
         </div>
-        <Teleport to="body">
+        <Teleport to="#main-wrapper">
             <div v-show="menuOpen" id="user-menu-popup" class="user-popup-menu" :style="menuStyle">
                 <div id="menu-username" class="menu-username">{{ displayName }}</div>
                 <a href="#" id="menu-signout" class="menu-item" @click.prevent="handleSignOut">

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -19,6 +19,7 @@ body {
     margin: 0;
     padding: 0;
     overflow: hidden;
+    --ui-scale: 1;
 
     ::-webkit-scrollbar {
         width: 0.3rem;
@@ -233,14 +234,19 @@ td [role="group"] {
     font-style: italic;
 }
 #main-wrapper {
-    height: 100vh;
-    height: 100dvh;
-    max-height: 100dvh;
+    width: calc(100vw / var(--ui-scale));
+    height: calc(100vh / var(--ui-scale));
+    height: calc(100dvh / var(--ui-scale));
+    max-height: calc(100dvh / var(--ui-scale));
     min-height: 0;
     overflow: hidden;
     background-color: var(--surface-100);
     display: flex;
     flex-direction: column;
+    transform: scale(var(--ui-scale));
+    transform-origin: top left;
+    container-type: inline-size;
+    container-name: main-wrapper;
 }
 /* StatusBar.vue root; avoid shrinking as a flex item under #main-wrapper */
 #status-bar {
@@ -1347,7 +1353,7 @@ each(range(12), {
     gap: 8px;
 }
 
-@media not all and (max-width: 575px) {
+@container main-wrapper (min-width: 576px) {
     .visible-on-phone-only {
         display: none !important;
     }
@@ -1364,7 +1370,7 @@ each(range(12), {
         overflow-y: auto;
     }
 }
-@media (max-width: 1055px) {
+@container main-wrapper (max-width: 1055px) {
     #tabs {
         li {
             a {
@@ -1435,7 +1441,7 @@ each(range(12), {
         }
     }
 }
-@media (max-width: 1055px) {
+@container main-wrapper (max-width: 1055px) {
     #tabs {
         li {
             a {
@@ -1642,12 +1648,12 @@ body.compact-header-layout {
         display: none !important;
     }
 }
-@media all and (max-width: 991px) {
+@container main-wrapper (max-width: 991px) {
     .md-min {
         display: none !important;
     }
 }
-@media all and (max-width: 575px) {
+@container main-wrapper (max-width: 575px) {
     .sm-min {
         display: none !important;
     }

--- a/src/index.html
+++ b/src/index.html
@@ -15,7 +15,8 @@
         <link rel="apple-touch-icon" href="/images/pwa/apple-touch-icon.png" sizes="128x128" />
         <meta name="theme-color" content="#eea600" />
     </head>
-    <body id="main-wrapper">
+    <body>
+        <div id="main-wrapper">
         <app />
         <dialog
             id="dialogWaiting"
@@ -122,5 +123,6 @@
             </div>
         </dialog>
 
+        </div>
     </body>
 </html>

--- a/src/js/UiScale.js
+++ b/src/js/UiScale.js
@@ -1,14 +1,27 @@
 import { get as getConfig } from "./ConfigStorage";
 
-const DEFAULT_SCALE = 100;
+const DEFAULT_UI_SCALE = 1;
+const MIN_UI_SCALE = 0.5;
+const MAX_UI_SCALE = 1.5;
+
+export function sanitizeUiScale(value) {
+    const numericValue = Number(value);
+    if (!Number.isFinite(numericValue)) {
+        return DEFAULT_UI_SCALE;
+    }
+    return Math.min(MAX_UI_SCALE, Math.max(MIN_UI_SCALE, numericValue));
+}
 
 export function applyUiScale(value) {
-    const scale = value ?? DEFAULT_SCALE;
-    document.documentElement.style.zoom = scale === 100 ? "" : `${scale}%`;
+    const scale = sanitizeUiScale(value);
+    document.body.style.setProperty("--ui-scale", scale);
+    return scale;
 }
 
 export function loadUiScale() {
     const result = getConfig("uiScale");
-    const scale = result.uiScale ?? DEFAULT_SCALE;
+    const scale = result.uiScale ?? DEFAULT_UI_SCALE;
     applyUiScale(scale);
 }
+
+export { DEFAULT_UI_SCALE, MIN_UI_SCALE, MAX_UI_SCALE };

--- a/src/js/UiScale.js
+++ b/src/js/UiScale.js
@@ -1,0 +1,14 @@
+import { get as getConfig } from "./ConfigStorage";
+
+const DEFAULT_SCALE = 100;
+
+export function applyUiScale(value) {
+    const scale = value ?? DEFAULT_SCALE;
+    document.documentElement.style.zoom = scale === 100 ? "" : `${scale}%`;
+}
+
+export function loadUiScale() {
+    const result = getConfig("uiScale");
+    const scale = result.uiScale ?? DEFAULT_SCALE;
+    applyUiScale(scale);
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -168,6 +168,9 @@ async function startProcess() {
         }
     }
 
+    // Apply persisted UI scale before initial tab mount to avoid flicker.
+    loadUiScale();
+
     // Kick off initial tab — sidebar handles subsequent clicks reactively.
     switchTab("landing", { mode: "disconnected" });
 
@@ -205,8 +208,6 @@ async function startProcess() {
         setDarkTheme(0);
         setConfig({ darkTheme: 0 });
     }
-
-    loadUiScale();
 
     window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function () {
         DarkTheme.autoSet();

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,6 +8,7 @@ import { initializeSerialBackend } from "./serial_backend.js";
 import CONFIGURATOR from "./data_storage.js";
 import CliAutoComplete from "./CliAutoComplete.js";
 import DarkTheme, { setDarkTheme } from "./DarkTheme.js";
+import { loadUiScale } from "./UiScale.js";
 import { applyExpertMode } from "./utils/applyExpertMode.js";
 import { mountVueTab } from "./vue_tab_mounter.js";
 import { switchTab } from "./tab_switch.js";
@@ -204,6 +205,8 @@ async function startProcess() {
         setDarkTheme(0);
         setConfig({ darkTheme: 0 });
     }
+
+    loadUiScale();
 
     window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", function () {
         DarkTheme.autoSet();


### PR DESCRIPTION
# Fix 4K Resolution Scaling - Implementation Plan

## Problem

On Android tablets with 4K (3840x2160) displays, the app UI is too large and doesn't fit the screen. This affects both the Capacitor app and the PWA. Android's high display density (560-640dpi) results in a CSS viewport of only ~960-1097px, which is at or below the app's 1024px minimum width.

## Root Cause Analysis

### Why CSS `zoom` doesn't work

CSS `zoom` on `document.documentElement` or `<body>` breaks **all** Floating UI (Reka UI) dropdown positioning. The root cause is a coordinate space mismatch in Floating UI's `detectOverflow()`:

- `getViewportRect()` uses `html.clientWidth/clientHeight` or `visualViewport` — returns **CSS pixels** (unzoomed)
- `getBoundingClientRect()` on elements returns **screen pixels** (zoomed)
- `detectOverflow()` subtracts them directly, mixing coordinate spaces
- This makes dropdowns flip/shift incorrectly or render off-screen

### Why `transform: scale()` on `<body>` doesn't work

Floating UI's `getContainingBlock()` skips `<body>` and `<html>` because they are "last traversable nodes" (`isLastTraversableNode` returns true). Even though `transform` on `<body>` creates a CSS containing block (making `position: fixed` children relative to body), Floating UI ignores it and returns `window` as the offset parent. This causes a coordinate mismatch:

- Floating UI computes positions in **viewport coordinates** (as if no transform exists)
- CSS renders `position: fixed` dropdowns relative to the **transformed body**
- Positions are off by the scale factor (e.g., at 70% scale, dropdowns shift toward top-left)

### Approaches rejected

| Approach | Issue |
|---|---|
| CSS `zoom` on html/body | Breaks all Floating UI positioning (coordinate mismatch) |
| `transform: scale()` on `<body>` | Floating UI skips body in `getContainingBlock()` — doesn't detect the transform |
| `position: "item-aligned"` on content | Still mispositions (uses similar rect math) |
| `:portal="false"` globally | Same `detectOverflow` bug applies without portals too |
| Viewport `initial-scale` | Doesn't reliably re-layout after page load on Android |
| Viewport meta `width=N` | Browser doesn't respond to dynamic viewport width changes |
| Patch Floating UI platform | Fragile, breaks on dependency updates |

## Solution: `transform: scale()` on a wrapper `<div>`

Apply `transform: scale(var(--ui-scale))` on a `<div id="main-wrapper">` inside `<body>`, not on `<body>` itself. Then redirect all Nuxt UI portals into that wrapper.

**Why this works:**
- Floating UI's `getContainingBlock()` detects transforms on regular `<div>` elements (they're not "last traversable nodes")
- `getScale()` reads the wrapper's `getBoundingClientRect()` vs `getCssDimensions()` and correctly computes the 0.7x scale factor
- `getRectRelativeToOffsetParent()` converts trigger coordinates from visual (post-transform) back to CSS (pre-transform) space
- `computePosition()` returns coordinates in the wrapper's CSS space → `translate(Xpx, Ypx)` positions correctly inside the transform
- Both trigger and dropdown are in the same transform context → visual scale matches
- Container queries on the wrapper ensure responsive breakpoints respond to scaled dimensions

```
Scale 70% with viewport width 1097px:
  --ui-scale: 0.7
  wrapper CSS width:  calc(100vw / 0.7) = 1567px
  wrapper CSS height: calc(100dvh / 0.7)
  transform: scale(0.7) from top-left
  visual size: 1567 * 0.7 = 1097px (fits viewport)
```

## Why the UI scale slider uses a native `<input type="range">` instead of USlider

Reka UI's `SliderHorizontal` caches the track's `getBoundingClientRect()` on drag start (`rectRef.value = rect` in `getValueFromPointerEvent`). As the user drags, the watcher fires `applyUiScale()` which changes `transform: scale()` on `#main-wrapper` — shifting the track's visual position and size mid-drag. The slider keeps using the stale cached rect, so the thumb diverges from the mouse pointer.

This is specific to this slider because it modifies the transform of its own container. USlider works fine for any other control in the app. The native `<input type="range">` works because the browser recalculates hit-testing internally on each pointer event without caching.

## Notes

- Default scale is 1 (100%) — `transform: scale(1)` is identity, no visual change
- A 4K user at ~3.5x density would use 0.5-0.7 to make the UI fit
- Persisted via ConfigStorage (localStorage)
- Loaded early in main.js so the correct scale applies before the UI renders
- On desktop (Tauri), the feature works the same way (transform-based, not viewport-dependent)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a UI Scale control (presets + slider) in Options; changes apply immediately and persist.

* **Localization**
  * Added localized label and description for the UI Scale control.

* **Layout / Responsiveness**
  * Introduced a scaling variable and updated root layout and responsive rules so the UI respects the selected scale.

* **UI Behavior**
  * Dialogs and popups now mount inside the main app wrapper.
  * Persisted UI scale is applied at startup to reduce visual flicker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->