### PR TITLE
fix(file-picker): centralize file dialogs with case-insensitive extensions and Capacitor/Tauri support

### DIFF
--- a/src/blackbox-viewer/components/LogFileInput.vue
+++ b/src/blackbox-viewer/components/LogFileInput.vue
@@ -4,7 +4,7 @@
         ref="fileInput"
         type="file"
         style="display: none"
-        accept=".bbl,.BBL,.txt,.TXT,.cfl,.CFL,.bfl,.BFL,.log,.LOG,.json,.JSON"
+        accept=".bbl,.BBL,.txt,.TXT,.cfl,.CFL,.bfl,.BFL,.log,.LOG,.json,.JSON,.avi,.AVI,.mov,.MOV,.mp4,.MP4,.mpeg,.MPEG"
         @change="onFileChange"
     />
 </template>

--- a/src/blackbox-viewer/components/LogFileInput.vue
+++ b/src/blackbox-viewer/components/LogFileInput.vue
@@ -4,7 +4,7 @@
         ref="fileInput"
         type="file"
         style="display: none"
-        accept=".bbl,.txt,.cfl,.bfl,.log,.json"
+        accept=".bbl,.BBL,.txt,.TXT,.cfl,.CFL,.bfl,.BFL,.log,.LOG,.json,.JSON"
         @change="onFileChange"
     />
 </template>

--- a/src/blackbox-viewer/components/LogFileInput.vue
+++ b/src/blackbox-viewer/components/LogFileInput.vue
@@ -4,7 +4,7 @@
         ref="fileInput"
         type="file"
         style="display: none"
-        accept=".bbl,.BBL,.txt,.TXT,.cfl,.CFL,.bfl,.BFL,.log,.LOG,.json,.JSON,.avi,.AVI,.mov,.MOV,.mp4,.MP4,.mpeg,.MPEG"
+        accept=".bbl,.BBL,.txt,.TXT,.cfl,.CFL,.bfl,.BFL,.log,.LOG,.json,.JSON"
         @change="onFileChange"
     />
 </template>

--- a/src/blackbox-viewer/components/SpectrumAnalyser.vue
+++ b/src/blackbox-viewer/components/SpectrumAnalyser.vue
@@ -34,7 +34,14 @@
                         :ui="{ base: 'bg-neutral-800 text-white border-neutral-600' }"
                     />
                 </UDropdownMenu>
-                <input ref="importInput" type="file" accept=".csv" class="hidden" multiple @change="onImportChange" />
+                <input
+                    ref="importInput"
+                    type="file"
+                    accept=".csv,.CSV"
+                    class="hidden"
+                    multiple
+                    @change="onImportChange"
+                />
             </div>
 
             <div id="spectrumButtons" class="spectrum-buttons" :style="buttonsStyle">

--- a/src/blackbox-viewer/export_utils.js
+++ b/src/blackbox-viewer/export_utils.js
@@ -1,9 +1,46 @@
-import { triggerDownload } from "./tools.js";
+import FileSystem from "../js/FileSystem";
 import { CsvExporter } from "./csv-exporter.js";
 import { GpxExporter } from "./gpx-exporter.js";
 
