### PR TITLE
fix(ios): allow cdylib link with app-provided local-network symbol

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -1,3 +1,12 @@
 fn main() {
+    // The iOS app links the staticlib (libapp.a), where `bf_trigger_local_network_permission`
+    // (see tcp.rs) is resolved from the Swift side compiled into the app. `cargo build --lib`
+    // also links the cdylib crate type, and a dylib link demands every symbol resolve up front —
+    // the Swift symbol isn't present there, so the cdylib link fails. The cdylib isn't loaded on
+    // iOS, so let that one symbol stay undefined in it; the staticlib is unaffected.
+    if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("ios") {
+        println!("cargo:rustc-link-arg-cdylib=-Wl,-U,_bf_trigger_local_network_permission");
+    }
+
     tauri_build::build()
 }


### PR DESCRIPTION
The nightly `Tauri iOS IPA (ad-hoc)` job fails at link with `Undefined symbols: _bf_trigger_local_network_permission` ([run](https://github.com/betaflight/betaflight-configurator/actions/runs/30603457659/job/91070847745)).

The symbol is provided by the Swift side (`LocalNetworkPermission.swift`) compiled into the app and resolved via the staticlib (`libapp.a`) the app links. But `cargo build --lib` also links the `cdylib` crate type, and a dylib link requires every symbol to resolve up front, where the Swift symbol is absent, so that link fails. The `cdylib` is collateral from the crate-type list and is not loaded on iOS.

PR CI only runs `cargo check` for the iOS target (no link step), which is why #5326 passed and the break only surfaced in the nightly full build.

Fix: in `build.rs`, for the iOS target only, emit `rustc-link-arg-cdylib=-Wl,-U,_bf_trigger_local_network_permission` so that one symbol may stay undefined in the (unused) cdylib. The staticlib the app links is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added iOS-specific build configuration to support successful application builds.
  * No changes to user-facing behavior on other platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->