### PR TITLE
Set modal z-index once in the Nuxt UI theme

### DIFF
--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -45,6 +45,12 @@ export default {
                 text: "whitespace-normal",
             },
         },
+        modal: {
+            slots: {
+                overlay: "fixed inset-0 z-3000",
+                content: "bg-default divide-y divide-default flex flex-col focus:outline-none z-3001",
+            },
+        },
         switch: {
             slots: {
                 base: "cursor-pointer",

--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -47,6 +47,11 @@ export default {
         },
         modal: {
             slots: {
+                // Slot overrides replace the base class string (not merged), so Nuxt UI's base
+                // classes are restated with the z-index appended. The bg-elevated/75 dimming is
+                // unaffected: it comes from the overlay variant, composed on top at runtime.
+                // z-3000/z-3001 keeps modals above all app dialogs (z-1000–2001) and the
+                // ConnectButton dropdown (z-2100), with the content above its own overlay.
                 overlay: "fixed inset-0 z-3000",
                 content: "bg-default divide-y divide-default flex flex-col focus:outline-none z-3001",
             },

--- a/src/components/dialogs/CopyProfileDialog.vue
+++ b/src/components/dialogs/CopyProfileDialog.vue
@@ -4,7 +4,6 @@
         :title="title"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
     >
         <template #body>
             <div class="flex flex-col gap-4">

--- a/src/components/dialogs/InformationDialog.vue
+++ b/src/components/dialogs/InformationDialog.vue
@@ -4,7 +4,6 @@
         :title="title"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
     >
         <template #body>
             <div v-html="text"></div>

--- a/src/components/dialogs/InteractiveDialog.vue
+++ b/src/components/dialogs/InteractiveDialog.vue
@@ -4,7 +4,7 @@
         :title="title"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'max-w-3xl w-[calc(100vw-2rem)] h-[80vh] z-3001' }"
+        :ui="{ content: 'max-w-3xl w-[calc(100vw-2rem)] h-[80vh]' }"
     >
         <template #body>
             <div class="flex flex-col h-full gap-3">

--- a/src/components/dialogs/LogDialog.vue
+++ b/src/components/dialogs/LogDialog.vue
@@ -1,5 +1,5 @@
 <template>
-    <UModal v-model:open="open" :title="$t('tabLog')" :ui="{ overlay: 'z-3000', content: 'max-w-4xl h-full z-3001' }">
+    <UModal v-model:open="open" :title="$t('tabLog')" :ui="{ content: 'max-w-4xl h-full' }">
         <template #body>
             <div class="flex flex-col min-h-full">
                 <div class="log-toolbar">

--- a/src/components/dialogs/OptionsDialog.vue
+++ b/src/components/dialogs/OptionsDialog.vue
@@ -2,7 +2,7 @@
     <UModal
         v-model:open="open"
         :title="$t('tabOptions')"
-        :ui="{ overlay: 'z-3000', content: 'max-w-4xl h-full z-3001' }"
+        :ui="{ content: 'max-w-4xl h-full' }"
     >
         <template #body>
             <div class="flex flex-col gap-4">

--- a/src/components/dialogs/ProfileSelectionDialog.vue
+++ b/src/components/dialogs/ProfileSelectionDialog.vue
@@ -4,7 +4,6 @@
         :title="title"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
     >
         <template #body>
             <div class="flex flex-col gap-4">

--- a/src/components/dialogs/RatesTypeDialog.vue
+++ b/src/components/dialogs/RatesTypeDialog.vue
@@ -4,7 +4,6 @@
         :title="title"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
     >
         <template #body>
             <div class="dialogRatesTypeContent" v-html="note"></div>

--- a/src/components/dialogs/RebootDialog.vue
+++ b/src/components/dialogs/RebootDialog.vue
@@ -4,7 +4,6 @@
         :title="status"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
     >
         <template #body>
             <UProgress :model-value="progress" :max="100" />

--- a/src/components/dialogs/ReportProblemsDialog.vue
+++ b/src/components/dialogs/ReportProblemsDialog.vue
@@ -4,7 +4,6 @@
         :title="$t('warningTitle')"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
     >
         <template #body>
             <div class="dialogReportProblems-header" v-html="$t('reportProblemsDialogHeader')"></div>

--- a/src/components/dialogs/WaitDialog.vue
+++ b/src/components/dialogs/WaitDialog.vue
@@ -4,7 +4,6 @@
         :title="title"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
     >
         <template #body>
             <div class="flex justify-center py-2">

--- a/src/components/dialogs/YesNoDialog.vue
+++ b/src/components/dialogs/YesNoDialog.vue
@@ -4,7 +4,6 @@
         :title="title"
         :close="false"
         :dismissible="false"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
     >
         <template #body>
             <!-- Note: 'text' is rendered using v-html to support bolding/links in i18n messages.

--- a/src/components/elements/Dialog.vue
+++ b/src/components/elements/Dialog.vue
@@ -4,7 +4,6 @@
         :title="title"
         :close="closeable"
         :dismissible="closeable"
-        :ui="{ overlay: 'z-3000', content: 'z-3001' }"
         @update:open="onOpenChange"
     >
         <template #body>

--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -104,7 +104,7 @@
                 :open="restoreProgressOpen"
                 :close="false"
                 :dismissible="false"
-                :ui="{ overlay: 'z-3000', content: 'w-[320px] z-3001' }"
+                :ui="{ content: 'w-[320px]' }"
             >
                 <template #body>
                     <div class="text-lg mb-2" v-html="$t('userBackupRestoreInProgress')"></div>
@@ -118,7 +118,7 @@
                 :open="restoreErrorsOpen"
                 :close="false"
                 :dismissible="false"
-                :ui="{ overlay: 'z-3000', content: 'w-[600px] max-w-[calc(100vw-2rem)] z-3001' }"
+                :ui="{ content: 'w-[600px] max-w-[calc(100vw-2rem)]' }"
             >
                 <template #title>
                     <span v-html="$t('userBackupRestoreErrors')"></span>

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -42,7 +42,7 @@
         </div>
 
         <!-- Snippet preview dialog -->
-        <UModal v-model:open="snippetPreviewOpen" :ui="{ overlay: 'z-3000', content: 'w-[600px] z-3001' }">
+        <UModal v-model:open="snippetPreviewOpen" :ui="{ content: 'w-[600px]' }">
             <template #body>
                 <div class="note mb-3">
                     <p v-html="$t('cliConfirmSnippetNote')"></p>
@@ -67,7 +67,7 @@
             :title="$t('supportWarningDialogTitle')"
             :close="false"
             :dismissible="false"
-            :ui="{ overlay: 'z-3000', content: 'w-[400px] z-3001' }"
+            :ui="{ content: 'w-[400px]' }"
         >
             <template #body>
                 <div class="mb-3" v-html="$t('supportWarningDialogText')"></div>

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -95,7 +95,6 @@
             :title="$t('warningTitle')"
             :close="false"
             :dismissible="false"
-            :ui="{ overlay: 'z-3000', content: 'z-3001' }"
         >
             <template #body>
                 <div v-html="$t('unstableFirmwareAcknowledgementDialog')"></div>
@@ -123,7 +122,6 @@
             v-model:open="verifyBoardOpen"
             :close="false"
             :dismissible="false"
-            :ui="{ overlay: 'z-3000', content: 'z-3001' }"
         >
             <template #body>
                 <div v-html="verifyBoardContentHtml"></div>

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -469,7 +469,7 @@
                 v-model:open="settingsChangedOpen"
                 :close="false"
                 :dismissible="false"
-                :ui="{ overlay: 'z-3000', content: 'w-[400px] z-3001' }"
+                :ui="{ content: 'w-[400px]' }"
             >
                 <template #body>
                     <div v-html="warningMessage"></div>
@@ -487,7 +487,7 @@
                 :title="$t('dialogDynFiltersChangeTitle')"
                 :close="false"
                 :dismissible="false"
-                :ui="{ overlay: 'z-3000', content: 'w-[400px] z-3001' }"
+                :ui="{ content: 'w-[400px]' }"
             >
                 <template #body>
                     <div v-html="$t('dialogDynFiltersChangeNote')"></div>

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -86,7 +86,7 @@
                                     :open="eraseOpen"
                                     :close="false"
                                     :dismissible="false"
-                                    :ui="{ overlay: 'z-3000', content: 'w-[36rem] max-w-[calc(100vw-2rem)] z-3001' }"
+                                    :ui="{ content: 'w-[36rem] max-w-[calc(100vw-2rem)]' }"
                                 >
                                     <template #body>
                                         <div class="dataflash-confirm-erase" :class="{ erasing: isErasing }">
@@ -120,7 +120,7 @@
                                     :open="saveOpen"
                                     :close="false"
                                     :dismissible="false"
-                                    :ui="{ overlay: 'z-3000', content: 'w-[36rem] max-w-[calc(100vw-2rem)] z-3001' }"
+                                    :ui="{ content: 'w-[36rem] max-w-[calc(100vw-2rem)]' }"
                                 >
                                     <template #body>
                                         <div class="dataflash-saving" :class="{ done: saveDone }">

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -419,7 +419,7 @@
                 <UModal
                     :open="fontManagerOpen"
                     :title="$t('osdSetupFontManagerTitle')"
-                    :ui="{ overlay: 'z-3000', content: 'w-[750px] z-3001' }"
+                    :ui="{ content: 'w-[750px]' }"
                     @update:open="(value) => !value && closeFontManager()"
                 >
                     <template #body>

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -153,7 +153,7 @@
             :open="store.applyState.progressDialogOpen"
             :close="false"
             :dismissible="false"
-            :ui="{ overlay: 'z-3000', content: 'w-[300px] z-3001' }"
+            :ui="{ content: 'w-[300px]' }"
         >
             <template #body>
                 <div class="text-lg mb-2" v-html="$t('presetsApplyingPresets')"></div>
@@ -166,7 +166,7 @@
             :open="store.applyState.cliErrorsDialogOpen"
             :close="false"
             :dismissible="false"
-            :ui="{ overlay: 'z-3000', content: 'w-[600px] max-w-[calc(100vw-2rem)] z-3001' }"
+            :ui="{ content: 'w-[600px] max-w-[calc(100vw-2rem)]' }"
         >
             <template #title>
                 <span v-html="$t('presetsCliErrorsWarning')"></span>

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -248,7 +248,6 @@
         <UModal
             v-model:open="confirmResetOpen"
             :title="$t('dialogConfirmResetTitle')"
-            :ui="{ overlay: 'z-3000', content: 'z-3001' }"
         >
             <template #body>
                 <div v-html="$t('dialogConfirmResetNote')"></div>
@@ -269,7 +268,7 @@
         <UModal
             v-model:open="buildInfoOpen"
             :title="state.buildInfoDialogTitle"
-            :ui="{ overlay: 'z-3000', content: 'w-fit max-w-2xl z-3001' }"
+            :ui="{ content: 'w-fit max-w-2xl' }"
         >
             <template #body>
                 <div class="dialogBuildInfoGrid-container">

--- a/src/components/tabs/UserProfileTab.vue
+++ b/src/components/tabs/UserProfileTab.vue
@@ -62,7 +62,7 @@
                     :close="false"
                     :dismissible="false"
                     :title="$t('titleEditProfile')"
-                    :ui="{ overlay: 'z-3000', content: 'w-[90%] max-w-[600px] z-3001' }"
+                    :ui="{ content: 'w-[90%] max-w-[600px]' }"
                 >
                     <template #body>
                         <div class="profile-edit-form">

--- a/src/components/tabs/presets/PresetDetailsDialog.vue
+++ b/src/components/tabs/presets/PresetDetailsDialog.vue
@@ -3,8 +3,7 @@
         :open="open"
         :close="false"
         :ui="{
-            overlay: 'z-3000',
-            content: 'w-[600px] max-w-[calc(100vw-2rem)] h-[520px] z-3001',
+            content: 'w-[600px] max-w-[calc(100vw-2rem)] h-[520px]',
             body: 'overflow-visible min-h-0',
         }"
         @update:open="onOpenChange"

--- a/src/components/tabs/presets/PresetSourcesDialog.vue
+++ b/src/components/tabs/presets/PresetSourcesDialog.vue
@@ -1,7 +1,7 @@
 <template>
     <UModal
         :open="open"
-        :ui="{ overlay: 'z-3000', content: 'w-[600px] max-w-[calc(100vw-2rem)] h-[520px] z-3001' }"
+        :ui="{ content: 'w-[600px] max-w-[calc(100vw-2rem)] h-[520px]' }"
         @update:open="onOpenChange"
     >
         <template #title>

--- a/src/components/user-session/UserSession.vue
+++ b/src/components/user-session/UserSession.vue
@@ -40,7 +40,7 @@
             </div>
 
             <!-- Login Dialog -->
-            <UModal v-model:open="loginDialogOpen" :ui="{ overlay: 'z-3000', content: 'max-w-sm z-3001' }">
+            <UModal v-model:open="loginDialogOpen" :ui="{ content: 'max-w-sm' }">
                 <template #header="{ close }">
                     <div class="flex items-start justify-between gap-2 w-full">
                         <div class="dialog-header-stack">
@@ -166,7 +166,7 @@
             </UModal>
 
             <!-- Verification Code Dialog -->
-            <UModal v-model:open="verificationDialogOpen" :ui="{ overlay: 'z-3000', content: 'max-w-sm z-3001' }">
+            <UModal v-model:open="verificationDialogOpen" :ui="{ content: 'max-w-sm' }">
                 <template #header="{ close }">
                     <div class="flex items-start justify-between gap-2 w-full">
                         <div class="dialog-header-stack">
@@ -207,7 +207,6 @@
                 :close="false"
                 :dismissible="false"
                 title=""
-                :ui="{ overlay: 'z-3000', content: 'z-3001' }"
             >
                 <template #body>
                     <div class="waiting-container">


### PR DESCRIPTION
The overlay z-3000 / content z-3001 pair was copy-pasted into the :ui prop of every UModal call site (~33 places). This moves it into the modal theme default in nuxt-ui.vite.js — same pattern as the existing tooltip override — so call sites only pass their own sizing classes. Call-site :ui overrides still merge on top at runtime. Verified the built CSS still generates both utilities now that they only appear in the theme config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized modal overlay/content styling across dialogs and tabs for more consistent stacking and behavior.
  * Removed hardcoded per-dialog z-index overrides, relying on the shared modal defaults for clearer, more uniform presentation.
  * Simplified several modal layouts to use consistent sizing/width constraints, improving appearance across different screen sizes.
* **Chores**
  * Updated shared modal configuration to enforce consistent overlay/content stacking globally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->