### PR TITLE
Fix Beepers.isEnabled mask check

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/blckmn/src/betaflight/app/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/blckmn/src/betaflight/app/node_modules

--- a/src/js/Beepers.js
+++ b/src/js/Beepers.js
@@ -61,8 +61,8 @@ class Beepers {
         const self = this;
 
         for (let i = 0; i < self._beepers.length; i++) {
-            if (self._beepers[i].name === beeperName && bit_check(self._beeperOfMask, self._beepers[i].bit)) {
-                return true;
+            if (self._beepers[i].name === beeperName) {
+                return !bit_check(self._beeperDisabledMask, self._beepers[i].bit);
             }
         }
         return false;

--- a/test/beepers.test.js
+++ b/test/beepers.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import Beepers from "../src/js/Beepers";
+import { bit_set } from "../src/js/bit";
+
+describe("Beepers", () => {
+    describe("isEnabled", () => {
+        it("returns true for a beeper whose bit is not in the disabled mask", () => {
+            const beepers = new Beepers();
+            expect(beepers.isEnabled("RX_LOST")).toBe(true);
+        });
+
+        it("returns false for a beeper whose bit is in the disabled mask", () => {
+            const beepers = new Beepers();
+            beepers.setDisabledMask(bit_set(0, 1));
+            expect(beepers.isEnabled("RX_LOST")).toBe(false);
+            expect(beepers.isEnabled("GYRO_CALIBRATED")).toBe(true);
+        });
+
+        it("returns false for an unknown beeper name", () => {
+            const beepers = new Beepers();
+            expect(beepers.isEnabled("NOT_A_BEEPER")).toBe(false);
+        });
+
+        it("respects the supported conditions filter", () => {
+            const beepers = new Beepers(undefined, ["RX_LOST"]);
+            expect(beepers.isEnabled("RX_LOST")).toBe(true);
+            expect(beepers.isEnabled("ARMING")).toBe(false);
+        });
+    });
+
+    describe("updateData", () => {
+        it("round-trips through the disabled mask", () => {
+            const beepers = new Beepers();
+            beepers.updateData({ type: "checkbox", checked: false, dataset: { bit: "3" } });
+            expect(beepers.isEnabled("DISARMING")).toBe(false);
+            expect(beepers.getDisabledMask()).toBe(bit_set(0, 3));
+
+            beepers.updateData({ type: "checkbox", checked: true, dataset: { bit: "3" } });
+            expect(beepers.isEnabled("DISARMING")).toBe(true);
+            expect(beepers.getDisabledMask()).toBe(0);
+        });
+    });
+});


### PR DESCRIPTION
isEnabled read the non-existent _beeperOfMask property (always falsy, so it always returned false) and even with the name corrected the logic was inverted — a beeper is enabled when its bit is NOT set in _beeperDisabledMask, matching how generateElements derives the checkbox state. Nothing calls isEnabled today, which is how both slipped through; fixed now with unit coverage so callers can rely on it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed beeper status handling so enabled/disabled states now follow the selected beeper and its current mask settings more reliably.
  * Improved support for filtered beeper options, ensuring only applicable beepers are shown as enabled.
  * Checkbox changes now correctly persist when toggling beepers on or off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->