### PR TITLE
fix(tabs): stop logging benign MSP cancellations as load failures

### DIFF
--- a/src/components/tabs/AuxiliaryTab.vue
+++ b/src/components/tabs/AuxiliaryTab.vue
@@ -163,6 +163,7 @@ import GUI from "../../js/gui";
 import { useInterval } from "../../composables/useInterval";
 import { useSaving } from "../../composables/useSaving";
 import { useReboot } from "../../composables/useReboot";
+import { runTabLoad } from "../../composables/useTabLoad";
 import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
 import { mspHelper } from "../../js/msp/MSPHelper";
@@ -641,20 +642,23 @@ export default defineComponent({
 
         const loadData = async () => {
             try {
-                await MSP.promise(MSPCodes.MSP_BOXNAMES);
-                await MSP.promise(MSPCodes.MSP_MODE_RANGES);
-                await MSP.promise(MSPCodes.MSP_MODE_RANGES_EXTRA);
-                await MSP.promise(MSPCodes.MSP_BOXIDS);
-                await MSP.promise(MSPCodes.MSP_RSSI_CONFIG);
-                await MSP.promise(MSPCodes.MSP_RC);
-                await new Promise((resolve) => mspHelper.loadSerialConfig(resolve));
+                await runTabLoad(
+                    async () => {
+                        await MSP.promise(MSPCodes.MSP_BOXNAMES);
+                        await MSP.promise(MSPCodes.MSP_MODE_RANGES);
+                        await MSP.promise(MSPCodes.MSP_MODE_RANGES_EXTRA);
+                        await MSP.promise(MSPCodes.MSP_BOXIDS);
+                        await MSP.promise(MSPCodes.MSP_RSSI_CONFIG);
+                        await MSP.promise(MSPCodes.MSP_RC);
+                        await new Promise((resolve) => mspHelper.loadSerialConfig(resolve));
 
-                requiredModeRangeCount.value = fcStore.modeRanges.length;
-                auxChannelCount.value = Math.max(0, (fcStore.rc?.active_channels || 0) - 4);
-                buildModesFromFC();
-                updateMarkers();
-            } catch (error) {
-                console.error("Failed to load auxiliary data", error);
+                        requiredModeRangeCount.value = fcStore.modeRanges.length;
+                        auxChannelCount.value = Math.max(0, (fcStore.rc?.active_channels || 0) - 4);
+                        buildModesFromFC();
+                        updateMarkers();
+                    },
+                    (error) => console.error("Failed to load auxiliary data", error),
+                );
             } finally {
                 await nextTick();
                 GUI.content_ready();

--- a/src/components/tabs/ConfigurationTab.vue
+++ b/src/components/tabs/ConfigurationTab.vue
@@ -201,6 +201,7 @@ import { useFlightControllerStore } from "@/stores/fc";
 import { useReboot } from "@/composables/useReboot";
 import { useIsMounted } from "@/composables/useIsMounted";
 import { useSaving } from "@/composables/useSaving";
+import { runTabLoad } from "@/composables/useTabLoad";
 import GUI from "../../js/gui";
 import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
@@ -356,48 +357,51 @@ export default defineComponent({
 
         // Loading Logic
         const loadConfig = async () => {
-            try {
-                if (!isMounted.value) return;
-                await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
-                await MSP.promise(MSPCodes.MSP_BEEPER_CONFIG);
-                await MSP.promise(MSPCodes.MSP_ARMING_CONFIG);
-                await MSP.promise(MSPCodes.MSP_SENSOR_CONFIG);
+            await runTabLoad(
+                async () => {
+                    if (!isMounted.value) return;
+                    await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
+                    await MSP.promise(MSPCodes.MSP_BEEPER_CONFIG);
+                    await MSP.promise(MSPCodes.MSP_ARMING_CONFIG);
+                    await MSP.promise(MSPCodes.MSP_SENSOR_CONFIG);
 
-                if (!isMounted.value) return;
+                    if (!isMounted.value) return;
 
-                if (semver.lt(fcStore.config.apiVersion, API_VERSION_1_45)) {
-                    await MSP.promise(MSPCodes.MSP_NAME);
-                }
+                    if (semver.lt(fcStore.config.apiVersion, API_VERSION_1_45)) {
+                        await MSP.promise(MSPCodes.MSP_NAME);
+                    }
 
-                if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_45)) {
-                    await MSP.promise(
-                        MSPCodes.MSP2_GET_TEXT,
-                        mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.CRAFT_NAME),
-                    );
-                }
+                    if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_45)) {
+                        await MSP.promise(
+                            MSPCodes.MSP2_GET_TEXT,
+                            mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.CRAFT_NAME),
+                        );
+                    }
 
-                await MSP.promise(MSPCodes.MSP_RX_CONFIG);
+                    await MSP.promise(MSPCodes.MSP_RX_CONFIG);
 
-                if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_45)) {
-                    await MSP.promise(
-                        MSPCodes.MSP2_GET_TEXT,
-                        mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.PILOT_NAME),
-                    );
-                }
+                    if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_45)) {
+                        await MSP.promise(
+                            MSPCodes.MSP2_GET_TEXT,
+                            mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.PILOT_NAME),
+                        );
+                    }
 
