### PR TITLE
fix(msp): disconnect with a dialog when the FC stops responding

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -650,6 +650,12 @@
     "connectionFailed": {
         "message": "<span class=\"message-negative\">Failed</span> to connect to the selected port. Check that the device is reachable and that the connection settings are correct, then try again."
     },
+    "connectionLostTitle": {
+        "message": "Connection lost"
+    },
+    "connectionLostUnresponsive": {
+        "message": "The flight controller <span class=\"message-negative\">stopped responding</span> and the connection was closed. Reconnect the board and try again; if the problem persists, power-cycle the flight controller."
+    },
     "serialPortClosedOk": {
         "message": "Serial port <span class=\"message-positive\">successfully</span> closed"
     },

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -56,6 +56,7 @@ const MSP = {
 
     callbacks: [],
     parked: new Map(), // errorAware requests parked behind an in-flight same-code request
+    onTimeout: null, // invoked with the code when an errorAware request exhausts MAX_RETRIES
     packet_error: 0,
     unsupported: 0,
 
@@ -580,16 +581,7 @@ const MSP = {
             console.warn(
                 `MSP: data request timed-out: ${obj.code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} QUEUE: ${this.callbacks.length} (${this.callbacks.map((e) => e.code)})`,
             );
-            serial.send(obj.requestBuffer, (_sendInfo) => {
-                obj.stop = performance.now();
-                const executionTime = Math.round(obj.stop - obj.start);
-                // We should probably give up connection if the request takes too long ?
-                if (executionTime > 5000) {
-                    console.warn(
-                        `MSP: data request took too long: ${obj.code} ID: ${serial.connectionId} TAB: ${GUI.active_tab} EXECUTION TIME: ${executionTime}ms`,
-                    );
-                }
-            });
+            serial.send(obj.requestBuffer);
             this._arm_timer(obj);
             return;
         }
@@ -612,6 +604,9 @@ const MSP = {
             console.error("MSP callback threw on timeout:", callbackError);
         }
         this._release_parked(obj.code);
+
+        // MAX_RETRIES sends produced no response: the link is unresponsive, not just slow.
+        this.onTimeout?.(obj.code);
     },
     _park(code, entry) {
         let queue = this.parked.get(code);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -37,6 +37,15 @@ const logHead = "[SERIAL-BACKEND]";
 let mspHelper;
 let connectionTimestamp = null;
 let liveDataRefreshTimerId = false;
+// Re-entrancy guard for the live-data poller. update_live_status is async and awaits a
+// sequential MSP chain; the setInterval that drives it fires on a fixed cadence regardless
+// of whether the previous cycle finished. On a slow-responding FC (e.g. STM32H5/C5) a cycle
+// can outlast the interval, so without this guard each tick would stack another full request
+// chain onto MSP.callbacks — the queue grows unbounded and the per-entry retries flood the
+// FC's serial buffer until it hangs. Skip a tick while the previous cycle is still in flight.
+// Set when MSP.onTimeout initiates teardown, so onClosed() raises the notice after the close
+// settles rather than having it clobbered by onClosed's own dialog dismissal.
+let connectionTimeoutPending = false;
 // Handle for the BLE/manual reboot flush-timeout / reconnect-retry chain (rebootReconnect).
 // Tracked so an intentional disconnect during the reboot window can cancel it — otherwise the
 // retry would resurrect a connection the user just cancelled.
@@ -686,6 +695,7 @@ function resetConnection() {
     getConnectionState().endFlashing();
 
     MSP.clearListeners();
+    MSP.onTimeout = null;
 
     if (DeviceHandler.devicePicker.selectedDevice !== "virtual") {
         serial.removeEventListener("receive", read_serial_adapter);
@@ -744,12 +754,12 @@ function abortConnection(messageKey) {
 
 // Surface a connection failure to the user with a dismissible dialog, not just a log line
 // that is easy to miss. `text` may contain HTML markup (InformationDialog renders it).
-function showConnectionFailedDialog(text) {
+function showConnectionFailedDialog(text, title = i18n.getMessage("connectionFailedTitle")) {
     const dialogStore = useDialogStore();
     dialogStore.open(
         "InformationDialog",
         {
-            title: i18n.getMessage("connectionFailedTitle"),
+            title,
             text,
             confirmText: i18n.getMessage("close"),
         },
@@ -818,6 +828,7 @@ function onOpen(openInfo) {
         FC.resetState();
         mspHelper = new MspHelper();
         MSP.listen(mspHelper.process_data.bind(mspHelper));
+        MSP.onTimeout = handleConnectionTimeout;
 
         console.log(`${logHead} Requesting configuration data`);
 
@@ -1230,6 +1241,17 @@ function onClosed(result) {
     // intentional and unexpected closes. A reboot's link drop is left alone
     // (notifyClosed ignores REBOOTING/RECONNECTING); its conclude settles it.
     getConnectionState().notifyClosed();
+
+    // Raise the dead-link notice now that teardown has settled: the dialog dismissal above
+    // (and finishClose's own) would otherwise clobber a dialog opened by the watchdog before
+    // this event fired.
+    if (connectionTimeoutPending) {
+        connectionTimeoutPending = false;
+        showConnectionFailedDialog(
+            i18n.getMessage("connectionLostUnresponsive"),
+            i18n.getMessage("connectionLostTitle"),
+        );
+    }
 }
 
 export function read_serial(info) {
@@ -1258,6 +1280,23 @@ async function requestLiveData(code, name) {
         console.error(`Failed to request ${name}:`, error);
         return true;
     }
+}
+
+// MSP.onTimeout hook: an errorAware request exhausted MAX_RETRIES, so the FC is unresponsive.
+// A hung FC keeps the transport physically open, so no "disconnect" event fires on its own.
+// Tear the link down like the reboot path: mark the disconnect intentional (so onClosed skips
+// the unexpected-disconnect teardown) and close WITHOUT the setArmingEnabled round-trip, which
+// would itself hang on the dead FC. Re-entrancy is bounded by the isConnected() gate — teardown
+// clears MSP.onTimeout and connection validity before another request can trip it.
+function handleConnectionTimeout() {
+    if (!isConnected()) {
+        return;
+    }
+
+    connectionTimeoutPending = true;
+    prepareDisconnect();
+    getConnectionState().concludeReboot(false);
+    finishClose(toggleStatus);
 }
 
 export async function update_sensor_status() {

--- a/test/js/msp_promise.test.js
+++ b/test/js/msp_promise.test.js
@@ -72,6 +72,23 @@ describe("MSP promise semantics", () => {
             await rejection;
             expect(MSP.callbacks).toHaveLength(0);
         });
+
+        it("invokes onTimeout with the code once retries are exhausted", async () => {
+            const onTimeout = vi.fn();
+            MSP.onTimeout = onTimeout;
+            try {
+                const rejection = expect(MSP.promise(EEPROM_WRITE_CODE)).rejects.toBeInstanceOf(MspTimeoutError);
+
+                await vi.advanceTimersByTimeAsync(MSP.TIMEOUT * (MSP.MAX_RETRIES - 1));
+                expect(onTimeout).not.toHaveBeenCalled(); // still retrying, not yet exhausted
+
+                await vi.advanceTimersByTimeAsync(MSP.TIMEOUT);
+                await rejection;
+                expect(onTimeout).toHaveBeenCalledExactlyOnceWith(EEPROM_WRITE_CODE);
+            } finally {
+                MSP.onTimeout = null;
+            }
+        });
     });
 
     describe("disconnect_cleanup", () => {

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -849,3 +849,50 @@ describe("shouldConcludeRebootDialog", () => {
         });
     });
 });
+
+describe("serial_backend MSP unresponsive-FC teardown", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        resetMocks();
+    });
+
+    it("registers MSP.onTimeout on connect and clears it on teardown", () => {
+        establishConnection();
+        expect(typeof MSP.onTimeout).toBe("function");
+
+        serialHandlers.disconnect({ detail: true }); // teardown -> resetConnection
+        expect(MSP.onTimeout).toBeNull();
+    });
+
+    it("drops the link and shows a dialog when a request exhausts its retries", () => {
+        establishConnection();
+        getConnectionState().setLinkOpen(true);
+        serial.disconnect.mockClear();
+        dialogStore.open.mockClear();
+
+        // Fire the hook MSP invokes after MAX_RETRIES with no response.
+        MSP.onTimeout(MSPCodes.MSP_ANALOG);
+
+        // Teardown initiated (finishClose -> serial.disconnect) without any MSP round-trip.
+        expect(serial.disconnect).toHaveBeenCalledTimes(1);
+
+        // The protocol "disconnect" event drives onClosed, which raises the notice only after
+        // the close settles (so it is not clobbered by onClosed's dialog dismissal).
+        serialHandlers.disconnect({ detail: true });
+        expect(dialogStore.open).toHaveBeenCalledWith(
+            "InformationDialog",
+            expect.objectContaining({ title: "connectionLostTitle", text: "connectionLostUnresponsive" }),
+            expect.anything(),
+        );
+    });
+
+    it("ignores the timeout hook when not connected", () => {
+        establishConnection();
+        getConnectionState().setLinkOpen(false);
+        serial.disconnect.mockClear();
+
+        MSP.onTimeout(MSPCodes.MSP_ANALOG);
+
+        expect(serial.disconnect).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

When a flight controller stops responding (e.g. it hangs while its USB/serial transport stays physically open), no `disconnect` event ever fires, so the background live-data poller kept retrying forever and the MSP queue grew unbounded — the app looked connected but was dead, with no feedback to the user.

## Changes

- **`msp.js`**: add an `onTimeout` hook, invoked when an `errorAware` request exhausts `MAX_RETRIES` (i.e. the FC produced no response after all retries).
- **`serial_backend.js`**: register the hook on connect / clear it on teardown. When it fires, tear the link down like the reboot path — mark the disconnect intentional (so `onClosed` doesn't double-tear-down) and close **without** the `setArmingEnabled` round-trip that would itself hang on a dead FC — then raise a "Connection lost" dialog from `onClosed` once teardown has settled (so it isn't clobbered by `onClosed`'s own dialog dismissal).
- **`messages.json`**: `connectionLostTitle` / `connectionLostUnresponsive` strings.

Builds on #5249 (which made `MSP.promise` reject on timeout/CRC/cancel); this consumes that signal to recover the session instead of spinning.

## Testing

- `msp_promise.test.js`: `onTimeout` fires exactly once with the code, only after retries are exhausted.
- `serial_backend.test.js`: hook registered on connect / cleared on teardown; firing it drops the link and shows the dialog; ignored when not connected.
- Full suite green.

## Notes

The FC-side root cause of the hang that motivated this (a NULL-deref in the firmware `sensor` CLI command) is fixed separately in betaflight/betaflight#15456. This change is the client-side complement: fail gracefully and tell the user rather than hang silently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer connection-loss notifications when the flight controller becomes unresponsive, including a friendly title and guidance to reconnect/try again, with power-cycling if it persists.

* **Bug Fixes**
  * Improved how unresponsive connections are torn down, ensuring timeout handling doesn’t affect later reconnections.
  * Ensured the unresponsive-flight-controller flow triggers the expected cleanup and user dialog only for an active connection, and that the timeout callback fires once after retries are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->