### PR TITLE
fix(options): USelect dropdowns unclickable in Options dialog

### DIFF
--- a/src/components/dialogs/OptionsDialog.vue
+++ b/src/components/dialogs/OptionsDialog.vue
@@ -44,6 +44,7 @@
                             size="sm"
                             v-model="settings.backupOnFlash"
                             class="min-w-40"
+                            :ui="{ content: 'z-3002' }"
                         />
                     </SettingRow>
                 </UiBox>
@@ -62,6 +63,7 @@
                             size="sm"
                             v-model="settings.darkTheme"
                             class="min-w-40"
+                            :ui="{ content: 'z-3002' }"
                         />
                     </SettingRow>
                     <SettingRow :label="$t('colorTheme')">
@@ -74,6 +76,7 @@
                             size="sm"
                             v-model="settings.colorTheme"
                             class="min-w-40"
+                            :ui="{ content: 'z-3002' }"
                         />
                     </SettingRow>
                     <div class="flex flex-col gap-2 py-2">
@@ -132,7 +135,7 @@
                                 icon: 'i-lucide-search',
                             }"
                             class="min-w-48"
-                            :ui="{ content: 'max-h-72' }"
+                            :ui="{ content: 'max-h-72 z-3002' }"
                         />
                     </SettingRow>
                 </UiBox>


### PR DESCRIPTION
## Summary

- USelect and USelectMenu dropdowns in OptionsDialog were rendering behind the modal overlay (z-3001), making them unclickable
- Add `z-3002` to the dropdown content layer of all 4 select components so they render above the modal
- Preserve existing `max-h-72` constraint on the language USelectMenu

## Root Cause

The Options modal uses `z-3000`/`z-3001` to stack above the mobile sidebar drawer (`z-index: 2000`). The USelect/USelectMenu dropdown popovers are teleported to `#main-wrapper` at a default z-index, landing behind the modal overlay.

## Test plan

- [ ] Open Options dialog, verify Firmware Backup dropdown opens and is selectable
- [ ] Verify Dark Theme dropdown opens and is selectable
- [ ] Verify Color Theme dropdown opens and is selectable
- [ ] Verify Language selector opens, scrolls correctly (max-height preserved), and is selectable
- [ ] Verify no regression in ConnectOptionsDialog or UserSession modal dropdowns
- [ ] Test on mobile viewport — dropdowns should still appear above both sidebar and modal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed dropdown menu layering in the Options dialog to ensure firmware backup, theme, and language selection menus display correctly above other content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->