### PR TITLE
fix(serial): close WebSerial port on page unload to prevent replug

### DIFF
--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -325,6 +325,60 @@ class WebSerial extends EventTarget {
         }
     }
 
+    forceClose() {
+        // Best-effort teardown for page-unload (pagehide / beforeunload).
+        // Instance refs are nulled immediately so the rest of the class sees a
+        // disconnected state; the actual async teardown runs in a Promise chain
+        // that Chrome typically drains before destroying the JS context.
+        if (!this.port && !this.reader && !this.writer) {
+            return;
+        }
+
+        this.connected = false;
+        this.transmitting = false;
+        this.reading = false;
+
+        this.removeEventListener("receive", this.handleReceiveBytes);
+
+        const reader = this.reader;
+        const writer = this.writer;
+        const port = this.port;
+        this.reader = null;
+        this.writer = null;
+        this.port = null;
+
+        if (port) port.removeEventListener("disconnect", this.handleDisconnect);
+
+        // Mirrors the disconnect() sequence but without awaiting at call-site.
+        (async () => {
+            // 1. Cancel reader — resolves the pending read in streamAsyncIterable,
+            //    whose finally block will call releaseLock() on the readable side.
+            if (reader) {
+                try {
+                    await reader.cancel();
+                } catch (_) {}
+            }
+
+            if (writer) {
+                try {
+                    writer.releaseLock();
+                } catch (_) {}
+            }
+
+            // Close port — Chrome allows this after reader.cancel() even if the
+            // reader lock is still technically held (streamAsyncIterable cleans up).
+            if (port) {
+                try {
+                    await port.close();
+                } catch (_) {}
+            }
+        })();
+
+        this.closeRequested = false;
+        this.connectionInfo = null;
+        this.connectionId = false;
+    }
+
     checkIsNeedBatchWrite() {
         const isMac = GUI.operating_system === "MacOS";
         return isMac && vendorIdNames[this.connectionInfo.usbVendorId] === "AT32";

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -347,7 +347,9 @@ class WebSerial extends EventTarget {
         this.writer = null;
         this.port = null;
 
-        if (port) port.removeEventListener("disconnect", this.handleDisconnect);
+        if (port) {
+            port.removeEventListener("disconnect", this.handleDisconnect);
+        }
 
         // Mirrors the disconnect() sequence but without awaiting at call-site.
         (async () => {
@@ -356,13 +358,13 @@ class WebSerial extends EventTarget {
             if (reader) {
                 try {
                     await reader.cancel();
-                } catch (_) {}
+                } catch (_e) {}
             }
 
             if (writer) {
                 try {
                     writer.releaseLock();
-                } catch (_) {}
+                } catch (_e) {}
             }
 
             // Close port — Chrome allows this after reader.cancel() even if the
@@ -370,7 +372,7 @@ class WebSerial extends EventTarget {
             if (port) {
                 try {
                     await port.close();
-                } catch (_) {}
+                } catch (_e) {}
             }
         })();
 

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -358,13 +358,17 @@ class WebSerial extends EventTarget {
             if (reader) {
                 try {
                     await reader.cancel();
-                } catch (_e) {}
+                } catch (error) {
+                    console.debug(`${logHead} forceClose: reader.cancel() failed during unload`, error);
+                }
             }
 
             if (writer) {
                 try {
                     writer.releaseLock();
-                } catch (_e) {}
+                } catch (error) {
+                    console.debug(`${logHead} forceClose: writer.releaseLock() failed during unload`, error);
+                }
             }
 
             // Close port — Chrome allows this after reader.cancel() even if the
@@ -372,7 +376,9 @@ class WebSerial extends EventTarget {
             if (port) {
                 try {
                     await port.close();
-                } catch (_e) {}
+                } catch (error) {
+                    console.debug(`${logHead} forceClose: port.close() failed during unload`, error);
+                }
             }
         })();
 

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -208,6 +208,14 @@ class Serial extends EventTarget {
         return result;
     }
 
+    forceClose() {
+        try {
+            this._protocol?.forceClose?.();
+        } catch (error) {
+            console.error(`${this.logHead} Error during force close:`, error);
+        }
+    }
+
     /**
      * Get the currently connected port
      */

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -91,6 +91,15 @@ export function initializeSerialBackend() {
 
     PortHandler.initialize();
     PortUsage.initialize();
+
+    // On page unload (refresh / tab close) close the serial port so the FC
+    // gets a clean disconnect and reconnection works without a physical replug.
+    window.addEventListener("pagehide", () => {
+        if (isConnected && !GUI.connect_lock) {
+            console.log(`${logHead} Page unloading while connected — force-closing serial port`);
+            serial.forceClose();
+        }
+    });
 }
 
 async function sendConfigTracking() {


### PR DESCRIPTION
## Summary

- Adds a `pagehide` listener in `initializeSerialBackend()` that calls `serial.forceClose()` when the page is refreshed or the tab is closed while connected
- Adds `forceClose()` to `WebSerial` — mirrors `disconnect()`'s cleanup sequence (cancel reader, release writer lock, close port) as a fire-and-forget async IIFE since `pagehide` handlers cannot `await`
- Adds `forceClose()` delegation on the `Serial` wrapper class with error handling

resolves #5109

## Test plan

- [x] Connect to FC via USB (non-CLI tab)
- [x] Press F5 or Ctrl+R to refresh
- [x] Verify reconnect works without unplugging USB
- [x] Verify normal disconnect button still works
- [x] Verify tab close and reopen reconnects cleanly

##  Caveat

- not easily resolvable for CLI tab, so deferred to a later PR if at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-facing "force close" to immediately tear down serial connections for reliable cleanup.
* **Bug Fixes**
  * Serial connections now reliably close on tab/page unload, avoiding stuck states that previously required replugging devices.
  * Teardown errors are handled and logged to aid diagnostics without blocking disconnect.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5110)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->