### PR TITLE
Add element name for Position Hold readiness OSD element

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8983,6 +8983,13 @@
     "osdDescElementNavMap": {
         "message": "Minimap showing home, the flight plan, and the flown trail"
     },
+    "osdTextElementPosHoldReady": {
+        "message": "Pos Hold ready",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPosHoldReady": {
+        "message": "Shows whether Position Hold's entry conditions are currently met, before the mode switch is engaged"
+    },
     "osdSetupPreviewCheckRulers": {
         "message": "Rulers",
         "description": "Label for the checkbox to toggle OSD preview rulers around the preview"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8984,7 +8984,7 @@
         "message": "Minimap showing home, the flight plan, and the flown trail"
     },
     "osdTextElementPosHoldReady": {
-        "message": "Pos Hold ready",
+        "message": "Position Hold Ready",
         "description": "One of the elements of the OSD"
     },
     "osdDescElementPosHoldReady": {

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -8920,6 +8920,69 @@
     "osdDescElementBatteryProfileName": {
         "message": "Shows the active battery profile name or index"
     },
+    "osdTextElementWpNumber": {
+        "message": "Waypoint number",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNumber": {
+        "message": "Shows the current/total waypoint number of the active flight plan"
+    },
+    "osdTextElementWpCurrentLat": {
+        "message": "Waypoint latitude",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLat": {
+        "message": "Shows the latitude of the current waypoint"
+    },
+    "osdTextElementWpCurrentLon": {
+        "message": "Waypoint longitude",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLon": {
+        "message": "Shows the longitude of the current waypoint"
+    },
+    "osdTextElementWpCurrentAlt": {
+        "message": "Waypoint altitude",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentAlt": {
+        "message": "Shows the altitude of the current waypoint"
+    },
+    "osdTextElementWpDistance": {
+        "message": "Waypoint distance",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDistance": {
+        "message": "Shows the distance to the current waypoint"
+    },
+    "osdTextElementWpDirection": {
+        "message": "Waypoint direction",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDirection": {
+        "message": "Shows a direction arrow pointing at the current waypoint"
+    },
+    "osdTextElementWpNextNumber": {
+        "message": "Next waypoint number",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNextNumber": {
+        "message": "Shows the next waypoint number in the active flight plan"
+    },
+    "osdTextElementWpEta": {
+        "message": "Waypoint ETA",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpEta": {
+        "message": "Shows the estimated time of arrival at the current waypoint"
+    },
+    "osdTextElementNavMap": {
+        "message": "Navigation map",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNavMap": {
+        "message": "Minimap showing home, the flight plan, and the flown trail"
+    },
     "osdSetupPreviewCheckRulers": {
         "message": "Rulers",
         "description": "Label for the checkbox to toggle OSD preview rulers around the preview"

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -286,6 +286,27 @@ OSD.drawCameraFramePreview = function () {
     return cameraFrame;
 };
 
+// firmware's NAV_MAP grid is a fixed NAV_MAP_COLS x NAV_MAP_ROWS (14x8, osd_nav_map.c) —
+// preview is a bordered box matching that footprint, not the live minimap content.
+OSD.drawNavMapPreview = function () {
+    const NAV_MAP_COLS = 14;
+    const NAV_MAP_ROWS = 8;
+
+    const navMap = [];
+
+    for (let x = 0; x < NAV_MAP_COLS; x++) {
+        const sym = x === 0 || x === NAV_MAP_COLS - 1 ? SYM.STICK_OVERLAY_CENTER : SYM.STICK_OVERLAY_HORIZONTAL;
+        navMap.push({ x, y: 0, sym }, { x, y: NAV_MAP_ROWS - 1, sym });
+    }
+
+    for (let y = 1; y < NAV_MAP_ROWS - 1; y++) {
+        const sym = SYM.STICK_OVERLAY_VERTICAL;
+        navMap.push({ x: 0, y, sym }, { x: NAV_MAP_COLS - 1, y, sym });
+    }
+
+    return navMap;
+};
+
 OSD.formatPidsPreview = function (axis) {
     const pidDefaults = FC.getPidDefaults();
     const p = pidDefaults[axis * 5].toString().padStart(3);
@@ -1338,6 +1359,93 @@ OSD.loadDisplayFields = function () {
             positionable: true,
             preview: "BAT1",
         },
+        WP_NUMBER: {
+            name: "WP_NUMBER",
+            text: "osdTextElementWpNumber",
+            desc: "osdDescElementWpNumber",
+            defaultPosition: -1,
+            draw_order: 625,
+            positionable: true,
+            preview: "WP1/12",
+        },
+        WP_CURRENT_LAT: {
+            name: "WP_CURRENT_LAT",
+            text: "osdTextElementWpCurrentLat",
+            desc: "osdDescElementWpCurrentLat",
+            defaultPosition: -1,
+            draw_order: 630,
+            positionable: true,
+            preview: `${FONT.symbol(SYM.GPS_LAT)}-00.0000000`,
+        },
+        WP_CURRENT_LON: {
+            name: "WP_CURRENT_LON",
+            text: "osdTextElementWpCurrentLon",
+            desc: "osdDescElementWpCurrentLon",
+            defaultPosition: -1,
+            draw_order: 635,
+            positionable: true,
+            preview: `${FONT.symbol(SYM.GPS_LON)}-000.0000000`,
+        },
+        WP_CURRENT_ALT: {
+            name: "WP_CURRENT_ALT",
+            text: "osdTextElementWpCurrentAlt",
+            desc: "osdDescElementWpCurrentAlt",
+            defaultPosition: -1,
+            draw_order: 640,
+            positionable: true,
+            preview(osdData) {
+                const unit = FONT.symbol(osdData.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                return `${FONT.symbol(SYM.ALTITUDE)}88${unit}`;
+            },
+        },
+        WP_DISTANCE: {
+            name: "WP_DISTANCE",
+            text: "osdTextElementWpDistance",
+            desc: "osdDescElementWpDistance",
+            defaultPosition: -1,
+            draw_order: 645,
+            positionable: true,
+            preview(osdData) {
+                const unit = FONT.symbol(osdData.unit_mode === 0 ? SYM.FEET : SYM.METRE);
+                return `120${unit}`;
+            },
+        },
+        WP_DIRECTION: {
+            name: "WP_DIRECTION",
+            text: "osdTextElementWpDirection",
+            desc: "osdDescElementWpDirection",
+            defaultPosition: -1,
+            draw_order: 650,
+            positionable: true,
+            preview: FONT.symbol(SYM.ARROW_SOUTH + 2),
+        },
+        WP_NEXT_NUMBER: {
+            name: "WP_NEXT_NUMBER",
+            text: "osdTextElementWpNextNumber",
+            desc: "osdDescElementWpNextNumber",
+            defaultPosition: -1,
+            draw_order: 655,
+            positionable: true,
+            preview: "NEXT4",
+        },
+        WP_ETA: {
+            name: "WP_ETA",
+            text: "osdTextElementWpEta",
+            desc: "osdDescElementWpEta",
+            defaultPosition: -1,
+            draw_order: 660,
+            positionable: true,
+            preview: "05:30",
+        },
+        NAV_MAP: {
+            name: "NAV_MAP",
+            text: "osdTextElementNavMap",
+            desc: "osdDescElementNavMap",
+            defaultPosition: -1,
+            draw_order: 665,
+            positionable: true,
+            preview: OSD.drawNavMapPreview,
+        },
     };
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
@@ -1473,6 +1581,18 @@ OSD.chooseFields = function () {
         OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
             F.OSD_CUSTOM_SERIAL_TEXT,
             F.BATTERY_PROFILE_NAME,
+            // Flight-plan waypoint elements and nav map, in firmware osd_items_e order
+            // (only compiled into firmware when USE_GPS && ENABLE_FLIGHT_PLAN / USE_OSD_NAV_MAP;
+            // harmless to list unconditionally here — see the DISPLAY_FIELDS ordering note above)
+            F.WP_NUMBER,
+            F.WP_CURRENT_LAT,
+            F.WP_CURRENT_LON,
+            F.WP_CURRENT_ALT,
+            F.WP_DISTANCE,
+            F.WP_DIRECTION,
+            F.WP_NEXT_NUMBER,
+            F.WP_ETA,
+            F.NAV_MAP,
         ]);
     }
     // Choose statistic fields

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -1446,6 +1446,15 @@ OSD.loadDisplayFields = function () {
             positionable: true,
             preview: OSD.drawNavMapPreview,
         },
+        POS_HOLD_READY: {
+            name: "POS_HOLD_READY",
+            text: "osdTextElementPosHoldReady",
+            desc: "osdDescElementPosHoldReady",
+            defaultPosition: -1,
+            draw_order: 670,
+            positionable: true,
+            preview: "POSH RDY",
+        },
     };
 
     if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
