### PR TITLE
fix(cli): keep enough scrollback for a full diff/dump (#5285)

### DIFF
--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -153,8 +153,14 @@ export function useCli() {
     let scrollNearBottomPx = 40; // fallback; updated dynamically via ResizeObserver
     let cliResizeObserver = null;
 
-    const MAX_OUTPUT_NODES = 4000; // ~4 nodes/line → ≈1000 rendered lines max
-    const PRUNE_TO_NODES = 2500;
+    // Cap DOM growth over long sessions, but keep enough visible scrollback to
+    // review a full `diff` + `dump` in one session. Each line is a few DOM nodes
+    // (highlight spans + <br>), so these caps hold several thousand lines — the
+    // old 4000-node cap (≈1000 lines) silently dropped the earliest output as
+    // soon as a dump exceeded it (#5285). The complete text is always kept in
+    // `outputHistory` for copy/save, independent of this DOM pruning.
+    const MAX_OUTPUT_NODES = 24000; // ≈6000 lines before a prune is triggered
+    const PRUNE_TO_NODES = 16000; // ≈4000 lines kept after a prune
 
     let outputBuffer = "";
     let outputFlushRaf = null;


### PR DESCRIPTION
The CLI output pane pruned to ~1000 rendered lines (MAX_OUTPUT_NODES=4000, ~4 nodes/line), deleting the earliest nodes from the DOM. A single dump — or a diff + dump in one session — exceeds that, so the beginning of the output became permanently unreachable by scrolling up.

Raise the prune caps to hold several thousand lines of visible scrollback (24000 nodes, prune to 16000), enough for a full diff/dump while still bounding DOM growth over very long sessions. The complete text was, and stays, retained in outputHistory for copy/save regardless of DOM pruning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Extended the amount of terminal output retained during long CLI sessions.
  * Reduced the frequency and impact of automatic output cleanup, preserving more historical content on screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->