### PR TITLE
feat(power): display power draw and voltage drop in Battery State

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5815,6 +5815,15 @@
     "powerBatteryAmperage": {
         "message": "Amperage"
     },
+    "powerBatteryPowerDraw": {
+        "message": "Power Draw"
+    },
+    "powerWattValue": {
+        "message": "$1 W"
+    },
+    "powerBatteryVoltageDrop": {
+        "message": "Voltage Drop"
+    },
     "powerBatteryCapacity": {
         "message": "Capacity (mAh)"
     },

--- a/src/components/tabs/PowerTab.vue
+++ b/src/components/tabs/PowerTab.vue
@@ -193,6 +193,14 @@
                             <span v-html="$t('powerBatteryAmperage')"></span>
                             <span>{{ $t("powerAmperageValue", { 1: batteryState.amperage.toFixed(2) }) }}</span>
                         </div>
+                        <div class="flex justify-between items-center">
+                            <span v-html="$t('powerBatteryPowerDraw')"></span>
+                            <span>{{ $t("powerWattValue", { 1: powerDraw.toFixed(1) }) }}</span>
+                        </div>
+                        <div class="flex justify-between items-center">
+                            <span v-html="$t('powerBatteryVoltageDrop')"></span>
+                            <span>{{ $t("powerVoltageValue", { 1: voltageDrop.toFixed(2) }) }}</span>
+                        </div>
                     </UiBox>
 
                     <!-- Amperage Configuration -->
@@ -386,6 +394,8 @@ export default defineComponent({
             activeBatteryProfile,
             batteryProfileName,
             batteryState,
+            powerDraw,
+            voltageDrop,
             voltageMeters,
             currentMeters,
             batteryConfig,
@@ -519,6 +529,8 @@ export default defineComponent({
             currentMeterTypeItems,
             onBatteryProfileChange,
             batteryState,
+            powerDraw,
+            voltageDrop,
             voltageMeters,
             currentMeters,
             batteryConfig,

--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -84,6 +84,14 @@ export function usePower() {
     const amperagecalibrationValue = ref(0);
 
     // Visibility computed properties
+    const powerDraw = computed(() => batteryState.voltage * batteryState.amperage);
+    const voltageDrop = computed(() => {
+        if (batteryState.cellCount <= 0) {
+            return 0;
+        }
+        return batteryConfig.vbatmaxcellvoltage * batteryState.cellCount - batteryState.voltage;
+    });
+
     const showVoltageConfiguration = computed(() => batteryConfig.voltageMeterSource !== 0);
     const showAmperageConfiguration = computed(() => batteryConfig.currentMeterSource !== 0);
     const showCalibration = computed(() => {
@@ -495,6 +503,8 @@ export function usePower() {
         activeBatteryProfile,
         batteryProfileName,
         batteryState,
+        powerDraw,
+        voltageDrop,
         voltageMeters,
         currentMeters,
         batteryConfig,


### PR DESCRIPTION
## Summary
- Add Power Draw row (voltage × amperage) showing watts with 1 decimal place
- Add Voltage Drop row (maxCellVoltage × cellCount - currentVoltage) showing volts with 2 decimal places
- Both are reactive computed properties in the `usePower` composable, updated live at the existing 200ms polling interval
- No new MSP commands — uses existing `MSP_BATTERY_STATE` and `MSP_BATTERY_CONFIG` data

## Test plan
- [ ] Connect to FC → Power tab → Battery State section shows "Power Draw" and "Voltage Drop" rows
- [ ] Verify values update live as throttle changes
- [ ] Disconnect battery → both rows show "0.0 W" and "0.00 V"
- [ ] Verify voltage drop is correct: (max cell voltage × cell count) - pack voltage
- [ ] Verify no new MSP commands in protocol debug log

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added battery power draw and voltage drop metrics to the Power display.
  * Power draw is shown with 1 decimal place precision.
  * Voltage drop is displayed with 2 decimal place precision.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->