### PR TITLE
refact: move OSD preview clamp helpers to composable & add tests(#5248)

### DIFF
--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -526,7 +526,7 @@
 import { ref, computed, onMounted, onUnmounted, nextTick, watch } from "vue";
 import { useOsdStore } from "@/stores/osd";
 import { useFlightControllerStore } from "@/stores/fc";
-import { useOsdPreview } from "@/composables/useOsdPreview";
+import { useOsdPreview, clampStringPreviewPosition, clampArrayPreviewPosition } from "@/composables/useOsdPreview";
 import { useOsdRuler } from "@/composables/useOsdRuler";
 import { useTransientLabel } from "@/composables/useTransientLabel";
 import { useSaving } from "@/composables/useSaving";
@@ -1061,10 +1061,6 @@ function onDragLeaveCell(event) {
     event.currentTarget.removeAttribute("style");
 }
 
-function isStringArrayPreview(preview) {
-    return Array.isArray(preview) && typeof preview[0] === "string";
-}
-
 function applyDragOffsetFromStartCell(position, event, displaySize, startIdx) {
     const x = Number.parseInt(event.dataTransfer.getData("x"), 10);
     const y = Number.parseInt(event.dataTransfer.getData("y"), 10);
@@ -1075,74 +1071,6 @@ function applyDragOffsetFromStartCell(position, event, displaySize, startIdx) {
     const draggedCellIdx = x + y * displaySize.x;
     const offsetIdx = position - draggedCellIdx;
     return startIdx + offsetIdx;
-}
-
-function clampStringPreviewPosition(displayItem, position, displaySize, cursorY) {
-    const elementWidth = Array.from(displayItem.preview || "").length;
-    const maxX = Math.max(0, displaySize.x - elementWidth);
-    const maxY = Math.max(0, displaySize.y - 1);
-    const row = clamp(cursorY, 0, maxY);
-
-    const rawX = position - row * displaySize.x;
-    const x = clamp(rawX, 0, maxX);
-
-    return row * displaySize.x + x;
-}
-
-function clampStringArrayPreviewPosition(position, displaySize, cursorX, limits) {
-    const selectedPositionX = position % displaySize.x;
-    let selectedPositionY = Math.trunc(position / displaySize.x);
-
-    if (position < 0) {
-        return null;
-    }
-    if (selectedPositionX > cursorX) {
-        position += displaySize.x - selectedPositionX;
-        selectedPositionY++;
-    } else if (selectedPositionX + limits.maxX > displaySize.x) {
-        position -= selectedPositionX + limits.maxX - displaySize.x;
-    }
-    if (selectedPositionY < 0) {
-        position += Math.abs(selectedPositionY) * displaySize.x;
-    } else if (selectedPositionY + limits.maxY > displaySize.y) {
-        position -= (selectedPositionY + limits.maxY - displaySize.y) * displaySize.x;
-    }
-
-    return position;
-}
-
-function clampObjectArrayPreviewPosition(position, displaySize, limits) {
-    const selectedPositionX = ((position % displaySize.x) + displaySize.x) % displaySize.x;
-    const selectedPositionY = Math.floor(position / displaySize.x);
-
-    if (selectedPositionX + limits.minX < 0) {
-        position += Math.abs(selectedPositionX + limits.minX);
-    } else if (limits.maxX > 0 && selectedPositionX + limits.maxX >= displaySize.x) {
-        position -= selectedPositionX + limits.maxX + 1 - displaySize.x;
-    }
-    if (selectedPositionY + limits.minY < 0) {
-        position += Math.abs(selectedPositionY + limits.minY) * displaySize.x;
-    } else if (limits.maxY > 0 && selectedPositionY + limits.maxY >= displaySize.y) {
-        position -= (selectedPositionY + limits.maxY - displaySize.y + 1) * displaySize.x;
-    }
-
-    if (position < 0) {
-        // The anchor of an element whose cells all sit below it (positive minY) may
-        // still land above row 0 after clamping, but positions pack into unsigned
-        // x/y for MSP (see stores/osd.js pack.position): settle on row 0, keeping
-        // the column instead of jumping to the top-left corner.
-        position = ((position % displaySize.x) + displaySize.x) % displaySize.x;
-    }
-
-    return position;
-}
-
-function clampArrayPreviewPosition(displayItem, position, displaySize, cursorX) {
-    const limits = searchLimitsElement(displayItem.preview);
-    if (isStringArrayPreview(displayItem.preview)) {
-        return clampStringArrayPreviewPosition(position, displaySize, cursorX, limits);
-    }
-    return clampObjectArrayPreviewPosition(position, displaySize, limits);
 }
 
 function onDropCell(event) {

--- a/src/composables/useOsdPreview.js
+++ b/src/composables/useOsdPreview.js
@@ -221,3 +221,111 @@ export function useOsdPreview() {
         searchLimitsElement,
     };
 }
+
+/**
+ * Check if the element preview is an array of strings.
+ * @param {any} preview - The preview property of the element.
+ * @returns {boolean} True if the preview is an array of strings.
+ */
+export function isStringArrayPreview(preview) {
+    return Array.isArray(preview) && typeof preview[0] === "string";
+}
+
+/**
+ * Clamp the position of a string OSD element (1D string) to screen bounds.
+ * @param {object} displayItem - The display item.
+ * @param {number} position - The proposed grid index.
+ * @param {object} displaySize - The screen size {x, y, total}.
+ * @param {number} cursorY - The row the user cursor is pointing to.
+ * @returns {number} The clamped position grid index.
+ */
+export function clampStringPreviewPosition(displayItem, position, displaySize, cursorY) {
+    const elementWidth = Array.from(displayItem.preview || "").length;
+    const maxX = Math.max(0, displaySize.x - elementWidth);
+    const maxY = Math.max(0, displaySize.y - 1);
+    const row = Math.min(Math.max(cursorY, 0), maxY);
+
+    const rawX = position - row * displaySize.x;
+    const x = Math.min(Math.max(rawX, 0), maxX);
+
+    return row * displaySize.x + x;
+}
+
+/**
+ * Clamp the position of a string-array OSD element to screen bounds.
+ * @param {number} position - The proposed grid index.
+ * @param {object} displaySize - The screen size {x, y, total}.
+ * @param {number} cursorX - The column the user cursor is pointing to.
+ * @param {object} limits - The layout limits {minX, maxX, minY, maxY}.
+ * @returns {number|null} The clamped position grid index or null if invalid.
+ */
+export function clampStringArrayPreviewPosition(position, displaySize, cursorX, limits) {
+    const selectedPositionX = position % displaySize.x;
+    let selectedPositionY = Math.trunc(position / displaySize.x);
+
+    if (position < 0) {
+        return null;
+    }
+    if (selectedPositionX > cursorX) {
+        position += displaySize.x - selectedPositionX;
+        selectedPositionY++;
+    } else if (selectedPositionX + limits.maxX > displaySize.x) {
+        position -= selectedPositionX + limits.maxX - displaySize.x;
+    }
+    if (selectedPositionY < 0) {
+        position += Math.abs(selectedPositionY) * displaySize.x;
+    } else if (selectedPositionY + limits.maxY > displaySize.y) {
+        position -= (selectedPositionY + limits.maxY - displaySize.y) * displaySize.x;
+    }
+
+    return position;
+}
+
+/**
+ * Clamp the position of an object-array OSD element to screen bounds.
+ * @param {number} position - The proposed grid index.
+ * @param {object} displaySize - The screen size {x, y, total}.
+ * @param {object} limits - The layout limits {minX, maxX, minY, maxY}.
+ * @returns {number} The clamped position grid index.
+ */
+export function clampObjectArrayPreviewPosition(position, displaySize, limits) {
+    const selectedPositionX = ((position % displaySize.x) + displaySize.x) % displaySize.x;
+    const selectedPositionY = Math.floor(position / displaySize.x);
+
+    if (selectedPositionX + limits.minX < 0) {
+        position += Math.abs(selectedPositionX + limits.minX);
+    } else if (limits.maxX > 0 && selectedPositionX + limits.maxX >= displaySize.x) {
+        position -= selectedPositionX + limits.maxX + 1 - displaySize.x;
+    }
+    if (selectedPositionY + limits.minY < 0) {
+        position += Math.abs(selectedPositionY + limits.minY) * displaySize.x;
+    } else if (limits.maxY > 0 && selectedPositionY + limits.maxY >= displaySize.y) {
+        position -= (selectedPositionY + limits.maxY - displaySize.y + 1) * displaySize.x;
+    }
+
+    if (position < 0) {
+        // The anchor of an element whose cells all sit below it (positive minY) may
+        // still land above row 0 after clamping, but positions pack into unsigned
+        // x/y for MSP (see stores/osd.js pack.position): settle on row 0, keeping
+        // the column instead of jumping to the top-left corner.
+        position = ((position % displaySize.x) + displaySize.x) % displaySize.x;
+    }
+
+    return position;
+}
+
+/**
+ * Clamp the position of any array OSD element (object array or string array) to screen bounds.
+ * @param {object} displayItem - The display item.
+ * @param {number} position - The proposed grid index.
+ * @param {object} displaySize - The screen size {x, y, total}.
+ * @param {number} cursorX - The column the user cursor is pointing to.
+ * @returns {number|null} The clamped position grid index or null if invalid.
+ */
+export function clampArrayPreviewPosition(displayItem, position, displaySize, cursorX) {
+    const limits = searchLimitsElement(displayItem.preview);
+    if (isStringArrayPreview(displayItem.preview)) {
+        return clampStringArrayPreviewPosition(position, displaySize, cursorX, limits);
+    }
+    return clampObjectArrayPreviewPosition(position, displaySize, limits);
+}

--- a/test/js/osd_preview_limits.test.js
+++ b/test/js/osd_preview_limits.test.js
@@ -200,7 +200,9 @@ describe("clampArrayPreviewPosition", () => {
         };
         // Dragged to row 15, col 28: index = 478. cursorX = 28.
         const result = clampArrayPreviewPosition(displayItem, 478, displaySize, 28);
-        expect(result).toBeDefined();
-        expect(result).not.toBeNull();
+        // limits: {minX:0, maxX:3, minY:0, maxY:2}
+        // X: 28 + 3 = 31 > 30 → position -= 1 → 477
+        // Y: 15 + 2 = 17 > 16 → position -= 30 → 447
+        expect(result).toEqual(447);
     });
 });

