### PR TITLE
fix: board alignment fixes pitch fix, roll logic, yaw back step

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1749,11 +1749,11 @@
     "boardAlignmentWizard-HintFlat": {
         "message": "Place the drone flat with the camera facing away from you (toward the screen)."
     },
-    "boardAlignmentWizard-HintPitchUp": {
-        "message": "Tilt the nose up by about 45°."
+    "boardAlignmentWizard-HintPitchDown": {
+        "message": "Tilt the nose down by about 45°, so the camera points toward the ground."
     },
     "boardAlignmentWizard-HintRollRight": {
-        "message": "Tilt the right side down by about 45°."
+        "message": "Tilt the right side down by about 45°, lowering the right arms and raising the left."
     },
     "boardAlignmentWizard-HintYawCW": {
         "message": "Rotate the drone about 45° clockwise (as seen from above)."
@@ -1825,10 +1825,13 @@
         "message": "The accelerometer is not reading gravity. Make sure the FC is connected and not in motion."
     },
     "boardAlignmentWizard-Error-no_pitch_tilt": {
-        "message": "Pitch gesture was not detected. Please retry and tilt the nose up further."
+        "message": "Pitch gesture was not detected. Please retry and tilt the nose down further."
     },
     "boardAlignmentWizard-Error-no_roll_tilt": {
         "message": "Roll gesture was not detected. Please retry and tilt the right side down further."
+    },
+    "boardAlignmentWizard-Error-gesture_direction_mismatch": {
+        "message": "One of the tilt gestures went the wrong way. Check the pitch and roll directions and try again."
     },
     "boardAlignmentWizard-StepFlat": {
         "message": "Flat"

--- a/src/components/dialogs/BoardAlignmentWizardDialog.vue
+++ b/src/components/dialogs/BoardAlignmentWizardDialog.vue
@@ -242,6 +242,7 @@ const COLLECTING_PHASES = new Set([
     "await_roll",
     "await_level_2",
     "await_yaw",
+    "await_level_3",
 ]);
 
 const CONFIRMED_PHASES = new Set(["confirmed_flat", "confirmed_pitch", "confirmed_roll", "confirmed_yaw"]);
@@ -252,6 +253,13 @@ const CONFIRMED_NEXT = {
     confirmed_pitch: "await_roll",
     confirmed_roll: "await_yaw",
     confirmed_yaw: "__compute__",
+};
+
+// Maps each return-to-level phase → the gesture it confirms once level is regained.
+const LEVEL_NEXT = {
+    await_level_1: "confirmed_pitch",
+    await_level_2: "confirmed_roll",
+    await_level_3: "confirmed_yaw",
 };
 
 // Metadata for the step timeline.
@@ -304,6 +312,7 @@ const PHASE_STEP_STATES = {
     await_level_2: ["done", "done", "confirmed", "pending"], // tilt captured, returning to level
     confirmed_roll: ["done", "done", "confirmed", "pending"],
     await_yaw: ["done", "done", "done", "active"],
+    await_level_3: ["done", "done", "done", "confirmed"], // rotation captured, returning to level
     confirmed_yaw: ["done", "done", "done", "confirmed"],
 };
 const timelineStepStates = computed(
@@ -324,6 +333,7 @@ const phaseHintText = computed(() => {
         case "confirmed_roll":
             return i18nMessage("boardAlignmentWizard-HintRollRight");
         case "await_yaw":
+        case "await_level_3":
         case "confirmed_yaw":
             return i18nMessage("boardAlignmentWizard-HintYawCW");
         default:
@@ -419,7 +429,9 @@ function stopAnimation() {
 function startPhaseAnimation() {
     stopAnimation();
     animationStartTime = performance.now();
-    setTopDownView(phase.value === "await_yaw");
+    // Hold the top-down view through the yaw step's return-to-level so the camera
+    // doesn't swing back mid-gesture.
+    setTopDownView(phase.value === "await_yaw" || phase.value === "await_level_3");
 
     const targetAngle = 45;
     const tick = () => {
@@ -557,6 +569,7 @@ function onImuSample() {
             break;
         case "await_level_1":
         case "await_level_2":
+        case "await_level_3":
             handleLevel(meanAccel, dwellMs);
             break;
         case "await_roll":
@@ -666,8 +679,12 @@ function handleLevel(meanAccel, dwellMs) {
     if (maxTilt > LEVEL_RETURN_DEG) return;
     if (dwellMs < LEVEL_HOLD_MS) return;
 
-    // Confirm the preceding pitch/roll gesture before advancing.
-    const next = phase.value === "await_level_1" ? "confirmed_pitch" : "confirmed_roll";
+    // Confirm the preceding gesture before advancing.
+    const next = LEVEL_NEXT[phase.value];
+    if (next === "confirmed_yaw") {
+        // Last gesture — no more IMU samples are needed after this.
+        stopPolling();
+    }
     advanceTo(next);
 }
 
@@ -675,8 +692,9 @@ function handleYaw() {
     const mag = Math.abs(captured.yawIntegralDeg);
     phaseDetail.value = `${i18nMessage("boardAlignmentWizard-YawProgress")}: ${mag.toFixed(0)}°`;
     if (mag >= YAW_DETECT_DEG) {
-        stopPolling();
-        advanceTo("confirmed_yaw");
+        // Level out before computing so the test phase starts from a settled,
+        // untilted drone rather than whatever pose the rotation ended in.
+        advanceTo("await_level_3");
     }
 }
 

--- a/src/components/dialogs/BoardAlignmentWizardDialog.vue
+++ b/src/components/dialogs/BoardAlignmentWizardDialog.vue
@@ -325,17 +325,20 @@ const phaseHintText = computed(() => {
         case "confirmed_flat":
             return i18nMessage("boardAlignmentWizard-HintFlat");
         case "await_pitch":
-        case "await_level_1":
         case "confirmed_pitch":
             return i18nMessage("boardAlignmentWizard-HintPitchDown");
         case "await_roll":
-        case "await_level_2":
         case "confirmed_roll":
             return i18nMessage("boardAlignmentWizard-HintRollRight");
         case "await_yaw":
-        case "await_level_3":
         case "confirmed_yaw":
             return i18nMessage("boardAlignmentWizard-HintYawCW");
+        // The gesture is already captured by this point — ask for level, matching the
+        // "Return to level" progress detail shown underneath.
+        case "await_level_1":
+        case "await_level_2":
+        case "await_level_3":
+            return i18nMessage("boardAlignmentWizard-HintLevel");
         default:
             return "";
     }

--- a/src/components/dialogs/BoardAlignmentWizardDialog.vue
+++ b/src/components/dialogs/BoardAlignmentWizardDialog.vue
@@ -318,7 +318,7 @@ const phaseHintText = computed(() => {
         case "await_pitch":
         case "await_level_1":
         case "confirmed_pitch":
-            return i18nMessage("boardAlignmentWizard-HintPitchUp");
+            return i18nMessage("boardAlignmentWizard-HintPitchDown");
         case "await_roll":
         case "await_level_2":
         case "confirmed_roll":
@@ -412,8 +412,9 @@ function stopAnimation() {
 
 /**
  * Drive the 3D model with a phase-specific looped animation showing the target
- * gesture. Pitch up = oscillate pitch 0 → 45 → 0; roll right = roll 0 → 45 → 0;
- * yaw CW = yaw 0 → -45 → 0.
+ * gesture. setModelRotation negates pitch and roll (matching the setup tab), so a
+ * positive angle renders nose-down / right-side-down. Nose down = oscillate pitch
+ * 0 → 45 → 0; roll right = roll 0 → 45 → 0; yaw CW = yaw 0 → -45 → 0.
  */
 function startPhaseAnimation() {
     stopAnimation();

--- a/src/js/utils/boardAlignment.js
+++ b/src/js/utils/boardAlignment.js
@@ -2,14 +2,19 @@
  * Board alignment detection.
  *
  * Determines how the flight controller is physically mounted relative to the
- * drone body by sampling gravity at three poses (flat, pitched up, rolled right)
+ * drone body by sampling gravity at three poses (flat, nose down, rolled right)
  * and integrating gyro during a yaw rotation as a sanity check.
+ *
+ * Throughout, the guiding rule is: the horizontal component of measured gravity
+ * points toward whichever end of the craft is RAISED. Elevating a body axis by θ
+ * gives world-up a `sin θ` component along that axis.
  *
  * The algorithm:
  *   1. At flat, the normalized accelerometer vector is world-up expressed in
  *      the FC frame (call it `upAxis`).
- *   2. When the user pitches up 45° (drone facing away), the horizontal accel
- *      component shifts toward the nose, so `forwardAxis = +normalize(h_pitch)`.
+ *   2. When the user pitches the nose down 45° (drone facing away), the tail is
+ *      the raised end, so the horizontal accel component points aft and
+ *      `forwardAxis = -normalize(h_pitch)`.
  *   3. For roll right (right wing down, = −Y side in Betaflight's Y=LEFT frame),
  *      the horizontal accel component shifts toward +Y (left/rising side).
  *      Betaflight uses a right-handed X=fwd, Y=left, Z=up body frame, so the
@@ -167,7 +172,7 @@ export function perpComponent(vec, axis) {
  *
  * Inputs:
  *   - flatAccel:  averaged accel 3-vector at the flat pose (g-units).
- *   - pitchAccel: averaged accel at the "pitched up ~45°" pose.
+ *   - pitchAccel: averaged accel at the "nose down ~45°" pose.
  *   - rollAccel:  averaged accel at the "rolled right ~45°" pose.
  *   - yawIntegral: gyro rotation integrated about `upAxis` during the yaw CW
  *     gesture, in degrees. Sign should be negative for a true CW (right-hand
@@ -178,7 +183,10 @@ export function perpComponent(vec, axis) {
  *
  * Returns: { roll, pitch, yaw, confidence } — angles snapped to multiples of 45°.
  *   `confidence` is one of "high" / "medium" / "low" based on residual orthogonality
- *   error and the yaw integral magnitude.
+ *   error and the yaw integral magnitude. `rightAgreement` is the raw measurement
+ *   agreement, before any correction.
+ *
+ *   On failure: { error } — see the `boardAlignmentWizard-Error-*` locale keys.
  */
 export function detectBoardAlignment({ flatAccel, pitchAccel, rollAccel, yawIntegral, currentAlignment }) {
     if (!flatAccel || !pitchAccel || !rollAccel) {
@@ -190,16 +198,14 @@ export function detectBoardAlignment({ flatAccel, pitchAccel, rollAccel, yawInte
         return { error: "no_gravity" };
     }
 
-    // Derive world-forward in FC frame from the pitch-up gesture.
-    // Convention: drone nose faces AWAY from the user. When pitched up, the gravity
-    // horizontal component shifts toward the tail (toward user), so negating it gives
-    // the nose direction — but since nose = away from user = the direction the accel
-    // horizontal component moves TOWARD when nose tilts up, we take it directly.
+    // Derive world-forward in FC frame from the nose-down gesture.
+    // The instruction is nose-DOWN, so the tail is the raised end and gravity's
+    // horizontal component points aft. Negate to get the nose direction.
     const hPitch = perpComponent(pitchAccel, upAxis);
     if (Math.hypot(hPitch[0], hPitch[1], hPitch[2]) < 0.05) {
         return { error: "no_pitch_tilt" };
     }
-    const forwardRaw = normalize(hPitch);
+    const forwardRaw = normalize(scale(hPitch, -1));
 
     // Derive the body-Y axis from the roll-right gesture.
     // Betaflight uses a Y=LEFT body frame (X=forward, Y=left, Z=up — right-handed).
@@ -213,15 +219,17 @@ export function detectBoardAlignment({ flatAccel, pitchAccel, rollAccel, yawInte
     const rightRaw = normalize(hRoll);
 
     // Gram-Schmidt: keep upAxis, orthogonalize forward, derive right = up × forward.
-    let forwardAxis = normalize(perpComponent(forwardRaw, upAxis));
-    let rightAxis = cross(upAxis, forwardAxis);
+    const forwardAxis = normalize(perpComponent(forwardRaw, upAxis));
+    const rightAxis = cross(upAxis, forwardAxis);
 
-    // Cross-check: both rightAxis (cross product) and rightRaw (measured from roll gesture)
-    // should point in the same body-Y direction (+Y = left in Betaflight's frame).
-    // If they disagree, the user's roll gesture was the wrong direction.
-    if (dot(rightAxis, rightRaw) < 0) {
-        rightAxis = scale(rightAxis, -1);
-        forwardAxis = scale(forwardAxis, -1);
+    // Cross-check: rightAxis (derived from the pitch gesture) and rightRaw (measured
+    // from the roll gesture) should point in the same body-Y direction (+Y = left in
+    // Betaflight's frame). A negative dot product proves that exactly one of the two
+    // gestures was performed in the wrong direction, but not which one — so bail out
+    // and let the user redo both rather than silently picking an interpretation.
+    const rightAgreement = dot(rightAxis, rightRaw); // 1 = perfect, -1 = opposite
+    if (rightAgreement < 0) {
+        return { error: "gesture_direction_mismatch" };
     }
 
     // World basis vectors as rows form the matrix M such that M · v_fc = v_world.
@@ -258,8 +266,9 @@ export function detectBoardAlignment({ flatAccel, pitchAccel, rollAccel, yawInte
     };
 
     // Confidence: high if the measured right matches the derived right closely AND the
-    // yaw integral magnitude is plausible. Otherwise medium / low.
-    const rightAgreement = dot(rightAxis, rightRaw); // 1 = perfect, -1 = opposite
+    // yaw integral magnitude is plausible. Otherwise medium / low. Note this can only
+    // grade how orthogonal the gestures were — a pair of consistently reversed gestures
+    // is indistinguishable from a mount yawed 180°, so it scores as high as a clean run.
     const yawMagnitude = Math.abs(yawIntegral || 0);
     let confidence = "high";
     if (rightAgreement < 0.85 || yawMagnitude < 20) {

--- a/test/js/board_alignment.test.js
+++ b/test/js/board_alignment.test.js
@@ -10,10 +10,12 @@ const DEG_TO_RAD = Math.PI / 180;
 //   - Betaflight body frame: X=forward, Y=left, Z=up (right-handed, Y=LEFT convention).
 //   - Drone nose faces AWAY from the user during calibration (+X = forward).
 //   - At flat, accel in body frame = (0, 0, 1) (gravity-opposite, normalized).
-//   - Pitch up 45° = drone nose tilts up = body rotates Ry(-45°).
-//     Accel = Ry(-45°)^T · (0,0,1) = Ry(+45°) · (0,0,1) = (sin45, 0, cos45).
+//   - Nose down 45° (the instructed pitch gesture) = body rotates Ry(+45°).
+//     Accel = Ry(+45°)^T · (0,0,1) = Ry(-45°) · (0,0,1) = (-sin45, 0, cos45).
+//     The horizontal component is aft (−X), toward the raised tail.
 //   - Roll right 45° (right wing = −Y side down) = body rotates Rx(+45°) in Y=LEFT frame.
 //     Accel = Rx(+45°)^T · (0,0,1) = Rx(-45°) · (0,0,1) = (0, sin45, cos45).
+//     The horizontal component is toward the raised left side (+Y).
 //   - Yaw CW 45° = -45° around world-Z (right-hand rule, thumb up gives CCW).
 //   - R_mount = rotation FC frame → world frame.
 //   - accel_fc = R_mount^T · (rotated gravity vector).
@@ -58,10 +60,20 @@ function matVec(m, v) {
  * Build the three synthetic accel samples for a given physical mount and current
  * configured alignment. Reproduces what the FC would report via MSP_RAW_IMU after
  * board-alignment correction.
+ *
+ * `reverse` lets a test simulate a user performing a gesture backwards:
+ * `{ pitch: true }` = nose up instead of down, `{ roll: true }` = left side down.
  */
 // mountYaw and currentAlignment.yaw use Betaflight's CW-positive convention (same as the wizard output).
 // eulerToMatrix uses CCW-positive (standard math), so we negate yaw when building the matrices.
-function makeSamples(mountRoll, mountPitch, mountYaw, currentAlignment = { roll: 0, pitch: 0, yaw: 0 }, noise = 0) {
+function makeSamples(
+    mountRoll,
+    mountPitch,
+    mountYaw,
+    currentAlignment = { roll: 0, pitch: 0, yaw: 0 },
+    noise = 0,
+    reverse = {},
+) {
     const rMount = eulerToMatrix(mountRoll, mountPitch, -mountYaw);
     const rCurrent = eulerToMatrix(currentAlignment.roll, currentAlignment.pitch, -currentAlignment.yaw);
 
@@ -69,16 +81,16 @@ function makeSamples(mountRoll, mountPitch, mountYaw, currentAlignment = { roll:
     // Post-alignment accel (what MSP_RAW_IMU returns) = R_current · raw_fc
     const post = (accelWorld) => matVec(rCurrent, matVec(transpose(rMount), accelWorld));
 
-    const pitchUp = 45 * DEG_TO_RAD;
-    const rollRight = 45 * DEG_TO_RAD;
+    const noseDown = (reverse.pitch ? -45 : 45) * DEG_TO_RAD;
+    const rollRight = (reverse.roll ? -45 : 45) * DEG_TO_RAD;
 
     // Gravity-opposite vector in drone body frame after each user gesture.
     // Betaflight uses Y=LEFT frame (X=fwd, Y=left, Z=up — right-handed).
     //   flat:        (0, 0, 1)
-    //   pitch up:    Ry(-45°) applied to body → world-up in body = Ry(+45°)·(0,0,1) = (sin45, 0, cos45)
+    //   nose down:   Ry(+45°) applied to body → world-up in body = Ry(-45°)·(0,0,1) = (-sin45, 0, cos45)
     //   roll right:  Right wing (−Y) down = Rx(+45°) applied to body → Rx(-45°)·(0,0,1) = (0, sin45, cos45)
     const accelFlatWorld = [0, 0, 1];
-    const accelPitchWorld = matVec(rotY(pitchUp), [0, 0, 1]);
+    const accelPitchWorld = matVec(rotY(-noseDown), [0, 0, 1]);
     const accelRollWorld = matVec(rotX(-rollRight), [0, 0, 1]);
 
     const jitter = () => (noise > 0 ? (Math.random() - 0.5) * 2 * noise : 0);
@@ -232,6 +244,49 @@ describe("detectBoardAlignment - delta from current alignment", () => {
                 expect(got[i][j]).toBeCloseTo(expected[i][j], 4);
             }
         }
+    });
+});
+
+describe("detectBoardAlignment - gesture direction", () => {
+    const identity = { roll: 0, pitch: 0, yaw: 0 };
+
+    it("reports high confidence and a raw agreement of ~1 for correct gestures", () => {
+        const samples = makeSamples(0, 0, 0);
+        const result = detectBoardAlignment({ ...samples, currentAlignment: identity });
+        expect(result).toMatchObject({ roll: 0, pitch: 0, yaw: 0, confidence: "high" });
+        expect(result.rightAgreement).toBeCloseTo(1, 6);
+    });
+
+    it("errors instead of reporting yaw 180 when only the roll gesture is reversed", () => {
+        // Left side down instead of right. The old code flipped both axes back into a
+        // valid right-handed frame and returned yaw 180 at "high" confidence.
+        const samples = makeSamples(0, 0, 0, identity, 0, { roll: true });
+        const result = detectBoardAlignment({ ...samples, currentAlignment: identity });
+        expect(result.error).toBe("gesture_direction_mismatch");
+    });
+
+    it("errors when only the pitch gesture is reversed", () => {
+        const samples = makeSamples(0, 0, 0, identity, 0, { pitch: true });
+        const result = detectBoardAlignment({ ...samples, currentAlignment: identity });
+        expect(result.error).toBe("gesture_direction_mismatch");
+    });
+
+    it("cannot detect two consistently reversed gestures (documented limitation)", () => {
+        // Nose up + left side down produces exactly the sample set a correctly performed
+        // run on a board mounted CW 180° produces, so no algorithm can tell them apart
+        // from accel alone. The yaw integral does not help: rotation about a known
+        // up-axis carries no information about which horizontal direction is the nose.
+        const reversed = makeSamples(0, 0, 0, identity, 0, { pitch: true, roll: true });
+        const yawed180 = makeSamples(0, 0, 180);
+        for (const key of ["flatAccel", "pitchAccel", "rollAccel"]) {
+            for (let i = 0; i < 3; i++) {
+                expect(reversed[key][i]).toBeCloseTo(yawed180[key][i], 6);
+            }
+        }
+
+        const result = detectBoardAlignment({ ...reversed, currentAlignment: identity });
+        expect(result.error).toBeUndefined();
+        expect(result.yaw).toBe(180);
     });
 });
 


### PR DESCRIPTION
Fixes contradicting wording in the pitch step.

The pitch gesture's sign was silently discarded: a reversed gesture flipped both derived axes back into a valid frame, so either direction produced the same result. A reversed roll gesture used the same path to return yaw 180 at "high" confidence, since rightAgreement was computed after the correction.

Adds a step to "yaw back" to center after the last axis, so when it goes to the "confirm" screen, the quad is straight.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “return to level” phase after yaw alignment to guide completion.
  * Enhanced wizard alignment visuals by keeping the top-down camera view through yaw and level confirmation.

* **Bug Fixes**
  * Updated pitch instructions and detection to use a nose-down gesture.
  * Improved tilt mismatch handling with clearer, more specific error messaging (including guidance for insufficient pitch tilt).

* **Tests**
  * Expanded coverage for reversed gesture direction scenarios and the new mismatch behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->