### PR TITLE
fix(pid-tuning): reflect TX-driven profile changes in the UI

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -5866,6 +5866,9 @@
     "powerBatteryProfileOption": {
         "message": "Battery Profile $1"
     },
+    "powerReceivedBatteryProfile": {
+        "message": "Flight controller set Battery Profile: <strong class=\"message-positive\">$1</strong>"
+    },
     "powerBatteryProfileNamePlaceholder": {
         "message": "e.g. LiPo, Li-Ion"
     },

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -160,6 +160,9 @@ const showAllPids = ref(false);
 const currentProfile = ref(FC.CONFIG.profile);
 const currentRateProfile = ref(0);
 const isMounted = ref(false);
+// Guards for the TX-driven profile sync (see watchers below).
+const isLoading = ref(false);
+let syncingFromFc = false;
 const pidSubTab = ref(null);
 const filterSubTab = ref(null);
 const ratesSubTab = ref(null);
@@ -228,6 +231,7 @@ const hasChanges = computed(() => pidTuningStore.hasChanges);
 
 // MSP Data Loading
 async function loadData() {
+    isLoading.value = true;
     try {
         if (!isMounted.value) {
             return false;
@@ -298,6 +302,8 @@ async function loadData() {
         console.error("[PidTuning] Failed to load data:", e);
         GUI.content_ready();
         return false;
+    } finally {
+        isLoading.value = false;
     }
 }
 
@@ -546,6 +552,53 @@ watch(
             FC.CONFIG.rateProfileNames[FC.CONFIG.rateProfile] = newValue;
         }
         onFormChanged();
+    },
+);
+
+// Keep the profile / rate-profile selectors in sync with TX-driven changes.
+// The global live-status poller (serial_backend.js) refreshes FC.CONFIG.profile and
+// FC.CONFIG.rateProfile via MSP_STATUS_EX every 250ms; an adjustment switch on the TX
+// can therefore change the active profile out from under the UI. Reflect that here and
+// reload — but never clobber unsaved edits or interrupt an in-flight load. Restores the
+// checkUpdateProfile() behaviour lost in the Vue migration (issue #5230).
+async function syncProfileFromFc(kind) {
+    // Skip while loading, while our own change is applying, or when the form is dirty
+    // (an in-progress edit takes precedence over a switch flip, matching legacy behaviour).
+    if (!isMounted.value || isLoading.value || syncingFromFc || pidTuningStore.hasChanges) {
+        return;
+    }
+
+    syncingFromFc = true;
+    try {
+        currentProfile.value = FC.CONFIG.profile;
+        currentRateProfile.value = FC.CONFIG.rateProfile;
+        await loadData();
+        gui_log(
+            i18n.getMessage(
+                kind === "rate" ? "pidTuningReceivedRateProfile" : "pidTuningReceivedProfile",
+                [(kind === "rate" ? FC.CONFIG.rateProfile : FC.CONFIG.profile) + 1],
+            ),
+        );
+    } finally {
+        syncingFromFc = false;
+    }
+}
+
+watch(
+    () => FC.CONFIG.profile,
+    (newValue) => {
+        if (newValue !== currentProfile.value) {
+            syncProfileFromFc("profile");
+        }
+    },
+);
+
+watch(
+    () => FC.CONFIG.rateProfile,
+    (newValue) => {
+        if (newValue !== currentRateProfile.value) {
+            syncProfileFromFc("rate");
+        }
     },
 );
 

--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -1,4 +1,4 @@
-import { reactive, ref, computed } from "vue";
+import { reactive, ref, computed, watch } from "vue";
 import semver from "semver";
 import { i18n } from "../js/localization";
 import { tracking } from "../js/Analytics";
@@ -9,6 +9,7 @@ import MSP from "../js/msp";
 import MSPCodes from "../js/msp/MSPCodes";
 import { useConnectionStore } from "../stores/connection";
 import GUI from "../js/gui";
