### PR TITLE
feat(flasher): highlight selected option in Board & Build dropdowns

### DIFF
--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -53,7 +53,10 @@ export default {
         select: {
             slots: {
                 base: "cursor-pointer",
-                item: "cursor-pointer",
+                // data-[state=checked] is set by Reka UI on the selected item; itemTrailingIcon
+                // only renders inside SelectItemIndicator so colouring it never affects other icons.
+                item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium",
+                itemTrailingIcon: "text-success",
             },
             defaultVariants: {
                 size: "sm",
@@ -62,7 +65,8 @@ export default {
         selectMenu: {
             slots: {
                 base: "cursor-pointer",
-                item: "cursor-pointer",
+                item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium",
+                itemTrailingIcon: "text-success",
             },
             defaultVariants: {
                 size: "sm",

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -56,7 +56,7 @@ export default {
                 // data-[state=checked] is set by Reka UI on the selected item; itemTrailingIcon
                 // only renders inside SelectItemIndicator so colouring it never affects other icons.
                 item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium",
-                itemTrailingIcon: "text-success",
+                itemTrailingIcon: "text-success-600 dark:text-success",
             },
             defaultVariants: {
                 size: "sm",
@@ -66,7 +66,7 @@ export default {
             slots: {
                 base: "cursor-pointer",
                 item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium",
-                itemTrailingIcon: "text-success",
+                itemTrailingIcon: "text-success-600 dark:text-success",
             },
             defaultVariants: {
                 size: "sm",

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -55,7 +55,7 @@ export default {
                 base: "cursor-pointer",
                 // data-[state=checked] is set by Reka UI on the selected item; itemTrailingIcon
                 // only renders inside SelectItemIndicator so colouring it never affects other icons.
-                item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium",
+                item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium data-[state=checked]:data-highlighted:before:bg-success/25",
                 itemTrailingIcon: "text-success-600 dark:text-success",
             },
             defaultVariants: {
@@ -65,7 +65,7 @@ export default {
         selectMenu: {
             slots: {
                 base: "cursor-pointer",
-                item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium",
+                item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium data-[state=checked]:data-highlighted:before:bg-success/25",
                 itemTrailingIcon: "text-success-600 dark:text-success",
             },
             defaultVariants: {

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -55,8 +55,8 @@ export default {
                 base: "cursor-pointer",
                 // data-[state=checked] is set by Reka UI on the selected item; itemTrailingIcon
                 // only renders inside SelectItemIndicator so colouring it never affects other icons.
-                item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium data-[state=checked]:data-highlighted:before:bg-success/25",
-                itemTrailingIcon: "text-success-600 dark:text-success",
+                item: "cursor-pointer data-[state=checked]:before:bg-primary/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium data-[state=checked]:data-highlighted:before:bg-primary/25",
+                itemTrailingIcon: "text-primary-700 dark:text-primary",
             },
             defaultVariants: {
                 size: "sm",
@@ -65,8 +65,8 @@ export default {
         selectMenu: {
             slots: {
                 base: "cursor-pointer",
-                item: "cursor-pointer data-[state=checked]:before:bg-success/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium data-[state=checked]:data-highlighted:before:bg-success/25",
-                itemTrailingIcon: "text-success-600 dark:text-success",
+                item: "cursor-pointer data-[state=checked]:before:bg-primary/15 data-[state=checked]:text-highlighted data-[state=checked]:font-medium data-[state=checked]:data-highlighted:before:bg-primary/25",
+                itemTrailingIcon: "text-primary-700 dark:text-primary",
             },
             defaultVariants: {
                 size: "sm",

--- a/src/components/ProgressRing.vue
+++ b/src/components/ProgressRing.vue
@@ -107,7 +107,7 @@ const dashOffset = computed(() => {
 const colorMap = {
     primary: "var(--primary-500)",
     success: "var(--success-500)",
-    warning: "var(--warning-500)",
+    warning: "var(--warning-700)",
     error: "var(--error-500)",
 };
 

--- a/src/components/ProgressRing.vue
+++ b/src/components/ProgressRing.vue
@@ -68,7 +68,7 @@ const props = defineProps({
     color: {
         type: String,
         default: "primary",
-        validator: (v) => ["primary", "success", "error"].includes(v),
+        validator: (v) => ["primary", "success", "warning", "error"].includes(v),
     },
     size: {
         type: Number,
@@ -107,6 +107,7 @@ const dashOffset = computed(() => {
 const colorMap = {
     primary: "var(--primary-500)",
     success: "var(--success-500)",
+    warning: "var(--warning-500)",
     error: "var(--error-500)",
 };
 

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -79,8 +79,14 @@ html {
     --success-transparent-3: rgba(112, 226, 18, 0.3);
     --success-transparent-4: rgba(112, 226, 18, 0.4);
 
+    --warning-400: #ff8533;
     --warning-500: #ff6600;
     --warning-600: #e65c00;
+
+    --warning-transparent-1: rgba(255, 102, 0, 0.1);
+    --warning-transparent-2: rgba(255, 102, 0, 0.2);
+    --warning-transparent-3: rgba(255, 102, 0, 0.3);
+    --warning-transparent-4: rgba(255, 102, 0, 0.4);
 
     --primary-action: var(--success-500);
     --primary-action-border: var(--success-600);
@@ -149,6 +155,10 @@ body[data-theme="contrast"] {
     --error-400: #ff7575;
     --error-500: #ff3333;
     --error-600: #cc0000;
+
+    --warning-400: #ffaa66;
+    --warning-500: #ff8800;
+    --warning-600: #cc6600;
 
     #tabs li.active a {
         color: #000;

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -82,6 +82,9 @@ html {
     --warning-400: #ff8533;
     --warning-500: #ff6600;
     --warning-600: #e65c00;
+    /* Dark rust used as foreground on light surfaces and on warning-tinted backgrounds — */
+    /* meets WCAG 1.4.11 3:1 against --surface-400 (#d6d6d6) where -500/-600 do not. */
+    --warning-700: #b34700;
 
     --warning-transparent-1: rgba(255, 102, 0, 0.1);
     --warning-transparent-2: rgba(255, 102, 0, 0.2);
@@ -114,6 +117,9 @@ html {
     --ui-primary: var(--primary-500);
     --ui-error: var(--ui-color-error-500);
     --ui-bg-muted: var(--color-neutral-850);
+
+    /* Lighter shade so warning foregrounds keep 3:1 against dark surfaces. */
+    --warning-700: #ff8533;
 
     --text: hsl(0, 0%, 95%);
 }


### PR DESCRIPTION
## Summary

- USelect / USelectMenu now visibly mark the currently-selected option in every dropdown across the app: a subtle 15% lime tint on the row plus a green check indicator. Hovering the selected row deepens the tint (25%) so it still gives hover feedback. Applies app-wide via `nuxt-ui.vite.js` theme overrides — keeps a single source of truth for select styling.
- Silences a `[Vue warn]` from the Firmware Flasher tab: `flashRingColor` and `flashResultRingColor` already returned `"warning"` during flashing, but `ProgressRing`'s validator only accepted `primary` / `success` / `error`. Adds `warning` to the validator and the colorMap.
- Fills out the `--warning-*` design-token family to match `--error-*` and `--success-*`: light `:root` gains `--warning-400`, four `--warning-transparent-*` siblings, and the new indicator-on-surface shade `--warning-700`. The `body[data-theme="contrast"]` block gets matching `--warning-400/500/600` overrides. `.dark` gets a `--warning-700` override too.
- WCAG 1.4.11 cleanup along the way:
  - Light-mode dropdown check indicator uses `text-success-600` for ≥3:1 against the tinted row (default `text-success` was ≈1.5:1).
  - ProgressRing's `warning` ring fill is routed through `--warning-700` so the orange clears 3:1 against the ring's `--surface-400` track in both light (≈3.83:1) and dark (≈5.2:1) modes.
- Drive-by fix: three `text-[var(--warning-700)]` references in `SensorsTab.vue` were resolving to an undefined token — now they work.

## Test plan

- [x] `npm run lint` — clean for files in this PR (pre-existing `RatesSubTab.vue` warning is unrelated).
- [x] `npm run test` — 97/97 vitest tests pass.
- [x] Manually flash a board from the Firmware Flasher tab; confirm:
  - No `[Vue warn]` about `ProgressRing` `color` in the devtools console.
  - The selected build type / board / firmware version row in each dropdown is visibly tinted and shows a green check.
  - Hovering the selected row deepens the tint instead of looking idle.
  - The progress ring during flashing renders in orange and is readable against the surrounding card in light mode.
- [x] Toggle between light, dark, and the high-contrast theme; confirm the selected-row tint and the warning ring colour stay legible in each.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added warning color support to the ProgressRing component
  * Extended warning color palette across the theme with additional transparent and contrast-aware variants

* **Style**
  * Enhanced select and select-menu styling to visibly indicate selected items
  * Improved trailing icon styling in select components with dark-mode-aware coloring

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5139?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->