### PR TITLE
Hide virtual mode toggle when expert mode is off

### DIFF
--- a/src/components/tabs/OptionsTab.vue
+++ b/src/components/tabs/OptionsTab.vue
@@ -21,7 +21,7 @@
                 <SettingRow :label="$t('showManualMode')">
                     <USwitch v-model="settings.showManualMode" size="sm" />
                 </SettingRow>
-                <SettingRow :label="$t('showVirtualMode')">
+                <SettingRow v-if="settings.expertMode" :label="$t('showVirtualMode')">
                     <USwitch v-model="settings.showVirtualMode" size="sm" />
                 </SettingRow>
                 <SettingRow :label="$t('showDevToolsOnStartup')">


### PR DESCRIPTION
Hides the "Enable virtual connection mode" toggle in Options tab when Expert mode is off, as it's not available in the connection dropdown in that occasion either.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The "Show Virtual Mode" setting in the Options tab is now conditionally displayed only when expert mode is enabled, streamlining the interface for standard users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->