### PR TITLE
Handle connection failures gracefully

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -640,6 +640,12 @@
     "serialPortOpenFail": {
         "message": "<span class=\"message-negative\">Failed</span> to open serial port"
     },
+    "connectionFailedTitle": {
+        "message": "Connection failed"
+    },
+    "connectionFailed": {
+        "message": "<span class=\"message-negative\">Failed</span> to connect to the selected port. Check that the device is reachable and that the connection settings are correct, then try again."
+    },
     "serialPortClosedOk": {
         "message": "Serial port <span class=\"message-positive\">successfully</span> closed"
     },

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -70,12 +70,18 @@ class Serial extends EventTarget {
                                 data: event.detail,
                                 protocolType: name,
                             };
-                        } else {
-                            // For other events, we can use the detail directly
+                        } else if (event.detail && typeof event.detail === "object") {
+                            // Object payloads (open info, device lists, socket info) get the
+                            // protocol tag merged in.
                             newDetail = {
                                 ...event.detail,
                                 protocolType: name,
                             };
+                        } else {
+                            // Preserve primitive/falsy details verbatim. A failed open signals
+                            // detail:false; wrapping it in an object would make it truthy and the
+                            // connect handler would treat the failure as a success.
+                            newDetail = event.detail;
                         }
 
                         // Dispatch the event with the new detail

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -462,21 +462,24 @@ function resetConnection() {
     PortHandler.portPickerDisabled = false;
 }
 
