### PR TITLE
fix(connection): end reboot dialog promptly for BLE/manual with Auto-Connect off

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -94,6 +94,50 @@ export function isDrivenRebootTarget(port) {
 }
 
 /**
+ * Decide whether the reboot progress dialog's poller should stop waiting (settle the reboot
+ * window, show "ready", close). Extracted as a pure predicate so the branch matrix is
+ * unit-testable without driving the dialog's intervals.
+ *
+ * - Always conclude once the FC has answered (connectionValid) or the window elapsed (timeout).
+ * - With Auto-Connect ON, keep waiting — the retry loop owns the reconnect.
+ * - With Auto-Connect OFF nothing will auto-reconnect, so conclude as soon as there's nothing
+ *   left to wait for:
+ *     - serial re-enumerates after the reboot, so wait for the port to reappear (portAvailable).
+ *     - driven targets (BLE, manual/TCP) never re-enumerate — portAvailable would never flip, so
+ *       the dialog used to hang until timeout. rebootReconnect() drops the stale link and then
+ *       closes the reboot window at the flush (~1.5s), so wait for the window to close rather
+ *       than concluding immediately: that keeps us from showing "ready" while the flush is still
+ *       pending (which would tear down a manual reconnect).
+ * @param {object} state
+ * @param {boolean} state.connectionValid - the rebooted FC has answered
+ * @param {boolean} state.timeoutReached - the reboot window has elapsed
+ * @param {boolean} state.autoConnect - Auto-Connect is enabled
+ * @param {boolean} state.portAvailable - a serial port is present (re-enumerated)
+ * @param {string} state.selectedDevice - the selected device path
+ * @param {boolean} state.rebootWindowOpen - the connection-state reboot window is still open
+ * @returns {boolean}
+ */
+export function shouldConcludeRebootDialog({
+    connectionValid,
+    timeoutReached,
+    autoConnect,
+    portAvailable,
+    selectedDevice,
+    rebootWindowOpen,
+}) {
+    if (connectionValid || timeoutReached) {
+        return true;
+    }
+    if (autoConnect) {
+        return false;
+    }
+    if (isDrivenRebootTarget(selectedDevice)) {
+        return !rebootWindowOpen;
+    }
+    return Boolean(portAvailable);
+}
+
+/**
  * Reconnect-window duration for the currently-selected target: driven (BLE/manual) reboots
  * get the longer window, serial re-enumeration keeps the original. Evaluated once per reboot
  * (passed to requestReboot) so the loop, dialog and dialog-suppression share one snapshot.
@@ -1469,9 +1513,17 @@ function showRebootDialog() {
     // Check for successful connection every 100ms with a timeout
     rebootDialogCheckTimerId = setInterval(() => {
         const connectionCheckTimeoutReached = Date.now() - windowStartedAt > windowMs;
-        const noSerialReconnect = !DeviceHandler.devicePicker.autoConnect && DeviceHandler.portAvailable;
 
-        if (CONFIGURATOR.connectionValid || connectionCheckTimeoutReached || noSerialReconnect) {
+        if (
+            shouldConcludeRebootDialog({
+                connectionValid: CONFIGURATOR.connectionValid,
+                timeoutReached: connectionCheckTimeoutReached,
+                autoConnect: DeviceHandler.devicePicker.autoConnect,
+                portAvailable: DeviceHandler.portAvailable,
+                selectedDevice: DeviceHandler.devicePicker.selectedDevice,
+                rebootWindowOpen: getConnectionState().isRebootWindowOpen,
+            })
+        ) {
             clearInterval(rebootDialogCheckTimerId);
             clearInterval(rebootDialogProgressTimerId);
             rebootDialogCheckTimerId = false;

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -219,6 +219,7 @@ import {
     disconnect,
     initializeSerialBackend,
     reinitializeConnection,
+    shouldConcludeRebootDialog,
 } from "../../src/js/serial_backend";
 import DeviceHandler from "../../src/js/device_handler";
 import CONFIGURATOR from "../../src/js/data_storage";
@@ -766,5 +767,85 @@ describe("serial_backend reinitializeConnection — virtualMode reboot path", ()
         } finally {
             vi.useRealTimers();
         }
+    });
+});
+
+describe("shouldConcludeRebootDialog", () => {
+    // Baseline: mid-reboot, nothing yet signals completion.
+    const base = {
+        connectionValid: false,
+        timeoutReached: false,
+        autoConnect: false,
+        portAvailable: false,
+        selectedDevice: "/dev/ttyACM0",
+        rebootWindowOpen: true,
+    };
+
+    it("concludes as soon as the FC answers, regardless of everything else", () => {
+        expect(shouldConcludeRebootDialog({ ...base, connectionValid: true })).toBe(true);
+        // Even with Auto-Connect on and the window still open.
+        expect(
+            shouldConcludeRebootDialog({
+                ...base,
+                connectionValid: true,
+                autoConnect: true,
+                selectedDevice: "bluetooth_1",
+            }),
+        ).toBe(true);
+    });
+
+    it("concludes when the reboot window has timed out", () => {
+        expect(shouldConcludeRebootDialog({ ...base, timeoutReached: true })).toBe(true);
+        expect(shouldConcludeRebootDialog({ ...base, timeoutReached: true, autoConnect: true })).toBe(true);
+    });
+
+    it("keeps waiting while Auto-Connect is on (the retry loop owns the reconnect)", () => {
+        // Serial, port already back — still wait, auto-connect will reconnect.
+        expect(shouldConcludeRebootDialog({ ...base, autoConnect: true, portAvailable: true })).toBe(false);
+        // BLE, window closed — still wait, auto-connect will reconnect.
+        expect(
+            shouldConcludeRebootDialog({
+                ...base,
+                autoConnect: true,
+                selectedDevice: "bluetooth_1",
+                rebootWindowOpen: false,
+            }),
+        ).toBe(false);
+    });
+
+    describe("Auto-Connect off", () => {
+        it("serial: waits for the port to re-enumerate, then concludes", () => {
+            expect(shouldConcludeRebootDialog({ ...base, portAvailable: false })).toBe(false);
+            expect(shouldConcludeRebootDialog({ ...base, portAvailable: true })).toBe(true);
+        });
+
+        it("BLE: waits for the reboot window to close (flush drops the stale link first)", () => {
+            // portAvailable never flips for BLE — must not gate on it.
+            expect(shouldConcludeRebootDialog({ ...base, selectedDevice: "bluetooth_1", rebootWindowOpen: true })).toBe(
+                false,
+            );
+            expect(
+                shouldConcludeRebootDialog({ ...base, selectedDevice: "bluetooth_1", rebootWindowOpen: false }),
+            ).toBe(true);
+            // Android BLE path id.
+            expect(
+                shouldConcludeRebootDialog({ ...base, selectedDevice: "bluetooth-AA:BB", rebootWindowOpen: false }),
+            ).toBe(true);
+        });
+
+        it("manual/TCP: waits for the reboot window to close", () => {
+            expect(shouldConcludeRebootDialog({ ...base, selectedDevice: "manual", rebootWindowOpen: true })).toBe(
+                false,
+            );
+            expect(shouldConcludeRebootDialog({ ...base, selectedDevice: "manual", rebootWindowOpen: false })).toBe(
+                true,
+            );
+        });
+
+        it("serial ignores the reboot-window flag (only re-enumeration concludes it)", () => {
+            // A closed window must NOT conclude a serial reboot on its own — serial owns its
+            // own conclusion via portAvailable, so this stays false until the port is back.
+            expect(shouldConcludeRebootDialog({ ...base, portAvailable: false, rebootWindowOpen: false })).toBe(false);
+        });
     });
 });


### PR DESCRIPTION
## Summary

Fixes the reboot progress dialog hanging for the full reboot window when rebooting a **BLE** or **manual/TCP** target with **Auto-Connect off**.

The dialog's poller ended early on:
```js
const noSerialReconnect = !PortHandler.portPicker.autoConnect && PortHandler.portAvailable;
if (CONFIGURATOR.connectionValid || connectionCheckTimeoutReached || noSerialReconnect) { ... }
```
`PortHandler.portAvailable` only tracks **serial** ports (set in the `"serial"` branch of `updateDeviceList`). For a BLE-only or manual/TCP target it never flips true, so `noSerialReconnect` stayed false and the dialog waited out the entire reboot window (up to 20 s for driven targets) — even though `rebootReconnect()` had already concluded the reboot when Auto-Connect was off.

## Fix

Extract the poller decision into an exported pure predicate `shouldConcludeRebootDialog(...)` (mirroring the existing `isDrivenRebootTarget` helper) and handle each transport by how it signals reboot completion:

| Case | Completion signal | Behaviour |
|------|-------------------|-----------|
| FC answered (`connectionValid`) / window timed out | — | conclude (unchanged) |
| Auto-Connect **on** | — | keep waiting; the retry loop owns the reconnect (unchanged) |
| Auto-Connect off, **serial** | port re-enumerates → `portAvailable` | wait for it (unchanged) |
| Auto-Connect off, **driven** (BLE, manual/TCP) | reboot window closes | **fixed** — was hanging until timeout |

### Why "wait for the window to close" and not "conclude immediately"

Concluding the driven case on the first poll tick (~100 ms) introduces a race. `rebootReconnect()`'s flush timer fires at `REBOOT_FLUSH_DELAY_MS` (~1.5 s) and does two things **in order**:
1. `disconnectForReboot()` — drops the stale BLE/manual link that survived the reboot,
2. `concludeReboot(false)` — closes the reboot window.

If the dialog showed "ready" and closed at ~100 ms, a user could manually reconnect in the ~1.5 s before the flush, and the pending `disconnectForReboot()` would tear their fresh connection back down.

Gating driven targets on `!getConnectionState().isRebootWindowOpen` makes the dialog conclude only **after** the flush has dropped the stale link and closed the window — no race, and the dialog still closes ~18 s sooner than before for the 20 s driven window.

## Scope / safety

- **Serial and Auto-Connect-on paths are provably unchanged**: for a serial path `isDrivenRebootTarget()` is `false`, so the condition still reduces to `portAvailable`; with Auto-Connect on the predicate returns `false` (retry loop keeps running). The `connectionValid` / timeout conclusions are preserved regardless of transport.
- `virtual` never reaches `showRebootDialog()` (it returns early in `reinitializeConnection`) and DFU (`usb_*`) has no MSP link to reboot, so BLE + manual is the complete, correct scope — consistent with `isDrivenRebootTarget`'s existing meaning.

## Test plan
- [x] New truth-table unit test for `shouldConcludeRebootDialog` (serial / BLE / manual × Auto-Connect on/off × window open/closed).
- [x] `npm run test` — full suite passes.
- [x] `npm run lint` — clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the reboot progress dialog so it stops polling and closes promptly when Auto-Connect is disabled, including for BLE and driven reboot targets.
  * Improved reboot completion detection to end polling based on reboot-window status and the relevant connectivity condition for the selected transport (instead of waiting for timeout).
  * Prevented the dialog from lingering longer than necessary when the device does not re-enumerate during reboot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->