### PR TITLE
ci(build): allow fork PR checkout under pull_request_target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,6 +58,7 @@ jobs:
         with:
           ref: ${{ inputs.commit_ref }}
           persist-credentials: false  # Don't persist GitHub token
+          allow-unsafe-pr-checkout: true  # checkout@v5 fork-checkout gate; job is contents:read, no secrets
 
       - name: Cache node_modules
         uses: actions/cache@v4


### PR DESCRIPTION
AI Generated pull-request

Every fork PR's "Build / build" check under the "Deployment (PR and Push to master/maintenance)" workflow fails at the checkout step, regardless of what the PR changes. Observed on #5298.

`actions/checkout@v5` refuses to check out a fork PR head under `pull_request_target` unless `allow-unsafe-pr-checkout: true` is explicitly set on the checkout step:

```
Error: Refusing to check out fork pull request code from a 'pull_request_target' workflow. ... To opt in ... set 'allow-unsafe-pr-checkout: true' on the actions/checkout step.
```

#5281 already reduced this job to `contents: read`, `persist-credentials: false`, and no signing secrets in the debug-build path that `pull_request_target` always uses — specifically so it would be safe to check out and build untrusted fork code. That PR's description states this checkout was already intended to happen; the missing `allow-unsafe-pr-checkout` flag looks like an oversight, since without it the checkout is refused outright and every downstream step (npm ci, build, APK) is skipped.

This PR sets that flag on the one checkout step in `build.yml`, restoring the behavior #5281 intended.

## Why the Build check on this PR itself stays red

`pull_request_target` always executes the calling workflow (`deploy.yml`) from the base repository's `master`, not the PR branch. A reusable workflow referenced by local path (`uses: ./.github/workflows/build.yml`) resolves to that same caller ref, so `build.yml` is also read from `master` — not from this branch's fix. Confirmed in the run log for this PR:

```
Uses: betaflight/betaflight-configurator/.github/workflows/build.yml@refs/heads/master (6983a2799...)
...
allow-unsafe-pr-checkout: false
```

`commit_ref` correctly points at this PR's head commit, but the `build.yml` logic doing the checkout is still master's pre-fix copy. This is inherent to how `pull_request_target` resolves workflow code (the same protection this PR is working within), not a defect in the diff. The check can only be validated by merging to `master` and observing it pass on the next fork PR.

## Test plan
- [ ] After merge, confirm the "Build / build" check passes on the next fork PR opened against master
- [ ] Confirm no signing secrets are referenced/exposed in the resulting debug build logs
