### PR TITLE
Update autopilot pid f term debug

### DIFF
--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -1123,7 +1123,7 @@ export function getDebugFieldNames(apiVersion) {
             "debug[3]": "I Term [dbg-axis] * 10",
             "debug[4]": "D Term [dbg-axis] * 10",
             "debug[5]": "A Term [dbg-axis] * 10",
-            "debug[6]": "PID Sum [dbg-axis] * 10",
+            "debug[6]": "F Term [dbg-axis] * 10",
             "debug[7]": "Status Flags [dbg-axis]",
         };
 


### PR DESCRIPTION
- keep in sync with https://github.com/betaflight/betaflight-configurator/pull/5295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the debug channel label for newer API versions to accurately identify the “F Term” value instead of “PID Sum.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->