### PR TITLE
fix(connection): tear down only on sustained link silence, not one MSP timeout

### DIFF
--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -575,6 +575,22 @@ const MSP = {
     _arm_timer(obj) {
         obj.timer = setTimeout(() => this._on_timeout(obj), this.TIMEOUT);
     },
+    /**
+     * Retry/timeout handler for a single queued MSP request.
+     *
+     * While retries remain it re-sends the request buffer and re-arms the timer. On exhaustion it
+     * clears the timer and, for errorAware requests, removes the queue entry, settles its awaiter
+     * with an {@link MspTimeoutError}, and releases any same-code requests parked behind it. Legacy
+     * (non-errorAware) requests are left queued so a late response can still resolve them.
+     *
+     * After an errorAware exhaustion it notifies {@link MSP.onTimeout}. The dead-versus-slow-link
+     * decision is deliberately made by that hook from the FC's actual traffic (see
+     * `handleConnectionTimeout` in serial_backend), not from this per-request failure — so a lone
+     * timeout on a high-latency transport does not tear down a healthy connection.
+     *
+     * @param {object} obj - the queued request entry (`code`, `requestBuffer`, `attempts`, `errorAware`, `callback`, `timer`, …).
+     * @returns {void}
+     */
     _on_timeout(obj) {
         if (obj.attempts < this.MAX_RETRIES) {
             obj.attempts++;
@@ -590,7 +606,7 @@ const MSP = {
         obj.timer = null;
 
         if (!obj.errorAware) {
-            // legacy: give up retrying but leave the entry queued so a late response still fires it
+            // Legacy path: stop retrying but keep the entry queued so a late response still resolves it.
             return;
         }
 
@@ -605,9 +621,8 @@ const MSP = {
         }
         this._release_parked(obj.code);
 
-        // This request exhausted MAX_RETRIES. Whether that means the link is dead is decided by
-        // the hook (handleConnectionTimeout) from the FC's actual traffic, not from this single
-        // request — a lone slow request on a high-latency transport is not a hung FC.
+        // Notify the liveness hook after a full errorAware exhaustion. It — not this per-request
+        // failure — classifies the link as dead or merely slow (see handleConnectionTimeout).
         this.onTimeout?.(obj.code);
     },
     _park(code, entry) {

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -605,7 +605,9 @@ const MSP = {
         }
         this._release_parked(obj.code);
 
-        // MAX_RETRIES sends produced no response: the link is unresponsive, not just slow.
+        // This request exhausted MAX_RETRIES. Whether that means the link is dead is decided by
+        // the hook (handleConnectionTimeout) from the FC's actual traffic, not from this single
+        // request — a lone slow request on a high-latency transport is not a hung FC.
         this.onTimeout?.(obj.code);
     },
     _park(code, entry) {

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -696,6 +696,9 @@ function resetConnection() {
 
     MSP.clearListeners();
     MSP.onTimeout = null;
+    // Clear the FC-liveness timestamp so the next connection can't inherit stale traffic state
+    // from this one and mis-classify a fresh link as still-alive in handleConnectionTimeout.
+    MSP.last_received_timestamp = null;
 
     if (DeviceHandler.devicePicker.selectedDevice !== "virtual") {
         serial.removeEventListener("receive", read_serial_adapter);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1282,24 +1282,37 @@ async function requestLiveData(code, name) {
     }
 }
 
-// A link is only "dead" once the FC has gone completely silent for this long. One MSP request
-// exhausting its retries (~MAX_RETRIES × TIMEOUT ≈ 3 s) is not enough on its own: a high-latency
-// transport (WiFi TCP bridge, BLE) can miss a single request while the link is still delivering
-// other traffic. The threshold sits above one request's retry window so a lone slow request never
-// trips teardown, but low enough that a genuinely hung FC is dropped promptly.
+/**
+ * Idle window, in milliseconds, of complete FC silence before the link is treated as dead.
+ *
+ * A single MSP request exhausting its retries spans only `MSP.MAX_RETRIES × MSP.TIMEOUT`
+ * (~3 s) of silence — a threshold a high-latency transport (WiFi/TCP bridge, BLE) can cross
+ * on a transient spike while the link is otherwise healthy. This window is set above one
+ * request's retry span so a lone slow request never triggers teardown, yet short enough that
+ * a genuinely hung FC is dropped promptly.
+ *
+ * @constant {number}
+ */
 const DEAD_LINK_TIMEOUT = 5000;
 
-// MSP.onTimeout hook: an errorAware request exhausted MAX_RETRIES. That alone does not mean the FC
-// is gone — decide from the link's actual liveness. MSP.last_received_timestamp advances on every
-// byte the FC sends, so if any traffic has arrived within DEAD_LINK_TIMEOUT the FC is alive but
-// slow: leave the link up and let the poller keep trying. Only when the FC has been fully silent
-// for the whole window is the link dead.
-//
-// A hung FC keeps the transport physically open, so no "disconnect" event fires on its own. When
-// the link really is dead, tear it down like the reboot path: mark the disconnect intentional (so
-// onClosed skips the unexpected-disconnect teardown) and close WITHOUT the setArmingEnabled
-// round-trip, which would itself hang on the dead FC. Re-entrancy is bounded by the isConnected()
-// gate — teardown clears MSP.onTimeout and connection validity before another request can trip it.
+/**
+ * `MSP.onTimeout` hook — runs when an errorAware request exhausts `MSP.MAX_RETRIES`.
+ *
+ * A single exhausted request does not imply the FC is gone, so teardown is gated on the link's
+ * measured liveness rather than one request's failure. `MSP.last_received_timestamp` advances on
+ * every inbound byte, so any traffic within {@link DEAD_LINK_TIMEOUT} means the FC is responsive
+ * but slow — the link is kept open for the poller to retry. Only uninterrupted silence for the
+ * full window is classified as a dead link.
+ *
+ * A hung FC keeps the transport physically open, so no `disconnect` event fires on its own. When
+ * the link is dead this mirrors the reboot teardown path: it flags the disconnect as intentional
+ * (so {@link onClosed} skips unexpected-disconnect handling) and closes without the
+ * `setArmingEnabled` round-trip, which would itself hang against the dead FC. Re-entrancy is
+ * bounded by the `isConnected()` guard — teardown clears `MSP.onTimeout` and the connection-valid
+ * flag before a subsequent timeout can re-enter.
+ *
+ * @returns {void}
+ */
 function handleConnectionTimeout() {
     if (!isConnected()) {
         return;
@@ -1307,7 +1320,7 @@ function handleConnectionTimeout() {
 
     const lastReceived = MSP.last_received_timestamp;
     if (lastReceived !== null && Date.now() - lastReceived < DEAD_LINK_TIMEOUT) {
-        // The FC is still sending us data — a slow request, not a dead link. Keep the link up.
+        // Inbound traffic within the window: the FC is responding, just slowly — keep the link.
         return;
     }
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1282,14 +1282,32 @@ async function requestLiveData(code, name) {
     }
 }
 
-// MSP.onTimeout hook: an errorAware request exhausted MAX_RETRIES, so the FC is unresponsive.
-// A hung FC keeps the transport physically open, so no "disconnect" event fires on its own.
-// Tear the link down like the reboot path: mark the disconnect intentional (so onClosed skips
-// the unexpected-disconnect teardown) and close WITHOUT the setArmingEnabled round-trip, which
-// would itself hang on the dead FC. Re-entrancy is bounded by the isConnected() gate — teardown
-// clears MSP.onTimeout and connection validity before another request can trip it.
+// A link is only "dead" once the FC has gone completely silent for this long. One MSP request
+// exhausting its retries (~MAX_RETRIES × TIMEOUT ≈ 3 s) is not enough on its own: a high-latency
+// transport (WiFi TCP bridge, BLE) can miss a single request while the link is still delivering
+// other traffic. The threshold sits above one request's retry window so a lone slow request never
+// trips teardown, but low enough that a genuinely hung FC is dropped promptly.
+const DEAD_LINK_TIMEOUT = 5000;
+
+// MSP.onTimeout hook: an errorAware request exhausted MAX_RETRIES. That alone does not mean the FC
+// is gone — decide from the link's actual liveness. MSP.last_received_timestamp advances on every
+// byte the FC sends, so if any traffic has arrived within DEAD_LINK_TIMEOUT the FC is alive but
+// slow: leave the link up and let the poller keep trying. Only when the FC has been fully silent
+// for the whole window is the link dead.
+//
+// A hung FC keeps the transport physically open, so no "disconnect" event fires on its own. When
+// the link really is dead, tear it down like the reboot path: mark the disconnect intentional (so
+// onClosed skips the unexpected-disconnect teardown) and close WITHOUT the setArmingEnabled
+// round-trip, which would itself hang on the dead FC. Re-entrancy is bounded by the isConnected()
+// gate — teardown clears MSP.onTimeout and connection validity before another request can trip it.
 function handleConnectionTimeout() {
     if (!isConnected()) {
+        return;
+    }
+
+    const lastReceived = MSP.last_received_timestamp;
+    if (lastReceived !== null && Date.now() - lastReceived < DEAD_LINK_TIMEOUT) {
+        // The FC is still sending us data — a slow request, not a dead link. Keep the link up.
         return;
     }
 

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 
 // ---------------------------------------------------------------------------
@@ -854,6 +854,12 @@ describe("serial_backend MSP unresponsive-FC teardown", () => {
     beforeEach(() => {
         setActivePinia(createPinia());
         resetMocks();
+    });
+
+    afterEach(() => {
+        // These cases drive MSP.last_received_timestamp directly; clear the singleton so a
+        // later test can't inherit stale traffic state.
+        MSP.last_received_timestamp = null;
     });
 
     it("registers MSP.onTimeout on connect and clears it on teardown", () => {

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -864,11 +864,14 @@ describe("serial_backend MSP unresponsive-FC teardown", () => {
         expect(MSP.onTimeout).toBeNull();
     });
 
-    it("drops the link and shows a dialog when a request exhausts its retries", () => {
+    it("drops the link and shows a dialog when the FC has gone fully silent", () => {
         establishConnection();
         getConnectionState().setLinkOpen(true);
         serial.disconnect.mockClear();
         dialogStore.open.mockClear();
+
+        // No FC traffic for longer than the dead-link window: the link really is dead.
+        MSP.last_received_timestamp = Date.now() - 10_000;
 
         // Fire the hook MSP invokes after MAX_RETRIES with no response.
         MSP.onTimeout(MSPCodes.MSP_ANALOG);
@@ -884,6 +887,19 @@ describe("serial_backend MSP unresponsive-FC teardown", () => {
             expect.objectContaining({ title: "connectionLostTitle", text: "connectionLostUnresponsive" }),
             expect.anything(),
         );
+    });
+
+    it("keeps the link up when the FC is still sending data (slow, not dead)", () => {
+        establishConnection();
+        getConnectionState().setLinkOpen(true);
+        serial.disconnect.mockClear();
+
+        // The FC answered other traffic moments ago — a single slow request is not a dead link.
+        MSP.last_received_timestamp = Date.now();
+
+        MSP.onTimeout(MSPCodes.MSP_ANALOG);
+
+        expect(serial.disconnect).not.toHaveBeenCalled();
     });
 
     it("ignores the timeout hook when not connected", () => {

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -870,13 +870,14 @@ describe("serial_backend MSP unresponsive-FC teardown", () => {
         serial.disconnect.mockClear();
         dialogStore.open.mockClear();
 
-        // No FC traffic for longer than the dead-link window: the link really is dead.
+        // last_received_timestamp older than DEAD_LINK_TIMEOUT (5 s): no inbound bytes for the
+        // whole window, so the link classifies as dead.
         MSP.last_received_timestamp = Date.now() - 10_000;
 
-        // Fire the hook MSP invokes after MAX_RETRIES with no response.
+        // MSP.onTimeout hook — fired after an errorAware request exhausts MAX_RETRIES.
         MSP.onTimeout(MSPCodes.MSP_ANALOG);
 
-        // Teardown initiated (finishClose -> serial.disconnect) without any MSP round-trip.
+        // Teardown runs via finishClose -> serial.disconnect, with no MSP round-trip to the dead FC.
         expect(serial.disconnect).toHaveBeenCalledTimes(1);
 
         // The protocol "disconnect" event drives onClosed, which raises the notice only after
@@ -894,7 +895,8 @@ describe("serial_backend MSP unresponsive-FC teardown", () => {
         getConnectionState().setLinkOpen(true);
         serial.disconnect.mockClear();
 
-        // The FC answered other traffic moments ago — a single slow request is not a dead link.
+        // last_received_timestamp inside DEAD_LINK_TIMEOUT: inbound traffic just arrived, so the
+        // exhausted request is a latency spike, not a dead link.
         MSP.last_received_timestamp = Date.now();
 
         MSP.onTimeout(MSPCodes.MSP_ANALOG);


### PR DESCRIPTION
## Problem

Arbitrary TCP connections broke on the Android app: a link that worked a week ago now drops itself shortly after connecting, with a "Connection lost" dialog. USB is unaffected.

## Root cause

#5306 added `MSP.onTimeout`, which `serial_backend` wires to `handleConnectionTimeout` to tear the link down when the FC stops responding. It fired the instant a **single** `errorAware` request (`MSP.promise`, used by the background live-data poller) exhausted `MAX_RETRIES` — i.e. after only `MAX_RETRIES × TIMEOUT` ≈ **3 s** of silence on one request.

- On a **low-latency** transport (USB) a request practically never misses three replies in a row, so the path was never exercised.
- On a **high-latency** transport — a raw-TCP/WiFi bridge (Android), or BLE — a single latency spike routinely exceeds that window, so a perfectly healthy link was proactively torn down.

One request's retry count is the wrong signal for "the FC is gone".

## Fix

Decide "dead" from the link's **actual liveness** instead. `MSP.last_received_timestamp` already advances on every byte the FC sends, so `handleConnectionTimeout` now only tears the link down when the FC has been **fully silent for `DEAD_LINK_TIMEOUT` (5 s)**. If any traffic arrived inside that window the FC is alive-but-slow: the link stays up and the poller keeps trying. A genuinely hung FC (no traffic at all) is still dropped promptly.

This is immune to the poll cadence and to how many requests happen to be in flight — it keys off real inbound traffic only.

The liveness timestamp is also cleared in `resetConnection()` (the single teardown/disconnect/abort choke point) so a new connection can't inherit stale traffic state from a previous one.

## Changes

- `src/js/serial_backend.js`
  - `handleConnectionTimeout` gates teardown on `MSP.last_received_timestamp` vs a new `DEAD_LINK_TIMEOUT` (5 s).
  - `resetConnection` clears `MSP.last_received_timestamp` alongside `MSP.onTimeout`.
- `src/js/msp.js` — comment only; `onTimeout` still fires per exhaustion, but the dead-or-slow decision is delegated to the hook.
- `test/js/serial_backend.test.js` — asserts a fully-silent FC tears down + shows the dialog, and that an FC still sending data is kept up; clears the liveness singleton after each dead-link case.

## Scope

Companion to #5318 (the Tauri/desktop app-freeze on a failed manual connection, fixed natively in `src-tauri/src/tcp.rs`). This PR is the JS-side regression that also affected reachable TCP links; the two are independent and don't overlap.

## Testing

- `npm run test` — 665 pass
- `npm run lint` — clean

Reported by @YarosMallorca.
