### PR TITLE
fix(autotune): never recommend less D-term filtering (flyaway safety)

### DIFF
--- a/src/js/blackbox/spectral_analysis.js
+++ b/src/js/blackbox/spectral_analysis.js
@@ -380,6 +380,13 @@ function computeGainScales(metrics, tf, targetBandwidthHz, targetPhaseMarginDeg)
         dScale *= 0.95;
     }
 
+    // D-term filter: derive a cutoff hint from where the measurement stops
+    // being coherent. NOTE: chirp coherence is NOT a gyro-noise measurement —
+    // a clean sweep says nothing about the broadband gyro/motor noise that
+    // D-term filtering exists to suppress. On a clean log findNoiseFloor()
+    // falls back to the top frequency, which would drive the cutoff up and
+    // *reduce* filtering — feeding D-term noise into the motors and risking
+    // instability/flyaway on arm. So this may only ever tighten filtering.
     const defaultFilterHz = 150;
     let filterScale = noiseFloorHz / defaultFilterHz;
 
@@ -389,7 +396,8 @@ function computeGainScales(metrics, tf, targetBandwidthHz, targetPhaseMarginDeg)
         iScale: clamp(iScale, 0.5, 2),
         dScale: clamp(dScale, 0.5, 2),
         ffScale: clamp(ffScale, 0.5, 2),
-        filterScale: clamp(filterScale, 0.5, 2),
+        // Safety: cap at 1.0 — never recommend *less* D-term filtering (see note above).
+        filterScale: clamp(filterScale, 0.5, 1),
     };
 }
 


### PR DESCRIPTION
## Problem

Partial fix for #5258 (Autotune apply → flyaway on arm).

The Autotune D-term filter recommendation is derived from **chirp coherence**, which can cause it to *reduce* D-term filtering and destabilise the craft. In `computeGainScales`:

```js
// findNoiseFloor(): first freq >20 Hz where coherence < 0.5, else frequencies.at(-1)
let filterScale = noiseFloorHz / defaultFilterHz;   // defaultFilterHz = 150
...
filterScale: clamp(filterScale, 0.5, 2),
```

On a clean log (high coherence — the *good* case), `findNoiseFloor` never trips and returns the top of the spectrum (Nyquist, ~1 kHz+), so `filterScale ≈ 1000/150 → clamped to 2`. The tool then **doubles the D-term filter cutoff, removing ~half the D-term filtering**.

Chirp coherence measures how well the gyro tracks the injected sweep — **not** the broadband gyro/motor noise that D-term filtering suppresses. A craft can have excellent chirp coherence and still have real 200–500 Hz noise, so removing D-term filtering here can feed noise into the motors and go unstable the instant motors spin (flyaway on arm), especially alongside the simultaneous P/D/FF increases the same function recommends.

## Fix

Cap `filterScale` at `1.0` so the recommendation can only ever **tighten** D-term filtering (lower cutoff / more filtering), never loosen it. Increasing filtering is safe; loosening it based on the wrong signal is not.

```diff
-        filterScale: clamp(filterScale, 0.5, 2),
+        filterScale: clamp(filterScale, 0.5, 1),
```

Plus a comment documenting why chirp coherence must not be used to reduce filtering.

## Scope

Deliberately minimal — the immediate safety footgun only. The broader hardening (source D-term filtering from real gyro-noise analysis, reconcile per-axis recommendations into the global sliders, add a joint stability guard, and gate "Apply" behind an explicit warning) is tracked in #5258.

## Testing

- No existing tests cover `recommendGains`/`computeGainScales`, so nothing is invalidated.
- Behaviour change: `filterScale` now clamps to `[0.5, 1.0]` instead of `[0.5, 2.0]`; the recommendation can no longer raise the D-term filter cutoff.

_(vitest not run in my local environment; CI covers the suite.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved D-term filtering recommendations by preventing them from becoming less restrictive than the default.
  * Added safeguards to ensure cleaner measurements only maintain or increase filtering rather than reduce it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->