### PR TITLE
iOS support for Betaflight

### DIFF
--- a/.github/workflows/ios-ipa.yml
+++ b/.github/workflows/ios-ipa.yml
@@ -1,0 +1,63 @@
+# Builds an unsigned iOS .ipa on a GitHub macOS runner, no local Mac or paid Apple account.
+# Signing is stripped from the Xcode project and the .app is zipped into an unsigned .ipa
+# that you re-sign on your own machine with a free Apple ID.
+#
+# The committed project pins a signing team and identity, so xcodebuild fails on CI until
+# the pbxproj is patched to turn signing off. Tauri drives the build because its Rust phase
+# needs the Tauri build server, which a bare xcodebuild can't reach.
+name: ios-unsigned-ipa
+on:
+  workflow_dispatch: {}
+jobs:
+  build:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - uses: dtolnay/rust-toolchain@stable
+      - run: rustup target add aarch64-apple-ios
+      - run: npm ci
+      - run: npm run build
+      - name: Strip code signing out of the Xcode project
+        run: |
+          PBX="src-tauri/gen/apple/betaflight-app.xcodeproj/project.pbxproj"
+          sed -i '' \
+            -e 's/DEVELOPMENT_TEAM = "[^"]*";/DEVELOPMENT_TEAM = "";/g' \
+            -e 's/CODE_SIGN_IDENTITY = "[^"]*";/CODE_SIGN_IDENTITY = ""; CODE_SIGNING_ALLOWED = NO; CODE_SIGNING_REQUIRED = NO; CODE_SIGN_STYLE = Manual;/g' \
+            "$PBX"
+          echo "--- signing lines after patch ---"
+          grep -n "CODE_SIGN\|DEVELOPMENT_TEAM" "$PBX" || true
+      - name: Build with Tauri (its server runs the Rust phase, IPA export may fail)
+        run: npm run tauri:ios:build -- --target aarch64 --ci || true
+      - name: Package the built .app into an unsigned .ipa
+        run: |
+          set -e
+          SEARCH="$HOME/Library/Developer/Xcode/DerivedData $PWD/src-tauri/gen/apple/build"
+          APP=$(find $SEARCH -type d -name "*.app" 2>/dev/null | grep -i "release-iphoneos" | head -1)
+          [ -z "$APP" ] && APP=$(find $SEARCH -type d -name "*.app" 2>/dev/null | grep -i iphoneos | grep -vi simulator | head -1)
+          echo "APP = $APP"
+          if [ -z "$APP" ]; then
+            echo "::error::No device .app was produced. Diagnostics:"
+            echo "--- .app dirs ---"; find $SEARCH -type d -name "*.app" 2>/dev/null | head -20
+            echo "--- DerivedData Products ---"; find "$HOME/Library/Developer/Xcode/DerivedData" -type d -path "*Products*iphoneos*" 2>/dev/null | head
+            exit 1
+          fi
+          rm -rf "$RUNNER_TEMP/Payload"; mkdir "$RUNNER_TEMP/Payload"
+          cp -R "$APP" "$RUNNER_TEMP/Payload/"
+          (cd "$RUNNER_TEMP" && zip -qr betaflight-unsigned.ipa Payload)
+          ls -la "$RUNNER_TEMP/betaflight-unsigned.ipa"
+          # A real app is ~13 MB. If it's tiny, the Tauri build failed and we packaged an
+          # empty .app, so fail loudly.
+          SIZE=$(stat -f%z "$RUNNER_TEMP/betaflight-unsigned.ipa")
+          echo "ipa size: $SIZE bytes"
+          if [ "$SIZE" -lt 1000000 ]; then
+            echo "::error::IPA is only $SIZE bytes, the 'Build with Tauri' step failed to produce a real app (compile/link error). Check that step's log."
+            exit 1
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: betaflight-ipa
+          path: ${{ runner.temp }}/betaflight-unsigned.ipa

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -156,6 +156,9 @@
     "cancel": {
         "message": "Cancel"
     },
+    "defaults": {
+        "message": "Defaults"
+    },
     "submit": {
         "message": "Submit"
     },

--- a/src-tauri/capabilities/mobile.json
+++ b/src-tauri/capabilities/mobile.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "../gen/schemas/desktop-schema.json",
+    "identifier": "mobile",
+    "description": "Capability for iOS and Android. The default one is desktop only, so without this the ACL denies every plugin command on mobile.",
+    "windows": ["*"],
+    "permissions": [
+        "core:default",
+        "shell:allow-open"
+    ]
+}

--- a/src-tauri/gen/apple/Sources/betaflight-app/main.mm
+++ b/src-tauri/gen/apple/Sources/betaflight-app/main.mm
@@ -1,6 +1,137 @@
 #include "bindings/bindings.h"
 