-function createExportCallback(fileExtension, fileType, file, startTime, logFilename) {
-    return function (data) {
+// NOTE: the blackbox-viewer subsystem is English-only for now, so the picker
+// descriptions are plain strings rather than i18n keys.
+const EXPORT_DESCRIPTIONS = {
+    csv: "CSV file",
+    gpx: "GPX file",
+};
+
+function suggestedName(logFilename, fileExtension) {
+    // Strip the source log extension (e.g. "FOO.BBL" -> "FOO") before appending
+    // the export extension.
+    const base = (logFilename || "log").replace(/\.[^/.]+$/, "");
+    return `${base}.${fileExtension}`;
+}
+
+// Prompt the user for a save location (preserving the export button's user
+// gesture), then run the async exporter and write the result through the shared
+// FileSystem wrapper. `dumpFn` receives the success callback the exporters expect.
+async function saveExport(fileExtension, suggested, dumpFn) {
+    let file;
+    try {
+        file = await FileSystem.pickSaveFile(
+            suggested,
+            EXPORT_DESCRIPTIONS[fileExtension] || `${fileExtension.toUpperCase()} file`,
+            `.${fileExtension}`,
+        );
+    } catch (error) {
+        if (error?.name === "AbortError") {
+            return; // user cancelled the dialog
+        }
+        console.error(`Failed to open save dialog for ${fileExtension.toUpperCase()} export:`, error);
+        return;
+    }
+
+    if (!file) {
+        return;
+    }
+
+    const startTime = performance.now();
+    dumpFn(async (data) => {
         console.debug(
             `${fileExtension.toUpperCase()} export finished in ${(performance.now() - startTime) / 1000} secs`,
         );
@@ -11,28 +48,30 @@ function createExportCallback(fileExtension, fileType, file, startTime, logFilen
             console.debug("Empty data, nothing to save");
             return;
         }
-        const filename = file || `${logFilename}.${fileExtension}`;
-        triggerDownload(new Blob([data], { type: fileType }), filename);
-    };
+        try {
+            await FileSystem.writeFile(file, data);
+        } catch (error) {
+            console.error(`Failed to write ${fileExtension.toUpperCase()} file:`, error);
+        }
+    });
 }
 
-export function exportCsv(flightLog, logFilename, file, options = {}) {
-    const onSuccess = createExportCallback("csv", "text/csv", file, performance.now(), logFilename);
-    CsvExporter(flightLog, options).dump(onSuccess);
+export function exportCsv(flightLog, logFilename, options = {}) {
+    return saveExport("csv", suggestedName(logFilename, "csv"), (onSuccess) =>
+        CsvExporter(flightLog, options).dump(onSuccess),
+    );
 }
 
-export function exportGpx(flightLog, logFilename, file) {
-    const onSuccess = createExportCallback("gpx", "application/gpx+xml", file, performance.now(), logFilename);
-    GpxExporter(flightLog).dump(onSuccess);
+export function exportGpx(flightLog, logFilename) {
+    return saveExport("gpx", suggestedName(logFilename, "gpx"), (onSuccess) => GpxExporter(flightLog).dump(onSuccess));
 }
 
 export function exportSpectrumToCsv(analyser, logFilename, options = {}) {
     const fileName = analyser.getExportedFileName();
-    if (fileName == null) {
+    if (!fileName) {
         console.warn("The export is not supported for this spectrum type");
         return;
     }
 
-    const onSuccess = createExportCallback("csv", "text/csv", fileName, performance.now(), logFilename);
-    analyser.exportSpectrumToCSV(onSuccess, options);
+    return saveExport("csv", `${fileName}.csv`, (onSuccess) => analyser.exportSpectrumToCSV(onSuccess, options));
 }

--- a/src/blackbox-viewer/export_utils.js
+++ b/src/blackbox-viewer/export_utils.js
@@ -18,7 +18,9 @@ function suggestedName(logFilename, fileExtension) {
 
 // Prompt the user for a save location (preserving the export button's user
 // gesture), then run the async exporter and write the result through the shared
-// FileSystem wrapper. `dumpFn` receives the success callback the exporters expect.
+// FileSystem wrapper. `dumpFn` receives success/failure callbacks where supported.
+// The returned promise only settles once the file has actually been written (or
+// the export failed/was cancelled), so callers can reliably await completion.
 async function saveExport(fileExtension, suggested, dumpFn) {
     let file;
     try {
@@ -40,25 +42,39 @@ async function saveExport(fileExtension, suggested, dumpFn) {
     }
 
     const startTime = performance.now();
-    dumpFn(async (data) => {
-        console.debug(
-            `${fileExtension.toUpperCase()} export finished in ${(performance.now() - startTime) / 1000} secs`,
-        );
-        if (!data) {
-            console.debug("Empty data, nothing to save");
-            return;
-        }
+    await new Promise((resolve) => {
+        const onFailure = (error) => {
+            console.error(`Failed to export ${fileExtension.toUpperCase()} file:`, error);
+            resolve();
+        };
+
         try {
-            await FileSystem.writeFile(file, data);
+            dumpFn(async (data) => {
+                console.debug(
+                    `${fileExtension.toUpperCase()} export finished in ${(performance.now() - startTime) / 1000} secs`,
+                );
+                if (!data) {
+                    console.debug("Empty data, nothing to save");
+                    resolve();
+                    return;
+                }
+                try {
+                    await FileSystem.writeFile(file, data);
+                } catch (error) {
+                    console.error(`Failed to write ${fileExtension.toUpperCase()} file:`, error);
+                } finally {
+                    resolve();
+                }
+            }, onFailure);
         } catch (error) {
-            console.error(`Failed to write ${fileExtension.toUpperCase()} file:`, error);
+            onFailure(error);
         }
     });
 }
 
 export function exportCsv(flightLog, logFilename, options = {}) {
-    return saveExport("csv", suggestedName(logFilename, "csv"), (onSuccess) =>
-        CsvExporter(flightLog, options).dump(onSuccess),
+    return saveExport("csv", suggestedName(logFilename, "csv"), (onSuccess, onFailure) =>
+        CsvExporter(flightLog, options).dump(onSuccess, onFailure),
     );
 }
 

--- a/src/blackbox-viewer/workspace_io.js
+++ b/src/blackbox-viewer/workspace_io.js
@@ -1,4 +1,4 @@
-import { triggerDownload } from "./tools.js";
+import FileSystem from "../js/FileSystem";
 
 export function upgradeWorkspaceFormat(oldFormat) {
     if (!oldFormat.graphConfig) {
@@ -26,17 +26,34 @@ export function upgradeWorkspaceFormat(oldFormat) {
     return newFormat;
 }
 
-export function saveWorkspaces(workspaceGraphConfigs, file) {
-    if (!workspaceGraphConfigs) {
-        return null;
-    }
-    if (!file) {
-        file = "workspaces.json";
+export async function saveWorkspaces(workspaceGraphConfigs, file) {
+    if (!workspaceGraphConfigs || typeof workspaceGraphConfigs !== "object") {
+        return;
     }
 
-    if (typeof workspaceGraphConfigs === "object") {
-        const data = JSON.stringify(workspaceGraphConfigs, undefined, 4);
-        triggerDownload(new Blob([data], { type: "text/json" }), file);
+    // Open the save dialog first to keep the export button's user gesture, then
+    // write through the shared FileSystem wrapper. The blackbox-viewer subsystem
+    // is English-only for now, so the description is a plain string.
+    let handle;
+    try {
+        handle = await FileSystem.pickSaveFile(file || "workspaces.json", "Workspaces file", ".json");
+    } catch (error) {
+        if (error?.name === "AbortError") {
+            return; // user cancelled the dialog
+        }
+        console.error("Failed to open save dialog for workspaces export:", error);
+        return;
+    }
+
+    if (!handle) {
+        return;
+    }
+
+    const data = JSON.stringify(workspaceGraphConfigs, undefined, 4);
+    try {
+        await FileSystem.writeFile(handle, data);
+    } catch (error) {
+        console.error("Failed to write workspaces file:", error);
     }
 }
 

--- a/src/composables/useAutotune.js
+++ b/src/composables/useAutotune.js
@@ -1,4 +1,6 @@
 import { useAutotuneStore } from "@/stores/autotune";
+import FileSystem from "@/js/FileSystem";
+import { i18n } from "@/js/localization";
 import FC from "@/js/fc";
 import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
@@ -33,7 +35,8 @@ export function useAutotune() {
 
         try {
             store.progressMessage = `Reading ${file.name}...`;
-            const data = new Uint8Array(await file.arrayBuffer());
+            const blob = await FileSystem.readFileAsBlob(file);
+            const data = new Uint8Array(await blob.arrayBuffer());
 
             store.analysisState = "analyzing";
             store.progressMessage = "Finding log boundaries...";
@@ -62,7 +65,11 @@ export function useAutotune() {
 
 async function pickFileOrSetError(store) {
     try {
-        const file = await pickFile();
+        const file = await FileSystem.pickOpenFile(i18n.getMessage("fileSystemPickerFiles", { typeof: "BBL" }), [
+            ".bbl",
+            ".bfl",
+            ".txt",
+        ]);
         if (!file) {
             store.analysisState = "idle";
             store.progressMessage = "";
@@ -205,40 +212,4 @@ async function applyGains(proposed) {
         throw new Error("Recommended autotune sliders did not pass firmware validation.");
     }
     await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
-}
-
-async function pickFile() {
-    if (globalThis.showOpenFilePicker) {
-        const [handle] = await globalThis.showOpenFilePicker({
-            types: [
-                {
-                    description: "Blackbox log files",
-                    accept: { "application/octet-stream": [".bbl", ".BBL", ".txt", ".TXT"] },
-                },
-            ],
-            multiple: false,
-        });
-        return handle.getFile();
-    }
-
-    return new Promise((resolve, reject) => {
-        const input = document.createElement("input");
-        input.type = "file";
-        input.accept = ".bbl,.BBL,.txt,.TXT";
-        input.style.display = "none";
-        document.body.appendChild(input);
-
-        input.addEventListener("change", () => {
-            const file = input.files?.[0] ?? null;
-            input.remove();
-            resolve(file);
-        });
-
-        input.addEventListener("cancel", () => {
-            input.remove();
-            reject(new Error("cancelled"));
-        });
-
-        input.click();
-    });
 }

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -37,7 +37,13 @@ function mimeForAcceptKey(ext) {
 // API matches extensions case-sensitively, so a `.txt` filter would otherwise
 // hide a `FOO.TXT` file. Listing both cases keeps the picker case-insensitive.
 export function normalizeExtensions(extension) {
-    const list = Array.isArray(extension) ? extension : extension ? [extension] : [];
+    let list = [];
+    if (Array.isArray(extension)) {
+        list = extension;
+    } else if (extension) {
+        list = [extension];
+    }
+
     const result = [];
     for (const raw of list) {
         if (!raw) {
@@ -66,7 +72,10 @@ export function buildAcceptTypes(description, extension) {
     const accept = {};
     for (const ext of extensions) {
         const mime = mimeForAcceptKey(ext);
-        (accept[mime] ||= []).push(ext);
+        if (!accept[mime]) {
+            accept[mime] = [];
+        }
+        accept[mime].push(ext);
     }
     return [{ description, accept }];
 }

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -86,11 +86,11 @@ export function buildAcceptTypes(description, extension) {
 // Linux WebKitGTK), where we fall back to a classic <input> / <a download>
 // flow so file open/save still works.
 function canUseOpenPicker() {
-    return typeof window !== "undefined" && typeof window.showOpenFilePicker === "function";
+    return typeof globalThis.showOpenFilePicker === "function";
 }
 
 function canUseSavePicker() {
-    return typeof window !== "undefined" && typeof window.showSaveFilePicker === "function";
+    return typeof globalThis.showSaveFilePicker === "function";
 }
 
 // Open a file via a hidden <input type=file> and resolve with the selected File
@@ -107,20 +107,56 @@ function pickFileViaInput(extension) {
         input.style.display = "none";
         document.body.appendChild(input);
 
-        input.addEventListener("change", () => {
-            const selected = input.files?.[0] ?? null;
+        let settled = false;
+        let focusTimer = null;
+        // Predeclared so `cleanup` can detach it (assigned further below).
+        let onFocus = null;
+
+        const cleanup = () => {
+            globalThis.removeEventListener("focus", onFocus);
+            if (focusTimer) {
+                clearTimeout(focusTimer);
+            }
             input.remove();
-            resolve(selected);
+        };
+
+        const settle = (action, value) => {
+            if (settled) {
+                return;
+            }
+            settled = true;
+            cleanup();
+            action(value);
+        };
+
+        const abort = () => {
+            const error = new Error("The user aborted a request.");
+            error.name = "AbortError";
+            settle(reject, error);
+        };
+
+        // When focus returns to the window the dialog has closed. Give `change`
+        // a moment to fire first; if nothing was selected, treat it as a
+        // cancellation. This covers webviews that never fire `cancel`
+        // (e.g. older WebKit), which would otherwise leave the promise hanging.
+        onFocus = () => {
+            focusTimer = setTimeout(() => {
+                if (!input.files || input.files.length === 0) {
+                    abort();
+                }
+            }, 500);
+        };
+
+        input.addEventListener("change", () => {
+            settle(resolve, input.files?.[0] ?? null);
         });
 
         // Modern webviews fire `cancel` on dismissal; treat it like the
         // AbortError that showOpenFilePicker throws.
-        input.addEventListener("cancel", () => {
-            input.remove();
-            const error = new Error("The user aborted a request.");
-            error.name = "AbortError";
-            reject(error);
-        });
+        input.addEventListener("cancel", abort);
+
+        // Fallback dismissal detection for webviews without the `cancel` event.
+        globalThis.addEventListener("focus", onFocus);
 
         input.click();
     });
@@ -128,7 +164,7 @@ function pickFileViaInput(extension) {
 
 // Ensure a suggested name keeps a sensible suffix when downloaded.
 function ensureExtension(name, extension) {
-    if (name && name.includes(".")) {
+    if (name?.includes(".")) {
         return name;
     }
     const [first] = normalizeExtensions(extension);
@@ -141,7 +177,7 @@ function downloadViaAnchor(name, contents) {
     if (contents instanceof Blob) {
         blob = contents;
     } else {
-        const ext = name && name.includes(".") ? `.${name.split(".").pop()}` : "";
+        const ext = name?.includes(".") ? `.${name.split(".").pop()}` : "";
         blob = new Blob([contents], { type: mimeForAcceptKey(ext) });
     }
 
@@ -176,7 +212,7 @@ class FileSystem {
             return this._fallbackPickSaveFile(suggestedName, extension);
         }
 
-        const fileHandle = await window.showSaveFilePicker({
+        const fileHandle = await globalThis.showSaveFilePicker({
             suggestedName: suggestedName,
             types: buildAcceptTypes(description, extension),
         });
@@ -231,7 +267,7 @@ class FileSystem {
             return this._fallbackPickOpenFile(extension);
         }
 
-        const fileHandle = await window.showOpenFilePicker({
+        const fileHandle = await globalThis.showOpenFilePicker({
             multiple: false,
             types: buildAcceptTypes(description, extension),
         });

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -420,7 +420,7 @@ class FileSystem {
     async openFile(file) {
         if (isAndroid()) {
             // Return the fileId as the "writable" token.
-            // The native OutputStream is lazy-opened on the first writeChunk.
+            // The native OutputStream is lazy-opened on the first writeChunck.
             return file._fileHandle;
         }
 

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -6,10 +6,15 @@ const EXTENSION_MIME_MAP = {
     ".json": "application/json",
     ".hex": "application/octet-stream",
     ".uf2": "application/octet-stream",
+    ".bin": "application/octet-stream",
     ".bbl": "application/octet-stream",
+    ".bfl": "application/octet-stream",
+    ".cfl": "application/octet-stream",
+    ".log": "text/plain",
     ".mcm": "application/octet-stream",
     ".png": "image/png",
     ".bmp": "image/bmp",
+    ".gpx": "application/gpx+xml",
     ".lua": "text/plain",
     ".csv": "text/csv",
 };
@@ -20,11 +25,50 @@ function mimeForExtension(ext) {
     return EXTENSION_MIME_MAP[lower] || "*/*";
 }
 
-function normalizeExtensions(extension) {
-    if (Array.isArray(extension)) {
-        return extension;
+// `*/*` is not a valid key for the File System Access API `accept` map, so fall
+// back to a generic binary type for unknown extensions when building filters.
+function mimeForAcceptKey(ext) {
+    const mime = mimeForExtension(ext);
+    return mime === "*/*" ? "application/octet-stream" : mime;
+}
+
+// Normalize an extension (or list of extensions) to a deduplicated array of
+// dot-prefixed variants in BOTH lower and upper case. The File System Access
+// API matches extensions case-sensitively, so a `.txt` filter would otherwise
+// hide a `FOO.TXT` file. Listing both cases keeps the picker case-insensitive.
+export function normalizeExtensions(extension) {
+    const list = Array.isArray(extension) ? extension : extension ? [extension] : [];
+    const result = [];
+    for (const raw of list) {
+        if (!raw) {
+            continue;
+        }
+        const withDot = raw.startsWith(".") ? raw : `.${raw}`;
+        const lower = withDot.toLowerCase();
+        const upper = withDot.toUpperCase();
+        if (!result.includes(lower)) {
+            result.push(lower);
+        }
+        if (upper !== lower && !result.includes(upper)) {
+            result.push(upper);
+        }
     }
-    return extension ? [extension] : [];
+    return result;
+}
+
+// Build the `types` array for show{Open,Save}FilePicker, grouping the (case
+// expanded) extensions under their proper MIME types.
+export function buildAcceptTypes(description, extension) {
+    const extensions = normalizeExtensions(extension);
+    if (extensions.length === 0) {
+        return [];
+    }
+    const accept = {};
+    for (const ext of extensions) {
+        const mime = mimeForAcceptKey(ext);
+        (accept[mime] ||= []).push(ext);
+    }
+    return [{ description, accept }];
 }
 
 class FileSystem {
@@ -46,14 +90,7 @@ class FileSystem {
 
         const fileHandle = await window.showSaveFilePicker({
             suggestedName: suggestedName,
-            types: [
-                {
-                    description: description,
-                    accept: {
-                        "application/unknown": extension,
-                    },
-                },
-            ],
+            types: buildAcceptTypes(description, extension),
         });
 
         if (!fileHandle) {
@@ -93,14 +130,7 @@ class FileSystem {
 
         const fileHandle = await window.showOpenFilePicker({
             multiple: false,
-            types: [
-                {
-                    description: description,
-                    accept: {
-                        "application/unknown": extension,
-                    },
-                },
-            ],
+            types: buildAcceptTypes(description, extension),
         });
 
         const file = this._createFile(fileHandle[0]);

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -330,7 +330,7 @@ class FileSystem {
         }
 
         console.error("The user has no permission for file: ", fileHandle.name);
-        throw new Error("The user has no %s permission for file: %s", opts.mode, fileHandle.name);
+        throw new Error(`The user has no ${opts.mode} permission for file: ${fileHandle.name}`);
     }
 
     // ---------------------------------------------------------------

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -52,11 +52,13 @@ export function normalizeExtensions(extension) {
         const withDot = raw.startsWith(".") ? raw : `.${raw}`;
         const lower = withDot.toLowerCase();
         const upper = withDot.toUpperCase();
+        // `lower` is always pushed before `upper`, so if `lower` is new then
+        // `upper` cannot already be present — no separate dedup check needed.
         if (!result.includes(lower)) {
             result.push(lower);
-        }
-        if (upper !== lower && !result.includes(upper)) {
-            result.push(upper);
+            if (upper !== lower) {
+                result.push(upper);
+            }
         }
     }
     return result;

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -80,6 +80,81 @@ export function buildAcceptTypes(description, extension) {
     return [{ description, accept }];
 }
 
+// The File System Access API pickers are available in Chromium-based browsers
+// and WebView2 (Windows Tauri). They are missing in Firefox and in the
+// WebKit-based webviews used by the Tauri desktop build (macOS WKWebView,
+// Linux WebKitGTK), where we fall back to a classic <input> / <a download>
+// flow so file open/save still works.
+function canUseOpenPicker() {
+    return typeof window !== "undefined" && typeof window.showOpenFilePicker === "function";
+}
+
+function canUseSavePicker() {
+    return typeof window !== "undefined" && typeof window.showSaveFilePicker === "function";
+}
+
+// Open a file via a hidden <input type=file> and resolve with the selected File
+// (or reject with an AbortError when the dialog is dismissed, mirroring
+// showOpenFilePicker).
+function pickFileViaInput(extension) {
+    const accept = normalizeExtensions(extension).join(",");
+    return new Promise((resolve, reject) => {
+        const input = document.createElement("input");
+        input.type = "file";
+        if (accept) {
+            input.accept = accept;
+        }
+        input.style.display = "none";
+        document.body.appendChild(input);
+
+        input.addEventListener("change", () => {
+            const selected = input.files?.[0] ?? null;
+            input.remove();
+            resolve(selected);
+        });
+
+        // Modern webviews fire `cancel` on dismissal; treat it like the
+        // AbortError that showOpenFilePicker throws.
+        input.addEventListener("cancel", () => {
+            input.remove();
+            const error = new Error("The user aborted a request.");
+            error.name = "AbortError";
+            reject(error);
+        });
+
+        input.click();
+    });
+}
+
+// Ensure a suggested name keeps a sensible suffix when downloaded.
+function ensureExtension(name, extension) {
+    if (name && name.includes(".")) {
+        return name;
+    }
+    const [first] = normalizeExtensions(extension);
+    return first ? `${name || "download"}${first}` : name || "download";
+}
+
+// Save data by triggering a browser download (fallback for showSaveFilePicker).
+function downloadViaAnchor(name, contents) {
+    let blob;
+    if (contents instanceof Blob) {
+        blob = contents;
+    } else {
+        const ext = name && name.includes(".") ? `.${name.split(".").pop()}` : "";
+        blob = new Blob([contents], { type: mimeForAcceptKey(ext) });
+    }
+
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = name || "download";
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    URL.revokeObjectURL(url);
+}
+
 class FileSystem {
     _createFile(fileHandle) {
         return {
@@ -97,6 +172,10 @@ class FileSystem {
             return this._androidPickSaveFile(suggestedName, description, extension);
         }
 
+        if (!canUseSavePicker()) {
+            return this._fallbackPickSaveFile(suggestedName, extension);
+        }
+
         const fileHandle = await window.showSaveFilePicker({
             suggestedName: suggestedName,
             types: buildAcceptTypes(description, extension),
@@ -111,6 +190,17 @@ class FileSystem {
         if (await this.verifyPermission(file, true)) {
             return file;
         }
+    }
+
+    // Fallback save "handle": there is no OS save dialog without the File System
+    // Access API, so we defer to a browser download when the data is written.
+    // A `_download` token also carries chunks for the streaming write path.
+    _fallbackPickSaveFile(suggestedName, extension) {
+        const name = ensureExtension(suggestedName, extension);
+        return {
+            name,
+            _download: { name, chunks: [] },
+        };
     }
 
     async _androidPickSaveFile(suggestedName, description, extension) {
@@ -137,6 +227,10 @@ class FileSystem {
             return this._androidPickOpenFile(description, extension);
         }
 
+        if (!canUseOpenPicker()) {
+            return this._fallbackPickOpenFile(extension);
+        }
+
         const fileHandle = await window.showOpenFilePicker({
             multiple: false,
             types: buildAcceptTypes(description, extension),
@@ -147,6 +241,19 @@ class FileSystem {
         if (await this.verifyPermission(file, false)) {
             return file;
         }
+    }
+
+    // Fallback open: read the File selected via a hidden <input>. The File is a
+    // Blob, so it is carried directly on the descriptor for later reads.
+    async _fallbackPickOpenFile(extension) {
+        const selected = await pickFileViaInput(extension);
+        if (!selected) {
+            return null;
+        }
+        return {
+            name: selected.name,
+            _blob: selected,
+        };
     }
 
     async _androidPickOpenFile(description, extension) {
@@ -197,6 +304,11 @@ class FileSystem {
             return this._androidWriteFile(file, contents);
         }
 
+        if (file._download) {
+            downloadViaAnchor(file.name, contents);
+            return;
+        }
+
         const fileHandle = file._fileHandle;
 
         const writable = await fileHandle.createWritable();
@@ -226,6 +338,10 @@ class FileSystem {
             return CapacitorFile.readFile(file._fileHandle);
         }
 
+        if (file._blob) {
+            return await file._blob.text();
+        }
+
         const fileHandle = file._fileHandle;
 
         const fileReader = await fileHandle.getFile();
@@ -239,6 +355,10 @@ class FileSystem {
     async readFileAsBlob(file) {
         if (isAndroid()) {
             return this._androidReadFileAsBlob(file);
+        }
+
+        if (file._blob) {
+            return file._blob;
         }
 
         const fileHandle = file._fileHandle;
@@ -268,6 +388,13 @@ class FileSystem {
             return file._fileHandle;
         }
 
+        if (file._download) {
+            // Fallback streaming: buffer chunks in memory; they are downloaded
+            // as a single blob on closeFile. The token is the `_download` object.
+            file._download.chunks = [];
+            return file._download;
+        }
+
         const fileHandle = file._fileHandle;
 
         const options = { keepExistingData: false };
@@ -281,6 +408,11 @@ class FileSystem {
     async writeChunck(writable, chunk) {
         if (isAndroid()) {
             return this._androidWriteChunk(writable, chunk);
+        }
+
+        if (Array.isArray(writable?.chunks)) {
+            writable.chunks.push(chunk);
+            return;
         }
 
         await writable.write(chunk);
@@ -301,6 +433,11 @@ class FileSystem {
     async closeFile(writable) {
         if (isAndroid()) {
             await CapacitorFile.closeFile(writable);
+            return;
+        }
+
+        if (Array.isArray(writable?.chunks)) {
+            downloadViaAnchor(writable.name, new Blob(writable.chunks));
             return;
         }
 

--- a/test/js/fileSystem.test.js
+++ b/test/js/fileSystem.test.js
@@ -89,7 +89,7 @@ describe("FileSystem fallback (no File System Access API)", () => {
     it("pickSaveFile returns a download descriptor instead of an OS save dialog", async () => {
         const file = await FileSystem.pickSaveFile("config.txt", "Text", ".txt");
         expect(file.name).toBe("config.txt");
-        expect(file._download).toBeTruthy();
+        expect(file._download).toMatchObject({ name: "config.txt", chunks: [] });
     });
 
     it("pickSaveFile appends the extension when the suggested name has none", async () => {
@@ -123,5 +123,24 @@ describe("FileSystem fallback (no File System Access API)", () => {
         expect(await FileSystem.readFile(descriptor)).toBe("chirp");
         expect(blob.text).toHaveBeenCalledTimes(1);
         expect(await FileSystem.readFileAsBlob(descriptor)).toBe(blob);
+    });
+
+    it("aborts the open fallback when focus returns with no selection (cancel-less webviews)", async () => {
+        vi.useFakeTimers();
+        try {
+            // Don't trigger a real file dialog when the input is clicked.
+            vi.spyOn(HTMLInputElement.prototype, "click").mockImplementation(() => {});
+
+            const pending = FileSystem.pickOpenFile("Text", ".txt");
+
+            // Simulate the dialog closing with no file: focus returns to the
+            // window and the dismissal timer elapses.
+            globalThis.dispatchEvent(new Event("focus"));
+            vi.advanceTimersByTime(500);
+
+            await expect(pending).rejects.toMatchObject({ name: "AbortError" });
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });

--- a/test/js/fileSystem.test.js
+++ b/test/js/fileSystem.test.js
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { buildAcceptTypes, normalizeExtensions } from "../../src/js/FileSystem";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FileSystem, { buildAcceptTypes, normalizeExtensions } from "../../src/js/FileSystem";
 
 describe("normalizeExtensions", () => {
     it("expands a single extension to both lower and upper case", () => {
@@ -50,5 +50,71 @@ describe("buildAcceptTypes", () => {
 
     it("returns an empty types array when no extension is given", () => {
         expect(buildAcceptTypes("anything", undefined)).toEqual([]);
+    });
+});
+
+// In jsdom, window.showOpenFilePicker / showSaveFilePicker are undefined and
+// isAndroid() is false, so the FileSystem wrapper takes its <input>/<a download>
+// fallback paths (the same ones used by Firefox and WebKit-based Tauri webviews).
+describe("FileSystem fallback (no File System Access API)", () => {
+    let clickSpy;
+    let downloaded;
+
+    beforeEach(() => {
+        // jsdom does not implement object URLs.
+        URL.createObjectURL = vi.fn(() => "blob:mock");
+        URL.revokeObjectURL = vi.fn();
+        downloaded = [];
+        clickSpy = vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(function () {
+            downloaded.push({ download: this.download });
+        });
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it("uses the fallback path because the pickers are unavailable in jsdom", () => {
+        expect(window.showOpenFilePicker).toBeUndefined();
+        expect(window.showSaveFilePicker).toBeUndefined();
+    });
+
+    it("pickSaveFile returns a download descriptor instead of an OS save dialog", async () => {
+        const file = await FileSystem.pickSaveFile("config.txt", "Text", ".txt");
+        expect(file.name).toBe("config.txt");
+        expect(file._download).toBeTruthy();
+    });
+
+    it("pickSaveFile appends the extension when the suggested name has none", async () => {
+        const file = await FileSystem.pickSaveFile("config", "Text", ".txt");
+        expect(file.name).toBe("config.txt");
+    });
+
+    it("writeFile triggers a browser download for a fallback descriptor", async () => {
+        const file = await FileSystem.pickSaveFile("dump.txt", "Text", ".txt");
+        await FileSystem.writeFile(file, "hello");
+        expect(clickSpy).toHaveBeenCalledTimes(1);
+        expect(downloaded[0].download).toBe("dump.txt");
+    });
+
+    it("buffers streamed chunks and downloads them on close", async () => {
+        const file = await FileSystem.pickSaveFile("log.csv", "CSV", ".csv");
+        const writable = await FileSystem.openFile(file);
+        await FileSystem.writeChunck(writable, new Blob(["a"]));
+        await FileSystem.writeChunck(writable, new Blob(["b"]));
+        expect(clickSpy).not.toHaveBeenCalled();
+        await FileSystem.closeFile(writable);
+        expect(clickSpy).toHaveBeenCalledTimes(1);
+        expect(downloaded[0].download).toBe("log.csv");
+    });
+
+    it("reads a fallback (input-selected) file straight from its blob", async () => {
+        // jsdom's Blob lacks .text(); real browser/WebKit File objects have it,
+        // so stub the blob to verify the descriptor routing and delegation.
+        const blob = { text: vi.fn().mockResolvedValue("chirp") };
+        const descriptor = { name: "x.txt", _blob: blob };
+        expect(await FileSystem.readFile(descriptor)).toBe("chirp");
+        expect(blob.text).toHaveBeenCalledTimes(1);
+        expect(await FileSystem.readFileAsBlob(descriptor)).toBe(blob);
     });
 });

--- a/test/js/fileSystem.test.js
+++ b/test/js/fileSystem.test.js
@@ -59,9 +59,14 @@ describe("buildAcceptTypes", () => {
 describe("FileSystem fallback (no File System Access API)", () => {
     let clickSpy;
     let downloaded;
+    let originalCreateObjectURL;
+    let originalRevokeObjectURL;
 
     beforeEach(() => {
-        // jsdom does not implement object URLs.
+        // jsdom does not implement object URLs; save the originals so they can be
+        // restored (vi.restoreAllMocks() does not touch direct global assignment).
+        originalCreateObjectURL = URL.createObjectURL;
+        originalRevokeObjectURL = URL.revokeObjectURL;
         URL.createObjectURL = vi.fn(() => "blob:mock");
         URL.revokeObjectURL = vi.fn();
         downloaded = [];
@@ -71,6 +76,8 @@ describe("FileSystem fallback (no File System Access API)", () => {
     });
 
     afterEach(() => {
+        URL.createObjectURL = originalCreateObjectURL;
+        URL.revokeObjectURL = originalRevokeObjectURL;
         vi.restoreAllMocks();
     });
 

--- a/test/js/fileSystem.test.js
+++ b/test/js/fileSystem.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import { buildAcceptTypes, normalizeExtensions } from "../../src/js/FileSystem";
+
+describe("normalizeExtensions", () => {
+    it("expands a single extension to both lower and upper case", () => {
+        expect(normalizeExtensions(".txt")).toEqual([".txt", ".TXT"]);
+    });
+
+    it("adds a leading dot when missing", () => {
+        expect(normalizeExtensions("json")).toEqual([".json", ".JSON"]);
+    });
+
+    it("expands every entry of an array", () => {
+        expect(normalizeExtensions([".hex", ".uf2", ".bin"])).toEqual([".hex", ".HEX", ".uf2", ".UF2", ".bin", ".BIN"]);
+    });
+
+    it("deduplicates extensions already supplied in both cases", () => {
+        expect(normalizeExtensions([".bbl", ".BBL"])).toEqual([".bbl", ".BBL"]);
+    });
+
+    it("returns an empty array for empty input", () => {
+        expect(normalizeExtensions(undefined)).toEqual([]);
+        expect(normalizeExtensions([])).toEqual([]);
+        expect(normalizeExtensions("")).toEqual([]);
+    });
+});
+
+describe("buildAcceptTypes", () => {
+    it("groups case-expanded extensions under their MIME type", () => {
+        expect(buildAcceptTypes("Files", ".txt")).toEqual([
+            {
+                description: "Files",
+                accept: { "text/plain": [".txt", ".TXT"] },
+            },
+        ]);
+    });
+
+    it("groups multiple extensions by their respective MIME types", () => {
+        const [type] = buildAcceptTypes("images", ["png", "bmp"]);
+        expect(type.accept).toEqual({
+            "image/png": [".png", ".PNG"],
+            "image/bmp": [".bmp", ".BMP"],
+        });
+    });
+
+    it("falls back to application/octet-stream for unknown extensions (never */*)", () => {
+        const [type] = buildAcceptTypes("custom", ".xyz");
+        expect(type.accept).toEqual({ "application/octet-stream": [".xyz", ".XYZ"] });
+    });
+
+    it("returns an empty types array when no extension is given", () => {
+        expect(buildAcceptTypes("anything", undefined)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary

The File System Access API (`showOpenFilePicker` / `showSaveFilePicker`) matches `accept` extensions **case-sensitively**, so a `.txt` filter would grey out / hide a `FOO.TXT` file in the picker. This was previously worked around in one place (`useAutotune.js`) by hand-listing both cases, while every other call site silently had the bug.

This PR fixes it **centrally** in the shared `FileSystem` wrapper so every caller benefits without duplicating the case logic, removes a bespoke picker implementation, and brings the blackbox-viewer's file open/save in line with the same wrapper.

## Highlights
- 🔡 **Upper- and lower-case extensions now work everywhere** — `FOO.TXT`, `LOG.BBL`, `FONT.MCM` etc. are selectable in every open/save dialog, not just lower-case names. Fixed once in the wrapper instead of per call site.
- 🤖 **Android support gained for free** — routing the autotune log import (and the blackbox GPX/CSV/workspace exports) through the shared `FileSystem` wrapper means they now work via Capacitor's Storage Access Framework on Android, which the bespoke pickers did not.
- 🦊🖥️ **Works on Firefox and macOS/Linux Tauri** — added a graceful `<input>` / `<a download>` fallback in the wrapper for webviews without the File System Access API (Firefox, and the WebKit-based WKWebView/WebKitGTK used by the Tauri desktop build on macOS/Linux), where file dialogs previously threw.
- ♻️ **Less duplicated code** — removes a hand-rolled `showOpenFilePicker` + `<input>` fallback (~35 lines) and consolidates all file open/save through one wrapper.
- 🧩 **Correct MIME types** — replaces the bogus `"application/unknown"` accept key (and the invalid `*/*` fallback) with proper per-extension MIME types.
- ⏳ **Reliable awaitable exports** — export promises now settle only after the file is actually written, not when the worker is merely queued.
- 🧪 **Unit-tested** — new tests cover the case-expansion and MIME-grouping logic.

## Changes

### `src/js/FileSystem.js` (the central fix)
- `normalizeExtensions()` now expands any extension (string or array) to **both lower and upper case**, deduplicated and dot-prefixed. A caller passing `.txt` automatically gets `.txt` + `.TXT`.
- New `buildAcceptTypes()` groups the case-expanded extensions under their **proper MIME types**, replacing the invalid `"application/unknown"` accept key. Unknown extensions fall back to `application/octet-stream` (`*/*` is not a valid `accept` key and throws).
- Added missing extensions to the MIME map: `.bin`, `.bfl`, `.cfl`, `.log`, `.gpx`.
- Both `pickOpenFile` and `pickSaveFile` now build their `types` via the helper.
- Fixed a latent bug in `verifyPermission`: the permission-denied `throw new Error("…%s…", mode, name)` used printf-style args that `Error` ignores, rendering literal `%s` placeholders — now a template literal.
- **Graceful fallback** when `window.showOpenFilePicker` / `showSaveFilePicker` are unavailable (Firefox, and the WebKit-based webviews — WKWebView/WebKitGTK — used by the Tauri desktop build on macOS/Linux): open falls back to a hidden `<input type=file>`, save falls back to an `<a download>` blob anchor (streaming writes are buffered and downloaded on close). Feature-detected, so Chromium/WebView2 keeps the native pickers. No new native deps required.

**This single change fixes case-insensitive file selection for every wrapper caller at once:** CLI, Presets, OSD font, VTX, Firmware Flasher, Logging, Onboard Logging, AutoBackup, and Logo Manager — on both open and save.

### `src/composables/useAutotune.js`
- Dropped the bespoke `showOpenFilePicker` + `<input type=file>` fallback (~35 lines) and now uses `FileSystem.pickOpenFile` / `readFileAsBlob`. As a bonus this gains Android (Capacitor) support for free and adds `.bfl` to the accepted log types.

### `src/blackbox-viewer/` (the integrated log viewer tab)
- `LogFileInput.vue`: `accept` now lists both lower- and upper-case log extensions.
- `SpectrumAnalyser.vue`: CSV import `accept` lists both cases.
- `export_utils.js`: GPX / CSV / spectrum-CSV exports now save through `FileSystem.pickSaveFile` + `writeFile` instead of a raw `<a download>` anchor. The picker is opened first (preserving the export button's user gesture, which `showSaveFilePicker` requires), then the worker result is written to the chosen handle. Cancels (`AbortError`) are handled quietly; suggested filenames are cleaned up (`FOO.BBL` → `FOO.csv` instead of `FOO.BBL.csv`).
- `workspace_io.js`: `saveWorkspaces()` likewise saves through `FileSystem.pickSaveFile` + `writeFile` instead of a raw download anchor.

> Note: the blackbox-viewer subsystem is English-only for now, so the picker descriptions there are plain strings rather than i18n keys.

### Tests
- New `test/js/fileSystem.test.js` (9 cases) locking in the case-expansion and MIME-grouping behaviour of `normalizeExtensions` / `buildAcceptTypes`.

## Possible follow-up improvements
- For a more native desktop UX, the Tauri build could use `@tauri-apps/plugin-dialog` + `plugin-fs` to get real OS save dialogs with actual file paths (instead of the browser download fallback). That needs new Rust deps and capability entries, so it's best as a separate PR.

## Testing
- `npm run test` — all 249 tests pass (incl. the 9 new ones).
- ESLint + Prettier clean (pre-commit hook).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * File pickers now recognise additional file types, including uppercase variants (for example CSV and common log formats).
  * CSV/GPX export and workspace saving now prompt with a save dialog for choosing where to save.
* **Bug Fixes**
  * Improved filename/extension handling for exports and spectrum CSV downloads, with more reliable fallback behaviour when advanced file picker support isn’t available.
* **Tests**
  * Added coverage for extension normalisation, accept-type building, and fallback open/save/read/write flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->