### PR TITLE
ci: attach desktop + Tauri APK to releases; per-platform downloads page

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -40,31 +40,19 @@ jobs:
       RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
       RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
 
+  # Build the Tauri desktop bundles (Windows/macOS/Linux) and the signed Tauri
+  # Android APK, then attach them to the release. The Tauri APK is the release's
+  # Android download; the Capacitor APK from build.yml is no longer attached.
   modern_release:
+    name: Attach Release Artifacts
+    needs: check_tag
+    if: needs.check_tag.outputs.should_run == 'true'
     permissions:
       contents: write
-    name: Attach Release Artifacts
-    needs: modern_build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Code Checkout
-        uses: actions/checkout@v5
-
-      - name: Fetch build artifacts (APK only at this stage)
-        uses: actions/download-artifact@v5
-        with:
-          name: betaflight-app-apk
-          path: artifacts
-
-      - name: Attach assets to release
-        run: |
-          set -x
-          ASSETS=()
-          ASSETS+=("artifacts/${{ needs.modern_build.outputs.apk_name }}")
-          TAG_NAME="${GITHUB_REF##*/}"
-          gh release upload "${TAG_NAME}" "${ASSETS[@]}"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: ./.github/workflows/tauri-release-assets.yml
+    with:
+      tag: ${{ github.event.release.tag_name }}
+    secrets: inherit
 
   prepare_environment:
     name: Prepare Environment Name

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -52,7 +52,11 @@ jobs:
     uses: ./.github/workflows/tauri-release-assets.yml
     with:
       tag: ${{ github.event.release.tag_name }}
-    secrets: inherit
+    secrets:
+      RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
+      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+      RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
 
   prepare_environment:
     name: Prepare Environment Name