--- a/test/js/osd_preview_limits.test.js
+++ b/test/js/osd_preview_limits.test.js
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
-import { useOsdPreview } from "../../src/composables/useOsdPreview.js";
+import {
+    useOsdPreview,
+    clampObjectArrayPreviewPosition,
+    clampStringPreviewPosition,
+    clampStringArrayPreviewPosition,
+    clampArrayPreviewPosition,
+} from "../../src/composables/useOsdPreview.js";
 
 // Preview shaped like ARTIFICIAL_HORIZON (see src/components/tabs/osd/osd.js):
 // cells span x -4..+4 and y +1..+7, so every rendered cell sits below the
@@ -73,5 +79,128 @@ describe("searchLimitsElement", () => {
 
         expect(searchLimitsElement([])).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
         expect(searchLimitsElement(null)).toEqual({ minX: 0, maxX: 0, minY: 0, maxY: 0 });
+    });
+});
+
+describe("clampObjectArrayPreviewPosition", () => {
+    const displaySize = { x: 30, y: 16, total: 480 };
+
+    it("clamps ARTIFICIAL_HORIZON correctly at the top edge without jumping to (0,0)", () => {
+        const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+        // Dragged to row -1, column 20: index = -30 + 20 = -10
+        // Since limits.minY = 0, anchor at y = -1 is out of bounds (topmost cell is y + minY = -1 < 0)
+        // It should clamp smoothly to anchor row 0, returning 20 (row 0, col 20).
+        const result = clampObjectArrayPreviewPosition(-10, displaySize, limits);
+        expect(result).toEqual(20);
+    });
+
+    it("correctly corrects out-of-bounds y < -limits.minY at the top edge", () => {
+        const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+        // Dragged to row -3, column 20: index = -90 + 20 = -70
+        // Topmost allowed anchor row is 0.
+        // Expected clamped index = 0 * 30 + 20 = 20.
+        const result = clampObjectArrayPreviewPosition(-70, displaySize, limits);
+        expect(result).toEqual(20);
+    });
+
+    it("clamps ARTIFICIAL_HORIZON correctly at the left edge", () => {
+        const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+        // Dragged to row 5, col 2: index = 150 + 2 = 152
+        // selectedPositionX = 2. selectedPositionX + limits.minX = 2 - 4 = -2 < 0.
+        // Adjusted: position += 2 => 154 (col 4).
+        // Leftmost visible cell is now at col 4 - 4 = 0.
+        const result = clampObjectArrayPreviewPosition(152, displaySize, limits);
+        expect(result).toEqual(154);
+    });
+
+    it("clamps ARTIFICIAL_HORIZON correctly at the right edge", () => {
+        const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+        // Dragged to row 5, col 28: index = 150 + 28 = 178
+        // selectedPositionX = 28. selectedPositionX + limits.maxX = 28 + 4 = 32 >= 30.
+        // Adjusted: position -= (28 + 4 + 1 - 30) = 178 - 3 = 175 (col 25).
+        // Rightmost visible cell is now at col 25 + 4 = 29.
+        const result = clampObjectArrayPreviewPosition(178, displaySize, limits);
+        expect(result).toEqual(175);
+    });
+
+    it("clamps ARTIFICIAL_HORIZON correctly at the bottom edge", () => {
+        const limits = { minX: -4, maxX: 4, minY: 0, maxY: 6 };
+        // Dragged to row 10, col 10: index = 310
+        // selectedPositionY = 10. selectedPositionY + limits.maxY = 10 + 6 = 16 >= 16.
+        // Adjusted: position -= (10 + 6 - 16 + 1) * 30 = 310 - 30 = 280 (row 9).
+        // Bottom-most visible cell is now at row 9 + 6 = 15.
+        const result = clampObjectArrayPreviewPosition(310, displaySize, limits);
+        expect(result).toEqual(280);
+    });
+
+    it("clamps negative-offset elements (e.g. HORIZON_SIDEBARS) correctly at the top edge", () => {
+        const limits = { minX: -7, maxX: 7, minY: -3, maxY: 3 };
+        // Dragged to row 1, col 15: index = 45
+        // selectedPositionY = 1. selectedPositionY + limits.minY = 1 - 3 = -2 < 0.
+        // Adjusted: position += 2 * 30 = 45 + 60 = 105 (row 3).
+        // Top-most visible cell is now at row 3 - 3 = 0.
+        const result = clampObjectArrayPreviewPosition(45, displaySize, limits);
+        expect(result).toEqual(105);
+    });
+});
+
+describe("clampStringPreviewPosition", () => {
+    const displaySize = { x: 30, y: 16, total: 480 };
+
+    it("clamps standard string elements within horizontal screen bounds", () => {
+        const displayItem = { preview: "HELLO" }; // length = 5
+        // Dragged to row 2, col 28: index = 60 + 28 = 88. cursorY = 2.
+        // Max allowed X = 30 - 5 = 25.
+        // Expected clamped index = 60 + 25 = 85.
+        const result = clampStringPreviewPosition(displayItem, 88, displaySize, 2);
+        expect(result).toEqual(85);
+    });
+});
+
+describe("clampStringArrayPreviewPosition", () => {
+    const displaySize = { x: 30, y: 16, total: 480 };
+
+    it("returns null for negative positions (regression guard)", () => {
+        const limits = { minX: 0, maxX: 5, minY: 0, maxY: 2 };
+        expect(clampStringArrayPreviewPosition(-10, displaySize, 10, limits)).toBeNull();
+    });
+
+    it("clamps string arrays within bounds", () => {
+        const limits = { minX: 0, maxX: 5, minY: 0, maxY: 2 };
+        // Row 15, col 28: index = 450 + 28 = 478. cursorX = 28.
+        // selectedPositionY = 15. limits.maxY = 2.
+        // 15 + 2 = 17 >= 16. Clamps Y to 14.
+        // selectedPositionX = 28. limits.maxX = 5.
+        // 28 + 5 = 33 >= 30. Clamps X to 25.
+        // Expected clamped index = 14 * 30 + 25 = 445.
+        const result = clampStringArrayPreviewPosition(478, displaySize, 28, limits);
+        expect(result).toEqual(445);
+    });
+});
+
+describe("clampArrayPreviewPosition", () => {
+    const displaySize = { x: 30, y: 16, total: 480 };
+
+    it("routes to clampObjectArrayPreviewPosition for object arrays", () => {
+        const displayItem = {
+            preview: [
+                { x: -4, y: 0, sym: 10 },
+                { x: 4, y: 6, sym: 10 },
+            ],
+        };
+        // Dragged to row -1, col 20: index = -10
+        // Clamps Y to 0, expected: 20
+        const result = clampArrayPreviewPosition(displayItem, -10, displaySize, 20);
+        expect(result).toEqual(20);
+    });
+
+    it("routes to clampStringArrayPreviewPosition for string arrays", () => {
+        const displayItem = {
+            preview: ["ABC", "DEF"],
+        };
+        // Dragged to row 15, col 28: index = 478. cursorX = 28.
+        const result = clampArrayPreviewPosition(displayItem, 478, displaySize, 28);
+        expect(result).toBeDefined();
+        expect(result).not.toBeNull();
     });
 });


