### PR TITLE
UI: Fix Open Font File button

### DIFF
--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -447,7 +447,7 @@
                             <UButton @click="loadCustomFontFile()" size="sm">
                                 {{ $t("osdSetupOpenFont") }}
                             </UButton>
-                            <span class="text-sm opacity-60">(.mcm)</span>
+                            <span class="text-sm opacity-60"></span>
                         </div>
 
                         <!-- Logo customization -->


### PR DESCRIPTION
### Before

<img width="513" height="579" alt="image" src="https://github.com/user-attachments/assets/f7fddadf-48e1-40dd-97c5-7bdd8670f971" />

### After

<img width="513" height="579" alt="image" src="https://github.com/user-attachments/assets/b73cdd0d-cbe3-4d00-bb76-65dbd16d7910" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the “(.mcm)” file-extension hint from the custom font upload dialog for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->