### PR TITLE
Add explicit permissions blocks for read-default GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -13,9 +13,6 @@ jobs:
   close-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Code Checkout
-        uses: actions/checkout@v5
-
       - name: autoclose
         shell: bash
         if: github.head_ref == 'master'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -41,6 +41,8 @@ jobs:
       RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
 
   modern_release:
+    permissions:
+      contents: write
     name: Attach Release Artifacts
     needs: modern_build
     runs-on: ubuntu-latest

--- a/.github/workflows/hide-artifact-links.yml
+++ b/.github/workflows/hide-artifact-links.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [synchronize, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   hide-artifacts-link-comments:
     name: Hide artifact links

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -5,6 +5,10 @@ on:
   schedule:
   - cron: "30 4 * * *"
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     name: 'Check and close stale issues'

--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -7,6 +7,10 @@ on:
 
 
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   crowdin-translations-to-pr:
     name: Create a PR with the latest translations from Crowdin


### PR DESCRIPTION
The org default GITHUB_TOKEN permission is now read. Adds explicit permissions blocks so these keep the write access they rely on: stale.yaml (label/close), hide-artifact-links.yml (hide PR comments), translations-pr.yml (push branch and open PR), and build-release.yml (upload the APK, scoped to the modern_release job). Also drops an unused actions/checkout from auto-close.yml, which only runs gh pr close.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved automation reliability by explicitly configuring permissions for release publishing, pull request management, issue maintenance, artifact-link handling, and translation updates.
  - Simplified pull request auto-closing automation by removing an unnecessary checkout step.
  - These updates help automated repository maintenance and release workflows operate consistently with the required access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->