### PR TITLE
fix(debug): align debug modes and fields with 1.48 firmware

### DIFF
--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -142,6 +142,7 @@ export function getDebugModes(apiVersion) {
     }
 
     if (semver.gte(apiVersion, API_VERSION_1_48)) {
+        removeArrayElement(result, "AUTOPILOT_POSITION");
         addArrayElement(result, "AUTOPILOT_PID");
     }
 

--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -144,6 +144,10 @@ export function getDebugModes(apiVersion) {
     if (semver.gte(apiVersion, API_VERSION_1_48)) {
         removeArrayElement(result, "AUTOPILOT_POSITION");
         addArrayElement(result, "AUTOPILOT_PID");
+        // POSITION_NAV is a reserved enum slot in firmware (no name/fields yet);
+        // it must occupy its index so AUTOPILOT_STOP decodes correctly.
+        addArrayElement(result, "POSITION_NAV");
+        addArrayElement(result, "AUTOPILOT_STOP");
     }
 
     return result;

--- a/src/stores/debug.js
+++ b/src/stores/debug.js
@@ -811,8 +811,19 @@ export const useDebugStore = defineStore("debug", () => {
                 "debug[1]": "P term (North) * 100",
                 "debug[2]": "I term (East) * 100",
                 "debug[3]": "I term (North) * 100",
-                "debug[4]": "D term (East) * 100",
-                "debug[5]": "D term (North) * 100",
+                "debug[4]": "II term (East) * 100",
+                "debug[5]": "II term (North) * 100",
+                "debug[6]": "Roll angle command * 100",
+                "debug[7]": "Pitch angle command * 100",
+            };
+
+            result.AUTOPILOT_STOP = {
+                "debug[all]": "Autopilot Stop",
+                "debug[0]": "Distance to target (cm)",
+                "debug[1]": "Horizontal speed (cm/s)",
+                "debug[2]": "Sticks active",
+                "debug[3]": "Nav active",
+                "debug[4]": "Position held",
                 "debug[6]": "Roll angle command * 100",
                 "debug[7]": "Pitch angle command * 100",
             };
@@ -826,6 +837,8 @@ export const useDebugStore = defineStore("debug", () => {
                 "debug[4]": "CPU Load at Sample",
             };
 
+            // POSITION_NAV is a reserved firmware enum slot with no fields yet,
+            // so it intentionally has no fieldNames entry.
             delete result.AUTOPILOT_POSITION;
         }
 

--- a/src/stores/debug.js
+++ b/src/stores/debug.js
@@ -742,8 +742,8 @@ export const useDebugStore = defineStore("debug", () => {
                 "debug[all]": "Autopilot Altitude",
                 "debug[0]": "Autopilot Throttle",
                 "debug[1]": "Tilt Multiplier",
-                "debug[2]": "Zero Altitude cm",
-                "debug[3]": "Altitude cm",
+                "debug[2]": "Target Altitude cm",
+                "debug[3]": "Current Altitude cm",
                 "debug[4]": "Altitude P",
                 "debug[5]": "Altitude I",
                 "debug[6]": "Altitude D",
@@ -825,6 +825,8 @@ export const useDebugStore = defineStore("debug", () => {
                 "debug[3]": "Gyro after all filtering [dbg-axis]",
                 "debug[4]": "CPU Load at Sample",
             };
+
+            delete result.AUTOPILOT_POSITION;
         }
 
         return result;

--- a/test/js/utils/debugModes.test.js
+++ b/test/js/utils/debugModes.test.js
@@ -42,12 +42,25 @@ describe("debugModes helper", () => {
             expect(modes.indexOf("OPTICALFLOW")).toBe(modes.indexOf("RANGEFINDER_QUALITY") + 1);
         });
 
-        it("appends AUTOPILOT_PID and drops AUTOPILOT_POSITION at API 1.48", () => {
+        it("appends AUTOPILOT_PID, POSITION_NAV, AUTOPILOT_STOP and drops AUTOPILOT_POSITION at API 1.48", () => {
             const modes = getDebugModes(API_VERSION_1_48);
-            expect(modes).toContain("AUTOPILOT_PID");
-            expect(modes.indexOf("AUTOPILOT_PID")).toBe(modes.length - 1);
             // AUTOPILOT_POSITION was removed from the firmware enum in 1.48.
             expect(modes).not.toContain("AUTOPILOT_POSITION");
+            // Tail must match the firmware debug_mode_e enum order exactly:
+            // AUTOPILOT_PID(99), POSITION_NAV(100), AUTOPILOT_STOP(101).
+            expect(getDebugModeIndex("AUTOPILOT_PID", API_VERSION_1_48)).toBe(99);
+            expect(getDebugModeIndex("POSITION_NAV", API_VERSION_1_48)).toBe(100);
+            expect(getDebugModeIndex("AUTOPILOT_STOP", API_VERSION_1_48)).toBe(101);
+            // AUTOPILOT_STOP is the last entry.
+            expect(modes.indexOf("AUTOPILOT_STOP")).toBe(modes.length - 1);
+        });
+
+        it("does not expose the 1.48 autopilot modes on 1.47 firmware", () => {
+            const modes = getDebugModes(API_VERSION_1_47);
+            expect(modes).toContain("AUTOPILOT_POSITION");
+            expect(modes).not.toContain("AUTOPILOT_PID");
+            expect(modes).not.toContain("POSITION_NAV");
+            expect(modes).not.toContain("AUTOPILOT_STOP");
         });
 
         it("returns a fresh array each call (safe to mutate)", () => {

--- a/test/js/utils/debugModes.test.js
+++ b/test/js/utils/debugModes.test.js
@@ -42,10 +42,12 @@ describe("debugModes helper", () => {
             expect(modes.indexOf("OPTICALFLOW")).toBe(modes.indexOf("RANGEFINDER_QUALITY") + 1);
         });
 
-        it("appends AUTOPILOT_PID at API 1.48", () => {
+        it("appends AUTOPILOT_PID and drops AUTOPILOT_POSITION at API 1.48", () => {
             const modes = getDebugModes(API_VERSION_1_48);
             expect(modes).toContain("AUTOPILOT_PID");
             expect(modes.indexOf("AUTOPILOT_PID")).toBe(modes.length - 1);
+            // AUTOPILOT_POSITION was removed from the firmware enum in 1.48.
+            expect(modes).not.toContain("AUTOPILOT_POSITION");
         });
 
         it("returns a fresh array each call (safe to mutate)", () => {
@@ -61,9 +63,10 @@ describe("debugModes helper", () => {
             expect(getDebugModeIndex("CHIRP", API_VERSION_1_47)).toBe(97);
         });
 
-        it("places CHIRP at index 97 for API 1.48 as well", () => {
-            // AUTOPILOT_PID is appended after CHIRP, so CHIRP's index is stable.
-            expect(getDebugModeIndex("CHIRP", API_VERSION_1_48)).toBe(97);
+        it("places CHIRP at index 96 for API 1.48 (AUTOPILOT_POSITION removed)", () => {
+            // AUTOPILOT_POSITION (index 96 in 1.47) was dropped from the firmware
+            // enum in 1.48, so CHIRP shifts down one to index 96.
+            expect(getDebugModeIndex("CHIRP", API_VERSION_1_48)).toBe(96);
         });
 
         it("returns -1 for CHIRP on pre-1.47 firmware", () => {


### PR DESCRIPTION
Keep the configurator's debug-mode list and field labels in sync with the Betaflight 1.48 firmware `debug_mode_e` enum (verified against betaflight/betaflight master).

## Changes

- **Remove `AUTOPILOT_POSITION` for API ≥ 1.48** — it was removed from the firmware enum in 1.48. Dropped from `getDebugModes()` (kept for 1.47) so `modes` and the `fieldNames` map stay consistent and blackbox `debug_mode` indices match firmware. (Addresses CodeRabbit's modes/fieldNames mismatch.)
- **Add `POSITION_NAV` (index 100) and `AUTOPILOT_STOP` (index 101)** for API ≥ 1.48. `POSITION_NAV` is a reserved firmware slot (no name/fields yet); it must occupy its index or `AUTOPILOT_STOP` would decode one index off.
- **Add `AUTOPILOT_STOP` field labels** (distance, horizontal speed, sticks active, nav active, position held, roll/pitch angle command); `debug[5]` intentionally omitted (unused in firmware).
- **Fix `AUTOPILOT_PID` `debug[4]/[5]` labels** — firmware documents these as "II term (East/North)", not "D term".
- **Relabel `AUTOPILOT_ALTITUDE` `debug[2]/[3]`** to "Target/Current Altitude cm".

## Test plan

- `npm run test` — `debugModes.test.js` passes 11/11, pinning absolute tail indices (`AUTOPILOT_PID=99`, `POSITION_NAV=100`, `AUTOPILOT_STOP=101`), `AUTOPILOT_POSITION` absent at 1.48 / present at 1.47, and that the new modes do not appear on 1.47 firmware.
- `npm run lint` — clean.

## Notes

- `POSITION_NAV` is intentionally selectable but unlabeled, mirroring the firmware reserved slot; when firmware implements it, add its `fieldNames`.
- Cross-repo follow-up: `blackbox-log-viewer` debug-mode field defs may need the same enum alignment for decoding 1.48 logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated autopilot debug labels for clarity (e.g., target/current altitude and PID terms).
  * Removed a redundant autopilot debug field from diagnostics and adjusted debug mode ordering.
* **Tests**
  * Added unit tests to verify the updated debug mode list, ordering, and index expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
