### PR TITLE
refactor(save): consolidate all config saves onto one runSave + saveToEeprom path

### DIFF
--- a/src/components/dialogs/MotorOutputReorderingDialog.vue
+++ b/src/components/dialogs/MotorOutputReorderingDialog.vue
@@ -76,6 +76,7 @@ import { mspHelper } from "@/js/msp/MSPHelper";
 import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
 import { i18n } from "@/js/localization";
+import { useReboot } from "@/composables/useReboot";
 
 const props = defineProps({
     droneConfiguration: {
@@ -95,6 +96,7 @@ const props = defineProps({
 const emit = defineEmits(["close"]);
 
 const fcStore = useFlightControllerStore();
+const { saveAndReboot } = useReboot();
 const dialogRef = ref(null);
 const canvasRef = ref(null);
 
@@ -278,7 +280,7 @@ const save = () => {
         MSPCodes.MSP2_SET_MOTOR_OUTPUT_REORDERING,
         mspHelper.crunch(MSPCodes.MSP2_SET_MOTOR_OUTPUT_REORDERING),
         false,
-        () => mspHelper.writeConfiguration(true),
+        () => saveAndReboot(),
     );
 
     close();

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -165,11 +165,13 @@ import WikiButton from "../elements/WikiButton.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
 import ChannelRangePips from "@/components/elements/ChannelRangePips.vue";
 import GUI from "../../js/gui";
+import { useTranslation } from "i18next-vue";
 import { useAdjustmentsState } from "@/composables/adjustments/useAdjustmentsState";
 import { useAdjustmentsData } from "@/composables/adjustments/useAdjustmentsData";
 import { useAdjustmentsSave } from "@/composables/adjustments/useAdjustmentsSave";
 import { useAdjustmentsPolling } from "@/composables/adjustments/useAdjustmentsPolling";
 
+const { t } = useTranslation();
 const { adjustments, hasChanges, storeOriginals, showAllSlots, activeCount, visibleAdjustments } =
     useAdjustmentsState();
 const {

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -165,13 +165,10 @@ import WikiButton from "../elements/WikiButton.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
 import ChannelRangePips from "@/components/elements/ChannelRangePips.vue";
 import GUI from "../../js/gui";
-import { useTranslation } from "i18next-vue";
 import { useAdjustmentsState } from "@/composables/adjustments/useAdjustmentsState";
 import { useAdjustmentsData } from "@/composables/adjustments/useAdjustmentsData";
 import { useAdjustmentsSave } from "@/composables/adjustments/useAdjustmentsSave";
 import { useAdjustmentsPolling } from "@/composables/adjustments/useAdjustmentsPolling";
-
-const { t } = useTranslation();
 
 const { adjustments, hasChanges, storeOriginals, showAllSlots, activeCount, visibleAdjustments } =
     useAdjustmentsState();
@@ -187,7 +184,7 @@ const {
     loadMSPData,
     initializeAdjustments,
 } = useAdjustmentsData(adjustments, t);
-const { saveAdjustments, isSaving } = useAdjustmentsSave(adjustments, storeOriginals, t);
+const { saveAdjustments, isSaving } = useAdjustmentsSave(adjustments, storeOriginals);
 const { rcChannelData, startRcDataPolling } = useAdjustmentsPolling();
 
 onMounted(async () => {

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -148,7 +148,12 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('adjustmentsSave')" :disabled="!hasChanges" @click="saveAdjustments" />
+            <UButton
+                :label="$t('adjustmentsSave')"
+                :disabled="!hasChanges"
+                :loading="isSaving"
+                @click="saveAdjustments"
+            />
         </div>
     </BaseTab>
 </template>
@@ -182,7 +187,7 @@ const {
     loadMSPData,
     initializeAdjustments,
 } = useAdjustmentsData(adjustments, t);
-const { saveAdjustments } = useAdjustmentsSave(adjustments, storeOriginals, t);
+const { saveAdjustments, isSaving } = useAdjustmentsSave(adjustments, storeOriginals, t);
 const { rcChannelData, startRcDataPolling } = useAdjustmentsPolling();
 
 onMounted(async () => {

--- a/src/components/tabs/AuxiliaryTab.vue
+++ b/src/components/tabs/AuxiliaryTab.vue
@@ -148,7 +148,7 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('auxiliaryButtonSave')" :disabled="!dirty" @click="saveModes" />
+            <UButton :label="$t('auxiliaryButtonSave')" :disabled="!dirty" :loading="isSaving" @click="saveModes" />
         </div>
     </BaseTab>
 </template>
@@ -161,6 +161,8 @@ import BaseTab from "./BaseTab.vue";
 import WikiButton from "../elements/WikiButton.vue";
 import GUI from "../../js/gui";
 import { useInterval } from "../../composables/useInterval";
+import { useSaving } from "../../composables/useSaving";
+import { useReboot } from "../../composables/useReboot";
 import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
 import { mspHelper } from "../../js/msp/MSPHelper";
@@ -571,60 +573,71 @@ export default defineComponent({
             autoSelectChannel(channels, activeChannels, fcStore.rssiConfig?.channel || 0);
         };
 
-        const saveModes = () => {
-            const nextModeRanges = [];
-            const nextModeRangesExtra = [];
+        const { isSaving, runSave } = useSaving();
+        const { saveToEeprom } = useReboot();
 
-            modes.forEach((mode) => {
-                mode.entries.forEach((entry) => {
-                    if (entry.kind === "range") {
-                        const [start, end] = normalizeRangeValues(entry.sliderRange);
-                        if (start >= end) {
-                            return;
-                        }
-                        nextModeRanges.push({
-                            id: mode.id,
-                            auxChannelIndex: entry.auxChannelIndex,
-                            range: { start, end },
+        const saveModes = () =>
+            runSave(
+                async () => {
+                    const nextModeRanges = [];
+                    const nextModeRangesExtra = [];
+
+                    modes.forEach((mode) => {
+                        mode.entries.forEach((entry) => {
+                            if (entry.kind === "range") {
+                                const [start, end] = normalizeRangeValues(entry.sliderRange);
+                                if (start >= end) {
+                                    return;
+                                }
+                                nextModeRanges.push({
+                                    id: mode.id,
+                                    auxChannelIndex: entry.auxChannelIndex,
+                                    range: { start, end },
+                                });
+                                nextModeRangesExtra.push({
+                                    id: mode.id,
+                                    modeLogic: entry.modeLogic,
+                                    linkedTo: 0,
+                                });
+                            } else if (entry.kind === "link") {
+                                if (!entry.linkedTo) {
+                                    return;
+                                }
+                                nextModeRanges.push({
+                                    id: mode.id,
+                                    auxChannelIndex: 0,
+                                    range: { start: CHANNEL_MIN, end: CHANNEL_MIN },
+                                });
+                                nextModeRangesExtra.push({
+                                    id: mode.id,
+                                    modeLogic: entry.modeLogic,
+                                    linkedTo: entry.linkedTo,
+                                });
+                            }
                         });
-                        nextModeRangesExtra.push({
-                            id: mode.id,
-                            modeLogic: entry.modeLogic,
-                            linkedTo: 0,
-                        });
-                    } else if (entry.kind === "link") {
-                        if (!entry.linkedTo) {
-                            return;
-                        }
+                    });
+
+                    const required = requiredModeRangeCount.value || 0;
+                    while (nextModeRanges.length < required) {
                         nextModeRanges.push({
-                            id: mode.id,
+                            id: 0,
                             auxChannelIndex: 0,
                             range: { start: CHANNEL_MIN, end: CHANNEL_MIN },
                         });
-                        nextModeRangesExtra.push({
-                            id: mode.id,
-                            modeLogic: entry.modeLogic,
-                            linkedTo: entry.linkedTo,
-                        });
+                        nextModeRangesExtra.push({ id: 0, modeLogic: 0, linkedTo: 0 });
                     }
-                });
-            });
 
-            const required = requiredModeRangeCount.value || 0;
-            while (nextModeRanges.length < required) {
-                nextModeRanges.push({ id: 0, auxChannelIndex: 0, range: { start: CHANNEL_MIN, end: CHANNEL_MIN } });
-                nextModeRangesExtra.push({ id: 0, modeLogic: 0, linkedTo: 0 });
-            }
+                    fcStore.modeRanges = nextModeRanges;
+                    fcStore.modeRangesExtra = nextModeRangesExtra;
 
-            fcStore.modeRanges = nextModeRanges;
-            fcStore.modeRangesExtra = nextModeRangesExtra;
+                    await mspHelper.sendModeRanges();
+                    await saveToEeprom();
 
-            mspHelper.sendModeRanges(() => {
-                mspHelper.writeConfiguration(false, () => {
+                    // Only after a successful persist: refresh the dirty baseline.
                     modesDirtyBaseline.value = serializeModesPayloadForDirtyCheck(nextModeRanges, nextModeRangesExtra);
-                });
-            });
-        };
+                },
+                { onError: (error) => console.error("Failed to save auxiliary modes", error) },
+            );
 
         const loadData = async () => {
             try {
@@ -681,6 +694,7 @@ export default defineComponent({
             removeEntry,
             markerPercentFor,
             saveModes,
+            isSaving,
             dirty,
         };
     },

--- a/src/components/tabs/AuxiliaryTab.vue
+++ b/src/components/tabs/AuxiliaryTab.vue
@@ -576,56 +576,56 @@ export default defineComponent({
         const { isSaving, runSave } = useSaving();
         const { saveToEeprom } = useReboot();
 
-        const saveModes = () =>
-            runSave(
-                async () => {
-                    const nextModeRanges = [];
-                    const nextModeRangesExtra = [];
+        // Build the MSP mode-range payload from the current UI model. Extracted from the save
+        // callback so runSave's body stays flat (avoids deep forEach-in-forEach-in-runSave nesting).
+        const buildModeRangePayload = () => {
+            const nextModeRanges = [];
+            const nextModeRangesExtra = [];
 
-                    modes.forEach((mode) => {
-                        mode.entries.forEach((entry) => {
-                            if (entry.kind === "range") {
-                                const [start, end] = normalizeRangeValues(entry.sliderRange);
-                                if (start >= end) {
-                                    return;
-                                }
-                                nextModeRanges.push({
-                                    id: mode.id,
-                                    auxChannelIndex: entry.auxChannelIndex,
-                                    range: { start, end },
-                                });
-                                nextModeRangesExtra.push({
-                                    id: mode.id,
-                                    modeLogic: entry.modeLogic,
-                                    linkedTo: 0,
-                                });
-                            } else if (entry.kind === "link") {
-                                if (!entry.linkedTo) {
-                                    return;
-                                }
-                                nextModeRanges.push({
-                                    id: mode.id,
-                                    auxChannelIndex: 0,
-                                    range: { start: CHANNEL_MIN, end: CHANNEL_MIN },
-                                });
-                                nextModeRangesExtra.push({
-                                    id: mode.id,
-                                    modeLogic: entry.modeLogic,
-                                    linkedTo: entry.linkedTo,
-                                });
-                            }
-                        });
-                    });
-
-                    const required = requiredModeRangeCount.value || 0;
-                    while (nextModeRanges.length < required) {
+            modes.forEach((mode) => {
+                mode.entries.forEach((entry) => {
+                    if (entry.kind === "range") {
+                        const [start, end] = normalizeRangeValues(entry.sliderRange);
+                        if (start >= end) {
+                            return;
+                        }
                         nextModeRanges.push({
-                            id: 0,
+                            id: mode.id,
+                            auxChannelIndex: entry.auxChannelIndex,
+                            range: { start, end },
+                        });
+                        nextModeRangesExtra.push({ id: mode.id, modeLogic: entry.modeLogic, linkedTo: 0 });
+                    } else if (entry.kind === "link") {
+                        if (!entry.linkedTo) {
+                            return;
+                        }
+                        nextModeRanges.push({
+                            id: mode.id,
                             auxChannelIndex: 0,
                             range: { start: CHANNEL_MIN, end: CHANNEL_MIN },
                         });
-                        nextModeRangesExtra.push({ id: 0, modeLogic: 0, linkedTo: 0 });
+                        nextModeRangesExtra.push({
+                            id: mode.id,
+                            modeLogic: entry.modeLogic,
+                            linkedTo: entry.linkedTo,
+                        });
                     }
+                });
+            });
+
+            const required = requiredModeRangeCount.value || 0;
+            while (nextModeRanges.length < required) {
+                nextModeRanges.push({ id: 0, auxChannelIndex: 0, range: { start: CHANNEL_MIN, end: CHANNEL_MIN } });
+                nextModeRangesExtra.push({ id: 0, modeLogic: 0, linkedTo: 0 });
+            }
+
+            return { nextModeRanges, nextModeRangesExtra };
+        };
+
+        const saveModes = () =>
+            runSave(
+                async () => {
+                    const { nextModeRanges, nextModeRangesExtra } = buildModeRangePayload();
 
                     fcStore.modeRanges = nextModeRanges;
                     fcStore.modeRangesExtra = nextModeRangesExtra;

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -247,7 +247,12 @@
             <!-- <div class="btn save_btn">
                 <button type="button" class="save" @click="saveConfig">{{ $t("configurationButtonSave") }}</button>
             </div> -->
-            <UButton :label="$t('configurationButtonSave')" :disabled="!dirty" @click="saveConfig" />
+            <UButton
+                :label="$t('configurationButtonSave')"
+                :disabled="!dirty"
+                :loading="isSaving"
+                @click="saveConfig"
+            />
         </div>
     </BaseTab>
 </template>
@@ -273,6 +278,8 @@ import { useConnectionStore } from "@/stores/connection";
 import { useNavigationStore } from "@/stores/navigation";
 import { useDialogStore } from "@/stores/dialog";
 import { useInterval } from "../../composables/useInterval";
+import { useSaving } from "../../composables/useSaving";
+import { useReboot } from "../../composables/useReboot";
 import WikiButton from "../elements/WikiButton.vue";
 import UiBox from "../elements/UiBox.vue";
 import SettingRow from "../elements/SettingRow.vue";
@@ -292,6 +299,9 @@ export default defineComponent({
         const connectionStore = useConnectionStore();
         const navigationStore = useNavigationStore();
         const dialogStore = useDialogStore();
+
+        const { isSaving, runSave } = useSaving();
+        const { saveAndReboot } = useReboot();
 
         const mapRef = ref(null);
         const mapContainerRef = ref(null);
@@ -740,15 +750,24 @@ export default defineComponent({
             }
         };
 
-        const saveConfig = async () => {
-            Object.assign(fcStore.gpsConfig, gpsConfig);
+        const saveConfig = () =>
+            runSave(
+                async () => {
+                    Object.assign(fcStore.gpsConfig, gpsConfig);
 
-            await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
-            await MSP.promise(MSPCodes.MSP_SET_GPS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_GPS_CONFIG));
+                    await MSP.promise(
+                        MSPCodes.MSP_SET_FEATURE_CONFIG,
+                        mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG),
+                    );
+                    await MSP.promise(MSPCodes.MSP_SET_GPS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_GPS_CONFIG));
 
-            mspHelper.writeConfiguration(true);
-            gpsTabBaseline.value = serializeGpsTabState();
-        };
+                    await saveAndReboot();
+
+                    // Only after a successful persist: refresh the dirty baseline.
+                    gpsTabBaseline.value = serializeGpsTabState();
+                },
+                { onError: (e) => console.error("Failed to save GPS configuration", e) },
+            );
 
         const initializeMap = () => {
             if (mapInstance.value || !mapRef.value) return;
@@ -840,6 +859,7 @@ export default defineComponent({
             toggleFullscreen,
             checkConnectivity,
             saveConfig,
+            isSaving,
             dirty,
             onGpsProtocolChange,
             loadingBarsUrl,

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -327,7 +327,7 @@
 
         <!-- Bottom Toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="saveButtonText" @click="save" />
+            <UButton :label="saveButtonText" :loading="isSaving" @click="save" />
         </div>
     </BaseTab>
 </template>
@@ -339,6 +339,7 @@ import WikiButton from "../elements/WikiButton.vue";
 import LedGrid from "./led_strip/LedGrid.vue";
 import HelpIcon from "../elements/HelpIcon.vue";
 import { useLedStrip } from "@/composables/useLedStrip";
+import { useSaving } from "@/composables/useSaving";
 import { useTransientLabel } from "@/composables/useTransientLabel";
 import { i18n } from "@/js/localization";
 import { gui_log } from "@/js/gui_log";
@@ -423,8 +424,8 @@ const colorHSV = reactive({ h: 0, s: 0, v: 0 });
 const { label: transientSaveButtonText, flash: flashSaveButtonText } = useTransientLabel(
     i18n.getMessage("ledStripButtonSave"),
 );
-const savingButtonText = ref(null);
-const saveButtonText = computed(() => savingButtonText.value || transientSaveButtonText.value);
+const saveButtonText = computed(() => transientSaveButtonText.value);
+const { isSaving, runSave } = useSaving();
 
 // Color setup popup state
 const isColorSlidersOpen = ref(false);
@@ -995,19 +996,21 @@ watch(isColorSlidersOpen, (newValue) => {
 });
 
 // Save
-async function save() {
-    try {
-        savingButtonText.value = i18n.getMessage("buttonSaving");
-        await saveConfig();
+function save() {
+    runSave(
+        async () => {
+            await saveConfig();
 
-        savingButtonText.value = null;
-        flashSaveButtonText(i18n.getMessage("buttonSaved"), 1500);
-
-        gui_log(i18n.getMessage("eeprom_saved_ok"));
-    } catch (error) {
-        console.error("Save failed:", error);
-        savingButtonText.value = null;
-    }
+            // Post-save UI runs only after the persist resolves.
+            flashSaveButtonText(i18n.getMessage("buttonSaved"), 1500);
+            gui_log(i18n.getMessage("eeprom_saved_ok"));
+        },
+        {
+            onError: (error) => {
+                console.error("Save failed:", error);
+            },
+        },
+    );
 }
 
 // Helper functions

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -517,7 +517,8 @@
                 <UButton
                     :label="$t('configurationButtonSave')"
                     :disabled="buttonStates.saveDisabled"
-                    @click="saveAndReboot(true)"
+                    :loading="isSaving"
+                    @click="handleSave(true)"
                 />
             </div>
         </div>
@@ -547,6 +548,8 @@ import { useMotorsState } from "@/composables/motors/useMotorsState";
 import { useMotorTesting } from "@/composables/motors/useMotorTesting";
 import { useMotorConfiguration } from "@/composables/motors/useMotorConfiguration";
 import { useMotorDataPolling } from "@/composables/motors/useMotorDataPolling";
+import { useSaving } from "@/composables/useSaving";
+import { useReboot } from "@/composables/useReboot";
 
 const API_VERSION_1_47 = "1.47.0";
 
@@ -556,6 +559,10 @@ const dialog = useDialog();
 // Initialize motors state management
 const motorsState = useMotorsState();
 const { configHasChanged, resetChanges } = motorsState;
+
+// Shared save discipline: runSave owns isSaving and swallows benign MspCancelledError.
+const { isSaving, runSave } = useSaving();
+const { saveToEeprom, saveAndReboot } = useReboot();
 
 // Warning dialog
 const settingsChangedOpen = ref(false);
@@ -1353,54 +1360,59 @@ const openEscDshotDirectionDialog = () => {
 };
 
 // Action Toolbar Buttons
-const saveAndReboot = async (reboot = true) => {
+const handleSave = (reboot = true) => {
     // Don't save if no changes
     if (!configHasChanged.value) {
         return;
     }
 
-    try {
-        // CRITICAL SAFETY: Stop motor testing and explicitly stop all motors before saving
-        // This prevents motors from spinning after reboot due to DShot beacon commands
-        if (motorsTestingEnabled.value) {
-            motorsTestingEnabled.value = false;
-            // Give a small delay for motor testing disable to complete
-            await new Promise((resolve) => setTimeout(resolve, 50));
-        }
+    return runSave(
+        async () => {
+            // CRITICAL SAFETY: Stop motor testing and explicitly stop all motors before saving
+            // This prevents motors from spinning after reboot due to DShot beacon commands
+            if (motorsTestingEnabled.value) {
+                motorsTestingEnabled.value = false;
+                // Give a small delay for motor testing disable to complete
+                await new Promise((resolve) => setTimeout(resolve, 50));
+            }
 
-        // Explicitly stop all motors to ensure no spinning after reboot
-        stopAllMotors(minSliderValue.value);
-        // Give time for motor stop command to be processed
-        await new Promise((resolve) => setTimeout(resolve, 100));
+            // Explicitly stop all motors to ensure no spinning after reboot
+            stopAllMotors(minSliderValue.value);
+            // Give time for motor stop command to be processed
+            await new Promise((resolve) => setTimeout(resolve, 100));
 
-        // Send feature config FIRST (for MOTOR_STOP, ESC_SENSOR, 3D features)
-        await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
+            // Send feature config FIRST (for MOTOR_STOP, ESC_SENSOR, 3D features)
+            await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
 
-        // Send all motor configuration changes in sequence
-        await MSP.promise(MSPCodes.MSP_SET_MIXER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MIXER_CONFIG));
-        await MSP.promise(MSPCodes.MSP_SET_MOTOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_CONFIG));
-        await MSP.promise(MSPCodes.MSP_SET_MOTOR_3D_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_3D_CONFIG));
-        await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
-        await MSP.promise(MSPCodes.MSP_SET_ARMING_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ARMING_CONFIG));
-        await MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG));
+            // Send all motor configuration changes in sequence
+            await MSP.promise(MSPCodes.MSP_SET_MIXER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MIXER_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_MOTOR_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_MOTOR_3D_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_MOTOR_3D_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_ARMING_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ARMING_CONFIG));
+            await MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG));
 
-        // Send analytics if there were changes tracked
-        if (motorsState.analyticsChanges.value && Object.keys(motorsState.analyticsChanges.value).length > 0) {
-            tracking.sendSaveAndChangeEvents(
-                tracking.EVENT_CATEGORIES.FLIGHT_CONTROLLER,
-                motorsState.analyticsChanges.value,
-                "motors",
-            );
-        }
+            // Persist to EEPROM, rebooting when requested.
+            if (reboot) {
+                await saveAndReboot();
+            } else {
+                await saveToEeprom();
+            }
 
-        // Reset state (clears changes and updates defaults)
-        resetChanges();
+            // Only after a successful persist: record analytics and refresh the dirty baseline.
+            if (motorsState.analyticsChanges.value && Object.keys(motorsState.analyticsChanges.value).length > 0) {
+                tracking.sendSaveAndChangeEvents(
+                    tracking.EVENT_CATEGORIES.FLIGHT_CONTROLLER,
+                    motorsState.analyticsChanges.value,
+                    "motors",
+                );
+            }
 
-        // Save to EEPROM and optionally reboot
-        mspHelper.writeConfiguration(reboot);
-    } catch (error) {
-        console.error("[Motors] Save failed:", error);
-    }
+            // Reset state (clears changes and updates defaults)
+            resetChanges();
+        },
+        { onError: (error) => console.error("[Motors] Save failed:", error) },
+    );
 };
 
 const stopMotors = () => {

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -281,7 +281,7 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('blackboxButtonSave')" :disabled="!dirty" @click="saveSettings" />
+            <UButton :label="$t('blackboxButtonSave')" :disabled="!dirty" :loading="isSaving" @click="saveSettings" />
         </div>
     </BaseTab>
 </template>
@@ -312,6 +312,8 @@ import { get as getConfig } from "../../js/ConfigStorage";
 import { sensorTypes } from "../../js/sensor_types";
 import { MspCancelledError } from "../../js/msp/mspErrors";
 import { bit_check, bit_set } from "../../js/bit";
+import { useSaving } from "../../composables/useSaving";
+import { useReboot } from "../../composables/useReboot";
 
 const BLOCK_SIZE = 4096;
 
@@ -368,6 +370,8 @@ export default defineComponent({
         const fcStore = useFlightControllerStore();
         const connectionStore = useConnectionStore();
         const debugStore = useDebugStore();
+        const { isSaving, runSave } = useSaving();
+        const { saveAndReboot } = useReboot();
 
         // Refs
         const eraseOpen = ref(false);
@@ -565,31 +569,44 @@ export default defineComponent({
             debugFieldsEnabled.value.splice(index, 1, value);
         }
 
-        async function saveSettings() {
+        function saveSettings() {
             if (!fcStore.blackbox?.supported) {
                 return;
             }
 
-            fcStore.blackbox.blackboxSampleRate = blackboxRate.value;
-            fcStore.blackbox.blackboxPDenom = blackboxRate.value;
-            fcStore.blackbox.blackboxDevice = blackboxDevice.value;
+            return runSave(
+                async () => {
+                    fcStore.blackbox.blackboxSampleRate = blackboxRate.value;
+                    fcStore.blackbox.blackboxPDenom = blackboxRate.value;
+                    fcStore.blackbox.blackboxDevice = blackboxDevice.value;
 
-            // Update disabled mask from checkboxes
-            let mask = 0;
-            debugFieldsEnabled.value.forEach((enabled, index) => {
-                if (!enabled) {
-                    mask = bit_set(mask, index);
-                }
-            });
-            fcStore.blackbox.blackboxDisabledMask = mask;
+                    // Update disabled mask from checkboxes
+                    let mask = 0;
+                    debugFieldsEnabled.value.forEach((enabled, index) => {
+                        if (!enabled) {
+                            mask = bit_set(mask, index);
+                        }
+                    });
+                    fcStore.blackbox.blackboxDisabledMask = mask;
 
-            await MSP.promise(MSPCodes.MSP_SET_BLACKBOX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BLACKBOX_CONFIG));
+                    await MSP.promise(
+                        MSPCodes.MSP_SET_BLACKBOX_CONFIG,
+                        mspHelper.crunch(MSPCodes.MSP_SET_BLACKBOX_CONFIG),
+                    );
 
-            fcStore.pidAdvancedConfig.debugMode = debugMode.value;
-            await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
+                    fcStore.pidAdvancedConfig.debugMode = debugMode.value;
+                    await MSP.promise(
+                        MSPCodes.MSP_SET_ADVANCED_CONFIG,
+                        mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG),
+                    );
 
-            mspHelper.writeConfiguration(true);
-            onboardLoggingBaseline.value = serializeOnboardLoggingState();
+                    await saveAndReboot();
+
+                    // Only after a successful persist: refresh the dirty baseline.
+                    onboardLoggingBaseline.value = serializeOnboardLoggingState();
+                },
+                { onError: (e) => console.error("Failed to save onboard logging settings", e) },
+            );
         }
 
         function askToEraseFlash() {
@@ -957,6 +974,7 @@ export default defineComponent({
             formatKilobytes,
             updateDebugField,
             saveSettings,
+            isSaving,
             dirty,
             askToEraseFlash,
             flashErase,

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -109,7 +109,7 @@
                     @click="refresh"
                     variant="soft"
                 />
-                <UButton :label="$t('pidTuningButtonSave')" :disabled="!hasChanges" @click="save" />
+                <UButton :label="$t('pidTuningButtonSave')" :disabled="!hasChanges" :loading="isSaving" @click="save" />
             </div>
         </div>
     </BaseTab>
@@ -140,6 +140,8 @@ import { useNavigationStore } from "@/stores/navigation";
 import { useDialog } from "@/composables/useDialog";
 import { useTranslation } from "i18next-vue";
 import { gui_log } from "@/js/gui_log";
+import { useSaving } from "@/composables/useSaving";
+import { useReboot } from "@/composables/useReboot";
 
 const { t } = useTranslation();
 const pidTuningStore = usePidTuningStore();
@@ -437,74 +439,79 @@ function toggleShowAllPids() {
 }
 
 // Save/Refresh
-async function save() {
+const { isSaving, runSave } = useSaving();
+const { saveToEeprom } = useReboot();
+
+function save() {
     if (!hasChanges.value) {
         return;
     }
 
-    try {
-        // Normalize profile names before saving
-        pidProfileName.value = pidProfileName.value.trim();
-        rateProfileName.value = rateProfileName.value.trim();
+    return runSave(
+        async () => {
+            // Normalize profile names before saving
+            pidProfileName.value = pidProfileName.value.trim();
+            rateProfileName.value = rateProfileName.value.trim();
 
-        // Save profile names to FC.CONFIG (API 1.45+)
-        if (FC.CONFIG.pidProfileNames) {
-            FC.CONFIG.pidProfileNames[FC.CONFIG.profile] = pidProfileName.value;
-        }
-        if (FC.CONFIG.rateProfileNames) {
-            FC.CONFIG.rateProfileNames[FC.CONFIG.rateProfile] = rateProfileName.value;
-        }
-
-        // Save PIDs
-        await MSP.promise(MSPCodes.MSP_SET_PID, mspHelper.crunch(MSPCodes.MSP_SET_PID));
-
-        // Save advanced tuning
-        await MSP.promise(MSPCodes.MSP_SET_PID_ADVANCED, mspHelper.crunch(MSPCodes.MSP_SET_PID_ADVANCED));
-
-        // Save RC tuning
-        await MSP.promise(MSPCodes.MSP_SET_RC_TUNING, mspHelper.crunch(MSPCodes.MSP_SET_RC_TUNING));
-
-        // Save filter config
-        await MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG));
-
-        // Save simplified tuning (sliders)
-        await MSP.promise(MSPCodes.MSP_SET_SIMPLIFIED_TUNING, mspHelper.crunch(MSPCodes.MSP_SET_SIMPLIFIED_TUNING));
-
-        // Save profile names to firmware (API 1.45+)
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+            // Save profile names to FC.CONFIG (API 1.45+)
             if (FC.CONFIG.pidProfileNames) {
-                await MSP.promise(
-                    MSPCodes.MSP2_SET_TEXT,
-                    mspHelper.crunch(MSPCodes.MSP2_SET_TEXT, MSPCodes.PID_PROFILE_NAME),
-                );
+                FC.CONFIG.pidProfileNames[FC.CONFIG.profile] = pidProfileName.value;
             }
             if (FC.CONFIG.rateProfileNames) {
-                await MSP.promise(
-                    MSPCodes.MSP2_SET_TEXT,
-                    mspHelper.crunch(MSPCodes.MSP2_SET_TEXT, MSPCodes.RATE_PROFILE_NAME),
-                );
+                FC.CONFIG.rateProfileNames[FC.CONFIG.rateProfile] = rateProfileName.value;
             }
-        }
 
-        // Write to EEPROM
-        await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
+            // Save PIDs
+            await MSP.promise(MSPCodes.MSP_SET_PID, mspHelper.crunch(MSPCodes.MSP_SET_PID));
 
-        // Re-validate sliders after save
-        await validateTuningSliders();
+            // Save advanced tuning
+            await MSP.promise(MSPCodes.MSP_SET_PID_ADVANCED, mspHelper.crunch(MSPCodes.MSP_SET_PID_ADVANCED));
 
-        // Force Vue components to update slider displays
-        if (pidSubTab.value?.forceUpdateSliders) {
-            pidSubTab.value.forceUpdateSliders();
-        }
-        if (filterSubTab.value?.forceUpdateSliders) {
-            filterSubTab.value.forceUpdateSliders();
-        }
+            // Save RC tuning
+            await MSP.promise(MSPCodes.MSP_SET_RC_TUNING, mspHelper.crunch(MSPCodes.MSP_SET_RC_TUNING));
 
-        // Update original values
-        storeOriginalValues();
-    } catch (e) {
-        console.error("[PidTuning] Save failed:", e);
-    }
+            // Save filter config
+            await MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG));
+
+            // Save simplified tuning (sliders)
+            await MSP.promise(MSPCodes.MSP_SET_SIMPLIFIED_TUNING, mspHelper.crunch(MSPCodes.MSP_SET_SIMPLIFIED_TUNING));
+
+            // Save profile names to firmware (API 1.45+)
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+                if (FC.CONFIG.pidProfileNames) {
+                    await MSP.promise(
+                        MSPCodes.MSP2_SET_TEXT,
+                        mspHelper.crunch(MSPCodes.MSP2_SET_TEXT, MSPCodes.PID_PROFILE_NAME),
+                    );
+                }
+                if (FC.CONFIG.rateProfileNames) {
+                    await MSP.promise(
+                        MSPCodes.MSP2_SET_TEXT,
+                        mspHelper.crunch(MSPCodes.MSP2_SET_TEXT, MSPCodes.RATE_PROFILE_NAME),
+                    );
+                }
+            }
+
+            // Persist to EEPROM (no reboot)
+            await saveToEeprom();
+
+            // Only after a successful persist: re-validate sliders, refresh the slider
+            // displays and update the dirty baseline.
+            await validateTuningSliders();
+
+            // Force Vue components to update slider displays
+            if (pidSubTab.value?.forceUpdateSliders) {
+                pidSubTab.value.forceUpdateSliders();
+            }
+            if (filterSubTab.value?.forceUpdateSliders) {
+                filterSubTab.value.forceUpdateSliders();
+            }
+
+            // Update original values
+            storeOriginalValues();
+        },
+        { onError: (e) => console.error("[PidTuning] Save failed:", e) },
+    );
 }
 
 async function refresh() {
@@ -567,10 +574,9 @@ async function syncProfileFromFc(kind) {
         currentRateProfile.value = FC.CONFIG.rateProfile;
         await loadData();
         gui_log(
-            i18n.getMessage(
-                kind === "rate" ? "pidTuningReceivedRateProfile" : "pidTuningReceivedProfile",
-                [(kind === "rate" ? FC.CONFIG.rateProfile : FC.CONFIG.profile) + 1],
-            ),
+            i18n.getMessage(kind === "rate" ? "pidTuningReceivedRateProfile" : "pidTuningReceivedProfile", [
+                (kind === "rate" ? FC.CONFIG.rateProfile : FC.CONFIG.profile) + 1,
+            ]),
         );
     } finally {
         syncingFromFc = false;

--- a/src/components/tabs/PowerTab.vue
+++ b/src/components/tabs/PowerTab.vue
@@ -267,7 +267,7 @@
                 @click="openCalibrationManager"
                 variant="soft"
             />
-            <UButton :label="$t('powerButtonSave')" :disabled="!dirty" @click="handleSave" />
+            <UButton :label="$t('powerButtonSave')" :disabled="!dirty" :loading="isSaving" @click="handleSave" />
         </div>
 
         <!-- Calibration Manager Dialog -->
@@ -377,6 +377,7 @@ import FC from "../../js/fc";
 import { i18n } from "../../js/localization";
 import { usePower } from "../../composables/usePower";
 import { useInterval } from "../../composables/useInterval";
+import { useSaving } from "../../composables/useSaving";
 
 export default defineComponent({
     name: "PowerTab",
@@ -482,9 +483,20 @@ export default defineComponent({
 
         // Interval cleanup handled automatically by useInterval on unmount
 
-        const handleSave = () => {
-            saveConfig(() => loadData());
-        };
+        const { isSaving, runSave } = useSaving();
+
+        const handleSave = () =>
+            runSave(
+                async () => {
+                    await saveConfig();
+                    await loadData();
+                },
+                {
+                    onError: (error) => {
+                        console.error("Error saving power configuration:", error);
+                    },
+                },
+            );
 
         const openCalibrationManager = () => {
             sourceschanged.value = false;
@@ -550,6 +562,7 @@ export default defineComponent({
             openCalibrationManager,
             calibrationVisibility,
             handleSave,
+            isSaving,
             vbatcalibrationValue,
             amperagecalibrationValue,
             vbatscalechanged,

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -513,7 +513,6 @@
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from "vue";
 import { useFlightControllerStore } from "@/stores/fc";
 import { useConnectionStore } from "@/stores/connection";
-import { useNavigationStore } from "@/stores/navigation";
 import { useReboot } from "@/composables/useReboot";
 import { useSaving } from "@/composables/useSaving";
 import { useInterval } from "../../composables/useInterval";
@@ -545,8 +544,7 @@ import SettingColumn from "../elements/SettingColumn.vue";
 const t = (key) => i18n.getMessage(key);
 const fcStore = useFlightControllerStore();
 const connectionStore = useConnectionStore();
-const navigationStore = useNavigationStore();
-const { reboot } = useReboot();
+const { saveAndReboot, saveToEeprom } = useReboot();
 const { addInterval, removeInterval } = useInterval();
 
 // Template refs
@@ -1057,17 +1055,6 @@ async function loadConfig() {
     }
 }
 
-function saveWithReboot() {
-    return new Promise((resolve) => {
-        mspHelper.writeConfiguration(true, () => {
-            navigationStore.cleanup(() => {
-                reboot();
-                resolve();
-            });
-        });
-    });
-}
-
 // Save configuration
 const saveConfig = (withReboot = false) =>
     runSave(
@@ -1105,11 +1092,9 @@ const saveConfig = (withReboot = false) =>
 
             if (withReboot) {
                 await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
-                await saveWithReboot();
+                await saveAndReboot();
             } else {
-                await new Promise((resolve) => {
-                    mspHelper.writeConfiguration(false, resolve);
-                });
+                await saveToEeprom();
                 gui_log(t("receiverConfigSaved") || "Configuration saved");
                 savedSnapshot.value = takeSnapshot();
             }

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -162,8 +162,7 @@ import FC from "@/js/fc";
 import MSP from "@/js/msp";
 import MSPCodes from "@/js/msp/MSPCodes";
 import { mspHelper } from "@/js/msp/MSPHelper";
-import { gui_log } from "@/js/gui_log";
-import { i18n } from "@/js/localization";
+import { isMspCancelled } from "@/js/msp/mspErrors";
 import { useInterval } from "@/composables/useInterval";
 import { useTimeout } from "@/composables/useTimeout";
 import { useSaving } from "@/composables/useSaving";
@@ -252,10 +251,14 @@ function marshalServoConfigs() {
 
 // Live-mode preview: push the current servo config to the FC without persisting.
 // sendServoConfigurations is now error-aware/async; this is fire-and-forget preview, so
-// swallow a rejection (e.g. a benign queue-clear on tab switch) rather than leak it.
+// ignore a benign queue-clear cancellation on tab switch but still log genuine failures.
 function updateServos() {
     marshalServoConfigs();
-    mspHelper.sendServoConfigurations().catch(() => {});
+    mspHelper.sendServoConfigurations().catch((error) => {
+        if (!isMspCancelled(error)) {
+            console.error("Failed to update servo configuration", error);
+        }
+    });
 }
 
 const saveServoConfig = () =>
@@ -264,7 +267,8 @@ const saveServoConfig = () =>
             marshalServoConfigs();
             await mspHelper.sendServoConfigurations();
             await saveToEeprom();
-            gui_log(i18n.getMessage("servosEepromSave"));
+            // saveToEeprom() already emits the shared "EEPROM saved" toast; servosEepromSave
+            // resolved to the same string, so it's dropped here to avoid a duplicate.
             originalConfigs.value = JSON.stringify(servoConfigs);
         },
         { onError: (e) => console.error("Failed to save servo configuration", e) },

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -140,7 +140,12 @@
         <!-- Save button toolbar -->
         <div v-if="isSupported" class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2">
-                <UButton :label="$t('servosButtonSave')" :disabled="!configHasChanged" @click="saveServoConfig" />
+                <UButton
+                    :label="$t('servosButtonSave')"
+                    :disabled="!configHasChanged"
+                    :loading="isSaving"
+                    @click="saveServoConfig"
+                />
             </div>
         </div>
     </BaseTab>
@@ -161,6 +166,8 @@ import { gui_log } from "@/js/gui_log";
 import { i18n } from "@/js/localization";
 import { useInterval } from "@/composables/useInterval";
 import { useTimeout } from "@/composables/useTimeout";
+import { useSaving } from "@/composables/useSaving";
+import { useReboot } from "@/composables/useReboot";
 import { clamp } from "@/js/utils/common";
 
 const { t } = useTranslation();
@@ -173,6 +180,8 @@ const originalConfigs = ref("");
 
 const { addInterval } = useInterval();
 const { addTimeout } = useTimeout();
+const { isSaving, runSave } = useSaving();
+const { saveToEeprom } = useReboot();
 
 const totalChannels = computed(() => FC.RC?.active_channels || 8);
 const auxChannelCount = computed(() => Math.max(0, totalChannels.value - 4));
@@ -211,11 +220,13 @@ function setChannelForward(servoIndex, channelIndex, event) {
 
 function onServoChange() {
     if (liveMode.value) {
-        addTimeout("servos_update", () => updateServos(false), 10);
+        addTimeout("servos_update", () => updateServos(), 10);
     }
 }
 
-function updateServos(saveToEeprom) {
+// Marshal reactive servoConfigs into FC.SERVO_CONFIG (clamping min/middle/max) so the
+// values sent over MSP match the UI. Also normalizes the reactive values in place.
+function marshalServoConfigs() {
     const SERVO_MIN = 500;
     const SERVO_MAX = 2500;
 
@@ -237,20 +248,25 @@ function updateServos(saveToEeprom) {
         src.middle = middle;
         src.max = max;
     }
-
-    mspHelper.sendServoConfigurations(() => {
-        if (saveToEeprom) {
-            mspHelper.writeConfiguration(false, () => {
-                gui_log(i18n.getMessage("servosEepromSave"));
-                originalConfigs.value = JSON.stringify(servoConfigs);
-            });
-        }
-    });
 }
 
-function saveServoConfig() {
-    updateServos(true);
+// Live-mode preview: push the current servo config to the FC without persisting.
+function updateServos() {
+    marshalServoConfigs();
+    mspHelper.sendServoConfigurations();
 }
+
+const saveServoConfig = () =>
+    runSave(
+        async () => {
+            marshalServoConfigs();
+            await mspHelper.sendServoConfigurations();
+            await saveToEeprom();
+            gui_log(i18n.getMessage("servosEepromSave"));
+            originalConfigs.value = JSON.stringify(servoConfigs);
+        },
+        { onError: (e) => console.error("Failed to save servo configuration", e) },
+    );
 
 function getServoData() {
     MSP.send_message(MSPCodes.MSP_SERVO, false, false, () => {

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -251,9 +251,11 @@ function marshalServoConfigs() {
 }
 
 // Live-mode preview: push the current servo config to the FC without persisting.
+// sendServoConfigurations is now error-aware/async; this is fire-and-forget preview, so
+// swallow a rejection (e.g. a benign queue-clear on tab switch) rather than leak it.
 function updateServos() {
     marshalServoConfigs();
-    mspHelper.sendServoConfigurations();
+    mspHelper.sendServoConfigurations().catch(() => {});
 }
 
 const saveServoConfig = () =>

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -368,8 +368,9 @@
                 </UDropdownMenu>
             </UFieldGroup>
             <UButton
-                :label="saveButtonOverride || $t('vtxButtonSave')"
+                :label="$t('vtxButtonSave')"
                 :disabled="saveButtonDisabled"
+                :loading="isSaving"
                 @click="handleSave"
             />
         </div>
@@ -387,6 +388,7 @@ import GUI from "../../js/gui";
 import { i18n } from "../../js/localization";
 import { useVtx } from "../../composables/useVtx";
 import { useInterval } from "../../composables/useInterval";
+import { useSaving } from "../../composables/useSaving";
 import { useTranslation } from "i18next-vue";
 
 export default defineComponent({
@@ -413,7 +415,6 @@ export default defineComponent({
             powerLevelList,
             deviceReady,
             vtxTypeString,
-            saveButtonText,
             saveButtonDisabled,
             vtxSupported,
             vtxTableNotConfigured,
@@ -437,8 +438,7 @@ export default defineComponent({
         } = useVtx();
 
         const { addInterval } = useInterval();
-
-        const saveButtonOverride = computed(() => saveButtonText.value || "");
+        const { isSaving, runSave } = useSaving();
 
         const lowPowerDisarmOptions = computed(() => [
             { value: 0, label: t("vtxLowPowerDisarmOption_0") },
@@ -504,9 +504,18 @@ export default defineComponent({
             GUI.content_ready();
         });
 
-        const handleSave = () => {
-            saveVtx();
-        };
+        const handleSave = () =>
+            runSave(
+                async () => {
+                    await saveVtx();
+                    await loadVtxConfig();
+                },
+                {
+                    onError: (error) => {
+                        console.error("Error saving VTX configuration:", error);
+                    },
+                },
+            );
 
         // --- VTX Table count setters (with change tracking) ---
 
@@ -647,7 +656,7 @@ export default defineComponent({
             deviceReady,
             vtxTypeString,
             saveButtonDisabled,
-            saveButtonOverride,
+            isSaving,
 
             // Computed
             vtxSupported,

--- a/src/composables/adjustments/useAdjustmentsSave.js
+++ b/src/composables/adjustments/useAdjustmentsSave.js
@@ -1,10 +1,9 @@
 import { mspHelper } from "../../js/msp/MSPHelper";
-import { gui_log } from "../../js/gui_log";
 import { useFlightControllerStore } from "@/stores/fc";
 import { useSaving } from "@/composables/useSaving";
 import { useReboot } from "@/composables/useReboot";
 
-export function useAdjustmentsSave(adjustments, storeOriginals, t) {
+export function useAdjustmentsSave(adjustments, storeOriginals) {
     const fcStore = useFlightControllerStore();
     const { isSaving, runSave } = useSaving();
     const { saveToEeprom } = useReboot();
@@ -64,8 +63,10 @@ export function useAdjustmentsSave(adjustments, storeOriginals, t) {
                 await mspHelper.sendAdjustmentRanges();
                 await saveToEeprom();
 
+                // saveToEeprom() already emits the shared "EEPROM saved" toast; the previous
+                // adjustmentsEepromSaved message resolved to the same string, so it's dropped
+                // here to avoid showing the identical toast twice.
                 storeOriginals();
-                gui_log(t("adjustmentsEepromSaved"));
             },
             {
                 onError: (error) => {

--- a/src/composables/adjustments/useAdjustmentsSave.js
+++ b/src/composables/adjustments/useAdjustmentsSave.js
@@ -1,69 +1,78 @@
-import MSP from "../../js/msp";
-import MSPCodes from "../../js/msp/MSPCodes";
 import { mspHelper } from "../../js/msp/MSPHelper";
 import { gui_log } from "../../js/gui_log";
 import { useFlightControllerStore } from "@/stores/fc";
+import { useSaving } from "@/composables/useSaving";
+import { useReboot } from "@/composables/useReboot";
 
 export function useAdjustmentsSave(adjustments, storeOriginals, t) {
     const fcStore = useFlightControllerStore();
+    const { isSaving, runSave } = useSaving();
+    const { saveToEeprom } = useReboot();
 
-    const saveAdjustments = () => {
-        const requiredAdjustmentRangeCount = fcStore.adjustmentRanges.length;
+    const saveAdjustments = () =>
+        runSave(
+            async () => {
+                const requiredAdjustmentRangeCount = fcStore.adjustmentRanges.length;
 
-        fcStore.adjustmentRanges = [];
+                fcStore.adjustmentRanges = [];
 
-        adjustments.forEach((adjustment) => {
-            if (adjustment.enabled) {
-                fcStore.adjustmentRanges.push({
-                    slotIndex: adjustment.slotIndex ?? 0,
-                    auxChannelIndex: adjustment.auxChannelIndex,
-                    range: {
-                        start: adjustment.range.start,
-                        end: adjustment.range.end,
-                    },
-                    adjustmentFunction: adjustment.adjustmentFunction,
-                    auxSwitchChannelIndex: adjustment.auxSwitchChannelIndex,
-                    adjustmentCenter: adjustment.adjustmentCenter || 0,
-                    adjustmentScale: adjustment.adjustmentScale || 0,
+                adjustments.forEach((adjustment) => {
+                    if (adjustment.enabled) {
+                        fcStore.adjustmentRanges.push({
+                            slotIndex: adjustment.slotIndex ?? 0,
+                            auxChannelIndex: adjustment.auxChannelIndex,
+                            range: {
+                                start: adjustment.range.start,
+                                end: adjustment.range.end,
+                            },
+                            adjustmentFunction: adjustment.adjustmentFunction,
+                            auxSwitchChannelIndex: adjustment.auxSwitchChannelIndex,
+                            adjustmentCenter: adjustment.adjustmentCenter || 0,
+                            adjustmentScale: adjustment.adjustmentScale || 0,
+                        });
+                    } else {
+                        fcStore.adjustmentRanges.push({
+                            slotIndex: 0,
+                            auxChannelIndex: 0,
+                            range: {
+                                start: 900,
+                                end: 900,
+                            },
+                            adjustmentFunction: 0,
+                            auxSwitchChannelIndex: 0,
+                            adjustmentCenter: 0,
+                            adjustmentScale: 0,
+                        });
+                    }
                 });
-            } else {
-                fcStore.adjustmentRanges.push({
-                    slotIndex: 0,
-                    auxChannelIndex: 0,
-                    range: {
-                        start: 900,
-                        end: 900,
-                    },
-                    adjustmentFunction: 0,
-                    auxSwitchChannelIndex: 0,
-                    adjustmentCenter: 0,
-                    adjustmentScale: 0,
-                });
-            }
-        });
 
-        for (let i = fcStore.adjustmentRanges.length; i < requiredAdjustmentRangeCount; i++) {
-            fcStore.adjustmentRanges.push({
-                slotIndex: 0,
-                auxChannelIndex: 0,
-                range: {
-                    start: 900,
-                    end: 900,
-                },
-                adjustmentFunction: 0,
-                auxSwitchChannelIndex: 0,
-                adjustmentCenter: 0,
-                adjustmentScale: 0,
-            });
-        }
+                for (let i = fcStore.adjustmentRanges.length; i < requiredAdjustmentRangeCount; i++) {
+                    fcStore.adjustmentRanges.push({
+                        slotIndex: 0,
+                        auxChannelIndex: 0,
+                        range: {
+                            start: 900,
+                            end: 900,
+                        },
+                        adjustmentFunction: 0,
+                        auxSwitchChannelIndex: 0,
+                        adjustmentCenter: 0,
+                        adjustmentScale: 0,
+                    });
+                }
 
-        mspHelper.sendAdjustmentRanges(() => {
-            MSP.send_message(MSPCodes.MSP_EEPROM_WRITE, false, false, () => {
+                await mspHelper.sendAdjustmentRanges();
+                await saveToEeprom();
+
                 storeOriginals();
                 gui_log(t("adjustmentsEepromSaved"));
-            });
-        });
-    };
+            },
+            {
+                onError: (error) => {
+                    console.error("Error saving adjustments configuration:", error);
+                },
+            },
+        );
 
-    return { saveAdjustments };
+    return { saveAdjustments, isSaving, runSave };
 }

--- a/src/composables/ports/usePortsConfiguration.js
+++ b/src/composables/ports/usePortsConfiguration.js
@@ -6,8 +6,11 @@ import { mspHelper } from "../../js/msp/MSPHelper";
 import { gui_log } from "../../js/gui_log";
 import { i18n } from "../../js/localization";
 import { tracking } from "../../js/Analytics";
+import { useReboot } from "../useReboot";
 
 export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
+    const { saveAndReboot } = useReboot();
+
     const getEnabledFeaturesFromPorts = (portsList) => {
         const flags = {
             rxSerial: false,
@@ -98,9 +101,7 @@ export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
         updateFeatures();
 
         const saveEeprom = () => {
-            mspHelper.writeConfiguration(true, () => {
-                gui_log(i18n.getMessage("portsEepromSave"));
-            });
+            saveAndReboot().then(() => gui_log(i18n.getMessage("portsEepromSave")));
         };
 
         mspHelper.sendSerialConfig(() => {

--- a/src/composables/useLedStrip.js
+++ b/src/composables/useLedStrip.js
@@ -98,11 +98,9 @@ function isVtxActive(activeFunction) {
 async function saveConfig() {
     const { saveToEeprom } = useReboot();
 
-    // These LED-strip senders are still callback-based, so Promise-wrap each one to await
-    // the write chain before persisting.
-    await new Promise((resolve) => mspHelper.sendLedStripConfig(resolve));
-    await new Promise((resolve) => mspHelper.sendLedStripColors(resolve));
-    await new Promise((resolve) => mspHelper.sendLedStripModeColors(resolve));
+    await mspHelper.sendLedStripConfig();
+    await mspHelper.sendLedStripColors();
+    await mspHelper.sendLedStripModeColors();
 
     await saveToEeprom();
 }

--- a/src/composables/useLedStrip.js
+++ b/src/composables/useLedStrip.js
@@ -5,6 +5,7 @@ import MSPCodes from "@/js/msp/MSPCodes";
 import { mspHelper } from "@/js/msp/MSPHelper";
 import semver from "semver";
 import { API_VERSION_1_46 } from "@/js/data_storage";
+import { useReboot } from "@/composables/useReboot";
 
 // Helper functions moved to outer scope
 function getGridPosition(index) {
@@ -91,24 +92,19 @@ function isVtxActive(activeFunction) {
     return activeFunctions.includes(activeFunction);
 }
 
-// Save configuration to flight controller
+// Save configuration to flight controller. Error/cancellation handling and the isSaving
+// state are owned by the caller's runSave() (useSaving); this only issues the MSP writes
+// and persists to EEPROM.
 async function saveConfig() {
-    // Refactored to reduce nesting
-    return new Promise((resolve) => {
-        const saveColors = () => {
-            mspHelper.sendLedStripColors(saveModeColors);
-        };
+    const { saveToEeprom } = useReboot();
 
-        const saveModeColors = () => {
-            mspHelper.sendLedStripModeColors(writeConfig);
-        };
+    // These LED-strip senders are still callback-based, so Promise-wrap each one to await
+    // the write chain before persisting.
+    await new Promise((resolve) => mspHelper.sendLedStripConfig(resolve));
+    await new Promise((resolve) => mspHelper.sendLedStripColors(resolve));
+    await new Promise((resolve) => mspHelper.sendLedStripModeColors(resolve));
 
-        const writeConfig = () => {
-            mspHelper.writeConfiguration(false, resolve);
-        };
-
-        mspHelper.sendLedStripConfig(saveColors);
-    });
+    await saveToEeprom();
 }
 
 export function useLedStrip() {

--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -11,6 +11,7 @@ import { useConnectionStore } from "../stores/connection";
 import GUI from "../js/gui";
 import { gui_log } from "../js/gui_log";
 import { isMspCancelled } from "../js/msp/mspErrors.js";
+import { useReboot } from "./useReboot";
 
 export function usePower() {
     const supported = computed(() => {
@@ -487,8 +488,11 @@ export function usePower() {
         amperagescalechanged.value = false;
     };
 
-    // Save configuration
-    const saveConfig = async (callback) => {
+    // Save configuration. Error/cancellation handling and the isSaving state are owned by the
+    // caller's runSave() (useSaving); this only marshals data and issues the MSP writes.
+    const saveConfig = async () => {
+        const { saveToEeprom } = useReboot();
+
         // Update FC data from reactive state
         FC.BATTERY_CONFIG.voltageMeterSource = batteryConfig.voltageMeterSource;
         FC.BATTERY_CONFIG.currentMeterSource = batteryConfig.currentMeterSource;
@@ -508,38 +512,28 @@ export function usePower() {
             FC.CURRENT_METER_CONFIGS[index].offset = config.offset;
         });
 
-        tracking.sendSaveAndChangeEvents(tracking.EVENT_CATEGORIES.FLIGHT_CONTROLLER, analyticsChanges, "power");
+        await MSP.promise(MSPCodes.MSP_SET_BATTERY_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BATTERY_CONFIG));
 
-        // Clear analytics changes
+        // Save battery profile name if supported
+        if (hasBatteryProfiles.value) {
+            FC.CONFIG.batteryProfileNames[FC.CONFIG.batteryProfile] = batteryProfileName.value;
+            await MSP.promise(
+                MSPCodes.MSP2_SET_TEXT,
+                mspHelper.crunch(MSPCodes.MSP2_SET_TEXT, MSPCodes.BATTERY_PROFILE_NAME),
+            );
+        }
+
+        await mspHelper.sendVoltageConfig();
+        await mspHelper.sendCurrentConfig();
+
+        await saveToEeprom();
+
+        // Only after a successful persist: record analytics and refresh the dirty baseline.
+        tracking.sendSaveAndChangeEvents(tracking.EVENT_CATEGORIES.FLIGHT_CONTROLLER, analyticsChanges, "power");
         for (const key in analyticsChanges) {
             delete analyticsChanges[key];
         }
-
-        try {
-            await MSP.promise(MSPCodes.MSP_SET_BATTERY_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_BATTERY_CONFIG));
-
-            // Save battery profile name if supported
-            if (hasBatteryProfiles.value) {
-                FC.CONFIG.batteryProfileNames[FC.CONFIG.batteryProfile] = batteryProfileName.value;
-                await MSP.promise(
-                    MSPCodes.MSP2_SET_TEXT,
-                    mspHelper.crunch(MSPCodes.MSP2_SET_TEXT, MSPCodes.BATTERY_PROFILE_NAME),
-                );
-            }
-
-            await mspHelper.sendVoltageConfig();
-            await mspHelper.sendCurrentConfig();
-            await mspHelper.writeConfiguration(false);
-            // Refresh the saveConfig() baseline so dirty reflects persisted values.
-            // Equivalent to updateStateFromFC() baseline reset without extra FC reads.
-            powerConfigBaseline.value = serializePowerConfig();
-
-            if (callback) {
-                callback();
-            }
-        } catch (error) {
-            console.error("Error saving power configuration:", error);
-        }
+        powerConfigBaseline.value = serializePowerConfig();
     };
 
     return {

--- a/src/composables/useReboot.js
+++ b/src/composables/useReboot.js
@@ -1,6 +1,11 @@
 import { reinitializeConnection } from "@/js/serial_backend"; // Backend logic
 import { useNavigationStore } from "@/stores/navigation";
 import { mspHelper } from "@/js/msp/MSPHelper";
+import MSP from "@/js/msp";
+import MSPCodes from "@/js/msp/MSPCodes";
+import FC from "@/js/fc";
+import { gui_log } from "@/js/gui_log";
+import { i18n } from "@/js/localization";
 
 export function useReboot() {
     // Reboot is owned end-to-end by serial_backend.reinitializeConnection(): it sends the
@@ -30,8 +35,27 @@ export function useReboot() {
         });
     }
 
+    /**
+     * Persist the current configuration to EEPROM without rebooting. This is the await-able,
+     * error-aware counterpart to the callback-based mspHelper.writeConfiguration: it uses an
+     * error-aware MSP request, so a tab switch / disconnect that clears the MSP queue rejects
+     * with MspCancelledError (letting runSave settle) instead of dropping the callback and
+     * hanging. Mirrors writeConfiguration's arming-safety guard; the 100ms settle delay is
+     * unnecessary because callers await their MSP_SET_* writes before persisting.
+     * @returns {Promise<void>} resolves once the EEPROM write is acknowledged
+     */
+    async function saveToEeprom() {
+        // Never persist while arming is possible (matches writeConfiguration).
+        if (!FC.CONFIG.armingDisabled) {
+            mspHelper.setArmingEnabled(false, false);
+        }
+        await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
+        gui_log(i18n.getMessage("configurationEepromSaved"));
+    }
+
     return {
         reboot,
         saveAndReboot,
+        saveToEeprom,
     };
 }

--- a/src/composables/useReboot.js
+++ b/src/composables/useReboot.js
@@ -7,6 +7,27 @@ import FC from "@/js/fc";
 import { gui_log } from "@/js/gui_log";
 import { i18n } from "@/js/localization";
 
+/**
+ * Persist the current configuration to EEPROM without rebooting. This is the await-able,
+ * error-aware counterpart to the callback-based mspHelper.writeConfiguration: it uses an
+ * error-aware MSP request, so a tab switch / disconnect that clears the MSP queue rejects
+ * with MspCancelledError (letting runSave settle) instead of dropping the callback and
+ * hanging. Mirrors writeConfiguration's arming-safety guard; the 100ms settle delay is
+ * unnecessary because callers await their MSP_SET_* writes before persisting.
+ *
+ * Defined at module scope (not per useReboot() call) because it closes over no
+ * composable-local state — only module-level imports.
+ * @returns {Promise<void>} resolves once the EEPROM write is acknowledged
+ */
+async function saveToEeprom() {
+    // Never persist while arming is possible (matches writeConfiguration).
+    if (!FC.CONFIG.armingDisabled) {
+        mspHelper.setArmingEnabled(false, false);
+    }
+    await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
+    gui_log(i18n.getMessage("configurationEepromSaved"));
+}
+
 export function useReboot() {
     // Reboot is owned end-to-end by serial_backend.reinitializeConnection(): it sends the
     // reboot command, drives the per-transport reconnect, shows the reboot progress dialog
@@ -33,24 +54,6 @@ export function useReboot() {
         return new Promise((resolve) => {
             mspHelper.writeConfiguration(false, () => cleanupAndReboot(resolve));
         });
-    }
-
-    /**
-     * Persist the current configuration to EEPROM without rebooting. This is the await-able,
-     * error-aware counterpart to the callback-based mspHelper.writeConfiguration: it uses an
-     * error-aware MSP request, so a tab switch / disconnect that clears the MSP queue rejects
-     * with MspCancelledError (letting runSave settle) instead of dropping the callback and
-     * hanging. Mirrors writeConfiguration's arming-safety guard; the 100ms settle delay is
-     * unnecessary because callers await their MSP_SET_* writes before persisting.
-     * @returns {Promise<void>} resolves once the EEPROM write is acknowledged
-     */
-    async function saveToEeprom() {
-        // Never persist while arming is possible (matches writeConfiguration).
-        if (!FC.CONFIG.armingDisabled) {
-            mspHelper.setArmingEnabled(false, false);
-        }
-        await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
-        gui_log(i18n.getMessage("configurationEepromSaved"));
     }
 
     return {

--- a/src/composables/useSaving.js
+++ b/src/composables/useSaving.js
@@ -1,9 +1,22 @@
 import { ref } from "vue";
 import { isMspCancelled } from "../js/msp/mspErrors.js";
 
+/**
+ * Shared save discipline for the config tabs: owns the `isSaving` flag, prevents concurrent
+ * saves, and centrally swallows benign MSP cancellations so no tab has to reimplement it.
+ * @returns {{ isSaving: import("vue").Ref<boolean>, runSave: (fn: () => Promise<void>, options?: { onError?: (error: unknown) => void }) => Promise<void> }}
+ */
 export function useSaving() {
     const isSaving = ref(false);
 
+    /**
+     * Run one save operation while `isSaving` is held true. A benign MspCancelledError
+     * (queue cleared by a tab switch / reboot-disconnect) is swallowed silently; any other
+     * error is passed to `onError` (or `console.error` when none is given).
+     * @param {() => Promise<void>} fn - the async save work (marshal + MSP writes + persist)
+     * @param {{ onError?: (error: unknown) => void }} [options] - genuine-failure handler
+     * @returns {Promise<void>}
+     */
     async function runSave(fn, { onError } = {}) {
         if (isSaving.value) {
             return;

--- a/src/composables/useVtx.js
+++ b/src/composables/useVtx.js
@@ -1,4 +1,4 @@
-import { reactive, ref, computed, toRaw, onScopeDispose } from "vue";
+import { reactive, ref, computed, toRaw } from "vue";
 import djv from "djv";
 import { i18n } from "../js/localization";
 import { tracking } from "../js/Analytics";
@@ -10,6 +10,7 @@ import { VtxDeviceTypes } from "../js/utils/VtxDeviceStatus/VtxDeviceStatus";
 import { generateFilename } from "../js/utils/generate_filename";
 import { gui_log } from "../js/gui_log";
 import FileSystem from "../js/FileSystem";
+import { useReboot } from "./useReboot";
 
 const MAX_POWERLEVEL_VALUES = 8;
 const MAX_BAND_VALUES = 8;
@@ -87,9 +88,9 @@ function buildPowerOptionsFromTable(powerLevelList, count) {
 }
 
 function sendMspPromise(code, buffer = false) {
-    return new Promise((resolve) => {
-        MSP.send_message(code, buffer, false, resolve);
-    });
+    // Error-aware: a tab switch / disconnect that clears the MSP queue rejects with
+    // MspCancelledError instead of dropping the callback and hanging.
+    return MSP.promise(code, buffer);
 }
 
 function buildPowerOptionsFromRange(range) {
@@ -141,10 +142,6 @@ export function useVtx() {
     // Device status
     const deviceReady = ref(false);
     const vtxTypeString = ref("");
-
-    // Save button state
-    const saveButtonText = ref("");
-    const saving = ref(false);
 
     // Dirty tracking
     const configSnapshot = ref("");
@@ -285,7 +282,7 @@ export function useVtx() {
         return serializeState() !== configSnapshot.value;
     });
 
-    const saveButtonDisabled = computed(() => saving.value || !configDirty.value);
+    const saveButtonDisabled = computed(() => !configDirty.value);
 
     // --- State sync helpers ---
 
@@ -372,92 +369,35 @@ export function useVtx() {
     }
 
     // --- Save ---
-
-    function saveVtx() {
-        if (updating.value) {
-            return;
-        }
-        updating.value = true;
+    // Error/cancellation handling and the isSaving state are owned by the caller's runSave()
+    // (useSaving); this only marshals data and issues the MSP writes. Persist is EEPROM-only
+    // (no reboot), matching the previous writeConfiguration(false) behavior. The exact set and
+    // order of MSP_SET_VTX* writes is preserved: VTX config, then each power level, then each band.
+    async function saveVtx() {
+        const { saveToEeprom } = useReboot();
 
         syncStateToFC();
 
+        await MSP.promise(MSPCodes.MSP_SET_VTX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_VTX_CONFIG));
+
+        for (let index = 0; index < FC.VTX_CONFIG.vtx_table_powerlevels; index++) {
+            FC.VTXTABLE_POWERLEVEL = { ...powerLevelList[index] };
+            await MSP.promise(
+                MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL,
+                mspHelper.crunch(MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL),
+            );
+        }
+
+        for (let index = 0; index < FC.VTX_CONFIG.vtx_table_bands; index++) {
+            FC.VTXTABLE_BAND = { ...bandList[index] };
+            await MSP.promise(MSPCodes.MSP_SET_VTXTABLE_BAND, mspHelper.crunch(MSPCodes.MSP_SET_VTXTABLE_BAND));
+        }
+
+        await saveToEeprom();
+
+        // Only after a successful persist: record analytics and clear the verify-table warning.
         tracking.sendSaveAndChangeEvents(tracking.EVENT_CATEGORIES.FLIGHT_CONTROLLER, toRaw(analyticsChanges), "vtx");
-
-        saveVtxConfig();
-    }
-
-    function saveVtxConfig() {
-        MSP.send_message(MSPCodes.MSP_SET_VTX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_VTX_CONFIG), false, () =>
-            saveVtxPowerLevels(0),
-        );
-    }
-
-    function saveVtxPowerLevels(index) {
-        if (index >= FC.VTX_CONFIG.vtx_table_powerlevels) {
-            saveVtxBands(0);
-            return;
-        }
-        FC.VTXTABLE_POWERLEVEL = { ...powerLevelList[index] };
-        MSP.send_message(
-            MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL,
-            mspHelper.crunch(MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL),
-            false,
-            () => saveVtxPowerLevels(index + 1),
-        );
-    }
-
-    function saveVtxBands(index) {
-        if (index >= FC.VTX_CONFIG.vtx_table_bands) {
-            saveToEeprom();
-            return;
-        }
-        FC.VTXTABLE_BAND = { ...bandList[index] };
-        MSP.send_message(MSPCodes.MSP_SET_VTXTABLE_BAND, mspHelper.crunch(MSPCodes.MSP_SET_VTXTABLE_BAND), false, () =>
-            saveVtxBands(index + 1),
-        );
-    }
-
-    function saveToEeprom() {
-        mspHelper.writeConfiguration(false, onSaveComplete);
-    }
-
-    let saveCompleteTimeout = null;
-    let saveCompleteReloadTimeout = null;
-
-    function clearSaveCompleteTimeouts() {
-        if (saveCompleteTimeout !== null) {
-            clearTimeout(saveCompleteTimeout);
-            saveCompleteTimeout = null;
-        }
-        if (saveCompleteReloadTimeout !== null) {
-            clearTimeout(saveCompleteReloadTimeout);
-            saveCompleteReloadTimeout = null;
-        }
-    }
-
-    onScopeDispose(clearSaveCompleteTimeouts);
-
-    function onSaveComplete() {
         savePending.value = false;
-
-        saveButtonText.value = i18n.getMessage("buttonSaving");
-        saving.value = true;
-
-        clearSaveCompleteTimeouts();
-
-        const buttonDelay = 1500;
-
-        saveCompleteTimeout = setTimeout(() => {
-            saveCompleteTimeout = null;
-            saveButtonText.value = i18n.getMessage("buttonSaved");
-
-            saveCompleteReloadTimeout = setTimeout(async () => {
-                saveCompleteReloadTimeout = null;
-                await loadVtxConfig();
-                saveButtonText.value = "";
-                saving.value = false;
-            }, buttonDelay);
-        }, buttonDelay);
     }
 
     // --- JSON Schema Validation ---
@@ -685,7 +625,6 @@ export function useVtx() {
         powerLevelList,
         deviceReady,
         vtxTypeString,
-        saveButtonText,
         saveButtonDisabled,
 
         // Computed

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2678,8 +2678,7 @@ MspHelper.prototype.sendAdjustmentRanges = async function () {
 };
 
 MspHelper.prototype.sendVoltageConfig = async function () {
-    for (let configIndex = 0; configIndex < FC.VOLTAGE_METER_CONFIGS.length; configIndex++) {
-        const config = FC.VOLTAGE_METER_CONFIGS[configIndex];
+    for (const config of FC.VOLTAGE_METER_CONFIGS) {
         const buffer = [];
 
         buffer.push8(config.id).push8(config.vbatscale).push8(config.vbatresdivval).push8(config.vbatresdivmultiplier);
@@ -2689,8 +2688,7 @@ MspHelper.prototype.sendVoltageConfig = async function () {
 };
 
 MspHelper.prototype.sendCurrentConfig = async function () {
-    for (let configIndex = 0; configIndex < FC.CURRENT_METER_CONFIGS.length; configIndex++) {
-        const config = FC.CURRENT_METER_CONFIGS[configIndex];
+    for (const config of FC.CURRENT_METER_CONFIGS) {
         const buffer = [];
 
         buffer.push8(config.id).push16(config.scale).push16(config.offset);
@@ -2699,18 +2697,8 @@ MspHelper.prototype.sendCurrentConfig = async function () {
     }
 };
 
-MspHelper.prototype.sendLedStripConfig = function (onCompleteCallback) {
-    let nextFunction = send_next_led_strip_config;
-
-    let ledIndex = 0;
-
-    if (FC.LED_STRIP.length == 0) {
-        onCompleteCallback();
-    } else {
-        send_next_led_strip_config();
-    }
-
-    function send_next_led_strip_config() {
+MspHelper.prototype.sendLedStripConfig = async function () {
+    for (let ledIndex = 0; ledIndex < FC.LED_STRIP.length; ledIndex++) {
         const led = FC.LED_STRIP[ledIndex];
         const buffer = [];
 
@@ -2769,53 +2757,31 @@ MspHelper.prototype.sendLedStripConfig = function (onCompleteCallback) {
             buffer.push32(mask);
         }
 
-        // prepare for next iteration
-        ledIndex++;
-        if (ledIndex == FC.LED_STRIP.length) {
-            nextFunction = onCompleteCallback;
-        }
-
-        MSP.send_message(MSPCodes.MSP_SET_LED_STRIP_CONFIG, buffer, false, nextFunction);
+        await MSP.promise(MSPCodes.MSP_SET_LED_STRIP_CONFIG, buffer);
     }
 };
 
-MspHelper.prototype.sendLedStripColors = function (onCompleteCallback) {
+MspHelper.prototype.sendLedStripColors = async function () {
     if (FC.LED_COLORS.length == 0) {
-        onCompleteCallback();
-    } else {
-        const buffer = [];
-
-        for (const color of FC.LED_COLORS) {
-            buffer.push16(color.h).push8(color.s).push8(color.v);
-        }
-        MSP.send_message(MSPCodes.MSP_SET_LED_COLORS, buffer, false, onCompleteCallback);
+        return;
     }
+
+    const buffer = [];
+
+    for (const color of FC.LED_COLORS) {
+        buffer.push16(color.h).push8(color.s).push8(color.v);
+    }
+
+    await MSP.promise(MSPCodes.MSP_SET_LED_COLORS, buffer);
 };
 
-MspHelper.prototype.sendLedStripModeColors = function (onCompleteCallback) {
-    let nextFunction = send_next_led_strip_mode_color;
-    let index = 0;
-
-    if (FC.LED_MODE_COLORS.length == 0) {
-        onCompleteCallback();
-    } else {
-        send_next_led_strip_mode_color();
-    }
-
-    function send_next_led_strip_mode_color() {
+MspHelper.prototype.sendLedStripModeColors = async function () {
+    for (const modeColor of FC.LED_MODE_COLORS) {
         const buffer = [];
-
-        const modeColor = FC.LED_MODE_COLORS[index];
 
         buffer.push8(modeColor.mode).push8(modeColor.direction).push8(modeColor.color);
 
-        // prepare for next iteration
-        index++;
-        if (index == FC.LED_MODE_COLORS.length) {
-            nextFunction = onCompleteCallback;
-        }
-
-        MSP.send_message(MSPCodes.MSP_SET_LED_STRIP_MODECOLOR, buffer, false, nextFunction);
+        await MSP.promise(MSPCodes.MSP_SET_LED_STRIP_MODECOLOR, buffer);
     }
 };
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2614,23 +2614,10 @@ MspHelper.prototype.dataflashRead = function (address, blockSize, onDataCallback
     );
 };
 
-MspHelper.prototype.sendServoConfigurations = function (onCompleteCallback) {
-    let nextFunction = send_next_servo_configuration;
-
-    let servoIndex = 0;
-
-    if (FC.SERVO_CONFIG.length == 0) {
-        onCompleteCallback();
-    } else {
-        nextFunction();
-    }
-
-    function send_next_servo_configuration() {
-        const buffer = [];
-
-        // send one at a time, with index
-
+MspHelper.prototype.sendServoConfigurations = async function () {
+    for (let servoIndex = 0; servoIndex < FC.SERVO_CONFIG.length; servoIndex++) {
         const servoConfiguration = FC.SERVO_CONFIG[servoIndex];
+        const buffer = [];
 
         buffer
             .push8(servoIndex)
@@ -2645,28 +2632,12 @@ MspHelper.prototype.sendServoConfigurations = function (onCompleteCallback) {
         }
         buffer.push8(out).push32(servoConfiguration.reversedInputSources);
 
-        // prepare for next iteration
-        servoIndex++;
-        if (servoIndex == FC.SERVO_CONFIG.length) {
-            nextFunction = onCompleteCallback;
-        }
-
-        MSP.send_message(MSPCodes.MSP_SET_SERVO_CONFIGURATION, buffer, false, nextFunction);
+        await MSP.promise(MSPCodes.MSP_SET_SERVO_CONFIGURATION, buffer);
     }
 };
 
-MspHelper.prototype.sendModeRanges = function (onCompleteCallback) {
-    let nextFunction = send_next_mode_range;
-
-    let modeRangeIndex = 0;
-
-    if (FC.MODE_RANGES.length == 0) {
-        onCompleteCallback();
-    } else {
-        send_next_mode_range();
-    }
-
-    function send_next_mode_range() {
+MspHelper.prototype.sendModeRanges = async function () {
+    for (let modeRangeIndex = 0; modeRangeIndex < FC.MODE_RANGES.length; modeRangeIndex++) {
         const modeRange = FC.MODE_RANGES[modeRangeIndex];
         const buffer = [];
 
@@ -2681,27 +2652,12 @@ MspHelper.prototype.sendModeRanges = function (onCompleteCallback) {
 
         buffer.push8(modeRangeExtra.modeLogic).push8(modeRangeExtra.linkedTo);
 
-        // prepare for next iteration
-        modeRangeIndex++;
-        if (modeRangeIndex == FC.MODE_RANGES.length) {
-            nextFunction = onCompleteCallback;
-        }
-        MSP.send_message(MSPCodes.MSP_SET_MODE_RANGE, buffer, false, nextFunction);
+        await MSP.promise(MSPCodes.MSP_SET_MODE_RANGE, buffer);
     }
 };
 
-MspHelper.prototype.sendAdjustmentRanges = function (onCompleteCallback) {
-    let nextFunction = send_next_adjustment_range;
-
-    let adjustmentRangeIndex = 0;
-
-    if (FC.ADJUSTMENT_RANGES.length == 0) {
-        onCompleteCallback();
-    } else {
-        send_next_adjustment_range();
-    }
-
-    function send_next_adjustment_range() {
+MspHelper.prototype.sendAdjustmentRanges = async function () {
+    for (let adjustmentRangeIndex = 0; adjustmentRangeIndex < FC.ADJUSTMENT_RANGES.length; adjustmentRangeIndex++) {
         const adjustmentRange = FC.ADJUSTMENT_RANGES[adjustmentRangeIndex];
         const buffer = [];
 
@@ -2717,12 +2673,7 @@ MspHelper.prototype.sendAdjustmentRanges = function (onCompleteCallback) {
             buffer.push16(adjustmentRange.adjustmentCenter || 0).push16(adjustmentRange.adjustmentScale || 0);
         }
 
-        // prepare for next iteration
-        adjustmentRangeIndex++;
-        if (adjustmentRangeIndex == FC.ADJUSTMENT_RANGES.length) {
-            nextFunction = onCompleteCallback;
-        }
-        MSP.send_message(MSPCodes.MSP_SET_ADJUSTMENT_RANGE, buffer, false, nextFunction);
+        await MSP.promise(MSPCodes.MSP_SET_ADJUSTMENT_RANGE, buffer);
     }
 };
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2697,65 +2697,53 @@ MspHelper.prototype.sendCurrentConfig = async function () {
     }
 };
 
+// Pack one LED's config into its 32-bit mask. The two API layouts are identical except for
+// where the colour and direction fields sit (overlay bits are always at +12), so both are
+// handled by passing those two offsets in — see sendLedStripConfig.
+function buildLedStripMask(led, colorOffset, directionOffset) {
+    let mask = 0;
+
+    mask |= led.y << 0;
+    mask |= led.x << 4;
+
+    for (let functionLetterIndex = 0; functionLetterIndex < led.functions.length; functionLetterIndex++) {
+        const fnIndex = ledBaseFunctionLetters.indexOf(led.functions[functionLetterIndex]);
+        if (fnIndex >= 0) {
+            mask |= fnIndex << 8;
+            break;
+        }
+    }
+
+    for (let overlayLetterIndex = 0; overlayLetterIndex < led.functions.length; overlayLetterIndex++) {
+        const bitIndex = ledOverlayLetters.indexOf(led.functions[overlayLetterIndex]);
+        if (bitIndex >= 0) {
+            mask |= bit_set(mask, bitIndex + 12);
+        }
+    }
+
+    mask |= led.color << colorOffset;
+
+    for (let directionLetterIndex = 0; directionLetterIndex < led.directions.length; directionLetterIndex++) {
+        const bitIndex = ledDirectionLetters.indexOf(led.directions[directionLetterIndex]);
+        if (bitIndex >= 0) {
+            mask |= bit_set(mask, bitIndex + directionOffset);
+        }
+    }
+
+    return mask;
+}
+
 MspHelper.prototype.sendLedStripConfig = async function () {
+    // API 1.46 shifted the colour (18 -> 22) and direction (22 -> 26) fields up in the mask.
+    const isNewLayout = semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46);
+    const colorOffset = isNewLayout ? 22 : 18;
+    const directionOffset = isNewLayout ? 26 : 22;
+
     for (let ledIndex = 0; ledIndex < FC.LED_STRIP.length; ledIndex++) {
-        const led = FC.LED_STRIP[ledIndex];
         const buffer = [];
 
         buffer.push(ledIndex);
-
-        let mask = 0;
-
-        mask |= led.y << 0;
-        mask |= led.x << 4;
-
-        for (let functionLetterIndex = 0; functionLetterIndex < led.functions.length; functionLetterIndex++) {
-            const fnIndex = ledBaseFunctionLetters.indexOf(led.functions[functionLetterIndex]);
-            if (fnIndex >= 0) {
-                mask |= fnIndex << 8;
-                break;
-            }
-        }
-
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
-            for (let overlayLetterIndex = 0; overlayLetterIndex < led.functions.length; overlayLetterIndex++) {
-                const bitIndex = ledOverlayLetters.indexOf(led.functions[overlayLetterIndex]);
-                if (bitIndex >= 0) {
-                    mask |= bit_set(mask, bitIndex + 12);
-                }
-            }
-
-            mask |= led.color << 22;
-
-            for (let directionLetterIndex = 0; directionLetterIndex < led.directions.length; directionLetterIndex++) {
-                const bitIndex = ledDirectionLetters.indexOf(led.directions[directionLetterIndex]);
-                if (bitIndex >= 0) {
-                    mask |= bit_set(mask, bitIndex + 26);
-                }
-            }
-
-            buffer.push32(mask);
-        } else {
-            for (let overlayLetterIndex = 0; overlayLetterIndex < led.functions.length; overlayLetterIndex++) {
-                const bitIndex = ledOverlayLetters.indexOf(led.functions[overlayLetterIndex]);
-                if (bitIndex >= 0) {
-                    mask |= bit_set(mask, bitIndex + 12);
-                }
-            }
-
-            mask |= led.color << 18;
-
-            for (let directionLetterIndex = 0; directionLetterIndex < led.directions.length; directionLetterIndex++) {
-                const bitIndex = ledDirectionLetters.indexOf(led.directions[directionLetterIndex]);
-                if (bitIndex >= 0) {
-                    mask |= bit_set(mask, bitIndex + 22);
-                }
-            }
-
-            mask |= 0 << 28; // parameters
-
-            buffer.push32(mask);
-        }
+        buffer.push32(buildLedStripMask(FC.LED_STRIP[ledIndex], colorOffset, directionOffset));
 
         await MSP.promise(MSPCodes.MSP_SET_LED_STRIP_CONFIG, buffer);
     }

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -2726,62 +2726,25 @@ MspHelper.prototype.sendAdjustmentRanges = function (onCompleteCallback) {
     }
 };
 
-MspHelper.prototype.sendVoltageConfig = function (onCompleteCallback) {
-    let nextFunction = send_next_voltage_config;
-
-    let configIndex = 0;
-
-    if (FC.VOLTAGE_METER_CONFIGS.length == 0) {
-        onCompleteCallback();
-    } else {
-        send_next_voltage_config();
-    }
-
-    function send_next_voltage_config() {
+MspHelper.prototype.sendVoltageConfig = async function () {
+    for (let configIndex = 0; configIndex < FC.VOLTAGE_METER_CONFIGS.length; configIndex++) {
+        const config = FC.VOLTAGE_METER_CONFIGS[configIndex];
         const buffer = [];
 
-        buffer
-            .push8(FC.VOLTAGE_METER_CONFIGS[configIndex].id)
-            .push8(FC.VOLTAGE_METER_CONFIGS[configIndex].vbatscale)
-            .push8(FC.VOLTAGE_METER_CONFIGS[configIndex].vbatresdivval)
-            .push8(FC.VOLTAGE_METER_CONFIGS[configIndex].vbatresdivmultiplier);
+        buffer.push8(config.id).push8(config.vbatscale).push8(config.vbatresdivval).push8(config.vbatresdivmultiplier);
 
-        // prepare for next iteration
-        configIndex++;
-        if (configIndex == FC.VOLTAGE_METER_CONFIGS.length) {
-            nextFunction = onCompleteCallback;
-        }
-
-        MSP.send_message(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG, buffer, false, nextFunction);
+        await MSP.promise(MSPCodes.MSP_SET_VOLTAGE_METER_CONFIG, buffer);
     }
 };
 
-MspHelper.prototype.sendCurrentConfig = function (onCompleteCallback) {
-    let nextFunction = send_next_current_config;
-
-    let configIndex = 0;
-
-    if (FC.CURRENT_METER_CONFIGS.length == 0) {
-        onCompleteCallback();
-    } else {
-        send_next_current_config();
-    }
-
-    function send_next_current_config() {
+MspHelper.prototype.sendCurrentConfig = async function () {
+    for (let configIndex = 0; configIndex < FC.CURRENT_METER_CONFIGS.length; configIndex++) {
+        const config = FC.CURRENT_METER_CONFIGS[configIndex];
         const buffer = [];
 
-        buffer
-            .push8(FC.CURRENT_METER_CONFIGS[configIndex].id)
-            .push16(FC.CURRENT_METER_CONFIGS[configIndex].scale)
-            .push16(FC.CURRENT_METER_CONFIGS[configIndex].offset);
+        buffer.push8(config.id).push16(config.scale).push16(config.offset);
 
-        // prepare for next iteration
-        configIndex++;
-        if (configIndex == FC.CURRENT_METER_CONFIGS.length) {
-            nextFunction = onCompleteCallback;
-        }
-
-        MSP.send_message(MSPCodes.MSP_SET_CURRENT_METER_CONFIG, buffer, false, nextFunction);
+        await MSP.promise(MSPCodes.MSP_SET_CURRENT_METER_CONFIG, buffer);
     }
 };
 

--- a/src/stores/osd.js
+++ b/src/stores/osd.js
@@ -392,10 +392,6 @@ export const useOsdStore = defineStore("osd", () => {
         );
     };
 
-    const saveToEeprom = async () => {
-        return MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
-    };
-
     const saveAllConfig = async () => {
         await MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, encodeOther());
 
@@ -450,7 +446,6 @@ export const useOsdStore = defineStore("osd", () => {
         saveOtherConfig,
         saveTimerConfig,
         saveStatisticItem,
-        saveToEeprom,
         saveAllConfig,
     };
 });

--- a/test/js/useVtx.test.js
+++ b/test/js/useVtx.test.js
@@ -2,12 +2,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { effectScope } from "vue";
 import FC from "../../src/js/fc";
 import MSP from "../../src/js/msp";
+import MSPCodes from "../../src/js/msp/MSPCodes";
 
 vi.mock("../../src/js/msp/MSPHelper", () => ({
     __esModule: true,
     mspHelper: {
-        writeConfiguration: vi.fn((reboot, callback) => callback && callback()),
         crunch: vi.fn(() => false),
+        setArmingEnabled: vi.fn(),
     },
 }));
 
@@ -29,68 +30,83 @@ vi.mock("../../src/js/Analytics", () => ({
     },
 }));
 
+// Persist is EEPROM-only; stub useReboot so the save path doesn't need Pinia/serial. The spy
+// stands in for the shared saveToEeprom() (which the tab now uses instead of writeConfiguration).
+const { saveToEepromMock } = vi.hoisted(() => ({ saveToEepromMock: vi.fn(async () => {}) }));
+vi.mock("../../src/composables/useReboot", () => ({
+    __esModule: true,
+    useReboot: () => ({ saveToEeprom: saveToEepromMock, saveAndReboot: vi.fn(), reboot: vi.fn() }),
+}));
+
 import { useVtx } from "../../src/composables/useVtx";
-import { mspHelper } from "../../src/js/msp/MSPHelper";
+import { tracking } from "../../src/js/Analytics";
 
 describe("useVtx", () => {
     let scope;
     let vtx;
 
     beforeEach(async () => {
-        vi.useFakeTimers();
         FC.resetState();
+        saveToEepromMock.mockClear();
+        tracking.sendSaveAndChangeEvents.mockClear();
 
-        vi.spyOn(MSP, "send_message").mockImplementation((code, data, retries, cb) => {
-            if (typeof cb === "function") {
-                cb();
-            }
-        });
+        // Error-aware MSP requests: the save/load chains now use MSP.promise everywhere.
+        vi.spyOn(MSP, "promise").mockResolvedValue(undefined);
 
         scope = effectScope();
         scope.run(() => {
             vtx = useVtx();
         });
 
-        // Bring the composable out of its initial "updating" state so saveVtx() is allowed to run.
+        // Bring the composable out of its initial "updating" state and take the dirty baseline.
         await vtx.loadVtxConfig();
+        MSP.promise.mockClear();
     });
 
     afterEach(() => {
         scope.stop();
-        vi.runAllTimers();
-        vi.useRealTimers();
         vi.restoreAllMocks();
     });
 
-    it("clears both onSaveComplete timers on scope dispose, so no reload happens after unmount", async () => {
-        vtx.saveVtx();
+    it("issues the exact set and order of MSP_SET_VTX* writes, then persists to EEPROM", async () => {
+        vtx.vtxConfig.vtx_table_powerlevels = 2;
+        vtx.vtxConfig.vtx_table_bands = 3;
 
-        expect(mspHelper.writeConfiguration).toHaveBeenCalledTimes(1);
-        expect(vtx.saveButtonText.value).toBe("buttonSaving");
+        await vtx.saveVtx();
 
-        const callsAfterSave = MSP.send_message.mock.calls.length;
+        const codes = MSP.promise.mock.calls.map((call) => call[0]);
+        expect(codes).toEqual([
+            MSPCodes.MSP_SET_VTX_CONFIG,
+            MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL,
+            MSPCodes.MSP_SET_VTXTABLE_POWERLEVEL,
+            MSPCodes.MSP_SET_VTXTABLE_BAND,
+            MSPCodes.MSP_SET_VTXTABLE_BAND,
+            MSPCodes.MSP_SET_VTXTABLE_BAND,
+        ]);
 
-        scope.stop();
-
-        // Advance past both chained 1500ms timeouts (3000ms total).
-        await vi.advanceTimersByTimeAsync(3100);
-
-        // No further MSP traffic should have occurred — the reload (loadVtxConfig) never ran,
-        // and the button text is stuck on "Saving" rather than being reset.
-        expect(MSP.send_message.mock.calls).toHaveLength(callsAfterSave);
-        expect(vtx.saveButtonText.value).toBe("buttonSaving");
+        // EEPROM persist happens once, after all the SET_ writes.
+        expect(saveToEepromMock).toHaveBeenCalledTimes(1);
     });
 
-    it("without dispose, the pending timers still fire and reload vtx config (proves the test is not vacuous)", async () => {
-        vtx.saveVtx();
+    it("records analytics and clears the pending-verify flag only after a successful persist", async () => {
+        vtx.savePending.value = true;
 
-        expect(vtx.saveButtonText.value).toBe("buttonSaving");
-        const callsAfterSave = MSP.send_message.mock.calls.length;
+        await vtx.saveVtx();
 
-        await vi.advanceTimersByTimeAsync(3100);
+        expect(saveToEepromMock).toHaveBeenCalledTimes(1);
+        expect(tracking.sendSaveAndChangeEvents).toHaveBeenCalledTimes(1);
+        expect(tracking.sendSaveAndChangeEvents).toHaveBeenCalledWith("fc", expect.any(Object), "vtx");
+        expect(vtx.savePending.value).toBe(false);
+    });
 
-        // loadVtxConfig() sent at least one further MSP_VTX_CONFIG request, and the button reset.
-        expect(MSP.send_message.mock.calls.length).toBeGreaterThan(callsAfterSave);
-        expect(vtx.saveButtonText.value).toBe("");
+    it("does not run analytics or clear pending-verify when an MSP write rejects", async () => {
+        vtx.savePending.value = true;
+        MSP.promise.mockRejectedValueOnce(new Error("boom"));
+
+        await expect(vtx.saveVtx()).rejects.toThrow("boom");
+
+        expect(saveToEepromMock).not.toHaveBeenCalled();
+        expect(tracking.sendSaveAndChangeEvents).not.toHaveBeenCalled();
+        expect(vtx.savePending.value).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary

Consolidates every flight-controller **config save** onto one shared path so there is a single save discipline app-wide — consistent `isSaving`/loading state, one place that swallows benign `MspCancelledError`, and one error-aware EEPROM-persist primitive. No tab reimplements save handling anymore.

**Invariant after this PR:** `mspHelper.writeConfiguration` is called **only** by `useReboot`. Every config save goes through `useSaving.runSave` + `useReboot.saveToEeprom()` / `saveAndReboot()`.

Implements #5271 in full.

> ✅ **Rebased onto `master`.** The prerequisite #5272 (benign `MSP` cancellation handling) has merged, so this branch is now based directly on `master` and no longer carries that commit.

## The shared primitives

- **`useSaving.runSave(fn, { onError })`** — owns `isSaving`, prevents concurrent saves, and centrally swallows benign `MspCancelledError` (queue cleared by a tab switch / reboot-disconnect); genuine failures go to `onError`.
- **`useReboot.saveToEeprom()`** — await-able, **error-aware** EEPROM persist (module-scope). Uses `MSP.promise`, so a queue-clear rejects instead of dropping a callback and hanging like `writeConfiguration`. Mirrors `writeConfiguration`'s arming-safety guard.
- **`useReboot.saveAndReboot()`** — the persist-then-reboot variant.

Per-tab data marshalling, analytics keys, dirty-baseline logic and any safety sequence intentionally stay inside each tab's `runSave(fn)`. The shared seam is the *discipline + persistence*, not the payload.

## Migrated saves (11)

Power, Gps, OnboardLogging, Servos, Auxiliary, Adjustments, LedStrip, Vtx, PidTuning, Motors — plus **Ports** (`usePortsConfiguration`). Motors keeps its motor-stop safety sequence first inside `runSave`.

The callback-based MSP senders these saves used are converted to error-aware `async` (single-caller each): `sendVoltageConfig`, `sendCurrentConfig`, `sendServoConfigurations`, `sendModeRanges`, `sendAdjustmentRanges`, `sendLedStripConfig`/`Colors`/`ModeColors`, and Vtx's save/load chains.

## Bugs found & fixed along the way

- **usePower no-op awaits** — `await`s on callback helpers (`sendVoltageConfig`/`sendCurrentConfig`/`writeConfiguration`) returned `undefined`, so the dirty baseline was captured before the writes completed.
- **ReceiverTab double-reboot** — `writeConfiguration(true)` reboots internally *and* the callback rebooted again via `navigationStore.cleanup`, firing two reconnect sequences. Now a single `saveAndReboot()`.
- **AdjustmentsTab `ReferenceError`** — a follow-up cleanup left `t` referenced after its declaration was removed; restored.
- Removed a dead duplicate `saveToEeprom` in the OSD store; routed `MotorOutputReorderingDialog` through `saveAndReboot()`; de-duplicated identical "EEPROM saved" toasts (Servos/Adjustments).

## Review & verification

- Adversarial per-tab verification + a 4-lens skeptical review of the whole branch.
- Every CodeRabbit round addressed (fixes + reasoned rejections, each replied to).
- The MSP sender rewrites were checked **byte-identical** to the originals (incl. `sendLedStripConfig` across 6144 input combinations).
- `npm run lint` clean; `npm test` — 623 passing.
- Note: save cancellation isn't reproducible in virtual mode (`MSP.promise` short-circuits), so the runtime paths are logic-/test-verified — worth a quick confirm on hardware.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Save actions across configuration tabs now show progress indicators and prevent duplicate submissions.
  * Configuration changes are persisted more reliably, with reboot handling where required.
  * Dirty-state tracking updates only after successful saves.
  * Benign connection cancellations no longer produce unnecessary error messages.
  * Servo, LED, VTX, GPS, motor, power, receiver, and other configuration saves now provide more consistent feedback and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
