### PR TITLE
Autotune: fix TAG8_8SVB variable-length group decoding

### DIFF
--- a/src/js/blackbox/chirp_bbl_parser.js
+++ b/src/js/blackbox/chirp_bbl_parser.js
@@ -636,8 +636,11 @@ function parseFrame( // NOSONAR S107,S3776 — ported frame decoder; signature f
         // --- Grouped encodings read multiple values at once ---
         let groupSize = encodingGroupSize(encoding);
         if (encoding === ENCODING_TAG8_8SVB) {
-            // Variable-length group: span all consecutive TAG8_8SVB fields.
-            groupSize = consecutiveEncodingRun(frameDef, i, ENCODING_TAG8_8SVB);
+            // Variable-length group. A single TAG8_8SVB tag carries at most 8
+            // values (one bit per value in its header byte). Longer runs mean
+            // the firmware emitted back-to-back TAG8_8SVB tags — cap to 8 here
+            // and let the outer loop pick up the next tag on the next pass.
+            groupSize = Math.min(consecutiveEncodingRun(frameDef, i, ENCODING_TAG8_8SVB), 8);
         }
 
         if (groupSize > 1) {

--- a/src/js/blackbox/chirp_bbl_parser.js
+++ b/src/js/blackbox/chirp_bbl_parser.js
@@ -80,7 +80,14 @@ function signExtend14Bit(word) {
 
 /**
  * Determine the "group size" for a grouped encoding type.
- * Grouped encodings read multiple field values from a single tag structure.
+ *
+ * TAG2_3S32, TAG2_3SVARIABLE and TAG8_4S16 are fixed-size group encodings
+ * (3 or 4 values per tag invocation). TAG8_8SVB is variable: the firmware
+ * calls `blackboxWriteTag8_8SVB(values, valueCount)` with a `valueCount`
+ * equal to the number of consecutive fields in the frame definition that
+ * share the TAG8_8SVB encoding, and the consumer must use that same run
+ * length when reading. Returning 0 here signals the caller to compute the
+ * run length from the surrounding frame definition.
  */
 function encodingGroupSize(encoding) {
     switch (encoding) {
@@ -91,10 +98,22 @@ function encodingGroupSize(encoding) {
         case ENCODING_TAG8_4S16:
             return 4;
         case ENCODING_TAG8_8SVB:
-            return 8;
+            return 0;
         default:
             return 1;
     }
+}
+
+/**
+ * Count how many consecutive fields starting at index `i` share the same
+ * encoding. Used to determine the variable group size for TAG8_8SVB runs.
+ */
+function consecutiveEncodingRun(frameDef, i, encoding) {
+    let n = 0;
+    while (i + n < frameDef.count && frameDef.encoding[i + n] === encoding) {
+        n++;
+    }
+    return n;
 }
 
 /**
@@ -615,7 +634,11 @@ function parseFrame( // NOSONAR S107,S3776 — ported frame decoder; signature f
         }
 
         // --- Grouped encodings read multiple values at once ---
-        const groupSize = encodingGroupSize(encoding);
+        let groupSize = encodingGroupSize(encoding);
+        if (encoding === ENCODING_TAG8_8SVB) {
+            // Variable-length group: span all consecutive TAG8_8SVB fields.
+            groupSize = consecutiveEncodingRun(frameDef, i, ENCODING_TAG8_8SVB);
+        }
 
         if (groupSize > 1) {
             // How many values remain in the frame


### PR DESCRIPTION
The chirp BBL parser hard-coded `TAG8_8SVB` to a group of 8 fields, but in Betaflight's blackbox format the firmware writes `valueCount` equal to the number of consecutive header fields sharing the encoding — and skips the header byte entirely when `valueCount == 1`. On logs where only RSSI is enabled in the optional-fields group (a common build) the parser misaligned by 7 bytes per P-frame and bailed before the chirp-active window, surfacing as "No chirp data found in any log segment" on perfectly valid chirp recordings. Fix counts consecutive `TAG8_8SVB`-encoded fields in `frameDef.encoding` to determine the run length dynamically; verified on two real failing logs which now parse cleanly with the expected per-axis segments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved blackbox flight log parsing to correctly handle variable-length grouped encodings, resulting in more accurate grouping and decoding of flight data and fewer misparsed frames in logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->