### PR TITLE
fix(blackbox): resolve export workers via import.meta.url

### DIFF
--- a/src/blackbox-viewer/csv-exporter.js
+++ b/src/blackbox-viewer/csv-exporter.js
@@ -26,7 +26,7 @@ export function CsvExporter(flightLog, opts = {}) {
         const frames = flightLog
                 .getChunksInTimeRange(flightLog.getMinTime(), flightLog.getMaxTime())
                 .map((chunk) => chunk.frames),
-            worker = new Worker("/js/webworkers/csv-export-worker.js");
+            worker = new Worker(new URL("../js/webworkers/csv-export-worker.js", import.meta.url));
 
         worker.onmessage = (event) => {
             success(event.data);

--- a/src/blackbox-viewer/gpx-exporter.js
+++ b/src/blackbox-viewer/gpx-exporter.js
@@ -10,7 +10,7 @@ export function GpxExporter(flightLog) {
         const frames = flightLog
                 .getChunksInTimeRange(flightLog.getMinTime(), flightLog.getMaxTime())
                 .map((chunk) => chunk.frames),
-            worker = new Worker("/js/webworkers/gpx-export-worker.js");
+            worker = new Worker(new URL("../js/webworkers/gpx-export-worker.js", import.meta.url));
 
         worker.onmessage = (event) => {
             success(event.data);

--- a/src/blackbox-viewer/spectrum-exporter.js
+++ b/src/blackbox-viewer/spectrum-exporter.js
@@ -21,7 +21,7 @@ export function SpectrumExporter(fftData, opts = {}) {
      * @param {function} success is a callback triggered when export is done
      */
     function dump(success) {
-        const worker = new Worker("/js/webworkers/spectrum-export-worker.js");
+        const worker = new Worker(new URL("../js/webworkers/spectrum-export-worker.js", import.meta.url));
 
         worker.onmessage = (event) => {
             success(event.data);


### PR DESCRIPTION
## Summary

The Blackbox log viewer tab (added in #5163) ships CSV, GPX and spectrum-CSV export, but none of them work at runtime: all three exporters load their web worker from the hardcoded absolute path `/js/webworkers/*.js`.

That path resolved in the original blackbox-log-viewer because the workers lived in `public/`, but in the configurator the workers are under `src/` (which Vite does **not** serve at the URL root), there is no `public/` dir, and `vite.config.js` sets `base: "./"` for Tauri/APK asset paths — so an absolute `/js/...` URL 404s and every export silently fails.

## Fix

Load the workers via Vite's native worker resolution:

```js
new Worker(new URL("../js/webworkers/<name>-export-worker.js", import.meta.url))
```

Vite bundles each worker as a hashed chunk and resolves it relative to the configured `base`, so exports work in dev, web build, and the Tauri/Capacitor (APK) builds. This matches the existing `new URL(..., import.meta.url)` asset idiom already used elsewhere (e.g. `GpsTab.vue`, `FailsafeTab.vue`). The workers stay classic (no internal imports), so no worker `type` change is needed.

Files changed (one line each):
- `src/blackbox-viewer/csv-exporter.js`
- `src/blackbox-viewer/gpx-exporter.js`
- `src/blackbox-viewer/spectrum-exporter.js`

## Testing

- [x] `eslint` + `prettier` pass (pre-commit)
- [ ] `npm run build` emits `*-export-worker-*.js` chunks with no path warnings
- [ ] Load a GPS `.bbl`; CSV / GPX / spectrum exports download valid files; no 404 for `*-export-worker.js` in DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the internal architecture of CSV, GPX, and spectrum export functionality to improve code quality and resource handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->