### PR TITLE
fix(ci): grant deploy job permissions for reusable Cloudflare workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,6 +67,10 @@ jobs:
   deploy:
     name: Deploy
     needs: [build, prepare_branch]
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
     uses: ./.github/workflows/deploy_cloudflare.yml
     with:
       branch_name: ${{ needs.prepare_branch.outputs.branch_name }}


### PR DESCRIPTION
### Problem

The deployment workflow failed validation:

> Invalid workflow file: `.github/workflows/deploy.yml#L67`
> The nested job 'deploy' is requesting 'actions: read, deployments: write', but is only allowed 'actions: none, deployments: none'.

### Cause

A reusable workflow can only use the permissions granted by the **calling job** — it cannot escalate beyond its caller. The `deploy` job in `deploy.yml` calls the reusable `deploy_cloudflare.yml`, which declares `actions: read` and `deployments: write`. Because the calling `deploy` job had no `permissions` block, it inherited the repo's restrictive default (`actions: none, deployments: none`), which capped the callee's requested permissions to `none` and failed validation.

### Fix

Add a `permissions` block to the calling `deploy` job matching what the callee declares (`actions: read`, `contents: read`, `deployments: write`).

Other jobs are unaffected: `pr_comment` already sets its own permissions, and the remaining jobs keep the repo default.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment permissions to support deployment operations while maintaining read-only access to repository and workflow data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->