--- a/.github/workflows/tauri-release-assets.yml
+++ b/.github/workflows/tauri-release-assets.yml
@@ -1,0 +1,259 @@
+name: Release platform assets
+
+# Builds the Tauri desktop bundles (Windows/macOS/Linux) and a signed Tauri
+# Android APK for a published release, then attaches them to that release.
+#
+# Called by build-release.yml on `release: published`, and runnable on its own
+# via workflow_dispatch to (re)build and attach assets to an existing tag —
+# e.g. to backfill a release cut before this workflow existed.
+#
+# Reuses the same secrets as the nightly build (no new ones): the Tauri APK
+# signs with RELEASE_KEYSTORE via the keystore.properties the Tauri Gradle
+# project reads.
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Release tag to build and attach assets to'
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to build and attach assets to'
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  NDK_VERSION: 27.2.12479018
+
+jobs:
+  desktop:
+    name: Desktop (${{ matrix.label }})
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            label: linux
+            target: ''
+          - os: macos-latest
+            label: macos-arm64
+            target: aarch64-apple-darwin
+          - os: macos-15-intel
+            label: macos-x64
+            target: x86_64-apple-darwin
+          - os: windows-latest
+            label: windows
+            target: ''
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install Tauri Linux prereqs
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libsoup-3.0-dev \
+            librsvg2-dev \
+            libssl-dev \
+            libudev-dev \
+            rpm
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@e081816240890017053eacbb1bdf337761dc5582 # 1.95.0
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Cache Cargo registry and target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+          key: ${{ matrix.label }}
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Tauri bundle
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.target }}" ]; then
+            npm run tauri:build -- --target ${{ matrix.target }}
+          else
+            npm run tauri:build
+          fi
+
+      - name: Stage desktop bundles
+        shell: bash
+        run: |
+          mkdir -p staging
+          shopt -s nullglob
+          for path in \
+            src-tauri/target/release/bundle/deb/*.deb \
+            src-tauri/target/release/bundle/rpm/*.rpm \
+            src-tauri/target/release/bundle/appimage/*.AppImage \
+            src-tauri/target/release/bundle/dmg/*.dmg \
+            src-tauri/target/release/bundle/nsis/*.exe \
+            src-tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb \
+            src-tauri/target/${{ matrix.target }}/release/bundle/rpm/*.rpm \
+            src-tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage \
+            src-tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg \
+            src-tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+          do
+            cp "$path" staging/
+          done
+          if ! compgen -G 'staging/*' > /dev/null; then
+            echo "No desktop bundles produced for ${{ matrix.label }}" >&2
+            exit 1
+          fi
+          node scripts/rename-tauri-bundles.mjs --dir staging
+          ls -la staging
+
+      - name: Upload desktop artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-desktop-${{ matrix.label }}
+          path: staging/*
+          if-no-files-found: error
+          retention-days: 30
+
+  android:
+    name: Android (Tauri APK)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # v3
+
+      - name: Install NDK
+        run: |
+          sdkmanager "ndk;${NDK_VERSION}"
+          echo "NDK_HOME=$ANDROID_HOME/ndk/${NDK_VERSION}" >> "$GITHUB_ENV"
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: aarch64-linux-android,armv7-linux-androideabi,i686-linux-android,x86_64-linux-android
+
+      - name: Cache Cargo registry and target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: src-tauri
+          key: tauri-android
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Sign with the same RELEASE_KEYSTORE the nightly Tauri APK uses, via the
+      # keystore.properties the Tauri Gradle project reads.
+      - name: Configure signing
+        env:
+          RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE }}
+          RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
+          RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
+          RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
+        run: |
+          : "${RELEASE_KEYSTORE_BASE64:?Set the RELEASE_KEYSTORE secret (base64 keystore)}"
+          : "${RELEASE_KEYSTORE_PASSWORD:?Set the RELEASE_KEYSTORE_PASSWORD secret}"
+          : "${RELEASE_KEY_ALIAS:?Set the RELEASE_KEY_ALIAS secret}"
+          : "${RELEASE_KEY_ALIAS_PASSWORD:?Set the RELEASE_KEY_ALIAS_PASSWORD secret}"
+          KS="$RUNNER_TEMP/betaflight-release.jks"
+          echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > "$KS"
+          {
+            printf 'storeFile=%s\n' "$KS"
+            printf 'storePassword=%s\n' "$RELEASE_KEYSTORE_PASSWORD"
+            printf 'keyAlias=%s\n' "$RELEASE_KEY_ALIAS"
+            printf 'keyPassword=%s\n' "$RELEASE_KEY_ALIAS_PASSWORD"
+          } > src-tauri/gen/android/keystore.properties
+
+      - name: Build signed APK
+        run: npx --no tauri android build --apk
+
+      - name: Stage APK
+        run: |
+          mkdir -p staging
+          VERSION=$(jq -r '.version' package.json)
+          APK_NAME="betaflight-app-${VERSION}.apk"
+          APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -path '*release*' | grep -iv unsigned | grep -i universal | head -1)
+          if [ -z "$APK" ]; then
+            APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -path '*release*' | grep -iv unsigned | head -1)
+          fi
+          if [ -z "$APK" ]; then
+            echo "No signed release APK produced" >&2
+            exit 1
+          fi
+          cp "$APK" "staging/${APK_NAME}"
+          ls -la staging
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-android-apk
+          path: staging/*
+          if-no-files-found: error
+          retention-days: 30
+
+  attach:
+    name: Attach assets to release
+    needs: [desktop, android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v5
+        with:
+          path: release-assets
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Upload to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          set -x
+          if ! compgen -G 'release-assets/*' > /dev/null; then
+            echo "No assets to attach" >&2
+            exit 1
+          fi
+          gh release upload "$TAG" release-assets/* --clobber

--- a/.github/workflows/tauri-release-assets.yml
+++ b/.github/workflows/tauri-release-assets.yml
@@ -91,7 +91,7 @@ jobs:
           key: ${{ matrix.label }}
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build Tauri bundle
         shell: bash

--- a/.github/workflows/tauri-release-assets.yml
+++ b/.github/workflows/tauri-release-assets.yml
@@ -18,6 +18,21 @@ on:
         description: 'Release tag to build and attach assets to'
         required: true
         type: string
+    # Only the Android signing secrets are passed through; the desktop builds
+    # need none, and the attach job uses the auto-provided GITHUB_TOKEN.
+    secrets:
+      RELEASE_KEYSTORE:
+        description: 'Base64-encoded Android signing keystore'
+        required: true
+      RELEASE_KEYSTORE_PASSWORD:
+        description: 'Keystore password'
+        required: true
+      RELEASE_KEY_ALIAS:
+        description: 'Signing key alias'
+        required: true
+      RELEASE_KEY_ALIAS_PASSWORD:
+        description: 'Signing key alias password'
+        required: true
   workflow_dispatch:
     inputs:
       tag:

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -351,7 +351,7 @@ function renderDownloadSection(latest) {
     }
 
     const assets = (latest.assets || [])
-        .filter((a) => !a.name.endsWith(".sha256"))
+        .filter((a) => !a.name.toLowerCase().endsWith(".sha256"))
         .map((a) => ({ filename: a.name, url: a.browser_download_url, size: a.size }));
 
     const buckets = new Map();
@@ -406,7 +406,7 @@ function renderReleaseHistorySection(releases) {
     const prereleaseCutoff = new Date();
     prereleaseCutoff.setMonth(prereleaseCutoff.getMonth() - PRERELEASE_VISIBILITY_MONTHS);
     const recent = releases
-        .map((r) => ({ release: r, assets: (r.assets || []).filter((a) => !a.name.endsWith(".sha256")) }))
+        .map((r) => ({ release: r, assets: (r.assets || []).filter((a) => !a.name.toLowerCase().endsWith(".sha256")) }))
         .filter(({ release, assets }) => {
             if (!release.published_at) {
                 return false;

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -273,11 +273,79 @@ function renderNightlySection(nightly) {
             </section>`;
 }
 
-function renderLatestStableSection(latest) {
+// Map a release asset filename to a download platform bucket. Returns null for
+// anything that isn't a recognised installer (e.g. checksums, source archives),
+// which then only shows up under the "All files" list.
+function classifyAsset(name) {
+    const n = name.toLowerCase();
+    if (n.endsWith(".apk")) {
+        return "android";
+    }
+    if (n.endsWith(".exe") || n.endsWith(".msi")) {
+        return "windows";
+    }
+    if (n.endsWith(".dmg") || n.endsWith(".app.tar.gz")) {
+        if (/aarch64|arm64/.test(n)) {
+            return "macos-arm64";
+        }
+        if (/x64|x86_64|intel/.test(n)) {
+            return "macos-x64";
+        }
+        return "macos";
+    }
+    if (n.endsWith(".appimage") || n.endsWith(".deb") || n.endsWith(".rpm")) {
+        return "linux";
+    }
+    return null;
+}
+
+// Card order and labels. A generic "macOS" bucket only appears when a dmg
+// carries no arch token; the arch-specific buckets are preferred.
+const DOWNLOAD_PLATFORMS = [
+    { key: "windows", title: "Windows" },
+    { key: "macos-arm64", title: "macOS (Apple Silicon)" },
+    { key: "macos-x64", title: "macOS (Intel)" },
+    { key: "macos", title: "macOS" },
+    { key: "linux", title: "Linux" },
+    { key: "android", title: "Android" },
+];
+
+// Within a platform, surface the most broadly-installable format first: an
+// AppImage runs on any Linux, an .exe installer over an .msi.
+function downloadPriority(filename) {
+    const n = filename.toLowerCase();
+    const order = [".appimage", ".exe", ".dmg", ".apk", ".deb", ".rpm", ".msi"];
+    const idx = order.findIndex((ext) => n.endsWith(ext));
+    return idx === -1 ? order.length : idx;
+}
+
+function platformCard(title, entries) {
+    const sorted = [...entries].sort((a, b) => downloadPriority(a.filename) - downloadPriority(b.filename));
+    const [primary, ...rest] = sorted;
+    const primarySize = formatBytes(primary.size);
+    const primaryMeta = [primary.filename, primarySize]
+        .filter(Boolean)
+        .map((s) => escapeHtml(s))
+        .join(" &middot; ");
+    const primaryBtn = `<a class="download-btn" href="${escapeHtml(primary.url)}">Download<span class="dl-meta">${primaryMeta}</span></a>`;
+    const extras = rest.length
+        ? `<div class="download-extra">${rest
+              .map((e) => `<a href="${escapeHtml(e.url)}">${escapeHtml(e.filename)}</a>`)
+              .join("")}</div>`
+        : "";
+    return `
+                <div class="download-card">
+                    <h3>${escapeHtml(title)}</h3>
+                    ${primaryBtn}
+                    ${extras}
+                </div>`;
+}
+
+function renderDownloadSection(latest) {
     if (!latest) {
         return `
             <section>
-                <h2>Latest stable release</h2>
+                <h2>Download the app</h2>
                 <p class="empty">No stable releases found.</p>
             </section>`;
     }
@@ -286,13 +354,37 @@ function renderLatestStableSection(latest) {
         .filter((a) => !a.name.endsWith(".sha256"))
         .map((a) => ({ filename: a.name, url: a.browser_download_url, size: a.size }));
 
+    const buckets = new Map();
+    for (const asset of assets) {
+        const key = classifyAsset(asset.filename);
+        if (!key) {
+            continue;
+        }
+        if (!buckets.has(key)) {
+            buckets.set(key, []);
+        }
+        buckets.get(key).push(asset);
+    }
+
+    const cards = DOWNLOAD_PLATFORMS.filter((p) => buckets.has(p.key))
+        .map((p) => platformCard(p.title, buckets.get(p.key)))
+        .join("");
+
     const meta = `Released ${escapeHtml(formatDate(latest.published_at))} &middot; tag <a href="${escapeHtml(latest.html_url)}">${escapeHtml(latest.tag_name)}</a>`;
+
+    const grid = cards ? `<div class="download-grid">${cards}</div>` : "";
+    const allFiles = `
+                <details class="all-files">
+                    <summary>All files</summary>
+                    ${fileList(assets)}
+                </details>`;
 
     return `
             <section>
-                <h2>Latest stable release</h2>
+                <h2>Download the app</h2>
                 <p class="meta">${meta}</p>
-                ${fileList(assets)}
+                ${grid}
+                ${allFiles}
             </section>`;
 }
 
@@ -405,17 +497,15 @@ try {
     const sections = [
         renderReleaseWebAppSection(topRelease, hero),
         renderWebAppSection(masterUrl, releaseUrl),
+        renderDownloadSection(latestStable),
         renderNightlySection(manifest.nightly),
-        renderLatestStableSection(latestStable),
         renderReleaseHistorySection(publicReleases),
     ].join("\n");
 
     const templatePath = join(__dirname, "templates", "downloads-index.html");
     const template = readFileSync(templatePath, "utf8");
     const generatedAt = manifest.generatedAt || new Date().toISOString();
-    const html = template
-        .replace("<!--SECTIONS-->", sections)
-        .replace("<!--GENERATED_AT-->", escapeHtml(generatedAt));
+    const html = template.replace("<!--SECTIONS-->", sections).replace("<!--GENERATED_AT-->", escapeHtml(generatedAt));
 
     writeFileSync(join(outputDir, "index.html"), html);
 

--- a/scripts/templates/downloads-index.html
+++ b/scripts/templates/downloads-index.html
@@ -4,7 +4,10 @@
         <meta charset="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <title>Betaflight downloads</title>
-        <meta name="description" content="Download Betaflight Configurator nightly builds, stable releases, and the web app." />
+        <meta
+            name="description"
+            content="Download Betaflight Configurator nightly builds, stable releases, and the web app."
+        />
         <link rel="icon" type="image/png" href="favicon.png" />
         <style>
             :root {
@@ -203,6 +206,66 @@
                 font-size: 1.15rem;
                 font-weight: 600;
             }
+
+            .download-grid {
+                display: grid;
+                grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+                gap: 0.75rem;
+                margin: 0.5rem 0 1rem;
+            }
+            .download-card {
+                background: var(--surface-200);
+                border: 1px solid var(--surface-400);
+                border-radius: 8px;
+                padding: 1rem;
+                display: flex;
+                flex-direction: column;
+                gap: 0.6rem;
+            }
+            .download-card h3 {
+                margin: 0;
+                font-size: 1rem;
+            }
+            .download-btn {
+                display: flex;
+                flex-direction: column;
+                gap: 0.15rem;
+                background: var(--primary-500);
+                color: var(--surface-100);
+                font-weight: 600;
+                text-align: center;
+                padding: 0.55rem 0.75rem;
+                border-radius: 6px;
+            }
+            .download-btn:hover {
+                background: var(--primary-700);
+                color: var(--text);
+                text-decoration: none;
+            }
+            .download-btn .dl-meta {
+                font-weight: 400;
+                font-size: 0.75rem;
+                opacity: 0.85;
+                word-break: break-all;
+            }
+            .download-extra {
+                display: flex;
+                flex-wrap: wrap;
+                gap: 0.75rem;
+                font-size: 0.8rem;
+                font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            }
+            details.all-files {
+                border: none;
+            }
+            details.all-files summary {
+                color: var(--text-dim);
+                font-weight: 400;
+                font-size: 0.9rem;
+            }
+            details.all-files ul.file-list {
+                margin: 0.5rem 0 0.25rem 1rem;
+            }
         </style>
     </head>
     <body>
@@ -216,7 +279,8 @@
             <!--SECTIONS-->
         </main>
         <footer>
-            Generated <!--GENERATED_AT-->. Source:
+            Generated
+            <!--GENERATED_AT-->. Source:
             <a href="https://github.com/betaflight/betaflight-configurator">betaflight/betaflight-configurator</a>.
         </footer>
     </body>


### PR DESCRIPTION
On `release: published`, the release only ever received the Capacitor Android APK. The downloads page generator already lists every release asset, so desktop and Tauri builds simply never made it onto the releases to be shown.

This builds the Tauri desktop bundles (Windows, macOS arm64 + x64, Linux) and a signed Tauri Android APK when a release is published and attaches them, with the Tauri APK replacing the Capacitor APK as the release's Android download. The builds are factored into a reusable `tauri-release-assets.yml` (`workflow_call` plus `workflow_dispatch` by tag) so an already-published release can be backfilled by dispatching it against that tag.

The downloads page now surfaces the latest stable release as prominent per-platform download cards (Linux leads with the AppImage, `.deb`/`.rpm` shown as extras; checksums excluded) with a collapsible full file list, instead of a bare list.

`build.yml` is unchanged; its Capacitor build and web `dist-files` are still consumed by the deploy jobs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added downloadable desktop bundles for Linux, macOS, and Windows, plus a signed Android APK.
  * Improved the downloads page with platform-specific cards, prioritized links, responsive layouts, and an expandable list of additional files.
  * Improved release download organization and checksum handling across supported platforms.

* **Chores**
  * Streamlined release publishing to automatically build and attach app downloads to releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->