### PR TITLE
fix(ui): give number input spinners non-overlapping, larger hit targets

### DIFF
--- a/nuxt-ui.vite.js
+++ b/nuxt-ui.vite.js
@@ -97,6 +97,20 @@ export default {
                 root: "min-w-12 w-28",
                 base: "appearance-none",
             },
+            variants: {
+                orientation: {
+                    vertical: {
+                        // Nuxt UI scales vertical spinners to 80%, leaving ~19x13px hit
+                        // targets whose click zones overlap mid-field. Instead, split the
+                        // field height between the two buttons (no overlap) and widen them —
+                        // width is unconstrained. Icons are sized to the button height.
+                        increment:
+                            "top-0 end-0 pe-1 h-1/2 scale-100 [&>button]:h-full [&>button]:py-0 [&>button]:px-1.5 [&>button>*]:size-3",
+                        decrement:
+                            "bottom-0 end-0 pe-1 h-1/2 scale-100 [&>button]:h-full [&>button]:py-0 [&>button]:px-1.5 [&>button>*]:size-3",
+                    },
+                },
+            },
             defaultVariants: {
                 size: "sm",
             },


### PR DESCRIPTION
## Summary

Addresses the "UInputNumber arrows are too small" known issue from #4995.

Vertical spinners are scaled to 80% by the upstream theme (~19x13px hit targets), and measured on master their click zones overlap by ~5px mid-field. Simply unscaling doesn't work - two 16px buttons can't fit a 24px field.

Instead each spinner now takes exactly half the field height (no overlap) with wider padding: 24x12px targets, integer-pixel rendering. Width stays moderate since the spinners overlay the field edge and the narrowest inputs are 48px. Horizontal orientation untouched.

Visually bigger chevrons would need horizontal orientation (arrows beside the field) - happy to do that as a follow up if preferred.

## Testing

Verified in virtual mode (Failsafe tab): buttons tile the field with 0px overlap, increment still commits and enables Save. 415 tests pass, lint clean, production build succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vertical number input controls by separating increment and decrement buttons.
  * Prevented overlapping click targets and refined button sizing, spacing, and icon alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->