### PR TITLE
Add AUTOPILOT arming disable flag and mission abort OSD warning

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1354,6 +1354,10 @@
         "message": "Position Hold is active",
         "description": "Message that pops up to describe the POSHOLD arming disable flag"
     },
+    "initialSetupArmingDisableFlagsTooltipAUTOPILOT": {
+        "message": "Autopilot mode switch is active",
+        "description": "Message that pops up to describe the AUTOPILOT arming disable flag"
+    },
     "initialSetupArmingDisableFlagsTooltipARM_SWITCH": {
         "message": "One of the others disarm flags is active when arming",
         "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"
@@ -7465,6 +7469,14 @@
     "osdWarningPosHoldFailed": {
         "message": "Position hold failed",
         "description": "Warns when the position hold fails (e.g. in GPS mode)"
+    },
+    "osdWarningTextAutopilotAbort": {
+        "message": "Autopilot mission aborted",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningAutopilotAbort": {
+        "message": "Autopilot mission aborted",
+        "description": "Warns when a waypoint mission aborts (GPS lost, stalled or flyaway)"
     },
     "osdWarningTextUnknown": {
         "message": "Unknown $1"

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -245,10 +245,7 @@
             </div>
         </div>
 
-        <UModal
-            v-model:open="confirmResetOpen"
-            :title="$t('dialogConfirmResetTitle')"
-        >
+        <UModal v-model:open="confirmResetOpen" :title="$t('dialogConfirmResetTitle')">
             <template #body>
                 <div v-html="$t('dialogConfirmResetNote')"></div>
             </template>
@@ -265,11 +262,7 @@
             </template>
         </UModal>
 
-        <UModal
-            v-model:open="buildInfoOpen"
-            :title="state.buildInfoDialogTitle"
-            :ui="{ content: 'w-fit max-w-2xl' }"
-        >
+        <UModal v-model:open="buildInfoOpen" :title="state.buildInfoDialogTitle" :ui="{ content: 'w-fit max-w-2xl' }">
             <template #body>
                 <div class="dialogBuildInfoGrid-container">
                     <div v-for="option in state.sortedBuildOptions" :key="option" class="dialogBuildInfoGrid-item">
@@ -306,7 +299,7 @@ import { mspHelper } from "../../js/msp/MSPHelper";
 import MSP from "../../js/msp";
 import Model from "../../js/model";
 import MSPCodes from "../../js/msp/MSPCodes";
-import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47 } from "../../js/data_storage";
+import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48 } from "../../js/data_storage";
 import { gui_log } from "../../js/gui_log";
 import { ispConnected } from "../../js/utils/connection";
 import { addArrayElementsAfter, replaceArrayElement } from "../../js/utils/array";
@@ -391,6 +384,10 @@ const prepareDisarmFlags = function () {
 
     if (semver.gte(cfg.apiVersion, API_VERSION_1_47)) {
         addArrayElementsAfter(elements, "MOTOR_PROTOCOL", ["CRASHFLIP", "ALTHOLD", "POSHOLD"]);
+    }
+
+    if (semver.gte(cfg.apiVersion, API_VERSION_1_48)) {
+        addArrayElementsAfter(elements, "POSHOLD", ["AUTOPILOT"]);
     }
 
     // Build arming flags state instead of manipulating DOM

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -1565,6 +1565,9 @@ OSD.chooseFields = function () {
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.filter((w) => w.name !== "RC_SMOOTHING_FAILURE");
         OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([F.POSHOLD_FAILED]);
     }
+    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_48)) {
+        OSD.constants.WARNINGS = OSD.constants.WARNINGS.concat([F.AUTOPILOT_ABORT]);
+    }
 };
 
 OSD.updateDisplaySize = function () {

--- a/src/components/tabs/osd/osd_constants.js
+++ b/src/components/tabs/osd/osd_constants.js
@@ -272,6 +272,11 @@ export const OSD_CONSTANTS = {
             text: "osdWarningTextPosHoldFailed",
             desc: "osdWarningPosHoldFailed",
         },
+        AUTOPILOT_ABORT: {
+            name: "AUTOPILOT_ABORT",
+            text: "osdWarningTextAutopilotAbort",
+            desc: "osdWarningAutopilotAbort",
+        },
     },
     FONT_TYPES: [
         { file: "default", name: "osdSetupFontTypeDefault" },


### PR DESCRIPTION
Companion to betaflight/betaflight#15408 (flight plan safety).

- Setup tab: `AUTOPILOT` arming disable flag after `POSHOLD` (firmware bit 28; `ARM_SWITCH` stays pinned to the last bit so older firmware is unaffected), gated on API 1.48.
- OSD tab: `AUTOPILOT_ABORT` warning appended after `POSHOLD_FAILED`, matching the firmware's `OSD_WARNING_AUTOPILOT_ABORT`, gated on API 1.48.
- English locale entries for both.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an Autopilot arming-disable indicator with a tooltip explaining when the mode switch is active.
  * Added on-screen warnings for aborted autopilot waypoint missions, including GPS loss, stalled missions, and flyaway conditions.
  * Updated setup and OSD displays to show these options on compatible firmware versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->