### PR TITLE
fix(setup): stack attitude/heading instruments below model on small screens

### DIFF
--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -18,10 +18,10 @@
                                 <dd class="roll">{{ state.attitude.roll }}</dd>
                             </dl>
                         </div>
-                        <div class="instruments-right">
-                            <span id="attitude"></span>
-                            <span id="heading"></span>
-                        </div>
+                    </div>
+                    <div class="instruments-right">
+                        <span id="attitude"></span>
+                        <span id="heading"></span>
                     </div>
                     <UButton
                         class="reset-zaxis"
@@ -838,6 +838,11 @@ function openBuildOptionsDialog() {
     @media all and (max-width: 575px) {
         .setup-info-grid {
             grid-template-columns: 1fr;
+        }
+        .instruments-right {
+            position: static;
+            justify-content: center;
+            padding: 0.5rem 0 0.75rem;
         }
     }
     .system_info {


### PR DESCRIPTION
On the Setup tab at phone widths the attitude (artificial horizon) and heading instruments were absolutely positioned over the 3D model and overlapped it. This moves them out of the canvas overlay so that on small screens (≤575px) they flow below the model, centred. Desktop is unchanged: `#interactive_block` is `position: relative` and flush with the canvas, so the instruments keep their bottom-right overlay position.

**Before (mobile) — instruments overlap the model**

![before mobile](https://raw.githubusercontent.com/blckmn/pr-assets/main/setup-mobile-instrument-overlap/before-mobile.png)

**After (mobile) — instruments below the model, centred**

![after mobile](https://raw.githubusercontent.com/blckmn/pr-assets/main/setup-mobile-instrument-overlap/after-mobile.png)

**After (desktop) — unchanged**

![after desktop](https://raw.githubusercontent.com/blckmn/pr-assets/main/setup-mobile-instrument-overlap/after-desktop.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of the attitude and heading indicators for better positioning across screen sizes.
  * Enhanced the display on small screens by centering the indicators and adding appropriate spacing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->