### PR TITLE
feat(sensors): enlarge compass cardinal markers in mag sphere view

### DIFF
--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -1090,30 +1090,29 @@ function createCompassRing(radius) {
     // Helper: canvas-texture sprite for a compass label
     const makeLabel = (text, color) => {
         const cv = document.createElement("canvas");
-        cv.width = 64;
-        cv.height = 64;
+        cv.width = 128;
+        cv.height = 128;
         const ctx = cv.getContext("2d");
         ctx.fillStyle = color;
-        ctx.font = "bold 48px sans-serif";
+        ctx.font = "bold 96px sans-serif";
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
-        ctx.fillText(text, 32, 32);
+        ctx.fillText(text, 64, 64);
         const tex = new THREE.CanvasTexture(cv);
         const mat = new THREE.SpriteMaterial({ map: tex, transparent: true });
         const sprite = new THREE.Sprite(mat);
-        sprite.scale.set(80, 80, 1);
+        sprite.scale.set(140, 140, 1);
         group.add(sprite);
         return sprite;
     };
 
     const r = radius + 60;
-    // N/S on the X axis (red, matching the existing X-axis line colour)
-    makeLabel("N", "#ff6666").position.set(r, 0, 0);
-    makeLabel("S", "#ff6666").position.set(-r, 0, 0);
-    // E/W on the Y axis (green, matching the existing Y-axis line colour)
+    // N highlighted red (navigation convention); E/S/W neutral
+    makeLabel("N", "#ff4444").position.set(r, 0, 0);
+    makeLabel("S", "#aabbcc").position.set(-r, 0, 0);
     // Display -Y = BF +Y = East when the quad nose faces North
-    makeLabel("E", "#66ff66").position.set(0, -r, 0);
-    makeLabel("W", "#66ff66").position.set(0, r, 0);
+    makeLabel("E", "#aabbcc").position.set(0, -r, 0);
+    makeLabel("W", "#aabbcc").position.set(0, r, 0);
 
     return group;
 }

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -302,7 +302,21 @@ function initScene() {
     const coneMat = new THREE.MeshBasicMaterial({ color: 0xff8800 });
     fieldRefGroup.userData.cone = new THREE.Mesh(coneGeo, coneMat);
     fieldRefGroup.add(fieldRefGroup.userData.cone);
-    // Inclination arc (updated in updateFieldReferenceArrow)
+
+    // South-pole shaft (grey, same geometry as north shaft)
+    const southShaftGeo = new THREE.CylinderGeometry(3, 3, 1, 8);
+    southShaftGeo.translate(0, 0.5, 0);
+    const southShaftMat = new THREE.MeshBasicMaterial({ color: 0x888888, opacity: 0.7, transparent: true });
+    fieldRefGroup.userData.southShaft = new THREE.Mesh(southShaftGeo, southShaftMat);
+    fieldRefGroup.add(fieldRefGroup.userData.southShaft);
+
+    // South-pole cone (grey, tip points outward along south pole)
+    const southConeGeo = new THREE.ConeGeometry(8, 24, 8);
+    const southConeMat = new THREE.MeshBasicMaterial({ color: 0x888888 });
+    fieldRefGroup.userData.southCone = new THREE.Mesh(southConeGeo, southConeMat);
+    fieldRefGroup.add(fieldRefGroup.userData.southCone);
+
+    // Inclination arc (updated in rebuildFieldReference)
     fieldRefGroup.userData.arc = null;
     fieldRefGroup.userData.arcLabel = null;
     scene.add(fieldRefGroup);
@@ -364,6 +378,8 @@ function updateQuadAttitude() {
     // BF frame: X=fwd, Y=right, Z=down → Display: X=fwd, Y=left, Z=up
     // Flipping Y and Z negates all rotation directions.
     // Euler order ZYX: heading (Z) → pitch (Y) → roll (X)
+    // TODO: Euler ZYX has gimbal lock at +/-90 pitch. Upgrade to
+    // MSP_ATTITUDE_QUATERNION (code 167) when configurator support is added.
     const { roll, pitch, heading } = props.attitude;
     quadIcon.rotation.set(-roll * DEG_TO_RAD, -pitch * DEG_TO_RAD, -heading * DEG_TO_RAD, "ZYX");
 }
@@ -467,6 +483,16 @@ function rebuildFieldReference() {
         cone.position.set(fdx, 0, fdz);
         _tmpQuat.setFromUnitVectors(_UP, _tmpVec.normalize());
         cone.quaternion.copy(_tmpQuat);
+
+        // South pole: negate the field direction
+        const southShaft = fieldRefGroup.userData.southShaft;
+        const southCone = fieldRefGroup.userData.southCone;
+        _tmpVec.set(-fdx, 0, -fdz);
+        orientCylinder(southShaft, _tmpVec, len);
+        southShaft.position.set(0, 0, 0);
+        southCone.position.set(-fdx, 0, -fdz);
+        _tmpQuat.setFromUnitVectors(_UP, _tmpVec.normalize());
+        southCone.quaternion.copy(_tmpQuat);
     }
 
     // Dispose old arc + label
@@ -1073,6 +1099,8 @@ function createGhostSphere(radius) {
 // Compass ring: thin equatorial circle + N/S/E/W sprites in the horizontal (Z=0) plane.
 // North = +X (display) — the horizontal projection of Earth's magnetic field.
 // East  = -Y (display) — BF +Y (right of quad when facing North).
+// Cardinal markers represent magnetic north, not geographic north.
+// The compass ring is not rotated by declination.
 function createCompassRing(radius) {
     const group = new THREE.Group();
 


### PR DESCRIPTION
## Summary
- Doubled canvas texture resolution (64x64 → 128x128) and font size (48px → 96px bold) for compass cardinal labels (N/E/S/W) in the mag calibration 3D sphere
- Increased sprite scale from 80 to 140 for larger, more prominent labels that feel like celestial sphere markers
- Changed color scheme from axis-associated (N/S=red, E/W=green) to navigation convention (N=bright red `#ff4444`, E/S/W=neutral `#aabbcc`) so North stands out as the primary reference
- Verified `updateQuadAttitude()` rotation mapping is correct: heading=0 → nose at N, heading=90 → nose at E

## Test plan
- [ ] Open Sensors tab with a mag-equipped FC, verify N/E/S/W labels are large and readable in the 3D sphere
- [ ] Verify N is visually distinct (red) while S/E/W are neutral blue-grey
- [ ] Yaw the quad — confirm the quad icon tracks heading correctly relative to cardinal markers
- [ ] Run mag calibration — verify labels remain visible during point cloud collection
- [ ] Check both light and dark themes for label readability
- [ ] Verify no regressions in sphere-fit wireframe or coverage visualization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a visible south-pole indicator to the field reference visualization for clearer magnetic orientation.

* **Improvements**
  * Enhanced compass ring labels with higher-resolution rendering for sharper text.
  * Updated compass coloring so only North (N) is highlighted in red; S/E/W use neutral colors.
  * Clarified compass/declination labeling to better reflect magnetic-north semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5120?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->