+#import <Foundation/Foundation.h>
+#import <Network/Network.h>
+
+// Bonjour browse that raises the one-time Local Network permission prompt.
+// Needs NSLocalNetworkUsageDescription and NSBonjourServices in Info.plist.
+static NSNetServiceBrowser *gLocalNetworkTrigger = nil;
+
+static void triggerLocalNetworkPermission(void) {
+    gLocalNetworkTrigger = [[NSNetServiceBrowser alloc] init];
+    [gLocalNetworkTrigger searchForServicesOfType:@"_betaflight._tcp" inDomain:@"local."];
+}
+
+// Network.framework TCP transport for iOS, since a raw socket never gets local network
+// access even with the permission granted. Rust registers its callbacks through here.
+extern "C" void rust_tcp_on_data(const uint8_t *bytes, size_t len);
+extern "C" void rust_tcp_on_closed(void);
+extern "C" void rust_register_tcp(int (*connect_fn)(const char *, uint16_t),
+                                  void (*send_fn)(const uint8_t *, size_t),
+                                  void (*close_fn)(void));
+
+static nw_connection_t gTcpConn = nil;
+static dispatch_queue_t gTcpQueue = nil;
+
+static void ios_tcp_receive_loop(nw_connection_t conn) {
+    nw_connection_receive(conn, 1, 65536,
+        ^(dispatch_data_t content, nw_content_context_t context, bool is_complete, nw_error_t error) {
+            (void)context;
+            if (content != NULL) {
+                dispatch_data_apply(content,
+                    ^bool(dispatch_data_t region, size_t offset, const void *buffer, size_t size) {
+                        (void)region; (void)offset;
+                        if (size > 0) {
+                            rust_tcp_on_data((const uint8_t *)buffer, size);
+                        }
+                        return true;
+                    });
+            }
+            if (error != NULL || is_complete) {
+                rust_tcp_on_closed();
+                return;
+            }
+            if (conn == gTcpConn) {
+                ios_tcp_receive_loop(conn);   // Re-arm
+            }
+        });
+}
+
+static int ios_tcp_connect(const char *ip, uint16_t port) {
+    if (gTcpQueue == nil) {
+        gTcpQueue = dispatch_queue_create("app.betaflight.tcp", DISPATCH_QUEUE_SERIAL);
+    }
+    if (gTcpConn != nil) {
+        nw_connection_cancel(gTcpConn);
+        gTcpConn = nil;
+    }
+
+    char portStr[8];
+    snprintf(portStr, sizeof(portStr), "%u", (unsigned)port);
+    nw_endpoint_t endpoint = nw_endpoint_create_host(ip, portStr);
+    nw_parameters_t params =
+        nw_parameters_create_secure_tcp(NW_PARAMETERS_DISABLE_PROTOCOL, NW_PARAMETERS_DEFAULT_CONFIGURATION);
+    nw_connection_t conn = nw_connection_create(endpoint, params);
+    gTcpConn = conn;
+    nw_connection_set_queue(conn, gTcpQueue);
+
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    __block bool ready = false;
+    __block int lastState = 0;   // Last connection state
+    __block int lastErrno = 0;   // POSIX errno, 0 if none
+    nw_connection_set_state_changed_handler(conn,
+        ^(nw_connection_state_t state, nw_error_t error) {
+            lastState = (int)state;
+            if (error) {
+                lastErrno = nw_error_get_error_code(error);
+            }
+            if (state == nw_connection_state_ready) {
+                ready = true;
+                dispatch_semaphore_signal(sem);
+                ios_tcp_receive_loop(conn);
+            } else if (state == nw_connection_state_failed || state == nw_connection_state_cancelled) {
+                if (!ready) {
+                    dispatch_semaphore_signal(sem);
+                }
+                rust_tcp_on_closed();
+            }
+        });
+    nw_connection_start(conn);
+
+    // NWConnection waits for the permission internally, so block the caller until it's
+    // ready or failed, with a 12s ceiling.
+    long timedOut = dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, 12LL * NSEC_PER_SEC));
+    if (ready) {
+        return 0;
+    }
+    nw_connection_cancel(conn);
+    if (gTcpConn == conn) {
+        gTcpConn = nil;
+    }
+    // Pack the state and errno into one code for tcp.rs.
+    int code = lastState * 1000 + (lastErrno % 1000);
+    if (code == 0) {
+        code = (timedOut != 0) ? 999000 : 997000;   // Timeout or unknown, stay non-zero
+    }
+    return code;
+}
+
+static void ios_tcp_send(const uint8_t *data, size_t len) {
+    nw_connection_t conn = gTcpConn;
+    if (conn == nil || data == NULL || len == 0) {
+        return;
+    }
+    dispatch_data_t dd = dispatch_data_create(data, len, gTcpQueue, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    nw_connection_send(conn, dd, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true,
+        ^(nw_error_t error) { (void)error; });
+}
+
+static void ios_tcp_close(void) {
+    if (gTcpConn != nil) {
+        nw_connection_cancel(gTcpConn);
+        gTcpConn = nil;
+    }
+}
+
 int main(int argc, char * argv[]) {
-	ffi::start_app();
-	return 0;
+    // Give Rust our TCP entry points before the app starts.
+    rust_register_tcp(ios_tcp_connect, ios_tcp_send, ios_tcp_close);
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)),
+                   dispatch_get_main_queue(), ^{
+        triggerLocalNetworkPermission();
+    });
+
+    ffi::start_app();
+    return 0;
 }

--- a/src-tauri/gen/apple/Sources/betaflight-app/main.mm
+++ b/src-tauri/gen/apple/Sources/betaflight-app/main.mm
@@ -20,6 +20,11 @@ extern "C" void rust_register_tcp(int (*connect_fn)(const char *, uint16_t),
                                   void (*send_fn)(const uint8_t *, size_t),
                                   void (*close_fn)(void));
 
+extern "C" void rust_udp_on_data(const uint8_t *bytes, size_t len);
+extern "C" void rust_register_udp(int (*open_fn)(const char *, uint16_t),
+                                  void (*send_fn)(const uint8_t *, size_t),
+                                  void (*close_fn)(void));
+
 static nw_connection_t gTcpConn = nil;
 static dispatch_queue_t gTcpQueue = nil;
 
@@ -123,9 +128,105 @@ static void ios_tcp_close(void) {
     }
 }
 
