### PR TITLE
fix(flasher): validate autobackup data and guard against invalid API version

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4368,6 +4368,9 @@
     "firmwareFlasherCanceledBackup": {
         "message": "Backup cancelled, flashing aborted"
     },
+    "firmwareFlasherBackupInvalidData": {
+        "message": "Backup failed: received invalid data from the device (not in CLI mode), flashing aborted"
+    },
     "firmwareFlasherLegacyLabel": {
         "message": "{{target}} (Legacy)",
         "description": "If we have a Unified target and a old style target available, we are labeling the older one"

--- a/src/js/fc.js
+++ b/src/js/fc.js
@@ -8,7 +8,9 @@ const MAX_BATTERY_PROFILES = 3;
 const INITIAL_CONFIG = {
     apiVersion: "0.0.0",
     flightControllerIdentifier: "",
-    flightControllerVersion: "",
+    // Valid semver default so consumers (e.g. CLI autocomplete) that call semver.*
+    // on it before MSP_FC_VERSION arrives don't throw "Invalid Version".
+    flightControllerVersion: "0.0.0",
     version: 0,
     buildInfo: "",
     buildKey: "",

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -821,10 +821,24 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     console.log("Reboot request accepted");
                     break;
 
-                case MSPCodes.MSP_API_VERSION:
+                case MSPCodes.MSP_API_VERSION: {
+                    // A truncated/corrupt payload makes readU8() return null, producing an
+                    // unparseable version like "null.null.0". This happens intermittently
+                    // with MSP corruption / firmware issues and makes every downstream
+                    // semver comparison throw "Invalid Version". Validate the constructed
+                    // string and keep the semver-valid default ("0.0.0") otherwise, so the
+                    // connection logic can detect and abort the handshake cleanly.
                     FC.CONFIG.mspProtocolVersion = data.readU8();
-                    FC.CONFIG.apiVersion = `${data.readU8()}.${data.readU8()}.0`;
+                    const apiVersion = `${data.readU8()}.${data.readU8()}.0`;
+                    if (semver.valid(apiVersion)) {
+                        FC.CONFIG.apiVersion = apiVersion;
+                    } else {
+                        console.error(
+                            `MSP_API_VERSION: received invalid version "${apiVersion}" - possible MSP corruption / firmware issue`,
+                        );
+                    }
                     break;
+                }
 
                 case MSPCodes.MSP_FC_VARIANT:
                     let fcVariantIdentifier = "";

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -513,7 +513,11 @@ function onOpen(openInfo) {
         MSP.send_message(MSPCodes.MSP_API_VERSION, false, false, function () {
             gui_log(i18n.getMessage("apiVersionReceived", FC.CONFIG.apiVersion));
 
-            if (FC.CONFIG.apiVersion.includes("null") || FC.CONFIG.apiVersion === "0.0.0") {
+            // "0.0.0" is the uninitialised default (no valid version received), and any
+            // unparseable string (e.g. "null.null.0" from a corrupt/truncated payload)
+            // would make the semver.gte() below throw. Reject both robustly instead of
+            // matching a specific garbage substring.
+            if (FC.CONFIG.apiVersion === "0.0.0" || !semver.valid(FC.CONFIG.apiVersion)) {
                 abortConnection();
                 return;
             }

--- a/src/js/utils/AutoBackup.js
+++ b/src/js/utils/AutoBackup.js
@@ -11,9 +11,33 @@ import { serial } from "../serial";
  *
  */
 
+// CLI dumps are plain text: printable ASCII plus tab, CR and LF.
+function isPrintableCharCode(charCode) {
+    return charCode === 9 || charCode === 10 || charCode === 13 || (charCode >= 32 && charCode <= 126);
+}
+
+// Count non-printable characters in a string (firmware-version-independent).
+function countNonPrintable(text) {
+    let invalid = 0;
+    for (let i = 0; i < text.length; i++) {
+        if (!isPrintableCharCode(text.charCodeAt(i))) {
+            invalid++;
+        }
+    }
+    return invalid;
+}
+
+// A real diff/dump is non-empty, pure printable text, and contains at least one
+// CLI comment line (every diff/dump emits `#` header comments). This avoids
+// matching a brittle version banner string that changes between releases.
+export function isPlausibleCliDump(text) {
+    return text.length > 0 && countNonPrintable(text) === 0 && text.split(/\r?\n/).some((line) => line.startsWith("#"));
+}
+
 class AutoBackup {
     constructor() {
         this.outputHistory = "";
+        this.invalidCharCount = 0;
         this.callback = null;
         // Store bound handler references to ensure proper removal
         this.boundReadSerialAdapter = null;
@@ -21,12 +45,40 @@ class AutoBackup {
         this.boundHandleDisconnect = null;
     }
 
+    // Reset the receive buffer and its validation counters together.
+    resetBuffer() {
+        this.outputHistory = "";
+        this.invalidCharCount = 0;
+    }
+
+    // A valid CLI dump is pure printable ASCII, so a single non-printable byte
+    // means the stream is not CLI text (e.g. the device is still in MSP/binary
+    // mode). Tracked incrementally via invalidCharCount so the growing buffer
+    // isn't re-scanned, and trips on the very first garbage byte.
+    isReceivingGarbage() {
+        return this.invalidCharCount > 0;
+    }
+
+    // Centralised failure path: stop the interval, leave CLI, surface an error
+    // to the user, and notify the caller that the backup did not succeed.
+    failBackup(intervalId, reason) {
+        clearInterval(intervalId);
+        console.error(`AutoBackup: Aborting - ${reason}`);
+        gui_log(i18n.getMessage("firmwareFlasherBackupInvalidData"));
+
+        this.sendCommand("exit", this.onClose.bind(this));
+
+        if (this.callback) {
+            this.callback(false);
+        }
+    }
+
     handleConnect(openInfo) {
         console.log("Connected to serial port:", openInfo);
         if (openInfo) {
             // Ensure we have a fresh start
             this.cleanupListeners();
-            this.outputHistory = "";
+            this.resetBuffer();
 
             // Store bound reference for later cleanup
             this.boundReadSerialAdapter = this.readSerialAdapter.bind(this);
@@ -65,6 +117,9 @@ class AutoBackup {
         const data = new Uint8Array(info.detail.data);
 
         for (const charCode of data) {
+            if (!isPrintableCharCode(charCode)) {
+                this.invalidCharCount++;
+            }
             const currentChar = String.fromCharCode(charCode);
             this.outputHistory += currentChar;
         }
@@ -113,7 +168,7 @@ class AutoBackup {
 
     waitForCommandCompletion(command) {
         // Clear previous output
-        this.outputHistory = "";
+        this.resetBuffer();
 
         // Add debug mode for troubleshooting
         const DEBUG = true;
@@ -140,6 +195,19 @@ class AutoBackup {
                     const lastChars = this.outputHistory.slice(-30).replace(/\r/g, "\\r").replace(/\n/g, "\\n");
                     console.log(`AutoBackup: Last chars: "${lastChars}"`);
                 }
+            }
+
+            // Early bail-out: a single non-printable byte means the device is not
+            // producing a valid CLI dump (e.g. it is still in MSP/binary mode).
+            // Saving this garbage to a backup file is worse than failing fast.
+            if (this.isReceivingGarbage()) {
+                this.failBackup(
+                    intervalId,
+                    `received invalid (non-printable) data after ${elapsedTime / 1000}s ` +
+                        `(${this.invalidCharCount} invalid of ${this.outputHistory.length} chars). ` +
+                        `Device is not in CLI mode.`,
+                );
+                return;
             }
 
             // More robust prompt detection with multiple patterns
@@ -185,16 +253,23 @@ class AutoBackup {
             }
             // Check if we've waited too long
             else if (elapsedTime >= maxWaitTime) {
-                clearInterval(intervalId);
                 console.error(`AutoBackup: Timeout waiting for command completion after ${maxWaitTime / 1000}s`);
-
-                // Try to save what we have (partial data is better than none)
-                if (DEBUG) console.log(`AutoBackup: Saving partial data, buffer length: ${this.outputHistory.length}`);
 
                 const lines = this.outputHistory.split(/\r?\n/);
                 // Remove first line if it contains the command
                 const filteredLines = lines[0].includes(command) ? lines.slice(1) : lines;
                 const data = filteredLines.join("\n");
+
+                // Only persist partial data if it actually looks like a CLI dump.
+                // Writing a truncated-but-valid backup beats nothing, but writing
+                // binary/garbage that merely never reached the prompt is worse.
+                if (!isPlausibleCliDump(data)) {
+                    this.failBackup(intervalId, "timed out without receiving a valid CLI dump.");
+                    return;
+                }
+
+                clearInterval(intervalId);
+                if (DEBUG) console.log(`AutoBackup: Saving partial data, buffer length: ${this.outputHistory.length}`);
 
                 this.sendCommand("exit", this.onClose.bind(this));
                 this.save(data);
@@ -212,7 +287,7 @@ class AutoBackup {
             serial.send(bufferOut);
 
             setTimeout(() => {
-                this.outputHistory = "";
+                this.resetBuffer();
                 resolve();
             }, 1000);
         });
@@ -235,7 +310,7 @@ class AutoBackup {
 
     execute(callback) {
         // Reset state at the beginning of a new run
-        this.outputHistory = "";
+        this.resetBuffer();
         this.callback = callback;
         this.cleanupListeners();
 

--- a/test/js/msp/MSPHelper.test.js
+++ b/test/js/msp/MSPHelper.test.js
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
+import semver from "semver";
 import MspHelper from "../../../src/js/msp/MSPHelper";
 import MSPCodes from "../../../src/js/msp/MSPCodes";
 import "../../../src/js/injected_methods";
@@ -47,6 +48,45 @@ describe("MspHelper", () => {
 
             expect(FC.CONFIG.mspProtocolVersion).toEqual(mspProtocolVersion);
             expect(FC.CONFIG.apiVersion).toEqual(`${apiVersionMajor}.${apiVersionMinor}.0`);
+        });
+        it("keeps a valid default apiVersion when MSP_API_VERSION payload is empty (MSP corruption)", () => {
+            // An empty/truncated payload makes readU8() return null, which would
+            // otherwise build the unparseable "null.null.0" and make every downstream
+            // semver comparison throw "Invalid Version".
+            mspHelper.process_data({
+                code: MSPCodes.MSP_API_VERSION,
+                dataView: new DataView(new Uint8Array([]).buffer),
+                crcError: false,
+                callbacks: [],
+            });
+
+            expect(FC.CONFIG.apiVersion).not.toContain("null");
+            expect(FC.CONFIG.apiVersion).toEqual("0.0.0"); // unchanged default
+            expect(semver.valid(FC.CONFIG.apiVersion)).not.toBeNull();
+        });
+        it("keeps a valid default apiVersion when MSP_API_VERSION payload is truncated (MSP corruption)", () => {
+            // Only the protocol-version byte present, major/minor missing -> "X.null.null".
+            mspHelper.process_data({
+                code: MSPCodes.MSP_API_VERSION,
+                dataView: new DataView(new Uint8Array([42]).buffer),
+                crcError: false,
+                callbacks: [],
+            });
+
+            expect(FC.CONFIG.apiVersion).not.toContain("null");
+            expect(FC.CONFIG.apiVersion).toEqual("0.0.0");
+            expect(semver.valid(FC.CONFIG.apiVersion)).not.toBeNull();
+        });
+        it("does not let a corrupt MSP_API_VERSION throw in a downstream semver comparison", () => {
+            mspHelper.process_data({
+                code: MSPCodes.MSP_API_VERSION,
+                dataView: new DataView(new Uint8Array([]).buffer),
+                crcError: false,
+                callbacks: [],
+            });
+
+            // Mirrors the guard in serial_backend.js after the MSP_API_VERSION callback.
+            expect(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)).not.toThrow();
         });
         it("handles MSP_PIDNAMES correctly", () => {
             let pidNamesCount = 1 + crypto.getRandomValues(new Uint8Array(1))[0];

--- a/test/js/utils/AutoBackup.test.js
+++ b/test/js/utils/AutoBackup.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import AutoBackup, { isPlausibleCliDump } from "../../../src/js/utils/AutoBackup.js";
+
+const CRLF = "\r\n";
+
+// Helper to build the event shape readSerialAdapter expects.
+function receiveEvent(text) {
+    return { detail: { data: Array.from(text, (ch) => ch.charCodeAt(0)) } };
+}
+
+describe("AutoBackup", () => {
+    beforeEach(() => {
+        AutoBackup.resetBuffer();
+    });
+
+    describe("garbage detection", () => {
+        it("does not flag a clean ASCII CLI stream as garbage", () => {
+            AutoBackup.readSerialAdapter(receiveEvent(`# Betaflight / STM32F405${CRLF}set foo = 1${CRLF}`));
+
+            expect(AutoBackup.invalidCharCount).toEqual(0);
+            expect(AutoBackup.isReceivingGarbage()).toEqual(false);
+        });
+
+        it("flags the stream as garbage on the very first non-printable byte", () => {
+            // A single NUL byte amongst otherwise printable data is enough.
+            AutoBackup.readSerialAdapter({ detail: { data: [0x23, 0x00, 0x41] } });
+
+            expect(AutoBackup.invalidCharCount).toEqual(1);
+            expect(AutoBackup.isReceivingGarbage()).toEqual(true);
+        });
+
+        it("counts high/control bytes (binary MSP traffic) as non-printable", () => {
+            AutoBackup.readSerialAdapter({ detail: { data: [0x90, 0x80, 0x01, 0x02] } });
+
+            expect(AutoBackup.invalidCharCount).toEqual(4);
+            expect(AutoBackup.isReceivingGarbage()).toEqual(true);
+        });
+
+        it("treats tab, CR and LF as printable", () => {
+            AutoBackup.readSerialAdapter({ detail: { data: [0x09, 0x0d, 0x0a, 0x20] } });
+
+            expect(AutoBackup.invalidCharCount).toEqual(0);
+            expect(AutoBackup.isReceivingGarbage()).toEqual(false);
+        });
+
+        it("resetBuffer clears the buffer and the invalid-char counter", () => {
+            AutoBackup.readSerialAdapter({ detail: { data: [0x00, 0x01] } });
+            expect(AutoBackup.isReceivingGarbage()).toEqual(true);
+
+            AutoBackup.resetBuffer();
+
+            expect(AutoBackup.outputHistory).toEqual("");
+            expect(AutoBackup.invalidCharCount).toEqual(0);
+            expect(AutoBackup.isReceivingGarbage()).toEqual(false);
+        });
+    });
+
+    describe("isPlausibleCliDump", () => {
+        it("accepts a real diff dump", () => {
+            const dump = `# version${CRLF}# Betaflight / STM32F405 (S405) 4.5.0${CRLF}set foo = 1${CRLF}`;
+            expect(isPlausibleCliDump(dump)).toEqual(true);
+        });
+
+        it("rejects empty data", () => {
+            expect(isPlausibleCliDump("")).toEqual(false);
+        });
+
+        it("rejects data containing any non-printable byte", () => {
+            const withNul = `# version${CRLF}set foo = ${String.fromCharCode(0)}${CRLF}`;
+            expect(isPlausibleCliDump(withNul)).toEqual(false);
+        });
+
+        it("rejects printable data with no CLI comment line", () => {
+            expect(isPlausibleCliDump(`set foo = 1${CRLF}set bar = 2${CRLF}`)).toEqual(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two robustness issues observed while **flashing local firmware over serial** (see original screenshots).

### 1. AutoBackup ingests garbage data
Before flashing, `AutoBackup` runs a `diff all` and saves the output. When the device is still in MSP/binary mode it accumulated raw serial bytes without any validation, producing either a corrupt backup file written to disk or a full 30s timeout, with the console spamming `AutoBackup: Waiting for Ns, buffer length: X chars` over binary noise.

A valid `diff all` dump is pure printable ASCII, so:
- The backup now **fails on the very first non-printable byte** (`isReceivingGarbage()`), routing through a centralised `failBackup()` -> `callback(false)` -> existing abort flow, with a user-facing error.
- The **timeout path** no longer persists partial data unless it's a plausible (non-empty, pure-ASCII, contains a `#` CLI comment line) dump.

### 2. `TypeError: Invalid Version: null.null.0` during local flashing
This was triggered by the **firmware flasher's** MSP capability probe (`webstm32.js` -> `MSPConnector`), reached via "Looking for capabilities via MSP". That path is **separate** from the normal `serial_backend` connection and has **no `apiVersion` guard** -- `MSPConnector` simply sends `MSP_API_VERSION` and proceeds. So when a truncated/corrupt payload (intermittent MSP corruption / firmware issue) made `readU8()` return `null`, `apiVersion` became `"null.null.0"` and every downstream `semver` comparison threw `TypeError: Invalid Version`.

Because the flasher path doesn't go through the `serial_backend` guard, the fix has to be at the **source**:
- `MSP_API_VERSION` now validates the constructed string with `semver.valid()` and keeps the semver-valid `"0.0.0"` default otherwise, logging it as possible MSP corruption. This protects **all** consumers (flasher path included), since `apiVersion` can no longer hold an unparseable value.
- Also hardened the `serial_backend.js` connection guard to reject **any** non-semver-valid `apiVersion` (instead of matching the literal `"null"` substring).
- `flightControllerVersion` now defaults to `"0.0.0"` (was `""`, which is invalid semver) so the CLI-autocomplete consumer can't throw on the uninitialised value.

The DFU and STM flasher paths were audited -- they never feed a device-sourced version to `semver` beyond `apiVersion`, which is now always valid.

## Testing
- Added `test/js/utils/AutoBackup.test.js` -- garbage detection + `isPlausibleCliDump`.
- Added cases to `test/js/msp/MSPHelper.test.js` -- `MSP_API_VERSION` corruption fallback keeps a valid version and doesn't throw downstream.
- `npm run lint` clean, `npm run test` -> 164 tests passing.

> [!NOTE]
> A new i18n key `firmwareFlasherBackupInvalidData` was added to `locales/en/messages.json`; other locales sync via Crowdin.