+import { gui_log } from "../js/gui_log";
 
 export function usePower() {
     const supported = computed(() => {
@@ -23,6 +24,9 @@ export function usePower() {
     });
     const activeBatteryProfile = ref(0);
     const batteryProfileName = ref("");
+    // Guards for the TX-driven battery-profile sync (see watcher below).
+    const isLoading = ref(false);
+    let syncingFromFc = false;
     const analyticsChanges = reactive({});
     const batteryState = reactive({
         cellCount: 0,
@@ -181,6 +185,8 @@ export function usePower() {
         const previousProfileName = batteryProfileName.value;
 
         try {
+            // Suppress the TX-driven sync watcher while we apply our own change
+            isLoading.value = true;
             // Pause global and local polling to prevent MSP_STATUS_EX from
             // overwriting FC.CONFIG.batteryProfile with stale data during the switch
             connectionStore.pauseLiveData();
@@ -209,13 +215,43 @@ export function usePower() {
             }
             throw error;
         } finally {
+            isLoading.value = false;
             connectionStore.resumeLiveData();
             GUI.interval_resume("power_data_pull_slow");
         }
     };
 
+    // Reflect TX-driven battery-profile changes in the UI. The global live-status poller
+    // (serial_backend.js) refreshes FC.CONFIG.batteryProfile via MSP_STATUS_EX every 250ms;
+    // an adjustment switch on the TX can change the active profile out from under the UI.
+    // Reload when that happens — but never during our own change (isLoading), an in-flight
+    // load, or while the form has unsaved edits. Mirrors the PID-tuning fix (issue #5230).
+    const syncBatteryProfileFromFc = async () => {
+        if (!hasBatteryProfiles.value || isLoading.value || syncingFromFc || dirty.value) {
+            return;
+        }
+
+        syncingFromFc = true;
+        try {
+            await loadData();
+            gui_log(i18n.getMessage("powerReceivedBatteryProfile", [FC.CONFIG.batteryProfile + 1]));
+        } finally {
+            syncingFromFc = false;
+        }
+    };
+
+    watch(
+        () => FC.CONFIG.batteryProfile,
+        (newValue) => {
+            if (newValue !== activeBatteryProfile.value) {
+                syncBatteryProfileFromFc();
+            }
+        },
+    );
+
     // Load data from flight controller
     const loadData = async () => {
+        isLoading.value = true;
         try {
             await MSP.promise(MSPCodes.MSP_STATUS_EX);
             await MSP.promise(MSPCodes.MSP_VOLTAGE_METERS);
@@ -232,6 +268,8 @@ export function usePower() {
             updateStateFromFC();
         } catch (error) {
             console.error("Error loading power data:", error);
+        } finally {
+            isLoading.value = false;
         }
     };
 


### PR DESCRIPTION
## Summary

Fixes #5230 — changing the active **rate profile** (and **battery profile**) from a TX adjustment switch was no longer reflected in the Configurator UI.

## Root cause

The Vue 3 migration of the PID Tuning tab (#4848, merged after the 2025.12 release) dropped the legacy 500 ms `update_profile` interval / `checkUpdateProfile()` in `src/js/tabs/pid_tuning.js`. That logic compared the selector against `FC.CONFIG.profile` / `rateProfile` (kept fresh by the global `MSP_STATUS_EX` poller) and, on a TX-driven change, updated the dropdown and reloaded the tab.

In the Vue tab, `currentProfile` / `currentRateProfile` are set once on load and never re-synced, so a switch flip was no longer picked up. The **Power tab** (`usePower.js`) has the same gap for Battery Profile (`BATTERY_PROFILE` is TX adjustment function #33).

## Fix

Restore the behaviour using Vue reactivity instead of polling. `FC` is `reactive()` and the global live-status poller already refreshes `FC.CONFIG.profile` / `rateProfile` / `batteryProfile` via `MSP_STATUS_EX`, so:

- **PidTuningTab.vue** — `watch` on `FC.CONFIG.profile` and `FC.CONFIG.rateProfile`; on a change that differs from the selector, re-sync and `loadData()`. Guarded by `isMounted` / `isLoading` / `syncingFromFc` / `pidTuningStore.hasChanges` so it never clobbers unsaved edits, re-enters during the tab's own `onProfileChange`, or fires during an in-flight load.
- **usePower.js** — same pattern on `FC.CONFIG.batteryProfile`, guarded by `hasBatteryProfiles` / `isLoading` / `syncingFromFc` / `dirty`. Adds the `powerReceivedBatteryProfile` message.

Tabs are unmounted (not kept alive) on switch, so the watchers auto-dispose — no polling on hidden tabs.

## Scope note

The related "the UI won't let me select another profile, it resets to the switch position" symptom in the report is **expected firmware behaviour**, not addressed here: while an adjustment actively holds a profile, the firmware re-applies it every loop and overrides any `MSP_SELECT_SETTING` from the Configurator. This PR restores the live *reflection* of the switch position, which is the actual regression.

## Testing

- [ ] SITL/hardware: bind an AUX switch to Rate Profile selection, confirm the PID Tuning "Rateprofile" label follows the switch.
- [ ] Same for Battery Profile on the Power tab (API 1.48+).

> Diagnosis and fix are currently based on code analysis; hardware/SITL verification still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Battery profile and PID/rate profile selections now stay in sync with live controller updates, helping the UI reflect changes made from the transmitter without requiring a refresh.
  * Added a new notification when the controller sets a battery profile.

* **Bug Fixes**
  * Reduced the chance of unsaved tuning changes being overwritten during live profile updates.
  * Improved loading behavior so profile refreshes are handled more safely during data fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->