### PR TITLE
fix(serial): offer only the binary WebSocket subprotocol, route mDNS and IPv6 manual targets

### DIFF
--- a/src/js/protocols/CapacitorTcp.js
+++ b/src/js/protocols/CapacitorTcp.js
@@ -1,5 +1,6 @@
 import { Capacitor } from "@capacitor/core";
 import { base64ToUint8Array, uint8ArrayToBase64 } from "../utils/bytes.js";
+import { bracketHost, unbracketHost } from "../utils/host.js";
 
 const BetaflightTcp = Capacitor?.Plugins?.BetaflightTcp;
 
@@ -82,9 +83,8 @@ class CapacitorTcp extends EventTarget {
     async connect(path, _options) {
         try {
             const url = new URL(path);
-            // Removes the brackets around an IPv6 host. The native plugin connects to a
-            // bare address.
-            const host = url.hostname.replace(/^\[|\]$/g, "");
+            // The native plugin connects to a bare address.
+            const host = unbracketHost(url.hostname);
             const port = Number.parseInt(url.port, 10) || 5761;
 
             console.log(`${this.logHead} Connecting to ${url}`);
@@ -92,7 +92,7 @@ class CapacitorTcp extends EventTarget {
             const result = await this.plugin.connect({ ip: host, port });
             if (result?.success) {
                 // An IPv6 host gets its brackets again, so that host:port stays unambiguous.
-                this.address = `${host.includes(":") ? `[${host}]` : host}:${port}`;
+                this.address = `${bracketHost(host)}:${port}`;
                 this.connected = true;
             } else {
                 throw new Error("Connect failed");

--- a/src/js/protocols/CapacitorTcp.js
+++ b/src/js/protocols/CapacitorTcp.js
@@ -82,14 +82,17 @@ class CapacitorTcp extends EventTarget {
     async connect(path, _options) {
         try {
             const url = new URL(path);
-            const host = url.hostname;
+            // Removes the brackets around an IPv6 host. The native plugin connects to a
+            // bare address.
+            const host = url.hostname.replace(/^\[|\]$/g, "");
             const port = Number.parseInt(url.port, 10) || 5761;
 
             console.log(`${this.logHead} Connecting to ${url}`);
 
             const result = await this.plugin.connect({ ip: host, port });
             if (result?.success) {
-                this.address = `${host}:${port}`;
+                // An IPv6 host gets its brackets again, so that host:port stays unambiguous.
+                this.address = `${host.includes(":") ? `[${host}]` : host}:${port}`;
                 this.connected = true;
             } else {
                 throw new Error("Connect failed");

--- a/src/js/protocols/TauriTcp.js
+++ b/src/js/protocols/TauriTcp.js
@@ -51,7 +51,9 @@ class TauriTcp extends EventTarget {
     _parseAddress(path) {
         const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(path) ? path : `tcp://${path}`;
         const url = new URL(withScheme);
-        return { host: url.hostname, port: Number.parseInt(url.port, 10) || 5761 };
+        // Removes the brackets around an IPv6 host. The Rust side gives the host to
+        // to_socket_addrs(), which accepts a bare address only.
+        return { host: url.hostname.replace(/^\[|\]$/g, ""), port: Number.parseInt(url.port, 10) || 5761 };
     }
 
     createPort(url) {
@@ -102,7 +104,8 @@ class TauriTcp extends EventTarget {
             await invoke("tcp_connect", { ip: host, port });
 
             // Keep the canonical tcp:// URL so path-based protocol detection still matches.
-            this.address = `tcp://${host}:${port}`;
+            // An IPv6 host gets its brackets again, because a URL needs them.
+            this.address = `tcp://${host.includes(":") ? `[${host}]` : host}:${port}`;
             this.connected = true;
             this.dispatchEvent(new CustomEvent("connect", { detail: this.address }));
             return true;

--- a/src/js/protocols/TauriTcp.js
+++ b/src/js/protocols/TauriTcp.js
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { bracketHost, unbracketHost } from "../utils/host.js";
 
 /**
  * Raw TCP transport for the Tauri shell (desktop and Android).
@@ -51,9 +52,8 @@ class TauriTcp extends EventTarget {
     _parseAddress(path) {
         const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(path) ? path : `tcp://${path}`;
         const url = new URL(withScheme);
-        // Removes the brackets around an IPv6 host. The Rust side gives the host to
-        // to_socket_addrs(), which accepts a bare address only.
-        return { host: url.hostname.replace(/^\[|\]$/g, ""), port: Number.parseInt(url.port, 10) || 5761 };
+        // The Rust side gives the host to to_socket_addrs(), which accepts a bare address only.
+        return { host: unbracketHost(url.hostname), port: Number.parseInt(url.port, 10) || 5761 };
     }
 
     createPort(url) {
@@ -105,7 +105,7 @@ class TauriTcp extends EventTarget {
 
             // Keep the canonical tcp:// URL so path-based protocol detection still matches.
             // An IPv6 host gets its brackets again, because a URL needs them.
-            this.address = `tcp://${host.includes(":") ? `[${host}]` : host}:${port}`;
+            this.address = `tcp://${bracketHost(host)}:${port}`;
             this.connected = true;
             this.dispatchEvent(new CustomEvent("connect", { detail: this.address }));
             return true;

--- a/src/js/protocols/WebSocket.js
+++ b/src/js/protocols/WebSocket.js
@@ -79,7 +79,7 @@ class Websocket extends EventTarget {
         // disconnect() against — and close — the newer socket.
         let ws;
         try {
-            ws = new WebSocket(this.address, ["binary", "wsSerial"]);
+            ws = new WebSocket(this.address, ["binary"]);
         } catch (e) {
             // Invalid URL/scheme, e.g. a raw tcp:// manual override, which a browser
             // cannot open (raw TCP needs the desktop app's native transport).

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -9,6 +9,19 @@ import CapacitorTcp from "./protocols/CapacitorTcp.js";
 import TauriSerial from "./protocols/TauriSerial.js";
 import TauriTcp from "./protocols/TauriTcp.js";
 
+// A host name or an IP address, with an optional port. The pattern permits the underscore.
+// mDNS host names can contain an underscore, for example elrs_rx.local.
+const HOST = "[a-z0-9._-]+(?::\\d+)?";
+/**
+ * Makes a regular expression for "<scheme>://host[:port][/path]".
+ * @param {string} scheme - one scheme, or an alternation of schemes, for example "wss?".
+ * @returns {RegExp} the case-insensitive pattern for that scheme.
+ */
+const urlPattern = (scheme) => new RegExp(`^(?:${scheme})://${HOST}(?:/.*)?$`, "i");
+const WEBSOCKET_URL = urlPattern("wss?");
+const TCP_URL = urlPattern("tcp");
+const BARE_HOST = new RegExp(`^${HOST}$`, "i");
+
 /**
  * Base Serial class that manages all protocol implementations
  * and handles event forwarding.
@@ -114,6 +127,16 @@ class Serial extends EventTarget {
     }
 
     /**
+     * Finds a registered protocol instance by slot name.
+     * @param {string|undefined} name - the slot name ("serial", "tcp", "websocket", ...).
+     * @returns {EventTarget|undefined} The instance, or undefined when the platform does not
+     *   register that slot.
+     */
+    _instance(name) {
+        return this._protocols.find((p) => p.name === name)?.instance;
+    }
+
+    /**
      * Selects the appropriate protocol based on port path
      * @param {string|function|null} portPath - Port path or callback function for virtual mode
      * @returns {EventTarget|undefined} The matching protocol instance, or undefined when none applies.
@@ -124,31 +147,28 @@ class Serial extends EventTarget {
         const s = typeof portPath === "string" ? portPath : "";
         // Default to serial for typical serial device identifiers.
         if (isFn || s === "virtual") {
-            return this._protocols.find((p) => p.name === "virtual")?.instance;
+            return this._instance("virtual");
         }
-        // WebSocket endpoints (ws://, wss://) speak the HTTP-upgrade handshake, so they need the
-        // WebSocket protocol — not raw TCP. On Tauri these are separate slots ("websocket" vs the
-        // Rust-backed "tcp"); fall back to "tcp" on platforms that register only one (the web shell
-        // already uses WebSocket for its "tcp" slot).
-        if (/^wss?:\/\/[a-z0-9.-]+(?::\d+)?(\/.*)?$/i.test(s)) {
-            return (
-                this._protocols.find((p) => p.name === "websocket")?.instance ??
-                this._protocols.find((p) => p.name === "tcp")?.instance
-            );
+        // WebSocket endpoints (ws://, wss://) use the HTTP upgrade handshake. Thus they need the
+        // WebSocket protocol, and not raw TCP. Tauri has two different slots: "websocket" and the
+        // Rust "tcp" slot. If a platform registers only one slot, use "tcp". The web shell uses
+        // WebSocket for its "tcp" slot.
+        if (WEBSOCKET_URL.test(s)) {
+            return this._instance("websocket") ?? this._instance("tcp");
         }
-        if (s === "manual" || /^tcp:\/\/[a-z0-9.-]+(?::\d+)?(\/.*)?$/i.test(s)) {
-            return this._protocols.find((p) => p.name === "tcp")?.instance;
+        if (s === "manual" || TCP_URL.test(s)) {
+            return this._instance("tcp");
         }
         if (s.startsWith("bluetooth")) {
-            return this._protocols.find((p) => p.name === "bluetooth")?.instance;
+            return this._instance("bluetooth");
         }
-        const serialInstance = this._protocols.find((p) => p.name === "serial")?.instance;
+        const serialInstance = this._instance("serial");
         // No native serial transport (iOS): a schemeless manual entry that looks like a network
         // host (an IP, a dotted hostname, or host:port — e.g. an ELRS Wi-Fi module at 10.0.0.1)
         // can only be a TCP endpoint, so route it to TCP rather than a serial slot that doesn't
         // exist. A device path (/dev/tty*, COM3) still resolves to no protocol, as before.
-        if (!serialInstance && /^[a-z0-9.-]+(?::\d+)?$/i.test(s) && (s.includes(".") || s.includes(":"))) {
-            return this._protocols.find((p) => p.name === "tcp")?.instance;
+        if (!serialInstance && BARE_HOST.test(s) && (s.includes(".") || s.includes(":"))) {
+            return this._instance("tcp");
         }
         return serialInstance;
     }
@@ -237,7 +257,7 @@ class Serial extends EventTarget {
     async getDevices(protocolType = null) {
         try {
             // Get the appropriate protocol
-            const targetProtocol = this._protocols.find((p) => p.name === protocolType?.toLowerCase())?.instance;
+            const targetProtocol = this._instance(protocolType?.toLowerCase());
 
             if (!targetProtocol) {
                 console.warn(`${this.logHead} No valid protocol for getting devices`);
@@ -266,7 +286,7 @@ class Serial extends EventTarget {
     async requestPermissionDevice(showAllDevices = false, protocolType) {
         let result = false;
         try {
-            const targetProtocol = this._protocols.find((p) => p.name === protocolType?.toLowerCase())?.instance;
+            const targetProtocol = this._instance(protocolType?.toLowerCase());
             result = await targetProtocol?.requestPermissionDevice(showAllDevices);
         } catch (error) {
             console.error(`${this.logHead} Error requesting device permission:`, error);

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -9,9 +9,10 @@ import CapacitorTcp from "./protocols/CapacitorTcp.js";
 import TauriSerial from "./protocols/TauriSerial.js";
 import TauriTcp from "./protocols/TauriTcp.js";
 
-// A host name or an IP address, with an optional port. The pattern permits the underscore.
-// mDNS host names can contain an underscore, for example elrs_rx.local.
-const HOST = "[a-z0-9._-]+(?::\\d+)?";
+// A host name, an IPv4 address, or an IPv6 address in brackets, with an optional port.
+// The pattern permits the underscore. mDNS host names can contain an underscore, for example
+// elrs_rx.local. An IPv6 address must have brackets, as in a URL, for example [fe80::1]:5761.
+const HOST = "(?:\\[[0-9a-f:.]+\\]|[a-z0-9._-]+)(?::\\d+)?";
 /**
  * Makes a regular expression for "<scheme>://host[:port][/path]".
  * @param {string} scheme - one scheme, or an alternation of schemes, for example "wss?".
@@ -164,7 +165,7 @@ class Serial extends EventTarget {
         }
         const serialInstance = this._instance("serial");
         // No native serial transport (iOS): a schemeless manual entry that looks like a network
-        // host (an IP, a dotted hostname, or host:port — e.g. an ELRS Wi-Fi module at 10.0.0.1)
+        // host (an IP, a dotted hostname, [IPv6], or host:port — e.g. an ELRS Wi-Fi module at 10.0.0.1)
         // can only be a TCP endpoint, so route it to TCP rather than a serial slot that doesn't
         // exist. A device path (/dev/tty*, COM3) still resolves to no protocol, as before.
         if (!serialInstance && BARE_HOST.test(s) && (s.includes(".") || s.includes(":"))) {

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -8,11 +8,12 @@ import CapacitorBle from "./protocols/CapacitorBle.js";
 import CapacitorTcp from "./protocols/CapacitorTcp.js";
 import TauriSerial from "./protocols/TauriSerial.js";
 import TauriTcp from "./protocols/TauriTcp.js";
+import { unbracketHost } from "./utils/host.js";
 
 // A host name, an IPv4 address, or an IPv6 address in brackets, with an optional port.
 // The pattern permits the underscore. mDNS host names can contain an underscore, for example
 // elrs_rx.local. An IPv6 address must have brackets, as in a URL, for example [fe80::1]:5761.
-const HOST = "(?:\\[[0-9a-f:.]+\\]|[a-z0-9._-]+)(?::\\d+)?";
+const HOST = String.raw`(?:\[[0-9a-f:.]+\]|[a-z0-9._-]+)(?::\d+)?`;
 /**
  * Makes a regular expression for "<scheme>://host[:port][/path]".
  * @param {string} scheme - one scheme, or an alternation of schemes, for example "wss?".
@@ -184,7 +185,7 @@ class Serial extends EventTarget {
         try {
             const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(target) ? target : `tcp://${target}`;
             // Strips IPv6 brackets so fe80::/10 link-local hosts can be matched.
-            const host = new URL(withScheme).hostname.toLowerCase().replace(/^\[|\]$/g, "");
+            const host = unbracketHost(new URL(withScheme).hostname.toLowerCase());
             return (
                 host.startsWith("10.") ||
                 host.startsWith("192.168.") ||

--- a/src/js/utils/host.js
+++ b/src/js/utils/host.js
@@ -1,0 +1,19 @@
+/**
+ * Removes the brackets around an IPv6 host: [fe80::1] becomes fe80::1.
+ * A native socket API accepts a bare address only.
+ * @param {string} host - a host name or an IP address, with or without brackets.
+ * @returns {string} the host, without brackets.
+ */
+export function unbracketHost(host) {
+    return host.replace(/^\[|\]$/g, "");
+}
+
+/**
+ * Puts brackets around an IPv6 host: fe80::1 becomes [fe80::1].
+ * A URL and a host:port pair need the brackets, because an IPv6 address contains colons.
+ * @param {string} host - a host name or an IP address, without brackets.
+ * @returns {string} the host, with brackets if the host is IPv6.
+ */
+export function bracketHost(host) {
+    return host.includes(":") ? `[${host}]` : host;
+}

--- a/test/js/serial.test.js
+++ b/test/js/serial.test.js
@@ -44,9 +44,15 @@ describe("serial.selectProtocol — Tauri transport routing", () => {
         expect(serial.selectProtocol("ws://elrs_rx.local:81/serial").constructor.name).toBe("Websocket");
     });
 
+    it("routes a bracketed IPv6 host to the WebSocket protocol", () => {
+        expect(serial.selectProtocol("ws://[fe80::1]").constructor.name).toBe("Websocket");
+        expect(serial.selectProtocol("ws://[fe80::1]:81/serial").constructor.name).toBe("Websocket");
+    });
+
     it("routes raw tcp:// to the Rust-backed TauriTcp protocol", () => {
         expect(serial.selectProtocol("tcp://192.168.0.10:5761").constructor.name).toBe("TauriTcp");
         expect(serial.selectProtocol("tcp://elrs_rx.local:5761").constructor.name).toBe("TauriTcp");
+        expect(serial.selectProtocol("tcp://[fe80::1]:5761").constructor.name).toBe("TauriTcp");
     });
 
     it("routes a bare 'manual' selection to the TCP slot", () => {
@@ -63,5 +69,7 @@ describe("serial.selectProtocol — Tauri transport routing", () => {
         expect(serial.selectProtocol("10.0.0.1").constructor.name).toBe("TauriTcp");
         expect(serial.selectProtocol("10.0.0.1:5761").constructor.name).toBe("TauriTcp");
         expect(serial.selectProtocol("elrs_rx.local:5761").constructor.name).toBe("TauriTcp");
+        expect(serial.selectProtocol("[fe80::1]").constructor.name).toBe("TauriTcp");
+        expect(serial.selectProtocol("[fe80::1]:5761").constructor.name).toBe("TauriTcp");
     });
 });

--- a/test/js/serial.test.js
+++ b/test/js/serial.test.js
@@ -39,8 +39,14 @@ describe("serial.selectProtocol — Tauri transport routing", () => {
         expect(serial.selectProtocol("ws://10.1.1.208:5761").constructor.name).toBe("Websocket");
     });
 
+    it("routes an mDNS host name that contains an underscore to the WebSocket protocol", () => {
+        expect(serial.selectProtocol("ws://elrs_rx.local").constructor.name).toBe("Websocket");
+        expect(serial.selectProtocol("ws://elrs_rx.local:81/serial").constructor.name).toBe("Websocket");
+    });
+
     it("routes raw tcp:// to the Rust-backed TauriTcp protocol", () => {
         expect(serial.selectProtocol("tcp://192.168.0.10:5761").constructor.name).toBe("TauriTcp");
+        expect(serial.selectProtocol("tcp://elrs_rx.local:5761").constructor.name).toBe("TauriTcp");
     });
 
     it("routes a bare 'manual' selection to the TCP slot", () => {
@@ -56,5 +62,6 @@ describe("serial.selectProtocol — Tauri transport routing", () => {
         // A bare ELRS/bridge IP has no serial slot to fall back to on iOS, so it must reach TCP.
         expect(serial.selectProtocol("10.0.0.1").constructor.name).toBe("TauriTcp");
         expect(serial.selectProtocol("10.0.0.1:5761").constructor.name).toBe("TauriTcp");
+        expect(serial.selectProtocol("elrs_rx.local:5761").constructor.name).toBe("TauriTcp");
     });
 });


### PR DESCRIPTION
### WebSocket subprotocol

The client offered two subprotocols, `binary` and `wsSerial`. A server that picks `wsSerial` gets a client that only ever speaks binary frames, so the negotiated name promises something the transport does not do. Only `binary` is offered now.

```js
ws = new WebSocket(this.address, ["binary"]);
```

### mDNS host names with an underscore

The host patterns in `selectProtocol()` did not accept an underscore, so `ws://elrs_rx.local/serial` did not match the WebSocket pattern. It fell through to the serial slot, or to no protocol at all on iOS, where no serial slot is registered. The same gap applied to `tcp://elrs_rx.local` and to a schemeless manual entry such as `elrs_rx.local:5761`.

The underscore is permitted now in all three patterns. mDNS host names can contain it, and ELRS receivers advertise such names.

### IPv6 targets

The same patterns rejected a bracketed IPv6 literal, although `isLocalNetworkAddress()` already classifies `fe80::/10` link-local hosts. `tcp://[fe80::1]:5761` and `ws://[fe80::1]` route correctly now.

`TauriTcp` and `CapacitorTcp` remove the brackets before the native connect, because `to_socket_addrs()` and the Capacitor plugin accept a bare address only. They put the brackets back in the address they keep, so the stored URL stays valid and still routes.

### Cleanup

* The host pattern was written out three times. It is one shared `HOST` constant now, with a `urlPattern(scheme)` builder for `WEBSOCKET_URL` and `TCP_URL`. `String.raw` keeps the pattern readable as the regular expression it becomes.
* `this._protocols.find((p) => p.name === X)?.instance` appeared eight times. It is a `_instance(name)` helper now, used by `selectProtocol()`, `getDevices()` and `requestPermissionDevice()`.
* The bracket logic for an IPv6 host is `unbracketHost()` and `bracketHost()` in the new `src/js/utils/host.js`. `TauriTcp`, `CapacitorTcp` and `isLocalNetworkAddress()` share it, instead of three copies of the same expression.

Routing behaviour is unchanged apart from the underscore and IPv6: the new patterns give identical results to the old ones for schemes, ports, paths, `manual`, `virtual`, `COM3` and `/dev/tty*`.

### Tests

`test/js/serial.test.js` covers `ws://elrs_rx.local`, `ws://elrs_rx.local:81/serial`, `tcp://elrs_rx.local:5761`, `ws://[fe80::1]:81/serial`, `tcp://[fe80::1]:5761`, and the schemeless `elrs_rx.local:5761` and `[fe80::1]:5761` iOS fallbacks.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket connection compatibility by using the supported binary subprotocol during connection setup.
  * Enhanced connection routing for manual targets, including mDNS hostnames with underscores and more reliable TCP fallback when serial transport isn’t available.
* **Tests**
  * Expanded protocol routing tests to cover WebSocket and TCP hostname patterns, plus iOS fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
