### PR TITLE
Use UProgress for the remaining bespoke progress bars

### DIFF
--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -127,7 +127,7 @@
                                             <h3>{{ $t("dataflashSavingTitle") }}</h3>
                                             <div class="dataflash-saving-before">
                                                 <div>{{ $t("dataflashSavingNote") }}</div>
-                                                <progress :value="saveProgress" min="0" max="100"></progress>
+                                                <UProgress :model-value="saveProgress" :max="100" size="2xl" />
                                                 <div class="buttons flex justify-end gap-2 mt-3">
                                                     <UButton
                                                         class="save-flash-cancel"
@@ -1081,21 +1081,6 @@ export default defineComponent({
     }
     .sdcard-free {
         direction: rtl;
-    }
-    progress {
-        &::-webkit-progress-bar {
-            background-color: var(--surface-500);
-        }
-        &::-webkit-progress-value {
-            background-color: var(--primary-500);
-            border-radius: 0 4px 4px 0;
-        }
-        border-radius: 4px;
-        overflow: hidden;
-        height: 24px;
-        display: block;
-        width: 100%;
-        margin: 1em 0;
     }
     dialog {
         width: 40em;

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -127,7 +127,7 @@
                                             <h3>{{ $t("dataflashSavingTitle") }}</h3>
                                             <div class="dataflash-saving-before">
                                                 <div>{{ $t("dataflashSavingNote") }}</div>
-                                                <UProgress :model-value="saveProgress" :max="100" size="2xl" />
+                                                <UProgress :model-value="saveProgress" :max="100" size="2xl" class="my-4" />
                                                 <div class="buttons flex justify-end gap-2 mt-3">
                                                     <UButton
                                                         class="save-flash-cancel"

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -482,7 +482,7 @@
 
                         <div class="relative mb-3">
                             <UProgress :model-value="uploadProgress" :max="100" size="2xl" color="warning" />
-                            <div class="text-center text-xs font-bold text-white absolute inset-0">
+                            <div class="absolute inset-0 flex items-center justify-center text-xs font-bold text-white">
                                 {{ uploadProgressLabel }}
                             </div>
                         </div>

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -480,9 +480,11 @@
                             </UButton>
                         </div>
 
-                        <div class="tab-osd-upload-progress mb-3">
-                            <progress class="tab-osd-progress-bar" :value="uploadProgress" min="0" max="100"></progress>
-                            <div class="tab-osd-progress-label">{{ uploadProgressLabel }}</div>
+                        <div class="relative mb-3">
+                            <UProgress :model-value="uploadProgress" :max="100" size="2xl" color="warning" />
+                            <div class="text-center text-xs font-bold text-white absolute inset-0">
+                                {{ uploadProgressLabel }}
+                            </div>
                         </div>
 
                         <UButton @click="flashFont()" color="success" size="sm">
@@ -1847,43 +1849,6 @@ onUnmounted(() => {
     background: currentColor;
     border-radius: 50%;
     opacity: 0.8;
-}
-
-/* Upload progress bar */
-.tab-osd-upload-progress {
-    display: grid;
-    grid-template-areas: "area";
-    width: 100%;
-}
-
-.tab-osd-progress-bar {
-    grid-area: area;
-    width: 100%;
-    height: 26px;
-    border-radius: 5px;
-    border: 1px solid var(--surface-500);
-    appearance: none;
-}
-
-.tab-osd-progress-bar::-webkit-progress-bar {
-    background-color: var(--text);
-    border-radius: 4px;
-    box-shadow: inset 0 0 5px #2f2f2f;
-}
-
-.tab-osd-progress-bar::-webkit-progress-value {
-    background-color: #f86008;
-    border-radius: 4px;
-}
-
-.tab-osd-progress-label {
-    grid-area: area;
-    width: 100%;
-    height: 26px;
-    line-height: 26px;
-    text-align: center;
-    color: white;
-    font-weight: bold;
 }
 
 /* Logo info list (validation markers) */

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -274,12 +274,7 @@
                     <!-- Collecting -->
                     <div v-if="alignDetectPhase === 'collecting'" class="flex items-center gap-3 flex-wrap">
                         <div class="flex-1 min-w-48">
-                            <div class="mag-align-progress-bar">
-                                <div
-                                    class="mag-align-progress-fill"
-                                    :style="{ width: alignDetectProgress + '%' }"
-                                ></div>
-                            </div>
+                            <UProgress :model-value="alignDetectProgress" :max="100" size="sm" />
                         </div>
                         <span class="text-xs text-[var(--surface-500)]">{{
                             $t("sensorConfigAlignSamples", { count: alignDetectSampleCount })
@@ -545,9 +540,12 @@
                                     <dt>{{ $t("magCalibrationResidual") }}</dt>
                                     <dd>{{ calResidualText }}</dd>
                                 </dl>
-                                <div v-if="cal.mode !== 'check'" class="mag-cal-progress-bar">
-                                    <div class="mag-cal-progress-fill" :style="{ width: cal.progress + '%' }"></div>
-                                </div>
+                                <UProgress
+                                    v-if="cal.mode !== 'check'"
+                                    :model-value="cal.progress"
+                                    :max="100"
+                                    size="sm"
+                                />
                                 <div v-if="cal.quality" class="text-xs font-semibold text-center">
                                     <span :class="'quality-' + cal.quality"
                                         >{{ $t(CAL_QUALITY_KEY[cal.quality]) }} ({{ cal.qualityScore }}%)</span
@@ -2600,21 +2598,6 @@ onMounted(() => {
         padding: 0.5rem 0;
     }
 
-    .mag-align-progress-bar {
-        width: 100%;
-        height: 4px;
-        background: var(--surface-300);
-        border-radius: 2px;
-        overflow: hidden;
-    }
-
-    .mag-align-progress-fill {
-        height: 100%;
-        background: var(--primary-500);
-        border-radius: 2px;
-        transition: width 0.3s ease;
-    }
-
     .confidence-high {
         color: var(--success-500);
     }
@@ -2684,21 +2667,6 @@ onMounted(() => {
     .mag-viz-mode-selector .mag-viz-active {
         color: #fff;
         background: #5f5f6d; /* rgba(255,255,255,0.3) over #1a1a2e — contrast 5.5:1 */
-    }
-
-    .mag-cal-progress-bar {
-        width: 100%;
-        height: 5px;
-        background: var(--surface-300);
-        border-radius: 3px;
-        overflow: hidden;
-    }
-
-    .mag-cal-progress-fill {
-        height: 100%;
-        background: var(--primary-500);
-        border-radius: 3px;
-        transition: width 0.3s ease;
     }
 
     .mag-cal-live-inline {


### PR DESCRIPTION
Replaces the two hand-rolled div bars in SensorsTab and the native <progress> elements in OnboardLoggingTab and OsdTab with the shared UProgress component, matching sizes to the original bar heights. Drops ~95 lines of bespoke CSS including OsdTab's hardcoded #f86008 (now the warning theme colour). Lint, tests and build all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Replaced native and custom progress bar implementations with a consistent built-in progress component for logging data saving, OSD font upload, and sensor calibration/alignment.
  * Updated the OSD upload progress to use an overlay-style, centered progress label for clearer status visibility.
  * Removed now-unneeded custom progress styling so these flows render more consistently across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->