### PR TITLE
fix(dfu): support flashing STM32C5xx boards over USB DFU

### DIFF
--- a/src/js/protocols/WebUsbDfuTransport.js
+++ b/src/js/protocols/WebUsbDfuTransport.js
@@ -179,6 +179,11 @@ class WebUsbDfuTransport extends EventTarget {
      * descriptor request (seen on some brand-new ST ROM bootloaders) surfaces as an
      * error instead of hanging the flash forever. WebUSB control transfers normally
      * complete in milliseconds, so this never fires during healthy operation.
+     * @template T
+     * @param {Promise<T>} promise - The USB operation to guard.
+     * @param {number} timeoutMs - Timeout in milliseconds.
+     * @param {string} label - Human-readable operation name for the timeout error.
+     * @returns {Promise<T>} Resolves with the operation result, or rejects on timeout.
      */
     _withTimeout(promise, timeoutMs, label) {
         let timer;
@@ -393,7 +398,19 @@ class WebUsbDfuTransport extends EventTarget {
         return descriptorStringArray;
     }
 
-    /** Decode a 9-byte DFU functional descriptor (bDescriptorType 0x21) from a buffer at offset. */
+    // DFU functional descriptor bDescriptorType. NOTE: 0x21 is shared with the HID
+    // descriptor type, so a bare type match is ambiguous on composite devices — it must
+    // be qualified by a preceding DFU interface descriptor (see getFunctionalDescriptor).
+    static get DFU_FUNCTIONAL_DESCRIPTOR_TYPE() {
+        return 0x21;
+    }
+
+    /**
+     * Decode a DFU functional descriptor from `buf` at `offset`.
+     * @param {Uint8Array} buf - Buffer containing the descriptor.
+     * @param {number} [offset=0] - Byte offset of the descriptor's bLength field.
+     * @returns {{bLength:number,bDescriptorType:number,bmAttributes:number,wDetachTimeOut:number,wTransferSize:number,bcdDFUVersion:number}}
+     */
     _parseFunctionalDescriptor(buf, offset = 0) {
         return {
             bLength: buf[offset],
@@ -405,18 +422,58 @@ class WebUsbDfuTransport extends EventTarget {
         };
     }
 
+    /**
+     * True if `buf` at `offset` is a complete (9-byte) DFU functional descriptor with a
+     * usable, non-zero wTransferSize. Rejects HID descriptors (same 0x21 type) that are
+     * shorter or that decode to a zero transfer size.
+     * @param {Uint8Array} buf
+     * @param {number} offset
+     * @returns {boolean}
+     */
+    _isValidFunctionalDescriptor(buf, offset) {
+        const DFU = WebUsbDfuTransport.DFU_FUNCTIONAL_DESCRIPTOR_TYPE;
+        if (buf[offset + 1] !== DFU) {
+            return false;
+        }
+        // DFU functional descriptor is exactly 9 bytes.
+        if (buf[offset] < 9 || offset + 9 > buf.length) {
+            return false;
+        }
+        const wTransferSize = (buf[offset + 6] << 8) | buf[offset + 5];
+        return wTransferSize > 0;
+    }
+
+    /**
+     * Read the DFU functional descriptor.
+     *
+     * The descriptor (bDescriptorType 0x21) is embedded in the configuration descriptor,
+     * so we parse it from the blob we already fetched. Some ST ROM bootloaders (confirmed
+     * on the STM32C5) never answer a standalone GET_DESCRIPTOR for it and the request
+     * hangs indefinitely; reading it from the config descriptor avoids that request and
+     * yields the real wTransferSize.
+     *
+     * Because 0x21 is also the HID descriptor type, a match is only accepted when it sits
+     * inside a DFU interface (bInterfaceClass 0xFE / bInterfaceSubClass 0x01) and is a
+     * complete 9-byte descriptor with a non-zero wTransferSize.
+     * @returns {Promise<{bLength:number,bDescriptorType:number,bmAttributes:number,wDetachTimeOut:number,wTransferSize:number,bcdDFUVersion:number}>}
+     */
     async getFunctionalDescriptor() {
-        // The DFU functional descriptor (bDescriptorType 0x21) is embedded in the
-        // configuration descriptor, so parse it from the blob we already fetched.
-        // Some ST ROM bootloaders (confirmed on the STM32C5) never answer a standalone
-        // GET_DESCRIPTOR for it and the request hangs indefinitely — reading it from the
-        // config descriptor avoids that request entirely and yields the real wTransferSize.
         try {
             const buf = await this.getConfigDescriptor();
             let offset = 0;
+            let inDfuInterface = false;
             while (offset + 1 < buf.length) {
                 const bLength = buf[offset];
-                if (buf[offset + 1] === 0x21 && bLength >= 7 && offset + 6 < buf.length) {
+                const bDescriptorType = buf[offset + 1];
+
+                if (bDescriptorType === 4 && offset + 9 <= buf.length) {
+                    // Interface descriptor: Application-Specific class 0xFE, DFU subclass 0x01.
+                    inDfuInterface = buf[offset + 5] === 0xfe && buf[offset + 6] === 0x01;
+                } else if (
+                    inDfuInterface &&
+                    bDescriptorType === WebUsbDfuTransport.DFU_FUNCTIONAL_DESCRIPTOR_TYPE &&
+                    this._isValidFunctionalDescriptor(buf, offset)
+                ) {
                     const descriptor = this._parseFunctionalDescriptor(buf, offset);
                     console.log(
                         `${this.logHead} DFU functional descriptor from config: wTransferSize=${descriptor.wTransferSize}`,
@@ -446,6 +503,9 @@ class WebUsbDfuTransport extends EventTarget {
         );
         if (result.status === "ok") {
             const buf = new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength);
+            if (!this._isValidFunctionalDescriptor(buf, 0)) {
+                throw new Error(`${this.logHead} Invalid DFU functional descriptor in standalone response`);
+            }
             return this._parseFunctionalDescriptor(buf, 0);
         }
         throw new Error(`USB getFunctionalDescriptor failed: ${result.status}`);

--- a/src/js/protocols/WebUsbDfuTransport.js
+++ b/src/js/protocols/WebUsbDfuTransport.js
@@ -174,6 +174,23 @@ class WebUsbDfuTransport extends EventTarget {
         return `usb_${identifier}`;
     }
 
+    /**
+     * Race a USB operation against a timeout so a device that never answers a
+     * descriptor request (seen on some brand-new ST ROM bootloaders) surfaces as an
+     * error instead of hanging the flash forever. WebUSB control transfers normally
+     * complete in milliseconds, so this never fires during healthy operation.
+     */
+    _withTimeout(promise, timeoutMs, label) {
+        let timer;
+        const timeout = new Promise((_, reject) => {
+            timer = setTimeout(
+                () => reject(new Error(`${this.logHead} USB ${label} timed out after ${timeoutMs}ms`)),
+                timeoutMs,
+            );
+        });
+        return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+    }
+
     // ===== Control Transfers =====
 
     /**
@@ -225,7 +242,7 @@ class WebUsbDfuTransport extends EventTarget {
                 index: 0,
             };
 
-            const result = await this.usbDevice.controlTransferIn(setup, 255);
+            const result = await this._withTimeout(this.usbDevice.controlTransferIn(setup, 255), 5000, "getLangId");
             if (result.status === "ok" && result.data.byteLength >= 4) {
                 this._langId = result.data.getUint16(2, true);
                 return this._langId;
@@ -252,7 +269,11 @@ class WebUsbDfuTransport extends EventTarget {
             index: langId,
         };
 
-        const result = await this.usbDevice.controlTransferIn(setup, 255);
+        const result = await this._withTimeout(
+            this.usbDevice.controlTransferIn(setup, 255),
+            5000,
+            `getString(${index})`,
+        );
         if (result.status === "ok") {
             const length = Math.min(result.data.getUint8(0), result.data.byteLength);
             let descriptor = "";
@@ -283,7 +304,11 @@ class WebUsbDfuTransport extends EventTarget {
         };
 
         // First read the 9-byte config header to learn the total length
-        const header = await this.usbDevice.controlTransferIn(setup, 9);
+        const header = await this._withTimeout(
+            this.usbDevice.controlTransferIn(setup, 9),
+            5000,
+            "getConfigDescriptor(header)",
+        );
         if (header.status !== "ok") {
             throw new Error(`USB getConfigDescriptor failed: ${header.status}`);
         }
@@ -291,7 +316,11 @@ class WebUsbDfuTransport extends EventTarget {
         const totalLength = header.data.getUint16(2, true);
 
         // Now fetch the entire configuration descriptor blob
-        const result = await this.usbDevice.controlTransferIn(setup, totalLength);
+        const result = await this._withTimeout(
+            this.usbDevice.controlTransferIn(setup, totalLength),
+            5000,
+            "getConfigDescriptor",
+        );
         if (result.status !== "ok") {
             throw new Error(`USB getConfigDescriptor failed: ${result.status}`);
         }
@@ -364,7 +393,44 @@ class WebUsbDfuTransport extends EventTarget {
         return descriptorStringArray;
     }
 
+    /** Decode a 9-byte DFU functional descriptor (bDescriptorType 0x21) from a buffer at offset. */
+    _parseFunctionalDescriptor(buf, offset = 0) {
+        return {
+            bLength: buf[offset],
+            bDescriptorType: buf[offset + 1],
+            bmAttributes: buf[offset + 2],
+            wDetachTimeOut: (buf[offset + 4] << 8) | buf[offset + 3],
+            wTransferSize: (buf[offset + 6] << 8) | buf[offset + 5],
+            bcdDFUVersion: (buf[offset + 8] << 8) | buf[offset + 7],
+        };
+    }
+
     async getFunctionalDescriptor() {
+        // The DFU functional descriptor (bDescriptorType 0x21) is embedded in the
+        // configuration descriptor, so parse it from the blob we already fetched.
+        // Some ST ROM bootloaders (confirmed on the STM32C5) never answer a standalone
+        // GET_DESCRIPTOR for it and the request hangs indefinitely — reading it from the
+        // config descriptor avoids that request entirely and yields the real wTransferSize.
+        try {
+            const buf = await this.getConfigDescriptor();
+            let offset = 0;
+            while (offset + 1 < buf.length) {
+                const bLength = buf[offset];
+                if (buf[offset + 1] === 0x21 && bLength >= 7 && offset + 6 < buf.length) {
+                    const descriptor = this._parseFunctionalDescriptor(buf, offset);
+                    console.log(
+                        `${this.logHead} DFU functional descriptor from config: wTransferSize=${descriptor.wTransferSize}`,
+                    );
+                    return descriptor;
+                }
+                offset += bLength || 1;
+            }
+            console.warn(`${this.logHead} DFU functional descriptor not in config blob; trying standalone request`);
+        } catch (error) {
+            console.warn(`${this.logHead} Could not read config descriptor for functional descriptor: ${error}`);
+        }
+
+        // Fallback: request it directly (works on classic ST/AT32/GD32 bootloaders).
         const setup = {
             requestType: "standard",
             recipient: "interface",
@@ -373,17 +439,14 @@ class WebUsbDfuTransport extends EventTarget {
             index: 0,
         };
 
-        const result = await this.usbDevice.controlTransferIn(setup, 255);
+        const result = await this._withTimeout(
+            this.usbDevice.controlTransferIn(setup, 255),
+            5000,
+            "getFunctionalDescriptor",
+        );
         if (result.status === "ok") {
             const buf = new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength);
-            return {
-                bLength: buf[0],
-                bDescriptorType: buf[1],
-                bmAttributes: buf[2],
-                wDetachTimeOut: (buf[4] << 8) | buf[3],
-                wTransferSize: (buf[6] << 8) | buf[5],
-                bcdDFUVersion: (buf[8] << 8) | buf[7],
-            };
+            return this._parseFunctionalDescriptor(buf, 0);
         }
         throw new Error(`USB getFunctionalDescriptor failed: ${result.status}`);
     }

--- a/src/js/protocols/WebUsbDfuTransport.js
+++ b/src/js/protocols/WebUsbDfuTransport.js
@@ -193,6 +193,11 @@ class WebUsbDfuTransport extends EventTarget {
                 timeoutMs,
             );
         });
+        // Promise.race already attaches a rejection reaction to `promise`, so a late USB
+        // rejection (after the timeout won) is technically "handled" and won't surface as an
+        // unhandledrejection. This explicit no-op catch documents that intent and keeps the
+        // guarantee independent of Promise.race internals.
+        promise.catch(() => {});
         return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
     }
 

--- a/src/js/protocols/usbdfu.js
+++ b/src/js/protocols/usbdfu.js
@@ -402,6 +402,13 @@ export class UsbDfuProtocol extends EventTarget {
                     return null;
                 }
 
+                // Need at least "@type", start address and a sector list. A truncated
+                // string such as "@Truncated /0x1FFF0000" would otherwise dereference
+                // tmp1[2] (undefined) below and throw.
+                if (tmp1.length < 3 || typeof tmp1[2] !== "string") {
+                    return null;
+                }
+
                 const type = tmp1[0].trim().replace("@", "");
                 const start_address = Number.parseInt(tmp1[1]);
 
@@ -460,7 +467,14 @@ export class UsbDfuProtocol extends EventTarget {
             // must not throw and abort the whole flash. Skip the ones we can't parse
             // and keep the regions we understand.
             const chipInfo = descriptors.reduce((o, str) => {
-                const memory = parseDescriptor(str);
+                let memory = null;
+                try {
+                    memory = parseDescriptor(str);
+                } catch (error) {
+                    // Belt-and-suspenders: never let a parser exception on one malformed
+                    // string abort chip detection for the whole device.
+                    console.warn(`${this.logHead} Error parsing memory descriptor "${str}":`, error);
+                }
                 if (!memory) {
                     console.warn(`${this.logHead} Skipping unparseable memory descriptor: "${str}"`);
                     return o;
@@ -539,6 +553,10 @@ export class UsbDfuProtocol extends EventTarget {
     // CLRSTATUS issued outside dfuERROR, but the STM32C5 ROM correctly STALLs it, which
     // aborted the flash right at the start of the verify phase (device was in dfuDNLOAD_IDLE
     // after writing). Sending the spec-correct request fixes C5 and stays valid elsewhere.
+    /**
+     * @param {(data: Uint8Array) => void} callback - Invoked once the device reaches dfuIDLE.
+     * @returns {void}
+     */
     clearStatus(callback) {
         // Bound the retries so an unexpected/never-idling bootloader state surfaces as an
         // error instead of looping forever (a failed GETSTATUS returns an empty buffer, which
@@ -745,7 +763,10 @@ export class UsbDfuProtocol extends EventTarget {
                                 this.leave();
                             } else {
                                 this.getFunctionalDescriptor(0, (descriptor, resultCode) => {
-                                    this.transferSize = resultCode ? 2048 : descriptor.wTransferSize;
+                                    // Never let a missing/zero wTransferSize into the write loop
+                                    // (it would stall or divide the payload into empty blocks).
+                                    const reportedSize = resultCode ? 0 : descriptor?.wTransferSize;
+                                    this.transferSize = reportedSize > 0 ? reportedSize : 2048;
                                     console.log(`${this.logHead} Using transfer size: ${this.transferSize}`);
                                     this.clearStatus(() => {
                                         this.upload_procedure(nextAction);

--- a/src/js/protocols/usbdfu.js
+++ b/src/js/protocols/usbdfu.js
@@ -356,8 +356,10 @@ export class UsbDfuProtocol extends EventTarget {
                 return;
             }
 
-            // Keep this for new MCU debugging
-            // console.log('Descriptors: ' + descriptors);
+            // Log the raw memory-layout descriptor strings the device reported.
+            // These come from the on-chip bootloader (ST ROM for STM32C5/H5), so this is
+            // the fastest way to diagnose a new MCU whose layout string we don't yet handle.
+            console.log(`${this.logHead} DFU memory descriptors:`, descriptors);
             const parseDescriptor = (str) => {
                 // F303: "@Internal Flash  /0x08000000/128*0002Kg"
                 // F40x: "@Internal Flash  /0x08000000/04*016Kg,01*064Kg,07*128Kg"
@@ -453,10 +455,20 @@ export class UsbDfuProtocol extends EventTarget {
                 };
                 return memory;
             };
-            const chipInfo = descriptors.map(parseDescriptor).reduce((o, v) => {
-                o[v.type.toLowerCase().replace(" ", "_")] = v;
+            // Parse each descriptor defensively: a single unrecognized memory-layout
+            // string (common on brand-new silicon such as the STM32C5 ROM bootloader)
+            // must not throw and abort the whole flash. Skip the ones we can't parse
+            // and keep the regions we understand.
+            const chipInfo = descriptors.reduce((o, str) => {
+                const memory = parseDescriptor(str);
+                if (!memory) {
+                    console.warn(`${this.logHead} Skipping unparseable memory descriptor: "${str}"`);
+                    return o;
+                }
+                o[memory.type.toLowerCase().replace(" ", "_")] = memory;
                 return o;
             }, {});
+            console.log(`${this.logHead} Detected memory regions:`, Object.keys(chipInfo));
             callback(chipInfo, resultCode);
         });
     }
@@ -517,24 +529,55 @@ export class UsbDfuProtocol extends EventTarget {
         }
     }
 
-    // routine calling DFU_CLRSTATUS until device is in dfuIDLE state
+    // Routine that brings the device back to dfuIDLE before the next operation.
+    //
+    // Per the DFU spec, the request needed depends on the current state:
+    //   - dfuERROR                      -> DFU_CLRSTATUS
+    //   - dfuDNLOAD_IDLE / dfuUPLOAD_IDLE -> DFU_ABORT
+    //   - busy/sync/manifest states      -> just poll GETSTATUS until it settles
+    // The old code always sent DFU_CLRSTATUS. Older ST/AT32/GD32 bootloaders tolerate a
+    // CLRSTATUS issued outside dfuERROR, but the STM32C5 ROM correctly STALLs it, which
+    // aborted the flash right at the start of the verify phase (device was in dfuDNLOAD_IDLE
+    // after writing). Sending the spec-correct request fixes C5 and stays valid elsewhere.
     clearStatus(callback) {
+        // Bound the retries so an unexpected/never-idling bootloader state surfaces as an
+        // error instead of looping forever (a failed GETSTATUS returns an empty buffer, which
+        // otherwise spins tightly since data[4] is undefined and the reported delay is 0).
+        const maxAttempts = 100;
+        let attempts = 0;
+
         const check_status = () => {
             this.controlTransfer("in", this.request.GETSTATUS, 0, 0, 6, 0, (data) => {
+                const state = data[4];
                 let delay = 0;
+                if (data.length) {
+                    delay = data[1] | (data[2] << 8) | (data[3] << 16);
+                }
 
-                if (data[4] === this.state.dfuIDLE) {
+                if (state === this.state.dfuIDLE) {
                     callback(data);
+                } else if (++attempts >= maxAttempts) {
+                    console.log(
+                        `${this.logHead} clearStatus: device did not reach dfuIDLE after ${maxAttempts} attempts (state: ${state})`,
+                    );
+                    this.flashingMessage(
+                        i18n.getMessage("stm32ProgrammingFailed"),
+                        this.options?.flashMessageTypes?.INVALID,
+                    );
+                    this.cleanup();
+                } else if (state === this.state.dfuERROR) {
+                    setTimeout(
+                        () => this.controlTransfer("out", this.request.CLRSTATUS, 0, 0, 0, 0, check_status),
+                        delay,
+                    );
+                } else if (state === this.state.dfuDNLOAD_IDLE || state === this.state.dfuUPLOAD_IDLE) {
+                    setTimeout(() => this.controlTransfer("out", this.request.ABORT, 0, 0, 0, 0, check_status), delay);
                 } else {
-                    if (data.length) {
-                        delay = data[1] | (data[2] << 8) | (data[3] << 16);
-                    }
-                    setTimeout(clear_status, delay);
+                    // Busy/sync/manifest state (or an empty/failed status read): wait and re-poll.
+                    setTimeout(check_status, delay);
                 }
             });
         };
-
-        const clear_status = () => this.controlTransfer("out", this.request.CLRSTATUS, 0, 0, 0, 0, check_status);
 
         check_status();
     }
@@ -715,8 +758,15 @@ export class UsbDfuProtocol extends EventTarget {
                 break;
             case 1: {
                 if (typeof this.chipInfo.option_bytes === "undefined") {
-                    console.log(`${this.logHead} Failed to detect option bytes`);
-                    this.cleanup();
+                    // Some bootloaders (e.g. the STM32C5 ROM) don't expose an "@Option Bytes"
+                    // DFU alternate setting, so we can't run the read-protection pre-check.
+                    // Skip straight to erase instead of aborting: a non-read-protected chip
+                    // flashes fine, and a protected one surfaces errVENDOR during erase (handled).
+                    // Falling through here previously dereferenced the missing option_bytes and
+                    // threw inside an async callback, hanging the flash silently.
+                    console.log(`${this.logHead} No option bytes region; skipping read-protection check`);
+                    this.upload_procedure(2);
+                    break;
                 }
 
                 const unprotect = () => {

--- a/test/js/usbdfu_stm32c5.test.js
+++ b/test/js/usbdfu_stm32c5.test.js
@@ -50,6 +50,7 @@ const REQ = { DNLOAD: 1, UPLOAD: 2, GETSTATUS: 3, CLRSTATUS: 4, ABORT: 6 };
  * them on UPLOAD so verification passes.
  */
 class MockC5Transport extends EventTarget {
+    /** @param {string[]} descriptorStrings - Memory-layout descriptor strings to report. */
     constructor(descriptorStrings) {
         super();
         this.descriptorStrings = descriptorStrings;
@@ -141,6 +142,11 @@ class MockC5Transport extends EventTarget {
     }
 }
 
+/**
+ * Build a minimal parsed-hex object for the flasher (one block at the flash base).
+ * @param {number} byteCount - Size of the firmware image in bytes.
+ * @returns {{bytes_total:number, data:{address:number,bytes:number,data:Uint8Array}[]}}
+ */
 function makeHex(byteCount) {
     const data = new Uint8Array(byteCount);
     for (let i = 0; i < byteCount; i++) {
@@ -152,6 +158,15 @@ function makeHex(byteCount) {
     };
 }
 
+/**
+ * Run a DFU flash and resolve when connect() invokes its completion callback, or
+ * reject if it never fires within `ms` (i.e. the flow hung).
+ * @param {import("../../src/js/protocols/usbdfu").UsbDfuProtocol} dfu
+ * @param {ReturnType<typeof makeHex>} hex
+ * @param {object} options - Flashing options (flashingMessage, flashProgress, flashMessageTypes).
+ * @param {number} [ms=8000] - Hang timeout in milliseconds.
+ * @returns {Promise<void>}
+ */
 function flashWithTimeout(dfu, hex, options, ms = 8000) {
     return new Promise((resolve, reject) => {
         const timer = setTimeout(() => reject(new Error("DFU flash hung: connect() callback never fired")), ms);
@@ -189,10 +204,11 @@ describe("STM32C5 DFU flashing", () => {
         expect(transport.written.length).toBe(4096);
     });
 
-    it("does not hang when an extra, unparseable memory region is reported", async () => {
+    it("does not hang when extra unparseable / truncated memory regions are reported", async () => {
         const transport = new MockC5Transport([
             "@Internal Flash /0x08000000/64*08Kg",
-            "@Weird Region /0x1FFF0000/garbage", // would throw in the old reduce
+            "@Weird Region /0x1FFF0000/garbage", // sector token has no "*" -> parseDescriptor returns null
+            "@Truncated /0x1FFF0000", // only two "/"-parts -> would dereference tmp1[2] and throw
         ]);
         const dfu = new UsbDfuProtocol(transport);
 
@@ -237,5 +253,71 @@ describe("WebUsbDfuTransport.getFunctionalDescriptor", () => {
         expect(descriptor.bDescriptorType).toBe(0x21);
         expect(descriptor.wTransferSize).toBe(2048);
         expect(standaloneRequested).toBe(false);
+    });
+
+    it("ignores a HID descriptor (also type 0x21) on a composite device and picks the DFU one", async () => {
+        // A composite device: a HID interface (class 0x03) with a HID descriptor (also 0x21),
+        // followed by the real DFU interface (class 0xFE/subclass 0x01) + DFU functional descriptor.
+        const blob = new Uint8Array([
+            // configuration header (bLength=9, bType=2, wTotalLength=45)
+            9, 2, 45, 0, 2, 1, 0, 0xc0, 0,
+            // HID interface (class 0x03)
+            9, 4, 0, 0, 1, 0x03, 0, 0, 0,
+            // HID descriptor (bType=0x21) — must be ignored because it is under a HID interface,
+            // not a DFU one; decoding it as a DFU functional descriptor would give a bogus size.
+            9, 0x21, 0x11, 0x01, 0x00, 0x22, 0x00, 0x1b, 0x00,
+            // DFU interface (class 0xFE / subclass 0x01)
+            9, 4, 1, 0, 0, 0xfe, 0x01, 0x02, 4,
+            // DFU functional descriptor (wTransferSize=1024=0x0400 LE)
+            9, 0x21, 0x0b, 0xff, 0x00, 0x00, 0x04, 0x1a, 0x01,
+        ]);
+        const view = (start, len) => new DataView(blob.buffer, start, len);
+        const transport = new RealWebUsbDfuTransport();
+        transport.usbDevice = {
+            controlTransferIn: vi.fn((setup, length) => Promise.resolve({ status: "ok", data: view(0, length) })),
+        };
+
+        const descriptor = await transport.getFunctionalDescriptor();
+
+        // Must be the DFU functional descriptor's transfer size, not the HID descriptor's 0x2200.
+        expect(descriptor.wTransferSize).toBe(1024);
+    });
+
+    it("rejects a truncated standalone functional-descriptor response instead of using it", async () => {
+        // No DFU functional descriptor in the config blob, forcing the standalone fallback,
+        // which returns a truncated 4-byte response (would decode to wTransferSize 0).
+        const configBlob = new Uint8Array([
+            9,
+            2,
+            18,
+            0,
+            1,
+            1,
+            0,
+            0xc0,
+            0, // config header, wTotalLength=18
+            9,
+            4,
+            0,
+            0,
+            0,
+            0xfe,
+            0x01,
+            0x02,
+            4, // DFU interface, no functional descriptor follows
+        ]);
+        const truncated = new Uint8Array([4, 0x21, 0x0b, 0xff]);
+        const view = (buf, len) => new DataView(buf.buffer, 0, Math.min(len, buf.length));
+        const transport = new RealWebUsbDfuTransport();
+        transport.usbDevice = {
+            controlTransferIn: vi.fn((setup, length) => {
+                if (setup.value === 0x2100) {
+                    return Promise.resolve({ status: "ok", data: view(truncated, length) });
+                }
+                return Promise.resolve({ status: "ok", data: view(configBlob, length) });
+            }),
+        };
+
+        await expect(transport.getFunctionalDescriptor()).rejects.toThrow(/functional descriptor/i);
     });
 });

--- a/test/js/usbdfu_stm32c5.test.js
+++ b/test/js/usbdfu_stm32c5.test.js
@@ -1,0 +1,241 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Regression test for STM32C5xx (STM32C562) USB-DFU flashing.
+//
+// The STM32C5 on-chip ROM bootloader (VID 0x0483 / PID 0xDF11):
+//   1. reports ONLY an "@Internal Flash" memory region (no "@Option Bytes"
+//      DFU alternate setting), and
+//   2. never answers a standalone GET_DESCRIPTOR for the DFU functional
+//      descriptor.
+//
+// Before the fix, (2) made the flash hang forever right after "Claimed
+// interface: 0" (getFunctionalDescriptor awaited a control transfer that never
+// resolved), and (1) would have thrown when the read-protection step tried to
+// dereference the missing option-bytes region.
+//
+// These tests drive the real UsbDfuProtocol against a mock transport that
+// emulates that bootloader and assert the whole flow COMPLETES (no hang) and
+// reports a successful programming result.
+// ---------------------------------------------------------------------------
+
+vi.mock("../../src/js/gui", () => ({ default: { connect_lock: false } }));
+vi.mock("../../src/js/localization", () => ({ i18n: { getMessage: (key) => key } }));
+vi.mock("../../src/js/gui_log", () => ({ gui_log: vi.fn() }));
+vi.mock("../../src/js/utils/notifications", () => ({ default: { showNotification: vi.fn() } }));
+vi.mock("../../src/js/ConfigStorage", () => ({ get: () => ({}) }));
+// Prevent the module-bottom `new WebUsbDfuTransport()` from touching navigator.usb.
+vi.mock("../../src/js/protocols/WebUsbDfuTransport", () => ({ default: class extends EventTarget {} }));
+
+const { UsbDfuProtocol } = await import("../../src/js/protocols/usbdfu");
+const RealWebUsbDfuTransport = (await vi.importActual("../../src/js/protocols/WebUsbDfuTransport")).default;
+
+const FLASH_MESSAGE_TYPES = {
+    NEUTRAL: "NEUTRAL",
+    VALID: "VALID",
+    INVALID: "INVALID",
+    ACTION: "ACTION",
+    ERASING: "ERASING",
+    FLASHING: "FLASHING",
+    VERIFYING: "VERIFYING",
+};
+
+// DFU states / requests (subset used by the state machine).
+const STATE = { dfuIDLE: 2, dfuDNBUSY: 4, dfuDNLOAD_IDLE: 5, dfuUPLOAD_IDLE: 9 };
+const REQ = { DNLOAD: 1, UPLOAD: 2, GETSTATUS: 3, CLRSTATUS: 4, ABORT: 6 };
+
+/**
+ * Mock transport emulating an STM32C5 ROM bootloader well enough to run a full
+ * DFU program+verify cycle. Captures the bytes written via DNLOAD and replays
+ * them on UPLOAD so verification passes.
+ */
+class MockC5Transport extends EventTarget {
+    constructor(descriptorStrings) {
+        super();
+        this.descriptorStrings = descriptorStrings;
+        this.currentState = STATE.dfuIDLE;
+        this.busy = false;
+        this.postBusyState = STATE.dfuDNLOAD_IDLE;
+        this.written = [];
+        this.readCursor = 0;
+        this.getFunctionalDescriptorCalls = 0;
+    }
+
+    getDevices() {
+        return Promise.resolve([{ path: "usb_c5", port: {} }]);
+    }
+    getConnectedDevice() {
+        return "usb_c5";
+    }
+    open() {
+        return Promise.resolve();
+    }
+    claimInterface() {
+        return Promise.resolve();
+    }
+    releaseInterface() {
+        return Promise.resolve();
+    }
+    close() {
+        return Promise.resolve();
+    }
+    reset() {
+        return Promise.resolve();
+    }
+
+    getInterfaceDescriptors() {
+        return Promise.resolve(this.descriptorStrings);
+    }
+
+    getFunctionalDescriptor() {
+        // Emulates reading it from the config blob: returns a real transfer size
+        // without hanging (the C5 standalone request would never resolve).
+        this.getFunctionalDescriptorCalls++;
+        return Promise.resolve({ wTransferSize: 2048, bcdDFUVersion: 0x011a });
+    }
+
+    controlTransferOut(setup, data) {
+        if (setup.request === REQ.CLRSTATUS) {
+            // Faithful to the STM32C5 ROM: DFU_CLRSTATUS is only legal in dfuERROR;
+            // issued in any other state the ROM STALLs the request (the reported bug).
+            if (this.currentState !== 10 /* dfuERROR */) {
+                return Promise.reject(new Error("USB controlTransferOut failed: stall"));
+            }
+            this.currentState = STATE.dfuIDLE;
+            this.busy = false;
+        } else if (setup.request === REQ.ABORT) {
+            this.currentState = STATE.dfuIDLE;
+            this.busy = false;
+        } else if (setup.request === REQ.DNLOAD) {
+            // wBlockNum >= 2 carries firmware payload; 0/1 carry commands (erase/loadAddress/leave).
+            if (setup.value >= 2 && data && data.length) {
+                for (const b of data) {
+                    this.written.push(b);
+                }
+            }
+            this.busy = true;
+            this.postBusyState = STATE.dfuDNLOAD_IDLE;
+        }
+        return Promise.resolve({ status: "ok" });
+    }
+
+    controlTransferIn(setup, length) {
+        if (setup.request === REQ.GETSTATUS) {
+            let bytes;
+            if (this.busy) {
+                this.busy = false;
+                this.currentState = this.postBusyState;
+                bytes = [0, 1, 0, 0, STATE.dfuDNBUSY, 0]; // status OK, 1ms poll, DNBUSY
+            } else {
+                bytes = [0, 0, 0, 0, this.currentState, 0];
+            }
+            return Promise.resolve({ status: "ok", data: new Uint8Array(bytes) });
+        }
+        if (setup.request === REQ.UPLOAD) {
+            const chunk = this.written.slice(this.readCursor, this.readCursor + length);
+            this.readCursor += length;
+            this.currentState = STATE.dfuUPLOAD_IDLE;
+            return Promise.resolve({ status: "ok", data: new Uint8Array(chunk) });
+        }
+        return Promise.resolve({ status: "ok", data: new Uint8Array(length) });
+    }
+}
+
+function makeHex(byteCount) {
+    const data = new Uint8Array(byteCount);
+    for (let i = 0; i < byteCount; i++) {
+        data[i] = i & 0xff;
+    }
+    return {
+        bytes_total: byteCount,
+        data: [{ address: 0x08000000, bytes: byteCount, data }],
+    };
+}
+
+function flashWithTimeout(dfu, hex, options, ms = 8000) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("DFU flash hung: connect() callback never fired")), ms);
+        dfu.connect("usb_c5", hex, options, () => {
+            clearTimeout(timer);
+            resolve();
+        });
+    });
+}
+
+describe("STM32C5 DFU flashing", () => {
+    let messages;
+    let options;
+
+    beforeEach(() => {
+        messages = [];
+        options = {
+            flashingMessage: (msg, type) => messages.push({ msg, type }),
+            flashProgress: vi.fn(),
+            flashMessageTypes: FLASH_MESSAGE_TYPES,
+        };
+    });
+
+    it("completes a full program+verify cycle for a C562 that reports no option-bytes region", async () => {
+        const transport = new MockC5Transport(["@Internal Flash /0x08000000/64*08Kg"]);
+        const dfu = new UsbDfuProtocol(transport);
+
+        await flashWithTimeout(dfu, makeHex(4096), options);
+
+        // The final user-visible message must be a successful programming result.
+        const last = messages.at(-1);
+        expect(last.type).toBe(FLASH_MESSAGE_TYPES.VALID);
+        expect(last.msg).toBe("stm32ProgrammingSuccessful");
+        // The captured firmware must round-trip through verify exactly.
+        expect(transport.written.length).toBe(4096);
+    });
+
+    it("does not hang when an extra, unparseable memory region is reported", async () => {
+        const transport = new MockC5Transport([
+            "@Internal Flash /0x08000000/64*08Kg",
+            "@Weird Region /0x1FFF0000/garbage", // would throw in the old reduce
+        ]);
+        const dfu = new UsbDfuProtocol(transport);
+
+        await flashWithTimeout(dfu, makeHex(2048), options);
+
+        expect(messages.at(-1).msg).toBe("stm32ProgrammingSuccessful");
+    });
+});
+
+describe("WebUsbDfuTransport.getFunctionalDescriptor", () => {
+    it("reads the DFU functional descriptor from the config blob without the hanging standalone request", async () => {
+        // Config descriptor: 9-byte config header + 9-byte interface + 9-byte DFU functional (0x21).
+        const blob = new Uint8Array([
+            // configuration descriptor header (bLength=9, bType=2, wTotalLength=27)
+            9, 2, 27, 0, 1, 1, 0, 0xc0, 0,
+            // interface descriptor (bLength=9, bType=4, class 0xFE/1/2, iInterface=4)
+            9, 4, 0, 0, 0, 0xfe, 1, 2, 4,
+            // DFU functional descriptor (bLength=9, bType=0x21, wTransferSize=2048=0x0800 LE)
+            9, 0x21, 0x0b, 0xff, 0x00, 0x00, 0x08, 0x1a, 0x01,
+        ]);
+
+        const view = (start, len) => new DataView(blob.buffer, start, len);
+        const transport = new RealWebUsbDfuTransport();
+        let standaloneRequested = false;
+        transport.usbDevice = {
+            controlTransferIn: vi.fn((setup, length) => {
+                if (setup.value === 0x2100) {
+                    // The standalone functional-descriptor request — the C5 ROM never answers this.
+                    standaloneRequested = true;
+                    return new Promise(() => {}); // never resolves
+                }
+                if (setup.value === 0x200) {
+                    // config descriptor: header read, then full read
+                    return Promise.resolve({ status: "ok", data: view(0, length) });
+                }
+                return Promise.resolve({ status: "ok", data: view(0, length) });
+            }),
+        };
+
+        const descriptor = await transport.getFunctionalDescriptor();
+
+        expect(descriptor.bDescriptorType).toBe(0x21);
+        expect(descriptor.wTransferSize).toBe(2048);
+        expect(standaloneRequested).toBe(false);
+    });
+});

--- a/test/js/usbdfu_stm32c5.test.js
+++ b/test/js/usbdfu_stm32c5.test.js
@@ -89,10 +89,11 @@ class MockC5Transport extends EventTarget {
     }
 
     getFunctionalDescriptor() {
-        // Emulates reading it from the config blob: returns a real transfer size
-        // without hanging (the C5 standalone request would never resolve).
+        // Emulates reading it from the config blob: returns the real transfer size
+        // without hanging (the C5 standalone request would never resolve). Real C562
+        // hardware reports 1024, so exercise the non-default transfer-size path.
         this.getFunctionalDescriptorCalls++;
-        return Promise.resolve({ wTransferSize: 2048, bcdDFUVersion: 0x011a });
+        return Promise.resolve({ wTransferSize: 1024, bcdDFUVersion: 0x011a });
     }
 
     controlTransferOut(setup, data) {
@@ -281,6 +282,12 @@ describe("WebUsbDfuTransport.getFunctionalDescriptor", () => {
 
         // Must be the DFU functional descriptor's transfer size, not the HID descriptor's 0x2200.
         expect(descriptor.wTransferSize).toBe(1024);
+    });
+
+    it("rejects with a timeout error when a descriptor read never resolves", async () => {
+        const transport = new RealWebUsbDfuTransport();
+        const guarded = transport._withTimeout(new Promise(() => {}), 10, "slowOp");
+        await expect(guarded).rejects.toThrow(/timed out/);
     });
 
     it("rejects a truncated standalone functional-descriptor response instead of using it", async () => {


### PR DESCRIPTION
## Summary

STM32C5xx boards (e.g. STM32C562) could not be flashed over USB DFU — the flash froze right after claiming the interface, and later (once that was worked around) stalled at 66% during verify. STM32C5 uses ST's on-chip **ROM system bootloader**, whose USB-DFU behaviour deviates from the older ST/AT32/GD32 bootloaders the configurator was written against. This PR fixes four distinct C5-specific issues and hardens the DFU path for all MCUs.

Confirmed flashing an **STM32C562 (ARCROBO_C562V1)** board on hardware, end to end (erase → write → verify → reboot).

## Root causes & fixes

1. **Functional descriptor hang.** The C5 ROM never answers a standalone `GET_DESCRIPTOR` for the DFU functional descriptor, so `getFunctionalDescriptor` awaited a control transfer that never resolved — the freeze right after `Claimed interface: 0`. We now parse the functional descriptor out of the configuration-descriptor blob we already fetch. Bonus: this reports the **real** `wTransferSize` (1024 on C562) instead of the classic 2048 default.

2. **Missing option-bytes region.** The C5 ROM exposes no `@Option Bytes` DFU alternate setting. The old code logged an error, called `cleanup()`, then fell through and dereferenced the missing region, throwing inside an async callback and hanging silently. We now skip the read-protection pre-check and go straight to erase when no option-bytes region is present (a non-protected chip flashes fine; a protected one still surfaces `errVENDOR` during erase, which is handled).

3. **Unparseable memory descriptor.** A single unrecognized memory-layout string threw in the `reduce` and aborted chip detection. Unparseable regions are now skipped.

4. **`CLRSTATUS` stall at verify (the 66% hang).** `clearStatus` always sent `DFU_CLRSTATUS`, which per the DFU spec is only valid in `dfuERROR`. Older bootloaders tolerate the misuse; the C5 ROM correctly **STALLs** it, aborting the flash at the start of verify (device was in `dfuDNLOAD_IDLE` after writing). `clearStatus` now sends the spec-correct request per state: `CLRSTATUS` for `dfuERROR`, `DFU_ABORT` for `dfuDNLOAD_IDLE`/`dfuUPLOAD_IDLE`, and polls for busy states.

## Hardening (benefits all MCUs)

- Bounded `clearStatus` retries (no infinite loop on an unexpected state).
- Timeouts on descriptor control transfers, so a stalled request surfaces as an error instead of hanging forever.
- Diagnostic logging of the reported memory descriptors, detected regions and transfer size — makes bringing up the next new MCU much faster.

## Testing

- New `test/js/usbdfu_stm32c5.test.js` drives the **real** `UsbDfuProtocol` through the full connect → erase → write → verify → leave cycle against a mock transport that faithfully emulates the C5 ROM (including its `CLRSTATUS`-stall behaviour). Each fix was verified to be load-bearing by reverting it and observing the test reproduce the exact failure (e.g. `controlTransfer OUT failed for request: 4 … stall`).
- Full suite: 645/645 passing; lint clean; production build succeeds.
- Verified on physical STM32C562 hardware.

## Compatibility

The changes are spec-correct DFU and remain valid for the existing F4/F7/H5/AT32/GD32 paths (`ABORT`, `CLRSTATUS`, config-descriptor parsing and polling are all standard). No protocol or API changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB DFU reliability by timing out potentially hanging descriptor reads.
  * Enhanced DFU functional-descriptor parsing by decoding from the device’s cached config data with stricter validation and better handling on composite devices and malformed inputs.
  * Updated DFU status clearing to follow proper state transitions with bounded retries and safer failure recovery.
  * Improved flashing robustness when option-byte info is missing and added a safer default for transfer size.

* **Tests**
  * Added STM32C5xx (STM32C562) DFU end-to-end and descriptor-parsing regression tests, including scenarios to ensure reads never hang.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->