### PR TITLE
fix(dfu): name the udev cause when Linux denies device access

### DIFF
--- a/src/js/protocols/WebUsbDfuTransport.js
+++ b/src/js/protocols/WebUsbDfuTransport.js
@@ -137,6 +137,11 @@ class WebUsbDfuTransport extends EventTarget {
     }
 
     async releaseInterface(interfaceNumber) {
+        // Cleanup after a failed open() runs the same teardown path, so there may be
+        // no device to release. Nothing was claimed in that case.
+        if (!this.usbDevice) {
+            return;
+        }
         await this.usbDevice.releaseInterface(interfaceNumber);
         console.log(`${this.logHead} Released interface: ${interfaceNumber}`);
     }

--- a/src/js/protocols/usbdfu.js
+++ b/src/js/protocols/usbdfu.js
@@ -22,6 +22,7 @@ import { i18n } from "../localization";
 import { gui_log } from "../gui_log";
 import NotificationManager from "../utils/notifications";
 import { get as getConfig } from "../ConfigStorage";
+import { getOS } from "../utils/checkCompatibility";
 import WebUsbDfuTransport from "./WebUsbDfuTransport";
 
 // Error constant used when an already-authorized DFU device isn't found
@@ -231,6 +232,12 @@ export class UsbDfuProtocol extends EventTarget {
             .catch((error) => {
                 console.log(`${this.logHead} Failed to open USB device:`, error);
                 gui_log(i18n.getMessage("usbDeviceOpenFail"));
+                // A SecurityError from open() means the OS refused access to the device node.
+                // On Linux that is a missing udev rule for the bootloader's vendor ID, which the
+                // bare "failed to open" message gives no clue about.
+                if (error?.name === "SecurityError" && getOS() === "Linux") {
+                    gui_log(i18n.getMessage("usbDeviceUdevNotice"));
+                }
                 this.cleanup();
             });
     }

