### PR TITLE
fix(failsafe): load mode data on first visit and replace v-html badges with UBadge

### DIFF
--- a/src/components/tabs/FailsafeTab.vue
+++ b/src/components/tabs/FailsafeTab.vue
@@ -50,7 +50,16 @@
                             <template v-for="(channel, index) in activeChannels" :key="index">
                                 <div>
                                     <span class="font-semibold text-sm">{{ channel.name }}</span>
-                                    <span v-if="channel.assignment" v-html="channel.assignment" class="ml-1"></span>
+                                    <span v-if="channel.assignments?.length" class="ml-1 inline-flex flex-wrap gap-0.5">
+                                        <UBadge
+                                            v-for="(badge, i) in channel.assignments"
+                                            :key="i"
+                                            :label="badge.label"
+                                            color="neutral"
+                                            variant="subtle"
+                                            size="sm"
+                                        />
+                                    </span>
                                 </div>
                                 <USelect
                                     v-model="rxFailConfig[index].mode"
@@ -425,6 +434,10 @@ const loadConfig = async () => {
 
         await MSP.promise(MSPCodes.MSP_RXFAIL_CONFIG);
         await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
+        await MSP.promise(MSPCodes.MSP_BOXNAMES);
+        await MSP.promise(MSPCodes.MSP_BOXIDS);
+        await MSP.promise(MSPCodes.MSP_RC);
+        await MSP.promise(MSPCodes.MSP_RSSI_CONFIG);
         await MSP.promise(MSPCodes.MSP_MODE_RANGES);
     } catch (e) {
         console.error("Failed to load Failsafe configuration", e);
@@ -542,14 +555,13 @@ const activeChannels = computed(() => {
 
     const auxAssignments = [];
     for (let i = 0; i < rc.value.active_channels - 4; i++) {
-        auxAssignments.push("");
+        auxAssignments.push([]);
     }
 
     if (rssiConfig.value && typeof rssiConfig.value.channel !== "undefined") {
         const index = rssiConfig.value.channel - 5;
         if (index >= 0 && index < auxAssignments.length) {
-            auxAssignments[index] +=
-                '<span class="bg-neutral-600 text-white text-xs font-semibold px-1 rounded border border-neutral-500 mr-0.5">RSSI</span>';
+            auxAssignments[index].push({ label: "RSSI" });
         }
     }
 
@@ -566,8 +578,7 @@ const activeChannels = computed(() => {
             const modeName = adjustBoxNameIfPeripheralWithModeID(modeId, auxConfig.value[modeIndex]);
 
             if (modeRange.auxChannelIndex < auxAssignments.length) {
-                auxAssignments[modeRange.auxChannelIndex] +=
-                    `<span class="bg-neutral-600 text-white text-xs font-semibold px-1 rounded border border-neutral-500 mr-0.5">${modeName}</span>`;
+                auxAssignments[modeRange.auxChannelIndex].push({ label: modeName });
             }
         }
     }
@@ -579,7 +590,7 @@ const activeChannels = computed(() => {
             const messageKey = `controlAxisAux${auxIndex++}`;
             channels.push({
                 name: t(messageKey),
-                assignment: auxAssignments[auxAssignmentIndex++] || "",
+                assignments: auxAssignments[auxAssignmentIndex++] || [],
             });
         }
     }


### PR DESCRIPTION
## Summary

- Fix missing mode assignment badges (ARM, BEEPER, etc.) in Stage 1 channel fallback settings on first visit to the Failsafe tab
- Add `MSP_BOXNAMES`, `MSP_BOXIDS`, `MSP_RC`, and `MSP_RSSI_CONFIG` fetches to `loadConfig()` — these were missing, causing `auxConfig`, `auxConfigIds`, `rc.active_channels`, and `rssiConfig` to be empty
- Also fixes `hasGpsRescueAsMode` computed which depends on `auxConfigIds` for GPS Rescue settings visibility
- Replace `v-html` badge rendering with `UBadge` components (`color="neutral" variant="subtle" size="sm"`) — eliminates raw HTML string concatenation in the `activeChannels` computed

## Test plan

- [ ] Connect to FC, navigate directly to Failsafe tab (without visiting Auxiliary first)
- [ ] Verify AUX channels show mode badges (ARM, BEEPER, HORIZON, etc.) matching Auxiliary tab configuration
- [ ] Verify RSSI badge appears when RSSI is assigned to an AUX channel
- [ ] Verify GPS Rescue settings appear when GPS Rescue is configured as a mode
- [ ] Verify saving failsafe settings still works (no regressions)
- [ ] Check badge appearance in both light and dark modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Thanks to @mituritsyn for the heads up.

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved how channel fallback assignments are displayed with enhanced data structure and badge-based rendering.
  * Extended configuration loading to retrieve additional system settings and information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5117)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->