### PR TITLE
Fix/magsphere-quaternion

### DIFF
--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -445,19 +445,18 @@ function updateQuadAttitude() {
         return;
     }
 
-    // Prefer quaternion (gimbal-lock-free) when available
+    // Q1 frame adapter: BF body-to-earth (FLU/NWU) → display (FRD/NED).
+    // Net result = Rx180 · q. Both attitude sources pass through the identical
+    // adapter + shared _BASE_180_X post-multiply so they cannot diverge.
     if (props.quaternion) {
         const { w, x, y, z } = props.quaternion;
-        // BF quaternion is body-to-earth. Q1 frame adapter (180°-about-X)
-        // converts FLU/NWU → FRD/NED: negate qy, qz.
         _targetQuat.set(x, -y, -z, w);
     } else if (props.attitude) {
-        // Fallback to Euler angles (has gimbal lock at +/-90 pitch)
         const { roll, pitch, heading } = props.attitude;
-        // BF body-to-earth Euler (ZYX): invert to earth-to-body, then convert to display frame.
-        // Display axes: X=BF_X, Y=-BF_Y, Z=-BF_Z → pitch & heading signs cancel with inversion.
-        const euler = new THREE.Euler(-roll * DEG_TO_RAD, pitch * DEG_TO_RAD, heading * DEG_TO_RAD, "ZYX");
-        _targetQuat.setFromEuler(euler);
+        const q = new THREE.Quaternion().setFromEuler(
+            new THREE.Euler(roll * DEG_TO_RAD, pitch * DEG_TO_RAD, heading * DEG_TO_RAD, "ZYX"),
+        );
+        _targetQuat.set(q.x, -q.y, -q.z, q.w);
     } else {
         return;
     }

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -121,6 +121,7 @@ const _targetQuat = new THREE.Quaternion();
 // 180° about X (forward axis): the Betaflight→scene frame adapter.
 // Derivation lives in updateQuadAttitude() — the one genuinely subtle spot.
 const _BASE_180_X = new THREE.Quaternion(1, 0, 0, 0);
+const _tmpEuler = new THREE.Euler();
 let smoothQuatInitialized = false;
 
 // Reference ghost sphere (shown before calibration data arrives)
@@ -465,10 +466,9 @@ function updateQuadAttitude() {
         // Euler fallback: build q from (roll, pitch, heading) in aerospace ZYX,
         // then the same adapter.
         const { roll, pitch, heading } = props.attitude;
-        const q = new THREE.Quaternion().setFromEuler(
-            new THREE.Euler(roll * DEG_TO_RAD, pitch * DEG_TO_RAD, heading * DEG_TO_RAD, "ZYX"),
-        );
-        _targetQuat.set(q.x, -q.y, -q.z, q.w);
+        _tmpEuler.set(roll * DEG_TO_RAD, pitch * DEG_TO_RAD, heading * DEG_TO_RAD, "ZYX");
+        _tmpQuat.setFromEuler(_tmpEuler);
+        _targetQuat.set(_tmpQuat.x, -_tmpQuat.y, -_tmpQuat.z, _tmpQuat.w);
     } else {
         return;
     }

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -118,6 +118,8 @@ let quadIcon = null;
 const ATTITUDE_SMOOTH = 0.12;
 const _smoothQuat = new THREE.Quaternion();
 const _targetQuat = new THREE.Quaternion();
+// 180° about X (forward axis): the Betaflight→scene frame adapter.
+// Derivation lives in updateQuadAttitude() — the one genuinely subtle spot.
 const _BASE_180_X = new THREE.Quaternion(1, 0, 0, 0);
 let smoothQuatInitialized = false;
 
