### PR TITLE
fix(autotune): tolerate out-of-range chirp axis from corrupt-frame re-sync

### DIFF
--- a/src/js/blackbox/chirp_bbl_parser.js
+++ b/src/js/blackbox/chirp_bbl_parser.js
@@ -1087,9 +1087,20 @@ function collectIfActive(state, ctx) {
     if (!state.chirpActive) {
         return;
     }
+    // Firmware only ever writes -1/0/1/2 to debug[1] (the chirp axis: -1 while
+    // inactive, 0/1/2 for roll/pitch/yaw). Any other value is a decode
+    // artifact produced when the parser re-syncs after a corrupt frame — the
+    // delta chain is briefly stale, so debug[1] can decode out of range. Drop
+    // the frame entirely so a transient glitch can't spawn a bogus
+    // out-of-range segment (rejected downstream as "unsupported DEBUG_CHIRP
+    // axis encoding") or pollute a valid segment with a garbage sample.
+    const axis = state.previous[ctx.debugIdx[1]];
+    if (axis < -1 || axis > 2) {
+        return;
+    }
     collectSample(state.previous, ctx.sampleIndices, ctx.sampleBuffers, ctx.hiResScale);
     updateSegments(state.previous, ctx.debugIdx, ctx.segments, ctx.rawSetpoint[0].length - 1, state.currentAxis);
-    state.currentAxis = state.previous[ctx.debugIdx[1]];
+    state.currentAxis = axis;
 }
 
 function handleSFrame(state, ctx) {


### PR DESCRIPTION
## Problem

The Autotune tab rejects some valid chirp logs with:

> Log uses unsupported DEBUG_CHIRP axis encoding. Use a log recorded with the companion firmware.

…even though the log **was** recorded with the right firmware and mode. In my case two logs from the same 2026.6.0-rc1 firmware behaved differently: `btfl_003` analyzed fine, `btfl_004` threw the error.

## Root cause

The chirp axis lives in `debug[1]`, which firmware only ever sets to `-1/0/1/2` (`-1` inactive, `0/1/2` = roll/pitch/yaw). `debug[1]` is **delta-encoded** in P-frames. When the parser hits a corrupt frame it re-syncs (`skipToNextFrame`) but the delta chain against `state.previous` is briefly stale, so the next decoded `debug[1]` can land **out of range**.

`collectIfActive()` recorded that value and `updateSegments()` created a bogus segment with `axis > 2`; `useAutotune`'s `analyzeLog()` then hard-threw `"unsupported DEBUG_CHIRP axis encoding"` for the entire log.

Whether this triggers is luck of placement: in `btfl_004` a dropped frame's re-sync glitch fell **inside a chirp-active window**; in `btfl_003` the dropped frames didn't. Both logs are otherwise fine — I confirmed with the reference `blackbox_decode`:

- `btfl_004`: 8 frames failed to decode out of ~219k; **`debug[1]` decodes to only `-1/0/1/2`** — the axis data itself is valid.
- The reference decoder invalidates history across gaps and never emits garbage; this lightweight parser did not.

## Fix

In `collectIfActive()`, drop any frame whose decoded axis is outside the firmware-guaranteed set `{-1,0,1,2}`. A transient decode artifact can no longer spawn a bogus out-of-range segment or pollute a valid segment with a garbage sample, so logs with minor corruption analyze from their valid segments (matching how the reference decoder tolerates dropped frames).

```js
const axis = state.previous[ctx.debugIdx[1]];
if (axis < -1 || axis > 2) {
    return;
}
```

## Testing

- Reproduced with a real 2026.6.0-rc1 `.bbl` (`btfl_004`) that previously threw; confirmed via reference `blackbox_decode` that its `debug[1]` is entirely `-1/0/1/2` (i.e. the out-of-range value is a parser artifact, not data).
- `btfl_003` (clean) is unaffected by the change.

_(vitest not run in my local environment; CI covers the suite. The change is confined to `collectIfActive`.)_

## Relationship to #5256

Independent of #5256 (which fixes the `debug_mode`/API-version resolution). That one gets a log **past** the debug_mode check; this one prevents a crash **after** it, on logs with minor frame corruption. Both are needed to analyze real-world 2026.6+ chirp logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chirp data processing by rejecting invalid axis values.
  * Prevented corrupted synchronization data from generating inaccurate chirp segments.
  * Preserved valid sample collection and segment updates when axis data is within the supported range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->