### PR TITLE
feat(firmware-flasher): add post-flash backup restore

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8344,6 +8344,38 @@
         "message": "This action requires Betaflight firmware {{required}} or newer (currently connected to {{current}}). Please update your flight controller firmware before continuing.",
         "description": "Warning shown when an MSP CLI action is attempted on firmware that does not support MSP CLI"
     },
+    "firmwareFlasherRestoreBackup": {
+        "message": "Restore Backup",
+        "description": "Button to restore pre-flash backup from flasher tab"
+    },
+    "firmwareFlasherRestoreBackupTitle": {
+        "message": "Restore Pre-Flash Backup",
+        "description": "Title for the restore backup confirmation dialog"
+    },
+    "firmwareFlasherRestoreBackupConfirm": {
+        "message": "This will restore the configuration backup taken before flashing. Continue?",
+        "description": "Confirmation message before restoring a pre-flash backup"
+    },
+    "firmwareFlasherRestoreBackupSuccess": {
+        "message": "Configuration backup restored successfully.",
+        "description": "Success message after restoring a pre-flash backup"
+    },
+    "firmwareFlasherRestoreBackupSuccessSkipped": {
+        "message": "Configuration backup restored, {{count}} line(s) skipped.",
+        "description": "Success message after restoring a pre-flash backup when some CLI lines were skipped"
+    },
+    "firmwareFlasherRestoreBackupFailed": {
+        "message": "Restore failed: {{1}}",
+        "description": "Error message when restoring a pre-flash backup fails"
+    },
+    "firmwareFlasherRestoreConnectionFailed": {
+        "message": "Could not connect to flight controller for restore.",
+        "description": "Error message when connection fails during restore"
+    },
+    "firmwareFlasherNoBackupAvailable": {
+        "message": "No backup is available to restore.",
+        "description": "Error message when no backup data is cached for restore"
+    },
     "presetsLoadingDumpAll": {
         "message": "Loading current configuration from the flight controller",
         "description": "Title for the waiting dialog when loading dump all into a file"

--- a/src/components/dialogs/OptionsDialog.vue
+++ b/src/components/dialogs/OptionsDialog.vue
@@ -34,19 +34,6 @@
                     <SettingRow :label="$t('showNotifications')">
                         <USwitch v-model="settings.showNotifications" size="sm" />
                     </SettingRow>
-                    <SettingRow :label="$t('firmwareBackupOnFlash')">
-                        <USelect
-                            :items="[
-                                { label: $t('firmwareBackupDisabled'), value: 0 },
-                                { label: $t('firmwareBackupEnabled'), value: 1 },
-                                { label: $t('firmwareBackupAsk'), value: 2 },
-                            ]"
-                            size="sm"
-                            v-model="settings.backupOnFlash"
-                            class="min-w-40"
-                            :ui="{ content: 'z-3002' }"
-                        />
-                    </SettingRow>
                 </UiBox>
 
                 <UiBox :title="$t('languageAndAppearanceSettings')">

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -48,6 +48,7 @@
                     :on-erase-chip-change="handleEraseChipChange"
                     :on-flash-manual-baud-change="handleFlashManualBaudChange"
                     :on-flash-manual-baud-rate-change="handleFlashManualBaudRateChange"
+                    :on-restore-backup="handleRestoreBackup"
                 />
             </div>
         </div>
@@ -169,7 +170,8 @@ import PortHandler from "../../js/port_handler";
 import { gui_log } from "../../js/gui_log";
 import semver from "semver";
 import FileSystem from "../../js/FileSystem";
-import AutoBackup from "../../js/utils/AutoBackup.js";
+import AutoBackup, { getLastBackupData, resetLastBackupData } from "../../js/utils/AutoBackup.js";
+import AutoRestore from "../../js/utils/AutoRestore.js";
 import { EventBus } from "../eventBus";
 import STM32 from "../../js/protocols/webstm32";
 import { ispConnected } from "../../js/utils/connection.js";
@@ -275,6 +277,9 @@ export default defineComponent({
             flashingInProgress: false,
             lastFlashResultText: "",
             lastFlashResultClass: "",
+            // Restore-backup lifecycle (post-flash)
+            restoreInProgress: false,
+            restoreCompleted: false,
         });
 
         // Sponsor component ref
