### PR TITLE
Tauri bundles: normalise filenames to use dashes

### DIFF
--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -158,14 +158,10 @@ jobs:
           STRIPPED="${PKG_VERSION%%-*}"
           SHA_SHORT="${COMMIT_SHA:0:8}"
           NIGHTLY_VERSION="${PKG_VERSION}-${SHA_SHORT}"
-          for f in staging/*; do
-            base=$(basename "$f")
-            new=${base//Betaflight App/betaflight-app}
-            new=${new/${STRIPPED}/${NIGHTLY_VERSION}}
-            if [[ "$new" != "$base" ]]; then
-              mv -- "$f" "staging/${new}"
-            fi
-          done
+          node scripts/rename-tauri-bundles.mjs \
+            --dir staging \
+            --from-version "${STRIPPED}" \
+            --to-version "${NIGHTLY_VERSION}"
           ls -la staging
 
       - name: Sync desktop bundles to R2

--- a/.github/workflows/tauri-release.yml
+++ b/.github/workflows/tauri-release.yml
@@ -64,16 +64,32 @@ jobs:
       - name: Build Tauri bundle
         run: npm run tauri:build
 
+      - name: Stage desktop bundles
+        shell: bash
+        run: |
+          mkdir -p staging
+          shopt -s nullglob
+          for path in \
+            src-tauri/target/release/bundle/deb/*.deb \
+            src-tauri/target/release/bundle/rpm/*.rpm \
+            src-tauri/target/release/bundle/appimage/*.AppImage \
+            src-tauri/target/release/bundle/dmg/*.dmg \
+            src-tauri/target/release/bundle/nsis/*.exe
+          do
+            cp "$path" staging/
+          done
+          if ! compgen -G 'staging/*' > /dev/null; then
+            echo "No desktop bundles produced for ${{ matrix.os }}" >&2
+            exit 1
+          fi
+          node scripts/rename-tauri-bundles.mjs --dir staging
+          ls -la staging
+
       - name: Upload desktop artifacts
         uses: actions/upload-artifact@v4
         with:
           name: betaflight-desktop-${{ matrix.os }}
-          path: |
-            src-tauri/target/release/bundle/deb/*.deb
-            src-tauri/target/release/bundle/rpm/*.rpm
-            src-tauri/target/release/bundle/appimage/*.AppImage
-            src-tauri/target/release/bundle/dmg/*.dmg
-            src-tauri/target/release/bundle/nsis/*.exe
+          path: staging/*
           if-no-files-found: error
           retention-days: 30
 

--- a/scripts/rename-tauri-bundles.mjs
+++ b/scripts/rename-tauri-bundles.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+/*
+ * Normalises Tauri bundle filenames in a directory so they use a consistent
+ * kebab-cased form: "Betaflight App" collapses to "betaflight-app", spaces
+ * and underscores become dashes, and the x86_64 architecture token is left
+ * intact. Optionally rewrites the version segment for nightly builds.
+ *
+ * Usage:
+ *   node rename-tauri-bundles.mjs --dir <path>
+ *                                [--from-version <v> --to-version <v>]
+ */
+import { readdirSync, renameSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ARCH_TOKEN = "x86_64";
+const ARCH_PLACEHOLDER = "\u0000ARCH\u0000";
+const ALLOWED_FLAGS = new Set(["dir", "from-version", "to-version"]);
+
+function parseArgs(argv) {
+    const args = {};
+    for (let i = 0; i < argv.length; i += 2) {
+        const flag = argv[i];
+        if (!flag?.startsWith("--")) {
+            throw new Error(`Expected a CLI flag starting with --, got: ${flag ?? "<missing>"}`);
+        }
+        const value = argv[i + 1];
+        if (value === undefined || value.startsWith("--")) {
+            throw new Error(`Missing value for CLI flag: ${flag}`);
+        }
+        const key = flag.slice(2);
+        if (!ALLOWED_FLAGS.has(key)) {
+            throw new Error(`Unknown CLI flag: ${flag}`);
+        }
+        args[key] = value;
+    }
+    return args;
+}
+
+function normalise(name) {
+    let next = name.replaceAll("Betaflight App", "betaflight-app");
+    next = next.replaceAll(ARCH_TOKEN, ARCH_PLACEHOLDER);
+    next = next.replaceAll(" ", "-");
+    next = next.replaceAll("_", "-");
+    next = next.replaceAll(ARCH_PLACEHOLDER, ARCH_TOKEN);
+    return next;
+}
+
+try {
+    const args = parseArgs(process.argv.slice(2));
+    if (!args.dir) {
+        throw new Error("--dir is required");
+    }
+    const fromVersion = args["from-version"];
+    const toVersion = args["to-version"];
+    if (Boolean(fromVersion) !== Boolean(toVersion)) {
+        throw new Error("--from-version and --to-version must be provided together");
+    }
+
+    const entries = readdirSync(args.dir);
+    let renamed = 0;
+    for (const name of entries) {
+        const full = join(args.dir, name);
+        if (!statSync(full).isFile()) {
+            continue;
+        }
+        let next = name;
+        if (fromVersion && next.includes(fromVersion)) {
+            next = next.replace(fromVersion, toVersion);
+        }
+        next = normalise(next);
+        if (next !== name) {
+            renameSync(full, join(args.dir, next));
+            renamed++;
+            console.log(`${name} -> ${next}`);
+        }
+    }
+    console.log(`Renamed ${renamed} of ${entries.length} files`);
+} catch (error) {
+    console.error(error.message);
+    process.exit(1);
+}


### PR DESCRIPTION
Spaces and underscores in Tauri's default bundle filenames now collapse to dashes (preserving the `x86_64` arch token), keeping the desktop and APK artefacts on the downloads page consistent. Shared rename script is reused by the nightly and release workflows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved desktop bundle naming consistency in build workflows by implementing automated normalization of release artifact filenames.
  * Enhanced release process reliability by staging and validating desktop bundles before artifact upload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->