### PR TITLE
feat(firmware-flasher): flash ESP32 .bin over serial bootloader

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -4356,6 +4356,30 @@
     "firmwareFlasherUF2SaveFailed": {
         "message": "Failed to save (flash) UF2"
     },
+    "firmwareFlasherEsp32Connecting": {
+        "message": "Connecting to ESP32 bootloader..."
+    },
+    "firmwareFlasherEsp32Detected": {
+        "message": "Detected $1"
+    },
+    "firmwareFlasherEsp32Flashing": {
+        "message": "Flashing ESP32..."
+    },
+    "firmwareFlasherEsp32Rebooting": {
+        "message": "Flashing complete, rebooting..."
+    },
+    "firmwareFlasherEsp32Complete": {
+        "message": "Flashed ESP32 successfully"
+    },
+    "firmwareFlasherEsp32Failed": {
+        "message": "ESP32 flashing failed: $1"
+    },
+    "firmwareFlasherEsp32NotSupported": {
+        "message": "ESP32 flashing requires the browser (Web Serial) build"
+    },
+    "firmwareFlasherEsp32NoPort": {
+        "message": "Select a serial port before flashing the ESP32"
+    },
     "firmwareFlasherClickToConnectDfu": {
         "message": "Click to connect to DFU device"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "d3": "^7.9.0",
         "djv": "^2.1.4",
         "dompurify": "^3.4.0",
+        "esptool-js": "^0.6.0",
         "geomagnetism": "^0.2.0",
         "i18next": "^24.2.2",
         "i18next-http-backend": "^3.0.5",
@@ -6853,6 +6854,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha512-LEeSAWeh2Gfa2FtlQE1shxQ8zi5F9GHarrGKz08TMdODD5T4eH6BMsvtnhbWZ+XQn+Gb6om/917ucvRu7l7ukw==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -9056,6 +9063,17 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/esptool-js": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/esptool-js/-/esptool-js-0.6.0.tgz",
+      "integrity": "sha512-ZyuSBXvmS+4DRKM6GrDHfCscnq3YSNlRfM+Zw0DoS7uC3SdkyC262s/ji4MjDYVmMH8SE2BiYx3/dZ1J23Xiew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "atob-lite": "^2.0.0",
+        "pako": "^2.1.0",
+        "tslib": "^2.4.1"
       }
     },
     "node_modules/esquery": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "d3": "^7.9.0",
     "djv": "^2.1.4",
     "dompurify": "^3.4.0",
