### PR TITLE
ci: sync Tauri bundle version to package.json before release build

### DIFF
--- a/.github/workflows/tauri-release-assets.yml
+++ b/.github/workflows/tauri-release-assets.yml
@@ -108,6 +108,24 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      # The Tauri config version drives desktop bundle names and the app's
+      # self-reported version, but the release bump only touches package.json.
+      # Sync it here so bundles carry the release version, not a stale one.
+      # Inlined (not a repo script) so it also works when building an old tag.
+      - name: Sync bundle version to package.json
+        shell: bash
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const version = JSON.parse(fs.readFileSync("package.json", "utf8")).version;
+            const conf = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
+            conf.version = version;
+            fs.writeFileSync("src-tauri/tauri.conf.json", JSON.stringify(conf, null, 2) + "\n");
+            const cargo = fs.readFileSync("src-tauri/Cargo.toml", "utf8").replace(/^version = ".*"$/m, `version = "${version}"`);
+            fs.writeFileSync("src-tauri/Cargo.toml", cargo);
+            console.log("Synced bundle version to", version);
+          '
+
       - name: Build Tauri bundle
         shell: bash
         run: |
@@ -196,6 +214,20 @@ jobs:
 
       - name: Install dependencies
         run: npm ci --ignore-scripts
+
+      # Keep the APK's internal version in step with package.json (see desktop job).
+      - name: Sync bundle version to package.json
+        run: |
+          node -e '
+            const fs = require("node:fs");
+            const version = JSON.parse(fs.readFileSync("package.json", "utf8")).version;
+            const conf = JSON.parse(fs.readFileSync("src-tauri/tauri.conf.json", "utf8"));
+            conf.version = version;
+            fs.writeFileSync("src-tauri/tauri.conf.json", JSON.stringify(conf, null, 2) + "\n");
+            const cargo = fs.readFileSync("src-tauri/Cargo.toml", "utf8").replace(/^version = ".*"$/m, `version = "${version}"`);
+            fs.writeFileSync("src-tauri/Cargo.toml", cargo);
+            console.log("Synced bundle version to", version);
+          '
 
       # Sign with the same RELEASE_KEYSTORE the nightly Tauri APK uses, via the
       # keystore.properties the Tauri Gradle project reads.


### PR DESCRIPTION
Follow-up to #5356. The release version bump only touches package.json, so tauri.conf.json and Cargo.toml stayed on an older version. Desktop bundles were then named with that stale version and the app self-reported the wrong version (the 2026.6.1 backfill produced Betaflight-2026.6.0-* assets).

This syncs tauri.conf.json and Cargo.toml to package.json in the release-assets workflow just before the build, so bundles carry the release version. It's inlined rather than a repo script so it also works when building an existing tag. Already applied on 2026.6-maintenance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Release builds now automatically synchronize application version information across desktop and Android packages.
  * Published artifacts will use the version specified in the application package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->