### PR TITLE
fix(ui): use black text on solid primary buttons in light mode

### DIFF
--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -25,8 +25,9 @@ export default {
                     variant: "solid",
                     // Primary is yellow (#ffbb00); Nuxt UI defaults text-inverted to #fff in light
                     // mode. Override with black text for both light and dark modes — yellow always
-                    // needs dark text regardless of theme.
-                    class: "!text-black disabled:bg-accented disabled:text-toned",
+                    // needs dark text regardless of theme. disabled:!text-toned restores the muted
+                    // disabled appearance which !text-black would otherwise override.
+                    class: "!text-black disabled:bg-accented disabled:!text-toned",
                 },
             ],
             defaultVariants: {

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -23,7 +23,10 @@ export default {
                 {
                     color: "primary",
                     variant: "solid",
-                    class: "disabled:bg-accented disabled:text-toned",
+                    // Primary is yellow (#ffbb00); Nuxt UI defaults text-inverted to #fff in light
+                    // mode. Override with black text for both light and dark modes — yellow always
+                    // needs dark text regardless of theme.
+                    class: "!text-black disabled:bg-accented disabled:text-toned",
                 },
             ],
             defaultVariants: {


### PR DESCRIPTION
AI generated pull-request

---

please check dark-theme for any regression.

---

## Problem

In light mode, all `UButton` components using the default `color="primary" variant="solid"` render white text on a yellow (`#ffbb00`) background. Nuxt UI v3 assigns `text-inverted` to solid buttons, which resolves to `#fff` in light mode — unreadable on yellow.

Affected buttons across all tabs: **Save**, **Save and Reboot**, **Calibrate**, **Show Live Sensor Data**, **Activate Bootloader / DFU**, **Enable All / Disable All**, **Import Blackbox Log**, **Submit Support Data**, and others.

## Fix

Add `!text-black` to the `color="primary" / variant="solid"` compound variant in `nuxt-ui.vite.js`. Yellow always requires dark text regardless of theme.

**Dark mode is unaffected:** `text-inverted` in dark mode already resolved to `neutral-900` (`oklch(20.5% 0 0)` ≈ near-black), so the change is visually imperceptible there.

## Change

```diff
- class: "disabled:bg-accented disabled:text-toned",
+ class: "!text-black disabled:bg-accented disabled:text-toned",
```




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected primary solid button text color to ensure readable contrast with the primary (yellow) style.
  * Preserved the muted appearance of disabled primary buttons so disabled text remains clearly toned against the override.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/betaflight/betaflight-configurator/pull/5144?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->