### PR TITLE
feat(port-picker): update connect/disconnect button labels for connection modes

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -122,7 +122,7 @@
         "description": "Helper text in the connect dialog when choosing the virtual FC mode."
     },
     "connectVirtual": {
-        "message": "Virtual",
+        "message": "Connect (Virtual)",
         "description": "Connect button label shown when virtual mode port is selected."
     },
     "connectManualDescription": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -72,6 +72,14 @@
         "message": "Disconnect (Virtual)",
         "description": "Disconnect button label shown when connected in virtual mode."
     },
+    "disconnectManual": {
+        "message": "Disconnect (Manual)",
+        "description": "Disconnect button label shown when connected via manual port override."
+    },
+    "disconnectBluetooth": {
+        "message": "Disconnect (Bluetooth)",
+        "description": "Disconnect button label shown when connected via Bluetooth."
+    },
     "portsSelectNoSelection": {
         "message": "Select your device",
         "description": "Text for the option to select a device in the port selection dropdown"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -68,6 +68,10 @@
     "disconnect": {
         "message": "Disconnect"
     },
+    "disconnectVirtual": {
+        "message": "Disconnect (Virtual)",
+        "description": "Disconnect button label shown when connected in virtual mode."
+    },
     "portsSelectNoSelection": {
         "message": "Select your device",
         "description": "Text for the option to select a device in the port selection dropdown"
@@ -116,6 +120,10 @@
     "connectVirtualDescription": {
         "message": "Simulate a flight controller without hardware.",
         "description": "Helper text in the connect dialog when choosing the virtual FC mode."
+    },
+    "connectVirtual": {
+        "message": "Virtual",
+        "description": "Connect button label shown when virtual mode port is selected."
     },
     "connectManualDescription": {
         "message": "Enter the serial path or URL to connect to.",

--- a/src/components/port-picker/ConnectButton.vue
+++ b/src/components/port-picker/ConnectButton.vue
@@ -8,10 +8,10 @@
             icon="i-lucide-link-2-off"
             size="sm"
             :loading="connecting"
-            :title="$t('disconnect')"
+            :title="disconnectLabel"
             @click="onDisconnectClick"
         >
-            <span class="sidebar-connect__label">{{ $t("disconnect") }}</span>
+            <span class="sidebar-connect__label">{{ disconnectLabel }}</span>
         </UButton>
         <UFieldGroup v-else size="sm" orientation="horizontal" class="sidebar-connect__group w-full !flex">
             <UButton
@@ -93,6 +93,11 @@ export default defineComponent({
 
         const isConnected = computed(() => connectionStore.connectionValid);
         const connecting = computed(() => Boolean(connectionStore.connectingTo));
+        const isVirtualMode = computed(() => connectionStore.virtualMode);
+
+        const disconnectLabel = computed(() =>
+            isVirtualMode.value ? i18n.getMessage("disconnectVirtual") : i18n.getMessage("disconnect"),
+        );
         const portPickerDisabled = computed(() => PortHandler.portPickerDisabled);
 
         const selectedPort = computed(() => PortHandler.portPicker.selectedPort);
@@ -112,6 +117,9 @@ export default defineComponent({
         const mainLabel = computed(() => {
             if (connecting.value) {
                 return i18n.getMessage("connecting");
+            }
+            if (selectedPort.value === "virtual") {
+                return i18n.getMessage("connectVirtual");
             }
             return selectedDisplayName.value ?? i18n.getMessage("connect");
         });
@@ -239,6 +247,7 @@ export default defineComponent({
             isConnected,
             connecting,
             portPickerDisabled,
+            disconnectLabel,
             mainLabel,
             menuItems,
             dialogOpen,

--- a/src/components/port-picker/ConnectButton.vue
+++ b/src/components/port-picker/ConnectButton.vue
@@ -94,10 +94,21 @@ export default defineComponent({
         const isConnected = computed(() => connectionStore.connectionValid);
         const connecting = computed(() => Boolean(connectionStore.connectingTo));
         const isVirtualMode = computed(() => connectionStore.virtualMode);
+        const connectedTo = computed(() => connectionStore.connectedTo);
 
-        const disconnectLabel = computed(() =>
-            isVirtualMode.value ? i18n.getMessage("disconnectVirtual") : i18n.getMessage("disconnect"),
-        );
+        const disconnectLabel = computed(() => {
+            if (isVirtualMode.value) {
+                return i18n.getMessage("disconnectVirtual");
+            }
+            const path = connectedTo.value ?? "";
+            if (path.startsWith("bluetooth")) {
+                return i18n.getMessage("disconnectBluetooth");
+            }
+            if (/^(tcp|ws|wss):\/\//.test(path)) {
+                return i18n.getMessage("disconnectManual");
+            }
+            return i18n.getMessage("disconnect");
+        });
         const portPickerDisabled = computed(() => PortHandler.portPickerDisabled);
 
         const selectedPort = computed(() => PortHandler.portPicker.selectedPort);


### PR DESCRIPTION
AI generated pull-request

---
| State | Connection type | Button label |
|---|---|---|
| Port selected, not connected | Virtual | `Connect (Virtual)` |
| Port selected, not connected | Any other | `Connect` / device display name |
| Connected | Virtual | `Disconnect (Virtual)` |
| Connected | Bluetooth | `Disconnect (Bluetooth)` |
| Connected | Manual (TCP/WS URL) | `Disconnect (Manual)` |
| Connected | Serial (USB cable) | `Disconnect` |
---

<img width="520" height="213" alt="image" src="https://github.com/user-attachments/assets/761323d8-9c3b-462c-8447-14ed71589fcf" />

<img width="508" height="157" alt="image" src="https://github.com/user-attachments/assets/fd9e25d6-5d96-480f-bf3f-6e83b9aaf01b" />

---

## Summary

When virtual mode is selected in the port picker, the connect button now displays **"Virtual"** instead of the generic "Connect". When connected in virtual mode, the disconnect button displays **"Disconnect (Virtual)"** instead of the generic "Disconnect".

## Changes

- `locales/en/messages.json`: Add `connectVirtual` ("Virtual") and `disconnectVirtual` ("Disconnect (Virtual)") i18n keys
- `src/components/port-picker/ConnectButton.vue`:
  - Expose `isVirtualMode` from `connectionStore.virtualMode`
  - Add `disconnectLabel` computed — returns `disconnectVirtual` when in virtual mode, `disconnect` otherwise
  - Add `connectVirtual` guard in `mainLabel` computed — returns `"Virtual"` when selected port is `virtual`
  - Bind disconnect button `:title` and label to `disconnectLabel`

## Behaviour

| State | Button label (before) | Button label (after) |
|---|---|---|
| Virtual port selected, not connected | Connect | Virtual |
| Connected in virtual mode | Disconnect | Disconnect (Virtual) |
| Normal port selected / connected | unchanged | unchanged |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection buttons now show virtual-mode-aware labels: the Connect button displays a virtual label when a virtual port is selected, and the Disconnect button shows context-appropriate labels based on connection type.

* **Documentation**
  * Added two English localization entries for the new virtual-mode connect/disconnect labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->