### PR TITLE
UX: Clean up sidebar, move log into its own modal, enhance UserSession with more NuxtUI components

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
     <UApp :tooltip="{ delayDuration: 100 }" portal="#main-wrapper">
         <div class="app-wrapper">
-            <div id="background" v-show="isRevealed" @click="isRevealed = false"></div>
+            <div id="background" v-if="isMobileSidebarOpen" aria-hidden="true" @click="isRevealed = false"></div>
             <div id="side_menu_swipe"></div>
             <div class="mobile-topbar" :class="{ 'mobile-topbar--hidden': topbarHidden }">
                 <UButton
@@ -18,7 +18,7 @@
                 <div class="mobile-topbar__spacer" aria-hidden="true"></div>
             </div>
             <div id="tab-content-container">
-                <div class="tab_container" :class="{ reveal: isRevealed }">
+                <div class="tab_container" :class="{ reveal: isMobileSidebarOpen }">
                     <betaflight-logo
                         :configurator-version="CONFIGURATOR.getDisplayVersion()"
                         :firmware-version="FC.CONFIG.flightControllerVersion"
@@ -117,10 +117,14 @@ const activeTabInstance = ref(null);
 
 const isRevealed = ref(false);
 const sidebarCompact = useMediaQuery("(max-width: 1055px)");
+const compactHeaderLayout = useMediaQuery(
+    "(max-width: 575px), (max-width: 950px) and (max-height: 500px) and (orientation: landscape)",
+);
+const isMobileSidebarOpen = computed(() => compactHeaderLayout.value && isRevealed.value);
 const isSidebarExpanded = computed(() => !sidebarCompact.value || isRevealed.value);
 