-                if (!isMounted.value) return;
+                    if (!isMounted.value) return;
 
-                await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG);
+                    await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG);
 
-                if (!isMounted.value) return;
+                    if (!isMounted.value) return;
 
-                await initializeUI();
-                await nextTick();
-                GUI.content_ready();
-            } catch (e) {
-                console.error("Failed to load configuration", e);
-                GUI.content_ready();
-            }
+                    await initializeUI();
+                    await nextTick();
+                    GUI.content_ready();
+                },
+                (e) => {
+                    console.error("Failed to load configuration", e);
+                    GUI.content_ready();
+                },
+            );
         };
 
         const initializeUI = async () => {

--- a/src/components/tabs/FailsafeTab.vue
+++ b/src/components/tabs/FailsafeTab.vue
@@ -393,6 +393,7 @@ import { computed, ref, watch, onMounted, nextTick } from "vue";
 import { useFlightControllerStore } from "@/stores/fc";
 import { useReboot } from "@/composables/useReboot";
 import { useSaving } from "@/composables/useSaving";
+import { runTabLoad } from "@/composables/useTabLoad";
 import BaseTab from "./BaseTab.vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import SettingRow from "@/components/elements/SettingRow.vue";
@@ -423,24 +424,25 @@ const { runSave } = useSaving();
 // --- Data loading ---
 
 const loadConfig = async () => {
-    try {
-        await MSP.promise(MSPCodes.MSP_RX_CONFIG);
-        await MSP.promise(MSPCodes.MSP_FAILSAFE_CONFIG);
+    await runTabLoad(
+        async () => {
+            await MSP.promise(MSPCodes.MSP_RX_CONFIG);
+            await MSP.promise(MSPCodes.MSP_FAILSAFE_CONFIG);
 
-        if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_41)) {
-            await MSP.promise(MSPCodes.MSP_GPS_RESCUE);
-        }
+            if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_41)) {
+                await MSP.promise(MSPCodes.MSP_GPS_RESCUE);
+            }
 
-        await MSP.promise(MSPCodes.MSP_RXFAIL_CONFIG);
-        await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
-        await MSP.promise(MSPCodes.MSP_BOXNAMES);
-        await MSP.promise(MSPCodes.MSP_BOXIDS);
-        await MSP.promise(MSPCodes.MSP_RC);
-        await MSP.promise(MSPCodes.MSP_RSSI_CONFIG);
-        await MSP.promise(MSPCodes.MSP_MODE_RANGES);
-    } catch (e) {
-        console.error("Failed to load Failsafe configuration", e);
-    }
+            await MSP.promise(MSPCodes.MSP_RXFAIL_CONFIG);
+            await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
+            await MSP.promise(MSPCodes.MSP_BOXNAMES);
+            await MSP.promise(MSPCodes.MSP_BOXIDS);
+            await MSP.promise(MSPCodes.MSP_RC);
+            await MSP.promise(MSPCodes.MSP_RSSI_CONFIG);
+            await MSP.promise(MSPCodes.MSP_MODE_RANGES);
+        },
+        (e) => console.error("Failed to load Failsafe configuration", e),
+    );
 };
 
 // --- Store data refs ---

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -341,6 +341,7 @@ import HelpIcon from "../elements/HelpIcon.vue";
 import { useLedStrip } from "@/composables/useLedStrip";
 import { useSaving } from "@/composables/useSaving";
 import { useTransientLabel } from "@/composables/useTransientLabel";
+import { runTabLoad } from "@/composables/useTabLoad";
 import { i18n } from "@/js/localization";
 import { gui_log } from "@/js/gui_log";
 import GUI from "@/js/gui";
