### PR TITLE
ci(ios): upload to TestFlight on published release using the tag as version

### DIFF
--- a/.github/workflows/tauri-ios-release.yml
+++ b/.github/workflows/tauri-ios-release.yml
@@ -91,9 +91,10 @@ jobs:
           RAW_TAG: ${{ github.event.release.tag_name }}
         run: |
           VER="${RAW_TAG#v}"
-          VER="${VER%%-*}"
-          if [[ ! "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Tag '$RAW_TAG' -> '$VER' is not a MAJOR.MINOR.PATCH version" >&2
+          if [[ "$VER" =~ ^([0-9]+\.[0-9]+\.[0-9]+)(-RC[0-9]+)?$ ]]; then
+            VER="${BASH_REMATCH[1]}"
+          else
+            echo "Tag '$RAW_TAG' -> '$VER' is not a MAJOR.MINOR.PATCH(-RCn) version" >&2
             exit 1
           fi
           echo "MARKETING_VERSION=$VER" >> "$GITHUB_ENV"

--- a/.github/workflows/tauri-ios-release.yml
+++ b/.github/workflows/tauri-ios-release.yml
@@ -20,11 +20,22 @@ name: Tauri iOS release
 
 on:
   workflow_dispatch:
+  release:
+    types: [published]
+
+concurrency:
+  group: ios-testflight
+  cancel-in-progress: false
 
 jobs:
   ios:
     name: Build & publish iOS bundle
     runs-on: macos-26
+    # Manual dispatch always runs; a published release only builds for the
+    # project's date-based tags (e.g. 2026.6.0, 2026.6.0-RC3).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      startsWith(github.event.release.tag_name, '20')
     permissions:
       contents: read
     env:
@@ -33,6 +44,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
         with:
+          ref: ${{ github.event.release.tag_name || github.ref }}
           persist-credentials: false
 
       - name: Select Xcode 26 (iOS 26 SDK)
@@ -71,6 +83,21 @@ jobs:
           printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
           echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
+      # Release builds take CFBundleShortVersionString from the tag; strip a
+      # leading v and any -RCn suffix so it is a valid Apple version string.
+      - name: Derive marketing version from release tag
+        if: github.event_name == 'release'
+        env:
+          RAW_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VER="${RAW_TAG#v}"
+          VER="${VER%%-*}"
+          if [[ ! "$VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag '$RAW_TAG' -> '$VER' is not a MAJOR.MINOR.PATCH version" >&2
+            exit 1
+          fi
+          echo "MARKETING_VERSION=$VER" >> "$GITHUB_ENV"
+
       - name: Build signed IPA
         env:
           IOS_CERTIFICATE: ${{ secrets.IOS_CERTIFICATE }}
@@ -79,8 +106,11 @@ jobs:
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
         run: |
-          npx tauri ios build --export-method app-store-connect \
-            -c "{\"bundle\":{\"iOS\":{\"bundleVersion\":\"${{ github.run_number }}\"}}}"
+          conf='{"bundle":{"iOS":{"bundleVersion":"${{ github.run_number }}"}}}'
+          if [ -n "${MARKETING_VERSION:-}" ]; then
+            conf='{"version":"'"$MARKETING_VERSION"'","bundle":{"iOS":{"bundleVersion":"${{ github.run_number }}"}}}'
+          fi
+          npx tauri ios build --export-method app-store-connect -c "$conf"
 
       - name: Locate IPA
         id: ipa


### PR DESCRIPTION
Automatically builds and uploads the signed iOS IPA to TestFlight whenever a GitHub release is published, so an App Store upload no longer needs a manual dispatch.

Adds a `release: [published]` trigger to `tauri-ios-release.yml` (the same trigger `build-release.yml` uses), gated to the project's date-based tags (`startsWith '20'`). Covers normal and RC pre-releases. The marketing version (`CFBundleShortVersionString`) is taken from the release tag, sanitised to `MAJOR.MINOR.PATCH` (a leading `v` and any `-RCn` suffix are stripped, e.g. `2026.6.0-RC3` becomes `2026.6.0`) since Apple rejects non-numeric version strings. `CFBundleVersion` remains `github.run_number` so every upload stays unique and monotonic, which also distinguishes multiple RC builds sharing one marketing version.

Manual `workflow_dispatch` is unchanged (still builds the version from `tauri.conf.json`). A `concurrency` group serialises uploads so overlapping releases do not race. Verified against the pinned Tauri CLI (2.11.4): a root `version` override via `-c` is a valid config field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS release build handling for published releases and manual runs.
  * Release tags are now validated and used to set the app’s marketing version.
  * Build metadata now consistently includes the iOS bundle version.
  * Prevented overlapping TestFlight release builds from being cancelled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->