### PR TITLE
Remove duplicate maintenance alias deploy from release workflow

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -123,19 +123,8 @@ jobs:
           echo "is_latest=false" >> $GITHUB_OUTPUT
           echo "✗ Not the latest release after $MAX_RETRIES attempts. Current: $RELEASE_TAG, Latest: $LATEST_TAG"
 
-  # Deploy to versioned maintenance branch
-  modern_deploy:
-    name: Deploy to Maintenance Branch
-    needs: [modern_build, prepare_environment]
-    uses: ./.github/workflows/deploy_cloudflare.yml
-    with:
-      branch_name: ${{ needs.prepare_environment.outputs.env_name }}
-      environment_name: ${{ needs.prepare_environment.outputs.env_name }}
-    secrets:
-      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-
-  # Deploy with the release tag as the Cloudflare branch alias
+  # Deploy with the release tag as the Cloudflare branch alias. The
+  # x.y-maintenance alias is handled by the push deploy when the branch moves.
   modern_deploy_tag:
     name: Deploy Release Tag
     needs: [modern_build, prepare_environment]


### PR DESCRIPTION
Cutting 2026.6.0-RC1 deployed the `2026.6-maintenance` alias twice: once from the version-bump push and again from the release workflow. The push deploy already updates the branch alias whenever the maintenance branch moves (and a release is always preceded by the version-bump push), so the release workflow now only deploys the tag alias. Production (`release`) deploy is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release deployment messaging for Cloudflare branch alias handling.
  * Removed the separate maintenance-branch deployment step from the release flow.
  * Release deployments now continue using the release tag, with maintenance aliases handled elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->