### PR TITLE
Fix virtual firmware version dropdown hidden behind connect dialog

### DIFF
--- a/src/components/port-picker/ConnectOptionsDialog.vue
+++ b/src/components/port-picker/ConnectOptionsDialog.vue
@@ -7,7 +7,12 @@
                 </p>
                 <label v-if="mode === 'virtual'" class="connect-options__field">
                     <span>{{ $t("virtualMSPVersion") }}</span>
-                    <USelect v-model="version" :items="firmwareVersions" size="sm" :ui="{ content: 'max-h-96' }" />
+                    <USelect
+                        v-model="version"
+                        :items="firmwareVersions"
+                        size="sm"
+                        :ui="{ content: 'max-h-96 z-3002' }"
+                    />
                 </label>
                 <label v-else class="connect-options__field">
                     <span>{{ $t("portOverrideText") }}</span>


### PR DESCRIPTION
The firmware version select in the virtual mode connect dialog rendered behind the modal overlay and could not be clicked. Modals sit at z-3000/3001 (global Nuxt UI theme) while the teleported select content keeps the default z-50, so it needs the same z-3002 override every other in-modal select already carries (OptionsDialog, CopyProfileDialog, WaypointEditor). Swept the rest of the app for the same pattern, this was the only remaining instance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the virtual-mode version picker dropdown styling to improve its display layering and positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->