### PR TITLE
Fix waypoint type/pattern dropdowns being unselectable in the flight plan editor

### DIFF
--- a/src/components/tabs/FlightPlan/WaypointEditor.vue
+++ b/src/components/tabs/FlightPlan/WaypointEditor.vue
@@ -2,7 +2,15 @@
     <Dialog v-model="showEditorDialog" :title="editMode ? $t('flightPlanEditWaypoint') : $t('flightPlanAddWaypoint')">
         <form ref="formElement" class="editor-form flex flex-col gap-3" @submit.prevent="handleSave">
             <SettingRow :label="$t('flightPlanType')" full-width>
-                <USelect v-model="form.type" :items="typeItems" :aria-label="$t('flightPlanType')" class="w-48" />
+                <!-- content z must clear the Dialog overlay/content (z-3000/3001) or the
+                     teleported option list renders behind the modal and can't be clicked. -->
+                <USelect
+                    v-model="form.type"
+                    :items="typeItems"
+                    :aria-label="$t('flightPlanType')"
+                    class="w-48"
+                    :ui="{ content: 'z-3002' }"
+                />
             </SettingRow>
 
             <SettingRow v-if="showPosition" :label="$t('flightPlanLatitude')" full-width>
@@ -82,6 +90,7 @@
                     :items="patternItems"
                     :aria-label="$t('flightPlanPattern')"
                     class="w-48"
+                    :ui="{ content: 'z-3002' }"
                 />
             </SettingRow>
         </form>


### PR DESCRIPTION
Users reported the waypoint type couldn't be changed on the Flight Plan page (stuck on "Fly Over").

The waypoint editor uses the shared `Dialog` (`UModal`), whose overlay is `z-3000` / content `z-3001` so it clears the Leaflet map. The **Waypoint Type** and **Hold pattern** `USelect` option lists teleport to `<body>` at Nuxt UI's default z-index, which sits *below* that overlay — so the open dropdown rendered behind the modal and none of the options could be clicked. Raised both selects' popover content above the dialog layers (`:ui="{ content: 'z-[3010]' }"`).

Verified end-to-end against the running app: every type is now selectable (Fly By, Hold, etc.), the conditional Hold pattern select works too (Figure-8), and waypoints save with the chosen type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved waypoint editor dropdown layering so waypoint **type** options remain clickable above the dialog overlay.
  * Improved waypoint editor dropdown layering so **pattern** options for **hold** waypoints also render above the dialog overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->