### PR TITLE
docs(connection): trim reboot-reconnect comments to the constraint

### DIFF
--- a/src/composables/useMspCliSession.js
+++ b/src/composables/useMspCliSession.js
@@ -71,23 +71,20 @@ export function scheduleReconnect() {
     const willAutoReconnect = PortHandler.portPicker.autoConnect;
     const target = PortHandler.portPicker.selectedPort;
 
-    // BLE and manual/TCP links never re-enumerate after an FC reboot — the device stays on
-    // the port list and no removedDevice/addedDevice cycle fires — so the passive path below
-    // (drop the link, let auto-connect pick up the re-added device) would leave them
-    // disconnected forever. Hand them to serial_backend's driven reboot cycle instead (flush
-    // delay -> drop the stale link without an MSP round-trip -> retry until the FC answers),
-    // the same machinery a BLE/manual Save & Reboot uses. It reads Auto-Connect live, so with
-    // it off the cycle still ends in a clean disconnect.
+    // BLE and manual/TCP links never re-enumerate after an FC reboot, so the passive path
+    // below (drop the link, let auto-connect pick up the re-added device) would leave them
+    // disconnected forever. Hand them to serial_backend's driven reboot cycle instead — the
+    // same machinery a BLE/manual Save & Reboot uses. It reads Auto-Connect live, so with it
+    // off the cycle still ends in a clean disconnect.
     if (isDrivenRebootTarget(target)) {
         scheduleRebootReconnect();
         return;
     }
 
-    // The FC reboots after save/exit, so its port drops and re-enumerates — often under a NEW id
-    // (e.g. serial_0 -> serial_1). We do NOT reconnect explicitly here: that would target the OLD
-    // id, which is gone ("device not found"), and race the reboot into a spurious failure dialog.
-    // Instead we just drop the now-stale link; when Auto-Connect is on, auto-connect picks up the
-    // re-added device and reconnects to it, and with it off the user reconnects manually.
+    // The FC reboots after save/exit, so its port drops and re-enumerates, often under a new id
+    // (serial_0 -> serial_1). Don't reconnect explicitly: that would target the old, gone id and
+    // race the reboot into a spurious failure dialog. Just drop the stale link — with Auto-Connect
+    // on, auto-connect picks up the re-added device; with it off, the user reconnects manually.
 
     // When we expect an auto-reconnect, hold the reconnect-in-progress window so selectActivePort()
     // keeps the current selection and does NOT hijack it with the expert-mode virtual/manual

--- a/src/composables/useReboot.js
+++ b/src/composables/useReboot.js
@@ -2,13 +2,10 @@ import { reinitializeConnection } from "@/js/serial_backend"; // Backend logic
 
 export function useReboot() {
     // Reboot is owned end-to-end by serial_backend.reinitializeConnection(): it sends the
-    // reboot command, drives the per-transport reconnect, shows the shared reboot progress
-    // dialog (the Vue RebootDialog, via the dialog store) and settles the connection-state
-    // phase. This composable is just the Vue-tab entry point — the former duplicate
-    // wait-loop + dialog that lived here diverged from the backend's and, on the serial
-    // path, never settled the phase (leaving isReconnecting stuck).
-    // Return the delegated call so callers keep the backend contract (it resolves to
-    // the reboot timestamp); the wrapper stays transparent rather than swallowing it.
+    // reboot command, drives the per-transport reconnect, shows the reboot progress dialog
+    // and settles the connection-state phase. This composable is just the Vue-tab entry point.
+    // Return the delegated call so callers keep the backend contract (it resolves to the
+    // reboot timestamp).
     const reboot = () => reinitializeConnection();
 
     return {

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -282,11 +282,10 @@ const MSP = {
             // message received, store dataview
             this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
         } else if (serial._protocol?.shouldBypassCrc?.(expectedChecksum)) {
-            // Capability check: only the Bluetooth protocols (WebBluetooth, CapacitorBle)
-            // implement shouldBypassCrc, for BT-11/CC2541 bridges that corrupt the MSP
-            // checksum to 0xff. Deliberately NOT gated on `serial.protocol === "bluetooth"`:
-            // that getter returns the lowercased constructor name ("webbluetooth"/
-            // "capacitorble"), so the old comparison never matched and the bypass was dead.
+            // Capability check: only the Bluetooth protocols implement shouldBypassCrc,
+            // for BT-11/CC2541 bridges that corrupt the MSP checksum to 0xff. Not gated
+            // on serial.protocol — that getter returns the lowercased constructor name,
+            // never "bluetooth".
             this.dataView = new DataView(this.message_buffer, 0, this.message_length_expected);
             this.crcError = false; // Override the CRC error for this specific case
         } else {

--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -88,8 +88,6 @@ class WebBluetooth extends EventTarget {
         if (this.closeRequested) {
             return;
         }
-        // Explicitly attribute the teardown: this is the DEVICE dropping the link
-        // (or the FC rebooting under it), not the configurator closing it.
         console.warn(`${this.logHead} Unsolicited GATT disconnect (device dropped the link) — tearing down`);
         this.disconnect();
     }
@@ -197,10 +195,9 @@ class WebBluetooth extends EventTarget {
     }
 
     async connect(path, options) {
-        // Serialize behind an in-flight teardown: doCleanup awaits stopNotifications, so
-        // disconnect() is genuinely async — a connect that started mid-teardown would
-        // reset closeRequested under it and then have its device/characteristics torn
-        // down by the resumed cleanup. The teardown promise never rejects.
+        // Serialize behind an in-flight teardown: a connect started mid-teardown would
+        // reset closeRequested under it and have its device/characteristics torn down
+        // by the resumed cleanup. The teardown promise never rejects.
         if (this._teardown) {
             await this._teardown;
             this._teardown = null;
@@ -228,19 +225,13 @@ class WebBluetooth extends EventTarget {
             await this.startNotifications();
             setupComplete = true;
         } catch (error) {
-            // Also log to the console — gui_log only reaches the in-app log panel, which
-            // makes a failed services/characteristics/notifications setup invisible in
-            // console captures while the connection still reports "opened".
             console.error(`${this.logHead} Connection setup failed:`, error);
             gui_log(i18n.getMessage("bluetoothConnectionError", [error]));
         }
 
-        // Require setup to have COMPLETED, not just gatt.connected. If getServices/
-        // getCharacteristics/startNotifications threw, gatt can still report connected
-        // while the session has no usable characteristics — treating that as success
-        // dispatches connect:true for a link that would only ever time out on MSP.
-        // Optional-chained: an unsolicited disconnect during setup nulls this.device, so
-        // the attempt must complete as a signaled failed open, not a swallowed TypeError.
+        // gatt can report connected while setup threw and left no usable characteristics,
+        // so require setup to have completed. Optional-chained: an unsolicited disconnect
+        // during setup nulls this.device.
         const connectionInfo = setupComplete && this.device?.gatt?.connected;
 
         if (connectionInfo && !this.openCanceled) {
@@ -407,12 +398,10 @@ class WebBluetooth extends EventTarget {
                 if (this.readCharacteristic) {
                     this.readCharacteristic.removeEventListener("characteristicvaluechanged", this.handleNotification);
 
-                    // Explicitly stop notifications BEFORE dropping the GATT link (only
-                    // possible while it is still up — an unplug/unsolicited drop skips
-                    // this). Without it, Chrome keeps the notify session marked active,
-                    // and on Linux/BlueZ startNotifications() on the NEXT connection can
-                    // resolve without re-arming the CCCD — a session that looks
-                    // subscribed but never receives (deaf), breaking disconnect/connect.
+                    // Stop notifications while the link is still up (an unplug/unsolicited
+                    // drop skips this): Chrome keeps the notify session marked active, and
+                    // on Linux/BlueZ the next connection's startNotifications() can then
+                    // resolve without re-arming the CCCD — subscribed but never receiving.
                     if (this.device.gatt?.connected) {
                         try {
                             await this.readCharacteristic.stopNotifications();

--- a/src/js/protocols/WebSocket.js
+++ b/src/js/protocols/WebSocket.js
@@ -81,10 +81,8 @@ class Websocket extends EventTarget {
         try {
             ws = new WebSocket(this.address, ["binary", "wsSerial"]);
         } catch (e) {
-            // Invalid URL/scheme — e.g. a raw tcp:// manual override, which a browser
-            // cannot open (raw TCP needs the desktop app's native transport). Signal a
-            // failed open so the connect flow recovers immediately instead of dying
-            // silently until the pre-open watchdog.
+            // Invalid URL/scheme, e.g. a raw tcp:// manual override, which a browser
+            // cannot open (raw TCP needs the desktop app's native transport).
             console.error(`${this.logHead} Failed to open ${this.address}:`, e);
             this.dispatchEvent(new CustomEvent("connect", { detail: false }));
             return;

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -502,12 +502,9 @@ function teardownConnectionUi() {
     GUI.pendingTab = null;
     const target = pendingTab === "firmware_flasher" ? "firmware_flasher" : "landing";
 
-    // Only blank the content area when we're actually LEAVING the current tab. When a
-    // burst of disconnects (an unstable BLE link during a reboot reconnect) runs this
-    // teardown repeatedly, we are already on the destination tab: unmounting would blank
-    // the screen while the follow-up switchTab no-ops (same tab) or races an in-flight
-    // mount, leaving a stuck black screen. switchTab remounts if the tab was somehow left
-    // unmounted, and no-ops when it is already showing.
+    // Only unmount when actually leaving the current tab: a repeated teardown (disconnect
+    // burst) already sits on the destination, and unmounting there blanks the content
+    // while switchTab no-ops on the same tab or races an in-flight mount.
     if (GUI.active_tab !== target) {
         // Clear the active root-mounted tab before navigation selects the next one.
         try {
@@ -572,21 +569,19 @@ function finishUnexpectedDisconnect() {
     teardownConnectionUi();
 }
 
-// Drop a connection whose MSP handshake stalled during the reboot retry loop, WITHOUT
-// ending the loop: we connected to a still-booting FC, so just close the dead link and let
-// the loop's next tick try again. Deliberately not disconnectForReboot() — its
-// prepareDisconnect() would stopRebootReconnect() and kill the very loop that must retry.
+// Drop a connection whose MSP handshake stalled during the reboot retry loop, without
+// ending the loop: the FC is still booting, so close the dead link and let the next tick
+// try again. Not disconnectForReboot() — its prepareDisconnect() would stopRebootReconnect().
 function dropStalledRebootConnection() {
     // onOpen advanced the phase to HANDSHAKING; re-assert the reconnect phase so
     // notifyClosed() leaves the window open and selectActivePort() keeps aiming at the
     // rebooting device instead of falling back mid-retry.
     getConnectionState().reconnectStarted();
 
-    // On a kept BLE link the stall just means the FC hasn't finished booting: keep riding
-    // the known-good session (app-level reset only) and let the next tick re-handshake.
-    // Dropping it here would force a real reconnect — the deaf-session trap this whole
-    // keep-the-link strategy exists to avoid. NOT prepareDisconnect(): its
-    // stopRebootReconnect would kill the live retry interval.
+    // On a kept BLE link, keep riding the known-good session (app-level reset only) and
+    // let the next tick re-handshake — dropping it would force the deaf-session reconnect
+    // the kept link exists to avoid. Not prepareDisconnect(): its stopRebootReconnect
+    // would kill the live retry interval.
     if (rebootLinkKept && serial.connected) {
         resetAppConnectionState();
         return;
@@ -1254,12 +1249,9 @@ export function reinitializeConnection(suppressDialog = false) {
     // Send reboot command to the flight controller
     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
 
-    // Force the connection invalid now so the reboot dialog and retry loop wait for a REAL
-    // reconnect. A BLE/manual link survives the reboot command (only the MCU restarts), so
-    // connectionValid stays stale-true until the flush drops it ~1.5s later — without this,
-    // the dialog's 100ms check-timer sees it true immediately, concludes the reboot, and
-    // (since the window moved into ConnectionState) nulls the reconnect window before the
-    // retry loop even arms, so no reconnect ever runs.
+    // A BLE/manual link survives the reboot command (only the MCU restarts), so
+    // connectionValid stays stale-true until the flush drops it ~1.5s later. Force it
+    // false now so the reboot dialog and retry loop wait for a real reconnect.
     CONFIGURATOR.connectionValid = false;
 
     if (isDrivenRebootTarget(currentPort)) {

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -68,16 +68,13 @@ const REBOOT_CONNECT_MAX_TIME_DRIVEN_MS = 20000;
 // then retry reconnecting on this cadence until the FC answers or the reboot window closes.
 const REBOOT_FLUSH_DELAY_MS = 1500;
 const REBOOT_RECONNECT_RETRY_MS = 1000;
-// How long an opened-but-silent link may stall in the MSP handshake during a reboot
-// reconnect before it is dropped for the next retry. Short by design: the FC not
-// answering MSP right after a reboot means we connected to a still-booting board, and
-// holding the dead link for the normal 10s handshake timeout would consume the whole
-// reboot window (the retry loop skips ticks while a connection is open).
+// How long a silent link may stall in the MSP handshake during a reboot reconnect before
+// it is dropped for the next retry. Short because the normal 10s handshake timeout would
+// consume the whole reboot window (the retry loop skips ticks while a connection is open).
 const REBOOT_HANDSHAKE_STALL_MS = 3000;
-// The BLE link was kept open across the current reboot (soft reset — see
-// softResetForReboot). While true, a stalled handshake keeps riding the same GATT
-// session instead of dropping it: the session is known-good (it carried the save and
-// the reboot ack), the FC just isn't answering yet. Cleared on any real transport close.
+// The BLE link was kept open across the current reboot (softResetForReboot). While true,
+// a stalled handshake keeps riding the known-good GATT session instead of dropping it.
+// Cleared on any real transport close.
 let rebootLinkKept = false;
 // Bytes arrived on the link since the current handshake began (reset in onOpen,
 // stamped by read_serial_adapter). The reboot stall watchdog uses it as its progress
@@ -609,11 +606,10 @@ function setConnectionTimeout() {
             // Re-check the loop live: it may have ended (or been cancelled) while we
             // stalled, in which case the normal failure path below owns the teardown.
             if (rebootReconnectTimerId !== false) {
-                // Progress-based deadline: any bytes in the last stall slice mean the FC
-                // is answering and the chain is just slow (BLE bridges chunk MSP into
-                // small GATT frames) — grant another slice instead of restarting the
-                // whole handshake from scratch. Only a SILENT link is dropped; the
-                // reboot window still bounds the total time.
+                // Progress-based deadline: bytes in the last stall slice mean the FC is
+                // answering, just slowly (BLE bridges chunk MSP into small GATT frames) —
+                // grant another slice rather than restart the handshake. Only a silent
+                // link is dropped; the reboot window still bounds total time.
                 if (rebootHandshakeSawTraffic) {
                     rebootHandshakeSawTraffic = false;
                     setConnectionTimeout();
@@ -668,13 +664,11 @@ function abortConnection(messageKey) {
     GUI.timeout_remove("connecting"); // kill post-open connecting timer
     GUI.timeout_remove("connectAttempt"); // kill pre-open watchdog
 
-    // A failed open/handshake during a reboot reconnect is expected flakiness (the device is
-    // re-enumerating), so suppress the failure dialog — but only with auto-connect on (else
-    // nothing retries and the failure is real). Check the open window as well as the phase:
-    // after the loop's first attempt the phase has left REBOOTING/RECONNECTING, so the phase
-    // alone would let later failures pop the dialog. Gate the window term on
-    // !rebootWindowExpired so a leaked window can't suppress real failures forever.
-    // (Captured before setPhase(FAILED) below overwrites the reconnect phase.)
+    // A failed open/handshake during a reboot reconnect is expected flakiness, so suppress
+    // the failure dialog — but only with auto-connect on, else nothing retries and the
+    // failure is real. Check the open window as well as the phase (later retries have left
+    // the reconnect phase), and gate it on !rebootWindowExpired so a leaked window can't
+    // suppress real failures forever. Captured before setPhase(FAILED) below.
     const state = getConnectionState();
     const duringRebootReconnect =
         (state.isRebootReconnecting || (state.isRebootWindowOpen && !state.rebootWindowExpired)) &&
@@ -1311,12 +1305,9 @@ function rebootReconnect() {
 
     rebootReconnectTimerId = setTimeout(() => {
         // If the link survived the reboot, reset the now-stale connection so the UI returns
-        // to the landing tab instead of sitting on a dead connection. For a BLE target that
-        // is about to auto-reconnect, keep the GATT session open (softResetForReboot) — the
-        // retry rides it, avoiding the deaf-session reconnect on Linux/BlueZ. Otherwise
-        // (serial/manual, or no auto-reconnect coming) drop the transport for real.
-        // (Both paths run prepareDisconnect, whose stopRebootReconnect on this already-fired
-        // timeout is harmless.)
+        // to the landing tab. For a BLE target about to auto-reconnect, keep the GATT session
+        // open (softResetForReboot) so the retry rides it, avoiding the deaf-session reconnect
+        // on Linux/BlueZ. Otherwise drop the transport for real.
         if (isConnected()) {
             const target = PortHandler.portPicker.selectedPort;
             const keepBleLink =

--- a/src/js/tab_switch.js
+++ b/src/js/tab_switch.js
@@ -45,11 +45,9 @@ export function switchTab(tabKey, options = {}) {
     const mode = options.mode ?? "disconnected";
     const label = options.label ?? defaultLabel(tabKey);
 
-    // Dedup only when the target is BOTH the active tab AND actually mounted. After
-    // unmountVueTab() (disconnect teardown) the content area is blank while GUI.active_tab
-    // still names the old tab, so an active_tab-only check would refuse to remount and
-    // leave a stuck blank screen — the burst of disconnects an unstable BLE link produces
-    // during a reboot reconnect hits this teardown->landing path repeatedly.
+    // Dedup only when the target is both the active tab and actually mounted: after
+    // unmountVueTab() the content area is blank while GUI.active_tab still names the
+    // old tab, and refusing to remount would leave it blank.
     const alreadyMounted = GUI.active_tab === tabKey && vueTabState.activeTabName === tabKey;
     if (alreadyMounted || GUI.tab_switch_in_progress) {
         return false;


### PR DESCRIPTION
Trims the verbose "investigation story" comments introduced in #5232 down to
the constraint they actually document, as requested in review.

The comments explained *how the bug was found* rather than *what the code must
not do*. The PR history already preserves that narrative; the source only needs
the constraint. This is a pure comment cleanup — **no behavior change**, only
`//` lines touched.

### Commit 1 — review suggestions
Applies blckmn's batch-apply suggestions (couldn't be pushed to the merged #5232):
- `src/js/msp.js` — `shouldBypassCrc` capability-check note
- `src/js/protocols/WebBluetooth.js` — teardown attribution, connect/teardown serialization, setup-completed check, stop-notifications ordering (two redundant notes removed outright)
- `src/js/protocols/WebSocket.js` — invalid URL/scheme note
- `src/js/serial_backend.js` — unmount-on-leave, stalled-reboot drop, kept-BLE-link, force-connection-invalid notes
- `src/js/tab_switch.js` — mount-aware dedup guard note

### Commit 2 — remaining cases
Same trim applied to the verbose connection-reliability comments the review
suggestions did not cover (found by sweeping `src/` for the same narrative +
editorial-emphasis style):
- `src/js/serial_backend.js` — `REBOOT_HANDSHAKE_STALL_MS` rationale, `rebootLinkKept` note, progress-based handshake deadline, reboot-reconnect dialog suppression, link-survived-reboot reset
- `src/composables/useMspCliSession.js` — BLE/manual driven-reboot handoff, re-enumeration / don't-reconnect-explicitly notes
- `src/composables/useReboot.js` — reboot-ownership note (dropped the "former duplicate wait-loop diverged" history)

Genuine constraint comments (import-cycle rationale, late-event guard, WeakMap
port-id keying, algorithm notes) were left intact.

Net: prose only, across comments.

Follow-up to review feedback on #5232.
