### PR TITLE
RFC: adjustmentFunction labels appear off-by-4 vs firmware enum (since 2018)

### DIFF
--- a/src/composables/adjustments/useAdjustmentsData.js
+++ b/src/composables/adjustments/useAdjustmentsData.js
@@ -22,6 +22,14 @@ export function useAdjustmentsData(adjustments, t) {
         return options;
     });
 
+    // NOTE: the localizations adjustmentsFunction25..adjustmentsFunction33 (and the
+    // 34-entry cap for API >= 1.48) appear to be stale relative to the firmware
+    // adjustmentFunction_e enum, which has had ROLL_RC_RATE/PITCH_RC_RATE/ROLL_RC_EXPO/
+    // PITCH_RC_EXPO at indices 25-28 since 2018 (firmware ee65eba88). The configurator
+    // sends adjustmentFunction over MSP as a raw u8 with no translation, so a user
+    // picking the entry labeled "PID-Audio Selection" (configurator label for index 25)
+    // actually configures ADJUSTMENT_ROLL_RC_RATE on the FC. See the open RFC for the
+    // full analysis and proposed remediation paths.
     const adjustmentFunctionCount = computed(() => {
         return fcStore.isApiVersionSupported(API_VERSION_1_48) ? 34 : 33;
     });


### PR DESCRIPTION
## Status

**Draft / RFC.** I'm raising this for discussion, not asking for a merge as-is. The diff is intentionally tiny (one comment block); the body is the actual deliverable.

## TL;DR

The configurator's `adjustmentsFunction25..adjustmentsFunction33` locale labels appear to be 4 positions out of date relative to the firmware `adjustmentFunction_e` enum, and have been since **June 2018**. Since `adjustmentFunction` round-trips as a raw `u8` over MSP, the dropdown labels users see don't match the firmware function those values actually activate. I'd like a sanity check from the maintainers before anyone (me or anyone else) touches the labels.

## What I think is happening

The firmware enum (`src/main/fc/rc_adjustments.h` on `betaflight/master`) currently is:

| Index | Enum |
|---|---|
| 12 | `ADJUSTMENT_RATE_PROFILE` |
| 24 | `ADJUSTMENT_HORIZON_STRENGTH` |
| 25 | `ADJUSTMENT_ROLL_RC_RATE` |
| 26 | `ADJUSTMENT_PITCH_RC_RATE` |
| 27 | `ADJUSTMENT_ROLL_RC_EXPO` |
| 28 | `ADJUSTMENT_PITCH_RC_EXPO` |
| 29 | `ADJUSTMENT_PID_AUDIO` |
| 30 | `ADJUSTMENT_PITCH_F` |
| 31 | `ADJUSTMENT_ROLL_F` |
| 32 | `ADJUSTMENT_YAW_F` |
| 33 | `ADJUSTMENT_OSD_PROFILE` |
| 34 | `ADJUSTMENT_LED_PROFILE` |
| 35 | `ADJUSTMENT_LED_DIMMER` |
| 36 | `ADJUSTMENT_SIMPLIFIED_MASTER_MULTIPLIER` |
| 37 | `ADJUSTMENT_BATTERY_PROFILE` |

The configurator's `locales/en/messages.json` (on `master`) has:

| Index | Configurator label |
|---|---|
| 24 | "Horizon Strength Adjustment" |
| 25 | "PID-Audio Selection" |
| 26 | "Pitch F Adjustment" |
| 27 | "Roll F Adjustment" |
| 28 | "Yaw F Adjustment" |
| 29 | "OSD Profile Selection" |
| 30 | "LED Profile Selection" |
| 31 | "LED Brightness Adjust" |
| 32 | "Slider Master Multiplier" |
| 33 | "Battery Profile Selection" |

So labels 25-33 in the configurator look like the labels for firmware indices 29-37 (i.e. shifted up by 4). Labels 34-37 don't exist at all.

## How the divergence happened (working theory)

- **2018-01-18** — firmware commit `ee65eba88` "Added selectable RaceFlight rates" inserted `ROLL_RC_RATE`/`PITCH_RC_RATE`/`ROLL_RC_EXPO`/`PITCH_RC_EXPO` at indices 25-28, pushing everything from `PID_AUDIO` onward down by 4.
- **2018-06-06** — configurator commit `a0aa154b` "Add PID-Audio adjustment" added `adjustmentsFunction25` = "PID-Audio Selection". This matched the *pre-2018* enum order but not the post-2018 firmware. No subsequent locale entries appear to correct it.

