### PR TITLE
feat(ios): native BLE transport via btleplug

### DIFF
--- a/.github/workflows/tauri-pr-build.yml
+++ b/.github/workflows/tauri-pr-build.yml
@@ -1,0 +1,160 @@
+name: Tauri PR build
+
+# Compile-checks the Tauri iOS and Android apps on every PR, without any signing
+# or store upload. iOS runs an unsigned simulator build (which still compiles and
+# links the Rust static lib, including the native BLE/TCP transports, against the
+# real iOS SDKs); Android produces a debug-keystore APK, mirroring the Capacitor
+# debug APK. Neither job receives release/signing secrets — they run untrusted PR
+# code with a read-only token, like the Capacitor debug build.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: tauri-pr-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  NDK_VERSION: 27.2.12479018
+
+jobs:
+  ios:
+    name: iOS (unsigned simulator build)
+    runs-on: macos-26
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Select Xcode 26 (iOS 26 SDK)
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
+        with:
+          xcode-version: '26'
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+
+      - name: Cache Cargo registry and target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build
+
+      - name: Generate Xcode project (xcodegen + Rust env)
+        run: npx tauri ios init
+
+      # Simulator builds require no code signing, so this validates the Swift app
+      # and the linked Rust lib (native BLE/TCP) without any Apple credentials.
+      - name: Build unsigned app for the simulator
+        run: |
+          xcodebuild build \
+            -project src-tauri/gen/apple/betaflight-app.xcodeproj \
+            -scheme betaflight-app_iOS \
+            -configuration debug \
+            -sdk iphonesimulator \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO
+
+      - name: Locate .app
+        id: app
+        run: |
+          shopt -s nullglob
+          apps=(build/Build/Products/*-iphonesimulator/*.app)
+          if [ ${#apps[@]} -lt 1 ]; then
+            echo "No .app produced" >&2
+            exit 1
+          fi
+          echo "path=${apps[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload iOS app artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: betaflight-app-ios-simulator
+          path: ${{ steps.app.outputs.path }}
+          if-no-files-found: error
+          retention-days: 14
+
+  android:
+    name: Android (debug APK)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install NDK
+        run: |
+          sdkmanager "ndk;${NDK_VERSION}"
+          echo "NDK_HOME=$ANDROID_HOME/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - name: Cache Cargo registry and target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Debug builds are signed with the Android debug keystore — enough for test
+      # installs, no release secrets needed (mirrors the Capacitor debug APK).
+      - name: Build debug APK
+        run: npx tauri android build --apk --debug
+
+      - name: Locate APK
+        id: apk
+        run: |
+          shopt -s nullglob
+          apks=(src-tauri/gen/android/app/build/outputs/apk/**/debug/*.apk)
+          if [ ${#apks[@]} -lt 1 ]; then
+            echo "No debug APK produced" >&2
+            exit 1
+          fi
+          echo "path=${apks[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Android APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: betaflight-app-android-debug
+          path: ${{ steps.apk.outputs.path }}
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/tauri-pr-build.yml
+++ b/.github/workflows/tauri-pr-build.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   ios:
-    name: iOS (unsigned simulator build)
+    name: iOS (compile check)
     runs-on: macos-26
     permissions:
       contents: read
@@ -44,7 +44,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
-          targets: aarch64-apple-ios,aarch64-apple-ios-sim
+          targets: aarch64-apple-ios
 
       - name: Cache Cargo registry and target
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -57,41 +57,14 @@ jobs:
       - name: Build frontend
         run: npm run build
 
-      - name: Generate Xcode project (xcodegen + Rust env)
-        run: npx tauri ios init
-
-      # Simulator builds require no code signing, so this validates the Swift app
-      # and the linked Rust lib (native BLE/TCP) without any Apple credentials.
-      # Release config (not debug): debug makes Tauri's xcode-script expect a live
-      # dev server, whereas release builds against the frontend bundled above.
-      - name: Build unsigned app for the simulator
-        run: |
-          xcodebuild build \
-            -project src-tauri/gen/apple/betaflight-app.xcodeproj \
-            -scheme betaflight-app_iOS \
-            -configuration release \
-            -sdk iphonesimulator \
-            -derivedDataPath build \
-            CODE_SIGNING_ALLOWED=NO
-
-      - name: Locate .app
-        id: app
-        run: |
-          shopt -s nullglob
-          apps=(build/Build/Products/*-iphonesimulator/*.app)
-          if [ ${#apps[@]} -lt 1 ]; then
-            echo "No .app produced" >&2
-            exit 1
-          fi
-          echo "path=${apps[0]}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload iOS app artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: betaflight-app-ios-simulator
-          path: ${{ steps.app.outputs.path }}
-          if-no-files-found: error
-          retention-days: 14
+      # A full unsigned iOS app build isn't cleanly supported (tauri ios build
+      # requires signing, and driving xcodebuild directly skips the dev-server
+      # setup its Rust xcode-script expects). Compiling the crate for the iOS
+      # target is the meaningful gate anyway: it type-checks the native transports
+      # (BLE via btleplug/CoreBluetooth, TCP) against the real iOS SDK, which can
+      # only be done on a macOS runner with Xcode.
+      - name: Cargo check (iOS target)
+        run: cargo check --manifest-path src-tauri/Cargo.toml --target aarch64-apple-ios
 
   android:
     name: Android (debug APK)

--- a/.github/workflows/tauri-pr-build.yml
+++ b/.github/workflows/tauri-pr-build.yml
@@ -42,7 +42,7 @@ jobs:
           cache: npm
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: aarch64-apple-ios
 
@@ -98,7 +98,7 @@ jobs:
           echo "NDK_HOME=$ANDROID_HOME/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
         with:
           targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
 

--- a/.github/workflows/tauri-pr-build.yml
+++ b/.github/workflows/tauri-pr-build.yml
@@ -52,7 +52,7 @@ jobs:
           workspaces: src-tauri
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build frontend
         run: npm run build
@@ -108,12 +108,12 @@ jobs:
           workspaces: src-tauri
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       # Debug builds are signed with the Android debug keystore — enough for test
       # installs, no release secrets needed (mirrors the Capacitor debug APK).
       - name: Build debug APK
-        run: npx tauri android build --apk --debug
+        run: npx --no tauri android build --apk --debug
 
       - name: Locate APK
         id: apk

--- a/.github/workflows/tauri-pr-build.yml
+++ b/.github/workflows/tauri-pr-build.yml
@@ -62,12 +62,14 @@ jobs:
 
       # Simulator builds require no code signing, so this validates the Swift app
       # and the linked Rust lib (native BLE/TCP) without any Apple credentials.
+      # Release config (not debug): debug makes Tauri's xcode-script expect a live
+      # dev server, whereas release builds against the frontend bundled above.
       - name: Build unsigned app for the simulator
         run: |
           xcodebuild build \
             -project src-tauri/gen/apple/betaflight-app.xcodeproj \
             -scheme betaflight-app_iOS \
-            -configuration debug \
+            -configuration release \
             -sdk iphonesimulator \
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -48,6 +48,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "async-trait"
+version = "0.1.91"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -98,6 +109,8 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 name = "betaflight-app"
 version = "2026.6.0"
 dependencies = [
+ "btleplug",
+ "futures",
  "serde",
  "serde_json",
  "tauri",
@@ -105,6 +118,8 @@ dependencies = [
  "tauri-plugin-serialplugin",
  "tauri-plugin-shell",
  "tauri-plugin-window-state",
+ "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -148,11 +163,49 @@ dependencies = [
 
 [[package]]
 name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
+]
+
+[[package]]
+name = "bluez-async"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84ae4213cc2a8dc663acecac67bbdad05142be4d8ef372b6903abf878b0c690a"
+dependencies = [
+ "bitflags 2.11.1",
+ "bluez-generated",
+ "dbus",
+ "dbus-tokio",
+ "futures",
+ "itertools",
+ "log",
+ "serde",
+ "serde-xml-rs",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "bluez-generated"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676783265eadd6f11829982792c6f303f3854d014edfba384685dcf237dd062"
+dependencies = [
+ "dbus",
 ]
 
 [[package]]
@@ -183,6 +236,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "btleplug"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9a11621cb2c8c024e444734292482b1ad86fb50ded066cf46252e46643c8748"
+dependencies = [
+ "async-trait",
+ "bitflags 2.11.1",
+ "bluez-async",
+ "dashmap 6.2.1",
+ "dbus",
+ "futures",
+ "jni 0.19.0",
+ "jni-utils",
+ "log",
+ "objc2 0.5.2",
+ "objc2-core-bluetooth",
+ "objc2-foundation 0.2.2",
+ "once_cell",
+ "static_assertions",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+ "windows",
+ "windows-future",
 ]
 
 [[package]]
@@ -534,14 +615,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "dbus"
 version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b942602992bb7acfd1f51c49811c58a610ef9181b6e66f3e519d79b540a3bf73"
 dependencies = [
+ "futures-channel",
+ "futures-util",
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dbus-tokio"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007688d459bc677131c063a3a77fb899526e17b7980f390b69644bdbc41fad13"
+dependencies = [
+ "dbus",
+ "libc",
+ "tokio",
 ]
 
 [[package]]
@@ -626,9 +747,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "libc",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -730,6 +851,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "embed-resource"
@@ -893,12 +1020,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -953,6 +1096,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1281,6 +1425,12 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1646,6 +1796,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1672,6 +1831,20 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
 ]
 
 [[package]]
@@ -1716,6 +1889,21 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jni-utils"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "259e9f2c3ead61de911f147000660511f07ab00adeed1d84f5ac4d0386e7a6c4"
+dependencies = [
+ "dashmap 5.5.3",
+ "futures",
+ "jni 0.19.0",
+ "log",
+ "once_cell",
+ "static_assertions",
+ "uuid",
 ]
 
 [[package]]
@@ -1989,10 +2177,10 @@ dependencies = [
  "dpi",
  "gtk",
  "keyboard-types",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.18.1",
  "serde",
@@ -2085,6 +2273,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2101,10 +2305,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2114,8 +2318,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-bluetooth"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a644b62ffb826a5277f536cf0f701493de420b13d40e700c452c36567771111"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
 ]
 
 [[package]]
@@ -2124,8 +2339,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2136,7 +2351,7 @@ checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -2147,7 +2362,7 @@ checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
  "bitflags 2.11.1",
  "dispatch2",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-io-surface",
 ]
@@ -2158,8 +2373,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d563b38d2b97209f8e861173de434bd0214cf020e3423a52624cd1d989f006"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2168,8 +2383,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca347214e24bc973fc025fd0d36ebb179ff30536ed1f80252706db19ee452009"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2179,7 +2394,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
 ]
@@ -2201,13 +2416,25 @@ dependencies = [
 
 [[package]]
 name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2218,7 +2445,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
 ]
 
@@ -2229,9 +2456,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2241,8 +2468,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-cloud-kit",
  "objc2-core-data",
  "objc2-core-foundation",
@@ -2250,7 +2477,7 @@ dependencies = [
  "objc2-core-image",
  "objc2-core-location",
  "objc2-core-text",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-quartz-core",
  "objc2-user-notifications",
 ]
@@ -2261,8 +2488,8 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9df9128cbbfef73cda168416ccf7f837b62737d748333bfe9ab71c245d76613e"
 dependencies = [
- "objc2",
- "objc2-foundation",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -2272,11 +2499,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
- "objc2",
+ "block2 0.6.2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
 ]
 
 [[package]]
@@ -3082,6 +3309,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-xml-rs"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc2215ce3e6a77550b80a1c37251b7d294febaf42e36e21b7b411e0bf54d540d"
+dependencies = [
+ "log",
+ "serde",
+ "thiserror 2.0.18",
+ "xml",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3354,10 +3593,10 @@ dependencies = [
  "bytemuck",
  "js-sys",
  "ndk",
- "objc2",
+ "objc2 0.6.4",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall",
@@ -3398,6 +3637,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -3488,6 +3733,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3527,7 +3783,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a33f7f9e486ade65fcf1e45c440f9236c904f5c1002cdc7fc6ae582777345ce4"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.6.2",
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
@@ -3538,14 +3794,14 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
  "ndk-sys",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "once_cell",
  "parking_lot",
@@ -3594,14 +3850,14 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
  "muda",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "percent-encoding",
@@ -3767,8 +4023,8 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
- "objc2",
+ "jni 0.21.1",
+ "objc2 0.6.4",
  "objc2-ui-kit",
  "objc2-web-kit",
  "raw-window-handle",
@@ -3790,9 +4046,9 @@ checksum = "a3989df2ae1c476404fe0a2e8ffc4cfbde97e51efd613c2bb5355fbc9ab52cf0"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "once_cell",
  "percent-encoding",
@@ -3991,6 +4247,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d06f0b082ba57c26b79407372e57cf2a1e28124f78e9479fe80322cf53420b"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4182,11 +4450,11 @@ dependencies = [
  "dirs",
  "libappindicator",
  "muda",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-core-graphics",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "png 0.18.1",
  "serde",
@@ -4651,10 +4919,10 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9bec5a31f3f9362f2258fd0e9c9dd61a9ca432e7306cc78c444258f0dce9a9c"
 dependencies = [
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "raw-window-handle",
  "windows-sys 0.59.0",
  "windows-version",
@@ -5152,7 +5420,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "186f9871daa55fd9c016578b810d149de58367113db7fb72b462d2323ce19514"
 dependencies = [
  "base64 0.22.1",
- "block2",
+ "block2 0.6.2",
  "cookie",
  "crossbeam-channel",
  "dirs",
@@ -5163,13 +5431,13 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
- "objc2",
+ "objc2 0.6.4",
  "objc2-app-kit",
  "objc2-core-foundation",
- "objc2-foundation",
+ "objc2-foundation 0.3.2",
  "objc2-ui-kit",
  "objc2-web-kit",
  "once_cell",
@@ -5209,6 +5477,12 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "xml"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,6 +30,14 @@ tauri-plugin-serialplugin = "2.21"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-window-state = "2"
 
+# Native BLE via btleplug's CoreBluetooth backend (shared by macOS and iOS). Scoped to Apple
+# targets so Linux (libdbus) and Windows (WinRT) desktop builds/CI are untouched by the spike.
+[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
+btleplug = "0.11"
+futures = "0.3"
+uuid = "1"
+tokio = { version = "1", features = ["time"] }
+
 [features]
 default = ["custom-protocol"]
 custom-protocol = ["tauri/custom-protocol"]

--- a/src-tauri/gen/apple/betaflight-app_iOS/Info.plist
+++ b/src-tauri/gen/apple/betaflight-app_iOS/Info.plist
@@ -26,6 +26,8 @@
 	<array>
 		<string>_betaflight._tcp</string>
 	</array>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Betaflight connects to your flight controller over Bluetooth Low Energy.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIRequiredDeviceCapabilities</key>

--- a/src-tauri/gen/apple/project.yml
+++ b/src-tauri/gen/apple/project.yml
@@ -57,6 +57,7 @@ targets:
         NSLocalNetworkUsageDescription: Betaflight connects to your flight controller bridge over the local network.
         NSBonjourServices:
           - _betaflight._tcp
+        NSBluetoothAlwaysUsageDescription: Betaflight connects to your flight controller over Bluetooth Low Energy.
     entitlements:
       path: betaflight-app_iOS/betaflight-app_iOS.entitlements
     scheme:
@@ -76,6 +77,7 @@ targets:
     dependencies:
       - framework: libapp.a
         embed: false
+      - sdk: CoreBluetooth.framework
       - sdk: CoreGraphics.framework
       - sdk: Network.framework
       - sdk: Metal.framework

--- a/src-tauri/src/ble.rs
+++ b/src-tauri/src/ble.rs
@@ -1,0 +1,248 @@
+//! Native BLE (GATT central) commands for the configurator.
+//!
+//! The Tauri webview exposes no usable Web Bluetooth on iOS (WKWebView has no
+//! `navigator.bluetooth`), so the JS `TauriBle` protocol drives these commands
+//! instead. Backed by btleplug, whose CoreBluetooth backend is shared between
+//! macOS and iOS — hence this module is gated to Apple targets (Linux would pull
+//! in libdbus and Windows a separate WinRT path; neither is needed for the iOS
+//! spike and both would touch desktop CI).
+//!
+//! A single connection is held in managed state. Notifications from the read
+//! characteristic are forwarded to the frontend via the `ble-data` event, and
+//! `ble-disconnected` fires when the link drops. An epoch counter fences each
+//! connection so a stale notification task (left over from a reconnect or
+//! disconnect) can never emit against the live peripheral.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use futures::StreamExt;
+use serde::{Deserialize, Serialize};
+use tauri::{AppHandle, Emitter, State};
+use uuid::Uuid;
+
+use btleplug::api::{Central, CharPropFlags, Characteristic, Manager as _, Peripheral as _, ScanFilter, WriteType};
+use btleplug::platform::{Adapter, Manager, Peripheral};
+
+/// How long a scan runs before returning the peripherals seen so far. BLE
+/// advertisements arrive every few hundred ms, so a couple of seconds catches
+/// the modules in range without making the picker feel stuck.
+const SCAN_DURATION: Duration = Duration::from_secs(3);
+
+/// A discovered peripheral, surfaced to the device picker.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BleDevice {
+    id: String,
+    name: String,
+    services: Vec<String>,
+}
+
+/// One entry of the JS `bluetoothDevices` table — the authoritative GATT map
+/// (remotely overridable), passed in at connect time so the Rust side never
+/// hard-codes UUIDs.
+#[derive(Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BleDeviceDescriptor {
+    service_uuid: String,
+    write_characteristic: String,
+    read_characteristic: String,
+}
+
+/// Which descriptor matched, so the frontend can restore its `deviceDescription`
+/// (used for the CC2541 CRC-corruption workaround).
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BleConnectResult {
+    service_uuid: String,
+}
+
+#[derive(Default)]
+pub struct BleState {
+    adapter: Mutex<Option<Adapter>>,
+    peripheral: Mutex<Option<Peripheral>>,
+    write_char: Mutex<Option<Characteristic>>,
+    epoch: Arc<AtomicU64>,
+}
+
+/// Lazily create and cache the first BLE adapter. The same adapter instance must
+/// serve both scan and connect: it holds the discovered-peripheral map that
+/// `peripheral()` lookups resolve against.
+async fn get_adapter(state: &State<'_, BleState>) -> Result<Adapter, String> {
+    if let Some(adapter) = state.adapter.lock().unwrap().clone() {
+        return Ok(adapter);
+    }
+    let manager = Manager::new().await.map_err(|e| e.to_string())?;
+    let adapter = manager
+        .adapters()
+        .await
+        .map_err(|e| e.to_string())?
+        .into_iter()
+        .next()
+        .ok_or_else(|| "no Bluetooth adapter available".to_string())?;
+    *state.adapter.lock().unwrap() = Some(adapter.clone());
+    Ok(adapter)
+}
+
+#[tauri::command]
+pub async fn ble_scan(state: State<'_, BleState>) -> Result<Vec<BleDevice>, String> {
+    let adapter = get_adapter(&state).await?;
+
+    // Empty filter = discover everything, mirroring Web Bluetooth's acceptAllDevices;
+    // service matching happens at connect time against the JS descriptor table.
+    adapter.start_scan(ScanFilter::default()).await.map_err(|e| e.to_string())?;
+    tokio::time::sleep(SCAN_DURATION).await;
+    let _ = adapter.stop_scan().await;
+
+    let peripherals = adapter.peripherals().await.map_err(|e| e.to_string())?;
+    let mut devices = Vec::new();
+    for peripheral in peripherals {
+        let props = peripheral.properties().await.ok().flatten();
+        // A peripheral with no advertised name is almost never a user-selectable FC
+        // bridge and only clutters the picker, so drop it.
+        let Some(name) = props.as_ref().and_then(|p| p.local_name.clone()) else {
+            continue;
+        };
+        let services = props.map(|p| p.services.iter().map(|u| u.to_string()).collect()).unwrap_or_default();
+        devices.push(BleDevice {
+            id: peripheral.id().to_string(),
+            name,
+            services,
+        });
+    }
+    Ok(devices)
+}
+
+#[tauri::command]
+pub async fn ble_connect(
+    app: AppHandle,
+    state: State<'_, BleState>,
+    id: String,
+    devices: Vec<BleDeviceDescriptor>,
+) -> Result<BleConnectResult, String> {
+    // Reserve this attempt's epoch before any await, so a slower attempt that gets
+    // superseded by a later connect/disconnect refuses to install its peripheral.
+    let epoch = state.epoch.clone();
+    let my_epoch = epoch.fetch_add(1, Ordering::SeqCst) + 1;
+
+    let adapter = get_adapter(&state).await?;
+    let peripherals = adapter.peripherals().await.map_err(|e| e.to_string())?;
+    let peripheral = peripherals
+        .into_iter()
+        .find(|p| p.id().to_string() == id)
+        .ok_or_else(|| "device not found — rescan and try again".to_string())?;
+
+    peripheral.connect().await.map_err(|e| e.to_string())?;
+    peripheral.discover_services().await.map_err(|e| e.to_string())?;
+
+    let characteristics = peripheral.characteristics();
+    let mut matched: Option<(String, Characteristic, Characteristic)> = None;
+    for descriptor in &devices {
+        let (Ok(service_uuid), Ok(write_uuid), Ok(read_uuid)) = (
+            Uuid::parse_str(&descriptor.service_uuid),
+            Uuid::parse_str(&descriptor.write_characteristic),
+            Uuid::parse_str(&descriptor.read_characteristic),
+        ) else {
+            continue;
+        };
+        let write = characteristics.iter().find(|c| c.service_uuid == service_uuid && c.uuid == write_uuid);
+        let read = characteristics.iter().find(|c| c.service_uuid == service_uuid && c.uuid == read_uuid);
+        if let (Some(write), Some(read)) = (write, read) {
+            matched = Some((descriptor.service_uuid.clone(), write.clone(), read.clone()));
+            break;
+        }
+    }
+
+    let (service_uuid, write_char, read_char) = match matched {
+        Some(found) => found,
+        None => {
+            let _ = peripheral.disconnect().await;
+            return Err("device exposes no supported Betaflight GATT service".to_string());
+        }
+    };
+
+    peripheral.subscribe(&read_char).await.map_err(|e| e.to_string())?;
+
+    // Install only if nothing superseded us while connecting; check and install under
+    // the same lock so a concurrent disconnect can't race the store.
+    {
+        let mut guard = state.peripheral.lock().unwrap();
+        if epoch.load(Ordering::SeqCst) != my_epoch {
+            drop(guard);
+            let _ = peripheral.disconnect().await;
+            return Err("connection attempt superseded".to_string());
+        }
+        *guard = Some(peripheral.clone());
+        *state.write_char.lock().unwrap() = Some(write_char);
+    }
+
+    spawn_notifications(app, epoch, my_epoch, peripheral, read_char.uuid);
+
+    Ok(BleConnectResult { service_uuid })
+}
+
+/// Forwards notifications from the read characteristic to the frontend until the
+/// peripheral drops the link or `epoch` no longer matches (a later reconnect or
+/// disconnect superseded it). The stream ending is treated as a disconnect.
+fn spawn_notifications(app: AppHandle, epoch: Arc<AtomicU64>, my_epoch: u64, peripheral: Peripheral, read_uuid: Uuid) {
+    tauri::async_runtime::spawn(async move {
+        let mut stream = match peripheral.notifications().await {
+            Ok(stream) => stream,
+            Err(_) => {
+                if epoch.load(Ordering::SeqCst) == my_epoch {
+                    let _ = app.emit("ble-disconnected", ());
+                }
+                return;
+            }
+        };
+
+        while let Some(notification) = stream.next().await {
+            if epoch.load(Ordering::SeqCst) != my_epoch {
+                return;
+            }
+            if notification.uuid == read_uuid {
+                let _ = app.emit("ble-data", notification.value);
+            }
+        }
+
+        // Stream ended: the link is gone. Only report it if we are still the live epoch.
+        if epoch.load(Ordering::SeqCst) == my_epoch {
+            let _ = app.emit("ble-disconnected", ());
+        }
+    });
+}
+
+#[tauri::command]
+pub async fn ble_send(state: State<'_, BleState>, data: Vec<u8>) -> Result<(), String> {
+    // Clone the handles out from under the locks before awaiting; btleplug's
+    // Peripheral/Characteristic are cheap Arc-backed clones.
+    let peripheral = state.peripheral.lock().unwrap().clone();
+    let write_char = state.write_char.lock().unwrap().clone();
+    let (Some(peripheral), Some(write_char)) = (peripheral, write_char) else {
+        return Err("BLE peripheral is not connected".to_string());
+    };
+
+    // Prefer acknowledged writes when the characteristic supports them (matching the
+    // Web Bluetooth path), falling back to write-without-response otherwise.
+    let write_type = if write_char.properties.contains(CharPropFlags::WRITE) {
+        WriteType::WithResponse
+    } else {
+        WriteType::WithoutResponse
+    };
+
+    peripheral.write(&write_char, &data, write_type).await.map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn ble_disconnect(state: State<'_, BleState>) -> Result<(), String> {
+    // Fence the notification task first so its stream-end doesn't emit a spurious
+    // ble-disconnected after an intentional teardown.
+    state.epoch.fetch_add(1, Ordering::SeqCst);
+    let peripheral = state.peripheral.lock().unwrap().take();
+    *state.write_char.lock().unwrap() = None;
+    if let Some(peripheral) = peripheral {
+        let _ = peripheral.disconnect().await;
+    }
+    Ok(())
+}

--- a/src-tauri/src/ble.rs
+++ b/src-tauri/src/ble.rs
@@ -134,7 +134,12 @@ pub async fn ble_connect(
         .ok_or_else(|| "device not found — rescan and try again".to_string())?;
 
     peripheral.connect().await.map_err(|e| e.to_string())?;
-    peripheral.discover_services().await.map_err(|e| e.to_string())?;
+    // From here the peripheral is connected, so every early return must disconnect it
+    // first or it leaks a live link the state never tracks.
+    if let Err(e) = peripheral.discover_services().await {
+        let _ = peripheral.disconnect().await;
+        return Err(e.to_string());
+    }
 
     let characteristics = peripheral.characteristics();
     let mut matched: Option<(String, Characteristic, Characteristic)> = None;
@@ -162,19 +167,28 @@ pub async fn ble_connect(
         }
     };
 
-    peripheral.subscribe(&read_char).await.map_err(|e| e.to_string())?;
+    if let Err(e) = peripheral.subscribe(&read_char).await {
+        let _ = peripheral.disconnect().await;
+        return Err(e.to_string());
+    }
 
     // Install only if nothing superseded us while connecting; check and install under
     // the same lock so a concurrent disconnect can't race the store.
-    {
+    let previous = {
         let mut guard = state.peripheral.lock().unwrap();
         if epoch.load(Ordering::SeqCst) != my_epoch {
             drop(guard);
             let _ = peripheral.disconnect().await;
             return Err("connection attempt superseded".to_string());
         }
-        *guard = Some(peripheral.clone());
+        let previous = guard.replace(peripheral.clone());
         *state.write_char.lock().unwrap() = Some(write_char);
+        previous
+    };
+    // Drop any peripheral we replaced (a reconnect without an intervening disconnect)
+    // after releasing the lock, so its link doesn't linger.
+    if let Some(previous) = previous {
+        let _ = previous.disconnect().await;
     }
 
     spawn_notifications(app, epoch, my_epoch, peripheral, read_char.uuid);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,5 +1,10 @@
 mod tcp;
 
+// Native BLE (btleplug/CoreBluetooth) is Apple-only: it shares the macOS/iOS backend and
+// avoids the libdbus (Linux) and WinRT (Windows) paths, which the iOS spike doesn't need.
+#[cfg(any(target_os = "ios", target_os = "macos"))]
+mod ble;
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     let builder = tauri::Builder::default().plugin(tauri_plugin_shell::init());
@@ -21,13 +26,28 @@ pub fn run() {
         Ok(())
     });
 
+    let builder = builder.manage(tcp::TcpState::default());
+
+    // On Apple targets register the native BLE transport alongside TCP; elsewhere only TCP
+    // exists, so the handler lists diverge.
+    #[cfg(any(target_os = "ios", target_os = "macos"))]
+    let builder = builder.manage(ble::BleState::default()).invoke_handler(tauri::generate_handler![
+        tcp::tcp_connect,
+        tcp::tcp_send,
+        tcp::tcp_disconnect,
+        ble::ble_scan,
+        ble::ble_connect,
+        ble::ble_send,
+        ble::ble_disconnect
+    ]);
+    #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+    let builder = builder.invoke_handler(tauri::generate_handler![
+        tcp::tcp_connect,
+        tcp::tcp_send,
+        tcp::tcp_disconnect
+    ]);
+
     builder
-        .manage(tcp::TcpState::default())
-        .invoke_handler(tauri::generate_handler![
-            tcp::tcp_connect,
-            tcp::tcp_send,
-            tcp::tcp_disconnect
-        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/js/protocols/TauriBle.js
+++ b/src/js/protocols/TauriBle.js
@@ -1,0 +1,220 @@
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { i18n } from "../localization";
+import { gui_log } from "../gui_log";
+import { bluetoothDevices } from "./devices";
+
+/**
+ * Native BLE transport for the Tauri iOS shell.
+ *
+ * WKWebView exposes no Web Bluetooth, so this drives the Rust `ble_*` commands
+ * (btleplug/CoreBluetooth) and receives notification bytes via the `ble-data` /
+ * `ble-disconnected` events. Presents the same EventTarget interface as
+ * `WebBluetooth`, so serial.js and serial_backend treat it identically.
+ */
+class TauriBle extends EventTarget {
+    constructor() {
+        super();
+
+        this.connected = false;
+        this.connectionId = false;
+        this.deviceDescription = null;
+
+        this.bitrate = 0;
+        this.bytesSent = 0;
+        this.bytesReceived = 0;
+        this.failed = 0;
+
+        this.devices = [];
+        this._connectedDevice = null;
+        this._unlisten = [];
+
+        this.logHead = "[BLE]";
+
+        this.bt11_crc_corruption_logged = false;
+
+        this.connect = this.connect.bind(this);
+        this.handleDisconnect = this.handleDisconnect.bind(this);
+    }
+
+    handleReceiveBytes(info) {
+        this.bytesReceived += info.detail.byteLength;
+    }
+
+    handleDisconnect() {
+        this.disconnect();
+    }
+
+    // Mirrors WebBluetooth/CapacitorBle: a stable `bluetooth_`-prefixed path keeps
+    // serial.js selectProtocol routing to the BLE slot, and the id (a CoreBluetooth
+    // UUID on iOS) is stable across scans so a pinned path re-resolves to the same device.
+    createPort(device) {
+        return {
+            path: `bluetooth_${device.id}`,
+            displayName: device.name || device.id,
+            vendorId: "unknown",
+            productId: device.id,
+            port: device,
+        };
+    }
+
+    getConnectedDevice() {
+        return this._connectedDevice;
+    }
+
+    isBT11CorruptionPattern(expectedChecksum) {
+        if (expectedChecksum !== 0xff || this.message_checksum === 0xff) {
+            return false;
+        }
+
+        if (!this.connected) {
+            return false;
+        }
+
+        if (!this.deviceDescription) {
+            return false;
+        }
+
+        return this.deviceDescription?.susceptibleToCrcCorruption ?? false;
+    }
+
+    shouldBypassCrc(expectedChecksum) {
+        if (this.isBT11CorruptionPattern(expectedChecksum)) {
+            if (!this.bt11_crc_corruption_logged) {
+                console.log(`${this.logHead} Detected BT-11/CC2541 CRC corruption (0xff), skipping CRC check`);
+                this.bt11_crc_corruption_logged = true;
+            }
+            return true;
+        }
+        return false;
+    }
+
+    // A BLE scan doubles as the permission gate: the first CoreBluetooth use raises the
+    // iOS Bluetooth prompt. The picker renders whatever this returns.
+    async getDevices() {
+        try {
+            const found = await invoke("ble_scan");
+            this.devices = found.map((device) => this.createPort(device));
+        } catch (e) {
+            console.error(`${this.logHead} Scan failed: ${e}`);
+        }
+        return this.devices;
+    }
+
+    // No OS device chooser on iOS — a scan surfaces the permission prompt and refreshes
+    // the list. Return the first hit to mirror CapacitorBle's shape.
+    async requestPermissionDevice() {
+        const devices = await this.getDevices();
+        return devices?.[0] ?? null;
+    }
+
+    async _teardownListeners() {
+        for (const unlisten of this._unlisten) {
+            try {
+                await unlisten();
+            } catch (e) {
+                console.error(`${this.logHead} Failed to remove listener: ${e}`);
+            }
+        }
+        this._unlisten = [];
+    }
+
+    async connect(path, _options) {
+        try {
+            const device = this.devices.find((d) => d.path === path);
+            const id = device ? device.port.id : path.replace(/^bluetooth_/, "");
+
+            // Drop listeners left over from a previous connection before re-registering,
+            // otherwise reconnects leak listeners and duplicate receive/disconnect handling.
+            await this._teardownListeners();
+
+            const dataUnlisten = await listen("ble-data", (event) => {
+                const bytes = new Uint8Array(event.payload);
+                this.handleReceiveBytes({ detail: bytes });
+                this.dispatchEvent(new CustomEvent("receive", { detail: bytes }));
+            });
+            const closedUnlisten = await listen("ble-disconnected", () => {
+                this.handleDisconnect();
+            });
+            this._unlisten = [dataUnlisten, closedUnlisten];
+
+            // Hand the JS GATT table to Rust so UUID matching (and remote overrides) stay
+            // authoritative here; Rust reports which service matched.
+            const descriptors = bluetoothDevices.map((d) => ({
+                name: d.name,
+                serviceUuid: d.serviceUuid,
+                writeCharacteristic: d.writeCharacteristic,
+                readCharacteristic: d.readCharacteristic,
+            }));
+
+            const result = await invoke("ble_connect", { id, devices: descriptors });
+
+            this.deviceDescription = bluetoothDevices.find((d) => d.serviceUuid === result.serviceUuid) ?? null;
+            this._connectedDevice = device ?? this._portInfo(id);
+            this.connected = true;
+            this.connectionId = path;
+            this.bytesReceived = 0;
+            this.bytesSent = 0;
+            this.failed = 0;
+
+            this.addEventListener("receive", this.handleReceiveBytes);
+
+            gui_log(i18n.getMessage("bluetoothConnected", [this._connectedDevice.displayName]));
+            this.dispatchEvent(new CustomEvent("connect", { detail: true }));
+            return true;
+        } catch (e) {
+            console.error(`${this.logHead} Failed to connect: ${e}`);
+            this.connected = false;
+            await this._teardownListeners();
+            this.dispatchEvent(new CustomEvent("connect", { detail: false }));
+            return false;
+        }
+    }
+
+    _portInfo(id) {
+        return { path: `bluetooth_${id}`, displayName: id, vendorId: "unknown", productId: id, port: { id } };
+    }
+
+    async disconnect() {
+        this.connected = false;
+        this.bytesReceived = 0;
+        this.bytesSent = 0;
+
+        try {
+            await invoke("ble_disconnect");
+            await this._teardownListeners();
+            this.removeEventListener("receive", this.handleReceiveBytes);
+            this.deviceDescription = null;
+            this._connectedDevice = null;
+            this.connectionId = false;
+            this.bt11_crc_corruption_logged = false;
+            this.dispatchEvent(new CustomEvent("disconnect", { detail: true }));
+            return true;
+        } catch (e) {
+            console.error(`${this.logHead} Failed to close connection: ${e}`);
+            await this._teardownListeners();
+            this.dispatchEvent(new CustomEvent("disconnect", { detail: false }));
+            return false;
+        }
+    }
+
+    async send(data, cb) {
+        let actualBytesSent = 0;
+        if (this.connected) {
+            const bytes = new Uint8Array(data);
+            try {
+                await invoke("ble_send", { data: Array.from(bytes) });
+                actualBytesSent = bytes.byteLength;
+                this.bytesSent += actualBytesSent;
+                cb?.({ error: null, bytesSent: actualBytesSent });
+            } catch (e) {
+                console.error(`${this.logHead} Failed to send data: ${e}`);
+                cb?.({ error: e, bytesSent: 0 });
+            }
+        }
+
+        return { bytesSent: actualBytesSent };
+    }
+}
+
+export default TauriBle;

--- a/src/js/protocols/TauriBle.js
+++ b/src/js/protocols/TauriBle.js
@@ -211,6 +211,8 @@ class TauriBle extends EventTarget {
                 console.error(`${this.logHead} Failed to send data: ${e}`);
                 cb?.({ error: e, bytesSent: 0 });
             }
+        } else {
+            cb?.({ error: "BLE peripheral is not connected", bytesSent: 0 });
         }
 
         return { bytesSent: actualBytesSent };

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -8,6 +8,7 @@ import CapacitorBle from "./protocols/CapacitorBle.js";
 import CapacitorTcp from "./protocols/CapacitorTcp.js";
 import TauriSerial from "./protocols/TauriSerial.js";
 import TauriTcp from "./protocols/TauriTcp.js";
