### PR TITLE
fix(port-picker): guard disconnectLabel against non-string connectedTo

### DIFF
--- a/src/components/port-picker/ConnectButton.vue
+++ b/src/components/port-picker/ConnectButton.vue
@@ -100,7 +100,7 @@ export default defineComponent({
             if (isVirtualMode.value) {
                 return i18n.getMessage("disconnectVirtual");
             }
-            const path = connectedTo.value ?? "";
+            const path = connectedTo.value || "";
             if (path.startsWith("bluetooth")) {
                 return i18n.getMessage("disconnectBluetooth");
             }


### PR DESCRIPTION
AI Generated pull-request

## Summary

- `GUI.connected_to` is initialised to `false` (not `null`/`undefined`)
- The `disconnectLabel` computed used `connectedTo.value ?? ""` — nullish coalescing passes `false` through unchanged
- `false.startsWith("bluetooth")` throws `TypeError: S.startsWith is not a function` after disconnect
- Fix: replace `??` with `||` so any falsy value (`false`, `null`, `undefined`) falls back to `""`

Reported by @haslinghuis after USB disconnect with PR #5145.

## Test plan
- [x] Build passes
- [x] Connect via USB, click Disconnect — no console TypeError
- [x] Connect via Bluetooth, click Disconnect — label shows "Disconnect (Bluetooth)" (pending @haslinghuis hardware verification)
- [x] Connect via Virtual, click Disconnect — label shows "Disconnect (Virtual)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the disconnect button label handling to properly handle certain falsy values in connection states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->