### PR TITLE
Fix icons for darkmode switch

### DIFF
--- a/src/components/sidebar/Sidebar.vue
+++ b/src/components/sidebar/Sidebar.vue
@@ -24,7 +24,7 @@
         </UTooltip>
         <UTooltip :text="$t('sidebarToggleDarkMode')" :delay-duration="300">
             <UButton
-                :icon="isDark ? 'i-lucide-moon' : 'i-lucide-sun'"
+                :icon="isDark ? 'i-lucide-sun' : 'i-lucide-moon'"
                 variant="ghost"
                 color="neutral"
                 square


### PR DESCRIPTION
- show moon icon when in light mode
- show sun icon when in dark mode

Or does icon (in master) show current state :stuck_out_tongue: 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the dark mode toggle button to display the appropriate icon based on the current theme state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->