### PR TITLE
fix(magsphere): correct East/West inversion in Euler attitude fallback

### DIFF
--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -463,10 +463,14 @@ function updateQuadAttitude() {
         const { w, x, y, z } = props.quaternion;
         _targetQuat.set(x, -y, -z, w);
     } else if (props.attitude) {
-        // Euler fallback: build q from (roll, pitch, heading) in aerospace ZYX,
-        // then the same adapter.
+        // Euler fallback (firmware without MSP_ATTITUDE_QUATERNION, API < 1.48).
+        // Reconstruct the same body(FLU)→earth(NWU) quaternion the quaternion path
+        // receives, then apply the same adapter. Betaflight heading is left-handed
+        // about the Up axis (firmware: yaw = -atan2(W, N)), so the ZYX yaw term must
+        // be NEGATED to reproduce that quaternion — otherwise East/West are swapped
+        // while roll/pitch stay correct.
         const { roll, pitch, heading } = props.attitude;
-        _tmpEuler.set(degToRad(roll), degToRad(pitch), degToRad(heading), "ZYX");
+        _tmpEuler.set(degToRad(roll), degToRad(pitch), degToRad(-heading), "ZYX");
         _tmpQuat.setFromEuler(_tmpEuler);
         _targetQuat.set(_tmpQuat.x, -_tmpQuat.y, -_tmpQuat.z, _tmpQuat.w);
     } else {


### PR DESCRIPTION
## Fixes #5217

### Problem
In the new Sensors → Magnetometer **Sphere View**, the quad animation points **East where it should point West** (heading mirrored about the N–S axis). Roll/pitch and N/S are correct — as the reporter noted, "the rest seems to be correct."

### Root cause
`MagSphereView.vue` → `updateQuadAttitude()` has two input paths:

1. **Quaternion path** (`MSP_ATTITUDE_QUATERNION`, firmware API ≥ 1.48) — correct.
2. **Euler fallback** (`roll/pitch/heading`, used when the FC does not provide the quaternion, i.e. API < 1.48) — **E/W inverted**.

Verified against `betaflight/master`:
- The attitude quaternion maps **body (FLU) → earth (NWU)** (`src/main/common/axis.h`, `src/main/flight/imu.c`).
- Firmware heading is **left-handed about the Up axis**: `yaw = -atan2(rMat[NWU_W][X], rMat[NWU_N][X])`.

The quaternion path carries that sign implicitly and is correct. The Euler fallback fed `heading` straight into a THREE.js `ZYX` euler (`+heading` about Z), producing the **mirror-image yaw** — swapping East/West while leaving roll/pitch/N/S correct.

This is a regression from #5187, which rewrote both paths but gave the fallback the wrong yaw sign.

### Fix
Negate the heading term so the fallback reconstructs the same body→earth quaternion the quaternion path receives:

```js
_tmpEuler.set(roll * DEG_TO_RAD, pitch * DEG_TO_RAD, -heading * DEG_TO_RAD, "ZYX");
```

### Verification
Reproduced the frame math standalone (matching THREE.js conventions). Quad nose direction for a level quad:

| heading | expected | quaternion path | euler (before) | euler (after) |
|---------|----------|-----------------|----------------|---------------|
| 90°     | East (+Y)| E ✅            | W ❌           | E ✅          |
| 270°    | West (−Y)| W ✅            | E ❌           | W ✅          |
| 0°/180° | N/S      | ✅             | ✅            | ✅           |

The corrected Euler path reproduces the (correct) quaternion path **exactly** for all tested roll/pitch/heading combinations, including combined cases (e.g. r=10 p=20 h=60, r=−15 p=25 h=300) — confirming that only the E/W heading term was wrong.

### Notes
- Triggered on firmware **without `MSP_ATTITUDE_QUATERNION` (API < 1.48)**. On API ≥ 1.48 the quaternion path is already correct; this makes the fallback consistent with it.
- Change is a single sign flip plus an explanatory comment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved magnetic calibration heading alignment by correcting the fallback Euler-angle calculation, keeping East/West orientation consistent with the quaternion-based display.
  * Reduced instances of mirrored or inverted heading behavior in the calibration sphere when quaternion data is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->