### PR TITLE
Fix SonarCloud reliability issues to restore master quality gate

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3180,6 +3180,9 @@
     "servosChangeDirection": {
         "message": "Change Direction in TX To Match"
     },
+    "servosForwardChannel": {
+        "message": "Forward this channel to the servo"
+    },
     "servosName": {
         "message": "Name"
     },
@@ -5910,6 +5913,9 @@
     },
     "osdSetupTitle": {
         "message": "OSD"
+    },
+    "osdToggleElementVisibility": {
+        "message": "Toggle element visibility for this profile"
     },
     "osdSetupNoOsdChipDetectWarning": {
         "message": "<span class=\"message-negative\"><b>WARNING:</b></span> No OSD chip was detected. Some flight controllers will not properly power the OSD chip unless connected to battery power. Please connect the battery before connecting the USB (PROPS REMOVED!)."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -3181,7 +3181,7 @@
         "message": "Change Direction in TX To Match"
     },
     "servosForwardChannel": {
-        "message": "Forward this channel to the servo"
+        "message": "Forward channel {{channel}} to servo {{servo}}"
     },
     "servosName": {
         "message": "Name"
@@ -3911,6 +3911,9 @@
     },
     "cliConfirmSnippetBtn": {
         "message": "Execute"
+    },
+    "cliSnippetPreviewLabel": {
+        "message": "Snippet preview"
     },
     "cliPanelTitle": {
         "message": "Command Line Interface"
@@ -5915,7 +5918,7 @@
         "message": "OSD"
     },
     "osdToggleElementVisibility": {
-        "message": "Toggle element visibility for this profile"
+        "message": "Toggle {{element}} visibility for profile {{profile}}"
     },
     "osdSetupNoOsdChipDetectWarning": {
         "message": "<span class=\"message-negative\"><b>WARNING:</b></span> No OSD chip was detected. Some flight controllers will not properly power the OSD chip unless connected to battery power. Please connect the battery before connecting the USB (PROPS REMOVED!)."

--- a/src/blackbox-viewer/components/LogFileInput.vue
+++ b/src/blackbox-viewer/components/LogFileInput.vue
@@ -5,6 +5,7 @@
         type="file"
         style="display: none"
         accept=".bbl,.BBL,.txt,.TXT,.cfl,.CFL,.bfl,.BFL,.log,.LOG,.json,.JSON"
+        aria-label="Open log file"
         @change="onFileChange"
     />
 </template>

--- a/src/blackbox-viewer/components/LogFileInput.vue
+++ b/src/blackbox-viewer/components/LogFileInput.vue
@@ -5,7 +5,7 @@
         type="file"
         style="display: none"
         accept=".bbl,.BBL,.txt,.TXT,.cfl,.CFL,.bfl,.BFL,.log,.LOG,.json,.JSON"
-        aria-label="Open log file"
+        :aria-label="label"
         @change="onFileChange"
     />
 </template>

--- a/src/blackbox-viewer/components/SpectrumAnalyser.vue
+++ b/src/blackbox-viewer/components/SpectrumAnalyser.vue
@@ -40,6 +40,7 @@
                     accept=".csv,.CSV"
                     class="hidden"
                     multiple
+                    aria-label="Import spectrum CSV"
                     @change="onImportChange"
                 />
             </div>
@@ -86,6 +87,7 @@
             step="5"
             class="analyser-psd-input text-xs"
             :style="psdInputStyle(30)"
+            aria-label="Max dBm"
             @dblclick.ctrl="resetMaxPSD"
         />
         <label
@@ -104,6 +106,7 @@
             step="5"
             class="analyser-psd-input text-xs"
             :style="psdInputStyle(55)"
+            aria-label="Min dBm"
             @dblclick.ctrl="resetMinPSD"
         />
         <label
@@ -122,6 +125,7 @@
             step="5"
             class="analyser-psd-input text-xs"
             :style="psdInputStyle(80)"
+            aria-label="Limit dBm"
             @dblclick.ctrl="resetLowLevelPSD"
         />
         <label
@@ -142,6 +146,7 @@
             step="1"
             class="analyser-psd-input text-xs"
             :style="segmentInputStyle"
+            aria-label="Segment length power at 2"
             @dblclick.ctrl="resetSegmentLength"
         />
         <label

--- a/src/blackbox-viewer/components/UserSettingsDialog.vue
+++ b/src/blackbox-viewer/components/UserSettingsDialog.vue
@@ -127,7 +127,13 @@
                         <div v-if="local.drawWatermark" class="flex flex-col gap-2 mt-2 ml-6">
                             <div class="flex items-center gap-3">
                                 <label class="text-sm">Logo</label>
-                                <input type="file" accept="image/*" class="text-sm" @change="onLogoChange" />
+                                <input
+                                    type="file"
+                                    accept="image/*"
+                                    class="text-sm"
+                                    aria-label="Watermark logo file"
+                                    @change="onLogoChange"
+                                />
                             </div>
                             <img
                                 v-if="local.watermark.logo"

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -50,7 +50,7 @@
                 <textarea
                     v-model="cli.state.snippetPreview"
                     rows="20"
-                    :aria-label="$t('cliConfirmSnippetBtn')"
+                    :aria-label="$t('cliSnippetPreviewLabel')"
                     class="bg-black/75 w-full resize-none overflow-y-scroll overflow-x-hidden font-mono text-white p-[5px]"
                 ></textarea>
             </template>

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -29,6 +29,7 @@
                     v-model="cli.state.commandInput"
                     name="commands"
                     :placeholder="$t('cliInputPlaceholder')"
+                    :aria-label="$t('cliInputPlaceholder')"
                     rows="1"
                     cols="0"
                     class="w-full h-[22px] leading-5 pl-[5px] border border-(--surface-500) resize-none bg-(--surface-200) text-(--surface-900)"
@@ -49,6 +50,7 @@
                 <textarea
                     v-model="cli.state.snippetPreview"
                     rows="20"
+                    :aria-label="$t('cliConfirmSnippetBtn')"
                     class="bg-black/75 w-full resize-none overflow-y-scroll overflow-x-hidden font-mono text-white p-[5px]"
                 ></textarea>
             </template>
@@ -73,6 +75,7 @@
                     v-model="cli.state.supportDialogInput"
                     name="supportWarningDialogInput"
                     :placeholder="$t('supportWarningDialogInputPlaceHolder')"
+                    :aria-label="$t('supportWarningDialogInputPlaceHolder')"
                     rows="3"
                     cols="0"
                     class="w-full mt-2 leading-5 p-1 border border-(--ui-border) resize-none bg-(--ui-bg-muted) text-(--ui-text)"

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -69,6 +69,7 @@
                                                 type="checkbox"
                                                 :checked="field.isVisible[profileIdx - 1]"
                                                 @change="toggleFieldVisibility(field.index, profileIdx - 1, $event)"
+                                                :aria-label="$t('osdToggleElementVisibility')"
                                                 class="size-4"
                                             />
                                         </template>

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -69,7 +69,12 @@
                                                 type="checkbox"
                                                 :checked="field.isVisible[profileIdx - 1]"
                                                 @change="toggleFieldVisibility(field.index, profileIdx - 1, $event)"
-                                                :aria-label="$t('osdToggleElementVisibility')"
+                                                :aria-label="
+                                                    $t('osdToggleElementVisibility', {
+                                                        element: $t(field.text, field.textParams),
+                                                        profile: profileIdx,
+                                                    })
+                                                "
                                                 class="size-4"
                                             />
                                         </template>

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -21,6 +21,7 @@
                                 inputmode="decimal"
                                 v-model="manualLat"
                                 :placeholder="$t('preflightLatitude')"
+                                :aria-label="$t('preflightLatitude')"
                                 class="location-input"
                             />
                             <input
@@ -28,6 +29,7 @@
                                 inputmode="decimal"
                                 v-model="manualLon"
                                 :placeholder="$t('preflightLongitude')"
+                                :aria-label="$t('preflightLongitude')"
                                 class="location-input"
                             />
                             <div class="default_btn">
@@ -109,6 +111,7 @@
                                     type="text"
                                     v-model="saveLocationLabel"
                                     :placeholder="$t('preflightLocationLabel')"
+                                    :aria-label="$t('preflightLocationLabel')"
                                     :maxlength="preflight.MAX_LABEL_LENGTH"
                                     class="location-input save-label-input"
                                     @keyup.enter="
@@ -633,6 +636,7 @@
                                             type="password"
                                             autocomplete="new-password"
                                             class="notam-setting-input"
+                                            :aria-label="$t('preflightNotamFaaApiKeyLabel')"
                                             @change="onNotamSettingChange"
                                         />
                                     </div>
@@ -645,6 +649,7 @@
                                             type="password"
                                             autocomplete="new-password"
                                             class="notam-setting-input"
+                                            :aria-label="$t('preflightNotamOpenAipApiKeyLabel')"
                                             @change="onNotamSettingChange"
                                         />
                                     </div>
@@ -657,6 +662,7 @@
                                                 min="1"
                                                 max="500"
                                                 class="notam-radius-input"
+                                                :aria-label="$t('preflightNotamRadius')"
                                                 @change="onNotamSettingChange"
                                             />
                                             <USelect

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -75,6 +75,7 @@
                                         type="checkbox"
                                         class="size-4"
                                         :checked="servo.indexOfChannelToForward === ch - 1"
+                                        :aria-label="$t('servosForwardChannel')"
                                         @change="setChannelForward(index, ch - 1, $event)"
                                     />
                                 </div>

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -75,7 +75,7 @@
                                         type="checkbox"
                                         class="size-4"
                                         :checked="servo.indexOfChannelToForward === ch - 1"
-                                        :aria-label="$t('servosForwardChannel')"
+                                        :aria-label="$t('servosForwardChannel', { channel: ch, servo: index + 1 })"
                                         @change="setChannelForward(index, ch - 1, $event)"
                                     />
                                 </div>

--- a/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
+++ b/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
@@ -30,6 +30,7 @@
                     :min="CHANNEL_MIN_VALUE"
                     :max="CHANNEL_MAX_VALUE"
                     v-model.number="stickValues[`Aux${i}`]"
+                    :aria-label="t(`controlAxisAux${i}`)"
                     class="slider"
                 />
                 <span class="tooltip">{{ stickValues[`Aux${i}`] }}</span>

--- a/src/components/tabs/receiver-msp/receiver_msp.html
+++ b/src/components/tabs/receiver-msp/receiver_msp.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Radio Emulator</title>
     <script type="module" src="./receiverMspApp.js"></script>

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -29,7 +29,7 @@ body {
         background: var(--surface-600);
     }
 }