-// Auto-close the drawer when leaving the compact breakpoint.
-watch(sidebarCompact, (compact) => {
+// Auto-close the drawer when leaving the mobile drawer breakpoint.
+watch(compactHeaderLayout, (compact) => {
     if (!compact) {
         isRevealed.value = false;
     }

--- a/src/App.vue
+++ b/src/App.vue
@@ -116,15 +116,15 @@ const CONNECTION = computed(() => currentVm()?.CONNECTION ?? connectionFallback)
 const activeTabInstance = ref(null);
 
 const isRevealed = ref(false);
-const sidebarCompact = useMediaQuery("(max-width: 1055px)");
-const compactHeaderLayout = useMediaQuery(
+const sidebarNarrow = useMediaQuery("(max-width: 1055px)");
+const isCompactBreakpoint = useMediaQuery(
     "(max-width: 575px), (max-width: 950px) and (max-height: 500px) and (orientation: landscape)",
 );
-const isMobileSidebarOpen = computed(() => compactHeaderLayout.value && isRevealed.value);
-const isSidebarExpanded = computed(() => !sidebarCompact.value || isRevealed.value);
+const isMobileSidebarOpen = computed(() => isCompactBreakpoint.value && isRevealed.value);
+const isSidebarExpanded = computed(() => !sidebarNarrow.value || isRevealed.value);
 
 // Auto-close the drawer when leaving the mobile drawer breakpoint.
-watch(compactHeaderLayout, (compact) => {
+watch(isCompactBreakpoint, (compact) => {
     if (!compact) {
         isRevealed.value = false;
     }

--- a/src/components/dialogs/LogDialog.vue
+++ b/src/components/dialogs/LogDialog.vue
@@ -1,0 +1,140 @@
+<template>
+    <UModal v-model:open="open" :title="$t('tabLog')" :ui="{ overlay: 'z-3000', content: 'max-w-4xl h-full z-3001' }">
+        <template #body>
+            <div class="flex flex-col min-h-full">
+                <div class="log-toolbar">
+                    <UButton
+                        icon="i-lucide-trash-2"
+                        :label="$t('logActionClear')"
+                        size="sm"
+                        color="neutral"
+                        variant="soft"
+                        @click="onClear"
+                    />
+                    <div class="log-autoscroll">
+                        <USwitch v-model="autoScroll" size="sm" :label="$t('logAutoScroll')" />
+                    </div>
+                </div>
+                <UiBox class="log-box">
+                    <div ref="scrollArea" class="log-scroll">
+                        <p v-for="entry in entries" :key="entry.id" class="log-entry">
+                            <span class="log-timestamp">{{ entry.timestamp }}</span>
+                            <span class="log-message" v-html="entry.message"></span>
+                        </p>
+                    </div>
+                </UiBox>
+            </div>
+        </template>
+    </UModal>
+</template>
+
+<script setup>
+import { computed, nextTick, ref, watch } from "vue";
+import UiBox from "../elements/UiBox.vue";
+import { useLogStore } from "../../stores/log";
+
+const props = defineProps({
+    modelValue: { type: Boolean, default: false },
+});
+const emit = defineEmits(["update:modelValue"]);
+
+const store = useLogStore();
+const entries = computed(() => store.entries);
+const autoScroll = ref(true);
+const scrollArea = ref(null);
+
+const open = computed({
+    get: () => props.modelValue,
+    set: (value) => emit("update:modelValue", value),
+});
+
+function scrollToBottom() {
+    const el = scrollArea.value;
+    if (el) {
+        el.scrollTop = el.scrollHeight;
+    }
+}
+
+function onClear() {
+    store.clear();
+}
+
+watch(
+    () => entries.value[entries.value.length - 1]?.id,
+    () => {
+        if (!autoScroll.value) {
+            return;
+        }
+        nextTick(scrollToBottom);
+    },
+);
+
+watch(open, (isOpen) => {
+    if (isOpen) {
+        nextTick(scrollToBottom);
+    }
+});
+</script>
+
+<style scoped lang="less">
+.content_wrapper {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.log-dialog-body {
+    height: min(75vh, 720px);
+}
+
+.log-toolbar {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-bottom: 0.5rem;
+}
+
+.log-autoscroll {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 12px;
+    color: var(--text);
+}
+
+.log-box {
+    display: flex;
+    flex: 1;
+    min-height: 0;
+}
+
+.log-box :deep(> div:last-child) {
+    flex: 1;
+    min-height: 0;
+    padding: 0;
+}
+
+.log-scroll {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0.75rem 1rem;
+    font-family: "Courier New", Courier, monospace;
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.log-entry {
+    margin: 0;
+    padding: 0;
+    color: var(--text);
+    word-break: break-word;
+    white-space: pre-wrap;
+}
+
+.log-timestamp {
+    color: var(--quietHeader);
+    margin-right: 0.5rem;
+}
+</style>

--- a/src/components/dialogs/OptionsDialog.vue
+++ b/src/components/dialogs/OptionsDialog.vue
@@ -1,7 +1,11 @@
 <template>
-    <UModal v-model:open="open" :title="$t('tabOptions')" :ui="{ content: 'max-w-2xl' }">
+    <UModal
+        v-model:open="open"
+        :title="$t('tabOptions')"
+        :ui="{ overlay: 'z-3000', content: 'max-w-4xl h-full z-3001' }"
+    >
         <template #body>
-            <div class="content_wrapper grid-box col1 options-dialog-body">
+            <div class="flex flex-col gap-4">
                 <UiBox>
                     <SettingRow :label="$t('expertMode')">
                         <USwitch v-model="settings.expertMode" size="sm" />
@@ -438,11 +442,3 @@ watch(
     },
 );
 </script>
-
-<style scoped>
-.options-dialog-body {
-    max-height: 70vh;
-    overflow-y: auto;
-    padding-top: 0.5rem;
-}
-</style>

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -53,10 +53,10 @@
                 :aria-label="$t('logActionShow')"
                 @click="logOpen = true"
                 size="xs"
-                class="mr-auto"
+                :class="{ 'mr-auto': !isCompact }"
             />
         </UTooltip>
-        <user-session></user-session>
+        <UserSession :is-compact="isCompact" />
     </div>
     <OptionsDialog v-model="optionsOpen" />
     <LogDialog v-model="logOpen" />
@@ -65,6 +65,7 @@
 <script setup>
 import { computed, inject, onMounted, onUnmounted, ref, watch } from "vue";
 import { useTranslation } from "i18next-vue";
+import UserSession from "@/components/user-session/UserSession.vue";
 import { sidebarItems, isItemVisible } from "./sidebar_items.js";
 import { useConnectionStore } from "@/stores/connection";
 import { useNavigationStore } from "@/stores/navigation";

--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -7,7 +7,10 @@
         :ui="navMenuUi"
         class="sidebar-nav pb-2"
     />
-    <div class="sidebar-footer" :class="{ 'sidebar-footer--compact': isCompact }">
+    <div
+        class="flex flex-row gap-1 border-t border-default pt-2 mt-auto items-center flex-wrap"
+        :class="{ 'sidebar-footer--compact': isCompact }"
+    >
         <UTooltip :text="$t('sidebarOpenOptions')" :delay-duration="300">
             <UButton
                 icon="i-lucide-settings"
@@ -16,6 +19,7 @@
                 square
                 :aria-label="$t('sidebarOpenOptions')"
                 @click="optionsOpen = true"
+                size="xs"
             />
         </UTooltip>
         <UTooltip :text="$t('sidebarToggleDarkMode')" :delay-duration="300">
@@ -26,21 +30,36 @@
                 square
                 :aria-label="$t('sidebarToggleDarkMode')"
                 @click="toggleDarkMode"
+                size="xs"
             />
         </UTooltip>
         <UTooltip :text="$t('sidebarToggleExpertMode')" :delay-duration="300">
             <UButton
                 icon="i-lucide-wrench"
-                variant="ghost"
+                :variant="expertModeOn ? 'soft' : 'ghost'"
                 :color="expertModeOn ? 'primary' : 'neutral'"
                 square
                 :aria-label="$t('sidebarToggleExpertMode')"
                 @click="toggleExpertMode"
+                size="xs"
+            />
+        </UTooltip>
+        <UTooltip :text="$t('logActionShow')" :delay-duration="300">
+            <UButton
+                :icon="sidebarItems.find((item) => item.key === 'log').icon"
+                variant="ghost"
+                color="neutral"
+                square
+                :aria-label="$t('logActionShow')"
+                @click="logOpen = true"
+                size="xs"
+                class="mr-auto"
             />
         </UTooltip>
         <user-session></user-session>
     </div>
     <OptionsDialog v-model="optionsOpen" />
+    <LogDialog v-model="logOpen" />
 </template>
 
 <script setup>
@@ -60,6 +79,7 @@ import { applyExpertMode } from "@/js/utils/applyExpertMode.js";
 import { isExpertModeEnabled } from "@/js/utils/isExpertModeEnabled.js";
 import { EventBus } from "@/components/eventBus.js";
 import OptionsDialog from "@/components/dialogs/OptionsDialog.vue";
+import LogDialog from "@/components/dialogs/LogDialog.vue";
 
 const { t } = useTranslation();
 const connectionStore = useConnectionStore();
@@ -110,6 +130,7 @@ const isAllowed = (item) => {
 const activeItems = computed(() =>
     sidebarItems
         .filter((item) => isModeVisible(item.mode))
+        .filter((item) => !item.hideInSidebar)
         .filter((item) => isAllowed(item))
         .filter((item) => isItemVisible(item, ctx.value)),
 );
@@ -136,6 +157,18 @@ watch(
         if (val) {
             optionsOpen.value = true;
             navigationStore.optionsDialogOpen = false;
+        }
+    },
+);
+
+// Log dialog
+const logOpen = ref(false);
+watch(
+    () => navigationStore.logDialogOpen,
+    (val) => {
+        if (val) {
+            logOpen.value = true;
+            navigationStore.logDialogOpen = false;
         }
     },
 );
@@ -186,15 +219,6 @@ onUnmounted(() => {
 <style scoped>
 .sidebar-nav {
     width: 100%;
-}
-
-.sidebar-footer {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    gap: 0.25rem;
-    padding: 0.5rem 0.25rem;
-    border-top: 1px solid var(--surface-400);
 }
 
 .sidebar-footer--compact {

--- a/src/components/sidebar/sidebar_items.js
+++ b/src/components/sidebar/sidebar_items.js
@@ -41,10 +41,10 @@ export const sidebarItems = [
 
     { key: "cli", mode: "cli", i18n: "tabCLI", icon: "i-lucide-terminal" },
 
-    { key: "log", mode: "shared", i18n: "tabLog", icon: "i-lucide-file-text", expert: true },
+    { key: "log", mode: "shared", i18n: "tabLog", icon: "i-lucide-file-text", expert: true, hideInSidebar: true },
 
-    { key: "backups", mode: "loggedin", i18n: "tabBackups", icon: "i-lucide-database" },
-    { key: "user_profile", mode: "loggedin", i18n: "tabUserProfile", icon: "i-lucide-user" },
+    { key: "backups", mode: "loggedin", i18n: "tabBackups", icon: "i-lucide-database", hideInSidebar: true },
+    { key: "user_profile", mode: "loggedin", i18n: "tabUserProfile", icon: "i-lucide-user", hideInSidebar: true },
 ];
 
 export function isItemVisible(item, ctx) {

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -1,18 +1,11 @@
 <template>
-    <div id="user-session-container" class="justify-self-end-auto">
+    <div class="justify-self-end-auto">
         <UDropdownMenu :items="getMenuItems()" v-if="isLoggedIn">
-            <UButton variant="ghost" color="neutral" size="xs" class="pr-3">
-                <UUser
-                    :name="displayName"
-                    :avatar="{
-                        src: avatarUrl,
-                        icon: 'i-lucide-user',
-                    }"
-                    size="sm"
-                />
+            <UButton variant="ghost" color="neutral" size="xs" class="py-1">
+                <UAvatar :src="avatarUrl" icon="i-lucide-user" size="sm" />
             </UButton>
         </UDropdownMenu>
-        <UButton v-else variant="ghost" color="neutral" size="xs" class="pr-3" @click="handleLoginClick">
+        <UButton v-else variant="ghost" color="neutral" size="xs" @click="handleLoginClick">
             <UUser
                 :name="$t('labelLogin')"
                 :avatar="{
@@ -212,34 +205,51 @@ import { switchTab } from "@/js/tab_switch.js";
 import { sidebarItems } from "@/components/sidebar/sidebar_items.js";
 import { i18n } from "@/js/localization";
 
-function getMenuItems() {
-    const items = ["backups", "user_profile"];
-    const trailingItems = [
-        { type: "separator" },
-        {
-            label: i18n.getMessage("labelSignOut"),
-            icon: "i-lucide-log-out",
-            color: "error",
-            onSelect: () => useUserSession().handleSignOut(),
-        },
-    ];
-
-    return sidebarItems
-        .filter((item) => items.includes(item.key))
-        .map((item) => ({
-            label: i18n.getMessage(item.i18n),
-            icon: item.icon,
-            onSelect: () => switchTab(item.key),
-        }))
-        .concat(trailingItems);
-}
-
 export default defineComponent({
     name: "UserSession",
 
     setup() {
+        const session = useUserSession();
+
+        function getMenuItems() {
+            const name = session.displayName.value || i18n.getMessage("tabUserProfile");
+            const src = session.avatarUrl.value;
+            const leadingItems = [
+                {
+                    label: name,
+                    avatar: {
+                        ...(src ? { src } : {}),
+                        icon: "i-lucide-user",
+                    },
+                    type: "label",
+                },
+                { type: "separator" },
+            ];
+            const tabKeys = ["backups", "user_profile"];
+            const trailingItems = [
+                { type: "separator" },
+                {
+                    label: i18n.getMessage("labelSignOut"),
+                    icon: "i-lucide-log-out",
+                    color: "error",
+                    onSelect: () => session.handleSignOut(),
+                },
+            ];
+
+            return leadingItems.concat(
+                sidebarItems
+                    .filter((item) => tabKeys.includes(item.key))
+                    .map((item) => ({
+                        label: i18n.getMessage(item.i18n),
+                        icon: item.icon,
+                        onSelect: () => switchTab(item.key),
+                    })),
+                trailingItems,
+            );
+        }
+
         return {
-            ...useUserSession(),
+            ...session,
             getMenuItems,
         };
     },

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -1,18 +1,32 @@
 <template>
     <div class="justify-self-end-auto">
-        <UDropdownMenu :items="getMenuItems()" v-if="isLoggedIn">
-            <UButton variant="ghost" color="neutral" size="xs" class="py-1">
-                <UAvatar :src="avatarUrl" icon="i-lucide-user" size="sm" />
+        <UDropdownMenu :items="getMenuItems()" v-if="isLoggedIn" :ui="{ content: 'z-3001' }">
+            <UButton
+                variant="ghost"
+                color="neutral"
+                size="xs"
+                class="py-1"
+                :aria-label="$t('tabUserProfile')"
+                square
+                :avatar="{
+                    icon: 'i-lucide-user',
+                    src: avatarUrl,
+                    size: 'xs',
+                }"
+            >
             </UButton>
         </UDropdownMenu>
-        <UButton v-else variant="ghost" color="neutral" size="xs" @click="handleLoginClick">
-            <UUser
-                :name="$t('labelLogin')"
-                :avatar="{
-                    icon: 'i-lucide-log-in',
-                }"
-                size="sm"
-            />
+        <UButton
+            v-else
+            variant="ghost"
+            color="neutral"
+            :size="isCompact ? 'xs' : 'sm'"
+            :class="{ 'py-2': !isCompact }"
+            :square="isCompact"
+            @click="handleLoginClick"
+            icon="i-lucide-log-in"
+        >
+            {{ isCompact ? "" : $t("labelLogin") }}
         </UButton>
         <Teleport to="#main-wrapper">
             <div v-show="menuOpen" id="user-menu-popup" class="user-popup-menu" :style="menuStyle">
@@ -24,7 +38,7 @@
             </div>
 
             <!-- Login Dialog -->
-            <UModal v-model:open="loginDialogOpen" :ui="{ content: 'max-w-sm' }">
+            <UModal v-model:open="loginDialogOpen" :ui="{ overlay: 'z-3000', content: 'max-w-sm z-3001' }">
                 <template #header="{ close }">
                     <div class="flex items-start justify-between gap-2 w-full">
                         <div class="dialog-header-stack">
@@ -150,7 +164,7 @@
             </UModal>
 
             <!-- Verification Code Dialog -->
-            <UModal v-model:open="verificationDialogOpen" :ui="{ content: 'max-w-sm' }">
+            <UModal v-model:open="verificationDialogOpen" :ui="{ overlay: 'z-3000', content: 'max-w-sm z-3001' }">
                 <template #header="{ close }">
                     <div class="flex items-start justify-between gap-2 w-full">
                         <div class="dialog-header-stack">
@@ -186,7 +200,13 @@
             </UModal>
 
             <!-- Waiting Dialog -->
-            <UModal v-model:open="waitingDialogOpen" :close="false" :dismissible="false" title="">
+            <UModal
+                v-model:open="waitingDialogOpen"
+                :close="false"
+                :dismissible="false"
+                title=""
+                :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+            >
                 <template #body>
                     <div class="waiting-container">
                         <div class="waiting-spinner" aria-hidden="true"></div>
@@ -207,7 +227,12 @@ import { i18n } from "@/js/localization";
 
 export default defineComponent({
     name: "UserSession",
-
+    props: {
+        isCompact: {
+            type: Boolean,
+            default: false,
+        },
+    },
     setup() {
         const session = useUserSession();
 
@@ -256,79 +281,7 @@ export default defineComponent({
 });
 </script>
 
-<style scoped>
-#user-session-container {
-    background-color: transparent;
-    font-size: 13px;
-    position: relative;
-
-    #open-login,
-    #user-menu-trigger {
-        position: relative;
-        width: 100%;
-        display: flex;
-        flex-direction: row;
-        align-items: center;
-        gap: 8px;
-        padding: 0.25rem;
-        color: var(--text);
-        text-decoration: none;
-        cursor: pointer;
-        transition: all 0.2s ease;
-        z-index: 0;
-
-        &:hover {
-            background-color: var(--surface-200);
-            border-radius: 0.5rem;
-        }
-    }
-
-    .user-avatar-icon {
-        width: 32px;
-        height: 32px;
-        border-radius: 50%;
-        object-fit: cover;
-        flex-shrink: 0;
-    }
-
-    .username {
-        font-size: 11px;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: nowrap;
-        flex: 1;
-    }
-
-    @media (max-width: 1055px) {
-        #open-login,
-        #user-menu-trigger {
-            justify-content: center;
-        }
-        .username {
-            display: none;
-        }
-    }
-
-    @media (max-width: 575px), (max-width: 950px) and (max-height: 500px) and (orientation: landscape) {
-        margin-bottom: 0.25rem;
-        .user-avatar-icon {
-            width: 32px;
-            height: 32px;
-        }
-    }
-}
-</style>
-
 <style>
-/* Show username when the compact navigation drawer is revealed — unscoped so the external .tab_container.reveal selector matches. */
-.tab_container.reveal #user-session-container #open-login,
-.tab_container.reveal #user-session-container #user-menu-trigger {
-    justify-content: flex-start !important;
-}
-.tab_container.reveal #user-session-container .username {
-    display: inline !important;
-}
-
 /* Unscoped styles for teleported popup menu */
 .user-popup-menu {
     position: fixed;

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -1,28 +1,26 @@
 <template>
-    <div id="user-session-container">
-        <div v-if="!isLoggedIn" id="user-logged-out" class="session-view">
-            <a href="#" id="open-login" class="tabicon" @click.prevent="handleLoginClick">
-                <img
-                    id="user-default-gravatar"
-                    src="/images/default-user-avatar.png"
-                    alt="User Default Avatar"
-                    class="user-avatar-icon"
+    <div id="user-session-container" class="justify-self-end-auto">
+        <UDropdownMenu :items="getMenuItems()" v-if="isLoggedIn">
+            <UButton variant="ghost" color="neutral" size="xs" class="pr-3">
+                <UUser
+                    :name="displayName"
+                    :avatar="{
+                        src: avatarUrl,
+                        icon: 'i-lucide-user',
+                    }"
+                    size="sm"
                 />
-                <span id="user-login-display" class="username">{{ $t("labelLogin") }}</span>
-            </a>
-        </div>
-
-        <div v-else id="user-logged-in" class="session-view">
-            <a href="#" id="user-menu-trigger" class="tabicon" @click.prevent="toggleMenu">
-                <img
-                    id="user-gravatar"
-                    :src="avatarUrl || '/images/default-user-avatar-loggedin.png'"
-                    alt="User Avatar"
-                    class="user-avatar-icon"
-                />
-                <span id="username-display" class="username">{{ displayName }}</span>
-            </a>
-        </div>
+            </UButton>
+        </UDropdownMenu>
+        <UButton v-else variant="ghost" color="neutral" size="xs" class="pr-3" @click="handleLoginClick">
+            <UUser
+                :name="$t('labelLogin')"
+                :avatar="{
+                    icon: 'i-lucide-log-in',
+                }"
+                size="sm"
+            />
+        </UButton>
         <Teleport to="#main-wrapper">
             <div v-show="menuOpen" id="user-menu-popup" class="user-popup-menu" :style="menuStyle">
                 <div id="menu-username" class="menu-username">{{ displayName }}</div>
@@ -210,12 +208,40 @@
 <script>
 import { defineComponent } from "vue";
 import { useUserSession } from "./UserSession";
+import { switchTab } from "@/js/tab_switch.js";
+import { sidebarItems } from "@/components/sidebar/sidebar_items.js";
+import { i18n } from "@/js/localization";
+
+function getMenuItems() {
+    const items = ["backups", "user_profile"];
+    const trailingItems = [
+        { type: "separator" },
+        {
+            label: i18n.getMessage("labelSignOut"),
+            icon: "i-lucide-log-out",
+            color: "error",
+            onSelect: () => useUserSession().handleSignOut(),
+        },
+    ];
+
+    return sidebarItems
+        .filter((item) => items.includes(item.key))
+        .map((item) => ({
+            label: i18n.getMessage(item.i18n),
+            icon: item.icon,
+            onSelect: () => switchTab(item.key),
+        }))
+        .concat(trailingItems);
+}
 
 export default defineComponent({
     name: "UserSession",
 
     setup() {
-        return useUserSession();
+        return {
+            ...useUserSession(),
+            getMenuItems,
+        };
     },
 });
 </script>
@@ -223,11 +249,8 @@ export default defineComponent({
 <style scoped>
 #user-session-container {
     background-color: transparent;
-    border-top: 1px solid var(--surface-300);
-    padding-top: 0.5rem;
     font-size: 13px;
     position: relative;
-    margin-top: auto;
 
     #open-login,
     #user-menu-trigger {
@@ -251,8 +274,8 @@ export default defineComponent({
     }
 
     .user-avatar-icon {
-        width: 48px;
-        height: 48px;
+        width: 32px;
+        height: 32px;
         border-radius: 50%;
         object-fit: cover;
         flex-shrink: 0;

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -16,18 +16,20 @@
             >
             </UButton>
         </UDropdownMenu>
-        <UButton
-            v-else
-            variant="ghost"
-            color="neutral"
-            :size="isCompact ? 'xs' : 'sm'"
-            :class="{ 'py-2': !isCompact }"
-            :square="isCompact"
-            @click="handleLoginClick"
-            icon="i-lucide-log-in"
-        >
-            {{ isCompact ? "" : $t("labelLogin") }}
-        </UButton>
+        <UTooltip :text="$t('labelLogin')" v-else :disabled="!isCompact">
+            <UButton
+                variant="ghost"
+                color="neutral"
+                :size="isCompact ? 'xs' : 'sm'"
+                :class="{ 'py-2': !isCompact }"
+                :square="isCompact"
+                @click="handleLoginClick"
+                icon="i-lucide-log-in"
+                :aria-label="$t('labelLogin')"
+            >
+                {{ isCompact ? "" : $t("labelLogin") }}
+            </UButton>
+        </UTooltip>
         <Teleport to="#main-wrapper">
             <div v-show="menuOpen" id="user-menu-popup" class="user-popup-menu" :style="menuStyle">
                 <div id="menu-username" class="menu-username">{{ displayName }}</div>

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -260,7 +260,7 @@ td [role="group"] {
     left: 0;
     right: 0;
     bottom: 0;
-    display: none;
+    display: block;
     backdrop-filter: blur(0.25rem);
 }
 #portsinput {

--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -37,7 +37,6 @@ class GuiControl {
             "user_profile",
             "backups",
             "flight_plan",
-            "log",
         ];
 
         this.defaultAllowedTabs = [
@@ -57,7 +56,6 @@ class GuiControl {
             "ports",
             "receiver",
             "sensors",
-            "log",
         ];
 
         this.defaultCloudBuildTabOptions = ["gps", "led_strip", "osd", "servos", "vtx", "flight_plan"];

--- a/src/js/vue_components.js
+++ b/src/js/vue_components.js
@@ -56,6 +56,5 @@ export const BetaflightComponents = {
         app.component("PreflightTab", VueTabComponents.preflight);
         app.component("VtxTab", VueTabComponents.vtx);
         app.component("PresetsTab", VueTabComponents.presets);
-        app.component("LogTab", VueTabComponents.log);
     },
 };

--- a/src/js/vue_tab_registry.js
+++ b/src/js/vue_tab_registry.js
@@ -25,7 +25,6 @@ import PidTuningTab from "../components/tabs/PidTuningTab.vue";
 import PreflightTab from "../components/tabs/PreflightTab.vue";
 import VtxTab from "../components/tabs/VtxTab.vue";
 import PresetsTab from "../components/tabs/PresetsTab.vue";
-import LogTab from "../components/tabs/LogTab.vue";
 
 export const VueTabComponents = {
     help: HelpTab,
@@ -55,5 +54,4 @@ export const VueTabComponents = {
     preflight: PreflightTab,
     vtx: VtxTab,
     presets: PresetsTab,
-    log: LogTab,
 };

--- a/test/js/sidebar_items.test.js
+++ b/test/js/sidebar_items.test.js
@@ -97,4 +97,15 @@ describe("isItemVisible", () => {
         };
         expect(isItemVisible(item, { expertMode: false, buildOptions: ["USE_FOO"] })).toBe(false);
     });
+
+    it("does not treat hideInSidebar as a visibility constraint for expert/build/feature checks", () => {
+        const item = {
+            key: "hidden_nav",
+            mode: "connected",
+            i18n: "tabHiddenNav",
+            icon: "i-lucide-eye-off",
+            hideInSidebar: true,
+        };
+        expect(isItemVisible(item, { expertMode: false })).toBe(true);
+    });
 });


### PR DESCRIPTION
- Log moved to button row
- Log made into a popup like the options, so that it's accessible above regular content
- Backups and User Profile moved to profile popup
- Profile button and popup use NuxtUI User and DropdownMenu
- DropdownMenu only shows when logged in, otherwise it presents as a normal button

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/ae8b48d8-28b3-44ee-948f-0f6736b6fada" />

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/b5259b74-e647-404a-8b47-3cfed7338867" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Log dialog accessible from the sidebar footer with auto-scroll and clear-log controls.

* **UI/UX Improvements**
  * Moved log access out of the main tabs into the sidebar dialog; log tab removed from tab list.
  * Redesigned user menu into a dropdown with avatar trigger.
  * Refined sidebar footer layout and smaller button sizing.
  * Updated modal sizing/overlay stacking and options dialog body layout.
  * Adjusted mobile sidebar reveal and overlay behavior.

* **Tests**
  * Added a test ensuring sidebar visibility logic respects the new hide-in-sidebar flag.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5118?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->