### PR TITLE
feature: add CH340 USB-to-Serial

### DIFF
--- a/android/app/src/main/res/xml/device_filter.xml
+++ b/android/app/src/main/res/xml/device_filter.xml
@@ -31,4 +31,7 @@
     <!-- Raspberry Pi Pico devices -->
     <usb-device vendor-id="11914" product-id="9" /> <!-- Raspberry Pi Pico VCP -->
     <usb-device vendor-id="11914" product-id="15" /> <!-- Raspberry Pi Pico in Bootloader mode -->
+
+    <!-- WCH (QinHeng Electronics) devices -->
+    <usb-device vendor-id="6790" product-id="29987" /> <!-- CH340 USB-to-Serial -->
 </resources>

--- a/android/app/src/main/res/xml/device_filter.xml
+++ b/android/app/src/main/res/xml/device_filter.xml
@@ -33,5 +33,8 @@
     <usb-device vendor-id="11914" product-id="15" /> <!-- Raspberry Pi Pico in Bootloader mode -->
 
     <!-- WCH (QinHeng Electronics) devices -->
+    <usb-device vendor-id="6790" product-id="29986" /> <!-- CH340 USB-to-Serial (variant) -->
     <usb-device vendor-id="6790" product-id="29987" /> <!-- CH340 USB-to-Serial -->
+    <usb-device vendor-id="6790" product-id="21795" /> <!-- CH341 USB-to-Serial -->
+    <usb-device vendor-id="6790" product-id="30084" /> <!-- CH340S USB-to-Serial -->
 </resources>

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -67,6 +67,7 @@ const defaultSerialDevices = [
     { vendorId: 11836, productId: 22336 }, // AT32 VCP
     { vendorId: 12619, productId: 22336 }, // APM32 VCP
     { vendorId: 11914, productId: 9 }, // Raspberry Pi Pico VCP
+    { vendorId: 6790, productId: 29987 }, // CH340 USB-to-Serial
 ];
 
 const defaultUsbFilters = [

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -67,7 +67,10 @@ const defaultSerialDevices = [
     { vendorId: 11836, productId: 22336 }, // AT32 VCP
     { vendorId: 12619, productId: 22336 }, // APM32 VCP
     { vendorId: 11914, productId: 9 }, // Raspberry Pi Pico VCP
+    { vendorId: 6790, productId: 29986 }, // CH340 USB-to-Serial (variant)
     { vendorId: 6790, productId: 29987 }, // CH340 USB-to-Serial
+    { vendorId: 6790, productId: 21795 }, // CH341 USB-to-Serial
+    { vendorId: 6790, productId: 30084 }, // CH340S USB-to-Serial
 ];
 
 const defaultUsbFilters = [

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -82,6 +82,7 @@ const defaultVendorIdNames = {
     1027: "FTDI",
     1155: "STM Electronics",
     4292: "Silicon Labs",
+    6790: "WCH (QinHeng Electronics)",
     11836: "AT32",
     12619: "Geehy Semiconductor",
     11914: "Raspberry Pi Pico",


### PR DESCRIPTION
Resolves https://github.com/betaflight/betaflight-configurator/issues/5051



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded support for additional WCH CH340/CH341 USB-to-Serial devices, increasing compatible hardware.
  * Added corresponding Android device filters so those devices are recognized on Android builds.
  * Added vendor display name "WCH (QinHeng Electronics)" for clearer device identification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5085)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->