### PR TITLE
Enhancement: Virtual Mode quality-of-life

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -119,6 +119,9 @@
     "bluetoothConnectionError": {
         "message": "Bluetooth error: $1"
     },
+    "virtualMode": {
+        "message": "Virtual Mode"
+    },
     "virtualMSPVersion": {
         "message": "Virtual Firmware Version"
     },

--- a/src/components/status-bar/StatusBar.vue
+++ b/src/components/status-bar/StatusBar.vue
@@ -86,6 +86,12 @@
                 </UTooltip>
                 <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
             </template>
+            <template v-if="isConnectedToVirtual">
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+                <UIcon name="i-lucide-cpu" class="size-4" />
+                <span>{{ $t("virtualMode") }}</span>
+                <USeparator orientation="vertical" :ui="{ root: 'py-1', border: 'border-accented' }" />
+            </template>
 
             <UIcon name="i-lucide-monitor" class="size-4" />
             <UTooltip :text="$t('versionLabelConfigurator')">
@@ -98,6 +104,7 @@
 <script>
 import { defineComponent, ref, computed, onMounted, onUnmounted } from "vue";
 import PortUtilization from "./PortUtilization.vue";
+import { useConnectionStore } from "../../stores/connection";
 import BatteryIcon from "../quad-status/BatteryIcon.vue";
 import BatteryLegend from "../quad-status/BatteryLegend.vue";
 import BottomStatusIcons from "../quad-status/BottomStatusIcons.vue";
