### PR TITLE
Consolidate duplicated utility helpers

### DIFF
--- a/src/components/ProgressRing.vue
+++ b/src/components/ProgressRing.vue
@@ -51,6 +51,7 @@
 
 <script setup>
 import { computed } from "vue";
+import { clamp } from "@/js/utils/common";
 
 const props = defineProps({
     label: {
@@ -91,7 +92,7 @@ const circumference = computed(() => 2 * Math.PI * radius.value);
 const effectiveMax = computed(() => (Number.isFinite(props.max) && props.max > 0 ? props.max : 100));
 const clampedValue = computed(() => {
     const v = Number.isFinite(props.value) ? props.value : 0;
-    return Math.min(Math.max(v, 0), effectiveMax.value);
+    return clamp(v, 0, effectiveMax.value);
 });
 const progressRatio = computed(() => clampedValue.value / effectiveMax.value);
 const progressPercent = computed(() => Math.round(progressRatio.value * 100));

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -31,8 +31,8 @@ import { ref, watch, onMounted, onBeforeUnmount } from "vue";
 import * as THREE from "three";
 import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 import { i18n } from "../../../js/localization";
+import { degToRad } from "../../../js/utils/common";
 
-const DEG_TO_RAD = Math.PI / 180;
 const DEFAULT_SPHERE_RADIUS = 400;
 
 const props = defineProps({
@@ -466,7 +466,7 @@ function updateQuadAttitude() {
         // Euler fallback: build q from (roll, pitch, heading) in aerospace ZYX,
         // then the same adapter.
         const { roll, pitch, heading } = props.attitude;
-        _tmpEuler.set(roll * DEG_TO_RAD, pitch * DEG_TO_RAD, heading * DEG_TO_RAD, "ZYX");
+        _tmpEuler.set(degToRad(roll), degToRad(pitch), degToRad(heading), "ZYX");
         _tmpQuat.setFromEuler(_tmpEuler);
         _targetQuat.set(_tmpQuat.x, -_tmpQuat.y, -_tmpQuat.z, _tmpQuat.w);
     } else {

--- a/src/components/dialogs/mag-calibration/MagSphereView.vue
+++ b/src/components/dialogs/mag-calibration/MagSphereView.vue
@@ -594,7 +594,7 @@ function rebuildFieldReference() {
         return;
     }
 
-    const incl = (props.inclination * Math.PI) / 180;
+    const incl = degToRad(props.inclination);
     const radius = DEFAULT_SPHERE_RADIUS;
     // Field direction: horizontal along +X (magnetic north), vertical along Z.
     // Scene is NED (Z-down, set in initScene): the downward field component is

--- a/src/components/quad-status/BatteryIcon.vue
+++ b/src/components/quad-status/BatteryIcon.vue
@@ -8,8 +8,7 @@
 
 <script>
 import { defineComponent, computed } from "vue";
-
-const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8;
+import { NO_BATTERY_VOLTAGE_MAXIMUM, estimateCellCount } from "../../js/utils/battery";
 
 export default defineComponent({
     props: {
@@ -35,13 +34,7 @@ export default defineComponent({
         },
     },
     setup(props) {
-        const nbCells = computed(() => {
-            let cells = Math.floor(props.voltage / props.vbatmaxcellvoltage) + 1;
-            if (props.voltage === 0) {
-                cells = 1;
-            }
-            return cells;
-        });
+        const nbCells = computed(() => estimateCellCount(props.voltage, props.vbatmaxcellvoltage));
 
         const min = computed(() => {
             return props.vbatwarningcellvoltage * nbCells.value;

--- a/src/components/quad-status/BatteryLegend.vue
+++ b/src/components/quad-status/BatteryLegend.vue
@@ -5,8 +5,7 @@
 </template>
 <script setup>
 import { computed } from "vue";
-
-const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8;
+import { NO_BATTERY_VOLTAGE_MAXIMUM, estimateCellCount } from "../../js/utils/battery";
 
 const props = defineProps({
     voltage: { type: Number, default: 0 },
@@ -15,10 +14,7 @@ const props = defineProps({
 });
 
 const reading = computed(() => {
-    let nbCells = Math.floor(props.voltage / props.vbatmaxcellvoltage) + 1;
-    if (props.voltage === 0) {
-        nbCells = 1;
-    }
+    const nbCells = estimateCellCount(props.voltage, props.vbatmaxcellvoltage);
     const cellsText = props.voltage > NO_BATTERY_VOLTAGE_MAXIMUM ? `${nbCells}S` : "USB";
     return `${props.voltage.toFixed(2)}V (${cellsText})`;
 });

--- a/src/components/sensor-status/SensorStatus.vue
+++ b/src/components/sensor-status/SensorStatus.vue
@@ -43,37 +43,19 @@
 
 <script setup>
 import { computed } from "vue";
-import { bit_check } from "../../js/bit";
+import { have_sensor } from "../../js/sensor_helpers";
 
 const props = defineProps({
     sensorsDetected: { type: Number, default: 0 },
     gpsFixState: { type: Number, default: 0 },
 });
 
-function haveSensor(sensorsDetected, sensorCode) {
-    switch (sensorCode) {
-        case "acc":
-            return bit_check(sensorsDetected, 0);
-        case "baro":
-            return bit_check(sensorsDetected, 1);
-        case "mag":
-            return bit_check(sensorsDetected, 2);
-        case "gps":
-            return bit_check(sensorsDetected, 3);
-        case "sonar":
-            return bit_check(sensorsDetected, 4);
-        case "gyro":
-            return bit_check(sensorsDetected, 5);
-    }
-    return false;
-}
-
-const setAccActive = computed(() => haveSensor(props.sensorsDetected, "acc"));
-const setGyroActive = computed(() => haveSensor(props.sensorsDetected, "gyro"));
-const setBaroActive = computed(() => haveSensor(props.sensorsDetected, "baro"));
-const setMagActive = computed(() => haveSensor(props.sensorsDetected, "mag"));
-const setSonarActive = computed(() => haveSensor(props.sensorsDetected, "sonar"));
-const gpsDetected = computed(() => haveSensor(props.sensorsDetected, "gps"));
+const setAccActive = computed(() => have_sensor(props.sensorsDetected, "acc"));
+const setGyroActive = computed(() => have_sensor(props.sensorsDetected, "gyro"));
+const setBaroActive = computed(() => have_sensor(props.sensorsDetected, "baro"));
+const setMagActive = computed(() => have_sensor(props.sensorsDetected, "mag"));
+const setSonarActive = computed(() => have_sensor(props.sensorsDetected, "sonar"));
+const gpsDetected = computed(() => have_sensor(props.sensorsDetected, "gps"));
 const hasFix = computed(() => props.gpsFixState > 0);
 const gpsOn = computed(() => gpsDetected.value || hasFix.value);
 const gpsActiveNoFix = computed(() => gpsOn.value && gpsDetected.value && !hasFix.value);

--- a/src/components/tabs/AuxiliaryTab.vue
+++ b/src/components/tabs/AuxiliaryTab.vue
@@ -179,14 +179,13 @@ import { get as getConfig, set as setConfig } from "../../js/ConfigStorage";
 import adjustBoxNameIfPeripheralWithModeID from "../../js/peripherals";
 import { i18n } from "../../js/localization";
 import { getTextWidth } from "../../js/utils/common";
+import { CHANNEL_MIN, CHANNEL_MAX, clampChannel, channelPercent } from "../../js/utils/rcChannel";
 import inflection from "inflection";
 import UiBox from "../elements/UiBox.vue";
 import HelpIcon from "../elements/HelpIcon.vue";
 import SettingRow from "../elements/SettingRow.vue";
 import DraggableMultiSlider from "../elements/DraggableMultiSlider.vue";
 
-const CHANNEL_MIN = 900;
-const CHANNEL_MAX = 2100;
 const CHANNEL_STEP = 25;
 const MIN_RANGE_GAP = 25;
 const DEFAULT_RANGE = { start: 1300, end: 1700 };
@@ -291,24 +290,6 @@ export default defineComponent({
         const infoMinWidthStyle = computed(() => {
             return infoMinWidth.value ? { minWidth: `${infoMinWidth.value}px` } : {};
         });
-
-        const clampChannel = (value) => {
-            if (value === undefined || value === null || Number.isNaN(value)) {
-                return 1500;
-            }
-            if (value < CHANNEL_MIN) {
-                return CHANNEL_MIN;
-            }
-            if (value > CHANNEL_MAX) {
-                return CHANNEL_MAX;
-            }
-            return value;
-        };
-
-        const channelPercent = (value) => {
-            const clamped = clampChannel(value);
-            return ((clamped - CHANNEL_MIN) / (CHANNEL_MAX - CHANNEL_MIN)) * 100;
-        };
 
         const updateInfoWidth = () => {
             const longestName = modes.reduce((max, mode) => Math.max(max, mode.displayName.length), 0);

--- a/src/components/tabs/FlightPlan/ElevationProfile.vue
+++ b/src/components/tabs/FlightPlan/ElevationProfile.vue
@@ -199,6 +199,7 @@
 import { ref, computed, watch } from "vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
+import { METERS_TO_FEET } from "@/js/utils/common";
 
 const { positionalWaypoints, selectedWaypointUid, selectWaypoint } = useFlightPlan();
 // Modifier waypoints (lat/lon = 0) would otherwise skew distance and altitude.
@@ -235,7 +236,6 @@ const MAX_SAMPLES_PER_SEGMENT = 50; // Maximum samples between waypoints
 const getSegmentKey = (fromUid, toUid) => `${fromUid}-${toUid}`;
 
 // Conversion constants
-const METERS_TO_FEET = 3.28084;
 const METERS_TO_NAUTICAL_MILES = 1 / 1852;
 
 // Calculate distance between two points using Haversine formula

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -532,6 +532,7 @@ import UiBox from "@/components/elements/UiBox.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
 import SettingRow from "@/components/elements/SettingRow.vue";
 import { i18n } from "@/js/localization";
+import { clamp } from "@/js/utils/common";
 
 import { FONT, SYM } from "@/js/utils/osdFont";
 import { OSD_CONSTANTS } from "./osd/osd_constants";
@@ -986,8 +987,8 @@ function getDragPreviewAnchor(displayItem, dragX, dragY, displaySize, dragPrevie
     const anchorY = (localY - dragPreviewMeta.minY) * charHeight + charHeight / 2;
 
     return {
-        x: Math.min(Math.max(anchorX, 0), dragPreviewMeta.widthPx),
-        y: Math.min(Math.max(anchorY, 0), dragPreviewMeta.heightPx),
+        x: clamp(anchorX, 0, dragPreviewMeta.widthPx),
+        y: clamp(anchorY, 0, dragPreviewMeta.heightPx),
     };
 }
 
@@ -1077,10 +1078,10 @@ function clampStringPreviewPosition(displayItem, position, displaySize, cursorY)
     const elementWidth = Array.from(displayItem.preview || "").length;
     const maxX = Math.max(0, displaySize.x - elementWidth);
     const maxY = Math.max(0, displaySize.y - 1);
-    const row = Math.min(Math.max(cursorY, 0), maxY);
+    const row = clamp(cursorY, 0, maxY);
 
     const rawX = position - row * displaySize.x;
-    const x = Math.min(Math.max(rawX, 0), maxX);
+    const x = clamp(rawX, 0, maxX);
 
     return row * displaySize.x + x;
 }

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -831,6 +831,7 @@ import { sensorTypes } from "../../js/sensor_types";
 import { useMagCalibration, computeDeclination, getGeoReference } from "../../composables/useMagCalibration";
 import { isMspCliSupported } from "../../composables/useMspCliSession";
 import { detectAlignment } from "../../js/utils/magAlignment";
+import { degToRad } from "../../js/utils/common";
 import { useDialog } from "@/composables/useDialog";
 import {
     characterizeTumble,
@@ -2112,8 +2113,6 @@ let altimeterIndicator = null;
 
 const { addInterval, pauseInterval, resumeInterval, removeAllIntervals } = useInterval();
 
-const DEG_TO_RAD = Math.PI / 180;
-
 const CARDINAL_DIRS = ["N", "NE", "E", "SE", "S", "SW", "W", "NW"];
 function toCardinal(deg) {
     return CARDINAL_DIRS[Math.round((((deg % 360) + 360) % 360) / 45) % 8];
@@ -2164,9 +2163,9 @@ function renderModel() {
         return;
     }
     const k = fcStore.sensorData.kinematics;
-    const x = k[1] * -DEG_TO_RAD;
-    const y = (k[2] * -1 - yawFix.value) * DEG_TO_RAD;
-    const z = k[0] * -DEG_TO_RAD;
+    const x = -degToRad(k[1]);
+    const y = degToRad(k[2] * -1 - yawFix.value);
+    const z = -degToRad(k[0]);
     modelInstance.rotateTo(x, y, z);
 }
 

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -1738,7 +1738,7 @@ async function acceptFullCal() {
     const result = characterizeTumble({
         samples,
         currentMatrix: R_cur,
-        inclinationRad: (geoRef.inclination * Math.PI) / 180,
+        inclinationRad: degToRad(geoRef.inclination),
     });
 
     if (!result.ok) {

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -161,6 +161,7 @@ import { gui_log } from "@/js/gui_log";
 import { i18n } from "@/js/localization";
 import { useInterval } from "@/composables/useInterval";
 import { useTimeout } from "@/composables/useTimeout";
+import { clamp } from "@/js/utils/common";
 
 const { t } = useTranslation();
 
@@ -188,13 +189,13 @@ const rateOptions = computed(() => {
 
 // Bar height as percentage (0-100) for UProgress
 function getBarHeight(value) {
-    const clamped = Math.min(Math.max(value - 1000, 0), 1000);
+    const clamped = clamp(value - 1000, 0, 1000);
     return (clamped / 1000) * 100;
 }
 
 // Bar opacity string for CSS variable
 function getBarOpacity(value) {
-    const alpha = Math.min(Math.max((value - 1000) / 1000, 0), 1);
+    const alpha = clamp((value - 1000) / 1000, 0, 1);
     return alpha.toFixed(2);
 }
 
@@ -222,9 +223,9 @@ function updateServos(saveToEeprom) {
         const src = servoConfigs[i];
         const cfg = FC.SERVO_CONFIG[i];
 
-        const min = Math.min(Math.max(src.min ?? SERVO_MIN, SERVO_MIN), SERVO_MAX);
-        const middle = Math.min(Math.max(src.middle ?? SERVO_MIN, SERVO_MIN), SERVO_MAX);
-        const max = Math.min(Math.max(src.max ?? SERVO_MAX, SERVO_MIN), SERVO_MAX);
+        const min = clamp(src.min ?? SERVO_MIN, SERVO_MIN, SERVO_MAX);
+        const middle = clamp(src.middle ?? SERVO_MIN, SERVO_MIN, SERVO_MAX);
+        const max = clamp(src.max ?? SERVO_MAX, SERVO_MIN, SERVO_MAX);
 
         cfg.min = min;
         cfg.middle = middle;

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -315,6 +315,7 @@ import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
 import RateCurve from "@/js/RateCurve";
 import Model from "@/js/model";
+import { degToRad } from "@/js/utils/common";
 import semver from "semver";
 import { API_VERSION_1_47 } from "@/js/data_storage";
 import betaflightLogo from "@/images/rate_logos/betaflight.svg";
@@ -1609,7 +1610,6 @@ function renderModel(timestamp) {
     // Only rotate when we have valid RC channel data
     if (channels?.[0] && channels?.[1] && channels?.[2]) {
         const rates = getCurrentRatesSnapshot();
-        const degToRad = (deg) => deg * (Math.PI / 180);
 
         const roll =
             (delta / 1000) *

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -361,7 +361,6 @@ let lastTimestamp = 0;
 let keepRendering = true;
 
 // API Version helpers
-const hasProfileNames = computed(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45));
 const hasThrottleHover = computed(() => semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47));
 
 // Rates Type

--- a/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
+++ b/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
@@ -50,6 +50,7 @@
 
 <script setup>
 import { ref, reactive, onMounted, onUnmounted } from "vue";
+import { clamp } from "@/js/utils/common";
 
 // i18n from parent window
 const i18n = globalThis.opener?.i18n;
@@ -98,7 +99,7 @@ function channelValueToStickPortion(channel) {
 }
 
 function stickPortionToChannelValue(portion) {
-    return Math.round(Math.min(Math.max(portion, 0), 1) * (CHANNEL_MAX_VALUE - CHANNEL_MIN_VALUE) + CHANNEL_MIN_VALUE);
+    return Math.round(clamp(portion, 0, 1) * (CHANNEL_MAX_VALUE - CHANNEL_MIN_VALUE) + CHANNEL_MIN_VALUE);
 }
 
 function startGimbalDrag(gimbalIndex, event) {

--- a/src/components/tabs/sensors/LiveSensorPanel.vue
+++ b/src/components/tabs/sensors/LiveSensorPanel.vue
@@ -106,6 +106,7 @@ import { useSensorsStore } from "@/stores/sensors";
 import { useSensorGraph } from "@/composables/useSensorGraph";
 import { useInterval } from "../../../composables/useInterval";
 import { have_sensor } from "../../../js/sensor_helpers";
+import { radToDeg, clamp } from "../../../js/utils/common";
 import {
     GYRO_SCALE_OPTIONS,
     ACCEL_SCALE_OPTIONS,
@@ -290,8 +291,8 @@ function update_imu_graphs() {
         const ax = fcStore.sensorData.accelerometer[0];
         const ay = fcStore.sensorData.accelerometer[1];
         const az = fcStore.sensorData.accelerometer[2];
-        const rollACC = Math.round(Math.atan2(ay, Math.hypot(ax, az)) * (180 / Math.PI));
-        const pitchACC = Math.round(Math.atan2(ax, Math.hypot(ay, az)) * (180 / Math.PI));
+        const rollACC = Math.round(radToDeg(Math.atan2(ay, Math.hypot(ax, az))));
+        const pitchACC = Math.round(radToDeg(Math.atan2(ax, Math.hypot(ay, az))));
         accelDisplay.x = `${ax.toFixed(2)} (${rollACC})`;
         accelDisplay.y = `${ay.toFixed(2)} (${pitchACC})`;
         accelDisplay.z = az.toFixed(2);
@@ -334,8 +335,7 @@ function liveDebugContext() {
         motorPoles: fcStore.motorConfig?.motor_poles || 1,
         gyroRawToDegreesPerSecond: (v) => v * (4 / 16.4),
         accRawToGs: (v) => v / 2048,
-        rcCommandRawToThrottle: (v) =>
-            Math.min(Math.max(((v - minThrottle) / (maxThrottle - minThrottle)) * 100, 0), 100),
+        rcCommandRawToThrottle: (v) => clamp(((v - minThrottle) / (maxThrottle - minThrottle)) * 100, 0, 100),
         throttleToRcCommandRaw: (v) => (v / 100) * (maxThrottle - minThrottle) + minThrottle,
     };
 }

--- a/src/composables/adjustments/useAdjustmentsData.js
+++ b/src/composables/adjustments/useAdjustmentsData.js
@@ -3,9 +3,8 @@ import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
 import { API_VERSION_1_48 } from "../../js/data_storage";
 import { useFlightControllerStore } from "@/stores/fc";
+import { channelPercent } from "../../js/utils/rcChannel";
 
-const CHANNEL_MIN = 900;
-const CHANNEL_MAX = 2100;
 const PIP_VALUES = [1000, 1200, 1500, 1800, 2000];
 
 // Wire u8 values whose firmware dispatch entry is ADJUSTMENT_MODE_SELECT
@@ -78,14 +77,6 @@ export function useAdjustmentsData(adjustments, t) {
         { value: "step", label: t("adjustmentsModeStep") },
         { value: "absolute", label: t("adjustmentsModeAbsolute") },
     ]);
-
-    const channelPercent = (value) => {
-        if (value === undefined || value === null || Number.isNaN(value)) {
-            return 50;
-        }
-        const clamped = Math.max(CHANNEL_MIN, Math.min(CHANNEL_MAX, value));
-        return ((clamped - CHANNEL_MIN) / (CHANNEL_MAX - CHANNEL_MIN)) * 100;
-    };
 
     const onEnableChange = (adjustment) => {
         if (adjustment.enabled) {

--- a/src/composables/usePreflight.js
+++ b/src/composables/usePreflight.js
@@ -6,6 +6,7 @@ import { ispConnected } from "../js/utils/connection";
 import { sortNotams, kmToNm } from "../js/notam/index.js";
 import { fetchFromFaa } from "../js/notam/faa.js";
 import { fetchFromOpenAip } from "../js/notam/openaip.js";
+import { METERS_TO_FEET } from "../js/utils/common";
 
 const SAVED_LOCATIONS_KEY = "preflight_saved_locations";
 const IP_GEOLOCATION_CONSENT_KEY = "preflight_ip_geolocation_consent";
@@ -160,7 +161,7 @@ function getDensityAltitude(elevationMeters, pressure, temp) {
     if (elevationMeters === null || pressure === null || temp === null) {
         return null;
     }
-    const elevationFeet = elevationMeters * 3.28084;
+    const elevationFeet = elevationMeters * METERS_TO_FEET;
     const pressureAltitudeFeet = (1013.25 - pressure) * 30 + elevationFeet;
     const isaTemp = 15 - (2 * elevationFeet) / 1000;
     return Math.round(pressureAltitudeFeet + 120 * (temp - isaTemp));

--- a/src/js/blackbox/spectral_analysis.js
+++ b/src/js/blackbox/spectral_analysis.js
@@ -9,6 +9,7 @@
  */
 
 import { ComplexFFT } from "./fft.js";
+import { clamp } from "../utils/common.js";
 
 // ---------------------------------------------------------------------------
 // Windowing
@@ -645,10 +646,6 @@ export function computeSpectrogram(signal, sampleRate, windowSize = 256, overlap
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function clamp(value, min, max) {
-    return Math.max(min, Math.min(max, value));
-}
 
 function nextPow2(n) {
     let p = 1;

--- a/src/js/utils/battery.js
+++ b/src/js/utils/battery.js
@@ -1,0 +1,8 @@
+export const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8;
+
+export function estimateCellCount(voltage, vbatmaxcellvoltage) {
+    if (voltage === 0) {
+        return 1;
+    }
+    return Math.floor(voltage / vbatmaxcellvoltage) + 1;
+}

--- a/src/js/utils/battery.js
+++ b/src/js/utils/battery.js
@@ -1,8 +1,8 @@
 export const NO_BATTERY_VOLTAGE_MAXIMUM = 1.8;
 
 export function estimateCellCount(voltage, vbatmaxcellvoltage) {
-    if (voltage === 0) {
+    if (!Number.isFinite(voltage) || !Number.isFinite(vbatmaxcellvoltage) || voltage <= 0 || vbatmaxcellvoltage <= 0) {
         return 1;
     }
-    return Math.floor(voltage / vbatmaxcellvoltage) + 1;
+    return Math.ceil(voltage / vbatmaxcellvoltage);
 }

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -5,10 +5,21 @@ export function millitime() {
 }
 
 const DEGREE_TO_RADIAN_RATIO = Math.PI / 180;
+const RADIAN_TO_DEGREE_RATIO = 180 / Math.PI;
 
 export function degToRad(degrees) {
     return degrees * DEGREE_TO_RADIAN_RATIO;
 }
+
+export function radToDeg(radians) {
+    return radians * RADIAN_TO_DEGREE_RATIO;
+}
+
+export function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+export const METERS_TO_FEET = 3.28084;
 
 export function bytesToSize(bytes) {
     let outputBytes;

--- a/src/js/utils/magAlignment.js
+++ b/src/js/utils/magAlignment.js
@@ -12,6 +12,8 @@
  * by only using roll/pitch from the accelerometer.
  */
 
+import { degToRad } from "./common.js";
+
 // Rotation matrices: sensor frame → body frame for each alignment value.
 // Alignment 0 (DEFAULT) is treated as identity (same as CW0).
 const ALIGNMENT_MATRICES = {
@@ -161,8 +163,8 @@ function evaluateCandidateDetailed(candidateMat, currentInv, samples) {
 
     for (const s of samples) {
         const bodyMag = mat3mulVec(combined, s.mag);
-        const rollRad = s.roll * (Math.PI / 180);
-        const pitchRad = s.pitch * (Math.PI / 180);
+        const rollRad = degToRad(s.roll);
+        const pitchRad = degToRad(s.pitch);
         const level = undoRollPitch(bodyMag, rollRad, pitchRad);
 
         verticals.push(level[2]);
@@ -191,8 +193,8 @@ function computeTiltCoverage(samples) {
     const TILT_THRESHOLD_RAD = (15 * Math.PI) / 180;
     let tilted = 0;
     for (const s of samples) {
-        const rollRad = s.roll * (Math.PI / 180);
-        const pitchRad = s.pitch * (Math.PI / 180);
+        const rollRad = degToRad(s.roll);
+        const pitchRad = degToRad(s.pitch);
         const tilt = Math.hypot(rollRad, pitchRad);
         if (tilt > TILT_THRESHOLD_RAD) {
             tilted++;

--- a/src/js/utils/magCharacterization.js
+++ b/src/js/utils/magCharacterization.js
@@ -10,6 +10,7 @@
  */
 
 import { ALIGNMENT_MATRICES } from "./magAlignment.js";
+import { radToDeg } from "./common.js";
 
 /**
  * Frobenius norm of (a - b). Both are 3x3 matrices (array-of-arrays).
@@ -48,11 +49,10 @@ export function matrixToEuler(m) {
         yaw = Math.atan2(-m[0][1], m[1][1]);
     }
 
-    const radToDeg = 180 / Math.PI;
     return {
-        roll: roll * radToDeg,
-        pitch: pitch * radToDeg,
-        yaw: yaw * radToDeg,
+        roll: radToDeg(roll),
+        pitch: radToDeg(pitch),
+        yaw: radToDeg(yaw),
     };
 }
 

--- a/src/js/utils/magTiltAlign.js
+++ b/src/js/utils/magTiltAlign.js
@@ -14,13 +14,11 @@
  */
 import { ALIGNMENT_MATRICES, ALIGNMENT_LABELS, eulerToMatrix, mat3mulVec } from "./magAlignment.js";
 import { snapToPreset, matrixToEuler } from "./magCharacterization.js";
-
-const DEG_TO_RAD = Math.PI / 180;
-const RAD_TO_DEG = 180 / Math.PI;
+import { degToRad, radToDeg, clamp } from "./common.js";
 
 // Robust M-estimator on the dip residual, in ANGLE space (latitude-independent).
-const SLACK_RAD = 3.0 * DEG_TO_RAD; // residual below this is free
-const CAP_RAD = 15.0 * DEG_TO_RAD; // residual above this is capped (outlier rejection)
+const SLACK_RAD = degToRad(3.0); // residual below this is free
+const CAP_RAD = degToRad(15.0); // residual above this is capped (outlier rejection)
 const MAX_PENALTY = (CAP_RAD - SLACK_RAD) * (CAP_RAD - SLACK_RAD);
 
 const MIN_SAMPLES = 20;
@@ -29,16 +27,6 @@ const COARSE_STEP = 15; // degrees
 const REFINE_STEP = 2; // degrees
 const REFINE_RADIUS = 12; // degrees
 const REFINE_TOP_N = 8; // how many of the top coarse candidates to refine
-
-function clamp(v, lo, hi) {
-    if (v < lo) {
-        return lo;
-    }
-    if (v > hi) {
-        return hi;
-    }
-    return v;
-}
 
 function normalize3(v) {
     const len = Math.hypot(v[0], v[1], v[2]);
@@ -54,8 +42,8 @@ function dot3(a, b) {
 
 /** Gravity (down) in the FLU body frame from roll/pitch (degrees). Level → [0,0,-1]. */
 function gravityInBody(rollDeg, pitchDeg) {
-    const r = rollDeg * DEG_TO_RAD;
-    const p = pitchDeg * DEG_TO_RAD;
+    const r = degToRad(rollDeg);
+    const p = degToRad(pitchDeg);
     return [Math.sin(p), -Math.sin(r) * Math.cos(p), -Math.cos(r) * Math.cos(p)];
 }
 
@@ -84,7 +72,7 @@ function meanResidualDeg(R, samples, expectedAngleRad) {
     for (const s of samples) {
         sum += dipResidualRad(R, s, expectedAngleRad);
     }
-    return (sum / samples.length) * RAD_TO_DEG;
+    return radToDeg(sum / samples.length);
 }
 
 function evalGrid(rollVals, pitchVals, yawVals, samples, expectedAngleRad, sink) {

--- a/src/js/utils/rcChannel.js
+++ b/src/js/utils/rcChannel.js
@@ -1,0 +1,21 @@
+export const CHANNEL_MIN = 900;
+export const CHANNEL_MAX = 2100;
+const CHANNEL_MID = 1500;
+
+export function clampChannel(value) {
+    if (value === undefined || value === null || Number.isNaN(value)) {
+        return CHANNEL_MID;
+    }
+    if (value < CHANNEL_MIN) {
+        return CHANNEL_MIN;
+    }
+    if (value > CHANNEL_MAX) {
+        return CHANNEL_MAX;
+    }
+    return value;
+}
+
+export function channelPercent(value) {
+    const clamped = clampChannel(value);
+    return ((clamped - CHANNEL_MIN) / (CHANNEL_MAX - CHANNEL_MIN)) * 100;
+}

--- a/test/js/utils/battery.test.js
+++ b/test/js/utils/battery.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { estimateCellCount } from "../../../src/js/utils/battery";
+
+describe("estimateCellCount", () => {
+    it("returns 1 cell when voltage is 0", () => {
+        expect(estimateCellCount(0, 4.2)).toBe(1);
+    });
+
+    it("estimates a single-cell pack", () => {
+        expect(estimateCellCount(4.1, 4.2)).toBe(1);
+    });
+
+    it("estimates a multi-cell pack", () => {
+        expect(estimateCellCount(16.4, 4.2)).toBe(4);
+    });
+
+    it("rounds down within a cell boundary", () => {
+        expect(estimateCellCount(8.39, 4.2)).toBe(2);
+    });
+});

--- a/test/js/utils/battery.test.js
+++ b/test/js/utils/battery.test.js
@@ -17,4 +17,12 @@ describe("estimateCellCount", () => {
     it("rounds down within a cell boundary", () => {
         expect(estimateCellCount(8.39, 4.2)).toBe(2);
     });
+
+    it("does not overestimate at an exact cell boundary", () => {
+        expect(estimateCellCount(8.4, 4.2)).toBe(2);
+    });
+
+    it("returns 1 cell when vbatmaxcellvoltage is unset", () => {
+        expect(estimateCellCount(12.6, 0)).toBe(1);
+    });
 });

--- a/test/js/utils/common.test.js
+++ b/test/js/utils/common.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { clamp, degToRad, radToDeg } from "../../../src/js/utils/common";
+
+describe("common helpers", () => {
+    describe("clamp", () => {
+        it("returns the value when within range", () => {
+            expect(clamp(5, 0, 10)).toBe(5);
+        });
+
+        it("clamps to the minimum", () => {
+            expect(clamp(-5, 0, 10)).toBe(0);
+        });
+
+        it("clamps to the maximum", () => {
+            expect(clamp(15, 0, 10)).toBe(10);
+        });
+    });
+
+    describe("degToRad / radToDeg", () => {
+        it("converts degrees to radians", () => {
+            expect(degToRad(180)).toBeCloseTo(Math.PI);
+            expect(degToRad(90)).toBeCloseTo(Math.PI / 2);
+        });
+
+        it("converts radians to degrees", () => {
+            expect(radToDeg(Math.PI)).toBeCloseTo(180);
+            expect(radToDeg(Math.PI / 2)).toBeCloseTo(90);
+        });
+
+        it("round-trips", () => {
+            expect(radToDeg(degToRad(37))).toBeCloseTo(37);
+        });
+    });
+});

--- a/test/js/utils/rcChannel.test.js
+++ b/test/js/utils/rcChannel.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { CHANNEL_MIN, CHANNEL_MAX, clampChannel, channelPercent } from "../../../src/js/utils/rcChannel";
+
+describe("rcChannel helpers", () => {
+    describe("clampChannel", () => {
+        it("returns the value when within range", () => {
+            expect(clampChannel(1500)).toBe(1500);
+        });
+
+        it("clamps below CHANNEL_MIN", () => {
+            expect(clampChannel(500)).toBe(CHANNEL_MIN);
+        });
+
+        it("clamps above CHANNEL_MAX", () => {
+            expect(clampChannel(3000)).toBe(CHANNEL_MAX);
+        });
+
+        it("falls back to the midpoint for NaN/undefined/null", () => {
+            expect(clampChannel(NaN)).toBe(1500);
+            expect(clampChannel(undefined)).toBe(1500);
+            expect(clampChannel(null)).toBe(1500);
+        });
+    });
+
+    describe("channelPercent", () => {
+        it("returns 0 at CHANNEL_MIN and 100 at CHANNEL_MAX", () => {
+            expect(channelPercent(CHANNEL_MIN)).toBe(0);
+            expect(channelPercent(CHANNEL_MAX)).toBe(100);
+        });
+
+        it("returns 50 for the midpoint channel value", () => {
+            expect(channelPercent(1500)).toBe(50);
+        });
+
+        it("returns 50 for a NaN fallback", () => {
+            expect(channelPercent(NaN)).toBe(50);
+        });
+    });
+});


### PR DESCRIPTION
Consolidates small utility logic that had drifted into copies: adds radToDeg, clamp and METERS_TO_FEET to common.js and replaces the local reimplementations (deg/rad conversion existed in seven places); extracts shared rcChannel.js (900/2100 constants plus clampChannel/channelPercent) for AuxiliaryTab and the adjustments composable; extracts battery.js estimateCellCount for BatteryIcon/BatteryLegend. One behaviour fix: SensorStatus.vue had a stale local copy of have_sensor missing the opticalflow case — it now imports the canonical helper, so the optical flow sensor is recognised there. New vitest coverage for the extracted helpers; full suite green (396 tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency across battery cell count display, sensor status indicators, RC channel/slider values, and OSD preview positioning.
  * Refined angle conversion used in calibration and 3D orientation/tilt calculations for more reliable visual behavior.
  * Standardized clamping and input handling to reduce edge-case display issues (including safer battery cell-count estimation for invalid inputs).
* **Tests**
  * Added unit tests for shared utility conversions, clamping behavior, RC channel helpers, and battery cell-count estimation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
