### PR TITLE
Added missed curves min-max control menu actions (set min/max by time interval for selected curves) in the blackbox log viewer

### DIFF
--- a/src/blackbox-viewer/components/GraphConfigDialog.vue
+++ b/src/blackbox-viewer/components/GraphConfigDialog.vue
@@ -847,11 +847,11 @@ function setMinMaxSelectedZoom(zoom) {
     }
 }
 
-function setMinMaxToFullRangeDuringAllTime(setCheckedOnly) {
+function setFieldsMinMaxToFullRange(setCheckedOnly, getMinMaxFunction) {
     if (currentState.value.graph?.fields && props.flightLog) {
         for (const [index, field] of currentState.value.graph.fields.entries()) {
             if (!setCheckedOnly || !currentState.value.isFieldChecked || currentState.value.isFieldChecked[index]) {
-                const mm = props.flightLog.getMinMaxForFieldDuringAllTime(field.name);
+                const mm = getMinMaxFunction(props.flightLog, props.grapher, field.name);
                 if (mm?.min !== undefined && mm?.max !== undefined) {
                     setMin(field, mm.min);
                     setMax(field, mm.max);
@@ -862,53 +862,42 @@ function setMinMaxToFullRangeDuringAllTime(setCheckedOnly) {
     }
 }
 
-function getMinMaxForFieldDuringWindowTimeInterval(setCheckedOnly) {
-    if (currentState.value.graph?.fields && props.flightLog && props.grapher) {
-        for (const [index, field] of currentState.value.graph.fields.entries()) {
-            if (!setCheckedOnly || !currentState.value.isFieldChecked || currentState.value.isFieldChecked[index]) {
-                const mm = GraphConfig.getMinMaxForFieldDuringWindowTimeInterval(
-                    props.flightLog,
-                    props.grapher,
-                    field.name,
-                );
-                if (mm?.min !== undefined && mm?.max !== undefined) {
-                    setMin(field, mm.min);
-                    setMax(field, mm.max);
-                }
-            }
-        }
-        emitUpdate();
-    }
+function setFieldsMinMaxToFullRangeDuringAllTime(setCheckedOnly) {
+    setFieldsMinMaxToFullRange(setCheckedOnly, GraphConfig.getMinMaxForFieldDuringAllTimeInterval);
 }
 
-function getMinMaxForFieldDuringMarkedInterval(setCheckedOnly) {
-    if (currentState.value.graph?.fields && props.flightLog && props.grapher) {
-        for (const [index, field] of currentState.value.graph.fields.entries()) {
-            if (!setCheckedOnly || !currentState.value.isFieldChecked || currentState.value.isFieldChecked[index]) {
-                const mm = GraphConfig.getMinMaxForFieldDuringMarkedInterval(
-                    props.flightLog,
-                    props.grapher,
-                    field.name,
-                );
-                if (mm?.min !== undefined && mm?.max !== undefined) {
-                    setMin(field, mm.min);
-                    setMax(field, mm.max);
-                }
-            }
-        }
-        emitUpdate();
-    }
+function setFieldsMinMaxToFullRangeDuringWindowTime(setCheckedOnly) {
+    setFieldsMinMaxToFullRange(setCheckedOnly, GraphConfig.getMinMaxForFieldDuringWindowTimeInterval);
 }
 
-function setMinMaxSelectedToFullRangeDuringAllTime() {
+function setFieldsMinMaxToFullRangeDuringMarkedTime(setCheckedOnly) {
+    setFieldsMinMaxToFullRange(setCheckedOnly, GraphConfig.getMinMaxForFieldDuringMarkedInterval);
+}
+
+function setSelectedFieldMinMaxToFullRange(getMinMaxFunction) {
     if (currentState.value.field?.name && props.flightLog) {
-        const mm = props.flightLog.getMinMaxForFieldDuringAllTime(currentState.value.field?.name);
+        const fieldName = currentState.value.field.name;
+        const mm = getMinMaxFunction(props.flightLog, props.grapher, fieldName);
         if (mm?.min !== undefined && mm?.max !== undefined) {
             setMin(currentState.value.field, mm.min);
             setMax(currentState.value.field, mm.max);
             emitUpdate();
         }
     }
+}
+
+function setSelectedFieldMinMaxToFullRangeDuringAllTime() {
+    setSelectedFieldMinMaxToFullRange((flightLog, grapher, fieldName) =>
+        GraphConfig.getMinMaxForFieldDuringAllTimeInterval(flightLog, fieldName),
+    );
+}
+
+function setSelectedFieldMinMaxToFullRangeDuringWindowTime() {
+    setSelectedFieldMinMaxToFullRange(GraphConfig.getMinMaxForFieldDuringWindowTimeInterval);
+}
+
+function setSelectedFieldMinMaxToFullRangeDuringMarkedTime() {
+    setSelectedFieldMinMaxToFullRange(GraphConfig.getMinMaxForFieldDuringMarkedInterval);
 }
 
 const zoom = 1.1;
@@ -924,7 +913,7 @@ const simpleMenuItems = computed(() => [
         {
             label: "Full range",
             onSelect() {
-                setMinMaxToFullRangeDuringAllTime();
+                setFieldsMinMaxToFullRangeDuringAllTime();
             },
         },
         {
@@ -972,7 +961,7 @@ const simpleMenuItems = computed(() => [
                     {
                         label: "Full range",
                         onSelect() {
-                            setMinMaxSelectedToFullRangeDuringAllTime();
+                            setSelectedFieldMinMaxToFullRangeDuringAllTime();
                         },
                     },
                     {
@@ -1077,21 +1066,21 @@ const extendedMenuItems = computed(() => [
                     {
                         label: "At the all time",
                         onSelect(e) {
-                            setMinMaxToFullRangeDuringAllTime(true);
+                            setFieldsMinMaxToFullRangeDuringAllTime(true);
                             e.preventDefault();
                         },
                     },
                     {
                         label: "At the window time",
                         onSelect(e) {
-                            getMinMaxForFieldDuringWindowTimeInterval(true);
+                            setFieldsMinMaxToFullRangeDuringWindowTime(true);
                             e.preventDefault();
                         },
                     },
                     {
                         label: "At the markers time",
                         onSelect(e) {
-                            getMinMaxForFieldDuringMarkedInterval(true);
+                            setFieldsMinMaxToFullRangeDuringMarkedTime(true);
                             e.preventDefault();
                         },
                     },
@@ -1206,21 +1195,21 @@ const extendedMenuItems = computed(() => [
                                 {
                                     label: "At the all time",
                                     onSelect(e) {
-                                        setMinMaxSelectedToFullRangeDuringAllTime();
+                                        setSelectedFieldMinMaxToFullRangeDuringAllTime();
                                         e.preventDefault();
                                     },
                                 },
                                 {
                                     label: "At the window time",
-                                    disabled: true,
                                     onSelect(e) {
+                                        setSelectedFieldMinMaxToFullRangeDuringWindowTime();
                                         e.preventDefault();
                                     },
                                 },
                                 {
                                     label: "At the markers time",
-                                    disabled: true,
                                     onSelect(e) {
+                                        setSelectedFieldMinMaxToFullRangeDuringMarkedTime();
                                         e.preventDefault();
                                     },
                                 },

--- a/src/blackbox-viewer/flightlog.js
+++ b/src/blackbox-viewer/flightlog.js
@@ -1383,11 +1383,11 @@ export function FlightLog(logData) {
     };
 
     /**
-     * Function to compute of min and max curve values during time interval.
-     * @param field_name String: Curve fields name.
-     * @param start_time Integer: The interval start time .
-     * @end_time start_time Integer: The interval end time .
-     * @returns {min: MinValue, max: MaxValue} if success, or undefined if error
+     * Function to compute min and max curve values during time interval.
+     * @param {string} field_name - Curve field name.
+     * @param {number} start_time - The interval start time.
+     * @param {number} end_time - The interval end time.
+     * @returns {{min: number, max: number} | undefined} - Min and max values if success, or undefined if error
      */
     this.getMinMaxForFieldDuringTimeInterval = function (field_name, start_time, end_time) {
         const chunks = this.getSmoothedChunksInTimeRange(start_time, end_time);

--- a/src/blackbox-viewer/flightlog.js
+++ b/src/blackbox-viewer/flightlog.js
@@ -1192,7 +1192,7 @@ export function FlightLog(logData) {
                         continue;
                     }
 
-                    for (centerFrameIndex = 0; centerFrameIndex < sourceChunks[centerChunkIndex].frames.length; ) {
+                    for (centerFrameIndex = 0; centerFrameIndex < sourceChunks[centerChunkIndex].frames.length;) {
                         let //Current beginning & end of the smoothing window:
                             leftChunkIndex = centerChunkIndex,
                             leftFrameIndex = centerFrameIndex,
@@ -1365,24 +1365,21 @@ export function FlightLog(logData) {
 
     this.getMinMaxForFieldDuringAllTime = function (field_name) {
         const stats = this.getStats();
-        let min = Number.MAX_VALUE,
-            max = -Number.MAX_VALUE;
+        let range;
 
         const fieldIndex = this.getMainFieldIndexByName(field_name),
             fieldStat = fieldIndex === undefined ? false : stats.field[fieldIndex];
 
         if (fieldStat) {
-            min = Math.min(min, fieldStat.min);
-            max = Math.max(max, fieldStat.max);
+            range = {
+                min: fieldStat.min,
+                max: fieldStat.max,
+            };
         } else {
-            const mm = this.getMinMaxForFieldDuringTimeInterval(field_name, this.getMinTime(), this.getMaxTime());
-            if (mm !== undefined) {
-                min = Math.min(mm.min, min);
-                max = Math.max(mm.max, max);
-            }
+            range = this.getMinMaxForFieldDuringTimeInterval(field_name, this.getMinTime(), this.getMaxTime());
         }
 
-        return { min: min, max: max };
+        return range;
     };
 
     /**
@@ -1390,7 +1387,7 @@ export function FlightLog(logData) {
      * @param field_name String: Curve fields name.
      * @param start_time Integer: The interval start time .
      * @end_time start_time Integer: The interval end time .
-     * @returns {min: MinValue, max: MaxValue} if success, or {min: Number.MAX_VALUE, max: Number.MAX_VALUE} if error
+     * @returns {min: MinValue, max: MaxValue} if success, or undefined if error
      */
     this.getMinMaxForFieldDuringTimeInterval = function (field_name, start_time, end_time) {
         const chunks = this.getSmoothedChunksInTimeRange(start_time, end_time);
@@ -1430,10 +1427,15 @@ export function FlightLog(logData) {
             }
             frameIndex = 0;
         }
-        return {
-            min: minValue,
-            max: maxValue,
-        };
+
+        if (minValue !== Number.MAX_VALUE && maxValue !== -Number.MAX_VALUE) {
+            return {
+                min: minValue,
+                max: maxValue,
+            };
+        } else {
+            return undefined;
+        }
     };
 
     this.getCurrentLogRowsCount = function () {

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -1405,6 +1405,26 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
 };
 
 /**
+ * Compute min-max values for field during all time.
+ *
+ * @param flightLog The reference to the FlightLog object
+ * @param fieldName Name of the field
+ */
+GraphConfig.getMinMaxForFieldDuringAllTimeInterval = function (flightLog, fieldName) {
+    const mm = flightLog.getMinMaxForFieldDuringAllTime(fieldName);
+    if (mm === undefined) {
+        return {
+            min: -500,
+            max: 500,
+        };
+    }
+
+    mm.min = FlightLogFieldPresenter.ConvertFieldValue(flightLog, fieldName, true, mm.min);
+    mm.max = FlightLogFieldPresenter.ConvertFieldValue(flightLog, fieldName, true, mm.max);
+    return mm;
+};
+
+/**
  * Compute min-max values for field during current windows time interval.
  *
  * @param flightLog The reference to the FlightLog object

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -1481,24 +1481,6 @@ GraphConfig.getMinMaxForFieldDuringMarkedInterval = function (flightLog, logGrap
 };
 
 /**
- * Compute min-max values for field during all time.
- * @param fieldName Name of the field
- */
-GraphConfig.getMinMaxForFieldDuringAllTime = function (flightLog, fieldName) {
-    const mm = flightLog.getMinMaxForFieldDuringAllTime(fieldName);
-    if (mm.min === Number.MAX_VALUE || mm.max === -Number.MAX_VALUE) {
-        return {
-            min: -500,
-            max: 500,
-        };
-    }
-
-    mm.min = FlightLogFieldPresenter.ConvertFieldValue(flightLog, fieldName, true, mm.min);
-    mm.max = FlightLogFieldPresenter.ConvertFieldValue(flightLog, fieldName, true, mm.max);
-    return mm;
-};
-
-/**
  * Get an array of suggested graph configurations will be usable for the fields available in the given flightlog.
  *
  * Supply an array of strings `graphNames` to only fetch the graph with the given names.


### PR DESCRIPTION
Resolved issues in the curves min-max control menu at the graph config dialogbox:
- Added missed curves units conversion for the all flight time interval curves minmax values
- Added missed curves min-max control menu actions for selected curves: set min/max by window and selected time interval
- The curves MinMax control menu code is refactored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added all-time, window-time, and marked-time min/max range options for selected curves and fields.
  * Enabled window and marker range selection for individual fields.
* **Bug Fixes**
  * Improved range calculations when bounds are unavailable or intervals contain no samples.
  * Ensured chart ranges use accurate values and units.
* **Refactor**
  * Unified range handling across available range options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->