### PR DESCRIPTION

#### **Description**
This PR addresses the remaining refactoring task outlined in #5248. It relocates the OSD preview clamping helper functions from the `OsdTab` component into the `useOsdPreview` composable to make them testable and reusable, and introduces a comprehensive unit test suite to cover all grid boundary constraints.

This refactor is purely structural and additive: it does not introduce any behavior or coordinate/geometry changes (which were already resolved independently in #5224).

#### **Changes**
- **`src/composables/useOsdPreview.js`**:
  - Relocated and exported: `isStringArrayPreview`, `clampStringPreviewPosition`, `clampStringArrayPreviewPosition`, `clampObjectArrayPreviewPosition`, and `clampArrayPreviewPosition`.
  - Kept them clean of component-only dependencies so they are easily importable in tests.
- **`src/components/tabs/OsdTab.vue`**:
  - Removed inline definitions of the clamp functions.
  - Imported and delegated logic to `clampArrayPreviewPosition` and `clampStringPreviewPosition` from `useOsdPreview.js`.
- **`test/js/osd_preview_limits.test.js`**:
  - Added comprehensive test suites verifying correct boundary clamp outcomes at all 4 grid edges (top, bottom, left, right).
  - Covered multiple OSD element configurations including `ARTIFICIAL_HORIZON` (which has positive-only Y offsets), `HORIZON_SIDEBARS` (mixed-sign offsets), standard strings, and string arrays.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved on-screen display (OSD) preview positioning to keep elements within valid screen boundaries.
  * Enhanced clamping behavior for string, string-array, and object-array previews, including proper handling of negative positions and wrap-around edge cases.
  * Strengthened placement of complex previews (such as artificial horizon layouts).
* **Tests**
  * Added unit tests covering preview clamping behavior, edge cases, and correct routing by preview type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->