### PR TITLE
ci(ios): replace nightly ad-hoc IPA with unsigned compile check

### DIFF
--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -1,15 +1,15 @@
 name: Nightly downloads
 
-# Builds Tauri desktop bundles + a Capacitor Android APK + signed Tauri mobile
-# builds (Android APK, and an ad-hoc iOS IPA) every day, uploads them to the
-# Cloudflare R2 bucket behind binaries.betaflight.com, regenerates the static
-# downloads index, and deploys it to the betaflight-downloads Cloudflare Pages
-# project (downloads.betaflight.com).
+# Builds Tauri desktop bundles + a Capacitor Android APK + a signed Tauri Android
+# APK every day, uploads them to the Cloudflare R2 bucket behind
+# binaries.betaflight.com, regenerates the static downloads index, and deploys it
+# to the betaflight-downloads Cloudflare Pages project (downloads.betaflight.com).
 #
-# The Tauri mobile jobs reuse existing secrets (no new ones): the Tauri APK signs
-# with RELEASE_KEYSTORE, and the ad-hoc IPA signs via the App Store Connect API
-# key (APPLE_API_KEY / APPLE_API_KEY_P8 / APPLE_API_ISSUER) with automatic signing,
-# so Xcode manages an ad-hoc profile — installable on devices registered to the team.
+# iOS ships via TestFlight (tauri-ios-release.yml), not the downloads page, so the
+# nightly runs the full unsigned iOS compile check from tauri-pr-build.yml instead
+# of building an IPA — it protects master without needing signing secrets.
+#
+# The Tauri Android job reuses the existing RELEASE_KEYSTORE secrets (no new ones).
 #
 # Required repository configuration:
 #   Variables:
@@ -449,125 +449,28 @@ jobs:
           name: manifest-tauri-android
           path: manifest-fragments/tauri-android.json
 
-  tauri_ios:
-    name: Tauri iOS IPA (ad-hoc)
-    needs: prepare
-    runs-on: macos-26
+  # Full unsigned iOS build — same check PRs run, so master stays iOS-buildable
+  # without any Apple signing secrets or a downloadable IPA.
+  tauri_ios_check:
+    name: Tauri iOS compile check
+    uses: ./.github/workflows/tauri-pr-build.yml
     permissions:
       contents: read
