### PR TITLE
improve OSD link quality and RSSI descriptions

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6084,7 +6084,14 @@
         "description": "One of the elements of the OSD"
     },
     "osdDescElementRssiValue": {
-        "message": "Instantaneous RSSI value (flashes when below alarm threshold)"
+        "message": "Instantaneous RSSI value (flashes when below alarm threshold). For modern protocols, use RSSI dBm instead."
+    },
+    "osdTextElementRssiDbmValue": {
+        "message": "RSSI dBm value",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRssiDbmValue": {
+        "message": "Received Signal Strength Indicator, this value indicates how loud the reception is in dBm"
     },
     "osdTextElementTimer": {
         "message": "Timer",
@@ -6675,7 +6682,7 @@
         "description": "One of the elements of the OSD"
     },
     "osdDescElementLinkQuality": {
-        "message": "Alternative indicator for 'link quality' based on frame loss - use with caution"
+        "message": "Link quality indicator based on the percentage of successfully received uncorrupted data packets"
     },
     "osdTextElementFlightDist": {
         "message": "Flight distance",
@@ -6739,13 +6746,6 @@
     },
     "osdDescElementOsdProfileName": {
         "message": "OSD profile name as set in the \"osd_profile_1_name\", \"osd_profile_2_name\" and \"osd_profile_3_name\" CLI variables"
-    },
-    "osdTextElementRssiDbmValue": {
-        "message": "RSSI dBm value",
-        "description": "One of the elements of the OSD"
-    },
-    "osdDescElementRssiDbmValue": {
-        "message": "Value in dBm of the RSSI signal if available"
     },
     "osdTextElementRcChannels": {
         "message": "RC Channels",


### PR DESCRIPTION
I've noticed from discussions in the local chat that the description for LQ has fallen a bit behind current realities and is misleading people. Users read the warning and end up not using this element.
also grouped RSSI elements and aaded a hint to use rssi dbm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined RSSI signal strength descriptions with updated guidance for modern protocols.
  * Added RSSI measurement in dBm (decibel-milliwatts) display option.
  * Clarified link quality metric description for improved user understanding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->