### PR TITLE
feat(pid): hide Absolute Control for API >= 1.48, preserve byte alignment

### DIFF
--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -1023,7 +1023,11 @@
                     ></span>
                 </div>
 
-                <SettingRow :label="$t('pidTuningAbsoluteControlGain')" :help="$t('pidTuningAbsoluteControlGainHelp')">
+                <SettingRow
+                    v-if="isPreApi148"
+                    :label="$t('pidTuningAbsoluteControlGain')"
+                    :help="$t('pidTuningAbsoluteControlGainHelp')"
+                >
                     <UInputNumber
                         v-model="advancedTuning.absoluteControlGain"
                         :step="1"
@@ -1050,7 +1054,7 @@ import {
     readPidSliderPositions,
 } from "@/composables/useTuningSliders";
 import semver from "semver";
-import { API_VERSION_1_45, API_VERSION_1_47 } from "@/js/data_storage";
+import { API_VERSION_1_45, API_VERSION_1_47, API_VERSION_1_48 } from "@/js/data_storage";
 import UiBox from "@/components/elements/UiBox.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
 import SettingRow from "@/components/elements/SettingRow.vue";
@@ -1123,6 +1127,8 @@ const cellCountItems = computed(() => [
 const isPreApi145 = computed(() => semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_45));
 // For API < 1.47, derivative and dmax column headers are swapped (PR #4173)
 const isPreApi147 = computed(() => semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_47));
+// Absolute Control was removed from firmware in API 1.48
+const isPreApi148 = computed(() => semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_48));
 const derivativeLabel = computed(() => (isPreApi147.value ? "pidTuningDMax" : "pidTuningDerivative"));
 const derivativeHelp = computed(() => (isPreApi147.value ? "pidTuningDMaxHelp" : "pidTuningDerivativeHelp"));
 const dMaxLabel = computed(() => (isPreApi147.value ? "pidTuningDerivative" : "pidTuningDMax"));
@@ -1360,9 +1366,7 @@ const itermRelaxEnabled = computed({
 
 const antiGravityEnabled = computed({
     get: () =>
-        isPreApi145.value
-            ? FC.ADVANCED_TUNING.itermAcceleratorGain !== 0
-            : FC.ADVANCED_TUNING.antiGravityGain !== 0,
+        isPreApi145.value ? FC.ADVANCED_TUNING.itermAcceleratorGain !== 0 : FC.ADVANCED_TUNING.antiGravityGain !== 0,
     set: (val) => {
         if (isPreApi145.value) {
             FC.ADVANCED_TUNING.itermAcceleratorGain = val ? FC.ADVANCED_TUNING.itermAcceleratorGain || 1000 : 0;
@@ -1375,9 +1379,7 @@ const antiGravityEnabled = computed({
 // Anti-gravity gain display value (divided by 10 for API 1.45+, divided by 1000 for older)
 const antiGravityGainValue = computed({
     get: () =>
-        isPreApi145.value
-            ? FC.ADVANCED_TUNING.itermAcceleratorGain / 1000
-            : FC.ADVANCED_TUNING.antiGravityGain / 10,
+        isPreApi145.value ? FC.ADVANCED_TUNING.itermAcceleratorGain / 1000 : FC.ADVANCED_TUNING.antiGravityGain / 10,
     set: (val) => {
         const parsed = Number.parseFloat(val);
         if (isPreApi145.value) {

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1228,7 +1228,11 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.ADVANCED_TUNING.smartFeedforward = data.readU8();
                     FC.ADVANCED_TUNING.itermRelax = data.readU8();
                     FC.ADVANCED_TUNING.itermRelaxType = data.readU8();
-                    FC.ADVANCED_TUNING.absoluteControlGain = data.readU8();
+                    if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_48)) {
+                        FC.ADVANCED_TUNING.absoluteControlGain = data.readU8();
+                    } else {
+                        data.readU8();
+                    }
                     FC.ADVANCED_TUNING.throttleBoost = data.readU8();
                     FC.ADVANCED_TUNING.acroTrainerAngleLimit = data.readU8();
                     FC.ADVANCED_TUNING.feedforwardRoll = data.readU16();
@@ -2228,8 +2232,13 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
                 .push8(FC.ADVANCED_TUNING.itermRotation)
                 .push8(FC.ADVANCED_TUNING.smartFeedforward)
                 .push8(FC.ADVANCED_TUNING.itermRelax)
-                .push8(FC.ADVANCED_TUNING.itermRelaxType)
-                .push8(FC.ADVANCED_TUNING.absoluteControlGain)
+                .push8(FC.ADVANCED_TUNING.itermRelaxType);
+            if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_48)) {
+                buffer.push8(FC.ADVANCED_TUNING.absoluteControlGain);
+            } else {
+                buffer.push8(0);
+            }
+            buffer
                 .push8(FC.ADVANCED_TUNING.throttleBoost)
                 .push8(FC.ADVANCED_TUNING.acroTrainerAngleLimit)
                 .push16(FC.ADVANCED_TUNING.feedforwardRoll)


### PR DESCRIPTION
## Summary

- `abs_control_gain` was deprecated in firmware API 1.48 (betaflight/betaflight#15023); the byte remains in the `MSP_ADVANCED_TUNING` / `MSP_SET_ADVANCED_TUNING` payload but firmware ignores it
- For API >= 1.48: consume the byte on read (discard) and write `0` on write to preserve stream alignment; hide the UI control with `v-if="isPreApi148"`
- For API < 1.48: read/store and write the actual value as before — no regression for older firmware

## Test plan

- [ ] Connect to firmware API >= 1.48: Absolute Control input is not shown in PID Tuning tab
- [ ] Connect to firmware API >= 1.48: save settings succeeds and all subsequent fields (Throttle Boost, Acro Trainer, etc.) are correct
- [ ] Connect to firmware API < 1.48: Absolute Control input is shown and saves correctly
- [ ] `npm run test` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The "Absolute Control Gain" setting in the PID tuning interface is now hidden when using firmware API version 1.48 or newer.

* **Refactor**
  * Improved firmware API version compatibility handling and message processing to ensure correct communication with all supported flight controller types across different API versions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5108)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->