@@ -550,12 +551,16 @@ const specialColorButtons = computed(() => [
 // Lifecycle
 const onTabMounted = async () => {
     try {
-        await loadData();
-        initializeGrid();
-        loadConfigValues();
+        await runTabLoad(
+            async () => {
+                await loadData();
+                initializeGrid();
+                loadConfigValues();
+            },
+            (error) => console.error("Failed to load LED strip data:", error),
+        );
+    } finally {
         GUI.content_ready();
-    } catch (error) {
-        console.error("Failed to load LED strip data:", error);
     }
 };
 

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -316,6 +316,7 @@ import { MspCancelledError } from "../../js/msp/mspErrors";
 import { bit_check, bit_set } from "../../js/bit";
 import { useSaving } from "../../composables/useSaving";
 import { useReboot } from "../../composables/useReboot";
+import { runTabLoad } from "../../composables/useTabLoad";
 
 const BLOCK_SIZE = 4096;
 
@@ -935,44 +936,47 @@ export default defineComponent({
 
         async function loadData() {
             try {
-                await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
-                await MSP.promise(MSPCodes.MSP_DATAFLASH_SUMMARY);
-                await MSP.promise(MSPCodes.MSP_SDCARD_SUMMARY);
-                await MSP.promise(MSPCodes.MSP_BLACKBOX_CONFIG);
-                await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG);
-                await MSP.promise(MSPCodes.MSP_SENSOR_CONFIG);
+                await runTabLoad(
+                    async () => {
+                        await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
+                        await MSP.promise(MSPCodes.MSP_DATAFLASH_SUMMARY);
+                        await MSP.promise(MSPCodes.MSP_SDCARD_SUMMARY);
+                        await MSP.promise(MSPCodes.MSP_BLACKBOX_CONFIG);
+                        await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG);
+                        await MSP.promise(MSPCodes.MSP_SENSOR_CONFIG);
 
-                if (fcStore.config?.apiVersion && semver.gte(fcStore.config.apiVersion, API_VERSION_1_45)) {
-                    await MSP.promise(
-                        MSPCodes.MSP2_GET_TEXT,
-                        mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.CRAFT_NAME),
-                    );
-                } else {
-                    await MSP.promise(MSPCodes.MSP_NAME);
-                }
+                        if (fcStore.config?.apiVersion && semver.gte(fcStore.config.apiVersion, API_VERSION_1_45)) {
+                            await MSP.promise(
+                                MSPCodes.MSP2_GET_TEXT,
+                                mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.CRAFT_NAME),
+                            );
+                        } else {
+                            await MSP.promise(MSPCodes.MSP_NAME);
+                        }
 
-                if (fcStore.config?.apiVersion && semver.gte(fcStore.config.apiVersion, API_VERSION_1_47)) {
-                    await MSP.promise(MSPCodes.MSP2_SENSOR_CONFIG_ACTIVE);
-                }
+                        if (fcStore.config?.apiVersion && semver.gte(fcStore.config.apiVersion, API_VERSION_1_47)) {
+                            await MSP.promise(MSPCodes.MSP2_SENSOR_CONFIG_ACTIVE);
+                        }
 
-                // Populate UI state
-                blackboxDevice.value = fcStore.blackbox?.blackboxDevice || 0;
-                blackboxRate.value = fcStore.blackbox?.blackboxSampleRate || 0;
-                debugMode.value = fcStore.pidAdvancedConfig?.debugMode || 0;
+                        // Populate UI state
+                        blackboxDevice.value = fcStore.blackbox?.blackboxDevice || 0;
+                        blackboxRate.value = fcStore.blackbox?.blackboxSampleRate || 0;
+                        debugMode.value = fcStore.pidAdvancedConfig?.debugMode || 0;
 
-                // Initialize debug fields checkboxes
-                if (showDebugFields.value) {
-                    const disabledMask = fcStore.blackbox?.blackboxDisabledMask || 0;
-                    debugFieldsEnabled.value = debugStore.enableFields.map((_, index) => {
-                        return !bit_check(disabledMask, index);
-                    });
-                }
+                        // Initialize debug fields checkboxes
+                        if (showDebugFields.value) {
+                            const disabledMask = fcStore.blackbox?.blackboxDisabledMask || 0;
+                            debugFieldsEnabled.value = debugStore.enableFields.map((_, index) => {
+                                return !bit_check(disabledMask, index);
+                            });
+                        }
 
-                updateVirtualGyro();
-                onboardLoggingBaseline.value = serializeOnboardLoggingState();
-                updateHtml();
-            } catch (error) {
-                console.error("Failed to load onboard logging data", error);
+                        updateVirtualGyro();
+                        onboardLoggingBaseline.value = serializeOnboardLoggingState();
+                        updateHtml();
+                    },
+                    (error) => console.error("Failed to load onboard logging data", error),
+                );
             } finally {
                 GUI.content_ready();
             }

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -530,6 +530,7 @@ import { useOsdPreview, clampStringPreviewPosition, clampArrayPreviewPosition } 
 import { useOsdRuler } from "@/composables/useOsdRuler";
 import { useTransientLabel } from "@/composables/useTransientLabel";
 import { useSaving } from "@/composables/useSaving";
+import { runTabLoad } from "@/composables/useTabLoad";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
 import UiBox from "@/components/elements/UiBox.vue";
@@ -1280,31 +1281,32 @@ function updatePreview() {
 
 // Load OSD configuration from FC
 async function loadConfig() {
-    try {
-        // Fetch OSD config via Store
-        await osdStore.fetchOsdConfig();
+    await runTabLoad(
+        async () => {
+            // Fetch OSD config via Store
+            await osdStore.fetchOsdConfig();
 
-        // Set initial profile from store state
-        previewProfile.value = osdStore.osdProfiles.selected || 0;
-        activeProfile.value = osdStore.osdProfiles.selected || 0;
+            // Set initial profile from store state
+            previewProfile.value = osdStore.osdProfiles.selected || 0;
+            activeProfile.value = osdStore.osdProfiles.selected || 0;
 
-        // Sync font state from memory
-        if (FONT.data?.loaded_font_file) {
-            const loadedIndex = fontTypes.value.findIndex((f) => f.file === FONT.data.loaded_font_file);
-            if (loadedIndex !== -1 && loadedIndex !== selectedFont.value) {
-                selectedFont.value = loadedIndex;
-                selectedFontPreset.value = loadedIndex;
-            } else if (loadedIndex === -1 && selectedFont.value !== -1) {
-                selectedFont.value = -1;
-                selectedFontPreset.value = -1;
+            // Sync font state from memory
+            if (FONT.data?.loaded_font_file) {
+                const loadedIndex = fontTypes.value.findIndex((f) => f.file === FONT.data.loaded_font_file);
+                if (loadedIndex !== -1 && loadedIndex !== selectedFont.value) {
+                    selectedFont.value = loadedIndex;
+                    selectedFontPreset.value = loadedIndex;
+                } else if (loadedIndex === -1 && selectedFont.value !== -1) {
+                    selectedFont.value = -1;
+                    selectedFontPreset.value = -1;
+                }
             }
-        }
 
-        updatePreview();
-        hasLoadedConfig.value = true;
-    } catch (error) {
-        console.error("Failed to load OSD configuration:", error);
-    }
+            updatePreview();
+            hasLoadedConfig.value = true;
+        },
+        (error) => console.error("Failed to load OSD configuration:", error),
+    );
 }
 
 async function refreshConfig() {

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -142,6 +142,7 @@ import { useTranslation } from "i18next-vue";
 import { gui_log } from "@/js/gui_log";
 import { useSaving } from "@/composables/useSaving";
 import { useReboot } from "@/composables/useReboot";
+import { runTabLoad } from "@/composables/useTabLoad";
 
 const { t } = useTranslation();
 const pidTuningStore = usePidTuningStore();
@@ -228,75 +229,79 @@ const hasChanges = computed(() => pidTuningStore.hasChanges);
 async function loadData() {
     isLoading.value = true;
     try {
-        if (!isMounted.value) {
-            return false;
-        }
+        return await runTabLoad(
+            async () => {
+                if (!isMounted.value) {
+                    return false;
+                }
 
-        // Load all PID tuning related MSP data
-        await MSP.promise(MSPCodes.MSP_PIDNAMES);
-        await MSP.promise(MSPCodes.MSP_PID);
-        await MSP.promise(MSPCodes.MSP_PID_ADVANCED);
-        await MSP.promise(MSPCodes.MSP_RC_TUNING);
-        await MSP.promise(MSPCodes.MSP_FILTER_CONFIG);
-        await MSP.promise(MSPCodes.MSP_RC_DEADBAND);
-        await MSP.promise(MSPCodes.MSP_MOTOR_CONFIG);
+                // Load all PID tuning related MSP data
+                await MSP.promise(MSPCodes.MSP_PIDNAMES);
+                await MSP.promise(MSPCodes.MSP_PID);
+                await MSP.promise(MSPCodes.MSP_PID_ADVANCED);
+                await MSP.promise(MSPCodes.MSP_RC_TUNING);
+                await MSP.promise(MSPCodes.MSP_FILTER_CONFIG);
+                await MSP.promise(MSPCodes.MSP_RC_DEADBAND);
+                await MSP.promise(MSPCodes.MSP_MOTOR_CONFIG);
 
-        // Profile names (API 1.45+)
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
-            await MSP.promise(
-                MSPCodes.MSP2_GET_TEXT,
-                mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.PID_PROFILE_NAME),
-            );
-            await MSP.promise(
-                MSPCodes.MSP2_GET_TEXT,
-                mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.RATE_PROFILE_NAME),
-            );
-        }
+                // Profile names (API 1.45+)
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+                    await MSP.promise(
+                        MSPCodes.MSP2_GET_TEXT,
+                        mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.PID_PROFILE_NAME),
+                    );
+                    await MSP.promise(
+                        MSPCodes.MSP2_GET_TEXT,
+                        mspHelper.crunch(MSPCodes.MSP2_GET_TEXT, MSPCodes.RATE_PROFILE_NAME),
+                    );
+                }
 
-        // Status EX (API 1.47+)
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
-            await MSP.promise(MSPCodes.MSP_STATUS_EX);
-        }
+                // Status EX (API 1.47+)
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
+                    await MSP.promise(MSPCodes.MSP_STATUS_EX);
+                }
 
-        await MSP.promise(MSPCodes.MSP_SIMPLIFIED_TUNING);
-        await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG);
-        await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
+                await MSP.promise(MSPCodes.MSP_SIMPLIFIED_TUNING);
+                await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG);
+                await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
 