--- a/test/js/usbdfu_open_failure.test.js
+++ b/test/js/usbdfu_open_failure.test.js
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Regression tests for the DFU open-failure path.
+//
+// On Linux the kernel exposes a USB device node the user can only read unless a
+// udev rule grants write access for that vendor ID. WebUSB `open()` then fails
+// with a SecurityError ("Access denied"), which reads as a configurator bug
+// unless the udev cause is spelled out — see a fresh X32 bootloader (0x3997).
+//
+// The teardown that follows a failed open must also stay quiet: no interface was
+// ever claimed, so releasing one is a no-op rather than a TypeError on a null
+// device.
+// ---------------------------------------------------------------------------
+
+vi.mock("../../src/js/gui", () => ({ default: { connect_lock: false } }));
+vi.mock("../../src/js/localization", () => ({ i18n: { getMessage: (key) => key } }));
+vi.mock("../../src/js/gui_log", () => ({ gui_log: vi.fn() }));
+vi.mock("../../src/js/utils/notifications", () => ({ default: { showNotification: vi.fn() } }));
+vi.mock("../../src/js/ConfigStorage", () => ({ get: () => ({}) }));
+vi.mock("../../src/js/utils/checkCompatibility", () => ({ getOS: vi.fn() }));
+// Prevent the module-bottom `new WebUsbDfuTransport()` from touching navigator.usb.
+vi.mock("../../src/js/protocols/WebUsbDfuTransport", () => ({ default: class extends EventTarget {} }));
+
+const { UsbDfuProtocol } = await import("../../src/js/protocols/usbdfu");
+const { gui_log } = await import("../../src/js/gui_log");
+const { getOS } = await import("../../src/js/utils/checkCompatibility");
+const RealWebUsbDfuTransport = (await vi.importActual("../../src/js/protocols/WebUsbDfuTransport")).default;
+
+/** Transport whose open() always rejects, recording the teardown that follows. */
+class FailingOpenTransport extends EventTarget {
+    constructor(error) {
+        super();
+        this.error = error;
+        this.released = [];
+        this.closeCount = 0;
+    }
+    open() {
+        return Promise.reject(this.error);
+    }
+    releaseInterface(interfaceNumber) {
+        this.released.push(interfaceNumber);
+        return Promise.resolve();
+    }
+    close() {
+        this.closeCount++;
+        return Promise.resolve();
+    }
+    getConnectedDevice() {
+        return null;
+    }
+}
+
+const accessDenied = () => {
+    const error = new Error("Failed to execute 'open' on 'USBDevice': Access denied.");
+    error.name = "SecurityError";
+    return error;
+};
+
+/** Drive openDevice() and let its promise chain (including cleanup) settle. */
+async function runOpen(transport) {
+    const dfu = new UsbDfuProtocol(transport);
+    dfu.connectedDevice = { path: "usb_test", port: {} };
+    dfu.openDevice();
+    for (let i = 0; i < 10; i++) {
+        await Promise.resolve();
+    }
+    return dfu;
+}
+
+describe("DFU open failure diagnostics", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("points at udev rules when Linux denies access to the device node", async () => {
+        getOS.mockReturnValue("Linux");
+
+        await runOpen(new FailingOpenTransport(accessDenied()));
+
+        const messages = gui_log.mock.calls.map(([message]) => message);
+        expect(messages).toContain("usbDeviceOpenFail");
+        expect(messages).toContain("usbDeviceUdevNotice");
+    });
+
+    it("omits the udev hint on platforms that have no udev", async () => {
+        getOS.mockReturnValue("Windows");
+
+        await runOpen(new FailingOpenTransport(accessDenied()));
+
+        const messages = gui_log.mock.calls.map(([message]) => message);
+        expect(messages).toContain("usbDeviceOpenFail");
+        expect(messages).not.toContain("usbDeviceUdevNotice");
+    });
+
+    it("omits the udev hint for open failures that are not access denials", async () => {
+        getOS.mockReturnValue("Linux");
+        const error = new Error("The device was disconnected.");
+        error.name = "NetworkError";
+
+        await runOpen(new FailingOpenTransport(error));
+
+        const messages = gui_log.mock.calls.map(([message]) => message);
+        expect(messages).toContain("usbDeviceOpenFail");
+        expect(messages).not.toContain("usbDeviceUdevNotice");
+    });
+
+    it("closes the device during cleanup after a failed open", async () => {
+        getOS.mockReturnValue("Linux");
+        const transport = new FailingOpenTransport(accessDenied());
+
+        await runOpen(transport);
+
+        expect(transport.released).toEqual([0]);
+        expect(transport.closeCount).toBe(1);
+    });
+
+    it("treats releaseInterface as a no-op when no device was ever opened", async () => {
+        const transport = new RealWebUsbDfuTransport();
+        transport.usbDevice = null;
+
+        await expect(transport.releaseInterface(0)).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Problem

Flashing a board whose bootloader vendor ID has no udev rule fails with a log that points nowhere useful:

```
[FIRMWARE_FLASHER] Selected port: usb_24012C822401
[USB DFU] Failed to open USB device: SecurityError: Failed to execute 'open' on 'USBDevice': Access denied.
[USB DFU] Script finished after: 0.01 seconds
[USB DFU] Could not release interface: 0 (TypeError: Cannot read properties of null (reading 'releaseInterface'))
[USB DFU] DFU Device closed
```

Two separate problems are visible here.

**1. The real cause is never stated.** With no udev rule for the vendor ID, the kernel leaves the device node root-owned:

```
$ lsusb
Bus 001 Device 085: ID 3997:df11 Xcorelabs DFU in FS Mode
$ ls -l /dev/bus/usb/001/085
crw-rw-r-- 1 root root 189, 84 /dev/bus/usb/001/085
```

WebUSB `open()` needs read **and** write access, so it gets `EACCES`, which Chrome surfaces as a `SecurityError`. The user sees only "Failed to open USB device" and reasonably concludes the app is broken.

`usbDeviceUdevNotice` ("Are **udev rules** installed correctly? See docs for instructions") already existed and is translated in some twenty locales — but `grep -rn usbDeviceUdevNotice src/` returns nothing. It was never wired up.

**2. Teardown logs a misleading TypeError.** `openDevice()`'s catch calls `cleanup()`, which calls `releaseInterface(0)` even though `open()` failed and `transport.usbDevice` is still `null`. The resulting `TypeError` is caught and logged, burying the actual error two lines up.

Surfaced by a new X-CORE Labs X32 board (`3997:df11`), but neither problem is X32-specific — any bootloader without a matching rule hits both. The missing X32 rule itself is betaflight/betaflight.com#739.

## Changes

- `usbdfu.js` — on a `SecurityError` from `open()` while `getOS() === "Linux"`, log `usbDeviceUdevNotice` alongside the existing failure message. Gated on Linux because udev is meaningless elsewhere, and on `SecurityError` because other open failures (device unplugged mid-flash) have nothing to do with permissions.
- `WebUsbDfuTransport.js` — `releaseInterface()` returns early when there is no device. Nothing was claimed, so there is nothing to release.

## Tests

New `test/js/usbdfu_open_failure.test.js`, 5 cases: the hint appears on a Linux access denial, is suppressed on Windows, is suppressed for a non-`SecurityError` failure, teardown still closes the device, and `releaseInterface` no-ops without a device.

Both behaviour tests were confirmed to fail with the two source changes stashed and pass with them applied, so they are not vacuous.

Full suite: 673 passed / 59 files. ESLint and Prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup after unsuccessful USB device connections to prevent additional errors.
  * Added a Linux-specific access guidance message when device permissions prevent opening a USB device.
  * Ensured the guidance appears only for relevant permission failures and platforms.

* **Tests**
  * Added coverage for failed connections, cleanup behavior, and platform-specific messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->