### PR TITLE
fix(presets): prevent sticky filter bar from overlaying Options dialog

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -306,6 +306,8 @@ td [role="group"] {
     min-width: 0;
     min-height: 0;
     transition: all 0.2s;
+    /* Scope tab-internal z-index values so they can't paint above teleported modals */
+    isolation: isolate;
     overflow-x: hidden;
     overflow-y: auto;
     /* Avoid horizontal jump when scrollbar appears/disappears (e.g. toggling long tab lists) */


### PR DESCRIPTION
Add `isolation: isolate` to #content so tab-internal z-index values are scoped and cannot paint above UModal overlays teleported to #main-wrapper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected modal dialog layering to ensure dialogs display above page content

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->