### PR TITLE
fix(motors): prevent sensor readout values from wrapping to a second line

### DIFF
--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -314,7 +314,7 @@
                                     >
                                         <span>{{ axis.toUpperCase() }}:</span>
                                         <span
-                                            class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px]"
+                                            class="w-32 text-right px-[3px] py-[2px] text-black rounded-[3px] whitespace-nowrap tabular-nums"
                                             :class="{
                                                 'bg-[#e24761]': axis === 'x',
                                                 'bg-[#49c747]': axis === 'y',
@@ -326,7 +326,7 @@
                                     <div class="flex justify-between py-0.5">
                                         <span>RMS:</span>
                                         <span
-                                            class="w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#f5a623]"
+                                            class="w-32 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#f5a623] whitespace-nowrap tabular-nums"
                                             >{{ rawDataDisplay.rms }}</span
                                         >
                                     </div>


### PR DESCRIPTION
## Description

In the **Motors** tab, the X/Y/Z and RMS sensor readout pills next to the gyro/accel graph would "jump" onto a second line whenever the sensor values grew large (i.e. exceeded the selected scale).

The value pills used a fixed `w-24` (96px) width, but the displayed string is formatted as `value ( max )` — e.g. `-7991.95 ( -7991.95 )`. Once the numbers are wide enough, the text no longer fits inside the box and wraps to a second line, making the pill taller and pushing every row below it down.

## Fix

In `src/components/tabs/MotorsTab.vue`, for the X/Y/Z and RMS value spans:

- `w-24` → `w-32` — holds the widest realistic reading fully inside the colored pill.
- add `whitespace-nowrap` — keeps the value on a single line, so the row height stays constant.
- add `tabular-nums` — equal-width digits so the number doesn't jiggle horizontally as it updates.

Template-only change; no motor/MSP logic touched.

## Before / After

| Before (`w-24`) | After (`w-32 nowrap tabular-nums`) |
| --- | --- |
| Large values wrap to a second line, rows jump down | Single line, uniform height, no jumping |

## Testing

Verified by reproducing the readout markup with the app's actual Open Sans font and Tailwind's `border-box` model: at the value magnitude from the report the `w-24` pills wrap (reproducing the bug), while the `w-32 whitespace-nowrap tabular-nums` pills render on a single line without jumping.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved sensor graph readout formatting with wider value fields.
  * Prevented numeric values from wrapping and stabilized digit alignment for clearer readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->