### PR TITLE
Unify Tab UI

### DIFF
--- a/src/components/elements/UiBox.vue
+++ b/src/components/elements/UiBox.vue
@@ -80,9 +80,12 @@ const props = defineProps({
     },
 });
 
+const emit = defineEmits(["toggle"]);
+
 const isOpen = ref(props.defaultOpen);
 function toggle() {
     isOpen.value = !isOpen.value;
+    emit("toggle", isOpen.value);
 }
 
 const typeClass = computed(() => {

--- a/src/components/elements/UiBox.vue
+++ b/src/components/elements/UiBox.vue
@@ -80,12 +80,9 @@ const props = defineProps({
     },
 });
 
-const emit = defineEmits(["toggle"]);
-
 const isOpen = ref(props.defaultOpen);
 function toggle() {
     isOpen.value = !isOpen.value;
-    emit("toggle", isOpen.value);
 }
 
 const typeClass = computed(() => {

--- a/src/components/elements/WikiButton.vue
+++ b/src/components/elements/WikiButton.vue
@@ -1,15 +1,13 @@
 <template>
-    <div class="cf_doc_version_bt">
-        <a
-            id="button-documentation"
-            :href="url"
-            target="_blank"
-            rel="noopener noreferrer"
-            :aria-label="$t('betaflightSupportButton')"
-        >
-            {{ $t("betaflightSupportButton") }}
-        </a>
-    </div>
+    <a
+        id="button-documentation"
+        :href="url"
+        target="_blank"
+        rel="noopener noreferrer"
+        :aria-label="$t('betaflightSupportButton')"
+    >
+        {{ $t("betaflightSupportButton") }}
+    </a>
 </template>
 
 <script>

--- a/src/components/elements/WikiButton.vue
+++ b/src/components/elements/WikiButton.vue
@@ -1,13 +1,18 @@
 <template>
-    <a
-        id="button-documentation"
-        :href="url"
-        target="_blank"
-        rel="noopener noreferrer"
-        :aria-label="$t('betaflightSupportButton')"
-    >
-        {{ $t("betaflightSupportButton") }}
-    </a>
+    <div class="wiki-btn-wrapper">
+        <UButton
+            id="button-documentation"
+            :href="url"
+            target="_blank"
+            rel="noopener noreferrer"
+            :aria-label="$t('betaflightSupportButton')"
+            color="primary"
+            variant="solid"
+            class="wiki-btn uppercase font-bold tracking-wide whitespace-nowrap"
+        >
+            {{ $t("betaflightSupportButton") }}
+        </UButton>
+    </div>
 </template>
 
 <script>
@@ -17,7 +22,6 @@ import { documentationLinks } from "@/config/documentationLinks";
 export default defineComponent({
     name: "WikiButton",
     props: {
-        // Accept either a full URL or a key to look up in documentationLinks
         docUrl: {
             type: String,
             required: true,
@@ -25,8 +29,6 @@ export default defineComponent({
     },
     setup(props) {
         const url = computed(() => {
-            // If it's a full URL (http/https), use it directly
-            // Otherwise, treat it as a key to look up in documentationLinks
             if (props.docUrl.startsWith("https")) {
                 return props.docUrl;
             }
@@ -37,3 +39,18 @@ export default defineComponent({
     },
 });
 </script>
+
+<style scoped>
+.wiki-btn-wrapper {
+    float: right;
+    margin-top: -45px;
+}
+
+.wiki-btn {
+    padding: 1px 9px;
+    font-size: 10px;
+    line-height: 17px;
+    letter-spacing: 0.03em;
+    transition: all ease 0.2s;
+}
+</style>

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -43,7 +43,7 @@
                             <span class="row-index">#{{ originalIndex + 1 }}</span>
                             <USwitch
                                 v-model="adjustment.enabled"
-                                size="sm"
+                                size="xs"
                                 @update:model-value="onEnableChange(adjustment)"
                             />
                         </div>

--- a/src/components/tabs/AdjustmentsTab.vue
+++ b/src/components/tabs/AdjustmentsTab.vue
@@ -152,6 +152,7 @@
                 :label="$t('adjustmentsSave')"
                 :disabled="!hasChanges"
                 :loading="isSaving"
+                size="xs"
                 @click="saveAdjustments"
             />
         </div>

--- a/src/components/tabs/AuxiliaryTab.vue
+++ b/src/components/tabs/AuxiliaryTab.vue
@@ -8,7 +8,7 @@
                 <UiBox highlight>
                     <p v-html="$t('auxiliaryHelp')"></p>
                 </UiBox>
-                <SettingRow :label="$t('auxiliaryToggleUnused')">
+                <SettingRow :label="$t('auxiliaryToggleUnused')" fullWidth>
                     <USwitch v-model="hideUnused" />
                 </SettingRow>
 
@@ -148,7 +148,13 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('auxiliaryButtonSave')" :disabled="!dirty" :loading="isSaving" @click="saveModes" />
+            <UButton
+                :label="$t('auxiliaryButtonSave')"
+                size="xs"
+                :disabled="!dirty"
+                :loading="isSaving"
+                @click="saveModes"
+            />
         </div>
     </BaseTab>
 </template>

--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -84,11 +84,11 @@
                 <div class="flex flex-col gap-3">
                     <div>
                         <label class="text-sm font-semibold block mb-1">{{ $t("labelName") }}</label>
-                        <UInput v-model="editForm.name" size="sm" class="w-full" />
+                        <UInput v-model="editForm.name" size="xs" class="w-full" />
                     </div>
                     <div>
                         <label class="text-sm font-semibold block mb-1">{{ $t("labelDescription") }}</label>
-                        <UTextarea v-model="editForm.description" size="sm" class="w-full" :rows="4" />
+                        <UTextarea v-model="editForm.description" size="xs" class="w-full" :rows="4" />
                     </div>
                     <div class="text-sm">
                         <span class="font-semibold">{{ $t("labelCreated") }}</span>

--- a/src/components/tabs/BackupsTab.vue
+++ b/src/components/tabs/BackupsTab.vue
@@ -9,12 +9,12 @@
 
             <template v-else>
                 <!-- Message from API (e.g. membership info) -->
-                <UiBox v-if="backupMessage" type="neutral">
+                <UiBox v-if="backupMessage" type="neutral" collapsible>
                     <p>{{ backupMessage }}</p>
                 </UiBox>
 
                 <!-- Backup list per craft -->
-                <UiBox :title="$t('tabBackups')">
+                <UiBox :title="$t('tabBackups')" type="neutral" collapsible>
                     <div v-if="backups.length === 0" class="text-dimmed text-sm py-4">
                         {{ $t("backupNoBackupsAvailable") }}
                     </div>
@@ -96,7 +96,7 @@
                     </div>
                 </div>
                 <template #footer>
-                    <UButton @click="saveBackupChanges" size="sm">
+                    <UButton @click="saveBackupChanges" size="xs">
                         {{ $t("actionSave") }}
                     </UButton>
                 </template>
@@ -156,7 +156,7 @@
             <UTooltip :text="$t('backupRequiresConnection')" :disabled="isConnected">
                 <span>
                     <UButton
-                        size="sm"
+                        size="xs"
                         icon="i-lucide-save"
                         :disabled="!isConnected"
                         :class="{ 'pointer-events-none': !isConnected }"

--- a/src/components/tabs/ConfigurationTab.vue
+++ b/src/components/tabs/ConfigurationTab.vue
@@ -1,198 +1,222 @@
 <template>
-    <div class="tab-configuration">
-        <div class="content_wrapper">
-            <div class="tab_title">{{ $t("tabConfiguration") }}</div>
-            <WikiButton docUrl="configuration" />
-            <UiBox highlight class="mb-3">
-                <p v-html="$t('configurationFeaturesHelp')"></p>
-            </UiBox>
+    <BaseTab tab-name="configuration">
+        <div class="tab-configuration">
+            <div class="content_wrapper">
+                <div class="tab_title">{{ $t("tabConfiguration") }}</div>
+                <WikiButton docUrl="configuration" />
+                <UiBox highlight class="mb-3">
+                    <p v-html="$t('configurationFeaturesHelp')"></p>
+                </UiBox>
 
-            <div class="grid-row grid-box col2">
-                <div class="col-span-1">
-                    <!-- SYSTEM CONFIGURATION -->
-                    <UiBox :title="$t('configurationSystem')">
-                        <UiBox highlight>
-                            <p class="systemconfigNote" v-html="$t('configurationLoopTimeHelp')"></p>
+                <div class="grid-row grid-box col2">
+                    <div class="col-span-1">
+                        <!-- SYSTEM CONFIGURATION -->
+                        <UiBox :title="$t('configurationSystem')" type="neutral" collapsible>
+                            <UiBox highlight>
+                                <p class="systemconfigNote" v-html="$t('configurationLoopTimeHelp')"></p>
+                            </UiBox>
+                            <SettingRow :label="$t('configurationGyroFrequency')">
+                                <UInput readonly disabled :value="gyroFrequencyDisplay" class="min-w-40" />
+                            </SettingRow>
+                            <SettingRow
+                                :label="$t('configurationPidProcessDenom')"
+                                :help="$t('configurationPidProcessDenomHelp')"
+                            >
+                                <USelect
+                                    :items="pidDenomOptions"
+                                    v-model="pidAdvancedConfig.pid_process_denom"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
                         </UiBox>
-                        <SettingRow :label="$t('configurationGyroFrequency')">
-                            <UInput readonly disabled :value="gyroFrequencyDisplay" class="min-w-40" />
-                        </SettingRow>
-                        <SettingRow
-                            :label="$t('configurationPidProcessDenom')"
-                            :help="$t('configurationPidProcessDenomHelp')"
-                        >
-                            <USelect
-                                :items="pidDenomOptions"
-                                v-model="pidAdvancedConfig.pid_process_denom"
-                                class="min-w-40"
-                            />
-                        </SettingRow>
-                    </UiBox>
 
-                    <!-- PERSONALIZATION -->
-                    <UiBox :title="$t('configurationPersonalization')">
-                        <SettingRow :label="$t('craftName')" :help="$t('configurationCraftNameHelp')">
-                            <UInput v-model="craftName" maxlength="16" class="min-w-40" />
-                        </SettingRow>
-                        <SettingRow
-                            :label="$t('configurationPilotName')"
-                            :help="$t('configurationPilotNameHelp')"
-                            v-if="showPilotName"
-                        >
-                            <UInput v-model="pilotName" maxlength="16" class="min-w-40" />
-                        </SettingRow>
-                    </UiBox>
+                        <!-- PERSONALIZATION -->
+                        <UiBox :title="$t('configurationPersonalization')" type="neutral" collapsible>
+                            <SettingRow :label="$t('craftName')" :help="$t('configurationCraftNameHelp')">
+                                <UInput v-model="craftName" maxlength="16" class="min-w-40" />
+                            </SettingRow>
+                            <SettingRow
+                                :label="$t('configurationPilotName')"
+                                :help="$t('configurationPilotNameHelp')"
+                                v-if="showPilotName"
+                            >
+                                <UInput v-model="pilotName" maxlength="16" class="min-w-40" />
+                            </SettingRow>
+                        </UiBox>
 
-                    <!-- CAMERA -->
-                    <UiBox :title="$t('configurationCamera')" v-if="accHardwareEnabled">
-                        <SettingRow :label="$t('configurationFpvCamAngleDegrees')">
-                            <UInputNumber
-                                v-model="fpvCamAngleDegrees"
-                                :step="1"
-                                :min="0"
-                                :max="90"
-                                orientation="vertical"
-                                size="xs"
-                                class="w-16"
-                            />
-                        </SettingRow>
-                    </UiBox>
+                        <!-- CAMERA -->
+                        <UiBox :title="$t('configurationCamera')" type="neutral" collapsible v-if="accHardwareEnabled">
+                            <SettingRow :label="$t('configurationFpvCamAngleDegrees')">
+                                <UInputNumber
+                                    v-model="fpvCamAngleDegrees"
+                                    :step="1"
+                                    :min="0"
+                                    :max="90"
+                                    orientation="vertical"
+                                    size="xs"
+                                    class="w-16"
+                                />
+                            </SettingRow>
+                        </UiBox>
 
-                    <!-- ARMING -->
-                    <UiBox
-                        :title="$t('configurationArming')"
-                        :help="$t('configurationArmingHelp')"
-                        v-if="accHardwareEnabled"
-                    >
-                        <SettingRow :label="$t('configurationSmallAngle')" :help="$t('configurationSmallAngleHelp')">
-                            <UInputNumber
-                                v-model="armingConfig.small_angle"
-                                :step="1"
-                                :min="0"
-                                :max="180"
-                                orientation="vertical"
-                                size="xs"
-                                class="w-16"
-                            />
-                        </SettingRow>
-                        <SettingRow
-                            :label="$t('configurationGyroCalOnFirstArm')"
-                            :help="$t('configurationGyroCalOnFirstArmHelp')"
-                            v-if="showGyroCalOnFirstArm"
+                        <!-- ARMING -->
+                        <UiBox
+                            :title="$t('configurationArming')"
+                            :help="$t('configurationArmingHelp')"
+                            type="neutral"
+                            collapsible
+                            v-if="accHardwareEnabled"
                         >
-                            <USwitch v-model="armingConfig.gyro_cal_on_first_arm_bool" />
-                        </SettingRow>
-                        <SettingRow
-                            :label="$t('configurationAutoDisarmDelay')"
-                            :help="$t('configurationAutoDisarmDelayHelp')"
-                            v-if="showAutoDisarmDelay"
-                        >
-                            <UInputNumber
-                                v-model="armingConfig.auto_disarm_delay"
-                                :step="1"
-                                :min="0"
-                                :max="60"
-                                orientation="vertical"
-                                size="xs"
-                                class="w-16"
-                            />
-                        </SettingRow>
-                    </UiBox>
+                            <SettingRow
+                                :label="$t('configurationSmallAngle')"
+                                :help="$t('configurationSmallAngleHelp')"
+                            >
+                                <UInputNumber
+                                    v-model="armingConfig.small_angle"
+                                    :step="1"
+                                    :min="0"
+                                    :max="180"
+                                    orientation="vertical"
+                                    size="xs"
+                                    class="w-16"
+                                />
+                            </SettingRow>
+                            <SettingRow
+                                :label="$t('configurationGyroCalOnFirstArm')"
+                                :help="$t('configurationGyroCalOnFirstArmHelp')"
+                                v-if="showGyroCalOnFirstArm"
+                            >
+                                <USwitch v-model="armingConfig.gyro_cal_on_first_arm_bool" />
+                            </SettingRow>
+                            <SettingRow
+                                :label="$t('configurationAutoDisarmDelay')"
+                                :help="$t('configurationAutoDisarmDelayHelp')"
+                                v-if="showAutoDisarmDelay"
+                            >
+                                <UInputNumber
+                                    v-model="armingConfig.auto_disarm_delay"
+                                    :step="1"
+                                    :min="0"
+                                    :max="60"
+                                    orientation="vertical"
+                                    size="xs"
+                                    class="w-16"
+                                />
+                            </SettingRow>
+                        </UiBox>
 
-                    <!-- FEATURES -->
-                    <UiBox :title="$t('configurationFeatures')">
-                        <SettingRow
-                            v-for="feature in featuresList"
-                            :key="feature.bit"
-                            fullWidth
-                            :help="feature.haveTip ? $t('feature' + feature.name + 'Tip') : undefined"
-                        >
-                            <USwitch
-                                :model-value="isFeatureEnabled(feature)"
-                                @update:model-value="(checked) => toggleFeature(feature, checked)"
-                            />
-                            <template #label>
-                                <span class="w-48 shrink-0 font-bold text-xs leading-snug">{{ feature.name }}</span>
-                                <span
-                                    class="min-w-0 flex-1 text-xs leading-snug"
-                                    v-html="$t('feature' + feature.name)"
-                                ></span>
-                            </template>
-                        </SettingRow>
-                    </UiBox>
+                        <!-- FEATURES -->
+                        <UiBox :title="$t('configurationFeatures')" type="neutral" collapsible>
+                            <SettingRow
+                                v-for="feature in featuresList"
+                                :key="feature.bit"
+                                fullWidth
+                                :help="feature.haveTip ? $t('feature' + feature.name + 'Tip') : undefined"
+                            >
+                                <USwitch
+                                    :model-value="isFeatureEnabled(feature)"
+                                    @update:model-value="(checked) => toggleFeature(feature, checked)"
+                                />
+                                <template #label>
+                                    <span class="w-48 shrink-0 font-bold text-xs leading-snug">{{ feature.name }}</span>
+                                    <span
+                                        class="min-w-0 flex-1 text-xs leading-snug"
+                                        v-html="$t('feature' + feature.name)"
+                                    ></span>
+                                </template>
+                            </SettingRow>
+                        </UiBox>
 
-                    <!-- DSHOT BEACON -->
-                    <UiBox :title="$t('configurationDshotBeeper')" :help="$t('configurationDshotBeaconHelp')">
-                        <SettingRow
-                            :label="$t('configurationDshotBeaconTone')"
-                            :help="$t('configurationUseDshotBeeper')"
+                        <!-- DSHOT BEACON -->
+                        <UiBox
+                            :title="$t('configurationDshotBeeper')"
+                            :help="$t('configurationDshotBeaconHelp')"
+                            type="neutral"
+                            collapsible
                         >
-                            <USelect
-                                v-model="dshotBeaconTone"
-                                class="min-w-24"
-                                :items="[
-                                    { label: $t('portsTelemetryDisabled'), value: 0 },
-                                    ...[1, 2, 3, 4, 5].map((i) => ({ label: String(i), value: i })),
-                                ]"
-                            />
-                        </SettingRow>
-                        <div class="flex gap-2">
-                            <UButton :label="$t('configurationBeeperEnableAll')" @click="enableAllDshot" size="xs" />
-                            <UButton :label="$t('configurationBeeperDisableAll')" @click="disableAllDshot" size="xs" />
-                        </div>
-                        <SettingRow v-for="cond in dshotBeaconConditionsList" :key="cond.bit" fullWidth>
-                            <USwitch
-                                :model-value="isDshotConditionEnabled(cond)"
-                                @update:model-value="(checked) => toggleDshotCondition(cond, checked)"
-                            />
-                            <template #label>
-                                <span class="w-20 shrink-0 font-bold text-xs leading-snug">{{ cond.name }}</span>
-                                <span
-                                    class="min-w-0 flex-1 text-xs leading-snug"
-                                    v-html="$t('beeper' + cond.name)"
-                                ></span>
-                            </template>
-                        </SettingRow>
-                    </UiBox>
-                </div>
+                            <SettingRow
+                                :label="$t('configurationDshotBeaconTone')"
+                                :help="$t('configurationUseDshotBeeper')"
+                            >
+                                <USelect
+                                    v-model="dshotBeaconTone"
+                                    class="min-w-24"
+                                    :items="[
+                                        { label: $t('portsTelemetryDisabled'), value: 0 },
+                                        ...[1, 2, 3, 4, 5].map((i) => ({ label: String(i), value: i })),
+                                    ]"
+                                />
+                            </SettingRow>
+                            <div class="flex gap-2">
+                                <UButton
+                                    :label="$t('configurationBeeperEnableAll')"
+                                    @click="enableAllDshot"
+                                    size="xs"
+                                />
+                                <UButton
+                                    :label="$t('configurationBeeperDisableAll')"
+                                    @click="disableAllDshot"
+                                    size="xs"
+                                />
+                            </div>
+                            <SettingRow v-for="cond in dshotBeaconConditionsList" :key="cond.bit" fullWidth>
+                                <USwitch
+                                    :model-value="isDshotConditionEnabled(cond)"
+                                    @update:model-value="(checked) => toggleDshotCondition(cond, checked)"
+                                />
+                                <template #label>
+                                    <span class="w-20 shrink-0 font-bold text-xs leading-snug">{{ cond.name }}</span>
+                                    <span
+                                        class="min-w-0 flex-1 text-xs leading-snug"
+                                        v-html="$t('beeper' + cond.name)"
+                                    ></span>
+                                </template>
+                            </SettingRow>
+                        </UiBox>
+                    </div>
 
-                <div class="col-span-1">
-                    <!-- BEEPER CONFIGURATION -->
-                    <UiBox :title="$t('configurationBeeper')">
-                        <div class="flex gap-2">
-                            <UButton :label="$t('configurationBeeperEnableAll')" @click="enableAllBeepers" size="xs" />
-                            <UButton
-                                :label="$t('configurationBeeperDisableAll')"
-                                @click="disableAllBeepers"
-                                size="xs"
-                            />
-                        </div>
-                        <SettingRow
-                            v-for="beeper in beepersList"
-                            :key="beeper.bit"
-                            v-show="beeper.visible !== false"
-                            fullWidth
-                        >
-                            <USwitch
-                                :model-value="isBeeperEnabled(beeper)"
-                                @update:model-value="(checked) => toggleBeeper(beeper, checked)"
-                            />
-                            <template #label>
-                                <span class="w-48 shrink-0 font-bold text-xs leading-snug">{{ beeper.name }}</span>
-                                <span
-                                    class="min-w-0 flex-1 text-xs leading-snug"
-                                    v-html="$t('beeper' + beeper.name)"
-                                ></span>
-                            </template>
-                        </SettingRow>
-                    </UiBox>
+                    <div class="col-span-1">
+                        <!-- BEEPER CONFIGURATION -->
+                        <UiBox :title="$t('configurationBeeper')" type="neutral" collapsible>
+                            <div class="flex gap-2">
+                                <UButton
+                                    :label="$t('configurationBeeperEnableAll')"
+                                    @click="enableAllBeepers"
+                                    size="xs"
+                                />
+                                <UButton
+                                    :label="$t('configurationBeeperDisableAll')"
+                                    @click="disableAllBeepers"
+                                    size="xs"
+                                />
+                            </div>
+                            <SettingRow
+                                v-for="beeper in beepersList"
+                                :key="beeper.bit"
+                                v-show="beeper.visible !== false"
+                                fullWidth
+                            >
+                                <USwitch
+                                    :model-value="isBeeperEnabled(beeper)"
+                                    @update:model-value="(checked) => toggleBeeper(beeper, checked)"
+                                />
+                                <template #label>
+                                    <span class="w-48 shrink-0 font-bold text-xs leading-snug">{{ beeper.name }}</span>
+                                    <span
+                                        class="min-w-0 flex-1 text-xs leading-snug"
+                                        v-html="$t('beeper' + beeper.name)"
+                                    ></span>
+                                </template>
+                            </SettingRow>
+                        </UiBox>
+                    </div>
                 </div>
             </div>
+            <div class="content_toolbar toolbar_fixed_bottom">
+                <UButton :label="$t('configurationButtonSave')" size="xs" :loading="isSaving" @click="saveConfig" />
+            </div>
         </div>
-        <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('configurationButtonSave')" :loading="isSaving" @click="saveConfig" />
-        </div>
-    </div>
+    </BaseTab>
 </template>
 
 <script>
@@ -211,6 +235,7 @@ import { i18n } from "../../js/localization";
 import semver from "semver";
 import { API_VERSION_1_45, API_VERSION_1_46 } from "../../js/data_storage";
 import { updateTabList } from "../../js/utils/updateTabList";
+import BaseTab from "./BaseTab.vue";
 import WikiButton from "../elements/WikiButton.vue";
 import UiBox from "../elements/UiBox.vue";
 import SettingRow from "../elements/SettingRow.vue";
@@ -218,6 +243,7 @@ import SettingRow from "../elements/SettingRow.vue";
 export default defineComponent({
     name: "ConfigurationTab",
     components: {
+        BaseTab,
         WikiButton,
         UiBox,
         SettingRow,

--- a/src/components/tabs/FailsafeTab.vue
+++ b/src/components/tabs/FailsafeTab.vue
@@ -52,7 +52,6 @@
                                             :label="badge.label"
                                             color="neutral"
                                             variant="subtle"
-                                            size="sm"
                                         />
                                     </span>
                                 </div>
@@ -358,7 +357,7 @@
                                     <USwitch
                                         v-model="gpsRescueAllowArmingWithoutFix"
                                         :disabled="isGpsSettingsDisabled"
-                                        size="sm"
+                                        size="xs"
                                     />
                                 </SettingRow>
                                 <SettingRow :label="$t('failsafeGpsRescueItemSanityChecks')">

--- a/src/components/tabs/FailsafeTab.vue
+++ b/src/components/tabs/FailsafeTab.vue
@@ -2,9 +2,7 @@
     <BaseTab tab-name="failsafe">
         <div class="content_wrapper">
             <div class="tab_title" v-html="$t('tabFailsafe')"></div>
-            <div class="cf_doc_version_bt">
-                <WikiButton docUrl="Failsafe" />
-            </div>
+            <WikiButton docUrl="Failsafe" />
 
             <UiBox type="warning" highlight class="mb-4">
                 <p class="text-sm" v-html="$t('failsafeFeaturesHelpNew')"></p>
@@ -14,7 +12,7 @@
                 <!-- Left Column -->
                 <div class="flex flex-col gap-4">
                     <!-- Pulse Range Settings -->
-                    <UiBox :title="$t('failsafePulsrangeTitle')" :help="$t('failsafePulsrangeHelp')">
+                    <UiBox :title="$t('failsafePulsrangeTitle')" type="neutral" collapsible>
                         <SettingRow :label="$t('failsafeRxMinUsecItem')">
                             <UInputNumber
                                 v-model="rxConfig.rx_min_usec"
@@ -42,10 +40,7 @@
                     </UiBox>
 
                     <!-- Channel Fallback Settings -->
-                    <UiBox
-                        :title="$t('failsafeChannelFallbackSettingsTitle')"
-                        :help="$t('failsafeChannelFallbackSettingsHelp')"
-                    >
+                    <UiBox :title="$t('failsafeChannelFallbackSettingsTitle')" type="neutral" collapsible>
                         <div class="grid grid-cols-[minmax(10rem,1fr)_7rem_5rem] gap-x-3 gap-y-1.5 items-center">
                             <template v-for="(channel, index) in activeChannels" :key="index">
                                 <div>
@@ -86,7 +81,7 @@
                 <!-- Right Column -->
                 <div class="flex flex-col gap-4">
                     <!-- Failsafe Switch -->
-                    <UiBox :title="$t('failsafeSwitchTitle')">
+                    <UiBox :title="$t('failsafeSwitchTitle')" type="neutral" collapsible>
                         <SettingRow :label="$t('failsafeSwitchModeItem')" :help="$t('failsafeSwitchModeHelp')">
                             <USelect
                                 v-model="failsafeConfig.failsafe_switch_mode"
@@ -97,7 +92,7 @@
                     </UiBox>
 
                     <!-- Stage 2 Settings -->
-                    <UiBox :title="$t('failsafeStageTwoSettingsTitle')">
+                    <UiBox :title="$t('failsafeStageTwoSettingsTitle')" type="neutral" collapsible>
                         <SettingRow :label="$t('failsafeDelayItem')" :help="$t('failsafeDelayHelp')">
                             <UInputNumber
                                 v-model="failsafeDelay"
@@ -383,7 +378,12 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('configurationButtonSave')" :disabled="!configHasChanged" @click="saveConfig" />
+            <UButton
+                :label="$t('configurationButtonSave')"
+                :disabled="!configHasChanged"
+                size="xs"
+                @click="saveConfig"
+            />
         </div>
     </BaseTab>
 </template>

--- a/src/components/tabs/FirmwareFlasherTab.vue
+++ b/src/components/tabs/FirmwareFlasherTab.vue
@@ -45,7 +45,7 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UFieldGroup size="sm" orientation="horizontal" class="flex!">
+            <UFieldGroup size="xs" orientation="horizontal" class="flex!">
                 <UButton
                     :disabled="state.flashButtonDisabled || activeFlasherStep !== 'flash'"
                     :color="state.flashButtonDisabled || activeFlasherStep !== 'flash' ? 'neutral' : 'success'"
@@ -63,7 +63,7 @@
                     />
                 </UDropdownMenu>
             </UFieldGroup>
-            <UFieldGroup size="sm" orientation="horizontal" class="flex!">
+            <UFieldGroup size="xs" orientation="horizontal" class="flex!">
                 <UButton :disabled="state.loadRemoteButtonDisabled" @click="handleLoadRemoteFile">{{
                     $t("firmwareFlasherButtonLoadOnline")
                 }}</UButton>

--- a/src/components/tabs/FlightPlan/ElevationProfile.vue
+++ b/src/components/tabs/FlightPlan/ElevationProfile.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('flightPlanElevationProfile')" class="elevation-profile">
+    <UiBox :title="$t('flightPlanElevationProfile')" type="neutral" collapsible class="elevation-profile">
         <template v-if="waypoints.length > 0">
             <div class="profile-stats">
                 <span class="stat">

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -1,6 +1,6 @@
 <template>
-    <UiBox :title="$t('flightPlanMap')" type="neutral" collapsible class="flight-plan-map">
-        <div class="map-container">
+    <UiBox :title="$t('flightPlanMap')" type="neutral" collapsible class="flight-plan-map" @toggle="onUiBoxToggle">
+        <div ref="mapContainerRef" class="map-container">
             <div ref="mapRef" class="map"></div>
             <div v-if="isLoading" class="map-loading">
                 <div class="loading-message">
@@ -15,7 +15,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onUnmounted } from "vue";
+import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import { initMap } from "@/js/utils/map";
 import { fromLonLat, toLonLat } from "ol/proj";
@@ -35,6 +35,7 @@ const { waypoints, positionalWaypoints, selectedWaypointUid, selectWaypoint, add
 const sortedWaypoints = positionalWaypoints;
 
 const mapRef = ref(null);
+const mapContainerRef = ref(null);
 const mapInstance = ref(null);
 const waypointLayer = ref(null);
 const pathLayer = ref(null);
@@ -291,6 +292,9 @@ const setupMapLayers = () => {
     // Initial map update
     updateMapFeatures();
 
+    // Observe container size changes (reopen from collapsed, window resize, etc.)
+    maybeSetupResizeObserver();
+
     // Map is now ready
     isLoading.value = false;
 };
@@ -481,9 +485,61 @@ watch(
     },
 );
 
+// ResizeObserver for reopening after collapse — OpenLayers needs updateSize()
+// when its container was hidden during initialization or became visible later.
+let resizeObserver = null;
+
+const setupResizeObserver = () => {
+    if (!mapContainerRef.value || !mapInstance.value?.map) {
+        return;
+    }
+
+    resizeObserver = new ResizeObserver((entries) => {
+        // Only trigger when container actually grew (reopened from collapsed)
+        for (const entry of entries) {
+            const { width, height } = entry.contentRect;
+            if ((width > 0 || height > 0) && mapInstance.value?.map) {
+                mapInstance.value.map.updateSize();
+                console.log("Map resized after container visibility change");
+                break;
+            }
+        }
+    });
+
+    resizeObserver.observe(mapContainerRef.value);
+};
+
+// Setup ResizeObserver after map is initialized
+const maybeSetupResizeObserver = async () => {
+    await nextTick();
+    if (mapContainerRef.value && mapInstance.value?.map) {
+        setupResizeObserver();
+    }
+};
+
+// Handle UiBox toggle — call updateSize when reopened so OpenLayers
+// recalculates dimensions after the container goes from display:none to visible.
+const onUiBoxToggle = (isOpen) => {
+    if (isOpen && mapInstance.value?.map) {
+        // v-show changes visibility, but OpenLayers can't measure correct
+        // dimensions until after the browser has painted.  Use requestAnimationFrame
+        // *after* nextTick so both Vue's DOM flush and one paint cycle are done.
+        nextTick(() => {
+            requestAnimationFrame(() => {
+                mapInstance.value.map.updateSize();
+                console.log("Map resized after UiBox reopen");
+            });
+        });
+    }
+};
+
 // Cleanup on unmount
 onUnmounted(() => {
     console.log("Cleaning up map");
+    if (resizeObserver && mapContainerRef.value) {
+        resizeObserver.unobserve(mapContainerRef.value);
+        resizeObserver.disconnect();
+    }
     if (mapInstance.value?.destroy) {
         mapInstance.value.destroy();
     }

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('flightPlanMap')" type="neutral" collapsible class="flight-plan-map" @toggle="onUiBoxToggle">
+    <UiBox :title="$t('flightPlanMap')" type="neutral" collapsible class="flight-plan-map">
         <div ref="mapContainerRef" class="map-container">
             <div ref="mapRef" class="map"></div>
             <div v-if="isLoading" class="map-loading">
@@ -15,7 +15,7 @@
 </template>
 
 <script setup>
-import { ref, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { ref, watch, onMounted, onUnmounted } from "vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import { initMap } from "@/js/utils/map";
 import { fromLonLat, toLonLat } from "ol/proj";
@@ -86,6 +86,10 @@ onMounted(async () => {
         console.error("Map ref not available");
         return;
     }
+
+    // Attach before the map exists: geolocation makes initialization async, and the
+    // observer only needs the container.
+    observeMapContainer();
 
     // Final fallback coordinates (Sydney Harbour Bridge, Australia)
     const finalFallbackLat = -33.8523;
@@ -292,11 +296,35 @@ const setupMapLayers = () => {
     // Initial map update
     updateMapFeatures();
 
-    // Observe container size changes (reopen from collapsed, window resize, etc.)
-    maybeSetupResizeObserver();
-
     // Map is now ready
     isLoading.value = false;
+};
+
+// The map lives inside a collapsible UiBox, so it can be laid out while it has no
+// box at all.  OpenLayers caches its viewport size and will not notice when the
+// container becomes visible again, leaving a blank or clipped map — watch the
+// container instead of any single trigger, which also covers window resizes.
+let resizeObserver = null;
+
+const observeMapContainer = () => {
+    if (resizeObserver || !mapContainerRef.value) {
+        return;
+    }
+
+    resizeObserver = new ResizeObserver((entries) => {
+        const mapObj = mapInstance.value?.map;
+        if (!mapObj) {
+            return;
+        }
+        for (const { contentRect } of entries) {
+            if (contentRect.width > 0 && contentRect.height > 0) {
+                mapObj.updateSize();
+                break;
+            }
+        }
+    });
+
+    resizeObserver.observe(mapContainerRef.value);
 };
 
 // Update path lines during drag in real-time
@@ -485,60 +513,12 @@ watch(
     },
 );
 
-// ResizeObserver for reopening after collapse — OpenLayers needs updateSize()
-// when its container was hidden during initialization or became visible later.
-let resizeObserver = null;
-
-const setupResizeObserver = () => {
-    if (!mapContainerRef.value || !mapInstance.value?.map) {
-        return;
-    }
-
-    resizeObserver = new ResizeObserver((entries) => {
-        // Only trigger when container actually grew (reopened from collapsed)
-        for (const entry of entries) {
-            const { width, height } = entry.contentRect;
-            if ((width > 0 || height > 0) && mapInstance.value?.map) {
-                mapInstance.value.map.updateSize();
-                console.log("Map resized after container visibility change");
-                break;
-            }
-        }
-    });
-
-    resizeObserver.observe(mapContainerRef.value);
-};
-
-// Setup ResizeObserver after map is initialized
-const maybeSetupResizeObserver = async () => {
-    await nextTick();
-    if (mapContainerRef.value && mapInstance.value?.map) {
-        setupResizeObserver();
-    }
-};
-
-// Handle UiBox toggle — call updateSize when reopened so OpenLayers
-// recalculates dimensions after the container goes from display:none to visible.
-const onUiBoxToggle = (isOpen) => {
-    if (isOpen && mapInstance.value?.map) {
-        // v-show changes visibility, but OpenLayers can't measure correct
-        // dimensions until after the browser has painted.  Use requestAnimationFrame
-        // *after* nextTick so both Vue's DOM flush and one paint cycle are done.
-        nextTick(() => {
-            requestAnimationFrame(() => {
-                mapInstance.value.map.updateSize();
-                console.log("Map resized after UiBox reopen");
-            });
-        });
-    }
-};
-
 // Cleanup on unmount
 onUnmounted(() => {
     console.log("Cleaning up map");
-    if (resizeObserver && mapContainerRef.value) {
-        resizeObserver.unobserve(mapContainerRef.value);
+    if (resizeObserver) {
         resizeObserver.disconnect();
+        resizeObserver = null;
     }
     if (mapInstance.value?.destroy) {
         mapInstance.value.destroy();

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('flightPlanMap')" class="flight-plan-map">
+    <UiBox :title="$t('flightPlanMap')" type="neutral" collapsible class="flight-plan-map">
         <div class="map-container">
             <div ref="mapRef" class="map"></div>
             <div v-if="isLoading" class="map-loading">

--- a/src/components/tabs/FlightPlan/FlightPlanMap.vue
+++ b/src/components/tabs/FlightPlan/FlightPlanMap.vue
@@ -26,6 +26,7 @@ import { Vector as SourceVector } from "ol/source";
 import { Style, Stroke, Circle, Fill, Text } from "ol/style";
 import { DragPan } from "ol/interaction";
 import { useFlightPlan } from "@/composables/useFlightPlan";
+import { useMapViewport } from "@/composables/useMapViewport";
 
 const { waypoints, positionalWaypoints, selectedWaypointUid, selectWaypoint, addWaypointAtLocation, updateWaypoint } =
     useFlightPlan();
@@ -37,6 +38,10 @@ const sortedWaypoints = positionalWaypoints;
 const mapRef = ref(null);
 const mapContainerRef = ref(null);
 const mapInstance = ref(null);
+const { observeContainer, teardown: teardownMapViewport } = useMapViewport(
+    mapContainerRef,
+    () => mapInstance.value?.map,
+);
 const waypointLayer = ref(null);
 const pathLayer = ref(null);
 const draggingWaypointUid = ref(null);
@@ -89,7 +94,7 @@ onMounted(async () => {
 
     // Attach before the map exists: geolocation makes initialization async, and the
     // observer only needs the container.
-    observeMapContainer();
+    observeContainer();
 
     // Final fallback coordinates (Sydney Harbour Bridge, Australia)
     const finalFallbackLat = -33.8523;
@@ -300,33 +305,6 @@ const setupMapLayers = () => {
     isLoading.value = false;
 };
 
-// The map lives inside a collapsible UiBox, so it can be laid out while it has no
-// box at all.  OpenLayers caches its viewport size and will not notice when the
-// container becomes visible again, leaving a blank or clipped map — watch the
-// container instead of any single trigger, which also covers window resizes.
-let resizeObserver = null;
-
-const observeMapContainer = () => {
-    if (resizeObserver || !mapContainerRef.value) {
-        return;
-    }
-
-    resizeObserver = new ResizeObserver((entries) => {
-        const mapObj = mapInstance.value?.map;
-        if (!mapObj) {
-            return;
-        }
-        for (const { contentRect } of entries) {
-            if (contentRect.width > 0 && contentRect.height > 0) {
-                mapObj.updateSize();
-                break;
-            }
-        }
-    });
-
-    resizeObserver.observe(mapContainerRef.value);
-};
-
 // Update path lines during drag in real-time
 const updatePathDuringDrag = (draggingUid, newCoordinates) => {
     if (!pathLayer.value) {
@@ -516,10 +494,7 @@ watch(
 // Cleanup on unmount
 onUnmounted(() => {
     console.log("Cleaning up map");
-    if (resizeObserver) {
-        resizeObserver.disconnect();
-        resizeObserver = null;
-    }
+    teardownMapViewport();
     if (mapInstance.value?.destroy) {
         mapInstance.value.destroy();
     }

--- a/src/components/tabs/FlightPlan/WaypointEditor.vue
+++ b/src/components/tabs/FlightPlan/WaypointEditor.vue
@@ -1,7 +1,7 @@
 <template>
     <Dialog v-model="showEditorDialog" :title="editMode ? $t('flightPlanEditWaypoint') : $t('flightPlanAddWaypoint')">
         <form ref="formElement" class="editor-form flex flex-col gap-3" @submit.prevent="handleSave">
-            <SettingRow :label="$t('flightPlanType')" full-width>
+            <SettingRow :label="$t('flightPlanType')" fullWidth>
                 <!-- content z must clear the Dialog overlay/content (z-3000/3001) or the
                      teleported option list renders behind the modal and can't be clicked. -->
                 <USelect
@@ -13,7 +13,7 @@
                 />
             </SettingRow>
 
-            <SettingRow v-if="showPosition" :label="$t('flightPlanLatitude')" full-width>
+            <SettingRow v-if="showPosition" :label="$t('flightPlanLatitude')" fullWidth>
                 <UInputNumber
                     v-model="form.latitude"
                     :step="0.000001"
@@ -25,7 +25,7 @@
                 />
             </SettingRow>
 
-            <SettingRow v-if="showPosition" :label="$t('flightPlanLongitude')" full-width>
+            <SettingRow v-if="showPosition" :label="$t('flightPlanLongitude')" fullWidth>
                 <UInputNumber
                     v-model="form.longitude"
                     :step="0.000001"
@@ -37,7 +37,7 @@
                 />
             </SettingRow>
 
-            <SettingRow v-if="showAltitude" :label="$t('flightPlanAltitude')" full-width>
+            <SettingRow v-if="showAltitude" :label="$t('flightPlanAltitude')" fullWidth>
                 <UInputNumber
                     v-model="form.altitude"
                     :step="1"
@@ -49,7 +49,7 @@
                 />
             </SettingRow>
 
-            <SettingRow v-if="showSpeed" :label="$t('flightPlanSpeed')" full-width>
+            <SettingRow v-if="showSpeed" :label="$t('flightPlanSpeed')" fullWidth>
                 <UInputNumber
                     v-model="form.speed"
                     :step="0.1"
@@ -61,7 +61,7 @@
                 />
             </SettingRow>
 
-            <SettingRow v-if="showYawRate" :label="$t('flightPlanYawRate')" full-width>
+            <SettingRow v-if="showYawRate" :label="$t('flightPlanYawRate')" fullWidth>
                 <UInputNumber
                     v-model="form.speed"
                     :step="1"
@@ -73,7 +73,7 @@
                 />
             </SettingRow>
 
-            <SettingRow v-if="showDuration" :label="durationLabel" full-width>
+            <SettingRow v-if="showDuration" :label="durationLabel" fullWidth>
                 <UInputNumber
                     v-model="form.duration"
                     :step="0.1"
@@ -84,7 +84,7 @@
                 />
             </SettingRow>
 
-            <SettingRow v-if="form.type === 'hold'" :label="$t('flightPlanPattern')" full-width>
+            <SettingRow v-if="form.type === 'hold'" :label="$t('flightPlanPattern')" fullWidth>
                 <USelect
                     v-model="form.pattern"
                     :items="patternItems"

--- a/src/components/tabs/FlightPlan/WaypointList.vue
+++ b/src/components/tabs/FlightPlan/WaypointList.vue
@@ -1,15 +1,15 @@
 <template>
-    <UiBox :title="$t('flightPlanWaypointList')" class="waypoint-list">
+    <UiBox :title="$t('flightPlanWaypointList')" type="neutral" collapsible class="waypoint-list">
         <div class="flex justify-end">
             <UButton
                 icon="i-lucide-plus"
-                size="sm"
+                size="xs"
                 :aria-label="$t('flightPlanAddWaypoint')"
                 @click="handleAddWaypoint"
             />
         </div>
 
-        <UiBox highlight class="mb-3" v-if="!waypoints.length">
+        <UiBox type="neutral" highlight class="mb-3" v-if="!waypoints.length">
             <p v-html="$t('flightPlanNoWaypoints')"></p>
         </UiBox>
         <div v-else class="waypoints">

--- a/src/components/tabs/FlightPlanTab.vue
+++ b/src/components/tabs/FlightPlanTab.vue
@@ -56,13 +56,19 @@
 
         <!-- Bottom toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom flex items-center gap-2">
-            <UButton variant="soft" color="error" @click="handleClear">
+            <UButton variant="soft" color="error" size="xs" @click="handleClear">
                 {{ $t("flightPlanClear") }}
             </UButton>
-            <UButton variant="soft" :disabled="!canUseFC" :title="$t('flightPlanLoadFromFC')" @click="handleLoad">
+            <UButton
+                variant="soft"
+                :disabled="!canUseFC"
+                :title="$t('flightPlanLoadFromFC')"
+                size="xs"
+                @click="handleLoad"
+            >
                 {{ $t("flightPlanLoad") }}
             </UButton>
-            <UButton :disabled="!canUseFC" :title="$t('flightPlanSaveToFC')" @click="handleSave">
+            <UButton :disabled="!canUseFC" :title="$t('flightPlanSaveToFC')" size="xs" @click="handleSave">
                 {{ $t("save") }}
             </UButton>
         </div>

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -64,7 +64,8 @@
                     <!-- GPS Signal Strength -->
                     <UiBox
                         :title="$t('gpsSignalStrHead')"
-                        type="neutral"
+                        :type="hasGpsSensor ? 'neutral' : 'warning'"
+                        :highlight="!hasGpsSensor"
                         collapsible
                         :help="$t('gpsSignalStrHeadHelp')"
                     >
@@ -173,7 +174,7 @@
                     </UiBox>
 
                     <!-- GPS Map -->
-                    <UiBox :title="$t('gpsMapHead')" type="neutral" collapsible>
+                    <UiBox :title="$t('gpsMapHead')" type="neutral" collapsible @toggle="onUiBoxToggle">
                         <div
                             v-show="showConnect"
                             class="flex flex-col items-center justify-center h-[433px] gap-2 text-center"
@@ -434,6 +435,9 @@ export default defineComponent({
         const mapLink = computed(() => {
             return `https://maps.google.com/?q=${gpsInfo.latitude},${gpsInfo.longitude}`;
         });
+
+        // Track UiBox open state to trigger OpenLayers updateSize on reopen.
+        const uiBoxOpen = ref(false);
 
         const showConnect = computed(() => !isOnline.value);
         const showWaiting = computed(() => isOnline.value && !showMap.value);
@@ -714,6 +718,51 @@ export default defineComponent({
             MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, getCompGpsData);
         };
 
+        // ResizeObserver for reopening after UiBox collapse — OpenLayers needs updateSize()
+        // when its container was hidden during initialization or became visible later.
+        let resizeObserver = null;
+
+        const setupResizeObserver = () => {
+            if (!mapContainerRef.value || !mapInstance.value?.map) {
+                return;
+            }
+
+            resizeObserver = new ResizeObserver((entries) => {
+                for (const entry of entries) {
+                    const { width, height } = entry.contentRect;
+                    if ((width > 0 || height > 0) && mapInstance.value?.map) {
+                        mapInstance.value.map.updateSize();
+                        break;
+                    }
+                }
+            });
+
+            resizeObserver.observe(mapContainerRef.value);
+        };
+
+        // Handle UiBox toggle — call updateSize when reopened so OpenLayers
+        // recalculates dimensions after the container goes from display:none to visible.
+        const onUiBoxToggle = (isOpen) => {
+            uiBoxOpen.value = isOpen;
+            if (isOpen && mapInstance.value?.map) {
+                // v-show changes visibility, but OpenLayers can't measure correct
+                // dimensions until after the browser has painted.  Use requestAnimationFrame
+                // *after* nextTick so both Vue's DOM flush and one paint cycle are done.
+                nextTick(() => {
+                    requestAnimationFrame(() => {
+                        mapInstance.value.map.updateSize();
+                    });
+                });
+            }
+        };
+
+        const maybeSetupResizeObserver = async () => {
+            await nextTick();
+            if (mapContainerRef.value && mapInstance.value?.map) {
+                setupResizeObserver();
+            }
+        };
+
         const { addInterval, removeAllIntervals } = useInterval();
 
         const checkConnectivity = () => {
@@ -779,7 +828,10 @@ export default defineComponent({
             if (mapInstance.value || !mapRef.value) return;
             mapInstance.value = initMap({ target: mapRef.value, defaultLayer: activeLayer.value });
             setLayer(activeLayer.value);
-            nextTick(() => mapInstance.value?.map?.updateSize());
+            nextTick(() => {
+                mapInstance.value?.map?.updateSize();
+                maybeSetupResizeObserver();
+            });
         };
 
         const onGpsProtocolChange = () => {
@@ -805,6 +857,10 @@ export default defineComponent({
             document.removeEventListener("fullscreenchange", handleFullscreenChange);
             document.removeEventListener("webkitfullscreenchange", handleFullscreenChange);
             document.removeEventListener("MSFullscreenChange", handleFullscreenChange);
+            if (resizeObserver && mapContainerRef.value) {
+                resizeObserver.unobserve(mapContainerRef.value);
+                resizeObserver.disconnect();
+            }
             if (mapInstance.value?.destroy) {
                 mapInstance.value.destroy();
             }
@@ -827,6 +883,7 @@ export default defineComponent({
                             mapObj.renderSync();
                         }
                     }
+                    maybeSetupResizeObserver();
                 });
             }
         });
@@ -853,6 +910,8 @@ export default defineComponent({
             showUbloxSbas,
             showPositionalDop,
             mapLink,
+            uiBoxOpen,
+            onUiBoxToggle,
             showConnect,
             showWaiting,
             showLoadMap,

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -174,7 +174,7 @@
                     </UiBox>
 
                     <!-- GPS Map -->
-                    <UiBox :title="$t('gpsMapHead')" type="neutral" collapsible @toggle="onUiBoxToggle">
+                    <UiBox :title="$t('gpsMapHead')" type="neutral" collapsible>
                         <div
                             v-show="showConnect"
                             class="flex flex-col items-center justify-center h-[433px] gap-2 text-center"
@@ -435,9 +435,6 @@ export default defineComponent({
         const mapLink = computed(() => {
             return `https://maps.google.com/?q=${gpsInfo.latitude},${gpsInfo.longitude}`;
         });
-
-        // Track UiBox open state to trigger OpenLayers updateSize on reopen.
-        const uiBoxOpen = ref(false);
 
         const showConnect = computed(() => !isOnline.value);
         const showWaiting = computed(() => isOnline.value && !showMap.value);
@@ -718,49 +715,32 @@ export default defineComponent({
             MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, getCompGpsData);
         };
 
-        // ResizeObserver for reopening after UiBox collapse — OpenLayers needs updateSize()
-        // when its container was hidden during initialization or became visible later.
+        // The map lives inside a collapsible UiBox and a v-show'd container, so it can be
+        // laid out while it has no box at all.  OpenLayers caches its viewport size and
+        // will not notice when the container becomes visible again, leaving a blank or
+        // clipped map — watch the container instead of any single trigger, which also
+        // covers window resizes and layout changes.
         let resizeObserver = null;
 
-        const setupResizeObserver = () => {
-            if (!mapContainerRef.value || !mapInstance.value?.map) {
+        const observeMapContainer = () => {
+            if (resizeObserver || !mapContainerRef.value) {
                 return;
             }
 
             resizeObserver = new ResizeObserver((entries) => {
-                for (const entry of entries) {
-                    const { width, height } = entry.contentRect;
-                    if ((width > 0 || height > 0) && mapInstance.value?.map) {
-                        mapInstance.value.map.updateSize();
+                const mapObj = mapInstance.value?.map;
+                if (!mapObj) {
+                    return;
+                }
+                for (const { contentRect } of entries) {
+                    if (contentRect.width > 0 && contentRect.height > 0) {
+                        mapObj.updateSize();
                         break;
                     }
                 }
             });
 
             resizeObserver.observe(mapContainerRef.value);
-        };
-
-        // Handle UiBox toggle — call updateSize when reopened so OpenLayers
-        // recalculates dimensions after the container goes from display:none to visible.
-        const onUiBoxToggle = (isOpen) => {
-            uiBoxOpen.value = isOpen;
-            if (isOpen && mapInstance.value?.map) {
-                // v-show changes visibility, but OpenLayers can't measure correct
-                // dimensions until after the browser has painted.  Use requestAnimationFrame
-                // *after* nextTick so both Vue's DOM flush and one paint cycle are done.
-                nextTick(() => {
-                    requestAnimationFrame(() => {
-                        mapInstance.value.map.updateSize();
-                    });
-                });
-            }
-        };
-
-        const maybeSetupResizeObserver = async () => {
-            await nextTick();
-            if (mapContainerRef.value && mapInstance.value?.map) {
-                setupResizeObserver();
-            }
         };
 
         const { addInterval, removeAllIntervals } = useInterval();
@@ -828,10 +808,7 @@ export default defineComponent({
             if (mapInstance.value || !mapRef.value) return;
             mapInstance.value = initMap({ target: mapRef.value, defaultLayer: activeLayer.value });
             setLayer(activeLayer.value);
-            nextTick(() => {
-                mapInstance.value?.map?.updateSize();
-                maybeSetupResizeObserver();
-            });
+            nextTick(() => mapInstance.value?.map?.updateSize());
         };
 
         const onGpsProtocolChange = () => {
@@ -843,6 +820,7 @@ export default defineComponent({
 
         onMounted(() => {
             nextTick(() => {
+                observeMapContainer();
                 initializeMap();
                 mapInstance.value?.map?.updateSize();
             });
@@ -857,9 +835,9 @@ export default defineComponent({
             document.removeEventListener("fullscreenchange", handleFullscreenChange);
             document.removeEventListener("webkitfullscreenchange", handleFullscreenChange);
             document.removeEventListener("MSFullscreenChange", handleFullscreenChange);
-            if (resizeObserver && mapContainerRef.value) {
-                resizeObserver.unobserve(mapContainerRef.value);
+            if (resizeObserver) {
                 resizeObserver.disconnect();
+                resizeObserver = null;
             }
             if (mapInstance.value?.destroy) {
                 mapInstance.value.destroy();
@@ -883,7 +861,7 @@ export default defineComponent({
                             mapObj.renderSync();
                         }
                     }
-                    maybeSetupResizeObserver();
+                    observeMapContainer();
                 });
             }
         });
@@ -910,8 +888,6 @@ export default defineComponent({
             showUbloxSbas,
             showPositionalDop,
             mapLink,
-            uiBoxOpen,
-            onUiBoxToggle,
             showConnect,
             showWaiting,
             showLoadMap,

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -285,6 +285,7 @@ import { useConnectionStore } from "@/stores/connection";
 import { useNavigationStore } from "@/stores/navigation";
 import { useDialogStore } from "@/stores/dialog";
 import { useInterval } from "../../composables/useInterval";
+import { useMapViewport } from "../../composables/useMapViewport";
 import { useSaving } from "../../composables/useSaving";
 import { useReboot } from "../../composables/useReboot";
 import WikiButton from "../elements/WikiButton.vue";
@@ -313,8 +314,13 @@ export default defineComponent({
         const mapRef = ref(null);
         const mapContainerRef = ref(null);
         const mapInstance = ref(null);
+        const {
+            isFullscreen,
+            toggleFullscreen,
+            observeContainer,
+            teardown: teardownMapViewport,
+        } = useMapViewport(mapContainerRef, () => mapInstance.value?.map);
         const activeLayer = ref("satellite");
-        const isFullscreen = ref(false);
         const isOnline = ref(false);
         const isWaiting = ref(true);
         const showMap = ref(false);
@@ -477,36 +483,6 @@ export default defineComponent({
         const zoomOut = () => {
             if (!mapInstance.value?.mapView) return;
             mapInstance.value.mapView.setZoom(mapInstance.value.mapView.getZoom() - 1);
-        };
-
-        const toggleFullscreen = () => {
-            const container = mapContainerRef.value;
-            if (!container) return;
-
-            if (!document.fullscreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement) {
-                if (container.requestFullscreen) {
-                    container.requestFullscreen();
-                } else if (container.webkitRequestFullscreen) {
-                    container.webkitRequestFullscreen();
-                } else if (container.msRequestFullscreen) {
-                    container.msRequestFullscreen();
-                }
-            } else if (document.exitFullscreen) {
-                document.exitFullscreen();
-            } else if (document.webkitExitFullscreen) {
-                document.webkitExitFullscreen();
-            } else if (document.msExitFullscreen) {
-                document.msExitFullscreen();
-            }
-        };
-
-        const handleFullscreenChange = () => {
-            isFullscreen.value = !!(
-                document.fullscreenElement ||
-                document.webkitFullscreenElement ||
-                document.msFullscreenElement
-            );
-            requestAnimationFrame(() => mapInstance.value?.map?.updateSize());
         };
 
         const getPositionalDopQuality = (positionalDop) => {
@@ -715,34 +691,6 @@ export default defineComponent({
             MSP.send_message(MSPCodes.MSP_RAW_GPS, false, false, getCompGpsData);
         };
 
-        // The map lives inside a collapsible UiBox and a v-show'd container, so it can be
-        // laid out while it has no box at all.  OpenLayers caches its viewport size and
-        // will not notice when the container becomes visible again, leaving a blank or
-        // clipped map — watch the container instead of any single trigger, which also
-        // covers window resizes and layout changes.
-        let resizeObserver = null;
-
-        const observeMapContainer = () => {
-            if (resizeObserver || !mapContainerRef.value) {
-                return;
-            }
-
-            resizeObserver = new ResizeObserver((entries) => {
-                const mapObj = mapInstance.value?.map;
-                if (!mapObj) {
-                    return;
-                }
-                for (const { contentRect } of entries) {
-                    if (contentRect.width > 0 && contentRect.height > 0) {
-                        mapObj.updateSize();
-                        break;
-                    }
-                }
-            });
-
-            resizeObserver.observe(mapContainerRef.value);
-        };
-
         const { addInterval, removeAllIntervals } = useInterval();
 
         const checkConnectivity = () => {
@@ -820,25 +768,16 @@ export default defineComponent({
 
         onMounted(() => {
             nextTick(() => {
-                observeMapContainer();
+                observeContainer();
                 initializeMap();
                 mapInstance.value?.map?.updateSize();
             });
             loadGpsConfig();
-            document.addEventListener("fullscreenchange", handleFullscreenChange);
-            document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
-            document.addEventListener("MSFullscreenChange", handleFullscreenChange);
         });
 
         const teardown = () => {
             removeAllIntervals();
-            document.removeEventListener("fullscreenchange", handleFullscreenChange);
-            document.removeEventListener("webkitfullscreenchange", handleFullscreenChange);
-            document.removeEventListener("MSFullscreenChange", handleFullscreenChange);
-            if (resizeObserver) {
-                resizeObserver.disconnect();
-                resizeObserver = null;
-            }
+            teardownMapViewport();
             if (mapInstance.value?.destroy) {
                 mapInstance.value.destroy();
             }
@@ -861,7 +800,7 @@ export default defineComponent({
                             mapObj.renderSync();
                         }
                     }
-                    observeMapContainer();
+                    observeContainer();
                 });
             }
         });

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -31,7 +31,7 @@
                                 :items="gpsProtocolItems"
                                 v-model="gpsConfig.provider"
                                 @update:model-value="onGpsProtocolChange"
-                                size="sm"
+                                size="xs"
                                 class="min-w-40"
                             />
                         </SettingRow>
@@ -57,7 +57,7 @@
                         </SettingRow>
 
                         <SettingRow v-if="showUbloxSbas" :label="$t('configurationGPSubxSbas')">
-                            <USelect :items="gpsSbasItems" v-model="gpsConfig.ublox_sbas" size="sm" class="min-w-40" />
+                            <USelect :items="gpsSbasItems" v-model="gpsConfig.ublox_sbas" size="xs" class="min-w-40" />
                         </SettingRow>
                     </UiBox>
 

--- a/src/components/tabs/GpsTab.vue
+++ b/src/components/tabs/GpsTab.vue
@@ -8,7 +8,12 @@
                 <!-- Left Column: Configuration + Signal Strength -->
                 <div class="lg:col-span-2 flex flex-col gap-4">
                     <!-- GPS Configuration -->
-                    <UiBox :title="$t('configurationGPS')" :help="$t('configurationGPSHelp')">
+                    <UiBox
+                        :title="$t('configurationGPS')"
+                        type="neutral"
+                        collapsible
+                        :help="$t('configurationGPSHelp')"
+                    >
                         <SettingRow
                             v-for="feature in gpsFeatures"
                             :key="feature.bit"
@@ -59,9 +64,9 @@
                     <!-- GPS Signal Strength -->
                     <UiBox
                         :title="$t('gpsSignalStrHead')"
+                        type="neutral"
+                        collapsible
                         :help="$t('gpsSignalStrHeadHelp')"
-                        :type="hasGpsSensor ? 'default' : 'warning'"
-                        :highlight="!hasGpsSensor"
                     >
                         <div v-if="!hasGpsSensor" class="text-center p-2 text-sm" v-html="$t('gpsSignalLost')"></div>
                         <div v-if="hasGpsSensor" class="text-xs">
@@ -108,7 +113,7 @@
                 <!-- Right Column: GPS Info + Map -->
                 <div class="lg:col-span-3 flex flex-col gap-4">
                     <!-- GPS Info -->
-                    <UiBox :title="$t('gpsHead')" :help="$t('gpsHeadHelp')">
+                    <UiBox :title="$t('gpsHead')" type="neutral" collapsible :help="$t('gpsHeadHelp')">
                         <div class="flex justify-between items-center">
                             <span v-html="$t('gps3dFix')"></span>
                             <span
@@ -168,13 +173,13 @@
                     </UiBox>
 
                     <!-- GPS Map -->
-                    <UiBox :title="$t('gpsMapHead')">
+                    <UiBox :title="$t('gpsMapHead')" type="neutral" collapsible>
                         <div
                             v-show="showConnect"
                             class="flex flex-col items-center justify-center h-[433px] gap-2 text-center"
                         >
                             <div>{{ $t("gpsMapMessage1") }}</div>
-                            <UButton variant="subtle" @click="checkConnectivity">
+                            <UButton variant="subtle" size="xs" @click="checkConnectivity">
                                 {{ $t("gpsMapRetry") }}
                             </UButton>
                         </div>
@@ -249,6 +254,7 @@
             </div> -->
             <UButton
                 :label="$t('configurationButtonSave')"
+                size="xs"
                 :disabled="!dirty"
                 :loading="isSaving"
                 @click="saveConfig"

--- a/src/components/tabs/HelpTab.vue
+++ b/src/components/tabs/HelpTab.vue
@@ -4,7 +4,7 @@
             <div class="tab_title">{{ $t("tabHelp") }}</div>
             <div class="grid-row grid-box col5">
                 <div class="col-span-3">
-                    <UiBox :title="$t('defaultDocumentationHead')" class="sm:h-full">
+                    <UiBox :title="$t('defaultDocumentationHead')" type="neutral" collapsible class="sm:h-full">
                         <p v-html="$t('defaultDocumentation')"></p>
                         <ul>
                             <li>
@@ -17,7 +17,7 @@
                     </UiBox>
                 </div>
                 <div class="col-span-2">
-                    <UiBox :title="$t('defaultSupportHead')" class="sm:h-full">
+                    <UiBox :title="$t('defaultSupportHead')" type="neutral" collapsible class="sm:h-full">
                         <p v-html="$t('defaultSupport')"></p>
                         <ul>
                             <li>

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -1467,7 +1467,7 @@ watch(auxChannelValue, (newVal) => {
     border: 2px solid var(--surface-600);
     border-radius: 6px;
     width: 167px;
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+    box-shadow: var(--shadow-popup);
 }
 
 .colorDefineSliderContainer {

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -4,7 +4,7 @@
             <div class="tab_title" v-html="$t('tabLedStrip')"></div>
             <WikiButton docUrl="led-strip" />
 
-            <UiBox type="neutral" collapsible class="mb-3">
+            <UiBox highlight class="mb-3">
                 <p v-html="$t('ledStripHelp')"></p>
             </UiBox>
 
@@ -243,6 +243,7 @@
                             <span class="colorDefineSliderValue Vvalue">{{ colorHSV.v }}</span>
                         </div>
                     </div>
+                    <!-- Color palette buttons (16 colored swatches) -->
                     <button
                         v-for="i in 16"
                         :key="`color-${i - 1}`"
@@ -286,7 +287,6 @@
                 <div class="section" v-html="$t('ledStripWiring')"></div>
                 <div class="wiring-container">
                     <UButton
-                        block
                         size="xs"
                         color="primary"
                         :variant="wireMode ? 'solid' : 'soft'"
@@ -320,7 +320,7 @@
 
         <!-- Bottom Toolbar -->
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="saveButtonText" :loading="isSaving" @click="save" />
+            <UButton size="xs" :label="saveButtonText" :loading="isSaving" @click="save" />
         </div>
     </BaseTab>
 </template>
@@ -942,9 +942,7 @@ function getModeColorButtonClass(mode, direction) {
 
 function getModeColorButtonStyle(mode, direction) {
     const colorIndex = getModeColor(mode, direction);
-    return {
-        backgroundColor: getColorStyle(colorIndex),
-    };
+    return { backgroundColor: getColorStyle(colorIndex) };
 }
 
 function getModeColorButtonLabel(direction) {
@@ -1166,58 +1164,47 @@ watch(auxChannelValue, (newVal) => {
     color: var(--error-500);
 }
 
-/* Buttons */
-button {
+/* Swatch buttons (mode colors, special colors, colour palette).
+ * These stay plain <button> elements because their background is driven by the
+ * LED colour data, but they follow the same radius/typography as UButton so the
+ * tab matches the rest of the UI.  The selectors are deliberately scoped to the
+ * swatch containers — a bare `button` rule would also hit every UButton on the
+ * tab and undo its Nuxt UI styling. */
+.mode_colors > button,
+.colors > button {
     text-align: center;
-    font-weight: bold;
+    font-weight: 500;
+    font-size: 12px;
+    line-height: 1;
     border: 1px solid var(--primary-600);
     background-color: var(--primary-500);
-    border-radius: 3px;
-    padding: 7px 6px;
-    margin: 3px 0;
+    border-radius: var(--ui-radius);
+    padding: 7px 10px;
+    margin: 3px 4px;
     cursor: pointer;
     transition: all 0.2s ease;
     color: black;
 }
 
-/* Buttons within controls - add left/right padding */
-.controls button {
-    padding: 7px 10px;
-    margin: 3px 4px;
-}
-
-button:hover:not(:disabled) {
+.mode_colors > button:hover:not(:disabled),
+.colors > button:hover:not(:disabled) {
     background-color: var(--primary-600);
     border-color: var(--primary-700);
 }
 
-button:active:not(:disabled) {
+.mode_colors > button:active:not(:disabled),
+.colors > button:active:not(:disabled) {
     transform: scale(0.98);
 }
 
-/* Disabled button styles */
-button:disabled,
-button.disabled {
+/* Disabled swatch buttons */
+.mode_colors > button:disabled,
+.colors > button:disabled {
     opacity: 0.5;
     cursor: not-allowed;
     background-color: var(--surface-300);
     border-color: var(--surface-500);
     color: white;
-}
-
-button:disabled:hover,
-button.disabled:hover {
-    background-color: var(--surface-300);
-    border-color: var(--surface-500);
-}
-
-button:disabled:active,
-button.disabled:active {
-    transform: none;
-}
-
-.save_btn {
-    min-width: 96px;
 }
 
 .w50 {
@@ -1363,6 +1350,105 @@ button.disabled:active {
     color: var(--text);
 }
 
+.colors {
+    height: 130px;
+    position: relative;
+    display: inline-grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: repeat(4, 1fr);
+    gap: 4px;
+    width: 49%;
+    vertical-align: middle;
+}
+
+/* Colors button defaults */
+.colors > button {
+    width: 100%;
+    height: 100%;
+    padding: 0;
+    margin: 0;
+    color: white;
+}
+
+.colors button:hover {
+    border-style: solid;
+}
+
+.colors button.btnOn {
+    border: 2px solid var(--text);
+}
+
+/* Default color backgrounds */
+.color-0 {
+    background: black;
+}
+
+.color-1 {
+    background: white;
+    color: black !important;
+}
+
+.color-2 {
+    background: red;
+}
+
+.color-3 {
+    background: orange;
+}
+
+.color-4 {
+    background: yellow;
+    color: black !important;
+}
+
+.color-5 {
+    background: greenyellow;
+    color: black !important;
+}
+
+.color-6 {
+    background: limegreen;
+}
+
+.color-7 {
+    background: palegreen;
+    color: black !important;
+}
+
+.color-8 {
+    background: cyan;
+    color: black !important;
+}
+
+.color-9 {
+    background: lightcyan;
+    color: black !important;
+}
+
+.color-10 {
+    background: dodgerblue;
+}
+
+.color-11 {
+    background: darkviolet;
+}
+
+.color-12 {
+    background: magenta;
+}
+
+.color-13 {
+    background: deeppink;
+}
+
+.color-14 {
+    background: black;
+}
+
+.color-15 {
+    background: black;
+}
+
 /* Color Define Sliders */
 .colorDefineSliders {
     display: none;
@@ -1457,111 +1543,8 @@ button.disabled:active {
     grid-row: 3;
 }
 
-/* Colors */
-.colors {
-    height: 130px;
-    position: relative;
-    display: inline-grid;
-    grid-template-columns: repeat(4, 1fr);
-    grid-template-rows: repeat(4, 1fr);
-    gap: 4px;
-    width: 49%;
-    vertical-align: middle;
-}
-
-.colors > button {
-    width: 100%;
-    height: 100%;
-    padding: 0;
-    color: white;
-}
-
-.colors button:hover {
-    border-style: solid;
-}
-
-.colors button.btnOn {
-    border: 2px solid var(--text);
-}
-
-/* Default color backgrounds */
-.color-0 {
-    background: black;
-}
-
-.color-1 {
-    background: white;
-    color: black !important;
-}
-
-.color-2 {
-    background: red;
-}
-
-.color-3 {
-    background: orange;
-}
-
-.color-4 {
-    background: yellow;
-    color: black !important;
-}
-
-.color-5 {
-    background: greenyellow;
-    color: black !important;
-}
-
-.color-6 {
-    background: limegreen;
-}
-
-.color-7 {
-    background: palegreen;
-    color: black !important;
-}
-
-.color-8 {
-    background: cyan;
-    color: black !important;
-}
-
-.color-9 {
-    background: lightcyan;
-    color: black !important;
-}
-
-.color-10 {
-    background: dodgerblue;
-}
-
-.color-11 {
-    background: darkviolet;
-}
-
-.color-12 {
-    background: magenta;
-}
-
-.color-13 {
-    background: deeppink;
-}
-
-.color-14 {
-    background: black;
-}
-
-.color-15 {
-    background: black;
-}
-
-/* Mode Colors */
+/* Mode / Special Color Buttons */
 .mode_colors button.btnOn {
-    border: 2px solid var(--text);
-}
-
-/* Special Colors */
-.special_colors button.btnOn {
     border: 2px solid var(--text);
 }
 

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -1183,6 +1183,14 @@ watch(auxChannelValue, (newVal) => {
     margin: 3px 4px;
     cursor: pointer;
     transition: all 0.2s ease;
+}
+
+/* Label contrast is chosen against the swatch background, not the theme: these
+ * buttons carry an inline background-color taken from the LED colour data (and
+ * --primary-500 until it loads), which does not follow light/dark mode.  var(--text)
+ * would turn the label white over a yellow or cyan swatch.  The palette swatches
+ * below pick their own literal per colour for the same reason. */
+.mode_colors > button {
     color: black;
 }
 

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -2,9 +2,9 @@
     <BaseTab tab-name="led-strip" @mounted="onTabMounted">
         <div class="content_wrapper" @keydown.esc="handleEscapeKey">
             <div class="tab_title" v-html="$t('tabLedStrip')"></div>
-            <WikiButton doc-url="led-strip" />
+            <WikiButton docUrl="led-strip" />
 
-            <UiBox highlight class="mb-3">
+            <UiBox type="neutral" collapsible class="mb-3">
                 <p v-html="$t('ledStripHelp')"></p>
             </UiBox>
 
@@ -39,7 +39,7 @@
                     <div class="clear-buttons-container">
                         <!-- Clear Buttons -->
                         <UButton
-                            size="sm"
+                            size="xs"
                             color="neutral"
                             variant="soft"
                             :disabled="!hasSelection"
@@ -47,7 +47,7 @@
                             @click="clearSelected"
                         />
                         <UButton
-                            size="sm"
+                            size="xs"
                             color="error"
                             variant="soft"
                             :label="$t('ledStripClearAllButton')"
@@ -63,7 +63,7 @@
                     <USelect
                         id="ledStripFunctionSelect"
                         :class="['functionSelect', 'min-w-48', selectedFunction]"
-                        size="sm"
+                        size="xs"
                         :items="functionItems"
                         v-model="selectedFunction"
                         @update:model-value="onFunctionChange"
@@ -77,7 +77,6 @@
                     <div class="modifier-row">
                         <USwitch
                             id="throttleHue"
-                            size="sm"
                             v-model="modifiers.throttleHue"
                             @update:model-value="onModifierChange('t')"
                             :label="$t('ledStripThrottleHue')"
@@ -85,7 +84,7 @@
                         <USelect
                             id="auxSelectThrottle"
                             class="auxSelect"
-                            size="sm"
+                            size="xs"
                             :items="auxChannelItems"
                             v-model="auxChannelValue"
                             :aria-label="$t('ledStripThrottleHueChannel')"
@@ -95,7 +94,6 @@
                     <div class="modifier-row">
                         <USwitch
                             id="larsonScanner"
-                            size="sm"
                             v-model="modifiers.larsonScanner"
                             @update:model-value="onModifierChange('o')"
                             :label="$t('ledStripLarsonOverlay')"
@@ -105,7 +103,6 @@
                     <div class="modifier-row">
                         <USwitch
                             id="blink"
-                            size="sm"
                             v-model="modifiers.blink"
                             @update:model-value="onModifierChange('b')"
                             :label="$t('ledStripBlinkAlwaysOverlay')"
@@ -115,7 +112,6 @@
                     <div class="modifier-row rainbowOverlay" v-show="showRainbow">
                         <USwitch
                             id="rainbow"
-                            size="sm"
                             v-model="modifiers.rainbow"
                             @update:model-value="onModifierChange('y')"
                             :label="$t('ledStripRainbowOverlay')"
@@ -143,7 +139,6 @@
                     <div class="modifier-row warningOverlay" v-show="showWarning">
                         <USwitch
                             id="warnings"
-                            size="sm"
                             v-model="overlayStates.warnings"
                             @update:model-value="onOverlayChange('w')"
                             :label="$t('ledStripWarningsOverlay')"
@@ -152,7 +147,6 @@
                     <div class="modifier-row indicatorOverlay">
                         <USwitch
                             id="indicator"
-                            size="sm"
                             v-model="overlayStates.indicator"
                             @update:model-value="onOverlayChange('i')"
                             :label="$t('ledStripIndecatorOverlay')"
@@ -161,7 +155,6 @@
                     <div class="modifier-row vtxOverlay" v-show="showVtx">
                         <USwitch
                             id="vtx"
-                            size="sm"
                             v-model="overlayStates.vtx"
                             @update:model-value="onOverlayChange('v')"
                             :label="$t('ledStripVtxOverlay')"
@@ -176,7 +169,7 @@
                     <USelect
                         id="ledStripModeColorsModeSelect"
                         class="modeSelect gps min-w-48"
-                        size="sm"
+                        size="xs"
                         :items="modeColorsModeItems"
                         v-model="modeColorsMode"
                     />
@@ -197,7 +190,7 @@
                     <UButton
                         v-for="dir in directions"
                         :key="dir"
-                        size="sm"
+                        size="xs"
                         color="primary"
                         :variant="activeDirections.has(dir) ? 'solid' : 'soft'"
                         :class="'dir-' + dir"
@@ -294,7 +287,7 @@
                 <div class="wiring-container">
                     <UButton
                         block
-                        size="sm"
+                        size="xs"
                         color="primary"
                         :variant="wireMode ? 'solid' : 'soft'"
                         :label="$t('ledStripWiringMode')"
@@ -302,7 +295,7 @@
                     />
                     <div class="wiringControls">
                         <UButton
-                            size="sm"
+                            size="xs"
                             color="neutral"
                             variant="soft"
                             class="w50"
@@ -310,7 +303,7 @@
                             @click="clearWiresSelected"
                         />
                         <UButton
-                            size="sm"
+                            size="xs"
                             color="error"
                             variant="soft"
                             class="w50"

--- a/src/components/tabs/LoggingTab.vue
+++ b/src/components/tabs/LoggingTab.vue
@@ -14,7 +14,7 @@
                             :model-value="selectedProperties.includes(prop.code)"
                             :disabled="isLogging || isBusy"
                             :label="prop.label"
-                            size="sm"
+                            size="xs"
                             class="w-44"
                             @update:model-value="toggleProperty(prop.code, $event)"
                         />
@@ -29,7 +29,7 @@
                     :items="speedItems"
                     :disabled="isLogging || isBusy"
                     class="w-28"
-                    size="sm"
+                    size="xs"
                 />
             </SettingRow>
 

--- a/src/components/tabs/LoggingTab.vue
+++ b/src/components/tabs/LoggingTab.vue
@@ -7,7 +7,7 @@
                 <p v-html="$t('loggingNote')"></p>
             </UiBox>
 
-            <UiBox :title="$t('loggingPropertiesTitle')" class="mt-6">
+            <UiBox :title="$t('loggingPropertiesTitle')" type="neutral" collapsible class="mt-6">
                 <div class="flex flex-col gap-1.5">
                     <div v-for="prop in propertyOptions" :key="prop.code" class="flex items-center gap-3">
                         <USwitch
@@ -23,7 +23,7 @@
                 </div>
             </UiBox>
 
-            <SettingRow :label="$t('loggingSamplingInterval')" class="mt-4">
+            <SettingRow :label="$t('loggingSamplingInterval')" fullWidth class="mt-4">
                 <USelect
                     v-model="samplingInterval"
                     :items="speedItems"
@@ -51,6 +51,7 @@
             <UButton
                 :label="$t('loggingButtonLogFile')"
                 :disabled="isLogging || isBusy"
+                size="xs"
                 @click="selectLogFile"
                 variant="soft"
             />
@@ -58,6 +59,7 @@
                 :label="startStopLabel"
                 :disabled="!canToggle"
                 :color="isLogging ? 'error' : selectedProperties.length ? 'success' : 'primary'"
+                size="xs"
                 @click="toggleLogging"
             />
         </div>

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -2,20 +2,18 @@
     <BaseTab tab-name="motors">
         <div class="content_wrapper">
             <div class="tab_title" v-html="$t('tabMotorTesting')"></div>
-            <div class="cf_doc_version_bt">
-                <WikiButton docUrl="motors" />
-            </div>
+            <WikiButton docUrl="motors" />
 
             <div class="grid-row grid-box col2 max-[1055px]:!grid-cols-1">
                 <div class="col-span-1">
                     <div class="flex flex-col gap-4">
                         <!-- MIXER -->
-                        <UiBox :title="$t('configurationMixer')">
+                        <UiBox :title="$t('configurationMixer')" type="neutral" collapsible>
                             <USelect v-model="fcStore.mixerConfig.mixer" :items="sortedMixerListItems" />
                             <SettingRow
                                 :label="$t('configurationReverseMotorSwitch')"
                                 :help="$t('configurationReverseMotorSwitchHelp')"
-                                full-width
+                                fullWidth
                             >
                                 <USwitch v-model="reverseMotorDir" size="sm" />
                             </SettingRow>
@@ -28,25 +26,27 @@
                                     v-if="isMotorReorderingAvailable"
                                     :label="$t('motorOutputReorderDialogOpen')"
                                     :disabled="buttonStates.toolsDisabled"
+                                    size="xs"
                                     @click="openMotorOutputReorderDialog()"
                                 />
                                 <UButton
                                     v-if="digitalProtocolConfigured"
                                     :label="$t('escDshotDirectionDialog-Open')"
                                     :disabled="buttonStates.toolsDisabled"
+                                    size="xs"
                                     @click="openEscDshotDirectionDialog()"
                                 />
                             </div>
                         </UiBox>
                         <!-- ESC FEATURES -->
-                        <UiBox :title="$t('configurationEscFeatures')">
+                        <UiBox :title="$t('configurationEscFeatures')" type="neutral" collapsible>
                             <div v-if="!protocolConfigured" class="text-sm text-orange-500">
                                 <p v-html="$t('configurationEscProtocolDisabled')"></p>
                             </div>
                             <SettingRow
                                 :label="$t('configurationEscProtocol')"
                                 :help="$t('configurationEscProtocolHelp')"
-                                full-width
+                                fullWidth
                             >
                                 <USelect
                                     v-model="selectedEscProtocol"
@@ -55,13 +55,13 @@
                                     @update:model-value="onProtocolChange"
                                 />
                             </SettingRow>
-                            <SettingRow v-if="showAnalogSettings" :label="$t('configurationunsyndePwm')" full-width>
+                            <SettingRow v-if="showAnalogSettings" :label="$t('configurationunsyndePwm')" fullWidth>
                                 <USwitch v-model="useUnsyncedPwm" size="sm" />
                             </SettingRow>
                             <SettingRow
                                 v-if="showAnalogSettings && useUnsyncedPwm"
                                 :label="$t('configurationUnsyncedPWMFreq')"
-                                full-width
+                                fullWidth
                             >
                                 <UInputNumber
                                     v-model="fcStore.pidAdvancedConfig.motor_pwm_rate"
@@ -74,7 +74,7 @@
                                     class="w-16"
                                 />
                             </SettingRow>
-                            <SettingRow v-if="protocolConfigured" full-width>
+                            <SettingRow v-if="protocolConfigured" fullWidth>
                                 <USwitch
                                     :model-value="isFeatureEnabled('MOTOR_STOP')"
                                     @update:model-value="toggleFeature('MOTOR_STOP', $event)"
@@ -86,7 +86,7 @@
                                     <span class="ml-2" v-html="$t('featureMOTOR_STOPTip')"></span>
                                 </template>
                             </SettingRow>
-                            <SettingRow v-if="digitalProtocolConfigured" full-width>
+                            <SettingRow v-if="digitalProtocolConfigured" fullWidth>
                                 <USwitch
                                     :model-value="isFeatureEnabled('ESC_SENSOR')"
                                     @update:model-value="toggleFeature('ESC_SENSOR', $event)"
@@ -101,7 +101,7 @@
                                 v-if="digitalProtocolConfigured"
                                 :label="$t('configurationDshotBidir')"
                                 :help="$t('configurationDshotBidirHelp')"
-                                full-width
+                                fullWidth
                             >
                                 <USwitch v-model="useDshotTelemetry" size="sm" />
                             </SettingRow>
@@ -109,7 +109,7 @@
                                 v-if="protocolConfigured && rpmFeaturesVisible"
                                 :label="$t('configurationMotorPolesLong')"
                                 :help="$t('configurationMotorPolesHelp')"
-                                full-width
+                                fullWidth
                             >
                                 <UInputNumber
                                     v-model="fcStore.motorConfig.motor_poles"
@@ -125,7 +125,7 @@
                                 v-if="showMotorIdle"
                                 :label="$t('configurationMotorIdle')"
                                 :help="$t('configurationMotorIdleHelp')"
-                                full-width
+                                fullWidth
                             >
                                 <UInputNumber
                                     v-model="fcStore.pidAdvancedConfig.motorIdle"
@@ -141,7 +141,7 @@
                                 v-if="showIdleMinRpm"
                                 :label="$t('pidTuningIdleMinRpm')"
                                 :help="$t('configurationMotorIdleRpmHelp')"
-                                full-width
+                                fullWidth
                             >
                                 <UInputNumber
                                     v-model="fcStore.advancedTuning.idleMinRpm"
@@ -158,7 +158,7 @@
                                 v-if="showAnalogSettings"
                                 :label="$t('configurationThrottleMinimumCommand')"
                                 :help="$t('configurationThrottleMinimumCommandHelp')"
-                                full-width
+                                fullWidth
                             >
                                 <UInputNumber
                                     v-model="fcStore.motorConfig.mincommand"
@@ -175,7 +175,7 @@
                                 v-if="showMinThrottle"
                                 :label="$t('configurationThrottleMinimum')"
                                 :help="$t('configurationThrottleMinimumHelp')"
-                                full-width
+                                fullWidth
                             >
                                 <UInputNumber
                                     v-model="fcStore.motorConfig.minthrottle"
@@ -188,11 +188,7 @@
                                     class="w-16"
                                 />
                             </SettingRow>
-                            <SettingRow
-                                v-if="showAnalogSettings"
-                                :label="$t('configurationThrottleMaximum')"
-                                full-width
-                            >
+                            <SettingRow v-if="showAnalogSettings" :label="$t('configurationThrottleMaximum')" fullWidth>
                                 <UInputNumber
                                     v-model="fcStore.motorConfig.maxthrottle"
                                     :min="0"
@@ -206,8 +202,8 @@
                             </SettingRow>
                         </UiBox>
                         <!-- 3D -->
-                        <UiBox :title="$t('configuration3d')">
-                            <SettingRow :help="$t('feature3DTip')" full-width>
+                        <UiBox :title="$t('configuration3d')" type="neutral" collapsible>
+                            <SettingRow :help="$t('feature3DTip')" fullWidth>
                                 <USwitch
                                     :model-value="isFeatureEnabled('3D')"
                                     @update:model-value="toggleFeature('3D', $event)"
@@ -218,7 +214,7 @@
                                 </template>
                             </SettingRow>
                             <template v-if="isFeatureEnabled('3D')">
-                                <SettingRow :label="$t('configuration3dDeadbandLow')" full-width>
+                                <SettingRow :label="$t('configuration3dDeadbandLow')" fullWidth>
                                     <UInputNumber
                                         v-model="fcStore.motor3dConfig.deadband3d_low"
                                         :min="1250"
@@ -230,7 +226,7 @@
                                         class="w-16"
                                     />
                                 </SettingRow>
-                                <SettingRow :label="$t('configuration3dDeadbandHigh')" full-width>
+                                <SettingRow :label="$t('configuration3dDeadbandHigh')" fullWidth>
                                     <UInputNumber
                                         v-model="fcStore.motor3dConfig.deadband3d_high"
                                         :min="1400"
@@ -242,7 +238,7 @@
                                         class="w-16"
                                     />
                                 </SettingRow>
-                                <SettingRow :label="$t('configuration3dNeutral')" full-width>
+                                <SettingRow :label="$t('configuration3dNeutral')" fullWidth>
                                     <UInputNumber
                                         v-model="fcStore.motor3dConfig.neutral"
                                         :min="1400"
@@ -455,7 +451,7 @@
 
                         <div class="p-3 border border-red-500/30 rounded-md bg-red-500/5">
                             <p class="text-sm mb-2" v-html="$t('motorsNotice')"></p>
-                            <SettingRow :label="$t('motorsEnableControl')" full-width>
+                            <SettingRow :label="$t('motorsEnableControl')" fullWidth>
                                 <USwitch v-model="motorsTestingEnabled" size="sm" />
                             </SettingRow>
                         </div>
@@ -476,7 +472,7 @@
                 </template>
                 <template #footer>
                     <div class="flex justify-end gap-2 w-full">
-                        <UButton :label="$t('motorsDialogSettingsChangedOk')" @click="closeWarningDialog" />
+                        <UButton :label="$t('motorsDialogSettingsChangedOk')" size="xs" @click="closeWarningDialog" />
                     </div>
                 </template>
             </UModal>
@@ -497,9 +493,14 @@
                         <UButton
                             :label="$t('presetsWarningDialogNoButton')"
                             variant="outline"
+                            size="xs"
                             @click="closeDynFiltersDialog"
                         />
-                        <UButton :label="$t('presetsWarningDialogYesButton')" @click="applyDynFiltersChange" />
+                        <UButton
+                            :label="$t('presetsWarningDialogYesButton')"
+                            size="xs"
+                            @click="applyDynFiltersChange"
+                        />
                     </div>
                 </template>
             </UModal>
@@ -513,12 +514,14 @@
                     :disabled="buttonStates.stopDisabled"
                     @click="stopMotors()"
                     color="error"
+                    size="xs"
                 />
                 <UButton
                     :label="$t('configurationButtonSave')"
                     :disabled="buttonStates.saveDisabled"
                     :loading="isSaving"
                     @click="handleSave(true)"
+                    size="xs"
                 />
             </div>
         </div>

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -15,7 +15,7 @@
                                 :help="$t('configurationReverseMotorSwitchHelp')"
                                 fullWidth
                             >
-                                <USwitch v-model="reverseMotorDir" size="sm" />
+                                <USwitch v-model="reverseMotorDir" size="xs" />
                             </SettingRow>
                             <div
                                 class="flex justify-center p-2.5 [&_svg]:w-[150px] [&_svg]:h-[150px] [&_svg]:ml-[15px]"
@@ -56,7 +56,7 @@
                                 />
                             </SettingRow>
                             <SettingRow v-if="showAnalogSettings" :label="$t('configurationunsyndePwm')" fullWidth>
-                                <USwitch v-model="useUnsyncedPwm" size="sm" />
+                                <USwitch v-model="useUnsyncedPwm" size="xs" />
                             </SettingRow>
                             <SettingRow
                                 v-if="showAnalogSettings && useUnsyncedPwm"
@@ -79,7 +79,7 @@
                                     :model-value="isFeatureEnabled('MOTOR_STOP')"
                                     @update:model-value="toggleFeature('MOTOR_STOP', $event)"
                                     :disabled="isFeatureEnabled('AIRMODE')"
-                                    size="sm"
+                                    size="xs"
                                 />
                                 <template #label>
                                     <span class="font-semibold">MOTOR_STOP</span>
@@ -90,7 +90,7 @@
                                 <USwitch
                                     :model-value="isFeatureEnabled('ESC_SENSOR')"
                                     @update:model-value="toggleFeature('ESC_SENSOR', $event)"
-                                    size="sm"
+                                    size="xs"
                                 />
                                 <template #label>
                                     <span class="font-semibold">ESC_SENSOR</span>
@@ -103,7 +103,7 @@
                                 :help="$t('configurationDshotBidirHelp')"
                                 fullWidth
                             >
-                                <USwitch v-model="useDshotTelemetry" size="sm" />
+                                <USwitch v-model="useDshotTelemetry" size="xs" />
                             </SettingRow>
                             <SettingRow
                                 v-if="protocolConfigured && rpmFeaturesVisible"
@@ -207,7 +207,7 @@
                                 <USwitch
                                     :model-value="isFeatureEnabled('3D')"
                                     @update:model-value="toggleFeature('3D', $event)"
-                                    size="sm"
+                                    size="xs"
                                 />
                                 <template #label>
                                     <span v-html="$t('feature3D')"></span>
@@ -452,7 +452,7 @@
                         <div class="p-3 border border-red-500/30 rounded-md bg-red-500/5">
                             <p class="text-sm mb-2" v-html="$t('motorsNotice')"></p>
                             <SettingRow :label="$t('motorsEnableControl')" fullWidth>
-                                <USwitch v-model="motorsTestingEnabled" size="sm" />
+                                <USwitch v-model="motorsTestingEnabled" size="xs" />
                             </SettingRow>
                         </div>
                     </div>

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -261,11 +261,14 @@
                         <!-- SENSOR GRAPH SECTION -->
                         <UiBox>
                             <div class="graph-grid">
+                                <!-- The `x` groups are positioned on the plot baseline by
+                                     applyGraphTransforms — their offset depends on the measured
+                                     height, so it must not be hardcoded here. -->
                                 <svg ref="graphSvg" id="graph" class="w-full h-full">
-                                    <g class="grid x" transform="translate(40, 120)"></g>
+                                    <g class="grid x"></g>
                                     <g class="grid y" transform="translate(40, 10)"></g>
-                                    <g class="data" transform="translate(41, 10)"></g>
-                                    <g class="axis x" transform="translate(40, 120)"></g>
+                                    <g class="data" transform="translate(40, 10)"></g>
+                                    <g class="axis x"></g>
                                     <g class="axis y" transform="translate(40, 10)"></g>
                                 </svg>
                                 <div
@@ -281,7 +284,7 @@
                                         <USelect
                                             v-model="sensorType"
                                             :items="sensorTypeItems"
-                                            class="min-w-24"
+                                            class="ml-auto min-w-24"
                                             size="xs"
                                         />
                                     </div>
@@ -310,7 +313,7 @@
                                     >
                                         <span>{{ axis.toUpperCase() }}:</span>
                                         <span
-                                            class="w-32 text-right px-[3px] py-[2px] text-black rounded-[3px] whitespace-nowrap tabular-nums"
+                                            class="min-w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] whitespace-nowrap tabular-nums"
                                             :class="{
                                                 'bg-[#e24761]': axis === 'x',
                                                 'bg-[#49c747]': axis === 'y',
@@ -322,7 +325,7 @@
                                     <div class="flex justify-between py-0.5">
                                         <span>RMS:</span>
                                         <span
-                                            class="w-32 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#f5a623] whitespace-nowrap tabular-nums"
+                                            class="min-w-24 text-right px-[3px] py-[2px] text-black rounded-[3px] bg-[#f5a623] whitespace-nowrap tabular-nums"
                                             >{{ rawDataDisplay.rms }}</span
                                         >
                                     </div>
@@ -340,7 +343,12 @@
                             </div>
                         </UiBox>
 
-                        <div class="motors">
+                        <!-- While motor testing is armed the page must not scroll under the
+                             pointer: a wheel notch in the gaps between the sliders would
+                             otherwise move the whole layout while the motors can spin.  The
+                             listener sits on the container so it also catches the grid
+                             gutters and the bar graph, not just the slider cells. -->
+                        <div class="motors" @wheel="onMotorTestWheel">
                             <ul :class="`grid-box col${numberOfValidOutputs + 1} h-5`">
                                 <li
                                     v-for="i in numberOfValidOutputs"
@@ -383,7 +391,7 @@
                             </ul>
                         </div>
 
-                        <div class="m-0 p-0 border-0 list-none outline-none">
+                        <div class="m-0 p-0 border-0 list-none outline-none" @wheel="onMotorTestWheel">
                             <ul :class="`grid-box col${numberOfValidOutputs + 1} mb-2`">
                                 <li
                                     v-for="i in numberOfValidOutputs"
@@ -407,7 +415,7 @@
                                         v-for="i in numberOfValidOutputs"
                                         :key="i"
                                         class="flex items-end justify-center"
-                                        @wheel.prevent="onSliderWheel(i - 1, $event)"
+                                        @wheel="onSliderWheel(i - 1, $event)"
                                     >
                                         <USlider
                                             orientation="vertical"
@@ -420,10 +428,7 @@
                                             @update:model-value="onMotorValueUpdate(i - 1, $event)"
                                         />
                                     </li>
-                                    <li
-                                        class="flex items-end justify-center"
-                                        @wheel.prevent="onSliderWheel(-1, $event)"
-                                    >
+                                    <li class="flex items-end justify-center" @wheel="onSliderWheel(-1, $event)">
                                         <USlider
                                             orientation="vertical"
                                             :min="minSliderValue"
@@ -933,7 +938,11 @@ watch(sensorType, (val) => {
 });
 
 // Graph State
-const margin = { top: 20, right: 30, bottom: 10, left: 20 };
+// `bottom` is the gutter that holds the x-axis tick labels, `top` the gap above the
+// plot.  The axis groups are positioned from these values in applyGraphTransforms —
+// never hardcode them in the SVG template, or the horizontal scale drifts off the
+// bottom of the plot as soon as the SVG is a different height than assumed.
+const margin = { top: 10, right: 10, bottom: 20, left: 40 };
 let graphHelpers = null;
 let graphData = [];
 let samples = 0;
@@ -969,6 +978,20 @@ function initDataArray(length) {
         data[i].max = 1;
     }
     return data;
+}
+
+// Place the axis, grid and data groups for the measured plot area: the y groups at
+// the top-left corner of the plot, the x groups on its baseline so the horizontal
+// scale always sits directly below the vertical one.
+function applyGraphTransforms(svg, helpers) {
+    const topLeft = `translate(${margin.left}, ${margin.top})`;
+    const baseline = `translate(${margin.left}, ${margin.top + helpers.height})`;
+
+    svg.select(".y.grid").attr("transform", topLeft);
+    svg.select(".y.axis").attr("transform", topLeft);
+    svg.select("g.data").attr("transform", topLeft);
+    svg.select(".x.grid").attr("transform", baseline);
+    svg.select(".x.axis").attr("transform", baseline);
 }
 
 function updateGraphHelperSize(helpers) {
@@ -1035,6 +1058,7 @@ function drawGraph(helpers, data, sampleNumber) {
     const svg = d3.select(graphSvg.value);
 
     updateGraphHelperSize(helpers); // Ensure size is current
+    applyGraphTransforms(svg, helpers);
 
     helpers.widthScale.domain([sampleNumber - 299, sampleNumber]);
     if (helpers.dynamicHeightDomain) {
@@ -1541,10 +1565,21 @@ const onMasterValueUpdate = (val) => {
     onMasterSliderChange();
 };
 
+// Swallow wheel events over the motor test controls while testing is armed, so the
+// page cannot scroll out from under the pointer while the motors can spin.  When
+// testing is off the sliders are inert and normal page scrolling is left alone.
+const onMotorTestWheel = (event) => {
+    if (motorsTestingEnabled.value) {
+        event.preventDefault();
+    }
+};
+
 const onSliderWheel = (index, event) => {
     if (!motorsTestingEnabled.value) {
         return;
     }
+
+    event.preventDefault();
 
     // index -1 for master
     const step = 25;

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -184,51 +184,41 @@
                                     </li>
                                 </ul>
 
-                                <div class="dataflash-buttons">
-                                    <a
-                                        class="regular-button erase-flash"
-                                        :class="{ disabled: dataflashUsedSize === 0 }"
-                                        href="#"
-                                        @click.prevent="askToEraseFlash"
-                                    >
-                                        {{ $t("dataflashButtonErase") }}
-                                    </a>
-                                    <a
-                                        class="regular-button require-msc-not-supported save-flash-erase"
-                                        :class="{ disabled: dataflashUsedSize === 0 }"
-                                        href="#"
-                                        @click.prevent="flashSaveBegin(true)"
-                                    >
-                                        {{ $t("dataflashButtonSaveAndErase") }}
-                                    </a>
-                                    <a
-                                        class="regular-button require-msc-not-supported save-flash"
-                                        :class="{ disabled: dataflashUsedSize === 0 }"
-                                        href="#"
-                                        @click.prevent="flashSaveBegin(false)"
-                                    >
-                                        {{ $t("dataflashButtonSaveFile") }}
-                                    </a>
-                                    <a
+                                <div class="dataflash-buttons flex gap-2">
+                                    <UButton
+                                        size="xs"
+                                        :disabled="dataflashUsedSize === 0"
+                                        :label="$t('dataflashButtonErase')"
+                                        @click="askToEraseFlash"
+                                    />
+                                    <UButton
+                                        size="xs"
+                                        :disabled="dataflashUsedSize === 0"
+                                        :label="$t('dataflashButtonSaveAndErase')"
+                                        @click="flashSaveBegin(true)"
+                                    />
+                                    <UButton
+                                        size="xs"
+                                        :disabled="dataflashUsedSize === 0"
+                                        :label="$t('dataflashButtonSaveFile')"
+                                        @click="flashSaveBegin(false)"
+                                    />
+                                    <UButton
                                         v-if="isExpertMode"
-                                        class="regular-button require-msc-supported save-flash-erase"
-                                        :class="{ disabled: dataflashUsedSize === 0 }"
-                                        href="#"
-                                        @click.prevent="flashSaveBegin(true)"
+                                        size="xs"
+                                        :disabled="dataflashUsedSize === 0"
+                                        :label="$t('dataflashButtonSaveAndErase')"
+                                        @click="flashSaveBegin(true)"
+                                    />
+                                    <UButton
+                                        size="xs"
+                                        :disabled="dataflashUsedSize === 0"
+                                        :label="$t('dataflashButtonSaveFile')"
                                     >
-                                        {{ $t("dataflashButtonSaveAndErase") }}
-                                    </a>
-                                    <a
-                                        class="regular-button require-msc-supported save-flash"
-                                        :class="{ disabled: dataflashUsedSize === 0 }"
-                                        href="#"
-                                        @click.prevent="flashSaveBegin(false)"
-                                    >
-                                        <span class="inline-flex items-center gap-1">
-                                            <span>{{ $t("dataflashButtonSaveFile") }}</span>
+                                        <template #trailing>
                                             <HelpIcon :text="$t('dataflashSaveFileDepreciationHint')" />
-                                        </span>
-                                    </a>
+                                        </template>
+                                    </UButton>
                                     <p v-html="$t('dataflashSavetoFileNote')"></p>
                                 </div>
                             </div>
@@ -275,16 +265,12 @@
 
                     <UiBox :title="$t('onboardLoggingMsc')" class="require-msc-supported" type="neutral" collapsible>
                         <div class="require-msc-supported">
-                            <div>
-                                <a
-                                    class="require-msc-ready regular-button onboardLoggingRebootMsc"
-                                    :class="{ disabled: !mscReady }"
-                                    href="#"
-                                    @click.prevent="rebootToMsc"
-                                >
-                                    {{ $t("onboardLoggingRebootMscText") }}
-                                </a>
-                            </div>
+                            <UButton
+                                size="xs"
+                                :disabled="!mscReady"
+                                :label="$t('onboardLoggingRebootMscText')"
+                                @click="rebootToMsc"
+                            />
                         </div>
                         <p v-html="$t('onboardLoggingMscNote')"></p>
                         <p class="require-msc-not-ready">{{ $t("onboardLoggingMscNotReady") }}</p>

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -184,7 +184,7 @@
                                     </li>
                                 </ul>
 
-                                <div class="dataflash-buttons flex gap-2">
+                                <div class="dataflash-buttons flex flex-wrap items-center gap-2">
                                     <UButton
                                         size="xs"
                                         :disabled="dataflashUsedSize === 0"
@@ -202,25 +202,13 @@
                                         :disabled="dataflashUsedSize === 0"
                                         :label="$t('dataflashButtonSaveFile')"
                                         @click="flashSaveBegin(false)"
-                                    />
-                                    <UButton
-                                        v-if="isExpertMode"
-                                        size="xs"
-                                        :disabled="dataflashUsedSize === 0"
-                                        :label="$t('dataflashButtonSaveAndErase')"
-                                        @click="flashSaveBegin(true)"
-                                    />
-                                    <UButton
-                                        size="xs"
-                                        :disabled="dataflashUsedSize === 0"
-                                        :label="$t('dataflashButtonSaveFile')"
                                     >
                                         <template #trailing>
                                             <HelpIcon :text="$t('dataflashSaveFileDepreciationHint')" />
                                         </template>
                                     </UButton>
-                                    <p v-html="$t('dataflashSavetoFileNote')"></p>
                                 </div>
+                                <p class="mt-2" v-html="$t('dataflashSavetoFileNote')"></p>
                             </div>
 
                             <p class="require-dataflash-not-present">{{ $t("dataflashNotPresentNote") }}</p>
@@ -281,7 +269,13 @@
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
-            <UButton :label="$t('blackboxButtonSave')" :disabled="!dirty" :loading="isSaving" @click="saveSettings" />
+            <UButton
+                :label="$t('blackboxButtonSave')"
+                size="xs"
+                :disabled="!dirty"
+                :loading="isSaving"
+                @click="saveSettings"
+            />
         </div>
     </BaseTab>
 </template>
@@ -1225,9 +1219,6 @@ export default defineComponent({
         display: none;
         border-radius: 5px;
     }
-}
-.dataflash-buttons {
-    display: inline-block;
 }
 .dataflash-confirm-erase.erasing {
     .dataflash-erase-progress {

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -28,24 +28,29 @@
 
                 <div class="grid-box col1">
                     <div class="require-blackbox-supported grid-box col1">
-                        <UiBox :title="$t('blackboxConfiguration')" v-show="blackboxConfigSupported">
+                        <UiBox
+                            :title="$t('blackboxConfiguration')"
+                            v-show="blackboxConfigSupported"
+                            type="neutral"
+                            collapsible
+                        >
                             <SettingRow :label="$t('onboardLoggingBlackbox')">
                                 <USelect
                                     v-model="blackboxDevice"
                                     :items="blackboxDeviceOptions"
-                                    size="sm"
+                                    size="xs"
                                     class="min-w-40"
                                 />
                             </SettingRow>
                             <SettingRow v-show="blackboxDevice !== 0" :label="$t('onboardLoggingRateOfLogging')">
-                                <USelect v-model="blackboxRate" :items="loggingRates" size="sm" class="min-w-40" />
+                                <USelect v-model="blackboxRate" :items="loggingRates" size="xs" class="min-w-40" />
                             </SettingRow>
                             <SettingRow :label="$t('onboardLoggingDebugMode')">
                                 <USelectMenu
                                     v-model="debugMode"
                                     value-key="value"
                                     :items="debugModes"
-                                    size="sm"
+                                    size="xs"
                                     leading-icon="i-lucide-bug"
                                     :search-input="{
                                         placeholder: $t('search'),
@@ -61,12 +66,14 @@
                             v-if="showDebugFields"
                             :title="$t('onboardLoggingDebugFields')"
                             v-show="blackboxConfigSupported"
+                            type="neutral"
+                            collapsible
                         >
                             <div class="blackboxDebugFieldsTable">
                                 <div v-for="(field, index) in debugFields" :key="index" class="debug-field-row">
                                     <USwitch
                                         :model-value="debugFieldsEnabled[index]"
-                                        size="sm"
+                                        size="xs"
                                         @update:model-value="updateDebugField(index, $event)"
                                     />
                                     <span>{{ field }}</span>
@@ -74,11 +81,11 @@
                             </div>
                         </UiBox>
 
-                        <UiBox :title="$t('onboardLoggingSerialLogger')">
+                        <UiBox :title="$t('onboardLoggingSerialLogger')" type="neutral" collapsible>
                             <p>{{ $t("serialLoggingSupportedNote") }}</p>
                         </UiBox>
 
-                        <UiBox :title="$t('onboardLoggingFlashLogger')">
+                        <UiBox :title="$t('onboardLoggingFlashLogger')" type="neutral" collapsible>
                             <div class="require-dataflash-supported">
                                 <p>{{ $t("dataflashNote") }}</p>
 
@@ -229,7 +236,12 @@
                             <p class="require-dataflash-not-present">{{ $t("dataflashNotPresentNote") }}</p>
                         </UiBox>
 
-                        <UiBox :title="$t('onboardLoggingOnboardSDCard')" class="require-sdcard-supported">
+                        <UiBox
+                            :title="$t('onboardLoggingOnboardSDCard')"
+                            class="require-sdcard-supported"
+                            type="neutral"
+                            collapsible
+                        >
                             <div class="sdcard">
                                 <div class="sdcard-icon"></div>
                                 <div class="sdcard-status" v-html="sdcardStatusText"></div>
@@ -261,7 +273,7 @@
                         </UiBox>
                     </div>
 
-                    <UiBox :title="$t('onboardLoggingMsc')" class="require-msc-supported">
+                    <UiBox :title="$t('onboardLoggingMsc')" class="require-msc-supported" type="neutral" collapsible>
                         <div class="require-msc-supported">
                             <div>
                                 <a

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -54,7 +54,7 @@
                                 v-model="elementSearchQuery"
                                 :placeholder="$t('search') + '...'"
                                 icon="i-lucide-search"
-                                size="sm"
+                                size="xs"
                                 class="mb-2"
                             />
                             <!-- Element list -->
@@ -393,7 +393,7 @@
                                             onWarningChange();
                                         }
                                     "
-                                    size="sm"
+                                    size="xs"
                                 />
                                 <span class="text-xs" :title="warning.desc ? $t(warning.desc) : undefined">{{
                                     $t(warning.text, warning.textParams)
@@ -422,7 +422,7 @@
                                             onStatChange(stat);
                                         }
                                     "
-                                    size="sm"
+                                    size="xs"
                                 />
                                 <span class="text-xs" :title="stat.desc ? $t(stat.desc) : undefined">{{
                                     $t(stat.text, stat.textParams)
@@ -457,11 +457,11 @@
                                 v-model="selectedFontPreset"
                                 :items="fontPresetSelectItems"
                                 :portal="false"
-                                size="sm"
+                                size="xs"
                                 class="min-w-40"
                             />
                             <span>{{ $t("osdSetupFontPresetsSelectorOr") }}</span>
-                            <UButton @click="loadCustomFontFile()" size="sm">
+                            <UButton @click="loadCustomFontFile()" size="xs">
                                 {{ $t("osdSetupOpenFont") }}
                             </UButton>
                             <span class="text-sm opacity-60"></span>
@@ -492,7 +492,7 @@
                         </div>
 
                         <div class="mb-3">
-                            <UButton @click="replaceLogoImage()" size="sm">
+                            <UButton @click="replaceLogoImage()" size="xs">
                                 <span v-html="$t('osdSetupCustomLogoOpenImageButton')"></span>
                             </UButton>
                         </div>
@@ -504,7 +504,7 @@
                             </div>
                         </div>
 
-                        <UButton @click="flashFont()" color="success" size="sm">
+                        <UButton @click="flashFont()" color="success" size="xs">
                             {{ $t("osdSetupUploadFont") }}
                         </UButton>
                     </template>
@@ -523,7 +523,7 @@
                 >
                     {{ $t("osdSetupFontManagerTitle") }}
                 </UButton>
-                <UFieldGroup size="sm" orientation="horizontal" class="flex!">
+                <UFieldGroup size="xs" orientation="horizontal" class="flex!">
                     <UButton @click="saveConfig()" :disabled="!osdStore.dirty || isSaving" size="xs">
                         {{ saveButtonText }}
                     </UButton>

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -34,7 +34,12 @@
                 <div class="grid-row grid-box col4">
                     <!-- Elements Column -->
                     <div class="col-span-1">
-                        <UiBox :title="$t('osdSetupElementsTitle')" :help="$t('osdSectionHelpElements')">
+                        <UiBox
+                            :title="$t('osdSetupElementsTitle')"
+                            type="neutral"
+                            collapsible
+                            :help="$t('osdSectionHelpElements')"
+                        >
                             <template #title>
                                 <HelpIcon :text="$t('osdSetupProfilesTitle')" />
                                 <span
@@ -228,7 +233,7 @@
                     <!-- Settings Column -->
                     <div class="col-span-1">
                         <!-- Active Profile Selector -->
-                        <UiBox :title="$t('osdSetupSelectedProfileTitle')">
+                        <UiBox :title="$t('osdSetupSelectedProfileTitle')" type="neutral" collapsible>
                             <SettingRow :label="$t('osdSetupSelectedProfileTitle')">
                                 <USelect v-model="activeProfile" :items="profileOptions" size="xs" />
                             </SettingRow>
@@ -241,6 +246,8 @@
                         <UiBox
                             v-if="osdStore.state.haveMax7456Configured || osdStore.state.isMspDevice"
                             :title="$t('osdSetupVideoFormatTitle')"
+                            type="neutral"
+                            collapsible
                             :help="$t('osdSectionHelpVideoMode')"
                         >
                             <SettingRow :label="$t('osdSetupVideoFormatTitle')">
@@ -262,6 +269,8 @@
                         <UiBox
                             v-if="osdStore.state.haveOsdFeature"
                             :title="$t('osdSetupUnitsTitle')"
+                            type="neutral"
+                            collapsible
                             :help="$t('osdSectionHelpUnits')"
                         >
                             <SettingRow :label="$t('osdSetupUnitsTitle')">
@@ -283,6 +292,8 @@
                         <UiBox
                             v-if="osdStore.state.haveOsdFeature && osdStore.timers.length > 0"
                             :title="$t('osdSetupTimersTitle')"
+                            type="neutral"
+                            collapsible
                             :help="$t('osdSectionHelpTimers')"
                         >
                             <div
@@ -337,6 +348,8 @@
                         <UiBox
                             v-if="osdStore.state.haveOsdFeature && alarmEntries.length > 0"
                             :title="$t('osdSetupAlarmsTitle')"
+                            type="neutral"
+                            collapsible
                             :help="$t('osdSectionHelpAlarms')"
                         >
                             <div
@@ -363,6 +376,8 @@
                         <UiBox
                             v-if="osdStore.state.haveOsdFeature && sortedWarnings.length > 0"
                             :title="$t('osdSetupWarningsTitle')"
+                            type="neutral"
+                            collapsible
                             :help="$t('osdSectionHelpWarnings')"
                         >
                             <div
@@ -390,6 +405,8 @@
                         <UiBox
                             v-if="osdStore.state.haveOsdFeature && sortedStatItems.length > 0"
                             :title="$t('osdSetupStatsTitle')"
+                            type="neutral"
+                            collapsible
                             :help="$t('osdSectionHelpStats')"
                         >
                             <div
@@ -502,11 +519,12 @@
                     :disabled="!osdStore.state.isMax7456FontDeviceDetected"
                     @click="openFontManager()"
                     variant="soft"
+                    size="xs"
                 >
                     {{ $t("osdSetupFontManagerTitle") }}
                 </UButton>
                 <UFieldGroup size="sm" orientation="horizontal" class="flex!">
-                    <UButton @click="saveConfig()" :disabled="!osdStore.dirty || isSaving">
+                    <UButton @click="saveConfig()" :disabled="!osdStore.dirty || isSaving" size="xs">
                         {{ saveButtonText }}
                     </UButton>
                     <UDropdownMenu v-slot="{ open }" :items="saveMenuItems" :content="{ align: 'end', side: 'top' }">
@@ -514,6 +532,7 @@
                             :disabled="!osdStore.dirty || isSaving"
                             :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'"
                             square
+                            size="xs"
                         />
                     </UDropdownMenu>
                 </UFieldGroup>

--- a/src/components/tabs/PidTuningTab.vue
+++ b/src/components/tabs/PidTuningTab.vue
@@ -108,8 +108,15 @@
                     :disabled="!hasChanges"
                     @click="refresh"
                     variant="soft"
+                    size="xs"
                 />
-                <UButton :label="$t('pidTuningButtonSave')" :disabled="!hasChanges" :loading="isSaving" @click="save" />
+                <UButton
+                    :label="$t('pidTuningButtonSave')"
+                    :disabled="!hasChanges"
+                    :loading="isSaving"
+                    @click="save"
+                    size="xs"
+                />
             </div>
         </div>
     </BaseTab>

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -2,17 +2,21 @@
     <BaseTab tab-name="ports">
         <div class="content_wrapper">
             <div class="tab_title" v-html="$t('tabPorts')"></div>
-            <div class="cf_doc_version_bt">
-                <WikiButton docUrl="ports" />
-            </div>
+            <WikiButton docUrl="ports" />
 
             <div class="require-support">
-                <UiBox type="warning" highlight class="mb-4">
+                <UiBox type="neutral" collapsible highlight class="mb-4">
+                    <template #title>
+                        <span class="font-semibold">{{ $t("tabPorts") }}</span>
+                    </template>
                     <p v-html="$t('portsHelp')"></p>
                     <p v-html="$t('portsMSPHelp')"></p>
                 </UiBox>
 
-                <UiBox v-if="vtxTableNotConfigured" type="warning" highlight class="mb-4">
+                <UiBox v-if="vtxTableNotConfigured" type="neutral" collapsible highlight class="mb-4">
+                    <template #title>
+                        <span class="font-semibold">{{ $t("portsVtxTableNotSet") }}</span>
+                    </template>
                     <p v-html="$t('portsVtxTableNotSet')"></p>
                 </UiBox>
 
@@ -99,17 +103,23 @@
 
                 <!-- Mobile: card per port -->
                 <div v-else class="flex flex-col gap-3">
-                    <UiBox v-for="port in ports" :key="port.identifier" :title="getPortName(port.identifier)">
+                    <UiBox
+                        v-for="port in ports"
+                        :key="port.identifier"
+                        type="neutral"
+                        collapsible
+                        :title="getPortName(port.identifier)"
+                    >
                         <!-- MSP -->
                         <div class="flex items-center gap-2">
-                            <USwitch v-model="port.msp" :disabled="port.identifier === 20" size="sm" />
+                            <USwitch v-model="port.msp" :disabled="port.identifier === 20" size="xs" />
                             <span class="text-xs flex-1">MSP</span>
                             <USelect v-model="port.msp_baudrate" :items="mspBaudItems" size="xs" />
                         </div>
 
                         <!-- Serial RX -->
                         <div class="flex items-center gap-2">
-                            <USwitch v-model="port.rxSerial" :disabled="isSerialRxDisabled(port)" size="sm" />
+                            <USwitch v-model="port.rxSerial" :disabled="isSerialRxDisabled(port)" size="xs" />
                             <span class="text-xs flex-1" v-html="$t('portsSerialRx')"></span>
                             <HelpIcon :text="$t('portsSerialRxHelp')" />
                         </div>

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -5,18 +5,12 @@
             <WikiButton docUrl="ports" />
 
             <div class="require-support">
-                <UiBox type="neutral" collapsible highlight class="mb-4">
-                    <template #title>
-                        <span class="font-semibold">{{ $t("tabPorts") }}</span>
-                    </template>
+                <UiBox type="warning" highlight class="mb-4">
                     <p v-html="$t('portsHelp')"></p>
                     <p v-html="$t('portsMSPHelp')"></p>
                 </UiBox>
 
-                <UiBox v-if="vtxTableNotConfigured" type="neutral" collapsible highlight class="mb-4">
-                    <template #title>
-                        <span class="font-semibold">{{ $t("portsVtxTableNotSet") }}</span>
-                    </template>
+                <UiBox v-if="vtxTableNotConfigured" type="warning" highlight class="mb-4">
                     <p v-html="$t('portsVtxTableNotSet')"></p>
                 </UiBox>
 
@@ -179,7 +173,7 @@
 
         <div class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2">
-                <UButton :label="$t('configurationButtonSave')" :disabled="!dirty" @click="saveConfig" />
+                <UButton :label="$t('configurationButtonSave')" size="xs" :disabled="!dirty" @click="saveConfig" />
             </div>
         </div>
     </BaseTab>

--- a/src/components/tabs/PowerTab.vue
+++ b/src/components/tabs/PowerTab.vue
@@ -8,13 +8,13 @@
             </div>
 
             <!-- Battery Profile Selector -->
-            <UiBox v-if="hasBatteryProfiles" :title="$t('powerBatteryProfile')">
+            <UiBox v-if="hasBatteryProfiles" :title="$t('powerBatteryProfile')" type="neutral" collapsible>
                 <SettingRow :label="$t('powerBatteryProfile')">
                     <USelect
                         :items="batteryProfileItems"
                         :model-value="activeBatteryProfile"
                         @update:model-value="onBatteryProfileChange"
-                        size="sm"
+                        size="xs"
                         class="min-w-40"
                     />
                 </SettingRow>
@@ -32,7 +32,7 @@
                 <!-- Left Column -->
                 <div class="flex flex-col gap-4">
                     <!-- Battery Configuration -->
-                    <UiBox :title="$t('powerBatteryHead')">
+                    <UiBox :title="$t('powerBatteryHead')" type="neutral" collapsible>
                         <SettingRow :label="$t('powerBatteryVoltageMeterSource')">
                             <USelect
                                 :items="batteryMeterTypeItems"
@@ -107,7 +107,7 @@
                     </UiBox>
 
                     <!-- Voltage Configuration -->
-                    <UiBox v-show="showVoltageConfiguration" :title="$t('powerVoltageHead')">
+                    <UiBox v-show="showVoltageConfiguration" :title="$t('powerVoltageHead')" type="neutral" collapsible>
                         <UiBox highlight class="mb-3">
                             <div v-html="$t('powerVoltageWarning')"></div>
                         </UiBox>
@@ -170,7 +170,7 @@
                 <!-- Right Column -->
                 <div class="flex flex-col gap-4">
                     <!-- Battery State -->
-                    <UiBox :title="$t('powerStateHead')">
+                    <UiBox :title="$t('powerStateHead')" type="neutral" collapsible>
                         <div class="flex justify-between items-center">
                             <span v-html="$t('powerBatteryConnected')"></span>
                             <span>
@@ -204,7 +204,12 @@
                     </UiBox>
 
                     <!-- Amperage Configuration -->
-                    <UiBox v-show="showAmperageConfiguration" :title="$t('powerAmperageHead')">
+                    <UiBox
+                        v-show="showAmperageConfiguration"
+                        :title="$t('powerAmperageHead')"
+                        type="neutral"
+                        collapsible
+                    >
                         <UiBox highlight class="mb-3">
                             <div v-html="$t('powerAmperageWarning')"></div>
                         </UiBox>
@@ -266,8 +271,15 @@
                 v-if="showCalibration"
                 @click="openCalibrationManager"
                 variant="soft"
+                size="xs"
             />
-            <UButton :label="$t('powerButtonSave')" :disabled="!dirty" :loading="isSaving" @click="handleSave" />
+            <UButton
+                :label="$t('powerButtonSave')"
+                :disabled="!dirty"
+                :loading="isSaving"
+                @click="handleSave"
+                size="xs"
+            />
         </div>
 
         <!-- Calibration Manager Dialog -->

--- a/src/components/tabs/PowerTab.vue
+++ b/src/components/tabs/PowerTab.vue
@@ -23,7 +23,7 @@
                         v-model="batteryProfileName"
                         maxlength="8"
                         :placeholder="$t('powerBatteryProfileNamePlaceholder')"
-                        size="sm"
+                        size="xs"
                     />
                 </SettingRow>
             </UiBox>
@@ -38,7 +38,7 @@
                                 :items="batteryMeterTypeItems"
                                 v-model="batteryConfig.voltageMeterSource"
                                 @update:model-value="onVoltageMeterSourceChange"
-                                size="sm"
+                                size="xs"
                                 class="min-w-40"
                             />
                         </SettingRow>
@@ -47,7 +47,7 @@
                                 :items="currentMeterTypeItems"
                                 v-model="batteryConfig.currentMeterSource"
                                 @update:model-value="onCurrentMeterSourceChange"
-                                size="sm"
+                                size="xs"
                                 class="min-w-40"
                             />
                         </SettingRow>

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -5,7 +5,7 @@
             <WikiButton docUrl="preflight" />
 
             <!-- Location Bar -->
-            <UiBox :title="$t('preflightLocation')">
+            <UiBox :title="$t('preflightLocation')" type="neutral" collapsible>
                 <div class="location-bar">
                     <div class="location-inputs">
                         <div class="default_btn">
@@ -221,7 +221,7 @@
                 <!-- Left Column: Weather -->
                 <div class="flex flex-col gap-4 md:col-span-3">
                     <!-- Current Weather -->
-                    <UiBox :title="$t('preflightCurrentWeather')">
+                    <UiBox :title="$t('preflightCurrentWeather')" type="neutral" collapsible>
                         <template #title>
                             <UIcon name="i-lucide-cloud-sun" class="size-4" />
                             <div v-if="preflight.weather.loading" class="text-primary">
@@ -301,7 +301,12 @@
                     </UiBox>
 
                     <!-- Flight Window -->
-                    <UiBox v-if="preflight.weather.daily" :title="$t('preflightFlightWindow')">
+                    <UiBox
+                        v-if="preflight.weather.daily"
+                        :title="$t('preflightFlightWindow')"
+                        type="neutral"
+                        collapsible
+                    >
                         <template #title>
                             <UIcon name="i-lucide-clock" class="size-4" />
                         </template>
@@ -371,7 +376,12 @@
                     </UiBox>
 
                     <!-- Wind at Altitude (Hourly) -->
-                    <UiBox :title="$t('preflightWindForecast')" :help="$t('preflightWindForecastHelp')">
+                    <UiBox
+                        :title="$t('preflightWindForecast')"
+                        type="neutral"
+                        collapsible
+                        :help="$t('preflightWindForecastHelp')"
+                    >
                         <template #title>
                             <UIcon name="i-lucide-wind" class="size-4" />
                         </template>
@@ -427,6 +437,8 @@
                     <UiBox
                         v-if="preflight.weather.forecast && preflight.weather.forecast.length > 0"
                         :title="$t('preflightForecast')"
+                        type="neutral"
+                        collapsible
                         :help="$t('preflightForecastHelp')"
                     >
                         <template #title>
@@ -484,7 +496,12 @@
                 <!-- Right Column: Solar, GNSS, Airspace -->
                 <div class="flex flex-col gap-4 md:col-span-2">
                     <!-- Solar Activity -->
-                    <UiBox :title="$t('preflightSolarActivity')" :help="$t('preflightSolarHelp')">
+                    <UiBox
+                        :title="$t('preflightSolarActivity')"
+                        type="neutral"
+                        collapsible
+                        :help="$t('preflightSolarHelp')"
+                    >
                         <template #title>
                             <UIcon name="i-lucide-sun" class="size-4" />
                         </template>
@@ -541,7 +558,7 @@
                     </UiBox>
 
                     <!-- GNSS Info -->
-                    <UiBox :title="$t('preflightGNSS')" :help="$t('preflightGNSSHelp')">
+                    <UiBox :title="$t('preflightGNSS')" type="neutral" collapsible :help="$t('preflightGNSSHelp')">
                         <template #title>
                             <UIcon name="i-lucide-satellite" class="size-4" />
                         </template>
@@ -568,7 +585,7 @@
                     </UiBox>
 
                     <!-- Airspace / No-Fly Zones -->
-                    <UiBox :title="$t('preflightAirspace')">
+                    <UiBox :title="$t('preflightAirspace')" type="neutral" collapsible>
                         <template #title>
                             <UIcon name="i-lucide-circle-off" class="size-4" />
                         </template>
@@ -771,7 +788,7 @@
                     </UiBox>
 
                     <!-- Map -->
-                    <UiBox :title="$t('preflightMap')" class="preflight-map-box">
+                    <UiBox :title="$t('preflightMap')" type="neutral" collapsible class="preflight-map-box">
                         <template #title>
                             <UIcon name="i-lucide-map-pinned" class="size-4" />
                         </template>

--- a/src/components/tabs/PreflightTab.vue
+++ b/src/components/tabs/PreflightTab.vue
@@ -853,6 +853,7 @@ import UiBox from "../elements/UiBox.vue";
 import GUI from "../../js/gui";
 import { i18n } from "@/js/localization";
 import { usePreflight } from "@/composables/usePreflight";
+import { useMapViewport } from "@/composables/useMapViewport";
 import { getNotamStatus } from "@/js/notam/index.js";
 import { initMap } from "../../js/utils/map";
 import { fromLonLat } from "ol/proj";
@@ -990,8 +991,13 @@ export default defineComponent({
         const mapRef = ref(null);
         const mapContainerRef = ref(null);
         const mapInstance = ref(null);
+        const {
+            isFullscreen,
+            toggleFullscreen,
+            observeContainer,
+            teardown: teardownMapViewport,
+        } = useMapViewport(mapContainerRef, () => mapInstance.value?.map);
         const activeLayer = ref("street");
-        const isFullscreen = ref(false);
         const detectingLocation = ref(false);
         const locationError = ref(null);
         const manualLat = ref("");
@@ -1415,37 +1421,6 @@ export default defineComponent({
             mapInstance.value.mapView.setZoom(mapInstance.value.mapView.getZoom() - 1);
         }
 
-        function toggleFullscreen() {
-            const container = mapContainerRef.value;
-            if (!container) {
-                return;
-            }
-            if (!document.fullscreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement) {
-                if (container.requestFullscreen) {
-                    container.requestFullscreen();
-                } else if (container.webkitRequestFullscreen) {
-                    container.webkitRequestFullscreen();
-                } else if (container.msRequestFullscreen) {
-                    container.msRequestFullscreen();
-                }
-            } else if (document.exitFullscreen) {
-                document.exitFullscreen();
-            } else if (document.webkitExitFullscreen) {
-                document.webkitExitFullscreen();
-            } else if (document.msExitFullscreen) {
-                document.msExitFullscreen();
-            }
-        }
-
-        function handleFullscreenChange() {
-            isFullscreen.value = !!(
-                document.fullscreenElement ||
-                document.webkitFullscreenElement ||
-                document.msFullscreenElement
-            );
-            requestAnimationFrame(() => mapInstance.value?.map?.updateSize());
-        }
-
         function getWindStatusClass(speed, gusts) {
             return preflight.getWindStatus(speed, gusts).cssClass;
         }
@@ -1615,10 +1590,8 @@ export default defineComponent({
 
         onMounted(() => {
             GUI.content_ready();
-            document.addEventListener("fullscreenchange", handleFullscreenChange);
-            document.addEventListener("webkitfullscreenchange", handleFullscreenChange);
-            document.addEventListener("MSFullscreenChange", handleFullscreenChange);
             nextTick(() => {
+                observeContainer();
                 if (preflight.location.latitude !== null) {
                     initializeMap();
                     updateMapPosition();
@@ -1627,9 +1600,7 @@ export default defineComponent({
         });
 
         onUnmounted(() => {
-            document.removeEventListener("fullscreenchange", handleFullscreenChange);
-            document.removeEventListener("webkitfullscreenchange", handleFullscreenChange);
-            document.removeEventListener("MSFullscreenChange", handleFullscreenChange);
+            teardownMapViewport();
             if (mapInstance.value?.destroy) {
                 mapInstance.value.destroy();
             }

--- a/src/components/tabs/PresetsTab.vue
+++ b/src/components/tabs/PresetsTab.vue
@@ -33,7 +33,7 @@
 
             <div v-else-if="store.hasLoadError" class="p-5">
                 <h3 v-html="$t('presetsLoadError')"></h3>
-                <UButton :label="$t('presetsReload')" class="mt-2" @click="reloadPresets" />
+                <UButton :label="$t('presetsReload')" class="mt-2" size="xs" @click="reloadPresets" />
             </div>
 
             <div v-else>
@@ -106,11 +106,17 @@
                 <UButton
                     :label="$t('presetsButtonCancel')"
                     :disabled="!store.canApply"
+                    size="xs"
                     @click="store.clearPickedPresets()"
                     color="error"
                     variant="soft"
                 />
-                <UButton :label="$t('presetsButtonSave')" :disabled="!store.canApply" @click="applyPickedPresets()" />
+                <UButton
+                    :label="$t('presetsButtonSave')"
+                    :disabled="!store.canApply"
+                    size="xs"
+                    @click="applyPickedPresets()"
+                />
             </div>
         </div>
 
@@ -194,9 +200,10 @@
                     <UButton
                         :label="$t('presetsButtonCancel')"
                         variant="outline"
+                        size="xs"
                         @click="closeCliErrorsWithoutSaving"
                     />
-                    <UButton :label="$t('presetsSaveAnyway')" @click="saveAnywayAfterCliErrors" />
+                    <UButton :label="$t('presetsSaveAnyway')" size="xs" @click="saveAnywayAfterCliErrors" />
                 </div>
             </template>
         </UModal>

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -514,7 +514,7 @@
                 variant="soft"
                 size="xs"
             />
-            <UFieldGroup size="sm" orientation="horizontal" class="flex!">
+            <UFieldGroup size="xs" orientation="horizontal" class="flex!">
                 <UButton @click="saveConfig(needReboot)" size="xs" :disabled="!dirty || isSaving">
                     {{ $t("receiverButtonSave") }}
                 </UButton>

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -10,7 +10,13 @@
             <div class="grid-row grid-box col5">
                 <!-- Left Column: Model Preview + Channel Bars -->
                 <div class="col-span-2">
-                    <UiBox :title="$t('receiverModelPreview')" :padding="false" class="bg-muted">
+                    <UiBox
+                        :title="$t('receiverModelPreview')"
+                        type="neutral"
+                        collapsible
+                        :padding="false"
+                        class="bg-muted"
+                    >
                         <div class="background_paper h-48 w-full" ref="modelPreviewContainer">
                             <canvas ref="modelCanvas"></canvas>
                         </div>
@@ -18,8 +24,8 @@
                     <!-- Failsafe / RX-loss warning -->
                     <UiBox
                         v-if="failsafeActive"
-                        highlight
-                        type="warning"
+                        type="neutral"
+                        collapsible
                         role="alert"
                         :title="$t('receiverFailsafeActiveTitle')"
                     >
@@ -55,7 +61,7 @@
                 <div class="col-span-3">
                     <!-- Receiver Mode -->
                     <div class="receiver">
-                        <UiBox :title="$t('configurationReceiver')">
+                        <UiBox :title="$t('configurationReceiver')" type="neutral" collapsible>
                             <SettingRow :label="$t('configurationReceiverMode')">
                                 <USelect
                                     :items="rxModeOptions"
@@ -144,6 +150,8 @@
                         <UiBox
                             :title="$t('configurationTelemetry')"
                             :help="$t('configurationTelemetryHelp')"
+                            type="neutral"
+                            collapsible
                             class="col-span-2"
                         >
                             <SettingRow :label="$t('featureTELEMETRY')">
@@ -155,7 +163,13 @@
                         </UiBox>
 
                         <!-- RSSI -->
-                        <UiBox :title="$t('configurationRSSI')" :help="$t('configurationRSSIHelp')" class="col-span-3">
+                        <UiBox
+                            :title="$t('configurationRSSI')"
+                            :help="$t('configurationRSSIHelp')"
+                            type="neutral"
+                            collapsible
+                            class="col-span-3"
+                        >
                             <div class="flex justify-between gap-2 flex-wrap">
                                 <SettingRow :label="$t('featureRSSI_ADC')">
                                     <USwitch
@@ -180,7 +194,7 @@
                         </UiBox>
 
                         <!-- Channel Map -->
-                        <UiBox :title="$t('receiverChannelMap')" class="col-span-1">
+                        <UiBox :title="$t('receiverChannelMap')" type="neutral" collapsible class="col-span-1">
                             <SettingRow>
                                 <UFieldGroup>
                                     <UInput
@@ -204,7 +218,7 @@
                         </UiBox>
 
                         <!-- Stick settings -->
-                        <UiBox :title="$t('receiverStickRange')" class="col-span-6">
+                        <UiBox :title="$t('receiverStickRange')" type="neutral" collapsible class="col-span-6">
                             <div class="grid grid-cols-3 gap-2">
                                 <SettingColumn
                                     :label="$t('receiverStickMin')"
@@ -258,7 +272,7 @@
                         </UiBox>
 
                         <!-- Deadband settings -->
-                        <UiBox :title="$t('receiverDeadband')" class="col-span-6">
+                        <UiBox :title="$t('receiverDeadband')" type="neutral" collapsible class="col-span-6">
                             <div class="grid grid-cols-3 gap-2">
                                 <SettingColumn
                                     :label="$t('receiverDeadband')"
@@ -310,7 +324,7 @@
                     </div>
 
                     <!-- RC Smoothing -->
-                    <UiBox :title="$t('receiverRcSmoothing')" class="col-span-6">
+                    <UiBox :title="$t('receiverRcSmoothing')" type="neutral" collapsible class="col-span-6">
                         <SettingRow :label="$t('receiverRcSmoothing')">
                             <USwitch
                                 :model-value="rxConfig.rcSmoothing === 1"
@@ -491,10 +505,17 @@
                 @click="openSticksWindow"
                 v-if="showSticksButton"
                 variant="soft"
+                size="xs"
             />
-            <UButton :label="$t('receiverButtonBind')" @click="sendBind" v-if="showBindButton" variant="soft" />
+            <UButton
+                :label="$t('receiverButtonBind')"
+                @click="sendBind"
+                v-if="showBindButton"
+                variant="soft"
+                size="xs"
+            />
             <UFieldGroup size="sm" orientation="horizontal" class="flex!">
-                <UButton @click="saveConfig(needReboot)" :disabled="!dirty || isSaving">
+                <UButton @click="saveConfig(needReboot)" size="xs" :disabled="!dirty || isSaving">
                     {{ $t("receiverButtonSave") }}
                 </UButton>
                 <UDropdownMenu v-slot="{ open }" :items="saveMenuItems" :content="{ align: 'end', side: 'top' }">

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -24,8 +24,8 @@
                     <!-- Failsafe / RX-loss warning -->
                     <UiBox
                         v-if="failsafeActive"
-                        type="neutral"
-                        collapsible
+                        highlight
+                        type="warning"
                         role="alert"
                         :title="$t('receiverFailsafeActiveTitle')"
                     >

--- a/src/components/tabs/ServosTab.vue
+++ b/src/components/tabs/ServosTab.vue
@@ -2,12 +2,10 @@
     <BaseTab tab-name="servos">
         <div class="content_wrapper">
             <div class="tab_title" v-html="$t('tabServos')"></div>
-            <div class="cf_doc_version_bt">
-                <WikiButton docUrl="servos" />
-            </div>
+            <WikiButton docUrl="servos" />
 
             <div v-if="isSupported" class="flex flex-col gap-4">
-                <UiBox :title="$t('servosChangeDirection')">
+                <UiBox :title="$t('servosChangeDirection')" type="neutral" collapsible>
                     <div class="overflow-x-auto">
                         <div
                             class="grid items-center gap-y-1 min-w-0"
@@ -90,13 +88,13 @@
                     </div>
 
                     <div class="flex items-center gap-2 mt-3">
-                        <USwitch v-model="liveMode" size="sm" />
+                        <USwitch v-model="liveMode" size="xs" />
                         <span class="text-sm">{{ $t("servosLiveMode") }}</span>
                     </div>
                 </UiBox>
 
                 <!-- Servo visualization bars -->
-                <UiBox :title="$t('servosText')" class="mt-4">
+                <UiBox :title="$t('servosText')" type="neutral" collapsible class="mt-4">
                     <ul class="grid grid-cols-8 gap-2 mb-1">
                         <li
                             v-for="i in 8"
@@ -144,6 +142,7 @@
                     :label="$t('servosButtonSave')"
                     :disabled="!configHasChanged"
                     :loading="isSaving"
+                    size="xs"
                     @click="saveServoConfig"
                 />
             </div>

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -36,7 +36,12 @@
 
             <!-- Info panels in responsive multi-column grid -->
             <div class="setup-info-grid">
-                <UiBox :title="$t('initialSetupInfoHead')" :help="$t('initialSetupInfoHeadHelp')" type="neutral">
+                <UiBox
+                    :title="$t('initialSetupInfoHead')"
+                    :help="$t('initialSetupInfoHeadHelp')"
+                    type="neutral"
+                    collapsible
+                >
                     <InfoGrid
                         :items="[
                             {
@@ -102,7 +107,12 @@
                         </template>
                     </InfoGrid>
                 </UiBox>
-                <UiBox :title="$t('initialSetupGPSHead')" :help="$t('initialSetupGPSHeadHelp')" type="neutral">
+                <UiBox
+                    :title="$t('initialSetupGPSHead')"
+                    :help="$t('initialSetupGPSHeadHelp')"
+                    type="neutral"
+                    collapsible
+                >
                     <InfoGrid
                         :items="[
                             { id: 'gps3dFix', i18n: 'gps3dFix', slotName: 'gps3dFix' },
@@ -124,7 +134,12 @@
                         </template>
                     </InfoGrid>
                 </UiBox>
-                <UiBox :title="$t('initialSetupInfoBuild')" :help="$t('initialSetupInfoFirmwareHelp')" type="neutral">
+                <UiBox
+                    :title="$t('initialSetupInfoBuild')"
+                    :help="$t('initialSetupInfoFirmwareHelp')"
+                    type="neutral"
+                    collapsible
+                >
                     <InfoGrid
                         :items="[
                             {
@@ -206,6 +221,7 @@
                             :label="$t('initialSetupButtonReset')"
                             color="error"
                             class="w-full justify-center"
+                            size="xs"
                             @click="showConfirmReset"
                         >
                             <template #trailing>
@@ -216,6 +232,7 @@
                             :label="$t('initialSetupButtonRebootBootloader')"
                             color="primary"
                             class="w-full justify-center"
+                            size="xs"
                             @click="onRebootBootloader"
                         >
                             <template #trailing>
@@ -230,6 +247,7 @@
                     :title="$t('initialSetupSonarHead')"
                     :help="$t('initialSetupSonarHeadHelp')"
                     type="neutral"
+                    collapsible
                 >
                     <InfoGrid
                         :items="[
@@ -255,9 +273,10 @@
                         :label="$t('dialogConfirmResetClose')"
                         color="neutral"
                         variant="outline"
+                        size="xs"
                         @click="cancelConfirmReset"
                     />
-                    <UButton :label="$t('dialogConfirmResetConfirm')" color="error" @click="confirmReset" />
+                    <UButton :label="$t('dialogConfirmResetConfirm')" color="error" size="xs" @click="confirmReset" />
                 </div>
             </template>
         </UModal>
@@ -272,7 +291,7 @@
             </template>
             <template #footer>
                 <div class="flex justify-end gap-2 w-full">
-                    <UButton :label="$t('close')" color="neutral" variant="outline" @click="closeBuildInfo" />
+                    <UButton :label="$t('close')" color="neutral" variant="outline" size="xs" @click="closeBuildInfo" />
                 </div>
             </template>
         </UModal>

--- a/src/components/tabs/UserProfileTab.vue
+++ b/src/components/tabs/UserProfileTab.vue
@@ -11,7 +11,7 @@
             <!-- Not Logged In State -->
             <div v-else-if="!isLoggedIn" class="grid-box col3">
                 <div class="options col-span-1"></div>
-                <UiBox class="options col-span-1" :title="$t('notLoggedIn')">
+                <UiBox class="options col-span-1" :title="$t('notLoggedIn')" type="neutral" collapsible>
                     <p>{{ $t("profileLoginMessage") }}</p>
                     <div class="button-container" style="text-align: center">
                         <button type="button" class="regular-button" @click="showLoginDialog">
@@ -101,7 +101,7 @@
                 </UModal>
 
                 <!-- Token Section -->
-                <UiBox class="options col-span-3" :title="$t('sectionUserTokens')">
+                <UiBox class="options col-span-3" :title="$t('sectionUserTokens')" type="neutral" collapsible>
                     <UTable :data="tokens" :columns="tokenColumns" :empty="$t('userTokenNoTokens')" class="text-sm">
                         <template #created-cell="{ row }">
                             {{ formatDate(row.original.created) }}
@@ -129,7 +129,7 @@
                 </UiBox>
 
                 <!-- Passkeys Section -->
-                <UiBox class="options col-span-3" :title="$t('sectionUserPasskeys')">
+                <UiBox class="options col-span-3" :title="$t('sectionUserPasskeys')" type="neutral" collapsible>
                     <UTable
                         :data="passkeys"
                         :columns="passkeyColumns"

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -3,34 +3,32 @@
         <div class="content_wrapper">
             <!-- Title -->
             <div class="tab_title" v-html="$t('tabVtx')"></div>
-            <div class="cf_doc_version_bt">
-                <WikiButton docUrl="vtx" />
-            </div>
+            <WikiButton docUrl="vtx" />
 
             <!-- Help note -->
-            <UiBox highlight class="mb-3" v-show="vtxSupported">
+            <UiBox highlight v-show="vtxSupported">
                 <p v-html="$t('vtxHelp')"></p>
             </UiBox>
 
             <!-- Not supported -->
-            <UiBox highlight class="mb-3" v-show="!vtxSupported">
+            <UiBox highlight v-show="!vtxSupported">
                 <div v-html="$t('vtxMessageNotSupported')"></div>
             </UiBox>
 
             <!-- Table not configured -->
-            <UiBox highlight class="mb-3" v-show="vtxTableNotConfigured">
+            <UiBox highlight v-show="vtxTableNotConfigured">
                 <div v-html="$t('vtxMessageTableNotConfigured')"></div>
             </UiBox>
 
             <!-- Factory bands not supported -->
-            <UiBox highlight class="mb-3" v-show="factoryBandsNotSupported">
+            <UiBox highlight v-show="factoryBandsNotSupported">
                 <div v-html="$t('vtxMessageFactoryBandsNotSupported')"></div>
             </UiBox>
 
             <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
                 <!-- Configuration Panel -->
                 <div class="lg:col-span-3" v-show="vtxSupported">
-                    <UiBox :title="$t('vtxSelectedMode')">
+                    <UiBox :title="$t('vtxSelectedMode')" type="neutral" collapsible class="mt-4">
                         <div class="flex flex-col gap-2">
                             <!-- Frequency/Channel toggle -->
                             <SettingRow :label="$t('vtxFrequencyChannel')" :help="$t('vtxFrequencyChannelHelp')">
@@ -103,7 +101,7 @@
 
                 <!-- VTX Info Panel -->
                 <div class="lg:col-span-1" v-show="vtxSupported">
-                    <UiBox :title="$t('vtxActualState')">
+                    <UiBox :title="$t('vtxActualState')" type="neutral" collapsible class="mt-4">
                         <div class="flex flex-col text-xs">
                             <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
                                 <span v-html="$t('vtxDeviceReady')"></span>
@@ -147,7 +145,7 @@
 
                 <!-- VTX Table -->
                 <div class="lg:col-span-4 overflow-x-auto">
-                    <UiBox :title="$t('vtxTable')" class="min-w-[750px]">
+                    <UiBox :title="$t('vtxTable')" type="neutral" collapsible class="mt-4 min-w-[750px]">
                         <div class="flex flex-col gap-4">
                             <!-- Bands and channels count -->
                             <div class="flex flex-wrap items-end gap-4">
@@ -348,20 +346,20 @@
             </div>
 
             <!-- Save pending warning -->
-            <UiBox highlight class="mb-3" v-show="savePending">
+            <UiBox highlight v-show="savePending">
                 <div v-html="$t('vtxMessageVerifyTable')"></div>
             </UiBox>
         </div>
 
         <!-- Toolbar -->
-        <div class="content_toolbar xs-compressed toolbar_fixed_bottom">
-            <UFieldGroup size="sm" orientation="horizontal">
+        <div class="content_toolbar toolbar_fixed_bottom">
+            <UFieldGroup size="xs" orientation="horizontal">
                 <UButton :label="$t('vtxButtonLoadFile')" @click="loadJsonFile" variant="soft" />
                 <UDropdownMenu v-slot="{ open }" :items="loadMenuItems" :content="{ align: 'end', side: 'top' }">
                     <UButton :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" square variant="soft" />
                 </UDropdownMenu>
             </UFieldGroup>
-            <UFieldGroup size="sm" orientation="horizontal">
+            <UFieldGroup size="xs" orientation="horizontal">
                 <UButton :label="$t('vtxButtonSaveFile')" @click="saveJsonFile" variant="soft" />
                 <UDropdownMenu v-slot="{ open }" :items="saveFileMenuItems" :content="{ align: 'end', side: 'top' }">
                     <UButton :icon="open ? 'i-lucide-chevron-up' : 'i-lucide-chevron-down'" square variant="soft" />

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -32,7 +32,7 @@
                         <div class="flex flex-col gap-2">
                             <!-- Frequency/Channel toggle -->
                             <SettingRow :label="$t('vtxFrequencyChannel')" :help="$t('vtxFrequencyChannelHelp')">
-                                <USwitch v-model="frequencyMode" size="sm" />
+                                <USwitch v-model="frequencyMode" size="xs" />
                             </SettingRow>
 
                             <!-- Band select -->
@@ -70,7 +70,7 @@
 
                             <!-- Pit mode -->
                             <SettingRow :label="$t('vtxPitMode')" :help="$t('vtxPitModeHelp')">
-                                <USwitch v-model="vtxConfig.vtx_pit_mode" size="sm" />
+                                <USwitch v-model="vtxConfig.vtx_pit_mode" size="xs" />
                             </SettingRow>
 
                             <!-- Pit mode frequency -->

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -15,15 +15,15 @@
                 <div v-html="$t('vtxMessageNotSupported')"></div>
             </UiBox>
 
-            <!-- Table not configured -->
-            <UiBox highlight v-show="vtxTableNotConfigured">
-                <div v-html="$t('vtxMessageTableNotConfigured')"></div>
-            </UiBox>
-
-            <!-- Factory bands not supported -->
-            <UiBox highlight v-show="factoryBandsNotSupported">
-                <div v-html="$t('vtxMessageFactoryBandsNotSupported')"></div>
-            </UiBox>
+            <!-- Table not configured / factory bands warnings -->
+            <div v-if="vtxTableNotConfigured || factoryBandsNotSupported" class="flex flex-col gap-2">
+                <UiBox v-show="vtxTableNotConfigured" highlight>
+                    <div v-html="$t('vtxMessageTableNotConfigured')"></div>
+                </UiBox>
+                <UiBox v-show="factoryBandsNotSupported" highlight>
+                    <div v-html="$t('vtxMessageFactoryBandsNotSupported')"></div>
+                </UiBox>
+            </div>
 
             <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
                 <!-- Configuration Panel -->

--- a/src/components/tabs/autotune/AutotuneImport.vue
+++ b/src/components/tabs/autotune/AutotuneImport.vue
@@ -1,9 +1,9 @@
 <template>
-    <UiBox :title="$t('autotuneImportTitle')">
+    <UiBox :title="$t('autotuneImportTitle')" type="neutral" collapsible>
         <!-- Idle / ready to import -->
         <div v-if="store.analysisState === 'idle'" class="flex items-center justify-between gap-4">
             <p v-html="$t('autotuneImportDescription')"></p>
-            <UButton @click="importAndAnalyze" size="sm">
+            <UButton @click="importAndAnalyze" size="xs">
                 {{ $t("autotuneImportButton") }}
             </UButton>
         </div>
@@ -20,7 +20,7 @@
         <!-- Error -->
         <div v-if="store.analysisState === 'error'">
             <p class="text-red-500 font-bold mb-2">{{ store.errorMessage }}</p>
-            <UButton @click="importAndAnalyze" size="sm">
+            <UButton @click="importAndAnalyze" size="xs">
                 {{ $t("autotuneImportRetry") }}
             </UButton>
         </div>
@@ -44,7 +44,7 @@
                     <span class="font-bold">{{ detectedAxes }}</span>
                 </div>
             </div>
-            <UButton @click="importAndAnalyze" size="sm">
+            <UButton @click="importAndAnalyze" size="xs">
                 {{ $t("autotuneImportAnother") }}
             </UButton>
         </div>

--- a/src/components/tabs/autotune/BodePlot.vue
+++ b/src/components/tabs/autotune/BodePlot.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('autotuneBodePlotTitle')">
+    <UiBox :title="$t('autotuneBodePlotTitle')" type="neutral" collapsible>
         <!-- Axis checkboxes — centred -->
         <div class="flex justify-center gap-5">
             <label

--- a/src/components/tabs/autotune/GainRecommendation.vue
+++ b/src/components/tabs/autotune/GainRecommendation.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('autotuneGainTitle')">
+    <UiBox :title="$t('autotuneGainTitle')" type="neutral" collapsible>
         <div v-if="visibleAxisList.length" class="overflow-x-auto mb-3">
             <table class="autotune-table w-full">
                 <!-- Axis group headers -->
@@ -71,7 +71,7 @@
                     </option>
                 </select>
             </label>
-            <UButton @click="onApply" size="sm" :disabled="!isConnected || !selectedAxisKey || applying">
+            <UButton @click="onApply" size="xs" :disabled="!isConnected || !selectedAxisKey || applying">
                 {{ $t("autotuneApplyGains") }}
             </UButton>
             <span v-if="!isConnected" class="text-sm text-dimmed" v-html="$t('autotuneConnectRequired')"></span>

--- a/src/components/tabs/autotune/SpectrogramPlot.vue
+++ b/src/components/tabs/autotune/SpectrogramPlot.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('autotuneSpectrogramTitle')">
+    <UiBox :title="$t('autotuneSpectrogramTitle')" type="neutral" collapsible>
         <div ref="container" class="w-full flex flex-col gap-3">
             <div v-for="axis in visibleAxes" :key="axis.key">
                 <span class="text-xs font-bold" :style="{ color: axis.color }">

--- a/src/components/tabs/firmware-flasher/FlasherBoardBuildTab.vue
+++ b/src/components/tabs/firmware-flasher/FlasherBoardBuildTab.vue
@@ -1,5 +1,5 @@
 <template>
-    <UiBox :title="$t('firmwareFlasherBoardSelectionHead')" type="neutral" class="mt-4">
+    <UiBox :title="$t('firmwareFlasherBoardSelectionHead')" type="neutral" collapsible class="mt-4">
         <UiBox
             highlight
             v-if="state.targetQualificationVisible"
@@ -7,17 +7,17 @@
         >
             {{ state.targetQualificationText }}
         </UiBox>
-        <SettingRow :label="$t('expertMode')" :help="$t('expertModeDescription')" full-width>
+        <SettingRow :label="$t('expertMode')" :help="$t('expertModeDescription')" fullWidth>
             <USwitch v-model="state.expertMode" @change="onExpertModeChange" />
         </SettingRow>
         <SettingRow
             :label="$t('firmwareFlasherShowDevelopmentReleases')"
             :help="$t('firmwareFlasherShowDevelopmentReleasesDescription')"
-            full-width
+            fullWidth
         >
             <USwitch v-model="state.showDevelopmentReleases" @change="onShowDevelopmentReleasesChange" />
         </SettingRow>
-        <SettingRow :help="$t('firmwareFlasherOnlineSelectBuildType')" full-width v-if="state.buildTypeRowVisible">
+        <SettingRow :help="$t('firmwareFlasherOnlineSelectBuildType')" fullWidth v-if="state.buildTypeRowVisible">
             <USelect
                 v-model="state.selectedBuildType"
                 :items="state.buildTypeOptions"
@@ -25,7 +25,7 @@
                 @update:model-value="onBuildTypeChange"
             />
         </SettingRow>
-        <SettingRow :help="$t('firmwareFlasherOnlineSelectBoardHint')" full-width>
+        <SettingRow :help="$t('firmwareFlasherOnlineSelectBoardHint')" fullWidth>
             <div class="flex items-center gap-2">
                 <UFieldGroup class="min-w-80">
                     <USelectMenu
@@ -48,12 +48,13 @@
                         :title="$t('firmwareFlasherOnlineSelectBoardDescription')"
                         icon="i-lucide-search"
                         :loading="boardSelection.state.detectingBoard"
+                        size="xs"
                         @click="onDetectBoard"
                     />
                 </UFieldGroup>
             </div>
         </SettingRow>
-        <SettingRow :help="$t('firmwareFlasherOnlineSelectFirmwareVersionDescription')" full-width>
+        <SettingRow :help="$t('firmwareFlasherOnlineSelectFirmwareVersionDescription')" fullWidth>
             <USelect
                 v-model="boardSelection.state.selectedFirmwareVersion"
                 value-key="release"
@@ -70,7 +71,7 @@
         <SettingRow
             :label="$t('firmwareFlasherFlashOnConnect')"
             :help="$t('firmwareFlasherFlashOnConnectDescription')"
-            full-width
+            fullWidth
             v-if="state.flashOnConnectWrapperVisible"
         >
             <USwitch v-model="state.flashOnConnect" />
@@ -80,6 +81,7 @@
     <UiBox
         :title="$t('firmwareFlasherBuildConfigurationHead')"
         type="neutral"
+        collapsible
         class="build_configuration col-span-1 mt-4"
     >
         <SettingRow :label="$t('coreBuild')" :help="$t('coreBuildModeDescription')">

--- a/src/components/tabs/firmware-flasher/FlasherFlashTab.vue
+++ b/src/components/tabs/firmware-flasher/FlasherFlashTab.vue
@@ -158,7 +158,13 @@
                     >{{ $t("firmwareFlasherReadMore") }}</a
                 >
             </UiBox>
-            <UiBox :title="$t('firmwareFlasherRecoveryHead')" highlight class="note-text-format">
+            <UiBox
+                :title="$t('firmwareFlasherRecoveryHead')"
+                type="neutral"
+                highlight
+                collapsible
+                class="note-text-format"
+            >
                 <p>{{ $t("firmwareFlasherRecoveryShort") }}</p>
                 <a
                     href="https://betaflight.com/docs/wiki/app/firmware-flasher-tab#troubleshooting"
@@ -174,26 +180,27 @@
             v-if="state.expertOptionsVisible"
             :title="$t('firmwareFlasherAdvancedTitle')"
             type="neutral"
+            collapsible
             class="mt-2"
         >
             <SettingRow
                 :label="$t('firmwareFlasherNoReboot')"
                 :help="$t('firmwareFlasherNoRebootDescription')"
-                full-width
+                fullWidth
             >
                 <USwitch v-model="state.noRebootSequence" @change="onNoRebootChange" />
             </SettingRow>
             <SettingRow
                 :label="$t('firmwareFlasherFullChipErase')"
                 :help="$t('firmwareFlasherFullChipEraseDescription')"
-                full-width
+                fullWidth
             >
                 <USwitch v-model="state.eraseChip" @change="onEraseChipChange" />
             </SettingRow>
             <SettingRow
                 :label="$t('firmwareFlasherManualBaud')"
                 :help="$t('firmwareFlasherManualBaudDescription')"
-                full-width
+                fullWidth
             >
                 <USwitch v-model="state.flashManualBaud" @change="onFlashManualBaudChange" />
                 <USelect
@@ -206,6 +213,7 @@
                         { value: 115200, label: '115200' },
                         { value: 57600, label: '57600' },
                     ]"
+                    size="xs"
                     class="min-w-24"
                     @update:model-value="onFlashManualBaudRateChange"
                 />
@@ -217,7 +225,7 @@
                         { label: $t('firmwareBackupEnabled'), value: 1 },
                         { label: $t('firmwareBackupAsk'), value: 2 },
                     ]"
-                    size="sm"
+                    size="xs"
                     v-model="backupOnFlash"
                     class="min-w-40"
                     :ui="{ content: 'z-3002' }"

--- a/src/components/tabs/pid-tuning/FilterSubTab.vue
+++ b/src/components/tabs/pid-tuning/FilterSubTab.vue
@@ -76,7 +76,7 @@
         <!-- Two Column Layout -->
         <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
             <!-- LEFT COLUMN: Non-Profile Filter Settings -->
-            <UiBox :title="$t('pidTuningNonProfileFilterSettings')" type="neutral">
+            <UiBox :title="$t('pidTuningNonProfileFilterSettings')" type="neutral" collapsible>
                 <!-- Gyro Lowpass Filters Section -->
                 <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
                     <span>{{ $t("pidTuningGyroLowpassFiltersGroup") }}</span>
@@ -399,7 +399,7 @@
             </UiBox>
 
             <!-- RIGHT COLUMN: Profile-dependent Filter Settings -->
-            <UiBox :title="$t('pidTuningFilterSettings')" type="neutral">
+            <UiBox :title="$t('pidTuningFilterSettings')" type="neutral" collapsible>
                 <!-- D-Term Lowpass Filters Section -->
                 <div class="flex items-center gap-2 font-semibold text-sm border-b border-default pb-1 mt-2">
                     <span>{{ $t("pidTuningDTermLowpassFiltersGroup") }}</span>

--- a/src/components/tabs/pid-tuning/PidSubTab.vue
+++ b/src/components/tabs/pid-tuning/PidSubTab.vue
@@ -3,7 +3,7 @@
         <!-- LEFT COLUMN: PID Table and Sliders -->
         <div class="flex flex-col gap-4">
             <!-- Tuning Sliders Section -->
-            <UiBox :title="$t('pidTuningSliders')" type="neutral">
+            <UiBox :title="$t('pidTuningSliders')" type="neutral" collapsible>
                 <!-- Slider Header: Mode select + range labels -->
                 <div class="flex items-center gap-3 mb-2">
                     <div class="flex items-center gap-2 min-w-44 shrink-0">
@@ -655,7 +655,7 @@
         <!-- RIGHT COLUMN: PID Controller Settings -->
         <div class="flex flex-col gap-4">
             <!-- PID Settings -->
-            <UiBox :title="$t('pidTuningPidSettings')" type="neutral">
+            <UiBox :title="$t('pidTuningPidSettings')" type="neutral" collapsible>
                 <!-- Feedforward Group -->
                 <div class="flex flex-col gap-2">
                     <span class="text-sm font-semibold" v-html="$t('pidTuningFeedforwardGroup')"></span>
@@ -925,7 +925,7 @@
             </UiBox>
 
             <!-- Motor Settings -->
-            <UiBox :title="$t('pidTuningMotorSettings')" type="neutral">
+            <UiBox :title="$t('pidTuningMotorSettings')" type="neutral" collapsible>
                 <SettingRow :label="$t('pidTuningThrottleBoost')" :help="$t('pidTuningThrottleBoostHelp')">
                     <UInputNumber
                         v-model="advancedTuning.throttleBoost"
@@ -1014,7 +1014,7 @@
             </UiBox>
 
             <!-- Misc Settings -->
-            <UiBox :title="$t('pidTuningMiscSettings')" type="neutral">
+            <UiBox :title="$t('pidTuningMiscSettings')" type="neutral" collapsible>
                 <SettingRow :label="$t('pidTuningCellCount')" :help="$t('pidTuningCellCountHelp')">
                     <USelect
                         v-model="advancedTuning.autoProfileCellCount"

--- a/src/components/tabs/pid-tuning/RatesSubTab.vue
+++ b/src/components/tabs/pid-tuning/RatesSubTab.vue
@@ -199,7 +199,7 @@
             </UiBox>
 
             <!-- Rate Curve -->
-            <UiBox :title="$t('pidTuningRatesCurve')" :help="$t('pidTuningRatesTip')" type="neutral">
+            <UiBox :title="$t('pidTuningRatesCurve')" :help="$t('pidTuningRatesTip')" type="neutral" collapsible>
                 <div
                     class="relative bg-white dark:bg-neutral-900 border border-default p-1"
                     style="height: 362px; min-width: 200px"
@@ -286,14 +286,14 @@
             </UiBox>
 
             <!-- Throttle Curve Preview -->
-            <UiBox :title="$t('pidTuningThrottleCurvePreview')" type="neutral">
+            <UiBox :title="$t('pidTuningThrottleCurvePreview')" type="neutral" collapsible>
                 <div class="bg-white dark:bg-neutral-900 border border-default p-1" style="height: 164px">
                     <canvas ref="throttleCurveCanvas" class="w-full h-full block"></canvas>
                 </div>
             </UiBox>
 
             <!-- Rates 3D Preview -->
-            <UiBox :title="$t('pidTuningRatesModelPreview')" type="neutral">
+            <UiBox :title="$t('pidTuningRatesModelPreview')" type="neutral" collapsible>
                 <div class="bg-white dark:bg-neutral-900 border border-default p-1 w-full" ref="ratesPreviewContainer">
                     <canvas ref="ratesPreviewCanvas" class="block"></canvas>
                 </div>

--- a/src/components/tabs/sensors/SensorGraph.vue
+++ b/src/components/tabs/sensors/SensorGraph.vue
@@ -3,11 +3,14 @@
         <!-- Normal sensor layout -->
         <UiBox v-if="!isDebug">
             <div class="grid grid-cols-[1fr_10rem] gap-4 w-full">
+                <!-- The `x` groups are positioned on the plot baseline by
+                     useSensorGraph's applyGraphTransforms — their offset depends on the
+                     measured height, so it must not be hardcoded here. -->
                 <svg :id="svgId" ref="svgElement" class="w-full h-full">
-                    <g class="grid x" transform="translate(40, 120)"></g>
+                    <g class="grid x"></g>
                     <g class="grid y" transform="translate(40, 10)"></g>
-                    <g class="data" transform="translate(41, 10)"></g>
-                    <g class="axis x" transform="translate(40, 120)"></g>
+                    <g class="data" transform="translate(40, 10)"></g>
+                    <g class="axis x"></g>
                     <g class="axis y" transform="translate(40, 10)"></g>
                 </svg>
                 <div class="text-[10px] flex flex-col gap-1 [&_button]:text-[10px]! [&_[data-slot=base]]:text-[10px]!">
@@ -64,10 +67,10 @@
         <UiBox v-else>
             <div class="grid grid-cols-[1fr_10rem] gap-4 w-full">
                 <svg :id="svgId" ref="svgElement" class="w-full h-[140px]">
-                    <g class="grid x" transform="translate(40, 120)"></g>
+                    <g class="grid x"></g>
                     <g class="grid y" transform="translate(40, 10)"></g>
-                    <g class="data" transform="translate(41, 10)"></g>
-                    <g class="axis x" transform="translate(40, 120)"></g>
+                    <g class="data" transform="translate(40, 10)"></g>
+                    <g class="axis x"></g>
                     <g class="axis y" transform="translate(40, 10)"></g>
                 </svg>
                 <div class="text-[10px] flex flex-col gap-1 [&_button]:text-[10px]! [&_[data-slot=base]]:text-[10px]!">

--- a/src/composables/useMapViewport.js
+++ b/src/composables/useMapViewport.js
@@ -1,0 +1,106 @@
+import { onScopeDispose, ref } from "vue";
+
+/**
+ * Viewport plumbing shared by the OpenLayers maps (GPS, Preflight, Flight Plan).
+ *
+ * Two concerns that every map tab needs and none of them should re-implement:
+ *
+ *  - Fullscreen toggling, including the WebKit and MS prefixed spellings, with the
+ *    map resized once the browser has switched modes.
+ *  - Keeping OpenLayers' cached viewport size in step with the container.  The maps
+ *    live inside collapsible UiBoxes that hide their content with `v-show`, so a map
+ *    can be laid out while it has no box at all; OpenLayers will not notice when the
+ *    container becomes visible again and renders blank or clipped.  Observing the
+ *    container covers that, plus window resizes and any other layout change.
+ *
+ * Document listeners are attached immediately and released when the owning
+ * component's scope is disposed, so callers only need to wire up the returned state.
+ *
+ * @param {import("vue").Ref<HTMLElement|null>} containerRef Element to fullscreen and observe.
+ * @param {() => object|null|undefined} getMap Resolves the ol/Map; it may not exist yet.
+ */
+export function useMapViewport(containerRef, getMap) {
+    const isFullscreen = ref(false);
+
+    const updateSize = () => getMap()?.updateSize();
+
+    const toggleFullscreen = () => {
+        const container = containerRef.value;
+        if (!container) {
+            return;
+        }
+
+        if (!document.fullscreenElement && !document.webkitFullscreenElement && !document.msFullscreenElement) {
+            if (container.requestFullscreen) {
+                container.requestFullscreen();
+            } else if (container.webkitRequestFullscreen) {
+                container.webkitRequestFullscreen();
+            } else if (container.msRequestFullscreen) {
+                container.msRequestFullscreen();
+            }
+        } else if (document.exitFullscreen) {
+            document.exitFullscreen();
+        } else if (document.webkitExitFullscreen) {
+            document.webkitExitFullscreen();
+        } else if (document.msExitFullscreen) {
+            document.msExitFullscreen();
+        }
+    };
+
+    const handleFullscreenChange = () => {
+        isFullscreen.value = !!(
+            document.fullscreenElement ||
+            document.webkitFullscreenElement ||
+            document.msFullscreenElement
+        );
+        // The map can only be measured once the browser has finished switching modes.
+        requestAnimationFrame(updateSize);
+    };
+
+    const FULLSCREEN_EVENTS = ["fullscreenchange", "webkitfullscreenchange", "MSFullscreenChange"];
+    for (const event of FULLSCREEN_EVENTS) {
+        document.addEventListener(event, handleFullscreenChange);
+    }
+
+    let resizeObserver = null;
+
+    /**
+     * Start watching the container.  Safe to call more than once and before the map
+     * exists — only the container is needed, and the map is resolved per callback.
+     */
+    const observeContainer = () => {
+        if (resizeObserver || !containerRef.value) {
+            return;
+        }
+
+        resizeObserver = new ResizeObserver((entries) => {
+            const map = getMap();
+            if (!map) {
+                return;
+            }
+            for (const { contentRect } of entries) {
+                if (contentRect.width > 0 && contentRect.height > 0) {
+                    map.updateSize();
+                    break;
+                }
+            }
+        });
+
+        resizeObserver.observe(containerRef.value);
+    };
+
+    /** Idempotent: callers with their own teardown path may also call this. */
+    const teardown = () => {
+        for (const event of FULLSCREEN_EVENTS) {
+            document.removeEventListener(event, handleFullscreenChange);
+        }
+        if (resizeObserver) {
+            resizeObserver.disconnect();
+            resizeObserver = null;
+        }
+    };
+
+    onScopeDispose(teardown);
+
+    return { isFullscreen, toggleFullscreen, observeContainer, teardown };
+}

--- a/src/composables/useSensorGraph.js
+++ b/src/composables/useSensorGraph.js
@@ -2,7 +2,11 @@ import { ref } from "vue";
 import * as d3 from "d3";
 
 export function useSensorGraph() {
-    const margin = { top: 20, right: 10, bottom: 10, left: 40 };
+    // `bottom` is the gutter that holds the x-axis tick labels, `top` the gap above
+    // the plot.  The axis groups are positioned from these values at draw time
+    // (see applyGraphTransforms) — never hardcode them in the SVG template, or the
+    // horizontal scale drifts off the bottom of the plot when the SVG is resized.
+    const margin = { top: 10, right: 10, bottom: 20, left: 40 };
 
     // Data arrays
     const gyro_data = ref([]);
@@ -63,18 +67,42 @@ export function useSensorGraph() {
         return sampleNumber + 1;
     }
 
+    // Returns true when the measured plot area changed, so callers can skip the
+    // expensive scale/clip-path rebuild while the SVG keeps its size.
     function measureGraphSize(helpers) {
         const node = d3.select(helpers.selector).node();
         if (!node) {
-            return;
+            return false;
         }
         const rect = node.getBoundingClientRect();
-        helpers.width = Math.max(0, rect.width - margin.left - margin.right);
-        helpers.height = Math.max(0, rect.height - margin.top - margin.bottom);
+        const width = Math.max(0, rect.width - margin.left - margin.right);
+        const height = Math.max(0, rect.height - margin.top - margin.bottom);
+        if (width === helpers.width && height === helpers.height) {
+            return false;
+        }
+        helpers.width = width;
+        helpers.height = height;
+        return true;
+    }
+
+    // Place the axis, grid and data groups for the measured plot area: the y groups
+    // at the top-left corner of the plot, the x groups on its baseline so the
+    // horizontal scale always sits directly below the vertical one.
+    function applyGraphTransforms(helpers) {
+        const element = d3.select(helpers.selector);
+        const topLeft = `translate(${margin.left}, ${margin.top})`;
+        const baseline = `translate(${margin.left}, ${margin.top + helpers.height})`;
+
+        element.select(".grid.y").attr("transform", topLeft);
+        element.select(".axis.y").attr("transform", topLeft);
+        element.select(".data").attr("transform", topLeft);
+        element.select(".grid.x").attr("transform", baseline);
+        element.select(".axis.x").attr("transform", baseline);
     }
 
     function updateGraphHelperSize(helpers) {
         measureGraphSize(helpers);
+        applyGraphTransforms(helpers);
 
         // Always initialize scales to prevent undefined errors
         helpers.scaleX = d3.scaleLinear().domain([0, 300]).range([0, helpers.width]);
@@ -143,8 +171,10 @@ export function useSensorGraph() {
     }
 
     function drawGraph(helpers, sampleNumber) {
-        // Re-measure if dimensions are not yet available (e.g. SVG was hidden via v-show)
-        if (!helpers.width || !helpers.height) {
+        // Re-measure every frame: the SVG may have been hidden via v-show when the
+        // graph was created, and it stretches with the window.  updateGraphHelperSize
+        // only rebuilds the scales and clip path when the size actually changed.
+        if (measureGraphSize(helpers) || !helpers.width || !helpers.height) {
             updateGraphHelperSize(helpers);
             if (!helpers.width || !helpers.height) {
                 return false;

--- a/src/css/theme.css
+++ b/src/css/theme.css
@@ -95,6 +95,9 @@ html {
     --primary-action-border: var(--success-600);
     --primary-action-hover: var(--success-400);
 
+    /* Elevation for floating panels (popovers, detached pickers). */
+    --shadow-popup: 0 4px 12px rgba(0, 0, 0, 0.3);
+
     --ui-radius: 0.35rem;
 }
 
@@ -120,6 +123,10 @@ html {
 
     /* Lighter shade so warning foregrounds keep 3:1 against dark surfaces. */
     --warning-700: #ff8533;
+
+    /* --surface-50 is nearly black in dark mode, where a 0.3 alpha shadow all but
+       disappears and floating panels lose their separation from the page. */
+    --shadow-popup: 0 4px 12px rgba(0, 0, 0, 0.6);
 
     --text: hsl(0, 0%, 95%);
 }

--- a/test/js/sensor_graph_axes.test.js
+++ b/test/js/sensor_graph_axes.test.js
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { useSensorGraph } from "../../src/composables/useSensorGraph.js";
+
+// The graph SVGs stretch with their container, so the x-axis offset cannot be
+// baked into the template — it has to be derived from the measured height, or the
+// horizontal scale ends up floating in the middle of the plot instead of sitting
+// on the baseline of the vertical scale (see ReceiverTab for the fixed-height case
+// that happened to work).
+const GRAPH_IDS = ["gyro", "accel", "mag", "altitude", "sonar"];
+
+// Mirrors the margins in useSensorGraph.
+const MARGIN = { top: 10, bottom: 20, left: 40, right: 10 };
+
+let svgHeight = 160;
+const SVG_WIDTH = 500;
+
+function buildGraph(id) {
+    const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    svg.id = id;
+    for (const className of ["grid x", "grid y", "data", "axis x", "axis y"]) {
+        const group = document.createElementNS("http://www.w3.org/2000/svg", "g");
+        group.setAttribute("class", className);
+        svg.appendChild(group);
+    }
+    // jsdom has no layout engine, so feed the composable a size of our choosing.
+    svg.getBoundingClientRect = () => ({ width: SVG_WIDTH, height: svgHeight });
+    document.body.appendChild(svg);
+}
+
+function transformOf(id, selector) {
+    return document.querySelector(`#${id} ${selector}`).getAttribute("transform");
+}
+
+describe("sensor graph axis placement", () => {
+    beforeEach(() => {
+        svgHeight = 160;
+        for (const id of GRAPH_IDS) {
+            buildGraph(id);
+        }
+    });
+
+    afterEach(() => {
+        document.body.innerHTML = "";
+    });
+
+    it("puts the horizontal scale on the baseline of the vertical scale", () => {
+        const { initializeGraphs } = useSensorGraph();
+        initializeGraphs({}, 0);
+
+        const plotHeight = svgHeight - MARGIN.top - MARGIN.bottom;
+
+        for (const id of GRAPH_IDS) {
+            expect(transformOf(id, ".axis.y")).toBe(`translate(${MARGIN.left}, ${MARGIN.top})`);
+            expect(transformOf(id, ".axis.x")).toBe(`translate(${MARGIN.left}, ${MARGIN.top + plotHeight})`);
+            // The grid must line up with the axes it belongs to.
+            expect(transformOf(id, ".grid.y")).toBe(transformOf(id, ".axis.y"));
+            expect(transformOf(id, ".grid.x")).toBe(transformOf(id, ".axis.x"));
+            // Data shares the plot origin with the vertical scale.
+            expect(transformOf(id, ".data")).toBe(transformOf(id, ".axis.y"));
+        }
+    });
+
+    it("leaves room below the plot for the x tick labels", () => {
+        const { initializeGraphs } = useSensorGraph();
+        initializeGraphs({}, 0);
+
+        const baseline = Number(transformOf("gyro", ".axis.x").match(/,\s*(\d+)/)[1]);
+        expect(svgHeight - baseline).toBe(MARGIN.bottom);
+    });
+
+    it("follows the SVG when it is resized", () => {
+        const { initializeGraphs, addGyroSample, updateGraphs } = useSensorGraph();
+        initializeGraphs({}, 0);
+
+        svgHeight = 260;
+        addGyroSample([1, 2, 3]);
+        updateGraphs();
+
+        const plotHeight = svgHeight - MARGIN.top - MARGIN.bottom;
+        expect(transformOf("gyro", ".axis.x")).toBe(`translate(${MARGIN.left}, ${MARGIN.top + plotHeight})`);
+    });
+});


### PR DESCRIPTION
### UI

- [x] First run on unifying Tab UI.
- [x] PreflightTab — 8 UiBox groups still need type="neutral" collapsible                                   
- [x] FlightPlanTab — 4 UiBox groups need the same                                                          
- [x] Remaining hardcoded colors — receiver channel bars are intentional, LED strip visualization (firmware colors), Backups loading state
- [x] Button size consistency — a handful of size="sm" → size="xs" in toolbar/header contexts
- [x] Square buttons in onboard_logging tab.
- [x] Square buttons in ledstrip tab.
- [x] Fix horizontal scales on sensors and motor tab.

### BUGFIX

- [x] Prevent window scrolling when using mouse for motor testing.


Remaining work for follow up.

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## UI Improvements

* Added collapsible, neutral-styled sections across configuration, flight planning, GPS, receiver, firmware, PID tuning, and other settings panels.
* Standardized compact controls, responsive layouts, spacing, documentation buttons, help panels, warnings, status displays, maps, charts, color controls, and empty states.
* Improved fullscreen map controls, toolbar consistency, and popup styling in light and dark themes.

## Bug Fixes

* Improved map and sensor graph rendering when containers resize or become visible.
* Prevented page scrolling while motor testing is armed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->