### PR TITLE
feat(receiver): warn when channel values are failsafe output

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2598,6 +2598,12 @@
     "receiverHelp": {
         "message": "&#8226;  <b><strong><a href=\"https://betaflight.com/docs/wiki/guides/current/Failsafe#testing-failsafe\" target=\"_blank\" rel=\"noopener noreferrer\">Always check that your Failsafe is working properly!</a></strong></b> The settings are in the Failsafe tab, which requires Expert Mode.<br> &#8226; <b>Use the latest Tx firmware!</b><br> &#8226; <strong><a href=\"https://betaflight.com/docs/development/Rx#disabling-the-opentxedgetx-adc-filter\" target=\"_blank\" rel=\"noopener noreferrer\">Disable the hardware ADC filter</a></strong> in the Transmitter if using OpenTx or EdgeTx.<br>Basic Setup: Configure the 'Receiver' settings correctly. Choose the correct ‘Channel Map’ for your radio. Check that the Roll, Pitch and other bar graphs move correctly. Adjust the channel endpoint or range values in the transmitter to ~1000 to ~2000, and set the midpoint to 1500. For more information, read the <strong><a href=\"https://betaflight.com/docs/development/Rx\" target=\"_blank\" rel=\"noopener noreferrer\">documentation</a></strong>."
     },
+    "receiverFailsafeActiveTitle": {
+        "message": "Failsafe active"
+    },
+    "receiverFailsafeActiveWarning": {
+        "message": "The flight controller is in failsafe. The channel values shown below are the failsafe output, not the live values coming from your receiver. Check your receiver link and failsafe settings."
+    },
     "receiverThrottleMid": {
         "message": "Throttle MID"
     },

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -15,6 +15,16 @@
                             <canvas ref="modelCanvas"></canvas>
                         </div>
                     </UiBox>
+                    <!-- Failsafe / RX-loss warning -->
+                    <UiBox
+                        v-if="failsafeActive"
+                        highlight
+                        type="warning"
+                        role="alert"
+                        :title="$t('receiverFailsafeActiveTitle')"
+                    >
+                        <p>{{ $t("receiverFailsafeActiveWarning") }}</p>
+                    </UiBox>
                     <!-- Channel Bars -->
                     <div class="bars">
                         <ul v-for="(channel, index) in channelBars" :key="index">
@@ -25,7 +35,7 @@
                                     :max="100"
                                     :ui="{
                                         base: 'w-full bg-elevated',
-                                        indicator: 'duration-50',
+                                        indicator: failsafeActive ? 'duration-50 !bg-warning' : 'duration-50',
                                     }"
                                     :disabled="rc.active_channels === 0"
                                     size="xl"
@@ -610,6 +620,11 @@ const rssiConfig = computed(() => fcStore.rssiConfig);
 const features = computed(() => fcStore.features);
 
 const rcDeadbandConfig = computed(() => fcStore.rcDeadbandConfig);
+
+// Failsafe / RX-loss indicator — detection lives in the fc store (reads the raw
+// armingDisableFlags bitmask). True when the FC is in failsafe or has lost the
+// RX link, so the banner/tint warn that channel values are failsafe output.
+const failsafeActive = computed(() => fcStore.failsafeActive);
 
 // Dirty state tracking
 const savedSnapshot = ref("");

--- a/src/stores/fc.js
+++ b/src/stores/fc.js
@@ -2,6 +2,25 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 import FC from "../js/fc";
 import semver from "semver";
