### PR TITLE
refactor(protocols): extract shared byte/string conversion helpers into utils/bytes.js

### DIFF
--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -1,5 +1,6 @@
 import { isAndroid } from "./utils/checkCompatibility";
 import CapacitorFile from "./protocols/CapacitorFile";
+import { hexStringToUint8Array, uint8ArrayToHexString } from "./utils/bytes.js";
 
 const EXTENSION_MIME_MAP = {
     ".txt": "text/plain",
@@ -362,7 +363,7 @@ class FileSystem {
         } else {
             // Uint8Array, ArrayBuffer, or Blob → convert to hex
             const bytes = await this._toUint8Array(contents);
-            const hex = CapacitorFile.uint8ArrayToHexString(bytes);
+            const hex = uint8ArrayToHexString(bytes);
             await CapacitorFile.writeFile(fileId, hex, "hex");
         }
     }
@@ -406,7 +407,7 @@ class FileSystem {
 
     async _androidReadFileAsBlob(file) {
         const hex = await CapacitorFile.readFileAsHex(file._fileHandle);
-        const bytes = CapacitorFile.hexStringToUint8Array(hex);
+        const bytes = hexStringToUint8Array(hex);
 
         // Determine MIME type from file name extension
         const ext = file.name ? `.${file.name.split(".").pop()}` : "";
@@ -460,7 +461,7 @@ class FileSystem {
         // chunk is a Blob (wrapping DataView for binary, or string for text)
         const buffer = await chunk.arrayBuffer();
         const bytes = new Uint8Array(buffer);
-        const hex = CapacitorFile.uint8ArrayToHexString(bytes);
+        const hex = uint8ArrayToHexString(bytes);
         await CapacitorFile.writeChunk(fileId, hex, "hex");
     }
 

--- a/src/js/protocols/CapacitorBle.js
+++ b/src/js/protocols/CapacitorBle.js
@@ -1,27 +1,9 @@
 import { Capacitor } from "@capacitor/core";
 import { bluetoothDevices } from "./devices";
+import { base64ToUint8Array, uint8ArrayToBase64 } from "../utils/bytes.js";
 
 const logHead = "[CAPACITORBLE]";
 const plugin = Capacitor?.Plugins?.BetaflightBle;
-
-const base64ToUint8Array = (b64) => {
-    if (!b64) return new Uint8Array(0);
-    const binary = atob(b64);
-    const len = binary.length;
-    const bytes = new Uint8Array(len);
-    for (let i = 0; i < len; i++) {
-        bytes[i] = binary.charCodeAt(i);
-    }
-    return bytes;
-};
-
-const uint8ArrayToBase64 = (bytes) => {
-    let binary = "";
-    for (let i = 0; i < bytes.byteLength; i++) {
-        binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary);
-};
 
 class CapacitorBle extends EventTarget {
     constructor() {

--- a/src/js/protocols/CapacitorDfu.js
+++ b/src/js/protocols/CapacitorDfu.js
@@ -1,4 +1,5 @@
 import { Capacitor } from "@capacitor/core";
+import { hexStringToUint8Array, uint8ArrayToHexString } from "../utils/bytes.js";
 
 const logHead = "[CAPACITOR DFU]";
 const BetaflightDfu = Capacitor?.Plugins?.BetaflightDfu;
@@ -140,7 +141,7 @@ class CapacitorDfu extends EventTarget {
 
         if (result.status === "ok" && result.data) {
             // Convert hex string to Uint8Array
-            const data = this.hexStringToUint8Array(result.data);
+            const data = hexStringToUint8Array(result.data);
             return { status: "ok", data };
         }
 
@@ -148,7 +149,7 @@ class CapacitorDfu extends EventTarget {
     }
 
     async controlTransferOut(request, value, index, data, timeout) {
-        const hexData = data ? this.uint8ArrayToHexString(new Uint8Array(data)) : "";
+        const hexData = data ? uint8ArrayToHexString(new Uint8Array(data)) : "";
         return BetaflightDfu.controlTransferOut({
             request,
             value,
@@ -188,25 +189,6 @@ class CapacitorDfu extends EventTarget {
             return result.descriptor;
         }
         return null;
-    }
-
-    // ===== Hex conversion helpers =====
-
-    hexStringToUint8Array(hexString) {
-        if (!hexString || hexString.length === 0) {
-            return new Uint8Array(0);
-        }
-        const bytes = new Uint8Array(hexString.length / 2);
-        for (let i = 0; i < hexString.length; i += 2) {
-            bytes[i / 2] = Number.parseInt(hexString.substring(i, i + 2), 16);
-        }
-        return bytes;
-    }
-
-    uint8ArrayToHexString(uint8Array) {
-        return Array.from(uint8Array)
-            .map((byte) => byte.toString(16).padStart(2, "0"))
-            .join("");
     }
 }
 

--- a/src/js/protocols/CapacitorFile.js
+++ b/src/js/protocols/CapacitorFile.js
@@ -173,30 +173,6 @@ class CapacitorFile {
             throw error;
         }
     }
-
-    // -----------------------------------------------------------
-    // Hex string helpers (same as CapacitorSerial)
-    // -----------------------------------------------------------
-
-    hexStringToUint8Array(hexString) {
-        if (!hexString || hexString.length === 0) {
-            return new Uint8Array(0);
-        }
-        if (hexString.length & 1) {
-            throw new Error(`Hex string has odd length: ${hexString.length}`);
-        }
-        const bytes = new Uint8Array(hexString.length / 2);
-        for (let i = 0; i < hexString.length; i += 2) {
-            bytes[i / 2] = Number.parseInt(hexString.substring(i, i + 2), 16);
-        }
-        return bytes;
-    }
-
-    uint8ArrayToHexString(uint8Array) {
-        return Array.from(uint8Array)
-            .map((byte) => byte.toString(16).padStart(2, "0"))
-            .join("");
-    }
 }
 
 export default new CapacitorFile();

--- a/src/js/protocols/CapacitorSerial.js
+++ b/src/js/protocols/CapacitorSerial.js
@@ -1,4 +1,5 @@
 import { Capacitor } from "@capacitor/core";
+import { hexStringToUint8Array, uint8ArrayToHexString } from "../utils/bytes.js";
 
 const logHead = "[CAPACITORSERIAL]";
 const BetaflightSerial = Capacitor?.Plugins?.BetaflightSerial;
@@ -51,7 +52,7 @@ class CapacitorSerial extends EventTarget {
 
     handleDataReceived(event) {
         // Convert hex string to Uint8Array
-        const data = this.hexStringToUint8Array(event.data);
+        const data = hexStringToUint8Array(event.data);
         this.bytesReceived += data.length;
 
         // Dispatch receive event with the data
@@ -269,7 +270,7 @@ class CapacitorSerial extends EventTarget {
 
         try {
             // Convert Uint8Array to hex string
-            const hexString = this.uint8ArrayToHexString(data);
+            const hexString = uint8ArrayToHexString(data);
             const result = await BetaflightSerial.write({ data: hexString });
 
             this.bytesSent += result.bytesSent;
@@ -289,25 +290,6 @@ class CapacitorSerial extends EventTarget {
 
     getConnectedPort() {
         return this.currentDevice;
-    }
-
-    // Helper methods for hex string conversion
-    hexStringToUint8Array(hexString) {
-        if (!hexString || hexString.length === 0) {
-            return new Uint8Array(0);
-        }
-
-        const bytes = new Uint8Array(hexString.length / 2);
-        for (let i = 0; i < hexString.length; i += 2) {
-            bytes[i / 2] = Number.parseInt(hexString.substring(i, i + 2), 16);
-        }
-        return bytes;
-    }
-
-    uint8ArrayToHexString(uint8Array) {
-        return Array.from(uint8Array)
-            .map((byte) => byte.toString(16).padStart(2, "0"))
-            .join("");
     }
 }
 

--- a/src/js/protocols/CapacitorTcp.js
+++ b/src/js/protocols/CapacitorTcp.js
@@ -1,27 +1,7 @@
 import { Capacitor } from "@capacitor/core";
+import { base64ToUint8Array, uint8ArrayToBase64 } from "../utils/bytes.js";
 
 const BetaflightTcp = Capacitor?.Plugins?.BetaflightTcp;
-
-function base64ToUint8Array(b64) {
-    const binary = atob(b64);
-    const len = binary.length;
-    const bytes = new Uint8Array(len);
-    for (let i = 0; i < len; i++) {
-        // The atob() function returns a binary string where each character represents a single byte (0–255).
-        // codePointAt() is designed for Unicode code points and can return values greater than 255, which will overflow Uint8Array slots and corrupt received data.
-        // Use charCodeAt(i) to safely extract byte values.
-        bytes[i] = binary.charCodeAt(i);
-    }
-    return bytes;
-}
-
-function uint8ArrayToBase64(bytes) {
-    let binary = "";
-    for (let i = 0; i < bytes.byteLength; i++) {
-        binary += String.fromCharCode(bytes[i]);
-    }
-    return btoa(binary);
-}
 
 class CapacitorTcp extends EventTarget {
     constructor() {

--- a/src/js/utils/bytes.js
+++ b/src/js/utils/bytes.js
@@ -44,10 +44,15 @@ export function uint8ArrayToBase64(bytes) {
  *
  * @param {string} hexString - The hex string (two chars per byte). Empty/falsy input yields an empty array.
  * @returns {Uint8Array} The parsed bytes.
+ * @throws {Error} If the hex string has an odd length.
  */
 export function hexStringToUint8Array(hexString) {
     if (!hexString || hexString.length === 0) {
         return new Uint8Array(0);
+    }
+
+    if (hexString.length & 1) {
+        throw new Error(`Hex string has odd length: ${hexString.length}`);
     }
 
     const bytes = new Uint8Array(hexString.length / 2);

--- a/src/js/utils/bytes.js
+++ b/src/js/utils/bytes.js
@@ -1,0 +1,70 @@
+/**
+ * Shared byte/string conversion helpers.
+ *
+ * Extracted from the transport protocols (CapacitorBle, CapacitorTcp,
+ * CapacitorSerial) so the conversions live in a single place.
+ */
+
+/**
+ * Decode a base64 string into a byte array.
+ *
+ * @param {string} b64 - The base64-encoded string. Falsy input yields an empty array.
+ * @returns {Uint8Array} The decoded bytes.
+ */
+export function base64ToUint8Array(b64) {
+    if (!b64) return new Uint8Array(0);
+    const binary = atob(b64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+        // The atob() function returns a binary string where each character represents a single byte (0–255).
+        // codePointAt() is designed for Unicode code points and can return values greater than 255, which will overflow Uint8Array slots and corrupt received data.
+        // Use charCodeAt(i) to safely extract byte values.
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+}
+
+/**
+ * Encode a byte array into a base64 string.
+ *
+ * @param {Uint8Array} bytes - The bytes to encode.
+ * @returns {string} The base64-encoded string.
+ */
+export function uint8ArrayToBase64(bytes) {
+    let binary = "";
+    for (let i = 0; i < bytes.byteLength; i++) {
+        binary += String.fromCharCode(bytes[i]);
+    }
+    return btoa(binary);
+}
+
+/**
+ * Parse a hex string into a byte array.
+ *
+ * @param {string} hexString - The hex string (two chars per byte). Empty/falsy input yields an empty array.
+ * @returns {Uint8Array} The parsed bytes.
+ */
+export function hexStringToUint8Array(hexString) {
+    if (!hexString || hexString.length === 0) {
+        return new Uint8Array(0);
+    }
+
+    const bytes = new Uint8Array(hexString.length / 2);
+    for (let i = 0; i < hexString.length; i += 2) {
+        bytes[i / 2] = Number.parseInt(hexString.substring(i, i + 2), 16);
+    }
+    return bytes;
+}
+
+/**
+ * Format a byte array as a hex string.
+ *
+ * @param {Uint8Array} uint8Array - The bytes to format.
+ * @returns {string} The hex string (two lowercase chars per byte).
+ */
+export function uint8ArrayToHexString(uint8Array) {
+    return Array.from(uint8Array)
+        .map((byte) => byte.toString(16).padStart(2, "0"))
+        .join("");
+}

--- a/src/js/utils/bytes.js
+++ b/src/js/utils/bytes.js
@@ -12,15 +12,16 @@
  * @returns {Uint8Array} The decoded bytes.
  */
 export function base64ToUint8Array(b64) {
-    if (!b64) return new Uint8Array(0);
+    if (!b64) {
+        return new Uint8Array(0);
+    }
     const binary = atob(b64);
     const len = binary.length;
     const bytes = new Uint8Array(len);
     for (let i = 0; i < len; i++) {
-        // The atob() function returns a binary string where each character represents a single byte (0–255).
-        // codePointAt() is designed for Unicode code points and can return values greater than 255, which will overflow Uint8Array slots and corrupt received data.
-        // Use charCodeAt(i) to safely extract byte values.
-        bytes[i] = binary.charCodeAt(i);
+        // atob() returns a binary string: every code unit is a single byte (0–255),
+        // so codePointAt(i) equals the byte value at i and never exceeds 255.
+        bytes[i] = binary.codePointAt(i);
     }
     return bytes;
 }
@@ -34,7 +35,8 @@ export function base64ToUint8Array(b64) {
 export function uint8ArrayToBase64(bytes) {
     let binary = "";
     for (let i = 0; i < bytes.byteLength; i++) {
-        binary += String.fromCharCode(bytes[i]);
+        // Each byte is 0–255, so fromCodePoint produces the matching single-byte binary-string char for btoa().
+        binary += String.fromCodePoint(bytes[i]);
     }
     return btoa(binary);
 }

--- a/test/js/bytes.test.js
+++ b/test/js/bytes.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import {
+    base64ToUint8Array,
+    uint8ArrayToBase64,
+    hexStringToUint8Array,
+    uint8ArrayToHexString,
+} from "../../src/js/utils/bytes.js";
+
+describe("bytes base64 helpers", () => {
+    it("round-trips a representative byte array including 0 and 255", () => {
+        const original = new Uint8Array([0, 1, 2, 127, 128, 200, 254, 255]);
+        const b64 = uint8ArrayToBase64(original);
+        const decoded = base64ToUint8Array(b64);
+        expect(decoded).toEqual(original);
+    });
+
+    it("encodes a known array to a known base64 string", () => {
+        // "Man" -> "TWFu"
+        const bytes = new Uint8Array([77, 97, 110]);
+        expect(uint8ArrayToBase64(bytes)).toBe("TWFu");
+    });
+
+    it("returns an empty Uint8Array for an empty string", () => {
+        expect(base64ToUint8Array("")).toEqual(new Uint8Array(0));
+    });
+
+    it("returns an empty Uint8Array for undefined (the falsy guard)", () => {
+        expect(base64ToUint8Array(undefined)).toEqual(new Uint8Array(0));
+    });
+});
+
+describe("bytes hex helpers", () => {
+    it("round-trips a representative byte array including 0 and 255", () => {
+        const original = new Uint8Array([0, 1, 2, 127, 128, 200, 254, 255]);
+        const hex = uint8ArrayToHexString(original);
+        const decoded = hexStringToUint8Array(hex);
+        expect(decoded).toEqual(original);
+    });
+
+    it("produces lowercase zero-padded two-char-per-byte output", () => {
+        const bytes = new Uint8Array([0, 15, 255]);
+        expect(uint8ArrayToHexString(bytes)).toBe("000fff");
+    });
+
+    it("parses hex back to the correct byte values", () => {
+        expect(hexStringToUint8Array("000fff")).toEqual(new Uint8Array([0, 15, 255]));
+    });
+
+    it("returns an empty Uint8Array for an empty string", () => {
+        expect(hexStringToUint8Array("")).toEqual(new Uint8Array(0));
+    });
+
+    it("returns an empty Uint8Array for undefined (the falsy guard)", () => {
+        expect(hexStringToUint8Array(undefined)).toEqual(new Uint8Array(0));
+    });
+});

--- a/test/js/bytes.test.js
+++ b/test/js/bytes.test.js
@@ -53,4 +53,8 @@ describe("bytes hex helpers", () => {
     it("returns an empty Uint8Array for undefined (the falsy guard)", () => {
         expect(hexStringToUint8Array(undefined)).toEqual(new Uint8Array(0));
     });
+
+    it("throws on an odd-length hex string", () => {
+        expect(() => hexStringToUint8Array("abc")).toThrow();
+    });
 });


### PR DESCRIPTION
Extracts the duplicated byte/string conversion helpers from the Capacitor transports into a single shared module. This is **item 4** of the serial-backend cleanup tracked in #4722, and the first step of the recommended implementation order there (S-effort, low-risk, no behaviour change).

## What changed

New `src/js/utils/bytes.js` with four pure, JSDoc'd named exports:

| Helper | Was |
|--------|-----|
| `base64ToUint8Array` / `uint8ArrayToBase64` | duplicated byte-for-byte in `CapacitorTcp.js` **and** `CapacitorBle.js` |
| `hexStringToUint8Array` / `uint8ArrayToHexString` | instance methods on `CapacitorSerial.js` |

Consumers now import from the shared module; the local copies are deleted:

- **`CapacitorTcp.js`** — base64 pair (was module-level functions)
- **`CapacitorBle.js`** — base64 pair (was arrow consts)
- **`CapacitorSerial.js`** — hex pair (was instance methods; both call sites de-`this`'d)

The same hex pair was also duplicated in **`CapacitorDfu.js`** and the **`CapacitorFile.js`** singleton (consumed by `FileSystem.js`). Second commit routes those through `bytes.js` too:

- **`CapacitorDfu.js`** — instance methods removed; both internal call sites use the imports.
- **`CapacitorFile.js` + `FileSystem.js`** — the singleton's externally-called hex methods removed; `FileSystem.js` imports the helpers directly and updates its three call sites. `CapacitorFile`'s file-op methods are untouched.

## Behaviour notes (both safe supersets)

- The canonical `base64ToUint8Array` is the **guarded** variant from `CapacitorBle` (falsy input → empty `Uint8Array`). For `CapacitorTcp` this is behaviour-preserving — its previous unguarded version would have thrown on falsy input; it now returns an empty array.
- The canonical `hexStringToUint8Array` adopts **`CapacitorFile`'s stricter odd-length guard** (throws on odd-length input). Byte-array round-trips never produce odd-length hex, so this only turns silent corruption into an explicit error; `CapacitorSerial`/`CapacitorDfu` gain the same defensive check.

No other behaviour changes.

## Tests

New `test/js/bytes.test.js` — 10 tests: round-trips (incl. `0` and `255`), known vectors (`"Man"→"TWFu"`, `[0,15,255]→"000fff"`), the empty/`undefined` guards, and the odd-length throw.

- `bytes.test.js`: 10/10 pass
- `fileSystem.test.js`: 16/16 pass (exercises the changed `FileSystem` call sites)
- `msp.test.js` + `serial_backend.test.js`: 28/28 pass (touched transports, no regression)
- ESLint clean on all changed files


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and unified encoding/decoding behavior across Bluetooth, Serial, TCP, DFU, and Android file read/write flows by using shared byte conversion logic.
  * Preserved correct handling of empty or missing payload data during transfers.
* **Tests**
  * Added automated coverage for Base64 and hexadecimal byte conversion helpers, including round-trip correctness, known mappings, and edge cases (empty input and odd-length hex error).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->