### PR TITLE
docs(agents): tests must catch bugs, not confirm the fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,7 @@ Already enforced by ESLint / Prettier / EditorConfig (and intentionally absent b
 | Don't edit `dist/`, `node_modules/`, generated output | 🚧 | Pre-commit hook by path (Phase 0) |
 | i18n source of truth is `locales/en/messages.json` (Crowdin syncs the rest) | 🚧 | Pre-commit hook rejecting non-`en` locale edits (Phase 0) |
 | Tests for non-trivial behaviour (Vitest, `npm run test`) | 📐 | Coverage gate is a proxy; review call |
+| Tests must catch bugs, not confirm the fix. A suite co-authored with the change is confirmation-biased — it passes while the code is still broken. Verify by driving the real behaviour (hardware/e2e), and write bug-hunting tests independently/adversarially, ideally blind to the implementation. | 📐 | Review call; separate adversarial pass |
 | One concern per PR (one tab, one store, one TS file) | 📐 | PR template / reviewer call |
 
 ## Phase plan


### PR DESCRIPTION
Adds one guidance row to `AGENTS.md` (the "Always-on" enforcement table):

> **Tests must catch bugs, not confirm the fix.** A suite co-authored with the change is confirmation-biased — it passes while the code is still broken. Verify by driving the real behaviour (hardware/e2e), and write bug-hunting tests independently/adversarially, ideally blind to the implementation.

## Why

Learned the hard way while debugging the BLE reconnect regression: tests written alongside the fix stayed green through several genuinely broken reconnect attempts, because they encoded the same wrong mental model as the fix — they confirmed the implementation rather than probing it. What actually caught the bugs was driving the real hardware plus diagnostic logging, i.e. an independent signal.

Documenting it so the next AI-assisted contribution reaches for an independent/adversarial test pass instead of a confirmation-biased one co-authored with the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified testing guidance to emphasize adversarial, bug-hunting verification over confirmation-biased checks.
  * Encouraged validation based on real behavior, including end-to-end and hardware-driven testing where applicable.
  * Added guidance to write tests independently and with a critical mindset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->