### PR TITLE
Autopilot PID debug: label debug[6] as F Term

### DIFF
--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -1123,7 +1123,7 @@ export function getDebugFieldNames(apiVersion) {
             "debug[3]": "I Term [dbg-axis] * 10",
             "debug[4]": "D Term [dbg-axis] * 10",
             "debug[5]": "A Term [dbg-axis] * 10",
-            "debug[6]": "PID Sum [dbg-axis] * 10",
+            "debug[6]": "F Term [dbg-axis] * 10",
             "debug[7]": "Status Flags [dbg-axis]",
         };
 


### PR DESCRIPTION
Firmware now logs the position-hold feedforward term in AUTOPILOT_PID slot 6 instead of the PID sum (the sum is derivable and still logged in AUTOPILOT_STOP), so the P/I/D/A/F terms all read individually. This relabels debug[6] to match.

Lockstep with betaflight/betaflight#15435.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the debug field label for API versions 1.48 and later to display “F Term [dbg-axis] * 10” instead of the previous, incorrect label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->