### PR TITLE
Enhancement: Remove Chromium check, FF 151 supports WebSerial

### DIFF
--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -60,7 +60,7 @@ export function isIOS() {
  * The host signals this by injecting a meta tag into the served HTML:
  *   <meta name="bf-transport" content="websocket">
  *
- * When present, Serial/Bluetooth/USB and the Chromium browser gate are
+ * When present, Serial/Bluetooth/USB browser API checks are
  * irrelevant — only WebSocket transport is needed.
  */
 export function isEmbeddedDeployment() {
@@ -80,7 +80,7 @@ export function checkCompatibility() {
     const hasSerialSupport = checkSerialSupport();
     const hasBluetoothSupport = checkBluetoothSupport();
     const hasUsbSupport = checkUsbSupport();
-    const isChromium = isChromiumBrowser();
+    const hasWebTransport = hasSerialSupport || hasBluetoothSupport || hasUsbSupport;
 
     const isNative = Capacitor.isNativePlatform();
     const isTauriShell = isTauri();
@@ -89,15 +89,11 @@ export function checkCompatibility() {
     const isTestEnvironment =
         typeof process !== "undefined" && (process.env.NODE_ENV === "test" || process.env.JEST_WORKER_ID !== undefined);
 
-    const compatible =
-        isTestEnvironment ||
-        isNative ||
-        isTauriShell ||
-        (isChromium && (hasSerialSupport || hasBluetoothSupport || hasUsbSupport));
+    const compatible = isTestEnvironment || isNative || isTauriShell || hasWebTransport;
 
     console.log("User Agent: ", navigator.userAgentData);
     console.log("Native: ", isNative);
-    console.log("Chromium: ", isChromium);
+    console.log("Chromium: ", isChromiumBrowser());
     console.log("Serial: ", hasSerialSupport);
     console.log("Bluetooth: ", hasBluetoothSupport);
     console.log("USB: ", hasUsbSupport);
@@ -110,21 +106,19 @@ export function checkCompatibility() {
         return true;
     }
 
-    let errorMessage = "";
-    if (!isChromium) {
-        errorMessage = "Betaflight app requires a Chromium based browser (Chrome, Chromium, Edge).<br/>";
+    let errorMessage =
+        "Betaflight requires a browser with at least one of: Web Serial, Web Bluetooth, or Web USB.<br/>";
+
+    if (!hasSerialSupport) {
+        errorMessage += "<br/>- Serial API support is not available.";
     }
 
     if (!hasBluetoothSupport) {
-        errorMessage += "<br/>- Bluetooth API support is disabled.";
-    }
-
-    if (!hasSerialSupport) {
-        errorMessage += "<br/>- Serial API support is disabled.";
+        errorMessage += "<br/>- Bluetooth API support is not available.";
     }
 
     if (!hasUsbSupport) {
-        errorMessage += "<br/>- USB API support is disabled.";
+        errorMessage += "<br/>- USB API support is not available.";
     }
 
     const body = document.body;


### PR DESCRIPTION
I looked at Firefox support before, when WebSerial was only available through an extension and a native host. We decided that relying on 3rd party tooling was likely too unreliable, and pretty cumbersome. But now with the release of Firefox 151, there's official support for WebSerial on desktop. https://hacks.mozilla.org/2026/05/web-serial-support-in-firefox/

This PR removes the Chromium checks to get a minimum working app out on Firefox for wider testing. I am able to connect and change settings (at least the few I quickly tried seemed to work 😅). As we get this out in front of more people, more changes may be necessary, but the implementation seems very similar to Chromium's so far.

<img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/65574106-a127-453b-8bc6-85dad25a50a1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser compatibility requirements—the app now only requires one of Web Serial, Web Bluetooth, or Web USB API support instead of stricter browser specifications.
  * Enhanced error messages to clearly indicate which browser APIs are missing for troubleshooting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->