### PR TITLE
Fix(pid-tuning): correct D-Term Lowpass 1 dynamic max cutoff constraints

### DIFF
--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -442,9 +442,9 @@
                                 :format-options="{ useGrouping: false }"
                                 class="w-16"
                                 v-model="dterm_lowpass_dyn_max_hz"
-                                :step="10"
-                                :min="200"
-                                :max="2000"
+                                :step="1"
+                                :min="1"
+                                :max="1000"
                                 :disabled="dtermInputsDisabled"
                             />
                         </div>


### PR DESCRIPTION
## Summary

The D-Term Lowpass 1 **dynamic** "Max Cutoff Frequency" input (`dterm_lowpass_dyn_max_hz`) enforced `min=200, max=2000, step=10` — values that match no other source in the firmware or configurator. As a result, any board configured via the simplified-tuning slider (which writes `150`) or with firmware defaults (`150`/`170`) held a value **below** the UI minimum, so the input snapped it back up to `200` and the user could not enter the legitimate value.

This was a regression introduced in the Nuxt UI PID tuning refactor (#5007); the field is the only one of the four dynamic LPF inputs that diverges.

## Fix

Align the field with the other dynamic LPF inputs and the firmware range:

| | before | after |
|---|---|---|
| `:min` | `200` | `1` |
| `:max` | `2000` | `1000` |
| `:step` | `10` | `1` |

## Reference (cross-checked)

| Source | min | max | default |
|---|---|---|---|
| Firmware `settings.c` (`dterm_lpf1_dyn_max_hz`) | 0 | `DYN_LPF_MAX_HZ` = 1000 | 150 |
| Simplified-tuning slider (`simplifiedTuning.js`) | clamps 0 | 1000 | writes 150 |
| Sibling fields (`dterm_lowpass_dyn_min_hz`, both gyro dyn fields) | 1 | 1000 | — |
| Legacy jQuery `pid_tuning.html` (all four dyn LPF fields) | 1 | 1000 | — |

## Steps to reproduce (before fix)

1. Open the PID Tuning → Filter tab.
2. Disable the D-Term LPF slider.
3. Set D-Term Lowpass 1 to dynamic mode and lower Max Cutoff Frequency below 200.
4. The value jumps back up to 200.

Reported on master (2026.6.0-alpha, 64611d1).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Fine-tuned numeric input configuration for D-Term Lowpass 1 dynamic cutoff maximum setting. The adjustment includes a refined increment step size for more granular control adjustments and modified minimum and maximum value bounds, enabling enhanced precision in filter parameter configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->