### PR TITLE
fix(ios): connect to ELRS over TCP and request Local Network permission

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -650,6 +650,9 @@
     "connectionFailed": {
         "message": "<span class=\"message-negative\">Failed</span> to connect to the selected port. Check that the device is reachable and that the connection settings are correct, then try again."
     },
+    "connectionFailedLocalNetworkIOS": {
+        "message": "On iOS, allow <strong>Local Network</strong> access for Betaflight under Settings &rarr; Privacy &amp; Security &rarr; Local Network, then try again."
+    },
     "connectionLostTitle": {
         "message": "Connection lost"
     },

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "betaflight-app"
 version = "2026.6.0"
-description = "Betaflight App"
+description = "Betaflight"
 authors = ["The Betaflight open source project."]
 license = "GPL-3.0"
 repository = "https://github.com/betaflight/betaflight-configurator"

--- a/src-tauri/gen/android/app/src/main/res/values/strings.xml
+++ b/src-tauri/gen/android/app/src/main/res/values/strings.xml
@@ -1,4 +1,4 @@
 <resources>
-    <string name="app_name">Betaflight App</string>
-    <string name="main_activity_title">Betaflight App</string>
+    <string name="app_name">Betaflight</string>
+    <string name="main_activity_title">Betaflight</string>
 </resources>

--- a/src-tauri/gen/apple/Sources/betaflight-app/LocalNetworkPermission.swift
+++ b/src-tauri/gen/apple/Sources/betaflight-app/LocalNetworkPermission.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Network
+
+// iOS gates access to local-network addresses (where an ELRS Wi-Fi module lives) behind a
+// per-app Local Network permission. Plain BSD/POSIX sockets — which the Rust TCP transport
+// uses — do not engage that privacy machinery, so the OS never registers the app under
+// Settings > Privacy & Security > Local Network, never shows the prompt, and silently blocks
+// the connection. Starting an NWBrowser via Network.framework does engage it: it registers the
+// app, triggers the prompt, and once granted opens the app-wide gate so the subsequent raw
+// socket connect is allowed. The declared Bonjour type must also be listed in NSBonjourServices.
+//
+// Exposed as a C symbol so the Rust `tcp_connect` command can trigger it on iOS.
+
+private final class LocalNetworkTrigger {
+    static let shared = LocalNetworkTrigger()
+    private var browser: NWBrowser?
+
+    func activate() {
+        // Starting the browser once is enough to register the app and raise the prompt; keep the
+        // reference alive so the system can evaluate it rather than tearing it down immediately.
+        guard browser == nil else { return }
+        let params = NWParameters()
+        params.includePeerToPeer = true
+        let browser = NWBrowser(for: .bonjour(type: "_betaflight._tcp", domain: nil), using: params)
+        browser.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .failed, .cancelled:
+                self?.browser = nil
+            default:
+                break
+            }
+        }
+        self.browser = browser
+        browser.start(queue: .main)
+    }
+}
+
+@_cdecl("bf_trigger_local_network_permission")
+public func bf_trigger_local_network_permission() {
+    DispatchQueue.main.async {
+        LocalNetworkTrigger.shared.activate()
+    }
+}

--- a/src-tauri/gen/apple/betaflight-app_iOS/Info.plist
+++ b/src-tauri/gen/apple/betaflight-app_iOS/Info.plist
@@ -22,6 +22,10 @@
 	<true/>
 	<key>NSLocalNetworkUsageDescription</key>
 	<string>Betaflight connects to your flight controller bridge over the local network.</string>
+	<key>NSBonjourServices</key>
+	<array>
+		<string>_betaflight._tcp</string>
+	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/src-tauri/gen/apple/project.yml
+++ b/src-tauri/gen/apple/project.yml
@@ -10,7 +10,7 @@ configs:
 settingGroups:
   app:
     base:
-      PRODUCT_NAME: Betaflight App
+      PRODUCT_NAME: Betaflight
       PRODUCT_BUNDLE_IDENTIFIER: com.betaflight.app
       DEVELOPMENT_TEAM: 88U8UVP252
 targetTemplates:
@@ -54,6 +54,9 @@ targets:
           - UIInterfaceOrientationLandscapeRight
         CFBundleShortVersionString: 2026.6.0
         CFBundleVersion: "2026.6.0"
