### PR TITLE
fix(cli, sensors): dangling MspCancelledError on CLI exit and Sensors 3D model load

### DIFF
--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -164,8 +164,10 @@ export default defineComponent({
             }
             TABS.cli.read = cli.read;
             TABS.cli.cleanup = (callback) => {
-                cli.cleanup();
-                if (callback) {
+                // cli.cleanup() returns true when leaving the CLI reboots the FC; it has already
+                // released the tab-switch lock, so skip mounting the destination tab into the
+                // dying link — reconnect lands on lastTab instead.
+                if (!cli.cleanup() && callback) {
                     callback();
                 }
             };

--- a/src/components/tabs/CliTab.vue
+++ b/src/components/tabs/CliTab.vue
@@ -164,9 +164,8 @@ export default defineComponent({
             }
             TABS.cli.read = cli.read;
             TABS.cli.cleanup = (callback) => {
-                // cli.cleanup() returns true when leaving the CLI reboots the FC; it has already
-                // released the tab-switch lock, so skip mounting the destination tab into the
-                // dying link — reconnect lands on lastTab instead.
+                // cli.cleanup() true => CLI exit rebooted the FC; skip the destination mount
+                // (reconnect lands on lastTab). Only mount when not rebooting.
                 if (!cli.cleanup() && callback) {
                     callback();
                 }

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -2383,6 +2383,10 @@ const loadConfig = async () => {
         await MSP.promise(MSPCodes.MSP_BOARD_ALIGNMENT_CONFIG);
         await MSP.promise(MSPCodes.MSP_ACC_TRIM);
         await MSP.promise(MSPCodes.MSP2_SENSOR_CONFIG_ACTIVE);
+        // The 3D model picks its mesh from FC.MIXER_CONFIG.mixer. Nothing else on this tab (nor
+        // the connect handshake) loads it, so without this it stays at its reset value 0 and the
+        // model loader fetches a non-existent `undefined.gltf`. Load it before initModel().
+        await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
 
         if (isApi146.value) {
             await MSP.promise(MSPCodes.MSP_COMPASS_CONFIG);

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -2383,9 +2383,8 @@ const loadConfig = async () => {
         await MSP.promise(MSPCodes.MSP_BOARD_ALIGNMENT_CONFIG);
         await MSP.promise(MSPCodes.MSP_ACC_TRIM);
         await MSP.promise(MSPCodes.MSP2_SENSOR_CONFIG_ACTIVE);
-        // The 3D model picks its mesh from FC.MIXER_CONFIG.mixer. Nothing else on this tab (nor
-        // the connect handshake) loads it, so without this it stays at its reset value 0 and the
-        // model loader fetches a non-existent `undefined.gltf`. Load it before initModel().
+        // initModel() reads FC.MIXER_CONFIG.mixer; load it here (nothing else on this tab does),
+        // else mixer stays 0 and the loader fetches a non-existent `undefined.gltf`.
         await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
 
         if (isApi146.value) {

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -678,6 +678,11 @@ export function useCli() {
         );
     };
 
+    /**
+     * Tear down the CLI session. When leaving an active CLI reboots the FC, the caller must skip
+     * mounting the destination tab into the rebooting link.
+     * @returns {boolean} true when this cleanup initiated the CLI-exit reboot.
+     */
     const cleanup = () => {
         GUI.timeout_remove("CLI_send_slowly");
         GUI.timeout_remove("enter_cli");
@@ -720,16 +725,17 @@ export function useCli() {
         }
 
         // Leaving an active CLI session reboots the FC: `exit` drops CLI mode and
-        // reinitializeConnection() issues MSP_SET_REBOOT. The reboot tears the link down and the
-        // reconnect flow lands on lastTab once it is healthy. Release the tab-switch lock and
-        // report the reboot so the caller skips mounting the destination tab into the dying link
-        // (its MSP init would just be cancelled).
+        // reinitializeConnection() issues MSP_SET_REBOOT. Report the reboot so the caller skips
+        // mounting the destination tab into the dying link (its MSP init would just be cancelled).
+        // The tab-switch lock stays held across the reboot handoff — clearing it here would let a
+        // second tab click mount another connected tab into the still-alive link. The ensuing
+        // disconnect (prepareDisconnect on every reboot path) releases the lock and lands the
+        // reconnect on lastTab.
         const rebooting = CONFIGURATOR.connectionValid && CONFIGURATOR.cliValid && CONFIGURATOR.cliActive;
         if (rebooting) {
             send(getCliCommand("exit\r", cliBuffer), function () {
                 reinitializeConnection();
             });
-            GUI.tab_switch_in_progress = false;
         }
 
         CONFIGURATOR.cliActive = false;

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -719,16 +719,25 @@ export function useCli() {
             copyResetTimeout = null;
         }
 
-        if (CONFIGURATOR.connectionValid && CONFIGURATOR.cliValid && CONFIGURATOR.cliActive) {
+        // Leaving an active CLI session reboots the FC: `exit` drops CLI mode and
+        // reinitializeConnection() issues MSP_SET_REBOOT. The reboot tears the link down and the
+        // reconnect flow lands on lastTab once it is healthy. Release the tab-switch lock and
+        // report the reboot so the caller skips mounting the destination tab into the dying link
+        // (its MSP init would just be cancelled).
+        const rebooting = CONFIGURATOR.connectionValid && CONFIGURATOR.cliValid && CONFIGURATOR.cliActive;
+        if (rebooting) {
             send(getCliCommand("exit\r", cliBuffer), function () {
                 reinitializeConnection();
             });
+            GUI.tab_switch_in_progress = false;
         }
 
         CONFIGURATOR.cliActive = false;
         CONFIGURATOR.cliValid = false;
 
         CliAutoComplete.cleanup();
+
+        return rebooting;
     };
 
     const adaptPhones = () => {

--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -679,9 +679,8 @@ export function useCli() {
     };
 
     /**
-     * Tear down the CLI session. When leaving an active CLI reboots the FC, the caller must skip
-     * mounting the destination tab into the rebooting link.
-     * @returns {boolean} true when this cleanup initiated the CLI-exit reboot.
+     * Tear down the CLI session.
+     * @returns {boolean} true when leaving CLI initiated an FC reboot (`exit` + MSP_SET_REBOOT).
      */
     const cleanup = () => {
         GUI.timeout_remove("CLI_send_slowly");
@@ -724,13 +723,8 @@ export function useCli() {
             copyResetTimeout = null;
         }
 
-        // Leaving an active CLI session reboots the FC: `exit` drops CLI mode and
-        // reinitializeConnection() issues MSP_SET_REBOOT. Report the reboot so the caller skips
-        // mounting the destination tab into the dying link (its MSP init would just be cancelled).
-        // The tab-switch lock stays held across the reboot handoff — clearing it here would let a
-        // second tab click mount another connected tab into the still-alive link. The ensuing
-        // disconnect (prepareDisconnect on every reboot path) releases the lock and lands the
-        // reconnect on lastTab.
+        // `exit` + MSP_SET_REBOOT reboots the FC. Keep tab_switch_in_progress held across the
+        // handoff; prepareDisconnect (run on every reboot path) releases it after the disconnect.
         const rebooting = CONFIGURATOR.connectionValid && CONFIGURATOR.cliValid && CONFIGURATOR.cliActive;
         if (rebooting) {
             send(getCliCommand("exit\r", cliBuffer), function () {


### PR DESCRIPTION
## Summary

Fixes two bugs surfaced while connecting, opening the CLI tab, and switching to another tab:

1. **Dangling `MspCancelledError` on CLI exit** (`fix(cli)`)
2. **Sensors tab 3D model fetching `undefined.gltf`** (`fix(sensors)`)

Two independent root causes, one per commit.

## 1. Dangling `MspCancelledError` on CLI exit

Leaving an active CLI session reboots the FC (`exit` + `reinitializeConnection()`'s `MSP_SET_REBOOT`). The tab-switch machinery then **synchronously mounted the destination tab**, whose `initialize()` fired its MSP chain into the link that was already being torn down by the reboot. Those in-flight requests were cancelled by `callbacks_cleanup()` and surfaced as:

```
Error during Setup initialize sequence: MspCancelledError: MSP queue cleared
```

The mount was also redundant — clicking a tab from CLI records it as `lastTab`, and the reboot → reconnect flow re-lands there once the link is healthy.

**Fix:** `useCli.cleanup()` now reports when leaving the CLI reboots the FC and releases the tab-switch lock (needed for the BLE soft-reset path, which keeps the link and never disconnects). The CLI cleanup wrapper skips mounting the destination tab in that case, letting reconnect own the next tab.

## 2. Sensors tab 3D model — `undefined.gltf`

The Sensors tab builds the 3D model from `FC.MIXER_CONFIG.mixer` but never requested `MSP_MIXER_CONFIG` — and neither does the connect handshake (only the Setup tab loads it). On a fresh connect the mixer stayed at its reset value `0`, so `mixerList[0 - 1]` was `undefined` and the loader fetched a non-existent `undefined.gltf`; the dev server answered with `index.html` and the GLTF parse threw:

```
Error loading model: SyntaxError: Unexpected token '<', "<!doctype "... is not valid JSON
THREE.Object3D.add: object not an instance of THREE.Object3D. null
```

**Fix:** load `MSP_MIXER_CONFIG` in `loadConfig()` before `initModel()`, mirroring the Setup tab. The model now shows the correct aircraft mesh, not just a non-crashing one.

## Testing

- `npm run test` — related suites pass (`serial_backend`, `msp_promise`, `connection_store`, `gui_reboot_parity`, `cli_copy_autocomplete_race`).
- Lint clean.
- Needs a quick hardware sanity check of the CLI-exit → other-tab flow on **USB serial** (re-enumerates → landing → auto-connect → `lastTab`) and **BLE/manual** (driven reconnect via `rebootReconnect`, no disconnect event).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI session cleanup to send the proper exit command and reliably reinitialize when leaving an active CLI session.
  * Updated CLI cleanup flow so follow-up actions only occur when cleanup indicates it’s appropriate.
  * Ensured the Sensors tab fetches mixer configuration before initializing the 3D model, preventing incorrect/failed mesh loading.
  * Corrected post-reboot state handling to reduce tab-switching issues after a CLI reboot.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->