-function abortConnection(messageKey = "serialPortOpenFail") {
+function abortConnection(messageKey) {
     GUI.timeout_remove("connecting"); // kill post-open connecting timer
     GUI.timeout_remove("connectAttempt"); // kill pre-open watchdog
+
+    // Default message reflects how far the attempt got: a port that already opened but failed
+    // the handshake (e.g. invalid API version) did not "fail to open".
+    const message = i18n.getMessage(messageKey ?? (GUI.connected_to ? "connectionFailed" : "serialPortOpenFail"));
 
     GUI.connected_to = false;
     GUI.connecting_to = false;
 
-    const message = i18n.getMessage(messageKey);
     gui_log(message);
     showConnectionFailedDialog(message);
 
     resetConnection();
 }
 
-// Surface a connection failure to the user with a dismissable dialog, not just a log line
+// Surface a connection failure to the user with a dismissible dialog, not just a log line
 // that is easy to miss. `text` may contain HTML markup (InformationDialog renders it).
 function showConnectionFailedDialog(text) {
     const dialogStore = useDialogStore();
@@ -874,7 +877,7 @@ function onClosed(result) {
     // established link — e.g. a ws:// endpoint refused before onopen, which dispatches only
     // "disconnect" and never "connect". Recover the Connect button and tell the user instead of
     // running the established-connection teardown.
-    if (GUI.connecting_to && !CONFIGURATOR.connectionValid) {
+    if (GUI.connecting_to && !CONFIGURATOR.connectionValid && !intentionalDisconnect) {
         abortConnection("connectionFailed");
         return;
     }

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -240,6 +240,21 @@ function beginConnect(selectedPort) {
     // lock port select & baud while we are connecting / connected
     PortHandler.portPickerDisabled = true;
 
+    // Safety net for the pre-open phase: some protocols (e.g. a ws:// endpoint that errors
+    // before onopen) never emit a "connect" event, so onOpen never runs to clear connecting_to
+    // and the Connect button would spin forever. If the attempt neither opens nor becomes valid
+    // within the window, recover the UI and tell the user. The disconnect-during-connect path in
+    // onClosed normally handles this sooner; this covers protocols that signal nothing at all.
+    GUI.timeout_add(
+        "connectAttempt",
+        function () {
+            if (GUI.connecting_to && !CONFIGURATOR.connectionValid) {
+                abortConnection("connectionFailed");
+            }
+        },
+        10000,
+    );
+
     // Set up event listeners for non-virtual connections
     if (selectedPort !== "virtual") {
         serial.removeEventListener("connect", connectHandler);
@@ -447,15 +462,35 @@ function resetConnection() {
     PortHandler.portPickerDisabled = false;
 }
 
-function abortConnection() {
-    GUI.timeout_remove("connecting"); // kill connecting timer
+function abortConnection(messageKey = "serialPortOpenFail") {
+    GUI.timeout_remove("connecting"); // kill post-open connecting timer
+    GUI.timeout_remove("connectAttempt"); // kill pre-open watchdog
 
     GUI.connected_to = false;
     GUI.connecting_to = false;
 
-    gui_log(i18n.getMessage("serialPortOpenFail"));
+    const message = i18n.getMessage(messageKey);
+    gui_log(message);
+    showConnectionFailedDialog(message);
 
     resetConnection();
+}
+
+// Surface a connection failure to the user with a dismissable dialog, not just a log line
+// that is easy to miss. `text` may contain HTML markup (InformationDialog renders it).
+function showConnectionFailedDialog(text) {
+    const dialogStore = useDialogStore();
+    dialogStore.open(
+        "InformationDialog",
+        {
+            title: i18n.getMessage("connectionFailedTitle"),
+            text,
+            confirmText: i18n.getMessage("close"),
+        },
+        {
+            confirm: () => dialogStore.close(),
+        },
+    );
 }
 
 // Centralized helper: show version mismatch warning and switch to CLI
@@ -487,6 +522,8 @@ function read_serial_adapter(event) {
 function onOpen(openInfo) {
     if (openInfo) {
         CONFIGURATOR.virtualMode = false;
+
+        GUI.timeout_remove("connectAttempt"); // port opened — pre-open watchdog no longer needed
 
         // update connected_to
         GUI.connected_to = GUI.connecting_to;
@@ -555,6 +592,7 @@ function onOpen(openInfo) {
 }
 
 function onOpenVirtual() {
+    GUI.timeout_remove("connectAttempt"); // virtual link is up — pre-open watchdog no longer needed
     GUI.connected_to = GUI.connecting_to;
     GUI.connecting_to = false;
 
@@ -831,6 +869,16 @@ function initFeaturesOnConnect() {
 }
 
 function onClosed(result) {
+    // A "disconnect" that arrives while we are still in the connect phase (onOpen never ran, so
+    // the link never became valid) is a *failed connection attempt*, not the loss of an
+    // established link — e.g. a ws:// endpoint refused before onopen, which dispatches only
+    // "disconnect" and never "connect". Recover the Connect button and tell the user instead of
+    // running the established-connection teardown.
+    if (GUI.connecting_to && !CONFIGURATOR.connectionValid) {
+        abortConnection("connectionFailed");
+        return;
+    }
+
     gui_log(i18n.getMessage(result ? "serialPortClosedOk" : "serialPortClosedFail"));
 
     // Clear connection timestamp


### PR DESCRIPTION
A failed connect attempt (e.g. a `ws://` endpoint that errors before `onopen`) left the green Connect button spinning forever with no feedback. The spinner is bound to `GUI.connecting_to`, which was only ever cleared via a `"connect"` event — but a socket that fails before opening dispatches only `"disconnect"`, so the flag was never reset.

`onClosed` now treats a disconnect that arrives while still connecting (link never became valid) as a failed attempt and routes it to `abortConnection`, recovering the button. `abortConnection` shows an `InformationDialog` instead of just a log line, and a 10s `connectAttempt` watchdog armed in `beginConnect` is a backstop for protocols that signal nothing at all.

Also fixes serial event forwarding, which merged `protocolType` into every non-receive detail via object spread — spreading `detail:false` produced a truthy `{protocolType}`, so `connectHandler`/`onOpen` always saw success and real serial open failures were silently swallowed. Falsy details now pass through verbatim, restoring the intended failure signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer connection failure messaging with a dedicated title and detailed guidance before retrying.

* **Bug Fixes**
  * Prevented stalled “connecting” states by detecting failures earlier during the connect attempt window and aborting safely.
  * Improved connection teardown behavior when disconnects occur mid-connection, ensuring the failure is surfaced consistently.
  * Preserved non-standard event detail payloads so failure details are forwarded accurately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->