### PR TITLE
Fix Backups tab access while connected and spurious restore CLI errors

### DIFF
--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -386,7 +386,12 @@ async function restoreBackup(backup) {
 
     const fileLines = text.split(/\r?\n/);
     const hasDefaultsPrefix = fileLines.some((line) => line.trim().toLowerCase() === "defaults nosave");
-    const commands = hasDefaultsPrefix ? fileLines : ["defaults nosave", "", ...fileLines];
+    // A `diff all` / `dump` backup ends with a `save`, which reboots the FC. Replaying it
+    // inside the batch reboots the FC mid-batch and the `save` response times out, surfacing
+    // as a spurious "CLI errors" warning on every restore. Drop it and let saveAndReconnect()
+    // persist and reconnect after the batch (it already tolerates the reboot timeout).
+    const withoutSave = fileLines.filter((line) => line.trim().toLowerCase() !== "save");
+    const commands = hasDefaultsPrefix ? withoutSave : ["defaults nosave", "", ...withoutSave];
 
     restoreProgress.value = 0;
     restoreProgressOpen.value = true;

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -269,7 +269,7 @@ export default defineComponent({
                     .map((item) => ({
                         label: i18n.getMessage(item.i18n),
                         icon: item.icon,
-                        onSelect: () => switchTab(item.key),
+                        onSelect: () => switchTab(item.key, { mode: item.mode }),
                     })),
                 trailingItems,
             );


### PR DESCRIPTION
Two fixes to the Backups tab, found while testing cloud backup/restore against a real FC (NERO F722, 2026.6.0-alpha).

- **Backups/User Profile unreachable while connected** — the user-session menu called `switchTab(item.key)` with no mode. When connected, `allowedTabs` omits these logged-in tabs (they only appear in the disconnected list), so the switch took the disallowed path and the tab never opened. Backup create/restore both require a connection, so the Backups tab was effectively unusable. Now passes `{ mode: item.mode }` so `switchTab` treats them as login-section tabs and bypasses the connection-gated list.
- **Restore always warned "Backup applied with CLI errors"** — a `diff all` backup ends with a trailing `save`, which reboots the FC. Replaying it inside the restore batch rebooted the FC mid-batch and the save response timed out after 5s, raising the warning on every restore while the clean success path never ran. Now stripped from the batch, leaving the existing `saveAndReconnect()` to persist and reconnect (it already tolerates the reboot timeout).

Verified end-to-end: connect -> create backup -> restore -> save/reboot/reconnect, clean success with no error dialog.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring backups now skips standalone `save` entries, preventing them from being replayed during restore.
  * Sidebar menu items now switch tabs with the correct mode, improving navigation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->