### PR TITLE
fix(sensors): clear acc calibration warning and pause poll during calibration

### DIFF
--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -1616,6 +1616,14 @@ const accNeedsCalibration = computed(() => {
 const calibratingAccel = ref(false);
 const { addTimeout } = useTimeout();
 
+// React to the firmware clearing the flag after calibration completes
+watch(accNeedsCalibration, (needsCal, wasNeeded) => {
+    if (wasNeeded && !needsCal && calibratingAccel.value) {
+        gui_log(i18n.getMessage("initialSetupAccelCalibEnded"));
+        calibratingAccel.value = false;
+    }
+});
+
 function onCalibrateAccel() {
     if (calibratingAccel.value) {
         return;
@@ -1635,9 +1643,15 @@ function onCalibrateAccel() {
             if (!isMounted.value) {
                 return;
             }
-            gui_log(i18n.getMessage("initialSetupAccelCalibEnded"));
-            calibratingAccel.value = false;
-            MSP.send_message(MSPCodes.MSP_STATUS_EX, false, false);
+            // Re-fetch board info to refresh configurationProblems; the watcher above
+            // handles cleanup when the flag clears. The callback acts as a fallback for
+            // firmware that does not report configurationProblems.
+            MSP.send_message(MSPCodes.MSP_BOARD_INFO, false, false, function () {
+                if (calibratingAccel.value) {
+                    gui_log(i18n.getMessage("initialSetupAccelCalibEnded"));
+                    calibratingAccel.value = false;
+                }
+            });
         },
         ACC_CALIBRATION_TIMEOUT_MS,
     );

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -1619,6 +1619,7 @@ const { addTimeout } = useTimeout();
 // React to the firmware clearing the flag after calibration completes
 watch(accNeedsCalibration, (needsCal, wasNeeded) => {
     if (wasNeeded && !needsCal && calibratingAccel.value) {
+        resumeInterval("sensors_attitude");
         gui_log(i18n.getMessage("initialSetupAccelCalibEnded"));
         calibratingAccel.value = false;
     }

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -1630,6 +1630,10 @@ function onCalibrateAccel() {
     }
     calibratingAccel.value = true;
 
+    // The MCU is locked in a busy loop during calibration and cannot process
+    // serial commands; pause the attitude poll to avoid flooding the buffer.
+    pauseInterval("sensors_attitude");
+
     MSP.send_message(MSPCodes.MSP_ACC_CALIBRATION, false, false, function () {
         if (!isMounted.value) {
             return;
@@ -1643,6 +1647,7 @@ function onCalibrateAccel() {
             if (!isMounted.value) {
                 return;
             }
+            resumeInterval("sensors_attitude");
             // Re-fetch board info to refresh configurationProblems; the watcher above
             // handles cleanup when the flag clears. The callback acts as a fallback for
             // firmware that does not report configurationProblems.
@@ -1674,7 +1679,7 @@ let attitudeIndicator = null;
 let headingIndicator = null;
 let altimeterIndicator = null;
 
-const { addInterval, removeAllIntervals } = useInterval();
+const { addInterval, pauseInterval, resumeInterval, removeAllIntervals } = useInterval();
 
 const DEG_TO_RAD = Math.PI / 180;
 

--- a/src/composables/useInterval.js
+++ b/src/composables/useInterval.js
@@ -28,6 +28,14 @@ export function useInterval() {
         }
     }
 
+    function pauseInterval(name) {
+        return GUI.interval_pause(name);
+    }
+
+    function resumeInterval(name) {
+        return GUI.interval_resume(name);
+    }
+
     function removeAllIntervals() {
         localIntervals.forEach((name) => GUI.interval_remove(name));
         localIntervals.length = 0;
@@ -40,6 +48,8 @@ export function useInterval() {
     return {
         addInterval,
         removeInterval,
+        pauseInterval,
+        resumeInterval,
         removeAllIntervals,
     };
 }

--- a/src/composables/useInterval.js
+++ b/src/composables/useInterval.js
@@ -1,6 +1,14 @@
 import { onUnmounted } from "vue";
 import GUI from "../js/gui";
 
+function pauseInterval(name) {
+    return GUI.interval_pause(name);
+}
+
+function resumeInterval(name) {
+    return GUI.interval_resume(name);
+}
+
 /**
  * A composable for managing named intervals via GUI's interval registry.
  * All intervals added through this composable are automatically removed
@@ -26,14 +34,6 @@ export function useInterval() {
         if (idx !== -1) {
             localIntervals.splice(idx, 1);
         }
-    }
-
-    function pauseInterval(name) {
-        return GUI.interval_pause(name);
-    }
-
-    function resumeInterval(name) {
-        return GUI.interval_resume(name);
     }
 
     function removeAllIntervals() {


### PR DESCRIPTION
## Description

The accelerometer "needs calibration" warning on the Sensors tab did not clear after a successful calibration, and the periodic attitude poll kept hitting the MCU while it was busy calibrating.

### Root cause

The warning banner is driven by `FC.CONFIG.configurationProblems`, which is **only** populated by `MSP_BOARD_INFO` (`MSPHelper.js`). After calibration the tab polled `MSP_STATUS_EX`, which does not carry `configurationProblems`, so the flag was never refreshed — the banner stayed visible until the next reconnect, and the watcher that was meant to clear it never fired.

### Changes

- **Refresh the right MSP message** — poll `MSP_BOARD_INFO` after calibration so `configurationProblems` is updated. A `watch(accNeedsCalibration, …)` clears the banner when the flag clears, with the request callback as a fallback for firmware that doesn't report `configurationProblems`.
- **Pause the attitude poll during calibration** — the MCU is locked in a busy loop during accelerometer calibration and cannot service serial commands, so the `sensors_attitude` interval would flood the serial buffer. It is now paused before calibration and resumed once the calibration window elapses, matching the legacy setup-tab behaviour.
- Expose `pauseInterval` / `resumeInterval` from the `useInterval` composable to support this.

## Testing

- Connect a board reporting the acc-needs-calibration flag, calibrate, and confirm the warning banner clears once calibration completes.
- Confirm the "Calibrating…" button state resets and the attitude display resumes afterwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Synced accelerometer calibration UI state with firmware so calibration start/stop stays consistent.
  * Paused attitude sensor polling during accelerometer calibration to reduce command-buffer flooding and UI slowdowns.
  * Improved calibration timeout handling: polling resumes and calibration only stops when calibration is still active, with configuration refresh triggered as a fallback.
  * Added interval pause/resume controls to make sensor update behavior more reliable during calibration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->