### PR TITLE
Resolved bug in drawing of dynamic filters curves at the spectrum chart

### DIFF
--- a/src/blackbox-viewer/graph_spectrum_plot.js
+++ b/src/blackbox-viewer/graph_spectrum_plot.js
@@ -1275,6 +1275,7 @@ GraphSpectrumPlot._drawLowpassDynFilter = function (
         const scaleX = WIDTH / maximalFrequency;
         const NUMBER_OF_POINTS = this._isFullScreen ? 30 : 10;
 
+        /** `@type` {Array<{x: number, y: number}>} */
         const points = [];
         for (let i = 0; i < NUMBER_OF_POINTS; i++) {
             const throttle = i / (NUMBER_OF_POINTS - 1);

--- a/src/blackbox-viewer/graph_spectrum_plot.js
+++ b/src/blackbox-viewer/graph_spectrum_plot.js
@@ -1275,7 +1275,6 @@ GraphSpectrumPlot._drawLowpassDynFilter = function (
         const scaleX = WIDTH / maximalFrequency;
         const NUMBER_OF_POINTS = this._isFullScreen ? 30 : 10;
 
-        let startPlot = false;
         const points = [];
         for (let i = 0; i < NUMBER_OF_POINTS; i++) {
             const throttle = i / (NUMBER_OF_POINTS - 1);
@@ -1286,21 +1285,10 @@ GraphSpectrumPlot._drawLowpassDynFilter = function (
             const frequency = (frequency2 - frequency1) * curve + frequency1;
 
             const x = scaleX * frequency;
-
-            if (x >= x1) {
-                if (startPlot === false) {
-                    // Interpolate a more or less correct y in the x1 position
-                    points.push({
-                        x: x1,
-                        y: y + (HEIGHT - y) * (1 - x1 / x),
-                    });
-                }
-                startPlot = true;
-                points.push({
-                    x,
-                    y,
-                });
-            }
+            points.push({
+                x,
+                y,
+            });
         }
 
         this._drawCurve(canvasCtx, points);


### PR DESCRIPTION
Resolved a small bug in drawing dynamic filters curves at the spectrum chart.
The curves first point was missed sometime by compare with x1 value (it depended on charts scale):
<img width="1373" height="753" alt="SpectrumFiltersCurve" src="https://github.com/user-attachments/assets/5021c371-d7fb-42fa-943f-0b1b0fd07747" />
It resoves now:
<img width="1377" height="753" alt="SpectrumFiltersCurve2" src="https://github.com/user-attachments/assets/6a38970e-aab3-4225-972f-4416a1a41cad" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic filter spectrum plotting so all computed points are rendered, producing smoother and more accurate curves.
  * Fixed an issue where portions of the curve prior to the first cutoff frequency could be omitted from the visualization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->