### PR TITLE
fix(autotune): correct CHIRP debug_mode index for logs without an API version

### DIFF
--- a/src/js/blackbox/chirp_bbl_parser.js
+++ b/src/js/blackbox/chirp_bbl_parser.js
@@ -14,7 +14,7 @@
 
 import { ArrayDataStream } from "./datastream.js";
 import "./decoders.js"; // side-effect: extends ArrayDataStream prototype
-import { API_VERSION_1_47 } from "../data_storage.js";
+import CONFIGURATOR from "../data_storage.js";
 import { getDebugModeIndex } from "../utils/debugModes.js";
 
 // ---------------------------------------------------------------------------
@@ -810,10 +810,19 @@ function skipToNextFrame(stream) {
  * CHIRP's current index via the shared debug-modes table (kept in sync
  * with firmware/debug.h via src/js/utils/debugModes.js).
  *
- * Prefer the API version embedded in the log header — it always matches the
- * firmware that produced this file. Fall back to the caller-supplied version
- * (e.g. from a connected FC) only when the header doesn't carry one, and
- * finally to the minimum supported version.
+ * Resolving CHIRP's index needs the firmware's API version. Prefer the API
+ * version recorded in the log, then the caller-supplied version (e.g. from a
+ * connected FC). Blackbox logs, however, do not record an API version — they
+ * only carry a "Firmware revision" string — so for offline log analysis both
+ * are usually absent. In that case fall back to the Configurator's
+ * max-supported API version: the API version is fixed per firmware release and
+ * the Configurator's max-supported API is release-aligned with firmware, so it
+ * is the correct assumption for a log that doesn't advertise its version.
+ *
+ * The previous fallback (the oldest chirp-capable API, 1.47) mis-computed
+ * CHIRP's index for current firmware: CHIRP is 97 at API 1.47 but 96 at API
+ * 1.48+, which rejected every valid chirp log from 2026.6+ firmware with
+ * "Log debug_mode is 96, expected 97".
  */
 function validateDebugModeIsChirp(sysConfig, apiVersion) {
     const logApiVersion = sysConfig.firmwareApiVersion;
@@ -825,7 +834,7 @@ function validateDebugModeIsChirp(sysConfig, apiVersion) {
     } else if (hasApiVersion) {
         effectiveApiVersion = apiVersion;
     } else {
-        effectiveApiVersion = API_VERSION_1_47;
+        effectiveApiVersion = CONFIGURATOR.API_VERSION_MAX_SUPPORTED;
     }
     const debugChirpIndex = getDebugModeIndex("CHIRP", effectiveApiVersion);
     if (debugChirpIndex < 0) {


### PR DESCRIPTION
## Problem

The Autotune tab rejects valid chirp logs from current firmware (Betaflight 2026.6 / API 1.48) with:

> Log debug_mode is 96, expected 97. This log was not recorded with debug_mode = CHIRP.

…even though the log **was** recorded with `debug_mode = CHIRP`.

## Root cause

`validateDebugModeIsChirp()` in `chirp_bbl_parser.js` resolves CHIRP's numeric `debug_mode` index from the firmware's API version, which it reads from `sysConfig.firmwareApiVersion`. That field is only populated from a `Firmware API version` header — **a header Betaflight blackbox never writes**. Real logs only carry `Firmware revision:Betaflight 2026.6.0-rc1 (…)`.

For offline log analysis there is also no connected FC, so `apiVersion` is undefined as well (`useAutotune.js` calls `parseChirpLog(data, log.start, log.end)` with no API version). The code then fell back to `API_VERSION_1_47`, where `CHIRP` is index **97**. On API 1.48 firmware CHIRP is index **96** (an enum entry ahead of it was removed), so the check always failed.

`getDebugModeIndex("CHIRP", …)`:

| API | CHIRP index |
|-----|-------------|
| 1.47 | 97 |
| 1.48 | 96 |

The debug-modes table itself is correct — this is purely the fallback selecting the wrong API version.

## Fix

Fall back to `CONFIGURATOR.API_VERSION_MAX_SUPPORTED` instead of the hard-coded oldest chirp-capable API. The API version is fixed per firmware release, and the Configurator's max-supported API is release-aligned with firmware, so it is the correct assumption for a log that doesn't advertise its own version. The existing "prefer log/FC API version when available" branches are unchanged.

## Testing

- Confirmed real 2026.6.0-rc1 chirp `.bbl` logs carry `debug_mode:96` and no API-version header (only `Firmware revision`) — the exact inputs that reach this fallback.
- `getDebugModeIndex("CHIRP", "1.48.0")` = 96 (matches the logs); the previous `…, "1.47.0")` = 97 (the failing value).
- Existing `debugModes.test.js` assertions (CHIRP = 97 @ 1.47, 96 @ 1.48) remain valid and unaffected.

_(vitest not run in my local environment; CI covers the suite. The change is a one-line fallback plus comment/import update.)_

## Possible follow-up

A complementary firmware change could emit a `Firmware API version` blackbox header so logs are self-describing (the Configurator already parses that key), which would also cover mixed old-log / newer-Configurator cases. This PR fixes the Configurator side so existing 2026.6+ logs analyze correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved offline blackbox log validation for newer firmware versions.
  * Corrected detection of the numeric CHIRP debug mode when version information is unavailable.
  * Updated related documentation to reflect the corrected validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->