### PR TITLE
fix(ios): exclude x86_64 from simulator builds

### DIFF
--- a/src-tauri/gen/apple/betaflight-app.xcodeproj/project.pbxproj
+++ b/src-tauri/gen/apple/betaflight-app.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 				DEVELOPMENT_TEAM = 88U8UVP252;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\".\"",
@@ -374,6 +375,7 @@
 				DEVELOPMENT_TEAM = 88U8UVP252;
 				ENABLE_BITCODE = NO;
 				"EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"\".\"",

--- a/src-tauri/gen/apple/project.yml
+++ b/src-tauri/gen/apple/project.yml
@@ -73,6 +73,7 @@ targets:
         LIBRARY_SEARCH_PATHS[arch=arm64]: $(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/$(PLATFORM_NAME) $(DEVELOPER_DIR)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift-5.0/$(PLATFORM_NAME)
         ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: true
         EXCLUDED_ARCHS[sdk=iphoneos*]: x86_64
+        EXCLUDED_ARCHS[sdk=iphonesimulator*]: x86_64
       groups: [app]
     dependencies:
       - framework: libapp.a


### PR DESCRIPTION
`npm run tauri:ios:dev` never completed. The build phase succeeded, then the archive phase failed with `ld: library 'app' not found`.

`tauri ios dev` archives with a generic simulator destination, where ONLY_ACTIVE_ARCH is NO, so Xcode builds every arch in VALID_ARCHS and ARCHS resolves to `arm64 x86_64`. x86_64 was excluded only for device builds (EXCLUDED_ARCHS[sdk=iphoneos*]), so the archive looked for Externals/x86_64/<config>/libapp.a. Nothing produces that: the Build Rust Code phase cannot emit it without the x86_64-apple-ios target, which neither CI nor the documented setup installs. The error reads as a missing library rather than a missing architecture, which is what made it confusing.

Excluding x86_64 for the simulator SDK as well resolves ARCHS to arm64 alone. No CI coverage is lost: all macOS jobs use macos-26, whose runner image is macos-26-arm64 (confirmed in a run log), and every workflow installs only aarch64-apple-ios. Simulator builds become Apple Silicon only, which was already the effective state since no x86_64 static lib was ever produced.

Verified end to end on an iPhone 17 Pro simulator (iOS 26.5, Xcode 26.6): build, archive, install and launch all succeed, and the app renders.

Both files are regenerated together, project.yml being the XcodeGen source and project.pbxproj its output, per #5340.