### PR TITLE
Settle MSP promises on timeout, disconnect and CRC failure

### DIFF
--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -127,7 +127,12 @@
                                             <h3>{{ $t("dataflashSavingTitle") }}</h3>
                                             <div class="dataflash-saving-before">
                                                 <div>{{ $t("dataflashSavingNote") }}</div>
-                                                <UProgress :model-value="saveProgress" :max="100" size="2xl" class="my-4" />
+                                                <UProgress
+                                                    :model-value="saveProgress"
+                                                    :max="100"
+                                                    size="2xl"
+                                                    class="my-4"
+                                                />
                                                 <div class="buttons flex justify-end gap-2 mt-3">
                                                     <UButton
                                                         class="save-flash-cancel"
@@ -305,6 +310,7 @@ import { isExpertModeEnabled } from "../../js/utils/isExpertModeEnabled";
 import NotificationManager from "../../js/utils/notifications";
 import { get as getConfig } from "../../js/ConfigStorage";
 import { sensorTypes } from "../../js/sensor_types";
+import { MspCancelledError } from "../../js/msp/mspErrors";
 
 const BLOCK_SIZE = 4096;
 
@@ -720,6 +726,11 @@ export default defineComponent({
 
                     function onChunkRead(chunkAddress, chunkDataView, bytesCompressed, error) {
                         if (error) {
+                            if (error instanceof MspCancelledError) {
+                                dismissSavingDialog();
+                                FileSystem.closeFile(openedFile);
+                                return;
+                            }
                             console.error("Error reading blackbox log:", error);
                             gui_log(
                                 `<strong><span class="message-negative">${i18n.getMessage("error", {

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -718,7 +718,18 @@ export default defineComponent({
 
                     showSavingDialog();
 
-                    function onChunkRead(chunkAddress, chunkDataView, bytesCompressed) {
+                    function onChunkRead(chunkAddress, chunkDataView, bytesCompressed, error) {
+                        if (error) {
+                            console.error("Error reading blackbox log:", error);
+                            gui_log(
+                                `<strong><span class="message-negative">${i18n.getMessage("error", {
+                                    errorMessage: error,
+                                })}</span></strong>`,
+                            );
+                            dismissSavingDialog();
+                            FileSystem.closeFile(openedFile);
+                            return;
+                        }
                         if (chunkDataView !== null) {
                             if (chunkDataView.byteLength > 0) {
                                 nextAddress += chunkDataView.byteLength;

--- a/src/composables/ports/usePortsState.js
+++ b/src/composables/ports/usePortsState.js
@@ -94,6 +94,10 @@ export function usePortsState(getRules) {
             })
             .catch((error) => {
                 console.error("Failed to load VTX config for ports tab:", error);
+                isLoading.value = false;
+                nextTick(() => {
+                    GUI.content_ready();
+                });
             });
     };
 

--- a/src/composables/ports/usePortsState.js
+++ b/src/composables/ports/usePortsState.js
@@ -88,9 +88,13 @@ export function usePortsState(getRules) {
     });
 
     const loadConfig = () => {
-        MSP.promise(MSPCodes.MSP_VTX_CONFIG).then(() => {
-            mspHelper.loadSerialConfig(handleSerialConfigLoaded);
-        });
+        MSP.promise(MSPCodes.MSP_VTX_CONFIG)
+            .then(() => {
+                mspHelper.loadSerialConfig(handleSerialConfigLoaded);
+            })
+            .catch((error) => {
+                console.error("Failed to load VTX config for ports tab:", error);
+            });
     };
 
     const vtxTableNotConfigured = computed(() => {

--- a/src/composables/useDataflashPull.js
+++ b/src/composables/useDataflashPull.js
@@ -50,7 +50,11 @@ export function useDataflashPull() {
             const result = await new Promise((resolve, reject) => {
                 let nextAddress = 0;
 
-                function onChunkRead(chunkAddress, chunkDataView) {
+                function onChunkRead(chunkAddress, chunkDataView, chunkDataSize, error) {
+                    if (error) {
+                        reject(error);
+                        return;
+                    }
                     if (chunkDataView === null) {
                         // Transient error — retry the same address.
                         mspHelper.dataflashRead(nextAddress, BLOCK_SIZE, onChunkRead);

--- a/src/composables/useLedStrip.js
+++ b/src/composables/useLedStrip.js
@@ -134,12 +134,16 @@ export function useLedStrip() {
 
     // Load LED configuration data
     async function loadData() {
-        await MSP.promise(MSPCodes.MSP_LED_STRIP_CONFIG);
-        await MSP.promise(MSPCodes.MSP_LED_COLORS);
-        await MSP.promise(MSPCodes.MSP_LED_STRIP_MODECOLOR);
+        try {
+            await MSP.promise(MSPCodes.MSP_LED_STRIP_CONFIG);
+            await MSP.promise(MSPCodes.MSP_LED_COLORS);
+            await MSP.promise(MSPCodes.MSP_LED_STRIP_MODECOLOR);
 
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
-            await MSP.promise(MSPCodes.MSP2_GET_LED_STRIP_CONFIG_VALUES);
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                await MSP.promise(MSPCodes.MSP2_GET_LED_STRIP_CONFIG_VALUES);
+            }
+        } catch (error) {
+            console.error("Error loading LED strip data:", error);
         }
     }
 

--- a/src/composables/useTuningSliders.js
+++ b/src/composables/useTuningSliders.js
@@ -102,7 +102,13 @@ export function calculateNewPids(s) {
         return Promise.resolve();
     }
 
-    return MSP.promise(MSPCodes.MSP_CALCULATE_SIMPLIFIED_PID, mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_PID));
+    return MSP.promise(
+        MSPCodes.MSP_CALCULATE_SIMPLIFIED_PID,
+        mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_PID),
+    ).catch((error) => {
+        console.error("Failed to calculate simplified PIDs:", error);
+        return undefined;
+    });
 }
 
 /**
@@ -124,7 +130,10 @@ export function calculateNewGyroFilters(multiplier) {
     return MSP.promise(
         MSPCodes.MSP_CALCULATE_SIMPLIFIED_GYRO,
         mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_GYRO),
-    );
+    ).catch((error) => {
+        console.error("Failed to calculate simplified gyro filters:", error);
+        return undefined;
+    });
 }
 
 /**
@@ -146,7 +155,10 @@ export function calculateNewDTermFilters(multiplier) {
     return MSP.promise(
         MSPCodes.MSP_CALCULATE_SIMPLIFIED_DTERM,
         mspHelper.crunch(MSPCodes.MSP_CALCULATE_SIMPLIFIED_DTERM),
-    );
+    ).catch((error) => {
+        console.error("Failed to calculate simplified D-term filters:", error);
+        return undefined;
+    });
 }
 
 /**
@@ -175,5 +187,10 @@ export function validateTuningSliders() {
         return Promise.resolve();
     }
 
-    return MSP.promise(MSPCodes.MSP_VALIDATE_SIMPLIFIED_TUNING).then(patchInvalidSliders);
+    return MSP.promise(MSPCodes.MSP_VALIDATE_SIMPLIFIED_TUNING)
+        .then(patchInvalidSliders)
+        .catch((error) => {
+            console.error("Failed to validate tuning sliders:", error);
+            return undefined;
+        });
 }

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -19,6 +19,13 @@ import { enableDevelopmentOptions } from "./utils/developmentOptions.js";
 import { loadDeviceFilters } from "./protocols/devices.js";
 import { pinia } from "./pinia_instance.js";
 import { useNavigationStore } from "../stores/navigation.js";
+import { MspCancelledError } from "./msp/mspErrors.js";
+
+window.addEventListener("unhandledrejection", (event) => {
+    if (event.reason instanceof MspCancelledError) {
+        event.preventDefault();
+    }
+});
 
 // Silence Capacitor bridge debug spam on native platforms
 if (Capacitor?.isNativePlatform?.() && typeof Capacitor.isLoggingEnabled === "boolean") {

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -1,6 +1,7 @@
 import GUI from "./gui.js";
 import CONFIGURATOR from "./data_storage.js";
 import { serial } from "./serial.js";
+import { MspCancelledError, MspTimeoutError } from "./msp/mspErrors.js";
 
 const MSP = {
     symbols: {
@@ -54,10 +55,12 @@ const MSP = {
     crcError: false,
 
     callbacks: [],
+    parked: new Map(), // errorAware requests parked behind an in-flight same-code request
     packet_error: 0,
     unsupported: 0,
 
     TIMEOUT: 1000,
+    MAX_RETRIES: 3,
 
     last_received_timestamp: null,
     listeners: [],
@@ -496,41 +499,56 @@ const MSP = {
             return false;
         }
 
+        return this._transmit(code, data, callback_sent, callback_msp, false);
+    },
+    _buffer_matches(entry, byteLength, keyCrc) {
+        return (
+            entry.requestBuffer?.byteLength === byteLength &&
+            this.crc8_dvb_s2_data(new Uint8Array(entry.requestBuffer), 0, entry.requestBuffer.byteLength) === keyCrc
+        );
+    },
+    _transmit(code, data, callback_sent, callback_msp, errorAware) {
         const bufferOut = code <= 254 ? this.encode_message_v1(code, data) : this.encode_message_v2(code, data);
         const view = new Uint8Array(bufferOut);
         const keyCrc = this.crc8_dvb_s2_data(view, 0, view.length);
+
+        // Per-code serialisation: an errorAware request whose code matches an in-flight
+        // errorAware entry with a DIFFERENT buffer parks behind it (identical buffers
+        // dedup and attach instead). Same-code legacy entries never cause parking.
+        if (errorAware) {
+            const differentInFlight = this.callbacks.some(
+                (i) => i.errorAware && i.code === code && !this._buffer_matches(i, bufferOut.byteLength, keyCrc),
+            );
+            if (differentInFlight) {
+                this._park(code, {
+                    code,
+                    requestBuffer: bufferOut,
+                    callback: callback_msp,
+                    callbackSent: callback_sent,
+                    errorAware: true,
+                });
+                return true;
+            }
+        }
+
         const requestExists = this.callbacks.some(
-            (i) =>
-                i.code === code &&
-                i.requestBuffer?.byteLength === bufferOut.byteLength &&
-                this.crc8_dvb_s2_data(new Uint8Array(i.requestBuffer), 0, i.requestBuffer.byteLength) === keyCrc,
+            (i) => i.code === code && this._buffer_matches(i, bufferOut.byteLength, keyCrc),
         );
 
         const obj = {
             code,
             requestBuffer: bufferOut,
             callback: callback_msp,
+            callbackSent: callback_sent,
+            errorAware,
+            attempts: 1,
             start: performance.now(),
         };
 
-        if (!requestExists) {
-            obj.timer = setTimeout(() => {
-                console.warn(
-                    `MSP: data request timed-out: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`,
-                );
-                serial.send(bufferOut, (_sendInfo) => {
-                    obj.stop = performance.now();
-                    const executionTime = Math.round(obj.stop - obj.start);
-                    // We should probably give up connection if the request takes too long ?
-                    if (executionTime > 5000) {
-                        console.warn(
-                            `MSP: data request took too long: ${code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} EXECUTION TIME: ${executionTime}ms`,
-                        );
-                    }
-
-                    clearTimeout(obj.timer); // prevent leaks
-                });
-            }, this.TIMEOUT);
+        // errorAware entries always arm their own timer (even when deduped) so an awaiter
+        // that attached onto a stalled request still settles.
+        if (errorAware || !requestExists) {
+            this._arm_timer(obj);
         }
 
         this.callbacks.push(obj);
@@ -546,28 +564,140 @@ const MSP = {
 
         return true;
     },
-    /**
-     * resolves: {command: code, data: data, length: message_length}
-     */
-    async promise(code, data) {
-        return new Promise((resolve) => {
-            this.send_message(code, data, false, (_data) => {
-                resolve(_data);
-            });
-        });
+    _arm_timer(obj) {
+        obj.timer = setTimeout(() => this._on_timeout(obj), this.TIMEOUT);
     },
-    callbacks_cleanup() {
-        for (const callback of this.callbacks) {
-            clearTimeout(callback.timer);
+    _on_timeout(obj) {
+        if (obj.attempts < this.MAX_RETRIES) {
+            obj.attempts++;
+            console.warn(
+                `MSP: data request timed-out: ${obj.code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`,
+            );
+            serial.send(obj.requestBuffer, (_sendInfo) => {
+                obj.stop = performance.now();
+                const executionTime = Math.round(obj.stop - obj.start);
+                // We should probably give up connection if the request takes too long ?
+                if (executionTime > 5000) {
+                    console.warn(
+                        `MSP: data request took too long: ${obj.code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} EXECUTION TIME: ${executionTime}ms`,
+                    );
+                }
+            });
+            this._arm_timer(obj);
+            return;
         }
 
+        clearTimeout(obj.timer);
+        obj.timer = null;
+
+        if (!obj.errorAware) {
+            // legacy: give up retrying but leave the entry queued so a late response still fires it
+            return;
+        }
+
+        const index = this.callbacks.indexOf(obj);
+        if (index !== -1) {
+            this.callbacks.splice(index, 1);
+        }
+        try {
+            obj.callback?.(null, new MspTimeoutError(`MSP request timed out: ${obj.code}`, obj.code));
+        } catch (callbackError) {
+            console.error("MSP callback threw on timeout:", callbackError);
+        }
+        this._release_parked(obj.code);
+    },
+    _park(code, entry) {
+        let queue = this.parked.get(code);
+        if (!queue) {
+            queue = [];
+            this.parked.set(code, queue);
+        }
+        queue.push(entry);
+    },
+    _release_parked(code) {
+        const queue = this.parked.get(code);
+        if (!queue || queue.length === 0) {
+            return;
+        }
+        if (this.callbacks.some((i) => i.errorAware && i.code === code)) {
+            return;
+        }
+
+        const entry = queue.shift();
+        if (queue.length === 0) {
+            this.parked.delete(code);
+        }
+
+        entry.attempts = 1;
+        entry.start = performance.now();
+        this._arm_timer(entry);
+        this.callbacks.push(entry);
+
+        serial.send(entry.requestBuffer, (sendInfo) => {
+            if (sendInfo.bytesSent === entry.requestBuffer.byteLength && entry.callbackSent) {
+                entry.callbackSent();
+            }
+        });
+    },
+    /**
+     * resolves: {command: code, data: data, length: message_length}
+     * rejects: MspTimeoutError, MspCancelledError or MspCrcError
+     */
+    async promise(code, data) {
+        if (code === undefined || CONFIGURATOR.virtualMode) {
+            return undefined;
+        }
+
+        if (!serial.connected) {
+            throw new MspCancelledError("MSP request while disconnected", code, "disconnected");
+        }
+
+        return new Promise((resolve, reject) => {
+            this._transmit(
+                code,
+                data,
+                false,
+                (response, error) => {
+                    if (error) {
+                        reject(error);
+                    } else {
+                        resolve(response);
+                    }
+                },
+                true,
+            );
+        });
+    },
+    callbacks_cleanup(error = new MspCancelledError("MSP queue cleared", undefined, "cleanup")) {
+        const pending = this.callbacks;
         this.callbacks = [];
+
+        const parked = [];
+        for (const queue of this.parked.values()) {
+            parked.push(...queue);
+        }
+        this.parked.clear();
+
+        for (const entry of pending) {
+            clearTimeout(entry.timer);
+        }
+
+        for (const entry of [...pending, ...parked]) {
+            if (!entry.errorAware) {
+                continue;
+            }
+            try {
+                entry.callback?.(null, error);
+            } catch (callbackError) {
+                console.error("MSP callback threw during cleanup:", callbackError);
+            }
+        }
     },
     disconnect_cleanup() {
         this.state = 0; // reset packet state for "clean" initial entry (this is only required if user hot-disconnects)
         this.packet_error = 0; // reset CRC packet error counter for next session
 
-        this.callbacks_cleanup();
+        this.callbacks_cleanup(new MspCancelledError("Serial connection closed", undefined, "disconnected"));
         // Tag the error so callers can distinguish an EXPECTED close-driven drain — a `save`/
         // `exit` reboots the FC, closing the port before it can reply — from a genuine command
         // failure. The save still succeeded; the board is just restarting.

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -501,23 +501,28 @@ const MSP = {
 
         return this._transmit(code, data, callback_sent, callback_msp, false);
     },
-    _buffer_matches(entry, byteLength, keyCrc) {
-        return (
-            entry.requestBuffer?.byteLength === byteLength &&
-            this.crc8_dvb_s2_data(new Uint8Array(entry.requestBuffer), 0, entry.requestBuffer.byteLength) === keyCrc
-        );
+    _buffer_matches(entry, view) {
+        if (entry.requestBuffer?.byteLength !== view.byteLength) {
+            return false;
+        }
+        const entryView = new Uint8Array(entry.requestBuffer);
+        for (let i = 0; i < view.byteLength; i++) {
+            if (entryView[i] !== view[i]) {
+                return false;
+            }
+        }
+        return true;
     },
     _transmit(code, data, callback_sent, callback_msp, errorAware) {
         const bufferOut = code <= 254 ? this.encode_message_v1(code, data) : this.encode_message_v2(code, data);
         const view = new Uint8Array(bufferOut);
-        const keyCrc = this.crc8_dvb_s2_data(view, 0, view.length);
 
         // Per-code serialisation: an errorAware request whose code matches an in-flight
         // errorAware entry with a DIFFERENT buffer parks behind it (identical buffers
         // dedup and attach instead). Same-code legacy entries never cause parking.
         if (errorAware) {
             const differentInFlight = this.callbacks.some(
-                (i) => i.errorAware && i.code === code && !this._buffer_matches(i, bufferOut.byteLength, keyCrc),
+                (i) => i.errorAware && i.code === code && !this._buffer_matches(i, view),
             );
             if (differentInFlight) {
                 this._park(code, {
@@ -531,9 +536,7 @@ const MSP = {
             }
         }
 
-        const requestExists = this.callbacks.some(
-            (i) => i.code === code && this._buffer_matches(i, bufferOut.byteLength, keyCrc),
-        );
+        const requestExists = this.callbacks.some((i) => i.code === code && this._buffer_matches(i, view));
 
         const obj = {
             code,

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -7,6 +7,7 @@ import semver from "semver";
 import vtxDeviceStatusFactory from "../utils/VtxDeviceStatus/VtxDeviceStatusFactory";
 import MSP from "../msp";
 import MSPCodes from "./MSPCodes";
+import { MspCrcError } from "./mspErrors";
 import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48 } from "../data_storage";
 import EscProtocols from "../utils/EscProtocols";
 import huffmanDecodeBuf from "../huffman";
@@ -1809,27 +1810,39 @@ MspHelper.prototype.process_data = function (dataHandler) {
         // iterating in reverse because we use .splice which modifies array length
         if (dataHandler.callbacks[i]?.code === code) {
             // save callback reference
-            const callback = dataHandler.callbacks[i].callback;
+            const entry = dataHandler.callbacks[i];
+            const callback = entry.callback;
 
             // remove timeout
-            clearTimeout(dataHandler.callbacks[i].timer);
+            clearTimeout(entry.timer);
 
             // remove object from array
             dataHandler.callbacks.splice(i, 1);
-            // Always invoke callback and pass crcError flag. Callbacks expect to
-            // receive the original DataView so they can choose how to handle CRC
-            // errors; don't replace the data with null here to avoid breaking
-            // existing consumers that dereference response.data before checking
-            // crcError.
-            if (callback) {
+            // Legacy callbacks receive the original DataView with the crcError flag so
+            // they can choose how to handle CRC errors; errorAware callbacks reject on
+            // crcError and otherwise receive the response as the first argument.
+            if (typeof callback === "function") {
                 try {
-                    callback({ command: code, data: data, length: data ? data.byteLength : 0, crcError: crcError });
+                    if (entry.errorAware) {
+                        if (crcError) {
+                            callback(null, new MspCrcError(`CRC error for MSP code ${code}`, code));
+                        } else {
+                            callback(
+                                { command: code, data: data, length: data ? data.byteLength : 0, crcError: crcError },
+                                undefined,
+                            );
+                        }
+                    } else {
+                        callback({ command: code, data: data, length: data ? data.byteLength : 0, crcError: crcError });
+                    }
                 } catch (e) {
                     console.error(`callback for code ${code} threw:`, e);
                 }
             }
         }
     }
+
+    dataHandler._release_parked?.(code);
 };
 
 /**
@@ -2525,59 +2538,59 @@ MspHelper.prototype.dataflashRead = function (address, blockSize, onDataCallback
     // Allow compression
     outData = outData.concat([1]);
 
-    MSP.send_message(
-        MSPCodes.MSP_DATAFLASH_READ,
-        outData,
-        false,
-        function (response) {
-            if (!response.crcError) {
-                const chunkAddress = response.data.readU32();
+    MSP.promise(MSPCodes.MSP_DATAFLASH_READ, outData).then(
+        (response) => {
+            const chunkAddress = response.data.readU32();
 
-                const headerSize = 7;
-                const dataSize = response.data.readU16();
-                const dataCompressionType = response.data.readU8();
+            const headerSize = 7;
+            const dataSize = response.data.readU16();
+            const dataCompressionType = response.data.readU8();
 
-                // Verify that the address of the memory returned matches what the caller asked for and there was not a CRC error
-                if (chunkAddress == address) {
-                    /* Strip that address off the front of the reply and deliver it separately so the caller doesn't have to
-                     * figure out the reply format:
-                     */
-                    if (dataCompressionType == 0) {
-                        onDataCallback(
-                            address,
-                            new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize),
-                        );
-                    } else if (dataCompressionType == 1) {
-                        // Read compressed char count to avoid decoding stray bit sequences as bytes
-                        const compressedCharCount = response.data.readU16();
+            // Verify that the address of the memory returned matches what the caller asked for
+            if (chunkAddress == address) {
+                /* Strip that address off the front of the reply and deliver it separately so the caller doesn't have to
+                 * figure out the reply format:
+                 */
+                if (dataCompressionType == 0) {
+                    onDataCallback(
+                        address,
+                        new DataView(response.data.buffer, response.data.byteOffset + headerSize, dataSize),
+                    );
+                } else if (dataCompressionType == 1) {
+                    // Read compressed char count to avoid decoding stray bit sequences as bytes
+                    const compressedCharCount = response.data.readU16();
 
-                        // Compressed format uses 2 additional bytes as a pseudo-header to denote the number of uncompressed bytes
-                        const compressedArray = new Uint8Array(
-                            response.data.buffer,
-                            response.data.byteOffset + headerSize + 2,
-                            dataSize - 2,
-                        );
-                        const decompressedArray = huffmanDecodeBuf(
-                            compressedArray,
-                            compressedCharCount,
-                            defaultHuffmanTree,
-                            defaultHuffmanLenIndex,
-                        );
+                    // Compressed format uses 2 additional bytes as a pseudo-header to denote the number of uncompressed bytes
+                    const compressedArray = new Uint8Array(
+                        response.data.buffer,
+                        response.data.byteOffset + headerSize + 2,
+                        dataSize - 2,
+                    );
+                    const decompressedArray = huffmanDecodeBuf(
+                        compressedArray,
+                        compressedCharCount,
+                        defaultHuffmanTree,
+                        defaultHuffmanLenIndex,
+                    );
 
-                        onDataCallback(address, new DataView(decompressedArray.buffer), dataSize);
-                    }
-                } else {
-                    // Report address error
-                    console.log(`Expected address ${address} but received ${chunkAddress} - retrying`);
-                    onDataCallback(address, null); // returning null to the callback forces a retry
+                    onDataCallback(address, new DataView(decompressedArray.buffer), dataSize);
                 }
             } else {
-                // Report crc error
-                console.log(`CRC error for address ${address} - retrying`);
+                // Report address error
+                console.log(`Expected address ${address} but received ${chunkAddress} - retrying`);
                 onDataCallback(address, null); // returning null to the callback forces a retry
             }
         },
-        true,
+        (error) => {
+            if (error instanceof MspCrcError) {
+                // Report crc error
+                console.log(`CRC error for address ${address} - retrying`);
+                onDataCallback(address, null); // returning null to the callback forces a retry
+            } else {
+                // Timeout or cancellation: surface the error as the fourth argument
+                onDataCallback(address, null, null, error);
+            }
+        },
     );
 };
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -1828,12 +1828,24 @@ MspHelper.prototype.process_data = function (dataHandler) {
                             callback(null, new MspCrcError(`CRC error for MSP code ${code}`, code));
                         } else {
                             callback(
-                                { command: code, data: data, length: data ? data.byteLength : 0, crcError: crcError },
+                                {
+                                    command: code,
+                                    data: data,
+                                    length: data ? data.byteLength : 0,
+                                    crcError: crcError,
+                                    unsupported: dataHandler.unsupported,
+                                },
                                 undefined,
                             );
                         }
                     } else {
-                        callback({ command: code, data: data, length: data ? data.byteLength : 0, crcError: crcError });
+                        callback({
+                            command: code,
+                            data: data,
+                            length: data ? data.byteLength : 0,
+                            crcError: crcError,
+                            unsupported: dataHandler.unsupported,
+                        });
                     }
                 } catch (e) {
                     console.error(`callback for code ${code} threw:`, e);
@@ -2574,6 +2586,14 @@ MspHelper.prototype.dataflashRead = function (address, blockSize, onDataCallback
                     );
 
                     onDataCallback(address, new DataView(decompressedArray.buffer), dataSize);
+                } else {
+                    console.error(`Unknown dataflash compression type ${dataCompressionType}`);
+                    onDataCallback(
+                        address,
+                        null,
+                        null,
+                        new Error(`Unknown dataflash compression type ${dataCompressionType}`),
+                    );
                 }
             } else {
                 // Report address error

--- a/src/js/msp/mspErrors.js
+++ b/src/js/msp/mspErrors.js
@@ -1,0 +1,29 @@
+export class MspError extends Error {
+    constructor(message, code) {
+        super(message);
+        this.name = "MspError";
+        this.code = code;
+    }
+}
+
+export class MspTimeoutError extends MspError {
+    constructor(message, code) {
+        super(message, code);
+        this.name = "MspTimeoutError";
+    }
+}
+
+export class MspCancelledError extends MspError {
+    constructor(message, code, reason = "cleanup") {
+        super(message, code);
+        this.name = "MspCancelledError";
+        this.reason = reason;
+    }
+}
+
+export class MspCrcError extends MspError {
+    constructor(message, code) {
+        super(message, code);
+        this.name = "MspCrcError";
+    }
+}

--- a/src/js/protocols/webstm32.js
+++ b/src/js/protocols/webstm32.js
@@ -12,6 +12,7 @@ import MSP from "../msp";
 import FC from "../fc";
 import { bit_check } from "../bit";
 import { gui_log } from "../gui_log";
+import { MspCancelledError } from "../msp/mspErrors";
 import MSPCodes from "../msp/MSPCodes";
 import PortUsage from "../port_usage";
 import { serial } from "../serial";
@@ -181,12 +182,24 @@ class STM32Protocol {
         const buffer = [];
         buffer.push8(this.rebootMode);
         setTimeout(() => {
-            MSP.promise(MSPCodes.MSP_SET_REBOOT, buffer).then(() => {
-                // if firmware doesn't flush MSP/serial send buffers and gracefully shutdown VCP connections we won't get a reply, so don't wait for it.
+            const disconnectFromMsp = () => {
                 this.mspConnector.disconnect((disconnectionResult) => {
                     console.log(`${this.logHead} Disconnecting from MSP`, disconnectionResult);
                 });
-            });
+            };
+            MSP.promise(MSPCodes.MSP_SET_REBOOT, buffer)
+                .then(() => {
+                    // if firmware doesn't flush MSP/serial send buffers and gracefully shutdown VCP connections we won't get a reply, so don't wait for it.
+                    disconnectFromMsp();
+                })
+                .catch((error) => {
+                    if (error instanceof MspCancelledError && error.reason === "disconnected") {
+                        // Expected: the FC drops the serial link as part of rebooting.
+                        disconnectFromMsp();
+                    } else {
+                        console.error(`${this.logHead} MSP_SET_REBOOT request failed:`, error);
+                    }
+                });
             console.log(`${this.logHead} Reboot request received by device`);
         }, 100);
     }
@@ -203,44 +216,48 @@ class STM32Protocol {
     lookingForCapabilitiesViaMSP() {
         console.log(`${this.logHead} Looking for capabilities via MSP`);
 
-        MSP.promise(MSPCodes.MSP_BOARD_INFO).then(() => {
-            if (bit_check(FC.CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_FLASH_BOOTLOADER)) {
-                // Board has flash bootloader
-                gui_log(i18n.getMessage("deviceRebooting_flashBootloader"));
-                console.log(`${this.logHead} flash bootloader detected`);
-                this.rebootMode = 4; // MSP_REBOOT_BOOTLOADER_FLASH
-            } else {
-                gui_log(i18n.getMessage("deviceRebooting_romBootloader"));
-                console.log(`${this.logHead} no flash bootloader detected`);
-                this.rebootMode = 1; // MSP_REBOOT_BOOTLOADER_ROM;
-            }
-
-            const selectedBoard =
-                this.serialOptions.selectedBoard && this.serialOptions.selectedBoard !== "0"
-                    ? this.serialOptions.selectedBoard
-                    : "NONE";
-            const connectedBoard = FC.CONFIG.boardName ? FC.CONFIG.boardName : "UNKNOWN";
-
-            try {
-                if (
-                    selectedBoard !== connectedBoard &&
-                    !this.serialOptions.localFirmwareLoaded &&
-                    this.serialOptions.showDialogVerifyBoard
-                ) {
-                    this.serialOptions.showDialogVerifyBoard(
-                        selectedBoard,
-                        connectedBoard,
-                        this.reboot.bind(this),
-                        this.onAbort.bind(this),
-                    );
+        MSP.promise(MSPCodes.MSP_BOARD_INFO)
+            .then(() => {
+                if (bit_check(FC.CONFIG.targetCapabilities, FC.TARGET_CAPABILITIES_FLAGS.HAS_FLASH_BOOTLOADER)) {
+                    // Board has flash bootloader
+                    gui_log(i18n.getMessage("deviceRebooting_flashBootloader"));
+                    console.log(`${this.logHead} flash bootloader detected`);
+                    this.rebootMode = 4; // MSP_REBOOT_BOOTLOADER_FLASH
                 } else {
+                    gui_log(i18n.getMessage("deviceRebooting_romBootloader"));
+                    console.log(`${this.logHead} no flash bootloader detected`);
+                    this.rebootMode = 1; // MSP_REBOOT_BOOTLOADER_ROM;
+                }
+
+                const selectedBoard =
+                    this.serialOptions.selectedBoard && this.serialOptions.selectedBoard !== "0"
+                        ? this.serialOptions.selectedBoard
+                        : "NONE";
+                const connectedBoard = FC.CONFIG.boardName ? FC.CONFIG.boardName : "UNKNOWN";
+
+                try {
+                    if (
+                        selectedBoard !== connectedBoard &&
+                        !this.serialOptions.localFirmwareLoaded &&
+                        this.serialOptions.showDialogVerifyBoard
+                    ) {
+                        this.serialOptions.showDialogVerifyBoard(
+                            selectedBoard,
+                            connectedBoard,
+                            this.reboot.bind(this),
+                            this.onAbort.bind(this),
+                        );
+                    } else {
+                        this.reboot();
+                    }
+                } catch (e) {
+                    console.error(e);
                     this.reboot();
                 }
-            } catch (e) {
-                console.error(e);
-                this.reboot();
-            }
-        });
+            })
+            .catch((error) => {
+                console.error(`${this.logHead} MSP_BOARD_INFO request failed:`, error);
+            });
     }
 
     handleMSPConnect() {

--- a/src/js/protocols/webstm32.js
+++ b/src/js/protocols/webstm32.js
@@ -198,6 +198,7 @@ class STM32Protocol {
                         disconnectFromMsp();
                     } else {
                         console.error(`${this.logHead} MSP_SET_REBOOT request failed:`, error);
+                        this.handleError();
                     }
                 });
             console.log(`${this.logHead} Reboot request received by device`);
@@ -257,6 +258,7 @@ class STM32Protocol {
             })
             .catch((error) => {
                 console.error(`${this.logHead} MSP_BOARD_INFO request failed:`, error);
+                this.handleError();
             });
     }
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -765,7 +765,11 @@ function checkReportProblem(problemName, problems) {
 }
 
 async function checkReportProblems() {
-    await MSP.promise(MSPCodes.MSP_STATUS);
+    try {
+        await MSP.promise(MSPCodes.MSP_STATUS);
+    } catch (error) {
+        console.error("Failed to request MSP_STATUS:", error);
+    }
 
     let needsProblemReportingDialog = false;
     let problems = [];
@@ -792,7 +796,11 @@ async function processBuildConfiguration() {
 
     if (buildOptionsSupported) {
         // get build key from firmware
-        await MSP.promise(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.BUILD_KEY));
+        try {
+            await MSP.promise(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.BUILD_KEY));
+        } catch (error) {
+            console.error("Failed to request build key:", error);
+        }
         gui_log(i18n.getMessage("buildKey", FC.CONFIG.buildKey));
 
         // firmware 1_45 or higher is required to support cloud build options
@@ -814,7 +822,12 @@ async function processBuildConfiguration() {
 }
 
 async function processUid() {
-    await MSP.promise(MSPCodes.MSP_UID);
+    try {
+        await MSP.promise(MSPCodes.MSP_UID);
+    } catch (error) {
+        console.error("Failed to request MSP_UID:", error);
+        return;
+    }
 
     connectionTimestamp = Date.now();
 
@@ -833,10 +846,14 @@ async function processUid() {
 }
 
 async function processCraftName() {
-    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
-        await MSP.promise(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.CRAFT_NAME));
-    } else {
-        await MSP.promise(MSPCodes.MSP_NAME);
+    try {
+        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+            await MSP.promise(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.CRAFT_NAME));
+        } else {
+            await MSP.promise(MSPCodes.MSP_NAME);
+        }
+    } catch (error) {
+        console.error("Failed to request craft name:", error);
     }
 
     gui_log(
@@ -847,7 +864,11 @@ async function processCraftName() {
     );
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
-        await MSP.promise(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.PILOT_NAME));
+        try {
+            await MSP.promise(MSPCodes.MSP2_GET_TEXT, mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.PILOT_NAME));
+        } catch (error) {
+            console.error("Failed to request pilot name:", error);
+        }
     }
 
     FC.CONFIG.armingDisabled = false;
@@ -1029,13 +1050,33 @@ export function read_serial(info) {
 }
 
 export async function update_sensor_status() {
-    await MSP.promise(MSPCodes.MSP_ANALOG);
-    await MSP.promise(MSPCodes.MSP_BATTERY_STATE);
-    await MSP.promise(MSPCodes.MSP_BOXNAMES);
-    await MSP.promise(MSPCodes.MSP_STATUS_EX);
+    try {
+        await MSP.promise(MSPCodes.MSP_ANALOG);
+    } catch (error) {
+        console.error("Failed to request MSP_ANALOG:", error);
+    }
+    try {
+        await MSP.promise(MSPCodes.MSP_BATTERY_STATE);
+    } catch (error) {
+        console.error("Failed to request MSP_BATTERY_STATE:", error);
+    }
+    try {
+        await MSP.promise(MSPCodes.MSP_BOXNAMES);
+    } catch (error) {
+        console.error("Failed to request MSP_BOXNAMES:", error);
+    }
+    try {
+        await MSP.promise(MSPCodes.MSP_STATUS_EX);
+    } catch (error) {
+        console.error("Failed to request MSP_STATUS_EX:", error);
+    }
 
     if (have_sensor(FC.CONFIG.activeSensors, "gps")) {
-        await MSP.promise(MSPCodes.MSP_RAW_GPS);
+        try {
+            await MSP.promise(MSPCodes.MSP_RAW_GPS);
+        } catch (error) {
+            console.error("Failed to request MSP_RAW_GPS:", error);
+        }
     }
 }
 

--- a/src/js/utils/osdFont.js
+++ b/src/js/utils/osdFont.js
@@ -278,6 +278,11 @@ FONT.upload = function ($progress) {
         .then(function () {
             console.log(`Uploaded all ${FONT.data.characters.length} characters`);
             gui_log(i18n.getMessage("osdSetupUploadingFontEnd", { length: FONT.data.characters.length }));
+        })
+        .catch((error) => {
+            console.error("Font upload failed:", error);
+            gui_log(i18n.getMessage("osdSetupUploadingFontFailed"));
+            throw error;
         });
 };
 

--- a/test/js/msp_promise.test.js
+++ b/test/js/msp_promise.test.js
@@ -5,7 +5,7 @@ import { serial } from "../../src/js/serial";
 import MspHelper from "../../src/js/msp/MSPHelper";
 import MSPCodes from "../../src/js/msp/MSPCodes";
 import CONFIGURATOR from "../../src/js/data_storage";
-import { MspTimeoutError, MspCrcError } from "../../src/js/msp/mspErrors";
+import { MspCancelledError, MspTimeoutError, MspCrcError } from "../../src/js/msp/mspErrors";
 
 const EEPROM_WRITE_CODE = MSPCodes.MSP_EEPROM_WRITE;
 
@@ -76,14 +76,38 @@ describe("MSP promise semantics", () => {
 
     describe("disconnect_cleanup", () => {
         it("rejects pending promise with MspCancelledError reason disconnected and empties queues", async () => {
-            const rejection = expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toMatchObject({
-                name: "MspCancelledError",
-                reason: "disconnected",
-            });
+            const promise = MSP.promise(EEPROM_WRITE_CODE);
+            promise.catch(() => {});
+            const instanceRejection = expect(promise).rejects.toBeInstanceOf(MspCancelledError);
+            const reasonRejection = expect(promise).rejects.toMatchObject({ reason: "disconnected" });
 
             MSP.disconnect_cleanup();
 
-            await rejection;
+            await instanceRejection;
+            await reasonRejection;
+            expect(MSP.callbacks).toHaveLength(0);
+            expect(MSP.parked.size).toBe(0);
+        });
+
+        it("rejects both an in-flight and a parked promise with MspCancelledError reason disconnected", async () => {
+            const inFlightPromise = MSP.promise(EEPROM_WRITE_CODE, [1]);
+            inFlightPromise.catch(() => {});
+            const parkedPromise = MSP.promise(EEPROM_WRITE_CODE, [2]);
+            parkedPromise.catch(() => {});
+
+            expect(MSP.parked.get(EEPROM_WRITE_CODE)).toHaveLength(1);
+
+            const inFlightInstanceRejection = expect(inFlightPromise).rejects.toBeInstanceOf(MspCancelledError);
+            const inFlightReasonRejection = expect(inFlightPromise).rejects.toMatchObject({ reason: "disconnected" });
+            const parkedInstanceRejection = expect(parkedPromise).rejects.toBeInstanceOf(MspCancelledError);
+            const parkedReasonRejection = expect(parkedPromise).rejects.toMatchObject({ reason: "disconnected" });
+
+            MSP.disconnect_cleanup();
+
+            await inFlightInstanceRejection;
+            await inFlightReasonRejection;
+            await parkedInstanceRejection;
+            await parkedReasonRejection;
             expect(MSP.callbacks).toHaveLength(0);
             expect(MSP.parked.size).toBe(0);
         });
@@ -91,14 +115,15 @@ describe("MSP promise semantics", () => {
 
     describe("callbacks_cleanup", () => {
         it("rejects pending promise with MspCancelledError reason cleanup", async () => {
-            const rejection = expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toMatchObject({
-                name: "MspCancelledError",
-                reason: "cleanup",
-            });
+            const promise = MSP.promise(EEPROM_WRITE_CODE);
+            promise.catch(() => {});
+            const instanceRejection = expect(promise).rejects.toBeInstanceOf(MspCancelledError);
+            const reasonRejection = expect(promise).rejects.toMatchObject({ reason: "cleanup" });
 
             MSP.callbacks_cleanup();
 
-            await rejection;
+            await instanceRejection;
+            await reasonRejection;
             expect(MSP.callbacks).toHaveLength(0);
         });
     });
@@ -107,10 +132,10 @@ describe("MSP promise semantics", () => {
         it("rejects with MspCancelledError reason disconnected when serial is not connected", async () => {
             serial._protocol = { connected: false };
 
-            await expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toMatchObject({
-                name: "MspCancelledError",
-                reason: "disconnected",
-            });
+            const promise = MSP.promise(EEPROM_WRITE_CODE);
+            promise.catch(() => {});
+            await expect(promise).rejects.toBeInstanceOf(MspCancelledError);
+            await expect(promise).rejects.toMatchObject({ reason: "disconnected" });
             expect(serialSendSpy).not.toHaveBeenCalled();
         });
 

--- a/test/js/msp_promise.test.js
+++ b/test/js/msp_promise.test.js
@@ -1,0 +1,262 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../src/js/injected_methods";
+import MSP from "../../src/js/msp";
+import { serial } from "../../src/js/serial";
+import MspHelper from "../../src/js/msp/MSPHelper";
+import MSPCodes from "../../src/js/msp/MSPCodes";
+import CONFIGURATOR from "../../src/js/data_storage";
+import { MspTimeoutError, MspCrcError } from "../../src/js/msp/mspErrors";
+
+const EEPROM_WRITE_CODE = MSPCodes.MSP_EEPROM_WRITE;
+
+function xorChecksum(bytes) {
+    return bytes.reduce((acc, byte) => acc ^ byte, 0);
+}
+
+function v1ResponseFrame(code, payload = []) {
+    const length = payload.length;
+    const checksum = xorChecksum([length, code, ...payload]);
+    return [0x24, 0x4d, 0x3e, length, code, ...payload, checksum];
+}
+
+function v1CorruptResponseFrame(code, payload = []) {
+    const length = payload.length;
+    const checksum = xorChecksum([length, code, ...payload]) ^ 0xff;
+    return [0x24, 0x4d, 0x3e, length, code, ...payload, checksum];
+}
+
+function readFrame(bytes) {
+    MSP.read({ data: new Uint8Array(bytes).buffer });
+}
+
+describe("MSP promise semantics", () => {
+    const mspHelper = new MspHelper();
+    let serialSendSpy;
+    let boundProcessData;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        serialSendSpy = vi.spyOn(serial, "send").mockImplementation(() => {});
+        serial._protocol = { connected: true };
+        CONFIGURATOR.virtualMode = false;
+
+        MSP.callbacks = [];
+        MSP.parked.clear();
+        MSP.state = MSP.decoder_states.IDLE;
+
+        MSP.listeners = [];
+        boundProcessData = mspHelper.process_data.bind(mspHelper);
+        MSP.listen(boundProcessData);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    describe("timeout", () => {
+        it("rejects with MspTimeoutError after MAX_RETRIES attempts and removes the queue entry", async () => {
+            const rejection = expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toBeInstanceOf(MspTimeoutError);
+
+            expect(serialSendSpy).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(MSP.TIMEOUT);
+            expect(serialSendSpy).toHaveBeenCalledTimes(2);
+
+            await vi.advanceTimersByTimeAsync(MSP.TIMEOUT);
+            expect(serialSendSpy).toHaveBeenCalledTimes(3);
+
+            await vi.advanceTimersByTimeAsync(MSP.TIMEOUT);
+            expect(serialSendSpy).toHaveBeenCalledTimes(3);
+
+            await rejection;
+            expect(MSP.callbacks).toHaveLength(0);
+        });
+    });
+
+    describe("disconnect_cleanup", () => {
+        it("rejects pending promise with MspCancelledError reason disconnected and empties queues", async () => {
+            const rejection = expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toMatchObject({
+                name: "MspCancelledError",
+                reason: "disconnected",
+            });
+
+            MSP.disconnect_cleanup();
+
+            await rejection;
+            expect(MSP.callbacks).toHaveLength(0);
+            expect(MSP.parked.size).toBe(0);
+        });
+    });
+
+    describe("callbacks_cleanup", () => {
+        it("rejects pending promise with MspCancelledError reason cleanup", async () => {
+            const rejection = expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toMatchObject({
+                name: "MspCancelledError",
+                reason: "cleanup",
+            });
+
+            MSP.callbacks_cleanup();
+
+            await rejection;
+            expect(MSP.callbacks).toHaveLength(0);
+        });
+    });
+
+    describe("send while disconnected / virtual mode", () => {
+        it("rejects with MspCancelledError reason disconnected when serial is not connected", async () => {
+            serial._protocol = { connected: false };
+
+            await expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toMatchObject({
+                name: "MspCancelledError",
+                reason: "disconnected",
+            });
+            expect(serialSendSpy).not.toHaveBeenCalled();
+        });
+
+        it("resolves undefined without touching serial.send when virtualMode is true", async () => {
+            CONFIGURATOR.virtualMode = true;
+
+            await expect(MSP.promise(EEPROM_WRITE_CODE)).resolves.toBeUndefined();
+            expect(serialSendSpy).not.toHaveBeenCalled();
+        });
+    });
+
+    describe("crc failure", () => {
+        it("rejects with MspCrcError when the response frame checksum is wrong", async () => {
+            const rejection = expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toBeInstanceOf(MspCrcError);
+
+            readFrame(v1CorruptResponseFrame(EEPROM_WRITE_CODE));
+
+            await rejection;
+        });
+    });
+
+    describe("per-code serialisation", () => {
+        it("parks a second errorAware request with a different payload behind the in-flight one, then releases it on response", async () => {
+            const firstPromise = MSP.promise(EEPROM_WRITE_CODE, [1]);
+            expect(serialSendSpy).toHaveBeenCalledTimes(1);
+
+            const secondPromise = MSP.promise(EEPROM_WRITE_CODE, [2]);
+            expect(serialSendSpy).toHaveBeenCalledTimes(1);
+            expect(MSP.parked.get(EEPROM_WRITE_CODE)).toHaveLength(1);
+
+            readFrame(v1ResponseFrame(EEPROM_WRITE_CODE, [1]));
+            await expect(firstPromise).resolves.toMatchObject({ command: EEPROM_WRITE_CODE });
+
+            expect(serialSendSpy).toHaveBeenCalledTimes(2);
+            expect(MSP.parked.has(EEPROM_WRITE_CODE)).toBe(false);
+
+            readFrame(v1ResponseFrame(EEPROM_WRITE_CODE, [2]));
+            const secondResult = await secondPromise;
+            expect(secondResult.command).toBe(EEPROM_WRITE_CODE);
+            expect(secondResult.data.byteLength).toBe(1);
+            expect(secondResult.data.getUint8(0)).toBe(2);
+        });
+
+        it("dedups two identical (payload-less) requests onto a single wire send and resolves both on one response", async () => {
+            // _transmit only skips the resend when `data` is falsy (`if (data || !requestExists)`),
+            // so true wire-level dedup only happens for no-payload requests; a truthy payload
+            // always resends even when the buffer already matches an in-flight entry.
+            const firstPromise = MSP.promise(EEPROM_WRITE_CODE);
+            const secondPromise = MSP.promise(EEPROM_WRITE_CODE);
+
+            expect(serialSendSpy).toHaveBeenCalledTimes(1);
+            expect(MSP.parked.size).toBe(0);
+            expect(MSP.callbacks.filter((entry) => entry.code === EEPROM_WRITE_CODE)).toHaveLength(2);
+
+            readFrame(v1ResponseFrame(EEPROM_WRITE_CODE));
+
+            await expect(firstPromise).resolves.toMatchObject({ command: EEPROM_WRITE_CODE });
+            await expect(secondPromise).resolves.toMatchObject({ command: EEPROM_WRITE_CODE });
+            expect(MSP.callbacks).toHaveLength(0);
+        });
+
+        it("releases a parked request on timeout exhaustion of the in-flight one, and the released request then times out on its own", async () => {
+            const firstRejection = expect(MSP.promise(EEPROM_WRITE_CODE, [1])).rejects.toBeInstanceOf(MspTimeoutError);
+            const secondRejection = expect(MSP.promise(EEPROM_WRITE_CODE, [2])).rejects.toBeInstanceOf(MspTimeoutError);
+
+            expect(serialSendSpy).toHaveBeenCalledTimes(1);
+            expect(MSP.parked.get(EEPROM_WRITE_CODE)).toHaveLength(1);
+
+            // exhaust the first request's retries (initial send + resends while attempts < MAX_RETRIES,
+            // exhaustion detected on the MAX_RETRIES-th timer firing, i.e. at MAX_RETRIES * TIMEOUT)
+            await vi.advanceTimersByTimeAsync(MSP.TIMEOUT * MSP.MAX_RETRIES);
+            await firstRejection;
+
+            // the parked request is released and transmitted once the first is gone
+            expect(MSP.parked.has(EEPROM_WRITE_CODE)).toBe(false);
+            expect(MSP.callbacks.some((entry) => entry.code === EEPROM_WRITE_CODE)).toBe(true);
+
+            // now let the released request exhaust its own retries
+            await vi.advanceTimersByTimeAsync(MSP.TIMEOUT * MSP.MAX_RETRIES);
+            await secondRejection;
+
+            expect(MSP.callbacks).toHaveLength(0);
+        });
+    });
+
+    describe("legacy interplay", () => {
+        it("does not park a promise behind an in-flight legacy request with a different payload", async () => {
+            // Dispatch (MSPHelper.process_data) matches queued callbacks entries by `code` alone,
+            // not by request buffer, so a single incoming frame resolves every same-code entry
+            // still queued — legacy and errorAware alike — regardless of which payload it was for.
+            let legacyCallbackArg;
+            MSP.send_message(EEPROM_WRITE_CODE, [1], false, (result) => {
+                legacyCallbackArg = result;
+            });
+            expect(serialSendSpy).toHaveBeenCalledTimes(1);
+
+            const promiseResult = MSP.promise(EEPROM_WRITE_CODE, [2]);
+            expect(serialSendSpy).toHaveBeenCalledTimes(2);
+            expect(MSP.parked.size).toBe(0);
+
+            readFrame(v1ResponseFrame(EEPROM_WRITE_CODE, [2]));
+
+            await expect(promiseResult).resolves.toMatchObject({ command: EEPROM_WRITE_CODE });
+            expect(legacyCallbackArg).toMatchObject({ command: EEPROM_WRITE_CODE });
+            expect(MSP.callbacks).toHaveLength(0);
+        });
+
+        it("does not invoke the legacy callback on callbacks_cleanup", () => {
+            const legacyCallback = vi.fn();
+            MSP.send_message(EEPROM_WRITE_CODE, [1], false, legacyCallback);
+
+            MSP.callbacks_cleanup();
+
+            expect(legacyCallback).not.toHaveBeenCalled();
+        });
+
+        it("does not invoke the legacy callback on retry exhaustion, but a late response still fires it", async () => {
+            const legacyCallback = vi.fn();
+            MSP.send_message(EEPROM_WRITE_CODE, [1], false, legacyCallback);
+
+            await vi.advanceTimersByTimeAsync(MSP.TIMEOUT * MSP.MAX_RETRIES);
+            expect(legacyCallback).not.toHaveBeenCalled();
+            expect(MSP.callbacks.some((entry) => entry.code === EEPROM_WRITE_CODE)).toBe(true);
+
+            readFrame(v1ResponseFrame(EEPROM_WRITE_CODE, [1]));
+            expect(legacyCallback).toHaveBeenCalledTimes(1);
+            expect(legacyCallback).toHaveBeenCalledWith(expect.objectContaining({ command: EEPROM_WRITE_CODE }));
+        });
+    });
+
+    describe("deduped errorAware awaiter", () => {
+        it("still times out even though it was deduped onto a legacy in-flight request", async () => {
+            const legacyCallback = vi.fn();
+            MSP.send_message(EEPROM_WRITE_CODE, undefined, false, legacyCallback);
+            expect(serialSendSpy).toHaveBeenCalledTimes(1);
+
+            const rejection = expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toBeInstanceOf(MspTimeoutError);
+
+            // deduped: no additional wire send at attach time
+            expect(serialSendSpy).toHaveBeenCalledTimes(1);
+
+            await vi.advanceTimersByTimeAsync(MSP.TIMEOUT * MSP.MAX_RETRIES);
+            await rejection;
+
+            expect(legacyCallback).not.toHaveBeenCalled();
+            expect(MSP.callbacks.some((entry) => entry.errorAware && entry.code === EEPROM_WRITE_CODE)).toBe(false);
+        });
+    });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,5 +1,12 @@
 import { JSDOM } from "jsdom";
 import { vi } from "vitest";
+import { MspCancelledError } from "../src/js/msp/mspErrors.js";
+
+globalThis.addEventListener?.("unhandledrejection", (event) => {
+    if (event.reason instanceof MspCancelledError) {
+        event.preventDefault();
+    }
+});
 
 const { window } = new JSDOM("");
 


### PR DESCRIPTION
`MSP.promise` never rejected: the per-request timer only logged and re-sent once, and `callbacks_cleanup` dropped pending callbacks without settling them on every tab switch and disconnect, so any outstanding `await MSP.promise(...)` hung forever — the stuck blackbox download spinner being the most visible casualty. Requests were also matched to responses by code alone, so two in-flight requests for the same code with different payloads could cross-resolve, and CRC-failed responses resolved "successfully" with a `crcError` flag almost nothing checked.

This ports the `_drain_cli_queue` discipline to the binary path:

- Promises reject with `MspTimeoutError` after retries (3 × 1s), `MspCancelledError` on queue drain or send-while-disconnected, and `MspCrcError` on checksum failure. Virtual mode still resolves `undefined`.
- Promise-based requests for the same code with different payloads are serialised, so responses can no longer cross-resolve. Plain `send_message` callbacks keep their existing behaviour throughout (never settled on timeout or drain, never parked); mixed promise/callback traffic for the same code behaves as before.
- `dataflashRead` moves onto the promise path and surfaces fatal errors to its callers, so an interrupted flash read now tears down cleanly instead of leaving the UI stuck.
- A global `unhandledrejection` guard swallows cancellation errors only — tab-switch drains of in-flight loads are routine, while timeout and CRC rejections stay visible as real signal. The hot paths (dataflash pull, onboard logging save, LED strip, connect helpers, OSD font upload, tuning sliders, STM32 reboot) handle rejections locally.

New coverage in `test/js/msp_promise.test.js`: timeout rejection and retry counts, disconnect and tab-switch drains, send-while-disconnected, virtual mode, CRC rejection, per-code serialisation and parked release, dedup, and legacy callback interplay.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling across dataflash saving, dataflash reads, MSP-driven calculations, LED strip loading, serial initialization, and font uploads.
  * Prevented expected cancellations from showing as noisy unhandled promise rejections.
  * Strengthened MSP request reliability with retryable timeouts, improved deduping/queuing, and clearer CRC/timeout/cancel behavior.
* **New Features**
  * Added dedicated MSP error types (timeout, cancellation, CRC) to standardize error reporting.
* **Tests**
  * Added/expanded MSP promise semantics coverage for timeouts, disconnect/cleanup cancellation, CRC failures, and queued request behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->