### PR TITLE
Use release tag as Cloudflare branch alias on release deploys

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -123,8 +123,20 @@ jobs:
           echo "is_latest=false" >> $GITHUB_OUTPUT
           echo "✗ Not the latest release after $MAX_RETRIES attempts. Current: $RELEASE_TAG, Latest: $LATEST_TAG"
 
-  # Deploy with the release tag as the Cloudflare branch alias
+  # Deploy to versioned maintenance branch
   modern_deploy:
+    name: Deploy to Maintenance Branch
+    needs: [modern_build, prepare_environment]
+    uses: ./.github/workflows/deploy_cloudflare.yml
+    with:
+      branch_name: ${{ needs.prepare_environment.outputs.env_name }}
+      environment_name: ${{ needs.prepare_environment.outputs.env_name }}
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+  # Deploy with the release tag as the Cloudflare branch alias
+  modern_deploy_tag:
     name: Deploy Release Tag
     needs: [modern_build, prepare_environment]
     uses: ./.github/workflows/deploy_cloudflare.yml

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -123,13 +123,13 @@ jobs:
           echo "is_latest=false" >> $GITHUB_OUTPUT
           echo "✗ Not the latest release after $MAX_RETRIES attempts. Current: $RELEASE_TAG, Latest: $LATEST_TAG"
 
-  # Deploy to versioned maintenance branch
+  # Deploy with the release tag as the Cloudflare branch alias
   modern_deploy:
-    name: Deploy to Maintenance Branch
+    name: Deploy Release Tag
     needs: [modern_build, prepare_environment]
     uses: ./.github/workflows/deploy_cloudflare.yml
     with:
-      branch_name: ${{ needs.prepare_environment.outputs.env_name }}
+      branch_name: ${{ github.event.release.tag_name }}
       environment_name: ${{ needs.prepare_environment.outputs.env_name }}
     secrets:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Adds a release deploy that uses the release tag (e.g. `2025.12.1`) as the Cloudflare Pages branch alias, giving each release a permanent versioned URL. The existing `x.y-maintenance` alias deploy is kept, so every release refreshes both the tag alias and its maintenance alias. Push deploys (master and `*-maintenance`) and PR deploys (`PR<number>`) are unchanged, as is the production `release` deploy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release deployments now use the published release tag as the deployment alias, helping ensure the live environment matches the tagged release more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->