### PR TITLE
Hide manual connection toggle when expert mode is off

### DIFF
--- a/src/components/dialogs/OptionsDialog.vue
+++ b/src/components/dialogs/OptionsDialog.vue
@@ -18,7 +18,7 @@
                     <SettingRow :label="$t('cliAutoComplete')">
                         <USwitch v-model="settings.cliAutoComplete" size="sm" />
                     </SettingRow>
-                    <SettingRow :label="$t('showManualMode')">
+                    <SettingRow v-if="settings.expertMode" :label="$t('showManualMode')">
                         <USwitch v-model="settings.showManualMode" size="sm" />
                     </SettingRow>
                     <SettingRow v-if="settings.expertMode" :label="$t('showVirtualMode')">


### PR DESCRIPTION
Hides manual mode toggle in the settings when expert mode is off because it's not accessible in that mode anyway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The “Manual Mode” option is now shown only when Expert Mode is enabled, simplifying the settings experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->