### PR TITLE
downloads page: render release downloads as per-platform link lists

### DIFF
--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -319,28 +319,6 @@ function downloadPriority(filename) {
     return idx === -1 ? order.length : idx;
 }
 
-function platformCard(title, entries) {
-    const sorted = [...entries].sort((a, b) => downloadPriority(a.filename) - downloadPriority(b.filename));
-    const [primary, ...rest] = sorted;
-    const primarySize = formatBytes(primary.size);
-    const primaryMeta = [primary.filename, primarySize]
-        .filter(Boolean)
-        .map((s) => escapeHtml(s))
-        .join(" &middot; ");
-    const primaryBtn = `<a class="download-btn" href="${escapeHtml(primary.url)}">Download<span class="dl-meta">${primaryMeta}</span></a>`;
-    const extras = rest.length
-        ? `<div class="download-extra">${rest
-              .map((e) => `<a href="${escapeHtml(e.url)}">${escapeHtml(e.filename)}</a>`)
-              .join("")}</div>`
-        : "";
-    return `
-                <div class="download-card">
-                    <h3>${escapeHtml(title)}</h3>
-                    ${primaryBtn}
-                    ${extras}
-                </div>`;
-}
-
 function renderDownloadSection(latest) {
     if (!latest) {
         return `
@@ -366,25 +344,22 @@ function renderDownloadSection(latest) {
         buckets.get(key).push(asset);
     }
 
-    const cards = DOWNLOAD_PLATFORMS.filter((p) => buckets.has(p.key))
-        .map((p) => platformCard(p.title, buckets.get(p.key)))
+    const blocks = DOWNLOAD_PLATFORMS.filter((p) => buckets.has(p.key))
+        .map((p) => {
+            const entries = [...buckets.get(p.key)].sort(
+                (a, b) => downloadPriority(a.filename) - downloadPriority(b.filename),
+            );
+            return `<h3>${escapeHtml(p.title)}</h3>${fileList(entries)}`;
+        })
         .join("");
 
     const meta = `Released ${escapeHtml(formatDate(latest.published_at))} &middot; tag <a href="${escapeHtml(latest.html_url)}">${escapeHtml(latest.tag_name)}</a>`;
-
-    const grid = cards ? `<div class="download-grid">${cards}</div>` : "";
-    const allFiles = `
-                <details class="all-files">
-                    <summary>All files</summary>
-                    ${fileList(assets)}
-                </details>`;
 
     return `
             <section>
                 <h2>Download the app</h2>
                 <p class="meta">${meta}</p>
-                ${grid}
-                ${allFiles}
+                ${blocks || fileList(assets)}
             </section>`;
 }
 

--- a/scripts/templates/downloads-index.html
+++ b/scripts/templates/downloads-index.html
@@ -206,66 +206,6 @@
                 font-size: 1.15rem;
                 font-weight: 600;
             }
-
-            .download-grid {
-                display: grid;
-                grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-                gap: 0.75rem;
-                margin: 0.5rem 0 1rem;
-            }
-            .download-card {
-                background: var(--surface-200);
-                border: 1px solid var(--surface-400);
-                border-radius: 8px;
-                padding: 1rem;
-                display: flex;
-                flex-direction: column;
-                gap: 0.6rem;
-            }
-            .download-card h3 {
-                margin: 0;
-                font-size: 1rem;
-            }
-            .download-btn {
-                display: flex;
-                flex-direction: column;
-                gap: 0.15rem;
-                background: var(--primary-500);
-                color: var(--surface-100);
-                font-weight: 600;
-                text-align: center;
-                padding: 0.55rem 0.75rem;
-                border-radius: 6px;
-            }
-            .download-btn:hover {
-                background: var(--primary-700);
-                color: var(--text);
-                text-decoration: none;
-            }
-            .download-btn .dl-meta {
-                font-weight: 400;
-                font-size: 0.75rem;
-                opacity: 0.85;
-                word-break: break-all;
-            }
-            .download-extra {
-                display: flex;
-                flex-wrap: wrap;
-                gap: 0.75rem;
-                font-size: 0.8rem;
-                font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-            }
-            details.all-files {
-                border: none;
-            }
-            details.all-files summary {
-                color: var(--text-dim);
-                font-weight: 400;
-                font-size: 0.9rem;
-            }
-            details.all-files ul.file-list {
-                margin: 0.5rem 0 0.25rem 1rem;
-            }
         </style>
     </head>
     <body>


### PR DESCRIPTION
Swaps the "Download the app" section from download-button cards to the same per-platform h3 + link-list style used by the Nightly and Recent releases sections, so it reads consistently with the rest of the page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated stable release downloads to display files under platform headings with ordered lists.
  - Removed download cards, primary buttons, supplemental metadata, and the expandable “All files” section.
  - When platform categories aren’t available, all downloads now appear in a single file list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->