@@ -264,7 +266,8 @@ function initScene() {
     smoothQuatInitialized = false;
     noseDirections = [];
 
-    // Camera — Z-up convention, pulled back for isometric overview
+    // Scene is NED: +Z is down, so visual "up" is -Z. Camera sits north-east and
+    // above the origin (+X north, +Y east, -Z up) for an isometric overview.
     camera = new THREE.PerspectiveCamera(50, width / height, 0.1, 50000);
     camera.up.set(0, 0, -1);
     camera.position.set(700, 560, -420);
@@ -445,15 +448,22 @@ function updateQuadAttitude() {
         return;
     }
 
-    // Betaflight stores the quaternion in FLU/NWU (X=forward, Y=left, Z=up).
-    // The viewer uses FRD/NED (X=forward, Y=right, Z=down). These differ by
-    // a 180° rotation about X — negate qy and qz to convert.
-    // Net result = Rx180 · q. Both sources pass through the same adapter
-    // + shared _BASE_180_X so the quaternion and Euler paths cannot diverge.
+    // Frame adapter. Betaflight attitude is FLU/NWU; this scene is FRD/NED.
+    // They differ by 180° about X (flip Y and Z), so the mesh gets Rx180·q.
+    //
+    // Done in two steps that look redundant but aren't — drop either and the
+    // hemisphere bug returns (hidden near the equator, obvious at high latitude):
+    //   1. set(x,-y,-z,w) is the conjugation p·q·p*   (p = _BASE_180_X = Rx180)
+    //   2. the ·_BASE_180_X below cancels the trailing p* (p*·p = I), leaving
+    //      net = p·q = Rx180·q — one proper rotation (det +1), independent of
+    //      field direction and sensor, hence correct in both hemispheres.
+    // Both input paths share this adapter so they can't diverge.
     if (props.quaternion) {
         const { w, x, y, z } = props.quaternion;
         _targetQuat.set(x, -y, -z, w);
     } else if (props.attitude) {
+        // Euler fallback: build q from (roll, pitch, heading) in aerospace ZYX,
+        // then the same adapter.
         const { roll, pitch, heading } = props.attitude;
         const q = new THREE.Quaternion().setFromEuler(
             new THREE.Euler(roll * DEG_TO_RAD, pitch * DEG_TO_RAD, heading * DEG_TO_RAD, "ZYX"),
@@ -463,12 +473,16 @@ function updateQuadAttitude() {
         return;
     }
 
+    // Ease in (slerp is right-equivariant, so smoothing before the ·_BASE_180_X
+    // gives the same net Rx180·q).
     if (!smoothQuatInitialized) {
         _smoothQuat.copy(_targetQuat);
         smoothQuatInitialized = true;
     } else {
         _smoothQuat.slerp(_targetQuat, ATTITUDE_SMOOTH);
     }
+    // Step 2: cancels the conjugation's p* → net Rx180·q. Dots and live-mag
+    // vectors are children of quadIcon, so they inherit it automatically.
     quadIcon.quaternion.copy(_smoothQuat).multiply(_BASE_180_X);
 }
 
@@ -1243,10 +1257,11 @@ function createCompassRing(radius) {
 
     // Place labels just outside the sphere surface (5% past edge)
     const r = radius * 1.05;
-    // N highlighted red (navigation convention); E/S/W neutral
+    // Compass markers in the scene's NED frame: North=+X, East=+Y.
+    // N/S are on ±X — the fixed axis of the Rx180 adapter — so unchanged.
     makeLabel("N", "#ff4444").position.set(r, 0, 0);
     makeLabel("S", "#aabbcc").position.set(-r, 0, 0);
-    // Display -Y = BF +Y = East when the quad nose faces North
+    // E/W are on ±Y, which the Rx180 adapter negates; with it in place East is +Y.
     makeLabel("E", "#aabbcc").position.set(0, r, 0);
     makeLabel("W", "#aabbcc").position.set(0, -r, 0);
 

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -118,6 +118,7 @@ let quadIcon = null;
 const ATTITUDE_SMOOTH = 0.12;
 const _smoothQuat = new THREE.Quaternion();
 const _targetQuat = new THREE.Quaternion();
+const _BASE_180_X = new THREE.Quaternion(1, 0, 0, 0);
 let smoothQuatInitialized = false;
 
 // Reference ghost sphere (shown before calibration data arrives)
@@ -265,8 +266,8 @@ function initScene() {
 
     // Camera — Z-up convention, pulled back for isometric overview
     camera = new THREE.PerspectiveCamera(50, width / height, 0.1, 50000);
-    camera.up.set(0, 0, 1);
-    camera.position.set(700, 560, 420);
+    camera.up.set(0, 0, -1);
+    camera.position.set(700, 560, -420);
     camera.lookAt(0, 0, 0);
 
     // Lighting
@@ -467,7 +468,7 @@ function updateQuadAttitude() {
     } else {
         _smoothQuat.slerp(_targetQuat, ATTITUDE_SMOOTH);
     }
-    quadIcon.quaternion.copy(_smoothQuat);
+    quadIcon.quaternion.copy(_smoothQuat).multiply(_BASE_180_X);
 }
 
 // Quaternion helpers for orienting cylinders along arbitrary axes
@@ -1245,8 +1246,8 @@ function createCompassRing(radius) {
     makeLabel("N", "#ff4444").position.set(r, 0, 0);
     makeLabel("S", "#aabbcc").position.set(-r, 0, 0);
     // Display -Y = BF +Y = East when the quad nose faces North
-    makeLabel("E", "#aabbcc").position.set(0, -r, 0);
-    makeLabel("W", "#aabbcc").position.set(0, r, 0);
+    makeLabel("E", "#aabbcc").position.set(0, r, 0);
+    makeLabel("W", "#aabbcc").position.set(0, -r, 0);
 
     return group;
 }

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -445,9 +445,11 @@ function updateQuadAttitude() {
         return;
     }
 
-    // Q1 frame adapter: BF body-to-earth (FLU/NWU) → display (FRD/NED).
-    // Net result = Rx180 · q. Both attitude sources pass through the identical
-    // adapter + shared _BASE_180_X post-multiply so they cannot diverge.
+    // Betaflight stores the quaternion in FLU/NWU (X=forward, Y=left, Z=up).
+    // The viewer uses FRD/NED (X=forward, Y=right, Z=down). These differ by
+    // a 180° rotation about X — negate qy and qz to convert.
+    // Net result = Rx180 · q. Both sources pass through the same adapter
+    // + shared _BASE_180_X so the quaternion and Euler paths cannot diverge.
     if (props.quaternion) {
         const { w, x, y, z } = props.quaternion;
         _targetQuat.set(x, -y, -z, w);

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -447,10 +447,9 @@ function updateQuadAttitude() {
     // Prefer quaternion (gimbal-lock-free) when available
     if (props.quaternion) {
         const { w, x, y, z } = props.quaternion;
-        // BF quaternion is body-to-earth; Three.js needs earth-to-body (conjugate).
-        // Conjugate: (w, -x, -y, -z), then BF→Display frame (negate Y and Z):
-        // Result: (w, -x, y, z) → Three.js Quaternion.set(x, y, z, w)
-        _targetQuat.set(-x, y, z, w);
+        // BF quaternion is body-to-earth. Q1 frame adapter (180°-about-X)
+        // converts FLU/NWU → FRD/NED: negate qy, qz.
+        _targetQuat.set(x, -y, -z, w);
     } else if (props.attitude) {
         // Fallback to Euler angles (has gimbal lock at +/-90 pitch)
         const { roll, pitch, heading } = props.attitude;


### PR DESCRIPTION
I opened up the magSphere viewer in latest configurator and everything felt weird :
Ended up chasing this bug for a while, the **scene was upside down** and **East/west were inverted** !

Here's the technical explanation (hopefully correct):
The FC sends a body-to-earth quaternion in FLU/NWU convention. The previous
code consumed it as Three.js `set(-x, y, z, w)`, which negates qx only —
inverting roll. This worked at low magnetic inclination (equator/southern
hemisphere) because the weak horizontal field made the orientation error
invisible against the display scene's other compensations. At high inclination
(71° north, Quebec) the dominant vertical field amplifies the mismatch,
collapsing the quad-icon dots and making the model appear upside-down.

Fix: `set(x, -y, -z, w)` — the Q1 adapter (180°-about-X) converting FLU/NWU
to FRD/NED. This is a proper rotation (det +1) and hemisphere-independent.
Scene corrections: camera Z-flip, E/W label swap, 180°-X post-multiply on
the quad-icon matching the new frame


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Corrected the 3D attitude display alignment and updated the camera framing in the magnetic sphere calibration view to match the intended perspective conventions.  
* Fixed quad orientation rendering to ensure both quaternion and Euler inputs are interpreted and applied consistently, resulting in accurate icon orientation.  
* Adjusted compass ring label placement so **E** and **W** appear on the correct sides for accurate direction feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->