### PR TITLE
Provided USB filtering for X32M7 in betaflight-configurator.

### DIFF
--- a/android/app/src/main/java/betaflight/app/protocols/dfu/BetaflightDfuPlugin.java
+++ b/android/app/src/main/java/betaflight/app/protocols/dfu/BetaflightDfuPlugin.java
@@ -61,6 +61,7 @@ public class BetaflightDfuPlugin extends Plugin {
         {0x2E3C, 0xDF11},  // AT32F435 DFU Bootloader
         {0x314B, 0x0106},  // APM32 DFU Bootloader
         {0x2E8A, 0x000F},  // Raspberry Pi Pico Bootloader
+        {0x3997, 0xDF11},  // X32 DFU Bootloader
     };
 
     // USB recipient bits not exposed by Android's UsbConstants

--- a/android/app/src/main/res/xml/device_filter.xml
+++ b/android/app/src/main/res/xml/device_filter.xml
@@ -37,4 +37,8 @@
     <usb-device vendor-id="6790" product-id="29987" /> <!-- CH340 USB-to-Serial -->
     <usb-device vendor-id="6790" product-id="21795" /> <!-- CH341 USB-to-Serial -->
     <usb-device vendor-id="6790" product-id="30084" /> <!-- CH340S USB-to-Serial -->
+    
+    <!-- X32 devices -->
+    <usb-device vendor-id="14743" product-id="22336" /> <!-- X32 VCP -->
+    <usb-device vendor-id="14743" product-id="57105" /> <!-- X32 DFU Bootloader -->
 </resources>

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -71,6 +71,7 @@ const defaultSerialDevices = [
     { vendorId: 6790, productId: 29987 }, // CH340 USB-to-Serial
     { vendorId: 6790, productId: 21795 }, // CH341 USB-to-Serial
     { vendorId: 6790, productId: 30084 }, // CH340S USB-to-Serial
+    { vendorId: 14743, productId: 22336 }, // X32 VCP
 ];
 
 const defaultUsbFilters = [
@@ -79,6 +80,7 @@ const defaultUsbFilters = [
     { vendorId: 11836, productId: 57105 }, // AT32F435 DFU Bootloader
     { vendorId: 12619, productId: 262 }, // APM32 DFU Bootloader
     { vendorId: 11914, productId: 15 }, // Raspberry Pi Pico in Bootloader mode
+    { vendorId: 14743, productId: 57105 }, // X32 DFU Bootloader
 ];
 
 const defaultVendorIdNames = {
@@ -89,6 +91,7 @@ const defaultVendorIdNames = {
     11836: "AT32",
     12619: "Geehy Semiconductor",
     11914: "Raspberry Pi Pico",
+    14743: "X-CORE LABS",
 };
 
 export const bluetoothDevices = [...defaultBluetoothDevices];


### PR DESCRIPTION
Add USB filtering for X32M7 in betaflight-configurator to improve device detection and DFU updates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for X32 devices from X-CORE LABS. These devices are now recognized and compatible during USB device discovery, including both VCP and DFU bootloader modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->