### PR TITLE
Restored "Wrong log rate" warning at the Blackbox explorer's status bar.

### DIFF
--- a/src/blackbox-viewer/components/StatusBar.vue
+++ b/src/blackbox-viewer/components/StatusBar.vue
@@ -5,6 +5,9 @@
             <span v-if="appStore.statusCells" class="status-item">{{ appStore.statusCells }}</span>
             <span v-if="appStore.statusLooptime" class="status-item">{{ appStore.statusLooptime }}</span>
             <span v-if="appStore.statusLograte" class="status-item">{{ appStore.statusLograte }}</span>
+            <span v-if="appStore.statusLograteWarning" class="status-item status-lograte-warning">{{
+                appStore.statusLograteWarning
+            }}</span>
             <span v-if="appStore.statusFlightMode" class="status-item status-flight-mode">{{
                 appStore.statusFlightMode
             }}</span>
@@ -68,6 +71,11 @@ const workspaceStore = useWorkspaceStore();
 
 .status-flight-mode {
     color: var(--color-primary-600, #e69400);
+    font-weight: 600;
+}
+
+.status-lograte-warning {
+    color: var(--error-500);
     font-weight: 600;
 }
 </style>

--- a/src/blackbox-viewer/flightlog.js
+++ b/src/blackbox-viewer/flightlog.js
@@ -17,6 +17,8 @@ import { IMU } from "./imu";
 import { FIFOCache } from "./cache";
 import { binarySearchOrPrevious, binarySearchOrNext, constrain, validate, firmwareGreaterOrEqual } from "./tools";
 
+const WARNING_RATE_DIFFERENCE = 0.05;
+
 /*
  * Double check that the indexes of each chunk in the array are in increasing order (bugcheck).
  */
@@ -136,6 +138,27 @@ export function FlightLog(logData) {
         index = index ?? logIndex;
         const directory = logIndexes.getIntraframeDirectory(index);
         return directory.maxTime - directory.minTime - directory.unLoggedTime;
+    };
+
+    this.getBlackboxRate = function () {
+        const sysConfig = this.getSysConfig();
+        const gyroRate = (1000000 / sysConfig["looptime"]).toFixed(0);
+        let blackBoxRate = (gyroRate * sysConfig["frameIntervalPNum"]) / sysConfig["frameIntervalPDenom"];
+        if (sysConfig.pid_process_denom != null) {
+            blackBoxRate /= sysConfig.pid_process_denom;
+        }
+        return blackBoxRate;
+    };
+
+    this.getActualLogRate = function () {
+        const loggedTime = this.getActualLoggedTime();
+        return loggedTime !== 0 ? (this.getCurrentLogRowsCount() / loggedTime) * 1000000 : 0;
+    };
+
+    this.isWrongLogRate = function () {
+        const blackboxRate = this.getBlackboxRate();
+        const actualLogRate = this.getActualLogRate();
+        return !actualLogRate || Math.abs(blackboxRate - actualLogRate) / actualLogRate > WARNING_RATE_DIFFERENCE;
     };
 
     /**

--- a/src/blackbox-viewer/flightlog.js
+++ b/src/blackbox-viewer/flightlog.js
@@ -142,17 +142,20 @@ export function FlightLog(logData) {
 
     this.getBlackboxRate = function () {
         const sysConfig = this.getSysConfig();
-        const gyroRate = (1000000 / sysConfig["looptime"]).toFixed(0);
+        if (!sysConfig["looptime"] || !sysConfig["frameIntervalPNum"] || !sysConfig["frameIntervalPDenom"]) {
+            return null;
+        }
+        const gyroRate = 1000000 / sysConfig["looptime"];
         let blackBoxRate = (gyroRate * sysConfig["frameIntervalPNum"]) / sysConfig["frameIntervalPDenom"];
         if (sysConfig.pid_process_denom != null) {
             blackBoxRate /= sysConfig.pid_process_denom;
         }
-        return blackBoxRate;
+        return Number.isFinite(blackBoxRate) && blackBoxRate > 0 ? blackBoxRate : null;
     };
 
     this.getActualLogRate = function () {
         const loggedTime = this.getActualLoggedTime();
-        return loggedTime !== 0 ? (this.getCurrentLogRowsCount() / loggedTime) * 1000000 : 0;
+        return loggedTime > 0 ? (this.getCurrentLogRowsCount() / loggedTime) * 1000000 : 0;
     };
 
     this.isWrongLogRate = function () {

--- a/src/blackbox-viewer/graph_spectrum_calc.js
+++ b/src/blackbox-viewer/graph_spectrum_calc.js
@@ -7,7 +7,6 @@ const FIELD_THROTTLE_NAME = ["rcCommands[3]"],
     FREQ_VS_THR_CHUNK_TIME_MS = 300,
     FREQ_VS_THR_WINDOW_DIVISOR = 6,
     MAX_ANALYSER_LENGTH = 300 * 1000 * 1000, // 5min
-    WARNING_RATE_DIFFERENCE = 0.05,
     MAX_RPM_HZ_VALUE = 800,
     RPM_AXIS_TOP_MARGIN_PERCENT = 2,
     MIN_SPECTRUM_SAMPLES_COUNT = 2048;
@@ -34,19 +33,12 @@ GraphSpectrumCalc.initialize = function (flightLog, sysConfig) {
     this._flightLog = flightLog;
     this._sysConfig = sysConfig;
 
-    const gyroRate = (1000000 / this._sysConfig["looptime"]).toFixed(0);
-    this._motorPoles = flightLog.getSysConfig()["motor_poles"];
-    this._blackBoxRate = (gyroRate * this._sysConfig["frameIntervalPNum"]) / this._sysConfig["frameIntervalPDenom"];
-    if (this._sysConfig.pid_process_denom != null) {
-        this._blackBoxRate = this._blackBoxRate / this._sysConfig.pid_process_denom;
-    }
+    this._motorPoles = sysConfig["motor_poles"];
+    this._blackBoxRate = flightLog.getBlackboxRate();
     this._BetaflightRate = this._blackBoxRate;
 
-    const actualLoggedTime = this._flightLog.getActualLoggedTime(),
-        length = flightLog.getCurrentLogRowsCount();
-
-    this._actualeRate = (1e6 * length) / actualLoggedTime;
-    if (Math.abs(this._BetaflightRate - this._actualeRate) / this._actualeRate > WARNING_RATE_DIFFERENCE) {
+    this._actualeRate = flightLog.getActualLogRate();
+    if (flightLog.isWrongLogRate()) {
         this._blackBoxRate = Math.round(this._actualeRate);
     }
 

--- a/src/blackbox-viewer/log_lifecycle.js
+++ b/src/blackbox-viewer/log_lifecycle.js
@@ -64,11 +64,19 @@ export function renderSelectedLogInfo() {
     );
     appStore.statusLooptime = looptimeText;
 
+    const blackboxRate = logStore.flightLog.getBlackboxRate();
     const lograteText =
         sysConfig["frameIntervalPDenom"] != null && sysConfig["frameIntervalPNum"] != null
-            ? `Sample Rate : ${sysConfig["frameIntervalPNum"]}/${sysConfig["frameIntervalPDenom"]}`
+            ? `Sample Rate : ${sysConfig["frameIntervalPNum"]}/${sysConfig["frameIntervalPDenom"]} (${blackboxRate.toFixed(0)}Hz)`
             : "";
     appStore.statusLograte = lograteText;
+
+    if (logStore.flightLog.isWrongLogRate()) {
+        const actualLogRate = logStore.flightLog.getActualLogRate();
+        appStore.statusLograteWarning = `Wrong log rate: ${actualLogRate.toFixed(0)}Hz`;
+    } else {
+        appStore.statusLograteWarning = null;
+    }
 
     const seekBar = graphStore.seekBar;
     seekBar.setTimeRange(

--- a/src/blackbox-viewer/stores/app.js
+++ b/src/blackbox-viewer/stores/app.js
@@ -14,6 +14,7 @@ export const useAppStore = defineStore("app", () => {
     const statusCells = ref("");
     const statusLooptime = ref("-");
     const statusLograte = ref("-");
+    const statusLograteWarning = ref(null);
     const statusFlightMode = ref("-");
     const statusMarkerOffset = ref("00:00.000");
     const statusViewerVersion = ref("-");
@@ -52,6 +53,7 @@ export const useAppStore = defineStore("app", () => {
         statusCells,
         statusLooptime,
         statusLograte,
+        statusLograteWarning,
         statusFlightMode,
         statusMarkerOffset,
         statusViewerVersion,


### PR DESCRIPTION
- Refactoring of actual and required log rate computing code.
- Restored "Wrong log rate" warning at the Black box explorer's status bar when actual log rate is lower than required.
- The log rate value is added into Sample rate status bar info.

Normal blackbox log rate:
<img width="164" height="39" alt="normal_log_rate" src="https://github.com/user-attachments/assets/0430c951-fab5-4a7b-8a66-132d8c34db18" />

Wrong log rate:
<img width="282" height="40" alt="wrong_log_rate" src="https://github.com/user-attachments/assets/4432b4da-0e1f-4ebf-9022-de5d3b85465f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new log-rate warning to the status bar when the recorded log rate looks inconsistent.
  * Status information now displays the expected blackbox rate alongside the observed rate.

* **Bug Fixes**
  * Improved log-rate detection by calculating expected vs actual rates and flagging mismatches more reliably.
  * Automatically adjusts the displayed expected rate when the logged data suggests an incorrect sample rate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->