+static nw_connection_t gUdpConn = nil;
+static dispatch_queue_t gUdpQueue = nil;
+
+static void ios_udp_receive_loop(nw_connection_t conn) {
+    nw_connection_receive(conn, 1, 65536,
+        ^(dispatch_data_t content, nw_content_context_t context, bool is_complete, nw_error_t error) {
+            (void)context; (void)is_complete;
+            if (content != NULL) {
+                dispatch_data_apply(content,
+                    ^bool(dispatch_data_t region, size_t offset, const void *buffer, size_t size) {
+                        (void)region; (void)offset;
+                        if (size > 0) {
+                            rust_udp_on_data((const uint8_t *)buffer, size);
+                        }
+                        return true;
+                    });
+            }
+            if (error == NULL && conn == gUdpConn) {
+                ios_udp_receive_loop(conn);
+            }
+        });
+}
+
+static int ios_udp_open(const char *ip, uint16_t port) {
+    if (gUdpQueue == nil) {
+        gUdpQueue = dispatch_queue_create("app.betaflight.udp", DISPATCH_QUEUE_SERIAL);
+    }
+    if (gUdpConn != nil) {
+        nw_connection_cancel(gUdpConn);
+        gUdpConn = nil;
+    }
+
+    char portStr[8];
+    snprintf(portStr, sizeof(portStr), "%u", (unsigned)port);
+    nw_endpoint_t endpoint = nw_endpoint_create_host(ip, portStr);
+    nw_parameters_t params =
+        nw_parameters_create_secure_udp(NW_PARAMETERS_DISABLE_PROTOCOL, NW_PARAMETERS_DEFAULT_CONFIGURATION);
+    nw_connection_t conn = nw_connection_create(endpoint, params);
+    gUdpConn = conn;
+    nw_connection_set_queue(conn, gUdpQueue);
+
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    __block bool ready = false;
+    __block int lastState = 0;
+    __block int lastErrno = 0;
+    nw_connection_set_state_changed_handler(conn,
+        ^(nw_connection_state_t state, nw_error_t error) {
+            lastState = (int)state;
+            if (error) {
+                lastErrno = nw_error_get_error_code(error);
+            }
+            if (state == nw_connection_state_ready) {
+                ready = true;
+                dispatch_semaphore_signal(sem);
+                ios_udp_receive_loop(conn);
+            } else if (state == nw_connection_state_failed || state == nw_connection_state_cancelled) {
+                if (!ready) {
+                    dispatch_semaphore_signal(sem);
+                }
+            }
+        });
+    nw_connection_start(conn);
+
+    long timedOut = dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, 12LL * NSEC_PER_SEC));
+    if (ready) {
+        return 0;
+    }
+    nw_connection_cancel(conn);
+    if (gUdpConn == conn) {
+        gUdpConn = nil;
+    }
+    int code = lastState * 1000 + (lastErrno % 1000);
+    if (code == 0) {
+        code = (timedOut != 0) ? 999000 : 997000;
+    }
+    return code;
+}
+
+static void ios_udp_send(const uint8_t *data, size_t len) {
+    nw_connection_t conn = gUdpConn;
+    if (conn == nil || data == NULL || len == 0) {
+        return;
+    }
+    dispatch_data_t dd = dispatch_data_create(data, len, gUdpQueue, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    nw_connection_send(conn, dd, NW_CONNECTION_DEFAULT_MESSAGE_CONTEXT, true,
+        ^(nw_error_t error) { (void)error; });
+}
+
+static void ios_udp_close(void) {
+    if (gUdpConn != nil) {
+        nw_connection_cancel(gUdpConn);
+        gUdpConn = nil;
+    }
+}
+
 int main(int argc, char * argv[]) {
     // Give Rust our TCP entry points before the app starts.
     rust_register_tcp(ios_tcp_connect, ios_tcp_send, ios_tcp_close);
+    rust_register_udp(ios_udp_open, ios_udp_send, ios_udp_close);
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(2 * NSEC_PER_SEC)),
                    dispatch_get_main_queue(), ^{

--- a/src-tauri/gen/apple/betaflight-app_iOS/Info.plist
+++ b/src-tauri/gen/apple/betaflight-app_iOS/Info.plist
@@ -22,6 +22,10 @@
 	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Betaflight connects to your flight controller bridge over the local network.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_betaflight._tcp</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod tcp;
+mod udp;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
@@ -13,7 +14,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             tcp::tcp_connect,
             tcp::tcp_send,
-            tcp::tcp_disconnect
+            tcp::tcp_disconnect,
+            udp::phoneflash_flash
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/tcp.rs
+++ b/src-tauri/src/tcp.rs
@@ -4,19 +4,73 @@
 //! (github.com/betaflight/bridge) speaks plain TCP on port 5761 — not
 //! WebSocket — so the JS `TauriTcp` protocol drives these commands instead.
 //!
-//! A single connection is held in managed state. The reader runs on its own
-//! thread and forwards bytes to the frontend via the `tcp-data` event;
-//! `tcp-closed` fires when the peer hangs up or the socket errors. An epoch
-//! counter fences each connection so a stale reader (left over from a
-//! reconnect or disconnect) can never emit against the live socket.
+//! Desktop and Android use std::net. iOS won't give a raw socket local network access
+//! even with the permission granted, so on iOS the socket lives in main.mm and hands
+//! its connect, send and close pointers to Rust through here.
 
-use std::io::{Read, Write};
-use std::net::{Shutdown, TcpStream};
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::net::TcpStream;
+use std::sync::atomic::AtomicU64;
 use std::sync::{Arc, Mutex};
-use std::thread;
 
 use tauri::{AppHandle, Emitter, State};
+
+#[cfg(not(target_os = "ios"))]
+use std::io::{Read, Write};
+#[cfg(not(target_os = "ios"))]
+use std::net::Shutdown;
+#[cfg(not(target_os = "ios"))]
+use std::sync::atomic::Ordering;
+#[cfg(not(target_os = "ios"))]
+use std::thread;
+
+#[cfg(target_os = "ios")]
+use std::ffi::CString;
+#[cfg(target_os = "ios")]
+use std::os::raw::c_char;
+
+// iOS Network.framework bridge, the socket lives in main.mm
+#[cfg(target_os = "ios")]
+type ConnectFn = extern "C" fn(*const c_char, u16) -> i32;
+#[cfg(target_os = "ios")]
+type SendFn = extern "C" fn(*const u8, usize);
+#[cfg(target_os = "ios")]
+type CloseFn = extern "C" fn();
+
+#[cfg(target_os = "ios")]
+static TCP_FNS: Mutex<Option<(ConnectFn, SendFn, CloseFn)>> = Mutex::new(None);
+
+// Live AppHandle so the native callbacks can emit events.
+#[cfg(target_os = "ios")]
+static IOS_APP: Mutex<Option<AppHandle>> = Mutex::new(None);
+
+/// Registers main.mm's NWConnection entry points.
+#[cfg(target_os = "ios")]
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_register_tcp(connect: ConnectFn, send: SendFn, close: CloseFn) {
+    *TCP_FNS.lock().unwrap() = Some((connect, send, close));
+}
+
+/// Called by main.mm with received bytes.
+#[cfg(target_os = "ios")]
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tcp_on_data(bytes: *const u8, len: usize) {
+    if bytes.is_null() || len == 0 {
+        return;
+    }
+    let data = unsafe { std::slice::from_raw_parts(bytes, len) }.to_vec();
+    if let Some(app) = IOS_APP.lock().unwrap().as_ref() {
+        let _ = app.emit("tcp-data", data);
+    }
+}
+
+/// Called by main.mm when the connection closes or fails.
+#[cfg(target_os = "ios")]
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_tcp_on_closed() {
+    if let Some(app) = IOS_APP.lock().unwrap().as_ref() {
+        let _ = app.emit("tcp-closed", ());
+    }
+}
 
 #[derive(Default)]
 pub struct TcpState {
@@ -31,62 +85,133 @@ pub fn tcp_connect(
     ip: String,
     port: u16,
 ) -> Result<(), String> {
-    let stream = TcpStream::connect((ip.as_str(), port)).map_err(|e| e.to_string())?;
-    // Disable Nagle to keep MSP round-trips snappy, matching the bridge.
-    let _ = stream.set_nodelay(true);
-
-    let reader = stream.try_clone().map_err(|e| e.to_string())?;
-
-    // Bump the epoch and tear down any previous connection so its reader stops.
-    let epoch = state.epoch.clone();
-    let my_epoch = epoch.fetch_add(1, Ordering::SeqCst) + 1;
-    if let Some(old) = state.stream.lock().unwrap().replace(stream) {
-        let _ = old.shutdown(Shutdown::Both);
+    #[cfg(target_os = "ios")]
+    {
+        let _ = state; // Socket lives in NWConnection on iOS
+        let fns = *TCP_FNS.lock().unwrap();
+        let connect = fns
+            .map(|(c, _, _)| c)
+            .ok_or_else(|| "native TCP transport not registered".to_string())?;
+        *IOS_APP.lock().unwrap() = Some(app);
+        let cip = CString::new(ip).map_err(|e| e.to_string())?;
+        let code = connect(cip.as_ptr(), port);
+        if code == 0 {
+            Ok(())
+        } else {
+            let state = code / 1000;
+            let errno = code % 1000;
+            let state_s = match state {
+                0 => "invalid",
+                1 => "waiting",
+                2 => "preparing",
+                4 => "failed",
+                5 => "cancelled",
+                999 => "timeout-12s",
+                _ => "?",
+            };
+            let errno_s = match errno {
+                0 => "-",
+                1 => "EPERM/denied",
+                49 => "EADDRNOTAVAIL",
+                50 => "ENETDOWN",
+                51 => "ENETUNREACH",
+                54 => "ECONNRESET",
+                60 => "ETIMEDOUT",
+                61 => "ECONNREFUSED",
+                64 => "EHOSTDOWN",
+                65 => "EHOSTUNREACH",
+                _ => "errno",
+            };
+            Err(format!(
+                "NWConnection failed, state={state} ({state_s}), errno={errno} ({errno_s})"
+            ))
+        }
     }
 
-    thread::spawn(move || {
-        let mut reader = reader;
-        let mut buf = [0u8; 4096];
-        loop {
-            // A newer connect/disconnect superseded us — exit without emitting.
-            if epoch.load(Ordering::SeqCst) != my_epoch {
-                break;
-            }
-            match reader.read(&mut buf) {
-                Ok(0) | Err(_) => {
-                    if epoch.load(Ordering::SeqCst) == my_epoch {
-                        let _ = app.emit("tcp-closed", ());
-                    }
+    #[cfg(not(target_os = "ios"))]
+    {
+        let stream = TcpStream::connect((ip.as_str(), port)).map_err(|e| e.to_string())?;
+        // Disable Nagle to keep MSP round-trips snappy, matching the bridge.
+        let _ = stream.set_nodelay(true);
+
+        let reader = stream.try_clone().map_err(|e| e.to_string())?;
+
+        // Bump the epoch and tear down any previous connection so its reader stops.
+        let epoch = state.epoch.clone();
+        let my_epoch = epoch.fetch_add(1, Ordering::SeqCst) + 1;
+        if let Some(old) = state.stream.lock().unwrap().replace(stream) {
+            let _ = old.shutdown(Shutdown::Both);
+        }
+
+        thread::spawn(move || {
+            let mut reader = reader;
+            let mut buf = [0u8; 4096];
+            loop {
+                if epoch.load(Ordering::SeqCst) != my_epoch {
                     break;
                 }
-                Ok(n) => {
-                    if epoch.load(Ordering::SeqCst) != my_epoch {
+                match reader.read(&mut buf) {
+                    Ok(0) | Err(_) => {
+                        if epoch.load(Ordering::SeqCst) == my_epoch {
+                            let _ = app.emit("tcp-closed", ());
+                        }
                         break;
                     }
-                    let _ = app.emit("tcp-data", buf[..n].to_vec());
+                    Ok(n) => {
+                        if epoch.load(Ordering::SeqCst) != my_epoch {
+                            break;
+                        }
+                        let _ = app.emit("tcp-data", buf[..n].to_vec());
+                    }
                 }
             }
-        }
-    });
+        });
 
-    Ok(())
+        Ok(())
+    }
 }
 
 #[tauri::command]
 pub fn tcp_send(state: State<'_, TcpState>, data: Vec<u8>) -> Result<(), String> {
-    let mut guard = state.stream.lock().unwrap();
-    match guard.as_mut() {
-        Some(stream) => stream.write_all(&data).map_err(|e| e.to_string()),
-        None => Err("TCP socket is not connected".into()),
+    #[cfg(target_os = "ios")]
+    {
+        let _ = state;
+        let fns = *TCP_FNS.lock().unwrap();
+        if let Some((_, send, _)) = fns {
+            send(data.as_ptr(), data.len());
+        }
+        Ok(())
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    {
+        let mut guard = state.stream.lock().unwrap();
+        match guard.as_mut() {
+            Some(stream) => stream.write_all(&data).map_err(|e| e.to_string()),
+            None => Err("TCP socket is not connected".into()),
+        }
     }
 }
 
 #[tauri::command]
 pub fn tcp_disconnect(state: State<'_, TcpState>) -> Result<(), String> {
-    // Fence the reader first so its closure doesn't emit a spurious tcp-closed.
-    state.epoch.fetch_add(1, Ordering::SeqCst);
-    if let Some(stream) = state.stream.lock().unwrap().take() {
-        let _ = stream.shutdown(Shutdown::Both);
+    #[cfg(target_os = "ios")]
+    {
+        let _ = state;
+        let fns = *TCP_FNS.lock().unwrap();
+        if let Some((_, _, close)) = fns {
+            close();
+        }
+        Ok(())
     }
-    Ok(())
+
+    #[cfg(not(target_os = "ios"))]
+    {
+        // Fence the reader first so its closure doesn't emit a spurious tcp-closed.
+        state.epoch.fetch_add(1, Ordering::SeqCst);
+        if let Some(stream) = state.stream.lock().unwrap().take() {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+        Ok(())
+    }
 }

--- a/src-tauri/src/udp.rs
+++ b/src-tauri/src/udp.rs
@@ -1,0 +1,271 @@
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter};
+
+#[cfg(not(target_os = "ios"))]
+use std::net::UdpSocket;
+
+#[cfg(target_os = "ios")]
+use std::ffi::CString;
+#[cfg(target_os = "ios")]
+use std::os::raw::c_char;
+#[cfg(target_os = "ios")]
+use std::sync::mpsc::{Receiver, Sender};
+#[cfg(target_os = "ios")]
+use std::sync::Mutex;
+
+const MAGIC: u32 = 0x4853_4C46;
+const REPLY: u8 = 0x80;
+const FC_BASE: u32 = 0x0800_0000;
+const CONFIG_LO: u32 = 0x0800_4000;
+const CONFIG_HI: u32 = 0x0800_8000;
+
+const PF_HELLO: u8 = 1;
+const PF_BEGIN: u8 = 2;
+const PF_WRITE: u8 = 3;
+const PF_END: u8 = 4;
+const PF_REBOOT: u8 = 5;
+
+#[derive(Deserialize)]
+pub struct Block {
+    pub address: u32,
+    pub data: Vec<u8>,
+}
+
+#[derive(Clone, Serialize)]
+struct Progress {
+    sent: u32,
+    total: u32,
+}
+
+#[cfg(target_os = "ios")]
+type UdpOpenFn = extern "C" fn(*const c_char, u16) -> i32;
+#[cfg(target_os = "ios")]
+type UdpSendFn = extern "C" fn(*const u8, usize);
+#[cfg(target_os = "ios")]
+type UdpCloseFn = extern "C" fn();
+
+#[cfg(target_os = "ios")]
+static UDP_FNS: Mutex<Option<(UdpOpenFn, UdpSendFn, UdpCloseFn)>> = Mutex::new(None);
+#[cfg(target_os = "ios")]
+static UDP_RX_TX: Mutex<Option<Sender<Vec<u8>>>> = Mutex::new(None);
+
+#[cfg(target_os = "ios")]
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_register_udp(open: UdpOpenFn, send: UdpSendFn, close: UdpCloseFn) {
+    *UDP_FNS.lock().unwrap() = Some((open, send, close));
+}
+
+#[cfg(target_os = "ios")]
+#[unsafe(no_mangle)]
+pub extern "C" fn rust_udp_on_data(bytes: *const u8, len: usize) {
+    if bytes.is_null() || len == 0 {
+        return;
+    }
+    let data = unsafe { std::slice::from_raw_parts(bytes, len) }.to_vec();
+    if let Some(tx) = UDP_RX_TX.lock().unwrap().as_ref() {
+        let _ = tx.send(data);
+    }
+}
+
+struct Link {
+    #[cfg(not(target_os = "ios"))]
+    sock: UdpSocket,
+    #[cfg(target_os = "ios")]
+    rx: Receiver<Vec<u8>>,
+}
+
+impl Link {
+    #[cfg(not(target_os = "ios"))]
+    fn open(ip: &str, port: u16) -> Result<Link, String> {
+        let sock = UdpSocket::bind("0.0.0.0:0").map_err(|e| e.to_string())?;
+        sock.connect((ip, port)).map_err(|e| e.to_string())?;
+        Ok(Link { sock })
+    }
+
+    #[cfg(target_os = "ios")]
+    fn open(ip: &str, port: u16) -> Result<Link, String> {
+        let fns = *UDP_FNS.lock().unwrap();
+        let open_fn = fns
+            .map(|(o, _, _)| o)
+            .ok_or_else(|| "native UDP transport not registered".to_string())?;
+        let (tx, rx) = std::sync::mpsc::channel();
+        *UDP_RX_TX.lock().unwrap() = Some(tx);
+        let cip = CString::new(ip).map_err(|e| e.to_string())?;
+        let code = open_fn(cip.as_ptr(), port);
+        if code != 0 {
+            *UDP_RX_TX.lock().unwrap() = None;
+            return Err(format!("NWConnection UDP open failed, code {code}"));
+        }
+        Ok(Link { rx })
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    fn send(&self, pkt: &[u8]) {
+        let _ = self.sock.send(pkt);
+    }
+
+    #[cfg(target_os = "ios")]
+    fn send(&self, pkt: &[u8]) {
+        if let Some((_, send, _)) = *UDP_FNS.lock().unwrap() {
+            send(pkt.as_ptr(), pkt.len());
+        }
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    fn recv(&self, timeout: Duration) -> Option<Vec<u8>> {
+        self.sock.set_read_timeout(Some(timeout.max(Duration::from_millis(1)))).ok()?;
+        let mut buf = [0u8; 2048];
+        match self.sock.recv(&mut buf) {
+            Ok(n) => Some(buf[..n].to_vec()),
+            Err(_) => None,
+        }
+    }
+
+    #[cfg(target_os = "ios")]
+    fn recv(&self, timeout: Duration) -> Option<Vec<u8>> {
+        self.rx.recv_timeout(timeout).ok()
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    fn drain(&self) {
+        let _ = self.sock.set_nonblocking(true);
+        let mut buf = [0u8; 2048];
+        while self.sock.recv(&mut buf).is_ok() {}
+        let _ = self.sock.set_nonblocking(false);
+    }
+
+    #[cfg(target_os = "ios")]
+    fn drain(&self) {
+        while self.rx.try_recv().is_ok() {}
+    }
+
+    #[cfg(not(target_os = "ios"))]
+    fn close(self) {}
+
+    #[cfg(target_os = "ios")]
+    fn close(self) {
+        if let Some((_, _, close)) = *UDP_FNS.lock().unwrap() {
+            close();
+        }
+        *UDP_RX_TX.lock().unwrap() = None;
+    }
+
+    fn request(&self, op: u8, args: &[u8], expect: u8, timeout: Duration, retries: u32) -> Result<Vec<u8>, String> {
+        let mut pkt = MAGIC.to_le_bytes().to_vec();
+        pkt.push(op);
+        pkt.extend_from_slice(args);
+        for _ in 0..retries {
+            self.drain();
+            self.send(&pkt);
+            let deadline = Instant::now() + timeout;
+            while let Some(remaining) = deadline.checked_duration_since(Instant::now()) {
+                let Some(reply) = self.recv(remaining) else { break };
+                if reply.len() >= 6
+                    && u32::from_le_bytes([reply[0], reply[1], reply[2], reply[3]]) == MAGIC
+                    && reply[4] == (expect | REPLY)
+                {
+                    if reply[5] != 0 {
+                        return Err(format!("FC rejected {expect:#04x} with error {}", reply[5]));
+                    }
+                    return Ok(reply);
+                }
+            }
+        }
+        Err(format!("no reply to {expect:#04x} after {retries} tries"))
+    }
+}
+
+fn crc32(buf: &[u8]) -> u32 {
+    let mut c: u32 = 0xFFFF_FFFF;
+    for &b in buf {
+        c ^= b as u32;
+        for _ in 0..8 {
+            c = (c >> 1) ^ (0xEDB8_8320 & 0u32.wrapping_sub(c & 1));
+        }
+    }
+    c ^ 0xFFFF_FFFF
+}
+
+fn run_flash(app: &AppHandle, ip: &str, port: u16, blocks: Vec<Block>) -> Result<(), String> {
+    let mut runs: Vec<(u32, Vec<u8>)> = Vec::new();
+    let mut stream: Vec<u8> = Vec::new();
+    let mut sorted = blocks;
+    sorted.retain(|b| !b.data.is_empty() && !(b.address >= CONFIG_LO && b.address < CONFIG_HI));
+    sorted.sort_by_key(|b| b.address);
+    for b in &sorted {
+        if b.address < FC_BASE || b.address % 4 != 0 {
+            return Err(format!("block at {:#010x} is not word aligned", b.address));
+        }
+        let mut d = b.data.clone();
+        while d.len() % 4 != 0 {
+            d.push(0xFF);
+        }
+        stream.extend_from_slice(&d);
+        runs.push((b.address - FC_BASE, d));
+    }
+    let total = stream.len() as u32;
+    if total == 0 {
+        return Err("no programmable data in the firmware".to_string());
+    }
+    let crc = crc32(&stream);
+
+    let link = Link::open(ip, port)?;
+
+    let hello = link.request(PF_HELLO, &[], PF_HELLO, Duration::from_millis(500), 60)?;
+    let max_chunk = if hello.len() >= 20 {
+        u16::from_le_bytes([hello[18], hello[19]]) as usize
+    } else {
+        1024
+    }
+    .max(4);
+
+    let mut begin = Vec::new();
+    begin.extend_from_slice(&total.to_le_bytes());
+    begin.extend_from_slice(&crc.to_le_bytes());
+    link.request(PF_BEGIN, &begin, PF_BEGIN, Duration::from_secs(3), 10)?;
+
+    let mut sent: u32 = 0;
+    for (off, data) in &runs {
+        let mut pos = 0usize;
+        while pos < data.len() {
+            let end = (pos + max_chunk).min(data.len());
+            let piece = &data[pos..end];
+            let mut args = Vec::with_capacity(6 + piece.len());
+            args.extend_from_slice(&(off + pos as u32).to_le_bytes());
+            args.extend_from_slice(&(piece.len() as u16).to_le_bytes());
+            args.extend_from_slice(piece);
+            link.request(PF_WRITE, &args, PF_WRITE, Duration::from_secs(6), 10)?;
+            pos = end;
+            sent += piece.len() as u32;
+            let _ = app.emit("phoneflash-progress", Progress { sent, total });
+        }
+    }
+
+    let end = link.request(PF_END, &[], PF_END, Duration::from_secs(6), 10)?;
+    if end.len() < 10 {
+        return Err("short END reply from FC".to_string());
+    }
+    let fc_crc = u32::from_le_bytes([end[6], end[7], end[8], end[9]]);
+    if fc_crc != crc {
+        return Err(format!("verify failed: FC crc {fc_crc:#010x} != {crc:#010x}"));
+    }
+
+    let _ = link.request(PF_REBOOT, &[], PF_REBOOT, Duration::from_secs(1), 2);
+    link.close();
+    Ok(())
+}
+
+#[tauri::command]
+pub fn phoneflash_flash(app: AppHandle, ip: String, port: u16, blocks: Vec<Block>) -> Result<(), String> {
+    std::thread::spawn(move || match run_flash(&app, &ip, port, blocks) {
+        Ok(()) => {
+            let _ = app.emit("phoneflash-done", ());
+        }
+        Err(e) => {
+            let _ = app.emit("phoneflash-error", e);
+        }
+    });
+    Ok(())
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,8 @@
         "security": {
             "csp": null,
             "capabilities": [
-                "default"
+                "default",
+                "mobile"
             ]
         },
         "windows": [

--- a/src/components/port-picker/ConnectOptionsDialog.vue
+++ b/src/components/port-picker/ConnectOptionsDialog.vue
@@ -17,6 +17,16 @@
         </template>
         <template #footer>
             <div class="connect-options__actions">
+                <UButton
+                    v-if="mode === 'manual'"
+                    color="neutral"
+                    variant="soft"
+                    size="sm"
+                    class="connect-options__defaults"
+                    @click="onDefaults"
+                >
+                    {{ $t("defaults") }}
+                </UButton>
                 <UButton color="neutral" variant="soft" size="sm" @click="onCancel">
                     {{ $t("cancel") }}
                 </UButton>
@@ -40,13 +50,15 @@ const FIRMWARE_VERSIONS = [
     { value: "1.44.0", label: "MSP: 1.44 | Firmware: 4.3.*" },
 ];
 
+const DEFAULT_MANUAL_PORT = "tcp://192.168.7.1:5761";
+
 export default defineComponent({
     name: "ConnectOptionsDialog",
     props: {
         modelValue: { type: Boolean, default: false },
         mode: { type: String, default: "virtual" },
         initialVersion: { type: String, default: "1.46.0" },
-        initialPortOverride: { type: String, default: "/dev/rfcomm0" },
+        initialPortOverride: { type: String, default: DEFAULT_MANUAL_PORT },
     },
     emits: ["update:modelValue", "confirm"],
     setup(props, { emit }) {
@@ -95,6 +107,10 @@ export default defineComponent({
             open.value = false;
         }
 
+        function onDefaults() {
+            portOverride.value = DEFAULT_MANUAL_PORT;
+        }
+
         return {
             open,
             version,
@@ -104,6 +120,7 @@ export default defineComponent({
             canConfirm,
             onCancel,
             onConfirm,
+            onDefaults,
         };
     },
 });
@@ -139,5 +156,9 @@ export default defineComponent({
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;
+}
+
+.connect-options__defaults {
+    margin-right: auto;
 }
 </style>

--- a/src/components/port-picker/PortOverrideOption.vue
+++ b/src/components/port-picker/PortOverrideOption.vue
@@ -15,7 +15,7 @@ export default defineComponent({
     props: {
         modelValue: {
             type: String,
-            default: "/dev/rfcomm0",
+            default: "tcp://192.168.7.1:5761",
         },
         isManual: {
             type: Boolean,

--- a/src/composables/useFirmwareFlashing.js
+++ b/src/composables/useFirmwareFlashing.js
@@ -1,4 +1,6 @@
 import { reactive } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 import { get as getConfig } from "../js/ConfigStorage";
 import { useDialog } from "./useDialog";
 import GUI from "../js/gui";
@@ -8,6 +10,11 @@ import read_hex_file from "../js/workers/hex_parser";
 import STM32 from "../js/protocols/webstm32";
 import ESP32 from "../js/protocols/esp32";
 import PortHandler from "../js/port_handler";
+import { serial } from "../js/serial";
+import { isTauriIOS } from "../js/utils/checkCompatibility";
+
+const PHONE_CONFIG_HOST = "192.168.7.1";
+const PHONE_FLASH_PORT = 5762;
 
 /**
  * A composable for managing firmware flashing operations.
@@ -260,6 +267,70 @@ export function useFirmwareFlashing(params = {}) {
     /**
      * Flash HEX firmware via selected port (DFU or Serial)
      */
+    const phoneConfigHost = () => {
+        if (serial.connected && serial.protocol === "tauritcp") {
+            try {
+                const url = new URL(serial.getConnectedPort()?.path ?? "");
+                if (url.hostname === PHONE_CONFIG_HOST) {
+                    return url.hostname;
+                }
+            } catch {
+                // fall through
+            }
+        }
+        return isTauriIOS() ? PHONE_CONFIG_HOST : null;
+    };
+
+    const flashViaPhoneConfig = async (firmware, host) => {
+        const blocks = (firmware?.data ?? []).map((b) => ({ address: b.address, data: Array.from(b.data) }));
+        if (!blocks.length) {
+            flashingMessage("No firmware loaded to flash", FLASH_MESSAGE_TYPES.INVALID);
+            return;
+        }
+
+        const unlisten = [];
+        let finish;
+        const done = new Promise((resolve) => (finish = resolve));
+
+        flashingMessage("Flashing firmware", FLASH_MESSAGE_TYPES.FLASHING);
+        flashProgress(0);
+
+        unlisten.push(
+            await listen("phoneflash-progress", (e) => {
+                const { sent, total } = e.payload ?? {};
+                flashProgress(total ? Math.floor((100 * sent) / total) : 0);
+            }),
+        );
+        unlisten.push(
+            await listen("phoneflash-done", () => {
+                flashProgress(100);
+                flashingMessage("Firmware flashed, rebooting", FLASH_MESSAGE_TYPES.VALID);
+                finish();
+            }),
+        );
+        unlisten.push(
+            await listen("phoneflash-error", (e) => {
+                flashingMessage(`Flash failed: ${e.payload}`, FLASH_MESSAGE_TYPES.INVALID);
+                finish();
+            }),
+        );
+
+        try {
+            await invoke("phoneflash_flash", { ip: host, port: PHONE_FLASH_PORT, blocks });
+            await done;
+        } catch (e) {
+            flashingMessage(`Flash failed: ${e}`, FLASH_MESSAGE_TYPES.INVALID);
+        } finally {
+            for (const u of unlisten) {
+                try {
+                    await u();
+                } catch (err) {
+                    console.error(`${logHead} failed to remove listener: ${err}`);
+                }
+            }
+        }
+    };
+
     const flashHexFirmware = async (options = {}) => {
         const {
             firmware,
@@ -285,6 +356,15 @@ export function useFirmwareFlashing(params = {}) {
 
         if (eraseChip) {
             flashing_options.erase_chip = true;
+        }
+
+        const pfHost = phoneConfigHost();
+        if (pfHost) {
+            tracking.sendEvent(tracking.EVENT_CATEGORIES.FLASHING, "Phone-config Flashing", {
+                filename: filename || null,
+            });
+            await flashViaPhoneConfig(firmware, pfHost);
+            return;
         }
 
         const port = PortHandler.portPicker.selectedPort;

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -1,4 +1,4 @@
-import { isAndroid } from "./utils/checkCompatibility";
+import { isAndroid, isTauriIOS } from "./utils/checkCompatibility";
 import CapacitorFile from "./protocols/CapacitorFile";
 
 const EXTENSION_MIME_MAP = {
@@ -103,7 +103,9 @@ function pickFileViaInput(extension) {
     return new Promise((resolve, reject) => {
         const input = document.createElement("input");
         input.type = "file";
-        if (accept) {
+        // iOS greys out extensions it can't map to a UTI (.hex/.uf2/.bin), so leave the picker
+        // unfiltered there and let the firmware parser validate the choice.
+        if (accept && !isTauriIOS()) {
             input.accept = accept;
         }
         input.style.display = "none";
@@ -157,8 +159,11 @@ function pickFileViaInput(extension) {
         // AbortError that showOpenFilePicker throws.
         input.addEventListener("cancel", abort);
 
-        // Fallback dismissal detection for webviews without the `cancel` event.
-        globalThis.addEventListener("focus", onFocus);
+        // Fallback dismissal detection for webviews without the `cancel` event. Skipped on iOS, where
+        // focus returns before `change` delivers the file, so it would abort a valid selection.
+        if (!isTauriIOS()) {
+            globalThis.addEventListener("focus", onFocus);
+        }
 
         input.click();
     });

--- a/src/js/port_handler.js
+++ b/src/js/port_handler.js
@@ -38,7 +38,7 @@ const PortHandler = new (function () {
     this.portPicker = {
         selectedPort: DEFAULT_PORT,
         selectedBauds: DEFAULT_BAUDS,
-        portOverride: getConfig("portOverride", "/dev/rfcomm0").portOverride,
+        portOverride: getConfig("portOverride", "tcp://192.168.7.1:5761").portOverride,
         virtualMspVersion: getConfig("virtualMspVersion", "1.46.0").virtualMspVersion,
         autoConnect: getConfig("autoConnect", false).autoConnect,
     };

--- a/src/js/protocols/TauriTcp.js
+++ b/src/js/protocols/TauriTcp.js
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { useDialogStore } from "../../stores/dialog";
 
 /**
  * Raw TCP transport for the Tauri shell (desktop and Android).
@@ -97,6 +98,21 @@ class TauriTcp extends EventTarget {
             return true;
         } catch (e) {
             console.error(`${this.logHead}Failed to connect to socket: ${e}`);
+            // Show the error in a dialog
+            try {
+                const dialogStore = useDialogStore();
+                dialogStore.open(
+                    "InformationDialog",
+                    {
+                        title: "Connection failed",
+                        text: String(e?.message ?? e),
+                        confirmText: "Close",
+                    },
+                    { confirm: () => dialogStore.close() },
+                );
+            } catch (dlgErr) {
+                console.error(`${this.logHead}Failed to show dialog: ${dlgErr}`);
+            }
             this.connected = false;
             await this._teardownListeners();
             this.dispatchEvent(new CustomEvent("connect", { detail: false }));

--- a/src/js/utils/developmentOptions.js
+++ b/src/js/utils/developmentOptions.js
@@ -15,7 +15,7 @@ export const DEFAULT_DEVELOPMENT_OPTIONS = {
  * Development options enabled for dev URLs (localhost, PR branches, master)
  */
 export const ENABLED_DEVELOPMENT_OPTIONS = {
-    showVirtualMode: true,
+    showVirtualMode: false,
     showManualMode: true,
     showAllSerialDevices: true,
     backupOnFlash: 2, // ask


### PR DESCRIPTION
The configurator already does raw TCP for the bridge on desktop and Android, but it's dead on iOS. iOS won't give a raw socket local network access even after you grant the permission, only Apple's Network.framework will. This adds an iOS path through Network.framework, so the configurator now runs on iPhone and iPad and reaches an FC over the local network, either the bridge over wifi or a USB cable on the phone-config firmware.

On iOS the socket lives in the native side (main.mm) with NWConnection and hands Rust a few function pointers to drive it. Every other platform keeps the existing std::net path. Plus a mobile capability file (the default one is desktop only), a Bonjour plist entry for the permission prompt, and an error dialog so failures aren't silent on the phone.

You can configure from the phone but can't flash firmware from iOS yet. That may come soon, flash from a PC for now.

There's a github actions workflow (ios-ipa.yml) that builds an unsigned ipa on a free runner so you can sideload without a paid apple account.

Tested on a sideloaded iPhone with USB-C, iOS 26. Live MSP on all the tabs plus the CLI with autocomplete. Works against both firmware builds, current master and 4.5.2, on a Foxeer F722 V4.

Please see https://github.com/betaflight/betaflight/pull/15377

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile capability support.
  * Added UDP “phone-config” HEX flashing with progress, done, and error events.
  * Improved iOS networking by bridging native TCP events into the app.
* **Bug Fixes**
  * TCP connection failures now show an information dialog with the error details.
* **UI / UX**
  * Added a “Defaults” button for manual port selection; updated connection defaults to the phone-config TCP gateway.
* **Platform Updates**
  * Improved iOS file picker fallback behavior and disabled a dev virtual-mode option.
* **CI / Build**
  * Added iOS CI to build and upload an unsigned IPA artifact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->