### PR TITLE
Fix: Accept unconfirmed strings for custom defines

### DIFF
--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -1280,6 +1280,15 @@ export default defineComponent({
             }
         };
 
+        const commitPendingCustomDefines = () => {
+            const input = document.querySelector("#customDefinesInfo input");
+            const tags = input?.value?.trim().split(/\s+/).filter(Boolean) ?? [];
+
+            if (tags.length > 0) {
+                state.customDefinesTags = [...new Set([...state.customDefinesTags, ...tags])];
+            }
+        };
+
         const processFile = async (data, key) => {
             const ext = getExtension(key);
             const result = await firmwareFlashing.processFirmware(data, ext, {
@@ -1573,6 +1582,7 @@ export default defineComponent({
             }
 
             if (state.targetDetail) {
+                commitPendingCustomDefines();
                 activeFlasherStep.value = "flash";
                 await nextTick();
                 flashingMessage($t("firmwareFlasherButtonDownloading"), FLASH_MESSAGE_TYPES.NEUTRAL);


### PR DESCRIPTION
When just typing in a define and not confirming by pressing `space` would silently drop it from the build request. This PR introduces a minimal fix that bypasses the advanced logic of Nuxt UI to make sure it goes through.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured manually entered custom define tags are included when loading a remote firmware file.
  * Improved handling of custom defines by trimming input, splitting tags cleanly, and removing duplicates before continuing the flash process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->