### PR TITLE
blackbox: UI for ring-buffer onboard-flash logging mode

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7609,6 +7609,9 @@
     "onboardLoggingFlashModeMismatch": {
         "message": "The selected flash mode doesn't match the format currently on the chip. Erase the onboard flash before logging — existing logs in the other format will not be readable."
     },
+    "onboardLoggingSaveToFileRingNote": {
+        "message": "Ring-mode flash uses a different on-disk layout (data → trailer → header per session) that the blackbox decoder does not parse directly from a raw flash dump. <b>Use USB Mass Storage Mode (below) instead</b> — it presents each log as a properly-formatted <code>.BBL</code> file."
+    },
     "onboardLoggingRateRingExceedsCap": {
         "message": "exceeds ring-mode rate cap"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7594,6 +7594,24 @@
     "onboardLoggingRateOfLogging": {
         "message": "Blackbox logging rate"
     },
+    "onboardLoggingFlashMode": {
+        "message": "Onboard flash mode"
+    },
+    "onboardLoggingFlashModeLinear": {
+        "message": "Linear (default — record until flash is full)"
+    },
+    "onboardLoggingFlashModeRing": {
+        "message": "Ring (overwrite oldest — always keep most recent flights)"
+    },
+    "onboardLoggingFlashModeRingHint": {
+        "message": "Ring mode continuously overwrites the oldest data so the flash always contains the most recent flights. Useful for long sessions, crash debugging (last few minutes are always retained), and field testing without USB cable management. Maximum effective frame rate is capped at ~1 kHz to fit the chip's sector-erase throughput; rates above that are disabled in the dropdown above."
+    },
+    "onboardLoggingFlashModeMismatch": {
+        "message": "The selected flash mode doesn't match the format currently on the chip. Erase the onboard flash before logging — existing logs in the other format will not be readable."
+    },
+    "onboardLoggingRateRingExceedsCap": {
+        "message": "exceeds ring-mode rate cap"
+    },
     "onboardLoggingDebugFields": {
         "message": "Debug Fields included"
     },

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -447,10 +447,11 @@ export default defineComponent({
         // the chip's sector-erase throughput, leading to dropped frames in the log.
         const RING_MAX_FRAME_HZ = 1000;
 
-        const flashModeOptions = computed(() => [
+        // Static array — not reactive. Plain `const` avoids needless computed tracking.
+        const flashModeOptions = [
             { label: i18n.getMessage("onboardLoggingFlashModeLinear"), value: 0 },
             { label: i18n.getMessage("onboardLoggingFlashModeRing"), value: 1 },
-        ]);
+        ];
 
         const loggingRates = computed(() => {
             const rates = [];

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -479,7 +479,7 @@ export default defineComponent({
                 rates.push({
                     value: i,
                     label: `1/${Math.pow(2, i)} (${loggingFrequency}${loggingFrequencyUnit})${
-                        overCap ? " — " + i18n.getMessage("onboardLoggingRateRingExceedsCap") : ""
+                        overCap ? ` — ${i18n.getMessage("onboardLoggingRateRingExceedsCap")}` : ""
                     }`,
                     disabled: overCap,
                 });
@@ -490,14 +490,22 @@ export default defineComponent({
         // True when a stored on-flash format exists and doesn't match the configured
         // mode — switching modes will require erasing flash before logging works.
         const flashModeMismatch = computed(() => {
-            if (!flashModeSupported.value) return false;
+            if (!flashModeSupported.value) {
+                return false;
+            }
             const fmt = fcStore.blackbox?.flashFormat;
             // 0 = EMPTY (no logs yet, can switch freely)
             // 1 = LINEAR, 2 = RING — must match flashMode
             // 3 = UNKNOWN — treat as needing erase to be safe
-            if (fmt === undefined || fmt === 0) return false;
-            if (fmt === 1 && flashMode.value === 0) return false;
-            if (fmt === 2 && flashMode.value === 1) return false;
+            if (fmt === undefined || fmt === 0) {
+                return false;
+            }
+            if (fmt === 1 && flashMode.value === 0) {
+                return false;
+            }
+            if (fmt === 2 && flashMode.value === 1) {
+                return false;
+            }
             return true;
         });
 

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -222,6 +222,7 @@
                                         <HelpIcon :text="$t('dataflashSaveFileDepreciationHint')" />
                                     </a>
                                     <p v-html="$t('dataflashSavetoFileNote')"></p>
+                                    <p v-if="flashFormatIsRing" class="note warning" v-html="$t('onboardLoggingSaveToFileRingNote')"></p>
                                 </div>
                             </div>
 
@@ -486,6 +487,17 @@ export default defineComponent({
                 });
             }
             return rates;
+        });
+
+        // True when the on-flash format is ring (regardless of currently-configured
+        // mode). Save-to-file does a raw partition dump via MSP_DATAFLASH_READ, which
+        // captures the physical ring layout (data → trailer → header per session) —
+        // the blackbox decoder expects header at the start of the file, so the dump
+        // won't decode cleanly. We show a hint directing the user to USB MSC where
+        // the on-device emfat layer presents the proper header || data per session.
+        const flashFormatIsRing = computed(() => {
+            // 0 = EMPTY, 1 = LINEAR, 2 = RING, 3 = UNKNOWN
+            return fcStore.blackbox?.flashFormat === 2;
         });
 
         // True when a stored on-flash format exists and doesn't match the configured
@@ -972,6 +984,7 @@ export default defineComponent({
             flashModeSupported,
             flashModeOptions,
             flashModeMismatch,
+            flashFormatIsRing,
             debugMode,
             debugFieldsEnabled,
             saveProgress,

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -40,6 +40,20 @@
                             <SettingRow v-show="blackboxDevice !== 0" :label="$t('onboardLoggingRateOfLogging')">
                                 <USelect v-model="blackboxRate" :items="loggingRates" size="sm" class="min-w-40" />
                             </SettingRow>
+                            <SettingRow v-show="flashModeSupported" :label="$t('onboardLoggingFlashMode')">
+                                <USelect
+                                    v-model="flashMode"
+                                    :items="flashModeOptions"
+                                    size="sm"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                            <div v-show="flashModeSupported && flashMode === 1" class="note">
+                                <p>{{ $t("onboardLoggingFlashModeRingHint") }}</p>
+                            </div>
+                            <div v-show="flashModeMismatch" class="note warning">
+                                <p>{{ $t("onboardLoggingFlashModeMismatch") }}</p>
+                            </div>
                             <SettingRow :label="$t('onboardLoggingDebugMode')">
                                 <USelectMenu
                                     v-model="debugMode"
@@ -286,7 +300,7 @@ import GUI from "../../js/gui";
 import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
 import { mspHelper } from "../../js/msp/MSPHelper";
-import { API_VERSION_1_45, API_VERSION_1_47 } from "../../js/data_storage";
+import { API_VERSION_1_45, API_VERSION_1_47, API_VERSION_1_49 } from "../../js/data_storage";
 import { i18n } from "../../js/localization";
 import semver from "semver";
 import { gui_log } from "../../js/gui_log";
@@ -361,6 +375,7 @@ export default defineComponent({
         // State
         const blackboxDevice = ref(0);
         const blackboxRate = ref(0);
+        const flashMode = ref(0); // 0 = LINEAR, 1 = RING (API 1.49+)
         const debugMode = ref(0);
         // Initialize all debug fields as enabled by default (empty array causes issues)
         const debugFieldsEnabled = ref(debugStore.enableFields ? debugStore.enableFields.map(() => true) : []);
@@ -418,6 +433,25 @@ export default defineComponent({
             return "no";
         });
 
+        const flashModeSupported = computed(() => {
+            return (
+                fcStore.config?.apiVersion &&
+                semver.gte(fcStore.config.apiVersion, API_VERSION_1_49) &&
+                dataflashSupported.value &&
+                blackboxDevice.value === 1
+            );
+        });
+
+        // Cap on the effective frame rate that ring mode can sustain on NOR flash.
+        // Mirrors BLACKBOX_RING_MAX_FRAME_HZ in blackbox.c. Higher rates would overrun
+        // the chip's sector-erase throughput, leading to dropped frames in the log.
+        const RING_MAX_FRAME_HZ = 1000;
+
+        const flashModeOptions = computed(() => [
+            { label: i18n.getMessage("onboardLoggingFlashModeLinear"), value: 0 },
+            { label: i18n.getMessage("onboardLoggingFlashModeRing"), value: 1 },
+        ]);
+
         const loggingRates = computed(() => {
             const rates = [];
 
@@ -428,20 +462,43 @@ export default defineComponent({
 
             const pidRate = fcStore.config.sampleRateHz / fcStore.pidAdvancedConfig.pid_process_denom;
             const sampleRateNum = 5;
+            // In ring mode the firmware silently clamps any rate that would exceed the
+            // chip's erase throughput (BLACKBOX_RING_MAX_FRAME_HZ). Disable those entries
+            // in the dropdown so the user sees up front which rates are allowed.
+            const ringActive = flashModeSupported.value && flashMode.value === 1;
 
             for (let i = 0; i < sampleRateNum; i++) {
-                let loggingFrequency = Math.round(pidRate / Math.pow(2, i));
+                const loggingFrequencyHz = Math.round(pidRate / Math.pow(2, i));
+                let loggingFrequency = loggingFrequencyHz;
                 let loggingFrequencyUnit = "Hz";
                 if (gcd(loggingFrequency, 1000) === 1000) {
                     loggingFrequency /= 1000;
                     loggingFrequencyUnit = "kHz";
                 }
+                const overCap = ringActive && loggingFrequencyHz > RING_MAX_FRAME_HZ;
                 rates.push({
                     value: i,
-                    label: `1/${Math.pow(2, i)} (${loggingFrequency}${loggingFrequencyUnit})`,
+                    label: `1/${Math.pow(2, i)} (${loggingFrequency}${loggingFrequencyUnit})${
+                        overCap ? " — " + i18n.getMessage("onboardLoggingRateRingExceedsCap") : ""
+                    }`,
+                    disabled: overCap,
                 });
             }
             return rates;
+        });
+
+        // True when a stored on-flash format exists and doesn't match the configured
+        // mode — switching modes will require erasing flash before logging works.
+        const flashModeMismatch = computed(() => {
+            if (!flashModeSupported.value) return false;
+            const fmt = fcStore.blackbox?.flashFormat;
+            // 0 = EMPTY (no logs yet, can switch freely)
+            // 1 = LINEAR, 2 = RING — must match flashMode
+            // 3 = UNKNOWN — treat as needing erase to be safe
+            if (fmt === undefined || fmt === 0) return false;
+            if (fmt === 1 && flashMode.value === 0) return false;
+            if (fmt === 2 && flashMode.value === 1) return false;
+            return true;
         });
 
         const debugModes = computed(() => {
@@ -533,6 +590,7 @@ export default defineComponent({
             JSON.stringify({
                 blackboxDevice: blackboxDevice.value,
                 blackboxRate: blackboxRate.value,
+                flashMode: flashMode.value,
                 debugMode: debugMode.value,
                 debugFieldsEnabled: [...debugFieldsEnabled.value],
             });
@@ -557,6 +615,8 @@ export default defineComponent({
             fcStore.blackbox.blackboxSampleRate = blackboxRate.value;
             fcStore.blackbox.blackboxPDenom = blackboxRate.value;
             fcStore.blackbox.blackboxDevice = blackboxDevice.value;
+            // Only sent over the wire when the FC supports API 1.49+; MSPHelper guards.
+            fcStore.blackbox.flashMode = flashMode.value;
 
             // Update disabled mask from checkboxes
             let mask = 0;
@@ -861,6 +921,7 @@ export default defineComponent({
                 // Populate UI state
                 blackboxDevice.value = fcStore.blackbox?.blackboxDevice || 0;
                 blackboxRate.value = fcStore.blackbox?.blackboxSampleRate || 0;
+                flashMode.value = fcStore.blackbox?.flashMode || 0;
                 debugMode.value = fcStore.pidAdvancedConfig?.debugMode || 0;
 
                 // Initialize debug fields checkboxes
@@ -898,6 +959,10 @@ export default defineComponent({
             savingDialog,
             blackboxDevice,
             blackboxRate,
+            flashMode,
+            flashModeSupported,
+            flashModeOptions,
+            flashModeMismatch,
             debugMode,
             debugFieldsEnabled,
             saveProgress,

--- a/src/js/data_storage.js
+++ b/src/js/data_storage.js
@@ -5,13 +5,14 @@ export const API_VERSION_1_45 = "1.45.0";
 export const API_VERSION_1_46 = "1.46.0";
 export const API_VERSION_1_47 = "1.47.0";
 export const API_VERSION_1_48 = "1.48.0";
+export const API_VERSION_1_49 = "1.49.0";
 
 import { reactive } from "vue";
 
 const CONFIGURATOR = reactive({
     // all versions are specified and compared using semantic versioning http://semver.org/
     API_VERSION_ACCEPTED: API_VERSION_1_44,
-    API_VERSION_MAX_SUPPORTED: API_VERSION_1_48,
+    API_VERSION_MAX_SUPPORTED: API_VERSION_1_49,
 
     connectionValid: false,
     connectionValidCliOnly: false,

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -465,6 +465,11 @@ const FC = {
             blackboxPDenom: 0,
             blackboxSampleRate: 0,
             blackboxDisabledMask: 0,
+            // API 1.49+: onboard-flash logging mode and detected on-flash format.
+            //   flashMode:   0 = LINEAR (default), 1 = RING
+            //   flashFormat: 0 = EMPTY, 1 = LINEAR, 2 = RING, 3 = UNKNOWN
+            flashMode: 0,
+            flashFormat: 3,
         };
 
         this.RC_DEADBAND_CONFIG = {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -7,7 +7,7 @@ import semver from "semver";
 import vtxDeviceStatusFactory from "../utils/VtxDeviceStatus/VtxDeviceStatusFactory";
 import MSP from "../msp";
 import MSPCodes from "./MSPCodes";
-import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48 } from "../data_storage";
+import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48, API_VERSION_1_49 } from "../data_storage";
 import EscProtocols from "../utils/EscProtocols";
 import huffmanDecodeBuf from "../huffman";
 import { defaultHuffmanTree, defaultHuffmanLenIndex } from "../default_huffman_tree";
@@ -1513,6 +1513,14 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
                         FC.BLACKBOX.blackboxDisabledMask = data.readU32();
                     }
+
+                    // Introduced in API version 1.49: ring-mode flash params.
+                    // flashMode = configured mode (0=LINEAR, 1=RING)
+                    // flashFormat = detected on-flash format (0=EMPTY, 1=LINEAR, 2=RING, 3=UNKNOWN)
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_49)) {
+                        FC.BLACKBOX.flashMode = data.readU8();
+                        FC.BLACKBOX.flashFormat = data.readU8();
+                    }
                     break;
                 case MSPCodes.MSP_SET_BLACKBOX_CONFIG:
                     console.log("Blackbox config saved");
@@ -2328,6 +2336,11 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
             // Introduced in 1.45
             if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
                 buffer.push32(FC.BLACKBOX.blackboxDisabledMask);
+            }
+
+            // Introduced in 1.49: ring-mode flash mode (LINEAR=0, RING=1).
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_49)) {
+                buffer.push8(FC.BLACKBOX.flashMode);
             }
 
             break;


### PR DESCRIPTION
## Summary

Pairs with [betaflight/betaflight#15197](https://github.com/betaflight/betaflight/pull/15197) (firmware MSP API 1.49). The firmware adds a ring-buffer logging mode for onboard SPI flash that overwrites oldest data once full; this PR adds the configurator UI for it.

This PR depends on the firmware PR landing first (or the API_VERSION_MAX_SUPPORTED bump should be reverted until then). The new fields are version-gated to API 1.49+, so older firmware is unaffected.

## What's new in the Blackbox tab

When **On-board flash** is selected as the logging device on a 1.49+ FC, a new dropdown appears:

> **Onboard flash mode:** \[Linear (default) | Ring (overwrite oldest)]

- **Linear** = bit-for-bit current behavior. Defaults to this for all existing users.
- **Ring** = continuously overwrites oldest data. Always keeps the most recent flights even after running out of free space.

When **Ring** is selected:

1. The **Logging rate** dropdown disables entries that exceed the chip's ~1 kHz frame-rate cap (driven by NOR sector-erase throughput). Labels show the cap on each disabled option, e.g. `1/2 (4kHz) — exceeds ring-mode rate cap`.
2. A short hint paragraph appears under the dropdown explaining ring mode and the rate cap.

If the FC reports that the flash currently contains a *different* format than the configured mode (e.g. Ring is selected but the chip still has Linear logs), a yellow warning appears:
> "The selected flash mode doesn't match the format currently on the chip. Erase the onboard flash before logging — existing logs in the other format will not be readable."

## Save-to-file hint on ring-mode chips

The existing "Save Flash to file" button does a raw partition dump via `MSP_DATAFLASH_READ`. On ring-mode chips the physical layout is `[data][trailer][header text]` per session (header at the END of each log's data) — the blackbox decoder doesn't parse such files directly and reports "no events". When the FC reports `flashFormat == RING`, a yellow note appears next to the Save buttons directing the user to USB Mass Storage Mode (which already presents each log as a proper `header || data` virtual file via the on-device emfat layer).

A full ring-aware save-to-file path (host-side trailer scan + per-session file split) is a substantial change and is left as a follow-up — for now the hint just steers users to the path that already works correctly.

## MSP wire changes

- `API_VERSION_MAX_SUPPORTED` bumped from 1.48 → 1.49
- `MSP_BLACKBOX_CONFIG` reads two new u8 fields at the end:
  - `flashMode` — configured (0=LINEAR, 1=RING)
  - `flashFormat` — detected on-flash format (0=EMPTY, 1=LINEAR, 2=RING, 3=UNKNOWN)
- `MSP_SET_BLACKBOX_CONFIG` writes the new `flashMode` byte at the end (firmware ignores it on older API versions; field is optional in the protocol).

## Files changed

- `locales/en/messages.json` — six new i18n strings
- `src/components/tabs/OnboardLoggingTab.vue` — dropdown, rate-cap awareness, hint, mismatch warning
- `src/js/data_storage.js` — new API_VERSION_1_49 constant
- `src/js/fc.js` — new `flashMode` / `flashFormat` defaults in `BLACKBOX`
- `src/js/msp/MSPHelper.js` — read/write the new MSP fields

## Test plan

- [ ] On a 1.49 FC with onboard flash: dropdown appears, switching to Ring disables high rates; hint paragraph shows
- [ ] On a 1.48 (older) FC: dropdown stays hidden; existing Blackbox tab behavior unchanged
- [ ] Switch Linear → Ring with existing linear logs → mismatch warning appears, "Erase Flash" button still works
- [ ] After erase, mismatch warning clears
- [ ] On a ring-formatted chip: Save-to-file ring-mode warning paragraph appears next to the Save buttons; existing raw-dump still functions (intended use is "advanced fallback only" with MSC as the supported path)
- [ ] Save settings persists `flashMode` (verify via CLI `dump | grep blackbox_flash_mode`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added flash mode selection (Linear / Ring) for blackbox onboard logging on compatible flight controllers.
  * Ring mode enforces a frame-rate cap and disables or annotates rate options that would exceed it.
  * Displays a mismatch warning if the selected flash mode differs from the chip’s current format.
  * “Save to file” shows a ring-layout note when applicable.
  * Flash mode is persisted, initialized from the device, and survives sessions.
  * UI localization added for labels, hints and rate-cap warnings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5090)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
