### PR TITLE
fix(connection): honor Auto-Connect setting after Save-and-Reboot

### DIFF
--- a/src/js/gui.js
+++ b/src/js/gui.js
@@ -414,7 +414,10 @@ class GuiControl {
         CONFIGURATOR.connectionValid = false;
 
         if (currentPort.startsWith("bluetooth") || currentPort === "manual") {
-            return setTimeout(emitToggle, 1500);
+            if (PortHandler.portPicker.autoConnect) {
+                return setTimeout(emitToggle, 1500);
+            }
+            return;
         }
 
         // Show reboot progress modal except for cli and presets tab

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -39,7 +39,6 @@ let liveDataRefreshTimerId = false;
 let isConnected = false;
 
 const REBOOT_CONNECT_MAX_TIME_MS = 10000;
-const REBOOT_GRACE_PERIOD_MS = 2000;
 let rebootTimestamp = 0;
 
 function isCliOnlyMode() {
@@ -67,13 +66,12 @@ export function initializeSerialBackend() {
 
     EventBus.$on("port-handler:auto-select-serial-device", function () {
         if (
-            (!GUI.connected_to &&
-                !GUI.connecting_to &&
-                !["cli", "firmware_flasher"].includes(GUI.active_tab) &&
-                PortHandler.portPicker.autoConnect &&
-                !isCliOnlyMode() &&
-                (connectionTimestamp === null || connectionTimestamp > 0)) ||
-            Date.now() - rebootTimestamp <= REBOOT_CONNECT_MAX_TIME_MS
+            !GUI.connected_to &&
+            !GUI.connecting_to &&
+            !["cli", "firmware_flasher"].includes(GUI.active_tab) &&
+            PortHandler.portPicker.autoConnect &&
+            !isCliOnlyMode() &&
+            (connectionTimestamp === null || connectionTimestamp > 0)
         ) {
             connectDisconnect();
         }
@@ -147,12 +145,6 @@ function canStartConnectionAction(selectedPort) {
 function beginConnect(selectedPort) {
     // prevent connection when we do not have permission
     if (selectedPort.startsWith("requestpermission")) {
-        return;
-    }
-
-    // When rebooting, adhere to the auto-connect setting
-    if (!PortHandler.portPicker.autoConnect && Date.now() - rebootTimestamp < REBOOT_GRACE_PERIOD_MS) {
-        console.log(`${logHead} Rebooting, not connecting`);
         return;
     }
 
@@ -810,9 +802,11 @@ export function reinitializeConnection(suppressDialog = false) {
     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
 
     if (currentPort.startsWith("bluetooth") || currentPort === "manual") {
-        setTimeout(function () {
-            connectDisconnect();
-        }, 1500);
+        if (PortHandler.portPicker.autoConnect) {
+            setTimeout(function () {
+                connectDisconnect();
+            }, 1500);
+        }
         return rebootTimestamp;
     }
 


### PR DESCRIPTION
## Summary

After applying a preset (e.g. ELRS 250 RCLink) and clicking **Save and Reboot**, the configurator was reconnecting to the FC automatically even when **Auto-Connect was disabled**. A 10-second post-reboot bypass branch in `port-handler:auto-select-serial-device` was firing `connectDisconnect()` unconditionally, on top of also bypassing the active-tab, `connected_to` and CLI-only-mode guards.

This PR drops that bypass entirely so the user's Auto-Connect setting is honored in all reboot paths.

### Changes

- **`src/js/serial_backend.js`**
  - Remove the `|| Date.now() - rebootTimestamp <= REBOOT_CONNECT_MAX_TIME_MS` branch from the `port-handler:auto-select-serial-device` handler.
  - Gate the bluetooth / manual-port 1.5s reconnect `setTimeout` in `reinitializeConnection()` on `autoConnect`.
  - Remove the now-redundant 2s reboot-grace-period guard in `beginConnect()` (it would otherwise block a manual reconnect within 2s of a reboot).
  - Drop unused `REBOOT_GRACE_PERIOD_MS` constant.
- **`src/js/gui.js`**
  - Same `autoConnect` gating on the bluetooth / manual 1.5s reconnect in `GUI.reinitializeConnection()`.

### Side effect

This also resolves a Receiver-tab stale-state symptom reported with the ELRS 250 preset flow: after Save-and-Reboot, the Receiver tab was showing the Serial Receiver UART as unselected until the user manually disconnected and reconnected. With Auto-Connect off the user now performs a clean manual reconnect, which runs the full connection sequence and repopulates `FC.*` state correctly; with Auto-Connect on the post-reboot reconnect goes through the same code path as a fresh connect.

## Test plan

- [x] Auto-Connect **off** + Save-and-Reboot from Presets tab (ELRS 250 RCLink preset, UART selected): FC reboots, reboot dialog closes shortly, configurator stays disconnected. Manual Connect succeeds and the Receiver tab now shows the Serial UART selection correctly on first navigation.
- [x] Auto-Connect **on** + Save-and-Reboot: configurator auto-reconnects as before.
- [ ] Bluetooth port + Save-and-Reboot with Auto-Connect off: configurator stays disconnected (logic-verified, not bench-tested).
- [ ] Manual-port mode + Save-and-Reboot with Auto-Connect off: configurator stays disconnected (logic-verified, not bench-tested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined bluetooth and manual port reconnection behavior to only schedule delayed connection events when auto-connect is enabled
  * Updated serial device auto-connect and reboot reconnection logic to improve connection reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5138?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->