### PR TITLE
Replace Font Awesome with Lucide icons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@capacitor/android": "8.3.4",
         "@capacitor/core": "8.3.4",
-        "@fortawesome/fontawesome-free": "^6.5.2",
         "@iconify-json/lucide": "^1.2.101",
         "@nuxt/ui": "^4.4.0",
         "@simplewebauthn/browser": "^13.2.2",
@@ -2384,15 +2383,6 @@
         "@floating-ui/dom": "^1.7.6",
         "@floating-ui/utils": "^0.2.11",
         "vue-demi": ">=0.13.0"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.7.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.7.2.tgz",
-      "integrity": "sha512-JUOtgFW6k9u4Y+xeIaEiLr3+cjoUPiAuLXoyKOJSia6Duzb7pq+A76P9ZdPDoAoxHdHzq6gE9/jKBGXlZT8FbA==",
-      "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "dependencies": {
     "@capacitor/android": "8.3.4",
     "@capacitor/core": "8.3.4",
-    "@fortawesome/fontawesome-free": "^6.5.2",
     "@iconify-json/lucide": "^1.2.101",
     "@nuxt/ui": "^4.4.0",
     "@simplewebauthn/browser": "^13.2.2",

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -2527,9 +2527,6 @@ export default defineComponent({
         z-index: auto;
         pointer-events: all;
         display: flex;
-        .fa-search::before {
-            font-size: 11px;
-        }
         span {
             padding: 0 0.5rem;
             background-color: var(--primary-500);

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -10,7 +10,7 @@
                     <div class="location-inputs">
                         <div class="default_btn">
                             <a href="#" @click.prevent="detectLocation" :class="{ disabled: detectingLocation }">
-                                <em class="fas fa-crosshairs"></em>
+                                <UIcon name="i-lucide-crosshair" class="size-4" />
                                 {{ detectingLocation ? $t("preflightDetecting") : $t("preflightUseMyLocation") }}
                             </a>
                         </div>
@@ -49,7 +49,7 @@
                             class="default_btn"
                         >
                             <a href="#" @click.prevent="showSaveDialog" :title="$t('preflightSaveLocation')">
-                                <em class="fas fa-bookmark"></em>
+                                <UIcon name="i-lucide-bookmark" class="size-4" />
                                 {{ $t("preflightSaveLocation") }}
                             </a>
                         </div>
@@ -71,7 +71,7 @@
                                     :class="{ disabled: selectedSavedIndex < 0 }"
                                     :title="$t('preflightRenameLocation')"
                                 >
-                                    <em class="fas fa-pencil-alt"></em>
+                                    <UIcon name="i-lucide-pencil" class="size-4" />
                                 </a>
                             </div>
                             <div class="default_btn saved-loc-btn">
@@ -81,7 +81,7 @@
                                     :class="{ disabled: selectedSavedIndex < 0 }"
                                     :title="$t('preflightDeleteLocation')"
                                 >
-                                    <em class="fas fa-trash-alt"></em>
+                                    <UIcon name="i-lucide-trash-2" class="size-4" />
                                 </a>
                             </div>
                             <div class="default_btn saved-loc-btn">
@@ -99,7 +99,7 @@
                                             : $t('preflightSaveLocation')
                                     "
                                 >
-                                    <em class="fas fa-bookmark"></em>
+                                    <UIcon name="i-lucide-bookmark" class="size-4" />
                                 </a>
                             </div>
                         </template>
@@ -135,7 +135,7 @@
                                 </div>
                                 <div class="default_btn saved-loc-btn">
                                     <a href="#" @click.prevent="cancelEditMode">
-                                        <em class="fas fa-times"></em>
+                                        <UIcon name="i-lucide-x" class="size-4" />
                                     </a>
                                 </div>
                             </div>
@@ -143,17 +143,17 @@
                     </div>
 
                     <div class="location-status" v-if="preflight.location.latitude !== null">
-                        <em class="fas fa-map-marker-alt"></em>
+                        <UIcon name="i-lucide-map-pin" class="size-4" />
                         {{ preflight.location.name }}
                         <span v-if="preflight.location.source" class="location-source"
                             >({{ preflight.location.source }})</span
                         >
                     </div>
                     <div class="location-error" v-if="locationError">
-                        <em class="fas fa-exclamation-triangle"></em> {{ locationError }}
+                        <UIcon name="i-lucide-triangle-alert" class="size-4" /> {{ locationError }}
                     </div>
                     <div class="ip-consent-prompt" v-if="showIpConsent">
-                        <em class="fas fa-shield-alt"></em>
+                        <UIcon name="i-lucide-shield" class="size-4" />
                         <span>{{ $t("preflightIpConsentMessage") }}</span>
                         <div class="ip-consent-actions">
                             <div class="default_btn">
@@ -181,7 +181,7 @@
                 <div class="launch-status-value">{{ $t(preflight.launchStatus.label) }}</div>
                 <div class="default_btn refresh-btn">
                     <a href="#" @click.prevent="refreshData" :class="{ disabled: preflight.isLoading }">
-                        <em class="fas fa-sync-alt" :class="{ 'fa-spin': preflight.isLoading }"></em>
+                        <UIcon name="i-lucide-refresh-cw" class="size-4" :class="{ 'animate-spin': preflight.isLoading }" />
                         {{ $t("preflightRefresh") }}
                     </a>
                 </div>
@@ -195,16 +195,16 @@
                     class="launch-check-item"
                     :class="chk.cssClass"
                 >
-                    <em
-                        class="fas"
-                        :class="
+                    <UIcon
+                        class="size-4"
+                        :name="
                             chk.level === 'good'
-                                ? 'fa-check-circle'
+                                ? 'i-lucide-circle-check'
                                 : chk.level === 'danger'
-                                  ? 'fa-times-circle'
-                                  : 'fa-exclamation-circle'
+                                  ? 'i-lucide-circle-x'
+                                  : 'i-lucide-circle-alert'
                         "
-                    ></em>
+                    />
                     {{ $t(chk.nameKey) }}
                 </span>
             </div>
@@ -214,14 +214,15 @@
                 <!-- Left Column: Weather -->
                 <div class="flex flex-col gap-4 md:col-span-3">
                     <!-- Current Weather -->
-                    <UiBox :title="`<em class='fas fa-cloud-sun'></em> ${$t('preflightCurrentWeather')}`">
+                    <UiBox :title="$t('preflightCurrentWeather')">
                         <template #title>
+                            <UIcon name="i-lucide-cloud-sun" class="size-4" />
                             <div v-if="preflight.weather.loading" class="text-primary">
-                                <em class="fas fa-spinner fa-spin"></em>
+                                <UIcon name="i-lucide-loader-circle" class="size-4 animate-spin" />
                             </div>
                         </template>
                         <div v-if="preflight.weather.error" class="error-message">
-                            <em class="fas fa-exclamation-circle"></em> {{ preflight.weather.error }}
+                            <UIcon name="i-lucide-circle-alert" class="size-4" /> {{ preflight.weather.error }}
                         </div>
                         <div v-else-if="preflight.weather.current" class="weather-grid">
                             <div class="weather-main">
@@ -295,8 +296,11 @@
                     <!-- Flight Window -->
                     <UiBox
                         v-if="preflight.weather.daily"
-                        :title="`<em class='fas fa-clock'></em> ${$t('preflightFlightWindow')}`"
+                        :title="$t('preflightFlightWindow')"
                     >
+                        <template #title>
+                            <UIcon name="i-lucide-clock" class="size-4" />
+                        </template>
                         <div class="flight-window-grid">
                             <div class="flight-window-item">
                                 <div class="fw-label">{{ $t("preflightSunrise") }}</div>
@@ -364,9 +368,12 @@
 
                     <!-- Wind at Altitude (Hourly) -->
                     <UiBox
-                        :title="`<em class='fas fa-wind'></em> ${$t('preflightWindForecast')}`"
+                        :title="$t('preflightWindForecast')"
                         :help="$t('preflightWindForecastHelp')"
                     >
+                        <template #title>
+                            <UIcon name="i-lucide-wind" class="size-4" />
+                        </template>
                         <UTable
                             :data="preflight.weather.hourly ?? []"
                             :columns="hourlyColumns"
@@ -418,9 +425,12 @@
                     <!-- 5-Day Forecast -->
                     <UiBox
                         v-if="preflight.weather.forecast && preflight.weather.forecast.length > 0"
-                        :title="`<em class='fas fa-calendar-alt'></em> ${$t('preflightForecast')}`"
+                        :title="$t('preflightForecast')"
                         :help="$t('preflightForecastHelp')"
                     >
+                        <template #title>
+                            <UIcon name="i-lucide-calendar" class="size-4" />
+                        </template>
                         <UTable
                             :data="preflight.weather.forecast"
                             :columns="forecastColumns"
@@ -474,11 +484,14 @@
                 <div class="flex flex-col gap-4 md:col-span-2">
                     <!-- Solar Activity -->
                     <UiBox
-                        :title="`<em class='fas fa-sun'></em> ${$t('preflightSolarActivity')}`"
+                        :title="$t('preflightSolarActivity')"
                         :help="$t('preflightSolarHelp')"
                     >
+                        <template #title>
+                            <UIcon name="i-lucide-sun" class="size-4" />
+                        </template>
                         <div v-if="preflight.solar.error" class="error-message">
-                            <em class="fas fa-exclamation-circle"></em> {{ preflight.solar.error }}
+                            <UIcon name="i-lucide-circle-alert" class="size-4" /> {{ preflight.solar.error }}
                         </div>
                         <div v-else-if="preflight.solar.kpIndex !== null" class="solar-info">
                             <div class="kp-display">
@@ -523,16 +536,19 @@
                             </div>
                         </div>
                         <div v-else-if="preflight.solar.loading" class="loading-placeholder">
-                            <em class="fas fa-spinner fa-spin"></em> {{ $t("preflightLoadingSolar") }}
+                            <UIcon name="i-lucide-loader-circle" class="size-4 animate-spin" /> {{ $t("preflightLoadingSolar") }}
                         </div>
                         <div v-else class="no-data">{{ $t("preflightNoData") }}</div>
                     </UiBox>
 
                     <!-- GNSS Info -->
                     <UiBox
-                        :title="`<em class='fas fa-satellite'></em> ${$t('preflightGNSS')}`"
+                        :title="$t('preflightGNSS')"
                         :help="$t('preflightGNSSHelp')"
                     >
+                        <template #title>
+                            <UIcon name="i-lucide-satellite" class="size-4" />
+                        </template>
                         <div class="gnss-info">
                             <p>{{ $t("preflightGNSSNote") }}</p>
                             <UTable
@@ -548,14 +564,17 @@
                             </UTable>
                             <div class="gnss-links">
                                 <a href="https://www.gnssplanning.com/" target="_blank" rel="noopener noreferrer">
-                                    <em class="fas fa-external-link-alt"></em> {{ $t("preflightGNSSPlanner") }}
+                                    <UIcon name="i-lucide-external-link" class="size-4" /> {{ $t("preflightGNSSPlanner") }}
                                 </a>
                             </div>
                         </div>
                     </UiBox>
 
                     <!-- Airspace / No-Fly Zones -->
-                    <UiBox :title="`<em class='fas fa-ban'></em> ${$t('preflightAirspace')}`">
+                    <UiBox :title="$t('preflightAirspace')">
+                        <template #title>
+                            <UIcon name="i-lucide-circle-off" class="size-4" />
+                        </template>
                         <div class="airspace-info">
                             <p>{{ $t("preflightAirspaceNote") }}</p>
                             <div class="airspace-links">
@@ -566,7 +585,7 @@
                                     rel="noopener noreferrer"
                                     class="airspace-link"
                                 >
-                                    <em class="fas fa-shield-alt"></em> {{ $t("preflightDroneSafetyMap") }}
+                                    <UIcon name="i-lucide-shield" class="size-4" /> {{ $t("preflightDroneSafetyMap") }}
                                 </a>
                                 <a
                                     v-if="preflight.location.latitude !== null"
@@ -575,7 +594,7 @@
                                     rel="noopener noreferrer"
                                     class="airspace-link"
                                 >
-                                    <em class="fas fa-map"></em> {{ $t("preflightAirspaceExplorer") }}
+                                    <UIcon name="i-lucide-map" class="size-4" /> {{ $t("preflightAirspaceExplorer") }}
                                 </a>
                                 <a
                                     v-if="preflight.location.latitude !== null"
@@ -584,7 +603,7 @@
                                     rel="noopener noreferrer"
                                     class="airspace-link"
                                 >
-                                    <em class="fas fa-exclamation-triangle"></em> {{ $t("preflightNOTAMs") }}
+                                    <UIcon name="i-lucide-triangle-alert" class="size-4" /> {{ $t("preflightNOTAMs") }}
                                 </a>
                                 <a
                                     v-if="preflight.location.latitude !== null"
@@ -593,7 +612,7 @@
                                     rel="noopener noreferrer"
                                     class="airspace-link"
                                 >
-                                    <em class="fas fa-exclamation-triangle"></em> {{ $t("preflightNOTAMsEU") }}
+                                    <UIcon name="i-lucide-triangle-alert" class="size-4" /> {{ $t("preflightNOTAMsEU") }}
                                 </a>
                             </div>
                         </div>
@@ -601,9 +620,12 @@
 
                     <!-- Map -->
                     <UiBox
-                        :title="`<em class='fas fa-map-marked-alt'></em> ${$t('preflightMap')}`"
+                        :title="$t('preflightMap')"
                         class="preflight-map-box"
                     >
+                        <template #title>
+                            <UIcon name="i-lucide-map-pinned" class="size-4" />
+                        </template>
                         <div class="preflight-map-container" ref="mapContainerRef">
                             <div id="preflight-map" class="preflight-map" ref="mapRef"></div>
                             <div class="controls">

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -27,7 +27,7 @@
             <div v-show="menuOpen" id="user-menu-popup" class="user-popup-menu" :style="menuStyle">
                 <div id="menu-username" class="menu-username">{{ displayName }}</div>
                 <a href="#" id="menu-signout" class="menu-item" @click.prevent="handleSignOut">
-                    <i class="fas fa-sign-out-alt"></i>
+                    <UIcon name="i-lucide-log-out" class="size-4" />
                     <span>{{ $t("labelSignOut") }}</span>
                 </a>
             </div>

--- a/src/js/browserMain.js
+++ b/src/js/browserMain.js
@@ -3,7 +3,6 @@ import "../../libraries/flightindicators.css";
 import "../css/theme.css";
 import "../css/main.less";
 import "../css/opensans_webfontkit/fonts.css";
-import "@fortawesome/fontawesome-free/css/all.css";
 import "../components/MotorOutputReordering/Styles.css";
 import "../components/EscDshotDirection/Styles.css";
 import "../css/dark-theme.less";


### PR DESCRIPTION
## Summary
- Replaced all remaining Font Awesome icon usage with Lucide `UIcon` components across PreflightTab, FirmwareFlasherTab, and UserSession
- Removed `@fortawesome/fontawesome-free` dependency and its CSS import from `browserMain.js`
- Moved inline FA icon HTML in `UiBox` `:title` props to proper `#title` slots with `UIcon` components
- Removed dead `.fa-search::before` CSS rule from FirmwareFlasherTab

## Test plan
- [x] Verify Preflight tab icons render correctly (weather, solar, GNSS, airspace, map sections)
- [x] Verify Preflight tab loading spinners animate
- [x] Verify Preflight tab launch status check icons (good/danger/warning)
- [x] Verify Firmware Flasher tab renders without issues
- [ ] Verify User Session sign-out icon displays correctly
- [x] Verify no Font Awesome CSS is bundled in production build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Transitioned all application icons from FontAwesome to Lucide icon set via updated component architecture
  * Removed FontAwesome package dependency, reducing project dependencies and overall bundle size

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5115)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->