### PR TITLE
feat: add devcontainer for development environment

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -46,13 +46,16 @@ ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="758
 
 # STM32 VCP (Virtual COM Port)
 
-SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0666", TAG+="uaccess"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0660", GROUP="plugdev", TAG+="uaccess"
 EOF
 
 sudo udevadm control --reload-rules
 ```
 
-The container is started with `--volume=/dev:/dev` and `--privileged` to pass through USB devices.
+By default the devcontainer runs unprivileged. To enable USB device access for serial/DFU communication with flight controllers, either:
+
+1. **devcontainer.json** — uncomment the `privileged` and `runArgs` lines
+2. **Docker CLI** — add `--privileged --volume=/dev:/dev` flags (see below)
 
 ## Using with VS Code
 
@@ -89,7 +92,7 @@ npm run tauri:dev # Desktop app (requires display)
 - **Node.js 24.x** — matches `.nvmrc`
 - **Rust 1.85** — matches `src-tauri/rust-toolchain.toml`, with Android cross-compilation targets
 - **Tauri system libs** — webkit2gtk, libsoup, librsvg, openssl, udev
-- **Android SDK** — platform-tools, build-tools 35, NDK 28, JDK 17
+- **Android SDK** — platform-tools, build-tools 35, NDK 28, JDK 21
 - **USB passthrough** — serial device access for flight controller communication
 
 ## Build targets

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -5,7 +5,7 @@ NOTE: Unless otherwise specified all commands below should be run from the main 
 ## Why use devcontainers?
 
 Devcontainers provide a consistent, reproducible development environment that works the same across machines.
-This container includes Node.js 24.x, Rust 1.85, and all Tauri system dependencies pre-installed.
+This container includes Node.js 24.x, Rust 1.95, and all Tauri system dependencies pre-installed.
 
 ## Prerequisites
 
@@ -25,32 +25,8 @@ docker run docker.io/library/hello-world
 
 ### USB device access
 
-For serial device access (connecting to flight controllers), define udev rules on the host:
-
-```bash
-sudo tee /etc/udev/rules.d/46-stdfu-permissions.rules <<EOF
-# DFU (Internal bootloader for STM32, GD32, AT32, APM32 and RP2040 MCUs)
-
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # STM32
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", MODE="0664", GROUP="plugdev" # GD32
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # AT32
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", MODE="0664", GROUP="plugdev" # RP2040
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", MODE="0664", GROUP="plugdev" # APM32
-
-# WCH CH340/CH341 USB-to-Serial
-
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5523", MODE="0664", GROUP="plugdev" # CH341
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7522", MODE="0664", GROUP="plugdev" # CH340 (variant)
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", MODE="0664", GROUP="plugdev" # CH340
-ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7584", MODE="0664", GROUP="plugdev" # CH340S
-
-# STM32 VCP (Virtual COM Port)
-
-SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0660", GROUP="plugdev", TAG+="uaccess"
-EOF
-
-sudo udevadm control --reload-rules
-```
+For serial device access (connecting to flight controllers), you need udev rules and group membership on the host.
+See the [Building in Ubuntu](https://betaflight.com/docs/development/building/Building-in-Ubuntu) guide for detailed setup instructions including DFU rules, CH340/CH341 USB-to-Serial rules, and VCP permissions.
 
 By default the devcontainer runs unprivileged. To enable USB device access for serial/DFU communication with flight controllers, either:
 
@@ -90,7 +66,7 @@ npm run tauri:dev # Desktop app (requires display)
 ## What's included
 
 - **Node.js 24.x** — matches `.nvmrc`
-- **Rust 1.85** — matches `src-tauri/rust-toolchain.toml`, with Android cross-compilation targets
+- **Rust 1.95** — matches `src-tauri/rust-toolchain.toml`, with Android cross-compilation targets
 - **Tauri system libs** — webkit2gtk, libsoup, librsvg, openssl, udev
 - **Android SDK** — platform-tools, build-tools 35, NDK 28, JDK 21
 - **USB passthrough** — serial device access for flight controller communication

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -25,13 +25,17 @@ docker run docker.io/library/hello-world
 
 ### USB device access
 
-For serial device access (connecting to flight controllers), you need udev rules and group membership on the host.
+For serial device access (connecting to flight controllers), you need udev rules and group membership on the **host** machine.
 See the [Building in Ubuntu](https://betaflight.com/docs/development/building/Building-in-Ubuntu) guide for detailed setup instructions including DFU rules, CH340/CH341 USB-to-Serial rules, and VCP permissions.
 
-By default the devcontainer runs unprivileged. To enable USB device access for serial/DFU communication with flight controllers, either:
+Inside the container, the `devpod` user is already a member of the `dialout` and `plugdev` groups for serial and USB device access.
+
+By default the devcontainer runs unprivileged (no hardware access). To enable USB device access for serial/DFU communication with flight controllers, either:
 
 1. **devcontainer.json** — uncomment the `privileged` and `runArgs` lines
 2. **Docker CLI** — add `--privileged --volume=/dev:/dev` flags (see below)
+
+> **Note:** Enabling `--privileged` with `--volume=/dev:/dev` grants the container access to **all** host devices. This is standard for hardware development but should only be used on trusted, single-user machines.
 
 ## Using with VS Code
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,127 @@
+# Using Devcontainers
+
+NOTE: Unless otherwise specified all commands below should be run from the main workspace folder of the betaflight-configurator repository.
+
+## Why use devcontainers?
+
+Devcontainers provide a consistent, reproducible development environment that works the same across machines.
+This container includes Node.js 24.x, Rust 1.85, and all Tauri system dependencies pre-installed.
+
+## Prerequisites
+
+Install Docker or Podman on your host machine.
+
+### Docker
+
+Follow the [official installation guide](https://docs.docker.com/engine/install/).
+After installation add your user to the `docker` group:
+
+```bash
+sudo systemctl enable --now docker
+sudo usermod -aG docker $USER
+# Log out and back in for group change to take effect
+docker run docker.io/library/hello-world
+```
+
+### USB device access
+
+For serial device access (connecting to flight controllers), define udev rules on the host:
+
+```bash
+sudo tee /etc/udev/rules.d/46-stdfu-permissions.rules <<EOF
+# DFU (Internal bootloader for STM32, GD32, AT32, APM32 and RP2040 MCUs)
+
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # STM32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="28e9", ATTRS{idProduct}=="0189", MODE="0664", GROUP="plugdev" # GD32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e3c", ATTRS{idProduct}=="df11", MODE="0664", GROUP="plugdev" # AT32
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="2e8a", ATTRS{idProduct}=="000f", MODE="0664", GROUP="plugdev" # RP2040
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="314b", ATTRS{idProduct}=="0106", MODE="0664", GROUP="plugdev" # APM32
+
+# WCH CH340/CH341 USB-to-Serial
+
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5523", MODE="0664", GROUP="plugdev" # CH341
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7522", MODE="0664", GROUP="plugdev" # CH340 (variant)
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7523", MODE="0664", GROUP="plugdev" # CH340
+ACTION=="add", SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="7584", MODE="0664", GROUP="plugdev" # CH340S
+
+# STM32 VCP (Virtual COM Port)
+
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", MODE="0666", TAG+="uaccess"
+EOF
+
+sudo udevadm control --reload-rules
+```
+
+The container is started with `--volume=/dev:/dev` and `--privileged` to pass through USB devices.
+
+## Using with VS Code
+
+Open the repository in VS Code and use the Dev Containers extension to build and run:
+
+1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Open the command palette (`Ctrl+Shift+P`) and select "Dev Containers: Reopen in Container"
+3. Wait for the container to build (first time takes a few minutes)
+
+## Using with Docker CLI
+
+```bash
+# Build the container
+docker build -t bf-configurator-dev .devcontainer/
+
+# Run interactively with USB access
+docker run -it --rm \
+  --privileged \
+  --volume=/dev:/dev \
+  -v "$(pwd)":/workspace \
+  -p 8080:8080 \
+  bf-configurator-dev
+
+# Inside the container
+npm install
+npm run dev       # Vite dev server on :8080
+npm run test      # Run tests
+npm run lint      # Lint check
+npm run tauri:dev # Desktop app (requires display)
+```
+
+## What's included
+
+- **Node.js 24.x** — matches `.nvmrc`
+- **Rust 1.85** — matches `src-tauri/rust-toolchain.toml`, with Android cross-compilation targets
+- **Tauri system libs** — webkit2gtk, libsoup, librsvg, openssl, udev
+- **Android SDK** — platform-tools, build-tools 35, NDK 28, JDK 17
+- **USB passthrough** — serial device access for flight controller communication
+
+## Build targets
+
+### Web (PWA)
+
+```bash
+npm run dev       # Dev server on :8080
+npm run build     # Production build
+```
+
+### Desktop (Tauri)
+
+```bash
+npm run tauri:dev    # Desktop app with hot reload
+npm run tauri:build  # Release build
+```
+
+### Android (Capacitor)
+
+```bash
+npm run android:dev      # Build + run on connected device/emulator
+npm run android:open     # Open in Android Studio
+npm run android:sync     # Sync web assets to Android project
+npm run android:release  # Release build
+```
+
+### Testing
+
+```bash
+npm run test      # Vitest (includes lint)
+npm run lint      # ESLint only
+npm run format    # Prettier
+npm run storybook # Component docs on :6006
+```

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -45,7 +45,7 @@ Open the repository in VS Code and use the Dev Containers extension to build and
 
 ```bash
 # Build the container
