### PR TITLE
Restored mouse scrolling group action at the legends charts caption

### DIFF
--- a/src/blackbox-viewer/components/LegendPanel.vue
+++ b/src/blackbox-viewer/components/LegendPanel.vue
@@ -52,6 +52,7 @@
                     class="graph-legend-group"
                     @click="onGraphClick($event, gi)"
                     @mousedown.middle.prevent="onResetPen(gi, null)"
+                    @wheel.prevent="onFieldWheel($event, gi, null)"
                 >
                     <UIcon name="i-lucide-trash-2" class="size-3.5 mr-1 inline-block align-middle" />
                     {{ graph.label }}

--- a/src/blackbox-viewer/main.js
+++ b/src/blackbox-viewer/main.js
@@ -643,8 +643,8 @@ export function bootstrapViewer() {
         };
         graphStore.fieldWheel = (gi, fi, delta, shiftKey, altKey, ctrlKey) => {
             const graphs = graphStore.activeGraphConfig.getGraphs();
-            const g = String(gi);
-            const f = String(fi);
+            const g = gi == null ? gi : String(gi);
+            const f = fi == null ? fi : String(fi);
             const increase = delta >= 0;
             let msg = null;
             if (shiftKey) {

--- a/src/blackbox-viewer/pen_adjustment.js
+++ b/src/blackbox-viewer/pen_adjustment.js
@@ -88,6 +88,15 @@ export function changePenSmoothing(graphs, group, field, delta) {
     return null;
 }
 
+function scaleMinMax(mimmax, scale) {
+    const middle = (mimmax.min + mimmax.max) / 2;
+    const halfRange = (mimmax.max - mimmax.min) / 2;
+    return {
+        min: middle - halfRange * scale,
+        max: middle + halfRange * scale,
+    };
+}
+
 export function changePenZoom(graphs, group, field, delta) {
     if (group == null && field == null) {
         return null;
@@ -102,16 +111,14 @@ export function changePenZoom(graphs, group, field, delta) {
         const gi = Number.parseInt(group, 10);
         let changedValue = `<h4></h4>${direction}`;
         for (const configField of graphs[gi].fields) {
-            configField.curve.MinMax.min *= scale;
-            configField.curve.MinMax.max *= scale;
+            configField.curve.MinMax = scaleMinMax(configField.curve.MinMax, scale);
             changedValue += `${configField.friendlyName}\n`;
         }
         return changedValue;
     }
     if (group != null && field != null) {
         const gi = Number.parseInt(group, 10);
-        graphs[gi].fields[field].curve.MinMax.min *= scale;
-        graphs[gi].fields[field].curve.MinMax.max *= scale;
+        graphs[gi].fields[field].curve.MinMax = scaleMinMax(graphs[gi].fields[field].curve.MinMax, scale);
         return `<h4></h4>${direction}${graphs[gi].fields[field].friendlyName}\n`;
     }
     return null;


### PR DESCRIPTION
Restored mouse scrolling group action at the legends charts caption

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Legend group headers now respond to mouse wheel events consistently with other legend interactions
  * Field adjustments now correctly handle null/undefined values
  
* **Improvements**
  * Curve zoom adjustments improved for more predictable behavior when scaling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->