### PR TITLE
fix(ci): grant deployments permission to release Cloudflare deploy jobs

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -130,6 +130,10 @@ jobs:
   modern_deploy_tag:
     name: Deploy Release Tag
     needs: [modern_build, prepare_environment]
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
     uses: ./.github/workflows/deploy_cloudflare.yml
     with:
       branch_name: ${{ github.event.release.tag_name }}
@@ -143,6 +147,10 @@ jobs:
     name: Deploy Latest to Production
     needs: [modern_build, check_latest]
     if: needs.check_latest.outputs.is_latest == 'true'
+    permissions:
+      actions: read
+      contents: read
+      deployments: write
     uses: ./.github/workflows/deploy_cloudflare.yml
     with:
       branch_name: "release"


### PR DESCRIPTION
The On Release workflow (build-release.yml) has no permissions granted to its two jobs that call the reusable deploy_cloudflare.yml (modern_deploy_tag and modern_deploy_latest). With the repo default token permissions set to read, those nested jobs request actions:read and deployments:write, which exceeds the caller grant, so GitHub rejects the whole workflow at parse time with a startup_failure ("The nested job deploy is requesting actions:read, deployments:write, but is only allowed actions:none, deployments:none").

This is latent on master because master never fires the release event, but it breaks every release: it surfaced cutting 2026.6.0-RC3, where the release build failed to start and nothing deployed to Cloudflare Pages. deploy.yml already grants these same permissions on its deploy job; this mirrors that on the two release deploy jobs.

The 2026.6-maintenance branch has already been fixed directly so RC3 could ship; this applies the same fix to master so future release lines are not affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow permissions to support Cloudflare releases.
  * Restricted deployment jobs to the minimum required access for reading project data and publishing deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->