-    env:
-      APPLE_DEVELOPMENT_TEAM: ${{ vars.APPLE_DEVELOPMENT_TEAM }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v5
-        with:
-          persist-credentials: false
-
-      - name: Select Xcode 26 (iOS 26 SDK)
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1
-        with:
-          xcode-version: '26'
-
-      - name: Setup Node
-        uses: actions/setup-node@v5
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
-        with:
-          targets: aarch64-apple-ios
-
-      - name: Cache Cargo registry and target
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        with:
-          workspaces: src-tauri
-          key: tauri-ios
-
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
-      # Same automatic (App Store Connect API key) signing the release workflow uses —
-      # Xcode manages the ad-hoc profile, so no manual certificate/profile is needed.
-      - name: Stage App Store Connect API key
-        env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_P8: ${{ secrets.APPLE_API_KEY_P8 }}
-        run: |
-          : "${APPLE_API_KEY:?Set the APPLE_API_KEY secret (key id)}"
-          : "${APPLE_API_KEY_P8:?Set the APPLE_API_KEY_P8 secret (.p8 contents)}"
-          mkdir -p "$HOME/.appstoreconnect/private_keys"
-          KEY_PATH="$HOME/.appstoreconnect/private_keys/AuthKey_${APPLE_API_KEY}.p8"
-          printf '%s' "$APPLE_API_KEY_P8" > "$KEY_PATH"
-          echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
-
-      # release-testing = ad-hoc export: installable on devices registered to the team,
-      # unlike the App Store IPA (which only installs via TestFlight).
-      - name: Build ad-hoc IPA
-        env:
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-        run: |
-          conf='{"bundle":{"iOS":{"bundleVersion":"${{ github.run_number }}"}}}'
-          npx --no tauri ios build --export-method release-testing -c "$conf"
-
-      - name: Stage IPA
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-          COMMIT_SHA: ${{ needs.prepare.outputs.commit_sha }}
-        run: |
-          mkdir -p staging
-          SHA_SHORT=$(echo "$COMMIT_SHA" | head -c 8)
-          IPA=$(ls src-tauri/gen/apple/build/arm64/*.ipa | head -1)
-          if [ -z "$IPA" ]; then
-            echo "No IPA produced" >&2
-            exit 1
-          fi
-          IPA_NAME="betaflight-app-tauri-${VERSION}-${SHA_SHORT}.ipa"
-          cp "$IPA" "staging/${IPA_NAME}"
-          echo "IPA_NAME=${IPA_NAME}" >> "$GITHUB_ENV"
-
-      - name: Sync IPA to R2
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.CLOUDFLARE_R2_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.CLOUDFLARE_R2_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: auto
-          R2_BUCKET: ${{ vars.CLOUDFLARE_R2_BUCKET }}
-          R2_ENDPOINT: ${{ vars.CLOUDFLARE_R2_ENDPOINT }}
-          PREFIX: ${{ needs.prepare.outputs.nightly_prefix }}/tauri-ios
-        run: |
-          aws s3 sync staging/ "s3://${R2_BUCKET}/${PREFIX}/" --endpoint-url "${R2_ENDPOINT}" --no-progress
-
-      - name: Emit manifest fragment
-        env:
-          PUBLIC_BASE: ${{ vars.CLOUDFLARE_R2_PUBLIC_BASE_URL }}
-          PREFIX: ${{ needs.prepare.outputs.nightly_prefix }}/tauri-ios
-        run: |
-          mkdir -p manifest-fragments
-          BASE="${PUBLIC_BASE%/}"
-          SIZE=$(stat -f %z "staging/${IPA_NAME}")
-          jq -n --arg label "iOS (ad-hoc IPA)" --arg url "${BASE}/${PREFIX}/${IPA_NAME}" --argjson size "$SIZE" \
-            '{label: $label, url: $url, size: $size}' > manifest-fragments/tauri-ios.json
-
-      - name: Upload manifest fragment
-        uses: actions/upload-artifact@v4
-        with:
-          name: manifest-tauri-ios
-          path: manifest-fragments/tauri-ios.json
+    with:
+      ios-only: true
 
   publish:
     name: Publish downloads index
-    # Run once the established desktop + Capacitor Android builds succeed; the new
-    # Tauri mobile jobs are best-effort (their fragments are included if present) so
-    # an iOS/Android signing hiccup can't block the whole downloads index.
+    # Run once the established desktop + Capacitor Android builds succeed; the
+    # Tauri Android job is best-effort (its fragment is included if present) so a
+    # signing hiccup can't block the whole downloads index.
     if: >-
       always() &&
       needs.prepare.result == 'success' &&
       needs.desktop.result == 'success' &&
       needs.android.result == 'success' &&
       github.ref == 'refs/heads/master'
-    needs: [prepare, desktop, android, tauri_android, tauri_ios]
+    needs: [prepare, desktop, android, tauri_android]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -603,7 +506,6 @@ jobs:
           const desktop = { windows: [], macos: [], linux: [] };
           let android = null;
           let tauriAndroid = null;
-          let tauriIos = null;
           for (const file of fs.readdirSync(fragmentsDir)) {
               const data = JSON.parse(fs.readFileSync(path.join(fragmentsDir, file), 'utf8'));
               if (file === 'android.json') {
@@ -612,10 +514,6 @@ jobs:
               }
               if (file === 'tauri-android.json') {
                   tauriAndroid = data;
-                  continue;
-              }
-              if (file === 'tauri-ios.json') {
-                  tauriIos = data;
                   continue;
               }
               for (const item of data) {
@@ -631,7 +529,6 @@ jobs:
                   desktop,
                   android,
                   tauriAndroid,
-                  tauriIos,
               },
           };
           fs.writeFileSync('manifest.json', JSON.stringify(manifest, null, 2));

--- a/.github/workflows/tauri-pr-build.yml
+++ b/.github/workflows/tauri-pr-build.yml
@@ -1,15 +1,24 @@
 name: Tauri PR build
 
 # Compile-checks the Tauri iOS and Android apps on every PR, without any signing
-# or store upload. iOS runs an unsigned simulator build (which still compiles and
-# links the Rust static lib, including the native BLE/TCP transports, against the
-# real iOS SDKs); Android produces a debug-keystore APK, mirroring the Capacitor
-# debug APK. Neither job receives release/signing secrets — they run untrusted PR
-# code with a read-only token, like the Capacitor debug build.
+# or store upload. iOS runs a full unsigned device build (Rust static lib + Swift
+# sources + linking against the real iOS SDK); Android produces a debug-keystore
+# APK, mirroring the Capacitor debug APK. Neither job receives release/signing
+# secrets — they run untrusted PR code with a read-only token, like the Capacitor
+# debug build.
+#
+# Also callable from other workflows (the nightly calls it with ios-only: true so
+# master keeps the full iOS compile check without shipping an IPA).
 
 on:
   pull_request:
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ios-only:
+        description: Run only the iOS compile check
+        type: boolean
+        default: false
 
 concurrency:
   group: tauri-pr-build-${{ github.event.pull_request.number || github.ref }}
@@ -54,20 +63,15 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
-      - name: Build frontend
-        run: npm run build
-
-      # A full unsigned iOS app build isn't cleanly supported (tauri ios build
-      # requires signing, and driving xcodebuild directly skips the dev-server
-      # setup its Rust xcode-script expects). Compiling the crate for the iOS
-      # target is the meaningful gate anyway: it type-checks the native transports
-      # (BLE via btleplug/CoreBluetooth, TCP) against the real iOS SDK, which can
-      # only be done on a macOS runner with Xcode.
-      - name: Cargo check (iOS target)
-        run: cargo check --manifest-path src-tauri/Cargo.toml --target aarch64-apple-ios
+      # Full device build (frontend, Rust static lib with the native BLE/TCP
+      # transports, Swift sources, linking against the real iOS SDK) — only the
+      # signing and IPA export are skipped, so no Apple secrets are needed.
+      - name: Full unsigned device build
+        run: npx --no tauri ios build --no-sign --archive-only
 
   android:
     name: Android (debug APK)
+    if: ${{ !inputs.ios-only }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -229,7 +229,7 @@ function renderNightlySection(nightly) {
     ];
     const hasDesktop = platforms.some((p) => Array.isArray(desktop[p.key]) && desktop[p.key].length > 0);
     const hasAndroid = Boolean(nightly?.android);
-    const tauriMobile = [nightly?.tauriAndroid, nightly?.tauriIos].filter(Boolean);
+    const tauriMobile = [nightly?.tauriAndroid].filter(Boolean);
     const hasTauriMobile = tauriMobile.length > 0;
 
     if (!nightly || (!hasDesktop && !hasAndroid && !hasTauriMobile)) {


### PR DESCRIPTION
The nightly ad-hoc IPA export fails every run (automatic signing via the App Store Connect API key hits a cloud signing permission error, and an ad-hoc IPA would only install on registered devices anyway). Since iOS ships via TestFlight, this removes the IPA from the nightly downloads entirely.

In its place, the PR iOS job is upgraded from `cargo check` to a full unsigned device build (`tauri ios build --no-sign --archive-only`), compiling and linking the frontend, Rust static lib and Swift sources against the real iOS SDK with no Apple secrets. `tauri-pr-build.yml` is now reusable (`workflow_call` with an `ios-only` input) and the nightly calls it, so master keeps the identical full compile check every night.

Note for anyone revisiting this: driving `xcodebuild` directly does not work, as the Build Rust Code phase reads options from a WebSocket server that only exists inside a parent tauri CLI process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nightly iOS validation with a complete unsigned device build.
  * Removed iOS artifacts from nightly mobile download listings.
  * Kept Android packaging and publishing checks aligned with their respective build results.

* **Chores**
  * Updated automated build workflows to support iOS-only validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->