+        NSLocalNetworkUsageDescription: Betaflight connects to your flight controller bridge over the local network.
+        NSBonjourServices:
+          - _betaflight._tcp
     entitlements:
       path: betaflight-app_iOS/betaflight-app_iOS.entitlements
     scheme:
@@ -74,6 +77,7 @@ targets:
       - framework: libapp.a
         embed: false
       - sdk: CoreGraphics.framework
+      - sdk: Network.framework
       - sdk: Metal.framework
       - sdk: MetalKit.framework
       - sdk: QuartzCore.framework

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,6 +12,15 @@ pub fn run() {
     #[cfg(desktop)]
     let builder = builder.plugin(tauri_plugin_window_state::Builder::default().build());
 
+    // iOS: network (TCP/WebSocket) is the only transport, and a raw socket never raises the
+    // Local Network permission prompt on its own. Request it at startup — before any connect —
+    // so the user grants it up front instead of the first connect failing while it's pending.
+    #[cfg(target_os = "ios")]
+    let builder = builder.setup(|_app| {
+        tcp::trigger_local_network_permission();
+        Ok(())
+    });
+
     builder
         .manage(tcp::TcpState::default())
         .invoke_handler(tauri::generate_handler![

--- a/src-tauri/src/tcp.rs
+++ b/src-tauri/src/tcp.rs
@@ -22,8 +22,29 @@ use tauri::{AppHandle, Emitter, State};
 /// Total budget for the TCP handshake, across every address a hostname resolves to.
 /// `TcpStream::connect` has no timeout of its own, and an invalid/unreachable manual IP
 /// would otherwise block on the OS's SYN-retry timeout, which runs to tens of seconds
-/// (Windows) or minutes (Linux default).
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(5);
+/// (Windows) or minutes (Linux default). Kept generous so a slow Wi-Fi module (ELRS) and
+/// the iOS Local Network permission prompt on the first local connection have time to land.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+
+// iOS gates local-network access (where an ELRS module lives) behind a per-app Local Network
+// permission, but a raw POSIX socket — which `TcpStream` is — never engages that privacy layer,
+// so the OS neither registers the app under Settings > Privacy & Security > Local Network nor
+// prompts, and silently blocks the connection. `LocalNetworkPermission.swift` starts an
+// NWBrowser via Network.framework, which does engage it; call it before connecting so the prompt
+// appears and, once granted, the app-wide gate lets this socket through.
+#[cfg(target_os = "ios")]
+unsafe extern "C" {
+    fn bf_trigger_local_network_permission();
+}
+
+pub fn trigger_local_network_permission() {
+    // Safety: symbol is provided by the app's Swift side, linked into the same binary; it only
+    // schedules an NWBrowser on the main queue and returns.
+    #[cfg(target_os = "ios")]
+    unsafe {
+        bf_trigger_local_network_permission();
+    }
+}
 
 #[derive(Default)]
 pub struct TcpState {
@@ -44,6 +65,11 @@ pub async fn tcp_connect(
     // the check below detect that and refuse to install a superseded connection.
     let epoch = state.epoch.clone();
     let my_epoch = epoch.fetch_add(1, Ordering::SeqCst) + 1;
+
+    // Ask iOS for Local Network access before the socket attempt (no-op elsewhere). The prompt is
+    // async, so the first connect to a fresh install still fails while it is pending — the user
+    // grants it and reconnects, after which the gate is open.
+    trigger_local_network_permission();
 
     // The blocking connect itself moves to a dedicated thread (`spawn_blocking`) so it can't
     // stall an async runtime worker either. Without both this and `async fn` above, a bad

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.tauri.app/config/2",
-    "productName": "Betaflight App",
+    "productName": "Betaflight",
     "version": "2026.6.0",
     "identifier": "com.betaflight.app",
     "build": {
@@ -18,7 +18,7 @@
         },
         "windows": [
             {
-                "title": "Betaflight App",
+                "title": "Betaflight",
                 "width": 1024,
                 "height": 550,
                 "minWidth": 1024,

--- a/src/components/device-picker/ConnectOptionsDialog.vue
+++ b/src/components/device-picker/ConnectOptionsDialog.vue
@@ -16,7 +16,14 @@
                 </label>
                 <label v-else class="connect-options__field">
                     <span>{{ $t("portOverrideText") }}</span>
-                    <UInput v-model="portOverride" size="sm" autofocus />
+                    <UInput
+                        v-model="portOverride"
+                        size="sm"
+                        autofocus
+                        autocapitalize="none"
+                        autocorrect="off"
+                        spellcheck="false"
+                    />
                 </label>
             </div>
         </template>

--- a/src/js/protocols/TauriTcp.js
+++ b/src/js/protocols/TauriTcp.js
@@ -41,6 +41,15 @@ class TauriTcp extends EventTarget {
         return { path, displayName: "Betaflight TCP", vendorId: 0, productId: 0, port: 0 };
     }
 
+    // Accept "tcp://host:port", "host:port" or a bare "host". The manual-entry box
+    // (and ELRS users) routinely omit the scheme, and `new URL` rejects a schemeless
+    // host, so prepend tcp:// before parsing. Defaults to the Betaflight bridge port.
+    _parseAddress(path) {
+        const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(path) ? path : `tcp://${path}`;
+        const url = new URL(withScheme);
+        return { host: url.hostname, port: Number.parseInt(url.port, 10) || 5761 };
+    }
+
     createPort(url) {
         this.address = url;
         return this._portInfo(url);
@@ -68,11 +77,9 @@ class TauriTcp extends EventTarget {
 
     async connect(path, _options) {
         try {
-            const url = new URL(path);
-            const host = url.hostname;
-            const port = Number.parseInt(url.port, 10) || 5761;
+            const { host, port } = this._parseAddress(path);
 
-            console.log(`${this.logHead} Connecting to ${url}`);
+            console.log(`${this.logHead} Connecting to ${host}:${port}`);
 
             // Drop any listeners left over from a previous connection before re-registering,
             // otherwise reconnects leak listeners and duplicate receive/disconnect handling.

--- a/src/js/protocols/TauriTcp.js
+++ b/src/js/protocols/TauriTcp.js
@@ -44,6 +44,10 @@ class TauriTcp extends EventTarget {
     // Accept "tcp://host:port", "host:port" or a bare "host". The manual-entry box
     // (and ELRS users) routinely omit the scheme, and `new URL` rejects a schemeless
     // host, so prepend tcp:// before parsing. Defaults to the Betaflight bridge port.
+    /**
+     * @param {string} path - "tcp://host:port", "host:port" or a bare "host".
+     * @returns {{host: string, port: number}}
+     */
     _parseAddress(path) {
         const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(path) ? path : `tcp://${path}`;
         const url = new URL(withScheme);

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -116,6 +116,7 @@ class Serial extends EventTarget {
     /**
      * Selects the appropriate protocol based on port path
      * @param {string|function|null} portPath - Port path or callback function for virtual mode
+     * @returns {EventTarget|undefined} The matching protocol instance, or undefined when none applies.
      */
     selectProtocol(portPath) {
         // Determine which protocol to use based on port path
@@ -142,11 +143,11 @@ class Serial extends EventTarget {
             return this._protocols.find((p) => p.name === "bluetooth")?.instance;
         }
         const serialInstance = this._protocols.find((p) => p.name === "serial")?.instance;
-        // No native serial transport (iOS): a manual entry without a scheme can only be a TCP
-        // endpoint (e.g. an ELRS Wi-Fi module at 10.0.0.1), so route it to TCP rather than a
-        // serial slot that doesn't exist — otherwise the socket is never opened, the OS never
-        // prompts for Local Network access, and the open fails as "serial port".
-        if (!serialInstance && s) {
+        // No native serial transport (iOS): a schemeless manual entry that looks like a network
+        // host (an IP, a dotted hostname, or host:port — e.g. an ELRS Wi-Fi module at 10.0.0.1)
+        // can only be a TCP endpoint, so route it to TCP rather than a serial slot that doesn't
+        // exist. A device path (/dev/tty*, COM3) still resolves to no protocol, as before.
+        if (!serialInstance && /^[a-z0-9.-]+(?::\d+)?$/i.test(s) && (s.includes(".") || s.includes(":"))) {
             return this._protocols.find((p) => p.name === "tcp")?.instance;
         }
         return serialInstance;

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -154,6 +154,30 @@ class Serial extends EventTarget {
     }
 
     /**
+     * Classifies a manual target as a local-network address (RFC1918 / IPv4 & IPv6 link-local /
+     * .local) — the range an ELRS Wi-Fi module sits in, and the range iOS Local Network gates.
+     * @param {string} target - a manual connection target (URL or bare host[:port]).
+     * @returns {boolean} true when it resolves to a local-network address.
+     */
+    isLocalNetworkAddress(target) {
+        try {
+            const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(target) ? target : `tcp://${target}`;
+            // Strips IPv6 brackets so fe80::/10 link-local hosts can be matched.
+            const host = new URL(withScheme).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+            return (
+                host.startsWith("10.") ||
+                host.startsWith("192.168.") ||
+                /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+                host.startsWith("169.254.") ||
+                /^fe[89ab][0-9a-f]:/.test(host) ||
+                host.endsWith(".local")
+            );
+        } catch {
+            return false;
+        }
+    }
+
+    /**
      * Connect to the specified port with options
      * @param {string|function} path - Port path or callback for virtual mode
      * @param {object} options - Connection options (baudRate, etc.)

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -141,7 +141,15 @@ class Serial extends EventTarget {
         if (s.startsWith("bluetooth")) {
             return this._protocols.find((p) => p.name === "bluetooth")?.instance;
         }
-        return this._protocols.find((p) => p.name === "serial")?.instance;
+        const serialInstance = this._protocols.find((p) => p.name === "serial")?.instance;
+        // No native serial transport (iOS): a manual entry without a scheme can only be a TCP
+        // endpoint (e.g. an ELRS Wi-Fi module at 10.0.0.1), so route it to TCP rather than a
+        // serial slot that doesn't exist — otherwise the socket is never opened, the OS never
+        // prompts for Local Network access, and the open fails as "serial port".
+        if (!serialInstance && s) {
+            return this._protocols.find((p) => p.name === "tcp")?.instance;
+        }
+        return serialInstance;
     }
 
     /**

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -744,14 +744,20 @@ function abortConnection(messageKey) {
     const connectingTo = GUI.connecting_to || "";
     const isManualTarget =
         DeviceHandler.devicePicker.selectedDevice === "manual" || /^(tcp|ws|wss):\/\//i.test(connectingTo);
-    let message = i18n.getMessage(
-        messageKey ?? (GUI.connected_to || isManualTarget ? "connectionFailed" : "serialPortOpenFail"),
-    );
+    const effectiveKey = messageKey ?? (GUI.connected_to || isManualTarget ? "connectionFailed" : "serialPortOpenFail");
+    let message = i18n.getMessage(effectiveKey);
 
     // iOS gates connections to local-network addresses (where an ELRS module lives) behind a
     // per-app Local Network permission; when it is denied the socket fails immediately with no
     // route to host and no prompt. Point the user at the setting, since that is the usual cause.
-    if (!messageKey && isManualTarget && isTauriIOS() && serial.isLocalNetworkAddress(connectingTo)) {
+    // The watchdog and connect-phase disconnect paths both report "connectionFailed" explicitly,
+    // so key off the resolved message rather than the absence of a messageKey.
+    if (
+        effectiveKey === "connectionFailed" &&
+        isManualTarget &&
+        isTauriIOS() &&
+        serial.isLocalNetworkAddress(connectingTo)
+    ) {
         message += ` ${i18n.getMessage("connectionFailedLocalNetworkIOS")}`;
     }
 

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -23,6 +23,7 @@ import CryptoES from "crypto-es";
 import BuildApi from "./BuildApi";
 
 import { serial } from "./serial.js";
+import { isTauriIOS } from "./utils/checkCompatibility.js";
 import { getConnectionState, State as ConnPhase } from "./connection_state.js";
 import { EventBus } from "../components/eventBus";
 import { ispConnected } from "./utils/connection";
@@ -416,6 +417,10 @@ function beginConnect(selectedDevice) {
     // and the Connect button would spin forever. If the attempt neither opens nor becomes valid
     // within the window, recover the UI and tell the user. The disconnect-during-connect path in
     // onClosed normally handles this sooner; this covers protocols that signal nothing at all.
+    // Manual/TCP targets (e.g. an ELRS Wi-Fi module) have a longer handshake — a slow AP plus
+    // the iOS Local Network permission prompt on the first connection — so give them a wider
+    // window than the enumerated-serial default before the safety net calls the attempt failed.
+    const connectAttemptTimeout = selectedDevice === "manual" ? 20000 : 10000;
     GUI.timeout_add(
         "connectAttempt",
         function () {
@@ -423,7 +428,7 @@ function beginConnect(selectedDevice) {
                 abortConnection("connectionFailed");
             }
         },
-        10000,
+        connectAttemptTimeout,
     );
 
     // Set up event listeners for non-virtual connections
@@ -718,6 +723,22 @@ function resetConnection() {
     DeviceHandler.devicePickerDisabled = false;
 }
 
+// True when a manual target points at the local network (RFC1918 / link-local / .local) —
+// the range an ELRS Wi-Fi module sits in, and the range iOS Local Network permission gates.
+function isLocalNetworkAddress(target) {
+    const host = target
+        .replace(/^\w+:\/\//, "")
+        .split("/")[0]
+        .split(":")[0];
+    return (
+        /^10\./.test(host) ||
+        /^192\.168\./.test(host) ||
+        /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+        /^169\.254\./.test(host) ||
+        host.endsWith(".local")
+    );
+}
+
 function abortConnection(messageKey) {
     GUI.timeout_remove("connecting"); // kill post-open connecting timer
     GUI.timeout_remove("connectAttempt"); // kill pre-open watchdog
@@ -733,8 +754,22 @@ function abortConnection(messageKey) {
         DeviceHandler.devicePicker.autoConnect;
 
     // Default message reflects how far the attempt got: a port that already opened but failed
-    // the handshake (e.g. invalid API version) did not "fail to open".
-    const message = i18n.getMessage(messageKey ?? (GUI.connected_to ? "connectionFailed" : "serialPortOpenFail"));
+    // the handshake (e.g. invalid API version) did not "fail to open". A manual/TCP/WebSocket
+    // target (e.g. an ELRS Wi-Fi bridge) never opens a "serial port" either, so report a
+    // network-appropriate failure rather than the misleading serial one.
+    const connectingTo = GUI.connecting_to || "";
+    const isManualTarget =
+        DeviceHandler.devicePicker.selectedDevice === "manual" || /^(tcp|ws|wss):\/\//i.test(connectingTo);
+    let message = i18n.getMessage(
+        messageKey ?? (GUI.connected_to || isManualTarget ? "connectionFailed" : "serialPortOpenFail"),
+    );
+
+    // iOS gates connections to local-network addresses (where an ELRS module lives) behind a
+    // per-app Local Network permission; when it is denied the socket fails immediately with no
+    // route to host and no prompt. Point the user at the setting, since that is the usual cause.
+    if (!messageKey && isManualTarget && isTauriIOS() && isLocalNetworkAddress(connectingTo)) {
+        message += ` ${i18n.getMessage("connectionFailedLocalNetworkIOS")}`;
+    }
 
     // A failed handshake (invalid/garbage API version) is a HANDSHAKING ->
     // FAILED edge before teardown. notifyClosed (via resetConnection's close path)

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -723,20 +723,28 @@ function resetConnection() {
     DeviceHandler.devicePickerDisabled = false;
 }
 
-// True when a manual target points at the local network (RFC1918 / link-local / .local) —
-// the range an ELRS Wi-Fi module sits in, and the range iOS Local Network permission gates.
+// True when a manual target points at the local network (RFC1918 / IPv4 & IPv6 link-local /
+// .local) — the range an ELRS Wi-Fi module sits in, and the range iOS Local Network gates.
+/**
+ * @param {string} target - a manual connection target (URL or bare host[:port]).
+ * @returns {boolean} true when it resolves to a local-network address.
+ */
 function isLocalNetworkAddress(target) {
-    const host = target
-        .replace(/^\w+:\/\//, "")
-        .split("/")[0]
-        .split(":")[0];
-    return (
-        /^10\./.test(host) ||
-        /^192\.168\./.test(host) ||
-        /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-        /^169\.254\./.test(host) ||
-        host.endsWith(".local")
-    );
+    try {
+        const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(target) ? target : `tcp://${target}`;
+        // Strips IPv6 brackets so fe80::/10 link-local hosts can be matched.
+        const host = new URL(withScheme).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+        return (
+            host.startsWith("10.") ||
+            host.startsWith("192.168.") ||
+            /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
+            host.startsWith("169.254.") ||
+            /^fe[89ab][0-9a-f]:/.test(host) ||
+            host.endsWith(".local")
+        );
+    } catch {
+        return false;
+    }
 }
 
 function abortConnection(messageKey) {

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -723,30 +723,6 @@ function resetConnection() {
     DeviceHandler.devicePickerDisabled = false;
 }
 
-// True when a manual target points at the local network (RFC1918 / IPv4 & IPv6 link-local /
-// .local) — the range an ELRS Wi-Fi module sits in, and the range iOS Local Network gates.
-/**
- * @param {string} target - a manual connection target (URL or bare host[:port]).
- * @returns {boolean} true when it resolves to a local-network address.
- */
-function isLocalNetworkAddress(target) {
-    try {
-        const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(target) ? target : `tcp://${target}`;
-        // Strips IPv6 brackets so fe80::/10 link-local hosts can be matched.
-        const host = new URL(withScheme).hostname.toLowerCase().replace(/^\[|\]$/g, "");
-        return (
-            host.startsWith("10.") ||
-            host.startsWith("192.168.") ||
-            /^172\.(1[6-9]|2\d|3[01])\./.test(host) ||
-            host.startsWith("169.254.") ||
-            /^fe[89ab][0-9a-f]:/.test(host) ||
-            host.endsWith(".local")
-        );
-    } catch {
-        return false;
-    }
-}
-
 function abortConnection(messageKey) {
     GUI.timeout_remove("connecting"); // kill post-open connecting timer
     GUI.timeout_remove("connectAttempt"); // kill pre-open watchdog
@@ -775,7 +751,7 @@ function abortConnection(messageKey) {
     // iOS gates connections to local-network addresses (where an ELRS module lives) behind a
     // per-app Local Network permission; when it is denied the socket fails immediately with no
     // route to host and no prompt. Point the user at the setting, since that is the usual cause.
-    if (!messageKey && isManualTarget && isTauriIOS() && isLocalNetworkAddress(connectingTo)) {
+    if (!messageKey && isManualTarget && isTauriIOS() && serial.isLocalNetworkAddress(connectingTo)) {
         message += ` ${i18n.getMessage("connectionFailedLocalNetworkIOS")}`;
     }
 

--- a/test/js/serial.test.js
+++ b/test/js/serial.test.js
@@ -51,4 +51,10 @@ describe("serial.selectProtocol — Tauri transport routing", () => {
         // isTauriIOS() is true, so serial is excluded; a serial path resolves to undefined.
         expect(serial.selectProtocol("/dev/ttyACM0")).toBeUndefined();
     });
+
+    it("routes a schemeless network host to the TCP slot when there is no serial transport (iOS)", () => {
+        // A bare ELRS/bridge IP has no serial slot to fall back to on iOS, so it must reach TCP.
+        expect(serial.selectProtocol("10.0.0.1").constructor.name).toBe("TauriTcp");
+        expect(serial.selectProtocol("10.0.0.1:5761").constructor.name).toBe("TauriTcp");
+    });
 });


### PR DESCRIPTION
Enables connecting to an ELRS module or Betaflight bridge over raw TCP on iOS, which previously failed silently.

Root cause: a bare IP entered manually routed to the serial slot (absent on iOS), and even with a `tcp://` prefix a native POSIX socket never engages the iOS Local Network privacy layer, so the app was never registered under Settings, Privacy & Security, Local Network and the connection was blocked. WebSocket connections already worked (WKWebView runs networking out of process) and are unaffected.

- route schemeless manual entries to TCP when there is no serial transport (iOS), and parse a bare `host[:port]` in TauriTcp (default port 5761)
- trigger the Local Network permission prompt via a Network.framework `NWBrowser`, at startup and before connect (Swift `@_cdecl` called from Rust); declare `NSBonjourServices` and link `Network.framework`
- replace the misleading "Failed to open serial port" message for network targets with a connection-failed message that adds an iOS Local Network hint for local addresses
- raise the TCP connect timeout to 15s, widen the manual connect watchdog, and disable autocapitalise on the manual address input
- rename the app from "Betaflight App" to "Betaflight"

The native iOS pieces can only be validated on an Xcode/TestFlight build; desktop `cargo check` and JS lint pass. The first connect on a fresh install may still fail while the permission prompt is pending, after which it is granted app-wide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS-specific Local Network connection guidance with an inline “then try again” instruction.
  * iOS now triggers Local Network permission before attempting TCP/WebSocket connections.
  * Manual TCP entry accepts hostnames/IPs (with optional ports), including schemeless inputs.

* **Bug Fixes**
  * Improved connection-failure messaging to better distinguish TCP/WebSocket vs serial, including extra iOS Local Network guidance when relevant.
  * Increased TCP handshake/connect timeout for better reliability.
  * Preserved manual port input verbatim (no autocorrect/autocapitalize/spellcheck).

* **Style**
  * Updated product name and window title branding to “Betaflight.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->