### PR TITLE
Feature the latest release web app at the top of the downloads page; white headings

### DIFF
--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -98,6 +98,102 @@ function fileList(entries) {
     return `<ul class="file-list">${entries.map(fileListItem).join("")}</ul>`;
 }
 
+// The per-release web app lives at https://<major>-<minor>.app.betaflight.com
+// (CalVer, e.g. 2026.6.0-RC1 -> https://2026-6.app.betaflight.com). That scheme
+// begins with 2026.6; older releases have no such subdomain.
+const RELEASE_WEBAPP_MIN = { major: 2026, minor: 6 };
+
+// Parse a CalVer/SemVer tag ("2026.6.0", "2026.6.0-RC1", "v2026.6.0") into its
+// numeric parts plus an optional pre-release string.
+function parseVersion(tag) {
+    const match = /(\d+)\.(\d+)\.(\d+)(?:-(.+))?/.exec(tag || "");
+    if (!match) {
+        return null;
+    }
+    return { major: Number(match[1]), minor: Number(match[2]), patch: Number(match[3]), pre: match[4] || null };
+}
+
+// SemVer pre-release comparison, natural within each dot identifier so RC10 > RC2.
+function comparePre(a, b) {
+    const chunks = (s) => s.match(/\d+|\D+/g) || [];
+    const ca = chunks(a);
+    const cb = chunks(b);
+    for (let i = 0; i < Math.max(ca.length, cb.length); i++) {
+        const x = ca[i];
+        const y = cb[i];
+        if (x === undefined) return -1;
+        if (y === undefined) return 1;
+        const xn = /^\d+$/.test(x);
+        const yn = /^\d+$/.test(y);
+        if (xn && yn) {
+            const d = Number(x) - Number(y);
+            if (d !== 0) return d;
+        } else if (x !== y) {
+            return x < y ? -1 : 1;
+        }
+    }
+    return 0;
+}
+
+// Returns >0 when a is the higher version. A final release outranks a
+// pre-release of the same major.minor.patch (SemVer precedence).
+function compareVersions(a, b) {
+    for (const key of ["major", "minor", "patch"]) {
+        if (a[key] !== b[key]) return a[key] - b[key];
+    }
+    if (!a.pre && b.pre) return 1;
+    if (a.pre && !b.pre) return -1;
+    if (!a.pre && !b.pre) return 0;
+    return comparePre(a.pre, b.pre);
+}
+
+// Highest-versioned release (CalVer/SemVer), regardless of publish order.
+function highestRelease(releases) {
+    let best = null;
+    for (const release of releases) {
+        const version = parseVersion(release.tag_name);
+        if (!version) {
+            continue;
+        }
+        if (!best || compareVersions(version, best.version) > 0) {
+            best = { release, version };
+        }
+    }
+    return best;
+}
+
+// Which web app the hero should point at. A final release is what
+// app.betaflight.com already serves, so link there; a pre-release (e.g. an RC)
+// gets its own versioned subdomain. Pre-releases predating the versioned scheme
+// have no subdomain, so no hero.
+function heroWebApp(top, releaseUrl) {
+    if (!top) {
+        return null;
+    }
+    if (!top.release.prerelease) {
+        return { url: releaseUrl };
+    }
+    const { major, minor } = top.version;
+    if (major * 1000 + minor < RELEASE_WEBAPP_MIN.major * 1000 + RELEASE_WEBAPP_MIN.minor) {
+        return null;
+    }
+    return { url: `https://${major}-${minor}.app.betaflight.com` };
+}
+
+function renderReleaseWebAppSection(top, hero) {
+    if (!top || !hero) {
+        return "";
+    }
+    const tag = escapeHtml(top.release.tag_name);
+    const host = escapeHtml(hero.url.replace(/^https:\/\//, ""));
+    return `
+            <section class="release-hero">
+                <h2>Betaflight App &mdash; ${tag}</h2>
+                <p><a class="hero-link" href="${escapeHtml(hero.url)}">Open the web app for this release &rarr;</a></p>
+                <p class="meta">Runs in your browser at ${host}</p>
+            </section>`;
+}
+
 function renderWebAppSection(masterUrl, releaseUrl) {
     return `
             <section>
@@ -282,7 +378,13 @@ try {
     const masterUrl = args["master-url"] || "https://master.betaflight-app.pages.dev";
     const releaseUrl = args["release-url"] || "https://app.betaflight.com";
 
+    // Feature the highest-versioned release at the top: final releases link to
+    // app.betaflight.com, pre-releases to their own versioned subdomain.
+    const topRelease = highestRelease(publicReleases);
+    const hero = heroWebApp(topRelease, releaseUrl);
+
     const sections = [
+        renderReleaseWebAppSection(topRelease, hero),
         renderWebAppSection(masterUrl, releaseUrl),
         renderNightlySection(manifest.nightly),
         renderLatestStableSection(latestStable),

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -106,7 +106,8 @@ const RELEASE_WEBAPP_MIN = { major: 2026, minor: 6 };
 // Parse a CalVer/SemVer tag ("2026.6.0", "2026.6.0-RC1", "v2026.6.0") into its
 // numeric parts plus an optional pre-release string.
 function parseVersion(tag) {
-    const match = /(\d+)\.(\d+)\.(\d+)(?:-(.+))?/.exec(tag || "");
+    // Start-anchored with a bounded pre-release class to keep matching linear.
+    const match = /^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?/.exec(tag || "");
     if (!match) {
         return null;
     }
@@ -121,13 +122,19 @@ function comparePre(a, b) {
     for (let i = 0; i < Math.max(ca.length, cb.length); i++) {
         const x = ca[i];
         const y = cb[i];
-        if (x === undefined) return -1;
-        if (y === undefined) return 1;
+        if (x === undefined) {
+            return -1;
+        }
+        if (y === undefined) {
+            return 1;
+        }
         const xn = /^\d+$/.test(x);
         const yn = /^\d+$/.test(y);
         if (xn && yn) {
             const d = Number(x) - Number(y);
-            if (d !== 0) return d;
+            if (d !== 0) {
+                return d;
+            }
         } else if (x !== y) {
             return x < y ? -1 : 1;
         }
@@ -139,11 +146,19 @@ function comparePre(a, b) {
 // pre-release of the same major.minor.patch (SemVer precedence).
 function compareVersions(a, b) {
     for (const key of ["major", "minor", "patch"]) {
-        if (a[key] !== b[key]) return a[key] - b[key];
+        if (a[key] !== b[key]) {
+            return a[key] - b[key];
+        }
     }
-    if (!a.pre && b.pre) return 1;
-    if (a.pre && !b.pre) return -1;
-    if (!a.pre && !b.pre) return 0;
+    if (!a.pre && b.pre) {
+        return 1;
+    }
+    if (a.pre && !b.pre) {
+        return -1;
+    }
+    if (!a.pre && !b.pre) {
+        return 0;
+    }
     return comparePre(a.pre, b.pre);
 }
 

--- a/scripts/templates/downloads-index.html
+++ b/scripts/templates/downloads-index.html
@@ -60,7 +60,7 @@
             header h1 {
                 font-size: 1.5rem;
                 margin: 0;
-                color: var(--primary-500);
+                color: #fff;
             }
 
             main {
@@ -75,7 +75,7 @@
 
             h2 {
                 font-size: 1.2rem;
-                color: var(--primary-500);
+                color: #fff;
                 border-bottom: 1px solid var(--surface-400);
                 padding-bottom: 0.4rem;
                 margin: 0 0 0.75rem;
@@ -83,9 +83,17 @@
 
             h3 {
                 font-size: 0.95rem;
-                color: var(--text);
+                color: #fff;
                 margin: 1rem 0 0.25rem;
                 font-weight: 600;
+            }
+
+            /* Headings are white, but a heading that carries an anchor keeps the
+               link colour so a linked heading still reads as a link. */
+            h1 a,
+            h2 a,
+            h3 a {
+                color: var(--link);
             }
 
             .meta,
@@ -159,6 +167,22 @@
             .empty {
                 color: var(--text-dim);
                 font-style: italic;
+            }
+
+            .release-hero {
+                background: var(--surface-200);
+                border: 1px solid var(--surface-400);
+                border-radius: 8px;
+                padding: 1.25rem 1.5rem;
+            }
+            .release-hero h2 {
+                border-bottom: none;
+                padding-bottom: 0;
+                margin-bottom: 0.5rem;
+            }
+            .hero-link {
+                font-size: 1.15rem;
+                font-weight: 600;
             }
         </style>
     </head>

--- a/scripts/templates/downloads-index.html
+++ b/scripts/templates/downloads-index.html
@@ -60,7 +60,7 @@
             header h1 {
                 font-size: 1.5rem;
                 margin: 0;
-                color: #fff;
+                color: var(--text);
             }
 
             main {
@@ -75,7 +75,7 @@
 
             h2 {
                 font-size: 1.2rem;
-                color: #fff;
+                color: var(--text);
                 border-bottom: 1px solid var(--surface-400);
                 padding-bottom: 0.4rem;
                 margin: 0 0 0.75rem;
@@ -83,7 +83,7 @@
 
             h3 {
                 font-size: 0.95rem;
-                color: #fff;
+                color: var(--text);
                 margin: 1rem 0 0.25rem;
                 font-weight: 600;
             }


### PR DESCRIPTION
Two changes to the `downloads.betaflight.com` static index (`scripts/generate-downloads-index.mjs` + template).

**Release web app hero.** Adds a hero at the top of the page linking to the highest-versioned release's web app. Selection is by CalVer/SemVer precedence, not publish date, so the newest release line wins even if an older line is published later, and RC10 outranks RC2. A final release is what `app.betaflight.com` already serves, so the hero links there; a pre-release (e.g. an RC) links to its own versioned subdomain — `2026.6.0-RC1` → `https://2026-6.app.betaflight.com` — for the scheme that begins with 2026.6. (No `npm` deps in the publish job, so the comparator is inline rather than the `semver` package.)

**White headings.** Section headings are now white; anchors inside a heading keep the link colour so a linked heading still reads as a link.

Verified by running the generator against fixtures for: RC pre-release (versioned subdomain), final release (app.betaflight.com), a final + its RC (final wins → app.betaflight.com), highest-version-beats-newest-date, and RC10 > RC2.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a release-specific “Betaflight App” hero section on downloads pages, highlighting the most relevant app link for the latest release.
  * Support now selects between a stable app link and a versioned app subdomain for eligible pre-releases (with older pre-releases omitting the hero).

* **Style**
  * Updated page heading styling for improved contrast and link color consistency.
  * Added new styling for the release hero area and a more prominent hero link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->