-docker build -t bf-configurator-dev .devcontainer/
+docker build -f .devcontainer/containerfile -t bf-configurator-dev .devcontainer/
 
 # Run interactively with USB access
 docker run -it --rm \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -38,7 +38,7 @@ By default the devcontainer runs unprivileged. To enable USB device access for s
 Open the repository in VS Code and use the Dev Containers extension to build and run:
 
 1. Install the [Dev Containers extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-2. Open the command palette (`Ctrl+Shift+P`) and select "Dev Containers: Reopen in Container"
+2. Open the command palette (`Ctrl+Shift+P` / `Cmd+Shift+P`) and select "Dev Containers: Reopen in Container"
 3. Wait for the container to build (first time takes a few minutes)
 
 ## Using with Docker CLI

--- a/.devcontainer/containerfile
+++ b/.devcontainer/containerfile
@@ -54,7 +54,8 @@ RUN apt-get update && \
     openjdk-21-jdk-headless \
     && rm -rf /var/lib/apt/lists/*
 
-ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
+ARG TARGETARCH=amd64
+ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk-${TARGETARCH}"
 
 # Install Android command-line tools and SDK
 ENV ANDROID_HOME=/opt/android-sdk

--- a/.devcontainer/containerfile
+++ b/.devcontainer/containerfile
@@ -89,6 +89,9 @@ RUN groupadd --gid $USER_GID $USERNAME && \
     useradd --uid $USER_UID --gid $USER_GID -m $USERNAME --shell /bin/bash && \
     echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
+# Add user to hardware access groups for USB serial devices
+RUN usermod -aG dialout,plugdev $USERNAME
+
 # Give user ownership of Android SDK
 RUN chown -R $USERNAME:$USERNAME ${ANDROID_HOME}
 

--- a/.devcontainer/containerfile
+++ b/.devcontainer/containerfile
@@ -94,7 +94,7 @@ RUN chown -R $USERNAME:$USERNAME ${ANDROID_HOME}
 
 # Install Rust toolchain as the user (matches src-tauri/rust-toolchain.toml)
 USER $USERNAME
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85 --profile minimal && \
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.95 --profile minimal && \
     /home/$USERNAME/.cargo/bin/rustup component add rustfmt clippy && \
     /home/$USERNAME/.cargo/bin/rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
 

--- a/.devcontainer/containerfile
+++ b/.devcontainer/containerfile
@@ -1,0 +1,107 @@
+# Use Debian 13 (Trixie) as base — matches firmware devcontainer
+FROM docker.io/library/debian:13-slim
+
+# Avoid interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update package lists and install base tools
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    locales \
+    git \
+    ca-certificates \
+    curl \
+    wget \
+    unzip \
+    bash \
+    bash-completion \
+    sudo \
+    usbutils \
+    nano \
+    btop \
+    build-essential \
+    pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+# Tauri system dependencies (webkit, soup, ssl, rsvg, udev for serial)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    libwebkit2gtk-4.1-dev \
+    libjavascriptcoregtk-4.1-dev \
+    libsoup-3.0-dev \
+    librsvg2-dev \
+    libssl-dev \
+    libudev-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Generate en_US.UTF-8 locale
+RUN sed -i 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    locale-gen
+
+# Set environment variables for locale
+ENV LANG=en_US.UTF-8 \
+    LANGUAGE=en_US:en \
+    LC_ALL=en_US.UTF-8
+
+# Install Node.js 24.x via NodeSource
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install JDK 21 for Gradle/Android builds (must be before sdkmanager)
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    openjdk-21-jdk-headless \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV JAVA_HOME="/usr/lib/jvm/java-21-openjdk-amd64"
+
+# Install Android command-line tools and SDK
+ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=${ANDROID_HOME}
+
+RUN mkdir -p ${ANDROID_HOME}/cmdline-tools && \
+    cd ${ANDROID_HOME}/cmdline-tools && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -O tools.zip && \
+    unzip -q tools.zip && \
+    mv cmdline-tools latest && \
+    rm tools.zip
+
+ENV PATH="${ANDROID_HOME}/cmdline-tools/latest/bin:${ANDROID_HOME}/platform-tools:${PATH}"
+
+# Accept licenses and install SDK components
+RUN yes | sdkmanager --licenses > /dev/null 2>&1 && \
+    sdkmanager --install \
+    "platform-tools" \
+    "platforms;android-35" \
+    "build-tools;35.0.0" \
+    "ndk;28.0.13004108"
+
+ENV NDK_HOME="${ANDROID_HOME}/ndk/28.0.13004108"
+
+# Create a non-root user
+ARG USERNAME=devpod
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $USER_GID -m $USERNAME --shell /bin/bash && \
+    echo "$USERNAME ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Give user ownership of Android SDK
+RUN chown -R $USERNAME:$USERNAME ${ANDROID_HOME}
+
+# Install Rust toolchain as the user (matches src-tauri/rust-toolchain.toml)
+USER $USERNAME
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain 1.85 --profile minimal && \
+    /home/$USERNAME/.cargo/bin/rustup component add rustfmt clippy && \
+    /home/$USERNAME/.cargo/bin/rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+
+# Add cargo to PATH
+ENV PATH="/home/$USERNAME/.cargo/bin:${PATH}"
+
+# Set working directory
+WORKDIR /workspace
+
+# Default command
+CMD [ "bash" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,10 +4,10 @@
     "dockerfile": "containerfile",
     "context": "."
   },
-  "privileged": true,
-  "runArgs": [
-    "--volume=/dev:/dev"
-  ],
   "remoteUser": "devpod",
-  "features": {}
+  "features": {},
+
+  // USB device access (optional — uncomment for serial/DFU access to flight controllers)
+  // "privileged": true,
+  // "runArgs": ["--volume=/dev:/dev"]
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "betaflight-configurator devcontainer",
+  "build": {
+    "dockerfile": "containerfile",
+    "context": "."
+  },
+  "privileged": true,
+  "runArgs": [
+    "--volume=/dev:/dev"
+  ],
+  "remoteUser": "devpod",
+  "features": {}
+}


### PR DESCRIPTION
## Summary
- Add devcontainer with Node.js 24, Rust 1.85, Tauri system libs, Android SDK (NDK 28, JDK 21)
- Supports all build targets: web (PWA), desktop (Tauri), Android (Capacitor)
- USB device passthrough (`--privileged` + `/dev` mount) for flight controller access
- Includes setup guide for Docker, VS Code, udev rules

## Test plan
- [x] Container builds successfully
- [x] `npm run test` passes (52/52 tests)
- [x] Node.js 24, Rust 1.85, JDK 21, Android SDK all present
- [x] USB passthrough works (`/dev/ttyACM0` accessible)
- [x] Tauri system libs detected (`pkg-config webkit2gtk-4.1`)
- [x] Rust Android targets installed (aarch64, armv7, i686, x86_64)
- [ ] `npm run tauri:build` completes
- [ ] `npm run android:dev` connects to emulator/device

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded Dev Container guide with prerequisites, USB/serial/DFU access options, VS Code Dev Containers and Docker CLI workflows, in-container npm workflows, and build/test commands for Web, Desktop (Tauri), and Android.

* **Chores**
  * Added a preconfigured development container (Node.js 24, Rust 1.95, Android SDK/NDK, Tauri libs), locale setup, non-root developer user, and optional USB/serial access configurations for streamlined development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5104?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->