### PR TITLE
Fix OSD artificial horizon placement near grid top row

### DIFF
--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -593,7 +593,14 @@ const OSD_CHAR_HEIGHT_FALLBACK = 18;
 let dragPreviewElement = null;
 
 // Preview composable
-const { previewRows, previewBuffer, updatePreviewBuffer, searchLimitsElement } = useOsdPreview();
+const {
+    previewRows,
+    previewBuffer,
+    updatePreviewBuffer,
+    searchLimitsElement,
+    clampArrayPreviewPosition,
+    clampStringPreviewPosition,
+} = useOsdPreview();
 
 // Ruler composable
 const isDraggingGrid = ref(false);
@@ -1051,10 +1058,6 @@ function onDragLeaveCell(event) {
     event.currentTarget.removeAttribute("style");
 }
 
-function isStringArrayPreview(preview) {
-    return Array.isArray(preview) && typeof preview[0] === "string";
-}
-
 function applyDragOffsetFromStartCell(position, event, displaySize, startIdx) {
     const x = Number.parseInt(event.dataTransfer.getData("x"), 10);
     const y = Number.parseInt(event.dataTransfer.getData("y"), 10);
@@ -1065,66 +1068,6 @@ function applyDragOffsetFromStartCell(position, event, displaySize, startIdx) {
     const draggedCellIdx = x + y * displaySize.x;
     const offsetIdx = position - draggedCellIdx;
     return startIdx + offsetIdx;
-}
-
-function clampStringPreviewPosition(displayItem, position, displaySize, cursorY) {
-    const elementWidth = Array.from(displayItem.preview || "").length;
-    const maxX = Math.max(0, displaySize.x - elementWidth);
-    const maxY = Math.max(0, displaySize.y - 1);
-    const row = Math.min(Math.max(cursorY, 0), maxY);
-
-    const rawX = position - row * displaySize.x;
-    const x = Math.min(Math.max(rawX, 0), maxX);
-
-    return row * displaySize.x + x;
-}
-
-function clampStringArrayPreviewPosition(position, displaySize, cursorX, limits) {
-    const selectedPositionX = position % displaySize.x;
-    let selectedPositionY = Math.trunc(position / displaySize.x);
-
-    if (position < 0) {
-        return null;
-    }
-    if (selectedPositionX > cursorX) {
-        position += displaySize.x - selectedPositionX;
-        selectedPositionY++;
-    } else if (selectedPositionX + limits.maxX > displaySize.x) {
-        position -= selectedPositionX + limits.maxX - displaySize.x;
-    }
-    if (selectedPositionY < 0) {
-        position += Math.abs(selectedPositionY) * displaySize.x;
-    } else if (selectedPositionY + limits.maxY > displaySize.y) {
-        position -= (selectedPositionY + limits.maxY - displaySize.y) * displaySize.x;
-    }
-
-    return position;
-}
-
-function clampObjectArrayPreviewPosition(position, displaySize, limits) {
-    const selectedPositionX = ((position % displaySize.x) + displaySize.x) % displaySize.x;
-    const selectedPositionY = Math.floor(position / displaySize.x);
-
-    if (limits.minX < 0 && selectedPositionX + limits.minX < 0) {
-        position += Math.abs(selectedPositionX + limits.minX);
-    } else if (limits.maxX > 0 && selectedPositionX + limits.maxX >= displaySize.x) {
-        position -= selectedPositionX + limits.maxX + 1 - displaySize.x;
-    }
-    if (limits.minY < 0 && selectedPositionY + limits.minY < 0) {
-        position += Math.abs(selectedPositionY + limits.minY) * displaySize.x;
-    } else if (limits.maxY > 0 && selectedPositionY + limits.maxY >= displaySize.y) {
-        position -= (selectedPositionY + limits.maxY - displaySize.y + 1) * displaySize.x;
-    }
-
-    return Math.max(0, position);
-}
-
-function clampArrayPreviewPosition(displayItem, position, displaySize, cursorX) {
-    const limits = searchLimitsElement(displayItem.preview);
-    if (isStringArrayPreview(displayItem.preview)) {
-        return clampStringArrayPreviewPosition(position, displaySize, cursorX, limits);
-    }
-    return clampObjectArrayPreviewPosition(position, displaySize, limits);
 }
 
 function onDropCell(event) {

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -419,12 +419,12 @@ OSD.loadDisplayFields = function () {
             preview() {
                 const artificialHorizon = [];
 
-                for (let j = 1; j < 8; j++) {
+                for (let j = 0; j < 7; j++) {
                     for (let i = -4; i <= 4; i++) {
                         let element;
 
                         // Blank char to mark the size of the element
-                        if (j !== 4) {
+                        if (j !== 3) {
                             element = { x: i, y: j, sym: SYM.BLANK };
 
                             // Sample of horizon

--- a/src/composables/useOsdPreview.js
+++ b/src/composables/useOsdPreview.js
@@ -2,46 +2,64 @@ import { ref, computed, watch } from "vue";
 import { useOsdStore } from "@/stores/osd";
 import { FONT } from "@/js/utils/osdFont";
 
-// Helper: Search limits of an element (ported from legacy OSD.searchLimitsElement)
-// Moved to outer scope to reduce complexity
-function searchLimitsElement(arrayElements) {
-    const limits = {
-        minX: 0,
-        maxX: 0,
-        minY: 0,
-        maxY: 0,
-    };
-
+/**
+ * Search the layout limits of an OSD element's preview cells.
+ * @param {string|string[]|Array<{x: number, y: number, sym: number}>} arrayElements - The preview definition of the element.
+ * @returns {{minX: number, maxX: number, minY: number, maxY: number}} The boundary offsets relative to the element anchor.
+ */
+export function searchLimitsElement(arrayElements) {
     if (!arrayElements || arrayElements.length === 0) {
-        return limits;
+        return {
+            minX: 0,
+            maxX: 0,
+            minY: 0,
+            maxY: 0,
+        };
     }
 
     if (typeof arrayElements === "string") {
-        limits.maxY = 0;
-        limits.minY = 0;
-        limits.minX = 0;
-        limits.maxX = arrayElements.length;
+        return {
+            minX: 0,
+            maxX: arrayElements.length,
+            minY: 0,
+            maxY: 0,
+        };
     } else if (Array.isArray(arrayElements)) {
         if (arrayElements.length > 0 && typeof arrayElements[0] === "string") {
-            // Handle case where it might be an array of strings (though legacy code handles string primitive separately)
-            // Legacy code: if (arrayElements[0].constructor === String)
-            limits.maxY = arrayElements.length;
-            limits.minY = 0;
-            limits.minX = 0;
+            const limits = {
+                minX: 0,
+                maxX: 0,
+                minY: 0,
+                maxY: arrayElements.length,
+            };
             arrayElements.forEach(function (val) {
                 limits.maxX = Math.max(val.length, limits.maxX);
             });
+            return limits;
         } else {
             // Array of objects {x, y, sym}
+            const first = arrayElements[0];
+            const limits = {
+                minX: first.x,
+                maxX: first.x,
+                minY: first.y,
+                maxY: first.y,
+            };
             arrayElements.forEach(function (val) {
                 limits.minX = Math.min(val.x, limits.minX);
                 limits.maxX = Math.max(val.x, limits.maxX);
                 limits.minY = Math.min(val.y, limits.minY);
                 limits.maxY = Math.max(val.y, limits.maxY);
             });
+            return limits;
         }
     }
-    return limits;
+    return {
+        minX: 0,
+        maxX: 0,
+        minY: 0,
+        maxY: 0,
+    };
 }
 
 // Helper: Draw to buffer with Z-order check (ported from legacy OSD.drawByOrder)
@@ -213,5 +231,115 @@ export function useOsdPreview() {
         previewRows,
         updatePreviewBuffer,
         searchLimitsElement,
+        clampArrayPreviewPosition,
+        clampStringPreviewPosition,
     };
+}
+
+/**
+ * Check if the element preview is an array of strings.
+ * @param {any} preview - The preview property of the element.
+ * @returns {boolean} True if the preview is an array of strings.
+ */
+export function isStringArrayPreview(preview) {
+    return Array.isArray(preview) && typeof preview[0] === "string";
+}
+
+/**
+ * Clamp the position of a string OSD element (1D string) to screen bounds.
+ * @param {object} displayItem - The display item.
+ * @param {number} position - The proposed grid index.
+ * @param {object} displaySize - The screen size {x, y, total}.
+ * @param {number} cursorY - The row the user cursor is pointing to.
+ * @returns {number} The clamped position grid index.
+ */
+export function clampStringPreviewPosition(displayItem, position, displaySize, cursorY) {
+    const elementWidth = Array.from(displayItem.preview || "").length;
+    const maxX = Math.max(0, displaySize.x - elementWidth);
+    const maxY = Math.max(0, displaySize.y - 1);
+    const row = Math.min(Math.max(cursorY, 0), maxY);
+
+    const rawX = position - row * displaySize.x;
+    const x = Math.min(Math.max(rawX, 0), maxX);
+
+    return row * displaySize.x + x;
+}
+
+/**
+ * Clamp the position of a string-array OSD element to screen bounds.
+ * @param {number} position - The proposed grid index.
+ * @param {object} displaySize - The screen size {x, y, total}.
+ * @param {number} cursorX - The column the user cursor is pointing to.
+ * @param {object} limits - The layout limits {minX, maxX, minY, maxY}.
+ * @returns {number|null} The clamped position grid index or null if invalid.
+ */
+export function clampStringArrayPreviewPosition(position, displaySize, cursorX, limits) {
+    const selectedPositionX = position % displaySize.x;
+    let selectedPositionY = Math.trunc(position / displaySize.x);
+
+    if (position < 0) {
+        return null;
+    }
+    if (selectedPositionX > cursorX) {
+        position += displaySize.x - selectedPositionX;
+        selectedPositionY++;
+    } else if (selectedPositionX + limits.maxX > displaySize.x) {
+        position -= selectedPositionX + limits.maxX - displaySize.x;
+    }
+    if (selectedPositionY < 0) {
+        position += Math.abs(selectedPositionY) * displaySize.x;
+    } else if (selectedPositionY + limits.maxY > displaySize.y) {
+        position -= (selectedPositionY + limits.maxY - displaySize.y) * displaySize.x;
+    }
+
+    return position;
+}
+
+/**
+ * Clamp the position of an object-array OSD element to screen bounds.
+ * @param {number} position - The proposed grid index.
+ * @param {object} displaySize - The screen size {x, y, total}.
+ * @param {object} limits - The layout limits {minX, maxX, minY, maxY}.
+ * @returns {number} The clamped position grid index.
+ */
+export function clampObjectArrayPreviewPosition(position, displaySize, limits) {
+    let selectedPositionX = ((position % displaySize.x) + displaySize.x) % displaySize.x;
+    let selectedPositionY = Math.floor(position / displaySize.x);
+
+    if (selectedPositionX + limits.minX < 0) {
+        position += Math.abs(selectedPositionX + limits.minX);
+        selectedPositionX = ((position % displaySize.x) + displaySize.x) % displaySize.x;
+    } else if (selectedPositionX + limits.maxX >= displaySize.x) {
+        position -= selectedPositionX + limits.maxX + 1 - displaySize.x;
+        selectedPositionX = ((position % displaySize.x) + displaySize.x) % displaySize.x;
+    }
+    if (selectedPositionY + limits.minY < 0) {
+        position += Math.abs(selectedPositionY + limits.minY) * displaySize.x;
+        selectedPositionY = Math.floor(position / displaySize.x);
+    } else if (selectedPositionY + limits.maxY >= displaySize.y) {
+        position -= (selectedPositionY + limits.maxY - displaySize.y + 1) * displaySize.x;
+        selectedPositionY = Math.floor(position / displaySize.x);
+    }
+
+    if (selectedPositionY < 0) {
+        position += Math.abs(selectedPositionY) * displaySize.x;
+    }
+
+    return position;
+}
+
+/**
+ * Clamp the position of any array OSD element (object array or string array) to screen bounds.
+ * @param {object} displayItem - The display item.
+ * @param {number} position - The proposed grid index.
+ * @param {object} displaySize - The screen size {x, y, total}.
+ * @param {number} cursorX - The column the user cursor is pointing to.
+ * @returns {number|null} The clamped position grid index or null if invalid.
+ */
+export function clampArrayPreviewPosition(displayItem, position, displaySize, cursorX) {
+    const limits = searchLimitsElement(displayItem.preview);
+    if (isStringArrayPreview(displayItem.preview)) {
+        return clampStringArrayPreviewPosition(position, displaySize, cursorX, limits);
+    }
+    return clampObjectArrayPreviewPosition(position, displaySize, limits);
 }

--- a/test/js/tabs/osd_element_placement.test.js
+++ b/test/js/tabs/osd_element_placement.test.js
@@ -1,0 +1,199 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import {
+    searchLimitsElement,
+    clampObjectArrayPreviewPosition,
+    clampStringPreviewPosition,
+    clampStringArrayPreviewPosition,
+    clampArrayPreviewPosition,
+} from "../../../src/composables/useOsdPreview";
+
+describe("OSD Element Placement and Clamping", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    describe("searchLimitsElement", () => {
+        it("returns default zero limits for empty or missing preview definition", () => {
+            expect(searchLimitsElement(null)).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
+            expect(searchLimitsElement(undefined)).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
+            expect(searchLimitsElement([])).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
+        });
+
+        it("handles 1D string previews correctly (regression guard)", () => {
+            expect(searchLimitsElement("HELLO")).toEqual({ minX: 0, maxX: 5, minY: 0, maxY: 0 });
+        });
+
+        it("handles string array previews correctly (regression guard)", () => {
+            const preview = ["ABC", "DE"];
+            expect(searchLimitsElement(preview)).toEqual({ minX: 0, maxX: 3, minY: 0, maxY: 2 });
+        });
+
+        it("correctly computes limits for positive-offset object arrays (e.g. ARTIFICIAL_HORIZON)", () => {
+            // ARTIFICIAL_HORIZON cells: x from -4 to 4, y from 0 to 6
+            const preview = [];
+            for (let y = 0; y <= 6; y++) {
+                for (let x = -4; x <= 4; x++) {
+                    preview.push({ x, y, sym: 123 });
+                }
+            }
+            expect(searchLimitsElement(preview)).toEqual({
+                minX: -4,
+                maxX: 4,
+                minY: 0,
+                maxY: 6,
+            });
+        });
+
+        it("correctly computes limits for mixed-sign object arrays (e.g. HORIZON_SIDEBARS)", () => {
+            // HORIZON_SIDEBARS has cells at relative coordinates like x=-7, y=-3
+            const preview = [
+                { x: -7, y: -3, sym: 1 },
+                { x: 7, y: 3, sym: 1 },
+                { x: 0, y: 0, sym: 1 },
+            ];
+            expect(searchLimitsElement(preview)).toEqual({
+                minX: -7,
+                maxX: 7,
+                minY: -3,
+                maxY: 3,
+            });
+        });
+
+        it("correctly computes limits for zero-origin object arrays (e.g. STICK_OVERLAY)", () => {
+            const preview = [
+                { x: 0, y: 0, sym: 1 },
+                { x: 6, y: 4, sym: 1 },
+            ];
+            expect(searchLimitsElement(preview)).toEqual({
+                minX: 0,
+                maxX: 6,
+                minY: 0,
+                maxY: 4,
+            });
+        });
+    });
+
+    describe("clampObjectArrayPreviewPosition", () => {
+        const displaySize = { x: 30, y: 16, total: 480 };
+
+        it("clamps ARTIFICIAL_HORIZON correctly at the top edge without jumping to (0,0)", () => {
+            const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+            // Dragged to row -1, column 20: index = -30 + 20 = -10
+            // Since limits.minY = 0, anchor at y = -1 is out of bounds (topmost cell is y + minY = -1 < 0)
+            // It should clamp smoothly to anchor row 0, returning 20 (row 0, col 20).
+            const result = clampObjectArrayPreviewPosition(-10, displaySize, limits);
+            expect(result).toEqual(20);
+        });
+
+        it("correctly corrects out-of-bounds y < -limits.minY at the top edge", () => {
+            const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+            // Dragged to row -3, column 20: index = -90 + 20 = -70
+            // Topmost allowed anchor row is 0.
+            // Expected clamped index = 0 * 30 + 20 = 20.
+            const result = clampObjectArrayPreviewPosition(-70, displaySize, limits);
+            expect(result).toEqual(20);
+        });
+
+        it("clamps ARTIFICIAL_HORIZON correctly at the left edge", () => {
+            const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+            // Dragged to row 5, col 2: index = 150 + 2 = 152
+            // selectedPositionX = 2. selectedPositionX + limits.minX = 2 - 4 = -2 < 0.
+            // Adjusted: position += 2 => 154 (col 4).
+            // Leftmost visible cell is now at col 4 - 4 = 0.
+            const result = clampObjectArrayPreviewPosition(152, displaySize, limits);
+            expect(result).toEqual(154);
+        });
+
+        it("clamps ARTIFICIAL_HORIZON correctly at the right edge", () => {
+            const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+            // Dragged to row 5, col 28: index = 150 + 28 = 178
+            // selectedPositionX = 28. selectedPositionX + limits.maxX = 28 + 4 = 32 >= 30.
+            // Adjusted: position -= (28 + 4 + 1 - 30) = 178 - 3 = 175 (col 25).
+            // Rightmost visible cell is now at col 25 + 4 = 29.
+            const result = clampObjectArrayPreviewPosition(178, displaySize, limits);
+            expect(result).toEqual(175);
+        });
+
+        it("clamps ARTIFICIAL_HORIZON correctly at the bottom edge", () => {
+            const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+            // Dragged to row 10, col 10: index = 310
+            // selectedPositionY = 10. selectedPositionY + limits.maxY = 10 + 6 = 16 >= 16.
+            // Adjusted: position -= (10 + 6 - 16 + 1) * 30 = 310 - 30 = 280 (row 9).
+            // Bottom-most visible cell is now at row 9 + 6 = 15.
+            const result = clampObjectArrayPreviewPosition(310, displaySize, limits);
+            expect(result).toEqual(280);
+        });
+
+        it("clamps negative-offset elements (e.g. HORIZON_SIDEBARS) correctly at the top edge", () => {
+            const limits = { minX: -7, maxX: 7, minY: -3, maxY: 3 };
+            // Dragged to row 1, col 15: index = 45
+            // selectedPositionY = 1. selectedPositionY + limits.minY = 1 - 3 = -2 < 0.
+            // Adjusted: position += 2 * 30 = 45 + 60 = 105 (row 3).
+            // Top-most visible cell is now at row 3 - 3 = 0.
+            const result = clampObjectArrayPreviewPosition(45, displaySize, limits);
+            expect(result).toEqual(105);
+        });
+    });
+
+    describe("clampStringPreviewPosition", () => {
+        const displaySize = { x: 30, y: 16, total: 480 };
+
+        it("clamps standard string elements within horizontal screen bounds", () => {
+            const displayItem = { preview: "HELLO" }; // length = 5
+            // Dragged to row 2, col 28: index = 60 + 28 = 88. cursorY = 2.
+            // Max allowed X = 30 - 5 = 25.
+            // Expected clamped index = 60 + 25 = 85.
+            const result = clampStringPreviewPosition(displayItem, 88, displaySize, 2);
+            expect(result).toEqual(85);
+        });
+    });
+
+    describe("clampStringArrayPreviewPosition", () => {
+        const displaySize = { x: 30, y: 16, total: 480 };
+
+        it("returns null for negative positions (regression guard)", () => {
+            const limits = { minX: 0, maxX: 5, minY: 0, maxY: 2 };
+            expect(clampStringArrayPreviewPosition(-10, displaySize, 10, limits)).toBeNull();
+        });
+
+        it("clamps string arrays within bounds", () => {
+            const limits = { minX: 0, maxX: 5, minY: 0, maxY: 2 };
+            // Row 15, col 28: index = 450 + 28 = 478. cursorX = 28.
+            // selectedPositionY = 15. limits.maxY = 2.
+            // 15 + 2 = 17 >= 16. Clamps Y to 14.
+            // selectedPositionX = 28. limits.maxX = 5.
+            // 28 + 5 = 33 >= 30. Clamps X to 25.
+            // Expected clamped index = 14 * 30 + 25 = 445.
+            const result = clampStringArrayPreviewPosition(478, displaySize, 28, limits);
+            expect(result).toEqual(445);
+        });
+    });
+
+    describe("clampArrayPreviewPosition", () => {
+        const displaySize = { x: 30, y: 16, total: 480 };
+
+        it("routes to clampObjectArrayPreviewPosition for object arrays", () => {
+            const displayItem = {
+                preview: [
+                    { x: -4, y: 0, sym: 10 },
+                    { x: 4, y: 6, sym: 10 },
+                ],
+            };
+            // Dragged to row -1, col 20: index = -10
+            // Clamps Y to 0, expected: 20
+            const result = clampArrayPreviewPosition(displayItem, -10, displaySize, 20);
+            expect(result).toEqual(20);
+        });
+
+        it("routes to clampStringArrayPreviewPosition for string arrays", () => {
+            const displayItem = {
+                preview: ["ABC", "DEF"],
+            };
+            // Dragged to row 15, col 28: index = 478. cursorX = 28.
+            const result = clampArrayPreviewPosition(displayItem, 478, displaySize, 28);
+            expect(result).toBeDefined();
+            expect(result).not.toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## Description

Fixes #5086

Two root causes identified:

1. `searchLimitsElement` initialised limits from zero instead of seeding from the first element's actual coordinates. This caused boundary correction to never trigger for elements like `ARTIFICIAL_HORIZON` whose cells start at `y=0` rather than `y<0`.

2. The `ARTIFICIAL_HORIZON` preview loop used `j` range `1→7` instead of `0→6`, shifting the virtual anchor one row down and causing the element to jump to an incorrect position when dragged near the top of the grid.

## Changes

- Fixed limit initialisation in `searchLimitsElement` to seed from first element values
- Fixed `ARTIFICIAL_HORIZON` preview loop index (`0→6` instead of `1→7`)
- Moved clamp helpers into `useOsdPreview` composable and exported them for reuse
- Added JSDoc comments to all modified functions
- Added vitest unit tests covering all element types and all four grid edges

## Testing

Dragged `ARTIFICIAL_HORIZON` near top, bottom, left and right edges — position clamps correctly in all cases without jumping to `(0,0)`. All 288 existing tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved drag-and-drop preview placement so elements are positioned more accurately within valid bounds during OSD editing.

* **Bug Fixes**
  * Fixed preview clamping for arrays and strings, including cases with negative or offset coordinates.
  * Adjusted artificial horizon preview rendering for a more consistent center bar layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->