### PR TITLE
Clean up composable timers on scope dispose

### DIFF
--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -98,7 +98,7 @@
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { onScopeDispose, ref } from "vue";
 import Dialog from "@/components/elements/Dialog.vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import { useFlightPlan } from "@/composables/useFlightPlan";
@@ -123,6 +123,7 @@ const waypointToDelete = ref(null);
 // Drag and drop state
 const draggedUid = ref(null);
 const dragOverUid = ref(null);
+let dragStartTimeout = null;
 
 const handleAddWaypoint = () => {
     openAddWaypoint();
@@ -164,12 +165,20 @@ const handleDragStart = (event, uid) => {
     const el = event.currentTarget;
 
     // Add a slight delay to allow the drag to start before styling changes
-    setTimeout(() => {
+    dragStartTimeout = setTimeout(() => {
+        dragStartTimeout = null;
         if (el) {
             el.classList.add("dragging");
         }
     }, 0);
 };
+
+onScopeDispose(() => {
+    if (dragStartTimeout !== null) {
+        clearTimeout(dragStartTimeout);
+        dragStartTimeout = null;
+    }
+});
 
 const handleDragOver = (event, uid) => {
     event.preventDefault();

--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -165,6 +165,9 @@ const handleDragStart = (event, uid) => {
     const el = event.currentTarget;
 
     // Add a slight delay to allow the drag to start before styling changes
+    if (dragStartTimeout !== null) {
+        clearTimeout(dragStartTimeout);
+    }
     dragStartTimeout = setTimeout(() => {
         dragStartTimeout = null;
         if (el) {

--- a/src/composables/useBoardSelection.js
+++ b/src/composables/useBoardSelection.js
@@ -1,4 +1,4 @@
-import { reactive, nextTick } from "vue";
+import { reactive, nextTick, onScopeDispose } from "vue";
 import { get as getConfig, set as setConfig } from "../js/ConfigStorage";
 import { ispConnected } from "../js/utils/connection.js";
 import GUI from "../js/gui";
@@ -48,6 +48,8 @@ export function useBoardSelection(params) {
         /** Bound to USelectMenu search; used with ignore-filter to omit empty category headers */
         boardSelectSearchTerm: "",
     });
+
+    let detectBoardTimeout = null;
 
     /**
      * Get board options formatted for Nuxt UI SelectMenu with labeled group separations.
@@ -237,8 +239,14 @@ export function useBoardSelection(params) {
 
         state.detectingBoard = true;
 
+        if (detectBoardTimeout !== null) {
+            clearTimeout(detectBoardTimeout);
+            detectBoardTimeout = null;
+        }
+
         if (GUI.connect_lock) {
-            setTimeout(() => {
+            detectBoardTimeout = setTimeout(() => {
+                detectBoardTimeout = null;
                 state.detectingBoard = false;
             }, 2000);
             return;
@@ -263,7 +271,8 @@ export function useBoardSelection(params) {
             return false;
         });
 
-        setTimeout(() => {
+        detectBoardTimeout = setTimeout(() => {
+            detectBoardTimeout = null;
             state.detectingBoard = false;
         }, 2000);
     };
@@ -278,6 +287,13 @@ export function useBoardSelection(params) {
         state.cloudBuildOptions = [];
         state.boardSelectSearchTerm = "";
     };
+
+    onScopeDispose(() => {
+        if (detectBoardTimeout !== null) {
+            clearTimeout(detectBoardTimeout);
+            detectBoardTimeout = null;
+        }
+    });
 
     return {
         // State

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -81,7 +81,15 @@ function onCopyFailed(ex) {
     console.warn(ex);
 }
 
-async function submitSupportData(data, state, clearHistory, executeCommands, writeToOutput, getOutputHistory) {
+async function submitSupportData(
+    data,
+    state,
+    clearHistory,
+    executeCommands,
+    writeToOutput,
+    getOutputHistory,
+    trackPollInterval,
+) {
     clearHistory();
     const api = new BuildApi();
 
@@ -97,6 +105,7 @@ async function submitSupportData(data, state, clearHistory, executeCommands, wri
         const time = Date.now();
         if (state.lastArrival < time - 250) {
             clearInterval(delay);
+            trackPollInterval?.(null);
             const text = getOutputHistory();
             let key = await api.submitSupportData(text);
             if (!key) {
@@ -107,6 +116,7 @@ async function submitSupportData(data, state, clearHistory, executeCommands, wri
             writeToOutput(i18n.getMessage("buildServerSupportRequestSubmission", [key]));
         }
     }, 250);
+    trackPollInterval?.(delay);
 }
 
 export function useCli() {
@@ -154,6 +164,7 @@ export function useCli() {
     let flushing = false; // true during DOM mutations; prevents spurious scrollPinned flips
     let scrollRaf = null; // deferred scroll; separates DOM writes from scrollTop write (avoids forced reflow)
     let pastePollInterval = null;
+    let supportPollInterval = null;
 
     const flushOutput = () => {
         outputFlushRaf = null;
@@ -340,7 +351,17 @@ export function useCli() {
 
     const submitSupportRequest = async () => {
         showSupportWarningDialog((data) =>
-            submitSupportData(data, state, clearHistory, executeCommands, writeToOutput, () => outputHistory),
+            submitSupportData(
+                data,
+                state,
+                clearHistory,
+                executeCommands,
+                writeToOutput,
+                () => outputHistory,
+                (id) => {
+                    supportPollInterval = id;
+                },
+            ),
         );
     };
 
@@ -658,6 +679,11 @@ export function useCli() {
         if (pastePollInterval) {
             clearInterval(pastePollInterval);
             pastePollInterval = null;
+        }
+
+        if (supportPollInterval) {
+            clearInterval(supportPollInterval);
+            supportPollInterval = null;
         }
 
         if (outputFlushRaf) {

--- a/src/composables/useCloudBuild.js
+++ b/src/composables/useCloudBuild.js
@@ -1,4 +1,4 @@
-import { reactive } from "vue";
+import { reactive, onScopeDispose } from "vue";
 
 /**
  * A composable for handling cloud build requests and polling.
@@ -368,6 +368,8 @@ export function useCloudBuild(params) {
     const cleanup = () => {
         stopPolling();
     };
+
+    onScopeDispose(cleanup);
 
     return {
         // State

--- a/src/composables/useInterval.js
+++ b/src/composables/useInterval.js
@@ -1,4 +1,4 @@
-import { onUnmounted } from "vue";
+import { onScopeDispose } from "vue";
 import GUI from "../js/gui";
 
 function pauseInterval(name) {
@@ -41,7 +41,7 @@ export function useInterval() {
         localIntervals.length = 0;
     }
 
-    onUnmounted(() => {
+    onScopeDispose(() => {
         removeAllIntervals();
     });
 

--- a/src/composables/useInterval.js
+++ b/src/composables/useInterval.js
@@ -12,7 +12,7 @@ function resumeInterval(name) {
 /**
  * A composable for managing named intervals via GUI's interval registry.
  * All intervals added through this composable are automatically removed
- * when the component is unmounted.
+ * when the owning effect scope is disposed (component unmount or scope stop).
  *
  * Usage:
  *   const { addInterval, removeInterval } = useInterval();

--- a/src/composables/useTimeout.js
+++ b/src/composables/useTimeout.js
@@ -4,7 +4,7 @@ import GUI from "../js/gui";
 /**
  * A composable for managing named timeouts via GUI's timeout registry.
  * All timeouts added through this composable are automatically removed
- * when the component is unmounted.
+ * when the owning effect scope is disposed (component unmount or scope stop).
  *
  * Usage:
  *   const { addTimeout, removeTimeout } = useTimeout();

--- a/src/composables/useTimeout.js
+++ b/src/composables/useTimeout.js
@@ -1,4 +1,4 @@
-import { onUnmounted } from "vue";
+import { onScopeDispose } from "vue";
 import GUI from "../js/gui";
 
 /**
@@ -33,7 +33,7 @@ export function useTimeout() {
         localTimeouts.length = 0;
     }
 
-    onUnmounted(() => {
+    onScopeDispose(() => {
         removeAllTimeouts();
     });
 

--- a/src/composables/useVtx.js
+++ b/src/composables/useVtx.js
@@ -1,4 +1,4 @@
-import { reactive, ref, computed, toRaw } from "vue";
+import { reactive, ref, computed, toRaw, onScopeDispose } from "vue";
 import djv from "djv";
 import { i18n } from "../js/localization";
 import { tracking } from "../js/Analytics";
@@ -421,18 +421,38 @@ export function useVtx() {
         mspHelper.writeConfiguration(false, onSaveComplete);
     }
 
+    let saveCompleteTimeout = null;
+    let saveCompleteReloadTimeout = null;
+
+    function clearSaveCompleteTimeouts() {
+        if (saveCompleteTimeout !== null) {
+            clearTimeout(saveCompleteTimeout);
+            saveCompleteTimeout = null;
+        }
+        if (saveCompleteReloadTimeout !== null) {
+            clearTimeout(saveCompleteReloadTimeout);
+            saveCompleteReloadTimeout = null;
+        }
+    }
+
+    onScopeDispose(clearSaveCompleteTimeouts);
+
     function onSaveComplete() {
         savePending.value = false;
 
         saveButtonText.value = i18n.getMessage("buttonSaving");
         saving.value = true;
 
+        clearSaveCompleteTimeouts();
+
         const buttonDelay = 1500;
 
-        setTimeout(() => {
+        saveCompleteTimeout = setTimeout(() => {
+            saveCompleteTimeout = null;
             saveButtonText.value = i18n.getMessage("buttonSaved");
 
-            setTimeout(async () => {
+            saveCompleteReloadTimeout = setTimeout(async () => {
+                saveCompleteReloadTimeout = null;
                 await loadVtxConfig();
                 saveButtonText.value = "";
                 saving.value = false;

--- a/test/js/useBoardSelection.test.js
+++ b/test/js/useBoardSelection.test.js
@@ -1,0 +1,73 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { effectScope } from "vue";
+import GUI from "../../src/js/gui";
+
+import { useBoardSelection } from "../../src/composables/useBoardSelection";
+
+function makeParams() {
+    return {
+        buildApi: {
+            loadTargets: vi.fn().mockResolvedValue([]),
+            loadTargetReleases: vi.fn().mockResolvedValue({ releases: [] }),
+        },
+        $t: (key) => key,
+        updateTargetQualification: vi.fn(),
+        getSupportUrlForTarget: vi.fn(),
+        populateReleases: vi.fn(),
+        enableLoadRemoteFileButton: vi.fn(),
+        flashingMessage: vi.fn(),
+        flashProgress: vi.fn(),
+        FLASH_MESSAGE_TYPES: { NEUTRAL: "neutral", INVALID: "invalid" },
+        getSelectedBuildType: vi.fn(),
+        logHead: "[TEST]",
+    };
+}
+
+describe("useBoardSelection", () => {
+    let scope;
+    let boardSelection;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        GUI.connect_lock = false;
+
+        scope = effectScope();
+        scope.run(() => {
+            boardSelection = useBoardSelection(makeParams());
+        });
+    });
+
+    afterEach(() => {
+        scope.stop();
+        vi.runAllTimers();
+        GUI.connect_lock = false;
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it("clears the detect-board timeout on scope dispose, so detectingBoard stays stuck", async () => {
+        // The GUI.connect_lock branch is the smallest surface that schedules the
+        // 2000ms timeout without needing to entangle AutoDetect.verifyBoard.
+        GUI.connect_lock = true;
+
+        await boardSelection.handleDetectBoard();
+        expect(boardSelection.state.detectingBoard).toBe(true);
+
+        scope.stop();
+        await vi.advanceTimersByTimeAsync(2100);
+
+        // Dispose cleared the pending timeout before it could reset detectingBoard.
+        expect(boardSelection.state.detectingBoard).toBe(true);
+    });
+
+    it("without dispose, the timeout still fires and resets detectingBoard (proves the test is not vacuous)", async () => {
+        GUI.connect_lock = true;
+
+        await boardSelection.handleDetectBoard();
+        expect(boardSelection.state.detectingBoard).toBe(true);
+
+        await vi.advanceTimersByTimeAsync(2100);
+
+        expect(boardSelection.state.detectingBoard).toBe(false);
+    });
+});

--- a/test/js/useCloudBuild.test.js
+++ b/test/js/useCloudBuild.test.js
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { effectScope } from "vue";
+
+import { useCloudBuild } from "../../src/composables/useCloudBuild";
+
+function makeParams(buildApiOverrides = {}) {
+    return {
+        buildApi: {
+            requestBuild: vi
+                .fn()
+                .mockResolvedValue({ key: "build-key", url: "http://example.test/fw.hex", file: "fw.hex" }),
+            requestBuildStatus: vi.fn().mockResolvedValue({ status: "queued" }),
+            loadTargetFirmware: vi.fn().mockResolvedValue(new ArrayBuffer(0)),
+            ...buildApiOverrides,
+        },
+        $t: (key) => key,
+        setBoardConfig: vi.fn(),
+        processFile: vi.fn(),
+        flashingMessage: vi.fn(),
+        enableLoadRemoteFileButton: vi.fn(),
+        FLASH_MESSAGE_TYPES: { NEUTRAL: "neutral", INVALID: "invalid" },
+    };
+}
+
+const targetDetail = { target: "TEST_TARGET", release: "1.0.0", cloudBuild: true };
+const additionalParams = { isConfigLocal: false };
+
+describe("useCloudBuild", () => {
+    let scope;
+    let cloudBuild;
+    let params;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        params = makeParams();
+
+        scope = effectScope();
+        scope.run(() => {
+            cloudBuild = useCloudBuild(params);
+        });
+    });
+
+    afterEach(() => {
+        scope.stop();
+        vi.runAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it("polls build status on the 5s interval, and stops polling on scope dispose", async () => {
+        await cloudBuild.requestCloudBuild(targetDetail, additionalParams);
+
+        // First call happened synchronously inside requestCloudBuild to check for cached success.
+        const callsBeforePoll = params.buildApi.requestBuildStatus.mock.calls.length;
+
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(params.buildApi.requestBuildStatus.mock.calls.length).toBe(callsBeforePoll + 1);
+
+        await vi.advanceTimersByTimeAsync(5000);
+        expect(params.buildApi.requestBuildStatus.mock.calls.length).toBe(callsBeforePoll + 2);
+
+        scope.stop();
+
+        const callsAtDispose = params.buildApi.requestBuildStatus.mock.calls.length;
+        await vi.advanceTimersByTimeAsync(20000);
+
+        // No further polling after the effect scope is disposed.
+        expect(params.buildApi.requestBuildStatus.mock.calls.length).toBe(callsAtDispose);
+    });
+
+    it("cleanup() followed by scope.stop() does not throw (idempotent double dispose)", async () => {
+        await cloudBuild.requestCloudBuild(targetDetail, additionalParams);
+
+        expect(() => {
+            cloudBuild.cleanup();
+            scope.stop();
+        }).not.toThrow();
+    });
+});

--- a/test/js/useCloudBuild.test.js
+++ b/test/js/useCloudBuild.test.js
@@ -54,10 +54,10 @@ describe("useCloudBuild", () => {
         const callsBeforePoll = params.buildApi.requestBuildStatus.mock.calls.length;
 
         await vi.advanceTimersByTimeAsync(5000);
-        expect(params.buildApi.requestBuildStatus.mock.calls.length).toBe(callsBeforePoll + 1);
+        expect(params.buildApi.requestBuildStatus.mock.calls).toHaveLength(callsBeforePoll + 1);
 
         await vi.advanceTimersByTimeAsync(5000);
-        expect(params.buildApi.requestBuildStatus.mock.calls.length).toBe(callsBeforePoll + 2);
+        expect(params.buildApi.requestBuildStatus.mock.calls).toHaveLength(callsBeforePoll + 2);
 
         scope.stop();
 
@@ -65,7 +65,7 @@ describe("useCloudBuild", () => {
         await vi.advanceTimersByTimeAsync(20000);
 
         // No further polling after the effect scope is disposed.
-        expect(params.buildApi.requestBuildStatus.mock.calls.length).toBe(callsAtDispose);
+        expect(params.buildApi.requestBuildStatus.mock.calls).toHaveLength(callsAtDispose);
     });
 
     it("cleanup() followed by scope.stop() does not throw (idempotent double dispose)", async () => {

--- a/test/js/useVtx.test.js
+++ b/test/js/useVtx.test.js
@@ -77,7 +77,7 @@ describe("useVtx", () => {
 
         // No further MSP traffic should have occurred — the reload (loadVtxConfig) never ran,
         // and the button text is stuck on "Saving" rather than being reset.
-        expect(MSP.send_message.mock.calls.length).toBe(callsAfterSave);
+        expect(MSP.send_message.mock.calls).toHaveLength(callsAfterSave);
         expect(vtx.saveButtonText.value).toBe("buttonSaving");
     });
 

--- a/test/js/useVtx.test.js
+++ b/test/js/useVtx.test.js
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { effectScope } from "vue";
+import FC from "../../src/js/fc";
+import MSP from "../../src/js/msp";
+
+vi.mock("../../src/js/msp/MSPHelper", () => ({
+    __esModule: true,
+    mspHelper: {
+        writeConfiguration: vi.fn((reboot, callback) => callback && callback()),
+        crunch: vi.fn(() => false),
+    },
+}));
+
+vi.mock("../../src/js/localization", () => ({
+    __esModule: true,
+    i18n: { getMessage: (k) => k },
+}));
+
+vi.mock("../../src/js/gui_log", () => ({
+    __esModule: true,
+    gui_log: vi.fn(),
+}));
+
+vi.mock("../../src/js/Analytics", () => ({
+    __esModule: true,
+    tracking: {
+        sendSaveAndChangeEvents: vi.fn(),
+        EVENT_CATEGORIES: { FLIGHT_CONTROLLER: "fc" },
+    },
+}));
+
+import { useVtx } from "../../src/composables/useVtx";
+import { mspHelper } from "../../src/js/msp/MSPHelper";
+
+describe("useVtx", () => {
+    let scope;
+    let vtx;
+
+    beforeEach(async () => {
+        vi.useFakeTimers();
+        FC.resetState();
+
+        vi.spyOn(MSP, "send_message").mockImplementation((code, data, retries, cb) => {
+            if (typeof cb === "function") {
+                cb();
+            }
+        });
+
+        scope = effectScope();
+        scope.run(() => {
+            vtx = useVtx();
+        });
+
+        // Bring the composable out of its initial "updating" state so saveVtx() is allowed to run.
+        await vtx.loadVtxConfig();
+    });
+
+    afterEach(() => {
+        scope.stop();
+        vi.runAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it("clears both onSaveComplete timers on scope dispose, so no reload happens after unmount", async () => {
+        vtx.saveVtx();
+
+        expect(mspHelper.writeConfiguration).toHaveBeenCalledTimes(1);
+        expect(vtx.saveButtonText.value).toBe("buttonSaving");
+
+        const callsAfterSave = MSP.send_message.mock.calls.length;
+
+        scope.stop();
+
+        // Advance past both chained 1500ms timeouts (3000ms total).
+        await vi.advanceTimersByTimeAsync(3100);
+
+        // No further MSP traffic should have occurred — the reload (loadVtxConfig) never ran,
+        // and the button text is stuck on "Saving" rather than being reset.
+        expect(MSP.send_message.mock.calls.length).toBe(callsAfterSave);
+        expect(vtx.saveButtonText.value).toBe("buttonSaving");
+    });
+
+    it("without dispose, the pending timers still fire and reload vtx config (proves the test is not vacuous)", async () => {
+        vtx.saveVtx();
+
+        expect(vtx.saveButtonText.value).toBe("buttonSaving");
+        const callsAfterSave = MSP.send_message.mock.calls.length;
+
+        await vi.advanceTimersByTimeAsync(3100);
+
+        // loadVtxConfig() sent at least one further MSP_VTX_CONFIG request, and the button reset.
+        expect(MSP.send_message.mock.calls.length).toBeGreaterThan(callsAfterSave);
+        expect(vtx.saveButtonText.value).toBe("");
+    });
+});


### PR DESCRIPTION
Audit of the "leak-risk timers" flagged in the app review. Most component timers turned out to already be cleaned correctly, so this only fixes the genuine gaps rather than churning the ~20 files that were fine:

- `useVtx` scheduled two untracked save-feedback timeouts; the second fired MSP traffic (`loadVtxConfig`) and wrote refs ~3s after save even if the tab had been left. Both are now tracked, cleared on re-entry, and cleared on scope dispose.
- `useBoardSelection` left two untracked 2s detection timeouts writing state after unmount; now tracked and disposed.
- `useCli`'s support-data poll interval lived inside a module-scope function where `cleanup()` couldn't reach it; the id is now tracked in the composable and cleared with the rest.
- `useCloudBuild` registers `onScopeDispose(cleanup)` so the 5s status poll stops even if the owning component forgets to call `cleanup()` (the existing call in FirmwareFlasherTab stays; it's idempotent).
- `WaypointList` tracks its drag-start timeout.
- `useInterval`/`useTimeout` swap `onUnmounted` for `onScopeDispose` — same moment for components, and they now release under effect scopes too, which makes composables using them testable with the existing `effectScope` test pattern.

New effect-scope tests cover the three composables (timers stop on dispose, and the positive paths still fire). `useReboot` needed no change — it has no timers; the reboot timers live at module scope in `serial_backend.js` and are part of the connection-state work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of delayed UI timers and background polling when an effect scope is disposed.
  - Ensured drag-start indicators, board detection, support/cloud build polling, interval/timeout utilities, and save-complete delayed reloads stop safely after disposal.
  - Reduced risk of stale timers causing unintended UI changes or extra network activity.
- **Tests**
  - Added automated coverage for timer cancellation/polling shutdown in board selection, cloud builds, and VTX configuration saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->