### PR TITLE
Migrate dialogs to Nuxt UI UModal for consistent look and feel

### DIFF
--- a/src/components/dialogs/CopyProfileDialog.vue
+++ b/src/components/dialogs/CopyProfileDialog.vue
@@ -1,37 +1,47 @@
 <template>
-    <dialog ref="dialogRef" class="dialogCopyProfile" @cancel.prevent="cancel">
-        <h3 class="dialogCopyProfileTitle">{{ title }}</h3>
-        <div class="content">
-            <div v-if="note" class="dialogCopyProfile-note" v-html="note"></div>
+    <UModal
+        :open="open"
+        :title="title"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+    >
+        <template #body>
+            <div class="flex flex-col gap-4">
+                <div v-if="note" v-html="note"></div>
 
-            <div v-if="profileOptions && profileOptions.length" class="contentProfile">
-                <div>
-                    <span>{{ profileText }}</span>
-                    <USelect v-model="selectedProfile" :items="profileOptions" :portal="false" class="min-w-40" />
-                </div>
-            </div>
+                <SettingRow v-if="profileOptions && profileOptions.length" :label="profileText">
+                    <USelect
+                        v-model="selectedProfile"
+                        :items="profileOptions"
+                        class="min-w-40"
+                        :ui="{ content: 'z-3002' }"
+                    />
+                </SettingRow>
 
-            <div v-if="rateOptions && rateOptions.length" class="contentRateProfile">
-                <div>
-                    <span>{{ rateProfileText }}</span>
-                    <USelect v-model="selectedRateProfile" :items="rateOptions" :portal="false" class="min-w-40" />
-                </div>
+                <SettingRow v-if="rateOptions && rateOptions.length" :label="rateProfileText">
+                    <USelect
+                        v-model="selectedRateProfile"
+                        :items="rateOptions"
+                        class="min-w-40"
+                        :ui="{ content: 'z-3002' }"
+                    />
+                </SettingRow>
             </div>
-        </div>
-        <div class="buttons">
-            <button type="button" class="dialogCopyProfile-confirmbtn regular-button" @click.prevent="confirm">
-                {{ confirmText }}
-            </button>
-            <button type="button" class="dialogCopyProfile-cancelbtn regular-button" @click.prevent="cancel">
-                {{ cancelText }}
-            </button>
-        </div>
-    </dialog>
+        </template>
+        <template #footer>
+            <div class="flex gap-2 justify-end w-full">
+                <UButton color="neutral" variant="soft" @click="cancel">{{ cancelText }}</UButton>
+                <UButton @click="confirm">{{ confirmText }}</UButton>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
 import { ref } from "vue";
 import { i18n } from "@/js/localization";