@@ -192,6 +199,9 @@ export default defineComponent({
         const currentTime = ref(Date.now());
         const expertMode = ref(isExpertModeEnabled());
         let interval = null;
+        const connectionStore = useConnectionStore();
+        const isVirtualMode = computed(() => connectionStore.virtualMode);
+        const isConnectedToVirtual = computed(() => connectionStore.connectedTo === "virtual");
 
         const onExpertModeChange = (enabled) => {
             expertMode.value = enabled;
@@ -274,6 +284,8 @@ export default defineComponent({
 
         return {
             expertMode,
+            isVirtualMode,
+            isConnectedToVirtual,
             displayedFirmwareTarget,
             displayedConfiguratorVersion,
             displayedFirmwareVersion,

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -579,12 +579,11 @@ import {
     NON_EXPERT_SLIDER_MAX_GYRO,
     NON_EXPERT_SLIDER_MIN_DTERM,
     NON_EXPERT_SLIDER_MAX_DTERM,
+    calculateNewGyroFilters,
+    calculateNewDTermFilters,
 } from "@/composables/useTuningSliders";
 import semver from "semver";
 import { API_VERSION_1_48 } from "@/js/data_storage";
-import MSP from "@/js/msp";
-import MSPCodes from "@/js/msp/MSPCodes";
-import { mspHelper } from "@/js/msp/MSPHelper";
 import UiBox from "@/components/elements/UiBox.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
 import SettingRow from "@/components/elements/SettingRow.vue";
@@ -1179,11 +1178,9 @@ watch(gyroFilterMultiplier, (newValue, oldValue) => {
         return;
     }
 
-    // Sync local slider position → FC state before MSP send (like master)
-    FC.TUNING_SLIDERS.slider_gyro_filter = 1;
-    FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = Math.round(newValue * 100);
-
-    MSP.promise(MSPCodes.MSP_CALCULATE_SIMPLIFIED_GYRO, mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_GYRO))
+    // Compute new gyro filter cutoffs (via FC on a real connection, or
+    // client-side in virtual mode).
+    calculateNewGyroFilters(newValue)
         .then(() => emit("change"))
         .catch((error) => {
             console.error("Failed to calculate simplified gyro filters:", error);
@@ -1213,11 +1210,9 @@ watch(dtermFilterMultiplier, (newValue, oldValue) => {
         return;
     }
 
-    // Sync local slider position → FC state before MSP send (like master)
-    FC.TUNING_SLIDERS.slider_dterm_filter = 1;
-    FC.TUNING_SLIDERS.slider_dterm_filter_multiplier = Math.round(newValue * 100);
-
-    MSP.promise(MSPCodes.MSP_CALCULATE_SIMPLIFIED_DTERM, mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_DTERM))
+    // Compute new D-term filter cutoffs (via FC on a real connection, or
+    // client-side in virtual mode).
+    calculateNewDTermFilters(newValue)
         .then(() => emit("change"))
         .catch((error) => {
             console.error("Failed to calculate simplified dterm filters:", error);

--- a/src/composables/useTuningSliders.js
+++ b/src/composables/useTuningSliders.js
@@ -2,6 +2,13 @@ import FC from "@/js/fc";
 import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
 import { mspHelper } from "@/js/msp/MSPHelper";
+import CONFIGURATOR from "@/js/data_storage";
+import {
+    applySimplifiedPids,
+    applySimplifiedGyroFilters,
+    applySimplifiedDtermFilters,
+    validateVirtualSimplifiedTuning,
+} from "@/js/simplifiedTuning";
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -87,7 +94,59 @@ export function calculateNewPids(s) {
     FC.TUNING_SLIDERS.slider_pitch_pi_gain = Math.round(s.pitchPIGain * 100);
     FC.TUNING_SLIDERS.slider_master_multiplier = Math.round(s.masterMultiplier * 100);
 
+    // In virtual mode there is no FC to crunch the sliders, so compute the
+    // resulting PID/feedforward/D-max values client-side (port of the firmware's
+    // simplified_tuning.c) and resolve immediately.
+    if (CONFIGURATOR.virtualMode) {
+        applySimplifiedPids();
+        return Promise.resolve();
+    }
+
     return MSP.promise(MSPCodes.MSP_CALCULATE_SIMPLIFIED_PID, mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_PID));
+}
+
+/**
+ * Write the gyro filter slider position to FC.TUNING_SLIDERS and compute the
+ * resulting gyro lowpass cutoffs.  Returns a promise that resolves after
+ * FC.FILTER_CONFIG has been updated.
+ *
+ * @param {number} multiplier  Gyro filter multiplier (decimal, e.g. 1.0)
+ */
+export function calculateNewGyroFilters(multiplier) {
+    FC.TUNING_SLIDERS.slider_gyro_filter = 1;
+    FC.TUNING_SLIDERS.slider_gyro_filter_multiplier = Math.round(multiplier * 100);
+
+    if (CONFIGURATOR.virtualMode) {
+        applySimplifiedGyroFilters();
+        return Promise.resolve();
+    }
+
+    return MSP.promise(
+        MSPCodes.MSP_CALCULATE_SIMPLIFIED_GYRO,
+        mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_GYRO),
+    );
+}
+
+/**
+ * Write the D-term filter slider position to FC.TUNING_SLIDERS and compute the
+ * resulting D-term lowpass cutoffs.  Returns a promise that resolves after
+ * FC.FILTER_CONFIG has been updated.
+ *
+ * @param {number} multiplier  D-term filter multiplier (decimal, e.g. 1.0)
+ */
+export function calculateNewDTermFilters(multiplier) {
+    FC.TUNING_SLIDERS.slider_dterm_filter = 1;
+    FC.TUNING_SLIDERS.slider_dterm_filter_multiplier = Math.round(multiplier * 100);
+
+    if (CONFIGURATOR.virtualMode) {
+        applySimplifiedDtermFilters();
+        return Promise.resolve();
+    }
+
+    return MSP.promise(
+        MSPCodes.MSP_CALCULATE_SIMPLIFIED_DTERM,
+        mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_DTERM),
+    );
 }
 
 /**
@@ -96,7 +155,7 @@ export function calculateNewPids(s) {
  * invalid slider modes are set to 0 (sliders off).  Returns a promise.
  */
 export function validateTuningSliders() {
-    return MSP.promise(MSPCodes.MSP_VALIDATE_SIMPLIFIED_TUNING).then(() => {
+    const patchInvalidSliders = () => {
         if (!FC.TUNING_SLIDERS.slider_pids_valid) {
             FC.TUNING_SLIDERS.slider_pids_mode = 0;
         }
@@ -106,5 +165,15 @@ export function validateTuningSliders() {
         if (!FC.TUNING_SLIDERS.slider_dterm_valid) {
             FC.TUNING_SLIDERS.slider_dterm_filter = 0;
         }
-    });
+    };
+
+    // In virtual mode, compare the stored PID/filter values against what the
+    // sliders would produce client-side instead of asking the FC.
+    if (CONFIGURATOR.virtualMode) {
+        validateVirtualSimplifiedTuning();
+        patchInvalidSliders();
+        return Promise.resolve();
+    }
+
+    return MSP.promise(MSPCodes.MSP_VALIDATE_SIMPLIFIED_TUNING).then(patchInvalidSliders);
 }

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -6,6 +6,7 @@ import CONFIGURATOR, { API_VERSION_1_47 } from "./data_storage";
 import { OSD } from "../components/tabs/osd/osd";
 import semver from "semver";
 import { addArrayElement, addArrayElementAfter } from "./utils/array";
+import { getDebugModes } from "./utils/debugModes";
 
 // pid.h PID_*_DEFAULT, pid.c resetPidProfile
 const DEFAULT_BETAFLIGHT_PIDS = [
@@ -131,6 +132,7 @@ const VirtualFC = {
             "USE_GPS",
             "USE_LED_STRIP",
             "USE_OSD",
+            "USE_VTX",
             "USE_SOFTSERIAL",
             "USE_SONAR",
             "USE_TELEMETRY",
@@ -138,6 +140,7 @@ const VirtualFC = {
             "USE_TRANSPONDER",
             "USE_SERIALRX_CRSF",
             "USE_SERIALRX_SBUS",
+            "USE_DSHOT",
         ];
 
         virtualFC.CONFIG.craftName = "BetaFlight";
@@ -252,6 +255,8 @@ const VirtualFC = {
 
         virtualFC.CONFIG.sampleRateHz = 12000;
         virtualFC.PID_ADVANCED_CONFIG.pid_process_denom = 2;
+        virtualFC.PID_ADVANCED_CONFIG.fast_pwm_protocol = 6; // DSHOT300
+        virtualFC.PID_ADVANCED_CONFIG.debugModeCount = getDebugModes(virtualFC.CONFIG.apiVersion).length;
         virtualFC.PIDS = virtualFC.PIDS.map((pid, index) => DEFAULT_BETAFLIGHT_PIDS[index]?.slice() ?? pid);
         virtualFC.PIDS_ACTIVE = virtualFC.PIDS.map((pid) => pid.slice());
         // pid.c simplified_pids_mode RPY; fc.js DEFAULT_TUNING_SLIDERS (all multipliers 100 = 1.0)
@@ -277,7 +282,11 @@ const VirtualFC = {
             ...DEFAULT_BETAFLIGHT_RX_CONFIG,
         };
 
-        virtualFC.BLACKBOX.supported = true;
+        virtualFC.BLACKBOX = {
+            ...virtualFC.BLACKBOX,
+            supported: true,
+            blackboxDevice: 1, // Onboard flash
+        };
 
         virtualFC.BATTERY_CONFIG = {
             vbatmincellvoltage: 3.7,

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -72,6 +72,11 @@ const DEFAULT_BETAFLIGHT_FILTER_CONFIG = {
     gyro_rpm_notch_weights: [100, 100, 100],
 };
 
+// rx.h SERIALRX_CRSF, pg/rx.c pgResetFn_rxConfig
+const DEFAULT_BETAFLIGHT_RX_CONFIG = {
+    serialrx_provider: 9,
+};
+
 const DEFAULT_BETAFLIGHT_ADVANCED_TUNING = {
     antiGravityGain: 80,
     itermRotation: 0,
@@ -131,6 +136,8 @@ const VirtualFC = {
             "USE_TELEMETRY",
             "USE_SERVOS",
             "USE_TRANSPONDER",
+            "USE_SERIALRX_CRSF",
+            "USE_SERIALRX_SBUS",
         ];
 
         virtualFC.CONFIG.craftName = "BetaFlight";
@@ -145,6 +152,7 @@ const VirtualFC = {
         virtualFC.FEATURE_CONFIG.features.enable("SONAR");
         virtualFC.FEATURE_CONFIG.features.enable("TELEMETRY");
         virtualFC.FEATURE_CONFIG.features.enable("TRANSPONDER");
+        virtualFC.FEATURE_CONFIG.features.enable("RX_SERIAL");
 
         virtualFC.BEEPER_CONFIG.beepers = new Beepers(FC.CONFIG);
         virtualFC.BEEPER_CONFIG.dshotBeaconConditions = new Beepers(FC.CONFIG, ["RX_LOST", "RX_SET"]);
@@ -264,6 +272,10 @@ const VirtualFC = {
             ...DEFAULT_BETAFLIGHT_ADVANCED_TUNING,
         };
         virtualFC.ADVANCED_TUNING_ACTIVE = { ...virtualFC.ADVANCED_TUNING };
+        virtualFC.RX_CONFIG = {
+            ...virtualFC.RX_CONFIG,
+            ...DEFAULT_BETAFLIGHT_RX_CONFIG,
+        };
 
         virtualFC.BLACKBOX.supported = true;
 

--- a/src/js/VirtualFC.js
+++ b/src/js/VirtualFC.js
@@ -7,6 +7,104 @@ import { OSD } from "../components/tabs/osd/osd";
 import semver from "semver";
 import { addArrayElement, addArrayElementAfter } from "./utils/array";
 
+// pid.h PID_*_DEFAULT, pid.c resetPidProfile
+const DEFAULT_BETAFLIGHT_PIDS = [
+    [45, 80, 30], // ROLL
+    [47, 84, 34], // PITCH
+    [45, 80, 0], // YAW
+    [50, 75, 75], // LEVEL
+    [40, 0, 0], // MAG
+];
+
+// controlrate_profile.c pgResetFn_controlRateProfiles
+const DEFAULT_BETAFLIGHT_RC_TUNING = {
+    RC_RATE: 0.07,
+    RC_EXPO: 0,
+    roll_rate: 0.67,
+    pitch_rate: 0.67,
+    yaw_rate: 0.67,
+    throttle_MID: 0.5,
+    throttle_EXPO: 0,
+    RC_YAW_EXPO: 0,
+    rcYawRate: 0.07,
+    rcPitchRate: 0.07,
+    RC_PITCH_EXPO: 0,
+    throttleLimitType: 0,
+    throttleLimitPercent: 100,
+    roll_rate_limit: 1998,
+    pitch_rate_limit: 1998,
+    yaw_rate_limit: 1998,
+    rates_type: 3, // RATES_TYPE_ACTUAL
+    throttle_HOVER: 0.5,
+};
+
+// pid.c resetPidProfile, gyro.c pgResetFn_gyroConfig, pg/dyn_notch.c, pg/rpm_filter.c
+const DEFAULT_BETAFLIGHT_FILTER_CONFIG = {
+    gyro_hardware_lpf: 0,
+    gyro_lowpass_hz: 250,
+    gyro_lowpass_dyn_min_hz: 250,
+    gyro_lowpass_dyn_max_hz: 500,
+    gyro_lowpass_type: 0,
+    gyro_lowpass2_hz: 500,
+    gyro_lowpass2_type: 0,
+    gyro_notch_hz: 0,
+    gyro_notch_cutoff: 0,
+    gyro_notch2_hz: 0,
+    gyro_notch2_cutoff: 0,
+    dterm_lowpass_hz: 75,
+    dterm_lowpass_dyn_min_hz: 75,
+    dterm_lowpass_dyn_max_hz: 150,
+    dterm_lowpass_type: 0,
+    dterm_lowpass2_hz: 150,
+    dterm_lowpass2_type: 0,
+    dyn_lpf_curve_expo: 5,
+    dterm_notch_hz: 0,
+    dterm_notch_cutoff: 0,
+    yaw_lowpass_hz: 100,
+    dyn_notch_q: 300,
+    dyn_notch_min_hz: 100,
+    dyn_notch_max_hz: 600,
+    dyn_notch_count: 3,
+    gyro_rpm_notch_harmonics: 3,
+    gyro_rpm_notch_min_hz: 100,
+    gyro_rpm_notch_fade_range_hz: 50,
+    gyro_rpm_notch_q: 500,
+    gyro_rpm_notch_weights: [100, 100, 100],
+};
+
+const DEFAULT_BETAFLIGHT_ADVANCED_TUNING = {
+    antiGravityGain: 80,
+    itermRotation: 0,
+    itermRelax: 1,
+    itermRelaxType: 1,
+    itermRelaxCutoff: 15,
+    throttleBoost: 5,
+    acroTrainerAngleLimit: 20,
+    feedforwardRoll: 120,
+    feedforwardPitch: 125,
+    feedforwardYaw: 120,
+    dMaxRoll: 40,
+    dMaxPitch: 46,
+    dMaxYaw: 0,
+    dMaxGain: 37,
+    dMaxAdvance: 20,
+    useIntegratedYaw: 0,
+    integratedYawRelax: 200,
+    motorOutputLimit: 100,
+    autoProfileCellCount: -1,
+    idleMinRpm: 0,
+    feedforward_averaging: 1,
+    feedforward_smooth_factor: 65,
+    feedforward_boost: 15,
+    feedforward_max_rate_limit: 90,
+    feedforward_jitter_factor: 7,
+    vbat_sag_compensation: 0,
+    thrustLinearization: 0,
+    tpaMode: 1,
+    tpaRate: 0.65,
+    tpaBreakpoint: 1350,
+};
+
 const VirtualFC = {
     // these values are manufactured to unlock all the functionality of the configurator, they dont represent actual hardware
     setVirtualConfig() {
@@ -146,6 +244,26 @@ const VirtualFC = {
 
         virtualFC.CONFIG.sampleRateHz = 12000;
         virtualFC.PID_ADVANCED_CONFIG.pid_process_denom = 2;
+        virtualFC.PIDS = virtualFC.PIDS.map((pid, index) => DEFAULT_BETAFLIGHT_PIDS[index]?.slice() ?? pid);
+        virtualFC.PIDS_ACTIVE = virtualFC.PIDS.map((pid) => pid.slice());
+        // pid.c simplified_pids_mode RPY; fc.js DEFAULT_TUNING_SLIDERS (all multipliers 100 = 1.0)
+        virtualFC.TUNING_SLIDERS = {
+            ...virtualFC.TUNING_SLIDERS,
+            ...virtualFC.getSliderDefaults(),
+        };
+        virtualFC.RC_TUNING = {
+            ...virtualFC.RC_TUNING,
+            ...DEFAULT_BETAFLIGHT_RC_TUNING,
+        };
+        virtualFC.FILTER_CONFIG = {
+            ...virtualFC.FILTER_CONFIG,
+            ...DEFAULT_BETAFLIGHT_FILTER_CONFIG,
+        };
+        virtualFC.ADVANCED_TUNING = {
+            ...virtualFC.ADVANCED_TUNING,
+            ...DEFAULT_BETAFLIGHT_ADVANCED_TUNING,
+        };
+        virtualFC.ADVANCED_TUNING_ACTIVE = { ...virtualFC.ADVANCED_TUNING };
 
         virtualFC.BLACKBOX.supported = true;
 

--- a/src/js/simplifiedTuning.js
+++ b/src/js/simplifiedTuning.js
@@ -1,0 +1,221 @@
+/**
+ * Client-side port of betaflight/src/main/config/simplified_tuning.c for virtual mode.
+ */
+
+import FC from "./fc";
+
+const PID_GAIN_MAX = 250;
+const F_GAIN_MAX = 1000;
+const DYN_LPF_MAX_HZ = 1000;
+const LPF_MAX_HZ = 1000;
+
+const GYRO_LPF1_DYN_MIN_HZ_DEFAULT = 250;
+const GYRO_LPF1_DYN_MAX_HZ_DEFAULT = 500;
+const GYRO_LPF2_HZ_DEFAULT = 500;
+
+const DTERM_LPF1_DYN_MIN_HZ_DEFAULT = 75;
+const DTERM_LPF1_DYN_MAX_HZ_DEFAULT = 150;
+const DTERM_LPF2_HZ_DEFAULT = 150;
+
+const PID_DEFAULTS = [
+    { P: 45, I: 80, D: 30, F: 120 },
+    { P: 47, I: 84, D: 34, F: 125 },
+    { P: 45, I: 80, D: 0, F: 120 },
+];
+
+const D_MAX_DEFAULT = [40, 46, 0];
+
+const FEEDFORWARD_KEYS = ["feedforwardRoll", "feedforwardPitch", "feedforwardYaw"];
+const DMAX_KEYS = ["dMaxRoll", "dMaxPitch", "dMaxYaw"];
+
+// The firmware's constrain() takes int arguments, so a float result is
+// truncated toward zero before clamping (see common/maths.h). Mirror that here
+// so virtual-mode PID/filter values match what a real FC computes.
+function constrain(value, min, max) {
+    return Math.min(max, Math.max(min, Math.trunc(value)));
+}
+
+function sliderFactorsFromTuningSliders(sliders = FC.TUNING_SLIDERS) {
+    return {
+        pidsMode: sliders.slider_pids_mode,
+        masterMultiplier: sliders.slider_master_multiplier / 100,
+        rollPitchRatio: sliders.slider_roll_pitch_ratio / 100,
+        iGain: sliders.slider_i_gain / 100,
+        dGain: sliders.slider_d_gain / 100,
+        piGain: sliders.slider_pi_gain / 100,
+        dMaxGain: sliders.slider_dmax_gain / 100,
+        feedforwardGain: sliders.slider_feedforward_gain / 100,
+        pitchPIGain: sliders.slider_pitch_pi_gain / 100,
+        gyroFilterMultiplier: sliders.slider_gyro_filter_multiplier,
+        dtermFilterMultiplier: sliders.slider_dterm_filter_multiplier,
+        gyroFilterEnabled: !!sliders.slider_gyro_filter,
+        dtermFilterEnabled: !!sliders.slider_dterm_filter,
+    };
+}
+
+function calculateAxisPidValues(factors, axis) {
+    const defaults = PID_DEFAULTS[axis];
+    const dMaxDefault = D_MAX_DEFAULT[axis];
+    const pitchDGain = axis === 1 ? factors.rollPitchRatio : 1;
+    const pitchPiGain = axis === 1 ? factors.pitchPIGain : 1;
+
+    const P = constrain(defaults.P * factors.masterMultiplier * factors.piGain * pitchPiGain, 0, PID_GAIN_MAX);
+    const I = constrain(
+        defaults.I * factors.masterMultiplier * factors.piGain * factors.iGain * pitchPiGain,
+        0,
+        PID_GAIN_MAX,
+    );
+    const D = constrain(defaults.D * factors.masterMultiplier * factors.dGain * pitchDGain, 0, PID_GAIN_MAX);
+    const F = constrain(defaults.F * factors.masterMultiplier * pitchPiGain * factors.feedforwardGain, 0, F_GAIN_MAX);
+
+    let dMax = 0;
+    if (dMaxDefault > 0) {
+        const dMaxScale = factors.dMaxGain + (1 - factors.dMaxGain) * (defaults.D / dMaxDefault);
+        dMax = constrain(
+            dMaxDefault * factors.masterMultiplier * factors.dGain * pitchDGain * dMaxScale,
+            0,
+            PID_GAIN_MAX,
+        );
+    }
+
+    return { P, I, D, F, dMax };
+}
+
+export function calculateSimplifiedPidValues(factors) {
+    if (!factors.pidsMode) {
+        return [];
+    }
+
+    const axes = [];
+    for (let axis = 0; axis <= factors.pidsMode; axis++) {
+        axes.push(calculateAxisPidValues(factors, axis));
+    }
+    return axes;
+}
+
+// `multiplier` is the integer slider value (e.g. 100 = 1.0x), matching the
+// firmware's simplified_gyro_filter_multiplier. The firmware uses integer
+// arithmetic (DEFAULT * multiplier / 100), which the truncating constrain()
+// reproduces.
+export function calculateSimplifiedGyroFilterValues(multiplier) {
+    const result = {};
+    if (FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz) {
+        result.gyro_lowpass_dyn_min_hz = constrain(
+            (GYRO_LPF1_DYN_MIN_HZ_DEFAULT * multiplier) / 100,
+            0,
+            DYN_LPF_MAX_HZ,
+        );
+        result.gyro_lowpass_dyn_max_hz = constrain(
+            (GYRO_LPF1_DYN_MAX_HZ_DEFAULT * multiplier) / 100,
+            0,
+            DYN_LPF_MAX_HZ,
+        );
+    }
+    if (FC.FILTER_CONFIG.gyro_lowpass_hz) {
+        result.gyro_lowpass_hz = constrain((GYRO_LPF1_DYN_MIN_HZ_DEFAULT * multiplier) / 100, 0, DYN_LPF_MAX_HZ);
+    }
+    if (FC.FILTER_CONFIG.gyro_lowpass2_hz) {
+        result.gyro_lowpass2_hz = constrain((GYRO_LPF2_HZ_DEFAULT * multiplier) / 100, 0, LPF_MAX_HZ);
+    }
+    return result;
+}
+
+// `multiplier` is the integer slider value (e.g. 100 = 1.0x), matching the
+// firmware's simplified_dterm_filter_multiplier.
+export function calculateSimplifiedDtermFilterValues(multiplier) {
+    const result = {};
+    if (FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz) {
+        result.dterm_lowpass_dyn_min_hz = constrain(
+            (DTERM_LPF1_DYN_MIN_HZ_DEFAULT * multiplier) / 100,
+            0,
+            DYN_LPF_MAX_HZ,
+        );
+        result.dterm_lowpass_dyn_max_hz = constrain(
+            (DTERM_LPF1_DYN_MAX_HZ_DEFAULT * multiplier) / 100,
+            0,
+            DYN_LPF_MAX_HZ,
+        );
+    }
+    if (FC.FILTER_CONFIG.dterm_lowpass_hz) {
+        result.dterm_lowpass_hz = constrain((DTERM_LPF1_DYN_MIN_HZ_DEFAULT * multiplier) / 100, 0, DYN_LPF_MAX_HZ);
+    }
+    if (FC.FILTER_CONFIG.dterm_lowpass2_hz) {
+        result.dterm_lowpass2_hz = constrain((DTERM_LPF2_HZ_DEFAULT * multiplier) / 100, 0, LPF_MAX_HZ);
+    }
+    return result;
+}
+
+export function applySimplifiedPids(sliders = FC.TUNING_SLIDERS) {
+    const factors = sliderFactorsFromTuningSliders(sliders);
+    const axes = calculateSimplifiedPidValues(factors);
+
+    for (let axis = 0; axis < axes.length; axis++) {
+        const { P, I, D, F, dMax } = axes[axis];
+        FC.PIDS[axis][0] = P;
+        FC.PIDS[axis][1] = I;
+        FC.PIDS[axis][2] = D;
+        FC.ADVANCED_TUNING[FEEDFORWARD_KEYS[axis]] = F;
+        FC.ADVANCED_TUNING[DMAX_KEYS[axis]] = dMax;
+    }
+}
+
+export function applySimplifiedGyroFilters(sliders = FC.TUNING_SLIDERS) {
+    if (!sliders.slider_gyro_filter) {
+        return;
+    }
+    Object.assign(FC.FILTER_CONFIG, calculateSimplifiedGyroFilterValues(sliders.slider_gyro_filter_multiplier));
+}
+
+export function applySimplifiedDtermFilters(sliders = FC.TUNING_SLIDERS) {
+    if (!sliders.slider_dterm_filter) {
+        return;
+    }
+    Object.assign(FC.FILTER_CONFIG, calculateSimplifiedDtermFilterValues(sliders.slider_dterm_filter_multiplier));
+}
+
+export function validateVirtualSimplifiedTuning() {
+    const factors = sliderFactorsFromTuningSliders();
+    let pidsValid = true;
+
+    if (factors.pidsMode > 0) {
+        const expected = calculateSimplifiedPidValues(factors);
+        for (let axis = 0; axis < expected.length; axis++) {
+            const { P, I, D, F, dMax } = expected[axis];
+            pidsValid =
+                pidsValid &&
+                FC.PIDS[axis][0] === P &&
+                FC.PIDS[axis][1] === I &&
+                FC.PIDS[axis][2] === D &&
+                FC.ADVANCED_TUNING[FEEDFORWARD_KEYS[axis]] === F &&
+                FC.ADVANCED_TUNING[DMAX_KEYS[axis]] === dMax;
+        }
+    }
+
+    let gyroValid = true;
+    if (factors.gyroFilterEnabled) {
+        const expected = calculateSimplifiedGyroFilterValues(factors.gyroFilterMultiplier);
+        gyroValid =
+            (!expected.gyro_lowpass_hz || FC.FILTER_CONFIG.gyro_lowpass_hz === expected.gyro_lowpass_hz) &&
+            (!expected.gyro_lowpass2_hz || FC.FILTER_CONFIG.gyro_lowpass2_hz === expected.gyro_lowpass2_hz) &&
+            (!expected.gyro_lowpass_dyn_min_hz ||
+                FC.FILTER_CONFIG.gyro_lowpass_dyn_min_hz === expected.gyro_lowpass_dyn_min_hz) &&
+            (!expected.gyro_lowpass_dyn_max_hz ||
+                FC.FILTER_CONFIG.gyro_lowpass_dyn_max_hz === expected.gyro_lowpass_dyn_max_hz);
+    }
+
+    let dtermValid = true;
+    if (factors.dtermFilterEnabled) {
+        const expected = calculateSimplifiedDtermFilterValues(factors.dtermFilterMultiplier);
+        dtermValid =
+            (!expected.dterm_lowpass_hz || FC.FILTER_CONFIG.dterm_lowpass_hz === expected.dterm_lowpass_hz) &&
+            (!expected.dterm_lowpass2_hz || FC.FILTER_CONFIG.dterm_lowpass2_hz === expected.dterm_lowpass2_hz) &&
+            (!expected.dterm_lowpass_dyn_min_hz ||
+                FC.FILTER_CONFIG.dterm_lowpass_dyn_min_hz === expected.dterm_lowpass_dyn_min_hz) &&
+            (!expected.dterm_lowpass_dyn_max_hz ||
+                FC.FILTER_CONFIG.dterm_lowpass_dyn_max_hz === expected.dterm_lowpass_dyn_max_hz);
+    }
+
+    FC.TUNING_SLIDERS.slider_pids_valid = pidsValid ? 1 : 0;
+    FC.TUNING_SLIDERS.slider_gyro_valid = gyroValid ? 1 : 0;
+    FC.TUNING_SLIDERS.slider_dterm_valid = dtermValid ? 1 : 0;
+}


### PR DESCRIPTION
- Add more default values matching the firmware to better represent real situations
- Add a Virtual Mode device to the status bar in place of a real FC
- Port C implementation of simplified tuning from the firmware to JS to be used with Virtual Mode
These changes improve Virtual Mode for showcase or explanation purposes, making it even more useful in cases where an FC isn't accessible. 

Please suggest other things you'd like to see in Virtual Mode, I'd like to improve it further while I'm at it.

Also fixes #3017

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtual mode fully supported for PID and filter tuning with client-side simplified calculations (no device roundtrips).
  * Tuning sliders recompute gyro and D-term filter values instantly in virtual mode.
  * Validation of simplified tuning runs locally in virtual mode and updates slider validity indicators.
  * Status bar now shows a virtual mode connection indicator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->