### PR TITLE
fix(sensors): restore debug graph auto-scale, add per-debug scale and global refresh

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3803,7 +3803,7 @@
         "message": "Refresh:"
     },
     "sensorsGlobalRefresh": {
-        "message": "Refresh rate:"
+        "message": "Refresh all:"
     },
     "sensorsScale": {
         "message": "Scale:"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3802,8 +3802,14 @@
     "sensorsRefresh": {
         "message": "Refresh:"
     },
+    "sensorsGlobalRefresh": {
+        "message": "Refresh rate:"
+    },
     "sensorsScale": {
         "message": "Scale:"
+    },
+    "sensorsScaleAuto": {
+        "message": "Auto"
     },
     "sensorsGyroSelect": {
         "message": "Gyroscope"

--- a/src/components/tabs/sensors/LiveSensorPanel.vue
+++ b/src/components/tabs/sensors/LiveSensorPanel.vue
@@ -47,7 +47,7 @@
                 <UInput v-show="checkboxes[5]" :model-value="debugModeName" size="xs" disabled class="w-40 font-mono" />
             </div>
 
-            <div class="flex items-center gap-2 ml-auto text-[10px] [&_[data-slot=base]]:!text-[10px]">
+            <div class="flex items-center gap-2 ml-auto text-[10px] [&_[data-slot=base]]:text-[10px]!">
                 <span v-html="$t('sensorsGlobalRefresh')"></span>
                 <USelect
                     :model-value="globalRate"

--- a/src/components/tabs/sensors/LiveSensorPanel.vue
+++ b/src/components/tabs/sensors/LiveSensorPanel.vue
@@ -67,9 +67,11 @@
             :visible="checkboxes[sensor.checkboxIndex]"
             :title="$t(sensor.titleKey)"
             :hint="sensor.hintKey ? $t(sensor.hintKey) : null"
+            :rate="rates[sensor.type]"
             :scale="sensor.hasScale ? scales[sensor.type] : null"
             :scale-options="sensor.scaleOptions"
             :display-values="sensor.getDisplayValues()"
+            @update:rate="updateRate(sensor.type, $event)"
             @update:scale="sensor.hasScale ? updateScale(sensor.type, $event) : null"
         />
 
@@ -81,10 +83,13 @@
                 :svg-id="`debug${i - 1}`"
                 :visible="true"
                 :title="debugTitles[i - 1]"
+                :show-refresh-rate="i === 1"
+                :rate="rates.debug"
                 :scale="debugScales[i - 1]"
                 :scale-options="DEBUG_SCALE_OPTIONS"
                 :display-values="[debugDisplay[i - 1]]"
                 :is-debug="true"
+                @update:rate="updateRate('debug', $event)"
                 @update:scale="updateDebugScale(i - 1, $event)"
             />
         </div>
@@ -118,7 +123,7 @@ const debugStore = useDebugStore();
 const sensorsStore = useSensorsStore();
 const { addInterval, removeInterval } = useInterval();
 
-const { checkboxes, globalRate, scales, debugScales, debugColumns } = storeToRefs(sensorsStore);
+const { checkboxes, globalRate, rates, scales, debugScales, debugColumns } = storeToRefs(sensorsStore);
 
 const refreshRateItems = REFRESH_RATE_OPTIONS.map((o) => ({ value: o.value, label: o.label }));
 
@@ -223,8 +228,8 @@ function initializeTimers() {
     removeInterval("sonar_pull");
     removeInterval("debug_pull");
 
-    // A single global refresh rate drives every graph so they stay in sync.
-    const rate = globalRate.value;
+    // Gyro/accel/mag share one MSP_RAW_IMU pull, so use the fastest of the three.
+    const fastest = Math.min(rates.value.gyro, rates.value.accel, rates.value.mag);
 
     if (checkboxes.value[0] || checkboxes.value[1] || checkboxes.value[2]) {
         addInterval(
@@ -232,7 +237,7 @@ function initializeTimers() {
             () => {
                 MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, update_imu_graphs);
             },
-            rate,
+            fastest,
             true,
         );
     }
@@ -243,7 +248,7 @@ function initializeTimers() {
             () => {
                 MSP.send_message(MSPCodes.MSP_ALTITUDE, false, false, update_altitude_graph);
             },
-            rate,
+            rates.value.altitude,
             true,
         );
     }
@@ -254,7 +259,7 @@ function initializeTimers() {
             () => {
                 MSP.send_message(MSPCodes.MSP_SONAR, false, false, update_sonar_graphs);
             },
-            rate,
+            rates.value.sonar,
             true,
         );
     }
@@ -265,7 +270,7 @@ function initializeTimers() {
             () => {
                 MSP.send_message(MSPCodes.MSP_DEBUG, false, false, update_debug_graphs);
             },
-            rate,
+            rates.value.debug,
             true,
         );
     }
