### PR TITLE
fix(pid): use FC.CONFIG.numProfiles for profile count

### DIFF
--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -164,6 +164,9 @@ const pidSubTab = ref(null);
 const filterSubTab = ref(null);
 const ratesSubTab = ref(null);
 
+// Profile count — matches original loadProfilesList() logic
+const numberOfProfiles = computed(() => FC.CONFIG.numProfiles ?? 3);
+
 // Rate profile count — matches original loadRateProfilesList() logic
 const numberOfRateProfiles = computed(() => {
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
@@ -175,7 +178,7 @@ const numberOfRateProfiles = computed(() => {
 // Items arrays for USelect / UTabs
 const profileItems = computed(() => {
     const items = [];
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < numberOfProfiles.value; i++) {
         items.push({ label: i18n.getMessage("pidTuningProfileOption", [i + 1]), value: i });
     }
     return items;
@@ -334,7 +337,7 @@ async function onRateProfileChange() {
 async function copyProfile() {
     // Create options for profiles excluding current one
     const options = [];
-    for (let i = 0; i < 3; i++) {
+    for (let i = 0; i < numberOfProfiles.value; i++) {
         if (i !== currentProfile.value) {
             const name = i18n.getMessage("pidTuningProfileOption", [i + 1]);
             options.push({ value: i, label: name });


### PR DESCRIPTION
## Summary

Fixes a regression between `2025.12-maintenance` and `master`: `FC.CONFIG.numProfiles` is no longer used to determine the number of PID profiles in the PID tuning tab.

During the Vue 3 migration of the PID tuning tab (#4848), the profile count was hardcoded to `3` in two places, ignoring `FC.CONFIG.numProfiles` — even though it is still read from MSP in `MSPHelper.js`. The legacy `pid_tuning.js` used:

```js
const numberOfProfiles = FC.CONFIG.numProfiles;
```

Note: the *rate* profile count was migrated correctly via a `numberOfRateProfiles` computed — only the regular profile count regressed.

## Changes

`src/components/tabs/PidTuningTab.vue`:
- Added `numberOfProfiles` computed (`FC.CONFIG.numProfiles ?? 3`), mirroring the existing `numberOfRateProfiles` pattern
- `profileItems` loop now uses `numberOfProfiles.value` instead of hardcoded `3`
- `copyProfile` loop now uses `numberOfProfiles.value` instead of hardcoded `3`

## Testing

- [ ] Profile selector lists the firmware-reported number of profiles
- [ ] Copy-profile dialog offers the correct set of target profiles

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated PID tuning profile management to dynamically adapt to the configured number of profiles, ensuring profile operations function correctly across all configured profiles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->