### PR TITLE
Fix rates preview not rendering correctly

### DIFF
--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -951,6 +951,10 @@ function updateRatesLabels() {
 
     const maxRate = Math.max(maxAngularVels.roll, maxAngularVels.pitch, maxAngularVels.yaw);
 
+    // Round up to the nearest 200 like the curve layer does, so the stick-position
+    // dots use the same vertical scale as the curve they sit on.
+    const maxRateRounded = rateCurve.setMaxAngularVel(maxRate);
+
     // Calculate scaling exactly like master
     const curveHeight = canvas.height;
     const curveWidth = canvas.width;
@@ -1041,6 +1045,12 @@ function updateRatesLabels() {
     // Add current RC stick values on the left side (like master)
     // Calculate stick values first, then add to balloons array AFTER sorting
     if (FC.RC && FC.RC.channels && FC.RC.channels[0] && FC.RC.channels[1] && FC.RC.channels[2]) {
+        // Draw the stick-position dots in the unscaled coordinate space so they line up
+        // with the rate curve (drawn without the horizontal textScale) instead of being
+        // squeezed toward the left edge. maxRateRounded matches the curve's vertical scale.
+        ctx.save();
+        ctx.scale(1 / textScale, 1);
+
         // Calculate current stick angular velocities
         const currentRollRate = rateCurve.drawStickPosition(
             FC.RC.channels[0],
@@ -1050,7 +1060,7 @@ function updateRatesLabels() {
             rates.superexpo,
             rates.deadband,
             rates.roll_rate_limit,
-            maxRate,
+            maxRateRounded,
             ctx,
             "#FF8080",
         );
@@ -1063,7 +1073,7 @@ function updateRatesLabels() {
             rates.superexpo,
             rates.deadband,
             rates.pitch_rate_limit,
-            maxRate,
+            maxRateRounded,
             ctx,
             "#80FF80",
         );
@@ -1076,10 +1086,12 @@ function updateRatesLabels() {
             rates.superexpo,
             rates.yawDeadband,
             rates.yaw_rate_limit,
-            maxRate,
+            maxRateRounded,
             ctx,
             "#8080FF",
         );
+
+        ctx.restore();
 
         // Sort right-side balloons first (like master)
         balloons.sort((a, b) => b.value - a.value);

--- a/src/js/RateCurve.js
+++ b/src/js/RateCurve.js
@@ -107,14 +107,21 @@ const RateCurve = function (useLegacyCurve) {
             context.fillStyle = stickColor || "#000000";
 
             context.translate(context.canvas.width / 2, context.canvas.height / 2);
+
+            // The canvas is drawn at a fixed square resolution but displayed at a
+            // non-square aspect ratio, which would stretch a plain circle horizontally.
+            // Compress the horizontal radius by the display aspect ratio so the
+            // indicator renders as a round dot.
+            const radius = context.canvas.height / DEFAULT_SIZE;
+            const { clientWidth, clientHeight } = context.canvas;
+            const aspect = clientWidth && clientHeight ? clientHeight / clientWidth : 1;
+
             context.beginPath();
-            context.arc(
-                rcData - 1500,
-                -rateScaling * currentValue,
-                context.canvas.height / DEFAULT_SIZE,
-                0,
-                2 * Math.PI,
-            );
+            if (context.ellipse) {
+                context.ellipse(rcData - 1500, -rateScaling * currentValue, radius * aspect, radius, 0, 0, 2 * Math.PI);
+            } else {
+                context.arc(rcData - 1500, -rateScaling * currentValue, radius, 0, 2 * Math.PI);
+            }
             context.fill();
             context.restore();
         }

--- a/test/js/RateCurve.test.js
+++ b/test/js/RateCurve.test.js
@@ -504,17 +504,23 @@ describe("RateCurve.getCurrentRates", () => {
 });
 
 describe("RateCurve.drawStickPosition return value", () => {
-    function makeContext(height) {
-        return {
+    function makeContext(height, { withEllipse = true, clientWidth, clientHeight } = {}) {
+        const context = {
             save: () => {},
             restore: () => {},
             translate: () => {},
             beginPath: () => {},
-            arc: () => {},
+            arcCalls: [],
+            ellipseCalls: [],
+            arc: (...args) => context.arcCalls.push(args),
             fill: () => {},
             fillStyle: undefined,
-            canvas: { width: 200, height },
+            canvas: { width: 200, height, clientWidth, clientHeight },
         };
+        if (withEllipse) {
+            context.ellipse = (...args) => context.ellipseCalls.push(args);
+        }
+        return context;
     }
 
     it("snaps to 0 when the computed rate is below 0.5 deg/s in magnitude", () => {
@@ -531,5 +537,47 @@ describe("RateCurve.drawStickPosition return value", () => {
         const context = makeContext(400);
         const result = rc.drawStickPosition(2000, 0.7, 1.0, 0, true, 0, 1000, 700, context);
         expect(result).toBe("667");
+    });
+
+    it("draws an aspect-compensated ellipse when the context supports it", () => {
+        FC.RC_TUNING = { rates_type: FC.RATES_TYPE.BETAFLIGHT };
+        const rc = makeRateCurve();
+        const height = 400;
+        const context = makeContext(height, { clientWidth: 800, clientHeight: 400 });
+        rc.drawStickPosition(2000, 0.7, 1.0, 0, true, 0, 1000, 700, context);
+
+        expect(context.arcCalls).toHaveLength(0);
+        expect(context.ellipseCalls).toHaveLength(1);
+
+        const radius = height / 60;
+        const aspect = 400 / 800;
+        const [x, , radiusX, radiusY] = context.ellipseCalls[0];
+        // Horizontal radius is compressed by the display aspect ratio; vertical is not.
+        expect(radiusX).toBeCloseTo(radius * aspect);
+        expect(radiusY).toBeCloseTo(radius);
+        expect(x).toBe(2000 - 1500);
+    });
+
+    it("uses a round ellipse when the display aspect ratio is unavailable", () => {
+        FC.RC_TUNING = { rates_type: FC.RATES_TYPE.BETAFLIGHT };
+        const rc = makeRateCurve();
+        const context = makeContext(400); // no clientWidth/clientHeight
+        rc.drawStickPosition(2000, 0.7, 1.0, 0, true, 0, 1000, 700, context);
+
+        expect(context.ellipseCalls).toHaveLength(1);
+        const [, , radiusX, radiusY] = context.ellipseCalls[0];
+        expect(radiusX).toBe(radiusY);
+    });
+
+    it("falls back to arc when the context has no ellipse method", () => {
+        FC.RC_TUNING = { rates_type: FC.RATES_TYPE.BETAFLIGHT };
+        const rc = makeRateCurve();
+        const context = makeContext(400, { withEllipse: false, clientWidth: 800, clientHeight: 400 });
+        rc.drawStickPosition(2000, 0.7, 1.0, 0, true, 0, 1000, 700, context);
+
+        expect(context.ellipse).toBeUndefined();
+        expect(context.arcCalls).toHaveLength(1);
+        const [, , radius] = context.arcCalls[0];
+        expect(radius).toBeCloseTo(400 / 60);
     });
 });


### PR DESCRIPTION
Fixes the circles in the "Rates Preview" not being rendered correctly.

`master.app.betaflight.com`:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/91df1f53-2fb0-43c7-9242-512eb3a7ceb6" />

Fix:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/6bcd381e-32bd-4923-8cd5-2515ea3ea25d" />

Tested on different screen sizes, works good now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved alignment between stick-position indicators and the rate curve.
  * Corrected indicator sizing on displays with non-square aspect ratios for more accurate proportions.
  * Added a rendering fallback for environments without advanced ellipse drawing support.
* **Tests**
  * Expanded drawing-behavior coverage to verify aspect-compensated indicator rendering and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->