### PR TITLE
feat(preflight): fetch NOTAMs and airspace data from location

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -9021,5 +9021,89 @@
     },
     "preflightForecastWeather": {
         "message": "Weather"
+    },
+    "preflightNotamProvider": {
+        "message": "NOTAM Provider"
+    },
+    "preflightNotamProviderNone": {
+        "message": "Disabled"
+    },
+    "preflightNotamProviderFaa": {
+        "message": "FAA NOTAM API (US, API key required)"
+    },
+    "preflightNotamProviderOpenaip": {
+        "message": "OpenAIP (Global airspace, API key required)"
+    },
+    "preflightNotamFaaApiKeyLabel": {
+        "message": "FAA API Key (client_id:client_secret)"
+    },
+    "preflightNotamOpenAipApiKeyLabel": {
+        "message": "OpenAIP API Key"
+    },
+    "preflightNotamRadius": {
+        "message": "Search Radius"
+    },
+    "preflightNotamRadiusUnitNm": {
+        "message": "NM"
+    },
+    "preflightNotamRadiusUnitKm": {
+        "message": "km"
+    },
+    "preflightNotamSettings": {
+        "message": "Airspace data settings"
+    },
+    "preflightNotamPrivacyNote": {
+        "message": "Airspace data sends your coordinates to the selected provider. No additional personal data is transmitted."
+    },
+    "preflightNotamLoading": {
+        "message": "Fetching airspace data..."
+    },
+    "preflightNotamEmpty": {
+        "message": "No notices found for this location and radius"
+    },
+    "preflightNotamApiKeyRequired": {
+        "message": "An API key is required for the selected provider. Enter your key in the settings above."
+    },
+    "preflightNotamFetchError": {
+        "message": "Failed to fetch airspace data"
+    },
+    "preflightNotamActiveNow": {
+        "message": "Active now"
+    },
+    "preflightNotamPermanent": {
+        "message": "Permanent"
+    },
+    "preflightNotamExpired": {
+        "message": "Expired"
+    },
+    "preflightNotamTypeTfr": {
+        "message": "TFR"
+    },
+    "preflightNotamTypeSua": {
+        "message": "SUA"
+    },
+    "preflightNotamTypeSnow": {
+        "message": "SNOWTAM"
+    },
+    "preflightNotamTypeAsh": {
+        "message": "ASHTAM"
+    },
+    "preflightNotamTypeNotam": {
+        "message": "NOTAM"
+    },
+    "preflightNotamAltFrom": {
+        "message": "Lower"
+    },
+    "preflightNotamAltTo": {
+        "message": "Upper"
+    },
+    "preflightNotamShowMore": {
+        "message": "Show more"
+    },
+    "preflightNotamShowLess": {
+        "message": "Show less"
+    },
+    "preflightNotamLastFetched": {
+        "message": "Last fetched"
     }
 }

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -1476,8 +1476,12 @@ export default defineComponent({
 
         const notamNeedsApiKey = computed(() => {
             const p = preflight.notamSettings.provider;
-            if (p === "faa") return !preflight.notamSettings.faaApiKey.trim();
-            if (p === "openaip") return !preflight.notamSettings.openAipApiKey.trim();
+            if (p === "faa") {
+                return !preflight.notamSettings.faaApiKey?.trim();
+            }
+            if (p === "openaip") {
+                return !preflight.notamSettings.openAipApiKey?.trim();
+            }
             return false;
         });
 
@@ -1526,20 +1530,30 @@ export default defineComponent({
 
         function getNotamStatusBadgeClass(item) {
             const cls = getNotamCardClass(item);
-            if (cls === "notam-card-active") return "notam-status-active";
-            if (cls === "notam-card-future") return "notam-status-future";
+            if (cls === "notam-card-active") {
+                return "notam-status-active";
+            }
+            if (cls === "notam-card-future") {
+                return "notam-status-future";
+            }
             return "notam-status-expired";
         }
 
         function getNotamStatusLabel(item) {
             const cls = getNotamCardClass(item);
-            if (cls === "notam-card-active") return i18n.getMessage("preflightNotamActiveNow");
-            if (cls === "notam-card-expired") return i18n.getMessage("preflightNotamExpired");
+            if (cls === "notam-card-active") {
+                return i18n.getMessage("preflightNotamActiveNow");
+            }
+            if (cls === "notam-card-expired") {
+                return i18n.getMessage("preflightNotamExpired");
+            }
             return null;
         }
 
         function formatNotamTime(dt) {
-            if (!dt) return "-";
+            if (!dt) {
+                return "-";
+            }
             return dt.toLocaleString([], {
                 month: "short",
                 day: "numeric",

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -616,8 +616,8 @@
                                         }}</label>
                                         <input
                                             v-model="preflight.notamSettings.faaApiKey"
-                                            type="text"
-                                            autocomplete="off"
+                                            type="password"
+                                            autocomplete="new-password"
                                             class="notam-setting-input"
                                             @change="onNotamSettingChange"
                                         />
@@ -628,8 +628,8 @@
                                         }}</label>
                                         <input
                                             v-model="preflight.notamSettings.openAipApiKey"
-                                            type="text"
-                                            autocomplete="off"
+                                            type="password"
+                                            autocomplete="new-password"
                                             class="notam-setting-input"
                                             @change="onNotamSettingChange"
                                         />
@@ -718,12 +718,12 @@
                                         </div>
                                         <div class="notam-card-body">
                                             <span v-if="!expandedNotams.has(item.id + ':' + item.source)">
-                                                {{ item.body.slice(0, 160)
-                                                }}<template v-if="item.body.length > 160">…</template>
+                                                {{ (item.body ?? "").slice(0, 160)
+                                                }}<template v-if="(item.body ?? '').length > 160">…</template>
                                             </span>
-                                            <span v-else>{{ item.body }}</span>
+                                            <span v-else>{{ item.body ?? "" }}</span>
                                             <a
-                                                v-if="item.body.length > 160"
+                                                v-if="(item.body ?? '').length > 160"
                                                 href="#"
                                                 class="notam-expand-link"
                                                 @click.prevent="toggleNotamExpand(item)"

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -596,6 +596,157 @@
                                     <em class="fas fa-exclamation-triangle"></em> {{ $t("preflightNOTAMsEU") }}
                                 </a>
                             </div>
+
+                            <!-- NOTAM Settings -->
+                            <details class="notam-settings">
+                                <summary><em class="fas fa-cog"></em> {{ $t("preflightNotamSettings") }}</summary>
+                                <div class="notam-settings-body">
+                                    <div class="notam-setting-row">
+                                        <label class="notam-setting-label">{{ $t("preflightNotamProvider") }}</label>
+                                        <USelect
+                                            v-model="notamProvider"
+                                            :items="notamProviderOptions"
+                                            class="notam-setting-select"
+                                            @update:model-value="onNotamSettingChange"
+                                        />
+                                    </div>
+                                    <div v-if="notamProvider === 'faa'" class="notam-setting-row">
+                                        <label class="notam-setting-label">{{
+                                            $t("preflightNotamFaaApiKeyLabel")
+                                        }}</label>
+                                        <input
+                                            v-model="preflight.notamSettings.faaApiKey"
+                                            type="text"
+                                            autocomplete="off"
+                                            class="notam-setting-input"
+                                            @change="onNotamSettingChange"
+                                        />
+                                    </div>
+                                    <div v-if="notamProvider === 'openaip'" class="notam-setting-row">
+                                        <label class="notam-setting-label">{{
+                                            $t("preflightNotamOpenAipApiKeyLabel")
+                                        }}</label>
+                                        <input
+                                            v-model="preflight.notamSettings.openAipApiKey"
+                                            type="text"
+                                            autocomplete="off"
+                                            class="notam-setting-input"
+                                            @change="onNotamSettingChange"
+                                        />
+                                    </div>
+                                    <div class="notam-setting-row">
+                                        <label class="notam-setting-label">{{ $t("preflightNotamRadius") }}</label>
+                                        <div class="notam-radius-group">
+                                            <input
+                                                v-model.number="preflight.notamSettings.radius"
+                                                type="number"
+                                                min="1"
+                                                max="500"
+                                                class="notam-radius-input"
+                                                @change="onNotamSettingChange"
+                                            />
+                                            <USelect
+                                                v-model="preflight.notamSettings.radiusUnit"
+                                                :items="notamRadiusUnitOptions"
+                                                class="notam-radius-unit"
+                                                @update:model-value="onNotamSettingChange"
+                                            />
+                                        </div>
+                                    </div>
+                                </div>
+                            </details>
+
+                            <!-- Privacy note -->
+                            <p v-if="notamProvider" class="notam-privacy-note">
+                                <em class="fas fa-info-circle"></em> {{ $t("preflightNotamPrivacyNote") }}
+                            </p>
+
+                            <!-- NOTAM data panel -->
+                            <UiBox v-if="notamProvider && notamNeedsApiKey" highlight class="mt-2">
+                                <p>{{ $t("preflightNotamApiKeyRequired") }}</p>
+                            </UiBox>
+                            <div v-else-if="notamProvider && preflight.location.latitude !== null" class="notam-panel">
+                                <div v-if="preflight.notams.loading" class="notam-loading">
+                                    <em class="fas fa-spinner fa-spin"></em> {{ $t("preflightNotamLoading") }}
+                                </div>
+                                <div v-else-if="preflight.notams.error" class="notam-error">
+                                    <em class="fas fa-exclamation-circle"></em>
+                                    {{ $t("preflightNotamFetchError") }}: {{ preflight.notams.error }}
+                                </div>
+                                <div v-else-if="preflight.notams.items.length === 0" class="notam-empty">
+                                    {{ $t("preflightNotamEmpty") }}
+                                </div>
+                                <div v-else class="notam-list">
+                                    <div
+                                        v-for="item in preflight.notams.items"
+                                        :key="item.id + ':' + item.source"
+                                        class="notam-card"
+                                        :class="getNotamCardClass(item)"
+                                    >
+                                        <div class="notam-card-header">
+                                            <span class="notam-id">{{ item.id }}</span>
+                                            <span class="notam-type-badge" :class="getNotamTypeBadgeClass(item.type)">
+                                                {{ getNotamTypeLabel(item.type) }}
+                                            </span>
+                                            <span
+                                                v-if="getNotamCardClass(item) !== 'notam-card-future'"
+                                                class="notam-status-badge"
+                                                :class="getNotamStatusBadgeClass(item)"
+                                            >
+                                                {{ getNotamStatusLabel(item) }}
+                                            </span>
+                                            <span class="notam-location">{{ item.location }}</span>
+                                        </div>
+                                        <div class="notam-card-times">
+                                            <span>
+                                                {{ formatNotamTime(item.startTime) }}
+                                                <template v-if="item.isPermanent">
+                                                    — {{ $t("preflightNotamPermanent") }}</template
+                                                >
+                                                <template v-else-if="item.endTime">
+                                                    — {{ formatNotamTime(item.endTime) }}</template
+                                                >
+                                            </span>
+                                        </div>
+                                        <div v-if="item.lowerAlt || item.upperAlt" class="notam-card-alt">
+                                            <template v-if="item.lowerAlt">
+                                                {{ $t("preflightNotamAltFrom") }}: {{ item.lowerAlt }}
+                                            </template>
+                                            <template v-if="item.upperAlt">
+                                                &nbsp;{{ $t("preflightNotamAltTo") }}: {{ item.upperAlt }}
+                                            </template>
+                                        </div>
+                                        <div class="notam-card-body">
+                                            <span v-if="!expandedNotams.has(item.id + ':' + item.source)">
+                                                {{ item.body.slice(0, 160)
+                                                }}<template v-if="item.body.length > 160">…</template>
+                                            </span>
+                                            <span v-else>{{ item.body }}</span>
+                                            <a
+                                                v-if="item.body.length > 160"
+                                                href="#"
+                                                class="notam-expand-link"
+                                                @click.prevent="toggleNotamExpand(item)"
+                                            >
+                                                {{
+                                                    expandedNotams.has(item.id + ":" + item.source)
+                                                        ? $t("preflightNotamShowLess")
+                                                        : $t("preflightNotamShowMore")
+                                                }}
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div v-if="preflight.notams.lastFetched" class="notam-timestamp">
+                                    {{ $t("preflightNotamLastFetched") }}:
+                                    {{
+                                        preflight.notams.lastFetched.toLocaleTimeString([], {
+                                            hour: "2-digit",
+                                            minute: "2-digit",
+                                        })
+                                    }}
+                                </div>
+                            </div>
                         </div>
                     </UiBox>
 
@@ -665,6 +816,7 @@ import UiBox from "../elements/UiBox.vue";
 import GUI from "../../js/gui";
 import { i18n } from "@/js/localization";
 import { usePreflight } from "@/composables/usePreflight";
+import { getNotamStatus } from "@/js/notam/index.js";
 import { initMap } from "../../js/utils/map";
 import { fromLonLat } from "ol/proj";
 
@@ -1298,6 +1450,118 @@ export default defineComponent({
             return preflight.getUvStatus(uv).label;
         }
 
+        // ── NOTAM logic ──────────────────────────────────────────────────────────
+
+        const expandedNotams = ref(new Set());
+
+        // Two-way binding for provider selector so changes propagate to notamSettings
+        const notamProvider = computed({
+            get: () => preflight.notamSettings.provider,
+            set: (val) => {
+                preflight.notamSettings.provider = val;
+            },
+        });
+
+        const notamProviderOptions = computed(() => [
+            { label: i18n.getMessage("preflightNotamProviderNone"), value: null },
+            // AviationWeather.gov excluded: /api/data/notam returns 404 — restore when a working endpoint is confirmed
+            { label: i18n.getMessage("preflightNotamProviderFaa"), value: "faa" },
+            { label: i18n.getMessage("preflightNotamProviderOpenaip"), value: "openaip" },
+        ]);
+
+        const notamRadiusUnitOptions = computed(() => [
+            { label: i18n.getMessage("preflightNotamRadiusUnitNm"), value: "NM" },
+            { label: i18n.getMessage("preflightNotamRadiusUnitKm"), value: "km" },
+        ]);
+
+        const notamNeedsApiKey = computed(() => {
+            const p = preflight.notamSettings.provider;
+            if (p === "faa") return !preflight.notamSettings.faaApiKey.trim();
+            if (p === "openaip") return !preflight.notamSettings.openAipApiKey.trim();
+            return false;
+        });
+
+        function onNotamSettingChange() {
+            preflight.persistNotamSettings();
+            const lat = preflight.location.latitude;
+            const lon = preflight.location.longitude;
+            if (lat !== null && lon !== null && !notamNeedsApiKey.value) {
+                preflight.fetchNotams(lat, lon);
+            }
+        }
+
+        const NOTAM_TYPE_LABELS = {
+            TFR: "preflightNotamTypeTfr",
+            SUA: "preflightNotamTypeSua",
+            SNOWTAM: "preflightNotamTypeSnow",
+            ASHTAM: "preflightNotamTypeAsh",
+            NOTAM: "preflightNotamTypeNotam",
+        };
+
+        const NOTAM_TYPE_BADGE_CLASSES = {
+            TFR: "notam-badge-tfr",
+            SUA: "notam-badge-sua",
+            SNOWTAM: "notam-badge-snow",
+            ASHTAM: "notam-badge-ash",
+            NOTAM: "notam-badge-notam",
+        };
+
+        function getNotamTypeLabel(type) {
+            return i18n.getMessage(NOTAM_TYPE_LABELS[type] ?? "preflightNotamTypeNotam");
+        }
+
+        function getNotamTypeBadgeClass(type) {
+            return NOTAM_TYPE_BADGE_CLASSES[type] ?? "notam-badge-notam";
+        }
+
+        const NOTAM_STATUS_CARD_CLASS = {
+            active: "notam-card-active",
+            future: "notam-card-future",
+            expired: "notam-card-expired",
+        };
+
+        function getNotamCardClass(item) {
+            return NOTAM_STATUS_CARD_CLASS[getNotamStatus(item)];
+        }
+
+        function getNotamStatusBadgeClass(item) {
+            const cls = getNotamCardClass(item);
+            if (cls === "notam-card-active") return "notam-status-active";
+            if (cls === "notam-card-future") return "notam-status-future";
+            return "notam-status-expired";
+        }
+
+        function getNotamStatusLabel(item) {
+            const cls = getNotamCardClass(item);
+            if (cls === "notam-card-active") return i18n.getMessage("preflightNotamActiveNow");
+            if (cls === "notam-card-expired") return i18n.getMessage("preflightNotamExpired");
+            return null;
+        }
+
+        function formatNotamTime(dt) {
+            if (!dt) return "-";
+            return dt.toLocaleString([], {
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+                timeZoneName: "short",
+            });
+        }
+
+        function toggleNotamExpand(item) {
+            const key = `${item.id}:${item.source}`;
+            const next = new Set(expandedNotams.value);
+            if (next.has(key)) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+            expandedNotams.value = next;
+        }
+
+        // ── End NOTAM logic ───────────────────────────────────────────────────────
+
         onMounted(() => {
             GUI.content_ready();
             document.addEventListener("fullscreenchange", handleFullscreenChange);
@@ -1397,6 +1661,19 @@ export default defineComponent({
             getUvStatusLabel,
             formatForecastDay,
             getForecastRowClass,
+            notamProvider,
+            notamProviderOptions,
+            notamRadiusUnitOptions,
+            notamNeedsApiKey,
+            expandedNotams,
+            onNotamSettingChange,
+            getNotamTypeLabel,
+            getNotamTypeBadgeClass,
+            getNotamCardClass,
+            getNotamStatusBadgeClass,
+            getNotamStatusLabel,
+            formatNotamTime,
+            toggleNotamExpand,
         };
     },
 });
@@ -1866,6 +2143,283 @@ export default defineComponent({
                     width: 16px;
                     text-align: center;
                 }
+            }
+        }
+
+        /* NOTAM settings accordion */
+        .notam-settings {
+            margin-top: 8px;
+            font-size: 12px;
+
+            summary {
+                display: flex;
+                align-items: center;
+                padding: 8px 12px;
+                background: var(--surface-200);
+                border: 1px solid var(--surface-400);
+                border-radius: 4px;
+                color: var(--primary-500);
+                text-decoration: none;
+                font-size: 13px;
+                font-weight: bold;
+                cursor: pointer;
+                user-select: none;
+                list-style: none;
+                transition: background 0.2s;
+
+                &:hover {
+                    background: var(--surface-300);
+                }
+
+                &::-webkit-details-marker {
+                    display: none;
+                }
+
+                em {
+                    margin-right: 8px;
+                    width: 16px;
+                    text-align: center;
+                }
+            }
+
+            &[open] summary {
+                border-radius: 4px 4px 0 0;
+                border-bottom: none;
+            }
+
+            .notam-settings-body {
+                padding: 10px;
+                border: 1px solid var(--surface-400);
+                border-top: none;
+                border-radius: 0 0 4px 4px;
+                display: flex;
+                flex-direction: column;
+                gap: 8px;
+            }
+
+            .notam-setting-row {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+            }
+
+            .notam-setting-label {
+                flex: 0 0 auto;
+                min-width: 110px;
+                font-size: 12px;
+                color: var(--text);
+            }
+
+            .notam-setting-select {
+                flex: 1;
+                min-width: 0;
+            }
+
+            .notam-setting-input {
+                flex: 1;
+                min-width: 0;
+                padding: 4px 8px;
+                border: 1px solid var(--surface-500);
+                border-radius: 3px;
+                background: var(--surface-200);
+                color: var(--text);
+                font-size: 12px;
+            }
+
+            .notam-radius-group {
+                display: flex;
+                gap: 6px;
+                flex: 1;
+            }
+
+            .notam-radius-input {
+                width: 70px;
+                padding: 4px 8px;
+                border: 1px solid var(--surface-500);
+                border-radius: 3px;
+                background: var(--surface-200);
+                color: var(--text);
+                font-size: 12px;
+            }
+
+            .notam-radius-unit {
+                width: 80px;
+            }
+        }
+
+        /* Privacy note */
+        .notam-privacy-note {
+            margin-top: 8px;
+            font-size: 11px;
+            color: var(--surface-600);
+            background: var(--surface-100);
+            border: 1px solid var(--surface-300);
+            border-radius: 4px;
+            padding: 6px 8px;
+
+            em {
+                margin-right: 4px;
+            }
+        }
+
+        /* NOTAM data panel */
+        .notam-panel {
+            margin-top: 10px;
+
+            .notam-loading,
+            .notam-empty {
+                font-size: 12px;
+                color: var(--surface-600);
+                padding: 8px 0;
+                text-align: center;
+
+                em {
+                    margin-right: 6px;
+                }
+            }
+
+            .notam-error {
+                font-size: 12px;
+                color: var(--color-error-600);
+                padding: 6px 8px;
+                background: var(--color-error-50);
+                border: 1px solid var(--color-error-300);
+                border-radius: 4px;
+
+                em {
+                    margin-right: 6px;
+                }
+            }
+
+            .notam-list {
+                display: flex;
+                flex-direction: column;
+                gap: 6px;
+                max-height: 400px;
+                overflow-y: auto;
+            }
+
+            .notam-card {
+                border: 1px solid var(--surface-400);
+                border-radius: 4px;
+                padding: 8px 10px;
+                font-size: 12px;
+                background: var(--surface-0);
+
+                &.notam-card-active {
+                    border-left: 3px solid var(--color-success-500);
+                }
+
+                &.notam-card-future {
+                    border-left: 3px solid var(--color-warning-500);
+                }
+
+                &.notam-card-expired {
+                    border-left: 3px solid var(--surface-400);
+                    opacity: 0.6;
+                }
+            }
+
+            .notam-card-header {
+                display: flex;
+                align-items: center;
+                flex-wrap: wrap;
+                gap: 6px;
+                margin-bottom: 4px;
+            }
+
+            .notam-id {
+                font-weight: 600;
+                font-size: 12px;
+            }
+
+            .notam-location {
+                color: var(--surface-600);
+                font-size: 11px;
+                margin-left: auto;
+            }
+
+            .notam-type-badge,
+            .notam-status-badge {
+                font-size: 10px;
+                font-weight: 600;
+                padding: 1px 6px;
+                border-radius: 3px;
+                text-transform: uppercase;
+            }
+
+            .notam-badge-notam {
+                background: var(--color-info-100);
+                color: var(--color-info-800);
+            }
+
+            .notam-badge-tfr {
+                background: var(--color-error-100);
+                color: var(--color-error-800);
+            }
+
+            .notam-badge-sua {
+                background: var(--color-warning-100);
+                color: var(--color-warning-800);
+            }
+
+            .notam-badge-snow {
+                background: var(--surface-100);
+                color: var(--surface-700);
+            }
+
+            .notam-badge-ash {
+                background: var(--surface-200);
+                color: var(--surface-700);
+            }
+
+            .notam-status-active {
+                background: var(--color-success-100);
+                color: var(--color-success-800);
+            }
+
+            .notam-status-future {
+                background: var(--color-warning-100);
+                color: var(--color-warning-800);
+            }
+
+            .notam-status-expired {
+                background: var(--surface-100);
+                color: var(--surface-600);
+            }
+
+            .notam-card-times {
+                font-size: 11px;
+                color: var(--surface-600);
+                margin-bottom: 3px;
+            }
+
+            .notam-card-alt {
+                font-size: 11px;
+                color: var(--surface-600);
+                margin-bottom: 3px;
+            }
+
+            .notam-card-body {
+                font-size: 12px;
+                line-height: 1.4;
+                word-break: break-word;
+            }
+
+            .notam-expand-link {
+                display: inline-block;
+                margin-left: 4px;
+                font-size: 11px;
+                color: var(--primary-500);
+                text-decoration: underline;
+                cursor: pointer;
+            }
+
+            .notam-timestamp {
+                margin-top: 6px;
+                font-size: 11px;
+                color: var(--surface-500);
+                text-align: right;
             }
         }
     }

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -928,6 +928,19 @@ function getForecastRowClass(day) {
     return "";
 }
 
+function formatNotamTime(dt) {
+    if (!dt) {
+        return "-";
+    }
+    return dt.toLocaleString([], {
+        month: "short",
+        day: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+        timeZoneName: "short",
+    });
+}
+
 export default defineComponent({
     name: "PreflightTab",
     components: {
@@ -1550,19 +1563,6 @@ export default defineComponent({
             return null;
         }
 
-        function formatNotamTime(dt) {
-            if (!dt) {
-                return "-";
-            }
-            return dt.toLocaleString([], {
-                month: "short",
-                day: "numeric",
-                hour: "2-digit",
-                minute: "2-digit",
-                timeZoneName: "short",
-            });
-        }
-
         function toggleNotamExpand(item) {
             const key = `${item.id}:${item.source}`;
             const next = new Set(expandedNotams.value);
@@ -1605,6 +1605,13 @@ export default defineComponent({
                     initializeMap();
                     updateMapPosition();
                 });
+            },
+        );
+
+        watch(
+            () => preflight.notams.items,
+            () => {
+                expandedNotams.value = new Set();
             },
         );
 

--- a/src/composables/usePreflight.js
+++ b/src/composables/usePreflight.js
@@ -828,6 +828,7 @@ async function fetchNotams(lat, lon) {
         notams.items = [];
         notams.error = null;
         notams.loading = false;
+        notams.lastFetched = null;
         return;
     }
     if (
@@ -837,6 +838,7 @@ async function fetchNotams(lat, lon) {
         notams.items = [];
         notams.error = null;
         notams.loading = false;
+        notams.lastFetched = null;
         return;
     }
     const requestId = ++notamRequestId;

--- a/src/composables/usePreflight.js
+++ b/src/composables/usePreflight.js
@@ -831,8 +831,8 @@ async function fetchNotams(lat, lon) {
         return;
     }
     if (
-        (notamSettings.provider === "faa" && !notamSettings.faaApiKey.trim()) ||
-        (notamSettings.provider === "openaip" && !notamSettings.openAipApiKey.trim())
+        (notamSettings.provider === "faa" && !notamSettings.faaApiKey?.trim()) ||
+        (notamSettings.provider === "openaip" && !notamSettings.openAipApiKey?.trim())
     ) {
         notams.items = [];
         notams.error = null;
@@ -856,7 +856,9 @@ async function fetchNotams(lat, lon) {
             default:
                 break;
         }
-        if (requestId !== notamRequestId) return;
+        if (requestId !== notamRequestId) {
+            return;
+        }
         notams.items = sortNotams(items);
         notams.lastFetched = new Date();
     } catch (err) {

--- a/src/composables/usePreflight.js
+++ b/src/composables/usePreflight.js
@@ -3,9 +3,18 @@ import geomagnetism from "geomagnetism";
 import SunCalc from "suncalc";
 import { get as getConfig, set as setConfig } from "../js/ConfigStorage";
 import { ispConnected } from "../js/utils/connection";
+import { sortNotams, kmToNm } from "../js/notam/index.js";
+import { fetchFromFaa } from "../js/notam/faa.js";
+import { fetchFromOpenAip } from "../js/notam/openaip.js";
 
 const SAVED_LOCATIONS_KEY = "preflight_saved_locations";
 const IP_GEOLOCATION_CONSENT_KEY = "preflight_ip_geolocation_consent";
+
+const NOTAM_PROVIDER_KEY = "preflight_notam_provider";
+const NOTAM_FAA_API_KEY = "preflight_notam_faa_api_key";
+const NOTAM_OPENAIP_API_KEY = "preflight_notam_openaip_api_key";
+const NOTAM_RADIUS_KEY = "preflight_notam_radius";
+const NOTAM_RADIUS_UNIT_KEY = "preflight_notam_radius_unit";
 const MAX_SAVED_LOCATIONS = 5;
 const MAX_LABEL_LENGTH = 20;
 
@@ -315,9 +324,51 @@ const solar = reactive({
 
 const savedLocations = reactive([]);
 
+const notamSettings = reactive({
+    provider: null, // "faa" | "openaip" | null
+    faaApiKey: "",
+    openAipApiKey: "",
+    radius: 25,
+    radiusUnit: "NM",
+});
+
+const notams = reactive({
+    loading: false,
+    error: null,
+    items: [],
+    lastFetched: null,
+});
+
+function loadNotamSettings() {
+    const stored = getConfig([
+        NOTAM_PROVIDER_KEY,
+        NOTAM_FAA_API_KEY,
+        NOTAM_OPENAIP_API_KEY,
+        NOTAM_RADIUS_KEY,
+        NOTAM_RADIUS_UNIT_KEY,
+    ]);
+    notamSettings.provider = stored[NOTAM_PROVIDER_KEY] ?? null;
+    notamSettings.faaApiKey = stored[NOTAM_FAA_API_KEY] ?? "";
+    notamSettings.openAipApiKey = stored[NOTAM_OPENAIP_API_KEY] ?? "";
+    const radius = Number(stored[NOTAM_RADIUS_KEY]);
+    notamSettings.radius = Number.isFinite(radius) && radius > 0 ? radius : 25;
+    notamSettings.radiusUnit = stored[NOTAM_RADIUS_UNIT_KEY] === "km" ? "km" : "NM";
+}
+
+function persistNotamSettings() {
+    const obj = {};
+    obj[NOTAM_PROVIDER_KEY] = notamSettings.provider;
+    obj[NOTAM_FAA_API_KEY] = notamSettings.faaApiKey;
+    obj[NOTAM_OPENAIP_API_KEY] = notamSettings.openAipApiKey;
+    obj[NOTAM_RADIUS_KEY] = notamSettings.radius;
+    obj[NOTAM_RADIUS_UNIT_KEY] = notamSettings.radiusUnit;
+    setConfig(obj);
+}
+
 let weatherRequestId = 0;
 let solarRequestId = 0;
 let elevationRequestId = 0;
+let notamRequestId = 0;
 
 function loadSavedLocations() {
     const stored = getConfig(SAVED_LOCATIONS_KEY);
@@ -421,7 +472,7 @@ function applySavedLocation(index) {
     return loc;
 }
 
-const isLoading = computed(() => weather.loading || solar.loading);
+const isLoading = computed(() => weather.loading || solar.loading || notams.loading);
 
 async function fetchWeather(lat, lon) {
     const requestId = ++weatherRequestId;
@@ -761,6 +812,64 @@ async function fetchElevation(lat, lon) {
     }
 }
 
+/**
+ * Compute the radius in NM to use for NOTAM fetches,
+ * converting from km if the user chose that unit.
+ */
+function getNotamRadiusNm() {
+    if (notamSettings.radiusUnit === "km") {
+        return kmToNm(notamSettings.radius);
+    }
+    return notamSettings.radius;
+}
+
+async function fetchNotams(lat, lon) {
+    if (!notamSettings.provider) {
+        notams.items = [];
+        notams.error = null;
+        notams.loading = false;
+        return;
+    }
+    if (
+        (notamSettings.provider === "faa" && !notamSettings.faaApiKey.trim()) ||
+        (notamSettings.provider === "openaip" && !notamSettings.openAipApiKey.trim())
+    ) {
+        notams.items = [];
+        notams.error = null;
+        notams.loading = false;
+        return;
+    }
+    const requestId = ++notamRequestId;
+    notams.loading = true;
+    notams.error = null;
+    notams.items = [];
+    try {
+        const radiusNm = getNotamRadiusNm();
+        let items = [];
+        switch (notamSettings.provider) {
+            case "faa":
+                items = await fetchFromFaa(lat, lon, radiusNm, notamSettings.faaApiKey);
+                break;
+            case "openaip":
+                items = await fetchFromOpenAip(lat, lon, radiusNm, notamSettings.openAipApiKey);
+                break;
+            default:
+                break;
+        }
+        if (requestId !== notamRequestId) return;
+        notams.items = sortNotams(items);
+        notams.lastFetched = new Date();
+    } catch (err) {
+        if (requestId === notamRequestId) {
+            notams.error = err.message;
+        }
+    } finally {
+        if (requestId === notamRequestId) {
+            notams.loading = false;
+        }
+    }
+}
+
 async function refreshAll() {
     if (location.latitude === null || location.longitude === null) {
         return;
@@ -769,7 +878,12 @@ async function refreshAll() {
     const lon = location.longitude;
     updateMagneticDeclination();
     updateCivilTwilight();
-    await Promise.allSettled([fetchWeather(lat, lon), fetchSolarActivity(), fetchElevation(lat, lon)]);
+    await Promise.allSettled([
+        fetchWeather(lat, lon),
+        fetchSolarActivity(),
+        fetchElevation(lat, lon),
+        fetchNotams(lat, lon),
+    ]);
 }
 
 const civilTwilight = ref(null);
@@ -787,8 +901,9 @@ function updateCivilTwilight() {
     civilTwilight.value = { dawn: times.dawn, dusk: times.dusk };
 }
 
-// Load saved locations once at module init
+// Load saved locations and NOTAM settings once at module init
 loadSavedLocations();
+loadNotamSettings();
 
 // ── Public API (singleton) ─────────────────────────────────────────────────────
 
@@ -800,10 +915,14 @@ export function usePreflight() {
         mag,
         civilTwilight,
         savedLocations,
+        notams,
+        notamSettings,
         isLoading,
         launchStatus,
         fetchWeather,
         fetchSolarActivity,
+        fetchNotams,
+        persistNotamSettings,
         useGeolocation,
         useIpGeolocationFallback,
         ipGeolocationConsent,

--- a/src/js/notam/faa.js
+++ b/src/js/notam/faa.js
@@ -1,0 +1,100 @@
+/**
+ * NOTAM adapter for the FAA External NOTAM API.
+ *
+ * Coverage:  USA
+ * Auth:      API key required (free registration at https://api.faa.gov)
+ *            Enter your key as "client_id:client_secret" in the settings.
+ * CORS:      Not verified for PWA/web builds — works in Tauri and Capacitor (native fetch).
+ *            If CORS is blocked in the browser, a network error is thrown.
+ * Endpoint:  https://external-api.faa.gov/notamapi/v1/notams
+ * Docs:      https://api.faa.gov/
+ */
+
+import { classifyFromQcode, parseNotamDate } from "./index.js";
+
+const BASE_URL = "https://external-api.faa.gov/notamapi/v1/notams";
+
+/**
+ * Extract a NotamItem from the FAA API's nested properties structure.
+ * @param {object} properties
+ * @returns {object} NotamItem
+ */
+export function extractNotam(properties) {
+    const core = properties?.coreNOTAMData?.notam ?? {};
+    const translations = properties?.coreNOTAMData?.notamTranslation ?? [];
+
+    const icaoText = translations.find((t) => t.type === "ICAO")?.simpleText ?? "";
+    const localText = translations.find((t) => t.type === "LOCAL_FORMAT")?.simpleText ?? "";
+    const body = icaoText || localText || core.text || core.icaoMessage || "";
+
+    const qcode = core.selectionCode ?? core.qCode ?? "";
+    const type = classifyFromQcode(qcode);
+
+    const endRaw = core.effectiveEnd ?? null;
+    const isPermanent = endRaw !== null && /PERM/i.test(String(endRaw));
+
+    return {
+        id: String(core.number ?? core.id ?? "Unknown").trim(),
+        type,
+        location: String(core.location ?? core.affectedFIR ?? "").trim(),
+        startTime: parseNotamDate(core.effectiveStart ?? null),
+        endTime: isPermanent ? null : parseNotamDate(endRaw),
+        isPermanent,
+        lowerAlt: core.minimumFL != null ? String(core.minimumFL) : null,
+        upperAlt: core.maximumFL != null ? String(core.maximumFL) : null,
+        body: String(body).trim(),
+        rawText: icaoText || null,
+        source: "faa",
+    };
+}
+
+/**
+ * Fetch NOTAMs from the FAA External NOTAM API.
+ * @param {number} lat
+ * @param {number} lon
+ * @param {number} radiusNm  search radius in nautical miles
+ * @param {string} apiKey    in format "client_id:client_secret"
+ * @returns {Promise<object[]>} array of NotamItem
+ */
+export async function fetchFromFaa(lat, lon, radiusNm, apiKey) {
+    const sep = apiKey.indexOf(":");
+    if (sep <= 0 || sep === apiKey.length - 1) {
+        throw new Error("FAA API key must be in format client_id:client_secret");
+    }
+    const clientId = apiKey.slice(0, sep).trim();
+    const clientSecret = apiKey.slice(sep + 1).trim();
+    if (!clientId || !clientSecret) {
+        throw new Error("FAA API key must be in format client_id:client_secret");
+    }
+
+    const params = new URLSearchParams({
+        latitudeDeg: lat.toFixed(4),
+        longitudeDeg: lon.toFixed(4),
+        radius: Math.max(1, Math.round(radiusNm)),
+        pageNum: 1,
+        pageSize: 100,
+    });
+
+    let response;
+    try {
+        response = await fetch(`${BASE_URL}?${params}`, {
+            headers: {
+                client_id: clientId,
+                client_secret: clientSecret,
+            },
+        });
+    } catch (err) {
+        if (err instanceof TypeError) {
+            throw new Error(
+                "FAA NOTAM API is not available in browser/PWA builds (CORS). Use Tauri desktop or Android.",
+            );
+        }
+        throw err;
+    }
+    if (!response.ok) {
+        throw new Error(`FAA NOTAM API error: ${response.status}`);
+    }
+    const data = await response.json();
+    const items = data?.items ?? [];
+    return items.map((item) => extractNotam(item?.properties ?? {}));
+}

--- a/src/js/notam/faa.js
+++ b/src/js/notam/faa.js
@@ -95,7 +95,7 @@ export async function fetchFromFaa(lat, lon, radiusNm, apiKey) {
         }
         if (err instanceof TypeError) {
             throw new Error(
-                "FAA NOTAM API is not available in browser/PWA builds (CORS). Use Tauri desktop or Android.",
+                "FAA NOTAM API request failed (network error or CORS block). Check connectivity, or use Tauri desktop or Android.",
             );
         }
         throw err;

--- a/src/js/notam/faa.js
+++ b/src/js/notam/faa.js
@@ -57,6 +57,9 @@ export function extractNotam(properties) {
  * @returns {Promise<object[]>} array of NotamItem
  */
 export async function fetchFromFaa(lat, lon, radiusNm, apiKey) {
+    if (typeof apiKey !== "string" || !apiKey.trim()) {
+        throw new Error("FAA API key must be in format client_id:client_secret");
+    }
     const sep = apiKey.indexOf(":");
     if (sep <= 0 || sep === apiKey.length - 1) {
         throw new Error("FAA API key must be in format client_id:client_secret");

--- a/src/js/notam/faa.js
+++ b/src/js/notam/faa.js
@@ -75,21 +75,29 @@ export async function fetchFromFaa(lat, lon, radiusNm, apiKey) {
         pageSize: 100,
     });
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15_000);
     let response;
     try {
         response = await fetch(`${BASE_URL}?${params}`, {
+            signal: controller.signal,
             headers: {
                 client_id: clientId,
                 client_secret: clientSecret,
             },
         });
     } catch (err) {
+        if (err.name === "AbortError") {
+            throw new Error("FAA NOTAM API request timed out");
+        }
         if (err instanceof TypeError) {
             throw new Error(
                 "FAA NOTAM API is not available in browser/PWA builds (CORS). Use Tauri desktop or Android.",
             );
         }
         throw err;
+    } finally {
+        clearTimeout(timeoutId);
     }
     if (!response.ok) {
         throw new Error(`FAA NOTAM API error: ${response.status}`);

--- a/src/js/notam/index.js
+++ b/src/js/notam/index.js
@@ -1,0 +1,116 @@
+/**
+ * Shared utilities for NOTAM data.
+ *
+ * NotamItem shape:
+ * {
+ *   id:          string        NOTAM identifier, e.g. "0/2345"
+ *   type:        "NOTAM" | "TFR" | "SUA" | "SNOWTAM" | "ASHTAM"
+ *   location:    string        ICAO code or coordinate description
+ *   startTime:   Date | null
+ *   endTime:     Date | null   null means PERM
+ *   isPermanent: boolean
+ *   lowerAlt:    string | null e.g. "SFC", "1000FT MSL"
+ *   upperAlt:    string | null e.g. "3000FT MSL", "UNL"
+ *   body:        string        plain-text description (E-field or equivalent)
+ *   rawText:     string | null original raw NOTAM text
+ *   source:      string        "faa" | "openaip"
+ * }
+ */
+
+// ICAO Q-code prefixes that map to specific airspace notice types
+const QCODE_TYPE_MAP = [
+    ["QRTCA", "TFR"],
+    ["QRTCL", "TFR"],
+    ["QRTCS", "TFR"],
+    ["QRFXX", "TFR"],
+    ["QRSAS", "SUA"],
+    ["QRSSA", "SUA"],
+    ["QRSUS", "SUA"],
+    ["QRSUT", "SUA"],
+    ["QSNTW", "SNOWTAM"],
+    ["QASHTW", "ASHTAM"],
+];
+
+/**
+ * Classify a NOTAM type from its Q-code.
+ * @param {string | null | undefined} qcode
+ * @returns {"NOTAM" | "TFR" | "SUA" | "SNOWTAM" | "ASHTAM"}
+ */
+export function classifyFromQcode(qcode) {
+    if (!qcode) return "NOTAM";
+    const upper = String(qcode).toUpperCase();
+    for (const [prefix, type] of QCODE_TYPE_MAP) {
+        if (upper.includes(prefix)) return type;
+    }
+    if (upper.includes("SNOWTAM")) return "SNOWTAM";
+    if (upper.includes("ASHTAM")) return "ASHTAM";
+    return "NOTAM";
+}
+
+/**
+ * Get the display status of a NOTAM item.
+ * @param {object} item NotamItem
+ * @returns {"active" | "future" | "expired"}
+ */
+export function getNotamStatus(item) {
+    const now = new Date();
+    if (item.isPermanent || item.endTime === null) {
+        if (!item.startTime || item.startTime <= now) return "active";
+        return "future";
+    }
+    if (item.startTime && item.startTime > now) return "future";
+    if (item.endTime < now) return "expired";
+    return "active";
+}
+
+/**
+ * Sort NOTAMs: active first, then future, then expired.
+ * Within each group, sort by start time ascending.
+ * @param {object[]} items
+ * @returns {object[]}
+ */
+export function sortNotams(items) {
+    const order = { active: 0, future: 1, expired: 2 };
+    return [...items].sort((a, b) => {
+        const sa = order[getNotamStatus(a)];
+        const sb = order[getNotamStatus(b)];
+        if (sa !== sb) return sa - sb;
+        const ta = a.startTime?.getTime() ?? 0;
+        const tb = b.startTime?.getTime() ?? 0;
+        return ta - tb;
+    });
+}
+
+/** Convert nautical miles to kilometres. */
+export function nmToKm(nm) {
+    return nm * 1.852;
+}
+
+/** Convert kilometres to nautical miles. */
+export function kmToNm(km) {
+    return km / 1.852;
+}
+
+/**
+ * Parse a date string from ICAO NOTAM format (YYMMDDHHMM) or ISO 8601.
+ * @param {string | null | undefined} str
+ * @returns {Date | null}
+ */
+export function parseNotamDate(str) {
+    if (!str) return null;
+    const s = String(str).trim();
+    if (/PERM/i.test(s)) return null;
+    // ICAO format: YYMMDDHHMM (10 digits)
+    if (/^\d{10}$/.test(s)) {
+        const yr = 2000 + Number(s.slice(0, 2));
+        const mo = Number(s.slice(2, 4)) - 1;
+        const dy = Number(s.slice(4, 6));
+        const hr = Number(s.slice(6, 8));
+        const mn = Number(s.slice(8, 10));
+        const d = new Date(Date.UTC(yr, mo, dy, hr, mn));
+        return Number.isNaN(d.getTime()) ? null : d;
+    }
+    // ISO 8601 and other browser-parseable formats
+    const d = new Date(s);
+    return Number.isNaN(d.getTime()) ? null : d;
+}

--- a/src/js/notam/openaip.js
+++ b/src/js/notam/openaip.js
@@ -96,9 +96,10 @@ export function normalise(raw) {
  * @returns {Promise<object[]>} array of NotamItem
  */
 export async function fetchFromOpenAip(lat, lon, radiusNm, apiKey) {
-    if (!apiKey || !apiKey.trim()) {
+    if (typeof apiKey !== "string" || !apiKey.trim()) {
         throw new Error("OpenAIP API key is required");
     }
+    const trimmedApiKey = apiKey.trim();
 
     const radiusKm = nmToKm(radiusNm);
 
@@ -117,7 +118,7 @@ export async function fetchFromOpenAip(lat, lon, radiusNm, apiKey) {
         response = await fetch(`${BASE_URL}?${params}`, {
             signal: controller.signal,
             headers: {
-                "x-openaip-api-key": apiKey.trim(),
+                "x-openaip-api-key": trimmedApiKey,
             },
         });
     } catch (err) {
@@ -125,7 +126,9 @@ export async function fetchFromOpenAip(lat, lon, radiusNm, apiKey) {
             throw new Error("OpenAIP API request timed out");
         }
         if (err instanceof TypeError) {
-            throw new Error("OpenAIP API is not available in browser/PWA builds (CORS). Use Tauri desktop or Android.");
+            throw new Error(
+                "OpenAIP API request failed (network error or CORS block). Check connectivity, or use Tauri desktop or Android.",
+            );
         }
         throw err;
     } finally {

--- a/src/js/notam/openaip.js
+++ b/src/js/notam/openaip.js
@@ -1,0 +1,124 @@
+/**
+ * Airspace adapter for OpenAIP.
+ *
+ * Coverage:  Global airspace data (CTRs, SUAs, restricted areas, etc.)
+ * Auth:      API key required (free tier at https://www.openaip.net/)
+ * CORS:      Not verified for PWA/web builds — works in Tauri and Capacitor (native fetch).
+ *            If CORS is blocked in the browser, a network error is thrown.
+ * Endpoint:  https://api.core.openaip.net/api/airspaces
+ * Docs:      https://docs.openaip.net/
+ *
+ * OpenAIP returns permanent/semi-permanent airspace features (SUAs, restricted areas).
+ * These are mapped to NotamItem objects with type "SUA".
+ */
+
+import { nmToKm } from "./index.js";
+
+const BASE_URL = "https://api.core.openaip.net/api/airspaces";
+
+// OpenAIP airspace type codes that correspond to SUAs / restricted areas.
+// https://docs.openaip.net/#tag/Airspaces/operation/getAirspace
+const SUA_TYPES = new Set([
+    2, // Restricted
+    3, // Danger
+    4, // Prohibited
+    5, // CTR
+    10, // TMA
+    14, // MOA (Military Operations Area)
+    28, // Warning
+]);
+
+const TYPE_LABELS = {
+    2: "Restricted",
+    3: "Danger",
+    4: "Prohibited",
+    5: "CTR",
+    10: "TMA",
+    14: "MOA",
+    28: "Warning",
+};
+
+/**
+ * Format an OpenAIP altitude object into a readable string.
+ * @param {object | null} alt
+ * @returns {string | null}
+ */
+export function formatAlt(alt) {
+    if (!alt) return null;
+    const unit = alt.unit === 6 ? "FL" : alt.unit === 1 ? "ft" : alt.unit === 2 ? "m" : "";
+    const ref = alt.referenceDatum === 1 ? " MSL" : alt.referenceDatum === 2 ? " AGL" : "";
+    if (unit === "FL") return `FL${alt.value}`;
+    if (alt.value === 0 && alt.referenceDatum === 2) return "SFC";
+    return `${alt.value}${unit}${ref}`;
+}
+
+/**
+ * Normalise a single OpenAIP airspace feature into a NotamItem.
+ * @param {object} raw
+ * @returns {object} NotamItem
+ */
+export function normalise(raw) {
+    const typeLabel = TYPE_LABELS[raw.type] ?? "Airspace";
+    const name = raw.name ?? "Unknown";
+    const country = raw.country ?? "";
+    const id = raw._id ?? raw.id ?? name;
+
+    return {
+        id: String(id).slice(0, 20),
+        type: "SUA",
+        location: country ? `${country} — ${name}` : name,
+        startTime: null,
+        endTime: null,
+        isPermanent: true,
+        lowerAlt: formatAlt(raw.lowerLimit),
+        upperAlt: formatAlt(raw.upperLimit),
+        body: `${typeLabel}: ${name}`,
+        rawText: null,
+        source: "openaip",
+    };
+}
+
+/**
+ * Fetch airspace data from OpenAIP for a given location.
+ * @param {number} lat
+ * @param {number} lon
+ * @param {number} radiusNm  search radius in nautical miles (converted to km for API)
+ * @param {string} apiKey
+ * @returns {Promise<object[]>} array of NotamItem
+ */
+export async function fetchFromOpenAip(lat, lon, radiusNm, apiKey) {
+    if (!apiKey || !apiKey.trim()) {
+        throw new Error("OpenAIP API key is required");
+    }
+
+    const radiusKm = nmToKm(radiusNm);
+
+    // OpenAIP accepts a geometry parameter as GeoJSON or simple lat/lon + distance.
+    // We use the pos (lat,lon) + dist (km) query pattern.
+    const params = new URLSearchParams({
+        pos: `${lat.toFixed(4)},${lon.toFixed(4)}`,
+        dist: Math.max(1, Math.round(radiusKm)),
+        limit: 100,
+    });
+
+    let response;
+    try {
+        response = await fetch(`${BASE_URL}?${params}`, {
+            headers: {
+                "x-openaip-api-key": apiKey.trim(),
+            },
+        });
+    } catch (err) {
+        if (err instanceof TypeError) {
+            throw new Error("OpenAIP API is not available in browser/PWA builds (CORS). Use Tauri desktop or Android.");
+        }
+        throw err;
+    }
+    if (!response.ok) {
+        throw new Error(`OpenAIP API error: ${response.status}`);
+    }
+    const data = await response.json();
+    const items = data?.items ?? (Array.isArray(data) ? data : []);
+
+    return items.filter((item) => SUA_TYPES.has(item.type)).map(normalise);
+}

--- a/src/js/notam/openaip.js
+++ b/src/js/notam/openaip.js
@@ -38,17 +38,26 @@ const TYPE_LABELS = {
     28: "Warning",
 };
 
+const UNIT_LABELS = { 1: "ft", 2: "m", 6: "FL" };
+const REF_LABELS = { 1: " MSL", 2: " AGL" };
+
 /**
  * Format an OpenAIP altitude object into a readable string.
  * @param {object | null} alt
  * @returns {string | null}
  */
 export function formatAlt(alt) {
-    if (!alt) return null;
-    const unit = alt.unit === 6 ? "FL" : alt.unit === 1 ? "ft" : alt.unit === 2 ? "m" : "";
-    const ref = alt.referenceDatum === 1 ? " MSL" : alt.referenceDatum === 2 ? " AGL" : "";
-    if (unit === "FL") return `FL${alt.value}`;
-    if (alt.value === 0 && alt.referenceDatum === 2) return "SFC";
+    if (!alt) {
+        return null;
+    }
+    const unit = UNIT_LABELS[alt.unit] ?? "";
+    const ref = REF_LABELS[alt.referenceDatum] ?? "";
+    if (unit === "FL") {
+        return `FL${alt.value}`;
+    }
+    if (alt.value === 0 && alt.referenceDatum === 2) {
+        return "SFC";
+    }
     return `${alt.value}${unit}${ref}`;
 }
 
@@ -101,18 +110,26 @@ export async function fetchFromOpenAip(lat, lon, radiusNm, apiKey) {
         limit: 100,
     });
 
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 15_000);
     let response;
     try {
         response = await fetch(`${BASE_URL}?${params}`, {
+            signal: controller.signal,
             headers: {
                 "x-openaip-api-key": apiKey.trim(),
             },
         });
     } catch (err) {
+        if (err.name === "AbortError") {
+            throw new Error("OpenAIP API request timed out");
+        }
         if (err instanceof TypeError) {
             throw new Error("OpenAIP API is not available in browser/PWA builds (CORS). Use Tauri desktop or Android.");
         }
         throw err;
+    } finally {
+        clearTimeout(timeoutId);
     }
     if (!response.ok) {
         throw new Error(`OpenAIP API error: ${response.status}`);

--- a/src/js/notam/openaip.js
+++ b/src/js/notam/openaip.js
@@ -73,7 +73,7 @@ export function normalise(raw) {
     const id = raw._id ?? raw.id ?? name;
 
     return {
-        id: String(id).slice(0, 20),
+        id: String(id),
         type: "SUA",
         location: country ? `${country} — ${name}` : name,
         startTime: null,

--- a/test/js/notam.test.js
+++ b/test/js/notam.test.js
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+import {
+    classifyFromQcode,
+    getNotamStatus,
+    sortNotams,
+    parseNotamDate,
+    nmToKm,
+    kmToNm,
+} from "../../src/js/notam/index.js";
+import { extractNotam } from "../../src/js/notam/faa.js";
+import { normalise as normaliseOpenAip, formatAlt } from "../../src/js/notam/openaip.js";
+
+describe("classifyFromQcode", () => {
+    it("returns NOTAM for null or empty", () => {
+        expect(classifyFromQcode(null)).toBe("NOTAM");
+        expect(classifyFromQcode("")).toBe("NOTAM");
+        expect(classifyFromQcode(undefined)).toBe("NOTAM");
+    });
+
+    it("classifies TFR Q-codes", () => {
+        expect(classifyFromQcode("QRTCA")).toBe("TFR");
+        expect(classifyFromQcode("QRTCL")).toBe("TFR");
+        expect(classifyFromQcode("QRTCS")).toBe("TFR");
+        expect(classifyFromQcode("KZLA/QRTCA/IV/NBO/A/000/999")).toBe("TFR");
+    });
+
+    it("classifies SUA Q-codes", () => {
+        expect(classifyFromQcode("QRSAS")).toBe("SUA");
+        expect(classifyFromQcode("QRSSA")).toBe("SUA");
+    });
+
+    it("classifies SNOWTAM", () => {
+        expect(classifyFromQcode("QSNTW")).toBe("SNOWTAM");
+        expect(classifyFromQcode("SNOWTAM")).toBe("SNOWTAM");
+    });
+
+    it("classifies ASHTAM", () => {
+        expect(classifyFromQcode("QASHTW")).toBe("ASHTAM");
+        expect(classifyFromQcode("ASHTAM")).toBe("ASHTAM");
+    });
+
+    it("returns NOTAM for unrecognised codes", () => {
+        expect(classifyFromQcode("QMXLC")).toBe("NOTAM");
+        expect(classifyFromQcode("QOBCE")).toBe("NOTAM");
+    });
+});
+
+describe("parseNotamDate", () => {
+    it("returns null for null or empty", () => {
+        expect(parseNotamDate(null)).toBeNull();
+        expect(parseNotamDate("")).toBeNull();
+        expect(parseNotamDate(undefined)).toBeNull();
+    });
+
+    it("returns null for PERM", () => {
+        expect(parseNotamDate("PERM")).toBeNull();
+        expect(parseNotamDate("perm")).toBeNull();
+    });
+
+    it("parses ICAO YYMMDDHHMM format", () => {
+        const d = parseNotamDate("2403151300");
+        expect(d).toBeInstanceOf(Date);
+        expect(d.getUTCFullYear()).toBe(2024);
+        expect(d.getUTCMonth()).toBe(2); // March = 2 (zero-indexed)
+        expect(d.getUTCDate()).toBe(15);
+        expect(d.getUTCHours()).toBe(13);
+        expect(d.getUTCMinutes()).toBe(0);
+    });
+
+    it("parses ISO 8601 format", () => {
+        const d = parseNotamDate("2024-06-01T12:00:00Z");
+        expect(d).toBeInstanceOf(Date);
+        expect(d.getUTCFullYear()).toBe(2024);
+        expect(d.getUTCMonth()).toBe(5); // June
+        expect(d.getUTCDate()).toBe(1);
+    });
+
+    it("returns null for unparseable strings", () => {
+        expect(parseNotamDate("not-a-date")).toBeNull();
+    });
+});
+
+describe("getNotamStatus", () => {
+    const past = new Date(Date.now() - 3_600_000);
+    const future = new Date(Date.now() + 3_600_000);
+    const farFuture = new Date(Date.now() + 7_200_000);
+
+    it("returns active when now is between start and end", () => {
+        expect(getNotamStatus({ startTime: past, endTime: future, isPermanent: false })).toBe("active");
+    });
+
+    it("returns future when start is in the future", () => {
+        expect(getNotamStatus({ startTime: future, endTime: farFuture, isPermanent: false })).toBe("future");
+    });
+
+    it("returns expired when end is in the past", () => {
+        const olderPast = new Date(Date.now() - 7_200_000);
+        expect(getNotamStatus({ startTime: olderPast, endTime: past, isPermanent: false })).toBe("expired");
+    });
+
+    it("returns active for permanent NOTAMs with past start", () => {
+        expect(getNotamStatus({ startTime: past, endTime: null, isPermanent: true })).toBe("active");
+    });
+
+    it("returns future for permanent NOTAMs with future start", () => {
+        expect(getNotamStatus({ startTime: future, endTime: null, isPermanent: true })).toBe("future");
+    });
+
+    it("returns active when endTime is null and startTime is null", () => {
+        expect(getNotamStatus({ startTime: null, endTime: null, isPermanent: false })).toBe("active");
+    });
+});
+
+describe("sortNotams", () => {
+    const past = new Date(Date.now() - 3_600_000);
+    const future = new Date(Date.now() + 3_600_000);
+    const farFuture = new Date(Date.now() + 7_200_000);
+    const farPast = new Date(Date.now() - 7_200_000);
+
+    const active = { id: "A", startTime: past, endTime: future, isPermanent: false };
+    const futureItem = { id: "B", startTime: future, endTime: farFuture, isPermanent: false };
+    const expired = { id: "C", startTime: farPast, endTime: past, isPermanent: false };
+
+    it("orders active before future before expired", () => {
+        const sorted = sortNotams([expired, futureItem, active]);
+        expect(sorted[0].id).toBe("A");
+        expect(sorted[1].id).toBe("B");
+        expect(sorted[2].id).toBe("C");
+    });
+
+    it("does not mutate the original array", () => {
+        const items = [expired, futureItem, active];
+        sortNotams(items);
+        expect(items[0].id).toBe("C");
+    });
+});
+
+describe("unit conversions", () => {
+    it("nmToKm converts correctly", () => {
+        expect(nmToKm(1)).toBeCloseTo(1.852, 3);
+        expect(nmToKm(25)).toBeCloseTo(46.3, 1);
+    });
+
+    it("kmToNm converts correctly", () => {
+        expect(kmToNm(1.852)).toBeCloseTo(1, 3);
+        expect(kmToNm(46.3)).toBeCloseTo(25, 1);
+    });
+
+    it("round-trips correctly", () => {
+        expect(kmToNm(nmToKm(25))).toBeCloseTo(25, 5);
+    });
+});
+
+describe("FAA extractNotam", () => {
+    it("maps standard FAA response structure", () => {
+        const props = {
+            coreNOTAMData: {
+                notam: {
+                    number: "1/2345",
+                    location: "KLAX",
+                    selectionCode: "QOBCE",
+                    effectiveStart: "2403151300",
+                    effectiveEnd: "2404151300",
+                    minimumFL: 0,
+                    maximumFL: 50,
+                },
+                notamTranslation: [{ type: "ICAO", simpleText: "NOTAM body text" }],
+            },
+        };
+        const item = extractNotam(props);
+        expect(item.id).toBe("1/2345");
+        expect(item.location).toBe("KLAX");
+        expect(item.type).toBe("NOTAM");
+        expect(item.body).toBe("NOTAM body text");
+        expect(item.startTime).toBeInstanceOf(Date);
+        expect(item.endTime).toBeInstanceOf(Date);
+        expect(item.lowerAlt).toBe("0");
+        expect(item.upperAlt).toBe("50");
+        expect(item.rawText).toBe("NOTAM body text");
+        expect(item.source).toBe("faa");
+    });
+
+    it("handles missing translations by falling back to core.text", () => {
+        const props = {
+            coreNOTAMData: {
+                notam: { number: "2/0001", text: "core text fallback" },
+                notamTranslation: [],
+            },
+        };
+        expect(extractNotam(props).body).toBe("core text fallback");
+    });
+
+    it("handles PERM end date", () => {
+        const props = {
+            coreNOTAMData: {
+                notam: { number: "3/0001", effectiveEnd: "PERM" },
+                notamTranslation: [],
+            },
+        };
+        const item = extractNotam(props);
+        expect(item.isPermanent).toBe(true);
+        expect(item.endTime).toBeNull();
+    });
+
+    it("handles null/missing properties gracefully", () => {
+        const item = extractNotam({});
+        expect(item.id).toBe("Unknown");
+        expect(item.source).toBe("faa");
+    });
+
+    it("classifies TFR from selectionCode", () => {
+        const props = {
+            coreNOTAMData: {
+                notam: { number: "T/001", selectionCode: "QRTCA" },
+                notamTranslation: [],
+            },
+        };
+        expect(extractNotam(props).type).toBe("TFR");
+    });
+});
+
+describe("OpenAIP formatAlt", () => {
+    it("formats flight level", () => {
+        expect(formatAlt({ value: 100, unit: 6 })).toBe("FL100");
+    });
+
+    it("formats surface", () => {
+        expect(formatAlt({ value: 0, unit: 1, referenceDatum: 2 })).toBe("SFC");
+    });
+
+    it("formats feet MSL", () => {
+        expect(formatAlt({ value: 3000, unit: 1, referenceDatum: 1 })).toBe("3000ft MSL");
+    });
+
+    it("formats feet AGL", () => {
+        expect(formatAlt({ value: 500, unit: 1, referenceDatum: 2 })).toBe("500ft AGL");
+    });
+
+    it("returns null for null input", () => {
+        expect(formatAlt(null)).toBeNull();
+    });
+});
+
+describe("OpenAIP normalise", () => {
+    it("maps a restricted airspace feature to a NotamItem", () => {
+        const raw = {
+            _id: "abc123",
+            type: 2,
+            name: "Restricted Area R-99",
+            country: "US",
+            lowerLimit: { value: 0, unit: 1, referenceDatum: 2 },
+            upperLimit: { value: 3000, unit: 1, referenceDatum: 1 },
+        };
+        const item = normaliseOpenAip(raw);
+        expect(item.id).toBe("abc123");
+        expect(item.type).toBe("SUA");
+        expect(item.location).toBe("US — Restricted Area R-99");
+        expect(item.isPermanent).toBe(true);
+        expect(item.lowerAlt).toBe("SFC");
+        expect(item.upperAlt).toBe("3000ft MSL");
+        expect(item.source).toBe("openaip");
+    });
+
+    it("uses name as id when _id is absent", () => {
+        const raw = { type: 3, name: "Danger Area D-7" };
+        const item = normaliseOpenAip(raw);
+        expect(item.id).toBe("Danger Area D-7".slice(0, 20));
+    });
+
+    it("returns null start and end times (permanent airspace)", () => {
+        const item = normaliseOpenAip({ type: 4, name: "P-1" });
+        expect(item.startTime).toBeNull();
+        expect(item.endTime).toBeNull();
+    });
+});

--- a/test/js/notam.test.js
+++ b/test/js/notam.test.js
@@ -264,7 +264,7 @@ describe("OpenAIP normalise", () => {
     it("uses name as id when _id is absent", () => {
         const raw = { type: 3, name: "Danger Area D-7" };
         const item = normaliseOpenAip(raw);
-        expect(item.id).toBe("Danger Area D-7".slice(0, 20));
+        expect(item.id).toBe("Danger Area D-7");
     });
 
     it("returns null start and end times (permanent airspace)", () => {


### PR DESCRIPTION
## Summary
- Adds an inline airspace data panel to the Preflight tab's Airspace section. When a location is set, fetches NOTAMs, TFRs, and SUAs from the user-selected provider and renders them as structured cards showing ID, type badge, location, effective window, altitude bounds, and an expandable description body. Cards are sorted active → future → expired.
- Supports two providers: FAA NOTAM API (USA, free API key) and OpenAIP (global airspace/SUAs, free API key). Provider, API key, and search radius (NM or km) are persisted in ConfigStorage. A guidance message is shown when a provider is selected but no key is entered yet. Settings changes trigger an immediate re-fetch when a location is already set.
- Adds 35 unit tests covering shared NOTAM utilities (`classifyFromQcode`, `parseNotamDate`, `getNotamStatus`, `sortNotams`, unit conversions) and both adapter normalisers (FAA `extractNotam`, OpenAIP `normalise`/`formatAlt`).

## Test plan
- [ ] Set a location in the Preflight tab
- [ ] Select FAA NOTAM API, enter a valid `client_id:client_secret` — cards should load for a US location
- [ ] Select OpenAIP, enter a valid API key — airspace cards load for any location
- [ ] Switch provider to Disabled — panel clears
- [ ] Select a provider but leave API key blank — guidance message shown (no red error)
- [ ] Change radius or unit — re-fetch triggers immediately
- [ ] Navigate away and back — settings persist (provider, key, radius, unit)
- [ ] Cards sorted: active (green border) → future (amber) → expired (dimmed)
- [ ] Expand/collapse long NOTAM body via "Show more" / "Show less"
- [ ] `npm run test` — 87 tests pass
- [ ] `npm run lint` — no errors

## Notes
- AviationWeather.gov (`/api/data/notam`) returns 404 and is excluded.
- EUROCONTROL/AutoRouter EU NOTAM support was investigated and deferred — AutoRouter uses ICAO FIR codes (not lat/lon) and requires OAuth; tracked for a follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NOTAM (airspace/no‑fly) support with selectable providers (Disabled/FAA/OpenAIP), API key entry, radius in NM/km, privacy note, on‑demand fetch
  * Preflight tab shows NOTAM list with status badges (Active now, Permanent, Expired), type labels (TFR, SUA, SNOWTAM, ASHTAM, NOTAM), altitude ranges, “Last fetched”, and expandable previews (Show more/less)
  * UI displays loading/empty/error/missing‑API states

* **Localization**
  * Added/updated Preflight NOTAM strings for providers, credentials, units, statuses, types, altitudes, and UI labels

* **Tests**
  * Added tests for NOTAM parsing, classification, formatting and provider integrations

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5107)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->