### PR TITLE
Route feature and beeper toggles through their helper classes

### DIFF
--- a/src/components/tabs/ConfigurationTab.vue
+++ b/src/components/tabs/ConfigurationTab.vue
@@ -208,7 +208,6 @@ import { gui_log } from "../../js/gui_log";
 import { i18n } from "../../js/localization";
 import semver from "semver";
 import { API_VERSION_1_45, API_VERSION_1_46 } from "../../js/data_storage";
-import { bit_check, bit_set, bit_clear } from "../../js/bit";
 import { updateTabList } from "../../js/utils/updateTabList";
 import WikiButton from "../elements/WikiButton.vue";
 import UiBox from "../elements/UiBox.vue";
@@ -262,11 +261,6 @@ export default defineComponent({
             });
         });
 
-        const MOTOR_STOP_FEATURE_BIT = 4;
-        const motorStopFeatureBit = computed(() => {
-            return featuresList.value.find((feature) => feature.name === "MOTOR_STOP")?.bit ?? MOTOR_STOP_FEATURE_BIT;
-        });
-
         const beepersList = computed(() => {
             if (!fcStore.beepers?.beepers?._beepers) {
                 return [];
@@ -282,8 +276,6 @@ export default defineComponent({
         });
 
         const dshotBeaconTone = ref(0); // 0 = disabled
-        const beeperDisabledMask = ref(0);
-        const dshotDisabledMask = ref(0);
 
         const syncBeeperStateFromStore = () => {
             if (!fcStore.beepers) {
@@ -293,142 +285,71 @@ export default defineComponent({
             if (fcStore.beepers.dshotBeaconTone != null) {
                 dshotBeaconTone.value = fcStore.beepers.dshotBeaconTone;
             }
-
-            if (fcStore.beepers.beepers) {
-                beeperDisabledMask.value = fcStore.beepers.beepers._beeperDisabledMask;
-            }
-
-            if (fcStore.beepers.dshotBeaconConditions) {
-                dshotDisabledMask.value = fcStore.beepers.dshotBeaconConditions._beeperDisabledMask;
-            }
         };
-
-        const featureMask = computed(() => {
-            if (!fcStore.features?.features) {
-                return 0;
-            }
-            return fcStore.features.features._featureMask;
-        });
 
         const showAutoDisarmDelay = computed(() => {
             if (!fcStore.config?.apiVersion || semver.lt(fcStore.config.apiVersion, API_VERSION_1_46)) {
                 return false;
             }
-            return bit_check(featureMask.value, motorStopFeatureBit.value);
+            return fcStore.features?.features?.isEnabled?.("MOTOR_STOP") ?? false;
         });
 
         // Methods for toggling bits
         const isFeatureEnabled = (feature) => {
-            if (!fcStore.features?.features) {
-                return false;
-            }
-            return bit_check(fcStore.features.features._featureMask, feature.bit);
+            return fcStore.features?.features?.isEnabled?.(feature.name) ?? false;
         };
 
         const toggleFeature = (feature, checked) => {
-            if (!fcStore.features?.features) {
+            const featuresHelper = fcStore.features?.features;
+            if (!featuresHelper) {
                 return;
             }
-            if (checked) {
-                fcStore.features.features._featureMask = bit_set(fcStore.features.features._featureMask, feature.bit);
-            } else {
-                fcStore.features.features._featureMask = bit_clear(fcStore.features.features._featureMask, feature.bit);
-            }
-            updateTabList(fcStore.features.features);
+            featuresHelper.updateData({ name: feature.name, checked });
+            updateTabList(featuresHelper);
         };
 
         const isBeeperEnabled = (beeper) => {
-            if (!fcStore.beepers?.beepers) {
-                return false;
-            }
-            // Note: Beeper logic uses DisabledMask, so checked means NOT disabled
-            return !bit_check(beeperDisabledMask.value, beeper.bit);
+            return fcStore.beepers?.beepers?.isEnabled?.(beeper.name) ?? false;
         };
 
         const toggleBeeper = (beeper, checked) => {
-            if (!fcStore.beepers?.beepers) {
-                return;
-            }
-            if (checked) {
-                // To enable, we CLEAR the disabled bit
-                beeperDisabledMask.value = bit_clear(beeperDisabledMask.value, beeper.bit);
-            } else {
-                // To disable, we SET the disabled bit
-                beeperDisabledMask.value = bit_set(beeperDisabledMask.value, beeper.bit);
-            }
-            fcStore.beepers.beepers._beeperDisabledMask = beeperDisabledMask.value;
+            fcStore.beepers?.beepers?.setEnabled?.(beeper.name, checked);
         };
 
         const enableAllBeepers = () => {
-            if (!fcStore.beepers?.beepers) {
-                return;
-            }
-            let mask = beeperDisabledMask.value;
             beepersList.value.forEach((beeper) => {
                 if (beeper.visible !== false) {
-                    mask = bit_clear(mask, beeper.bit);
+                    fcStore.beepers.beepers.setEnabled(beeper.name, true);
                 }
             });
-            beeperDisabledMask.value = mask;
-            fcStore.beepers.beepers._beeperDisabledMask = mask;
         };
 
         const disableAllBeepers = () => {
-            if (!fcStore.beepers?.beepers) {
-                return;
-            }
-            let mask = beeperDisabledMask.value;
             beepersList.value.forEach((beeper) => {
                 if (beeper.visible !== false) {
-                    mask = bit_set(mask, beeper.bit);
+                    fcStore.beepers.beepers.setEnabled(beeper.name, false);
                 }
             });
-            beeperDisabledMask.value = mask;
-            fcStore.beepers.beepers._beeperDisabledMask = mask;
         };
 
         const isDshotConditionEnabled = (cond) => {
-            if (!fcStore.beepers?.dshotBeaconConditions) {
-                return false;
-            }
-            // Same logic as beepers (DisabledMask)
-            return !bit_check(dshotDisabledMask.value, cond.bit);
+            return fcStore.beepers?.dshotBeaconConditions?.isEnabled?.(cond.name) ?? false;
         };
 
         const toggleDshotCondition = (cond, checked) => {
-            if (!fcStore.beepers?.dshotBeaconConditions) {
-                return;
-            }
-            if (checked) {
-                dshotDisabledMask.value = bit_clear(dshotDisabledMask.value, cond.bit);
-            } else {
-                dshotDisabledMask.value = bit_set(dshotDisabledMask.value, cond.bit);
-            }
-            fcStore.beepers.dshotBeaconConditions._beeperDisabledMask = dshotDisabledMask.value;
+            fcStore.beepers?.dshotBeaconConditions?.setEnabled?.(cond.name, checked);
         };
 
         const enableAllDshot = () => {
-            if (!fcStore.beepers?.dshotBeaconConditions) {
-                return;
-            }
-            let mask = dshotDisabledMask.value;
             dshotBeaconConditionsList.value.forEach((cond) => {
-                mask = bit_clear(mask, cond.bit);
+                fcStore.beepers.dshotBeaconConditions.setEnabled(cond.name, true);
             });
-            dshotDisabledMask.value = mask;
-            fcStore.beepers.dshotBeaconConditions._beeperDisabledMask = mask;
         };
 
         const disableAllDshot = () => {
-            if (!fcStore.beepers?.dshotBeaconConditions) {
-                return;
-            }
-            let mask = dshotDisabledMask.value;
             dshotBeaconConditionsList.value.forEach((cond) => {
-                mask = bit_set(mask, cond.bit);
+                fcStore.beepers.dshotBeaconConditions.setEnabled(cond.name, false);
             });
-            dshotDisabledMask.value = mask;
-            fcStore.beepers.dshotBeaconConditions._beeperDisabledMask = mask;
         };
 
         // Read-only: acc hardware state from store (toggle moved to SensorConfigTab)

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -436,7 +436,9 @@ export default defineComponent({
 
         const toggleFeature = (feature, checked) => {
             const featuresHelper = fcStore.features?.features;
-            if (!featuresHelper) return;
+            if (!featuresHelper) {
+                return;
+            }
             featuresHelper.updateData({ name: feature.name, checked });
             updateTabList(featuresHelper);
         };

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -268,7 +268,6 @@ import { have_sensor } from "../../js/sensor_helpers";
 import semver from "semver";
 import { API_VERSION_1_46 } from "../../js/data_storage";
 import { i18n } from "../../js/localization";
-import { bit_check, bit_clear, bit_set } from "../../js/bit";
 import { useFlightControllerStore } from "@/stores/fc";
 import { useConnectionStore } from "@/stores/connection";
 import { useNavigationStore } from "@/stores/navigation";
@@ -359,7 +358,7 @@ export default defineComponent({
 
         const serializeGpsTabState = () =>
             JSON.stringify({
-                featureMask: fcStore.features?.features?._featureMask ?? 0,
+                gpsFeatureEnabled: fcStore.features?.features?.isEnabled?.("GPS") ?? false,
                 provider: gpsConfig.provider,
                 auto_baud: gpsConfig.auto_baud,
                 auto_config: gpsConfig.auto_config,
@@ -432,18 +431,14 @@ export default defineComponent({
         });
 
         const isFeatureEnabled = (feature) => {
-            if (!fcStore.features?.features) return false;
-            return bit_check(fcStore.features.features._featureMask, feature.bit);
+            return fcStore.features?.features?.isEnabled?.(feature.name) ?? false;
         };
 
         const toggleFeature = (feature, checked) => {
-            if (!fcStore.features?.features) return;
-            if (checked) {
-                fcStore.features.features._featureMask = bit_set(fcStore.features.features._featureMask, feature.bit);
-            } else {
-                fcStore.features.features._featureMask = bit_clear(fcStore.features.features._featureMask, feature.bit);
-            }
-            updateTabList(fcStore.features.features);
+            const featuresHelper = fcStore.features?.features;
+            if (!featuresHelper) return;
+            featuresHelper.updateData({ name: feature.name, checked });
+            updateTabList(featuresHelper);
         };
 
         const setLayer = (layerKey) => {

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -526,7 +526,7 @@ import GUI from "@/js/gui";
 import Model from "@/js/model";
 import RateCurve from "@/js/RateCurve";
 import { degToRad } from "@/js/utils/common";
-import { bit_check, bit_set, bit_clear } from "@/js/bit";
+import { bit_check } from "@/js/bit";
 import { get as getConfig, set as setConfig } from "@/js/ConfigStorage";
 import { updateTabList } from "@/js/utils/updateTabList";
 import { gui_log } from "@/js/gui_log";
@@ -649,7 +649,8 @@ function takeSnapshot() {
         deadband: rcDeadbandConfig.value?.deadband,
         yawDeadband: rcDeadbandConfig.value?.yaw_deadband,
         deadband3dThrottle: rcDeadbandConfig.value?.deadband3d_throttle,
-        featureMask: features.value?.features?._featureMask,
+        telemetryEnabled: features.value?.features?.isEnabled?.("TELEMETRY") ?? false,
+        rssiAdcEnabled: features.value?.features?.isEnabled?.("RSSI_ADC") ?? false,
         elrsBindingPhrase: elrsBindingPhrase.value,
         setpointManualMode: setpointManualMode.value,
         throttleManualMode: throttleManualMode.value,
@@ -935,19 +936,23 @@ function toggleRssiAdc(checked) {
 
 function onRxModeChange() {
     // Update feature mask based on selected RX mode
-    if (features.value?.features?._features) {
+    const featuresHelper = features.value?.features;
+    if (featuresHelper?._features) {
         const selectedBit = selectedRxMode.value;
         // Clear all RX mode bits first, then set the selected one
-        for (const feature of features.value.features._features) {
+        for (const feature of featuresHelper._features) {
             if (feature.mode === "select" && feature.group === "rxMode") {
-                features.value.features._featureMask = bit_clear(features.value.features._featureMask, feature.bit);
+                featuresHelper.disable(feature.name);
             }
         }
         // Set the selected RX mode bit (if not "None" which is -1)
         if (selectedBit !== -1) {
-            features.value.features._featureMask = bit_set(features.value.features._featureMask, selectedBit);
+            const selectedFeature = featuresHelper.findFeatureByBit(selectedBit);
+            if (selectedFeature) {
+                featuresHelper.enable(selectedFeature.name);
+            }
         }
-        updateTabList(features.value.features);
+        updateTabList(featuresHelper);
         needReboot.value = true;
     }
 }
@@ -1009,11 +1014,10 @@ async function loadConfig() {
 
         // Initialize selectedRxMode from feature mask
         if (features.value?.features?._features) {
-            const featureMask = features.value.features._featureMask;
             let foundRxMode = -1;
             for (const feature of features.value.features._features) {
                 if (feature.mode === "select" && feature.group === "rxMode") {
-                    if (bit_check(featureMask, feature.bit)) {
+                    if (features.value.features.isEnabled(feature.name)) {
                         foundRxMode = feature.bit;
                         break;
                     }

--- a/src/js/Beepers.js
+++ b/src/js/Beepers.js
@@ -67,6 +67,20 @@ class Beepers {
         }
         return false;
     }
+    setEnabled(beeperName, enabled) {
+        const self = this;
+
+        for (let i = 0; i < self._beepers.length; i++) {
+            if (self._beepers[i].name === beeperName) {
+                if (enabled) {
+                    self._beeperDisabledMask = bit_clear(self._beeperDisabledMask, self._beepers[i].bit);
+                } else {
+                    self._beeperDisabledMask = bit_set(self._beeperDisabledMask, self._beepers[i].bit);
+                }
+                return;
+            }
+        }
+    }
     generateElements(template, destination) {
         const self = this;
 

--- a/src/js/Beepers.js
+++ b/src/js/Beepers.js
@@ -74,10 +74,8 @@ class Beepers {
         }
     }
     generateElements(template, destination) {
-        const self = this;
-
-        for (let i = 0; i < self._beepers.length; i++) {
-            if (self._beepers[i].visible) {
+        for (let i = 0; i < this._beepers.length; i++) {
+            if (this._beepers[i].visible) {
                 const element = template.cloneNode(true);
                 destination.appendChild(element);
 
@@ -87,17 +85,17 @@ class Beepers {
 
                 if (inputElement) {
                     inputElement.id = `beeper-${i}`;
-                    inputElement.name = self._beepers[i].name;
-                    inputElement.title = self._beepers[i].name;
-                    inputElement.checked = !bit_check(self._beeperDisabledMask, self._beepers[i].bit);
-                    inputElement.dataset.bit = self._beepers[i].bit;
+                    inputElement.name = this._beepers[i].name;
+                    inputElement.title = this._beepers[i].name;
+                    inputElement.checked = !bit_check(this._beeperDisabledMask, this._beepers[i].bit);
+                    inputElement.dataset.bit = this._beepers[i].bit;
                 }
 
                 if (labelElement) {
-                    labelElement.textContent = self._beepers[i].name;
+                    labelElement.textContent = this._beepers[i].name;
                 }
                 if (spanElement) {
-                    spanElement.setAttribute("i18n", `beeper${self._beepers[i].name}`);
+                    spanElement.setAttribute("i18n", `beeper${this._beepers[i].name}`);
                 }
 
                 element.style.display = "";

--- a/src/js/Beepers.js
+++ b/src/js/Beepers.js
@@ -58,26 +58,18 @@ class Beepers {
         self._beeperDisabledMask = beeperDisabledMask;
     }
     isEnabled(beeperName) {
-        const self = this;
+        const beeper = this._beepers.find((b) => b.name === beeperName);
 
-        for (let i = 0; i < self._beepers.length; i++) {
-            if (self._beepers[i].name === beeperName) {
-                return !bit_check(self._beeperDisabledMask, self._beepers[i].bit);
-            }
-        }
-        return false;
+        return beeper ? !bit_check(this._beeperDisabledMask, beeper.bit) : false;
     }
     setEnabled(beeperName, enabled) {
-        const self = this;
+        const beeper = this._beepers.find((b) => b.name === beeperName);
 
-        for (let i = 0; i < self._beepers.length; i++) {
-            if (self._beepers[i].name === beeperName) {
-                if (enabled) {
-                    self._beeperDisabledMask = bit_clear(self._beeperDisabledMask, self._beepers[i].bit);
-                } else {
-                    self._beeperDisabledMask = bit_set(self._beeperDisabledMask, self._beepers[i].bit);
-                }
-                return;
+        if (beeper) {
+            if (enabled) {
+                this._beeperDisabledMask = bit_clear(this._beeperDisabledMask, beeper.bit);
+            } else {
+                this._beeperDisabledMask = bit_set(this._beeperDisabledMask, beeper.bit);
             }
         }
     }

--- a/test/beepers.test.js
+++ b/test/beepers.test.js
@@ -40,4 +40,27 @@ describe("Beepers", () => {
             expect(beepers.getDisabledMask()).toBe(0);
         });
     });
+
+    describe("setEnabled", () => {
+        it("clears the disabled bit when enabling a beeper by name", () => {
+            const beepers = new Beepers();
+            beepers.setDisabledMask(bit_set(0, 3));
+            beepers.setEnabled("DISARMING", true);
+            expect(beepers.isEnabled("DISARMING")).toBe(true);
+            expect(beepers.getDisabledMask()).toBe(0);
+        });
+
+        it("sets the disabled bit when disabling a beeper by name", () => {
+            const beepers = new Beepers();
+            beepers.setEnabled("DISARMING", false);
+            expect(beepers.isEnabled("DISARMING")).toBe(false);
+            expect(beepers.getDisabledMask()).toBe(bit_set(0, 3));
+        });
+
+        it("leaves the mask untouched for an unknown beeper name", () => {
+            const beepers = new Beepers();
+            beepers.setEnabled("NOT_A_BEEPER", false);
+            expect(beepers.getDisabledMask()).toBe(0);
+        });
+    });
 });


### PR DESCRIPTION
ConfigurationTab, GpsTab and ReceiverTab were reaching into Features' and Beepers' private _featureMask/_beeperDisabledMask with hand-rolled bit_set/bit_clear. Reads now go through isEnabled() and writes through updateData()/enable()/disable(), with a new Beepers.setEnabled() (tested) for per-beeper toggling. Checkbox toggles now use updateData(), which also records the analytics changes those tabs were silently skipping. MSP output is unchanged — serialisation still reads getMask()/getDisabledMask() and the bit math is identical. No component touches the private mask fields any more.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved configuration toggles across configuration, GPS, and receiver settings for more consistent, immediate behavior.
  * Beeper controls now provide direct enable/disable handling.

* **Bug Fixes**
  * Improved state tracking for GPS, RX mode, and beeper-related settings so the UI more reliably reflects and detects current configuration.
  * Updated feature-toggle handling to refresh settings consistently across the involved tabs.

* **Tests**
  * Added coverage for beeper enable/disable behavior to ensure correct state updates for known and unknown beepers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->