### PR TITLE
Unify Blackbox Explorer into the host app and preserve its log across tab switches

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,12 +30,14 @@
                     <div class="clear-both"></div>
                 </div>
                 <div id="content" @scroll.passive="onContentScroll">
-                    <component
-                        :is="activeTabComponent"
-                        v-if="activeTabComponent"
-                        :key="vueTabState.activeTabKey"
-                        ref="activeTabInstance"
-                    />
+                    <keep-alive :include="keptAliveTabs">
+                        <component
+                            :is="activeTabComponent"
+                            v-if="activeTabComponent"
+                            :key="activeTabKey"
+                            ref="activeTabInstance"
+                        />
+                    </keep-alive>
                 </div>
             </div>
             <status-bar
@@ -183,6 +185,16 @@ const activeTabComponent = computed(() => {
     const tabName = vueTabState.activeTabName;
     return tabName ? (VueTabComponents[tabName] ?? null) : null;
 });
+
+// Tabs that keep their state (and heavy resources) alive across switches rather than being torn
+// down. Matched by component name.
+const keptAliveTabs = ["BlackboxViewerTab"];
+
+// The mounter bumps activeTabKey on every switch to force a fresh instance. Kept-alive tabs need
+// a stable key instead, or keep-alive caches by an ever-changing key and never restores.
+const activeTabKey = computed(() =>
+    vueTabState.activeTabName === "blackbox_viewer" ? "blackbox_viewer" : vueTabState.activeTabKey,
+);
 
 provide("betaflightModel", currentVm());
 provide("gui", GUI);

