### PR TITLE
Route ws/wss to WebSocket on Tauri so WSS works on iOS

### DIFF
--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -111,13 +111,13 @@ class Serial extends EventTarget {
         // WebSocket protocol — not raw TCP. On Tauri these are separate slots ("websocket" vs the
         // Rust-backed "tcp"); fall back to "tcp" on platforms that register only one (the web shell
         // already uses WebSocket for its "tcp" slot).
-        if (/^wss?:\/\/[A-Za-z0-9.-]+(?::\d+)?(\/.*)?$/i.test(s)) {
+        if (/^wss?:\/\/[a-z0-9.-]+(?::\d+)?(\/.*)?$/i.test(s)) {
             return (
                 this._protocols.find((p) => p.name === "websocket")?.instance ??
                 this._protocols.find((p) => p.name === "tcp")?.instance
             );
         }
-        if (s === "manual" || /^tcp:\/\/[A-Za-z0-9.-]+(?::\d+)?(\/.*)?$/i.test(s)) {
+        if (s === "manual" || /^tcp:\/\/[a-z0-9.-]+(?::\d+)?(\/.*)?$/i.test(s)) {
             return this._protocols.find((p) => p.name === "tcp")?.instance;
         }
         if (s.startsWith("bluetooth")) {

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -31,12 +31,15 @@ class Serial extends EventTarget {
             ];
         } else if (isTauri()) {
             // Tauri shell: raw TCP via the Rust tcp_* commands (so the Betaflight bridge
-            // on 5761 works), bluetooth via the web API the webview exposes. Native serial
-            // (tauri-plugin-serialplugin) is desktop + Android only — iOS has no USB serial.
+            // on 5761 works), and WebSocket (ws://, wss://) via the WebSocket API the webview
+            // exposes — these are distinct transports, so they get distinct slots. Bluetooth
+            // via the web API the webview exposes. Native serial (tauri-plugin-serialplugin)
+            // is desktop + Android only — iOS has no USB serial.
             this._protocols = [
                 ...(isTauriIOS() ? [] : [{ name: "serial", instance: new TauriSerial() }]),
                 { name: "bluetooth", instance: new WebBluetooth() },
                 { name: "tcp", instance: new TauriTcp() },
+                { name: "websocket", instance: new Websocket() },
             ];
         } else {
             this._protocols = [
@@ -104,7 +107,17 @@ class Serial extends EventTarget {
         if (isFn || s === "virtual") {
             return this._protocols.find((p) => p.name === "virtual")?.instance;
         }
-        if (s === "manual" || /^(tcp|ws|wss):\/\/[A-Za-z0-9.-]+(?::\d+)?(\/.*)?$/.test(s)) {
+        // WebSocket endpoints (ws://, wss://) speak the HTTP-upgrade handshake, so they need the
+        // WebSocket protocol — not raw TCP. On Tauri these are separate slots ("websocket" vs the
+        // Rust-backed "tcp"); fall back to "tcp" on platforms that register only one (the web shell
+        // already uses WebSocket for its "tcp" slot).
+        if (/^wss?:\/\/[A-Za-z0-9.-]+(?::\d+)?(\/.*)?$/i.test(s)) {
+            return (
+                this._protocols.find((p) => p.name === "websocket")?.instance ??
+                this._protocols.find((p) => p.name === "tcp")?.instance
+            );
+        }
+        if (s === "manual" || /^tcp:\/\/[A-Za-z0-9.-]+(?::\d+)?(\/.*)?$/i.test(s)) {
             return this._protocols.find((p) => p.name === "tcp")?.instance;
         }
         if (s.startsWith("bluetooth")) {

--- a/test/js/serial.test.js
+++ b/test/js/serial.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// Force the Tauri shell so the protocol list registers both the Rust-backed raw-TCP
+// slot and the WebSocket slot — the case the ws/wss vs tcp routing fix is about.
+vi.mock("../../src/js/utils/checkCompatibility.js", () => ({
+    isAndroid: () => false,
+    isTauri: () => true,
+    isTauriIOS: () => true,
+}));
+
+// Replace each protocol with a tiny EventTarget stub so construction is side-effect free
+// and instances are identifiable by class name.
+const stub = (tag) =>
+    ({
+        [tag]: class extends EventTarget {},
+    })[tag];
+
+vi.mock("../../src/js/protocols/WebSerial.js", () => ({ default: stub("WebSerial") }));
+vi.mock("../../src/js/protocols/WebBluetooth.js", () => ({ default: stub("WebBluetooth") }));
+vi.mock("../../src/js/protocols/WebSocket.js", () => ({ default: stub("Websocket") }));
+vi.mock("../../src/js/protocols/VirtualSerial.js", () => ({ default: stub("VirtualSerial") }));
+vi.mock("../../src/js/protocols/CapacitorSerial.js", () => ({ default: stub("CapacitorSerial") }));
+vi.mock("../../src/js/protocols/CapacitorBle.js", () => ({ default: stub("CapacitorBle") }));
+vi.mock("../../src/js/protocols/CapacitorTcp.js", () => ({ default: stub("CapacitorTcp") }));
+vi.mock("../../src/js/protocols/TauriSerial.js", () => ({ default: stub("TauriSerial") }));
+vi.mock("../../src/js/protocols/TauriTcp.js", () => ({ default: stub("TauriTcp") }));
+
+let serial;
+beforeEach(async () => {
+    ({ serial } = await import("../../src/js/serial.js"));
+});
+
+describe("serial.selectProtocol — Tauri transport routing", () => {
+    it("routes wss:// to the WebSocket protocol, not raw TCP", () => {
+        expect(serial.selectProtocol("wss://example.com:5761").constructor.name).toBe("Websocket");
+    });
+
+    it("routes ws:// to the WebSocket protocol", () => {
+        expect(serial.selectProtocol("ws://10.1.1.208:5761").constructor.name).toBe("Websocket");
+    });
+
+    it("routes raw tcp:// to the Rust-backed TauriTcp protocol", () => {
+        expect(serial.selectProtocol("tcp://192.168.0.10:5761").constructor.name).toBe("TauriTcp");
+    });
+
+    it("routes a bare 'manual' selection to the TCP slot", () => {
+        expect(serial.selectProtocol("manual").constructor.name).toBe("TauriTcp");
+    });
+
+    it("does not register a USB serial slot on iOS", () => {
+        // isTauriIOS() is true, so serial is excluded; a serial path resolves to undefined.
+        expect(serial.selectProtocol("/dev/ttyACM0")).toBeUndefined();
+    });
+});


### PR DESCRIPTION
On Tauri the `"tcp"` protocol slot is `TauriTcp` (raw Rust sockets, for the FC bridge on :5761). `selectProtocol` routed `ws://`, `wss://` and `tcp://` all into that one slot — but raw TCP cannot perform the WebSocket HTTP-upgrade handshake, so WSS was broken on iOS (and desktop Tauri) while raw `tcp://` worked.

WKWebView exposes the `WebSocket` API and the Tauri CSP is `null`, so the browser `Websocket` protocol works once it is actually selected. This registers a distinct `"websocket"` slot on the Tauri branch and routes by scheme: `ws://`/`wss://` → websocket (falling back to the `tcp` slot where only one is registered), and `tcp://`/`manual` → tcp.

Backward compatible: the web shell keeps using `Websocket` for its `tcp` slot via the fallback, and Android is unchanged. Adds `test/js/serial.test.js` covering the Tauri routing. No Info.plist change needed — `wss://` to a TLS host is allowed by default ATS and raw TCP is already covered by `NSLocalNetworkUsageDescription`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved transport selection for Tauri connections with dedicated handling for WebSocket endpoints (`ws://` and `wss://`), including sensible fallback to TCP when WebSocket isn’t available.
  * Better separation of TCP, WebSocket, Bluetooth, and native serial choices.

* **Bug Fixes**
  * Corrected endpoint matching so `tcp://...` and `"manual"` map to the intended TCP transport.
  * Ensured USB serial isn’t offered on iOS where it isn’t supported.

* **Tests**
  * Added coverage for Tauri transport routing and iOS behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->