### PR TITLE
fix(serial): recover BLE UI after disconnect and Save-and-Reboot

### DIFF
--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -71,9 +71,16 @@ class WebBluetooth extends EventTarget {
         this.bytesReceived += info.detail.byteLength;
     }
 
+    // Unsolicited disconnect (the device's gattserverdisconnected/disconnect event). Tear the
+    // connection down so serial_backend returns to the landing tab. The guard skips the
+    // re-entrant event our own gatt.disconnect() triggers. The device is intentionally NOT
+    // removed from the list — BLE links drop transiently (reboot/boot bounce) and the paired
+    // device can be reconnected by path, so removing it would only force needless re-discovery.
     handleDisconnect() {
+        if (this.closeRequested) {
+            return;
+        }
         this.disconnect();
-        this.closeRequested = true;
     }
 
     getConnectedPort() {
@@ -323,6 +330,9 @@ class WebBluetooth extends EventTarget {
         if (this.closeRequested) {
             return;
         }
+        // Mark closing now — before the gatt.disconnect() below — so the gattserverdisconnected
+        // event it triggers is recognized by handleDisconnect as our own teardown, not an unplug.
+        this.closeRequested = true;
 
         const doCleanup = async () => {
             this.removeEventListener("receive", this.handleReceiveBytes);
@@ -330,12 +340,17 @@ class WebBluetooth extends EventTarget {
             if (this.device) {
                 this.device.removeEventListener("disconnect", this.handleDisconnect.bind(this));
                 this.device.removeEventListener("gattserverdisconnected", this.handleDisconnect);
-                this.readCharacteristic.removeEventListener(
-                    "characteristicvaluechanged",
-                    this.handleNotification.bind(this),
-                );
 
-                if (this.device.gatt.connected) {
+                // readCharacteristic may already be false from a prior teardown — guard
+                // before calling, or false.removeEventListener throws and aborts cleanup.
+                if (this.readCharacteristic) {
+                    this.readCharacteristic.removeEventListener(
+                        "characteristicvaluechanged",
+                        this.handleNotification.bind(this),
+                    );
+                }
+
+                if (this.device.gatt?.connected) {
                     this.device.gatt.disconnect();
                 }
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -39,6 +39,10 @@ let liveDataRefreshTimerId = false;
 // Tracked so an intentional disconnect during the reboot window can cancel it — otherwise the
 // retry would resurrect a connection the user just cancelled.
 let rebootReconnectTimerId = false;
+// Handles for the reboot progress modal's intervals, tracked so closeRebootDialog() can dismiss
+// the modal (and stop its timers) when a user disconnect cancels the reboot.
+let rebootDialogProgressTimerId = false;
+let rebootDialogCheckTimerId = false;
 
 let isConnected = false;
 
@@ -148,6 +152,21 @@ function stopRebootReconnect() {
     }
 }
 
+// Dismiss the reboot progress modal and stop its timers. Called when a user disconnect cancels
+// the reboot (otherwise the modal would linger until its own 10s timeout), and at the start of
+// showRebootDialog() to clear any stale modal/intervals from a prior reboot.
+function closeRebootDialog() {
+    if (rebootDialogProgressTimerId !== false) {
+        clearInterval(rebootDialogProgressTimerId);
+        rebootDialogProgressTimerId = false;
+    }
+    if (rebootDialogCheckTimerId !== false) {
+        clearInterval(rebootDialogCheckTimerId);
+        rebootDialogCheckTimerId = false;
+    }
+    document.getElementById("rebootProgressDialog")?.close();
+}
+
 function prepareDisconnect() {
     // Mark this as an intentional disconnect so the later protocol "disconnect" event
     // (handled by onClosed) does not run the unexpected-disconnect teardown on top of
@@ -167,6 +186,11 @@ function prepareDisconnect() {
 
 function beginDisconnect() {
     prepareDisconnect();
+
+    // A user-initiated disconnect during the reboot window must also dismiss the reboot modal —
+    // prepareDisconnect() only stops the reconnect timers. (disconnectForReboot does NOT close it:
+    // the modal must stay up while the reboot's own reconnect runs.)
+    closeRebootDialog();
 
     mspHelper?.setArmingEnabled(true, false, function () {
         finishClose(toggleStatus);
@@ -933,8 +957,6 @@ export function reinitializeConnection(suppressDialog = false) {
 // as the FC restarts, and no single disconnect event marks "FC ready". Runs whether or not the
 // reboot dialog is shown.
 function rebootReconnect() {
-    const reconnect = PortHandler.portPicker.autoConnect;
-
     // Cancel any prior reboot cycle (e.g. a second Save-and-Reboot within the window) so we
     // never run two overlapping retry loops.
     stopRebootReconnect();
@@ -947,20 +969,22 @@ function rebootReconnect() {
             disconnectForReboot();
         }
 
-        // Honor Auto-Connect: when it is off, stay on the landing tab and let the user reconnect
-        // manually (the reboot dialog closes via its no-reconnect check).
-        if (!reconnect) {
+        // Honor Auto-Connect — read it live (not snapshotted at reboot start) so toggling it off
+        // during the reboot window takes effect. When off, stay on the landing tab and let the
+        // user reconnect manually (the reboot dialog closes via its no-reconnect check).
+        if (!PortHandler.portPicker.autoConnect) {
             rebootReconnectTimerId = false;
             return;
         }
 
-        // Retry connecting until the rebooted FC answers (connectionValid) or the reboot window
-        // closes. Early attempts may connect to a still-booting FC and get dropped; the device
-        // stays listed (we never remove it on disconnect), so a later attempt succeeds once the
-        // FC is stable. connectDisconnect here takes the connect branch (isConnected is false).
+        // Retry connecting until the rebooted FC answers (connectionValid), the reboot window
+        // closes, or Auto-Connect is turned off mid-window. Early attempts may connect to a
+        // still-booting FC and get dropped; the device stays listed (we never remove it on
+        // disconnect), so a later attempt succeeds once the FC is stable. connectDisconnect here
+        // takes the connect branch (isConnected is false).
         rebootReconnectTimerId = setInterval(() => {
             const timedOut = Date.now() - rebootTimestamp > REBOOT_CONNECT_MAX_TIME_MS;
-            if (CONFIGURATOR.connectionValid || timedOut) {
+            if (CONFIGURATOR.connectionValid || timedOut || !PortHandler.portPicker.autoConnect) {
                 stopRebootReconnect();
                 return;
             }
@@ -974,6 +998,9 @@ function rebootReconnect() {
 function showRebootDialog() {
     gui_log(i18n.getMessage("deviceRebooting"));
 
+    // Clear any leftover modal/intervals from a prior reboot before starting a new one.
+    closeRebootDialog();
+
     // Show reboot progress modal
     const rebootDialog = document.getElementById("rebootProgressDialog") || createRebootProgressDialog();
     rebootDialog.querySelector(".reboot-progress-bar").style.width = "0%";
@@ -985,7 +1012,7 @@ function showRebootDialog() {
     // Calculate increment to reach 100% when the timeout elapses (runs every 100ms)
     const progressIncrement = 100 / (REBOOT_CONNECT_MAX_TIME_MS / 100);
 
-    const progressInterval = setInterval(() => {
+    rebootDialogProgressTimerId = setInterval(() => {
         progress += progressIncrement;
         if (progress <= 100) {
             rebootDialog.querySelector(".reboot-progress-bar").style.width = `${progress}%`;
@@ -993,13 +1020,15 @@ function showRebootDialog() {
     }, 100);
 
     // Check for successful connection every 100ms with a timeout
-    const connectionCheckInterval = setInterval(() => {
+    rebootDialogCheckTimerId = setInterval(() => {
         const connectionCheckTimeoutReached = Date.now() - rebootTimestamp > REBOOT_CONNECT_MAX_TIME_MS;
         const noSerialReconnect = !PortHandler.portPicker.autoConnect && PortHandler.portAvailable;
 
         if (CONFIGURATOR.connectionValid || connectionCheckTimeoutReached || noSerialReconnect) {
-            clearInterval(connectionCheckInterval);
-            clearInterval(progressInterval);
+            clearInterval(rebootDialogCheckTimerId);
+            clearInterval(rebootDialogProgressTimerId);
+            rebootDialogCheckTimerId = false;
+            rebootDialogProgressTimerId = false;
 
             rebootDialog.querySelector(".reboot-progress-bar").style.width = "100%";
             rebootDialog.querySelector(".reboot-status").textContent = i18n.getMessage("rebootFlightControllerReady");

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -35,10 +35,27 @@ const logHead = "[SERIAL-BACKEND]";
 let mspHelper;
 let connectionTimestamp = null;
 let liveDataRefreshTimerId = false;
+// Handle for the BLE/manual reboot flush-timeout / reconnect-retry chain (rebootReconnect).
+// Tracked so an intentional disconnect during the reboot window can cancel it — otherwise the
+// retry would resurrect a connection the user just cancelled.
+let rebootReconnectTimerId = false;
 
 let isConnected = false;
 
+// True while an intentional disconnect (Disconnect button, or removed-device toggle)
+// is in flight. finishClose() owns the full teardown in that case; onClosed() uses this
+// flag to tell an intentional disconnect apart from an unexpected one (unplug / FC reboot
+// / BLE drop) and avoid tearing down twice. Set in beginDisconnect(), reset on connect,
+// and consumed (read-and-reset) in onClosed().
+let intentionalDisconnect = false;
+
 const REBOOT_CONNECT_MAX_TIME_MS = 10000;
+// BLE/manual links usually survive an FC reboot (the radio stays connected while only the
+// MCU restarts), so no disconnect event fires and we must drive the disconnect/reconnect
+// cycle ourselves. Wait for the reboot command to flush before dropping the stale link,
+// then retry reconnecting on this cadence until the FC answers or the reboot window closes.
+const REBOOT_FLUSH_DELAY_MS = 1500;
+const REBOOT_RECONNECT_RETRY_MS = 1000;
 let rebootTimestamp = 0;
 
 function isCliOnlyMode() {
@@ -51,7 +68,12 @@ const toggleStatus = function () {
 
 function connectHandler(event) {
     onOpen(event.detail);
-    toggleStatus();
+    // Only flip the connected flag when the port actually opened. A failed open
+    // (event.detail falsy) runs abortConnection inside onOpen; toggling here too would
+    // leave isConnected out of sync with the real state and break reconnect retries.
+    if (event.detail) {
+        toggleStatus();
+    }
 }
 
 function disconnectHandler(event) {
@@ -116,15 +138,47 @@ async function sendConfigTracking() {
     });
 }
 
-function beginDisconnect() {
+function stopRebootReconnect() {
+    if (rebootReconnectTimerId !== false) {
+        // The id may be a timeout (flush phase) or an interval (retry phase); clear both — they
+        // share an id space and clearing the wrong kind is harmless.
+        clearTimeout(rebootReconnectTimerId);
+        clearInterval(rebootReconnectTimerId);
+        rebootReconnectTimerId = false;
+    }
+}
+
+function prepareDisconnect() {
+    // Mark this as an intentional disconnect so the later protocol "disconnect" event
+    // (handled by onClosed) does not run the unexpected-disconnect teardown on top of
+    // finishClose(). Covers both the Disconnect button and the removedDevice route.
+    intentionalDisconnect = true;
+
+    // Cancel any in-flight reboot reconnect so a user-initiated disconnect during the reboot
+    // window is not undone by a retry. (The reboot retry itself reconnects via beginConnect,
+    // which does not pass through here, so the loop is unaffected.)
+    stopRebootReconnect();
+
     GUI.configuration_loaded = false;
     GUI.timeout_kill_all();
     GUI.interval_kill_all();
     GUI.tab_switch_cleanup(() => (GUI.tab_switch_in_progress = false));
+}
+
+function beginDisconnect() {
+    prepareDisconnect();
 
     mspHelper?.setArmingEnabled(true, false, function () {
         finishClose(toggleStatus);
     });
+}
+
+// Disconnect when the FC is rebooting: identical to beginDisconnect but WITHOUT the
+// setArmingEnabled MSP round-trip, which would hang waiting for a response the rebooting
+// FC cannot send. Tears the (now-stale) connection down directly.
+function disconnectForReboot() {
+    prepareDisconnect();
+    finishClose(toggleStatus);
 }
 
 // Explicit disconnect entry point. Safer than `connectDisconnect()` for
@@ -143,6 +197,12 @@ function canStartConnectionAction(selectedPort) {
 }
 
 function beginConnect(selectedPort) {
+    // Clear the intentional-disconnect guard on every connect attempt. A protocol whose
+    // disconnect() short-circuits (e.g. WebBluetooth when closeRequested is already set)
+    // may never dispatch the "disconnect" event that would otherwise consume the flag, so
+    // resetting here keeps a stale flag from downgrading a later unexpected disconnect.
+    intentionalDisconnect = false;
+
     // prevent connection when we do not have permission
     if (selectedPort.startsWith("requestpermission")) {
         return;
@@ -241,6 +301,42 @@ function defaultDisplayForTag(tag) {
     return tagDisplayCache[tag];
 }
 
+// Shared connection-scoped UI teardown, run by BOTH the intentional disconnect
+// (finishClose) and the unexpected disconnect (finishUnexpectedDisconnect) paths so the
+// two cannot drift. Deliberately scoped to the steps finishClose adds on top of
+// resetConnection() — it must NOT repeat resetConnection's work (listeners,
+// connectionValid/cli flags, live-data timer, portPickerDisabled).
+function teardownConnectionUi() {
+    MSP.disconnect_cleanup();
+    PortUsage.reset();
+    // To trigger the UI updates by Vue reset the state.
+    FC.resetState();
+
+    GUI.connected_to = false;
+    GUI.allowedTabs = GUI.defaultAllowedTabsWhenDisconnected.slice();
+    // Release any in-progress operation lock (OSD save / flashing). The disconnect
+    // invalidates that operation, and switchTab is silently rejected while the lock is
+    // held — which would otherwise leave a blank content area after unmountVueTab().
+    GUI.connect_lock = false;
+
+    // Clear the active root-mounted tab before navigation selects the next one.
+    try {
+        unmountVueTab();
+    } catch (e) {
+        console.warn("unmountVueTab failed:", e);
+    }
+
+    // allowedTabs (set above) must already include "landing"/"firmware_flasher" before this,
+    // or switchTab silently rejects the disconnected tab.
+    const pendingTab = GUI.pendingTab;
+    GUI.pendingTab = null;
+    if (pendingTab === "firmware_flasher") {
+        switchTab("firmware_flasher", { mode: "disconnected" });
+    } else {
+        switchTab("landing", { mode: "disconnected" });
+    }
+}
+
 function finishClose(finishedCallback) {
     const wasConnected = CONFIGURATOR.connectionValid;
 
@@ -255,14 +351,6 @@ function finishClose(finishedCallback) {
         onClosed(true);
     }
 
-    MSP.disconnect_cleanup();
-    PortUsage.reset();
-    // To trigger the UI updates by Vue reset the state.
-    FC.resetState();
-
-    GUI.connected_to = false;
-    GUI.allowedTabs = GUI.defaultAllowedTabsWhenDisconnected.slice();
-
     // close problems dialog
     document.getElementById("dialogReportProblems-closebtn")?.click();
 
@@ -270,13 +358,6 @@ function finishClose(finishedCallback) {
     PortHandler.portPickerDisabled = false;
 
     if (wasConnected) {
-        // Clear the active root-mounted tab before navigation selects the next one.
-        try {
-            unmountVueTab();
-        } catch (e) {
-            console.warn("unmountVueTab failed:", e);
-        }
-
         // close cliPanel if left open; dismiss Pinia dialogs (e.g. InteractiveDialog, or
         // InformationDialog from showVersionMismatchAndCli) so disconnect does not leave a modal open
         const dialogStore = useDialogStore();
@@ -286,15 +367,22 @@ function finishClose(finishedCallback) {
         }
     }
 
-    const pendingTab = GUI.pendingTab;
-    GUI.pendingTab = null;
-    if (pendingTab === "firmware_flasher") {
-        switchTab("firmware_flasher", { mode: "disconnected" });
-    } else {
-        switchTab("landing", { mode: "disconnected" });
-    }
+    teardownConnectionUi();
 
     finishedCallback();
+}
+
+// Complete the teardown for an UNEXPECTED disconnect (cable unplug / FC reboot / BLE drop).
+// finishClose() is never reached on this path because the protocol only emits a "disconnect"
+// event (no "removedDevice") for BLE/Capacitor/WebSocket/TCP. Deliberately does NOT call
+// mspHelper.setArmingEnabled — the link is already gone, so that MSP callback would never fire.
+function finishUnexpectedDisconnect() {
+    // Mirror the toggleStatus that finishClose runs via finishedCallback for intentional
+    // disconnects. Reset before the UI teardown so a late removedDevice cannot re-enter
+    // connectDisconnect() against a still-"connected" state.
+    isConnected = false;
+
+    teardownConnectionUi();
 }
 
 function setConnectionTimeout() {
@@ -732,6 +820,17 @@ function onClosed(result) {
     useDialogStore().close();
 
     resetConnection();
+
+    // onClosed runs for BOTH disconnect paths: intentional (finishClose → serial.disconnect()
+    // → protocol "disconnect" event, which fires on a later microtask) and unexpected (unplug /
+    // FC reboot / BLE drop). Read-and-reset the guard here — it cannot be cleared in finishClose(),
+    // which returns before this microtask runs. Intentional disconnects are already fully torn
+    // down by finishClose(); for unexpected ones complete the same UI teardown now.
+    const wasIntentional = intentionalDisconnect;
+    intentionalDisconnect = false;
+    if (!wasIntentional) {
+        finishUnexpectedDisconnect();
+    }
 }
 
 export function read_serial(info) {
@@ -802,11 +901,15 @@ export function reinitializeConnection(suppressDialog = false) {
     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
 
     if (currentPort.startsWith("bluetooth") || currentPort === "manual") {
-        if (PortHandler.portPicker.autoConnect) {
-            setTimeout(function () {
-                connectDisconnect();
-            }, 1500);
+        // BLE/manual links usually survive the FC reboot — the radio stays connected while
+        // only the MCU restarts — so no disconnect event fires and the configurator would be
+        // left holding a stale connection. Drive it ourselves: show the reboot dialog, drop
+        // the stale link once the command has flushed, then reconnect when Auto-Connect is on.
+        // The dialog polls connectionValid and closes on reconnect or timeout (same as serial).
+        if (!suppressDialog && !["cli", "presets"].includes(GUI.active_tab)) {
+            showRebootDialog();
         }
+        rebootReconnect();
         return rebootTimestamp;
     }
 
@@ -824,6 +927,48 @@ export function reinitializeConnection(suppressDialog = false) {
     }
 
     return rebootTimestamp;
+}
+
+// Drive the disconnect/reconnect cycle for a BLE/manual reboot. The link bounces (or survives)
+// as the FC restarts, and no single disconnect event marks "FC ready". Runs whether or not the
+// reboot dialog is shown.
+function rebootReconnect() {
+    const reconnect = PortHandler.portPicker.autoConnect;
+
+    // Cancel any prior reboot cycle (e.g. a second Save-and-Reboot within the window) so we
+    // never run two overlapping retry loops.
+    stopRebootReconnect();
+
+    rebootReconnectTimerId = setTimeout(() => {
+        // If the link survived the reboot, drop the now-stale connection so the UI returns to
+        // the landing tab instead of sitting on a dead connection. (disconnectForReboot ->
+        // prepareDisconnect calls stopRebootReconnect on the already-fired timeout — harmless.)
+        if (isConnected) {
+            disconnectForReboot();
+        }
+
+        // Honor Auto-Connect: when it is off, stay on the landing tab and let the user reconnect
+        // manually (the reboot dialog closes via its no-reconnect check).
+        if (!reconnect) {
+            rebootReconnectTimerId = false;
+            return;
+        }
+
+        // Retry connecting until the rebooted FC answers (connectionValid) or the reboot window
+        // closes. Early attempts may connect to a still-booting FC and get dropped; the device
+        // stays listed (we never remove it on disconnect), so a later attempt succeeds once the
+        // FC is stable. connectDisconnect here takes the connect branch (isConnected is false).
+        rebootReconnectTimerId = setInterval(() => {
+            const timedOut = Date.now() - rebootTimestamp > REBOOT_CONNECT_MAX_TIME_MS;
+            if (CONFIGURATOR.connectionValid || timedOut) {
+                stopRebootReconnect();
+                return;
+            }
+            if (!isConnected && !GUI.connecting_to) {
+                connectDisconnect();
+            }
+        }, REBOOT_RECONNECT_RETRY_MS);
+    }, REBOOT_FLUSH_DELAY_MS);
 }
 
 function showRebootDialog() {

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -409,9 +409,33 @@ describe("serial_backend BLE Save-and-Reboot reconnect", () => {
             // User hits Disconnect before/while the reboot reconnect is pending — it must be
             // cancelled, not resurrect the connection on a later tick.
             disconnect();
+            // Complete the disconnect (the mocked setArmingEnabled doesn't auto-invoke its
+            // callback) so module-private isConnected resets and doesn't leak into later tests.
+            mspHelperInstance.setArmingEnabled.mock.calls.at(-1)?.[2]?.();
 
             serial.connect.mockClear();
             vi.advanceTimersByTime(15000); // cover flush + the full retry window
+            expect(serial.connect).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("stops reconnect retries when Auto-Connect is turned off mid-reboot", () => {
+        vi.useFakeTimers();
+        try {
+            PortHandler.portPicker.selectedPort = "bluetooth_1";
+            PortHandler.portPicker.autoConnect = true;
+            establishConnection();
+
+            reinitializeConnection();
+            vi.advanceTimersByTime(1500); // flush -> disconnectForReboot, retry armed
+
+            // User turns Auto-Connect off before the first retry tick.
+            PortHandler.portPicker.autoConnect = false;
+            serial.connect.mockClear();
+
+            vi.advanceTimersByTime(5000); // several retry ticks
             expect(serial.connect).not.toHaveBeenCalled();
         } finally {
             vi.useRealTimers();

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -1,0 +1,420 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+// ---------------------------------------------------------------------------
+// serial_backend.js pulls in a very large import graph (MSP, MSPHelper, FC,
+// localization, Analytics, BuildApi, crypto, ...). We mock every collaborator
+// so the module loads in isolation and we can drive the connect/disconnect
+// event handlers directly and observe the UI-teardown side effects.
+// ---------------------------------------------------------------------------
+
+// vi.mock factories are hoisted above all module-level declarations, so any
+// shared mutable objects they reference must be created with vi.hoisted().
+const { GUI, serial, serialHandlers, unmountVueTab, switchTab, dialogStore, mspHelperInstance } = vi.hoisted(() => {
+    const serialHandlers = {};
+    return {
+        // GUI default object — only the members serial_backend touches.
+        GUI: {
+            connect_lock: false,
+            connected_to: false,
+            connecting_to: false,
+            configuration_loaded: false,
+            active_tab: "landing",
+            tab_switch_in_progress: false,
+            allowedTabs: [],
+            defaultAllowedTabsWhenDisconnected: ["landing", "firmware_flasher"],
+            defaultAllowedFCTabsWhenConnected: [],
+            defaultAllowedTabs: [],
+            defaultCloudBuildTabOptions: [],
+            pendingTab: null,
+            timeout_kill_all: vi.fn(),
+            interval_kill_all: vi.fn(),
+            timeout_add: vi.fn(),
+            timeout_remove: vi.fn(),
+            tab_switch_cleanup: vi.fn((cb) => cb && cb()),
+            showCliPanel: vi.fn(),
+            selectDefaultTabWhenConnected: vi.fn(),
+        },
+        // serial: capture the connect/disconnect handlers registered by beginConnect.
+        serialHandlers,
+        serial: {
+            connected: false,
+            addEventListener: vi.fn((type, handler) => {
+                serialHandlers[type] = handler;
+            }),
+            removeEventListener: vi.fn(),
+            connect: vi.fn(),
+            disconnect: vi.fn(),
+            forceClose: vi.fn(),
+        },
+        unmountVueTab: vi.fn(),
+        switchTab: vi.fn(),
+        dialogStore: {
+            activeDialog: null,
+            open: vi.fn(),
+            close: vi.fn(),
+        },
+        mspHelperInstance: {
+            setArmingEnabled: vi.fn(),
+            process_data: vi.fn(),
+            crunch: vi.fn(() => []),
+            RESET_TYPES: { CUSTOM_DEFAULTS: 0 },
+        },
+    };
+});
+
+vi.mock("../../src/js/gui.js", () => ({
+    __esModule: true,
+    default: GUI,
+    TABS: {},
+}));
+
+vi.mock("../../src/js/serial.js", () => ({
+    __esModule: true,
+    serial,
+}));
+
+// MSP — send_message is a no-op so onOpen's MSP chain stalls harmlessly
+// (its callback never fires, so nothing past MSP_API_VERSION runs).
+vi.mock("../../src/js/msp", () => ({
+    __esModule: true,
+    default: {
+        send_message: vi.fn(),
+        promise: vi.fn(() => Promise.resolve()),
+        listen: vi.fn(),
+        clearListeners: vi.fn(),
+        disconnect_cleanup: vi.fn(),
+        read: vi.fn(),
+    },
+}));
+
+vi.mock("../../src/js/msp/MSPHelper", () => ({
+    __esModule: true,
+    default: vi.fn(() => mspHelperInstance),
+}));
+
+vi.mock("../../src/js/msp/MSPCodes", () => ({
+    __esModule: true,
+    default: new Proxy({}, { get: (_t, p) => p }),
+}));
+
+vi.mock("../../src/js/port_usage", () => ({
+    __esModule: true,
+    default: { initialize: vi.fn(), reset: vi.fn() },
+}));
+
+vi.mock("../../src/js/port_handler", () => ({
+    __esModule: true,
+    default: {
+        initialize: vi.fn(),
+        portPickerDisabled: false,
+        portAvailable: false,
+        portPicker: {
+            selectedPort: "/dev/ttyACM0",
+            portOverride: "/dev/ttyACM0",
+            selectedBauds: 115200,
+            autoConnect: false,
+            virtualMspVersion: "1.46.0",
+        },
+    },
+}));
+
+vi.mock("../../src/js/vue_tab_mounter", () => ({
+    __esModule: true,
+    unmountVueTab,
+}));
+
+vi.mock("../../src/js/tab_switch", () => ({
+    __esModule: true,
+    switchTab,
+}));
+
+vi.mock("../../src/stores/dialog", () => ({
+    __esModule: true,
+    useDialogStore: () => dialogStore,
+}));
+
+vi.mock("../../src/stores/connection", () => ({
+    __esModule: true,
+    useConnectionStore: () => ({ liveDataPaused: false }),
+}));
+
+vi.mock("../../src/js/fc", () => ({
+    __esModule: true,
+    default: {
+        CONFIG: {
+            apiVersion: "1.47.0",
+            flightControllerVersion: "",
+            flightControllerIdentifier: "BTFL",
+            boardType: 0,
+            buildOptions: [],
+        },
+        FEATURE_CONFIG: { features: {} },
+        BEEPER_CONFIG: {},
+        TARGET_CAPABILITIES_FLAGS: {},
+        CONFIGURATION_STATES: {},
+        CONFIGURATION_PROBLEM_FLAGS: {},
+        resetState: vi.fn(),
+    },
+}));
+
+vi.mock("../../src/js/data_storage", () => ({
+    __esModule: true,
+    default: {
+        connectionValid: false,
+        cliValid: false,
+        cliActive: false,
+        virtualMode: false,
+        API_VERSION_ACCEPTED: "1.46.0",
+    },
+    API_VERSION_1_45: "1.45.0",
+    API_VERSION_1_46: "1.46.0",
+    API_VERSION_1_47: "1.47.0",
+}));
+
+vi.mock("../../src/js/Analytics", () => ({
+    __esModule: true,
+    tracking: {
+        sendEvent: vi.fn(),
+        EVENT_CATEGORIES: { FLIGHT_CONTROLLER: "fc" },
+    },
+}));
+
+vi.mock("../../src/js/localization", () => ({
+    __esModule: true,
+    i18n: { getMessage: (k) => k },
+}));
+
+vi.mock("../../src/js/gui_log", () => ({
+    __esModule: true,
+    gui_log: vi.fn(),
+}));
+
+// Remaining graph members that get imported but are not central to these tests.
+vi.mock("../../src/js/Features", () => ({ __esModule: true, default: vi.fn() }));
+vi.mock("../../src/js/Beepers", () => ({ __esModule: true, default: vi.fn() }));
+vi.mock("../../src/js/VirtualFC", () => ({
+    __esModule: true,
+    default: { setVirtualConfig: vi.fn() },
+}));
+vi.mock("../../src/js/BuildApi", () => ({ __esModule: true, default: vi.fn() }));
+vi.mock("../../src/js/bit.js", () => ({ __esModule: true, bit_check: () => false }));
+vi.mock("../../src/js/sensor_helpers", () => ({ __esModule: true, have_sensor: () => false }));
+vi.mock("../../src/js/utils/updateTabList", () => ({ __esModule: true, updateTabList: vi.fn() }));
+vi.mock("../../src/js/utils/applyExpertMode", () => ({ __esModule: true, applyExpertMode: vi.fn() }));
+vi.mock("../../src/js/ConfigStorage", () => ({ __esModule: true, get: () => ({}) }));
+vi.mock("../../src/js/utils/connection", () => ({ __esModule: true, ispConnected: () => false }));
+vi.mock("../../src/components/eventBus", () => ({
+    __esModule: true,
+    EventBus: { $on: vi.fn(), $emit: vi.fn() },
+}));
+
+import { connectDisconnect, disconnect, reinitializeConnection } from "../../src/js/serial_backend";
+import PortHandler from "../../src/js/port_handler";
+
+// Reset all mock state and bring the module to a known DISCONNECTED state
+// before each test. Because module-private state (isConnected,
+// intentionalDisconnect) persists across tests in the same module instance,
+// each test that needs a connection establishes it explicitly and tears it
+// down so the next test starts clean.
+function resetMocks() {
+    vi.clearAllMocks();
+    Object.keys(serialHandlers).forEach((k) => delete serialHandlers[k]);
+    GUI.connect_lock = false;
+    GUI.connected_to = false;
+    GUI.connecting_to = false;
+    GUI.pendingTab = null;
+    GUI.allowedTabs = [];
+    serial.connected = false;
+    dialogStore.activeDialog = null;
+    // Restore the port picker (the reboot test mutates these).
+    PortHandler.portPicker.selectedPort = "/dev/ttyACM0";
+    PortHandler.portPicker.autoConnect = false;
+}
+
+// Drive the module into a "connected" state without the heavy MSP chain.
+// connectDisconnect() (disconnected branch) -> beginConnect() registers the
+// handlers and calls serial.connect(); we then fire the captured "connect"
+// handler which calls onOpen() (MSP chain stalls on the mocked no-op
+// send_message) and toggleStatus() -> module isConnected becomes true.
+function establishConnection() {
+    connectDisconnect();
+    expect(serial.connect).toHaveBeenCalled();
+    // onOpen needs connecting_to so connected_to is set; beginConnect set it.
+    serialHandlers.connect({ detail: true });
+}
+
+describe("serial_backend disconnect convergence", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        resetMocks();
+    });
+
+    it("UNEXPECTED disconnect runs the shared UI teardown", () => {
+        establishConnection();
+
+        // Sanity: connect path registered a disconnect handler.
+        expect(typeof serialHandlers.disconnect).toBe("function");
+
+        // Pre-teardown baseline.
+        switchTab.mockClear();
+        unmountVueTab.mockClear();
+        GUI.connect_lock = true; // simulate an in-progress operation lock
+        GUI.connected_to = "/dev/ttyACM0";
+
+        // Fire the protocol "disconnect" event -> disconnectHandler -> onClosed(true).
+        serialHandlers.disconnect({ detail: true });
+
+        expect(switchTab).toHaveBeenCalledWith("landing", { mode: "disconnected" });
+        expect(unmountVueTab).toHaveBeenCalledTimes(1);
+        expect(GUI.connect_lock).toBe(false);
+        expect(GUI.connected_to).toBe(false);
+    });
+
+    it("UNEXPECTED disconnect does NOT call mspHelper.setArmingEnabled", () => {
+        establishConnection();
+        mspHelperInstance.setArmingEnabled.mockClear();
+
+        serialHandlers.disconnect({ detail: true });
+
+        expect(mspHelperInstance.setArmingEnabled).not.toHaveBeenCalled();
+    });
+
+    it("after an UNEXPECTED disconnect, module isConnected is reset (next action takes connect branch)", () => {
+        establishConnection();
+        serialHandlers.disconnect({ detail: true });
+
+        // If isConnected were still true, connectDisconnect would take the
+        // disconnect branch. It must instead attempt a fresh connect.
+        serial.connect.mockClear();
+        connectDisconnect();
+
+        expect(serial.connect).toHaveBeenCalled();
+    });
+
+    it("INTENTIONAL disconnect does NOT double-fire teardown on the later disconnect event", () => {
+        establishConnection();
+
+        switchTab.mockClear();
+        unmountVueTab.mockClear();
+
+        // User presses Disconnect -> exported disconnect() -> beginDisconnect()
+        // sets intentionalDisconnect = true and (because mspHelper exists)
+        // invokes the setArmingEnabled callback synchronously in our mock?
+        // Our mock does NOT call the callback, so finishClose runs only when
+        // the callback fires. To exercise the guard deterministically, invoke
+        // the setArmingEnabled callback ourselves to run finishClose once.
+        mspHelperInstance.setArmingEnabled.mockClear();
+        disconnect();
+
+        // beginDisconnect should have requested arming-enable with a callback.
+        expect(mspHelperInstance.setArmingEnabled).toHaveBeenCalledTimes(1);
+        const finishClose = mspHelperInstance.setArmingEnabled.mock.calls[0][2];
+        expect(typeof finishClose).toBe("function");
+
+        // Run the intentional teardown (finishClose) once.
+        finishClose();
+        const switchTabCallsAfterIntentional = switchTab.mock.calls.length;
+        expect(switchTabCallsAfterIntentional).toBeGreaterThanOrEqual(1);
+
+        // Now the protocol emits its "disconnect" event on a later microtask.
+        // The guard (intentionalDisconnect) should make onClosed skip the
+        // unexpected-disconnect teardown -> no ADDITIONAL switchTab call.
+        serialHandlers.disconnect({ detail: true });
+
+        expect(switchTab.mock.calls.length).toBe(switchTabCallsAfterIntentional);
+    });
+
+    it("a FAILED open does not mark the module connected (reconnect retries keep working)", () => {
+        connectDisconnect();
+        expect(serial.connect).toHaveBeenCalled();
+
+        // Fire the connect handler with a falsy detail = open failed.
+        serialHandlers.connect({ detail: false });
+
+        // isConnected must stay false: the next action attempts a fresh connect,
+        // not a disconnect. (Before the fix, connectHandler toggled unconditionally.)
+        serial.connect.mockClear();
+        connectDisconnect();
+        expect(serial.connect).toHaveBeenCalled();
+    });
+});
+
+describe("serial_backend BLE Save-and-Reboot reconnect", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        resetMocks();
+    });
+
+    it("drops the stale link after the flush delay, then retries connecting (auto-connect on)", () => {
+        vi.useFakeTimers();
+        try {
+            PortHandler.portPicker.selectedPort = "bluetooth_1";
+            PortHandler.portPicker.autoConnect = true;
+            establishConnection();
+
+            serial.disconnect.mockClear();
+            serial.connect.mockClear();
+
+            reinitializeConnection();
+
+            // Nothing happens until the reboot command has had time to flush.
+            expect(serial.disconnect).not.toHaveBeenCalled();
+
+            // After the flush delay the surviving link is torn down cleanly.
+            vi.advanceTimersByTime(1500);
+            expect(serial.disconnect).toHaveBeenCalled();
+
+            // Then the retry loop reconnects (device stays listed, so connect-by-path works).
+            vi.advanceTimersByTime(1000);
+            expect(serial.connect).toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("does not auto-reconnect when auto-connect is off (clean disconnect only)", () => {
+        vi.useFakeTimers();
+        try {
+            PortHandler.portPicker.selectedPort = "bluetooth_1";
+            PortHandler.portPicker.autoConnect = false;
+            establishConnection();
+
+            serial.disconnect.mockClear();
+            serial.connect.mockClear();
+
+            reinitializeConnection();
+            vi.advanceTimersByTime(1500);
+
+            // Stale link dropped...
+            expect(serial.disconnect).toHaveBeenCalled();
+
+            // ...but no reconnect attempts over the rest of the reboot window.
+            vi.advanceTimersByTime(10000);
+            expect(serial.connect).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    it("an intentional disconnect during the reboot window cancels the reconnect retry", () => {
+        vi.useFakeTimers();
+        try {
+            PortHandler.portPicker.selectedPort = "bluetooth_1";
+            PortHandler.portPicker.autoConnect = true;
+            establishConnection();
+
+            reinitializeConnection(); // schedules the reboot reconnect
+
+            // User hits Disconnect before/while the reboot reconnect is pending — it must be
+            // cancelled, not resurrect the connection on a later tick.
+            disconnect();
+
+            serial.connect.mockClear();
+            vi.advanceTimersByTime(15000); // cover flush + the full retry window
+            expect(serial.connect).not.toHaveBeenCalled();
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Over Bluetooth (WebBluetooth), an unexpected disconnect — cable/dongle
unplug, FC power-off, or the reboot from **Save and Reboot** — left the
configurator stuck: the Connect button was dead and the last tab kept
showing. Serial was unaffected. This converges the disconnect handling so
BLE recovers like serial does.

Root cause: BLE never fires the `removedDevice` event the old recovery path
relied on. The reliable signal is the device-level `gattserverdisconnected`
→ `"disconnect"` → `onClosed`, which only did a *partial* teardown (it left
`GUI.connected_to` set, the module `isConnected` flag true, and never
switched tabs). Save-and-Reboot is worse: the BLE radio keeps the link up
while only the MCU restarts, so **no** disconnect event fires at all.

## Changes

- **`serial_backend.js`** — `onClosed` now completes the full teardown for
  unexpected disconnects (`finishUnexpectedDisconnect` via a shared
  `teardownConnectionUi()`), gated by an `intentionalDisconnect` flag so the
  intentional path (which already tears down in `finishClose`) doesn't run
  twice. Returns to the landing tab with a working Connect button.
- **Save-and-Reboot over BLE/manual** — `rebootReconnect()` drops the stale
  link after the reboot command flushes, then (Auto-Connect gated) retries
  connecting until the FC is back; `disconnectForReboot()` skips the arming
  MSP round-trip that would hang on a rebooting FC. Reboot timers are tracked
  and cancelled on an intentional disconnect so a retry can't resurrect a
  connection the user just cancelled.
- **`connectHandler`** only marks the session connected on a *successful*
  open (a failed open no longer wedges reconnect).
- **`WebBluetooth.js`** — null-guard `disconnect()` cleanup (fixes a
  `TypeError` that crashed reconnect after a partial teardown) and make
  teardown single-fire via `closeRequested`. The paired device stays listed
  and reconnects by path (removing it on transient BLE drops forced needless
  re-discovery).

## Test plan

- `test/js/serial_backend.test.js` (new): unexpected vs intentional teardown,
  no `setArmingEnabled` on a dead link, `isConnected` reset, failed-open,
  BLE reboot reconnect (Auto-Connect on/off), and intentional-disconnect
  cancels the reboot retry. **134 tests pass** (`npm run test`), lint clean.
- Hardware-verified (SpeedyBee F405 Mini, BLE): (1) Save-and-Reboot
  Auto-Connect ON → reconnects, device stays listed; (2) Save-and-Reboot
  Auto-Connect OFF → clean disconnect to landing; (3) unplug/power-off →
  lands on landing, reconnects; (4) user Disconnect → lands on landing,
  reconnects.

## Notes / follow-ups (out of scope)

- Reconnect to a still-booting FC may take an extra Connect click (transient
  `crc`/`norevis`) — never strands the UI.
- Pre-existing: `WebBluetooth.disconnect()` `removeEventListener` calls are
  no-ops (bind-ref mismatch); the new `closeRequested` guard covers re-entry.
  A bind-once fix was tried and reverted — it makes `gatt.disconnect()`
  actually drop the surviving link and breaks reboot reconnect, so it needs
  care.
- Retiring the non-reactive module `isConnected` in favour of
  `CONFIGURATOR.connectionValid` would remove the underlying dual-source-of-
  truth fragility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Bluetooth disconnect handling that better separates intentional vs unexpected teardowns, reducing spurious cleanup errors.
  * Fixed connection-state desyncs during rapid connect/disconnect sequences and improved UI stability during transitions.
* **New Features**
  * Improved reboot reconnect flow with robust retry behavior and clearer reboot dialog progress.
* **Tests**
  * Added comprehensive backend tests covering connect/reconnect and disconnect scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->