### PR TITLE
fix(ui): don't show "not-allowed" cursor on UInputNumber steppers at min/max

### DIFF
--- a/src/css/main.less
+++ b/src/css/main.less
@@ -175,6 +175,15 @@ input[type="checkbox"] {
 td [role="group"] {
     display: flex;
 }
+/* UInputNumber: don't show a "not-allowed" cursor on the increment/decrement
+ * stepper buttons when a value reaches its min/max. The two buttons sit close
+ * together in a narrow field, so the sign reads as the whole control being
+ * locked when only that one direction is unavailable (issue #5011). Scoped to
+ * :not([data-disabled]) roots so genuinely disabled fields keep not-allowed. */
+[data-slot="root"]:not([data-disabled]) [data-slot="increment"] button:disabled,
+[data-slot="root"]:not([data-disabled]) [data-slot="decrement"] button:disabled {
+    cursor: default;
+}
 .noarrows {
     input::-webkit-outer-spin-button,
     input::-webkit-inner-spin-button {


### PR DESCRIPTION
## Summary

Removes the misleading `not-allowed` cursor that appears on a `UInputNumber`'s increment/decrement stepper button when the value reaches its **min or max**.

Reported in #5011 (2026.6 Nuxt UI migration corrections):

> Intermittently, see restrictions on changing parameters. […] ah, controls are too close. could we remove this sign for text fields with up down buttons?

## Root cause

When a numeric value hits a boundary, `reka-ui`'s `NumberFieldIncrement`/`Decrement` marks that one `<button>` as `disabled`. Nuxt UI's `UButton` base theme carries `disabled:cursor-not-allowed`, so the boundary stepper shows the "blocked" sign — even though the field itself is still fully editable. Because the two steppers sit close together in a narrow field, the sign reads as the *whole control* being locked.

## Fix

One scoped CSS rule in `src/css/main.less`, next to the existing `UInputNumber` override:

```less
[data-slot="root"]:not([data-disabled]) [data-slot="increment"] button:disabled,
[data-slot="root"]:not([data-disabled]) [data-slot="decrement"] button:disabled {
    cursor: default;
}
```

- **Scoped to `:not([data-disabled])` roots** — `reka-ui` only stamps `data-disabled` on the root when the *whole field* is disabled, so genuinely disabled fields keep `not-allowed` (correct UX); only the min/max boundary case loses the misleading sign.
- **Global, not per-call-site** — there are ~180 `UInputNumber` usages; a single CSS rule beats editing each and matches the project's established pattern of overriding Nuxt UI in `main.less` (no Nuxt UI `app.config` theming exists).
- **No `!important`** — unlayered `main.less` already wins over Nuxt UI's `@layer` utilities (same as the sibling `td [role="group"]` rule).

## Testing

- `lessc` compiles `main.less` cleanly; the rule emits verbatim.
- `prettier --check` passes.
- Selector verified against the rendered DOM in the installed `@nuxt/ui` `InputNumber.vue` and `reka-ui` `NumberField*` sources (`data-slot="root"`/`increment`/`decrement`, `button:disabled`, root `data-disabled` only when field-disabled).

Refs #5011

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated number input controls so unavailable increment and decrement buttons display the standard cursor instead of a “not allowed” cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->