+    "esptool-js": "^0.6.0",
     "geomagnetism": "^0.2.0",
     "i18next": "^24.2.2",
     "i18next-http-backend": "^3.0.5",

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -414,7 +414,7 @@ export default defineComponent({
             enableLoadRemoteFileButton(true);
             enableLoadFileButton(true);
 
-            if (firmwareFlashing.getParsedHex() || firmwareFlashing.getUf2Binary()) {
+            if (firmwareFlashing.getParsedHex() || firmwareFlashing.getUf2Binary() || firmwareFlashing.getEspBinary()) {
                 if (state.preFlashingMessage && state.preFlashingMessageType) {
                     flashingMessage(state.preFlashingMessage, state.preFlashingMessageType);
                 }

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -405,7 +405,11 @@ export default defineComponent({
             state.flashProgressValue = 0;
             state.flashingInProgress = false;
             GUI.flashingInProgress = false;
-            enableFlashButton(!!firmwareFlashing.getParsedHex() || !!firmwareFlashing.getUf2Binary());
+            enableFlashButton(
+                !!firmwareFlashing.getParsedHex() ||
+                    !!firmwareFlashing.getUf2Binary() ||
+                    !!firmwareFlashing.getEspBinary(),
+            );
             updateDfuExitButtonState();
             enableLoadRemoteFileButton(true);
             enableLoadFileButton(true);
@@ -1648,7 +1652,11 @@ export default defineComponent({
             state.developmentFirmwareLoaded = false;
 
             try {
-                const file = await FileSystem.pickOpenFile($t("fileSystemPickerFirmwareFiles"), [".hex", ".uf2"]);
+                const file = await FileSystem.pickOpenFile($t("fileSystemPickerFirmwareFiles"), [
+                    ".hex",
+                    ".uf2",
+                    ".bin",
+                ]);
 
                 if (!file) {
                     enableLoadRemoteFileButton(true);
@@ -1658,7 +1666,7 @@ export default defineComponent({
 
                 const extension = getExtension(file.name);
 
-                if (extension === "uf2") {
+                if (extension === "uf2" || extension === "bin") {
                     const data = await FileSystem.readFileAsBlob(file);
                     await processFirmwareFile(file, extension, data);
                 } else if (extension === "hex") {

--- a/src/composables/useFirmwareFlashing.js
+++ b/src/composables/useFirmwareFlashing.js
@@ -6,6 +6,7 @@ import ConfigInserter from "../js/ConfigInserter";
 import { tracking } from "../js/Analytics";
 import read_hex_file from "../js/workers/hex_parser";
 import STM32 from "../js/protocols/webstm32";
+import ESP32 from "../js/protocols/esp32";
 import PortHandler from "../js/port_handler";
 
 /**
@@ -27,6 +28,7 @@ export function useFirmwareFlashing(params = {}) {
     const firmwareState = reactive({
         parsedHex: null,
         uf2Binary: null,
+        espBinary: null,
         intelHex: null,
     });
 
@@ -36,6 +38,7 @@ export function useFirmwareFlashing(params = {}) {
     const clearFirmwareState = () => {
         firmwareState.parsedHex = null;
         firmwareState.uf2Binary = null;
+        firmwareState.espBinary = null;
         firmwareState.intelHex = null;
     };
 
@@ -169,7 +172,38 @@ export function useFirmwareFlashing(params = {}) {
     };
 
     /**
-     * Process firmware file (HEX or UF2) based on extension
+     * Process a raw ESP32 .bin firmware image (merged image flashed at offset 0x0)
+     */
+    const processBin = async (data, options) => {
+        const { enableLoadRemoteFileButton, showLoadedFirmware, key, isLocalFile } = options;
+
+        let bytes;
+        if (!data) {
+            bytes = undefined;
+        } else if (data instanceof Blob) {
+            bytes = new Uint8Array(await data.arrayBuffer());
+        } else if (data instanceof ArrayBuffer) {
+            bytes = new Uint8Array(data);
+        } else {
+            bytes = data;
+        }
+
+        if (!bytes || bytes.byteLength === 0) {
+            const errorMessage = isLocalFile
+                ? `Failed to load ${key}`
+                : $t?.("firmwareFlasherFailedToLoadOnlineFirmware");
+            flashingMessage?.(errorMessage, FLASH_MESSAGE_TYPES?.NEUTRAL);
+            enableLoadRemoteFileButton?.(true);
+            return null;
+        }
+
+        firmwareState.espBinary = bytes;
+        showLoadedFirmware?.(key, bytes.byteLength);
+        return { espBinary: bytes, firmwareType: "BIN" };
+    };
+
+    /**
+     * Process firmware file (HEX, UF2 or ESP32 BIN) based on extension
      */
     const processFirmware = async (data, extension, options) => {
         const { enableFlashButton, enableLoadRemoteFileButton, showLoadedFirmware, key, isLocalFile } = options;
@@ -193,6 +227,13 @@ export function useFirmwareFlashing(params = {}) {
                 });
             } else if (fileExtension === "uf2") {
                 return await processUf2(data, {
+                    enableLoadRemoteFileButton,
+                    showLoadedFirmware,
+                    key,
+                    isLocalFile,
+                });
+            } else if (fileExtension === "bin") {
+                return await processBin(data, {
                     enableLoadRemoteFileButton,
                     showLoadedFirmware,
                     key,
@@ -285,6 +326,38 @@ export function useFirmwareFlashing(params = {}) {
                     resetFlashingState?.();
                 });
         }
+    };
+
+    /**
+     * Flash a raw ESP32 .bin image over the serial ROM bootloader (browser Web Serial only).
+     */
+    const flashEspFirmware = async (options = {}) => {
+        const { filename } = options;
+
+        const image = firmwareState.espBinary;
+        if (!image) {
+            flashingMessage?.($t?.("firmwareFlasherFirmwareNotLoaded"), FLASH_MESSAGE_TYPES?.INVALID);
+            return false;
+        }
+
+        const port = PortHandler.portPicker.selectedPort;
+        if (!port || !port.startsWith("serial")) {
+            flashingMessage?.($t?.("firmwareFlasherEsp32NoPort"), FLASH_MESSAGE_TYPES?.INVALID);
+            return false;
+        }
+
+        tracking.sendEvent(tracking.EVENT_CATEGORIES.FLASHING, "ESP32 Flashing", {
+            filename: filename || null,
+        });
+
+        // esptool-js connects at the ROM baud (115200) and bumps to this rate after the stub loads.
+        const ESP_FLASH_BAUD = 460800;
+
+        return ESP32.connect(port, ESP_FLASH_BAUD, image, {
+            flashingMessage,
+            flashProgress,
+            flashMessageTypes: FLASH_MESSAGE_TYPES,
+        });
     };
 
     /**
@@ -415,6 +488,21 @@ export function useFirmwareFlashing(params = {}) {
             enableDfuExitButton?.(dfuAvailable);
 
             report("uf2-complete", { saved });
+            return;
+        }
+
+        // ESP32 .bin flow — flashed over the serial ROM bootloader via esptool-js.
+        // Bypasses the STM32 MSP reboot-to-bootloader and the backup machinery.
+        if (firmwareType === "BIN") {
+            const flashed = await flashEspFirmware({ filename });
+
+            resumeSponsorInterval?.();
+            enableFlashButton?.(true);
+            enableLoadRemoteFileButton?.(true);
+            enableLoadFileButton?.(true);
+            enableDfuExitButton?.(dfuAvailable);
+
+            report("bin-complete", { flashed });
             return;
         }
 
@@ -554,6 +642,7 @@ export function useFirmwareFlashing(params = {}) {
         // Getters (for backward compatibility)
         getParsedHex: () => firmwareState.parsedHex,
         getUf2Binary: () => firmwareState.uf2Binary,
+        getEspBinary: () => firmwareState.espBinary,
         getIntelHex: () => firmwareState.intelHex,
 
         // Methods

--- a/src/composables/useFirmwareFlashing.js
+++ b/src/composables/useFirmwareFlashing.js
@@ -179,16 +179,18 @@ export function useFirmwareFlashing(params = {}) {
 
         let bytes;
         if (!data) {
-            bytes = undefined;
+            bytes = null;
         } else if (data instanceof Blob) {
             bytes = new Uint8Array(await data.arrayBuffer());
         } else if (data instanceof ArrayBuffer) {
             bytes = new Uint8Array(data);
-        } else {
+        } else if (data instanceof Uint8Array) {
             bytes = data;
+        } else {
+            bytes = null;
         }
 
-        if (!bytes || bytes.byteLength === 0) {
+        if (!(bytes instanceof Uint8Array) || bytes.byteLength === 0) {
             const errorMessage = isLocalFile
                 ? `Failed to load ${key}`
                 : $t?.("firmwareFlasherFailedToLoadOnlineFirmware");
@@ -340,15 +342,14 @@ export function useFirmwareFlashing(params = {}) {
             return false;
         }
 
-        const port = PortHandler.portPicker.selectedPort;
-        if (!port || !port.startsWith("serial")) {
-            flashingMessage?.($t?.("firmwareFlasherEsp32NoPort"), FLASH_MESSAGE_TYPES?.INVALID);
-            return false;
-        }
-
         tracking.sendEvent(tracking.EVENT_CATEGORIES.FLASHING, "ESP32 Flashing", {
             filename: filename || null,
         });
+
+        // Let ESP32.connect() own environment gating (Web Serial only) and port
+        // validation, so the correct message is shown on Tauri/Capacitor and when
+        // no port is selected.
+        const port = PortHandler.portPicker.selectedPort;
 
         // esptool-js connects at the ROM baud (115200) and bumps to this rate after the stub loads.
         const ESP_FLASH_BAUD = 460800;
@@ -494,15 +495,23 @@ export function useFirmwareFlashing(params = {}) {
         // ESP32 .bin flow — flashed over the serial ROM bootloader via esptool-js.
         // Bypasses the STM32 MSP reboot-to-bootloader and the backup machinery.
         if (firmwareType === "BIN") {
-            const flashed = await flashEspFirmware({ filename });
-
-            resumeSponsorInterval?.();
-            enableFlashButton?.(true);
-            enableLoadRemoteFileButton?.(true);
-            enableLoadFileButton?.(true);
-            enableDfuExitButton?.(dfuAvailable);
-
-            report("bin-complete", { flashed });
+            // Hold the connect lock for the duration of the long-running flash so
+            // nothing else grabs the port, and always finalise the UI in finally.
+            GUI.connect_lock = true;
+            try {
+                const flashed = await flashEspFirmware({ filename });
+                if (!flashed) {
+                    flashProgress?.(100);
+                }
+                report("bin-complete", { flashed });
+            } finally {
+                GUI.connect_lock = false;
+                resumeSponsorInterval?.();
+                enableFlashButton?.(true);
+                enableLoadRemoteFileButton?.(true);
+                enableLoadFileButton?.(true);
+                enableDfuExitButton?.(dfuAvailable);
+            }
             return;
         }
 

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -100,6 +100,16 @@ class WebSerial extends EventTarget {
         return this.port;
     }
 
+    /**
+     * Return the raw W3C SerialPort for a given path, so callers that need direct
+     * port access (e.g. esptool-js for ESP32 flashing) can own open/close and signals.
+     * @param {string} path - port path (e.g. "serial")
+     * @returns {SerialPort|undefined}
+     */
+    getNativePort(path) {
+        return this.ports.find((device) => device.path === path)?.port;
+    }
+
     createPort(port) {
         const portInfo = port.getInfo();
         const displayName = vendorIdNames[portInfo.usbVendorId]

--- a/src/js/protocols/esp32.js
+++ b/src/js/protocols/esp32.js
@@ -1,0 +1,133 @@
+/*
+    ESP32 firmware flashing over the serial ROM bootloader.
+
+    Wraps the espressif `esptool-js` library (SLIP framing, per-chip stub loaders,
+    chip auto-detection and the DTR/RTS reset sequence). A merged image
+    (bootloader + partition table + application) is flashed at offset 0x0; the
+    chip type is auto-detected so a single .bin works across esp32/s2/s3/c3.
+
+    Scope: the browser Web Serial path only. esptool-js needs a W3C SerialPort
+    with setSignals() for the reset-to-bootloader sequence, which the Tauri and
+    Capacitor serial layers do not expose yet.
+*/
+import { i18n } from "../localization";
+import { serial } from "../serial";
+import { isAndroid, isTauri } from "../utils/checkCompatibility";
+
+const logHead = "[ESP32]";
+
+class ESP32Protocol {
+    constructor() {
+        this.transport = null;
+        this.loader = null;
+    }
+
+    /**
+     * Flash a merged ESP32 image at offset 0x0.
+     *
+     * @param {string} port - selected serial port path (e.g. "serial")
+     * @param {number} baud - post-stub baud rate
+     * @param {Uint8Array} image - merged firmware image
+     * @param {object} options - { flashingMessage, flashProgress, flashMessageTypes }
+     * @returns {Promise<boolean>} true on success
+     */
+    async connect(port, baud, image, options = {}) {
+        const { flashingMessage, flashProgress, flashMessageTypes: TYPES } = options;
+
+        const message = (key, type, ...args) =>
+            flashingMessage?.(args.length ? i18n.getMessage(key, args) : i18n.getMessage(key), type);
+
+        // esptool-js requires a W3C SerialPort with DTR/RTS control — browser Web Serial only.
+        if (isTauri() || isAndroid() || !navigator.serial) {
+            console.warn(`${logHead} ESP32 flashing requires the browser Web Serial path`);
+            message("firmwareFlasherEsp32NotSupported", TYPES?.INVALID);
+            flashProgress?.(0);
+            return false;
+        }
+
+        if (!image || image.byteLength === 0) {
+            message("firmwareFlasherFirmwareNotLoaded", TYPES?.INVALID);
+            return false;
+        }
+
+        const serialProtocol = serial.selectProtocol(port);
+        const nativePort = serialProtocol?.getNativePort?.(port);
+        if (!nativePort) {
+            console.error(`${logHead} No native serial port for path:`, port);
+            message("firmwareFlasherEsp32NoPort", TYPES?.INVALID);
+            return false;
+        }
+
+        // esptool-js owns the port (open/close, readable/writable, signals) for the
+        // duration of flashing, so the wrapper must not be holding it.
+        if (serialProtocol.connected) {
+            await serialProtocol.disconnect();
+        }
+
+        // Keep esptool-js out of the main bundle — only needed when flashing ESP32.
+        const { ESPLoader, Transport } = await import("esptool-js");
+
+        const terminal = {
+            clean: () => {},
+            write: (data) => console.log(`${logHead} ${data}`),
+            writeLine: (data) => console.log(`${logHead} ${data}`),
+        };
+
+        let success = false;
+        try {
+            this.transport = new Transport(nativePort, false);
+            this.loader = new ESPLoader({
+                transport: this.transport,
+                baudrate: baud || 115200,
+                terminal,
+            });
+
+            message("firmwareFlasherEsp32Connecting", TYPES?.ACTION);
+            flashProgress?.(0);
+
+            const chip = await this.loader.main(); // reset -> sync -> detect -> stub
+            console.log(`${logHead} Detected chip: ${chip}`);
+            flashingMessage?.(i18n.getMessage("firmwareFlasherEsp32Detected", [chip]), TYPES?.NEUTRAL);
+
+            message("firmwareFlasherEsp32Flashing", TYPES?.FLASHING);
+            await this.loader.writeFlash({
+                fileArray: [{ data: image, address: 0 }],
+                flashSize: "keep",
+                flashMode: "keep",
+                flashFreq: "keep",
+                eraseAll: false,
+                compress: true,
+                reportProgress: (_fileIndex, written, total) => {
+                    if (total > 0) {
+                        flashProgress?.(Math.round((written / total) * 100));
+                    }
+                },
+            });
+
+            message("firmwareFlasherEsp32Rebooting", TYPES?.NEUTRAL);
+            await this.loader.after("hard_reset");
+
+            success = true;
+            flashProgress?.(100);
+            message("firmwareFlasherEsp32Complete", TYPES?.VALID);
+        } catch (error) {
+            console.error(`${logHead} Flashing failed:`, error);
+            flashingMessage?.(i18n.getMessage("firmwareFlasherEsp32Failed", [error.message || error]), TYPES?.INVALID);
+            flashProgress?.(100);
+        } finally {
+            try {
+                await this.transport?.disconnect();
+            } catch (e) {
+                console.warn(`${logHead} Transport disconnect error (can be ignored):`, e);
+            }
+            this.transport = null;
+            this.loader = null;
+        }
+
+        return success;
+    }
+}
+
+const ESP32 = new ESP32Protocol();
+
+export default ESP32;

--- a/src/js/protocols/esp32.js
+++ b/src/js/protocols/esp32.js
@@ -17,10 +17,8 @@ import { isAndroid, isTauri } from "../utils/checkCompatibility";
 const logHead = "[ESP32]";
 
 class ESP32Protocol {
-    constructor() {
-        this.transport = null;
-        this.loader = null;
-    }
+    transport = null;
+    loader = null;
 
     /**
      * Flash a merged ESP32 image at offset 0x0.
@@ -38,7 +36,7 @@ class ESP32Protocol {
             flashingMessage?.(args.length ? i18n.getMessage(key, args) : i18n.getMessage(key), type);
 
         // esptool-js requires a W3C SerialPort with DTR/RTS control — browser Web Serial only.
-        if (isTauri() || isAndroid() || !navigator.serial) {
+        if (isTauri() || isAndroid() || !globalThis.navigator?.serial) {
             console.warn(`${logHead} ESP32 flashing requires the browser Web Serial path`);
             message("firmwareFlasherEsp32NotSupported", TYPES?.INVALID);
             flashProgress?.(0);


### PR DESCRIPTION
Adds ESP32 firmware flashing to the firmware flasher: pick a merged ESP32 `.bin` and flash it at offset `0x0` over the serial ROM bootloader, alongside the existing HEX (STM32) and UF2 paths.

It wraps the espressif `esptool-js` library (SLIP framing, per-chip stub loaders, chip auto-detection and the DTR/RTS reset sequence), so a single `.bin` works across esp32/s2/s3/c3. The library is lazy-loaded so it stays out of the main bundle. A new `BIN` firmware type routes to a dedicated ESP flow that bypasses the STM32 MSP reboot and backup machinery.

Scope is the browser Web Serial path for now — esptool-js needs a W3C SerialPort with DTR/RTS control, which the Tauri and Capacitor serial layers do not expose yet, so those are guarded out gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added browser-based ESP32 firmware flashing over Web Serial
  * Added support for uploading raw `.bin` firmware files (in addition to existing formats)
  * Added localized status and error messages for the ESP32 flashing workflow (connecting, detecting, flashing, rebooting, complete, and failure cases)

* **Improvements**
  * Updated the firmware flashing workflow to recognize ESP binaries as “loaded” and to support the new BIN flash path
<!-- end of auto-generated comment: release notes by coderabbit.ai -->