### PR TITLE
Add element names for waypoint/nav-map OSD fields

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8920,6 +8920,69 @@
     "osdDescElementBatteryProfileName": {
         "message": "Shows the active battery profile name or index"
     },
+    "osdTextElementWpNumber": {
+        "message": "Waypoint number",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNumber": {
+        "message": "Shows the current/total waypoint number of the active flight plan"
+    },
+    "osdTextElementWpCurrentLat": {
+        "message": "Waypoint latitude",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLat": {
+        "message": "Shows the latitude of the current waypoint"
+    },
+    "osdTextElementWpCurrentLon": {
+        "message": "Waypoint longitude",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLon": {
+        "message": "Shows the longitude of the current waypoint"
+    },
+    "osdTextElementWpCurrentAlt": {
+        "message": "Waypoint altitude",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentAlt": {
+        "message": "Shows the altitude of the current waypoint"
+    },
+    "osdTextElementWpDistance": {
+        "message": "Waypoint distance",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDistance": {
+        "message": "Shows the distance to the current waypoint"
+    },
+    "osdTextElementWpDirection": {
+        "message": "Waypoint direction",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDirection": {
+        "message": "Shows a direction arrow pointing at the current waypoint"
+    },
+    "osdTextElementWpNextNumber": {
+        "message": "Next waypoint number",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNextNumber": {
+        "message": "Shows the next waypoint number in the active flight plan"
+    },
+    "osdTextElementWpEta": {
+        "message": "Waypoint ETA",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpEta": {
+        "message": "Shows the estimated time of arrival at the current waypoint"
+    },
+    "osdTextElementNavMap": {
+        "message": "Navigation map",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNavMap": {
+        "message": "Minimap showing home, the flight plan, and the flown trail"
+    },
     "osdSetupPreviewCheckRulers": {
         "message": "Rulers",
         "description": "Label for the checkbox to toggle OSD preview rulers around the preview"

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -288,6 +288,9 @@ OSD.drawCameraFramePreview = function () {
 
 // Firmware's NAV_MAP grid is a fixed 14x8 (osd_nav_map.c). This preview
 // draws a bordered box at that size, not the live minimap content.
+/**
+ * @returns {Array<{x: number, y: number, sym: number}>} Border cells for the NAV_MAP preview grid.
+ */
 OSD.drawNavMapPreview = function () {
     const NAV_MAP_COLS = 14;
     const NAV_MAP_ROWS = 8;

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -286,6 +286,27 @@ OSD.drawCameraFramePreview = function () {
     return cameraFrame;
 };
 
+// firmware's NAV_MAP grid is a fixed NAV_MAP_COLS x NAV_MAP_ROWS (14x8, osd_nav_map.c) —
+// preview is a bordered box matching that footprint, not the live minimap content.
+OSD.drawNavMapPreview = function () {
+    const NAV_MAP_COLS = 14;
+    const NAV_MAP_ROWS = 8;
+
+    const navMap = [];
+
+    for (let x = 0; x < NAV_MAP_COLS; x++) {
+        const sym = x === 0 || x === NAV_MAP_COLS - 1 ? SYM.STICK_OVERLAY_CENTER : SYM.STICK_OVERLAY_HORIZONTAL;
+        navMap.push({ x, y: 0, sym }, { x, y: NAV_MAP_ROWS - 1, sym });
+    }
+
+    for (let y = 1; y < NAV_MAP_ROWS - 1; y++) {
+        const sym = SYM.STICK_OVERLAY_VERTICAL;
+        navMap.push({ x: 0, y, sym }, { x: NAV_MAP_COLS - 1, y, sym });
+    }
+
+    return navMap;
+};
+
 OSD.formatPidsPreview = function (axis) {
     const pidDefaults = FC.getPidDefaults();
     const p = pidDefaults[axis * 5].toString().padStart(3);
@@ -1338,6 +1359,93 @@ OSD.loadDisplayFields = function () {
             positionable: true,
             preview: "BAT1",
         },
+        WP_NUMBER: {
+            name: "WP_NUMBER",
+            text: "osdTextElementWpNumber",
+            desc: "osdDescElementWpNumber",
+            defaultPosition: -1,
+            draw_order: 625,
+            positionable: true,
+            preview: "WP1/12",
+        },
+        WP_CURRENT_LAT: {
+            name: "WP_CURRENT_LAT",
+            text: "osdTextElementWpCurrentLat",
+            desc: "osdDescElementWpCurrentLat",
+            defaultPosition: -1,
+            draw_order: 630,
+            positionable: true,
+            preview: `${FONT.symbol(SYM.GPS_LAT)}-00.0000000`,
+        },
+        WP_CURRENT_LON: {
+            name: "WP_CURRENT_LON",
+            text: "osdTextElementWpCurrentLon",
+            desc: "osdDescElementWpCurrentLon",
+            defaultPosition: -1,
+            draw_order: 635,
+            positionable: true,
+            preview: `${FONT.symbol(SYM.GPS_LON)}-000.0000000`,
+        },
+        WP_CURRENT_ALT: {
+            name: "WP_CURRENT_ALT",
+            text: "osdTextElementWpCurrentAlt",
+            desc: "osdDescElementWpCurrentAlt",
+            defaultPosition: -1,
+            draw_order: 640,
+            positionable: true,
+            preview(osdData) {
+                const unit = FONT.symbol(osdData.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                return `${FONT.symbol(SYM.ALTITUDE)}88${unit}`;
+            },
+        },
+        WP_DISTANCE: {
+            name: "WP_DISTANCE",
+            text: "osdTextElementWpDistance",
+            desc: "osdDescElementWpDistance",
+            defaultPosition: -1,
+            draw_order: 645,
+            positionable: true,
+            preview(osdData) {
+                const unit = FONT.symbol(osdData.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                return `120${unit}`;
+            },
+        },
+        WP_DIRECTION: {
+            name: "WP_DIRECTION",
+            text: "osdTextElementWpDirection",
+            desc: "osdDescElementWpDirection",
+            defaultPosition: -1,
+            draw_order: 650,
+            positionable: true,
+            preview: FONT.symbol(SYM.ARROW_SOUTH + 2),
+        },
+        WP_NEXT_NUMBER: {
+            name: "WP_NEXT_NUMBER",
+            text: "osdTextElementWpNextNumber",
+            desc: "osdDescElementWpNextNumber",
+            defaultPosition: -1,
+            draw_order: 655,
+            positionable: true,
+            preview: "NEXT4",
+        },
+        WP_ETA: {
+            name: "WP_ETA",
+            text: "osdTextElementWpEta",
+            desc: "osdDescElementWpEta",
+            defaultPosition: -1,
+            draw_order: 660,
+            positionable: true,
+            preview: "05:30",
+        },
+        NAV_MAP: {
+            name: "NAV_MAP",
+            text: "osdTextElementNavMap",
+            desc: "osdDescElementNavMap",
+            defaultPosition: -1,
+            draw_order: 665,
+            positionable: true,
+            preview: OSD.drawNavMapPreview,
+        },
     };
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
@@ -1473,6 +1581,18 @@ OSD.chooseFields = function () {
         OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
             F.OSD_CUSTOM_SERIAL_TEXT,
             F.BATTERY_PROFILE_NAME,
+            // Flight-plan waypoint elements and nav map, in firmware osd_items_e order
+            // (only compiled into firmware when USE_GPS && ENABLE_FLIGHT_PLAN / USE_OSD_NAV_MAP;
+            // harmless to list unconditionally here — see the DISPLAY_FIELDS ordering note above)
+            F.WP_NUMBER,
+            F.WP_CURRENT_LAT,
+            F.WP_CURRENT_LON,
+            F.WP_CURRENT_ALT,
+            F.WP_DISTANCE,
+            F.WP_DIRECTION,
+            F.WP_NEXT_NUMBER,
+            F.WP_ETA,
+            F.NAV_MAP,
         ]);
     }
     // Choose statistic fields

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -286,8 +286,8 @@ OSD.drawCameraFramePreview = function () {
     return cameraFrame;
 };
 
-// firmware's NAV_MAP grid is a fixed NAV_MAP_COLS x NAV_MAP_ROWS (14x8, osd_nav_map.c) —
-// preview is a bordered box matching that footprint, not the live minimap content.
+// Firmware's NAV_MAP grid is a fixed 14x8 (osd_nav_map.c). This preview
+// draws a bordered box at that size, not the live minimap content.
 OSD.drawNavMapPreview = function () {
     const NAV_MAP_COLS = 14;
     const NAV_MAP_ROWS = 8;
@@ -1581,19 +1581,34 @@ OSD.chooseFields = function () {
         OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
             F.OSD_CUSTOM_SERIAL_TEXT,
             F.BATTERY_PROFILE_NAME,
-            // Flight-plan waypoint elements and nav map, in firmware osd_items_e order
-            // (only compiled into firmware when USE_GPS && ENABLE_FLIGHT_PLAN / USE_OSD_NAV_MAP;
-            // harmless to list unconditionally here — see the DISPLAY_FIELDS ordering note above)
-            F.WP_NUMBER,
-            F.WP_CURRENT_LAT,
-            F.WP_CURRENT_LON,
-            F.WP_CURRENT_ALT,
-            F.WP_DISTANCE,
-            F.WP_DIRECTION,
-            F.WP_NEXT_NUMBER,
-            F.WP_ETA,
-            F.NAV_MAP,
         ]);
+
+        // Waypoint/nav-map enum entries only exist in firmware when their compile
+        // flags are present. Unconditional listing would misalign every later
+        // DISPLAY_FIELDS position on builds lacking them. Gate on reported build options.
+        const buildOptions = FC.CONFIG.buildOptions ?? [];
+        const hasFlightPlanWaypoints = buildOptions.includes("USE_GPS") && buildOptions.includes("USE_FLIGHT_PLAN");
+        const hasNavMap =
+            hasFlightPlanWaypoints &&
+            !buildOptions.includes("USE_WING") &&
+            (buildOptions.includes("USE_OSD_SD") || buildOptions.includes("USE_OSD_HD"));
+
+        if (hasFlightPlanWaypoints) {
+            OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
+                F.WP_NUMBER,
+                F.WP_CURRENT_LAT,
+                F.WP_CURRENT_LON,
+                F.WP_CURRENT_ALT,
+                F.WP_DISTANCE,
+                F.WP_DIRECTION,
+                F.WP_NEXT_NUMBER,
+                F.WP_ETA,
+            ]);
+        }
+
+        if (hasNavMap) {
+            OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([F.NAV_MAP]);
+        }
     }
     // Choose statistic fields
     // Nothing much to do here, I'm preempting there being new statistics

