### PR TITLE
Show backup tab buttons disabled with hint when no FC connected

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -9181,6 +9181,10 @@
     "backupNoBackupsAvailable": {
         "message": "No backups available"
     },
+    "backupRequiresConnection": {
+        "message": "Connect a flight controller to enable this action",
+        "description": "Tooltip shown on disabled backup and restore buttons when no flight controller is connected"
+    },
     "titleEditBackup": {
         "message": "Edit Backup"
     },

--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -39,17 +39,21 @@
                                         >
                                             {{ $t("actionDownload") }}
                                         </UButton>
-                                        <UButton
-                                            v-if="isConnected"
-                                            size="xs"
-                                            variant="soft"
-                                            color="success"
-                                            icon="i-lucide-upload"
-                                            :disabled="isRestoreBusy"
-                                            @click="restoreBackup(row.original)"
-                                        >
-                                            {{ $t("actionRestore") }}
-                                        </UButton>
+                                        <UTooltip :text="$t('backupRequiresConnection')" :disabled="isConnected">
+                                            <span>
+                                                <UButton
+                                                    size="xs"
+                                                    variant="soft"
+                                                    color="success"
+                                                    icon="i-lucide-upload"
+                                                    :disabled="!isConnected || isRestoreBusy"
+                                                    :class="{ 'pointer-events-none': !isConnected }"
+                                                    @click="restoreBackup(row.original)"
+                                                >
+                                                    {{ $t("actionRestore") }}
+                                                </UButton>
+                                            </span>
+                                        </UTooltip>
                                         <UButton
                                             size="xs"
                                             variant="soft"
@@ -99,12 +103,7 @@
             </Dialog>
 
             <!-- Restore progress dialog -->
-            <UModal
-                :open="restoreProgressOpen"
-                :close="false"
-                :dismissible="false"
-                :ui="{ content: 'w-[320px]' }"
-            >
+            <UModal :open="restoreProgressOpen" :close="false" :dismissible="false" :ui="{ content: 'w-[320px]' }">
                 <template #body>
                     <div class="text-lg mb-2" v-html="$t('userBackupRestoreInProgress')"></div>
                     <div class="text-sm text-dimmed" v-html="$t('presetsPleaseWait')"></div>
@@ -152,11 +151,21 @@
         </div>
 
         <!-- Bottom toolbar -->
-        <div v-if="isConnected" class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
+        <div class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
             <div class="flex-1"></div>
-            <UButton @click="createBackup" size="sm" icon="i-lucide-save">
-                {{ $t("actionBackup") }}
-            </UButton>
+            <UTooltip :text="$t('backupRequiresConnection')" :disabled="isConnected">
+                <span>
+                    <UButton
+                        size="sm"
+                        icon="i-lucide-save"
+                        :disabled="!isConnected"
+                        :class="{ 'pointer-events-none': !isConnected }"
+                        @click="createBackup"
+                    >
+                        {{ $t("actionBackup") }}
+                    </UButton>
+                </span>
+            </UTooltip>
         </div>
     </BaseTab>
 </template>


### PR DESCRIPTION
On the backups tab the Restore and Backup buttons were hidden entirely when no flight controller was connected. They now stay visible but disabled, with a tooltip explaining a flight controller connection is required. The disabled button sits in a span wrapper with pointer-events disabled so the tooltip still opens on hover (browsers suppress hover events on disabled native buttons).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup and restore actions now remain visible when no flight controller is connected.
  * Disabled actions display a tooltip explaining that a connection is required.

* **Bug Fixes**
  * Prevented backup and restore actions from being activated while disconnected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->