+import TauriBle from "./protocols/TauriBle.js";
 
 /**
  * Base Serial class that manages all protocol implementations
@@ -37,7 +38,9 @@ class Serial extends EventTarget {
             // is desktop + Android only — iOS has no USB serial.
             this._protocols = [
                 ...(isTauriIOS() ? [] : [{ name: "serial", instance: new TauriSerial() }]),
-                { name: "bluetooth", instance: new WebBluetooth() },
+                // iOS WKWebView has no Web Bluetooth, so use the native btleplug transport there;
+                // desktop Tauri keeps the webview's Web Bluetooth.
+                { name: "bluetooth", instance: isTauriIOS() ? new TauriBle() : new WebBluetooth() },
                 { name: "tcp", instance: new TauriTcp() },
                 { name: "websocket", instance: new Websocket() },
             ];

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -224,6 +224,9 @@ export function checkBluetoothSupport() {
     let result = false;
     if (isAndroid()) {
         result = true;
+    } else if (isTauriIOS()) {
+        // Native btleplug transport — WKWebView has no navigator.bluetooth.
+        result = true;
     } else if (navigator.bluetooth) {
         result = true;
     } else if (isIOS()) {


### PR DESCRIPTION
Adds a native BLE (GATT central) transport for the iOS Tauri build. WKWebView exposes no Web Bluetooth, so BLE never worked on iOS. This drives btleplug (its CoreBluetooth backend is shared with macOS) through native `ble_*` Rust commands and a `TauriBle` protocol that presents the same interface as `WebBluetooth`, mirroring the existing native TCP transport (ble-data/ble-disconnected events, epoch-fenced single connection).

The JS `bluetoothDevices` UUID table stays authoritative and is passed to Rust at connect, so GATT matching and remote overrides live in one place; Rust returns the matched service so the CC2541 CRC-bypass still works. The iOS "bluetooth" slot and `checkBluetoothSupport()` now route to the native transport; desktop Tauri keeps Web Bluetooth.

btleplug is scoped to Apple targets (ios/macos), so Linux (libdbus) and Windows (WinRT) desktop builds and CI are untouched. No Swift bridge is needed, unlike Local Network: CoreBluetooth's own APIs raise the iOS permission prompt, so only `NSBluetoothAlwaysUsageDescription` plus the CoreBluetooth framework are added.

Draft: the CoreBluetooth path can only be exercised on an Xcode/TestFlight build. Host `cargo check` (wiring) and JS lint pass locally; `ble.rs` itself compiles only on a Mac (the iOS cross-check dies in an objc2 build script that needs xcrun).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added native Bluetooth Low Energy support for iOS and macOS via Tauri, including scanning, connecting to matching services/characteristics, sending data with write-with-response when available, receiving notifications, and disconnecting.
  * Introduced a native BLE transport for Tauri iOS shells, integrated into the Bluetooth flow.

* **Bug Fixes**
  * Improved Bluetooth capability detection for iOS when running inside a Tauri shell.
  * Enhanced reliability by cleaning up BLE event listeners and preventing duplicate handlers across reconnects.

* **Chores**
  * Added PR CI compile checks for iOS and an Android debug build/upload step.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->