### PR TITLE
fix(serial): ignore device events for ports the transport does not list

### DIFF
--- a/src/js/connection_state.js
+++ b/src/js/connection_state.js
@@ -9,10 +9,11 @@
  * imports only `vue` (no Pinia, no serial_backend), so the serial/port layer can
  * import it without a cycle or an active-pinia requirement.
  *
- * There is no transition table and no reconnect token: a reconnect simply
- * re-uses the previously-selected port (the device re-enumerates with the same
- * stable id), and selectActivePort() consults isReconnecting to avoid hijacking
- * the selection with the expert-mode virtual/manual fallback mid-reboot.
+ * There is no transition table and no reconnect token. A reconnect uses the port from the last
+ * selection. selectActivePort() reads isReconnecting and keeps that selection. It does not
+ * change the selection to the expert-mode virtual or manual device during a reboot.
+ * If the device comes back with a new id, the addedDevice event selects it again. The retry
+ * loop then uses the new selection.
  */
 import { ref } from "vue";
 

--- a/src/js/device_handler.js
+++ b/src/js/device_handler.js
@@ -233,6 +233,16 @@ DeviceHandler.sortPorts = function (ports) {
     });
 };
 
+DeviceHandler.isKnownDevicePath = function (path) {
+    if (!path) {
+        return false;
+    }
+
+    return [this.currentSerialPorts, this.currentBluetoothPorts, this.currentUsbPorts].some((devices) =>
+        devices.some((device) => device.path === path),
+    );
+};
+
 DeviceHandler.selectActivePort = function (suggestedDevice = false) {
     const deviceFilter = ["AT32", "CP210", "SPR", "STM"];
     let selectedDevice;
@@ -261,8 +271,11 @@ DeviceHandler.selectActivePort = function (suggestedDevice = false) {
         return selectedDevice;
     }
 
-    // Return the suggested device (the new device that has been detected)
-    if (!selectedDevice && suggestedDevice) {
+    // suggestedDevice is an addedDevice payload captured before updateDeviceList() re-read the
+    // transport, so it can already be stale: on Linux a CDC-ACM node is removed and re-added
+    // while udev/ModemManager probe it, and the port that fired `connect` is gone by the time we
+    // look. Selecting a path the transport no longer lists makes auto-connect fail the lookup.
+    if (!selectedDevice && suggestedDevice && this.isKnownDevicePath(suggestedDevice.path)) {
         selectedDevice = suggestedDevice.path;
     }
 

--- a/src/js/device_handler.js
+++ b/src/js/device_handler.js
@@ -271,10 +271,10 @@ DeviceHandler.selectActivePort = function (suggestedDevice = false) {
         return selectedDevice;
     }
 
-    // suggestedDevice is an addedDevice payload captured before updateDeviceList() re-read the
-    // transport, so it can already be stale: on Linux a CDC-ACM node is removed and re-added
-    // while udev/ModemManager probe it, and the port that fired `connect` is gone by the time we
-    // look. Selecting a path the transport no longer lists makes auto-connect fail the lookup.
+    // The code reads suggestedDevice from an addedDevice event. updateDeviceList() reads the
+    // transport again after that. The device can be absent at this point. On Linux, udev and
+    // ModemManager remove a CDC-ACM node and add it again while they examine it. Auto-connect
+    // fails if the selection holds a path that the transport does not list.
     if (!selectedDevice && suggestedDevice && this.isKnownDevicePath(suggestedDevice.path)) {
         selectedDevice = suggestedDevice.path;
     }
@@ -326,9 +326,9 @@ DeviceHandler.selectActivePort = function (suggestedDevice = false) {
         selectedDevice = "manual";
     }
 
-    // While reconnecting, keep the previously-selected device rather than dropping
-    // to "noselection": it re-enumerates with the same stable id, so the existing
-    // selection is still the right target. Never virtual/manual.
+    // During a reconnect, keep the device from the last selection. Do not change it to
+    // "noselection". The device is absent for a short time only. If it comes back with a new
+    // id, the addedDevice event selects it again. Do not use virtual or manual here.
     if (!selectedDevice && reconnectInProgress) {
         selectedDevice = this.devicePicker.selectedDevice;
     }

--- a/src/js/device_handler.js
+++ b/src/js/device_handler.js
@@ -29,6 +29,10 @@ function createDfuProtocol() {
 
 const dfuProtocol = createDfuProtocol();
 
+function samePaths(a, b) {
+    return a.length === b.length && a.every((device, index) => device.path === b[index].path);
+}
+
 const DeviceHandler = new (function () {
     this.logHead = "[DEVICEHANDLER]";
 
@@ -334,12 +338,17 @@ DeviceHandler.selectActivePort = function (suggestedDevice = false) {
     }
 
     // Return the default port if no other port was selected
+    const previousDevice = this.devicePicker.selectedDevice;
     this.devicePicker.selectedDevice = selectedDevice || DEFAULT_PORT;
 
-    console.log(
-        `${this.logHead} Automatically selected device is '${this.devicePicker.selectedDevice}' - suggested:`,
-        suggestedDevice,
-    );
+    // One plug-in gives a burst of device events. Each event runs this function and gets the
+    // same result. Log the selection only when it changes.
+    if (this.devicePicker.selectedDevice !== previousDevice) {
+        console.log(
+            `${this.logHead} Automatically selected device is '${this.devicePicker.selectedDevice}' - suggested:`,
+            suggestedDevice,
+        );
+    }
 
     return selectedDevice;
 };
@@ -400,25 +409,36 @@ DeviceHandler.updateDeviceList = async function (deviceType) {
         const orderedPorts = this.sortPorts(ports);
 
         // Update the appropriate properties based on device type
+        let previousPorts;
+        let label;
+
         switch (deviceType) {
             case "bluetooth":
+                previousPorts = this.currentBluetoothPorts;
+                label = "bluetooth";
                 this.bluetoothAvailable = orderedPorts.length > 0;
                 this.currentBluetoothPorts = [...orderedPorts];
-                console.log(`${this.logHead} Found bluetooth port(s)`, orderedPorts);
                 break;
             case "usb":
+                previousPorts = this.currentUsbPorts;
+                label = "DFU";
                 this.dfuAvailable = orderedPorts.length > 0;
                 this.currentUsbPorts = [...orderedPorts];
-                console.log(`${this.logHead} Found DFU port(s)`, orderedPorts);
                 break;
             case "serial":
+                previousPorts = this.currentSerialPorts;
+                label = "serial";
                 this.portAvailable = orderedPorts.length > 0;
                 this.currentSerialPorts = [...orderedPorts];
-                console.log(`${this.logHead} Found serial port(s)`, orderedPorts);
                 break;
             default:
                 console.warn(`${this.logHead} Unknown device type for updating ports: ${deviceType}`);
                 return [];
+        }
+
+        // A burst of device events refreshes the same list many times. Log it only on a change.
+        if (!samePaths(orderedPorts, previousPorts)) {
+            console.log(`${this.logHead} Found ${label} port(s)`, orderedPorts);
         }
 
         return orderedPorts;

--- a/src/js/device_handler.js
+++ b/src/js/device_handler.js
@@ -29,6 +29,11 @@ function createDfuProtocol() {
 
 const dfuProtocol = createDfuProtocol();
 
+/**
+ * @param {Array<{path: string}>} a
+ * @param {Array<{path: string}>} b
+ * @returns {boolean} true when both lists hold the same paths in the same order
+ */
 function samePaths(a, b) {
     return a.length === b.length && a.every((device, index) => device.path === b[index].path);
 }
@@ -237,6 +242,10 @@ DeviceHandler.sortPorts = function (ports) {
     });
 };
 
+/**
+ * @param {string} path - a device path
+ * @returns {boolean} true when the serial, Bluetooth or USB list holds this path
+ */
 DeviceHandler.isKnownDevicePath = function (path) {
     if (!path) {
         return false;

--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -71,6 +71,14 @@ class WebBluetooth extends EventTarget {
 
     handleRemovedDevice(device) {
         const removed = this.devices.find((port) => port.port === device);
+
+        // The list does not hold this device. Both `disconnect` and `gattserverdisconnected`
+        // can report the same device, so the second event finds nothing. There is no device to
+        // report.
+        if (!removed) {
+            return;
+        }
+
         this.devices = this.devices.filter((port) => port.port !== device);
         this.dispatchEvent(new CustomEvent("removedDevice", { detail: removed }));
     }

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -42,6 +42,7 @@ class WebSerial extends EventTarget {
     // current list. The WeakMap lets the browser release the entry with the SerialPort.
     #portIds = new WeakMap();
     #nextPortId = 0;
+    #loadGeneration = 0;
 
     constructor() {
         super();
@@ -155,8 +156,17 @@ class WebSerial extends EventTarget {
     }
 
     async loadDevices() {
+        const generation = ++this.#loadGeneration;
+
         try {
             const ports = await navigator.serial.getPorts();
+
+            // A burst of device events starts several refreshes at once, and getPorts() gives
+            // no order guarantee. An older call that finishes last must not put its list back.
+            // getDevices() reads this.ports after the await, so it still returns the newest.
+            if (generation !== this.#loadGeneration) {
+                return;
+            }
             this.ports = ports.map((port) => this.createPort(port));
         } catch (error) {
             console.error(`${logHead} Error loading devices:`, error);

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -91,6 +91,14 @@ class WebSerial extends EventTarget {
 
     handleRemovedDevice(device) {
         const removed = this.ports.find((port) => port.port === device);
+
+        // The list does not hold this port, because loadDevices() removed it before. There is
+        // no device to report. An event with no detail only makes the listeners refresh the
+        // list again for nothing.
+        if (!removed) {
+            return;
+        }
+
         this.ports = this.ports.filter((port) => port.port !== device);
         this.dispatchEvent(new CustomEvent("removedDevice", { detail: removed }));
     }

--- a/src/js/protocols/WebSerial.js
+++ b/src/js/protocols/WebSerial.js
@@ -35,11 +35,11 @@ async function* streamAsyncIterable(reader, keepReadingFlag) {
  * WebSerial protocol implementation for the Serial base class
  */
 class WebSerial extends EventTarget {
-    // Stable id per physical SerialPort object. The browser reuses the same
-    // SerialPort instance across an MCU-reboot USB re-enumeration, so keying the
-    // id off object identity yields an id that survives device-list rebuilds —
-    // unlike a bare counter that would reset every time loadDevices() runs.
-    // WeakMap so entries are collected once the browser drops the SerialPort.
+    // Each SerialPort object has its own id. The id stays the same when the code builds the
+    // device list again. A counter alone would give a different number each time.
+    // But the id changes if the device disconnects and then connects again, because Chrome
+    // makes a new SerialPort object for it. Do not keep a path. Read the path from the
+    // current list. The WeakMap lets the browser release the entry with the SerialPort.
     #portIds = new WeakMap();
     #nextPortId = 0;
 
@@ -119,11 +119,9 @@ class WebSerial extends EventTarget {
     }
 
     /**
-     * Return the stable id for a SerialPort object, minting one on first sighting
-     * and reusing it for the same object thereafter. The same reused SerialPort
-     * across a re-enumeration therefore always maps to the same path.
+     * Get the id of a SerialPort object. Make a new id if the object is new.
      * @param {SerialPort} port
-     * @returns {string} stable id, e.g. "serial_0"
+     * @returns {string} the id, for example "serial_0"
      */
     #getStablePortId(port) {
         let id = this.#portIds.get(port);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -388,10 +388,14 @@ export function disconnect() {
     beginDisconnect();
 }
 
-// GUI.connecting_to is set while an attempt is in flight. A second open() on the same
-// SerialPort gives an InvalidStateError, and its failure dialog hides that the first attempt was
-// good. The reboot loop and the auto-select listener each make this test before they call
-// connectDisconnect(). Make it here, for all callers.
+/**
+ * GUI.connecting_to is set while an attempt is in flight. A second open() on the same SerialPort
+ * gives an InvalidStateError, and its failure dialog hides that the first attempt was good. The
+ * reboot loop and the auto-select listener each make this test before they call
+ * connectDisconnect(). Make it here, for all callers.
+ * @param {string} selectedDevice - the selected device path
+ * @returns {boolean} true when a connect attempt can start now
+ */
 function canStartConnectionAction(selectedDevice) {
     return (
         !GUI.connect_lock && !GUI.connecting_to && selectedDevice !== "noselection" && !selectedDevice.startsWith("usb")

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -202,8 +202,8 @@ export function initializeSerialBackend() {
             !isCliOnlyMode() &&
             (connectionTimestamp === null || connectionTimestamp > 0)
         ) {
-            // The device re-enumerated with the same stable id, so the selection
-            // is already aimed at it — just connect.
+            // selectActivePort points the selection at the device that sent this event.
+            // Connect to it.
             connectDisconnect();
         }
     });
@@ -1432,11 +1432,10 @@ export function reinitializeConnection(suppressDialog = false) {
 
     const currentPort = DeviceHandler.devicePicker.selectedDevice;
 
-    // requestReboot() above put the connection state into REBOOTING, so
-    // selectActivePort() reports isReconnecting and keeps the current selection
-    // instead of hijacking it with the expert-mode virtual/manual fallback while
-    // the FC is briefly off the port list. The device re-enumerates with the same
-    // stable id, so reconnect simply re-uses currentPort — no token needed.
+    // requestReboot() above sets the connection state to REBOOTING. selectActivePort() then
+    // reports isReconnecting and keeps the current selection. It does not change the selection
+    // to the expert-mode virtual or manual device while the FC is off the port list.
+    // The reconnect uses currentPort again. A token is not necessary.
 
     // Send reboot command to the flight controller
     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
@@ -1567,9 +1566,11 @@ function rebootReconnect() {
                 // traffic can't collide with the new connection's request chain.
                 MSP.disconnect_cleanup();
 
-                // selectActivePort keeps the current selection while reconnecting
-                // (isReconnecting), so it still aims at the originally-connected
-                // device — which re-enumerates with the same stable id. Just connect.
+                // selectActivePort keeps the current selection during a reconnect
+                // (isReconnecting). The selection stays on the device that was connected.
+                // If that device comes back with a new id, the addedDevice event changes the
+                // selection to the new id. An attempt before one of these two events fails.
+                // The loop then tries again.
                 connectDisconnect();
             }
         }, REBOOT_RECONNECT_RETRY_MS);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1567,10 +1567,10 @@ function rebootReconnect() {
                 MSP.disconnect_cleanup();
 
                 // selectActivePort keeps the current selection during a reconnect
-                // (isReconnecting). The selection stays on the device that was connected.
-                // If that device comes back with a new id, the addedDevice event changes the
-                // selection to the new id. An attempt before one of these two events fails.
-                // The loop then tries again.
+                // (isReconnecting), but only while no other device in the lists matches the
+                // device filter. The attempt then fails until the device comes back, and the
+                // loop tries again. If another device does match, selectActivePort selects
+                // that device and this attempt connects to it.
                 connectDisconnect();
             }
         }, REBOOT_RECONNECT_RETRY_MS);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -388,8 +388,14 @@ export function disconnect() {
     beginDisconnect();
 }
 
+// GUI.connecting_to is set while an attempt is in flight. A second open() on the same
+// SerialPort gives an InvalidStateError, and its failure dialog hides that the first attempt was
+// good. The reboot loop and the auto-select listener each make this test before they call
+// connectDisconnect(). Make it here, for all callers.
 function canStartConnectionAction(selectedDevice) {
-    return !GUI.connect_lock && selectedDevice !== "noselection" && !selectedDevice.startsWith("usb");
+    return (
+        !GUI.connect_lock && !GUI.connecting_to && selectedDevice !== "noselection" && !selectedDevice.startsWith("usb")
+    );
 }
 
 function beginConnect(selectedDevice) {

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1567,10 +1567,8 @@ function rebootReconnect() {
                 MSP.disconnect_cleanup();
 
                 // selectActivePort keeps the current selection during a reconnect
-                // (isReconnecting), but only while no other device in the lists matches the
-                // device filter. The attempt then fails until the device comes back, and the
-                // loop tries again. If another device does match, selectActivePort selects
-                // that device and this attempt connects to it.
+                // (isReconnecting). The selection points at the device from before the reboot.
+                // The attempt fails while that device is absent. The loop then tries again.
                 connectDisconnect();
             }
         }, REBOOT_RECONNECT_RETRY_MS);

--- a/test/js/device_handler.test.js
+++ b/test/js/device_handler.test.js
@@ -202,10 +202,10 @@ describe("DeviceHandler.selectActivePort — preset/reboot -> virtual regression
     });
 });
 
-// Regression: on Linux the FC surfaces as two ports in quick succession (udev/ModemManager
-// re-enumerate the CDC-ACM node) and only the second survives the refresh. Carrying the first
-// one's addedDevice payload into the selection aimed auto-connect at a dead path —
-// "[WEBSERIAL] Device not found: serial_5".
+// Regression. On Linux the FC gives two ports quickly, because udev and ModemManager remove
+// the CDC-ACM node and add it again. Only the second port stays in the list after the refresh.
+// The addedDevice event of the first port put a dead path in the selection. Auto-connect then
+// used that path and failed with "[WEBSERIAL] Device not found: serial_5".
 describe("DeviceHandler.selectActivePort — stale addedDevice suggestion", () => {
     beforeEach(() => {
         resetPortHandler();
@@ -214,7 +214,7 @@ describe("DeviceHandler.selectActivePort — stale addedDevice suggestion", () =
     it("ignores a suggested device that is no longer in the refreshed lists", () => {
         const ghost = { path: "serial_5", displayName: "Betaflight STM Electronics" };
         const real = { path: "serial_6", displayName: "Betaflight STM Electronics" };
-        // The refresh already dropped the ghost; only the surviving port is listed.
+        // The refresh removed the first port. The list holds the second port only.
         DeviceHandler.currentSerialPorts = [real];
 
         const selected = DeviceHandler.selectActivePort(ghost);
@@ -233,8 +233,8 @@ describe("DeviceHandler.selectActivePort — stale addedDevice suggestion", () =
         expect(DeviceHandler.devicePicker.selectedDevice).toBe("serial_6");
     });
 
-    // The suggestion is the only way a device outside the AT32/CP210/SPR/STM filter can be
-    // auto-selected, so validating it must not collapse into "must match the filter".
+    // Only the suggestion can select a device that the AT32/CP210/SPR/STM filter does not
+    // match. The check on the suggestion must not apply that filter too.
     it("honours a present suggestion whose displayName does not match the device filter", () => {
         const odd = { path: "serial_7", displayName: "Betaflight VID:1234 PID:5678" };
         DeviceHandler.currentSerialPorts = [odd];

--- a/test/js/device_handler.test.js
+++ b/test/js/device_handler.test.js
@@ -202,6 +202,59 @@ describe("DeviceHandler.selectActivePort — preset/reboot -> virtual regression
     });
 });
 
+// Regression: on Linux the FC surfaces as two ports in quick succession (udev/ModemManager
+// re-enumerate the CDC-ACM node) and only the second survives the refresh. Carrying the first
+// one's addedDevice payload into the selection aimed auto-connect at a dead path —
+// "[WEBSERIAL] Device not found: serial_5".
+describe("DeviceHandler.selectActivePort — stale addedDevice suggestion", () => {
+    beforeEach(() => {
+        resetPortHandler();
+    });
+
+    it("ignores a suggested device that is no longer in the refreshed lists", () => {
+        const ghost = { path: "serial_5", displayName: "Betaflight STM Electronics" };
+        const real = { path: "serial_6", displayName: "Betaflight STM Electronics" };
+        // The refresh already dropped the ghost; only the surviving port is listed.
+        DeviceHandler.currentSerialPorts = [real];
+
+        const selected = DeviceHandler.selectActivePort(ghost);
+
+        expect(selected).not.toBe("serial_5");
+        expect(DeviceHandler.devicePicker.selectedDevice).toBe("serial_6");
+    });
+
+    it("still honours a suggested device that is present in the refreshed lists", () => {
+        const real = { path: "serial_6", displayName: "Betaflight STM Electronics" };
+        DeviceHandler.currentSerialPorts = [real];
+
+        const selected = DeviceHandler.selectActivePort(real);
+
+        expect(selected).toBe("serial_6");
+        expect(DeviceHandler.devicePicker.selectedDevice).toBe("serial_6");
+    });
+
+    // The suggestion is the only way a device outside the AT32/CP210/SPR/STM filter can be
+    // auto-selected, so validating it must not collapse into "must match the filter".
+    it("honours a present suggestion whose displayName does not match the device filter", () => {
+        const odd = { path: "serial_7", displayName: "Betaflight VID:1234 PID:5678" };
+        DeviceHandler.currentSerialPorts = [odd];
+
+        const selected = DeviceHandler.selectActivePort(odd);
+
+        expect(selected).toBe("serial_7");
+    });
+
+    it("falls through to 'noselection' when the only suggestion is a ghost", () => {
+        DeviceHandler.currentSerialPorts = [];
+        isExpertModeEnabled.mockReturnValue(false);
+
+        const selected = DeviceHandler.selectActivePort({ path: "serial_5", displayName: "Betaflight STM" });
+
+        expect(selected).toBeUndefined();
+        expect(DeviceHandler.devicePicker.selectedDevice).toBe("noselection");
+    });
+});
+
 describe("DeviceHandler show* setters", () => {
     beforeEach(() => {
         resetPortHandler();

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -281,6 +281,36 @@ function establishVirtualConnection() {
     expect(serial.connect).toHaveBeenCalled();
 }
 
+// Granting permission from the Connect button starts two connects: the addedDevice event that
+// requestPermissionDevice() raises reaches the auto-select listener, and ConnectButton then
+// connects again when the await returns. The second open() on the same SerialPort throws
+// InvalidStateError, and its "Connection failed" dialog hides that the first open worked.
+describe("serial_backend connectDisconnect — attempt already in flight", () => {
+    beforeEach(() => {
+        resetMocks();
+    });
+
+    it("does not start a second connect while one is in flight", () => {
+        connectDisconnect();
+
+        expect(serial.connect).toHaveBeenCalledTimes(1);
+        expect(GUI.connecting_to).toBe("/dev/ttyACM0");
+
+        connectDisconnect();
+
+        expect(serial.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it("connects again once the attempt has settled", () => {
+        connectDisconnect();
+        GUI.connecting_to = false;
+
+        connectDisconnect();
+
+        expect(serial.connect).toHaveBeenCalledTimes(2);
+    });
+});
+
 describe("serial_backend disconnect convergence", () => {
     beforeEach(() => {
         setActivePinia(createPinia());

--- a/test/js/webserial.test.js
+++ b/test/js/webserial.test.js
@@ -1,16 +1,16 @@
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
-// WebSerial stable device identity.
+// WebSerial device identity.
 //
-// The browser reuses the same SerialPort object across an MCU-reboot USB
-// re-enumeration, so a stable id keyed off that object's identity is the
-// correct, reconnect-safe device path. These tests prove:
-//   (a) the same SerialPort object yields the same path across repeated
-//       createPort/loadDevices calls (stability),
-//   (b) two different SerialPort objects get distinct paths,
-//   (c) removing device A does not match/disconnect device B,
-//   (d) selectProtocol still routes the new "serial_N" id to WebSerial.
+// A path is the id of one SerialPort object. The id stays the same while the browser gives
+// back the same object. The id changes if the device disconnects and connects again, because
+// Chrome makes a new object. These tests show:
+//   (a) the same SerialPort object gives the same path for each
+//       createPort/loadDevices call (stability),
+//   (b) two different SerialPort objects get different paths,
+//   (c) the removal of device A does not disconnect device B,
+//   (d) selectProtocol sends the new "serial_N" id to WebSerial.
 //
 // `./devices` is mocked so WebSerial loads without its real import graph.
 // ---------------------------------------------------------------------------
@@ -99,7 +99,7 @@ describe("WebSerial stable device identity", () => {
         await ws.loadDevices();
         const pathAfterFirst = ws.ports[0].path;
 
-        // Simulate a re-enumeration: the browser hands back the SAME object.
+        // The browser gives back the same object.
         await ws.loadDevices();
         const pathAfterSecond = ws.ports[0].path;
 

--- a/test/js/webserial.test.js
+++ b/test/js/webserial.test.js
@@ -157,6 +157,31 @@ describe("WebSerial stable device identity", () => {
         expect(ws.ports).toHaveLength(1);
     });
 
+    // A burst of device events starts several refreshes at once. getPorts() gives no order
+    // guarantee, so an older call can finish last and put a list back that no longer applies.
+    it("does not let a slow refresh replace a newer device list", async () => {
+        const WebSerial = await loadWebSerial();
+        const ws = new WebSerial();
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const older = makeFakePort();
+        const newer = makeFakePort();
+        let resolveSlow;
+        navigator.serial.getPorts
+            .mockImplementationOnce(() => new Promise((resolve) => (resolveSlow = resolve)))
+            .mockImplementationOnce(async () => [newer]);
+
+        const slow = ws.loadDevices();
+        await ws.loadDevices();
+
+        expect(ws.ports.map((device) => device.port)).toEqual([newer]);
+
+        resolveSlow([older]);
+        await slow;
+
+        expect(ws.ports.map((device) => device.port)).toEqual([newer]);
+    });
+
     it("connect() resolves the live SerialPort via the stable id and sets connectionId to it", async () => {
         const WebSerial = await loadWebSerial();
         const ws = new WebSerial();

--- a/test/js/webserial.test.js
+++ b/test/js/webserial.test.js
@@ -137,6 +137,26 @@ describe("WebSerial stable device identity", () => {
         expect(ws.ports.map((p) => p.path)).toEqual([pathB]);
     });
 
+    // A plug-in gives a burst of connect events, and loadDevices() keeps only the port that
+    // getPorts() reports. The other ports send a disconnect event later. The list does not hold
+    // them, so an event for them carries no device. Such an event makes the listeners refresh
+    // the list and warn for nothing.
+    it("sends no removedDevice event for a port that is not in the list", async () => {
+        const WebSerial = await loadWebSerial();
+        const ws = new WebSerial();
+
+        const listed = makeFakePort();
+        ws.ports = [ws.createPort(listed)];
+
+        const removed = [];
+        ws.addEventListener("removedDevice", (e) => removed.push(e.detail));
+
+        ws.handleRemovedDevice(makeFakePort());
+
+        expect(removed).toEqual([]);
+        expect(ws.ports).toHaveLength(1);
+    });
+
     it("connect() resolves the live SerialPort via the stable id and sets connectionId to it", async () => {
         const WebSerial = await loadWebSerial();
         const ws = new WebSerial();


### PR DESCRIPTION
### Problem

With Auto-Connect enabled, a user reported that the configurator fails to open the port — once on device plug-in, and again on the reconnect after Save and Reboot. Each time, a failed connect is immediately followed by a successful one:

```
[DEVICEHANDLER] serial device added: {path: 'serial_5', displayName: 'Betaflight STM Electronics', …}
[DEVICEHANDLER] serial device added: {path: 'serial_6', displayName: 'Betaflight STM Electronics', …}
[DEVICEHANDLER] Found serial port(s) [{…}]
[DEVICEHANDLER] Automatically selected device is 'serial_5' - suggested: {…}
[SERIAL-BACKEND] Connecting to: serial_5
[WEBSERIAL] Device not found: serial_5      <-- error
[DEVICEHANDLER] Automatically selected device is 'serial_6' - suggested: {…}
[WEBSERIAL] Connection opened with ID: serial_6, Baud: 115200
```

It does not reproduce on every machine, which made it look intermittent. Part of that is browser version: recent browser updates changed the enumeration behaviour described below, so an up-to-date browser hits this where an older one did not. The configurator was relying on behaviour that no longer holds.

### Root cause

On the affected setup the FC raises a **burst** of connect events for one board — two in the first report, six in a later capture — with a matching burst of disconnect events. Only one port survives: `navigator.serial.getPorts()` returns a single entry. The browser makes a new `SerialPort` object each time the port re-enumerates, and on Linux udev/ModemManager grab `/dev/ttyACM*` to examine it, which removes and adds the node repeatedly. Setups that do not examine the FC, and browsers that have not taken the change, see one event and never hit this.

Everything that follows is the same defect in different places: **the code acts on an event about a device that is not in the list.**

**1. Auto-connect aimed at a port that had already gone.** `handleDeviceAdded()` captures the `addedDevice` payload, then awaits `updateDeviceList()` — which has `WebSerial.loadDevices()` rebuild `this.ports` from `getPorts()`. The extra ports are gone by then, but `selectActivePort()`'s suggested-device branch was the one branch that did not select out of the current lists:

```js
if (!selectedDevice && suggestedDevice) {
    selectedDevice = suggestedDevice.path;   // no longer listed
}
```

So `devicePicker.selectedDevice` became `serial_5` and `WebSerial.connect()` failed its lookup in the very list the path had just been removed from.

**2. Removal events for ports that were never listed.** `handleRemovedDevice()` dispatched `removedDevice` with an undefined detail for each of those ports. `device_handler` then logged, warned with a stack trace, refreshed the whole list and re-ran `selectActivePort()` — five times per unplug, for a device nobody was tracking. `WebBluetooth` has the same shape, where `disconnect` and `gattserverdisconnected` can both report one device.

**3. Refreshes finishing out of order.** The burst starts several `loadDevices()` calls at once and `getPorts()` gives no ordering guarantee, so an older call could finish last and put its list back over a newer one — leaving `this.ports` holding a port that had already gone, which is the same dead-path failure again.

**4. Repeated identical logging.** The burst ran `updateDeviceList()` and `selectActivePort()` once per event, with the same result each time.

### A second issue, found while testing this

Granting permission from the **Connect** button showed `Connection failed / Failed to open serial port`, even though the connection then worked. Using the *Cannot find my USB device* entry instead was fine.

```
[SERIAL-BACKEND] Connecting to: serial_0
[SERIAL-BACKEND] Connecting to: serial_0          <-- twice
[WEBSERIAL] Error connecting: InvalidStateError: Failed to execute 'open' on
           'SerialPort': A call to open() is already in progress.
[WEBSERIAL] Connection opened with ID: serial_0, Baud: 115200
```

Two connects race for one port. `onConnectClick()` awaits `requestDevicePermission("serial")`; inside that, `requestPermissionDevice()` calls `handleNewDevice()`, which dispatches `addedDevice` — that reaches the auto-select listener, which connects. Then the await returns and `ConnectButton` connects again. The second `open()` throws, and its dialog hides that the first one succeeded.

The dropdown entry never hit this: `DevicesInput.onChangePort()` only requests permission and lets the auto-select listener do the connecting.

### Fix

- `selectActivePort()` has an invariant — it returns a path that exists in the current device lists — and every branch honoured it except the suggestion. Validate the suggestion against the refreshed lists, so a port that has gone falls through and the surviving port's own `addedDevice` event drives the connect. `handleDeviceAdded()`'s existing `selectedDevice === device.path` guard then suppresses the wrong auto-connect. This also covers `addedUsbDevice()` and `requestDevicePermission()`, which reach `selectActivePort()` the same way.
- `handleRemovedDevice()` returns early when the port is not in the list, in both `WebSerial` and `WebBluetooth`.
- `loadDevices()` guards its assignment with a generation counter, so only the newest refresh applies. `getDevices()` reads `this.ports` after its await, so every caller in the burst still returns the newest list and `device_handler` needs no guard of its own.
- The selection and the port list are logged only when they change.
- `canStartConnectionAction()` also tests `GUI.connecting_to`. The reboot retry loop and the auto-select listener each made that test before calling `connectDisconnect()`; `ConnectButton` did not, so it now holds for every caller.

Console output for one unplug goes from 23 lines (5 of them stack traces) to 3, and for one plug-in from 18 to 8. The six `serial device added` lines stay: those events are real, and they are the evidence that diagnosed this.

### Notes for reviewers

- The suggestion remains the only route by which a device outside the `AT32`/`CP210`/`SPR`/`STM` display-name filter can be auto-selected, so the check is presence-in-list only — it deliberately does not also require a filter match. A test pins that.
- The out-of-order guard is not applied to `WebBluetooth`. Same code shape, but nothing drives concurrent same-type refreshes there: `refreshAllDeviceLists()` issues one call per transport, not several per transport.
- Some commits are comment-only. Five comments justified the reconnect design by claiming the device *"re-enumerates with the same stable id"*. That held when it was written and no longer does — the logs show `serial_6` returning as `serial_7`/`serial_8`, because the id is keyed off `SerialPort` object identity and the browser now allocates a new object per enumeration. The reconnect works anyway, but for a different reason than the comments gave: `selectActivePort()` re-derives the selection from the live list on every `addedDevice` event. The comments now say that, in ASD-STE100.
- I looked at making the id genuinely survive a re-enumeration and decided against it. Web Serial exposes no serial number — `SerialPortInfo` is `usbVendorId`/`usbProductId` only — so a returning port could only be paired to a departed one by make, which cannot tell two identical boards apart. Happy to revisit if reviewers disagree.
- Still one round-trip to `getPorts()` per event in the burst. That is now harmless rather than wrong, but coalescing the burst into a single refresh would remove the redundant work. It wants its own change.

### Testing

8 tests added:

- `test/js/device_handler.test.js` — the suggestion that is no longer listed, the suggestion that is, the present-but-unfiltered suggestion, and fall-through to `noselection`.
- `test/js/webserial.test.js` — no removal event for a port that is not in the list; a slow refresh does not replace a newer list.
- `test/js/serial_backend.test.js` — no second connect while one is in flight; connecting again once the attempt has settled.

Both race tests were checked to fail without their guard, since a race test that passes either way pins nothing. Full suite: 688 passing. ESLint and Prettier clean.

Confirmed working on the affected Linux setup by the original reporter, for plug-in, Save and Reboot, and unplug.
