### PR TITLE
Flight plan: support TAKEOFF and modifier waypoint types

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3307,11 +3307,23 @@
     "flightPlanDuration": {
         "message": "Hold Duration <span class=\"units\">min</span>"
     },
+    "flightPlanDurationAria": {
+        "message": "Hold Duration in minutes",
+        "description": "Plain-text aria-label variant of flightPlanDuration for screen readers"
+    },
     "flightPlanDelayDuration": {
         "message": "Delay Duration <span class=\"units\">min</span>"
     },
+    "flightPlanDelayDurationAria": {
+        "message": "Delay Duration in minutes",
+        "description": "Plain-text aria-label variant of flightPlanDelayDuration for screen readers"
+    },
     "flightPlanYawRate": {
         "message": "Yaw Rate <span class=\"units\">°/s</span>"
+    },
+    "flightPlanYawRateAria": {
+        "message": "Yaw Rate in degrees per second",
+        "description": "Plain-text aria-label variant of flightPlanYawRate for screen readers"
     },
     "flightPlanPattern": {
         "message": "Hold Pattern"
@@ -3384,6 +3396,15 @@
     },
     "flightPlanInvalidLongitude": {
         "message": "Invalid longitude (must be between -180 and 180)"
+    },
+    "flightPlanInvalidAltitude": {
+        "message": "Invalid altitude (must be zero or positive)"
+    },
+    "flightPlanInvalidDuration": {
+        "message": "Invalid duration (must be zero or positive)"
+    },
+    "flightPlanInvalidYawRate": {
+        "message": "Invalid yaw rate (must be zero or positive)"
     },
     "flightPlanConfirmDelete": {
         "message": "Are you sure you want to delete this waypoint?"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3289,8 +3289,29 @@
     "flightPlanTypeLand": {
         "message": "Land"
     },
+    "flightPlanTypeTakeoff": {
+        "message": "Take Off"
+    },
+    "flightPlanTypeAltChange": {
+        "message": "Change Altitude",
+        "description": "Modifier waypoint type: changes the altitude of the next positional waypoint"
+    },
+    "flightPlanTypeDelay": {
+        "message": "Delay",
+        "description": "Modifier waypoint type: pauses traversal for a duration"
+    },
+    "flightPlanTypeYawRate": {
+        "message": "Yaw Rate Cap",
+        "description": "Modifier waypoint type: caps the yaw rate of the next positional waypoint"
+    },
     "flightPlanDuration": {
         "message": "Hold Duration <span class=\"units\">min</span>"
+    },
+    "flightPlanDelayDuration": {
+        "message": "Delay Duration <span class=\"units\">min</span>"
+    },
+    "flightPlanYawRate": {
+        "message": "Yaw Rate <span class=\"units\">°/s</span>"
     },
     "flightPlanPattern": {
         "message": "Hold Pattern"

--- a/src/components/tabs/FlightPlan/ElevationProfile.vue
+++ b/src/components/tabs/FlightPlan/ElevationProfile.vue
@@ -146,7 +146,7 @@
                             class="waypoint-label"
                             text-anchor="middle"
                         >
-                            WP{{ index + 1 }}
+                            WP{{ point.order + 1 }}
                         </text>
                     </g>
 
@@ -166,7 +166,7 @@
                             class="tooltip-text"
                             text-anchor="middle"
                         >
-                            WP{{ hoveredPoint.index + 1 }}
+                            WP{{ hoveredPoint.order + 1 }}
                         </text>
                         <text
                             :x="hoveredPoint.tooltipX"
@@ -311,6 +311,7 @@ const profilePoints = computed(() => {
 
         return {
             uid: wp.uid,
+            order: wp.order,
             altitude: wp.altitude,
             distance: cumulativeDistance,
             latitude: wp.latitude,

--- a/src/components/tabs/FlightPlan/ElevationProfile.vue
+++ b/src/components/tabs/FlightPlan/ElevationProfile.vue
@@ -200,8 +200,9 @@ import { ref, computed, watch } from "vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
 
-const { sortedWaypoints, selectedWaypointUid, selectWaypoint } = useFlightPlan();
-const waypoints = sortedWaypoints;
+const { positionalWaypoints, selectedWaypointUid, selectWaypoint } = useFlightPlan();
+// Modifier waypoints (lat/lon = 0) would otherwise skew distance and altitude.
+const waypoints = positionalWaypoints;
 
 const chartSvg = ref(null);
 const hoveredPoint = ref(null);

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -27,8 +27,12 @@ import { Style, Stroke, Circle, Fill, Text } from "ol/style";
 import { DragPan } from "ol/interaction";
 import { useFlightPlan } from "@/composables/useFlightPlan";
 
-const { waypoints, sortedWaypoints, selectedWaypointUid, selectWaypoint, addWaypointAtLocation, updateWaypoint } =
+const { waypoints, positionalWaypoints, selectedWaypointUid, selectWaypoint, addWaypointAtLocation, updateWaypoint } =
     useFlightPlan();
+
+// Map renders only positional waypoints (lat/lon meaningful); modifier types
+// have no horizontal position and would otherwise be plotted at (0, 0).
+const sortedWaypoints = positionalWaypoints;
 
 const mapRef = ref(null);
 const mapInstance = ref(null);

--- a/src/components/tabs/FlightPlan/WaypointEditor.vue
+++ b/src/components/tabs/FlightPlan/WaypointEditor.vue
@@ -1,7 +1,11 @@
 <template>
     <Dialog v-model="showEditorDialog" :title="editMode ? $t('flightPlanEditWaypoint') : $t('flightPlanAddWaypoint')">
         <form ref="formElement" class="editor-form flex flex-col gap-3" @submit.prevent="handleSave">
-            <SettingRow :label="$t('flightPlanLatitude')" full-width>
+            <SettingRow :label="$t('flightPlanType')" full-width>
+                <USelect v-model="form.type" :items="typeItems" :aria-label="$t('flightPlanType')" class="w-48" />
+            </SettingRow>
+
+            <SettingRow v-if="showPosition" :label="$t('flightPlanLatitude')" full-width>
                 <UInputNumber
                     v-model="form.latitude"
                     :step="0.000001"
@@ -13,7 +17,7 @@
                 />
             </SettingRow>
 
-            <SettingRow :label="$t('flightPlanLongitude')" full-width>
+            <SettingRow v-if="showPosition" :label="$t('flightPlanLongitude')" full-width>
                 <UInputNumber
                     v-model="form.longitude"
                     :step="0.000001"
@@ -25,7 +29,7 @@
                 />
             </SettingRow>
 
-            <SettingRow :label="$t('flightPlanAltitude')" full-width>
+            <SettingRow v-if="showAltitude" :label="$t('flightPlanAltitude')" full-width>
                 <UInputNumber
                     v-model="form.altitude"
                     :step="1"
@@ -37,7 +41,7 @@
                 />
             </SettingRow>
 
-            <SettingRow :label="$t('flightPlanSpeed')" full-width>
+            <SettingRow v-if="showSpeed" :label="$t('flightPlanSpeed')" full-width>
                 <UInputNumber
                     v-model="form.speed"
                     :step="0.1"
@@ -49,17 +53,25 @@
                 />
             </SettingRow>
 
-            <SettingRow :label="$t('flightPlanType')" full-width>
-                <USelect v-model="form.type" :items="typeItems" :aria-label="$t('flightPlanType')" class="w-48" />
+            <SettingRow v-if="showYawRate" :label="$t('flightPlanYawRate')" full-width>
+                <UInputNumber
+                    v-model="form.speed"
+                    :step="1"
+                    :min="0"
+                    :max="720"
+                    required
+                    :aria-label="$t('flightPlanYawRate')"
+                    class="w-48"
+                />
             </SettingRow>
 
-            <SettingRow v-if="form.type === 'hold'" :label="$t('flightPlanDuration')" full-width>
+            <SettingRow v-if="showDuration" :label="durationLabel" full-width>
                 <UInputNumber
                     v-model="form.duration"
                     :step="0.1"
                     :min="0"
                     :max="60"
-                    :aria-label="$t('flightPlanDuration')"
+                    :aria-label="durationLabel"
                     class="w-48"
                 />
             </SettingRow>
@@ -95,8 +107,15 @@ import SettingRow from "@/components/elements/SettingRow.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
 
 const { t } = useTranslation();
-const { editingWaypointUid, editingWaypoint, showEditorDialog, addWaypoint, updateWaypoint, cancelEdit } =
-    useFlightPlan();
+const {
+    editingWaypointUid,
+    editingWaypoint,
+    showEditorDialog,
+    addWaypoint,
+    updateWaypoint,
+    cancelEdit,
+    isModifierWaypointType,
+} = useFlightPlan();
 
 // Form element ref for validation
 const formElement = ref(null);
@@ -123,6 +142,10 @@ const typeItems = computed(() => [
     { label: t("flightPlanTypeFlyby"), value: "flyby" },
     { label: t("flightPlanTypeHold"), value: "hold" },
     { label: t("flightPlanTypeLand"), value: "land" },
+    { label: t("flightPlanTypeTakeoff"), value: "takeoff" },
+    { label: t("flightPlanTypeAltChange"), value: "alt_change" },
+    { label: t("flightPlanTypeDelay"), value: "delay" },
+    { label: t("flightPlanTypeYawRate"), value: "yaw_rate" },
 ]);
 
 const patternItems = computed(() => [
@@ -130,6 +153,16 @@ const patternItems = computed(() => [
     { label: t("flightPlanPatternFigure8"), value: "figure8" },
     { label: t("flightPlanPatternOrbit"), value: "orbit" },
 ]);
+
+// Field visibility per waypoint type. Modifier types ignore lat/lon, and each
+// modifier uses just one storage slot (alt, duration or speed-as-deg/s).
+const isModifier = computed(() => isModifierWaypointType(form.type));
+const showPosition = computed(() => !isModifier.value);
+const showAltitude = computed(() => !isModifier.value || form.type === "alt_change");
+const showSpeed = computed(() => !isModifier.value);
+const showYawRate = computed(() => form.type === "yaw_rate");
+const showDuration = computed(() => form.type === "hold" || form.type === "delay");
+const durationLabel = computed(() => (form.type === "delay" ? t("flightPlanDelayDuration") : t("flightPlanDuration")));
 
 // Watch for editing waypoint changes and populate form
 watch(editingWaypoint, (waypoint) => {
@@ -194,36 +227,22 @@ const handleSave = () => {
         return;
     }
 
-    if (editMode.value) {
-        // Update existing waypoint
-        const success = updateWaypoint(editingWaypointUid.value, {
-            latitude: form.latitude,
-            longitude: form.longitude,
-            altitude: form.altitude,
-            speed: form.speed,
-            type: form.type,
-            duration: form.duration,
-            pattern: form.pattern,
-        });
-        if (success) {
-            resetForm();
-            showEditorDialog.value = false;
-        }
-    } else {
-        // Add new waypoint
-        const success = addWaypoint({
-            latitude: form.latitude,
-            longitude: form.longitude,
-            altitude: form.altitude,
-            speed: form.speed,
-            type: form.type,
-            duration: form.duration,
-            pattern: form.pattern,
-        });
-        if (success) {
-            resetForm();
-            showEditorDialog.value = false;
-        }
+    // Modifier waypoints have no horizontal position; firmware ignores lat/lon.
+    const payload = {
+        latitude: isModifier.value ? 0 : form.latitude,
+        longitude: isModifier.value ? 0 : form.longitude,
+        altitude: form.altitude,
+        speed: form.speed,
+        type: form.type,
+        duration: form.duration,
+        pattern: form.pattern,
+    };
+
+    const success = editMode.value ? updateWaypoint(editingWaypointUid.value, payload) : addWaypoint(payload);
+
+    if (success) {
+        resetForm();
+        showEditorDialog.value = false;
     }
 };
 

--- a/src/components/tabs/FlightPlan/WaypointEditor.vue
+++ b/src/components/tabs/FlightPlan/WaypointEditor.vue
@@ -60,7 +60,7 @@
                     :min="0"
                     :max="720"
                     required
-                    :aria-label="$t('flightPlanYawRate')"
+                    :aria-label="$t('flightPlanYawRateAria')"
                     class="w-48"
                 />
             </SettingRow>
@@ -71,7 +71,7 @@
                     :step="0.1"
                     :min="0"
                     :max="60"
-                    :aria-label="durationLabel"
+                    :aria-label="durationAriaLabel"
                     class="w-48"
                 />
             </SettingRow>
@@ -163,6 +163,10 @@ const showSpeed = computed(() => !isModifier.value);
 const showYawRate = computed(() => form.type === "yaw_rate");
 const showDuration = computed(() => form.type === "hold" || form.type === "delay");
 const durationLabel = computed(() => (form.type === "delay" ? t("flightPlanDelayDuration") : t("flightPlanDuration")));
+// Aria labels avoid the `<span class="units">` markup that the visual labels carry.
+const durationAriaLabel = computed(() =>
+    form.type === "delay" ? t("flightPlanDelayDurationAria") : t("flightPlanDurationAria"),
+);
 
 // Watch for editing waypoint changes and populate form
 watch(editingWaypoint, (waypoint) => {
@@ -208,6 +212,38 @@ watch(
     },
 );
 
+// Build a save payload, zeroing slots that aren't meaningful for the type so
+// modifier waypoints don't leak stale form values into CLI/FC round-trips.
+const buildPayload = () => {
+    const base = { type: form.type, latitude: 0, longitude: 0, altitude: 0, speed: 0, duration: 0, pattern: "circle" };
+    switch (form.type) {
+        case "alt_change":
+            return { ...base, altitude: form.altitude };
+        case "delay":
+            return { ...base, duration: form.duration };
+        case "yaw_rate":
+            return { ...base, speed: form.speed };
+        case "hold":
+            return {
+                ...base,
+                latitude: form.latitude,
+                longitude: form.longitude,
+                altitude: form.altitude,
+                speed: form.speed,
+                duration: form.duration,
+                pattern: form.pattern,
+            };
+        default:
+            return {
+                ...base,
+                latitude: form.latitude,
+                longitude: form.longitude,
+                altitude: form.altitude,
+                speed: form.speed,
+            };
+    }
+};
+
 // Reset form to defaults
 const resetForm = () => {
     form.latitude = 0;
@@ -227,16 +263,9 @@ const handleSave = () => {
         return;
     }
 
-    // Modifier waypoints have no horizontal position; firmware ignores lat/lon.
-    const payload = {
-        latitude: isModifier.value ? 0 : form.latitude,
-        longitude: isModifier.value ? 0 : form.longitude,
-        altitude: form.altitude,
-        speed: form.speed,
-        type: form.type,
-        duration: form.duration,
-        pattern: form.pattern,
-    };
+    // Each modifier type uses just one storage slot; zero the rest so the CLI
+    // round-trip and FC executor only see meaningful values for that type.
+    const payload = buildPayload();
 
     const success = editMode.value ? updateWaypoint(editingWaypointUid.value, payload) : addWaypoint(payload);
 

--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -32,14 +32,30 @@
                 <div class="waypoint-order">{{ waypoint.order + 1 }}</div>
                 <div class="waypoint-info">
                     <div class="waypoint-coords">
-                        {{ waypoint.latitude.toFixed(6) }}°, {{ waypoint.longitude.toFixed(6) }}°
+                        <template v-if="isModifierWaypointType(waypoint.type)">
+                            {{ getWaypointTypeLabel(waypoint.type) }}
+                        </template>
+                        <template v-else>
+                            {{ waypoint.latitude.toFixed(6) }}°, {{ waypoint.longitude.toFixed(6) }}°
+                        </template>
                     </div>
                     <div class="waypoint-details">
-                        {{ waypoint.altitude }}ft AMSL - {{ waypoint.speed }}kts -
-                        {{ getWaypointTypeLabel(waypoint.type) }}
-                        <span v-if="waypoint.type === 'hold'" class="hold-details">
-                            ({{ waypoint.duration }}min, {{ getPatternLabel(waypoint.pattern) }})
-                        </span>
+                        <template v-if="waypoint.type === 'alt_change'">
+                            {{ $t("flightPlanTypeAltChange") }} → {{ waypoint.altitude }}ft AMSL
+                        </template>
+                        <template v-else-if="waypoint.type === 'delay'">
+                            {{ $t("flightPlanTypeDelay") }}: {{ waypoint.duration }}min
+                        </template>
+                        <template v-else-if="waypoint.type === 'yaw_rate'">
+                            {{ $t("flightPlanTypeYawRate") }}: {{ waypoint.speed }}°/s
+                        </template>
+                        <template v-else>
+                            {{ waypoint.altitude }}ft AMSL - {{ waypoint.speed }}kts -
+                            {{ getWaypointTypeLabel(waypoint.type) }}
+                            <span v-if="waypoint.type === 'hold'" class="hold-details">
+                                ({{ waypoint.duration }}min, {{ getPatternLabel(waypoint.pattern) }})
+                            </span>
+                        </template>
                     </div>
                 </div>
                 <div class="flex gap-1 flex-shrink-0">
@@ -98,6 +114,7 @@ const {
     removeWaypoint,
     reorderWaypoints,
     getWaypointTypeLabel,
+    isModifierWaypointType,
 } = useFlightPlan();
 
 const showDeleteDialog = ref(false);

--- a/src/composables/useFlightPlan.js
+++ b/src/composables/useFlightPlan.js
@@ -20,6 +20,10 @@ const TYPE_TO_CLI = {
     flyby: "FLYBY",
     hold: "HOLD",
     land: "LAND",
+    takeoff: "TAKEOFF",
+    alt_change: "ALT_CHANGE",
+    delay: "DELAY",
+    yaw_rate: "YAW_RATE",
 };
 
 // Type mapping (firmware → configurator)
@@ -28,7 +32,17 @@ const CLI_TO_TYPE = {
     FLYBY: "flyby",
     HOLD: "hold",
     LAND: "land",
+    TAKEOFF: "takeoff",
+    ALT_CHANGE: "alt_change",
+    DELAY: "delay",
+    YAW_RATE: "yaw_rate",
 };
+
+// Modifier types carry no horizontal position; they mutate executor state and
+// then drain onto the next positional waypoint. Map/profile views skip these.
+const MODIFIER_TYPES = new Set(["alt_change", "delay", "yaw_rate"]);
+
+export const isModifierWaypointType = (type) => MODIFIER_TYPES.has(type);
 
 // Pattern mapping (configurator → firmware)
 const PATTERN_TO_CLI = {
@@ -56,6 +70,12 @@ const sortedWaypoints = computed(() => {
     return [...state.waypoints].sort((a, b) => a.order - b.order);
 });
 
+// Positional waypoints only — used by map and elevation profile, which both
+// rely on lat/lon and would otherwise plot modifier waypoints at (0,0).
+const positionalWaypoints = computed(() => {
+    return sortedWaypoints.value.filter((wp) => !isModifierWaypointType(wp.type));
+});
+
 const selectedWaypoint = computed(() => {
     return state.waypoints.find((wp) => wp.uid === state.selectedWaypointUid);
 });
@@ -67,6 +87,10 @@ const editingWaypoint = computed(() => {
 export function useFlightPlan() {
     // Validate waypoint data
     const validateWaypoint = (waypointData) => {
+        // Modifier types carry no horizontal position — skip coord/alt checks.
+        if (isModifierWaypointType(waypointData.type)) {
+            return true;
+        }
         if (waypointData.latitude < -90 || waypointData.latitude > 90) {
             gui_log(i18n.getMessage("flightPlanInvalidLatitude"));
             return false;
@@ -308,18 +332,20 @@ export function useFlightPlan() {
         }
 
         const altCm = Number.parseInt(parts[5], 10);
-        const speedCms = Number.parseInt(parts[6], 10);
+        const speedRaw = Number.parseInt(parts[6], 10);
         const durationDs = Number.parseInt(parts[8], 10);
         const typeName = parts[7].toUpperCase();
         const patternName = parts[9].toUpperCase();
+        const type = CLI_TO_TYPE[typeName] ?? DEFAULT_TYPE;
 
         return {
             uid: crypto.randomUUID(),
             latitude: Number.parseFloat(parts[3]),
             longitude: Number.parseFloat(parts[4]),
             altitude: Math.round(altCm / FEET_TO_CM),
-            speed: Math.round((speedCms / KNOTS_TO_CMS) * 10) / 10,
-            type: CLI_TO_TYPE[typeName] ?? DEFAULT_TYPE,
+            // YAW_RATE stores degrees/sec in the speed slot, not cm/s.
+            speed: type === "yaw_rate" ? speedRaw : Math.round((speedRaw / KNOTS_TO_CMS) * 10) / 10,
+            type,
             duration: Math.round((durationDs / MINUTES_TO_DECISECONDS) * 10) / 10,
             pattern: CLI_TO_PATTERN[patternName] ?? "orbit",
             order: Number.parseInt(parts[2], 10),
@@ -331,12 +357,12 @@ export function useFlightPlan() {
         const lat = wp.latitude.toFixed(7);
         const lon = wp.longitude.toFixed(7);
         const altCm = Math.round(wp.altitude * FEET_TO_CM);
-        const speedCms = Math.round(wp.speed * KNOTS_TO_CMS);
+        const speedRaw = wp.type === "yaw_rate" ? Math.round(wp.speed) : Math.round(wp.speed * KNOTS_TO_CMS);
         const typeCli = TYPE_TO_CLI[wp.type] ?? "FLYOVER";
         const durationDs = Math.round(wp.duration * MINUTES_TO_DECISECONDS);
         const patternCli = PATTERN_TO_CLI[wp.pattern] ?? "ORBIT";
 
-        return `waypoint insert ${index} ${lat} ${lon} ${altCm} ${speedCms} ${typeCli} ${durationDs} ${patternCli}`;
+        return `waypoint insert ${index} ${lat} ${lon} ${altCm} ${speedRaw} ${typeCli} ${durationDs} ${patternCli}`;
     };
 
     // Load waypoints from flight controller via CLI
@@ -420,6 +446,10 @@ export function useFlightPlan() {
             flyby: i18n.getMessage("flightPlanTypeFlyby"),
             hold: i18n.getMessage("flightPlanTypeHold"),
             land: i18n.getMessage("flightPlanTypeLand"),
+            takeoff: i18n.getMessage("flightPlanTypeTakeoff"),
+            alt_change: i18n.getMessage("flightPlanTypeAltChange"),
+            delay: i18n.getMessage("flightPlanTypeDelay"),
+            yaw_rate: i18n.getMessage("flightPlanTypeYawRate"),
         };
         return labels[type] || type;
     };
@@ -428,6 +458,7 @@ export function useFlightPlan() {
         // State (as computed for read-only access)
         waypoints: computed(() => state.waypoints),
         sortedWaypoints, // Already a computed property
+        positionalWaypoints, // Already a computed property
         selectedWaypointUid: computed(() => state.selectedWaypointUid),
         editingWaypointUid: computed(() => state.editingWaypointUid),
         showEditorDialog: computed({
@@ -456,5 +487,6 @@ export function useFlightPlan() {
         openAddWaypoint,
         cancelEdit,
         getWaypointTypeLabel,
+        isModifierWaypointType,
     };
 }

--- a/src/composables/useFlightPlan.js
+++ b/src/composables/useFlightPlan.js
@@ -87,8 +87,25 @@ const editingWaypoint = computed(() => {
 export function useFlightPlan() {
     // Validate waypoint data
     const validateWaypoint = (waypointData) => {
-        // Modifier types carry no horizontal position — skip coord/alt checks.
+        // Modifier types carry no horizontal position — skip coord checks but
+        // still validate the slot that's meaningful for each modifier type.
         if (isModifierWaypointType(waypointData.type)) {
+            if (waypointData.type === "alt_change") {
+                if (!Number.isFinite(waypointData.altitude) || waypointData.altitude < 0) {
+                    gui_log(i18n.getMessage("flightPlanInvalidAltitude") || "Altitude must be positive");
+                    return false;
+                }
+            } else if (waypointData.type === "delay") {
+                if (!Number.isFinite(waypointData.duration) || waypointData.duration < 0) {
+                    gui_log(i18n.getMessage("flightPlanInvalidDuration") || "Duration must be positive");
+                    return false;
+                }
+            } else if (waypointData.type === "yaw_rate") {
+                if (!Number.isFinite(waypointData.speed) || waypointData.speed < 0) {
+                    gui_log(i18n.getMessage("flightPlanInvalidYawRate") || "Yaw rate must be positive");
+                    return false;
+                }
+            }
             return true;
         }
         if (waypointData.latitude < -90 || waypointData.latitude > 90) {
@@ -192,16 +209,10 @@ export function useFlightPlan() {
             return false;
         }
 
-        // Validate if coordinates are being updated
-        if (updates.latitude !== undefined || updates.longitude !== undefined || updates.altitude !== undefined) {
-            const testData = {
-                latitude: updates.latitude ?? waypoint.latitude,
-                longitude: updates.longitude ?? waypoint.longitude,
-                altitude: updates.altitude ?? waypoint.altitude,
-            };
-            if (!validateWaypoint(testData)) {
-                return false;
-            }
+        // Validate against the merged state so modifier-specific guards see
+        // their relevant slot (altitude/duration/speed), not just lat/lon/alt.
+        if (!validateWaypoint({ ...waypoint, ...updates })) {
+            return false;
         }
 
         Object.assign(waypoint, updates);


### PR DESCRIPTION
Adds round-trip support for the four new waypoint types the firmware exposes via `waypoint list` / `waypoint insert`: `TAKEOFF` (positional) and the modifier types `ALT_CHANGE`, `DELAY`, `YAW_RATE`. Modifier waypoints carry no horizontal position — the editor hides lat/lon/altitude/speed where they don't apply, list and map filter them out of position views, and `YAW_RATE`'s speed slot is treated as degrees/sec rather than knots.

Depends on the firmware PR adding the new CLI types — paired with betaflight/betaflight#15030 follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four waypoint types: Take Off, Change Altitude, Delay, and Yaw Rate.
  * Flight plan editor: selector for waypoint type, context-sensitive inputs (lat/lon, altitude, duration, yaw) and improved save behavior.
  * UI: map, profile, and list now render only positional waypoints and show type-specific labels.
  * Added i18n keys and ARIA labels for new UI fields and messages.

* **Bug Fixes**
  * Fixed elevation/profile distortions caused by modifier-only waypoints.
  * Improved validation/messages for altitude, duration, and yaw-rate inputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->