--- a/test/js/tabs/osd_battery_profile.test.js
+++ b/test/js/tabs/osd_battery_profile.test.js
@@ -104,6 +104,15 @@ function buildAllDisplayFields() {
         // API 1.48
         "OSD_CUSTOM_SERIAL_TEXT",
         "BATTERY_PROFILE_NAME",
+        "WP_NUMBER",
+        "WP_CURRENT_LAT",
+        "WP_CURRENT_LON",
+        "WP_CURRENT_ALT",
+        "WP_DISTANCE",
+        "WP_DIRECTION",
+        "WP_NEXT_NUMBER",
+        "WP_ETA",
+        "NAV_MAP",
     ];
 
     const fields = {};


### PR DESCRIPTION
AI Generated pull-request

## Summary
Adds Configurator field entries for 9 OSD elements already merged into `betaflight/betaflight` master's `osd_items_e` enum (flight-plan waypoint elements and the nav map), which currently have no Configurator-side name and only show in the element list as generic "Unknown N" placeholders:

- `OSD_WP_NUMBER`, `OSD_WP_CURRENT_LAT`, `OSD_WP_CURRENT_LON`, `OSD_WP_CURRENT_ALT`, `OSD_WP_DISTANCE`, `OSD_WP_DIRECTION`, `OSD_WP_NEXT_NUMBER`, `OSD_WP_ETA` (gated firmware-side by `USE_GPS && ENABLE_FLIGHT_PLAN`)
- `OSD_NAV_MAP` (gated firmware-side by `USE_OSD_NAV_MAP`)