-        // Initialize profile names from FC.CONFIG
-        if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
-            pidProfileName.value = FC.CONFIG.pidProfileNames?.[FC.CONFIG.profile] || "";
-            rateProfileName.value = FC.CONFIG.rateProfileNames?.[FC.CONFIG.rateProfile] || "";
-        }
+                // Initialize profile names from FC.CONFIG
+                if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_45)) {
+                    pidProfileName.value = FC.CONFIG.pidProfileNames?.[FC.CONFIG.profile] || "";
+                    rateProfileName.value = FC.CONFIG.rateProfileNames?.[FC.CONFIG.rateProfile] || "";
+                }
 
-        if (!isMounted.value) {
-            return;
-        }
+                if (!isMounted.value) {
+                    return;
+                }
 
-        // Initialize UI state
-        initializeUI();
+                // Initialize UI state
+                initializeUI();
 
-        // Validate slider positions against FC state (determines whether
-        // sliders are valid and should be enabled).  Must happen before
-        // snapshot so slider-validated values are captured as originals.
-        await validateTuningSliders();
+                // Validate slider positions against FC state (determines whether
+                // sliders are valid and should be enabled).  Must happen before
+                // snapshot so slider-validated values are captured as originals.
+                await validateTuningSliders();
 
-        // Force sub-tabs to sync their local slider refs from FC state
-        if (pidSubTab.value?.forceUpdateSliders) {
-            pidSubTab.value.forceUpdateSliders();
-        }
-        if (filterSubTab.value?.forceUpdateSliders) {
-            filterSubTab.value.forceUpdateSliders();
-        }
+                // Force sub-tabs to sync their local slider refs from FC state
+                if (pidSubTab.value?.forceUpdateSliders) {
+                    pidSubTab.value.forceUpdateSliders();
+                }
+                if (filterSubTab.value?.forceUpdateSliders) {
+                    filterSubTab.value.forceUpdateSliders();
+                }
 
