### PR TITLE
fix(serial): prevent reconnect to virtual device after preset apply

### DIFF
--- a/src/composables/useMspCliSession.js
+++ b/src/composables/useMspCliSession.js
@@ -3,6 +3,7 @@ import semver from "semver";
 import MSP from "../js/msp";
 import GUI from "../js/gui";
 import FC from "../js/fc";
+import PortHandler from "../js/port_handler";
 import { connectDisconnect } from "../js/serial_backend";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 2000;
@@ -66,8 +67,22 @@ export function readDumpAll() {
 }
 
 export function scheduleReconnect() {
+    // Pin the port we are connected to right now. The save/exit that precedes this reboots the
+    // FC, so the port briefly disappears; the live selectedPort can then be auto-reassigned
+    // (e.g. to "virtual" in expert mode). Capturing synchronously here — before the async
+    // device-removal callback runs — lets us reconnect to the original FC, not the fallback.
+    const pinnedPort = PortHandler.portPicker.selectedPort;
     GUI.timeout_remove(RECONNECT_TIMEOUT_NAME);
-    GUI.timeout_add(RECONNECT_TIMEOUT_NAME, () => connectDisconnect(), RECONNECT_DELAY_MS);
+    GUI.timeout_add(
+        RECONNECT_TIMEOUT_NAME,
+        () => {
+            if (pinnedPort && !["noselection", "virtual", "manual"].includes(pinnedPort)) {
+                PortHandler.portPicker.selectedPort = pinnedPort;
+            }
+            connectDisconnect();
+        },
+        RECONNECT_DELAY_MS,
+    );
 }
 
 export function cancelScheduledReconnect() {

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -231,6 +231,14 @@ PortHandler.selectActivePort = function (suggestedDevice = false) {
     const deviceFilter = ["AT32", "CP210", "SPR", "STM"];
     let selectedPort;
 
+    // Whether a real device was selected before this re-evaluation. When a real port is only
+    // transiently gone (e.g. the USB CDC device drops off the bus while the FC reboots after a
+    // save / preset-apply), we must NOT auto-switch the selection to the virtual/manual
+    // fallback below — doing so makes the reconnect land on the fake device instead of the
+    // rebooting FC. The real port re-selects itself once it re-enumerates.
+    const priorPort = this.portPicker.selectedPort;
+    const hadRealSelection = !!priorPort && !["noselection", "virtual", "manual"].includes(priorPort);
+
     // First check for active connections
     if (serial.connected) {
         selectedPort = this.currentSerialPorts.find((device) => device === serial.getConnectedPort());
@@ -284,14 +292,15 @@ PortHandler.selectActivePort = function (suggestedDevice = false) {
         }
     }
 
-    // Expert-only fallbacks: only surface virtual/manual when expert mode is on.
+    // Expert-only fallbacks: only surface virtual/manual when expert mode is on, and never as
+    // a replacement for a real device that was just lost (see hadRealSelection above).
     const expertMode = isExpertModeEnabled();
 
-    if (!selectedPort && expertMode && this.showVirtualMode) {
+    if (!selectedPort && !hadRealSelection && expertMode && this.showVirtualMode) {
         selectedPort = "virtual";
     }
 
-    if (!selectedPort && expertMode && this.showManualMode) {
+    if (!selectedPort && !hadRealSelection && expertMode && this.showManualMode) {
         selectedPort = "manual";
     }
 

--- a/test/js/port_handler.test.js
+++ b/test/js/port_handler.test.js
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// isExpertModeEnabled gates the virtual/manual fallback in selectActivePort; force it on so
+// the fallback branch is reachable in these tests.
+vi.mock("../../src/js/utils/isExpertModeEnabled", () => ({
+    __esModule: true,
+    isExpertModeEnabled: () => true,
+}));
+
+// Keep the heavy connection/DFU dependencies inert — selectActivePort only reads a few flags.
+vi.mock("../../src/js/serial.js", () => ({
+    __esModule: true,
+    serial: { connected: false, getConnectedPort: () => undefined },
+}));
+vi.mock("../../src/js/protocols/usbdfu", () => ({
+    __esModule: true,
+    default: { usbDevice: null, getConnectedPort: () => null },
+    UsbDfuProtocol: class {},
+}));
+vi.mock("../../src/js/protocols/CapacitorDfuTransport", () => ({ __esModule: true, default: class {} }));
+vi.mock("../../src/js/ConfigStorage", () => ({ __esModule: true, get: () => ({}) }));
+vi.mock("../../src/components/eventBus", () => ({ __esModule: true, EventBus: { $emit: vi.fn() } }));
+vi.mock("../../src/js/utils/checkCompatibility.js", () => ({
+    __esModule: true,
+    checkCompatibility: () => {},
+    checkBluetoothSupport: () => false,
+    checkSerialSupport: () => false,
+    checkUsbSupport: () => false,
+    isAndroid: () => false,
+}));
+
+import PortHandler from "../../src/js/port_handler";
+
+describe("PortHandler.selectActivePort virtual/manual fallback guard", () => {
+    beforeEach(() => {
+        PortHandler.currentSerialPorts = [];
+        PortHandler.currentUsbPorts = [];
+        PortHandler.currentBluetoothPorts = [];
+        PortHandler.showVirtualMode = true;
+        PortHandler.showManualMode = false;
+    });
+
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("does NOT demote a real, transiently-absent selection to virtual (FC reboot)", () => {
+        // Simulates the USB port disappearing while the FC reboots after a save / preset-apply.
+        PortHandler.portPicker.selectedPort = "/dev/ttyACM0";
+
+        PortHandler.selectActivePort();
+
+        expect(PortHandler.portPicker.selectedPort).toBe("noselection");
+        expect(PortHandler.portPicker.selectedPort).not.toBe("virtual");
+    });
+
+    it("still falls back to virtual on a fresh start (no prior real selection)", () => {
+        PortHandler.portPicker.selectedPort = "noselection";
+
+        PortHandler.selectActivePort();
+
+        expect(PortHandler.portPicker.selectedPort).toBe("virtual");
+    });
+
+    it("keeps virtual when already on virtual and no real device appears", () => {
+        PortHandler.portPicker.selectedPort = "virtual";
+
+        PortHandler.selectActivePort();
+
+        expect(PortHandler.portPicker.selectedPort).toBe("virtual");
+    });
+});


### PR DESCRIPTION
## Problem

After applying a preset in the **Presets** tab, the configurator saves and reboots the
flight controller and then reconnects — but with **Expert mode on** and the **Virtual**
port visible, it reconnects to the **Virtual** device instead of the real FC. The user is
left looking at a simulated flight controller. (Same latent race affects other
save-and-reboot paths.)

## Root cause

When `save` reboots the FC, its USB CDC port drops off the bus for ~1–3 s while it
re-enumerates. The removal triggers `PortHandler.selectActivePort()`, which finds no real
device and falls through to the expert-only fallback, **silently rewriting the selected
port to `"virtual"`**. The Presets reconnect then connects to that corrupted selection.

## Fix

- **`port_handler.js`** — `selectActivePort()` no longer demotes a real, previously-selected
  port to the `virtual`/`manual` fallback when that port is only *transiently* absent (FC
  reboot). The fallback still applies on a fresh start (no prior real selection) and when
  already on `virtual`. This addresses the root cause across every reboot path.
- **`useMspCliSession.js`** — `scheduleReconnect()` now pins the connected port
  synchronously (before the async device-removal callback runs), so the reconnect targets
  the original FC even if the live selection changed during the reboot window.

## Testing

- New `test/js/port_handler.test.js` covers the no-demote guard (real selection is not
  demoted to virtual; fresh-start fallback still works; staying on virtual still works).
- Full suite green: **243 tests passing**, ESLint clean.
- Manual: apply a preset with Expert mode on and the Virtual port visible — reconnects to
  the real FC, not Virtual.

## Notes

This is the targeted fix for the user-visible bug. A follow-up reworks the connection
lifecycle into a single event-driven state machine (covering reconnect + firmware flasher,
replacing MCU/platform-dependent timeouts) so this class of bug stops recurring; the
pinning idea here is the same one that work generalizes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port reconnection behavior so the app remembers the previously selected device during reconnect attempts.
  * Prevented unexpected switching to fallback ports when a real device is only temporarily unavailable, helping preserve the user’s current selection.
* **Tests**
  * Added coverage for reconnect and port-selection scenarios, including temporary device loss and expert-mode fallback cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->