### PR TITLE
fix: sync tauri.conf/Cargo/Cargo.lock version to package.json

### DIFF
--- a/scripts/sync-tauri-version.mjs
+++ b/scripts/sync-tauri-version.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Syncs the version from package.json into the Tauri bundle metadata
- * (src-tauri/tauri.conf.json and src-tauri/Cargo.toml).
+ * (src-tauri/tauri.conf.json, src-tauri/Cargo.toml and the crate's pinned
+ * version in src-tauri/Cargo.lock).
  *
  * Tauri requires a plain SemVer string (e.g. "2026.6.0"), so pre-release
  * suffixes like "-alpha" are stripped. The stripped version is still unique
@@ -9,7 +10,7 @@
  *
  * Runs automatically via `beforeBuildCommand` in tauri.conf.json.
  */
-import { readFileSync, writeFileSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -20,7 +21,9 @@ const pkg = JSON.parse(readFileSync(resolve(projectRoot, "package.json"), "utf8"
 const version = pkg.version.split("-", 1)[0];
 
 if (!/^\d+\.\d+\.\d+$/.test(version)) {
-    console.error(`sync-tauri-version: package.json version "${pkg.version}" did not produce a valid SemVer after stripping pre-release tag (got "${version}").`);
+    console.error(
+        `sync-tauri-version: package.json version "${pkg.version}" did not produce a valid SemVer after stripping pre-release tag (got "${version}").`,
+    );
     process.exit(1);
 }
 
@@ -47,4 +50,23 @@ const updated = cargo.replace(packageVersionRe, `$1${version}$3`);
 if (updated !== cargo) {
     writeFileSync(cargoPath, updated);
     console.log(`sync-tauri-version: Cargo.toml → ${version}`);
+}
+
+// Cargo.lock — keep the crate's pinned version in step so the lockfile does not
+// drift (cargo would otherwise rewrite it on the next unlocked build, and a
+// --locked build would fail). Scope the edit to the crate's own [[package]]
+// entry, matched by the name taken from Cargo.toml's [package] section.
+const nameMatch = cargo.match(/^\[package\][\s\S]*?^name\s*=\s*"([^"]+)"/m);
+const lockPath = resolve(projectRoot, "src-tauri/Cargo.lock");
+if (nameMatch && existsSync(lockPath)) {
+    const crateName = nameMatch[1];
+    const lock = readFileSync(lockPath, "utf8");
+    const lockVersionRe = new RegExp(
+        `(name = "${crateName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}"\\nversion = ")([^"]+)(")`,
+    );
+    const lockUpdated = lock.replace(lockVersionRe, `$1${version}$3`);
+    if (lockUpdated !== lock) {
+        writeFileSync(lockPath, lockUpdated);
+        console.log(`sync-tauri-version: Cargo.lock → ${version}`);
+    }
 }

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -107,7 +107,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "betaflight-app"
-version = "2026.6.0"
+version = "2026.12.0"
 dependencies = [
  "btleplug",
  "futures",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "betaflight-app"
-version = "2026.6.0"
+version = "2026.12.0"
 description = "Betaflight"
 authors = ["The Betaflight open source project."]
 license = "GPL-3.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schema.tauri.app/config/2",
     "productName": "Betaflight",
-    "version": "2026.6.0",
+    "version": "2026.12.0",
     "identifier": "com.betaflight.app",
     "build": {
         "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Follow-up to #5356 / #5357. The Tauri bundle version comes from the committed src-tauri/tauri.conf.json (and Cargo.toml/Cargo.lock), not package.json. The release bump only touches package.json, so these drifted and clean builds (nightly, release, first local build after a bump) bundled a stale version. The beforeBuildCommand sync can't fix the current build because Tauri reads the config version before that hook runs.

This brings tauri.conf.json, Cargo.toml and Cargo.lock in step with package.json (2026.12.0), and extends sync-tauri-version.mjs to also update the crate's pinned version in Cargo.lock. Same change already applied to 2026.6-maintenance. Keeping these committed in sync means every clean build reads the correct version regardless of the hook timing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 2026.12.0.
  * Improved release version synchronization to keep packaged application metadata consistent.
  * Enhanced validation and reporting when version information changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->