### PR TITLE
Sidebar: gate Autotune behind expert mode and relocate beside Blackbox

### DIFF
--- a/src/components/sidebar/sidebar_items.js
+++ b/src/components/sidebar/sidebar_items.js
@@ -4,7 +4,6 @@ export const sidebarItems = [
     { key: "help", mode: "disconnected", i18n: "tabHelp", icon: "i-lucide-help-circle" },
     { key: "preflight", mode: "disconnected", i18n: "tabPreflight", icon: "i-lucide-clipboard-check" },
     { key: "flight_plan", mode: "disconnected", i18n: "tabFlightPlan", icon: "i-lucide-route", expert: true },
-    { key: "autotune", mode: "shared", i18n: "tabAutotune", icon: "i-lucide-gauge" },
 
     { key: "setup", mode: "connected", i18n: "tabSetup", icon: "i-lucide-sliders-horizontal" },
     { key: "sensors", mode: "connected", i18n: "tabSensorConfig", icon: "i-lucide-cpu" },
@@ -39,6 +38,7 @@ export const sidebarItems = [
     },
     { key: "logging", mode: "connected", i18n: "tabLogging", icon: "i-lucide-file-text", expert: true },
     { key: "onboard_logging", mode: "connected", i18n: "tabOnboardLogging", icon: "i-lucide-database" },
+    { key: "autotune", mode: "shared", i18n: "tabAutotune", icon: "i-lucide-gauge", expert: true },
 
     { key: "cli", mode: "cli", i18n: "tabCLI", icon: "i-lucide-terminal" },
 


### PR DESCRIPTION
Marks the new Autotune sidebar entry as `expert: true` so it only appears when expert mode is on, and moves it down next to the Blackbox / Onboard Logging tab where it logically belongs (it operates on chirp blackbox logs).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Autotune feature is now available only when expert mode is enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5126?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->