### PR TITLE
Stop exposing Android signing secrets to pull_request_target builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,20 +14,22 @@ on:
         required: false
         type: boolean
 # 📌 2. DEFINE SECRETS THE WORKFLOW ACCEPTS
+#    Only consumed by release builds (debug_build == false). Debug builds run
+#    untrusted PR code and must never receive these, so they are optional.
     secrets:
       RELEASE_KEYSTORE:
         description: 'Base64 encoded keystore file.'
-        required: true
+        required: false
       RELEASE_KEYSTORE_PASSWORD:
         description: 'Keystore password.'
-        required: true
+        required: false
       # Add all other signing secrets here...
       RELEASE_KEY_ALIAS:
         description: 'Key alias.'
-        required: true
+        required: false
       RELEASE_KEY_ALIAS_PASSWORD:
         description: 'Key alias password.'
-        required: true
+        required: false
 # 🌟 3. DEFINE OUTPUTS THE WORKFLOW PRODUCES
     outputs:
       apk_url:
@@ -40,6 +42,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # Runs untrusted PR code on pull_request_target; keep the token read-only.
+    permissions:
+      contents: read
 
     # 🌟 Define the outputs for the entire job
     outputs:
@@ -80,7 +86,19 @@ jobs:
           java-version: '21'
           cache: gradle
 
+      # Debug builds run untrusted PR code (this checkout is the PR head), so
+      # the release signing secrets are never referenced here. The APK is
+      # signed with the Android debug keystore, which is enough for test installs.
+      - name: Build debug APK
+        if: ${{ inputs.debug_build }}
+        run: |
+          pushd android >/dev/null
+          ./gradlew clean
+          ./gradlew assembleDebug
+          popd >/dev/null
+
       - name: Build and Sign Android APK
+        if: ${{ !inputs.debug_build }}
         env:
           RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
@@ -115,11 +133,13 @@ jobs:
             echo "--- DEBUG MODE ---"
             SHA=$(echo ${{ github.event.pull_request.head.sha }} | head -c 8)
             apk_name=betaflight-app-$VERSION-$SHA.apk
+            apk_path=android/app/build/outputs/apk/debug/app-debug.apk
           else
             echo "--- RELEASE MODE ---"
             apk_name=betaflight-app-$VERSION.apk
+            apk_path=android/app/build/outputs/apk/release/app-release.apk
           fi
-          cp android/app/build/outputs/apk/release/app-release.apk artifacts/$apk_name
+          cp "$apk_path" artifacts/$apk_name
           echo "apk_name=$apk_name" >> $GITHUB_OUTPUT
 
       - name: Upload APK as Artifact

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,19 +30,17 @@ jobs:
           # Set a simple output to confirm the value
           echo "EVENT: ${{ github.event_name }}, COMMIT_REF=$COMMIT_REF"
 
-  # Build the code (minimal secrets here)
+  # Preview builds only. This runs on pull_request_target and checks out
+  # untrusted PR code, so it is always a debug build and is never passed the
+  # release signing secrets. Signed release APKs are produced by
+  # build-release.yml (release) and manual-build.yml (workflow_dispatch).
   build:
     name: Build
     needs: commit_reference
     uses: ./.github/workflows/build.yml
     with:
-      debug_build: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request' }}
+      debug_build: true
       commit_ref: ${{ needs.commit_reference.outputs.COMMIT_REF }}
-    secrets:
-      RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
-      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-      RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
 
   # Prepare branch name for deployment
   prepare_branch:


### PR DESCRIPTION
`deploy.yml` runs on `pull_request_target` and calls the reusable `build.yml` with `commit_ref` set to the PR head SHA, so it checks out and executes untrusted fork code (`npm ci` lifecycle scripts, `npm run build`, `capacitor.config.generator.mjs`, `./gradlew`). That job was also handed the `RELEASE_KEYSTORE`, `RELEASE_KEYSTORE_PASSWORD`, `RELEASE_KEY_ALIAS` and `RELEASE_KEY_ALIAS_PASSWORD` secrets, meaning any fork PR could exfiltrate the Android release signing key and passwords (the org fork-PR policy only gates first-time contributors).

Preview builds are previews, so they don't need the release key. `deploy.yml` now always sets `debug_build: true` and no longer passes any signing secrets. In `build.yml` the release-signing step is gated on `debug_build == false`; debug builds instead run `assembleDebug` (Android debug keystore, fine for test installs), the signing secrets are now optional, and the build job token is pinned to `contents: read`. Signed release APKs are unchanged: they still come from `build-release.yml` (release published) and `manual-build.yml` (workflow_dispatch).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for generating unsigned debug APKs without release signing credentials.
  - Release APK builds continue to use signing credentials when applicable.

- **Bug Fixes**
  - Preview builds now consistently produce the correct debug APK artifact.
  - Improved build security by restricting workflow access to read-only repository contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->