### PR TITLE
fix(adjustments): restore tooltip z-index above sticky header

### DIFF
--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -32,7 +32,7 @@ export default {
         },
         tooltip: {
             slots: {
-                content: "ring-2 ring-primary max-w-sm lg:max-w-lg h-fit",
+                content: "ring-2 ring-primary max-w-sm lg:max-w-lg h-fit z-[9999]",
                 arrow: "fill-primary stroke-primary",
                 text: "whitespace-normal",
             },

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -32,7 +32,11 @@ export default {
         },
         tooltip: {
             slots: {
-                content: "ring-2 ring-primary max-w-sm lg:max-w-lg h-fit z-[9999]",
+                // z-[2500]: slot overrides replace the full class string, dropping Nuxt UI's default
+                // z-50. Without an explicit z-index, tooltips render behind the sticky header (z-10)
+                // due to the stacking context created by #main-wrapper's transform:scale(). 2500
+                // clears all app dialogs (z-1000–2001) and the ConnectButton dropdown (z-2100).
+                content: "ring-2 ring-primary max-w-sm lg:max-w-lg h-fit z-[2500]",
                 arrow: "fill-primary stroke-primary",
                 text: "whitespace-normal",
             },


### PR DESCRIPTION
Adjustments tab tooltip renders behind grey bar:

<img width="1918" height="1044" alt="image" src="https://github.com/user-attachments/assets/088152c7-7e2a-44b0-9043-f210087fc675" />


## Summary

- The `content` slot override in `nuxt-ui.vite.js` replaced the full Nuxt UI class string, inadvertently dropping the default `z-50` applied to tooltip content
- Without a z-index, tooltips rendered behind the sticky adjustments header (`z-index: 10`) inside `#main-wrapper` (which creates a new stacking context via `transform: scale()`)
- Adds `z-[9999]` to the `content` slot so tooltips always appear above all in-page stacking contexts

## Test plan

- [ ] Open the Adjustments tab
- [ ] Hover the `?` help icons in the column headers
- [ ] Verify the tooltip renders above the adjustment rows and sticky header

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced tooltip layering to ensure tooltips display above other page elements.
  * Improved tooltip stacking and display behavior for more consistent, reliable visibility across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->