--- a/src/blackbox-viewer/App.vue
+++ b/src/blackbox-viewer/App.vue
@@ -337,17 +337,19 @@ function onGotoBookmark(index) {
 
 // Drag-and-drop file loading (window-level)
 function onDragOver(e) {
+    // Always swallow the browser default so a stray file drop never navigates away, even while
+    // the viewer is kept alive behind another tab; only the copy affordance is viewer-specific.
+    e.preventDefault();
     if (!appStore.viewerActive) {
         return;
     }
-    e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
 }
 function onDrop(e) {
+    e.preventDefault();
     if (!appStore.viewerActive) {
         return;
     }
-    e.preventDefault();
     const item = e.dataTransfer.items?.[0];
     const entry = item?.webkitGetAsEntry?.();
     if (entry?.isFile) {

--- a/src/blackbox-viewer/App.vue
+++ b/src/blackbox-viewer/App.vue
@@ -1,113 +1,111 @@
 <template>
-    <UApp>
-        <div id="blackbox-app">
-            <!-- Teleported into legacy DOM layout -->
-            <Teleport to="#vue-welcome">
-                <WelcomePage @files-selected="onFilesSelected" />
-            </Teleport>
-            <Teleport to="#vue-navbar">
-                <AppToolbar
-                    @files-selected="onFilesSelected"
-                    @open-settings="onOpenSettings"
-                    @open-keys="onOpenKeys"
-                    @export-csv="onExportCsv"
-                    @export-gpx="onExportGpx"
-                />
-            </Teleport>
-            <Teleport to="#vue-statusbar">
-                <StatusBar @goto-bookmark="onGotoBookmark" />
-            </Teleport>
-
-            <Teleport to="#vue-view-controls">
-                <ViewControls
-                    :header-active="appStore.headerDialogOpen"
-                    :table-active="graphStore.hasTableOverlay"
-                    :video-active="appStore.viewVideo"
-                    :craft-active="graphStore.hasCraft"
-                    :sticks-active="graphStore.hasSticks"
-                    :analyser-active="graphStore.hasAnalyser"
-                    :map-active="graphStore.hasMap"
-                    @view-config="onViewConfig"
-                    @toggle-header="onToggleHeader"
-                    @toggle-table="onToggleTable"
-                    @toggle-video="onToggleVideo"
-                    @toggle-craft="onToggleCraft"
-                    @toggle-sticks="onToggleSticks"
-                    @toggle-analyser="onToggleAnalyser"
-                    @toggle-map="onToggleMap"
-                />
-            </Teleport>
-            <Teleport to="#vue-playback">
-                <PlaybackControls
-                    @jump-start="onJumpStart"
-                    @jump-end="onJumpEnd"
-                    @step-back="onStepBack"
-                    @step-forward="onStepForward"
-                    @play-pause="onPlayPause"
-                    @video-jump-start="onVideoJumpStart"
-                    @video-jump-end="onVideoJumpEnd"
-                />
-            </Teleport>
-
-            <Teleport to="#vue-speed-panel">
-                <SpeedPanel @rate-change="onRateChange" />
-            </Teleport>
-            <Teleport to="#vue-zoom-panel">
-                <ZoomPanel @zoom-change="onZoomChange" />
-            </Teleport>
-            <Teleport to="#vue-time-panel">
-                <TimePanel @time-change="onTimeChange" />
-            </Teleport>
-            <Teleport to="#vue-sync-panel">
-                <SyncPanel
-                    @sync-back="onSyncBack"
-                    @sync-forward="onSyncForward"
-                    @sync-here="onSyncHere"
-                    @smart-sync="onSmartSync"
-                    @offset-change="onOffsetChange"
-                />
-            </Teleport>
-            <Teleport to="#vue-workspace-panel">
-                <WorkspacePanel
-                    @switch-workspace="onSwitchWorkspace"
-                    @save-workspace="onSaveWorkspace"
-                    @apply-default="onApplyDefaultWorkspace"
-                />
-            </Teleport>
-            <Teleport to="#vue-log-panel">
-                <LogPanel />
-            </Teleport>
-
-            <Teleport to="#vue-analyser">
-                <SpectrumAnalyser />
-            </Teleport>
-            <Teleport to="#vue-legend-panel">
-                <LegendPanel />
-            </Teleport>
-            <FieldValuesPanel />
-            <ConfigurationPanel />
-            <Teleport to="#vue-seekbar-toolbar">
-                <SeekBarToolbar />
-            </Teleport>
-
-            <!-- Dialogs -->
-            <KeysDialog v-model:open="appStore.keysDialogOpen" />
-            <UserSettingsDialog v-model:open="appStore.settingsDialogOpen" @save="onSaveSettings" />
-            <GraphConfigDialog
-                v-model:open="appStore.graphConfigDialogOpen"
-                :flightLog="logStore.flightLog"
-                :graphConfig="graphStore.activeGraphConfig"
-                :grapher="graphStore.graph"
-                @save="onGraphConfigSave"
-                @update="onGraphConfigUpdate"
+    <div id="blackbox-app">
+        <!-- Teleported into legacy DOM layout -->
+        <Teleport to="#vue-welcome">
+            <WelcomePage @files-selected="onFilesSelected" />
+        </Teleport>
+        <Teleport to="#vue-navbar">
+            <AppToolbar
+                @files-selected="onFilesSelected"
+                @open-settings="onOpenSettings"
+                @open-keys="onOpenKeys"
+                @export-csv="onExportCsv"
+                @export-gpx="onExportGpx"
             />
-            <HeaderDialog v-model:open="appStore.headerDialogOpen" :sysConfig="sysConfig" />
-        </div>
-    </UApp>
+        </Teleport>
+        <Teleport to="#vue-statusbar">
+            <StatusBar @goto-bookmark="onGotoBookmark" />
+        </Teleport>
+
+        <Teleport to="#vue-view-controls">
+            <ViewControls
+                :header-active="appStore.headerDialogOpen"
+                :table-active="graphStore.hasTableOverlay"
+                :video-active="appStore.viewVideo"
+                :craft-active="graphStore.hasCraft"
+                :sticks-active="graphStore.hasSticks"
+                :analyser-active="graphStore.hasAnalyser"
+                :map-active="graphStore.hasMap"
+                @view-config="onViewConfig"
+                @toggle-header="onToggleHeader"
+                @toggle-table="onToggleTable"
+                @toggle-video="onToggleVideo"
+                @toggle-craft="onToggleCraft"
+                @toggle-sticks="onToggleSticks"
+                @toggle-analyser="onToggleAnalyser"
+                @toggle-map="onToggleMap"
+            />
+        </Teleport>
+        <Teleport to="#vue-playback">
+            <PlaybackControls
+                @jump-start="onJumpStart"
+                @jump-end="onJumpEnd"
+                @step-back="onStepBack"
+                @step-forward="onStepForward"
+                @play-pause="onPlayPause"
+                @video-jump-start="onVideoJumpStart"
+                @video-jump-end="onVideoJumpEnd"
+            />
+        </Teleport>
+
+        <Teleport to="#vue-speed-panel">
+            <SpeedPanel @rate-change="onRateChange" />
+        </Teleport>
+        <Teleport to="#vue-zoom-panel">
+            <ZoomPanel @zoom-change="onZoomChange" />
+        </Teleport>
+        <Teleport to="#vue-time-panel">
+            <TimePanel @time-change="onTimeChange" />
+        </Teleport>
+        <Teleport to="#vue-sync-panel">
+            <SyncPanel
+                @sync-back="onSyncBack"
+                @sync-forward="onSyncForward"
+                @sync-here="onSyncHere"
+                @smart-sync="onSmartSync"
+                @offset-change="onOffsetChange"
+            />
+        </Teleport>
+        <Teleport to="#vue-workspace-panel">
+            <WorkspacePanel
+                @switch-workspace="onSwitchWorkspace"
+                @save-workspace="onSaveWorkspace"
+                @apply-default="onApplyDefaultWorkspace"
+            />
+        </Teleport>
+        <Teleport to="#vue-log-panel">
+            <LogPanel />
+        </Teleport>
+
+        <Teleport to="#vue-analyser">
+            <SpectrumAnalyser />
+        </Teleport>
+        <Teleport to="#vue-legend-panel">
+            <LegendPanel />
+        </Teleport>
+        <FieldValuesPanel />
+        <ConfigurationPanel />
+        <Teleport to="#vue-seekbar-toolbar">
+            <SeekBarToolbar />
+        </Teleport>
+
+        <!-- Dialogs -->
+        <KeysDialog v-model:open="appStore.keysDialogOpen" />
+        <UserSettingsDialog v-model:open="appStore.settingsDialogOpen" @save="onSaveSettings" />
+        <GraphConfigDialog
+            v-model:open="appStore.graphConfigDialogOpen"
+            :flightLog="logStore.flightLog"
+            :graphConfig="graphStore.activeGraphConfig"
+            :grapher="graphStore.graph"
+            @save="onGraphConfigSave"
+            @update="onGraphConfigUpdate"
+        />
+        <HeaderDialog v-model:open="appStore.headerDialogOpen" :sysConfig="sysConfig" />
+    </div>
 </template>
 
 <script setup>
-import { computed, watchEffect, onMounted, onUnmounted, inject } from "vue";
+import { computed, watchEffect, onMounted, onUnmounted, inject, unref } from "vue";
 import { useGraphStore } from "./stores/graph.js";
 import { useAppStore } from "./stores/app.js";
 import { useLogStore, FIRMWARE_CLASSES } from "./stores/log.js";
@@ -144,11 +142,18 @@ const workspaceStore = useWorkspaceStore();
 
 // State classes are applied to the viewer root element (provided by the embedding tab) so
 // they stay scoped to the viewer subtree and never leak onto the host configurator's <html>.
-const viewerRoot = inject("bbvRoot", null);
+// Embedded: a ref to the tab root, null until the tab mounts. Standalone: nothing injected.
+const injectedRoot = inject("bbvRoot", null);
 
 // Centralized CSS class binding — replaces 27 imperative html.classList calls in main.js
 watchEffect(() => {
-    const cl = (viewerRoot ?? document.documentElement).classList;
+    // Only fall back to <html> when running standalone (no root injected); when embedded, wait
+    // for the ref to resolve rather than toggling classes onto the host document.
+    const el = injectedRoot === null ? document.documentElement : unref(injectedRoot);
+    if (!el) {
+        return;
+    }
+    const cl = el.classList;
     cl.toggle("has-log", logStore.hasLog);
     cl.toggle("has-video", logStore.hasVideo);
     cl.toggle("has-gps", logStore.hasGps);
@@ -332,10 +337,16 @@ function onGotoBookmark(index) {
 
 // Drag-and-drop file loading (window-level)
 function onDragOver(e) {
+    if (!appStore.viewerActive) {
+        return;
+    }
     e.preventDefault();
     e.dataTransfer.dropEffect = "copy";
 }
 function onDrop(e) {
+    if (!appStore.viewerActive) {
+        return;
+    }
     e.preventDefault();
     const item = e.dataTransfer.items?.[0];
     const entry = item?.webkitGetAsEntry?.();

--- a/src/blackbox-viewer/grapher.js
+++ b/src/blackbox-viewer/grapher.js
@@ -68,7 +68,7 @@ export function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, cr
         craft3D = null,
         craft2D = null,
         analyser = null /* define a new spectrum analyser */,
-        watermarkLogo /* Watermark feature */;
+        watermarkLogo; /* Watermark feature */
     this.onSeek = null;
 
     this.getAnalyser = function () {
@@ -1188,8 +1188,6 @@ export function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, cr
 
     graphConfig.addListener(this.refreshGraphConfig);
     this.refreshGraphConfig();
-
-    document.documentElement.classList.toggle("has-grid-override", options["graphGridOverride"]);
 
     this.resize(canvas.width, canvas.height);
 }

--- a/src/blackbox-viewer/keyboard_handler.js
+++ b/src/blackbox-viewer/keyboard_handler.js
@@ -284,6 +284,10 @@ export function createKeydownHandler(ctx) {
     }
 
     return function (e) {
+        // Dormant behind other tabs (embedded): don't hijack keys the user means for the host.
+        if (!appStore.viewerActive) {
+            return;
+        }
         const shifted = e.altKey || e.shiftKey || e.ctrlKey || e.metaKey;
         if (e.key === "Enter" && e.target.type === "text" && !e.target.closest(".modal")) {
             e.target.blur();

--- a/src/blackbox-viewer/log_lifecycle.js
+++ b/src/blackbox-viewer/log_lifecycle.js
@@ -1,4 +1,4 @@
-import pinia from "./pinia_instance.js";
+import { pinia } from "@/js/pinia_instance.js";
 import { useLogStore } from "./stores/log.js";
 import { useGraphStore } from "./stores/graph.js";
 import { useAppStore } from "./stores/app.js";

--- a/src/blackbox-viewer/main.js
+++ b/src/blackbox-viewer/main.js
@@ -47,7 +47,7 @@ import {
 import { PrefStorage } from "./pref_storage.js";
 import { DarkTheme } from "./dark_theme.js";
 import { ThemeColors } from "./theme_colors.js";
-import pinia from "./pinia_instance.js";
+import { pinia } from "@/js/pinia_instance.js";
 import { useLogStore } from "./stores/log.js";
 import { useGraphStore } from "./stores/graph.js";
 import { usePlaybackStore, GRAPH_STATE_PAUSED } from "./stores/playback.js";
@@ -541,6 +541,9 @@ export function bootstrapViewer() {
         }
 
         const onDocumentWheel = function (e) {
+            if (!appStore.viewerActive) {
+                return;
+            }
             if (e.target.classList.contains("no-wheel")) {
                 e.preventDefault();
                 return;

--- a/src/blackbox-viewer/pinia_instance.js
+++ b/src/blackbox-viewer/pinia_instance.js
@@ -1,5 +1,0 @@
-import { createPinia } from "pinia";
-
-const pinia = createPinia();
-
-export default pinia;

--- a/src/blackbox-viewer/playback_controls.js
+++ b/src/blackbox-viewer/playback_controls.js
@@ -1,5 +1,5 @@
 import { throttle } from "throttle-debounce";
-import pinia from "./pinia_instance.js";
+import { pinia } from "@/js/pinia_instance.js";
 import { useLogStore } from "./stores/log.js";
 import { useGraphStore, GRAPH_MIN_ZOOM, GRAPH_MAX_ZOOM } from "./stores/graph.js";
 import {

--- a/src/blackbox-viewer/stores/app.js
+++ b/src/blackbox-viewer/stores/app.js
@@ -6,6 +6,11 @@ export const useAppStore = defineStore("app", () => {
     const viewVideo = ref(true);
     const darkThemeEnabled = ref(false);
 
+    // True while the viewer is the visible tab. Embedded, the host tab flips this on
+    // activate/deactivate so the viewer's document-level handlers (keyboard, wheel, drag) go
+    // dormant behind other tabs. Defaults true so the standalone viewer is unaffected.
+    const viewerActive = ref(true);
+
     // Filename of loaded log (pushed from legacy code)
     const logFilename = ref("");
 
@@ -48,6 +53,7 @@ export const useAppStore = defineStore("app", () => {
         legendHidden,
         viewVideo,
         darkThemeEnabled,
+        viewerActive,
         logFilename,
         statusVersion,
         statusCells,

--- a/src/blackbox-viewer/stores/log.js
+++ b/src/blackbox-viewer/stores/log.js
@@ -16,7 +16,7 @@ const FIRMWARE_CLASS_MAP = {
 
 export const FIRMWARE_CLASSES = Object.values(FIRMWARE_CLASS_MAP);
 
-export const useLogStore = defineStore("log", () => {
+export const useLogStore = defineStore("blackboxLog", () => {
     const flightLog = ref(null);
     const flightLogDataArray = ref(null);
     const currentBlackboxTime = ref(0);

--- a/src/blackbox-viewer/video_handler.js
+++ b/src/blackbox-viewer/video_handler.js
@@ -1,4 +1,4 @@
-import pinia from "./pinia_instance.js";
+import { pinia } from "@/js/pinia_instance.js";
 import { useLogStore } from "./stores/log.js";
 import { useGraphStore } from "./stores/graph.js";
 import { usePlaybackStore } from "./stores/playback.js";

--- a/src/blackbox-viewer/vue_init.js
+++ b/src/blackbox-viewer/vue_init.js
@@ -1,10 +1,7 @@
-import { createApp } from "vue";
-import ui from "@nuxt/ui/vue-plugin";
-import App from "./App.vue";
-import pinia from "./pinia_instance.js";
-import { getNuxtUiRouter } from "./nuxt_ui_router.js";
-import { bootstrapViewer } from "./main.js";
+import { pinia } from "@/js/pinia_instance.js";
 import { useAppStore } from "./stores/app.js";
+import { usePlaybackStore, GRAPH_STATE_PLAY, GRAPH_STATE_PAUSED } from "./stores/playback.js";
+import { setGraphState, updateCanvasSize } from "./playback_controls.js";
 import { DarkTheme } from "./dark_theme.js";
 import "./css/main.css";
 
@@ -19,52 +16,23 @@ export function setBlackboxViewerDark(enabled) {
     useAppStore(pinia).darkThemeEnabled = enabled;
 }
 
-// Single live instance — the viewer tab mounts at most once at a time.
-let current = null;
-
 /**
- * Mount the blackbox log viewer inside the given root element. The root must contain the
- * viewer scaffold (the teleport-target divs + canvases) and a `#vue-app` mount point.
- * Returns nothing; pair every call with destroyBlackboxViewer() on unmount.
+ * Track whether the viewer tab is the visible one. Kept alive across tab switches, the viewer
+ * must go dormant when hidden: its document-level handlers gate on appStore.viewerActive, its
+ * render loop is paused, and on return the canvases (detached while cached) are re-measured.
  */
-export function initBlackboxViewer(rootEl, options = {}) {
-    if (current) {
-        return;
+export function setViewerActive(active) {
+    const appStore = useAppStore(pinia);
+    appStore.viewerActive = active;
+
+    if (active) {
+        // Cached canvases lost their layout while detached; resize to the live box and repaint.
+        updateCanvasSize();
+    } else {
+        // Stop the background render loop rather than animate an off-screen graph.
+        const playbackStore = usePlaybackStore(pinia);
+        if (playbackStore.graphState === GRAPH_STATE_PLAY) {
+            setGraphState(GRAPH_STATE_PAUSED);
+        }
     }
-
-    const app = createApp(App);
-    // Provide the root so the viewer applies its state classes here instead of <html>.
-    app.provide("bbvRoot", rootEl);
-    // Provide the host-supplied FC dataflash pull capability (or null when unavailable).
-    app.provide("bbvDataflash", options.dataflash ?? null);
-    app.use(pinia);
-    app.use(getNuxtUiRouter());
-    app.use(ui);
-    app.mount(rootEl.querySelector("#vue-app"));
-
-    // Run the legacy imperative bootstrap (canvas wiring, store callbacks, listeners) and
-    // keep its teardown handle for clean unmount.
-    const teardown = bootstrapViewer();
-
-    current = { app, teardown };
-}
-
-/** Reverse initBlackboxViewer: tear down listeners/loops/instances and unmount the app. */
-export function destroyBlackboxViewer() {
-    if (!current) {
-        return;
-    }
-
-    const { app, teardown } = current;
-    try {
-        teardown?.();
-    } catch (e) {
-        console.error("blackbox-viewer: teardown failed", e);
-    }
-    try {
-        app.unmount();
-    } catch (e) {
-        console.error("blackbox-viewer: unmount failed", e);
-    }
-    current = null;
 }

--- a/src/components/tabs/BlackboxViewerTab.vue
+++ b/src/components/tabs/BlackboxViewerTab.vue
@@ -39,22 +39,35 @@
 
             <div id="vue-statusbar" class="vue-statusbar"></div>
 
-            <!-- Mount point for the viewer's Vue app -->
-            <div id="vue-app"></div>
+            <!-- Viewer UI. Gated until the scaffold above is in the document, so its Teleports
+                 resolve their targets (the #vue-* divs) instead of racing the same mount pass. -->
+            <BlackboxViewerApp v-if="viewerReady" />
         </div>
     </BaseTab>
 </template>
 
 <script setup>
-import { nextTick, onMounted, onBeforeUnmount, ref } from "vue";
+import { nextTick, onActivated, onDeactivated, onMounted, onBeforeUnmount, provide, ref } from "vue";
 import BaseTab from "./BaseTab.vue";
 import GUI from "../../js/gui";
-import { initBlackboxViewer, destroyBlackboxViewer, setBlackboxViewerDark } from "../../blackbox-viewer/vue_init.js";
+import BlackboxViewerApp from "../../blackbox-viewer/App.vue";
+import { bootstrapViewer } from "../../blackbox-viewer/main.js";
+import { setBlackboxViewerDark, setViewerActive } from "../../blackbox-viewer/vue_init.js";
 import { useDataflashPull } from "../../composables/useDataflashPull";
 
+// Named so <keep-alive :include> in App.vue can target this tab (and only this tab) for caching.
+defineOptions({ name: "BlackboxViewerTab" });
+
 const rootRef = ref(null);
+const viewerReady = ref(false);
 let themeObserver = null;
+let teardownViewer = null;
 const dataflash = useDataflashPull();
+
+// The viewer renders as a child of this tab, on the host's Vue app and pinia. Hand it the
+// root element (for its scoped state classes) and the FC dataflash pull via provide/inject.
+provide("bbvRoot", rootRef);
+provide("bbvDataflash", dataflash);
 
 // The configurator drives dark mode by toggling `.dark` on <html>; mirror it into the viewer.
 function hostIsDark() {
@@ -62,9 +75,13 @@ function hostIsDark() {
 }
 
 onMounted(async () => {
-    // Scaffold DOM is in place; mount the viewer into it.
+    // Scaffold divs are now in the document; render the viewer so its Teleports find them.
     await nextTick();
-    initBlackboxViewer(rootRef.value, { dataflash });
+    viewerReady.value = true;
+    // Let the viewer mount, then run the legacy imperative bootstrap (canvas wiring, store
+    // callbacks, listeners) and keep its teardown handle.
+    await nextTick();
+    teardownViewer = bootstrapViewer();
     setBlackboxViewerDark(hostIsDark());
 
     // Keep the viewer theme in sync if the host theme changes while the tab is open.
@@ -74,10 +91,19 @@ onMounted(async () => {
     GUI.content_ready();
 });
 
+// Kept alive across tab switches: pause/resume instead of unmounting so the loaded log survives.
+onActivated(() => setViewerActive(true));
+onDeactivated(() => setViewerActive(false));
+
 onBeforeUnmount(() => {
     themeObserver?.disconnect();
     themeObserver = null;
-    destroyBlackboxViewer();
+    try {
+        teardownViewer?.();
+    } catch (e) {
+        console.error("blackbox-viewer: teardown failed", e);
+    }
+    teardownViewer = null;
 });
 </script>
 


### PR DESCRIPTION
The Blackbox Explorer ran as a separate Vue app (its own createApp, pinia, router and @nuxt/ui) mounted imperatively into a host tab, so switching tabs tore it down and dropped the loaded log (#5350). This folds it onto the host app as a normal tab and keeps it alive across switches, so the log, graph and playhead survive.

Key changes: the viewer engine modules share the host pinia (second createApp removed, viewer App.vue rendered as a child of the tab); the viewer log store id is renamed to blackboxLog to avoid colliding with the host log store; the tab is cached with keep-alive plus a stable key; the viewer's document keyboard, wheel and drag handlers and its render loop gate on a viewerActive flag so they go dormant behind other tabs, with playback paused on hide and canvases re-measured on return; the viewer's nested UApp is dropped in favour of the host one; and a dead has-grid-override toggle that wrote onto the host html is removed.

Most of the src/blackbox-viewer/App.vue diff is reindentation from removing the UApp wrapper.

Closes #5350


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Preserves tab state and loaded resources when switching between tabs.
  - Automatically pauses the viewer when inactive and resumes it when reactivated.
  - Resizes the viewer appropriately when returning to an active tab.

- **Bug Fixes**
  - Prevents inactive viewers from intercepting keyboard, mouse-wheel, and drag-and-drop interactions.
  - Improves embedded viewer behavior while retaining standalone functionality.
  - Ensures dropped files are processed only by the active viewer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->