### PR TITLE
feat(adjustments): explicit mode selector with conditional center/scale fields

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2911,11 +2911,23 @@
     "adjustmentsColumnViaChannel": {
         "message": "via channel"
     },
+    "adjustmentsColumnMode": {
+        "message": "mode"
+    },
+    "adjustmentsModeStep": {
+        "message": "Step"
+    },
+    "adjustmentsModeAbsolute": {
+        "message": "Absolute"
+    },
+    "adjustmentsModeSelection": {
+        "message": "Selection"
+    },
     "adjustmentsColumnAdjustmentCenter": {
-        "message": "w/ center (val.)"
+        "message": "center (val.)"
     },
     "adjustmentsColumnAdjustmentScale": {
-        "message": "and range|scale (val.|%)"
+        "message": "scale (val.|%)"
     },
     "adjustmentsCenterHelp": {
         "message": "Sets the mid-point or reference value used by the adjustment function.<br /><br /><strong>Slider Adjustments:</strong><br />For slider adjustments, set Adjustment Center to 0. The current slider position will be utilized for the adjustment up/down.<br /><br /><strong>Selection Adjustments:</strong><br />Set Adjustment Center to 0, or to a specific microsecond (uS) value if you want to offset the switch reference point from 1500uS when initiating the RC adjustment.<br /><br /><strong>Stepped Adjustments:</strong><br />Set Adjustment Center to 0 for the current value of the item being adjusted to be utilized.<br /><br /><strong>Absolute Adjustments:</strong><br />To use the Absolute adjustment method, you must set both Adjustment Center and Scale to specify the desired value and range. The range is calculated as: Center ± Scale. For example, setting Adjustment Center to 50 and Adjustment Scale to 25 creates a range from 25 to 75, with the center position (switch or POT) mapped to 50.<br /><br />Visit <a href=\"https://www.betaflight.com/docs/development/Inflight-Adjustments\" target=\"_blank\" rel=\"noopener noreferrer\">this page</a> for more info.",

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -129,7 +129,7 @@
                                 orientation="vertical"
                                 class="w-20"
                                 :disabled="!adjustment.enabled"
-                                :min="0"
+                                :min="1"
                                 :max="2000"
                                 :step="1"
                             />

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -20,6 +20,7 @@
                     <div>{{ $t("adjustmentsColumnIsInRange") }}</div>
                     <div>{{ $t("adjustmentsColumnThenApplyFunction") }}</div>
                     <div>{{ $t("adjustmentsColumnViaChannel") }}</div>
+                    <div>{{ $t("adjustmentsColumnMode") }}</div>
                     <div>
                         {{ $t("adjustmentsColumnAdjustmentCenter") }}
                         <HelpIcon :text="$t('adjustmentsCenterHelp')" />
@@ -95,6 +96,7 @@
                                 :disabled="!adjustment.enabled"
                                 searchable
                                 class="w-full"
+                                @update:model-value="onFunctionChange(adjustment)"
                             />
                         </div>
 
@@ -106,8 +108,22 @@
                             />
                         </div>
 
+                        <div class="adjustment-mode" :data-label="$t('adjustmentsColumnMode')">
+                            <span v-if="adjustment.mode === 'selection'" class="mode-badge">
+                                {{ $t("adjustmentsModeSelection") }}
+                            </span>
+                            <USelect
+                                v-else
+                                :model-value="adjustment.mode"
+                                :items="stepModeOptions"
+                                :disabled="!adjustment.enabled"
+                                @update:model-value="onModeChange(adjustment, $event)"
+                            />
+                        </div>
+
                         <div class="adjustment-center" :data-label="$t('adjustmentsColumnAdjustmentCenter')">
                             <UInputNumber
+                                v-if="adjustment.mode === 'absolute'"
                                 v-model="adjustment.adjustmentCenter"
                                 size="xs"
                                 orientation="vertical"
@@ -117,10 +133,12 @@
                                 :max="2000"
                                 :step="1"
                             />
+                            <span v-else class="cell-na">—</span>
                         </div>
 
                         <div class="adjustment-scale" :data-label="$t('adjustmentsColumnAdjustmentScale')">
                             <UInputNumber
+                                v-if="adjustment.mode === 'absolute'"
                                 v-model="adjustment.adjustmentScale"
                                 size="xs"
                                 orientation="vertical"
@@ -130,6 +148,7 @@
                                 :max="2000"
                                 :step="1"
                             />
+                            <span v-else class="cell-na">—</span>
                         </div>
                     </div>
                 </div>
@@ -161,9 +180,12 @@ const { adjustments, hasChanges, storeOriginals, showAllSlots, activeCount, visi
 const {
     auxChannelOptions,
     sortedFunctions,
+    stepModeOptions,
     pipValues,
     channelPercent,
     onEnableChange,
+    onModeChange,
+    onFunctionChange,
     loadMSPData,
     initializeAdjustments,
 } = useAdjustmentsData(adjustments, t);
@@ -198,7 +220,7 @@ onMounted(async () => {
 .adjustments-header,
 .adjustment {
     display: grid;
-    grid-template-columns: 3.5rem 5rem 1fr 13rem 5rem 4.5rem 4.5rem;
+    grid-template-columns: 3.5rem 5rem 1fr 13rem 5rem 7rem 4.5rem 4.5rem;
     gap: 12px;
     padding: 12px 16px;
 }
@@ -231,6 +253,7 @@ onMounted(async () => {
 .adjustment-disabled .adjustment-range,
 .adjustment-disabled .adjustment-function,
 .adjustment-disabled .adjustment-via,
+.adjustment-disabled .adjustment-mode,
 .adjustment-disabled .adjustment-center,
 .adjustment-disabled .adjustment-scale {
     pointer-events: none;
@@ -298,6 +321,23 @@ onMounted(async () => {
     font-size: 10px;
     color: var(--text-tertiary);
     white-space: nowrap;
+}
+
+.mode-badge {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--text-secondary);
+    background: var(--ui-bg-muted);
+    padding: 2px 6px;
+    border-radius: 4px;
+    white-space: nowrap;
+}
+
+.cell-na {
+    font-size: 13px;
+    color: var(--text-tertiary);
+    display: block;
+    text-align: center;
 }
 
 /* Responsive layout */

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -220,7 +220,7 @@ onMounted(async () => {
 .adjustments-header,
 .adjustment {
     display: grid;
-    grid-template-columns: 3.5rem 5rem 1fr 13rem 5rem 7rem 4.5rem 4.5rem;
+    grid-template-columns: 3.5rem 5rem 1fr 13rem 5rem 7rem 5rem 5rem;
     gap: 12px;
     padding: 12px 16px;
 }

--- a/src/composables/adjustments/useAdjustmentsData.js
+++ b/src/composables/adjustments/useAdjustmentsData.js
@@ -8,21 +8,28 @@ const CHANNEL_MIN = 900;
 const CHANNEL_MAX = 2100;
 const PIP_VALUES = [1000, 1200, 1500, 1800, 2000];
 
-// Functions the firmware marks as ADJUSTMENT_MODE_SELECT (no center/scale).
-// Indices match the adjustmentFunction enum in rc_adjustments.h, cross-checked
-// against defaultAdjustmentConfigs[] in rc_adjustments.c:
-//   12: ADJUSTMENT_RATE_PROFILE
-//   24: ADJUSTMENT_HORIZON_STRENGTH
-//   29: ADJUSTMENT_PID_AUDIO
-//   33: ADJUSTMENT_OSD_PROFILE
-//   34: ADJUSTMENT_LED_PROFILE
-//   35: ADJUSTMENT_LED_DIMMER
-//   36: ADJUSTMENT_SIMPLIFIED_MASTER_MULTIPLIER
-//   37: ADJUSTMENT_BATTERY_PROFILE
-// 34-37 are not currently reachable through the function dropdown
-// (adjustmentFunctionCount caps at 34) but are listed for correctness when a
-// future API version raises that cap.
-const SELECT_MODE_FUNCTIONS = new Set([12, 24, 29, 33, 34, 35, 36, 37]);
+// Wire u8 values whose firmware dispatch entry is ADJUSTMENT_MODE_SELECT
+// (i.e. no center/scale).
+//
+// IMPORTANT: these indices are NOT positions in the adjustmentFunction_e enum.
+// Firmware looks up the configured u8 via:
+//   defaultAdjustmentConfigs[adjustmentConfig - 1]   (rc_adjustments.c)
+// and that table was never extended to include the per-axis RC rates / expo
+// (enum values 25-28: ROLL_RC_RATE, PITCH_RC_RATE, ROLL_RC_EXPO, PITCH_RC_EXPO),
+// so dispatch table indices shift up by 4 from enum value 25 onward. The
+// configurator's adjustmentsFunctionN locale labels reflect the dispatch
+// behaviour, not the enum, which is what users actually experience on hardware.
+//
+// What this set means in terms of what the FC actually fires for each u8:
+//   12: RATE_PROFILE
+//   24: HORIZON_STRENGTH
+//   25: PID_AUDIO
+//   29: OSD_PROFILE
+//   30: LED_PROFILE
+//   31: LED_DIMMER
+//   32: SIMPLIFIED_MASTER_MULTIPLIER
+//   33: BATTERY_PROFILE
+const SELECT_MODE_FUNCTIONS = new Set([12, 24, 25, 29, 30, 31, 32, 33]);
 
 export function getAdjustmentMode(adjustmentFunction, adjustmentCenter) {
     if (SELECT_MODE_FUNCTIONS.has(adjustmentFunction)) {

--- a/src/composables/adjustments/useAdjustmentsData.js
+++ b/src/composables/adjustments/useAdjustmentsData.js
@@ -14,12 +14,10 @@ const PIP_VALUES = [1000, 1200, 1500, 1800, 2000];
 // OSD Profile, LED Profile, LED Brightness, Slider Multiplier, Battery Profile
 const SELECT_MODE_FUNCTIONS = new Set([12, 24, 25, 29, 30, 31, 32, 33]);
 
-export function getFunctionMode(adjustmentFunction) {
-    return SELECT_MODE_FUNCTIONS.has(adjustmentFunction) ? "selection" : "step";
-}
-
 export function getAdjustmentMode(adjustmentFunction, adjustmentCenter) {
-    if (SELECT_MODE_FUNCTIONS.has(adjustmentFunction)) return "selection";
+    if (SELECT_MODE_FUNCTIONS.has(adjustmentFunction)) {
+        return "selection";
+    }
     return adjustmentCenter > 0 ? "absolute" : "step";
 }
 
@@ -59,10 +57,10 @@ export function useAdjustmentsData(adjustments, t) {
         return [first, ...rest];
     });
 
-    const stepModeOptions = [
+    const stepModeOptions = computed(() => [
         { value: "step", label: t("adjustmentsModeStep") },
         { value: "absolute", label: t("adjustmentsModeAbsolute") },
-    ];
+    ]);
 
     const channelPercent = (value) => {
         if (value === undefined || value === null || Number.isNaN(value)) {

--- a/src/composables/adjustments/useAdjustmentsData.js
+++ b/src/composables/adjustments/useAdjustmentsData.js
@@ -8,21 +8,21 @@ const CHANNEL_MIN = 900;
 const CHANNEL_MAX = 2100;
 const PIP_VALUES = [1000, 1200, 1500, 1800, 2000];
 
-// Functions the configurator treats as ADJUSTMENT_MODE_SELECT (no center/scale).
-// Indices map to the adjustmentFunction enum in rc_adjustments.h:
+// Functions the firmware marks as ADJUSTMENT_MODE_SELECT (no center/scale).
+// Indices match the adjustmentFunction enum in rc_adjustments.h, cross-checked
+// against defaultAdjustmentConfigs[] in rc_adjustments.c:
 //   12: ADJUSTMENT_RATE_PROFILE
 //   24: ADJUSTMENT_HORIZON_STRENGTH
-//   25: ADJUSTMENT_ROLL_RC_RATE
 //   29: ADJUSTMENT_PID_AUDIO
-//   30: ADJUSTMENT_PITCH_F
-//   31: ADJUSTMENT_ROLL_F
-//   32: ADJUSTMENT_YAW_F
 //   33: ADJUSTMENT_OSD_PROFILE
-// NOTE: this set's membership does not exactly match the firmware's SELECT-mode
-// list (firmware has 12, 24, 29, 33, 34, 35, 36, 37). Reconciling that — and
-// adding the missing LED/Simplified Master Multiplier/Battery Profile entries
-// — is tracked separately so as not to change behaviour from this PR.
-const SELECT_MODE_FUNCTIONS = new Set([12, 24, 25, 29, 30, 31, 32, 33]);
+//   34: ADJUSTMENT_LED_PROFILE
+//   35: ADJUSTMENT_LED_DIMMER
+//   36: ADJUSTMENT_SIMPLIFIED_MASTER_MULTIPLIER
+//   37: ADJUSTMENT_BATTERY_PROFILE
+// 34-37 are not currently reachable through the function dropdown
+// (adjustmentFunctionCount caps at 34) but are listed for correctness when a
+// future API version raises that cap.
+const SELECT_MODE_FUNCTIONS = new Set([12, 24, 29, 33, 34, 35, 36, 37]);
 
 export function getAdjustmentMode(adjustmentFunction, adjustmentCenter) {
     if (SELECT_MODE_FUNCTIONS.has(adjustmentFunction)) {

--- a/src/composables/adjustments/useAdjustmentsData.js
+++ b/src/composables/adjustments/useAdjustmentsData.js
@@ -8,10 +8,20 @@ const CHANNEL_MIN = 900;
 const CHANNEL_MAX = 2100;
 const PIP_VALUES = [1000, 1200, 1500, 1800, 2000];
 
-// Functions that use ADJUSTMENT_MODE_SELECT in rc_adjustments.c
-// (profile/mode switching — no center/scale applicable)
-// Indices 12,24,25,29-33 map to: Rate Profile, Horizon Strength, PID-Audio,
-// OSD Profile, LED Profile, LED Brightness, Slider Multiplier, Battery Profile
+// Functions the configurator treats as ADJUSTMENT_MODE_SELECT (no center/scale).
+// Indices map to the adjustmentFunction enum in rc_adjustments.h:
+//   12: ADJUSTMENT_RATE_PROFILE
+//   24: ADJUSTMENT_HORIZON_STRENGTH
+//   25: ADJUSTMENT_ROLL_RC_RATE
+//   29: ADJUSTMENT_PID_AUDIO
+//   30: ADJUSTMENT_PITCH_F
+//   31: ADJUSTMENT_ROLL_F
+//   32: ADJUSTMENT_YAW_F
+//   33: ADJUSTMENT_OSD_PROFILE
+// NOTE: this set's membership does not exactly match the firmware's SELECT-mode
+// list (firmware has 12, 24, 29, 33, 34, 35, 36, 37). Reconciling that — and
+// adding the missing LED/Simplified Master Multiplier/Battery Profile entries
+// — is tracked separately so as not to change behaviour from this PR.
 const SELECT_MODE_FUNCTIONS = new Set([12, 24, 25, 29, 30, 31, 32, 33]);
 
 export function getAdjustmentMode(adjustmentFunction, adjustmentCenter) {

--- a/src/composables/adjustments/useAdjustmentsData.js
+++ b/src/composables/adjustments/useAdjustmentsData.js
@@ -8,6 +8,21 @@ const CHANNEL_MIN = 900;
 const CHANNEL_MAX = 2100;
 const PIP_VALUES = [1000, 1200, 1500, 1800, 2000];
 
+// Functions that use ADJUSTMENT_MODE_SELECT in rc_adjustments.c
+// (profile/mode switching — no center/scale applicable)
+// Indices 12,24,25,29-33 map to: Rate Profile, Horizon Strength, PID-Audio,
+// OSD Profile, LED Profile, LED Brightness, Slider Multiplier, Battery Profile
+const SELECT_MODE_FUNCTIONS = new Set([12, 24, 25, 29, 30, 31, 32, 33]);
+
+export function getFunctionMode(adjustmentFunction) {
+    return SELECT_MODE_FUNCTIONS.has(adjustmentFunction) ? "selection" : "step";
+}
+
+export function getAdjustmentMode(adjustmentFunction, adjustmentCenter) {
+    if (SELECT_MODE_FUNCTIONS.has(adjustmentFunction)) return "selection";
+    return adjustmentCenter > 0 ? "absolute" : "step";
+}
+
 export function useAdjustmentsData(adjustments, t) {
     const fcStore = useFlightControllerStore();
 
@@ -44,6 +59,11 @@ export function useAdjustmentsData(adjustments, t) {
         return [first, ...rest];
     });
 
+    const stepModeOptions = [
+        { value: "step", label: t("adjustmentsModeStep") },
+        { value: "absolute", label: t("adjustmentsModeAbsolute") },
+    ];
+
     const channelPercent = (value) => {
         if (value === undefined || value === null || Number.isNaN(value)) {
             return 50;
@@ -61,6 +81,24 @@ export function useAdjustmentsData(adjustments, t) {
         } else {
             adjustment.range.start = 900;
             adjustment.range.end = 900;
+        }
+    };
+
+    const onModeChange = (adjustment, newMode) => {
+        if (newMode === "step") {
+            adjustment.adjustmentCenter = 0;
+            adjustment.adjustmentScale = 0;
+        } else if (newMode === "absolute") {
+            if (adjustment.adjustmentCenter === 0) {
+                adjustment.adjustmentCenter = 50;
+            }
+        }
+    };
+
+    const onFunctionChange = (adjustment) => {
+        if (SELECT_MODE_FUNCTIONS.has(adjustment.adjustmentFunction)) {
+            adjustment.adjustmentCenter = 0;
+            adjustment.adjustmentScale = 0;
         }
     };
 
@@ -95,6 +133,9 @@ export function useAdjustmentsData(adjustments, t) {
                 adjustmentCenter: range.adjustmentCenter ?? 0,
                 adjustmentScale: range.adjustmentScale ?? 0,
                 enabled: isEnabled,
+                get mode() {
+                    return getAdjustmentMode(this.adjustmentFunction, this.adjustmentCenter);
+                },
                 get rangeArray() {
                     return [this.range.start, this.range.end];
                 },
@@ -111,9 +152,12 @@ export function useAdjustmentsData(adjustments, t) {
         auxChannelCount,
         auxChannelOptions,
         sortedFunctions,
+        stepModeOptions,
         pipValues,
         channelPercent,
         onEnableChange,
+        onModeChange,
+        onFunctionChange,
         loadMSPData,
         initializeAdjustments,
     };


### PR DESCRIPTION
## Summary

- Adds a **Mode** column to the Adjustments tab with a Step/Absolute dropdown for each slot
- Functions that use selection mode (profile switching, master multiplier, etc.) show a read-only **Selection** badge instead of a dropdown
- **Center** and **Scale** input fields are now hidden unless the slot is in Absolute mode, reducing visual noise for the common step-mode case
- Switching function to a selection-mode function automatically clears center/scale to 0

## Motivation

Previously the mode was implicit — users had to know that center=0 meant step mode and center>0 meant absolute mode. This made it easy to accidentally leave stale center/scale values and hard to discover absolute mode existed.

## Changes

- `useAdjustmentsData.js`: added `SELECT_MODE_FUNCTIONS` set, `getAdjustmentMode()` helper, `stepModeOptions`, `onModeChange()`, `onFunctionChange()`; reactive adjustment objects now expose a `mode` computed getter
- `AdjustmentsTab.vue`: 8-column grid, Mode column with `USelect` or badge, center/scale cells gated on `adjustment.mode === 'absolute'`
- `locales/en/messages.json`: new keys `adjustmentsColumnMode`, `adjustmentsModeStep`, `adjustmentsModeAbsolute`, `adjustmentsModeSelection`

## Test plan

- [ ] Step mode slot: Mode dropdown shows "Step", center/scale show —
- [ ] Switch Mode to Absolute: center/scale inputs appear, default center=50
- [ ] Switch Mode back to Step: center/scale clear to 0 and inputs hide
- [ ] Select a selection-mode function (e.g. Profile Selection): Mode badge shows "Selection", center/scale show —
- [ ] Switch back to a non-selection function: Mode dropdown reappears
- [ ] Existing absolute adjustments (center>0) load correctly as Absolute mode
- [ ] Save roundtrip: saved values persist correctly after reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Mode column in the Adjustments tab with selectable modes: Step, Absolute, and Selection; includes a selection-mode badge and step selector. Controls are mode-aware and switching modes updates related adjustment values.

* **UI Improvements**
  * Clarified labels to "center (val.)" and "scale (val.|%)" and added new mode option labels for improved clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5088)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->