@@ -1472,6 +1481,11 @@ OSD.constants = OSD_CONSTANTS;
 OSD.chooseFields = function () {
     let F = OSD.ALL_DISPLAY_FIELDS;
 
+    // DISPLAY_FIELDS order must exactly mirror firmware's osd_items_e enum order:
+    // decode() maps wire position N to DISPLAY_FIELDS[N] positionally. New entries
+    // must be inserted at the same relative position firmware adds them, not
+    // simply appended — appending after a later-in-enum element (e.g. after
+    // POS_HOLD_READY) would misalign positions on any build where both compile in.
     OSD.constants.DISPLAY_FIELDS = [
         F.RSSI_VALUE,
         F.MAIN_BATT_VOLTAGE,
@@ -1593,6 +1607,9 @@ OSD.chooseFields = function () {
             F.WP_NEXT_NUMBER,
             F.WP_ETA,
             F.NAV_MAP,
+            // OSD_POS_HOLD_READY: firmware side still unmerged (betaflight PR #15465),
+            // sits after OSD_NAV_MAP in that PR's osd_items_e ordering.
+            F.POS_HOLD_READY,
         ]);
     }
     // Choose statistic fields

--- a/src/components/tabs/osd/osd.js
+++ b/src/components/tabs/osd/osd.js
@@ -286,8 +286,8 @@ OSD.drawCameraFramePreview = function () {
     return cameraFrame;
 };
 
