### PR TITLE
style(theme): unify Roll/Pitch/Yaw and X/Y/Z axis colors to RGB across all tabs

### DIFF
--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -316,9 +316,9 @@
                                         <span
                                             class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px]"
                                             :class="{
-                                                'bg-[#1fb1f0]': axis === 'x',
-                                                'bg-[#97d800]': axis === 'y',
-                                                'bg-[#e24761]': axis === 'z',
+                                                'bg-[#e24761]': axis === 'x',
+                                                'bg-[#49c747]': axis === 'y',
+                                                'bg-[#477ac7]': axis === 'z',
                                             }"
                                             >{{ rawDataDisplay[axis] }}</span
                                         >
@@ -326,7 +326,7 @@
                                     <div class="flex justify-between py-0.5">
                                         <span>RMS:</span>
                                         <span
-                                            class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#00d800]"
+                                            class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#f5a623]"
                                             >{{ rawDataDisplay.rms }}</span
                                         >
                                     </div>

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -1258,10 +1258,10 @@ onUnmounted(() => {
     background-color: #e24761;
 }
 .pid_pitch {
-    background-color: #97d800;
+    background-color: #49c747;
 }
 .pid_yaw {
-    background-color: #1fb1f0;
+    background-color: #477ac7;
 }
 .pid_roll,
 .pid_pitch,

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1300,22 +1300,22 @@ onUnmounted(() => {
         gap: 0.5rem;
         &:nth-of-type(1) {
             :deep([data-slot="indicator"]) {
-                background-color: #f1453d;
+                background-color: #e24761;
             }
         }
         &:nth-of-type(2) {
             :deep([data-slot="indicator"]) {
-                background-color: #673fb4;
+                background-color: #49c747;
             }
         }
         &:nth-of-type(3) {
             :deep([data-slot="indicator"]) {
-                background-color: #2b98f0;
+                background-color: #477ac7;
             }
         }
         &:nth-of-type(4) {
             :deep([data-slot="indicator"]) {
-                background-color: #1fbcd2;
+                background-color: #f5a623;
             }
         }
         &:nth-of-type(5) {
@@ -1437,16 +1437,16 @@ onUnmounted(() => {
         border-radius: 3px;
     }
     .ch1 {
-        background-color: #f1453d;
+        background-color: #e24761;
     }
     .ch2 {
-        background-color: #673fb4;
+        background-color: #49c747;
     }
     .ch3 {
-        background-color: #2b98f0;
+        background-color: #477ac7;
     }
     .ch4 {
-        background-color: #1fbcd2;
+        background-color: #f5a623;
     }
 }
 
@@ -1455,16 +1455,16 @@ onUnmounted(() => {
     color: var(--text);
     .line {
         &:nth-child(1) {
-            stroke: #f1453d;
+            stroke: #e24761;
         }
         &:nth-child(2) {
-            stroke: #673fb4;
+            stroke: #49c747;
         }
         &:nth-child(3) {
-            stroke: #2b98f0;
+            stroke: #477ac7;
         }
         &:nth-child(4) {
-            stroke: #1fbcd2;
+            stroke: #f5a623;
         }
         &:nth-child(5) {
             stroke: #159588;

--- a/src/components/tabs/autotune/BodePlot.vue
+++ b/src/components/tabs/autotune/BodePlot.vue
@@ -42,7 +42,7 @@ const phaseSvg = ref(null);
 const sensitivitySvg = ref(null);
 const stepSvg = ref(null);
 
-const AXIS_COLORS = { roll: "#e74c3c", pitch: "#2ecc71", yaw: "#3498db" };
+const AXIS_COLORS = { roll: "#e24761", pitch: "#49c747", yaw: "#477ac7" };
 const AXES = [
     { key: "roll", labelKey: "autotuneAxisRoll", colorClass: "toggle-roll" },
     { key: "pitch", labelKey: "autotuneAxisPitch", colorClass: "toggle-pitch" },

--- a/src/components/tabs/autotune/GainRecommendation.vue
+++ b/src/components/tabs/autotune/GainRecommendation.vue
@@ -101,9 +101,9 @@ const selectedAxisKey = ref(null);
 const isConnected = computed(() => connectionStore.connectionValid);
 
 const AXIS_DEFS = [
-    { key: "roll", labelKey: "autotuneAxisRoll", color: "#e74c3c", pidKey: "rollPID" },
-    { key: "pitch", labelKey: "autotuneAxisPitch", color: "#2ecc71", pidKey: "pitchPID" },
-    { key: "yaw", labelKey: "autotuneAxisYaw", color: "#3498db", pidKey: "yawPID" },
+    { key: "roll", labelKey: "autotuneAxisRoll", color: "#e24761", pidKey: "rollPID" },
+    { key: "pitch", labelKey: "autotuneAxisPitch", color: "#49c747", pidKey: "pitchPID" },
+    { key: "yaw", labelKey: "autotuneAxisYaw", color: "#477ac7", pidKey: "yawPID" },
 ];
 
 const PID_ROWS = [

--- a/src/components/tabs/autotune/SpectrogramPlot.vue
+++ b/src/components/tabs/autotune/SpectrogramPlot.vue
@@ -26,9 +26,9 @@ const container = ref(null);
 const canvasRefs = {};
 
 const AXIS_DEFS = [
-    { key: "roll", labelKey: "autotuneAxisRoll", color: "#e74c3c" },
-    { key: "pitch", labelKey: "autotuneAxisPitch", color: "#2ecc71" },
-    { key: "yaw", labelKey: "autotuneAxisYaw", color: "#3498db" },
+    { key: "roll", labelKey: "autotuneAxisRoll", color: "#e24761" },
+    { key: "pitch", labelKey: "autotuneAxisPitch", color: "#49c747" },
+    { key: "yaw", labelKey: "autotuneAxisYaw", color: "#477ac7" },
 ];
 
 const MARGIN = { top: 4, right: 10, bottom: 24, left: 55 };

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -881,21 +881,21 @@ function drawRateCurves() {
     nextTick(() => updateRatesLabels());
 }
 
-// Balloon label configuration
+// Balloon label configuration — RGB axis palette (Roll=#e24761, Pitch=#49c747, Yaw=#477ac7)
 const BALLOON_COLORS = {
     roll: {
-        color: "rgba(255,128,128,0.4)",
-        border: "rgba(255,128,128,0.6)",
+        color: "rgba(226,71,97,0.4)",
+        border: "rgba(226,71,97,0.6)",
         text: "#000000",
     },
     pitch: {
-        color: "rgba(128,255,128,0.4)",
-        border: "rgba(128,255,128,0.6)",
+        color: "rgba(73,199,71,0.4)",
+        border: "rgba(73,199,71,0.6)",
         text: "#000000",
     },
     yaw: {
-        color: "rgba(128,128,255,0.4)",
-        border: "rgba(128,128,255,0.6)",
+        color: "rgba(71,122,199,0.4)",
+        border: "rgba(71,122,199,0.6)",
         text: "#000000",
     },
 };

--- a/src/components/tabs/sensors/SensorGraph.vue
+++ b/src/components/tabs/sensors/SensorGraph.vue
@@ -41,9 +41,9 @@
                             <span
                                 class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px]"
                                 :class="{
-                                    'bg-[#1fb1f0]': axis === 'x',
-                                    'bg-[#97d800]': axis === 'y',
-                                    'bg-[#e24761]': axis === 'z',
+                                    'bg-[#e24761]': axis === 'x',
+                                    'bg-[#49c747]': axis === 'y',
+                                    'bg-[#477ac7]': axis === 'z',
                                 }"
                                 >{{ displayValues[i] }}</span
                             >
@@ -52,7 +52,7 @@
                     <template v-else>
                         <div class="flex justify-between py-0.5">
                             <span>X:</span>
-                            <span class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#1fb1f0]">{{
+                            <span class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#e24761]">{{
                                 displayValues[0]
                             }}</span>
                         </div>
@@ -84,7 +84,7 @@
                     </div>
                     <div class="flex justify-between py-0.5">
                         <span>Value:</span>
-                        <span class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#1fb1f0]">{{
+                        <span class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#e24761]">{{
                             displayValues[0]
                         }}</span>
                     </div>

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1300,13 +1300,13 @@ each(range(12), {
 }
 .plot_control {
     .x {
-        background-color: #1fb1f0;
+        background-color: #e24761;
     }
     .y {
-        background-color: #97d800;
+        background-color: #49c747;
     }
     .z {
-        background-color: #e24761;
+        background-color: #477ac7;
     }
     .x,
     .y,
@@ -1316,25 +1316,25 @@ each(range(12), {
 }
 .line {
     &:nth-child(1) {
-        stroke: #1fb1f0;
+        stroke: #e24761;
     }
     &:nth-child(2) {
-        stroke: #97d800;
+        stroke: #49c747;
     }
     &:nth-child(3) {
-        stroke: #e24761;
+        stroke: #477ac7;
     }
 }
 .legend {
     .item {
         &:nth-child(1) {
-            fill: #1fb1f0;
+            fill: #e24761;
         }
         &:nth-child(2) {
-            fill: #97d800;
+            fill: #49c747;
         }
         &:nth-child(3) {
-            fill: #e24761;
+            fill: #477ac7;
         }
     }
 }


### PR DESCRIPTION
## Summary

Standardizes axis colors on a single RGB palette already used by the PID Tuning subtab. Previously four divergent palettes existed across the UI and two tabs had the axis order inverted.

**Unified palette:**

| Slot | Color | Roles |
|------|-------|-------|
| 1st | `#e24761` red | Roll, X |
| 2nd | `#49c747` green | Pitch, Y |
| 3rd | `#477ac7` blue | Yaw, Z |
| 4th | `#f5a623` amber | Throttle (Receiver ch4), RMS (Motors) |

**Issues fixed:**
- **Motors** and **Sensors** tabs had X/Y/Z mapped in BGR order (X=blue, Z=red) — now correctly RGB.
- **Receiver** tab showed Pitch in purple (`#673fb4`) — now green to match the rest of the UI.
- **Motors RMS** swatch (`#00d800`) and **Receiver Throttle** (cyan `#1fbcd2`) collided with the new Pitch green — both recolored to a shared amber so the "fourth indicator after RGB" reads consistently across the two tabs.
- **Autotune** plots (Bode, Spectrogram, GainRecommendation) used the Flat-UI palette (`#e74c3c/#2ecc71/#3498db`) — now match the canonical palette.
- **`main.less`** SVG plot lines/legends used by sensor and motor graphs — flipped from BGR to RGB.
- Stale `.pid_roll/.pid_pitch/.pid_yaw` CSS in `PidTuningTab.vue` and rgba balloon variants in `RatesSubTab.vue` aligned to the canonical hex.

Receiver channels 5–16 (aux) keep their existing material-design palette — no axis semantics apply.

## Test plan

- [ ] PID Tuning → Rates: balloon labels show red/green/blue for Roll/Pitch/Yaw curve maxes
- [ ] Motors: vibration X/Y/Z bars read red/green/blue; RMS swatch is amber and clearly distinct from Y
- [ ] Sensors: gyro/accel/mag X/Y/Z lines read red/green/blue in both legend swatches and SVG plot strokes
- [ ] Receiver: channel bars 1–3 (Roll/Pitch/Yaw) read red/green/blue; channel 4 (Throttle) is amber; aux channels 5–16 unchanged; RX plot strokes match the legend
- [ ] Autotune: Bode, Spectrogram and Gain Recommendation panels show red/green/blue for Roll/Pitch/Yaw and match the rest of the UI
- [ ] Light + dark themes both look correct
- [ ] No regression in non-axis colors (PreflightTab error text, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the application's visual color scheme across multiple components, including sensor displays, PID tuning row highlights, receiver channel indicators, auto-tune plot axes, rate curve labels, and chart visualizations throughout the interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5142?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->