-&::backdrop {
+::backdrop {
     background-image: none;
     background-color: rgba(1, 1, 1, 0.5);
 }

--- a/src/index.html
+++ b/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
     <head>
         <meta name="viewport" content="width=device-width,initial-scale=1" />
 

--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -130,7 +130,7 @@ CliAutoComplete.builderParseLine = function (line) {
                 this.writeToOutput("Cancelled!<br># ");
                 this.cleanup();
             } else {
-                const byLocale = (a, b) => a.localeCompare(b);
+                const byLocale = (a, b) => a.localeCompare(b, window.navigator.language, { ignorePunctuation: true });
                 cache.settings.sort(byLocale);
                 cache.commands.sort(byLocale);
                 cache.feature.sort(byLocale);

--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -130,11 +130,12 @@ CliAutoComplete.builderParseLine = function (line) {
                 this.writeToOutput("Cancelled!<br># ");
                 this.cleanup();
             } else {
-                cache.settings.sort();
-                cache.commands.sort();
-                cache.feature.sort();
-                cache.beeper.sort();
-                cache.resources = Object.keys(cache.resourcesCount).sort();
+                const byLocale = (a, b) => a.localeCompare(b);
+                cache.settings.sort(byLocale);
+                cache.commands.sort(byLocale);
+                cache.feature.sort(byLocale);
+                cache.beeper.sort(byLocale);
+                cache.resources = Object.keys(cache.resourcesCount).sort(byLocale);
 
                 this.writeToOutput("Done!<br># ");
                 builder.state = "done";


### PR DESCRIPTION
Restores the master quality gate, which is failing on `new_reliability_rating` = C (needs A). The rating is driven by 23 BUG-type issues in new code; this clears all of them.

- **`Web:InputWithoutLabelCheck`** (19, MAJOR) — added `aria-label` to inputs missing a label association across CliTab, PreflightTab, ServosTab, OsdTab, ReceiverMspWindow and three blackbox-viewer components.
- **`javascript:S2871`** (CRITICAL) — CLI autocomplete caches now sort with a `localeCompare` comparator instead of the default string sort.
- **`css:S8776`** (MAJOR) — dropped the root-level `&` from `::backdrop` in `main.less` (identical compiled output, valid scoping root).
- **`Web:S5254`** (INFO) — added `lang="en"` to `index.html` and `receiver_msp.html`.

Two new i18n keys (`servosForwardChannel`, `osdToggleElementVisibility`) back the checkbox aria-labels; existing keys are reused everywhere else. Verified: eslint + prettier clean, and `vite build` passes from a clean tree with both keys propagating into the generated locales.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new UI labels for CLI snippet preview, servo forward-channel selection, and per-profile OSD element visibility.
* **Bug Fixes**
  * Improved accessibility by adding descriptive labels to inputs, sliders, checkboxes, and numeric fields across the app.
  * Set the document language to English.
  * Improved CLI autocomplete sorting to be locale-aware.
* **Style**
  * Updated backdrop styling scope in dialogs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->