### PR TITLE
Fix select hiding in PidTuning Tab for copy PID / RATE profile dialogs

### DIFF
--- a/src/components/dialogs/CopyProfileDialog.vue
+++ b/src/components/dialogs/CopyProfileDialog.vue
@@ -7,14 +7,14 @@
             <div v-if="profileOptions && profileOptions.length" class="contentProfile">
                 <div>
                     <span>{{ profileText }}</span>
-                    <USelect v-model="selectedProfile" :items="profileOptions" class="min-w-40" />
+                    <USelect v-model="selectedProfile" :items="profileOptions" :portal="false" class="min-w-40" />
                 </div>
             </div>
 
             <div v-if="rateOptions && rateOptions.length" class="contentRateProfile">
                 <div>
                     <span>{{ rateProfileText }}</span>
-                    <USelect v-model="selectedRateProfile" :items="rateOptions" class="min-w-40" />
+                    <USelect v-model="selectedRateProfile" :items="rateOptions" :portal="false" class="min-w-40" />
                 </div>
             </div>
         </div>


### PR DESCRIPTION
# Summary                                                                        

## Issue

In PidTuningTab, the copy PID and RATE profile dialogs only show one selection
- the USelect dropdown is hidden behind the dialog.                  

## Root Cause

CopyProfileDialog.vue uses a native <dialog> element with showModal(). When open, the <dialog> creates a new stacking context. Nuxt UI's USelect renders its dropdown via a SelectPortal that teleports content to  <body> by default. Since the teleported dropdown is in the body (outside the dialog's stacking context), the <dialog>'s ::backdrop and stacking context obscure it.                                                                    

## Fix

Added :portal="false" to both <USelect> elements in CopyProfileDialog.vue (lines 10 and 17). This disables the teleport, so the dropdown renders inside the dialog's DOM tree where it's properly visible within the dialog's stacking context.                                                                       

## Files changed
 - src/components/dialogs/CopyProfileDialog.vue — added :portal="false" to both USelect components



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dropdown display behavior in the copy profile dialog to prevent portal rendering issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->