Field entries and `DISPLAY_FIELDS` insertion follow firmware's exact `osd_items_e` order (appended after `BATTERY_PROFILE_NAME`, under the existing `API_VERSION_1_48` gate — no MSP API version bump accompanied the firmware side of these elements). Added a comment documenting the positional-ordering requirement on `DISPLAY_FIELDS`, since a future addition appended after these instead of at the matching firmware position would silently misalign positions on any build compiling both.

`NAV_MAP`'s preview is a bordered-box placeholder sized to firmware's fixed 14x8 grid (`osd_nav_map.c`), not the live minimap content — matching the existing `CAMERA_FRAME` preview convention for grid-shaped elements.

## Test plan
- [x] `npx eslint src/components/tabs/osd/osd.js test/js/tabs/osd_battery_profile.test.js` — clean
- [x] `npx vitest run test/js/` — 667/667 tests pass (57 files)
- [x] Verified via a scratch test (not included): all 9 fields resolve to non-empty i18n text/desc, and appear in `DISPLAY_FIELDS` in exact firmware enum order immediately after `BATTERY_PROFILE_NAME`
- [ ] Live hardware verification against a board with `ENABLE_FLIGHT_PLAN`/`USE_OSD_NAV_MAP` compiled in — not yet performed (these flags are compiled in only one config in the entire `src/config` submodule today, `SITL_GAZEBO`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added waypoint navigation details to the on-screen display, including waypoint number, coordinates, altitude, distance, direction, next waypoint, and ETA.
  * Added a navigation-map preview showing the home position, flight plan, and flown trail.
  * Navigation fields are available for API version 1.48 and later when GPS and flight-plan support are enabled.
  * Navigation-map previews require compatible non-wing firmware with SD or HD OSD support.
  * Added English localization for the new navigation information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->