+import SettingRow from "../elements/SettingRow.vue";
 
 const props = defineProps({
     title: { type: String, default: "" },
@@ -46,18 +56,18 @@ const props = defineProps({
 
 const emit = defineEmits(["confirm", "cancel"]);
 
-const dialogRef = ref(null);
+const open = ref(false);
 const selectedProfile = ref(null);
 const selectedRateProfile = ref(null);
 
 const show = () => {
     selectedProfile.value = props.profileOptions?.length ? props.profileOptions[0].value : null;
     selectedRateProfile.value = props.rateOptions?.length ? props.rateOptions[0].value : null;
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 const confirm = () => {
@@ -73,31 +83,5 @@ const cancel = () => {
 defineExpose({
     show,
     close,
-    dialog: dialogRef,
 });
 </script>
-
-<style scoped>
-.dialogCopyProfile {
-    width: fit-content;
-    max-width: 500px;
-}
-
-.dialogCopyProfile-note {
-    margin-top: 10px;
-}
-
-.contentProfile,
-.contentRateProfile {
-    margin-top: 20px;
-}
-
-.dialogCopyProfile-confirmbtn {
-    margin: 0;
-    margin-right: 12px;
-}
-
-.dialogCopyProfile-cancelbtn {
-    margin: 0;
-}
-</style>

--- a/src/components/dialogs/InformationDialog.vue
+++ b/src/components/dialogs/InformationDialog.vue
@@ -1,17 +1,20 @@
 <template>
-    <dialog ref="dialogRef" class="dialogInformation" @cancel.prevent>
-        <h3 class="dialogInformationTitle">{{ title }}</h3>
-        <div class="dialogInformationContent" v-html="text"></div>
-        <div class="buttons">
-            <button
-                type="button"
-                class="dialogInformation-confirmButton regular-button"
-                @click.prevent="$emit('confirm')"
-            >
-                {{ confirmText }}
-            </button>
-        </div>
-    </dialog>
+    <UModal
+        :open="open"
+        :title="title"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+    >
+        <template #body>
+            <div v-html="text"></div>
+        </template>
+        <template #footer>
+            <div class="flex justify-end w-full">
+                <UButton @click="$emit('confirm')">{{ confirmText }}</UButton>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
@@ -28,54 +31,18 @@ defineProps({
 
 defineEmits(["confirm"]);
 
-const dialogRef = ref(null);
+const open = ref(false);
 
 const show = () => {
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 defineExpose({
     show,
     close,
-    // Expose the raw element just in case, though show/close should suffice
-    dialog: dialogRef,
 });
 </script>
-
-<style scoped>
-.dialogInformation {
-    display: block;
-    z-index: 1000;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    margin: 0;
-    border: none;
-    padding: 1rem;
-    /* Reset default dialog styles if needed, though scoped styles usually suffice */
-}
-
-/* Native backdrop styling */
-.dialogInformation::backdrop {
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 999;
-}
-
-/* Hide the dialog when not open (native behavior handles this, but explicit hiding avoids FOUC in some cases if polyfilled, though native doesn't need it. 
-   However, Vue might render it initially. Native <dialog> is hidden by default unless 'open' is present. 
-   We removed 'open', so it should be hidden. 
-   BUT: The previous CSS had `display: block`. We need to ensure that doesn't force it to show when closed. 
-   Native dialogs have `display: none` by default. 
-   The scoped style `.dialogInformation { display: block; ... }` overrides the user agent stylesheet.
-   We need to fix this.
-*/
-
-.dialogInformation:not([open]) {
-    display: none;
-}
-</style>

--- a/src/components/dialogs/InteractiveDialog.vue
+++ b/src/components/dialogs/InteractiveDialog.vue
@@ -10,8 +10,19 @@
             <div class="flex flex-col h-full gap-3">
                 <!-- cli-response / cli-command are driven imperatively by gui.js via their ids;
                      kept as raw elements so the CLI panel's DOM hooks (textContent/value/onchange/focus) work. -->
-                <textarea id="cli-response" class="cli-response flex-1 w-full" readonly></textarea>
-                <input id="cli-command" class="cli-command w-full" type="text" :placeholder="commandPlaceholder" />
+                <textarea
+                    id="cli-response"
+                    class="cli-response flex-1 w-full"
+                    readonly
+                    :aria-label="$t('cliPanelTitle')"
+                ></textarea>
+                <input
+                    id="cli-command"
+                    class="cli-command w-full"
+                    type="text"
+                    :placeholder="commandPlaceholder"
+                    :aria-label="$t('cliCommand')"
+                />
             </div>
         </template>
         <template #footer>

--- a/src/components/dialogs/InteractiveDialog.vue
+++ b/src/components/dialogs/InteractiveDialog.vue
@@ -1,22 +1,25 @@
 <template>
-    <dialog ref="dialogRef" class="dialogInteractive" @cancel.prevent>
-        <h3 class="dialogInteractiveTitle">{{ title }}</h3>
-        <div class="dialogInteractiveContent"></div>
-
-        <div class="cli-response">
-            <textarea id="cli-response" readonly rows="32" cols="96"></textarea>
-        </div>
-
-        <div class="cli-command">
-            <input type="text" id="cli-command" :placeholder="commandPlaceholder" />
-        </div>
-
-        <div class="buttons">
-            <button type="button" class="dialogInteractive-closeButton regular-button" @click.prevent="$emit('close')">
-                {{ buttonCloseText }}
-            </button>
-        </div>
-    </dialog>
+    <UModal
+        :open="open"
+        :title="title"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'max-w-3xl w-[calc(100vw-2rem)] h-[80vh] z-3001' }"
+    >
+        <template #body>
+            <div class="flex flex-col h-full gap-3">
+                <!-- cli-response / cli-command are driven imperatively by gui.js via their ids;
+                     kept as raw elements so the CLI panel's DOM hooks (textContent/value/onchange/focus) work. -->
+                <textarea id="cli-response" class="cli-response flex-1 w-full" readonly></textarea>
+                <input id="cli-command" class="cli-command w-full" type="text" :placeholder="commandPlaceholder" />
+            </div>
+        </template>
+        <template #footer>
+            <div class="flex justify-end w-full">
+                <UButton @click="$emit('close')">{{ buttonCloseText }}</UButton>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
@@ -39,64 +42,42 @@ defineProps({
 
 defineEmits(["close"]);
 
-const dialogRef = ref(null);
+const open = ref(false);
 
 const show = () => {
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 defineExpose({
     show,
     close,
-    dialog: dialogRef,
 });
 </script>
 
 <style scoped>
-.dialogInteractive {
-    display: block;
-    z-index: 1000;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    margin: 0;
-    width: fit-content;
-}
-
-.dialogInteractive::backdrop {
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 999;
-}
-
-.dialogInteractive:not([open]) {
-    display: none;
-}
-
-.dialogInteractive-closeButton {
-    margin: 0px;
-}
-
-.cli-command input {
-    width: 100%;
-    margin-top: 12px;
-    margin-bottom: 12px;
-}
-
 .cli-response {
-    margin-top: 12px;
-    margin-bottom: 12px;
+    min-height: 0;
+    padding: 0.5rem 0.75rem;
+    font-family: "Courier New", Courier, monospace;
+    font-size: 11px;
+    line-height: 1.4;
     white-space: pre-line;
-    height: 100%;
-    width: 100%;
+    resize: none;
+    color: var(--text);
+    background-color: var(--surface-0);
+    border: 1px solid var(--subtleAccent);
+    border-radius: 4px;
 }
 
-.cli-response textarea {
-    font-size: 11px;
-    object-fit: contain;
+.cli-command {
+    padding: 0.4rem 0.75rem;
+    color: var(--text);
+    background-color: var(--surface-0);
+    border: 1px solid var(--subtleAccent);
+    border-radius: 4px;
 }
 </style>

--- a/src/components/dialogs/ProfileSelectionDialog.vue
+++ b/src/components/dialogs/ProfileSelectionDialog.vue
@@ -1,29 +1,24 @@
 <template>
-    <dialog ref="dialogRef" class="dialogProfileSelection" @cancel.prevent="cancel">
-        <h3 class="dialogProfileSelectionTitle">{{ title }}</h3>
-        <div class="dialogProfileSelectionContent">
-            <p>{{ message }}</p>
-            <div class="profile-options">
-                <label v-for="option in options" :key="option.value" class="profile-option">
-                    <input type="radio" :value="option.value" v-model="selectedValue" name="profileSelection" />
-                    <span>{{ option.label }}</span>
-                </label>
+    <UModal
+        :open="open"
+        :title="title"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+    >
+        <template #body>
+            <div class="flex flex-col gap-4">
+                <p>{{ message }}</p>
+                <URadioGroup v-model="selectedValue" :items="options" />
             </div>
-        </div>
-        <div class="buttons">
-            <button type="button" class="dialogProfileSelection-cancelButton regular-button" @click.prevent="cancel">
-                {{ cancelText }}
-            </button>
-            <button
-                type="button"
-                class="dialogProfileSelection-confirmButton regular-button"
-                :disabled="selectedValue === null"
-                @click.prevent="confirm"
-            >
-                {{ confirmText }}
-            </button>
-        </div>
-    </dialog>
+        </template>
+        <template #footer>
+            <div class="flex gap-2 justify-end w-full">
+                <UButton color="neutral" variant="soft" @click="cancel">{{ cancelText }}</UButton>
+                <UButton :disabled="selectedValue === null" @click="confirm">{{ confirmText }}</UButton>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
@@ -45,16 +40,16 @@ defineProps({
 
 const emit = defineEmits(["confirm", "cancel"]);
 
-const dialogRef = ref(null);
+const open = ref(false);
 const selectedValue = ref(null);
 
 const show = () => {
     selectedValue.value = null;
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 const confirm = () => {
@@ -72,101 +67,5 @@ const cancel = () => {
 defineExpose({
     show,
     close,
-    dialog: dialogRef,
 });
 </script>
-
-<style scoped>
-.dialogProfileSelection {
-    border: none;
-    border-radius: 8px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-    padding: 0;
-    background: var(--boxBackground, #f5f5f5);
-    color: var(--text, #000);
-    max-width: 500px;
-    width: 90vw;
-}
-
-.dialogProfileSelectionTitle {
-    margin: 0;
-    padding: 20px 20px 10px 20px;
-    font-size: 18px;
-    font-weight: bold;
-    border-bottom: 1px solid var(--subtleAccent, #ddd);
-}
-
-.dialogProfileSelectionContent {
-    padding: 20px;
-}
-
-.dialogProfileSelectionContent p {
-    margin: 0 0 15px 0;
-    line-height: 1.4;
-}
-
-.profile-options {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-}
-
-.profile-option {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 8px 12px;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: background-color 0.2s;
-}
-
-.profile-option:hover {
-    background: var(--hoverBackground, rgba(0, 0, 0, 0.05));
-}
-
-.profile-option input[type="radio"] {
-    margin: 0;
-}
-
-.buttons {
-    display: flex;
-    justify-content: flex-end;
-    gap: 10px;
-    padding: 15px 20px 20px 20px;
-    border-top: 1px solid var(--subtleAccent, #ddd);
-}
-
-.buttons button {
-    padding: 8px 16px;
-    border: none;
-    border-radius: 4px;
-    cursor: pointer;
-    font-size: 14px;
-    transition: background-color 0.2s;
-}
-
-.dialogProfileSelection-cancelButton {
-    background: var(--buttonBackground, #f0f0f0);
-    color: var(--text, #000);
-}
-
-.dialogProfileSelection-cancelButton:hover {
-    background: var(--buttonHoverBackground, #e0e0e0);
-}
-
-.dialogProfileSelection-confirmButton {
-    background: var(--accent, #007bff);
-    color: var(--buttonText, #fff);
-}
-
-.dialogProfileSelection-confirmButton:hover:not(:disabled) {
-    background: var(--accentHover, #0056b3);
-}
-
-.dialogProfileSelection-confirmButton:disabled {
-    background: var(--disabledBackground, #ccc);
-    cursor: not-allowed;
-    opacity: 0.6;
-}
-</style>

--- a/src/components/dialogs/RatesTypeDialog.vue
+++ b/src/components/dialogs/RatesTypeDialog.vue
@@ -1,16 +1,21 @@
 <template>
-    <dialog ref="dialogRef" class="dialogRatesType" @cancel.prevent>
-        <h3 class="dialogRatesTypeTitle">{{ title }}</h3>
-        <div class="dialogRatesTypeContent" v-html="note"></div>
-        <div class="buttons">
-            <button type="button" class="dialogRatesType-confirmbtn regular-button" @click="confirmHandler">
-                {{ confirmText }}
-            </button>
-            <button type="button" class="dialogRatesType-cancelbtn regular-button" @click="cancelHandler">
-                {{ cancelText }}
-            </button>
-        </div>
-    </dialog>
+    <UModal
+        :open="open"
+        :title="title"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+    >
+        <template #body>
+            <div class="dialogRatesTypeContent" v-html="note"></div>
+        </template>
+        <template #footer>
+            <div class="flex gap-2 justify-end w-full">
+                <UButton color="neutral" variant="soft" @click="cancelHandler">{{ cancelText }}</UButton>
+                <UButton @click="confirmHandler">{{ confirmText }}</UButton>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
@@ -25,14 +30,14 @@ defineProps({
 
 const emit = defineEmits(["confirm", "cancel"]);
 
-const dialogRef = ref(null);
+const open = ref(false);
 
 const show = () => {
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 const confirmHandler = () => {
@@ -48,29 +53,12 @@ const cancelHandler = () => {
 defineExpose({
     show,
     close,
-    dialog: dialogRef,
 });
 </script>
 
 <style scoped>
-.dialogRatesType {
-    width: fit-content;
-    max-width: 400px;
-}
-
 .dialogRatesTypeContent {
-    margin-bottom: 12px;
-    margin-top: 12px;
     white-space: pre-line;
-}
-
-.dialogRatesType-confirmbtn {
-    margin: 0;
-    margin-right: 12px;
-}
-
-.dialogRatesType-cancelbtn {
-    margin: 0;
 }
 
 /* Warning message styling (note uses v-html, so target message-negative) */

--- a/src/components/dialogs/RebootDialog.vue
+++ b/src/components/dialogs/RebootDialog.vue
@@ -1,12 +1,15 @@
 <template>
-    <dialog ref="dialogRef" class="dialogReboot" @cancel.prevent>
-        <div class="content">
-            <div class="reboot-status">{{ status }}</div>
-            <div class="reboot-progress-container">
-                <div class="reboot-progress-bar" :style="{ width: progress + '%' }"></div>
-            </div>
-        </div>
-    </dialog>
+    <UModal
+        :open="open"
+        :title="status"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+    >
+        <template #body>
+            <UProgress :model-value="progress" :max="100" />
+        </template>
+    </UModal>
 </template>
 
 <script setup>
@@ -23,67 +26,18 @@ defineProps({
     },
 });
 
-const dialogRef = ref(null);
+const open = ref(false);
 
 const show = () => {
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 defineExpose({
     show,
     close,
-    dialog: dialogRef,
 });
 </script>
-
-<style scoped>
-.dialogReboot:not([open]) {
-    display: none;
-}
-
-.dialogReboot {
-    display: block;
-    z-index: 1000;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    margin: 0;
-
-    border: 1px solid var(--subtleAccent);
-    border-radius: 5px;
-    background-color: var(--surface-100);
-    color: var(--text);
-    padding: 20px;
-    max-width: 400px;
-    width: 100%;
-}
-
-.dialogReboot::backdrop {
-    background: rgba(0, 0, 0, 0.5);
-}
-
-.reboot-progress-container {
-    width: 100%;
-    background-color: var(--surface-0);
-    border-radius: 3px;
-    margin: 15px 0 5px;
-    height: 10px;
-    overflow: hidden;
-}
-
-.reboot-progress-bar {
-    height: 100%;
-    background-color: var(--primary-500);
-    transition: width 0.1s linear;
-}
-
-.reboot-status {
-    text-align: center;
-    margin: 10px 0;
-}
-</style>

--- a/src/components/dialogs/ReportProblemsDialog.vue
+++ b/src/components/dialogs/ReportProblemsDialog.vue
@@ -1,7 +1,12 @@
 <template>
-    <dialog ref="dialogRef" class="dialogReportProblems" @cancel.prevent>
-        <h3>{{ $t("warningTitle") }}</h3>
-        <div class="content">
+    <UModal
+        :open="open"
+        :title="$t('warningTitle')"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+    >
+        <template #body>
             <div class="dialogReportProblems-header" v-html="$t('reportProblemsDialogHeader')"></div>
             <ul class="dialogReportProblems-list">
                 <li
@@ -12,13 +17,13 @@
                 ></li>
             </ul>
             <div class="dialogReportProblems-footer" v-html="$t('reportProblemsDialogFooter')"></div>
-        </div>
-        <div class="buttons">
-            <button type="button" class="regular-button" @click.prevent="handleClose">
-                {{ $t("close") }}
-            </button>
-        </div>
-    </dialog>
+        </template>
+        <template #footer>
+            <div class="flex justify-end w-full">
+                <UButton @click="handleClose">{{ $t("close") }}</UButton>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
@@ -33,14 +38,14 @@ defineProps({
 
 const emit = defineEmits(["close"]);
 
-const dialogRef = ref(null);
+const open = ref(false);
 
 const show = () => {
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 const handleClose = () => {
@@ -51,47 +56,11 @@ const handleClose = () => {
 defineExpose({
     show,
     close,
-    dialog: dialogRef,
 });
 </script>
 
 <style scoped>
-.dialogReportProblems {
-    display: block;
-    z-index: 1000;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    margin: 0;
-    border: 1px solid var(--surface-500);
-    border-radius: 8px;
-    padding: 15px 20px;
-    background: var(--surface-100);
-    min-width: 300px;
-    max-width: 600px;
-}
-
-.dialogReportProblems::backdrop {
-    background: rgba(0, 0, 0, 0.5);
-    z-index: 999;
-}
-
-.dialogReportProblems:not([open]) {
-    display: none;
-}
-
-.dialogReportProblems h3 {
-    margin: 0 0 10px 0;
-    color: var(--text);
-}
-
-.dialogReportProblems .content {
-    margin-bottom: 15px;
-}
-
 .dialogReportProblems-header {
-    margin-top: 10px;
     margin-bottom: 5px;
 }
 
@@ -108,10 +77,6 @@ defineExpose({
 }
 
 .dialogReportProblems-footer {
-    margin-bottom: 10px;
-}
-
-.dialogReportProblems .buttons {
-    text-align: right;
+    margin-top: 10px;
 }
 </style>

--- a/src/components/dialogs/WaitDialog.vue
+++ b/src/components/dialogs/WaitDialog.vue
@@ -1,13 +1,22 @@
 <template>
-    <dialog ref="dialogRef" class="dialogWait" @cancel.prevent>
-        <ProgressRing indeterminate :size="80" :stroke-width="6" color="primary" class="dialogWait-spinner" />
-        <h3 class="dialogWaitTitle">{{ title }}</h3>
-        <div class="buttons" v-if="showCancel">
-            <button type="button" class="dialogWait-cancelButton regular-button" @click="$emit('cancel')">
-                {{ cancelText }}
-            </button>
-        </div>
-    </dialog>
+    <UModal
+        :open="open"
+        :title="title"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+    >
+        <template #body>
+            <div class="flex justify-center py-2">
+                <ProgressRing indeterminate :size="80" :stroke-width="6" color="primary" />
+            </div>
+        </template>
+        <template v-if="showCancel" #footer>
+            <div class="flex justify-end w-full">
+                <UButton color="neutral" variant="soft" @click="$emit('cancel')">{{ cancelText }}</UButton>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
@@ -29,45 +38,18 @@ defineProps({
 
 defineEmits(["cancel"]);
 
-const dialogRef = ref(null);
+const open = ref(false);
 
 const show = () => {
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 defineExpose({
     show,
     close,
-    dialog: dialogRef,
 });
 </script>
-
-<style scoped>
-.dialogWait:not([open]) {
-    display: none;
-}
-
-.dialogWait {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    z-index: 1000;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    margin: 0;
-}
-
-.dialogWait-spinner {
-    margin: 1rem auto;
-}
-
-.dialogWait::backdrop {
-    background: rgba(0, 0, 0, 0.5);
-}
-</style>

--- a/src/components/dialogs/YesNoDialog.vue
+++ b/src/components/dialogs/YesNoDialog.vue
@@ -1,14 +1,23 @@
 <template>
-    <dialog ref="dialogRef" class="dialogYesNo" @cancel.prevent>
-        <h3 class="dialogYesNoTitle">{{ title }}</h3>
-        <div class="dialogYesNoContent" v-html="text"></div>
-        <div class="buttons">
-            <button type="button" class="dialogYesNo-yesButton regular-button" @click="$emit('yes')">
-                {{ yesText }}
-            </button>
-            <button type="button" class="dialogYesNo-noButton regular-button" @click="$emit('no')">{{ noText }}</button>
-        </div>
-    </dialog>
+    <UModal
+        :open="open"
+        :title="title"
+        :close="false"
+        :dismissible="false"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+    >
+        <template #body>
+            <!-- Note: 'text' is rendered using v-html to support bolding/links in i18n messages.
+                 Ensure that only trusted content (e.g. from i18n) is passed to this prop. -->
+            <div v-html="text"></div>
+        </template>
+        <template #footer>
+            <div class="flex gap-2 justify-end w-full">
+                <UButton color="neutral" variant="soft" @click="$emit('no')">{{ noText }}</UButton>
+                <UButton @click="$emit('yes')">{{ yesText }}</UButton>
+            </div>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
@@ -16,8 +25,6 @@ import { ref } from "vue";
 
 defineProps({
     title: String,
-    // Note: 'text' is rendered using v-html to support bolding/links in i18n messages.
-    // Ensure that only trusted content (e.g. from i18n) is passed to this prop.
     text: String,
     yesText: String,
     noText: String,
@@ -25,39 +32,18 @@ defineProps({
 
 defineEmits(["yes", "no"]);
 
-const dialogRef = ref(null);
+const open = ref(false);
 
 const show = () => {
-    dialogRef.value?.showModal();
+    open.value = true;
 };
 
 const close = () => {
-    dialogRef.value?.close();
+    open.value = false;
 };
 
 defineExpose({
     show,
     close,
-    dialog: dialogRef,
 });
 </script>
-
-<style scoped>
-.dialogYesNo:not([open]) {
-    display: none;
-}
-
-.dialogYesNo {
-    display: block;
-    z-index: 1000;
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    margin: 0;
-}
-
-.dialogYesNo::backdrop {
-    background: rgba(0, 0, 0, 0.5);
-}
-</style>

--- a/src/components/elements/Dialog.vue
+++ b/src/components/elements/Dialog.vue
@@ -4,14 +4,16 @@
         :title="title"
         :close="closeable"
         :dismissible="closeable"
-        :ui="{ overlay: 'z-3000', content: 'z-3001', footer: 'justify-end' }"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
         @update:open="onOpenChange"
     >
         <template #body>
             <slot></slot>
         </template>
         <template v-if="$slots.footer" #footer>
-            <slot name="footer"></slot>
+            <div class="flex justify-end gap-2 w-full">
+                <slot name="footer"></slot>
+            </div>
         </template>
     </UModal>
 </template>

--- a/src/components/elements/Dialog.vue
+++ b/src/components/elements/Dialog.vue
@@ -1,36 +1,22 @@
 <template>
-    <Teleport to="#main-wrapper">
-        <dialog v-if="modelValue" ref="dialogRef" class="dialog-modal" @close="handleClose">
-            <div class="dialog-title-bar">
-                <div class="dialog-title">
-                    {{ title }}
-                </div>
-                <button
-                    v-if="closeable"
-                    class="dialog-close"
-                    type="button"
-                    :aria-label="$t('dialogClose')"
-                    @click="close"
-                >
-                    <svg width="10" height="10" version="1.1" xmlns="http://www.w3.org/2000/svg">
-                        <line x1="0" y1="0" x2="10" y2="10" stroke="var(--surface-950)" stroke-width="2" />
-                        <line x1="0" y1="10" x2="10" y2="0" stroke="var(--surface-950)" stroke-width="2" />
-                    </svg>
-                </button>
-            </div>
-            <div class="dialog-content">
-                <slot></slot>
-            </div>
-            <div v-if="$slots.footer" class="dialog-footer">
-                <slot name="footer"></slot>
-            </div>
-        </dialog>
-    </Teleport>
+    <UModal
+        :open="modelValue"
+        :title="title"
+        :close="closeable"
+        :dismissible="closeable"
+        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+        @update:open="onOpenChange"
+    >
+        <template #body>
+            <slot></slot>
+        </template>
+        <template v-if="$slots.footer" #footer>
+            <slot name="footer"></slot>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
-import { ref, watch, onMounted } from "vue";
-
 const props = defineProps({
     modelValue: {
         type: Boolean,
@@ -48,7 +34,12 @@ const props = defineProps({
 
 const emit = defineEmits(["update:modelValue", "close"]);
 
-const dialogRef = ref(null);
+const onOpenChange = (open) => {
+    emit("update:modelValue", open);
+    if (!open) {
+        emit("close");
+    }
+};
 
 const close = () => {
     if (props.closeable) {
@@ -57,111 +48,7 @@ const close = () => {
     }
 };
 
-const handleClose = () => {
-    // Handle native dialog close events (ESC key, backdrop click)
-    emit("update:modelValue", false);
-    emit("close");
-};
-
-watch(
-    () => props.modelValue,
-    async (newValue) => {
-        if (newValue) {
-            // Wait for next tick to ensure DOM is updated with v-if
-            await new Promise((resolve) => setTimeout(resolve, 0));
-
-            if (!dialogRef.value) {
-                return;
-            }
-
-            // Only call showModal if dialog is not already open
-            if (!dialogRef.value.open) {
-                dialogRef.value.showModal();
-            }
-            // Reset scrolling
-            const content = dialogRef.value.querySelector(".dialog-content");
-            if (content) {
-                content.scrollTop = 0;
-            }
-        } else if (dialogRef.value?.open) {
-            // When closing, forcibly call close() if dialog exists and is open
-            dialogRef.value.close();
-        }
-    },
-);
-
-onMounted(async () => {
-    if (props.modelValue) {
-        // Wait for next tick to ensure DOM is ready
-        await new Promise((resolve) => setTimeout(resolve, 0));
-
-        if (dialogRef.value && !dialogRef.value.open) {
-            dialogRef.value.showModal();
-        }
-    }
-});
-
 defineExpose({
     close,
 });
 </script>
-
-<style scoped>
-.dialog-modal {
-    border: none;
-    border-radius: 4px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    padding: 0;
-    max-width: 90vw;
-    max-height: 90vh;
-    display: flex;
-    flex-direction: column;
-}
-
-.dialog-modal::backdrop {
-    background-color: rgba(0, 0, 0, 0.5);
-}
-
-.dialog-title-bar {
-    display: flex;
-    height: 47px;
-    background: var(--surface-300);
-    border-bottom: 2px solid var(--primary-500);
-}
-
-.dialog-title {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    padding: 15px;
-}
-
-.dialog-close {
-    flex: 0 0 47px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    background: none;
-    border: none;
-    padding: 0;
-}
-
-.dialog-close:hover {
-    background: var(--surface-400);
-}
-
-.dialog-content {
-    padding: 20px;
-    overflow-y: auto;
-    flex: 1;
-    min-height: 0;
-}
-
-.dialog-footer {
-    padding: 15px 20px;
-    background: var(--surface-100);
-    border-top: 1px solid var(--surface-500);
-    flex-shrink: 0;
-}
-</style>

--- a/src/components/elements/Dialog.vue
+++ b/src/components/elements/Dialog.vue
@@ -4,7 +4,7 @@
         :title="title"
         :close="closeable"
         :dismissible="closeable"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+        :ui="{ overlay: 'z-3000', content: 'z-3001', footer: 'justify-end' }"
         @update:open="onOpenChange"
     >
         <template #body>

--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -100,11 +100,18 @@
             </Dialog>
 
             <!-- Restore progress dialog -->
-            <dialog ref="restoreProgressDialogRef" class="w-[320px] h-fit p-6" @cancel.prevent>
-                <div class="text-lg mb-2" v-html="$t('userBackupRestoreInProgress')"></div>
-                <div class="text-sm text-dimmed" v-html="$t('presetsPleaseWait')"></div>
-                <UProgress :model-value="restoreProgress" :max="100" class="mt-3" />
-            </dialog>
+            <UModal
+                :open="restoreProgressOpen"
+                :close="false"
+                :dismissible="false"
+                :ui="{ overlay: 'z-3000', content: 'w-[320px] z-3001' }"
+            >
+                <template #body>
+                    <div class="text-lg mb-2" v-html="$t('userBackupRestoreInProgress')"></div>
+                    <div class="text-sm text-dimmed" v-html="$t('presetsPleaseWait')"></div>
+                    <UProgress :model-value="restoreProgress" :max="100" class="mt-3" />
+                </template>
+            </UModal>
 
             <!-- Restore errors dialog -->
             <dialog
@@ -180,7 +187,6 @@ const restoreProgressOpen = ref(false);
 const restoreErrors = ref([]);
 const restoreErrorsOpen = ref(false);
 const restoreSavePressed = ref(false);
-const restoreProgressDialogRef = ref(null);
 const restoreErrorsDialogRef = ref(null);
 let userApi = null;
 let unsubscribeLogin = null;
@@ -421,18 +427,6 @@ async function handleRestoreErrorsClose() {
         scheduleReconnect();
     }
 }
-
-watch(restoreProgressOpen, async (isOpen) => {
-    await nextTick();
-    if (!restoreProgressDialogRef.value) {
-        return;
-    }
-    if (isOpen && !restoreProgressDialogRef.value.open) {
-        restoreProgressDialogRef.value.showModal();
-    } else if (!isOpen && restoreProgressDialogRef.value.open) {
-        restoreProgressDialogRef.value.close();
-    }
-});
 
 watch(restoreErrorsOpen, async (isOpen) => {
     await nextTick();

--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -114,32 +114,42 @@
             </UModal>
 
             <!-- Restore errors dialog -->
-            <dialog
-                ref="restoreErrorsDialogRef"
-                class="w-[600px] max-w-[calc(100vw-2rem)] h-fit p-6"
-                @close="handleRestoreErrorsClose"
-                @cancel.prevent
+            <UModal
+                :open="restoreErrorsOpen"
+                :close="false"
+                :dismissible="false"
+                :ui="{ overlay: 'z-3000', content: 'w-[600px] max-w-[calc(100vw-2rem)] z-3001' }"
             >
-                <div class="text-lg mb-2" v-html="$t('userBackupRestoreErrors')"></div>
-                <div class="backups_cli_background">
-                    <div class="backups_cli_window">
-                        <template v-for="(failure, idx) in restoreErrors" :key="idx">
-                            <div>{{ failure.command }}</div>
-                            <div
-                                v-for="(line, lineIdx) in failure.response"
-                                :key="lineIdx"
-                                :class="{ error_message: line.startsWith('###ERROR') }"
-                            >
-                                {{ line }}
-                            </div>
-                        </template>
+                <template #title>
+                    <span v-html="$t('userBackupRestoreErrors')"></span>
+                </template>
+                <template #body>
+                    <div class="backups_cli_background">
+                        <div class="backups_cli_window">
+                            <template v-for="(failure, idx) in restoreErrors" :key="idx">
+                                <div>{{ failure.command }}</div>
+                                <div
+                                    v-for="(line, lineIdx) in failure.response"
+                                    :key="lineIdx"
+                                    :class="{ error_message: line.startsWith('###ERROR') }"
+                                >
+                                    {{ line }}
+                                </div>
+                            </template>
+                        </div>
                     </div>
-                </div>
-                <div class="flex gap-2 justify-end mt-3">
-                    <UButton :label="$t('presetsButtonCancel')" variant="outline" @click="closeRestoreErrors(false)" />
-                    <UButton :label="$t('presetsSaveAnyway')" @click="closeRestoreErrors(true)" />
-                </div>
-            </dialog>
+                </template>
+                <template #footer>
+                    <div class="flex justify-end gap-2 w-full">
+                        <UButton
+                            :label="$t('presetsButtonCancel')"
+                            variant="outline"
+                            @click="closeRestoreErrors(false)"
+                        />
+                        <UButton :label="$t('presetsSaveAnyway')" @click="closeRestoreErrors(true)" />
+                    </div>
+                </template>
+            </UModal>
         </div>
 
         <!-- Bottom toolbar -->
@@ -153,7 +163,7 @@
 </template>
 
 <script setup>
-import { ref, computed, nextTick, onMounted, onUnmounted, watch } from "vue";
+import { ref, computed, onMounted, onUnmounted } from "vue";
 import { useTranslation } from "i18next-vue";
 import BaseTab from "./BaseTab.vue";
 import UiBox from "../elements/UiBox.vue";
@@ -187,7 +197,6 @@ const restoreProgressOpen = ref(false);
 const restoreErrors = ref([]);
 const restoreErrorsOpen = ref(false);
 const restoreSavePressed = ref(false);
-const restoreErrorsDialogRef = ref(null);
 let userApi = null;
 let unsubscribeLogin = null;
 let unsubscribeLogout = null;
@@ -408,6 +417,7 @@ async function restoreBackup(backup) {
 function closeRestoreErrors(saveAnyway) {
     restoreSavePressed.value = saveAnyway;
     restoreErrorsOpen.value = false;
+    handleRestoreErrorsClose();
 }
 
 async function handleRestoreErrorsClose() {
@@ -427,18 +437,6 @@ async function handleRestoreErrorsClose() {
         scheduleReconnect();
     }
 }
-
-watch(restoreErrorsOpen, async (isOpen) => {
-    await nextTick();
-    if (!restoreErrorsDialogRef.value) {
-        return;
-    }
-    if (isOpen && !restoreErrorsDialogRef.value.open) {
-        restoreErrorsDialogRef.value.showModal();
-    } else if (!isOpen && restoreErrorsDialogRef.value.open) {
-        restoreErrorsDialogRef.value.close();
-    }
-});
 
 async function deleteBackup(backupId) {
     const confirmed = globalThis.confirm(t("confirmDelete", { item: t("itemBackup") }));

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -60,9 +60,14 @@
         </UModal>
 
         <!-- Support warning dialog -->
-        <dialog ref="supportWarningDialogRef" class="w-[400px] h-fit">
-            <div class="p-4">
-                <h3 class="font-semibold mb-2">{{ $t("supportWarningDialogTitle") }}</h3>
+        <UModal
+            v-model:open="supportWarningOpen"
+            :title="$t('supportWarningDialogTitle')"
+            :close="false"
+            :dismissible="false"
+            :ui="{ overlay: 'z-3000', content: 'w-[400px] z-3001' }"
+        >
+            <template #body>
                 <div class="mb-3" v-html="$t('supportWarningDialogText')"></div>
                 <textarea
                     v-model="cli.state.supportDialogInput"
@@ -72,12 +77,14 @@
                     cols="0"
                     class="w-full mt-2 leading-5 p-1 border border-(--ui-border) resize-none bg-(--ui-bg-muted) text-(--ui-text)"
                 ></textarea>
-                <div class="flex gap-2 mt-3">
-                    <UButton :label="$t('submit')" @click="handleSupportSubmit" />
+            </template>
+            <template #footer>
+                <div class="flex justify-end gap-2 w-full">
                     <UButton :label="$t('cancel')" variant="outline" @click="handleSupportCancel" />
+                    <UButton :label="$t('submit')" @click="handleSupportSubmit" />
                 </div>
-            </div>
-        </dialog>
+            </template>
+        </UModal>
 
         <!-- Bottom toolbar -->
         <div class="content_toolbar xs-compressed toolbar_fixed_bottom flex items-center gap-2">
@@ -246,7 +253,7 @@ export default defineComponent({
             cliWindowRef: cli.cliWindowRef,
             commandInputRef: cli.commandInputRef,
             snippetPreviewOpen: cli.snippetPreviewOpen,
-            supportWarningDialogRef: cli.supportWarningDialogRef,
+            supportWarningOpen: cli.supportWarningOpen,
         };
     },
 });

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -41,21 +41,23 @@
         </div>
 
         <!-- Snippet preview dialog -->
-        <dialog ref="snippetPreviewDialogRef" closedby="any" class="w-[600px] h-fit">
-            <div class="p-4">
+        <UModal v-model:open="snippetPreviewOpen" :ui="{ overlay: 'z-3000', content: 'w-[600px] z-3001' }">
+            <template #body>
                 <div class="note mb-3">
                     <p v-html="$t('cliConfirmSnippetNote')"></p>
                 </div>
                 <textarea
                     v-model="cli.state.snippetPreview"
                     rows="20"
-                    class="bg-black/75 w-full resize-none overflow-y-scroll overflow-x-hidden font-mono text-white p-[5px] mb-[5px]"
+                    class="bg-black/75 w-full resize-none overflow-y-scroll overflow-x-hidden font-mono text-white p-[5px]"
                 ></textarea>
-                <div class="mt-3">
+            </template>
+            <template #footer>
+                <div class="flex justify-end gap-2 w-full">
                     <UButton :label="$t('cliConfirmSnippetBtn')" @click="handleSnippetConfirm" />
                 </div>
-            </div>
-        </dialog>
+            </template>
+        </UModal>
 
         <!-- Support warning dialog -->
         <dialog ref="supportWarningDialogRef" class="w-[400px] h-fit">
@@ -243,7 +245,7 @@ export default defineComponent({
             windowWrapperRef: cli.windowWrapperRef,
             cliWindowRef: cli.cliWindowRef,
             commandInputRef: cli.commandInputRef,
-            snippetPreviewDialogRef: cli.snippetPreviewDialogRef,
+            snippetPreviewOpen: cli.snippetPreviewOpen,
             supportWarningDialogRef: cli.supportWarningDialogRef,
         };
     },

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -90,43 +90,34 @@
             </UFieldGroup>
         </div>
 
-        <dialog
-            ref="unstableFirmwareDialog"
-            id="dialogUnstableFirmwareAcknowledgement"
-            @close="handleUnstableFirmwareDialogClose"
+        <UModal
+            v-model:open="unstableFirmwareOpen"
+            :title="$t('warningTitle')"
+            :close="false"
+            :dismissible="false"
+            :ui="{ overlay: 'z-3000', content: 'z-3001' }"
         >
-            <h3>{{ $t("warningTitle") }}</h3>
-            <div class="content">
+            <template #body>
                 <div v-html="$t('unstableFirmwareAcknowledgementDialog')"></div>
-                <div class="flex items-center gap-2">
+                <div class="flex items-center gap-2 mt-3">
                     <USwitch
                         v-model="state.dialogUnstableFirmwareAcknowledgementCheckbox"
                         :aria-label="$t('unstableFirmwareAcknowledgement')"
                     />
                     <span v-html="$t('unstableFirmwareAcknowledgement')"></span>
                 </div>
-            </div>
-            <div class="dialog_toolbar">
-                <div class="btn">
-                    <a
-                        :class="['regular-button', { disabled: !state.dialogUnstableFirmwareAcknowledgementCheckbox }]"
-                        href="#"
-                        id="dialogUnstableFirmwareAcknowledgement-flashbtn"
-                        @click.prevent="handleUnstableFirmwareFlash"
-                        >{{ $t("unstableFirmwareAcknowledgementFlash") }}</a
-                    >
+            </template>
+            <template #footer>
+                <div class="flex justify-end gap-2 w-full">
+                    <UButton :label="$t('cancel')" variant="outline" @click="handleUnstableFirmwareCancel" />
+                    <UButton
+                        :label="$t('unstableFirmwareAcknowledgementFlash')"
+                        :disabled="!state.dialogUnstableFirmwareAcknowledgementCheckbox"
+                        @click="handleUnstableFirmwareFlash"
+                    />
                 </div>
-                <div class="btn">
-                    <a
-                        href="#"
-                        id="dialogUnstableFirmwareAcknowledgement-cancelbtn"
-                        class="regular-button"
-                        @click.prevent="handleUnstableFirmwareCancel"
-                        >{{ $t("cancel") }}</a
-                    >
-                </div>
-            </div>
-        </dialog>
+            </template>
+        </UModal>
 
         <dialog ref="verifyBoardDialog" id="dialog-verify-board" @close="handleVerifyBoardDialogClose">
             <div id="dialog-verify-board-content-wrapper">
@@ -292,7 +283,7 @@ export default defineComponent({
         const verifyBoardOnAbortCallback = ref(null);
 
         // Unstable firmware dialog refs
-        const unstableFirmwareDialog = ref(null);
+        const unstableFirmwareOpen = ref(false);
         const unstableFirmwareAcknowledgementCallback = ref(null);
 
         let dfuMonitorInterval = null;
@@ -1218,20 +1209,8 @@ export default defineComponent({
         };
 
         const showAcknowledgementDialog = async (acknowledgementCallback) => {
-            await nextTick();
-
-            if (!unstableFirmwareDialog.value) {
-                console.error("Dialog element not found");
-                return;
-            }
-
             unstableFirmwareAcknowledgementCallback.value = acknowledgementCallback;
-            unstableFirmwareDialog.value.showModal();
-        };
-
-        const handleUnstableFirmwareDialogClose = () => {
-            state.dialogUnstableFirmwareAcknowledgementCheckbox = false;
-            unstableFirmwareAcknowledgementCallback.value = null;
+            unstableFirmwareOpen.value = true;
         };
 
         const initiateFlashing = async () => {
@@ -1694,12 +1673,14 @@ export default defineComponent({
                 return;
             }
 
-            if (unstableFirmwareDialog.value) {
-                unstableFirmwareDialog.value.close();
-            }
+            unstableFirmwareOpen.value = false;
 
-            if (unstableFirmwareAcknowledgementCallback.value) {
-                unstableFirmwareAcknowledgementCallback.value();
+            const acknowledgementCallback = unstableFirmwareAcknowledgementCallback.value;
+            state.dialogUnstableFirmwareAcknowledgementCheckbox = false;
+            unstableFirmwareAcknowledgementCallback.value = null;
+
+            if (acknowledgementCallback) {
+                acknowledgementCallback();
             }
 
             await startFlashing().catch((error) => {
@@ -1709,9 +1690,8 @@ export default defineComponent({
 
         const handleUnstableFirmwareCancel = () => {
             state.dialogUnstableFirmwareAcknowledgementCheckbox = false;
-            if (unstableFirmwareDialog.value) {
-                unstableFirmwareDialog.value.close();
-            }
+            unstableFirmwareAcknowledgementCallback.value = null;
+            unstableFirmwareOpen.value = false;
         };
 
         const handleVerifyBoardAbort = () => {
@@ -1899,7 +1879,7 @@ export default defineComponent({
             sponsorTile,
             verifyBoardDialog,
             verifyBoardContent,
-            unstableFirmwareDialog,
+            unstableFirmwareOpen,
             // Functions
             enableFlashButton,
             enableLoadRemoteFileButton,
@@ -1937,7 +1917,6 @@ export default defineComponent({
             showDfuButton,
             handleUnstableFirmwareFlash,
             handleUnstableFirmwareCancel,
-            handleUnstableFirmwareDialogClose,
             handleVerifyBoardAbort,
             handleVerifyBoardContinue,
             handleVerifyBoardDialogClose,

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -119,27 +119,26 @@
             </template>
         </UModal>
 
-        <dialog ref="verifyBoardDialog" id="dialog-verify-board" @close="handleVerifyBoardDialogClose">
-            <div id="dialog-verify-board-content-wrapper">
-                <div ref="verifyBoardContent" id="dialog-verify-board-content"></div>
-                <div class="btn dialog-buttons">
-                    <a
-                        href="#"
-                        id="dialog-verify-board-abort-confirmbtn"
-                        class="regular-button"
-                        @click.prevent="handleVerifyBoardAbort"
-                        >{{ $t("firmwareFlasherButtonAbort") }}</a
-                    >
-                    <a
-                        href="#"
-                        id="dialog-verify-board-continue-confirmbtn"
-                        class="regular-button"
-                        @click.prevent="handleVerifyBoardContinue"
-                        >{{ $t("firmwareFlasherButtonContinue") }}</a
-                    >
+        <UModal
+            v-model:open="verifyBoardOpen"
+            :close="false"
+            :dismissible="false"
+            :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+        >
+            <template #body>
+                <div v-html="verifyBoardContentHtml"></div>
+            </template>
+            <template #footer>
+                <div class="flex justify-end gap-2 w-full">
+                    <UButton
+                        :label="$t('firmwareFlasherButtonAbort')"
+                        variant="outline"
+                        @click="handleVerifyBoardAbort"
+                    />
+                    <UButton :label="$t('firmwareFlasherButtonContinue')" @click="handleVerifyBoardContinue" />
                 </div>
-            </div>
-        </dialog>
+            </template>
+        </UModal>
     </BaseTab>
 </template>
 
@@ -277,8 +276,8 @@ export default defineComponent({
         const sponsorTile = ref(null);
 
         // Verify board dialog refs
-        const verifyBoardDialog = ref(null);
-        const verifyBoardContent = ref(null);
+        const verifyBoardOpen = ref(false);
+        const verifyBoardContentHtml = ref("");
         const verifyBoardOnAcceptCallback = ref(null);
         const verifyBoardOnAbortCallback = ref(null);
 
@@ -1695,28 +1694,23 @@ export default defineComponent({
         };
 
         const handleVerifyBoardAbort = () => {
-            if (verifyBoardDialog.value) {
-                verifyBoardDialog.value.close();
-            }
-
-            if (verifyBoardOnAbortCallback.value) {
-                verifyBoardOnAbortCallback.value();
+            verifyBoardOpen.value = false;
+            const onAbort = verifyBoardOnAbortCallback.value;
+            verifyBoardOnAcceptCallback.value = null;
+            verifyBoardOnAbortCallback.value = null;
+            if (onAbort) {
+                onAbort();
             }
         };
 
         const handleVerifyBoardContinue = () => {
-            if (verifyBoardDialog.value) {
-                verifyBoardDialog.value.close();
-            }
-
-            if (verifyBoardOnAcceptCallback.value) {
-                verifyBoardOnAcceptCallback.value();
-            }
-        };
-
-        const handleVerifyBoardDialogClose = () => {
+            verifyBoardOpen.value = false;
+            const onAccept = verifyBoardOnAcceptCallback.value;
             verifyBoardOnAcceptCallback.value = null;
             verifyBoardOnAbortCallback.value = null;
+            if (onAccept) {
+                onAccept();
+            }
         };
 
         // Handle restore backup functionality
@@ -1788,17 +1782,15 @@ export default defineComponent({
         };
 
         const showDialogVerifyBoard = (selected, verified, onAccept, onAbort) => {
-            if (verifyBoardContent.value) {
-                verifyBoardContent.value.innerHTML = $t("firmwareFlasherVerifyBoard", {
-                    selected_board: selected,
-                    verified_board: verified,
-                });
-            }
+            verifyBoardContentHtml.value = $t("firmwareFlasherVerifyBoard", {
+                selected_board: selected,
+                verified_board: verified,
+            });
 
-            if (verifyBoardDialog.value && !verifyBoardDialog.value.hasAttribute("open")) {
+            if (!verifyBoardOpen.value) {
                 verifyBoardOnAcceptCallback.value = onAccept;
                 verifyBoardOnAbortCallback.value = onAbort;
-                verifyBoardDialog.value.showModal();
+                verifyBoardOpen.value = true;
             }
         };
 
@@ -1877,8 +1869,8 @@ export default defineComponent({
             FLASH_MESSAGE_TYPES,
             // Template refs
             sponsorTile,
-            verifyBoardDialog,
-            verifyBoardContent,
+            verifyBoardOpen,
+            verifyBoardContentHtml,
             unstableFirmwareOpen,
             // Functions
             enableFlashButton,
@@ -1919,7 +1911,6 @@ export default defineComponent({
             handleUnstableFirmwareCancel,
             handleVerifyBoardAbort,
             handleVerifyBoardContinue,
-            handleVerifyBoardDialogClose,
             handleRestoreBackup,
             saveFirmware,
         };

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -465,12 +465,21 @@
             </div>
 
             <!-- Warning Dialog -->
-            <dialog id="dialog-settings-changed" ref="dialogSettingsChanged" class="w-[400px] h-fit">
-                <div class="p-4">
-                    <div class="mb-4" v-html="warningMessage"></div>
-                    <UButton :label="$t('motorsDialogSettingsChangedOk')" @click="closeWarningDialog" />
-                </div>
-            </dialog>
+            <UModal
+                v-model:open="settingsChangedOpen"
+                :close="false"
+                :dismissible="false"
+                :ui="{ overlay: 'z-3000', content: 'w-[400px] z-3001' }"
+            >
+                <template #body>
+                    <div v-html="warningMessage"></div>
+                </template>
+                <template #footer>
+                    <div class="flex justify-end gap-2 w-full">
+                        <UButton :label="$t('motorsDialogSettingsChangedOk')" @click="closeWarningDialog" />
+                    </div>
+                </template>
+            </UModal>
 
             <!-- Dynamic Notch Filters Dialog -->
             <dialog id="dialog-dyn-filters" ref="dialogDynFilters" class="w-[400px] h-fit">
@@ -542,16 +551,16 @@ const motorsState = useMotorsState();
 const { configHasChanged, resetChanges } = motorsState;
 
 // Warning dialog
-const dialogSettingsChanged = ref(null);
+const settingsChangedOpen = ref(false);
 const warningMessage = ref("");
 
 const showWarningDialog = (message) => {
     warningMessage.value = message;
-    dialogSettingsChanged.value?.showModal();
+    settingsChangedOpen.value = true;
 };
 
 const closeWarningDialog = () => {
-    dialogSettingsChanged.value?.close();
+    settingsChangedOpen.value = false;
 };
 
 // Dynamic notch filter dialog

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -482,20 +482,27 @@
             </UModal>
 
             <!-- Dynamic Notch Filters Dialog -->
-            <dialog id="dialog-dyn-filters" ref="dialogDynFilters" class="w-[400px] h-fit">
-                <div class="p-4">
-                    <div class="font-semibold mb-2" v-html="$t('dialogDynFiltersChangeTitle')"></div>
-                    <div class="mb-4" v-html="$t('dialogDynFiltersChangeNote')"></div>
-                    <div class="flex gap-2">
-                        <UButton :label="$t('presetsWarningDialogYesButton')" @click="applyDynFiltersChange" />
+            <UModal
+                v-model:open="dialogDynFiltersOpen"
+                :title="$t('dialogDynFiltersChangeTitle')"
+                :close="false"
+                :dismissible="false"
+                :ui="{ overlay: 'z-3000', content: 'w-[400px] z-3001' }"
+            >
+                <template #body>
+                    <div v-html="$t('dialogDynFiltersChangeNote')"></div>
+                </template>
+                <template #footer>
+                    <div class="flex justify-end gap-2 w-full">
                         <UButton
                             :label="$t('presetsWarningDialogNoButton')"
                             variant="outline"
                             @click="closeDynFiltersDialog"
                         />
+                        <UButton :label="$t('presetsWarningDialogYesButton')" @click="applyDynFiltersChange" />
                     </div>
-                </div>
-            </dialog>
+                </template>
+            </UModal>
         </div>
 
         <!-- Fixed Bottom Toolbar -->
@@ -564,18 +571,18 @@ const closeWarningDialog = () => {
 };
 
 // Dynamic notch filter dialog
-const dialogDynFilters = ref(null);
+const dialogDynFiltersOpen = ref(false);
 const previousDshotBidir = ref(false);
 const dshotBidirInitialized = ref(false);
 const previousFilterDynQ = ref(null);
 const previousFilterDynCount = ref(null);
 
 const showDynFiltersDialog = () => {
-    dialogDynFilters.value?.showModal();
+    dialogDynFiltersOpen.value = true;
 };
 
 const closeDynFiltersDialog = () => {
-    dialogDynFilters.value?.close();
+    dialogDynFiltersOpen.value = false;
 };
 
 const applyDynFiltersChange = () => {

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -116,34 +116,40 @@
                                     </template>
                                 </UModal>
 
-                                <dialog ref="savingDialog" class="dataflash-saving">
-                                    <h3>{{ $t("dataflashSavingTitle") }}</h3>
-                                    <div class="dataflash-saving-before">
-                                        <div>{{ $t("dataflashSavingNote") }}</div>
-                                        <progress :value="saveProgress" min="0" max="100"></progress>
-                                        <div class="buttons">
-                                            <a
-                                                href="#"
-                                                class="save-flash-cancel regular-button"
-                                                @click.prevent="flashSaveCancel"
-                                            >
-                                                {{ $t("dataflashButtonSaveCancel") }}
-                                            </a>
+                                <UModal
+                                    :open="saveOpen"
+                                    :close="false"
+                                    :dismissible="false"
+                                    :ui="{ overlay: 'z-3000', content: 'w-[36rem] max-w-[calc(100vw-2rem)] z-3001' }"
+                                >
+                                    <template #body>
+                                        <div class="dataflash-saving" :class="{ done: saveDone }">
+                                            <h3>{{ $t("dataflashSavingTitle") }}</h3>
+                                            <div class="dataflash-saving-before">
+                                                <div>{{ $t("dataflashSavingNote") }}</div>
+                                                <progress :value="saveProgress" min="0" max="100"></progress>
+                                                <div class="buttons flex justify-end gap-2 mt-3">
+                                                    <UButton
+                                                        class="save-flash-cancel"
+                                                        variant="outline"
+                                                        :label="$t('dataflashButtonSaveCancel')"
+                                                        @click="flashSaveCancel"
+                                                    />
+                                                </div>
+                                            </div>
+                                            <div class="dataflash-saving-after">
+                                                <div>{{ $t("dataflashSavingNoteAfter") }}</div>
+                                                <div class="buttons flex justify-end gap-2 mt-3">
+                                                    <UButton
+                                                        class="save-flash-dismiss"
+                                                        :label="$t('dataflashButtonSaveDismiss')"
+                                                        @click="dismissSavingDialog"
+                                                    />
+                                                </div>
+                                            </div>
                                         </div>
-                                    </div>
-                                    <div class="dataflash-saving-after">
-                                        <div>{{ $t("dataflashSavingNoteAfter") }}</div>
-                                        <div class="buttons">
-                                            <a
-                                                href="#"
-                                                class="save-flash-dismiss regular-button"
-                                                @click.prevent="dismissSavingDialog"
-                                            >
-                                                {{ $t("dataflashButtonSaveDismiss") }}
-                                            </a>
-                                        </div>
-                                    </div>
-                                </dialog>
+                                    </template>
+                                </UModal>
 
                                 <ul class="dataflash-contents">
                                     <li
@@ -276,7 +282,7 @@
 </template>
 
 <script>
-import { defineComponent, ref, computed, onMounted, onUnmounted, nextTick } from "vue";
+import { defineComponent, ref, computed, onMounted, onUnmounted } from "vue";
 import { useFlightControllerStore } from "@/stores/fc";
 import { useConnectionStore } from "@/stores/connection";
 import BaseTab from "./BaseTab.vue";
@@ -358,7 +364,8 @@ export default defineComponent({
 
         // Refs
         const eraseOpen = ref(false);
-        const savingDialog = ref(null);
+        const saveOpen = ref(false);
+        const saveDone = ref(false);
 
         // State
         const blackboxDevice = ref(0);
@@ -631,14 +638,12 @@ export default defineComponent({
         function showSavingDialog() {
             saveProgress.value = 0;
             saveCancelled.value = false;
-            savingDialog.value?.showModal();
-            nextTick(() => {
-                savingDialog.value?.classList.remove("done");
-            });
+            saveDone.value = false;
+            saveOpen.value = true;
         }
 
         function dismissSavingDialog() {
-            savingDialog.value?.close();
+            saveOpen.value = false;
         }
 
         function markSavingDialogDone(startTime, totalBytes, totalBytesCompressed) {
@@ -657,9 +662,7 @@ export default defineComponent({
                 );
             }
 
-            nextTick(() => {
-                savingDialog.value?.classList.add("done");
-            });
+            saveDone.value = true;
 
             if (getConfig("showNotifications").showNotifications) {
                 NotificationManager.showNotification("Betaflight App", {
@@ -895,7 +898,8 @@ export default defineComponent({
         return {
             MSP,
             eraseOpen,
-            savingDialog,
+            saveOpen,
+            saveDone,
             blackboxDevice,
             blackboxRate,
             debugMode,

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -82,37 +82,39 @@
                             <div class="require-dataflash-supported">
                                 <p>{{ $t("dataflashNote") }}</p>
 
-                                <dialog
-                                    ref="eraseDialog"
-                                    class="dataflash-confirm-erase"
-                                    :class="{ erasing: isErasing }"
+                                <UModal
+                                    :open="eraseOpen"
+                                    :close="false"
+                                    :dismissible="false"
+                                    :ui="{ overlay: 'z-3000', content: 'w-[36rem] max-w-[calc(100vw-2rem)] z-3001' }"
                                 >
-                                    <h3>{{ $t("dataflashConfirmEraseTitle") }}</h3>
-                                    <div class="dataflash-confirm-erase-note">
-                                        {{ $t("dataflashConfirmEraseNote") }}
-                                    </div>
-                                    <div class="dataflash-erase-progress">
-                                        <div class="data-loading">
-                                            <p>{{ $t("onboardLoggingEraseInProgress") }}</p>
+                                    <template #body>
+                                        <div class="dataflash-confirm-erase" :class="{ erasing: isErasing }">
+                                            <h3>{{ $t("dataflashConfirmEraseTitle") }}</h3>
+                                            <div class="dataflash-confirm-erase-note">
+                                                {{ $t("dataflashConfirmEraseNote") }}
+                                            </div>
+                                            <div class="dataflash-erase-progress">
+                                                <div class="data-loading">
+                                                    <p>{{ $t("onboardLoggingEraseInProgress") }}</p>
+                                                </div>
+                                            </div>
+                                            <div class="buttons flex justify-end gap-2 mt-3">
+                                                <UButton
+                                                    class="erase-flash-cancel"
+                                                    variant="outline"
+                                                    :label="$t('dataflashButtonEraseCancel')"
+                                                    @click="flashEraseCancel"
+                                                />
+                                                <UButton
+                                                    class="erase-flash-confirm"
+                                                    :label="$t('dataflashButtonEraseConfirm')"
+                                                    @click="flashErase"
+                                                />
+                                            </div>
                                         </div>
-                                    </div>
-                                    <div class="buttons">
-                                        <a
-                                            href="#"
-                                            class="erase-flash-confirm regular-button"
-                                            @click.prevent="flashErase"
-                                        >
-                                            {{ $t("dataflashButtonEraseConfirm") }}
-                                        </a>
-                                        <a
-                                            href="#"
-                                            class="erase-flash-cancel regular-button"
-                                            @click.prevent="flashEraseCancel"
-                                        >
-                                            {{ $t("dataflashButtonEraseCancel") }}
-                                        </a>
-                                    </div>
-                                </dialog>
+                                    </template>
+                                </UModal>
 
                                 <dialog ref="savingDialog" class="dataflash-saving">
                                     <h3>{{ $t("dataflashSavingTitle") }}</h3>
@@ -355,7 +357,7 @@ export default defineComponent({
         const debugStore = useDebugStore();
 
         // Refs
-        const eraseDialog = ref(null);
+        const eraseOpen = ref(false);
         const savingDialog = ref(null);
 
         // State
@@ -581,7 +583,7 @@ export default defineComponent({
                 return;
             }
             eraseCancelled.value = false;
-            eraseDialog.value?.showModal();
+            eraseOpen.value = true;
         }
 
         function flashErase() {
@@ -594,7 +596,7 @@ export default defineComponent({
         function flashEraseCancel() {
             eraseCancelled.value = true;
             isErasing.value = false;
-            eraseDialog.value?.close();
+            eraseOpen.value = false;
             connectionStore.resumeLiveData();
         }
 
@@ -603,7 +605,7 @@ export default defineComponent({
                 if (connectionStore.connectionValid && !eraseCancelled.value) {
                     if (fcStore.dataflash?.ready) {
                         isErasing.value = false;
-                        eraseDialog.value?.close();
+                        eraseOpen.value = false;
                         connectionStore.resumeLiveData();
                         if (getConfig("showNotifications").showNotifications) {
                             NotificationManager.showNotification("Betaflight App", {
@@ -674,10 +676,8 @@ export default defineComponent({
         function conditionallyEraseFlash(maxBytes, nextAddress) {
             if (Number.isFinite(maxBytes) && nextAddress >= maxBytes) {
                 eraseCancelled.value = false;
-                nextTick(() => {
-                    eraseDialog.value?.classList.add("erasing");
-                });
-                eraseDialog.value?.showModal();
+                isErasing.value = true;
+                eraseOpen.value = true;
                 MSP.send_message(MSPCodes.MSP_DATAFLASH_ERASE, false, false, pollForEraseCompletion);
             } else {
                 gui_log(
@@ -894,7 +894,7 @@ export default defineComponent({
 
         return {
             MSP,
-            eraseDialog,
+            eraseOpen,
             savingDialog,
             blackboxDevice,
             blackboxRate,

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -410,21 +410,13 @@
                 </div>
 
                 <!-- Font Manager Dialog -->
-                <dialog ref="fontManagerDialog" class="html-dialog w-[750px] h-fit">
-                    <div class="flex h-12 bg-elevated border-b border-default">
-                        <div class="flex-1 flex items-center px-4 font-semibold">
-                            {{ $t("osdSetupFontManagerTitle") }}
-                        </div>
-                        <UButton
-                            @click="closeFontManager"
-                            icon="i-lucide-x"
-                            variant="ghost"
-                            color="neutral"
-                            size="sm"
-                            class="my-auto mr-2"
-                        />
-                    </div>
-                    <div class="p-5">
+                <UModal
+                    :open="fontManagerOpen"
+                    :title="$t('osdSetupFontManagerTitle')"
+                    :ui="{ overlay: 'z-3000', content: 'w-[750px] z-3001' }"
+                    @update:open="(value) => !value && closeFontManager()"
+                >
+                    <template #body>
                         <h1 class="text-lg font-bold mb-1">{{ $t("osdSetupFontPresets") }}</h1>
                         <div class="flex flex-wrap gap-0 my-3" ref="fontPreviewContainer">
                             <img
@@ -490,8 +482,8 @@
                         <UButton @click="flashFont()" color="success" size="sm">
                             {{ $t("osdSetupUploadFont") }}
                         </UButton>
-                    </div>
-                </dialog>
+                    </template>
+                </UModal>
             </div>
         </div>
 
@@ -554,7 +546,7 @@ const fcStore = useFlightControllerStore();
 const previewContainer = ref(null);
 const previewContainerOuter = ref(null);
 const rulerCanvas = ref(null);
-const fontManagerDialog = ref(null);
+const fontManagerOpen = ref(false);
 const fontPreviewContainer = ref(null);
 const logoPreview = ref(null);
 
@@ -1429,7 +1421,7 @@ const fontDataVersion = ref(0);
 let lastFontPresetRequestId = 0;
 
 function closeFontManager() {
-    fontManagerDialog.value?.close();
+    fontManagerOpen.value = false;
 }
 
 function loadCustomFontFile() {
@@ -1453,7 +1445,7 @@ async function openFontManager() {
     FONT.initData();
 
     // Show the dialog first so DOM elements are available for LogoManager
-    fontManagerDialog.value?.showModal?.();
+    fontManagerOpen.value = true;
     await nextTick();
 
     // Initialize LogoManager (caches DOM elements via querySelector)

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -149,11 +149,18 @@
             @deactivate-source="handleDeactivateSource"
         />
 
-        <dialog ref="progressDialogRef" class="w-[300px] h-fit p-6" @cancel.prevent>
-            <div class="text-lg mb-2" v-html="$t('presetsApplyingPresets')"></div>
-            <div class="text-sm text-(--ui-text-muted)" v-html="$t('presetsPleaseWait')"></div>
-            <UProgress :model-value="store.applyState.progress" :max="100" class="mt-3" />
-        </dialog>
+        <UModal
+            :open="store.applyState.progressDialogOpen"
+            :close="false"
+            :dismissible="false"
+            :ui="{ overlay: 'z-3000', content: 'w-[300px] z-3001' }"
+        >
+            <template #body>
+                <div class="text-lg mb-2" v-html="$t('presetsApplyingPresets')"></div>
+                <div class="text-sm text-(--ui-text-muted)" v-html="$t('presetsPleaseWait')"></div>
+                <UProgress :model-value="store.applyState.progress" :max="100" class="mt-3" />
+            </template>
+        </UModal>
 
         <dialog
             ref="cliErrorsDialogRef"
@@ -218,7 +225,6 @@ const store = usePresetsStore();
 const connectionStore = useConnectionStore();
 const dialog = useDialog();
 const cliSession = useMspCliSession();
-const progressDialogRef = ref(null);
 const cliErrorsDialogRef = ref(null);
 const searchPlaceholder = 'example: "karate race", or "5\'\' freestyle"';
 
@@ -229,23 +235,6 @@ function reportProgress({ index, total }) {
     }
     store.updateApplyProgress(Math.round((index / total) * 100));
 }
-
-watch(
-    () => store.applyState.progressDialogOpen,
-    async (isOpen) => {
-        await nextTick();
-
-        if (!progressDialogRef.value) {
-            return;
-        }
-
-        if (isOpen && !progressDialogRef.value.open) {
-            progressDialogRef.value.showModal();
-        } else if (!isOpen && progressDialogRef.value.open) {
-            progressDialogRef.value.close();
-        }
-    },
-);
 
 watch(
     () => store.applyState.cliErrorsDialogOpen,

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -162,39 +162,48 @@
             </template>
         </UModal>
 
-        <dialog
-            ref="cliErrorsDialogRef"
-            class="w-[600px] max-w-[calc(100vw-2rem)] h-fit p-6"
-            @close="handleCliErrorsDialogClose"
-            @cancel.prevent
+        <UModal
+            :open="store.applyState.cliErrorsDialogOpen"
+            :close="false"
+            :dismissible="false"
+            :ui="{ overlay: 'z-3000', content: 'w-[600px] max-w-[calc(100vw-2rem)] z-3001' }"
         >
-            <div class="text-lg mb-2" v-html="$t('presetsCliErrorsWarning')"></div>
-            <div class="presets_cli_background">
-                <div class="presets_cli_window">
-                    <div class="presets_cli_wrapper">
-                        <template v-for="(failure, idx) in store.applyState.cliErrors" :key="idx">
-                            <div>{{ failure.command }}</div>
-                            <div
-                                v-for="(line, lineIdx) in failure.response"
-                                :key="lineIdx"
-                                :class="{ error_message: line.startsWith('###ERROR') }"
-                            >
-                                {{ line }}
-                            </div>
-                        </template>
+            <template #title>
+                <span v-html="$t('presetsCliErrorsWarning')"></span>
+            </template>
+            <template #body>
+                <div class="presets_cli_background">
+                    <div class="presets_cli_window">
+                        <div class="presets_cli_wrapper">
+                            <template v-for="(failure, idx) in store.applyState.cliErrors" :key="idx">
+                                <div>{{ failure.command }}</div>
+                                <div
+                                    v-for="(line, lineIdx) in failure.response"
+                                    :key="lineIdx"
+                                    :class="{ error_message: line.startsWith('###ERROR') }"
+                                >
+                                    {{ line }}
+                                </div>
+                            </template>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <div class="flex gap-2 justify-end mt-3">
-                <UButton :label="$t('presetsButtonCancel')" variant="outline" @click="closeCliErrorsWithoutSaving" />
-                <UButton :label="$t('presetsSaveAnyway')" @click="saveAnywayAfterCliErrors" />
-            </div>
-        </dialog>
+            </template>
+            <template #footer>
+                <div class="flex justify-end gap-2 w-full">
+                    <UButton
+                        :label="$t('presetsButtonCancel')"
+                        variant="outline"
+                        @click="closeCliErrorsWithoutSaving"
+                    />
+                    <UButton :label="$t('presetsSaveAnyway')" @click="saveAnywayAfterCliErrors" />
+                </div>
+            </template>
+        </UModal>
     </BaseTab>
 </template>
 
 <script setup>
-import { nextTick, ref, watch } from "vue";
 import BaseTab from "./BaseTab.vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
@@ -225,7 +234,6 @@ const store = usePresetsStore();
 const connectionStore = useConnectionStore();
 const dialog = useDialog();
 const cliSession = useMspCliSession();
-const cliErrorsDialogRef = ref(null);
 const searchPlaceholder = 'example: "karate race", or "5\'\' freestyle"';
 
 function reportProgress({ index, total }) {
@@ -235,23 +243,6 @@ function reportProgress({ index, total }) {
     }
     store.updateApplyProgress(Math.round((index / total) * 100));
 }
-
-watch(
-    () => store.applyState.cliErrorsDialogOpen,
-    async (isOpen) => {
-        await nextTick();
-
-        if (!cliErrorsDialogRef.value) {
-            return;
-        }
-
-        if (isOpen && !cliErrorsDialogRef.value.open) {
-            cliErrorsDialogRef.value.showModal();
-        } else if (!isOpen && cliErrorsDialogRef.value.open) {
-            cliErrorsDialogRef.value.close();
-        }
-    },
-);
 
 async function onTabMounted() {
     store.initialize();
@@ -493,6 +484,7 @@ async function saveAnywayAfterCliErrors() {
 
 function closeCliErrorsWithoutSaving() {
     store.closeCliErrorsDialog(false);
+    handleCliErrorsDialogClose();
 }
 
 async function handleCliErrorsDialogClose() {

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -245,21 +245,26 @@
             </div>
         </div>
 
-        <dialog class="dialogConfirmReset" ref="dialogConfirmReset">
-            <h3>{{ $t("dialogConfirmResetTitle") }}</h3>
-            <div class="content">
-                <div style="margin-top: 10px" v-html="$t('dialogConfirmResetNote')"></div>
-            </div>
-            <div class="buttons">
-                <UButton :label="$t('dialogConfirmResetConfirm')" color="error" @click="confirmReset" />
-                <UButton
-                    :label="$t('dialogConfirmResetClose')"
-                    color="neutral"
-                    variant="outline"
-                    @click="cancelConfirmReset"
-                />
-            </div>
-        </dialog>
+        <UModal
+            v-model:open="confirmResetOpen"
+            :title="$t('dialogConfirmResetTitle')"
+            :ui="{ overlay: 'z-3000', content: 'z-3001' }"
+        >
+            <template #body>
+                <div v-html="$t('dialogConfirmResetNote')"></div>
+            </template>
+            <template #footer>
+                <div class="flex justify-end gap-2 w-full">
+                    <UButton
+                        :label="$t('dialogConfirmResetClose')"
+                        color="neutral"
+                        variant="outline"
+                        @click="cancelConfirmReset"
+                    />
+                    <UButton :label="$t('dialogConfirmResetConfirm')" color="error" @click="confirmReset" />
+                </div>
+            </template>
+        </UModal>
 
         <dialog class="dialogBuildInfo" ref="dialogBuildInfo">
             <h3>{{ state.buildInfoDialogTitle }}</h3>
@@ -455,7 +460,7 @@ const updateExpertMode = (enabled) => {
 
 let mountedFlag = true;
 const isExpert = ref(isExpertModeEnabled());
-const dialogConfirmReset = ref(null);
+const confirmResetOpen = ref(false);
 const dialogBuildInfo = ref(null);
 
 function resetZaxis() {
@@ -472,21 +477,15 @@ function onRebootBootloader() {
 }
 
 function showConfirmReset() {
-    if (dialogConfirmReset.value) {
-        dialogConfirmReset.value.showModal();
-    }
+    confirmResetOpen.value = true;
 }
 
 function cancelConfirmReset() {
-    if (dialogConfirmReset.value) {
-        dialogConfirmReset.value.close();
-    }
+    confirmResetOpen.value = false;
 }
 
 function confirmReset() {
-    if (dialogConfirmReset.value) {
-        dialogConfirmReset.value.close();
-    }
+    confirmResetOpen.value = false;
     MSP.send_message(MSPCodes.MSP_RESET_CONF, false, false, function () {
         gui_log(t("initialSetupSettingsRestored"));
         GUI.tab_switch_cleanup(function () {

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -266,19 +266,24 @@
             </template>
         </UModal>
 
-        <dialog class="dialogBuildInfo" ref="dialogBuildInfo">
-            <h3>{{ state.buildInfoDialogTitle }}</h3>
-            <div class="contentBuildInfo">
-                <div class="dialogBuildInfoGrid-container" style="margin-top: 10px">
+        <UModal
+            v-model:open="buildInfoOpen"
+            :title="state.buildInfoDialogTitle"
+            :ui="{ overlay: 'z-3000', content: 'w-fit max-w-2xl z-3001' }"
+        >
+            <template #body>
+                <div class="dialogBuildInfoGrid-container">
                     <div v-for="option in state.sortedBuildOptions" :key="option" class="dialogBuildInfoGrid-item">
                         {{ option }}
                     </div>
                 </div>
-            </div>
-            <div class="dialogButtons">
-                <UButton :label="$t('close')" color="neutral" variant="outline" @click="closeBuildInfo" />
-            </div>
-        </dialog>
+            </template>
+            <template #footer>
+                <div class="flex justify-end gap-2 w-full">
+                    <UButton :label="$t('close')" color="neutral" variant="outline" @click="closeBuildInfo" />
+                </div>
+            </template>
+        </UModal>
     </BaseTab>
 </template>
 
@@ -461,7 +466,7 @@ const updateExpertMode = (enabled) => {
 let mountedFlag = true;
 const isExpert = ref(isExpertModeEnabled());
 const confirmResetOpen = ref(false);
-const dialogBuildInfo = ref(null);
+const buildInfoOpen = ref(false);
 
 function resetZaxis() {
     yaw_fix.value = fcStore.sensorData.kinematics[2] * -1;
@@ -496,9 +501,7 @@ function confirmReset() {
 }
 
 function closeBuildInfo() {
-    if (dialogBuildInfo.value) {
-        dialogBuildInfo.value.close();
-    }
+    buildInfoOpen.value = false;
 }
 
 const canvasWrapper = ref(null);
@@ -791,9 +794,7 @@ function openBuildOptionsDialog() {
     );
     state.buildInfoDialogTitle = t("initialSetupInfoBuildOptionList");
 
-    if (dialogBuildInfo.value && !dialogBuildInfo.value.hasAttribute("open")) {
-        dialogBuildInfo.value.showModal();
-    }
+    buildInfoOpen.value = true;
 }
 </script>
 

--- a/src/components/tabs/UserProfileTab.vue
+++ b/src/components/tabs/UserProfileTab.vue
@@ -57,44 +57,49 @@
                 </UiBox>
 
                 <!-- Edit Profile Dialog -->
-                <dialog ref="editDialogRef" class="profile-edit-dialog" @cancel="cancelEdit">
-                    <h3>{{ $t("titleEditProfile") }}</h3>
-                    <div class="profile-edit-form">
-                        <p>
-                            <label for="edit-name">{{ $t("labelName") }}</label>
-                            <input v-model="editForm.name" type="text" id="edit-name" name="name" />
-                        </p>
-                        <p>
-                            <label for="edit-address">{{ $t("labelAddress") }}</label>
-                            <input v-model="editForm.address" type="text" id="edit-address" name="address" />
-                        </p>
-                        <p>
-                            <label for="edit-country">{{ $t("labelCountry") }}</label>
-                            <input v-model="editForm.country" type="text" id="edit-country" name="country" />
-                        </p>
-                        <p>
-                            <label for="edit-avatar">{{ $t("labelAvatarUrl") }}</label>
-                            <input
-                                v-model="editForm.avatar"
-                                type="url"
-                                id="edit-avatar"
-                                name="avatar"
-                                :placeholder="$t('placeholderAvatarUrl')"
-                            />
-                        </p>
-                        <p v-if="editError" class="profile-edit-error" role="alert" aria-live="polite">
-                            {{ editError }}
-                        </p>
-                        <div class="buttons">
-                            <button type="button" class="regular-button" @click="saveProfileChanges">
-                                {{ $t("actionSave") }}
-                            </button>
-                            <button type="button" class="regular-button" @click="cancelEdit">
-                                {{ $t("cancel") }}
-                            </button>
+                <UModal
+                    :open="editOpen"
+                    :close="false"
+                    :dismissible="false"
+                    :title="$t('titleEditProfile')"
+                    :ui="{ overlay: 'z-3000', content: 'w-[90%] max-w-[600px] z-3001' }"
+                >
+                    <template #body>
+                        <div class="profile-edit-form">
+                            <p>
+                                <label for="edit-name">{{ $t("labelName") }}</label>
+                                <input v-model="editForm.name" type="text" id="edit-name" name="name" />
+                            </p>
+                            <p>
+                                <label for="edit-address">{{ $t("labelAddress") }}</label>
+                                <input v-model="editForm.address" type="text" id="edit-address" name="address" />
+                            </p>
+                            <p>
+                                <label for="edit-country">{{ $t("labelCountry") }}</label>
+                                <input v-model="editForm.country" type="text" id="edit-country" name="country" />
+                            </p>
+                            <p>
+                                <label for="edit-avatar">{{ $t("labelAvatarUrl") }}</label>
+                                <input
+                                    v-model="editForm.avatar"
+                                    type="url"
+                                    id="edit-avatar"
+                                    name="avatar"
+                                    :placeholder="$t('placeholderAvatarUrl')"
+                                />
+                            </p>
+                            <p v-if="editError" class="profile-edit-error" role="alert" aria-live="polite">
+                                {{ editError }}
+                            </p>
                         </div>
-                    </div>
-                </dialog>
+                    </template>
+                    <template #footer>
+                        <div class="flex justify-end gap-2 w-full">
+                            <UButton :label="$t('cancel')" variant="outline" @click="cancelEdit" />
+                            <UButton :label="$t('actionSave')" @click="saveProfileChanges" />
+                        </div>
+                    </template>
+                </UModal>
 
                 <!-- Token Section -->
                 <UiBox class="options col-span-3" :title="$t('sectionUserTokens')">
@@ -178,7 +183,7 @@ const profile = ref(null);
 const editForm = ref({ name: "", address: "", country: "", avatar: "" });
 const tokens = ref([]);
 const passkeys = ref([]);
-const editDialogRef = ref(null);
+const editOpen = ref(false);
 let userApi = null;
 let unsubscribeLogin = null;
 let unsubscribeLogout = null;
@@ -267,12 +272,12 @@ function startEdit() {
     editForm.value.country = profile.value.country || "";
     editForm.value.avatar = profile.value.avatar || "";
     editError.value = null;
-    editDialogRef.value?.showModal();
+    editOpen.value = true;
 }
 
 function cancelEdit() {
     editError.value = null;
-    editDialogRef.value?.close();
+    editOpen.value = false;
 }
 
 async function saveProfileChanges() {
@@ -297,7 +302,7 @@ async function saveProfileChanges() {
         profile.value.country = editForm.value.country;
         profile.value.avatar = editForm.value.avatar;
         gui_log(t("userProfileUpdateSuccess"));
-        editDialogRef.value?.close();
+        editOpen.value = false;
     } catch (error) {
         editError.value = `${t("userProfileUpdateFailed")}: ${error.message || error}`;
         gui_log(editError.value);
@@ -378,6 +383,28 @@ onUnmounted(() => {
 </script>
 
 <style lang="less">
+/* Edit-profile form lives in a teleported UModal, so these are global (not nested under .tab-user_profile) */
+.profile-edit-form label {
+    display: block;
+    margin-bottom: 5px;
+    font-weight: bold;
+}
+.profile-edit-form input {
+    width: 100%;
+    padding: 5px;
+    margin-bottom: 10px;
+    border: 1px solid var(--surface-400);
+    border-radius: 4px;
+}
+.profile-edit-error {
+    color: var(--error-500);
+    font-size: 12px;
+    margin: 10px 0;
+    padding: 8px;
+    background-color: rgba(255, 0, 0, 0.1);
+    border-radius: 4px;
+}
+
 .tab-user_profile {
     font-family: "Segoe UI", Tahoma, Geneva, Verdana, sans-serif;
 
@@ -414,51 +441,6 @@ onUnmounted(() => {
             min-width: 60px;
             display: inline-block;
         }
-    }
-
-    .profile-edit-dialog {
-        z-index: 1000;
-        position: fixed;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        margin: 0;
-        width: 90%;
-        max-width: 600px;
-        max-height: 90vh;
-        overflow-y: auto;
-        border: 1px solid var(--surface-400);
-        border-radius: 8px;
-        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
-
-        &::backdrop {
-            background: rgba(0, 0, 0, 0.5);
-        }
-    }
-
-    .profile-edit-form {
-        label {
-            display: block;
-            margin-bottom: 5px;
-            font-weight: bold;
-        }
-
-        input {
-            width: 100%;
-            padding: 5px;
-            margin-bottom: 10px;
-            border: 1px solid var(--surface-400);
-            border-radius: 4px;
-        }
-    }
-
-    .profile-edit-error {
-        color: var(--error-500);
-        font-size: 12px;
-        margin: 10px 0;
-        padding: 8px;
-        background-color: rgba(255, 0, 0, 0.1);
-        border-radius: 4px;
     }
 
     .content_wrapper .data-loading {

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -1,12 +1,16 @@
 <template>
-    <dialog
-        ref="dialogRef"
-        class="w-[600px] max-w-[calc(100vw-2rem)] h-[520px] p-3 pb-0"
-        @close="emit('close')"
-        @cancel.prevent="requestClose"
+    <UModal
+        :open="open"
+        :close="false"
+        :ui="{
+            overlay: 'z-3000',
+            content: 'w-[600px] max-w-[calc(100vw-2rem)] h-[520px] z-3001',
+            body: 'overflow-visible',
+        }"
+        @update:open="onOpenChange"
     >
-        <div class="flex flex-col flex-1 min-h-0 h-full">
-            <div class="flex flex-col flex-1 min-h-0">
+        <template #body>
+            <div class="flex flex-col flex-1 min-h-0 h-full">
                 <div v-if="!loading && preset" class="flex flex-col flex-1 min-h-0">
                     <PresetCard
                         :preset="preset"
@@ -104,8 +108,10 @@
                 <div v-if="loading" class="data-loading h-[300px]"></div>
                 <div v-if="error" class="p-5 text-(--ui-error)">{{ error }}</div>
             </div>
+        </template>
 
-            <div class="flex flex-wrap items-center justify-between gap-2 mt-auto mx-[-12px] py-2 px-3">
+        <template #footer>
+            <div class="flex flex-wrap items-center justify-between gap-2 w-full">
                 <div class="flex items-center flex-wrap gap-1.5">
                     <UButton
                         v-if="!showCli"
@@ -147,12 +153,12 @@
                     <UButton :label="$t('close')" variant="outline" @click="requestClose" />
                 </div>
             </div>
-        </div>
-    </dialog>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
-import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import { marked } from "marked";
 import DOMPurify from "dompurify";
 import { i18n } from "@/js/localization";
@@ -223,7 +229,6 @@ const emit = defineEmits([
     "options-expanded-change",
 ]);
 
-const dialogRef = ref(null);
 const optionsDetailsRef = ref(null);
 
 function handleClickOutside(event) {
@@ -290,26 +295,14 @@ const descriptionHtml = computed(() => {
     return wrapper.innerHTML;
 });
 
-watch(
-    () => props.open,
-    async (isOpen) => {
-        await nextTick();
-
-        if (!dialogRef.value) {
-            return;
-        }
-
-        if (isOpen && !dialogRef.value.open) {
-            dialogRef.value.showModal();
-        } else if (!isOpen && dialogRef.value.open) {
-            dialogRef.value.close();
-        }
-    },
-    { immediate: true },
-);
-
 function requestClose() {
     emit("close");
+}
+
+function onOpenChange(value) {
+    if (!value && props.open) {
+        requestClose();
+    }
 }
 
 function sanitizeExternalHttpUrl(rawUrl) {
@@ -347,14 +340,9 @@ function handleOptionsToggle(event) {
 </script>
 
 <style>
-/* Details dialog: show as flex when open */
-dialog[open]:has(.preset-description-text) {
-    display: flex;
-}
-
-/* Preset title styling inside the details dialog */
-.tab-presets dialog .preset-description-text + .preset-description-text,
-.tab-presets dialog .preset-description-text {
+/* Preset description styling (modal body is teleported, so no .tab-presets ancestor) */
+.preset-description-text + .preset-description-text,
+.preset-description-text {
     padding-top: 6px;
     padding-bottom: 6px;
     margin-top: 12px;

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -111,7 +111,7 @@
         </template>
 
         <template #footer>
-            <div class="flex flex-wrap items-center justify-between gap-2 w-full">
+            <div class="flex flex-wrap items-center justify-end gap-2 w-full">
                 <div class="flex items-center flex-wrap gap-1.5">
                     <UButton
                         v-if="!showCli"
@@ -148,7 +148,7 @@
                         data-testid="preset-discussion-link"
                     />
                 </div>
-                <div class="flex flex-wrap justify-end gap-1.5 ml-auto">
+                <div class="flex flex-wrap justify-end gap-1.5">
                     <UButton :label="$t('presetsApply')" :disabled="loading || !!error" @click="handleApply" />
                     <UButton :label="$t('close')" variant="outline" @click="requestClose" />
                 </div>

--- a/src/components/tabs/presets/PresetSourcesDialog.vue
+++ b/src/components/tabs/presets/PresetSourcesDialog.vue
@@ -1,42 +1,42 @@
 <template>
-    <dialog ref="dialogRef" class="w-[600px] h-[520px] p-3" @close="emit('close')" @cancel.prevent="emit('close')">
-        <div class="flex flex-col h-full">
-            <div
-                class="pb-1 border-b border-(--ui-primary) mb-3 text-2xl font-bold"
-                v-html="$t('presetsSourcesDialogTitle')"
-            ></div>
-            <div class="flex-1 overflow-y-auto overflow-x-hidden min-h-0">
-                <UiBox type="warning" highlight class="mb-3">
-                    <span v-html="$t('presets_sources_dialog_warning')"></span>
-                </UiBox>
-                <div>
-                    <PresetSourceCard
-                        v-for="source in sources"
-                        :key="source.id"
-                        :source="source"
-                        :selected="selectedSourceId === source.id"
-                        :active="activeSourceIds.includes(source.id)"
-                        @select="selectedSourceId = source.id"
-                        @save="emit('save-source', source.id, $event)"
-                        @delete="emit('delete-source', source.id)"
-                        @activate="emit('activate-source', source.id)"
-                        @deactivate="emit('deactivate-source', source.id)"
-                    />
-                </div>
+    <UModal
+        :open="open"
+        :ui="{ overlay: 'z-3000', content: 'w-[600px] max-w-[calc(100vw-2rem)] h-[520px] z-3001' }"
+        @update:open="onOpenChange"
+    >
+        <template #title>
+            <span v-html="$t('presetsSourcesDialogTitle')"></span>
+        </template>
+        <template #body>
+            <UiBox type="warning" highlight class="mb-3">
+                <span v-html="$t('presets_sources_dialog_warning')"></span>
+            </UiBox>
+            <div>
+                <PresetSourceCard
+                    v-for="source in sources"
+                    :key="source.id"
+                    :source="source"
+                    :selected="selectedSourceId === source.id"
+                    :active="activeSourceIds.includes(source.id)"
+                    @select="selectedSourceId = source.id"
+                    @save="emit('save-source', source.id, $event)"
+                    @delete="emit('delete-source', source.id)"
+                    @activate="emit('activate-source', source.id)"
+                    @deactivate="emit('deactivate-source', source.id)"
+                />
             </div>
-
-            <div class="content_toolbar mt-auto">
-                <div class="flex gap-2 justify-end">
-                    <UButton :label="$t('presetsSourcesDialogAddNew')" variant="outline" @click="handleAddSource" />
-                    <UButton :label="$t('OK')" @click="emit('close')" />
-                </div>
+        </template>
+        <template #footer>
+            <div class="flex gap-2 justify-end w-full">
+                <UButton :label="$t('presetsSourcesDialogAddNew')" variant="outline" @click="handleAddSource" />
+                <UButton :label="$t('OK')" @click="emit('close')" />
             </div>
-        </div>
-    </dialog>
+        </template>
+    </UModal>
 </template>
 
 <script setup>
-import { nextTick, ref, watch } from "vue";
+import { ref, watch } from "vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import PresetSourceCard from "./PresetSourceCard.vue";
 
@@ -64,23 +64,13 @@ const emit = defineEmits([
     "deactivate-source",
 ]);
 
-const dialogRef = ref(null);
 const selectedSourceId = ref("");
 
 watch(
     () => props.open,
-    async (isOpen) => {
-        await nextTick();
-
-        if (!dialogRef.value) {
-            return;
-        }
-
-        if (isOpen && !dialogRef.value.open) {
+    (isOpen) => {
+        if (isOpen) {
             selectedSourceId.value = props.activeSourceIds[0] ?? props.sources[0]?.id ?? "";
-            dialogRef.value.showModal();
-        } else if (!isOpen && dialogRef.value.open) {
-            dialogRef.value.close();
         }
     },
     { immediate: true },
@@ -98,6 +88,12 @@ watch(
         }
     },
 );
+
+function onOpenChange(value) {
+    if (!value && props.open) {
+        emit("close");
+    }
+}
 
 function handleAddSource() {
     emit("add-source");

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -134,7 +134,7 @@ export function useCli() {
     const cliWindowRef = ref(null);
     const commandInputRef = ref(null);
     const snippetPreviewOpen = ref(false);
-    const supportWarningDialogRef = ref(null);
+    const supportWarningOpen = ref(false);
 
     // Support dialog callback
     let supportDialogCallback = null;
@@ -345,15 +345,11 @@ export function useCli() {
 
     const showSupportWarningDialog = (onAccept) => {
         supportDialogCallback = onAccept;
-        if (supportWarningDialogRef.value && !supportWarningDialogRef.value.hasAttribute("open")) {
-            supportWarningDialogRef.value.showModal();
-        }
+        supportWarningOpen.value = true;
     };
 
     const handleSupportDialogSubmit = () => {
-        if (supportWarningDialogRef.value) {
-            supportWarningDialogRef.value.close();
-        }
+        supportWarningOpen.value = false;
         if (supportDialogCallback) {
             supportDialogCallback(state.supportDialogInput);
             supportDialogCallback = null;
@@ -362,9 +358,7 @@ export function useCli() {
     };
 
     const handleSupportDialogCancel = () => {
-        if (supportWarningDialogRef.value) {
-            supportWarningDialogRef.value.close();
-        }
+        supportWarningOpen.value = false;
         supportDialogCallback = null;
         state.supportDialogInput = "";
     };
@@ -721,7 +715,7 @@ export function useCli() {
         cliWindowRef,
         commandInputRef,
         snippetPreviewOpen,
-        supportWarningDialogRef,
+        supportWarningOpen,
         initialize,
         cleanup,
         clearHistory,

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -133,7 +133,7 @@ export function useCli() {
     const windowWrapperRef = ref(null);
     const cliWindowRef = ref(null);
     const commandInputRef = ref(null);
-    const snippetPreviewDialogRef = ref(null);
+    const snippetPreviewOpen = ref(false);
     const supportWarningDialogRef = ref(null);
 
     // Support dialog callback
@@ -284,16 +284,12 @@ export function useCli() {
         const executeSnippet = () => {
             const commands = state.snippetPreview;
             executeCommands(commands);
-            if (snippetPreviewDialogRef.value) {
-                snippetPreviewDialogRef.value.close();
-            }
+            snippetPreviewOpen.value = false;
         };
 
         const previewCommands = (result, _fileName) => {
             state.snippetPreview = result;
-            if (snippetPreviewDialogRef.value) {
-                snippetPreviewDialogRef.value.showModal();
-            }
+            snippetPreviewOpen.value = true;
         };
 
         const file = await FileSystem.pickOpenFile(i18n.getMessage("fileSystemPickerFiles", { typeof: "TXT" }), ".txt");
@@ -724,7 +720,7 @@ export function useCli() {
         windowWrapperRef,
         cliWindowRef,
         commandInputRef,
-        snippetPreviewDialogRef,
+        snippetPreviewOpen,
         supportWarningDialogRef,
         initialize,
         cleanup,

--- a/test/js/preset_details_dialog.test.js
+++ b/test/js/preset_details_dialog.test.js
@@ -83,14 +83,16 @@ describe("PresetDetailsDialog", () => {
 
         await nextTick();
 
-        const htmlBlock = wrapper.container.querySelector('[data-testid="preset-html-description"]');
+        // UModal teleports its body/footer to document.body, so query the document
+        // rather than the mount container.
+        const htmlBlock = document.querySelector('[data-testid="preset-html-description"]');
         expect(htmlBlock.innerHTML).toContain("<h1");
         expect(htmlBlock.querySelector("a").getAttribute("target")).toBe("_blank");
-        const discussionBtn = wrapper.container.querySelector('[data-testid="preset-discussion-link"]');
+        const discussionBtn = document.querySelector('[data-testid="preset-discussion-link"]');
         expect(discussionBtn).toBeTruthy();
         expect(discussionBtn.hasAttribute("href")).toBe(false);
 
-        const checkbox = wrapper.container.querySelector('input[type="checkbox"]');
+        const checkbox = document.querySelector('input[type="checkbox"]');
         checkbox.checked = false;
         checkbox.dispatchEvent(new Event("change"));
 


### PR DESCRIPTION
Standardises the configurator's modals on Nuxt UI `UModal`, removing two of the three parallel dialog implementations currently in use.

- `elements/Dialog.vue` now wraps `UModal` with its public API unchanged (`v-model`, `title`, `closeable`, default/footer slots, exposed `close()`), so its 5 call sites (waypoint editor, flight plan, power, backups) adopt the Nuxt UI look from one change. Footer actions are right-aligned for consistency.
- The 8 `dialogStore`-driven global dialogs (YesNo, Information, Reboot, Wait, ProfileSelection, CopyProfile, RatesType, ReportProblems) now use `UModal` with `UButton` actions. ProfileSelection's raw radios become `URadioGroup`, Reboot's progress bar becomes `UProgress`, CopyProfile reflows onto `SettingRow` + the existing `USelect`s.
- The form/complex dialogs follow: the CLI panel (`InteractiveDialog`), `PresetDetailsDialog` and `PresetSourcesDialog`. The CLI panel keeps its `cli-response`/`cli-command` elements raw — `gui.js` drives them imperatively by id — and just gains the `UModal` chrome. The preset dialogs keep their body overflow visible so the options dropdown isn't clipped.

These are force-a-choice dialogs, so `dismissible`/`close` are disabled to stop ESC/X bypassing the store callbacks. One behavioural change falls out of this: ESC no longer dismisses ProfileSelection/CopyProfile (close via the Cancel button), matching the others. The move also fixes a latent dark-mode bug where ProfileSelection and Wait rendered with light backgrounds.

Verified: lint and build pass, and every dialog was screenshot-checked in light and dark mode. The remaining tab-embedded raw `<dialog>` migrations are a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated multiple dialog-based flows to a unified modal system for consistent layout, focus/scroll behavior, and footer action placement.
  * Standardized open/close handling and confirm/cancel actions across dialogs using button-driven controls.
  * Updated modal content rendering to dedicated body/footer sections, including rich HTML, selections/radio options, and progress indicators.
  * Refined modal styling (spacing, typography, and alignment) to match the new shared modal structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
