### PR TITLE
fix(connection): stop logging benign MSP cancellations on tab switch

### DIFF
--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -10,6 +10,7 @@ import MSPCodes from "../js/msp/MSPCodes";
 import { useConnectionStore } from "../stores/connection";
 import GUI from "../js/gui";
 import { gui_log } from "../js/gui_log";
+import { isMspCancelled } from "../js/msp/mspErrors.js";
 
 export function usePower() {
     const supported = computed(() => {
@@ -345,6 +346,12 @@ export function usePower() {
                 amperage: FC.BATTERY_STATE.amperage,
             });
         } catch (error) {
+            // Same lifecycle race as the main live-data poller: switching away from the Power tab
+            // (or a disconnect) clears the MSP queue and cancels the in-flight poll. Expected — the
+            // interval is torn down on tab switch anyway — so don't log the cancellation.
+            if (isMspCancelled(error)) {
+                return;
+            }
             console.error("Error updating live data:", error);
         }
     };

--- a/src/composables/useSaving.js
+++ b/src/composables/useSaving.js
@@ -1,4 +1,5 @@
 import { ref } from "vue";
+import { isMspCancelled } from "../js/msp/mspErrors.js";
 
 export function useSaving() {
     const isSaving = ref(false);
@@ -11,6 +12,13 @@ export function useSaving() {
         try {
             await fn();
         } catch (e) {
+            // A tab switch, or the reboot/disconnect that a Save-and-Reboot triggers, clears the
+            // MSP queue and cancels the in-flight request. The save itself already went through (or
+            // the user navigated away), so this is not a real failure — don't log it or surface a
+            // "save failed" notification to the caller.
+            if (isMspCancelled(e)) {
+                return;
+            }
             if (onError) {
                 onError(e);
             } else {

--- a/src/js/msp/mspErrors.js
+++ b/src/js/msp/mspErrors.js
@@ -27,3 +27,13 @@ export class MspCrcError extends MspError {
         this.name = "MspCrcError";
     }
 }
+
+/**
+ * True when an error is a benign MSP request cancellation — the queue was cleared on a tab
+ * switch (reason "cleanup") or a disconnect/reboot (reason "disconnected"), not a real request
+ * failure (timeout, CRC). Lifecycle code (the live-data poller, the shared save helper) uses
+ * this to avoid logging or surfacing an expected cancellation as a failure.
+ */
+export function isMspCancelled(error) {
+    return error instanceof MspCancelledError;
+}

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -30,6 +30,7 @@ import { unmountVueTab } from "./vue_tab_mounter";
 import { switchTab } from "./tab_switch";
 import { useConnectionStore } from "../stores/connection";
 import { useDialogStore } from "../stores/dialog";
+import { isMspCancelled } from "./msp/mspErrors.js";
 
 const logHead = "[SERIAL-BACKEND]";
 
@@ -1197,38 +1198,52 @@ export function read_serial(info) {
     }
 }
 
+// Request one live-data value. Returns false when the poll cycle should stop because the
+// MSP queue was cleared out from under us — a tab switch (tab_switch_cleanup) or a
+// disconnect settles the in-flight request with MspCancelledError. That is an expected
+// lifecycle event for a background poller that outlives any single tab, so it is swallowed
+// silently; genuine failures (timeout, CRC) are still logged and the cycle continues.
+async function requestLiveData(code, name) {
+    try {
+        await MSP.promise(code);
+        return true;
+    } catch (error) {
+        if (isMspCancelled(error)) {
+            return false;
+        }
+        console.error(`Failed to request ${name}:`, error);
+        return true;
+    }
+}
+
 export async function update_sensor_status() {
-    try {
-        await MSP.promise(MSPCodes.MSP_ANALOG);
-    } catch (error) {
-        console.error("Failed to request MSP_ANALOG:", error);
+    if (!(await requestLiveData(MSPCodes.MSP_ANALOG, "MSP_ANALOG"))) {
+        return;
     }
-    try {
-        await MSP.promise(MSPCodes.MSP_BATTERY_STATE);
-    } catch (error) {
-        console.error("Failed to request MSP_BATTERY_STATE:", error);
+    if (!(await requestLiveData(MSPCodes.MSP_BATTERY_STATE, "MSP_BATTERY_STATE"))) {
+        return;
     }
-    try {
-        await MSP.promise(MSPCodes.MSP_BOXNAMES);
-    } catch (error) {
-        console.error("Failed to request MSP_BOXNAMES:", error);
+    if (!(await requestLiveData(MSPCodes.MSP_BOXNAMES, "MSP_BOXNAMES"))) {
+        return;
     }
-    try {
-        await MSP.promise(MSPCodes.MSP_STATUS_EX);
-    } catch (error) {
-        console.error("Failed to request MSP_STATUS_EX:", error);
+    if (!(await requestLiveData(MSPCodes.MSP_STATUS_EX, "MSP_STATUS_EX"))) {
+        return;
     }
 
     if (have_sensor(FC.CONFIG.activeSensors, "gps")) {
-        try {
-            await MSP.promise(MSPCodes.MSP_RAW_GPS);
-        } catch (error) {
-            console.error("Failed to request MSP_RAW_GPS:", error);
-        }
+        await requestLiveData(MSPCodes.MSP_RAW_GPS, "MSP_RAW_GPS");
     }
 }
 
 async function update_live_status() {
+    // Don't poll while a tab switch is tearing down the old tab and mounting the new one:
+    // tab_switch_cleanup() clears the MSP queue, so a poll issued now would just be cancelled.
+    // Skipping keeps the background poller from firing requests straight into that cleanup;
+    // the interval resumes normally on the next tick once the switch has settled.
+    if (GUI.tab_switch_in_progress) {
+        return;
+    }
+
     // Check if live data is paused via Pinia store
     const connectionStore = useConnectionStore();
     if (connectionStore.liveDataPaused) {


### PR DESCRIPTION
## Summary

Stops the console noise (and false "save failed" notifications) caused by benign MSP request cancellations when switching tabs or on Save-and-Reboot, e.g.:

```
Failed to request MSP_BOXNAMES: MspCancelledError: MSP queue cleared
    at Object.callbacks_cleanup ...
    at Proxy.tab_switch_cleanup ...
```

Fixes it where live data is managed rather than guarding every call site.

## Root cause

Every reported error was a **live-data poller** request (`MSP_ANALOG` / `MSP_BATTERY_STATE` / `MSP_BOXNAMES` / `MSP_STATUS_EX` / `MSP_RAW_GPS`) — the tab name in each log was just *when* the switch happened, not the source.

- `update_sensor_status()` is a free-running `setInterval(…, 250)` that is **not** registered with the GUI interval system, so `tab_switch_cleanup()`'s `interval_kill_all()` never stops it, and it keeps firing straight into the tab-switch queue-clear.
- Regression origin: **#5249** made `MSP.callbacks_cleanup()` *settle* in-flight promises by **rejecting** them with `MspCancelledError` (a correct change that stops leaks/hangs). Before that, the poller's in-flight promise silently never settled, so nothing was ever logged. After it, the poller's `catch` logs the expected cancellation as a failure.

## Changes

- **`update_live_status()`** skips while `GUI.tab_switch_in_progress`, so the background poller no longer issues requests into the queue-clear window.
- **`update_sensor_status()`** owns its cancellation via a small `requestLiveData()` helper: a queue-clear aborts the cycle quietly; genuine timeout/CRC failures are still logged per request.
- **`usePower.updateLiveData`** (the Power tab's 200 ms poller) gets the same treatment.
- **`runSave`** (the shared save helper used by Configuration/Sensors/OSD/Receiver/Failsafe) swallows the cancellation centrally, so a Save-and-Reboot no longer surfaces a false "save failed".
- Adds **`isMspCancelled()`** in `mspErrors.js` as the single predicate for "benign cancellation".

## Testing

- `npm run lint` — clean
- `npm test` — 622/622 passing
- Note: not reproducible in virtual mode (`MSP.promise` short-circuits), so this is logic- and test-verified; a quick confirm with a board connected is worthwhile.

## Follow-up

#5271 tracks migrating the remaining bespoke config-save handlers (PidTuning, Motors, Power, Gps, OnboardLogging, LedStrip, Servos, Auxiliary, Vtx) onto the shared `runSave` path so there's a single save discipline.