@@ -339,6 +344,11 @@ function displayDebugColumnNames() {
 
 function onCheckboxChange() {
     sensorsStore.saveToConfig();
+    initializeTimers();
+}
+
+function updateRate(sensor, value) {
+    sensorsStore.updateRate(sensor, value);
     initializeTimers();
 }
 

--- a/src/components/tabs/sensors/LiveSensorPanel.vue
+++ b/src/components/tabs/sensors/LiveSensorPanel.vue
@@ -46,6 +46,17 @@
                 />
                 <UInput v-show="checkboxes[5]" :model-value="debugModeName" size="xs" disabled class="w-40 font-mono" />
             </div>
+
+            <div class="flex items-center gap-2 ml-auto text-[10px] [&_[data-slot=base]]:!text-[10px]">
+                <span v-html="$t('sensorsGlobalRefresh')"></span>
+                <USelect
+                    :model-value="globalRate"
+                    :items="refreshRateItems"
+                    @update:model-value="updateGlobalRate(Number($event))"
+                    class="min-w-24"
+                    size="xs"
+                />
+            </div>
         </div>
 
         <SensorGraph
@@ -56,11 +67,9 @@
             :visible="checkboxes[sensor.checkboxIndex]"
             :title="$t(sensor.titleKey)"
             :hint="sensor.hintKey ? $t(sensor.hintKey) : null"
-            :rate="rates[sensor.type]"
             :scale="sensor.hasScale ? scales[sensor.type] : null"
             :scale-options="sensor.scaleOptions"
             :display-values="sensor.getDisplayValues()"
-            @update:rate="updateRate(sensor.type, $event)"
             @update:scale="sensor.hasScale ? updateScale(sensor.type, $event) : null"
         />
 
@@ -72,11 +81,11 @@
                 :svg-id="`debug${i - 1}`"
                 :visible="true"
                 :title="debugTitles[i - 1]"
-                :show-refresh-rate="i === 1"
-                :rate="rates.debug"
+                :scale="debugScales[i - 1]"
+                :scale-options="DEBUG_SCALE_OPTIONS"
                 :display-values="[debugDisplay[i - 1]]"
                 :is-debug="true"
-                @update:rate="updateRate('debug', $event)"
+                @update:scale="updateDebugScale(i - 1, $event)"
             />
         </div>
     </div>
@@ -91,7 +100,13 @@ import { useSensorsStore } from "@/stores/sensors";
 import { useSensorGraph } from "@/composables/useSensorGraph";
 import { useInterval } from "../../../composables/useInterval";
 import { have_sensor } from "../../../js/sensor_helpers";
-import { GYRO_SCALE_OPTIONS, ACCEL_SCALE_OPTIONS, MAG_SCALE_OPTIONS } from "./constants";
+import {
+    GYRO_SCALE_OPTIONS,
+    ACCEL_SCALE_OPTIONS,
+    MAG_SCALE_OPTIONS,
+    DEBUG_SCALE_OPTIONS,
+    REFRESH_RATE_OPTIONS,
+} from "./constants";
 import SensorGraph from "./SensorGraph.vue";
 import MSP from "../../../js/msp";
 import MSPCodes from "../../../js/msp/MSPCodes";
@@ -103,7 +118,9 @@ const debugStore = useDebugStore();
 const sensorsStore = useSensorsStore();
 const { addInterval, removeInterval } = useInterval();
 
-const { checkboxes, rates, scales, debugColumns } = storeToRefs(sensorsStore);
+const { checkboxes, globalRate, scales, debugScales, debugColumns } = storeToRefs(sensorsStore);
+
+const refreshRateItems = REFRESH_RATE_OPTIONS.map((o) => ({ value: o.value, label: o.label }));
 
 const {
     addGyroSample,
@@ -114,6 +131,7 @@ const {
     addDebugSample,
     incrementDebugCounter,
     updateScales: updateGraphScales,
+    setDebugScales: updateGraphDebugScales,
     updateGraphs,
     initializeGraphs,
 } = useSensorGraph();
@@ -205,7 +223,8 @@ function initializeTimers() {
     removeInterval("sonar_pull");
     removeInterval("debug_pull");
 
-    const fastest = Math.min(rates.value.gyro, rates.value.accel, rates.value.mag);
+    // A single global refresh rate drives every graph so they stay in sync.
+    const rate = globalRate.value;
 
     if (checkboxes.value[0] || checkboxes.value[1] || checkboxes.value[2]) {
         addInterval(
@@ -213,7 +232,7 @@ function initializeTimers() {
             () => {
                 MSP.send_message(MSPCodes.MSP_RAW_IMU, false, false, update_imu_graphs);
             },
-            fastest,
+            rate,
             true,
         );
     }
@@ -224,7 +243,7 @@ function initializeTimers() {
             () => {
                 MSP.send_message(MSPCodes.MSP_ALTITUDE, false, false, update_altitude_graph);
             },
-            rates.value.altitude,
+            rate,
             true,
         );
     }
@@ -235,7 +254,7 @@ function initializeTimers() {
             () => {
                 MSP.send_message(MSPCodes.MSP_SONAR, false, false, update_sonar_graphs);
             },
-            rates.value.sonar,
+            rate,
             true,
         );
     }
@@ -246,7 +265,7 @@ function initializeTimers() {
             () => {
                 MSP.send_message(MSPCodes.MSP_DEBUG, false, false, update_debug_graphs);
             },
-            rates.value.debug,
+            rate,
             true,
         );
     }
@@ -323,15 +342,19 @@ function onCheckboxChange() {
     initializeTimers();
 }
 
-function updateRate(sensor, value) {
-    sensorsStore.updateRate(sensor, value);
+function updateGlobalRate(value) {
+    sensorsStore.updateGlobalRate(value);
     initializeTimers();
 }
 
 function updateScale(sensor, value) {
     sensorsStore.updateScale(sensor, value);
     updateGraphScales(scales.value);
-    initializeTimers();
+}
+
+function updateDebugScale(index, value) {
+    sensorsStore.updateDebugScale(index, value);
+    updateGraphDebugScales(debugScales.value);
 }
 
 onMounted(async () => {
@@ -367,6 +390,7 @@ onMounted(async () => {
     await nextTick();
     initializeGraphs(null, debugColumns.value);
     updateGraphScales(scales.value);
+    updateGraphDebugScales(debugScales.value);
     initializeTimers();
 });
 </script>

--- a/src/components/tabs/sensors/SensorGraph.vue
+++ b/src/components/tabs/sensors/SensorGraph.vue
@@ -10,7 +10,7 @@
                     <g class="axis x" transform="translate(40, 120)"></g>
                     <g class="axis y" transform="translate(40, 10)"></g>
                 </svg>
-                <div class="text-[10px] flex flex-col gap-1 [&_button]:!text-[10px] [&_[data-slot=base]]:!text-[10px]">
+                <div class="text-[10px] flex flex-col gap-1 [&_button]:text-[10px]! [&_[data-slot=base]]:text-[10px]!">
                     <div class="font-bold mb-2 flex items-center gap-1">
                         <span v-html="title"></span>
                         <HelpIcon v-if="hint" :text="hint" />
@@ -70,7 +70,7 @@
                     <g class="axis x" transform="translate(40, 120)"></g>
                     <g class="axis y" transform="translate(40, 10)"></g>
                 </svg>
-                <div class="text-[10px] flex flex-col gap-1 [&_button]:!text-[10px] [&_[data-slot=base]]:!text-[10px]">
+                <div class="text-[10px] flex flex-col gap-1 [&_button]:text-[10px]! [&_[data-slot=base]]:text-[10px]!">
                     <div class="font-bold mb-2"><span v-html="title"></span></div>
                     <div v-if="showRefreshRate" class="flex items-center gap-2">
                         <span class="flex-1" v-html="$t('sensorsRefresh')"></span>

--- a/src/components/tabs/sensors/SensorGraph.vue
+++ b/src/components/tabs/sensors/SensorGraph.vue
@@ -15,16 +15,6 @@
                         <span v-html="title"></span>
                         <HelpIcon v-if="hint" :text="hint" />
                     </div>
-                    <div v-if="showRefreshRate" class="flex items-center gap-2">
-                        <span class="flex-1" v-html="$t('sensorsRefresh')"></span>
-                        <USelect
-                            :model-value="rate"
-                            :items="refreshRateItems"
-                            @update:model-value="$emit('update:rate', Number($event))"
-                            class="min-w-24"
-                            size="xs"
-                        />
-                    </div>
                     <div v-if="scaleOptions" class="flex items-center gap-2">
                         <span class="flex-1" v-html="$t('sensorsScale')"></span>
                         <USelect
@@ -72,12 +62,12 @@
                 </svg>
                 <div class="text-[10px] flex flex-col gap-1 [&_button]:!text-[10px] [&_[data-slot=base]]:!text-[10px]">
                     <div class="font-bold mb-2"><span v-html="title"></span></div>
-                    <div v-if="showRefreshRate" class="flex items-center gap-2">
-                        <span class="flex-1" v-html="$t('sensorsRefresh')"></span>
+                    <div v-if="scaleOptions" class="flex items-center gap-2">
+                        <span class="flex-1" v-html="$t('sensorsScale')"></span>
                         <USelect
-                            :model-value="rate"
-                            :items="refreshRateItems"
-                            @update:model-value="$emit('update:rate', Number($event))"
+                            :model-value="scale"
+                            :items="scaleItems"
+                            @update:model-value="$emit('update:scale', Number($event))"
                             class="min-w-24"
                             size="xs"
                         />
@@ -96,7 +86,8 @@
 
 <script setup>
 import { ref, computed } from "vue";
-import { REFRESH_RATE_OPTIONS } from "./constants";
+import { DEBUG_SCALE_AUTO } from "./constants";
+import { i18n } from "@/js/localization";
 import UiBox from "@/components/elements/UiBox.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
 
@@ -108,19 +99,21 @@ const props = defineProps({
     visible: { type: Boolean, default: true },
     title: { type: String, required: true },
     hint: { type: String, default: null },
-    showRefreshRate: { type: Boolean, default: true },
-    rate: { type: Number, default: 50 },
     scale: { type: Number, default: null },
     scaleOptions: { type: Array, default: null },
     displayValues: { type: Array, required: true },
     isDebug: { type: Boolean, default: false },
 });
 
-const refreshRateItems = REFRESH_RATE_OPTIONS.map((o) => ({ value: o.value, label: o.label }));
+const scaleItems = computed(
+    () =>
+        props.scaleOptions?.map((v) => ({
+            value: v,
+            label: v === DEBUG_SCALE_AUTO ? i18n.getMessage("sensorsScaleAuto") : String(v),
+        })) ?? [],
+);
 
-const scaleItems = computed(() => props.scaleOptions?.map((v) => ({ value: v, label: String(v) })) ?? []);
-
-defineEmits(["update:rate", "update:scale"]);
+defineEmits(["update:scale"]);
 defineExpose({ svgElement });
 </script>
 

--- a/src/components/tabs/sensors/SensorGraph.vue
+++ b/src/components/tabs/sensors/SensorGraph.vue
@@ -15,6 +15,16 @@
                         <span v-html="title"></span>
                         <HelpIcon v-if="hint" :text="hint" />
                     </div>
+                    <div v-if="showRefreshRate" class="flex items-center gap-2">
+                        <span class="flex-1" v-html="$t('sensorsRefresh')"></span>
+                        <USelect
+                            :model-value="rate"
+                            :items="refreshRateItems"
+                            @update:model-value="$emit('update:rate', Number($event))"
+                            class="min-w-24"
+                            size="xs"
+                        />
+                    </div>
                     <div v-if="scaleOptions" class="flex items-center gap-2">
                         <span class="flex-1" v-html="$t('sensorsScale')"></span>
                         <USelect
@@ -62,6 +72,16 @@
                 </svg>
                 <div class="text-[10px] flex flex-col gap-1 [&_button]:!text-[10px] [&_[data-slot=base]]:!text-[10px]">
                     <div class="font-bold mb-2"><span v-html="title"></span></div>
+                    <div v-if="showRefreshRate" class="flex items-center gap-2">
+                        <span class="flex-1" v-html="$t('sensorsRefresh')"></span>
+                        <USelect
+                            :model-value="rate"
+                            :items="refreshRateItems"
+                            @update:model-value="$emit('update:rate', Number($event))"
+                            class="min-w-24"
+                            size="xs"
+                        />
+                    </div>
                     <div v-if="scaleOptions" class="flex items-center gap-2">
                         <span class="flex-1" v-html="$t('sensorsScale')"></span>
                         <USelect
@@ -86,7 +106,7 @@
 
 <script setup>
 import { ref, computed } from "vue";
-import { DEBUG_SCALE_AUTO } from "./constants";
+import { DEBUG_SCALE_AUTO, REFRESH_RATE_OPTIONS } from "./constants";
 import { i18n } from "@/js/localization";
 import UiBox from "@/components/elements/UiBox.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
@@ -99,11 +119,15 @@ const props = defineProps({
     visible: { type: Boolean, default: true },
     title: { type: String, required: true },
     hint: { type: String, default: null },
+    showRefreshRate: { type: Boolean, default: true },
+    rate: { type: Number, default: 50 },
     scale: { type: Number, default: null },
     scaleOptions: { type: Array, default: null },
     displayValues: { type: Array, required: true },
     isDebug: { type: Boolean, default: false },
 });
+
+const refreshRateItems = REFRESH_RATE_OPTIONS.map((o) => ({ value: o.value, label: o.label }));
 
 const scaleItems = computed(
     () =>
@@ -113,7 +137,7 @@ const scaleItems = computed(
         })) ?? [],
 );
 
-defineEmits(["update:scale"]);
+defineEmits(["update:rate", "update:scale"]);
 defineExpose({ svgElement });
 </script>
 

--- a/src/components/tabs/sensors/constants.js
+++ b/src/components/tabs/sensors/constants.js
@@ -15,3 +15,9 @@ export const REFRESH_RATE_OPTIONS = [
 export const GYRO_SCALE_OPTIONS = [1, 2, 3, 4, 5, 10, 25, 50, 100, 200, 300, 400, 500, 1000, 2000];
 export const ACCEL_SCALE_OPTIONS = [0.5, 1, 2];
 export const MAG_SCALE_OPTIONS = [100, 200, 500, 1000, 2000, 5000, 10000];
+
+// Debug scale options. A value of 0 means "Auto": the Y-axis follows the data
+// range (the 2025.12-maintenance behaviour). Any other value fixes the axis to
+// the symmetric range [-value, value].
+export const DEBUG_SCALE_AUTO = 0;
+export const DEBUG_SCALE_OPTIONS = [DEBUG_SCALE_AUTO, 50, 100, 250, 500, 1000, 2000, 5000, 10000];

--- a/src/composables/useSensorGraph.js
+++ b/src/composables/useSensorGraph.js
@@ -101,11 +101,14 @@ export function useSensorGraph() {
         }
     }
 
-    function initGraph(selector, sampleCount, heightRef, dataRef) {
+    function initGraph(selector, sampleCount, heightRef, dataRef, dynamic = false) {
         const helpers = {
             selector,
             data: dataRef,
             scaleYMax: heightRef,
+            // When dynamic, the Y-axis follows the data range instead of the
+            // fixed symmetric [-scaleYMax, scaleYMax] domain.
+            dynamic,
         };
         updateGraphHelperSize(helpers);
         const element = d3.select(helpers.selector);
@@ -150,7 +153,17 @@ export function useSensorGraph() {
 
         // Update scales with current dimensions
         helpers.scaleX.domain([sampleNumber - 299, sampleNumber]).range([0, helpers.width]);
-        helpers.scaleY.domain([-helpers.scaleYMax.value, helpers.scaleYMax.value]).range([helpers.height, 0]);
+        if (helpers.dynamic) {
+            // Follow the data range (matches 2025.12-maintenance debug graphs).
+            const limits = [];
+            for (const series of helpers.data) {
+                limits.push(series.min, series.max);
+            }
+            const [min, max] = d3.extent(limits);
+            helpers.scaleY.domain([min ?? -1, max ?? 1]).range([helpers.height, 0]);
+        } else {
+            helpers.scaleY.domain([-helpers.scaleYMax.value, helpers.scaleYMax.value]).range([helpers.height, 0]);
+        }
 
         const element = d3.select(helpers.selector);
 
@@ -204,7 +217,8 @@ export function useSensorGraph() {
 
         debugHelpers = [];
         for (let i = 0; i < debugColumns; i++) {
-            debugHelpers.push(initGraph(`#debug${i}`, 1, ref(500), debug_data.value[i]));
+            // Default to dynamic (Auto) scaling, restoring the legacy behaviour.
+            debugHelpers.push(initGraph(`#debug${i}`, 1, ref(500), debug_data.value[i], true));
         }
     }
 
@@ -217,6 +231,19 @@ export function useSensorGraph() {
         }
         if (magHelpers) {
             magHelpers.scaleYMax.value = scales.mag;
+        }
+    }
+
+    function setDebugScales(debugScales) {
+        for (let i = 0; i < debugHelpers.length; i++) {
+            const helper = debugHelpers[i];
+            const scale = debugScales?.[i] ?? 0;
+            if (scale > 0) {
+                helper.dynamic = false;
+                helper.scaleYMax.value = scale;
+            } else {
+                helper.dynamic = true;
+            }
         }
     }
 
@@ -298,6 +325,7 @@ export function useSensorGraph() {
         debug_data,
         initializeGraphs,
         updateScales,
+        setDebugScales,
         updateGraphs,
         addGyroSample,
         addAccelSample,

--- a/src/stores/sensors.js
+++ b/src/stores/sensors.js
@@ -6,15 +6,8 @@ export const useSensorsStore = defineStore("sensors", () => {
     // Sensor visibility checkboxes
     const checkboxes = ref([false, false, false, false, false, false]);
 
-    // Refresh rates (ms)
-    const rates = reactive({
-        gyro: 50,
-        accel: 50,
-        mag: 50,
-        altitude: 100,
-        sonar: 100,
-        debug: 500,
-    });
+    // Global refresh rate (ms) shared by every graph so they stay in sync
+    const globalRate = ref(50);
 
     // Scale values
     const scales = reactive({
@@ -22,6 +15,9 @@ export const useSensorsStore = defineStore("sensors", () => {
         accel: 2,
         mag: 2000,
     });
+
+    // Per-column debug scales (0 = Auto / dynamic). Indexed by debug column.
+    const debugScales = ref(new Array(8).fill(0));
 
     // Debug columns
     const debugColumns = ref(4);
@@ -32,11 +28,22 @@ export const useSensorsStore = defineStore("sensors", () => {
             if (config.checkboxes) {
                 checkboxes.value = config.checkboxes;
             }
-            if (config.rates) {
-                Object.assign(rates, config.rates);
+            if (typeof config.globalRate === "number") {
+                globalRate.value = config.globalRate;
+            } else if (config.rates) {
+                // Migrate legacy per-sensor rates to a single global rate.
+                const legacy = Object.values(config.rates).filter((v) => typeof v === "number");
+                if (legacy.length) {
+                    globalRate.value = Math.min(...legacy);
+                }
             }
             if (config.scales) {
                 Object.assign(scales, config.scales);
+            }
+            if (Array.isArray(config.debugScales)) {
+                for (let i = 0; i < debugScales.value.length; i++) {
+                    debugScales.value[i] = config.debugScales[i] ?? 0;
+                }
             }
             if (config.debugColumns) {
                 debugColumns.value = config.debugColumns;
@@ -47,19 +54,25 @@ export const useSensorsStore = defineStore("sensors", () => {
     function saveToConfig() {
         setConfig("sensors_tab", {
             checkboxes: checkboxes.value,
-            rates,
+            globalRate: globalRate.value,
             scales,
+            debugScales: debugScales.value,
             debugColumns: debugColumns.value,
         });
     }
 
-    function updateRate(sensor, value) {
-        rates[sensor] = value;
+    function updateGlobalRate(value) {
+        globalRate.value = value;
         saveToConfig();
     }
 
     function updateScale(sensor, value) {
         scales[sensor] = value;
+        saveToConfig();
+    }
+
+    function updateDebugScale(index, value) {
+        debugScales.value[index] = value;
         saveToConfig();
     }
 
@@ -70,13 +83,15 @@ export const useSensorsStore = defineStore("sensors", () => {
 
     return {
         checkboxes,
-        rates,
+        globalRate,
         scales,
+        debugScales,
         debugColumns,
         loadFromConfig,
         saveToConfig,
-        updateRate,
+        updateGlobalRate,
         updateScale,
+        updateDebugScale,
         updateCheckbox,
     };
 });

--- a/src/stores/sensors.js
+++ b/src/stores/sensors.js
@@ -6,8 +6,19 @@ export const useSensorsStore = defineStore("sensors", () => {
     // Sensor visibility checkboxes
     const checkboxes = ref([false, false, false, false, false, false]);
 
-    // Global refresh rate (ms) shared by every graph so they stay in sync
+    // Global refresh rate (ms). Setting it applies the same rate to every graph
+    // so they stay in sync; individual graphs can still be tuned afterwards.
     const globalRate = ref(50);
+
+    // Per-graph refresh rates (ms)
+    const rates = reactive({
+        gyro: 50,
+        accel: 50,
+        mag: 50,
+        altitude: 100,
+        sonar: 100,
+        debug: 500,
+    });
 
     // Scale values
     const scales = reactive({
@@ -28,10 +39,13 @@ export const useSensorsStore = defineStore("sensors", () => {
             if (config.checkboxes) {
                 checkboxes.value = config.checkboxes;
             }
+            if (config.rates) {
+                Object.assign(rates, config.rates);
+            }
             if (typeof config.globalRate === "number") {
                 globalRate.value = config.globalRate;
             } else if (config.rates) {
-                // Migrate legacy per-sensor rates to a single global rate.
+                // Seed the global control from the fastest saved per-sensor rate.
                 const legacy = Object.values(config.rates).filter((v) => typeof v === "number");
                 if (legacy.length) {
                     globalRate.value = Math.min(...legacy);
@@ -55,14 +69,24 @@ export const useSensorsStore = defineStore("sensors", () => {
         setConfig("sensors_tab", {
             checkboxes: checkboxes.value,
             globalRate: globalRate.value,
+            rates,
             scales,
             debugScales: debugScales.value,
             debugColumns: debugColumns.value,
         });
     }
 
+    function updateRate(sensor, value) {
+        rates[sensor] = value;
+        saveToConfig();
+    }
+
     function updateGlobalRate(value) {
         globalRate.value = value;
+        // Apply the global rate to every graph so they stay in sync.
+        for (const sensor of Object.keys(rates)) {
+            rates[sensor] = value;
+        }
         saveToConfig();
     }
 
@@ -84,11 +108,13 @@ export const useSensorsStore = defineStore("sensors", () => {
     return {
         checkboxes,
         globalRate,
+        rates,
         scales,
         debugScales,
         debugColumns,
         loadFromConfig,
         saveToConfig,
+        updateRate,
         updateGlobalRate,
         updateScale,
         updateDebugScale,


### PR DESCRIPTION
## Summary

After the Sensors tab was rebuilt with the new live sensor data view (#5096), debug graphs regressed: the new `useSensorGraph` hardcoded **every** debug graph to a fixed ±500 Y-axis. In 2025.12-maintenance the debug graphs auto-scaled to the data range, while only gyro/accel/mag used fixed scales.

This PR restores the original behaviour and adds two related improvements.

## Changes

### 1. Restore dynamic debug graph Y-scale (the regression)
- `useSensorGraph.js`: `initGraph` now takes a `dynamic` flag; `drawGraph` derives the Y-domain from the data extent (`d3.extent` of each series' running min/max) when dynamic, otherwise uses the fixed `[-scaleYMax, scaleYMax]`. Debug graphs initialise as dynamic — matching the legacy `initDataArray` defaults (`min=-1, max=1`) and running-extremes logic exactly.

### 2. Per-debug-value scale select
- `constants.js`: new `DEBUG_SCALE_OPTIONS` with `0 = Auto` (dynamic) plus fixed steps (50…10000).
- `SensorGraph.vue`: the debug layout renders a scale select; value `0` shows as "Auto" (i18n `sensorsScaleAuto`).
- `useSensorGraph.js`: new `setDebugScales()` toggles each column between dynamic (Auto) and a fixed `±value`.
- Choice persists per debug column in the sensors store.

### 3. Refresh rate: per-graph + global
- **Per-graph refresh**: each graph keeps its own refresh select — Gyroscope, Accelerometer, Magnetometer, Altitude, Sonar individually, plus a single select for the Debug section (all debug values arrive in one `MSP_DEBUG` message, so one rate drives that pull).
- **Global "Refresh all"**: a single control at the top of the panel applies its value to every per-graph rate at once so the graphs stay in sync. Individual graphs can still be tuned afterwards.
- The store keeps both `globalRate` and the per-sensor `rates`; both persist to config, and saved per-sensor rates are loaded as before.

## Testing
- `npm run test` — 152 tests pass
- `npm run lint` — clean
- `npm run build` — succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shared global refresh-rate control for all sensor graphs
  * Per-debug-column scale controls and an "Auto" debug-scale option
  * Scale selector added to debug graph UI
  * New UI translations for refresh label and "Auto"

* **Improvements**
  * Dynamic Y-axis scaling for debug graphs; changing scales no longer restarts timers
  * Persisted global refresh rate and debug-scale settings in configuration
<!-- end of auto-generated comment: release notes by coderabbit.ai -->