-// firmware's NAV_MAP grid is a fixed NAV_MAP_COLS x NAV_MAP_ROWS (14x8, osd_nav_map.c) —
-// preview is a bordered box matching that footprint, not the live minimap content.
+// Firmware's NAV_MAP grid is a fixed 14x8 (osd_nav_map.c). This preview
+// draws a bordered box at that size, not the live minimap content.
 OSD.drawNavMapPreview = function () {
     const NAV_MAP_COLS = 14;
     const NAV_MAP_ROWS = 8;
@@ -1481,11 +1481,9 @@ OSD.constants = OSD_CONSTANTS;
 OSD.chooseFields = function () {
     let F = OSD.ALL_DISPLAY_FIELDS;
 
-    // DISPLAY_FIELDS order must exactly mirror firmware's osd_items_e enum order:
-    // decode() maps wire position N to DISPLAY_FIELDS[N] positionally. New entries
-    // must be inserted at the same relative position firmware adds them, not
-    // simply appended — appending after a later-in-enum element (e.g. after
-    // POS_HOLD_READY) would misalign positions on any build where both compile in.
+    // DISPLAY_FIELDS order must mirror firmware's osd_items_e enum order.
+    // decode() maps wire position N to DISPLAY_FIELDS[N] positionally.
+    // Insert new entries at their matching firmware position, not the end.
     OSD.constants.DISPLAY_FIELDS = [
         F.RSSI_VALUE,
         F.MAIN_BATT_VOLTAGE,
@@ -1595,22 +1593,40 @@ OSD.chooseFields = function () {
         OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
             F.OSD_CUSTOM_SERIAL_TEXT,
             F.BATTERY_PROFILE_NAME,
-            // Flight-plan waypoint elements and nav map, in firmware osd_items_e order
-            // (only compiled into firmware when USE_GPS && ENABLE_FLIGHT_PLAN / USE_OSD_NAV_MAP;
-            // harmless to list unconditionally here — see the DISPLAY_FIELDS ordering note above)
-            F.WP_NUMBER,
-            F.WP_CURRENT_LAT,
-            F.WP_CURRENT_LON,
-            F.WP_CURRENT_ALT,
-            F.WP_DISTANCE,
-            F.WP_DIRECTION,
-            F.WP_NEXT_NUMBER,
-            F.WP_ETA,
-            F.NAV_MAP,
-            // OSD_POS_HOLD_READY: firmware side still unmerged (betaflight PR #15465),
-            // sits after OSD_NAV_MAP in that PR's osd_items_e ordering.
-            F.POS_HOLD_READY,
         ]);
+
+        // Waypoint/nav-map/pos-hold-ready enum entries only exist in firmware
+        // when their compile flags are present. Unconditional listing would
+        // misalign every later DISPLAY_FIELDS position on builds lacking them.
+        // Gate on reported build options instead.
+        const buildOptions = FC.CONFIG.buildOptions ?? [];
+        const hasFlightPlanWaypoints = buildOptions.includes("USE_GPS") && buildOptions.includes("USE_FLIGHT_PLAN");
+        const hasNavMap =
+            hasFlightPlanWaypoints &&
+            !buildOptions.includes("USE_WING") &&
+            (buildOptions.includes("USE_OSD_SD") || buildOptions.includes("USE_OSD_HD"));
+        const hasPositionHold = buildOptions.includes("USE_POSITION_HOLD");
+
+        if (hasFlightPlanWaypoints) {
+            OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([
+                F.WP_NUMBER,
+                F.WP_CURRENT_LAT,
+                F.WP_CURRENT_LON,
+                F.WP_CURRENT_ALT,
+                F.WP_DISTANCE,
+                F.WP_DIRECTION,
+                F.WP_NEXT_NUMBER,
+                F.WP_ETA,
+            ]);
+        }
+
+        if (hasNavMap) {
+            OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([F.NAV_MAP]);
+        }
+
+        if (hasPositionHold) {
+            OSD.constants.DISPLAY_FIELDS = OSD.constants.DISPLAY_FIELDS.concat([F.POS_HOLD_READY]);
+        }
     }
     // Choose statistic fields
     // Nothing much to do here, I'm preempting there being new statistics

--- a/test/js/tabs/osd_battery_profile.test.js
+++ b/test/js/tabs/osd_battery_profile.test.js
@@ -113,6 +113,7 @@ function buildAllDisplayFields() {
         "WP_NEXT_NUMBER",
         "WP_ETA",
         "NAV_MAP",
+        "POS_HOLD_READY",
     ];
 
     const fields = {};

--- a/test/js/tabs/osd_battery_profile.test.js
+++ b/test/js/tabs/osd_battery_profile.test.js
@@ -104,6 +104,15 @@ function buildAllDisplayFields() {
         // API 1.48
         "OSD_CUSTOM_SERIAL_TEXT",
         "BATTERY_PROFILE_NAME",
+        "WP_NUMBER",
+        "WP_CURRENT_LAT",
+        "WP_CURRENT_LON",
+        "WP_CURRENT_ALT",
+        "WP_DISTANCE",
+        "WP_DIRECTION",
+        "WP_NEXT_NUMBER",
+        "WP_ETA",
+        "NAV_MAP",
     ];
 
     const fields = {};


### PR DESCRIPTION
AI Generated pull-request

## Summary
Depends on #5337 (still open) and betaflight/betaflight#15465 (still unmerged firmware). This branch is built on top of #5337's commit, so **the diff currently includes both #5337's WP_*/NAV_MAP changes and this PR's Position-Hold-readiness change combined** — it will narrow to just the incremental change once #5337 merges and this branch is rebased onto the new master.

Adds a Configurator field entry for `OSD_POS_HOLD_READY`, a new OSD element from betaflight PR #15465 that shows whether Position Hold's entry conditions are met before the mode switch is engaged.

`POS_HOLD_READY` is appended after `NAV_MAP` in both `ALL_DISPLAY_FIELDS` and `DISPLAY_FIELDS`, matching PR #15465's firmware `osd_items_e` ordering (`OSD_NAV_MAP` before `OSD_POS_HOLD_READY`), under the existing `API_VERSION_1_48` gate.

## Test plan
- [x] `npx eslint src/components/tabs/osd/osd.js test/js/tabs/osd_battery_profile.test.js` — clean
- [x] `npx vitest run test/js/` — 667/667 tests pass (57 files)
- [ ] Live hardware verification against a betaflight PR #15465 build with `USE_POSITION_HOLD` compiled — see betaflight/betaflight#15465 for firmware-side hardware verification status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added English labels for waypoint information, navigation maps, and position-hold readiness in the OSD.
  * Added a position-hold readiness indicator when supported by the flight controller.
  * Added support for displaying waypoint numbers, coordinates, distance, direction, and ETA.

* **Tests**
  * Updated OSD coverage for the latest waypoint and navigation display fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->