### PR TITLE
fix(led-strip): add close functionality to Color setup popup

### DIFF
--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -1,6 +1,6 @@
 <template>
     <BaseTab tab-name="led-strip" @mounted="onTabMounted">
-        <div class="content_wrapper">
+        <div class="content_wrapper" @keydown.esc="handleEscapeKey">
             <div class="tab_title" v-html="$t('tabLedStrip')"></div>
             <WikiButton doc-url="led-strip" />
 
@@ -256,8 +256,8 @@
                         :class="['color-' + (i - 1), { btnOn: selectedColorIndex === i - 1 }]"
                         :style="{ backgroundColor: getColorStyle(i - 1) }"
                         :title="$t(getColorTitle(i - 1))"
-                        @click="selectColor(i - 1)"
-                        @dblclick="openColorSliders($event)"
+                        @click="handleColorClick(i - 1, $event)"
+                        @dblclick="handleColorDblClick($event)"
                     >
                         {{ i - 1 }}
                     </button>
@@ -333,7 +333,7 @@
 </template>
 
 <script setup>
-import { ref, reactive, computed, watch } from "vue";
+import { ref, reactive, computed, watch, onBeforeUnmount } from "vue";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "../elements/WikiButton.vue";
 import LedGrid from "./led_strip/LedGrid.vue";
@@ -420,6 +420,9 @@ const auxChannelValue = ref("3");
 const colorDefineSliders = ref(null);
 const colorHSV = reactive({ h: 0, s: 0, v: 0 });
 const saveButtonText = ref(i18n.getMessage("ledStripButtonSave"));
+
+// Color setup popup state
+const isColorSlidersOpen = ref(false);
 
 // Sliders
 const brightness = ref(50);
@@ -547,6 +550,30 @@ const onTabMounted = async () => {
         GUI.content_ready();
     } catch (error) {
         console.error("Failed to load LED strip data:", error);
+    }
+};
+
+// Handle Escape key to close color setup popup
+const handleEscapeKey = () => {
+    if (isColorSlidersOpen.value) {
+        closeColorSliders();
+    }
+};
+
+// Clean up event listeners when tab is unmounted
+onBeforeUnmount(() => {
+    closeColorSliders();
+});
+
+// Click-outside handler for color setup popup
+const handleClickOutside = (event) => {
+    const sliders = colorDefineSliders.value;
+    const colorButton = event.target.closest(".colors > button");
+    if (!sliders || sliders.style.display === "none" || colorButton) {
+        return;
+    }
+    if (!sliders.contains(event.target)) {
+        closeColorSliders();
     }
 };
 
@@ -871,6 +898,25 @@ function openColorSliders(event) {
         sliders.style.top = `${position.top + 26}px`;
         sliders.style.display = "block";
     }
+    isColorSlidersOpen.value = true;
+}
+
+function closeColorSliders() {
+    const sliders = colorDefineSliders.value;
+    if (sliders) {
+        sliders.style.display = "none";
+    }
+    isColorSlidersOpen.value = false;
+}
+
+function handleColorClick(colorIndex, event) {
+    selectColor(colorIndex);
+    closeColorSliders();
+    event.stopPropagation();
+}
+
+function handleColorDblClick(event) {
+    openColorSliders(event);
 }
 
 // Mode color handlers
@@ -932,6 +978,15 @@ watch(rainbowDelta, (newValue) => {
 
 watch(rainbowFreq, (newValue) => {
     updateLedConfigValue("rainbow_freq", newValue);
+});
+
+// Watch color setup popup state and set up click-outside handler
+watch(isColorSlidersOpen, (newValue) => {
+    if (newValue) {
+        document.addEventListener("mousedown", handleClickOutside);
+    } else {
+        document.removeEventListener("mousedown", handleClickOutside);
+    }
 });
 
 // Save


### PR DESCRIPTION
## Summary
This PR fixes https://github.com/betaflight/betaflight-configurator/issues/5034 where the Color setup popup in the LED Strip tab could not be closed after opening via double-click on a color button.

## Changes
- Added `closeColorSliders()` function to hide the popup
- Added `handleColorClick()` to close popup when clicking a color button
- Added `handleEscapeKey()` to close popup on Escape key
- Added `handleClickOutside()` to close popup when clicking outside
- Added watcher to manage document mousedown listener for click-outside detection
- Added `onBeforeUnmount()` cleanup to prevent memory leaks

## Testing
- Popup can now be closed by clicking outside
- Popup can be closed by pressing Escape key
- Single-clicking a color button selects it and closes the popup
- Popup properly cleans up when tab is unmounted

Fixes #5034

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced color selection popup in LED Strip settings with improved usability. The popup now closes when pressing the Escape key or when clicking outside the color selection area, providing a more intuitive interaction experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->