## Why I think it matters

`MSPHelper.js` (`src/js/msp/MSPHelper.js`, around line 1056 / 2645) reads and writes `adjustmentFunction` as a single `u8`, with no translation table. So whatever index the configurator's dropdown stores is exactly what the firmware uses to look up `defaultAdjustmentConfigs[]`.

A user who currently selects the dropdown entry **labeled** "PID-Audio Selection" stores `adjustmentFunction = 25` in their config. Firmware then activates `ADJUSTMENT_ROLL_RC_RATE`. Functionally they get Roll RC Rate adjustment, but the configurator UI tells them it's PID-Audio. Same shift applies to every label from 25 through 33.

I haven't been able to find user-facing reports of this on the issue tracker (search came back empty for "adjustment"+"select mode" / "SELECT_MODE_FUNCTIONS" / a few related queries), so it's possible:

1. Almost no-one is using these higher-index adjustments in practice, OR
2. People who *do* use them have just learned to ignore the labels and pick by trial, OR
3. I'm misreading something — please tell me which.

The new "Mode" column work in [#5088](https://github.com/betaflight/betaflight-configurator/pull/5088) surfaced this when I tried to align that PR's `SELECT_MODE_FUNCTIONS` set with firmware reality.

## Knock-on effects

- `adjustmentFunctionCount` returns 33 (pre-1.48) or 34 (>= 1.48), so indices 34-37 (`LED_PROFILE`, `LED_DIMMER`, `SIMPLIFIED_MASTER_MULTIPLIER`, `BATTERY_PROFILE`) are not selectable from the dropdown today, even though firmware has supported them for some time.
- Localizations for `adjustmentsFunction34`..`adjustmentsFunction37` don't exist in any locale.
- The `SELECT_MODE_FUNCTIONS` set introduced by [#5088](https://github.com/betaflight/betaflight-configurator/pull/5088) — which I authored, originally with the same off-by-4 set as the labels — has been corrected on that PR's branch to match firmware (`{12, 24, 29, 33, 34, 35, 36, 37}`), but the *labels* themselves are master-level concerns and out of scope there.

## Questions for the devs

1. **Is my analysis right?** Specifically: is the firmware enum the source of truth that the configurator's u8 must match, with no translation layer I'm missing?
2. **If yes, what's the preferred remediation?** Three paths I can think of:
   - **(a) Pure label fix.** Renumber the existing English strings 25-33 to their firmware-correct names (and add 34-37). No code change, no behaviour change — users would simply see correct labels for whatever value is already in their config. Other locales would need regeneration via the existing translation flow.
   - **(b) Label fix + cap bump.** As (a), plus raise `adjustmentFunctionCount` so 34-37 become selectable. This is a feature addition (LED Profile / Battery Profile etc. become reachable from the configurator UI for the first time).
   - **(c) Generate labels from firmware.** Source the function names from a single-source-of-truth definition shared with firmware (or replicated mechanically) so this kind of drift can't happen again. Heaviest lift, biggest payoff.
3. **For path (a) or (b): is there a concern about existing user configs?** Their stored `adjustmentFunction` u8 won't change — only the label they see will change to match what the FC actually does. I think this is strictly an improvement, but flagging it.
4. **Is there a test/test fixture** I should add to lock the configurator labels and `adjustmentFunctionCount` against the firmware enum at a known revision?

Happy to do the work for whichever path you prefer; just want to align before redoing nine locale entries × N locales.

## What's in this draft

A single comment block in `src/composables/adjustments/useAdjustmentsData.js` near `adjustmentFunctionCount`, pointing future readers at this RFC. Nothing functional.

## Cross-references

- [betaflight-configurator#5088](https://github.com/betaflight/betaflight-configurator/pull/5088) — the PR that surfaced this when I tried to align `SELECT_MODE_FUNCTIONS` with firmware.
- Firmware enum: `src/main/fc/rc_adjustments.h` (`betaflight/master`).
- Firmware function table: `src/main/fc/rc_adjustments.c` (`defaultAdjustmentConfigs[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)