### PR TITLE
fix(dfu): crash when flashing without full chip erase

### DIFF
--- a/src/js/protocols/usbdfu.js
+++ b/src/js/protocols/usbdfu.js
@@ -173,12 +173,12 @@ export class UsbDfuProtocol extends EventTarget {
             this.options.erase_chip = true;
         }
 
-        // Calculate progress weight based on whether erase is enabled
-        // If erase: 0-33% erase, 33-66% flash, 66-100% verify
-        // If no erase: 0-50% flash, 50-100% verify
+        // Calculate progress weight based on whether full-chip erase is enabled
+        // Full chip erase: 0-33% erase, 33-66% flash, 66-100% verify
+        // Selective erase: 0-10% erase, 10-50% flash, 50-100% verify
         this.progressWeights = this.options.erase_chip
             ? { erase: [0, 33], flash: [33, 66], verify: [66, 100] }
-            : { erase: null, flash: [0, 50], verify: [50, 100] };
+            : { erase: [0, 10], flash: [10, 50], verify: [50, 100] };
 
         // reset and set some variables before we start
         this.upload_time_start = new Date().getTime();
@@ -912,7 +912,7 @@ export class UsbDfuProtocol extends EventTarget {
                 let total_erased = 0; // bytes
 
                 const erase_page_next = () => {
-                    // Calculate progress within erase phase (0-33%)
+                    // Calculate progress within erase phase
                     const eraseStart = this.progressWeights.erase[0];
                     const eraseRange = this.progressWeights.erase[1] - this.progressWeights.erase[0];
                     const eraseProgress = ((page + 1) / erase_pages.length) * eraseRange;


### PR DESCRIPTION
- fixes #4998

## Summary

- Fix `TypeError` crash during DFU flashing when "full chip erase" is unchecked
- `progressWeights.erase` was set to `null` for selective erase, but `erase_page_next()` unconditionally indexed into it
- Replace `null` with `[0, 10]` to give selective erase a proper 10% progress bar weight
- Update comments to accurately describe both full-chip and selective erase progress distributions

## Test plan

- [ ] Flash firmware with "full chip erase" **checked** — verify progress bar advances through erase (0-33%), flash (33-66%), verify (66-100%) without errors
- [ ] Flash firmware with "full chip erase" **unchecked** — verify no crash and progress bar advances through erase (0-10%), flash (10-50%), verify (50-100%)
- [ ] Verify progress bar has no gaps or jumps between phases in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved progress bar accuracy during firmware flashing when chip erase is disabled. The progress bar now displays distinct phases for erase (0–10%), flash (10–50%), and verify (50–100%), providing clearer visibility into the flashing process stages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->