@@ -461,6 +466,10 @@ export default defineComponent({
             state.localFirmwareLoaded = false;
             state.filename = null;
             clearLoadedFirmwareInfo();
+            // NOTE: Do not reset the backup here. After a serial flash the board
+            // reboots and the device-removed event calls clearBufferedFirmware(),
+            // which would wipe the backup needed by the post-flash restore button.
+            // The backup is reset when a new flash begins (handleFlashFirmware).
         };
 
         const showLoadedFirmware = (filename, bytes) => {
@@ -1510,9 +1519,14 @@ export default defineComponent({
                 return;
             }
 
+            // Reset any previous backup cache before starting a new flash
+            resetLastBackupData();
+
             state.progressLabelText = "";
             state.lastFlashResultText = "";
             state.lastFlashResultClass = "";
+            state.restoreInProgress = false;
+            state.restoreCompleted = false;
             state.flashingInProgress = true;
             GUI.flashingInProgress = true;
             activeFlasherStep.value = "flash";
@@ -1725,6 +1739,74 @@ export default defineComponent({
             verifyBoardOnAbortCallback.value = null;
         };
 
+        // Handle restore backup functionality
+        const handleRestoreBackup = async () => {
+            // Check if there's a backup available
+            const backupData = getLastBackupData();
+            if (!backupData) {
+                dialog.openInfo(
+                    $t("warningTitle"),
+                    $t("firmwareFlasherNoBackupAvailable"),
+                    () => {}, // Empty callback to satisfy onConfirm requirement
+                );
+                return;
+            }
+
+            // Check if firmware version supports MSP CLI (4.5.4+)
+            // Note: We check the API version directly in AutoRestore.execute() for more accuracy
+            // This check is for user experience to show an info dialog before the operation
+            // But we still let the operation proceed since it will be verified in AutoRestore
+
+            // Confirmation dialog
+            dialog.openYesNo(
+                $t("firmwareFlasherRestoreBackupTitle"),
+                $t("firmwareFlasherRestoreBackupConfirm"),
+                async () => {
+                    // Parse backup content into CLI lines
+                    const fileLines = backupData.split(/\r?\n/).map((line) => line.trim());
+
+                    // Prepend "defaults nosave" if not present
+                    const hasDefaultsNoSave = fileLines.some((line) => line.trim().toLowerCase() === "defaults nosave");
+                    const cliLines = hasDefaultsNoSave ? fileLines : ["defaults nosave", ...fileLines];
+
+                    // Set connect lock to prevent tab switching interference
+                    GUI.connect_lock = true;
+                    state.restoreInProgress = true;
+
+                    // Open wait dialog
+                    dialog.openWait($t("firmwareFlasherRestoreBackupTitle"), null);
+
+                    // Execute restore
+                    AutoRestore.execute(cliLines, (result) => {
+                        dialog.close();
+                        GUI.connect_lock = false;
+                        state.restoreInProgress = false;
+
+                        if (result.success) {
+                            // Hide the restore button — restore already applied and saved.
+                            state.restoreCompleted = true;
+                            if (result.skipped > 0) {
+                                gui_log($t("firmwareFlasherRestoreBackupSuccessSkipped", { count: result.skipped }));
+                            } else {
+                                gui_log($t("firmwareFlasherRestoreBackupSuccess"));
+                            }
+                        } else {
+                            const errorMsg = result.errors || "Unknown error";
+                            gui_log($t("firmwareFlasherRestoreBackupFailed", { 1: errorMsg }));
+                            dialog.openInfo(
+                                $t("warningTitle"),
+                                $t("firmwareFlasherRestoreBackupFailed", { 1: errorMsg }),
+                                () => {}, // onConfirm — openInfo's 3rd arg must be a callback, not options
+                            );
+                        }
+                    });
+                },
+                () => {
+                    // No-op for "No" click
+                },
+            );
+        };
+
         const showDialogVerifyBoard = (selected, verified, onAccept, onAbort) => {
             if (verifyBoardContent.value) {
                 verifyBoardContent.value.innerHTML = $t("firmwareFlasherVerifyBoard", {
@@ -1859,6 +1941,7 @@ export default defineComponent({
             handleVerifyBoardAbort,
             handleVerifyBoardContinue,
             handleVerifyBoardDialogClose,
+            handleRestoreBackup,
             saveFirmware,
         };
     },

--- a/src/components/tabs/firmware-flasher/FlasherFlashTab.vue
+++ b/src/components/tabs/firmware-flasher/FlasherFlashTab.vue
@@ -120,7 +120,19 @@
                         </span>
                     </div>
                 </div>
-                <div></div>
+                <div>
+                    <UButton
+                        v-if="showRestoreButton"
+                        size="xs"
+                        color="success"
+                        icon="i-lucide-upload"
+                        :loading="restoreInProgress"
+                        @click="onRestoreBackup"
+                        :disabled="restoreInProgress"
+                    >
+                        {{ $t("firmwareFlasherRestoreBackup") }}
+                    </UButton>
+                </div>
             </div>
 
             <!-- Firmware Loaded Rows (online only) -->
@@ -198,15 +210,30 @@
                     @update:model-value="onFlashManualBaudRateChange"
                 />
             </SettingRow>
+            <SettingRow :label="$t('firmwareBackupOnFlash')">
+                <USelect
+                    :items="[
+                        { label: $t('firmwareBackupDisabled'), value: 0 },
+                        { label: $t('firmwareBackupEnabled'), value: 1 },
+                        { label: $t('firmwareBackupAsk'), value: 2 },
+                    ]"
+                    size="sm"
+                    v-model="backupOnFlash"
+                    class="min-w-40"
+                    :ui="{ content: 'z-3002' }"
+                />
+            </SettingRow>
         </UiBox>
     </div>
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed, ref, watch } from "vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import SettingRow from "@/components/elements/SettingRow.vue";
 import ProgressRing from "@/components/ProgressRing.vue";
+import { get as getConfig, set as setConfig } from "@/js/ConfigStorage";
+import { getLastBackupData } from "@/js/utils/AutoBackup";
 
 const props = defineProps({
     state: { type: Object, required: true },
@@ -217,6 +244,7 @@ const props = defineProps({
     onEraseChipChange: { type: Function, required: true },
     onFlashManualBaudChange: { type: Function, required: true },
     onFlashManualBaudRateChange: { type: Function, required: true },
+    onRestoreBackup: { type: Function, required: true },
 });
 
 // True while flash is actively running (progress updates flowing)
@@ -249,6 +277,34 @@ const flashResultRingColor = computed(() => {
         default:
             return "primary";
     }
+});
+
+// backupOnFlash preference — read from ConfigStorage on mount, persisted via watch
+const backupOnFlash = ref(getConfig("backupOnFlash", 1).backupOnFlash ?? 1);
+watch(
+    () => backupOnFlash.value,
+    (v) => setConfig({ backupOnFlash: v }),
+);
+
+// Restore progress busy flag (driven by the parent via shared state)
+const restoreInProgress = computed(() => props.state.restoreInProgress);
+
+// Show restore button only when flash succeeded, not flashing, restore not already
+// done, and backup data exists.
+// Note: No longer checking PortHandler.portAvailable as it's stale after flash
+const showRestoreButton = computed(() => {
+    if (props.state.flashingInProgress) {
+        return false;
+    }
+    if (props.state.lastFlashResultClass !== "valid" || !props.state.lastFlashResultText) {
+        return false;
+    }
+    if (props.state.restoreInProgress || props.state.restoreCompleted) {
+        return false;
+    }
+    // Only show if we have a backup available (checking for null or empty string)
+    const backupData = getLastBackupData();
+    return backupData !== null && backupData !== "";
 });
 </script>
 

--- a/src/js/utils/AutoBackup.js
+++ b/src/js/utils/AutoBackup.js
@@ -1,3 +1,4 @@
+import { ref } from "vue";
 import PortHandler from "../port_handler";
 import FileSystem from "../FileSystem";
 import { generateFilename } from "./generate_filename";
@@ -7,9 +8,28 @@ import { serial } from "../serial";
 
 /**
  *
- * Bacup the current configuration to a file before flashing in serial mode
+ * Backup the current configuration to a file before flashing in serial mode
  *
  */
+
+/**
+ * Reactive cache of the last captured backup data (the `diff all` output).
+ * Reactive so Vue computeds (e.g. the post-flash restore button) re-evaluate
+ * when the backup is captured or reset.
+ */
+const _lastBackupData = ref(null);
+
+export function getLastBackupData() {
+    return _lastBackupData.value;
+}
+
+export function setLastBackupData(data) {
+    _lastBackupData.value = data;
+}
+
+export function resetLastBackupData() {
+    _lastBackupData.value = null;
+}
 
 class AutoBackup {
     constructor() {
@@ -180,6 +200,10 @@ class AutoBackup {
 
                 if (DEBUG) console.log(`AutoBackup: Final data length: ${data.length} chars`);
 
+                // Hold the captured backup in memory immediately so it is available
+                // for restore regardless of whether the file-save picker succeeds.
+                setLastBackupData(data);
+
                 this.sendCommand("exit", this.onClose.bind(this));
                 this.save(data);
             }
@@ -195,6 +219,9 @@ class AutoBackup {
                 // Remove first line if it contains the command
                 const filteredLines = lines[0].includes(command) ? lines.slice(1) : lines;
                 const data = filteredLines.join("\n");
+
+                // Hold partial backup data in memory as well — better than nothing.
+                setLastBackupData(data);
 
                 this.sendCommand("exit", this.onClose.bind(this));
                 this.save(data);

--- a/src/js/utils/AutoBackup.js
+++ b/src/js/utils/AutoBackup.js
@@ -284,10 +284,8 @@ class AutoBackup {
                 const filteredLines = lines[0].includes(command) ? lines.slice(1) : lines;
                 const data = filteredLines.join("\n");
 
-<<<<<<< HEAD
                 // Hold partial backup data in memory as well — better than nothing.
                 setLastBackupData(data);
-=======
                 // Only persist partial data if it actually looks like a CLI dump.
                 // Writing a truncated-but-valid backup beats nothing, but writing
                 // binary/garbage that merely never reached the prompt is worse.
@@ -298,7 +296,6 @@ class AutoBackup {
 
                 clearInterval(intervalId);
                 if (DEBUG) console.log(`AutoBackup: Saving partial data, buffer length: ${this.outputHistory.length}`);
->>>>>>> origin/master
 
                 this.sendCommand("exit", this.onClose.bind(this));
                 this.save(data);

--- a/src/js/utils/AutoRestore.js
+++ b/src/js/utils/AutoRestore.js
@@ -48,25 +48,33 @@ class AutoRestore {
     }
 
     handleSerialReceive(event) {
-        MSP.read(event.detail);
+        // MSP.read accepts either the raw bytes or the { data } wrapper, but pass
+        // event.detail.data to match the convention used by serial_backend.
+        MSP.read(event.detail.data);
     }
 
     handleConnect(event) {
         this.onConnect(event.detail);
     }
 
-    handleDisconnect(event) {
+    handleDisconnect() {
         // A disconnect while saving means the FC rebooted after a successful save —
         // that is the expected success path, not a failure.
         if (this._saving) {
             this._cleanup(true, null);
             return;
         }
-        this._cleanup(false, i18n.getMessage(event.detail ? "serialPortClosedOk" : "serialPortClosedFail"));
+        // An unexpected disconnect before save is a restore failure; use the
+        // restore-specific message (the generic "serial port closed" wording is
+        // misleading here).
+        this._cleanup(false, i18n.getMessage("firmwareFlasherRestoreConnectionFailed"));
     }
 
     async onConnect(openInfo) {
-        if (!openInfo) {
+        // A "connect" event can fire for a failed attempt too (the serial wrapper
+        // normalizes the detail into a truthy object), so verify the transport is
+        // actually connected rather than relying on openInfo being falsy.
+        if (!openInfo || !serial.connected) {
             this._cleanup(false, i18n.getMessage("serialPortOpenFail"));
             return;
         }
@@ -187,7 +195,7 @@ class AutoRestore {
             }
 
             // Backup did not contain a `save` line — persist explicitly.
-            this._finishWithSave(errors);
+            await this._finishWithSave(errors);
         } catch (error) {
             console.error("AutoRestore: CLI command execution failed:", error);
             this._cleanup(false, String(error));
@@ -207,7 +215,7 @@ class AutoRestore {
             console.warn(`AutoRestore: restore applied with ${errors.length} ignored CLI error(s)`, errors);
         }
 
-        gui_log("Saving configuration...");
+        gui_log(i18n.getMessage("buttonSaving"));
         this._saving = true;
         MSP.send_cli_command("save");
         await new Promise((resolve) => setTimeout(resolve, SAVE_FLUSH_MS));

--- a/src/js/utils/AutoRestore.js
+++ b/src/js/utils/AutoRestore.js
@@ -1,0 +1,277 @@
+import PortHandler from "../port_handler";
+import { gui_log } from "../gui_log";
+import { i18n } from "../localization";
+import MspHelper from "../msp/MSPHelper";
+import FC from "../fc";
+import MSP from "../msp";
+import MSPCodes from "../msp/MSPCodes";
+import GUI from "../gui";
+import { serial } from "../serial";
+import { MIN_FC_VERSION_FOR_MSP_CLI, isMspCliSupported } from "../../composables/useMspCliSession";
+import semver from "semver";
+import CONFIGURATOR from "../data_storage";
+
+const DEFAULT_COMMAND_TIMEOUT_MS = 2000;
+const CONNECT_TIMEOUT_MS = 10000;
+const TIMEOUT_NAME = "msp_restore_timeout";
+// Time to let the `save` command flush to the FC before we tear down the connection.
+const SAVE_FLUSH_MS = 500;
+
+class AutoRestore {
+    constructor() {
+        this.boundHandleConnect = this.handleConnect.bind(this);
+        this.boundHandleDisconnect = this.handleDisconnect.bind(this);
+        this.boundHandleSerialReceive = this.handleSerialReceive.bind(this);
+        this._callback = null;
+        this._mspHelper = null;
+        this._cliLines = null;
+        // Count of CLI lines that returned an error (rejected/###ERROR) during restore.
+        this._skipped = 0;
+        // True while the `save` command is in flight. A `save` reboots the FC, so the
+        // resulting disconnect/timeout is expected success, not a failure.
+        this._saving = false;
+    }
+
+    canAttemptConnection() {
+        if (CONFIGURATOR.virtualMode) {
+            gui_log(i18n.getMessage("firmwareFlasherNoValidPort"));
+            return false;
+        }
+
+        if (serial.connected) {
+            console.warn("AutoRestore: Attempting to connect while already connected");
+            gui_log(i18n.getMessage("serialPortOpenFail"));
+            return false;
+        }
+
+        return true;
+    }
+
+    handleSerialReceive(event) {
+        MSP.read(event.detail);
+    }
+
+    handleConnect(event) {
+        this.onConnect(event.detail);
+    }
+
+    handleDisconnect(event) {
+        // A disconnect while saving means the FC rebooted after a successful save —
+        // that is the expected success path, not a failure.
+        if (this._saving) {
+            this._cleanup(true, null);
+            return;
+        }
+        this._cleanup(false, i18n.getMessage(event.detail ? "serialPortClosedOk" : "serialPortClosedFail"));
+    }
+
+    async onConnect(openInfo) {
+        if (!openInfo) {
+            this._cleanup(false, i18n.getMessage("serialPortOpenFail"));
+            return;
+        }
+
+        // CRITICAL: Reset FC state to clear stale data before any MSP queries
+        FC.resetState();
+
+        // Set up receive handler
+        serial.removeEventListener("receive", this.boundHandleSerialReceive);
+        serial.addEventListener("receive", this.boundHandleSerialReceive);
+
+        // Create MSP helper and listen for incoming data
+        this._mspHelper = new MspHelper();
+        MSP.listen(this._mspHelper.process_data.bind(this._mspHelper));
+
+        // Set connect timeout — if API version not received within CONNECT_TIMEOUT_MS, abort
+        GUI.timeout_add(
+            TIMEOUT_NAME,
+            () => {
+                this._cleanup(false, i18n.getMessage("firmwareFlasherRestoreConnectionFailed"));
+            },
+            CONNECT_TIMEOUT_MS,
+        );
+
+        try {
+            // Query API version first
+            await MSP.promise(MSPCodes.MSP_API_VERSION);
+            GUI.timeout_remove(TIMEOUT_NAME);
+
+            // Handle potential API version parsing issues
+            if (
+                !FC.CONFIG.apiVersion ||
+                FC.CONFIG.apiVersion.includes("null") ||
+                semver.lt(FC.CONFIG.apiVersion, "1.39.0")
+            ) {
+                this._cleanup(false, i18n.getMessage("firmwareFlasherRestoreConnectionFailed"));
+                return;
+            }
+
+            // Query FC version to check MSP CLI support
+            await MSP.promise(MSPCodes.MSP_FC_VERSION);
+
+            const fcVersion = FC.CONFIG.flightControllerVersion;
+            // MIN_FC_VERSION_FOR_MSP_CLI is a flight-controller version (4.5.4), so it
+            // must be compared against flightControllerVersion — NOT apiVersion (1.x.x).
+            if (!isMspCliSupported()) {
+                const message = i18n.getMessage("mspCliFirmwareTooOld", {
+                    required: MIN_FC_VERSION_FOR_MSP_CLI,
+                    current: fcVersion || "unknown",
+                });
+                gui_log(message);
+                this._cleanup(false, message);
+                return;
+            }
+
+            // Handshake OK — proceed to send CLI commands
+            this._sendCliCommands();
+        } catch (error) {
+            console.error("AutoRestore: MSP query failed:", error);
+            // Only cleanup if not already cleaned up (guard against double cleanup)
+            if (this._callback) {
+                this._cleanup(false, i18n.getMessage("firmwareFlasherRestoreConnectionFailed"));
+            }
+        }
+    }
+
+    async _sendCliCommands() {
+        const cliLines = this._cliLines;
+        const errors = [];
+
+        try {
+            for (const line of cliLines) {
+                const trimmed = line.trim();
+                if (!trimmed || trimmed.startsWith("#")) {
+                    continue;
+                }
+
+                // `save` reboots the FC and persists the config. A `diff`/`dump` backup
+                // ends with `save`, so it arrives here as a normal batch line. It never
+                // returns a CLI prompt (the board reboots), so don't wait for one — flag
+                // the save, fire it, and finish. The reboot's disconnect is then treated
+                // as success by handleDisconnect (and this path) instead of a failure.
+                if (trimmed.toLowerCase() === "save") {
+                    await this._finishWithSave(errors);
+                    return;
+                }
+
+                const response = await new Promise((resolve, reject) => {
+                    MSP.send_cli_command(
+                        trimmed,
+                        (data, error) => {
+                            if (error) {
+                                reject(error);
+                                return;
+                            }
+                            resolve(Array.isArray(data) ? data : []);
+                        },
+                        { timeoutMs: DEFAULT_COMMAND_TIMEOUT_MS },
+                    );
+                }).catch((error) => {
+                    const message = String(error?.message ?? error);
+                    errors.push({ command: trimmed, error: message });
+                    gui_log(`CLI command failed: ${trimmed} — ${message}`);
+                    return null;
+                });
+
+                // Check for error lines in response
+                if (response) {
+                    const errorLines = response.filter((l) => l && l.startsWith("###ERROR"));
+                    if (errorLines.length > 0) {
+                        errors.push({ command: trimmed, error: errorLines.join("; ") });
+                        gui_log(`CLI command failed: ${trimmed} — ${errorLines.join("; ")}`);
+                    }
+                }
+
+                // Small delay between commands
+                await new Promise((resolve) => setTimeout(resolve, 15));
+            }
+
+            // Backup did not contain a `save` line — persist explicitly.
+            this._finishWithSave(errors);
+        } catch (error) {
+            console.error("AutoRestore: CLI command execution failed:", error);
+            this._cleanup(false, String(error));
+        }
+    }
+
+    /**
+     * Issue `save` (which reboots the FC) and report success. Per-line CLI errors are
+     * logged but never fail the restore; only a connection loss BEFORE save (reported via
+     * handleDisconnect with _saving=false) is a failure.
+     */
+    async _finishWithSave(errors) {
+        // Record skipped lines before save so this path and the save-reboot disconnect
+        // path (handleDisconnect) report the same count.
+        this._skipped = errors.length;
+        if (errors.length > 0) {
+            console.warn(`AutoRestore: restore applied with ${errors.length} ignored CLI error(s)`, errors);
+        }
+
+        gui_log("Saving configuration...");
+        this._saving = true;
+        MSP.send_cli_command("save");
+        await new Promise((resolve) => setTimeout(resolve, SAVE_FLUSH_MS));
+
+        this._cleanup(true, null);
+    }
+
+    _cleanup(success, errorMsg) {
+        // Guard against double-invocation (e.g. timeout + disconnect)
+        if (!this._callback) {
+            return;
+        }
+        const callback = this._callback;
+        this._callback = null;
+        this._saving = false;
+
+        try {
+            serial.disconnect();
+        } catch (e) {
+            console.error("AutoRestore: disconnect error:", e);
+        }
+
+        serial.removeEventListener("receive", this.boundHandleSerialReceive);
+        serial.removeEventListener("connect", this.boundHandleConnect);
+        serial.removeEventListener("disconnect", this.boundHandleDisconnect);
+
+        MSP.clearListeners();
+        MSP.disconnect_cleanup();
+        FC.resetState();
+
+        GUI.timeout_remove(TIMEOUT_NAME);
+
+        callback({ success, errors: errorMsg, skipped: this._skipped });
+    }
+
+    async execute(cliLines, callback) {
+        if (!this.canAttemptConnection()) {
+            callback({ success: false, errors: i18n.getMessage("firmwareFlasherRestoreConnectionFailed") });
+            return;
+        }
+
+        this._cliLines = cliLines;
+        this._callback = callback;
+        this._saving = false;
+        this._skipped = 0;
+
+        // The board is already booted and the port is available when restore is invoked,
+        // so connect directly — no need to wait for the port.
+        const port = PortHandler.portPicker.selectedPort;
+        const baud = PortHandler.portPicker.selectedBauds;
+
+        try {
+            serial.addEventListener("connect", this.boundHandleConnect, { once: true });
+            serial.addEventListener("disconnect", this.boundHandleDisconnect, { once: true });
+
+            const result = await serial.connect(port, { baudRate: baud });
+            if (!result) {
+                this._cleanup(false, i18n.getMessage("firmwareFlasherRestoreConnectionFailed"));
+            }
+        } catch (error) {
+            console.error("AutoRestore: Connection exception:", error);
+            this._cleanup(false, i18n.getMessage("firmwareFlasherRestoreConnectionFailed"));
+        }
+    }
+}
+
+export default new AutoRestore();

--- a/src/js/utils/AutoRestore.js
+++ b/src/js/utils/AutoRestore.js
@@ -224,11 +224,11 @@ class AutoRestore {
         this._callback = null;
         this._saving = false;
 
-        try {
-            serial.disconnect();
-        } catch (e) {
-            console.error("AutoRestore: disconnect error:", e);
-        }
+        // serial.disconnect() is async; _cleanup is not, so handle any rejection with
+        // .catch() rather than a (useless) synchronous try/catch.
+        serial.disconnect().catch((error) => {
+            console.error("AutoRestore: disconnect error:", error);
+        });
 
         serial.removeEventListener("receive", this.boundHandleSerialReceive);
         serial.removeEventListener("connect", this.boundHandleConnect);


### PR DESCRIPTION
## Description

Adds an in-place **restore** of the pre-flash backup to the firmware flasher. After flashing, users can re-apply the configuration that was backed up during `backupOnFlash` directly from the post-flash success UI — without reconnecting and navigating to the Presets tab.

## Changes

- **Backup cache (`AutoBackup`)**: the captured `diff all` output is held in a reactive cache the moment it is parsed, independent of the file-save picker. It is no longer wiped by the post-flash device-removed event, so it survives the board reboot and is available for restore. Reset only when a new flash starts.
- **Restore (`AutoRestore`, new)**: opens a dedicated MSP CLI session, replays the backup CLI lines and `save`, then cleans up (like AutoDetect). Key behaviours:
  - The `save`-induced reboot/disconnect is treated as **success** (not a failure).
  - A `save` line contained in the backup batch is handled correctly (no spurious "port closed" failure, no redundant double-save).
  - MSP CLI support is checked against `flightControllerVersion` (>= 4.5.4), not `apiVersion`.
  - Per-line CLI errors (e.g. a setting the firmware build doesn't recognise) are reported as "N line(s) skipped" rather than failing the whole restore.
- **Firmware flasher UI**: the **Restore Backup** button appears in the post-flash success row when a backup exists. It is hidden during a restore and after a **successful** restore, and re-offered after a failed one.
- **Options**: moved the *Backup on flash* preference out of the Options dialog into the firmware flasher advanced settings.

## Testing

- Verified on hardware (SpeedyBee F405 Mini, 2026.6.0 firmware): flash -> reboot -> restore applies the backup and saves; success is reported correctly and the button is removed afterwards.
- `npm run lint` clean; locale JSON validated.

## Notes

- Available for firmware that supports MSP CLI (>= 4.5.4).
- Restore connects over the serial port that re-enumerates after flashing; DFU/local flows without a serial backup do not show the button.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Restore backup flow: "Restore backup" button, confirmation dialogs, progress state, connection locking, and post‑flash restore action.
  * Advanced "Backup on flash" option to capture backups automatically.

* **Improved Reliability**
  * In‑memory caching of the latest backup so a post‑flash restore remains available even if the device is removed.

* **Localization**
  * Added English strings for restore button, confirmations, success (including partial‑skip) and error messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->