### PR TITLE
Update FirmwareFlasherTab.vue to always show "Exit DFU mode" when active

### DIFF
--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -47,6 +47,13 @@
         <div class="content_toolbar toolbar_fixed_bottom">
             <UFieldGroup size="sm" orientation="horizontal" class="flex!">
                 <UButton
+                    v-if="!state.dfuExitButtonDisabled"
+                    icon="i-lucide-usb"
+                    @click="handleExitDfu"
+                >
+                    {{ $t("firmwareFlasherExitDfu") }}
+                </UButton>
+                <UButton
                     :disabled="state.flashButtonDisabled || activeFlasherStep !== 'flash'"
                     :color="state.flashButtonDisabled || activeFlasherStep !== 'flash' ? 'neutral' : 'success'"
                     :loading="state.flashingInProgress"

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -45,14 +45,16 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UFieldGroup size="sm" orientation="horizontal" class="flex!">
-                <UButton
-                    v-if="!state.dfuExitButtonDisabled"
-                    icon="i-lucide-usb"
-                    @click="handleExitDfu"
-                >
-                    {{ $t("firmwareFlasherExitDfu") }}
-                </UButton>
+            <UButton
+                v-if="dfuExitAvailable"
+                icon="i-lucide-usb"
+                size="xs"
+                :disabled="state.flashingInProgress"
+                @click="handleExitDfu"
+            >
+                {{ $t("firmwareFlasherExitDfu") }}
+            </UButton>
+            <UFieldGroup size="xs" orientation="horizontal" class="flex!">
                 <UButton
                     :disabled="state.flashButtonDisabled || activeFlasherStep !== 'flash'"
                     :color="state.flashButtonDisabled || activeFlasherStep !== 'flash' ? 'neutral' : 'success'"


### PR DESCRIPTION
I would like to change the firmware flasher tab to show the option to "Exit DFU device" as its own button when a DFU device is active for consistency with the layout of previous Betaflight Configurator versions. There are guides showing users how to exit DFU mode on FCs where the boot button is shared between the MCU and e.g. an ELRS receiver (see "Previous versions" below), and users are confused by the new layout. 

Current:
<img width="594" height="206" alt="image" src="https://github.com/user-attachments/assets/89da23f1-deaf-4b78-af12-844414679b72" />

Previous versions:
<img width="1275" height="861" alt="image" src="https://github.com/user-attachments/assets/1609ce37-364a-4083-bc04-af51b1a068e2" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * The firmware flasher’s **Exit DFU** control now appears when exiting DFU mode is available.
  * The control uses a more compact layout and is disabled while firmware flashing is in progress.
  * Updated the toolbar presentation for clearer, more consistent interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->