### PR TITLE
fix(osd): clamp virtual-anchor elements when dragged to grid edges

### DIFF
--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -1105,18 +1105,26 @@ function clampObjectArrayPreviewPosition(position, displaySize, limits) {
     const selectedPositionX = ((position % displaySize.x) + displaySize.x) % displaySize.x;
     const selectedPositionY = Math.floor(position / displaySize.x);
 
-    if (limits.minX < 0 && selectedPositionX + limits.minX < 0) {
+    if (selectedPositionX + limits.minX < 0) {
         position += Math.abs(selectedPositionX + limits.minX);
     } else if (limits.maxX > 0 && selectedPositionX + limits.maxX >= displaySize.x) {
         position -= selectedPositionX + limits.maxX + 1 - displaySize.x;
     }
-    if (limits.minY < 0 && selectedPositionY + limits.minY < 0) {
+    if (selectedPositionY + limits.minY < 0) {
         position += Math.abs(selectedPositionY + limits.minY) * displaySize.x;
     } else if (limits.maxY > 0 && selectedPositionY + limits.maxY >= displaySize.y) {
         position -= (selectedPositionY + limits.maxY - displaySize.y + 1) * displaySize.x;
     }
 
-    return Math.max(0, position);
+    if (position < 0) {
+        // The anchor of an element whose cells all sit below it (positive minY) may
+        // still land above row 0 after clamping, but positions pack into unsigned
+        // x/y for MSP (see stores/osd.js pack.position): settle on row 0, keeping
+        // the column instead of jumping to the top-left corner.
+        position = ((position % displaySize.x) + displaySize.x) % displaySize.x;
+    }
+
+    return position;
 }
 
 function clampArrayPreviewPosition(displayItem, position, displaySize, cursorX) {

--- a/src/composables/useOsdPreview.js
+++ b/src/composables/useOsdPreview.js
@@ -32,7 +32,13 @@ function searchLimitsElement(arrayElements) {
                 limits.maxX = Math.max(val.length, limits.maxX);
             });
         } else {
-            // Array of objects {x, y, sym}
+            // Array of objects {x, y, sym}. Seed the limits from the first cell so
+            // elements whose cells all sit on one side of the anchor (e.g.
+            // ARTIFICIAL_HORIZON spans y +1..+7) report their true extents.
+            limits.minX = arrayElements[0].x;
+            limits.maxX = arrayElements[0].x;
+            limits.minY = arrayElements[0].y;
+            limits.maxY = arrayElements[0].y;
             arrayElements.forEach(function (val) {
                 limits.minX = Math.min(val.x, limits.minX);
                 limits.maxX = Math.max(val.x, limits.maxX);

--- a/test/js/osd_preview_limits.test.js
+++ b/test/js/osd_preview_limits.test.js
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { useOsdPreview } from "../../src/composables/useOsdPreview.js";
+
+// Preview shaped like ARTIFICIAL_HORIZON (see src/components/tabs/osd/osd.js):
+// cells span x -4..+4 and y +1..+7, so every rendered cell sits below the
+// stored anchor position and the element's true minimum Y offset is +1.
+function buildArtificialHorizonPreview() {
+    const preview = [];
+    for (let y = 1; y < 8; y++) {
+        for (let x = -4; x <= 4; x++) {
+            preview.push({ x, y, sym: 0x20 });
+        }
+    }
+    return preview;
+}
+
+// Preview shaped like HORIZON_SIDEBARS: cells span both sides of the anchor.
+function buildHorizonSidebarsPreview() {
+    const preview = [];
+    for (let y = -3; y <= 3; y++) {
+        preview.push({ x: -7, y, sym: 0x20 });
+        preview.push({ x: 7, y, sym: 0x20 });
+    }
+    return preview;
+}
+
+describe("searchLimitsElement", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    it("reports the true offset limits for elements whose cells all sit below the anchor", () => {
+        const { searchLimitsElement } = useOsdPreview();
+
+        const limits = searchLimitsElement(buildArtificialHorizonPreview());
+
+        expect(limits.minX).toBe(-4);
+        expect(limits.maxX).toBe(4);
+        expect(limits.minY).toBe(1);
+        expect(limits.maxY).toBe(7);
+    });
+
+    it("reports unchanged limits for elements spanning both sides of the anchor", () => {
+        const { searchLimitsElement } = useOsdPreview();
+
+        const limits = searchLimitsElement(buildHorizonSidebarsPreview());
+
+        expect(limits.minX).toBe(-7);
+        expect(limits.maxX).toBe(7);
+        expect(limits.minY).toBe(-3);
+        expect(limits.maxY).toBe(3);
+    });
+
+    it("keeps legacy behavior for string previews", () => {
+        const { searchLimitsElement } = useOsdPreview();
+
+        const limits = searchLimitsElement("BAT1");
+
+        expect(limits).toEqual({ minX: 0, maxX: 4, minY: 0, maxY: 0 });
+    });
+
+    it("keeps legacy behavior for string array previews", () => {
+        const { searchLimitsElement } = useOsdPreview();
+
+        const limits = searchLimitsElement(["ABC", "DEFGH"]);
+
+        expect(limits).toEqual({ minX: 0, maxX: 5, minY: 0, maxY: 2 });
+    });
+
+    it("returns zeroed limits for empty previews", () => {
+        const { searchLimitsElement } = useOsdPreview();
+
+        expect(searchLimitsElement([])).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
+        expect(searchLimitsElement(null)).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
+    });
+});


### PR DESCRIPTION
## Summery
Fixes #5086

Dragging the Artificial Horizon element near the top of the OSD grid made it jump to the top-left corner (position 0) instead of clamping to the nearest valid position. Any element whose preview cells all sit below its stored anchor is affected: the anchor is a virtual point above the visible cells, so its correct clamped index can go negative.

Both bugs from the issue's analysis were real:

1. `searchLimitsElement` initialized all limits to 0 and only widened them, so for `ARTIFICIAL_HORIZON` (cells y +1..+7) `minY` stayed 0 instead of +1 and the top-boundary correction in `clampObjectArrayPreviewPosition` never engaged.
2. The final `Math.max(0, position)` then flattened the negative anchor index to cell 0, discarding the column the element was dropped in.

## Changes

- `searchLimitsElement` seeds the limits from the first preview cell so one-sided elements report their true extents. Elements spanning both sides of the anchor (e.g. `HORIZON_SIDEBARS`) get identical results as before, and the string / string-array branches are untouched.
- The top/left boundary corrections are no longer gated on `limits.minX/minY < 0` — the gate was redundant for every case it allowed (a wrapped X or non-negative anchor row can't produce a negative sum with non-negative limits) and only served to skip the broken case.
- If the anchor still lands above row 0 after clamping (only possible for positive-`minY` elements), it settles on row 0 keeping its column, since positions pack into unsigned x/y for MSP (`pack.position` in `stores/osd.js`).

`applyPresetPosition` also consumes `limits.minY` as its anchor offset, so preset placement for `ARTIFICIAL_HORIZON` is now compensated correctly as well (it was one row off before).

## Testing

- New unit tests for `searchLimitsElement`: virtual-anchor shape, both-sides shape, string / string-array / empty previews. `npx vitest run` passes all tests, `npm run lint` is clean and works. (`npm run build`) succeeds.
- Manually verified in virtual mode: before, dragging AH's center cell to the top row jumped the element to position 0 with its negative-x cells wrapping to the right screen edge; after, it clamps flush to the top keeping the drop column (anchor row 0, cells rows 1–7). Bottom and left edges clamp flush as well, and normal relative drag behaviour is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview positioning so object-based grids stay within bounds more reliably, including cases that previously snapped incorrectly at the edges.
  * Refined limit detection for structured preview content so offsets are calculated more accurately.
* **Tests**
  * Added coverage for preview limit calculations across structured, string-based, empty, and null inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->