### PR TITLE
fix(logging): stop dataflash Erase / Save and Erase dialog hanging forever

### DIFF
--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -620,14 +620,28 @@ export default defineComponent({
         }
 
         async function flashErase() {
-            connectionStore.pauseLiveData();
-            // Await the drain: clearMspQueue() resolves callbacks_cleanup() asynchronously, so
-            // firing it unawaited would wipe the pollForEraseCompletion callback we register just
-            // below (the erase send is non-errorAware and cleanup drops it silently) — leaving the
-            // dialog stuck forever even though the FC does erase. Drain first, then register.
-            await connectionStore.clearMspQueue();
-            isErasing.value = true;
-            MSP.send_message(MSPCodes.MSP_DATAFLASH_ERASE, false, false, pollForEraseCompletion);
+            try {
+                connectionStore.pauseLiveData();
+                // Await the drain: clearMspQueue() resolves callbacks_cleanup() asynchronously, so
+                // firing it unawaited would wipe the pollForEraseCompletion callback we register just
+                // below (the erase send is non-errorAware and cleanup drops it silently) — leaving the
+                // dialog stuck forever even though the FC does erase. Drain first, then register.
+                await connectionStore.clearMspQueue();
+                isErasing.value = true;
+                MSP.send_message(MSPCodes.MSP_DATAFLASH_ERASE, false, false, pollForEraseCompletion);
+            } catch (error) {
+                // Startup failed before the erase poll could take over: restore the UI and
+                // live-data pump so the dialog doesn't strand, and surface the failure.
+                console.error("Failed to start dataflash erase", error);
+                isErasing.value = false;
+                eraseOpen.value = false;
+                connectionStore.resumeLiveData();
+                gui_log(
+                    `<strong><span class="message-negative">${i18n.getMessage("error", {
+                        errorMessage: error,
+                    })}</span></strong>`,
+                );
+            }
         }
 
         function flashEraseCancel() {
@@ -648,7 +662,13 @@ export default defineComponent({
                 // keep polling rather than abandon the dialog on a single missed summary.
                 await MSP.promise(MSPCodes.MSP_DATAFLASH_SUMMARY);
             } catch {
-                // Ignore transient timeouts/cancellations and re-poll below.
+                // Summary timed out/cancelled (flash unresponsive mid-erase). Re-poll without
+                // reading the stale cached ready flag — it still holds the pre-erase value and
+                // would otherwise close the dialog before the erase has actually finished.
+                if (connectionStore.connectionValid && !eraseCancelled.value) {
+                    setTimeout(pollForEraseCompletion, 500);
+                }
+                return;
             }
 
             if (!connectionStore.connectionValid || eraseCancelled.value) {

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -217,8 +217,10 @@
                                         href="#"
                                         @click.prevent="flashSaveBegin(false)"
                                     >
-                                        <span>{{ $t("dataflashButtonSaveFile") }}</span>
-                                        <HelpIcon :text="$t('dataflashSaveFileDepreciationHint')" />
+                                        <span class="inline-flex items-center gap-1">
+                                            <span>{{ $t("dataflashButtonSaveFile") }}</span>
+                                            <HelpIcon :text="$t('dataflashSaveFileDepreciationHint')" />
+                                        </span>
                                     </a>
                                     <p v-html="$t('dataflashSavetoFileNote')"></p>
                                 </div>

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -617,9 +617,13 @@ export default defineComponent({
             eraseOpen.value = true;
         }
 
-        function flashErase() {
+        async function flashErase() {
             connectionStore.pauseLiveData();
-            connectionStore.clearMspQueue();
+            // Await the drain: clearMspQueue() resolves callbacks_cleanup() asynchronously, so
+            // firing it unawaited would wipe the pollForEraseCompletion callback we register just
+            // below (the erase send is non-errorAware and cleanup drops it silently) — leaving the
+            // dialog stuck forever even though the FC does erase. Drain first, then register.
+            await connectionStore.clearMspQueue();
             isErasing.value = true;
             MSP.send_message(MSPCodes.MSP_DATAFLASH_ERASE, false, false, pollForEraseCompletion);
         }
@@ -631,24 +635,37 @@ export default defineComponent({
             connectionStore.resumeLiveData();
         }
 
-        function pollForEraseCompletion() {
-            flashUpdateSummary(() => {
-                if (connectionStore.connectionValid && !eraseCancelled.value) {
-                    if (fcStore.dataflash?.ready) {
-                        isErasing.value = false;
-                        eraseOpen.value = false;
-                        connectionStore.resumeLiveData();
-                        if (getConfig("showNotifications").showNotifications) {
-                            NotificationManager.showNotification("Betaflight App", {
-                                body: i18n.getMessage("flashEraseDoneNotification"),
-                                icon: "/images/pwa/favicon.ico",
-                            });
-                        }
-                    } else {
-                        setTimeout(pollForEraseCompletion, 500);
-                    }
+        async function pollForEraseCompletion() {
+            if (!connectionStore.connectionValid || eraseCancelled.value) {
+                return;
+            }
+
+            try {
+                // errorAware request so a timeout settles instead of stranding a legacy
+                // callback: the flash chip can stop answering MSP mid-erase, and we must
+                // keep polling rather than abandon the dialog on a single missed summary.
+                await MSP.promise(MSPCodes.MSP_DATAFLASH_SUMMARY);
+            } catch {
+                // Ignore transient timeouts/cancellations and re-poll below.
+            }
+
+            if (!connectionStore.connectionValid || eraseCancelled.value) {
+                return;
+            }
+
+            if (fcStore.dataflash?.ready) {
+                isErasing.value = false;
+                eraseOpen.value = false;
+                connectionStore.resumeLiveData();
+                if (getConfig("showNotifications").showNotifications) {
+                    NotificationManager.showNotification("Betaflight App", {
+                        body: i18n.getMessage("flashEraseDoneNotification"),
+                        icon: "/images/pwa/favicon.ico",
+                    });
                 }
-            });
+            } else {
+                setTimeout(pollForEraseCompletion, 500);
+            }
         }
 
         function flashUpdateSummary(onDone) {
@@ -670,7 +687,7 @@ export default defineComponent({
             saveOpen.value = false;
         }
 
-        function markSavingDialogDone(startTime, totalBytes, totalBytesCompressed) {
+        function logSaveStats(startTime, totalBytes, totalBytesCompressed) {
             const totalTime = (Date.now() - startTime) / 1000;
             console.log(
                 `Received ${totalBytes} bytes in ${totalTime.toFixed(2)}s (${(totalBytes / totalTime / 1024).toFixed(
@@ -686,13 +703,25 @@ export default defineComponent({
                 );
             }
 
-            saveDone.value = true;
-
             if (getConfig("showNotifications").showNotifications) {
                 NotificationManager.showNotification("Betaflight App", {
                     body: i18n.getMessage("flashDownloadDoneNotification"),
                     icon: "/images/pwa/favicon.ico",
                 });
+            }
+        }
+
+        function completeSave(startTime, nextAddress, totalBytesCompressed, maxBytes, alsoErase) {
+            logSaveStats(startTime, nextAddress, totalBytesCompressed);
+
+            if (alsoErase && !saveCancelled.value) {
+                // Save-and-erase: skip the "Save completed, press OK" confirmation and flow
+                // straight into the erase, which shows its own progress dialog. The extra OK
+                // step only made sense for the plain save-to-file flow.
+                dismissSavingDialog();
+                conditionallyEraseFlash(maxBytes, nextAddress);
+            } else {
+                saveDone.value = true;
             }
         }
 
@@ -702,6 +731,7 @@ export default defineComponent({
 
         function conditionallyEraseFlash(maxBytes, nextAddress) {
             if (Number.isFinite(maxBytes) && nextAddress >= maxBytes) {
+                connectionStore.pauseLiveData();
                 eraseCancelled.value = false;
                 isErasing.value = true;
                 eraseOpen.value = true;
@@ -768,19 +798,24 @@ export default defineComponent({
                                     totalBytesCompressed += bytesCompressed;
                                 }
 
-                                saveProgress.value = (nextAddress / maxBytes) * 100;
+                                // Clamp: the final chunk can push nextAddress past the
+                                // reported usedSize, and UProgress rejects value > max (100).
+                                saveProgress.value = Math.min((nextAddress / maxBytes) * 100, 100);
 
                                 const blob = new Blob([chunkDataView]);
                                 FileSystem.writeChunck(openedFile, blob).then(() => {
                                     if (saveCancelled.value || nextAddress >= maxBytes) {
+                                        FileSystem.closeFile(openedFile);
                                         if (saveCancelled.value) {
                                             dismissSavingDialog();
                                         } else {
-                                            markSavingDialogDone(startTime, nextAddress, totalBytesCompressed);
-                                        }
-                                        FileSystem.closeFile(openedFile);
-                                        if (!saveCancelled.value && alsoErase) {
-                                            conditionallyEraseFlash(maxBytes, nextAddress);
+                                            completeSave(
+                                                startTime,
+                                                nextAddress,
+                                                totalBytesCompressed,
+                                                maxBytes,
+                                                alsoErase,
+                                            );
                                         }
                                         return;
                                     }
@@ -794,11 +829,8 @@ export default defineComponent({
                                 });
                             } else {
                                 // Zero-byte block = end of file
-                                markSavingDialogDone(startTime, nextAddress, totalBytesCompressed);
                                 FileSystem.closeFile(openedFile);
-                                if (!saveCancelled.value && alsoErase) {
-                                    conditionallyEraseFlash(maxBytes, nextAddress);
-                                }
+                                completeSave(startTime, nextAddress, totalBytesCompressed, maxBytes, alsoErase);
                             }
                         } else {
                             // Error - retry

--- a/src/composables/useDataflashPull.js
+++ b/src/composables/useDataflashPull.js
@@ -22,6 +22,14 @@ export function useDataflashPull() {
         () => !!GUI.connected_to && connectionStore.connectionValid && (FC.DATAFLASH?.usedSize || 0) > 0,
     );
 
+    /**
+     * Pull the onboard dataflash log into memory.
+     *
+     * @returns {Promise<Uint8Array>} Resolves with the downloaded log bytes.
+     * @throws {Error} If not connected or the flight controller holds no log data.
+     * @throws {MspTimeoutError|MspCancelledError|MspCrcError} If the underlying MSP
+     *   summary/read flow fails (e.g. timeout, disconnect or queue drain).
+     */
     async function pull() {
         if (!GUI.connected_to) {
             throw new Error("Not connected to a flight controller");
@@ -29,11 +37,6 @@ export function useDataflashPull() {
 
         pulling.value = true;
         progress.value = 0;
-        connectionStore.pauseLiveData();
-        // Await the drain before the first MSP request: clearMspQueue() runs callbacks_cleanup()
-        // asynchronously, which would otherwise reject the MSP_DATAFLASH_SUMMARY promise we await
-        // just below (it settles errorAware entries with MspCancelledError) and abort the pull.
-        await connectionStore.clearMspQueue();
 
         const cleanup = () => {
             pulling.value = false;
@@ -41,6 +44,12 @@ export function useDataflashPull() {
         };
 
         try {
+            connectionStore.pauseLiveData();
+            // Await the drain before the first MSP request: clearMspQueue() runs callbacks_cleanup()
+            // asynchronously, which would otherwise reject the MSP_DATAFLASH_SUMMARY promise we await
+            // just below (it settles errorAware entries with MspCancelledError) and abort the pull.
+            await connectionStore.clearMspQueue();
+
             // Refresh the occupied size before reading.
             await MSP.promise(MSPCodes.MSP_DATAFLASH_SUMMARY);
             const maxBytes = FC.DATAFLASH?.usedSize || 0;

--- a/src/composables/useDataflashPull.js
+++ b/src/composables/useDataflashPull.js
@@ -30,7 +30,10 @@ export function useDataflashPull() {
         pulling.value = true;
         progress.value = 0;
         connectionStore.pauseLiveData();
-        connectionStore.clearMspQueue();
+        // Await the drain before the first MSP request: clearMspQueue() runs callbacks_cleanup()
+        // asynchronously, which would otherwise reject the MSP_DATAFLASH_SUMMARY promise we await
+        // just below (it settles errorAware entries with MspCancelledError) and abort the pull.
+        await connectionStore.clearMspQueue();
 
         const cleanup = () => {
             pulling.value = false;


### PR DESCRIPTION
## Summary

Fixes the onboard-logging dataflash **Erase** and **Save and Erase** actions hanging on their progress dialog (reported on 2026.6 RC2). The flash was actually erased on the FC, but the Configurator dialog never closed and could not be dismissed, forcing a physical disconnect.

## Root cause

`flashErase()` called `connectionStore.clearMspQueue()` **without awaiting it**. `clearMspQueue()` runs `MSP.callbacks_cleanup()` on a later microtask, which wiped the `pollForEraseCompletion` callback that the `MSP_DATAFLASH_ERASE` send registered one line later. Because the erase message is non-`errorAware`, cleanup dropped its callback *silently* — so the FC erased the flash but the poll that closes the dialog never ran.

## Changes

- **`flashErase()`**: `await clearMspQueue()` before registering the poll callback, so the drain can't wipe it.
- **`pollForEraseCompletion()`**: use the `errorAware` `MSP.promise` with `try/catch` so a summary request that times out while the flash chip is unresponsive mid-erase keeps polling instead of stranding the dialog.
- **Save and Erase**: pause live data before the post-save erase, and flow straight into the erase without the stray "Save completed, press OK" confirmation step (the file-picker still lets you abort before anything is written).
- Clamp save progress to `<= 100` to silence the `UProgress` `value > max` console warning.
- **`useDataflashPull.pull()`**: `await clearMspQueue()` before the first `MSP.promise` so cleanup can't reject the opening summary request (same race).
- Keep the **Save flash to file** button's label and help icon on one line (the `HelpIcon` block-level root was wrapping onto its own line inside the button).

## Testing

- Verified on hardware (Air65-class FC with onboard flash):
  - **Erase** completes and the dialog closes automatically.
  - **Save and Erase** saves the log, then erases and closes without requiring a confirmation click.
  - Cancelling on the file picker aborts cleanly.
- Confirmed the `Save flash to file` button renders label + help icon on a single line.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved flash erase reliability by ensuring pending communication is fully cleared before erase starts.
  * Reduced race conditions during erase completion checks with a more robust polling flow and safer transient failure handling.
  * Streamlined log save completion so the saving dialog closes correctly, including zero-byte cases, and reliably triggers flash erase when requested.
  * Clamped download progress to a maximum of 100% to prevent over-reporting.
* **UI Improvements**
  * Refined the save-file option layout so the save label and deprecation hint align cleanly in a single row.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->