+import { bit_check } from "../js/bit";
+
+// Failsafe / RX-loss detection from CONFIG.armingDisableFlags.
+// NOTE: these are BIT POSITIONS (the `bit` arg to bit_check), NOT the firmware
+// mask values. They deliberately do NOT mirror the firmware enum literals
+// (ARMING_DISABLED_FAILSAFE = 1<<1, RX_FAILSAFE = 1<<2, BOXFAILSAFE = 1<<4).
+// Naming them `*_BIT` prevents a "correction" to mask values that would silently
+// break detection. Positions match SetupTab disarmFlagElements ordering (idx
+// 1/2/4) and are stable across all API versions (only bits >=20 get remapped).
+export const FAILSAFE_BIT = 1; // ARMING_DISABLED_FAILSAFE
+export const RX_FAILSAFE_BIT = 2; // ARMING_DISABLED_RX_FAILSAFE (shown elsewhere as RXLOSS)
+export const BOXFAILSAFE_BIT = 4; // ARMING_DISABLED_BOXFAILSAFE (failsafe aux switch)
+
+// Pure detector — true when failsafe/RX-loss is asserted by the FC. Exported so
+// it can be unit-tested directly against the same logic the store/getter uses.
+export function isFailsafeActive(armingDisableFlags) {
+    const flags = armingDisableFlags ?? 0;
+    return bit_check(flags, FAILSAFE_BIT) || bit_check(flags, RX_FAILSAFE_BIT) || bit_check(flags, BOXFAILSAFE_BIT);
+}
 
 export const useFlightControllerStore = defineStore("flightController", () => {
     // Proxy state directly to legacy reactive objects
@@ -287,6 +306,11 @@ export const useFlightControllerStore = defineStore("flightController", () => {
         return armingFlags.value.filter((f) => f.visible).map((f) => f.name);
     });
 
+    // Failsafe / RX-loss indicator. Reads the raw armingDisableFlags bitmask
+    // (NOT activeFlagNames, which is only populated by the Setup tab), so it is
+    // valid on any tab and while disarmed on the bench.
+    const failsafeActive = computed(() => isFailsafeActive(config.value?.armingDisableFlags));
+
     // Constants (delegated from FC)
     const TARGET_CAPABILITIES_FLAGS = FC.TARGET_CAPABILITIES_FLAGS;
 
@@ -374,6 +398,7 @@ export const useFlightControllerStore = defineStore("flightController", () => {
         updateArmingFlags,
         isReadyToArm,
         activeFlagNames,
+        failsafeActive,
         isApiVersionSupported,
         isApiVersionLessThan,
         TARGET_CAPABILITIES_FLAGS,

--- a/test/js/tabs/receiver_failsafe.test.js
+++ b/test/js/tabs/receiver_failsafe.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { bit_check, bit_set } from "../../../src/js/bit.js";
+import { isFailsafeActive, FAILSAFE_BIT, RX_FAILSAFE_BIT, BOXFAILSAFE_BIT } from "../../../src/stores/fc.js";
+
+// ---------------------------------------------------------------------------
+// ReceiverTab.vue adds a failsafe / RX-loss warning banner driven by
+// `fcStore.failsafeActive`, whose detection lives in `isFailsafeActive` in
+// src/stores/fc.js. We import the REAL detector (and the REAL bit constants)
+// here, so this is a genuine regression guard: if someone "corrects" a
+// constant to a firmware mask value (1 << 1 etc.), these tests go red.
+//
+// The constants are BIT POSITIONS (the second arg to bit_check), not the
+// firmware mask values.
+// ---------------------------------------------------------------------------
+
+describe("ReceiverTab failsafe detection", () => {
+    describe("bit constants are positions, not masks", () => {
+        it("uses positions 1 / 2 / 4", () => {
+            expect(FAILSAFE_BIT).toBe(1);
+            expect(RX_FAILSAFE_BIT).toBe(2);
+            expect(BOXFAILSAFE_BIT).toBe(4);
+        });
+
+        it("bit_check checks bit POSITION, not mask value", () => {
+            // value 2 == bit position 1 set
+            expect(bit_check(0b10, 1)).toBe(true);
+            // value 2 does NOT have bit position 2 set
+            expect(bit_check(0b10, 2)).toBe(false);
+        });
+    });
+
+    describe("active flags (banner shown)", () => {
+        it("returns true when only FAILSAFE (pos 1) is set", () => {
+            expect(isFailsafeActive(bit_set(0, FAILSAFE_BIT))).toBe(true); // value 2
+        });
+
+        it("returns true when only RX_FAILSAFE (pos 2) is set", () => {
+            expect(isFailsafeActive(bit_set(0, RX_FAILSAFE_BIT))).toBe(true); // value 4
+        });
+
+        it("returns true when only BOXFAILSAFE (pos 4) is set", () => {
+            expect(isFailsafeActive(bit_set(0, BOXFAILSAFE_BIT))).toBe(true); // value 16
+        });
+
+        it("returns true for raw mask values 2, 4 and 16", () => {
+            expect(isFailsafeActive(2)).toBe(true);
+            expect(isFailsafeActive(4)).toBe(true);
+            expect(isFailsafeActive(16)).toBe(true);
+        });
+
+        it("returns true when multiple failsafe bits are set together", () => {
+            let flags = 0;
+            flags = bit_set(flags, FAILSAFE_BIT);
+            flags = bit_set(flags, RX_FAILSAFE_BIT);
+            flags = bit_set(flags, BOXFAILSAFE_BIT);
+            expect(isFailsafeActive(flags)).toBe(true); // value 22
+        });
+
+        it("returns true when a failsafe bit is set alongside unrelated bits", () => {
+            let flags = 0;
+            flags = bit_set(flags, 7); // THROTTLE
+            flags = bit_set(flags, 12); // CALIBRATING
+            flags = bit_set(flags, RX_FAILSAFE_BIT); // the only relevant one
+            expect(isFailsafeActive(flags)).toBe(true);
+        });
+    });
+
+    describe("inactive flags (banner hidden)", () => {
+        it("returns false when no flags are set", () => {
+            expect(isFailsafeActive(0)).toBe(false);
+        });
+
+        it("returns false for undefined/null flags (optional chaining fallback)", () => {
+            expect(isFailsafeActive(undefined)).toBe(false);
+            expect(isFailsafeActive(null)).toBe(false);
+        });
+
+        it("returns false for unrelated bit ARMED (pos 0, value 1)", () => {
+            expect(isFailsafeActive(bit_set(0, 0))).toBe(false); // value 1
+        });
+
+        it("returns false for unrelated bit at pos 3 (value 8, between our bits)", () => {
+            expect(isFailsafeActive(bit_set(0, 3))).toBe(false); // value 8
+        });
+
+        it("returns false for THROTTLE (pos 7) only", () => {
+            expect(isFailsafeActive(bit_set(0, 7))).toBe(false); // value 128
+        });
+
+        it("returns false for CALIBRATING (pos 12) only", () => {
+            expect(isFailsafeActive(bit_set(0, 12))).toBe(false); // value 4096
+        });
+
+        it("returns false for several unrelated bits set together", () => {
+            let flags = 0;
+            flags = bit_set(flags, 0); // ARMED
+            flags = bit_set(flags, 3);
+            flags = bit_set(flags, 7); // THROTTLE
+            flags = bit_set(flags, 12); // CALIBRATING
+            expect(isFailsafeActive(flags)).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #5157.

When the flight controller is in failsafe (RX loss or failsafe switch), the firmware substitutes the live receiver channel values with failsafe values, and `MSP_RC` returns those substituted values. The Receiver tab displayed them with no indication that failsafe was active — so the channels appear stuck at neutral and the receiver looks broken. The issue reporter lost ~4 hours debugging an Ethos Ch8 default that silently tripped failsafe.

This adds a clear indication on the Receiver tab when failsafe/RX-loss is active:

- **Warning banner** above the channel bars explaining that the values shown are failsafe output, not live receiver input.
- **Channel bars tinted** warning-orange while failsafe is active.

Detection reads the existing `CONFIG.armingDisableFlags` bitmask (`FAILSAFE` / `RX_FAILSAFE` / `BOXFAILSAFE` bits), which is already polled live via `MSP_STATUS_EX` on every tab — so it works **while disarmed on the bench**, which is exactly when the Receiver tab is used. No new MSP polling, no firmware change.

## Changes

- `src/stores/fc.js` — new exported pure helper `isFailsafeActive(flags)` + `FAILSAFE_BIT`/`RX_FAILSAFE_BIT`/`BOXFAILSAFE_BIT` constants (bit *positions*, deliberately not firmware mask values — commented to prevent a regression), and a reactive `failsafeActive` store getter reading the raw bitmask.
- `src/components/tabs/ReceiverTab.vue` — `failsafeActive` computed; warning banner (`UiBox` with `role="alert"` for screen readers); conditional `!bg-warning` tint on the channel-bar `UProgress` indicators.
- `locales/en/messages.json` — two new i18n keys (`receiverFailsafeActiveTitle`, `receiverFailsafeActiveWarning`).
- `test/js/tabs/receiver_failsafe.test.js` — 15 tests importing the real detector, covering the bit truth table (bits 1/2/4 active; 0/undefined/null and unrelated flags like THROTTLE/CALIBRATING inactive).

## Test plan

- [x] `npm run test` — 150 tests pass (15 new)
- [x] `npm run lint` — clean
- [x] Prettier — clean
- Banner + bar tint appear when the FC reports failsafe / RX loss, clear automatically on recovery (no tab switch), and do not trigger for unrelated arming-disable reasons.

## Out of scope

Displaying genuine *raw, pre-failsafe* channel values (the reporter's "two sliders" idea) would require a new/extended MSP message in the firmware plus an API-version bump. This configurator-only change solves the actual confusion (users not realizing failsafe is engaged) and can ship immediately.

## Notes

- The overlaid channel-value text contrast over light bar colors is a pre-existing concern across all channels and is intentionally left untouched to keep this change tight.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* **Receiver failsafe detection and status display:** When the flight controller enters failsafe mode, a warning banner now appears in the receiver tab, clearly indicating that failsafe is active and that displayed channel values are failsafe outputs rather than live receiver values.
* **Visual indicator for failsafe state:** Channel progress bars now switch to a warning colour when failsafe mode is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->