### PR TITLE
fix(pwa): skip service worker on Capacitor/Tauri builds

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -45,11 +45,11 @@
         "message": "You need to refresh the page to get the latest changes. Refreshing it now will reload the page and you will lose any unsaved changes and will abort any operation in progress.<br><br>Do you want to refresh it now? You can also dismiss this message and refresh the page manually later.",
         "description": "Text of the window that appears when the app needs to be refreshed to get the latest changes"
     },
-    "pwaOnOffilenReadyTitle": {
+    "pwaOnOfflineReadyTitle": {
         "message": "The application is ready to be used offline",
         "description": "Title of the window that appears when the app is ready to be installed and used offline"
     },
-    "pwaOnOffilenReadyText": {
+    "pwaOnOfflineReadyText": {
         "message": "You can install it as an standalone application on your device if you want. Search for the option in your browser address bar or menu.",
         "description": "Text of the window that appears when the app is ready to be installed and used offline"
     },

--- a/src/js/browserMain.js
+++ b/src/js/browserMain.js
@@ -12,11 +12,12 @@ import { i18n } from "./localization";
 import { pinia } from "./pinia_instance";
 import { useDialogStore } from "../stores/dialog";
 import { registerSW } from "virtual:pwa-register";
-import { isAndroid, isEmbeddedDeployment } from "./utils/checkCompatibility.js";
+import { isPwaContext } from "./utils/checkCompatibility.js";
 
-// Skip PWA/service-worker on embedded deployments (WebSocket-only host, plain HTTP)
-// and Android native builds where they are unnecessary
-if (!isAndroid() && !isEmbeddedDeployment()) {
+// The PWA service worker (and its offline-ready / update dialogs) is only
+// meaningful for the web/PWA build, so skip it on natively packaged shells
+// (Capacitor, Tauri) and embedded deployments.
+if (isPwaContext()) {
     const dialogStore = useDialogStore(pinia);
     const updateSW = registerSW({
         onNeedRefresh() {
@@ -43,8 +44,8 @@ if (!isAndroid() && !isEmbeddedDeployment()) {
             dialogStore.open(
                 "InformationDialog",
                 {
-                    title: i18n.getMessage("pwaOnOffilenReadyTitle"),
-                    text: i18n.getMessage("pwaOnOffilenReadyText"),
+                    title: i18n.getMessage("pwaOnOfflineReadyTitle"),
+                    text: i18n.getMessage("pwaOnOfflineReadyText"),
                     confirmText: i18n.getMessage("OK"),
                 },
                 { confirm: () => dialogStore.close() },

--- a/src/js/browserMain.js
+++ b/src/js/browserMain.js
@@ -14,9 +14,6 @@ import { useDialogStore } from "../stores/dialog";
 import { registerSW } from "virtual:pwa-register";
 import { isPwaContext } from "./utils/checkCompatibility.js";
 
-// The PWA service worker (and its offline-ready / update dialogs) is only
-// meaningful for the web/PWA build, so skip it on natively packaged shells
-// (Capacitor, Tauri) and embedded deployments.
 if (isPwaContext()) {
     const dialogStore = useDialogStore(pinia);
     const updateSW = registerSW({

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -1,7 +1,12 @@
 import { Capacitor } from "@capacitor/core";
 
-// Detects OS using modern userAgentData API with fallback to legacy platform
-// Returns standardized OS name string or "unknown"
+/**
+ * Detect the host OS using the modern userAgentData API with a fallback to the
+ * legacy navigator.platform / userAgent strings.
+ *
+ * @returns {string} Standardized OS name ("MacOS", "iOS", "Windows", "Android",
+ * "Linux", "ChromeOS") or "unknown".
+ */
 export function getOS() {
     let os = "unknown";
     const userAgent = globalThis.navigator.userAgent;
@@ -27,6 +32,9 @@ export function getOS() {
     return os;
 }
 
+/**
+ * @returns {boolean} Whether the current browser is Chromium-based (Chrome, Edge, …).
+ */
 export function isChromiumBrowser() {
     if (navigator.userAgentData) {
         return navigator.userAgentData.brands.some((brand) => {
@@ -39,6 +47,9 @@ export function isChromiumBrowser() {
     return ua.includes("chrom") || ua.includes("edg");
 }
 
+/**
+ * @returns {boolean} Whether running as a Capacitor native build on Android.
+ */
 export function isAndroid() {
     if (Capacitor.isNativePlatform()) {
         return Capacitor.getPlatform() === "android";
@@ -46,6 +57,9 @@ export function isAndroid() {
     return false;
 }
 
+/**
+ * @returns {boolean} Whether running as a Capacitor native build on iOS.
+ */
 export function isIOS() {
     if (Capacitor.isNativePlatform()) {
         return Capacitor.getPlatform() === "ios";
@@ -62,15 +76,23 @@ export function isIOS() {
  *
  * When present, Serial/Bluetooth/USB browser API checks are
  * irrelevant — only WebSocket transport is needed.
+ *
+ * @returns {boolean} Whether the WebSocket transport metadata is present.
  */
 export function isEmbeddedDeployment() {
     return document.querySelector('meta[name="bf-transport"]')?.content === "websocket";
 }
 
+/**
+ * @returns {boolean} Whether running inside a Tauri shell (desktop or iOS).
+ */
 export function isTauri() {
     return typeof globalThis !== "undefined" && "__TAURI_INTERNALS__" in globalThis;
 }
 
+/**
+ * @returns {boolean} Whether running inside a Tauri shell on iOS/iPadOS.
+ */
 export function isTauriIOS() {
     if (!isTauri()) {
         return false;
@@ -93,6 +115,14 @@ export function isPwaContext() {
     return !Capacitor.isNativePlatform() && !isTauri() && !isEmbeddedDeployment();
 }
 
+/**
+ * Verify the runtime can talk to a flight controller and, when it cannot,
+ * replace the page body with an error message.
+ *
+ * @returns {boolean} True when a compatible transport (or native/Tauri shell,
+ * or test environment) is available.
+ * @throws {Error} When no compatible browser transport is found.
+ */
 export function checkCompatibility() {
     if (isEmbeddedDeployment()) {
         console.log("[COMPAT] Embedded deployment detected — skipping browser checks");
@@ -170,6 +200,9 @@ export function checkCompatibility() {
     throw new Error("No compatible browser found.");
 }
 
+/**
+ * @returns {boolean} Whether a serial transport is available on this platform.
+ */
 export function checkSerialSupport() {
     let result = false;
     // iOS (Capacitor or Tauri) has no USB serial API, so don't advertise it there.
@@ -184,6 +217,9 @@ export function checkSerialSupport() {
     return result;
 }
 
+/**
+ * @returns {boolean} Whether a Bluetooth transport is available on this platform.
+ */
 export function checkBluetoothSupport() {
     let result = false;
     if (isAndroid()) {
@@ -196,6 +232,9 @@ export function checkBluetoothSupport() {
     return result;
 }
 
+/**
+ * @returns {boolean} Whether a USB transport is available on this platform.
+ */
 export function checkUsbSupport() {
     let result = false;
     if (isAndroid()) {

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -81,6 +81,16 @@ export function isTauriIOS() {
     return /iPad|iPhone|iPod/.test(ua) || (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
 }
 
+/**
+ * True only when running as a genuine web/PWA build, i.e. not inside a natively
+ * packaged shell (Capacitor Android/iOS, Tauri desktop/iOS) and not an embedded
+ * deployment (WebSocket-only host over plain HTTP). Use this to gate PWA-only
+ * behaviour such as service-worker registration and its update dialogs.
+ */
+export function isPwaContext() {
+    return !Capacitor.isNativePlatform() && !isTauri() && !isEmbeddedDeployment();
+}
+
 export function checkCompatibility() {
     if (isEmbeddedDeployment()) {
         console.log("[COMPAT] Embedded deployment detected — skipping browser checks");

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -84,8 +84,10 @@ export function isTauriIOS() {
 /**
  * True only when running as a genuine web/PWA build, i.e. not inside a natively
  * packaged shell (Capacitor Android/iOS, Tauri desktop/iOS) and not an embedded
- * deployment (WebSocket-only host over plain HTTP). Use this to gate PWA-only
- * behaviour such as service-worker registration and its update dialogs.
+ * deployment identified by the WebSocket transport metadata. Use this to gate
+ * PWA-only behaviour such as service-worker registration and its update dialogs.
+ *
+ * @returns {boolean} Whether the runtime is a web/PWA context.
  */
 export function isPwaContext() {
     return !Capacitor.isNativePlatform() && !isTauri() && !isEmbeddedDeployment();


### PR DESCRIPTION
## Description

The PWA service worker — and its offline-ready / update dialogs (`onOfflineReady`, `onNeedRefresh`) — was only gated against Capacitor Android and embedded deployments. As a result it still registered, and the `pwaOnOfflineReadyTitle` dialog still fired, on **Tauri (desktop/iOS)** and **Capacitor iOS**, where a service worker is meaningless because the app is packaged natively.

This PR registers the service worker only on genuine web/PWA builds.

## Changes

- Add an `isPwaContext()` helper to `src/js/utils/checkCompatibility.js`:
  ```js
  export function isPwaContext() {
      return !Capacitor.isNativePlatform() && !isTauri() && !isEmbeddedDeployment();
  }
  ```
  `Capacitor.isNativePlatform()` covers both Capacitor Android and iOS; `isTauri()` covers Tauri desktop and iOS.
- `browserMain.js` now guards service-worker registration with `isPwaContext()` and no longer imports `Capacitor` directly.
- Fix the `pwaOnOffilenReady*` key typo (`Offilen` → `Offline`) in the code and the English source locale. The remaining locale files are handled by Crowdin.

## Testing

- Web/PWA build: service worker registers and offline-ready/update dialogs behave as before.
- Tauri and Capacitor (Android/iOS) builds: no service-worker registration, dialogs no longer fire.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the “offline ready” i18n keys (previously misspelled) so the title and description render correctly.
  * Improved PWA behavior by more accurately detecting the web/PWA runtime before registering the service worker and showing offline/update dialogs.
  * Ensured offline/update dialogs are suppressed in native and embedded runtime contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->