-        // Store original values for revert
-        storeOriginalValues();
+                // Store original values for revert
+                storeOriginalValues();
 
-        GUI.content_ready();
-        return true;
-    } catch (e) {
-        console.error("[PidTuning] Failed to load data:", e);
-        GUI.content_ready();
-        return false;
+                GUI.content_ready();
+                return true;
+            },
+            (e) => {
+                console.error("[PidTuning] Failed to load data:", e);
+                GUI.content_ready();
+            },
+        );
     } finally {
         isLoading.value = false;
     }

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -515,6 +515,7 @@ import { useFlightControllerStore } from "@/stores/fc";
 import { useConnectionStore } from "@/stores/connection";
 import { useReboot } from "@/composables/useReboot";
 import { useSaving } from "@/composables/useSaving";
+import { runTabLoad } from "@/composables/useTabLoad";
 import { useInterval } from "../../composables/useInterval";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
@@ -996,63 +997,70 @@ async function refreshTab() {
     gui_log(t("receiverDataRefreshed"));
 }
 
+// Find the rx mode bit for the currently enabled "select"/"rxMode" feature, or -1 if none is.
+function findSelectedRxMode(featuresApi) {
+    for (const feature of featuresApi.getFeatures()) {
+        if (feature.mode === "select" && feature.group === "rxMode" && featuresApi.isEnabled(feature.name)) {
+            return feature.bit;
+        }
+    }
+    return -1;
+}
+
+// Look up a stored ELRS binding phrase for the FC's current UID, if any.
+function findElrsBindingPhrase(elrsUid) {
+    if (!elrsUid) {
+        return null;
+    }
+    return lookupElrsBindingPhrase(elrsUid.join(","));
+}
+
 // Load configuration
 async function loadConfig() {
-    try {
-        await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
-        await MSP.promise(MSPCodes.MSP_RC);
-        await MSP.promise(MSPCodes.MSP_RSSI_CONFIG);
-        await MSP.promise(MSPCodes.MSP_RC_TUNING);
-        await MSP.promise(MSPCodes.MSP_RX_MAP);
-        await MSP.promise(MSPCodes.MSP_RC_DEADBAND);
-        await MSP.promise(MSPCodes.MSP_RX_CONFIG);
-        await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
+    await runTabLoad(
+        async () => {
+            await MSP.promise(MSPCodes.MSP_FEATURE_CONFIG);
+            await MSP.promise(MSPCodes.MSP_RC);
+            await MSP.promise(MSPCodes.MSP_RSSI_CONFIG);
+            await MSP.promise(MSPCodes.MSP_RC_TUNING);
+            await MSP.promise(MSPCodes.MSP_RX_MAP);
+            await MSP.promise(MSPCodes.MSP_RC_DEADBAND);
+            await MSP.promise(MSPCodes.MSP_RX_CONFIG);
+            await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
 
-        // Update local state from FC
-        updateChannelMapFromRcMap();
+            // Update local state from FC
+            updateChannelMapFromRcMap();
 
-        // Initialize selectedRxMode from feature mask
-        if (features.value?.features?.getFeatures?.()) {
-            let foundRxMode = -1;
-            for (const feature of features.value.features.getFeatures()) {
-                if (feature.mode === "select" && feature.group === "rxMode") {
-                    if (features.value.features.isEnabled(feature.name)) {
-                        foundRxMode = feature.bit;
-                        break;
-                    }
-                }
+            // Initialize selectedRxMode from feature mask
+            if (features.value?.features?.getFeatures?.()) {
+                selectedRxMode.value = findSelectedRxMode(features.value.features);
             }
-            selectedRxMode.value = foundRxMode;
-        }
 
-        // Load ELRS binding phrase if applicable
-        if (elrsBindingPhraseEnabled.value && rxConfig.value?.elrsUid) {
-            const uidString = rxConfig.value.elrsUid.join(",");
-            const storedPhrase = lookupElrsBindingPhrase(uidString);
+            // Load ELRS binding phrase if applicable
+            const storedPhrase = elrsBindingPhraseEnabled.value ? findElrsBindingPhrase(rxConfig.value?.elrsUid) : null;
             if (storedPhrase) {
                 elrsBindingPhrase.value = storedPhrase;
             }
-        }
 
-        // Set RC smoothing modes based on cutoff values
-        setpointManualMode.value = rxConfig.value?.rcSmoothingSetpointCutoff === 0 ? "0" : "1";
-        if (showThrottleSmoothingOptions.value) {
-            throttleManualMode.value = rxConfig.value?.rcSmoothingThrottleCutoff === 0 ? "0" : "1";
-        } else {
-            feedforwardManualMode.value = rxConfig.value?.rcSmoothingFeedforwardCutoff === 0 ? "0" : "1";
-        }
+            // Set RC smoothing modes based on cutoff values
+            setpointManualMode.value = rxConfig.value?.rcSmoothingSetpointCutoff === 0 ? "0" : "1";
+            if (showThrottleSmoothingOptions.value) {
+                throttleManualMode.value = rxConfig.value?.rcSmoothingThrottleCutoff === 0 ? "0" : "1";
+            } else {
+                feedforwardManualMode.value = rxConfig.value?.rcSmoothingFeedforwardCutoff === 0 ? "0" : "1";
+            }
 
-        // Load saved refresh rate
-        const savedRate = getConfig("rx_refresh_rate");
-        if (savedRate?.rx_refresh_rate) {
-            refreshRate.value = savedRate.rx_refresh_rate;
-        }
+            // Load saved refresh rate
+            const savedRate = getConfig("rx_refresh_rate");
+            if (savedRate?.rx_refresh_rate) {
+                refreshRate.value = savedRate.rx_refresh_rate;
+            }
 
-        needReboot.value = false;
-        savedSnapshot.value = takeSnapshot();
-    } catch (e) {
-        console.error("Failed to load Receiver configuration", e);
-    }
+            needReboot.value = false;
+            savedSnapshot.value = takeSnapshot();
+        },
+        (e) => console.error("Failed to load Receiver configuration", e),
+    );
 }
 
 // Save configuration

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -818,6 +818,7 @@ import { useFlightControllerStore } from "@/stores/fc";
 import { useReboot } from "@/composables/useReboot";
 import { useIsMounted } from "@/composables/useIsMounted";
 import { useSaving } from "@/composables/useSaving";
+import { runTabLoad } from "@/composables/useTabLoad";
 import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
 import { mspHelper } from "../../js/msp/MSPHelper.js";
@@ -2373,63 +2374,66 @@ function setupPeripherals() {
 // --- Load ---
 
 const loadConfig = async () => {
-    try {
-        if (!isMounted.value) {
-            return;
-        }
+    await runTabLoad(
+        async () => {
+            if (!isMounted.value) {
+                return;
+            }
 
-        await MSP.promise(MSPCodes.MSP_SENSOR_CONFIG);
-        await MSP.promise(MSPCodes.MSP_SENSOR_ALIGNMENT);
-        await MSP.promise(MSPCodes.MSP_BOARD_ALIGNMENT_CONFIG);
-        await MSP.promise(MSPCodes.MSP_ACC_TRIM);
-        await MSP.promise(MSPCodes.MSP2_SENSOR_CONFIG_ACTIVE);
-        // initModel() reads FC.MIXER_CONFIG.mixer; load it here (nothing else on this tab does),
-        // else mixer stays 0 and the loader fetches a non-existent `undefined.gltf`.
-        await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
+            await MSP.promise(MSPCodes.MSP_SENSOR_CONFIG);
+            await MSP.promise(MSPCodes.MSP_SENSOR_ALIGNMENT);
+            await MSP.promise(MSPCodes.MSP_BOARD_ALIGNMENT_CONFIG);
+            await MSP.promise(MSPCodes.MSP_ACC_TRIM);
+            await MSP.promise(MSPCodes.MSP2_SENSOR_CONFIG_ACTIVE);
+            // initModel() reads FC.MIXER_CONFIG.mixer; load it here (nothing else on this tab does),
+            // else mixer stays 0 and the loader fetches a non-existent `undefined.gltf`.
+            await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
 
-        if (isApi146.value) {
-            await MSP.promise(MSPCodes.MSP_COMPASS_CONFIG);
-        }
+            if (isApi146.value) {
+                await MSP.promise(MSPCodes.MSP_COMPASS_CONFIG);
+            }
 
-        if (isApi147.value) {
-            await MSP.promise(MSPCodes.MSP2_GYRO_SENSOR);
-        }
+            if (isApi147.value) {
+                await MSP.promise(MSPCodes.MSP2_GYRO_SENSOR);
+            }
 
-        if (!isMounted.value) {
-            return;
-        }
+            if (!isMounted.value) {
+                return;
+            }
 
-        try {
-            sensorTypesData.value = await sensorTypes();
-        } catch (error) {
-            sensorTypesData.value = null;
-            console.warn("Failed to load sensor types", error);
-        }
+            try {
+                sensorTypesData.value = await sensorTypes();
+            } catch (error) {
+                sensorTypesData.value = null;
+                console.warn("Failed to load sensor types", error);
+            }
 
-        hydrateSensorConfig();
-        hydrateAlignment();
-        resolveSensorNames();
-        setupMagSection();
-        setupPeripherals();
+            hydrateSensorConfig();
+            hydrateAlignment();
+            resolveSensorNames();
+            setupMagSection();
+            setupPeripherals();
 
-        baseline.value = serializeState();
+            baseline.value = serializeState();
 
-        await nextTick();
+            await nextTick();
 
-        if (!isMounted.value) {
-            return;
-        }
+            if (!isMounted.value) {
+                return;
+            }
 
-        // Initialize 3D model, instruments, and start attitude polling
-        initModel();
-        initInstruments();
-        addInterval("sensors_attitude", pollAttitude, ATTITUDE_POLL_MS, true);
+            // Initialize 3D model, instruments, and start attitude polling
+            initModel();
+            initInstruments();
+            addInterval("sensors_attitude", pollAttitude, ATTITUDE_POLL_MS, true);
 
-        GUI.content_ready();
-    } catch (e) {
-        console.error("Failed to load sensor config", e);
-        GUI.content_ready();
-    }
+            GUI.content_ready();
+        },
+        (e) => {
+            console.error("Failed to load sensor config", e);
+            GUI.content_ready();
+        },
+    );
 };
 
 // --- Save ---

--- a/src/composables/useTabLoad.js
+++ b/src/composables/useTabLoad.js
@@ -1,0 +1,23 @@
+import { isMspCancelled } from "../js/msp/mspErrors.js";
+
+/**
+ * Shared tab-load guard: runs a tab's `loadConfig` MSP chain and swallows a benign
+ * MspCancelledError — the queue is cleared (reason "cleanup"/"disconnected") when the tab is
+ * switched away from or the link drops while the chain is still in flight, which is expected
+ * and not a real failure. Any other error (timeout, CRC, ...) is passed to `onError`.
+ * @template T
+ * @param {() => Promise<T>} fn - the async loadConfig work (the MSP chain)
+ * @param {(error: unknown) => void} onError - genuine-failure handler
+ * @returns {Promise<T|undefined>} fn's resolved value, or undefined if cancelled/failed
+ */
+export async function runTabLoad(fn, onError) {
+    try {
+        return await fn();
+    } catch (error) {
+        if (isMspCancelled(error)) {
+            return undefined;
+        }
+        onError(error);
+        return undefined;
+    }
+}

--- a/test/js/useTabLoad.test.js
+++ b/test/js/useTabLoad.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { runTabLoad } from "../../src/composables/useTabLoad";
+import { MspCancelledError } from "../../src/js/msp/mspErrors";
+
+describe("useTabLoad", () => {
+    it("returns the loader's resolved value on success and never calls onError", async () => {
+        const onError = vi.fn();
+
+        const result = await runTabLoad(() => Promise.resolve("ok"), onError);
+
+        expect(result).toBe("ok");
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("swallows a benign MspCancelledError silently (no onError call)", async () => {
+        const onError = vi.fn();
+        const error = new MspCancelledError("MSP queue cleared", undefined, "cleanup");
+
+        const result = await runTabLoad(() => Promise.reject(error), onError);
+
+        expect(result).toBeUndefined();
+        expect(onError).not.toHaveBeenCalled();
+    });
+
+    it("routes a genuine failure to onError", async () => {
+        const onError = vi.fn();
+        const error = new Error("timeout");
+
+        const result = await runTabLoad(() => Promise.reject(error), onError);
+
+        expect(result).toBeUndefined();
+        expect(onError).toHaveBeenCalledWith(error);
+    });
+});


### PR DESCRIPTION
Summary

Switching away from a connected tab before its loadConfig MSP chain finishes is expected to cancel the in-flight requests (MSP.callbacks_cleanup, since #5249) — that part is correct. The bug was that every tab's loadConfig catch treated the resulting MspCancelledError as a real failure and logged Failed to load ... configuration to the console. Pure noise: no data is lost, the tab is being torn down anyway.

Fix

Added a small runTabLoad helper (src/composables/useTabLoad.js), mirroring the existing useSaving/runSave pattern, that swallows benign isMspCancelled errors and forwards genuine ones (timeout, CRC, ...) to the caller's onError. Routed the following tabs' loadConfig/loadData through it instead of patching each catch block individually:

- Failsafe
- Configuration
- Receiver
- Osd
- PidTuning
- LedStrip
- Sensors
- Auxiliary
- OnboardLogging

BackupsTab was also mentioned in the issue but doesn't call MSP at all (it's REST/CLI-dump based), so it's unaffected and left alone.

Also cleaned up ReceiverTab.vue's loadConfig while I was in there — it was already too complex before this PR (SonarLint flagged it at 24, limit is 15), so I pulled the messy nested loop that figures out the selected RX mode, plus the ELRS binding-phrase lookup, into two small helper functions. Same behavior, just easier to read. Not related to the actual bug, just noticed it and fixed it along the way.


Testing

- Reproduced the bug on real hardware: rapidly switching away from the Failsafe tab mid-load reliably triggered the console error before the fix.
- Confirmed the error no longer appears after the fix, same repro steps.
- Added test/js/useTabLoad.test.js covering the helper (success passthrough, cancellation swallowed, genuine error forwarded).
- Full test suite passes (npm test, 658/658).
- npm run build passes.

Fixes #5311


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and more consistent tab initialization across configuration, receiver, failsafe, sensors, LED strip, OSD, PID tuning, onboard logging, and auxiliary tabs.
  * Loading failures are now handled more reliably, and the UI reaches its “ready” state on both success and failure.
  * Cancelled loading operations are handled quietly to avoid unnecessary error output.
* **Tests**
  * Added unit tests ensuring the shared tab-loading helper behaves correctly for successful loads, cancelled operations, and unexpected failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->