### PR TITLE
fix(connection): honest connect failures, and one owner for the reboot

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -411,7 +411,7 @@
         "message": "Flight Controller is ready"
     },
     "rebootFlightControllerFailed": {
-        "message": "Flight Controller did <span class=\"message-negative\">not</span> reconnect"
+        "message": "Flight Controller did not reconnect"
     },
     "deviceRebooting": {
         "message": "Device - <span class=\"message-negative\">Rebooting</span>"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -410,6 +410,9 @@
     "rebootFlightControllerReady": {
         "message": "Flight Controller is ready"
     },
+    "rebootFlightControllerFailed": {
+        "message": "Flight Controller did <span class=\"message-negative\">not</span> reconnect"
+    },
     "deviceRebooting": {
         "message": "Device - <span class=\"message-negative\">Rebooting</span>"
     },

--- a/src/components/dialogs/RebootDialog.vue
+++ b/src/components/dialogs/RebootDialog.vue
@@ -1,10 +1,5 @@
 <template>
-    <UModal
-        :open="open"
-        :title="status"
-        :close="false"
-        :dismissible="false"
-    >
+    <UModal :open="open" :title="status" :close="false" :dismissible="false">
         <template #body>
             <UProgress :model-value="progress" :max="100" />
         </template>
@@ -12,31 +7,60 @@
 </template>
 
 <script setup>
-import { ref } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
+import { getConnectionState } from "@/js/connection_state";
+import { useDialogStore } from "@/stores/dialog";
+import CONFIGURATOR from "@/js/data_storage";
+import { i18n } from "@/js/localization";
 
-defineProps({
-    status: {
-        type: String,
-        default: "Rebooting...",
-    },
-    progress: {
-        type: Number,
-        default: 0,
-    },
-});
+// How long the outcome stays on screen before the dialog closes itself.
+const RESULT_LINGER_MS = 1000;
+const TICK_MS = 100;
 
+const dialogStore = useDialogStore();
 const open = ref(false);
 
-const show = () => {
-    open.value = true;
-};
+// The reboot window is nulled the moment the reboot concludes, so snapshot its numbers —
+// the last frame still needs them to draw a full bar.
+const startedAt = getConnectionState().rebootWindowStartedAt;
+const durationMs = getConnectionState().rebootWindowMs || 1;
 
-const close = () => {
-    open.value = false;
-};
+const now = ref(Date.now());
+const ticker = setInterval(() => (now.value = Date.now()), TICK_MS);
+
+// serial_backend's reconnect cycle owns the window: it waits for the FC, retries, and
+// concludes. This dialog only reports what that owner decided.
+const rebooting = computed(() => getConnectionState().isRebootWindowOpen);
+const progress = computed(() => (rebooting.value ? Math.min(100, ((now.value - startedAt) / durationMs) * 100) : 100));
+const status = computed(() => {
+    if (rebooting.value) {
+        return i18n.getMessage("rebootFlightController");
+    }
+    return i18n.getMessage(
+        CONFIGURATOR.connectionValid ? "rebootFlightControllerReady" : "rebootFlightControllerFailed",
+    );
+});
+
+function stopTicker() {
+    clearInterval(ticker);
+}
+
+watch(
+    rebooting,
+    (stillRebooting) => {
+        if (stillRebooting) {
+            return;
+        }
+        stopTicker();
+        setTimeout(() => dialogStore.close(), RESULT_LINGER_MS);
+    },
+    { immediate: true },
+);
+
+onBeforeUnmount(stopTicker);
 
 defineExpose({
-    show,
-    close,
+    show: () => (open.value = true),
+    close: () => (open.value = false),
 });
 </script>

--- a/src/components/dialogs/RebootDialog.vue
+++ b/src/components/dialogs/RebootDialog.vue
@@ -41,8 +41,15 @@ const status = computed(() => {
     );
 });
 
-function stopTicker() {
+let lingerTimer = null;
+
+// The dialog store holds one activeDialog. A user disconnect closes this dialog through
+// serial_backend, unmounting the component — a linger timer left running would then close
+// whatever dialog took the slot in the meantime.
+function stopTimers() {
     clearInterval(ticker);
+    clearTimeout(lingerTimer);
+    lingerTimer = null;
 }
 
 watch(
@@ -51,13 +58,16 @@ watch(
         if (stillRebooting) {
             return;
         }
-        stopTicker();
-        setTimeout(() => dialogStore.close(), RESULT_LINGER_MS);
+        clearInterval(ticker);
+        lingerTimer = setTimeout(() => {
+            lingerTimer = null;
+            dialogStore.close();
+        }, RESULT_LINGER_MS);
     },
     { immediate: true },
 );
 
-onBeforeUnmount(stopTicker);
+onBeforeUnmount(stopTimers);
 
 defineExpose({
     show: () => (open.value = true),

--- a/src/composables/useMspCliSession.js
+++ b/src/composables/useMspCliSession.js
@@ -1,11 +1,8 @@
 import { ref } from "vue";
 import semver from "semver";
 import MSP from "../js/msp";
-import GUI from "../js/gui";
 import FC from "../js/fc";
-import { disconnect, isDrivenRebootTarget, scheduleRebootReconnect } from "../js/serial_backend";
-import DeviceHandler from "../js/device_handler";
-import { getConnectionState, State } from "../js/connection_state";
+import { cancelRebootReconnect, scheduleRebootReconnect } from "../js/serial_backend";
 
 const DEFAULT_COMMAND_TIMEOUT_MS = 2000;
 const SAVE_COMMAND_TIMEOUT_MS = 5000;
@@ -13,8 +10,6 @@ const DUMP_READ_TIMEOUT_MS = 10000;
 const LINE_DELAY_MS = 15;
 const PROFILE_COMMAND_DELAY_MS = 100;
 const ERROR_PREFIX = "###ERROR";
-const RECONNECT_TIMEOUT_NAME = "msp_cli_reconnect";
-const RECONNECT_DELAY_MS = 500;
 
 export const MIN_FC_VERSION_FOR_MSP_CLI = "4.5.4";
 
@@ -67,53 +62,20 @@ export function readDumpAll() {
     return send("diff all", { timeoutMs: DUMP_READ_TIMEOUT_MS });
 }
 
+/**
+ * A CLI `save`/`exit` has already rebooted the FC. Hand the wait to serial_backend's reconnect
+ * cycle — the same one a Save & Reboot uses, minus the reboot command it does not need to send.
+ * The cycle drops the stale link, retries while Auto-Connect is on, and ends the window on a
+ * deadline. Previously this path ran its own 500 ms timeout and put the connection state into
+ * RECONNECTING with no window, so a device that never came back left the phase there for good.
+ */
 export function scheduleReconnect() {
-    const willAutoReconnect = DeviceHandler.devicePicker.autoConnect;
-    const target = DeviceHandler.devicePicker.selectedDevice;
-
-    // BLE and manual/TCP links never re-enumerate after an FC reboot, so the passive path
-    // below (drop the link, let auto-connect pick up the re-added device) would leave them
-    // disconnected forever. Hand them to serial_backend's driven reboot cycle instead — the
-    // same machinery a BLE/manual Save & Reboot uses. It reads Auto-Connect live, so with it
-    // off the cycle still ends in a clean disconnect.
-    if (isDrivenRebootTarget(target)) {
-        scheduleRebootReconnect();
-        return;
-    }
-
-    // The FC reboots after save/exit, so its port drops and re-enumerates, often under a new id
-    // (serial_0 -> serial_1). Don't reconnect explicitly: that would target the old, gone id and
-    // race the reboot into a spurious failure dialog. Just drop the stale link — with Auto-Connect
-    // on, auto-connect picks up the re-added device; with it off, the user reconnects manually.
-
-    // When we expect an auto-reconnect, hold the reconnect-in-progress window so selectActivePort()
-    // keeps the current selection and does NOT hijack it with the expert-mode virtual/manual
-    // fallback while the device is briefly off the port list.
-    if (willAutoReconnect && target && target !== "noselection" && target !== "virtual" && target !== "manual") {
-        getConnectionState().reconnectStarted();
-    }
-
-    GUI.timeout_remove(RECONNECT_TIMEOUT_NAME);
-    GUI.timeout_add(
-        RECONNECT_TIMEOUT_NAME,
-        () => {
-            // Drop the stale link only. disconnect() is a no-op if the reboot already closed the
-            // port; reconnection (if any) is auto-connect's job on device re-enumeration.
-            disconnect();
-        },
-        RECONNECT_DELAY_MS,
-    );
+    scheduleRebootReconnect();
 }
 
+/** Abandon that wait (a tab unmounting mid-reconnect). */
 export function cancelScheduledReconnect() {
-    const removed = GUI.timeout_remove(RECONNECT_TIMEOUT_NAME);
-    // Only conclude the window this function actually cancelled: the timer was still
-    // pending (removed) AND we are still in the RECONNECTING wait it opened. Once the
-    // timer has fired, connectDisconnect() owns the phase (CONNECTING/HANDSHAKING) and
-    // its own concludeReboot settles it — forcing IDLE here would abort a live connect.
-    if (removed && getConnectionState().state === State.RECONNECTING) {
-        getConnectionState().concludeReboot(false);
-    }
+    cancelRebootReconnect();
 }
 
 // A `save`/`exit` reboots the FC, so the port closes before the command can reply and its

--- a/src/js/connection_state.js
+++ b/src/js/connection_state.js
@@ -1,12 +1,12 @@
 /**
  * connection_state.js — connection-status holder.
  *
- * Tracks the current lifecycle PHASE plus two operational flags serial_backend
- * reads (linkOpen, intentionalDisconnect). State lives in Vue `ref`s so both
- * plain callers (read the getters synchronously) and Vue consumers (a `computed`
- * that reads a getter automatically tracks the underlying ref) stay in sync with
- * no hand-rolled observer — same approach as data_storage.js. Leaf module: it
- * imports only `vue` (no Pinia, no serial_backend), so the serial/port layer can
+ * Tracks the current lifecycle PHASE plus the operational flags serial_backend reads
+ * (linkOpen, intentionalDisconnect, the attempt's origin). Read by the serial, reboot and
+ * flashing paths — serial_backend, device_handler, useMspCliSession, useFirmwareFlashing,
+ * webstm32; the UI reads CONFIGURATOR.connectionValid, not this. State lives in Vue
+ * `ref`s, so a `computed` over a getter would track it if a consumer ever needs that. Leaf
+ * module: it imports only `vue` (no Pinia, no serial_backend), so the serial/port layer can
  * import it without a cycle or an active-pinia requirement.
  *
  * There is no transition table and no reconnect token. A reconnect uses the port from the last
@@ -30,9 +30,6 @@ export const State = Object.freeze({
     FAILED: "FAILED",
 });
 
-/** Phases that count as "ready" (a usable connection from the user's view). */
-const READY_STATES = Object.freeze(new Set([State.CONNECTED, State.CLI]));
-
 /**
  * Phases during which a connect/reconnect attempt is in flight. selectActivePort()
  * suppresses the expert-mode virtual/manual fallback throughout this whole window —
@@ -52,6 +49,11 @@ const RECONNECTING_STATES = Object.freeze(
  */
 const REBOOT_OWNED_STATES = Object.freeze(new Set([State.REBOOTING, State.RECONNECTING]));
 
+/** @param {string} phase @returns {boolean} the reboot owns this phase */
+function rebootOwns(phase) {
+    return REBOOT_OWNED_STATES.has(phase);
+}
+
 export class ConnectionState {
     constructor() {
         this._state = ref(State.IDLE);
@@ -67,15 +69,10 @@ export class ConnectionState {
         this._rebootWindow = ref(null);
         // The attempt in flight was started by the app, not the user.
         this._automaticAttempt = ref(false);
-        this.logHead = "[CONNECTION]";
     }
 
     get state() {
         return this._state.value;
-    }
-
-    get isReady() {
-        return READY_STATES.has(this._state.value);
     }
 
     get isFlashing() {
@@ -93,7 +90,7 @@ export class ConnectionState {
      */
     attemptStarted(automatic = false) {
         this._automaticAttempt.value = automatic;
-        if (!this.isRebootReconnecting) {
+        if (!rebootOwns(this._state.value)) {
             this.setPhase(State.CONNECTING);
         }
     }
@@ -105,14 +102,6 @@ export class ConnectionState {
      */
     get failureIsUserFacing() {
         return !this._automaticAttempt.value || this._linkOpen.value;
-    }
-
-    /**
-     * A reboot-driven reconnect is in progress (REBOOTING/RECONNECTING), as opposed to a
-     * fresh connect (CONNECTING/HANDSHAKING).
-     */
-    get isRebootReconnecting() {
-        return REBOOT_OWNED_STATES.has(this._state.value);
     }
 
     /** Set the lifecycle phase. */
@@ -176,7 +165,7 @@ export class ConnectionState {
      * phase — including an unexpected drop mid-CONNECTING/HANDSHAKING — settles to IDLE.
      */
     notifyClosed() {
-        if (this._state.value === State.IDLE || REBOOT_OWNED_STATES.has(this._state.value)) {
+        if (this._state.value === State.IDLE || rebootOwns(this._state.value)) {
             return;
         }
         this.setPhase(State.IDLE);

--- a/src/js/connection_state.js
+++ b/src/js/connection_state.js
@@ -65,8 +65,7 @@ export class ConnectionState {
         // may take — the retry loop and the reboot dialog read the same snapshot, taken
         // once per reboot.
         this._rebootWindow = ref(null);
-        // The attempt in flight was started by the app, not the user. Written only by
-        // attemptStarted(), which every real connect attempt calls.
+        // The attempt in flight was started by the app, not the user.
         this._automaticAttempt = ref(false);
         this.logHead = "[CONNECTION]";
     }
@@ -89,11 +88,7 @@ export class ConnectionState {
     }
 
     /**
-     * A connect attempt begins. `automatic` records that the app started it — a device event
-     * or the reboot retry loop — rather than the user. IDLE -> CONNECTING, except during a
-     * reboot-driven reconnect, whose phase already describes the attempt: keeping it is what
-     * lets the retry loop recognise its own premature attempts. Readiness (onOpen ->
-     * HANDSHAKING, finishOpen/connectCli -> CONNECTED/CLI) advances it on success.
+     * A connect attempt begins. A reboot reconnect keeps its own phase.
      * @param {boolean} [automatic=false] - the app started this attempt, not the user
      */
     attemptStarted(automatic = false) {
@@ -104,14 +99,9 @@ export class ConnectionState {
     }
 
     /**
-     * Is a failed attempt one the user should be told about? Yes when they asked for it, and
-     * yes when the link had already opened — a handshake that fails after the port opens
-     * (unsupported firmware, garbage API version) is terminal, not flakiness.
-     *
-     * No when the app started the attempt and the link never opened. A device can vanish
-     * between the list refresh and the open — a plug-in raises a burst of events and the port
-     * re-enumerates through it — and the next event or retry connects, so a dialog would
-     * report a failure that is already being recovered from.
+     * Should a failed attempt reach the user? Yes if they asked for it, or if the link had
+     * opened — a handshake rejected after the open is terminal. An app-initiated attempt
+     * that never opened is retried by the next device event, so it stays quiet.
      */
     get failureIsUserFacing() {
         return !this._automaticAttempt.value || this._linkOpen.value;

--- a/src/js/connection_state.js
+++ b/src/js/connection_state.js
@@ -117,9 +117,11 @@ export class ConnectionState {
      * refreshed — a second save inside the window restarts the clock, matching the
      * retry loop's own restart.
      * @param {number} [windowMs=10000] - how long the reconnect may take
+     * @param {?object} [target=null] - which device is coming back (device_handler's
+     *   describeDevice output). Held opaquely: this module knows the window, not devices.
      */
-    requestReboot(windowMs = 10000) {
-        this._rebootWindow.value = { startedAt: Date.now(), durationMs: windowMs };
+    requestReboot(windowMs = 10000, target = null) {
+        this._rebootWindow.value = { startedAt: Date.now(), durationMs: windowMs, target };
         if (this.isReconnecting) {
             return;
         }
@@ -134,6 +136,11 @@ export class ConnectionState {
     /** Duration of the open reboot window (0 if none) — snapshotted at requestReboot. */
     get rebootWindowMs() {
         return this._rebootWindow.value?.durationMs ?? 0;
+    }
+
+    /** The device the open window is waiting for (null if none, or if it was not identified). */
+    get rebootTarget() {
+        return this._rebootWindow.value?.target ?? null;
     }
 
     /** Start timestamp of the open reboot window (0 if none). */

--- a/src/js/connection_state.js
+++ b/src/js/connection_state.js
@@ -236,11 +236,6 @@ export class ConnectionState {
         this._linkOpen.value = Boolean(open);
     }
 
-    toggleLinkOpen() {
-        this._linkOpen.value = !this._linkOpen.value;
-        return this._linkOpen.value;
-    }
-
     /** Hard shutdown for page unload (pagehide): collapse to IDLE, ungated. */
     shutdown() {
         this._linkOpen.value = false;

--- a/src/js/connection_state.js
+++ b/src/js/connection_state.js
@@ -62,9 +62,12 @@ export class ConnectionState {
         this._linkOpen = ref(false);
         // The reboot reconnect window: { startedAt, durationMs } while a reboot is in
         // progress, null otherwise. Single source of truth for how long the reconnect
-        // may take — the retry loop, the reboot dialog and abortConnection's dialog
-        // suppression all read the same snapshot, taken once per reboot.
+        // may take — the retry loop and the reboot dialog read the same snapshot, taken
+        // once per reboot.
         this._rebootWindow = ref(null);
+        // The attempt in flight was started by the app, not the user. Written only by
+        // attemptStarted(), which every real connect attempt calls.
+        this._automaticAttempt = ref(false);
         this.logHead = "[CONNECTION]";
     }
 
@@ -86,10 +89,37 @@ export class ConnectionState {
     }
 
     /**
+     * A connect attempt begins. `automatic` records that the app started it — a device event
+     * or the reboot retry loop — rather than the user. IDLE -> CONNECTING, except during a
+     * reboot-driven reconnect, whose phase already describes the attempt: keeping it is what
+     * lets the retry loop recognise its own premature attempts. Readiness (onOpen ->
+     * HANDSHAKING, finishOpen/connectCli -> CONNECTED/CLI) advances it on success.
+     * @param {boolean} [automatic=false] - the app started this attempt, not the user
+     */
+    attemptStarted(automatic = false) {
+        this._automaticAttempt.value = automatic;
+        if (!this.isRebootReconnecting) {
+            this.setPhase(State.CONNECTING);
+        }
+    }
+
+    /**
+     * Is a failed attempt one the user should be told about? Yes when they asked for it, and
+     * yes when the link had already opened — a handshake that fails after the port opens
+     * (unsupported firmware, garbage API version) is terminal, not flakiness.
+     *
+     * No when the app started the attempt and the link never opened. A device can vanish
+     * between the list refresh and the open — a plug-in raises a burst of events and the port
+     * re-enumerates through it — and the next event or retry connects, so a dialog would
+     * report a failure that is already being recovered from.
+     */
+    get failureIsUserFacing() {
+        return !this._automaticAttempt.value || this._linkOpen.value;
+    }
+
+    /**
      * A reboot-driven reconnect is in progress (REBOOTING/RECONNECTING), as opposed to a
-     * fresh user-initiated connect (CONNECTING/HANDSHAKING). A failed open in this window is
-     * expected flakiness — the device is briefly gone while it re-enumerates — so callers
-     * suppress the user-facing "connection failed" dialog and let auto-connect recover.
+     * fresh connect (CONNECTING/HANDSHAKING).
      */
     get isRebootReconnecting() {
         return REBOOT_OWNED_STATES.has(this._state.value);

--- a/src/js/device_handler.js
+++ b/src/js/device_handler.js
@@ -243,6 +243,38 @@ DeviceHandler.sortPorts = function (ports) {
 };
 
 /**
+ * Describe a listed device well enough to recognise it after a reboot. A re-enumerating
+ * device usually comes back under a NEW path (the browser mints a fresh SerialPort object),
+ * so the USB ids travel with it.
+ * @param {string} path - a device path
+ * @returns {?{path: string, vendorId: *, productId: *}} null when the path is not listed
+ */
+DeviceHandler.describeDevice = function (path) {
+    const device = [...this.currentSerialPorts, ...this.currentBluetoothPorts].find((port) => port.path === path);
+
+    return device ? { path: device.path, vendorId: device.vendorId, productId: device.productId } : null;
+};
+
+/**
+ * The listed device matching a descriptor: the same path if it came back as itself, otherwise
+ * the same make. Undefined while it is away.
+ * @param {?{path: string, vendorId: *, productId: *}} target - from describeDevice()
+ * @returns {object|undefined} the device wrapper
+ */
+DeviceHandler.findDescribedDevice = function (target) {
+    if (!target) {
+        return undefined;
+    }
+
+    const devices = [...this.currentSerialPorts, ...this.currentBluetoothPorts];
+
+    return (
+        devices.find((device) => device.path === target.path) ??
+        devices.find((device) => device.vendorId === target.vendorId && device.productId === target.productId)
+    );
+};
+
+/**
  * @param {string} path - a device path
  * @returns {boolean} true when the serial, Bluetooth or USB list holds this path
  */
@@ -282,6 +314,15 @@ DeviceHandler.selectActivePort = function (suggestedDevice = false) {
         console.log(`${this.logHead} Using connected device: ${selectedDevice.path}`);
         selectedDevice = selectedDevice.path;
         return selectedDevice;
+    }
+
+    // Mid-reboot, prefer the device that was rebooted. A plug-in raises a burst of events and
+    // another device can be added while the FC is away; without this the selection follows
+    // whichever event arrived last, and the reconnect aims at a device nobody asked for.
+    // A preference, not a restriction: if the rebooted device is not back, the rules below
+    // still apply, so a board that returns as something else is not locked out.
+    if (!selectedDevice) {
+        selectedDevice = this.findDescribedDevice(getConnectionState().rebootTarget)?.path;
     }
 
     // The code reads suggestedDevice from an addedDevice event. updateDeviceList() reads the

--- a/src/js/device_handler.js
+++ b/src/js/device_handler.js
@@ -258,6 +258,10 @@ DeviceHandler.describeDevice = function (path) {
 /**
  * The listed device matching a descriptor: the same path if it came back as itself, otherwise
  * the same make. Undefined while it is away.
+ *
+ * The make comparison needs both ids: SerialPortInfo carries usbVendorId/usbProductId for USB
+ * ports only, so a platform-native port (a built-in COM port, a Bluetooth SPP one) has neither
+ * and `undefined === undefined` would match it to any other port without ids.
  * @param {?{path: string, vendorId: *, productId: *}} target - from describeDevice()
  * @returns {object|undefined} the device wrapper
  */
@@ -267,11 +271,13 @@ DeviceHandler.findDescribedDevice = function (target) {
     }
 
     const devices = [...this.currentSerialPorts, ...this.currentBluetoothPorts];
+    const byPath = devices.find((device) => device.path === target.path);
 
-    return (
-        devices.find((device) => device.path === target.path) ??
-        devices.find((device) => device.vendorId === target.vendorId && device.productId === target.productId)
-    );
+    if (byPath || target.vendorId === undefined || target.productId === undefined) {
+        return byPath;
+    }
+
+    return devices.find((device) => device.vendorId === target.vendorId && device.productId === target.productId);
 };
 
 /**

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -144,6 +144,9 @@ export function initializeSerialBackend() {
         if (
             !GUI.connected_to &&
             !GUI.connecting_to &&
+            // The listener must also stay off the CLI tab: a live CLI session is not an MSP
+            // connection and taking the port would end it. The reconnect cycle has its own,
+            // wider rule — it runs when a reboot has already ended that session.
             !["cli", "firmware_flasher"].includes(GUI.active_tab) &&
             DeviceHandler.devicePicker.autoConnect &&
             !isCliOnlyMode() &&
@@ -200,6 +203,26 @@ async function sendConfigTracking() {
         deviceIdentifier: CryptoES.SHA1(FC.CONFIG.deviceIdentifier).toString(),
         buildKey: FC.CONFIG.buildKey,
     });
+}
+
+/**
+ * The flasher talks to the board itself (DFU or raw serial), so nothing may take the port
+ * while it is open. The CLI tab is deliberately NOT here: the reconnect cycle only runs
+ * because a reboot ended the CLI session, and refusing to reconnect there would strand the
+ * user on a dead CLI tab.
+ * @returns {boolean} true while the flasher is active
+ */
+function flasherOwnsPort() {
+    return GUI.active_tab === "firmware_flasher";
+}
+
+/**
+ * May the reconnect cycle connect right now? Read on every tick: Auto-Connect can be switched
+ * off mid-window, and the user can walk into the flasher while the FC is still rebooting.
+ * @returns {boolean}
+ */
+function rebootReconnectAllowed() {
+    return DeviceHandler.devicePicker.autoConnect && !flasherOwnsPort();
 }
 
 function stopRebootReconnect() {
@@ -1437,13 +1460,15 @@ function rebootReconnect() {
     rebootReconnectTimerId = setTimeout(() => {
         const driven = isDrivenRebootTarget(DeviceHandler.devicePicker.selectedDevice);
 
-        // A link still open once the reboot command has flushed is stale: the FC is restarting
-        // and nothing useful can travel over it. Drop it, whatever the transport — serial
-        // usually dropped itself on re-enumeration and this is a no-op, a driven link never
-        // gets a disconnect event and would otherwise linger. The one exception is a BLE
-        // target about to auto-reconnect: keep its GATT session (softResetForReboot), because
-        // dropping and re-establishing it produces deaf sessions on Linux/BlueZ.
-        if (isConnected()) {
+        // Only a driven link is dropped here. It survives the reboot — just the MCU restarts —
+        // and gets no disconnect event, so without this the app holds a dead connection. A
+        // serial link that is still open means the FC did not reboot after all (or the OS has
+        // not noticed yet): dropping it would tear down a working connection and bounce the
+        // user off the tab they just opened, which is what leaving the CLI tab does. Leave it
+        // to the transport. The exception is a BLE target about to auto-reconnect: keep its
+        // GATT session (softResetForReboot), because re-establishing it produces deaf sessions
+        // on Linux/BlueZ.
+        if (driven && isConnected()) {
             const target = DeviceHandler.devicePicker.selectedDevice;
             const keepBleLink =
                 typeof target === "string" && target.startsWith("bluetooth") && DeviceHandler.devicePicker.autoConnect;
@@ -1459,7 +1484,7 @@ function rebootReconnect() {
         // the link is down and nothing will reconnect it — so end the window now. Serial waits
         // for its port to re-enumerate (below) so the user can reconnect to a device that is
         // actually back.
-        if (driven && !DeviceHandler.devicePicker.autoConnect) {
+        if (driven && !rebootReconnectAllowed()) {
             rebootReconnectTimerId = false;
             getConnectionState().concludeReboot(false);
             return;
@@ -1482,7 +1507,9 @@ function rebootReconnect() {
             // not-expired, so a live loop must treat "no longer open" as a stop too.
             const state = getConnectionState();
             const timedOut = state.rebootWindowExpired || !state.isRebootWindowOpen;
-            const autoConnect = DeviceHandler.devicePicker.autoConnect;
+            // Read live: Auto-Connect can be switched off mid-window, and the user can walk
+            // into a tab that owns the port while the FC is still rebooting.
+            const mayConnect = rebootReconnectAllowed();
             // Auto-Connect off: nothing will reconnect, so the wait ends as soon as there is
             // nothing left to wait for — our device listed again for serial, immediately for a
             // driven target (its link is already down). The question is about THIS device, not
@@ -1492,7 +1519,10 @@ function rebootReconnect() {
             const ourDeviceBack = target
                 ? Boolean(DeviceHandler.findDescribedDevice(target))
                 : DeviceHandler.isKnownDevicePath(DeviceHandler.devicePicker.selectedDevice);
-            const waitedOut = !autoConnect && (driven || ourDeviceBack);
+            // A tab that owns the port ends the window at once rather than waiting for the
+            // device: holding it open keeps selectActivePort pinned to the serial selection,
+            // which is exactly what stops the flasher from picking up the board.
+            const waitedOut = !mayConnect && (driven || flasherOwnsPort() || ourDeviceBack);
 
             if (CONFIGURATOR.connectionValid || timedOut || waitedOut) {
                 stopRebootReconnect();
@@ -1503,7 +1533,7 @@ function rebootReconnect() {
                 releaseKeptRebootLink();
                 return;
             }
-            if (autoConnect && !isConnected() && !GUI.connecting_to) {
+            if (mayConnect && !isConnected() && !GUI.connecting_to) {
                 // Re-derive the kept-link flag from protocol truth before reconnecting.
                 // A real transport close normally clears it via onClosed, but between
                 // attempts serial_backend's disconnect listener is detached

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -51,10 +51,6 @@ let connectionTimeoutPending = false;
 // Tracked so an intentional disconnect during the reboot window can cancel it — otherwise the
 // retry would resurrect a connection the user just cancelled.
 let rebootReconnectTimerId = false;
-// Handles for the reboot progress modal's intervals, tracked so closeRebootDialog() can dismiss
-// the modal (and stop its timers) when a user disconnect cancels the reboot.
-let rebootDialogProgressTimerId = false;
-let rebootDialogCheckTimerId = false;
 
 // The transport-open flag formerly stored here as `isConnected` now lives in
 // the connection state — read via `getConnectionState().linkOpen`, mutated via setLinkOpen.
@@ -101,33 +97,6 @@ let rebootHandshakeSawTraffic = false;
  */
 export function isDrivenRebootTarget(port) {
     return typeof port === "string" && (port.startsWith("bluetooth") || port === "manual");
-}
-
-/**
- * Should the reboot dialog's poller stop waiting (settle the window, show "ready", close)?
- * A pure predicate so the branch matrix is testable without driving the dialog's intervals.
- * Each branch has its own concluder: Auto-Connect on -> the retry loop; off + driven target ->
- * rebootReconnect()'s flush closes the window; off + serial -> nothing else runs, so the port
- * coming back is the only signal.
- * @param {{connectionValid: boolean, timeoutReached: boolean, autoConnect: boolean,
- *          portAvailable: boolean, selectedDevice: string, rebootWindowOpen: boolean}} state
- * @returns {boolean}
- */
-export function shouldConcludeRebootDialog({
-    connectionValid,
-    timeoutReached,
-    autoConnect,
-    portAvailable,
-    selectedDevice,
-    rebootWindowOpen,
-}) {
-    if (connectionValid || timeoutReached) {
-        return true;
-    }
-    if (autoConnect) {
-        return false;
-    }
-    return isDrivenRebootTarget(selectedDevice) ? !rebootWindowOpen : Boolean(portAvailable);
 }
 
 /**
@@ -242,18 +211,9 @@ function stopRebootReconnect() {
     }
 }
 
-// Dismiss the reboot progress modal and stop its timers. Called when a user disconnect cancels
-// the reboot (otherwise the modal would linger until its own 10s timeout), and at the start of
-// showRebootDialog() to clear any stale modal/intervals from a prior reboot.
+// Dismiss the reboot progress modal. Called when a user disconnect cancels the reboot — the
+// dialog closes itself on a concluded window, but a cancel must not wait for its linger.
 function closeRebootDialog() {
-    if (rebootDialogProgressTimerId !== false) {
-        clearInterval(rebootDialogProgressTimerId);
-        rebootDialogProgressTimerId = false;
-    }
-    if (rebootDialogCheckTimerId !== false) {
-        clearInterval(rebootDialogCheckTimerId);
-        rebootDialogCheckTimerId = false;
-    }
     const dialogStore = useDialogStore();
     if (dialogStore.activeDialog?.type === "RebootDialog") {
         dialogStore.close();
@@ -1227,8 +1187,8 @@ function onClosed(result) {
 
     // USB/cable disconnect invokes this path (not finishClose). Clear any Pinia modal
     // (e.g. InformationDialog from showVersionMismatchAndCli) so it does not linger — but
-    // NOT the reboot progress dialog: a reboot's own port-drop lands here, and the reboot
-    // flow (showRebootDialog's check-timer / closeRebootDialog) owns dismissing it.
+    // NOT the reboot progress dialog: a reboot's own port-drop lands here, and the dialog
+    // dismisses itself once the reconnect cycle concludes the window.
     const dialogStore = useDialogStore();
     if (dialogStore.activeDialog?.type !== "RebootDialog") {
         dialogStore.close();
@@ -1548,75 +1508,8 @@ function rebootReconnect() {
 function showRebootDialog() {
     gui_log(i18n.getMessage("deviceRebooting"));
 
-    // Clear any leftover modal/intervals from a prior reboot before starting a new one.
-    closeRebootDialog();
-
-    // Show the reboot progress modal (the shared Vue RebootDialog via the dialog store —
-    // the CLI and Vue-tab reboot paths now share this single implementation).
-    const dialogStore = useDialogStore();
-    dialogStore.open("RebootDialog", {
-        status: i18n.getMessage("rebootFlightController"),
-        progress: 0,
-    });
-
-    // Snapshot the window opened by requestReboot(): the dialog tracks the same start
-    // and duration as the retry loop, and stays consistent even after concludeReboot
-    // clears the live window.
-    const windowStartedAt = getConnectionState().rebootWindowStartedAt;
-    const windowMs = getConnectionState().rebootWindowMs;
-
-    // Update progress during reboot
-    let progress = 0;
-    // Calculate increment to reach 100% when the timeout elapses (runs every 100ms)
-    const progressIncrement = 100 / (windowMs / 100);
-
-    rebootDialogProgressTimerId = setInterval(() => {
-        progress += progressIncrement;
-        if (progress <= 100) {
-            dialogStore.updateProps({ progress });
-        }
-    }, 100);
-
-    // Check for successful connection every 100ms with a timeout
-    rebootDialogCheckTimerId = setInterval(() => {
-        const connectionCheckTimeoutReached = Date.now() - windowStartedAt > windowMs;
-
-        if (
-            shouldConcludeRebootDialog({
-                connectionValid: CONFIGURATOR.connectionValid,
-                timeoutReached: connectionCheckTimeoutReached,
-                autoConnect: DeviceHandler.devicePicker.autoConnect,
-                portAvailable: DeviceHandler.portAvailable,
-                selectedDevice: DeviceHandler.devicePicker.selectedDevice,
-                rebootWindowOpen: getConnectionState().isRebootWindowOpen,
-            })
-        ) {
-            clearInterval(rebootDialogCheckTimerId);
-            clearInterval(rebootDialogProgressTimerId);
-            rebootDialogCheckTimerId = false;
-            rebootDialogProgressTimerId = false;
-
-            // The reboot window has closed (reconnected / timed out / not auto-reconnecting):
-            // concludeReboot settles to IDLE so normal port selection resumes.
-            getConnectionState().concludeReboot(CONFIGURATOR.connectionValid);
-
-            dialogStore.updateProps({
-                progress: 100,
-                status: i18n.getMessage("rebootFlightControllerReady"),
-            });
-
-            // Close the dialog after showing "ready" message briefly
-            setTimeout(() => {
-                if (dialogStore.activeDialog?.type === "RebootDialog") {
-                    dialogStore.close();
-                }
-            }, 1000);
-
-            if (connectionCheckTimeoutReached) {
-                console.log(`${logHead} Reboot timeout reached`);
-            } else {
-                gui_log(i18n.getMessage("deviceReady"));
-            }
-        }
-    }, 100);
+    // The dialog is a view of the reboot window: it renders progress from the window the
+    // reconnect cycle opened, reports what that cycle concluded, and closes itself. It does
+    // not decide when the reboot is over — that owner is rebootReconnect().
+    useDialogStore().open("RebootDialog");
 }

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1412,6 +1412,17 @@ export function scheduleRebootReconnect() {
     rebootReconnect();
 }
 
+/**
+ * Abandon a reconnect cycle in progress (a tab leaving, a flow cancelling its own reboot).
+ * Stops the timers and settles the window; harmless when no reboot is running.
+ */
+export function cancelRebootReconnect() {
+    stopRebootReconnect();
+    if (getConnectionState().isRebootWindowOpen) {
+        getConnectionState().concludeReboot(CONFIGURATOR.connectionValid);
+    }
+}
+
 // Drive the disconnect/reconnect cycle for a BLE/manual reboot. The link bounces (or survives)
 // as the FC restarts, and no single disconnect event marks "FC ready". Runs whether or not the
 // reboot dialog is shown.
@@ -1423,14 +1434,16 @@ function rebootReconnect() {
     rebootReconnectTimerId = setTimeout(() => {
         const driven = isDrivenRebootTarget(DeviceHandler.devicePicker.selectedDevice);
 
-        // A driven link survives the reboot — only the MCU restarts, so no disconnect event
-        // ever fires and the app would hold a stale connection. Drop it here. A BLE target
-        // about to auto-reconnect keeps its GATT session (softResetForReboot) instead:
-        // dropping it produces deaf sessions on Linux/BlueZ. Serial re-enumerates and drops
-        // itself, so leave that link alone.
-        if (driven && isConnected()) {
+        // A link still open once the reboot command has flushed is stale: the FC is restarting
+        // and nothing useful can travel over it. Drop it, whatever the transport — serial
+        // usually dropped itself on re-enumeration and this is a no-op, a driven link never
+        // gets a disconnect event and would otherwise linger. The one exception is a BLE
+        // target about to auto-reconnect: keep its GATT session (softResetForReboot), because
+        // dropping and re-establishing it produces deaf sessions on Linux/BlueZ.
+        if (isConnected()) {
             const target = DeviceHandler.devicePicker.selectedDevice;
-            const keepBleLink = target.startsWith("bluetooth") && DeviceHandler.devicePicker.autoConnect;
+            const keepBleLink =
+                typeof target === "string" && target.startsWith("bluetooth") && DeviceHandler.devicePicker.autoConnect;
             if (keepBleLink) {
                 softResetForReboot();
             } else {

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -164,13 +164,19 @@ function isCliOnlyMode() {
 }
 
 function connectHandler(event) {
-    onOpen(event.detail);
     // Only mark the link open when the port actually opened. A failed open (event.detail
-    // falsy) runs abortConnection inside onOpen; setting the flag here too would leave it
+    // falsy) runs abortConnection inside onOpen; setting the flag there too would leave it
     // out of sync with the real state and break reconnect retries.
+    //
+    // Before onOpen, not after: onOpen starts the MSP handshake, and MSP.send_message runs
+    // its callback synchronously when the link has already dropped again (msp.js — no
+    // serial.connected). That callback sees the apiVersion FC.resetState() just reset to
+    // "0.0.0" and calls abortConnection(), which asks failureIsUserFacing whether the link
+    // had opened. Setting the flag afterwards would answer "no" and hide the failure.
     if (event.detail) {
         getConnectionState().setLinkOpen(true);
     }
+    onOpen(event.detail);
 }
 
 function disconnectHandler(event) {
@@ -399,6 +405,11 @@ function canStartConnectionAction(selectedDevice) {
     );
 }
 
+/**
+ * Start a connect attempt on the selected device.
+ * @param {string} selectedDevice - the selected device path, or "virtual"/"manual"
+ * @param {boolean} automatic - the app started this attempt (device event, reboot retry)
+ */
 function beginConnect(selectedDevice, automatic) {
     // Clear the intentional-disconnect guard on every connect attempt. A protocol whose
     // disconnect() short-circuits (e.g. WebBluetooth when closeRequested is already set)

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1468,9 +1468,13 @@ function rebootReconnect() {
             const timedOut = state.rebootWindowExpired || !state.isRebootWindowOpen;
             const autoConnect = DeviceHandler.devicePicker.autoConnect;
             // Auto-Connect off: nothing will reconnect, so the wait ends as soon as there is
-            // nothing left to wait for — the port back for serial, immediately for a driven
-            // target (its link is already down).
-            const waitedOut = !autoConnect && (driven || DeviceHandler.portAvailable);
+            // nothing left to wait for — the selection listed again for serial, immediately for
+            // a driven target (its link is already down). Not DeviceHandler.portAvailable: that
+            // is true for ANY serial port, so a machine with others would end the wait while the
+            // rebooting device was still gone. device_handler re-points the selection when the
+            // device returns under a new id, so this follows it.
+            const waitedOut =
+                !autoConnect && (driven || DeviceHandler.isKnownDevicePath(DeviceHandler.devicePicker.selectedDevice));
 
             if (CONFIGURATOR.connectionValid || timedOut || waitedOut) {
                 stopRebootReconnect();

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -164,15 +164,8 @@ function isCliOnlyMode() {
 }
 
 function connectHandler(event) {
-    // Only mark the link open when the port actually opened. A failed open (event.detail
-    // falsy) runs abortConnection inside onOpen; setting the flag there too would leave it
-    // out of sync with the real state and break reconnect retries.
-    //
-    // Before onOpen, not after: onOpen starts the MSP handshake, and MSP.send_message runs
-    // its callback synchronously when the link has already dropped again (msp.js — no
-    // serial.connected). That callback sees the apiVersion FC.resetState() just reset to
-    // "0.0.0" and calls abortConnection(), which asks failureIsUserFacing whether the link
-    // had opened. Setting the flag afterwards would answer "no" and hide the failure.
+    // Before onOpen: its MSP handshake can abort synchronously, and abortConnection reads
+    // this flag to decide whether the failure reaches the user.
     if (event.detail) {
         getConnectionState().setLinkOpen(true);
     }
@@ -204,9 +197,7 @@ export function initializeSerialBackend() {
             (connectionTimestamp === null || connectionTimestamp > 0)
         ) {
             // selectActivePort points the selection at the device that sent this event.
-            // Connect to it. The app started this, not the user: a plug-in can raise a burst
-            // of device events and the port can vanish again between the list refresh and the
-            // open, so a failure here is retried by the next event rather than reported.
+            // Connect to it. Automatic: the next event retries a failure here.
             connectDisconnect({ automatic: true });
         }
     });
@@ -406,9 +397,8 @@ function canStartConnectionAction(selectedDevice) {
 }
 
 /**
- * Start a connect attempt on the selected device.
  * @param {string} selectedDevice - the selected device path, or "virtual"/"manual"
- * @param {boolean} automatic - the app started this attempt (device event, reboot retry)
+ * @param {boolean} automatic - the app started this attempt, not the user
  */
 function beginConnect(selectedDevice, automatic) {
     // Clear the intentional-disconnect guard on every connect attempt. A protocol whose
@@ -457,8 +447,6 @@ function beginConnect(selectedDevice, automatic) {
         serial.removeEventListener("disconnect", disconnectHandler);
         serial.addEventListener("disconnect", disconnectHandler);
 
-        // The attempt begins: phase and who started it, in the connection state. Virtual
-        // connections skip this — they cannot fail to open, so nothing reads either.
         getConnectionState().attemptStarted(automatic);
     }
 
@@ -486,9 +474,7 @@ function registerCliHotkey() {
 }
 
 /**
- * Toggle the connection. Callers that connect on the app's own initiative — a device
- * event, the reboot retry loop — pass `automatic: true`, so a failure that the app will
- * retry by itself is not reported as if the user had asked for it. See abortConnection().
+ * Toggle the connection.
  * @param {{automatic?: boolean}} [options] - automatic: the app started this, not the user
  */
 export function connectDisconnect({ automatic = false } = {}) {
@@ -623,8 +609,6 @@ function finishClose() {
 
     teardownConnectionUi();
 
-    // The link is down. finishUnexpectedDisconnect() clears the same flag for the other
-    // teardown path, before its UI teardown — it has a late removedDevice to outrun.
     getConnectionState().setLinkOpen(false);
 }
 
@@ -638,9 +622,8 @@ function finishUnexpectedDisconnect() {
     GUI.timeout_remove("connecting");
     GUI.timeout_remove("connectAttempt");
 
-    // Mirror the flag reset finishClose() makes for intentional disconnects. Reset before
-    // the UI teardown so a late removedDevice cannot re-enter connectDisconnect() against a
-    // still-"connected" state.
+    // Before the UI teardown, so a late removedDevice cannot re-enter connectDisconnect()
+    // against a still-"connected" state.
     getConnectionState().setLinkOpen(false);
 
     teardownConnectionUi();
@@ -748,11 +731,7 @@ function abortConnection(messageKey) {
     GUI.timeout_remove("connecting"); // kill post-open connecting timer
     GUI.timeout_remove("connectAttempt"); // kill pre-open watchdog
 
-    // Report failures the user asked for; stay quiet about attempts the app made on its own,
-    // which are the ones something retries. See ConnectionState.failureIsUserFacing. Read
-    // before setPhase(FAILED) below, which ends the attempt this describes.
-    // Auto-Connect is not tested here: with it off there are no automatic attempts at all —
-    // the auto-select listener requires it and the reboot retry loop stops on it.
+    // Read before setPhase(FAILED) below, which ends the attempt it describes.
     const reportFailure = getConnectionState().failureIsUserFacing;
 
     // Default message reflects how far the attempt got: a port that already opened but failed
@@ -790,8 +769,7 @@ function abortConnection(messageKey) {
     // FAILED is not a reconnecting phase, so selectActivePort() resumes its normal
     // fallback rather than staying aimed at a dead target.
 
-    // The log panel keeps every failure — it is the trail a user pastes into a bug report.
-    // Only the dialog is withheld.
+    // The log panel keeps every failure; only the dialog is withheld.
     gui_log(message);
     if (reportFailure) {
         showConnectionFailedDialog(message);
@@ -1588,8 +1566,7 @@ function rebootReconnect() {
 
                 // selectActivePort keeps the current selection during a reconnect
                 // (isReconnecting). The selection points at the device from before the reboot.
-                // The attempt fails while that device is absent. The loop then tries again,
-                // so the failure is not reported (automatic).
+                // The attempt fails while that device is absent. The loop then tries again.
                 connectDisconnect({ automatic: true });
             }
         }, REBOOT_RECONNECT_RETRY_MS);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1366,8 +1366,12 @@ export function reinitializeConnection() {
     }
 
     // Open the reboot window in the connection state: the single owner of the reboot
-    // lifecycle's start time, duration and phase.
-    getConnectionState().requestReboot(rebootConnectWindowMs());
+    // lifecycle's start time, duration, phase — and which device it is waiting for, captured
+    // now while that device is still listed.
+    getConnectionState().requestReboot(
+        rebootConnectWindowMs(),
+        DeviceHandler.describeDevice(DeviceHandler.devicePicker.selectedDevice),
+    );
 
     // requestReboot() above sets the connection state to REBOOTING. selectActivePort() then
     // reports isReconnecting and keeps the current selection. It does not change the selection
@@ -1404,7 +1408,10 @@ export function reinitializeConnection() {
  * -> retry cycle as a BLE/manual Save & Reboot; Auto-Connect is honored inside rebootReconnect().
  */
 export function scheduleRebootReconnect() {
-    getConnectionState().requestReboot(rebootConnectWindowMs());
+    getConnectionState().requestReboot(
+        rebootConnectWindowMs(),
+        DeviceHandler.describeDevice(DeviceHandler.devicePicker.selectedDevice),
+    );
     rebootReconnect();
 }
 
@@ -1477,13 +1484,15 @@ function rebootReconnect() {
             const timedOut = state.rebootWindowExpired || !state.isRebootWindowOpen;
             const autoConnect = DeviceHandler.devicePicker.autoConnect;
             // Auto-Connect off: nothing will reconnect, so the wait ends as soon as there is
-            // nothing left to wait for — the selection listed again for serial, immediately for
-            // a driven target (its link is already down). Not DeviceHandler.portAvailable: that
-            // is true for ANY serial port, so a machine with others would end the wait while the
-            // rebooting device was still gone. device_handler re-points the selection when the
-            // device returns under a new id, so this follows it.
-            const waitedOut =
-                !autoConnect && (driven || DeviceHandler.isKnownDevicePath(DeviceHandler.devicePicker.selectedDevice));
+            // nothing left to wait for — our device listed again for serial, immediately for a
+            // driven target (its link is already down). The question is about THIS device, not
+            // about port count: a machine with other serial ports must not end the wait while
+            // the rebooting one is still away.
+            const target = state.rebootTarget;
+            const ourDeviceBack = target
+                ? Boolean(DeviceHandler.findDescribedDevice(target))
+                : DeviceHandler.isKnownDevicePath(DeviceHandler.devicePicker.selectedDevice);
+            const waitedOut = !autoConnect && (driven || ourDeviceBack);
 
             if (CONFIGURATOR.connectionValid || timedOut || waitedOut) {
                 stopRebootReconnect();

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -203,8 +203,10 @@ export function initializeSerialBackend() {
             (connectionTimestamp === null || connectionTimestamp > 0)
         ) {
             // selectActivePort points the selection at the device that sent this event.
-            // Connect to it.
-            connectDisconnect();
+            // Connect to it. The app started this, not the user: a plug-in can raise a burst
+            // of device events and the port can vanish again between the list refresh and the
+            // open, so a failure here is retried by the next event rather than reported.
+            connectDisconnect({ automatic: true });
         }
     });
 
@@ -402,7 +404,7 @@ function canStartConnectionAction(selectedDevice) {
     );
 }
 
-function beginConnect(selectedDevice) {
+function beginConnect(selectedDevice, automatic) {
     // Clear the intentional-disconnect guard on every connect attempt. A protocol whose
     // disconnect() short-circuits (e.g. WebBluetooth when closeRequested is already set)
     // may never dispatch the "disconnect" event that would otherwise consume the flag, so
@@ -449,14 +451,9 @@ function beginConnect(selectedDevice) {
         serial.removeEventListener("disconnect", disconnectHandler);
         serial.addEventListener("disconnect", disconnectHandler);
 
-        // A connect attempt begins. IDLE -> CONNECTING. During a reboot-driven reconnect
-        // the phase is REBOOTING/RECONNECTING — keep it, so a transient failed open (the
-        // rebooting device is still re-enumerating) is recognised as reconnect flakiness
-        // rather than a user-facing connect failure. Readiness (onOpen -> HANDSHAKING,
-        // finishOpen/connectCli -> CONNECTED/CLI) advances it on success.
-        if (!getConnectionState().isRebootReconnecting) {
-            getConnectionState().setPhase(ConnPhase.CONNECTING);
-        }
+        // The attempt begins: phase and who started it, in the connection state. Virtual
+        // connections skip this — they cannot fail to open, so nothing reads either.
+        getConnectionState().attemptStarted(automatic);
     }
 
     serial.connect(
@@ -482,7 +479,13 @@ function registerCliHotkey() {
     };
 }
 
-export function connectDisconnect() {
+/**
+ * Toggle the connection. Callers that connect on the app's own initiative — a device
+ * event, the reboot retry loop — pass `automatic: true`, so a failure that the app will
+ * retry by itself is not reported as if the user had asked for it. See abortConnection().
+ * @param {{automatic?: boolean}} [options] - automatic: the app started this, not the user
+ */
+export function connectDisconnect({ automatic = false } = {}) {
     if (GUI.connect_lock) {
         return;
     }
@@ -506,7 +509,7 @@ export function connectDisconnect() {
         if (!canStartConnectionAction(selectedDevice)) {
             return;
         }
-        beginConnect(selectedDevice);
+        beginConnect(selectedDevice, automatic);
     }
 
     registerCliHotkey();
@@ -737,15 +740,12 @@ function abortConnection(messageKey) {
     GUI.timeout_remove("connecting"); // kill post-open connecting timer
     GUI.timeout_remove("connectAttempt"); // kill pre-open watchdog
 
-    // A failed open/handshake during a reboot reconnect is expected flakiness, so suppress
-    // the failure dialog — but only with auto-connect on, else nothing retries and the
-    // failure is real. Check the open window as well as the phase (later retries have left
-    // the reconnect phase), and gate it on !rebootWindowExpired so a leaked window can't
-    // suppress real failures forever. Captured before setPhase(FAILED) below.
-    const state = getConnectionState();
-    const duringRebootReconnect =
-        (state.isRebootReconnecting || (state.isRebootWindowOpen && !state.rebootWindowExpired)) &&
-        DeviceHandler.devicePicker.autoConnect;
+    // Report failures the user asked for; stay quiet about attempts the app made on its own,
+    // which are the ones something retries. See ConnectionState.failureIsUserFacing. Read
+    // before setPhase(FAILED) below, which ends the attempt this describes.
+    // Auto-Connect is not tested here: with it off there are no automatic attempts at all —
+    // the auto-select listener requires it and the reboot retry loop stops on it.
+    const reportFailure = getConnectionState().failureIsUserFacing;
 
     // Default message reflects how far the attempt got: a port that already opened but failed
     // the handshake (e.g. invalid API version) did not "fail to open". A manual/TCP/WebSocket
@@ -782,8 +782,10 @@ function abortConnection(messageKey) {
     // FAILED is not a reconnecting phase, so selectActivePort() resumes its normal
     // fallback rather than staying aimed at a dead target.
 
+    // The log panel keeps every failure — it is the trail a user pastes into a bug report.
+    // Only the dialog is withheld.
     gui_log(message);
-    if (!duringRebootReconnect) {
+    if (reportFailure) {
         showConnectionFailedDialog(message);
     }
 
@@ -1431,7 +1433,7 @@ export function reinitializeConnection(suppressDialog = false) {
         connectDisconnect();
         if (DeviceHandler.devicePicker.autoConnect) {
             setTimeout(function () {
-                connectDisconnect();
+                connectDisconnect({ automatic: true });
             }, 500);
             getConnectionState().concludeReboot(true);
             return rebootTimestamp;
@@ -1578,8 +1580,9 @@ function rebootReconnect() {
 
                 // selectActivePort keeps the current selection during a reconnect
                 // (isReconnecting). The selection points at the device from before the reboot.
-                // The attempt fails while that device is absent. The loop then tries again.
-                connectDisconnect();
+                // The attempt fails while that device is absent. The loop then tries again,
+                // so the failure is not reported (automatic).
+                connectDisconnect({ automatic: true });
             }
         }, REBOOT_RECONNECT_RETRY_MS);
     }, REBOOT_FLUSH_DELAY_MS);

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -104,27 +104,13 @@ export function isDrivenRebootTarget(port) {
 }
 
 /**
- * Decide whether the reboot progress dialog's poller should stop waiting (settle the reboot
- * window, show "ready", close). Extracted as a pure predicate so the branch matrix is
- * unit-testable without driving the dialog's intervals.
- *
- * - Always conclude once the FC has answered (connectionValid) or the window elapsed (timeout).
- * - With Auto-Connect ON, keep waiting — the retry loop owns the reconnect.
- * - With Auto-Connect OFF nothing will auto-reconnect, so conclude as soon as there's nothing
- *   left to wait for:
- *     - serial re-enumerates after the reboot, so wait for the port to reappear (portAvailable).
- *     - driven targets (BLE, manual/TCP) never re-enumerate — portAvailable would never flip, so
- *       the dialog used to hang until timeout. rebootReconnect() drops the stale link and then
- *       closes the reboot window at the flush (~1.5s), so wait for the window to close rather
- *       than concluding immediately: that keeps us from showing "ready" while the flush is still
- *       pending (which would tear down a manual reconnect).
- * @param {object} state
- * @param {boolean} state.connectionValid - the rebooted FC has answered
- * @param {boolean} state.timeoutReached - the reboot window has elapsed
- * @param {boolean} state.autoConnect - Auto-Connect is enabled
- * @param {boolean} state.portAvailable - a serial port is present (re-enumerated)
- * @param {string} state.selectedDevice - the selected device path
- * @param {boolean} state.rebootWindowOpen - the connection-state reboot window is still open
+ * Should the reboot dialog's poller stop waiting (settle the window, show "ready", close)?
+ * A pure predicate so the branch matrix is testable without driving the dialog's intervals.
+ * Each branch has its own concluder: Auto-Connect on -> the retry loop; off + driven target ->
+ * rebootReconnect()'s flush closes the window; off + serial -> nothing else runs, so the port
+ * coming back is the only signal.
+ * @param {{connectionValid: boolean, timeoutReached: boolean, autoConnect: boolean,
+ *          portAvailable: boolean, selectedDevice: string, rebootWindowOpen: boolean}} state
  * @returns {boolean}
  */
 export function shouldConcludeRebootDialog({
@@ -141,10 +127,7 @@ export function shouldConcludeRebootDialog({
     if (autoConnect) {
         return false;
     }
-    if (isDrivenRebootTarget(selectedDevice)) {
-        return !rebootWindowOpen;
-    }
-    return Boolean(portAvailable);
+    return isDrivenRebootTarget(selectedDevice) ? !rebootWindowOpen : Boolean(portAvailable);
 }
 
 /**

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -90,12 +90,13 @@ let rebootLinkKept = false;
 let rebootHandshakeSawTraffic = false;
 
 /**
- * Whether a target's transport never re-enumerates after an FC reboot (BLE, manual/TCP),
- * so its reconnect must be DRIVEN by the retry loop rather than left to auto-connect.
+ * Whether a target's transport never re-enumerates after an FC reboot (BLE, manual/TCP).
+ * Such a link survives the reboot and gets no disconnect event, and with Auto-Connect off
+ * there is nothing for the reconnect cycle to wait for.
  * @param {string} port - the selected port path
  * @returns {boolean}
  */
-export function isDrivenRebootTarget(port) {
+function isDrivenRebootTarget(port) {
     return typeof port === "string" && (port.startsWith("bluetooth") || port === "manual");
 }
 
@@ -1352,24 +1353,21 @@ function startLiveDataRefreshTimer() {
     liveDataRefreshTimerId = setInterval(update_live_status, 250);
 }
 
-export function reinitializeConnection(suppressDialog = false) {
-    // Open the reboot window in the connection state (single owner of the reboot
-    // lifecycle: start time, duration, phase). Virtual toggles settle immediately below.
-    getConnectionState().requestReboot(rebootConnectWindowMs());
-    const rebootTimestamp = getConnectionState().rebootWindowStartedAt;
-
+export function reinitializeConnection() {
+    // Virtual has no FC to reboot: toggle the fake link, and toggle it back with Auto-Connect
+    // on. No reboot window — nothing is going away that we have to wait for, and the phase
+    // follows the toggle instead of being declared CONNECTED before the reconnect runs.
     if (CONFIGURATOR.virtualMode) {
         connectDisconnect();
         if (DeviceHandler.devicePicker.autoConnect) {
-            setTimeout(function () {
-                connectDisconnect({ automatic: true });
-            }, 500);
-            getConnectionState().concludeReboot(true);
-            return rebootTimestamp;
+            setTimeout(() => connectDisconnect({ automatic: true }), 500);
         }
-        getConnectionState().concludeReboot(false);
-        return rebootTimestamp;
+        return;
     }
+
+    // Open the reboot window in the connection state: the single owner of the reboot
+    // lifecycle's start time, duration and phase.
+    getConnectionState().requestReboot(rebootConnectWindowMs());
 
     // requestReboot() above sets the connection state to REBOOTING. selectActivePort() then
     // reports isReconnecting and keeps the current selection. It does not change the selection
@@ -1391,13 +1389,11 @@ export function reinitializeConnection(suppressDialog = false) {
     if (["cli", "presets"].includes(GUI.active_tab)) {
         console.log(`${logHead} Rebooting in ${GUI.active_tab} tab, skipping reboot dialog`);
         gui_log(i18n.getMessage("deviceRebooting"));
-    } else if (!suppressDialog) {
+    } else {
         showRebootDialog();
     }
 
     rebootReconnect();
-
-    return rebootTimestamp;
 }
 
 /**

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -57,8 +57,8 @@ let rebootDialogProgressTimerId = false;
 let rebootDialogCheckTimerId = false;
 
 // The transport-open flag formerly stored here as `isConnected` now lives in
-// the connection state — read via `getConnectionState().linkOpen`, mutated via setLinkOpen/
-// toggleLinkOpen. Kept as a local read-through helper so the call sites stay terse.
+// the connection state — read via `getConnectionState().linkOpen`, mutated via setLinkOpen.
+// Kept as a local read-through helper so the call sites stay terse.
 const isConnected = () => getConnectionState().linkOpen;
 
 // The intentional-disconnect flag — telling an intentional disconnect apart
@@ -163,18 +163,13 @@ function isCliOnlyMode() {
     return getConfig("cliOnlyMode")?.cliOnlyMode === true;
 }
 
-const toggleStatus = function () {
-    // Transport-open flag now lives in the connection state (was module-private isConnected).
-    getConnectionState().toggleLinkOpen();
-};
-
 function connectHandler(event) {
     onOpen(event.detail);
-    // Only flip the connected flag when the port actually opened. A failed open
-    // (event.detail falsy) runs abortConnection inside onOpen; toggling here too would
-    // leave isConnected out of sync with the real state and break reconnect retries.
+    // Only mark the link open when the port actually opened. A failed open (event.detail
+    // falsy) runs abortConnection inside onOpen; setting the flag here too would leave it
+    // out of sync with the real state and break reconnect retries.
     if (event.detail) {
-        toggleStatus();
+        getConnectionState().setLinkOpen(true);
     }
 }
 
@@ -321,7 +316,7 @@ function beginDisconnect() {
     getConnectionState().concludeReboot(false);
 
     mspHelper?.setArmingEnabled(true, false, function () {
-        finishClose(toggleStatus);
+        finishClose();
     });
 }
 
@@ -331,7 +326,7 @@ function beginDisconnect() {
 function disconnectForReboot() {
     console.log(`${logHead} Dropping stale link for reboot (flush timeout)`);
     prepareDisconnect();
-    finishClose(toggleStatus);
+    finishClose();
 }
 
 // App-level connection teardown WITHOUT dropping the transport: everything onClosed's
@@ -585,7 +580,7 @@ function teardownConnectionUi() {
     switchTab(target, { mode: "disconnected" });
 }
 
-function finishClose(finishedCallback) {
+function finishClose() {
     const wasConnected = CONFIGURATOR.connectionValid;
 
     if (semver.lt(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
@@ -617,7 +612,9 @@ function finishClose(finishedCallback) {
 
     teardownConnectionUi();
 
-    finishedCallback();
+    // The link is down. finishUnexpectedDisconnect() clears the same flag for the other
+    // teardown path, before its UI teardown — it has a late removedDevice to outrun.
+    getConnectionState().setLinkOpen(false);
 }
 
 // Complete the teardown for an UNEXPECTED disconnect (cable unplug / FC reboot / BLE drop).
@@ -630,9 +627,9 @@ function finishUnexpectedDisconnect() {
     GUI.timeout_remove("connecting");
     GUI.timeout_remove("connectAttempt");
 
-    // Mirror the toggleStatus that finishClose runs via finishedCallback for intentional
-    // disconnects. Reset before the UI teardown so a late removedDevice cannot re-enter
-    // connectDisconnect() against a still-"connected" state.
+    // Mirror the flag reset finishClose() makes for intentional disconnects. Reset before
+    // the UI teardown so a late removedDevice cannot re-enter connectDisconnect() against a
+    // still-"connected" state.
     getConnectionState().setLinkOpen(false);
 
     teardownConnectionUi();
@@ -657,7 +654,7 @@ function dropStalledRebootConnection() {
     }
 
     getConnectionState().markIntentionalDisconnect();
-    finishClose(toggleStatus);
+    finishClose();
 }
 
 function setConnectionTimeout() {
@@ -1367,7 +1364,7 @@ function handleConnectionTimeout() {
     connectionTimeoutPending = true;
     prepareDisconnect();
     getConnectionState().concludeReboot(false);
-    finishClose(toggleStatus);
+    finishClose();
 }
 
 export async function update_sensor_status() {

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1411,12 +1411,10 @@ export function reinitializeConnection(suppressDialog = false) {
         return rebootTimestamp;
     }
 
-    const currentPort = DeviceHandler.devicePicker.selectedDevice;
-
     // requestReboot() above sets the connection state to REBOOTING. selectActivePort() then
     // reports isReconnecting and keeps the current selection. It does not change the selection
-    // to the expert-mode virtual or manual device while the FC is off the port list.
-    // The reconnect uses currentPort again. A token is not necessary.
+    // to the expert-mode virtual or manual device while the FC is off the port list, and it
+    // re-points the selection when the device returns under a new id.
 
     // Send reboot command to the flight controller
     MSP.send_message(MSPCodes.MSP_SET_REBOOT, false, false);
@@ -1426,37 +1424,18 @@ export function reinitializeConnection(suppressDialog = false) {
     // false now so the reboot dialog and retry loop wait for a real reconnect.
     CONFIGURATOR.connectionValid = false;
 
-    if (isDrivenRebootTarget(currentPort)) {
-        // BLE/manual links usually survive the FC reboot — the radio stays connected while
-        // only the MCU restarts — so no disconnect event fires and the configurator would be
-        // left holding a stale connection. Drive it ourselves: show the reboot dialog, drop
-        // the stale link once the command has flushed, then reconnect when Auto-Connect is on.
-        // The dialog polls connectionValid and closes on reconnect or timeout (same as serial).
-        if (!suppressDialog && !["cli", "presets"].includes(GUI.active_tab)) {
-            showRebootDialog();
-        }
-        rebootReconnect();
-        return rebootTimestamp;
-    }
-
-    // Show reboot progress modal except for cli and presets tab
+    // One reconnect cycle for every hardware target. It owns the window: it waits for the FC
+    // to answer, retries while Auto-Connect is on, and concludes on success or timeout —
+    // including for serial, which previously had no owner at all and relied on a device event
+    // reaching the auto-select listener.
     if (["cli", "presets"].includes(GUI.active_tab)) {
         console.log(`${logHead} Rebooting in ${GUI.active_tab} tab, skipping reboot dialog`);
         gui_log(i18n.getMessage("deviceRebooting"));
-        gui_log(i18n.getMessage("deviceReady"));
-
-        // No reconnect loop runs here (auto-connect handles it); settle the connection state
-        // read-model now. Authoritative readiness wiring lands later.
-        getConnectionState().concludeReboot(false);
-        return rebootTimestamp;
-    }
-    // Show reboot progress modal. The dialog's check-timer concludes the reboot window;
-    // when it's suppressed, nothing else would, so conclude here to avoid a leaked window.
-    if (!suppressDialog) {
+    } else if (!suppressDialog) {
         showRebootDialog();
-    } else {
-        getConnectionState().concludeReboot(false);
     }
+
+    rebootReconnect();
 
     return rebootTimestamp;
 }
@@ -1482,14 +1461,16 @@ function rebootReconnect() {
     stopRebootReconnect();
 
     rebootReconnectTimerId = setTimeout(() => {
-        // If the link survived the reboot, reset the now-stale connection so the UI returns
-        // to the landing tab. For a BLE target about to auto-reconnect, keep the GATT session
-        // open (softResetForReboot) so the retry rides it, avoiding the deaf-session reconnect
-        // on Linux/BlueZ. Otherwise drop the transport for real.
-        if (isConnected()) {
+        const driven = isDrivenRebootTarget(DeviceHandler.devicePicker.selectedDevice);
+
+        // A driven link survives the reboot — only the MCU restarts, so no disconnect event
+        // ever fires and the app would hold a stale connection. Drop it here. A BLE target
+        // about to auto-reconnect keeps its GATT session (softResetForReboot) instead:
+        // dropping it produces deaf sessions on Linux/BlueZ. Serial re-enumerates and drops
+        // itself, so leave that link alone.
+        if (driven && isConnected()) {
             const target = DeviceHandler.devicePicker.selectedDevice;
-            const keepBleLink =
-                typeof target === "string" && target.startsWith("bluetooth") && DeviceHandler.devicePicker.autoConnect;
+            const keepBleLink = target.startsWith("bluetooth") && DeviceHandler.devicePicker.autoConnect;
             if (keepBleLink) {
                 softResetForReboot();
             } else {
@@ -1497,13 +1478,13 @@ function rebootReconnect() {
             }
         }
 
-        // Honor Auto-Connect — read it live (not snapshotted at reboot start) so toggling it off
-        // during the reboot window takes effect. When off, stay on the landing tab and let the
-        // user reconnect manually (the reboot dialog closes via its no-reconnect check).
-        if (!DeviceHandler.devicePicker.autoConnect) {
+        // Auto-Connect is read live (not snapshotted at reboot start) so toggling it off
+        // mid-window takes effect. With it off a driven target has nothing left to wait for —
+        // the link is down and nothing will reconnect it — so end the window now. Serial waits
+        // for its port to re-enumerate (below) so the user can reconnect to a device that is
+        // actually back.
+        if (driven && !DeviceHandler.devicePicker.autoConnect) {
             rebootReconnectTimerId = false;
-            // No automatic reconnect will run, so end the reconnect-in-progress window
-            // (concludeReboot settles to IDLE) and let normal selection resume.
             getConnectionState().concludeReboot(false);
             return;
         }
@@ -1511,11 +1492,13 @@ function rebootReconnect() {
         // Entering the retry phase: REBOOTING -> RECONNECTING in the connection state read-model.
         getConnectionState().reconnectStarted();
 
-        // Retry connecting until the rebooted FC answers (connectionValid), the reboot window
-        // closes, or Auto-Connect is turned off mid-window. Early attempts may connect to a
-        // still-booting FC and get dropped; the device stays listed (we never remove it on
-        // disconnect), so a later attempt succeeds once the FC is stable. connectDisconnect here
-        // takes the connect branch (isConnected is false).
+        // Wait for the rebooted FC. With Auto-Connect on, retry the connection: early attempts
+        // may reach a still-booting FC and get dropped; the device stays listed (we never remove
+        // it on disconnect), so a later attempt succeeds once it is stable. connectDisconnect
+        // takes the connect branch (isConnected is false). With Auto-Connect on, a serial device
+        // that re-enumerates is normally connected by the addedDevice listener before a tick
+        // comes round — this loop is the backstop for when that event does not arrive, and the
+        // owner that ends the window either way.
         rebootReconnectTimerId = setInterval(() => {
             // Stop when the window has run out OR another owner already concluded it:
             // the reboot dialog's check timer and this loop share one window, and
@@ -1523,16 +1506,22 @@ function rebootReconnect() {
             // not-expired, so a live loop must treat "no longer open" as a stop too.
             const state = getConnectionState();
             const timedOut = state.rebootWindowExpired || !state.isRebootWindowOpen;
-            if (CONFIGURATOR.connectionValid || timedOut || !DeviceHandler.devicePicker.autoConnect) {
+            const autoConnect = DeviceHandler.devicePicker.autoConnect;
+            // Auto-Connect off: nothing will reconnect, so the wait ends as soon as there is
+            // nothing left to wait for — the port back for serial, immediately for a driven
+            // target (its link is already down).
+            const waitedOut = !autoConnect && (driven || DeviceHandler.portAvailable);
+
+            if (CONFIGURATOR.connectionValid || timedOut || waitedOut) {
                 stopRebootReconnect();
-                // The reboot window has closed (reconnected, timed out, or auto-connect off):
-                // concludeReboot settles to IDLE so normal selection resumes. A kept BLE
+                // The reboot window has closed (reconnected, timed out, or nothing left to wait
+                // for): concludeReboot settles to IDLE so normal selection resumes. A kept BLE
                 // link that never made it back to connected is dropped for real here.
                 getConnectionState().concludeReboot(CONFIGURATOR.connectionValid);
                 releaseKeptRebootLink();
                 return;
             }
-            if (!isConnected() && !GUI.connecting_to) {
+            if (autoConnect && !isConnected() && !GUI.connecting_to) {
                 // Re-derive the kept-link flag from protocol truth before reconnecting.
                 // A real transport close normally clears it via onClosed, but between
                 // attempts serial_backend's disconnect listener is detached

--- a/src/stores/connection.js
+++ b/src/stores/connection.js
@@ -2,7 +2,6 @@ import { defineStore } from "pinia";
 import { computed, ref } from "vue";
 import CONFIGURATOR from "../js/data_storage";
 import DeviceHandler from "../js/device_handler";
-import { getConnectionState } from "../js/connection_state";
 import { getLockManager } from "../js/lock_manager";
 
 export const useConnectionStore = defineStore("connection", () => {
@@ -43,14 +42,6 @@ export const useConnectionStore = defineStore("connection", () => {
 
     const selectedDevice = computed(() => DeviceHandler.devicePicker.selectedDevice);
 
-    // Thin reactive read-model of the connection status holder. Its phase lives in
-    // Vue refs, so a computed that reads the getters tracks them directly — no
-    // subscribe/snapshot bridge — giving Vue components one canonical source for
-    // lifecycle phase / readiness instead of the legacy CONFIGURATOR/GUI globals.
-    const connection = getConnectionState();
-    const connectionPhase = computed(() => connection.state);
-    const connectionReady = computed(() => connection.isReady);
-
     // Live data refresh control
     const liveDataPaused = ref(false);
 
@@ -79,9 +70,6 @@ export const useConnectionStore = defineStore("connection", () => {
         cliValid,
         clearMspQueue,
         selectedDevice,
-        // Connection-state read-model (read-only)
-        connectionPhase,
-        connectionReady,
         liveDataPaused,
         pauseLiveData,
         resumeLiveData,

--- a/test/js/connection_state.test.js
+++ b/test/js/connection_state.test.js
@@ -8,41 +8,33 @@ import {
 } from "../../src/js/connection_state.js";
 
 // ---------------------------------------------------------------------------
-// Connection-status holder: current phase + linkOpen / intentionalDisconnect
-// flags. No transition table and no reconnect token — phase is set explicitly,
-// and a reconnect just re-uses the previously-selected port. State lives in Vue
-// refs, so the getters are both synchronously readable and reactively trackable.
+// Connection-status holder: current phase + linkOpen / intentionalDisconnect /
+// attempt-origin flags. No transition table and no reconnect token — phase is set
+// explicitly, and a reconnect just re-uses the previously-selected port.
 // ---------------------------------------------------------------------------
 
 const make = () => new ConnectionState();
 
 describe("phase + readiness", () => {
-    it("starts IDLE / not-ready", () => {
+    it("starts IDLE", () => {
         const c = make();
         expect(c.state).toBe(State.IDLE);
-        expect(c.isReady).toBe(false);
     });
 
-    it("setPhase moves the phase and CONNECTED/CLI are ready", () => {
+    it("setPhase moves the phase", () => {
         const c = make();
         c.setPhase(State.CONNECTING);
         expect(c.state).toBe(State.CONNECTING);
-        expect(c.isReady).toBe(false);
         c.setPhase(State.CONNECTED);
-        expect(c.isReady).toBe(true);
-        c.setPhase(State.CLI);
-        expect(c.isReady).toBe(true);
+        expect(c.state).toBe(State.CONNECTED);
     });
 
     it("is reactive: a computed over a getter tracks setPhase with no manual bridge", () => {
         const c = make();
         const phase = computed(() => c.state);
-        const ready = computed(() => c.isReady);
         expect(phase.value).toBe(State.IDLE);
-        expect(ready.value).toBe(false);
         c.setPhase(State.CONNECTED);
         expect(phase.value).toBe(State.CONNECTED);
-        expect(ready.value).toBe(true);
     });
 });
 
@@ -53,7 +45,7 @@ describe("attempt origin / failure reporting", () => {
         expect(c.state).toBe(State.CONNECTING);
     });
 
-    // Both halves of isRebootReconnecting. Each case needs its own instance —
+    // Both reboot-owned phases. Each case needs its own instance —
     // requestReboot() is a no-op once a phase is in flight.
     it.each([
         ["REBOOTING", (c) => c.requestReboot(), State.REBOOTING],
@@ -115,10 +107,13 @@ describe("reboot / reconnect window", () => {
             c.setPhase(phase);
             expect(c.isReconnecting).toBe(true);
         }
-        c.setPhase(State.CONNECTED);
-        expect(c.isReconnecting).toBe(false);
-        c.setPhase(State.IDLE);
-        expect(c.isReconnecting).toBe(false);
+        // The settled and failed phases exist to be outside that set: a failed open never
+        // reaches notifyClosed (the transport reports connect:false, not a disconnect), so
+        // FAILED is what lets selectActivePort stop aiming at the dead port.
+        for (const phase of [State.CONNECTED, State.CLI, State.FAILED, State.IDLE]) {
+            c.setPhase(phase);
+            expect(c.isReconnecting).toBe(false);
+        }
     });
 
     it("concludeReboot settles to CONNECTED on success / IDLE on failure", () => {

--- a/test/js/connection_state.test.js
+++ b/test/js/connection_state.test.js
@@ -46,6 +46,39 @@ describe("phase + readiness", () => {
     });
 });
 
+describe("attempt origin / failure reporting", () => {
+    it("attemptStarted enters CONNECTING, but keeps a reboot reconnect's own phase", () => {
+        const c = make();
+        c.attemptStarted();
+        expect(c.state).toBe(State.CONNECTING);
+
+        c.requestReboot();
+        c.reconnectStarted();
+        c.attemptStarted(true); // the retry loop's attempt
+        expect(c.state).toBe(State.RECONNECTING);
+    });
+
+    it("reports a user-initiated failure, stays quiet about the app's own", () => {
+        const c = make();
+
+        c.attemptStarted(); // the user pressed Connect
+        expect(c.failureIsUserFacing).toBe(true);
+
+        c.attemptStarted(true); // a device event / the retry loop
+        expect(c.failureIsUserFacing).toBe(false);
+    });
+
+    it("reports an automatic attempt's failure once the link had opened", () => {
+        // A handshake rejected after the port opened (unsupported firmware, garbage API
+        // version) is terminal — no retry turns it into a working connection.
+        const c = make();
+        c.attemptStarted(true);
+        c.setLinkOpen(true);
+
+        expect(c.failureIsUserFacing).toBe(true);
+    });
+});
+
 describe("reboot / reconnect window", () => {
     it("requestReboot enters REBOOTING and does not re-enter once reconnecting", () => {
         const c = make();

--- a/test/js/connection_state.test.js
+++ b/test/js/connection_state.test.js
@@ -169,13 +169,13 @@ describe("operational flags", () => {
         expect(c.consumeIntentionalDisconnect()).toBe(false);
     });
 
-    it("linkOpen set / toggle", () => {
+    it("linkOpen set", () => {
         const c = make();
         expect(c.linkOpen).toBe(false);
         c.setLinkOpen(true);
         expect(c.linkOpen).toBe(true);
-        expect(c.toggleLinkOpen()).toBe(false);
-        expect(c.toggleLinkOpen()).toBe(true);
+        c.setLinkOpen(false);
+        expect(c.linkOpen).toBe(false);
     });
 });
 

--- a/test/js/connection_state.test.js
+++ b/test/js/connection_state.test.js
@@ -53,9 +53,8 @@ describe("attempt origin / failure reporting", () => {
         expect(c.state).toBe(State.CONNECTING);
     });
 
-    // Both halves of isRebootReconnecting: a reboot owns its phase, and an attempt made
-    // inside that window must not overwrite it with CONNECTING. Each case needs its own
-    // instance — requestReboot() is a no-op once the phase is already in flight.
+    // Both halves of isRebootReconnecting. Each case needs its own instance —
+    // requestReboot() is a no-op once a phase is in flight.
     it.each([
         ["REBOOTING", (c) => c.requestReboot(), State.REBOOTING],
         [
@@ -87,8 +86,7 @@ describe("attempt origin / failure reporting", () => {
     });
 
     it("reports an automatic attempt's failure once the link had opened", () => {
-        // A handshake rejected after the port opened (unsupported firmware, garbage API
-        // version) is terminal — no retry turns it into a working connection.
+        // Terminal: no retry turns a rejected handshake into a working connection.
         const c = make();
         c.attemptStarted(true);
         c.setLinkOpen(true);

--- a/test/js/connection_state.test.js
+++ b/test/js/connection_state.test.js
@@ -47,15 +47,33 @@ describe("phase + readiness", () => {
 });
 
 describe("attempt origin / failure reporting", () => {
-    it("attemptStarted enters CONNECTING, but keeps a reboot reconnect's own phase", () => {
+    it("attemptStarted enters CONNECTING", () => {
         const c = make();
         c.attemptStarted();
         expect(c.state).toBe(State.CONNECTING);
+    });
 
-        c.requestReboot();
-        c.reconnectStarted();
-        c.attemptStarted(true); // the retry loop's attempt
-        expect(c.state).toBe(State.RECONNECTING);
+    // Both halves of isRebootReconnecting: a reboot owns its phase, and an attempt made
+    // inside that window must not overwrite it with CONNECTING. Each case needs its own
+    // instance — requestReboot() is a no-op once the phase is already in flight.
+    it.each([
+        ["REBOOTING", (c) => c.requestReboot(), State.REBOOTING],
+        [
+            "RECONNECTING",
+            (c) => {
+                c.requestReboot();
+                c.reconnectStarted();
+            },
+            State.RECONNECTING,
+        ],
+    ])("attemptStarted keeps a reboot reconnect's own phase (%s)", (_label, enterPhase, expected) => {
+        const c = make();
+        c.setPhase(State.CONNECTED);
+        enterPhase(c);
+
+        c.attemptStarted(true);
+
+        expect(c.state).toBe(expected);
     });
 
     it("reports a user-initiated failure, stays quiet about the app's own", () => {

--- a/test/js/connection_store.test.js
+++ b/test/js/connection_store.test.js
@@ -2,8 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 
 // ---------------------------------------------------------------------------
-// useConnectionStore is a thin reactive read-model of the connection state.
-// The store's heavy legacy collaborators are stubbed; the connection state is the real one.
+// useConnectionStore is a thin reactive read-model over CONFIGURATOR, the device picker
+// and the lock manager. The store's heavy legacy collaborators are stubbed.
 // ---------------------------------------------------------------------------
 
 vi.mock("../../src/js/gui", () => ({ default: { connecting_to: false, connected_to: false, connect_lock: false } }));
@@ -14,17 +14,14 @@ vi.mock("../../src/js/device_handler", () => ({ default: { devicePicker: { selec
 vi.mock("../../src/js/msp", () => ({ default: { callbacks_cleanup: () => {} } }));
 
 import { useConnectionStore } from "../../src/stores/connection.js";
-import { getConnectionState, __resetConnectionStateForTests, State } from "../../src/js/connection_state.js";
 import { __resetLockManagerForTests } from "../../src/js/lock_manager.js";
 
 beforeEach(() => {
     setActivePinia(createPinia());
-    __resetConnectionStateForTests();
     __resetLockManagerForTests();
 });
 
 afterEach(() => {
-    __resetConnectionStateForTests();
     __resetLockManagerForTests();
 });
 
@@ -47,29 +44,5 @@ describe("store owns connection-target state (folded from GuiControl)", () => {
         expect(store.connectLock).toBe(true);
         store.connectLock = false;
         expect(store.connectLock).toBe(false);
-    });
-});
-
-describe("connection store connection-state read-model", () => {
-    it("exposes the initial phase", () => {
-        const store = useConnectionStore();
-        expect(store.connectionPhase).toBe(State.IDLE);
-        expect(store.connectionReady).toBe(false);
-    });
-
-    it("reactively reflects phase changes", () => {
-        const store = useConnectionStore();
-        const connection = getConnectionState();
-
-        connection.setPhase(State.CONNECTING);
-        expect(store.connectionPhase).toBe(State.CONNECTING);
-
-        connection.setPhase(State.CONNECTED);
-        expect(store.connectionPhase).toBe(State.CONNECTED);
-        expect(store.connectionReady).toBe(true);
-
-        connection.setPhase(State.IDLE);
-        expect(store.connectionPhase).toBe(State.IDLE);
-        expect(store.connectionReady).toBe(false);
     });
 });

--- a/test/js/device_handler.test.js
+++ b/test/js/device_handler.test.js
@@ -255,6 +255,64 @@ describe("DeviceHandler.selectActivePort — stale addedDevice suggestion", () =
     });
 });
 
+// A rebooting device usually comes back under a NEW path — the browser mints a fresh
+// SerialPort object — so "is it back?" cannot be a path comparison, and it must not degrade
+// into "is anything back?" either.
+describe("DeviceHandler reboot-target identity", () => {
+    beforeEach(() => {
+        resetPortHandler();
+    });
+
+    const fc = { path: "serial_6", displayName: "Betaflight STM Electronics", vendorId: 1155, productId: 22336 };
+    const other = { path: "serial_2", displayName: "Betaflight CP210", vendorId: 4292, productId: 60000 };
+
+    it("describes a listed device, and nothing for one that is not listed", () => {
+        DeviceHandler.currentSerialPorts = [fc];
+
+        expect(DeviceHandler.describeDevice("serial_6")).toEqual({
+            path: "serial_6",
+            vendorId: 1155,
+            productId: 22336,
+        });
+        expect(DeviceHandler.describeDevice("serial_99")).toBeNull();
+    });
+
+    it("finds the device again under a new path, by make", () => {
+        const target = { path: "serial_6", vendorId: 1155, productId: 22336 };
+        DeviceHandler.currentSerialPorts = [other, { ...fc, path: "serial_13" }];
+
+        expect(DeviceHandler.findDescribedDevice(target)?.path).toBe("serial_13");
+    });
+
+    it("does not mistake another device for it", () => {
+        const target = { path: "serial_6", vendorId: 1155, productId: 22336 };
+        DeviceHandler.currentSerialPorts = [other];
+
+        expect(DeviceHandler.findDescribedDevice(target)).toBeUndefined();
+        expect(DeviceHandler.findDescribedDevice(null)).toBeUndefined();
+    });
+
+    it("selectActivePort prefers the rebooted device over another that just appeared", () => {
+        // The burst case: our FC comes back as serial_13 while an unrelated device is added
+        // too. Without the preference the selection follows whichever event arrived last.
+        DeviceHandler.currentSerialPorts = [other, { ...fc, path: "serial_13" }];
+        getConnectionState().requestReboot(10000, { path: "serial_6", vendorId: 1155, productId: 22336 });
+
+        const selected = DeviceHandler.selectActivePort(other);
+
+        expect(selected).toBe("serial_13");
+    });
+
+    it("is a preference, not a lock: an unrecognised return still gets selected", () => {
+        // A board that comes back as something else (different USB descriptor) must not be
+        // locked out — the normal rules still apply when the target is not found.
+        DeviceHandler.currentSerialPorts = [other];
+        getConnectionState().requestReboot(10000, { path: "serial_6", vendorId: 1155, productId: 22336 });
+
+        expect(DeviceHandler.selectActivePort(other)).toBe("serial_2");
+    });
+});
+
 describe("DeviceHandler show* setters", () => {
     beforeEach(() => {
         resetPortHandler();

--- a/test/js/device_handler.test.js
+++ b/test/js/device_handler.test.js
@@ -284,6 +284,16 @@ describe("DeviceHandler reboot-target identity", () => {
         expect(DeviceHandler.findDescribedDevice(target)?.path).toBe("serial_13");
     });
 
+    it("does not match on absent USB ids — a port without them is not 'the same make'", () => {
+        // SerialPortInfo has usbVendorId/usbProductId for USB ports only. Two platform-native
+        // ports (built-in COM, Bluetooth SPP) both carry undefined, and undefined === undefined
+        // would pair them up.
+        const target = { path: "serial_6", vendorId: undefined, productId: undefined };
+        DeviceHandler.currentSerialPorts = [{ path: "serial_1", displayName: "COM3" }];
+
+        expect(DeviceHandler.findDescribedDevice(target)).toBeUndefined();
+    });
+
     it("does not mistake another device for it", () => {
         const target = { path: "serial_6", vendorId: 1155, productId: 22336 };
         DeviceHandler.currentSerialPorts = [other];

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -522,19 +522,51 @@ describe("serial_backend connect-failure dialog", () => {
     });
 
     it("reports an app-initiated failure AFTER the link opened (handshake rejected)", () => {
-        // onOpen set connected_to, so the link was up and the failure is the handshake
-        // (unsupported/garbage API version) — terminal, not enumeration flakiness. Nothing
-        // retries it into working, so the user must be told however the attempt started.
+        // The link was up and the failure is the handshake (unsupported/garbage API version)
+        // — terminal, not enumeration flakiness. Nothing retries it into working, so the user
+        // must be told however the attempt started.
         DeviceHandler.devicePicker.autoConnect = true;
 
         connectDisconnect({ automatic: true });
-        serialHandlers.connect({ detail: true }); // opened -> HANDSHAKING, connected_to set
+        serialHandlers.connect({ detail: true }); // opened -> linkOpen, HANDSHAKING
         dialogStore.open.mockClear();
 
-        FC.CONFIG.apiVersion = "0.0.0";
-        MSP.send_message.mock.calls.at(-1)?.[3]?.(); // MSP_API_VERSION callback -> abortConnection
+        // FC.CONFIG is module state on the mock and resetMocks() does not restore it, so put
+        // the supported version back before the next test inherits an unsupported FC.
+        const apiVersion = FC.CONFIG.apiVersion;
+        try {
+            FC.CONFIG.apiVersion = "0.0.0";
+            MSP.send_message.mock.calls.at(-1)?.[3]?.(); // MSP_API_VERSION callback -> abortConnection
+        } finally {
+            FC.CONFIG.apiVersion = apiVersion;
+        }
 
         expect(infoDialogCount()).toBe(1);
+    });
+
+    it("reports a handshake rejected synchronously, inside onOpen", () => {
+        // MSP.send_message runs its callback synchronously when the link has dropped again by
+        // the time onOpen starts the handshake. abortConnection then runs before connectHandler
+        // returns, so the link-open flag has to be set before onOpen, not after it.
+        DeviceHandler.devicePicker.autoConnect = true;
+        const apiVersion = FC.CONFIG.apiVersion;
+
+        try {
+            connectDisconnect({ automatic: true });
+            dialogStore.open.mockClear();
+
+            // FC.resetState() leaves apiVersion "0.0.0"; the synchronous callback sees that.
+            MSP.send_message.mockImplementationOnce((_code, _data, _sent, callback) => {
+                FC.CONFIG.apiVersion = "0.0.0";
+                callback?.();
+            });
+
+            serialHandlers.connect({ detail: true });
+
+            expect(infoDialogCount()).toBe(1);
+        } finally {
+            FC.CONFIG.apiVersion = apiVersion;
+        }
     });
 
     it("stays silent when a reboot reconnect's open fails (the loop retries)", () => {

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -810,13 +810,83 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             // The reboot forces the connection invalid so the dialog/loop wait for a real reconnect.
             expect(CONFIGURATOR.connectionValid).toBe(false);
 
-            // Unlike the BLE/manual path, serial relies on the real protocol "disconnect" event
-            // from the cable dropping — it does NOT self-schedule a disconnect or reconnect loop.
+            // Serial drops its own link when the FC re-enumerates, so the cycle never forces a
+            // disconnect the way the driven path does — and with the link still up it makes no
+            // connect attempt either.
             vi.advanceTimersByTime(20000);
             expect(serial.disconnect).not.toHaveBeenCalled();
             expect(serial.connect).not.toHaveBeenCalled();
 
             serialHandlers.disconnect({ detail: true }); // teardown (cable-drop never fired)
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    // Serial used to have no owner: the reconnect depended on an addedDevice event reaching the
+    // auto-select listener. That listener is still the fast path, but the cycle now backstops it
+    // and ends the window either way.
+    it("reconnects a serial target from the cycle when no device event arrives", () => {
+        vi.useFakeTimers();
+        try {
+            DeviceHandler.devicePicker.selectedDevice = "/dev/ttyACM0";
+            DeviceHandler.devicePicker.autoConnect = true;
+            CONFIGURATOR.connectionValid = true;
+            establishConnection();
+
+            reinitializeConnection(true);
+            serialHandlers.disconnect({ detail: true }); // the FC's re-enumeration drops the link
+            serial.connect.mockClear();
+
+            vi.advanceTimersByTime(1500 + 1000); // flush, then the first retry tick
+            expect(serial.connect).toHaveBeenCalled();
+        } finally {
+            vi.advanceTimersByTime(30000); // drain the window
+            vi.useRealTimers();
+        }
+    });
+
+    it("a user disconnect during the reboot cancels the cycle and closes the window", () => {
+        vi.useFakeTimers();
+        try {
+            DeviceHandler.devicePicker.selectedDevice = "/dev/ttyACM0";
+            DeviceHandler.devicePicker.autoConnect = true;
+            CONFIGURATOR.connectionValid = true;
+            establishConnection();
+
+            reinitializeConnection(true);
+            disconnect(); // user hits Disconnect mid-reboot
+            mspHelperInstance.setArmingEnabled.mock.calls.at(-1)?.[2]?.(); // complete the close
+            serial.connect.mockClear();
+
+            vi.advanceTimersByTime(30000);
+
+            expect(serial.connect).not.toHaveBeenCalled();
+            expect(getConnectionState().isRebootWindowOpen).toBe(false);
+        } finally {
+            vi.useRealTimers();
+        }
+    });
+
+    // The window is shared: the dialog's timer can conclude it first. A closed window reads as
+    // NOT expired, so a loop testing expiry alone would spin forever.
+    it("stops when another owner concludes the window", () => {
+        vi.useFakeTimers();
+        try {
+            DeviceHandler.devicePicker.selectedDevice = "/dev/ttyACM0";
+            DeviceHandler.devicePicker.autoConnect = true;
+            CONFIGURATOR.connectionValid = true;
+            establishConnection();
+
+            reinitializeConnection(true);
+            serialHandlers.disconnect({ detail: true });
+            vi.advanceTimersByTime(1500); // into the retry phase
+
+            getConnectionState().concludeReboot(false); // another owner settles it
+            serial.connect.mockClear();
+
+            vi.advanceTimersByTime(30000);
+            expect(serial.connect).not.toHaveBeenCalled();
         } finally {
             vi.useRealTimers();
         }

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -113,6 +113,9 @@ vi.mock("../../src/js/device_handler", () => ({
         devicePickerDisabled: false,
         portAvailable: false,
         isKnownDevicePath: vi.fn(() => false),
+        // The reboot window captures which device it waits for; the cycle asks whether it is back.
+        describeDevice: vi.fn((path) => ({ path, vendorId: 1155, productId: 22336 })),
+        findDescribedDevice: vi.fn(() => undefined),
         devicePicker: {
             selectedDevice: "/dev/ttyACM0",
             portOverride: "/dev/ttyACM0",
@@ -869,15 +872,14 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
     // Auto-Connect off: nothing reconnects, so the wait ends as soon as there is nothing left
     // to wait for. For serial that is the port coming back — the user can reconnect to a device
     // that is actually there. (Was shouldConcludeRebootDialog's serial branch.)
-    it("with Auto-Connect off, ends the window when the SELECTED device is listed again", () => {
-        // Not "a serial port exists": a machine with other ports would end the wait while the
-        // rebooting device was still gone.
+    it("with Auto-Connect off, ends the window when OUR device is back — not any port", () => {
         vi.useFakeTimers();
         try {
             DeviceHandler.devicePicker.selectedDevice = "/dev/ttyACM0";
             DeviceHandler.devicePicker.autoConnect = false;
-            DeviceHandler.portAvailable = true; // other ports are present throughout
-            DeviceHandler.isKnownDevicePath.mockReturnValue(false);
+            DeviceHandler.portAvailable = true; // other serial ports are present throughout
+            DeviceHandler.isKnownDevicePath.mockReturnValue(true); // and one shares our path shape
+            DeviceHandler.findDescribedDevice.mockReturnValue(undefined); // but ours is away
             CONFIGURATOR.connectionValid = true;
             establishConnection();
 
@@ -888,13 +890,14 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             vi.advanceTimersByTime(1500 + 3000); // flush plus several ticks
             expect(getConnectionState().isRebootWindowOpen).toBe(true); // ours is gone: keep waiting
 
-            DeviceHandler.isKnownDevicePath.mockReturnValue(true); // re-enumerated
+            DeviceHandler.findDescribedDevice.mockReturnValue({ path: "serial_9" }); // back, new id
             vi.advanceTimersByTime(1000);
             expect(getConnectionState().isRebootWindowOpen).toBe(false);
             expect(serial.connect).not.toHaveBeenCalled(); // nothing auto-reconnects
         } finally {
             DeviceHandler.portAvailable = false;
             DeviceHandler.isKnownDevicePath.mockReturnValue(false);
+            DeviceHandler.findDescribedDevice.mockReturnValue(undefined);
             vi.useRealTimers();
         }
     });

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -219,7 +219,6 @@ import {
     disconnect,
     initializeSerialBackend,
     reinitializeConnection,
-    shouldConcludeRebootDialog,
 } from "../../src/js/serial_backend";
 import DeviceHandler from "../../src/js/device_handler";
 import CONFIGURATOR from "../../src/js/data_storage";
@@ -868,7 +867,36 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
         }
     });
 
-    // The window is shared: the dialog's timer can conclude it first. A closed window reads as
+    // Auto-Connect off: nothing reconnects, so the wait ends as soon as there is nothing left
+    // to wait for. For serial that is the port coming back — the user can reconnect to a device
+    // that is actually there. (Was shouldConcludeRebootDialog's serial branch.)
+    it("with Auto-Connect off, ends the window when the serial port comes back", () => {
+        vi.useFakeTimers();
+        try {
+            DeviceHandler.devicePicker.selectedDevice = "/dev/ttyACM0";
+            DeviceHandler.devicePicker.autoConnect = false;
+            DeviceHandler.portAvailable = false;
+            CONFIGURATOR.connectionValid = true;
+            establishConnection();
+
+            reinitializeConnection(true);
+            serialHandlers.disconnect({ detail: true });
+            serial.connect.mockClear(); // establishConnection's own open
+
+            vi.advanceTimersByTime(1500 + 3000); // flush plus several ticks
+            expect(getConnectionState().isRebootWindowOpen).toBe(true); // port still gone: keep waiting
+
+            DeviceHandler.portAvailable = true; // re-enumerated
+            vi.advanceTimersByTime(1000);
+            expect(getConnectionState().isRebootWindowOpen).toBe(false);
+            expect(serial.connect).not.toHaveBeenCalled(); // nothing auto-reconnects
+        } finally {
+            DeviceHandler.portAvailable = false;
+            vi.useRealTimers();
+        }
+    });
+
+    // The window is shared: another owner can conclude it first. A closed window reads as
     // NOT expired, so a loop testing expiry alone would spin forever.
     it("stops when another owner concludes the window", () => {
         vi.useFakeTimers();
@@ -952,86 +980,6 @@ describe("serial_backend reinitializeConnection — virtualMode reboot path", ()
         } finally {
             vi.useRealTimers();
         }
-    });
-});
-
-describe("shouldConcludeRebootDialog", () => {
-    // Baseline: mid-reboot, nothing yet signals completion.
-    const base = {
-        connectionValid: false,
-        timeoutReached: false,
-        autoConnect: false,
-        portAvailable: false,
-        selectedDevice: "/dev/ttyACM0",
-        rebootWindowOpen: true,
-    };
-
-    it("concludes as soon as the FC answers, regardless of everything else", () => {
-        expect(shouldConcludeRebootDialog({ ...base, connectionValid: true })).toBe(true);
-        // Even with Auto-Connect on and the window still open.
-        expect(
-            shouldConcludeRebootDialog({
-                ...base,
-                connectionValid: true,
-                autoConnect: true,
-                selectedDevice: "bluetooth_1",
-            }),
-        ).toBe(true);
-    });
-
-    it("concludes when the reboot window has timed out", () => {
-        expect(shouldConcludeRebootDialog({ ...base, timeoutReached: true })).toBe(true);
-        expect(shouldConcludeRebootDialog({ ...base, timeoutReached: true, autoConnect: true })).toBe(true);
-    });
-
-    it("keeps waiting while Auto-Connect is on (the retry loop owns the reconnect)", () => {
-        // Serial, port already back — still wait, auto-connect will reconnect.
-        expect(shouldConcludeRebootDialog({ ...base, autoConnect: true, portAvailable: true })).toBe(false);
-        // BLE, window closed — still wait, auto-connect will reconnect.
-        expect(
-            shouldConcludeRebootDialog({
-                ...base,
-                autoConnect: true,
-                selectedDevice: "bluetooth_1",
-                rebootWindowOpen: false,
-            }),
-        ).toBe(false);
-    });
-
-    describe("Auto-Connect off", () => {
-        it("serial: waits for the port to re-enumerate, then concludes", () => {
-            expect(shouldConcludeRebootDialog({ ...base, portAvailable: false })).toBe(false);
-            expect(shouldConcludeRebootDialog({ ...base, portAvailable: true })).toBe(true);
-        });
-
-        it("BLE: waits for the reboot window to close (flush drops the stale link first)", () => {
-            // portAvailable never flips for BLE — must not gate on it.
-            expect(shouldConcludeRebootDialog({ ...base, selectedDevice: "bluetooth_1", rebootWindowOpen: true })).toBe(
-                false,
-            );
-            expect(
-                shouldConcludeRebootDialog({ ...base, selectedDevice: "bluetooth_1", rebootWindowOpen: false }),
-            ).toBe(true);
-            // Android BLE path id.
-            expect(
-                shouldConcludeRebootDialog({ ...base, selectedDevice: "bluetooth-AA:BB", rebootWindowOpen: false }),
-            ).toBe(true);
-        });
-
-        it("manual/TCP: waits for the reboot window to close", () => {
-            expect(shouldConcludeRebootDialog({ ...base, selectedDevice: "manual", rebootWindowOpen: true })).toBe(
-                false,
-            );
-            expect(shouldConcludeRebootDialog({ ...base, selectedDevice: "manual", rebootWindowOpen: false })).toBe(
-                true,
-            );
-        });
-
-        it("serial ignores the reboot-window flag (only re-enumeration concludes it)", () => {
-            // A closed window must NOT conclude a serial reboot on its own — serial owns its
-            // own conclusion via portAvailable, so this stays false until the port is back.
-            expect(shouldConcludeRebootDialog({ ...base, portAvailable: false, rebootWindowOpen: false })).toBe(false);
-        });
     });
 });
 

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -225,6 +225,8 @@ import DeviceHandler from "../../src/js/device_handler";
 import CONFIGURATOR from "../../src/js/data_storage";
 import MSP from "../../src/js/msp";
 import MSPCodes from "../../src/js/msp/MSPCodes";
+import FC from "../../src/js/fc";
+import { EventBus } from "../../src/components/eventBus";
 import { __resetConnectionStateForTests, getConnectionState } from "../../src/js/connection_state.js";
 
 // Reset all mock state and bring the module to a known DISCONNECTED state
@@ -458,56 +460,125 @@ describe("serial_backend disconnect convergence", () => {
     });
 });
 
+// The failure dialog is decided by who started the attempt, not by which lifecycle phase we
+// are in. The app tells the user about failures the user asked for and stays quiet about
+// attempts it made on its own — those are exactly the ones something retries. A reboot
+// reconnect is one instance of that rule, not a special case.
 describe("serial_backend connect-failure dialog", () => {
     beforeEach(() => {
         setActivePinia(createPinia());
         resetMocks();
     });
 
-    it("shows the connection-failed dialog when a user-initiated connect fails to open", () => {
-        // IDLE -> connectDisconnect -> beginConnect (CONNECTING). A failed open is a genuine
-        // user-facing failure, so the dialog must appear.
+    function infoDialogCount() {
+        return dialogStore.open.mock.calls.filter((c) => c[0] === "InformationDialog").length;
+    }
+
+    it("shows the dialog when a user-initiated connect fails to open", () => {
+        // IDLE -> connectDisconnect -> beginConnect (CONNECTING). The user asked for this
+        // attempt, so its failure is theirs to see.
         connectDisconnect();
         expect(serial.connect).toHaveBeenCalled();
 
         serialHandlers.connect({ detail: false }); // open failed -> onOpen(false) -> abortConnection
 
-        const infoDialogs = dialogStore.open.mock.calls.filter((c) => c[0] === "InformationDialog");
-        expect(infoDialogs).toHaveLength(1);
+        expect(infoDialogCount()).toBe(1);
     });
 
-    it("stays silent when a reboot reconnect's open fails with auto-connect on (device still re-enumerating)", () => {
-        // The preset/CLI save-and-reboot reconnect window: scheduleReconnect() put the phase
-        // in RECONNECTING. A premature connect attempt (fired before the rebooting device is
-        // back) fails to open — but auto-connect recovers on re-enumeration, so this must NOT
-        // pop a "Failed to open serial port" dialog. (The reported spurious-dialog bug.)
+    it("still shows the dialog for a user-initiated failure while Auto-Connect is ON", () => {
+        // Auto-Connect does not make a user's own Connect click silent: a port held by another
+        // application fails every time and no device event follows to retry it.
         DeviceHandler.devicePicker.autoConnect = true;
-        getConnectionState().reconnectStarted(); // RECONNECTING
-        dialogStore.open.mockClear();
-
-        connectDisconnect(); // beginConnect preserves RECONNECTING
-        expect(serial.connect).toHaveBeenCalled();
-
-        serialHandlers.connect({ detail: false }); // premature failed open -> abortConnection
-
-        const infoDialogs = dialogStore.open.mock.calls.filter((c) => c[0] === "InformationDialog");
-        expect(infoDialogs).toHaveLength(0);
-        // The attempt is still torn down so auto-connect can re-fire (connecting_to cleared).
-        expect(GUI.connecting_to).toBe(false);
-    });
-
-    it("still shows the dialog on a reboot reconnect failure when auto-connect is OFF (nothing retries)", () => {
-        // Without auto-connect there is no auto-recovery, so a failed reconnect open is a real
-        // dead end the user must be told about — suppression must NOT apply.
-        DeviceHandler.devicePicker.autoConnect = false;
-        getConnectionState().reconnectStarted(); // RECONNECTING
-        dialogStore.open.mockClear();
 
         connectDisconnect();
         serialHandlers.connect({ detail: false });
 
-        const infoDialogs = dialogStore.open.mock.calls.filter((c) => c[0] === "InformationDialog");
-        expect(infoDialogs).toHaveLength(1);
+        expect(infoDialogCount()).toBe(1);
+    });
+
+    it("stays silent when an app-initiated open fails, and recovers on the next device event", () => {
+        // A plug-in raises a burst of device events; the port can vanish between the list
+        // refresh and the open, so the auto-select listener's attempt fails. Another event
+        // follows and connects, so the failure must not reach the user. (Issue #5368.)
+        DeviceHandler.devicePicker.autoConnect = true;
+
+        connectDisconnect({ automatic: true });
+        expect(serial.connect).toHaveBeenCalled();
+
+        serialHandlers.connect({ detail: false }); // port vanished -> abortConnection
+
+        expect(infoDialogCount()).toBe(0);
+        // Torn down, so the next event can attempt again and the UI is not left mid-connect.
+        expect(GUI.connecting_to).toBe(false);
+        expect(DeviceHandler.devicePickerDisabled).toBe(false);
+
+        // The next device event connects, on the port that came back.
+        serial.connect.mockClear();
+        connectDisconnect({ automatic: true });
+        expect(serial.connect).toHaveBeenCalled();
+        serialHandlers.connect({ detail: true });
+        expect(GUI.connected_to).toBe("/dev/ttyACM0");
+        expect(infoDialogCount()).toBe(0);
+    });
+
+    it("reports an app-initiated failure AFTER the link opened (handshake rejected)", () => {
+        // onOpen set connected_to, so the link was up and the failure is the handshake
+        // (unsupported/garbage API version) — terminal, not enumeration flakiness. Nothing
+        // retries it into working, so the user must be told however the attempt started.
+        DeviceHandler.devicePicker.autoConnect = true;
+
+        connectDisconnect({ automatic: true });
+        serialHandlers.connect({ detail: true }); // opened -> HANDSHAKING, connected_to set
+        dialogStore.open.mockClear();
+
+        FC.CONFIG.apiVersion = "0.0.0";
+        MSP.send_message.mock.calls.at(-1)?.[3]?.(); // MSP_API_VERSION callback -> abortConnection
+
+        expect(infoDialogCount()).toBe(1);
+    });
+
+    it("stays silent when a reboot reconnect's open fails (the loop retries)", () => {
+        // The preset/CLI save-and-reboot reconnect window: the retry loop drives the attempt,
+        // so a premature open against a still-rebooting device is expected and silent — the
+        // same rule as the burst above, no reboot-specific branch.
+        DeviceHandler.devicePicker.autoConnect = true;
+        getConnectionState().reconnectStarted(); // RECONNECTING
+        dialogStore.open.mockClear();
+
+        connectDisconnect({ automatic: true }); // beginConnect preserves RECONNECTING
+        expect(serial.connect).toHaveBeenCalled();
+
+        serialHandlers.connect({ detail: false }); // premature failed open -> abortConnection
+
+        expect(infoDialogCount()).toBe(0);
+        expect(GUI.connecting_to).toBe(false);
+    });
+
+    it("makes no automatic attempt at all with Auto-Connect OFF", () => {
+        // Why abortConnection() no longer tests autoConnect: with it off nothing connects on
+        // the app's own initiative, so every failure that can happen is a user's to see. An
+        // automatic caller added later without that gate would break that reasoning, so pin
+        // it on the real listener registered by initializeSerialBackend.
+        initializeSerialBackend();
+        const autoSelect = EventBus.$on.mock.calls.find(
+            (c) => c[0] === "device-handler:auto-select-serial-device",
+        )?.[1];
+        expect(autoSelect).toBeTypeOf("function");
+
+        DeviceHandler.devicePicker.autoConnect = false;
+        serial.connect.mockClear();
+        autoSelect();
+        expect(serial.connect).not.toHaveBeenCalled();
+
+        // With it on, the same listener connects — and its failure stays silent, which is
+        // what makes the attempt automatic rather than merely unattended.
+        DeviceHandler.devicePicker.autoConnect = true;
+        dialogStore.open.mockClear();
+        autoSelect();
+        expect(serial.connect).toHaveBeenCalled();
+
+        serialHandlers.connect({ detail: false });
+        expect(infoDialogCount()).toBe(0);
     });
 });
 

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -792,7 +792,7 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
         resetMocks();
     });
 
-    it("sends MSP_SET_REBOOT, forces connectionValid false, and drops a link still open at the flush", () => {
+    it("sends MSP_SET_REBOOT, forces connectionValid false, and leaves a live serial link alone", () => {
         vi.useFakeTimers();
         try {
             // Plain USB/serial path: not bluetooth, not manual, not virtual.
@@ -811,13 +811,13 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             expect(MSP.send_message).toHaveBeenCalledWith(MSPCodes.MSP_SET_REBOOT, false, false);
             // The reboot forces the connection invalid so the cycle waits for a real reconnect.
             expect(CONFIGURATOR.connectionValid).toBe(false);
-            expect(serial.disconnect).not.toHaveBeenCalled(); // nothing before the flush
 
-            // A serial link normally dies with the FC's re-enumeration before the flush, so this
-            // is usually a no-op. Here it is still open — the FC ignored the command, or the OS
-            // has not noticed yet — and a link to a rebooting FC is stale whatever the transport.
+            // A serial link that is still open after the flush means the FC did not reboot, or
+            // the OS has not noticed yet. Dropping it would tear down a working connection and
+            // throw the user off the tab they just opened — the CLI-tab exit path does exactly
+            // this. The transport owns that link; only driven targets are dropped here.
             vi.advanceTimersByTime(1500);
-            expect(serial.disconnect).toHaveBeenCalledTimes(1);
+            expect(serial.disconnect).not.toHaveBeenCalled();
         } finally {
             vi.advanceTimersByTime(30000); // drain the window
             vi.useRealTimers();

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -803,10 +803,9 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             serial.disconnect.mockClear();
             serial.connect.mockClear();
 
-            const ts = reinitializeConnection(true); // suppressDialog: skip DOM modal
+            reinitializeConnection();
 
             expect(MSP.send_message).toHaveBeenCalledWith(MSPCodes.MSP_SET_REBOOT, false, false);
-            expect(typeof ts).toBe("number");
             // The reboot forces the connection invalid so the cycle waits for a real reconnect.
             expect(CONFIGURATOR.connectionValid).toBe(false);
             expect(serial.disconnect).not.toHaveBeenCalled(); // nothing before the flush
@@ -833,7 +832,7 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             CONFIGURATOR.connectionValid = true;
             establishConnection();
 
-            reinitializeConnection(true);
+            reinitializeConnection();
             serialHandlers.disconnect({ detail: true }); // the FC's re-enumeration drops the link
             serial.connect.mockClear();
 
@@ -853,7 +852,7 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             CONFIGURATOR.connectionValid = true;
             establishConnection();
 
-            reinitializeConnection(true);
+            reinitializeConnection();
             disconnect(); // user hits Disconnect mid-reboot
             mspHelperInstance.setArmingEnabled.mock.calls.at(-1)?.[2]?.(); // complete the close
             serial.connect.mockClear();
@@ -882,7 +881,7 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             CONFIGURATOR.connectionValid = true;
             establishConnection();
 
-            reinitializeConnection(true);
+            reinitializeConnection();
             serialHandlers.disconnect({ detail: true });
             serial.connect.mockClear(); // establishConnection's own open
 
@@ -910,7 +909,7 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             CONFIGURATOR.connectionValid = true;
             establishConnection();
 
-            reinitializeConnection(true);
+            reinitializeConnection();
             serialHandlers.disconnect({ detail: true });
             vi.advanceTimersByTime(1500); // into the retry phase
 

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -112,6 +112,7 @@ vi.mock("../../src/js/device_handler", () => ({
         initialize: vi.fn(),
         devicePickerDisabled: false,
         portAvailable: false,
+        isKnownDevicePath: vi.fn(() => false),
         devicePicker: {
             selectedDevice: "/dev/ttyACM0",
             portOverride: "/dev/ttyACM0",
@@ -870,12 +871,15 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
     // Auto-Connect off: nothing reconnects, so the wait ends as soon as there is nothing left
     // to wait for. For serial that is the port coming back — the user can reconnect to a device
     // that is actually there. (Was shouldConcludeRebootDialog's serial branch.)
-    it("with Auto-Connect off, ends the window when the serial port comes back", () => {
+    it("with Auto-Connect off, ends the window when the SELECTED device is listed again", () => {
+        // Not "a serial port exists": a machine with other ports would end the wait while the
+        // rebooting device was still gone.
         vi.useFakeTimers();
         try {
             DeviceHandler.devicePicker.selectedDevice = "/dev/ttyACM0";
             DeviceHandler.devicePicker.autoConnect = false;
-            DeviceHandler.portAvailable = false;
+            DeviceHandler.portAvailable = true; // other ports are present throughout
+            DeviceHandler.isKnownDevicePath.mockReturnValue(false);
             CONFIGURATOR.connectionValid = true;
             establishConnection();
 
@@ -884,14 +888,15 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             serial.connect.mockClear(); // establishConnection's own open
 
             vi.advanceTimersByTime(1500 + 3000); // flush plus several ticks
-            expect(getConnectionState().isRebootWindowOpen).toBe(true); // port still gone: keep waiting
+            expect(getConnectionState().isRebootWindowOpen).toBe(true); // ours is gone: keep waiting
 
-            DeviceHandler.portAvailable = true; // re-enumerated
+            DeviceHandler.isKnownDevicePath.mockReturnValue(true); // re-enumerated
             vi.advanceTimersByTime(1000);
             expect(getConnectionState().isRebootWindowOpen).toBe(false);
             expect(serial.connect).not.toHaveBeenCalled(); // nothing auto-reconnects
         } finally {
             DeviceHandler.portAvailable = false;
+            DeviceHandler.isKnownDevicePath.mockReturnValue(false);
             vi.useRealTimers();
         }
     });

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -789,7 +789,7 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
         resetMocks();
     });
 
-    it("sends MSP_SET_REBOOT, forces connectionValid false, and does NOT self-drive disconnect/connect", () => {
+    it("sends MSP_SET_REBOOT, forces connectionValid false, and drops a link still open at the flush", () => {
         vi.useFakeTimers();
         try {
             // Plain USB/serial path: not bluetooth, not manual, not virtual.
@@ -807,18 +807,17 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
 
             expect(MSP.send_message).toHaveBeenCalledWith(MSPCodes.MSP_SET_REBOOT, false, false);
             expect(typeof ts).toBe("number");
-            // The reboot forces the connection invalid so the dialog/loop wait for a real reconnect.
+            // The reboot forces the connection invalid so the cycle waits for a real reconnect.
             expect(CONFIGURATOR.connectionValid).toBe(false);
+            expect(serial.disconnect).not.toHaveBeenCalled(); // nothing before the flush
 
-            // Serial drops its own link when the FC re-enumerates, so the cycle never forces a
-            // disconnect the way the driven path does — and with the link still up it makes no
-            // connect attempt either.
-            vi.advanceTimersByTime(20000);
-            expect(serial.disconnect).not.toHaveBeenCalled();
-            expect(serial.connect).not.toHaveBeenCalled();
-
-            serialHandlers.disconnect({ detail: true }); // teardown (cable-drop never fired)
+            // A serial link normally dies with the FC's re-enumeration before the flush, so this
+            // is usually a no-op. Here it is still open — the FC ignored the command, or the OS
+            // has not noticed yet — and a link to a rebooting FC is stale whatever the transport.
+            vi.advanceTimersByTime(1500);
+            expect(serial.disconnect).toHaveBeenCalledTimes(1);
         } finally {
+            vi.advanceTimersByTime(30000); // drain the window
             vi.useRealTimers();
         }
     });

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -460,9 +460,7 @@ describe("serial_backend disconnect convergence", () => {
     });
 });
 
-// The failure dialog is decided by who started the attempt, not by which lifecycle phase we
-// are in. The app tells the user about failures the user asked for and stays quiet about
-// attempts it made on its own — those are exactly the ones something retries. A reboot
+// The failure dialog follows who started the attempt, not the lifecycle phase. A reboot
 // reconnect is one instance of that rule, not a special case.
 describe("serial_backend connect-failure dialog", () => {
     beforeEach(() => {
@@ -475,8 +473,6 @@ describe("serial_backend connect-failure dialog", () => {
     }
 
     it("shows the dialog when a user-initiated connect fails to open", () => {
-        // IDLE -> connectDisconnect -> beginConnect (CONNECTING). The user asked for this
-        // attempt, so its failure is theirs to see.
         connectDisconnect();
         expect(serial.connect).toHaveBeenCalled();
 
@@ -486,8 +482,7 @@ describe("serial_backend connect-failure dialog", () => {
     });
 
     it("still shows the dialog for a user-initiated failure while Auto-Connect is ON", () => {
-        // Auto-Connect does not make a user's own Connect click silent: a port held by another
-        // application fails every time and no device event follows to retry it.
+        // A port held by another application fails every time; no device event retries it.
         DeviceHandler.devicePicker.autoConnect = true;
 
         connectDisconnect();
@@ -497,9 +492,7 @@ describe("serial_backend connect-failure dialog", () => {
     });
 
     it("stays silent when an app-initiated open fails, and recovers on the next device event", () => {
-        // A plug-in raises a burst of device events; the port can vanish between the list
-        // refresh and the open, so the auto-select listener's attempt fails. Another event
-        // follows and connects, so the failure must not reach the user. (Issue #5368.)
+        // The port vanished between the list refresh and the open (issue #5368).
         DeviceHandler.devicePicker.autoConnect = true;
 
         connectDisconnect({ automatic: true });
@@ -508,11 +501,10 @@ describe("serial_backend connect-failure dialog", () => {
         serialHandlers.connect({ detail: false }); // port vanished -> abortConnection
 
         expect(infoDialogCount()).toBe(0);
-        // Torn down, so the next event can attempt again and the UI is not left mid-connect.
+        // Torn down, so the next event can attempt again and the UI is not stuck mid-connect.
         expect(GUI.connecting_to).toBe(false);
         expect(DeviceHandler.devicePickerDisabled).toBe(false);
 
-        // The next device event connects, on the port that came back.
         serial.connect.mockClear();
         connectDisconnect({ automatic: true });
         expect(serial.connect).toHaveBeenCalled();
@@ -522,17 +514,14 @@ describe("serial_backend connect-failure dialog", () => {
     });
 
     it("reports an app-initiated failure AFTER the link opened (handshake rejected)", () => {
-        // The link was up and the failure is the handshake (unsupported/garbage API version)
-        // — terminal, not enumeration flakiness. Nothing retries it into working, so the user
-        // must be told however the attempt started.
+        // A handshake rejected after the open is terminal, whoever started the attempt.
         DeviceHandler.devicePicker.autoConnect = true;
 
         connectDisconnect({ automatic: true });
         serialHandlers.connect({ detail: true }); // opened -> linkOpen, HANDSHAKING
         dialogStore.open.mockClear();
 
-        // FC.CONFIG is module state on the mock and resetMocks() does not restore it, so put
-        // the supported version back before the next test inherits an unsupported FC.
+        // FC.CONFIG is module state on the mock; resetMocks() does not restore it.
         const apiVersion = FC.CONFIG.apiVersion;
         try {
             FC.CONFIG.apiVersion = "0.0.0";
@@ -545,9 +534,8 @@ describe("serial_backend connect-failure dialog", () => {
     });
 
     it("reports a handshake rejected synchronously, inside onOpen", () => {
-        // MSP.send_message runs its callback synchronously when the link has dropped again by
-        // the time onOpen starts the handshake. abortConnection then runs before connectHandler
-        // returns, so the link-open flag has to be set before onOpen, not after it.
+        // MSP.send_message calls back synchronously when the link dropped again, so
+        // abortConnection runs before connectHandler returns.
         DeviceHandler.devicePicker.autoConnect = true;
         const apiVersion = FC.CONFIG.apiVersion;
 
@@ -555,7 +543,6 @@ describe("serial_backend connect-failure dialog", () => {
             connectDisconnect({ automatic: true });
             dialogStore.open.mockClear();
 
-            // FC.resetState() leaves apiVersion "0.0.0"; the synchronous callback sees that.
             MSP.send_message.mockImplementationOnce((_code, _data, _sent, callback) => {
                 FC.CONFIG.apiVersion = "0.0.0";
                 callback?.();
@@ -570,9 +557,7 @@ describe("serial_backend connect-failure dialog", () => {
     });
 
     it("stays silent when a reboot reconnect's open fails (the loop retries)", () => {
-        // The preset/CLI save-and-reboot reconnect window: the retry loop drives the attempt,
-        // so a premature open against a still-rebooting device is expected and silent — the
-        // same rule as the burst above, no reboot-specific branch.
+        // The retry loop drives the attempt, so a premature open is expected and silent.
         DeviceHandler.devicePicker.autoConnect = true;
         getConnectionState().reconnectStarted(); // RECONNECTING
         dialogStore.open.mockClear();
@@ -588,9 +573,7 @@ describe("serial_backend connect-failure dialog", () => {
 
     it("makes no automatic attempt at all with Auto-Connect OFF", () => {
         // Why abortConnection() no longer tests autoConnect: with it off nothing connects on
-        // the app's own initiative, so every failure that can happen is a user's to see. An
-        // automatic caller added later without that gate would break that reasoning, so pin
-        // it on the real listener registered by initializeSerialBackend.
+        // the app's own initiative, so every failure left is a user's to see.
         initializeSerialBackend();
         const autoSelect = EventBus.$on.mock.calls.find(
             (c) => c[0] === "device-handler:auto-select-serial-device",
@@ -602,8 +585,7 @@ describe("serial_backend connect-failure dialog", () => {
         autoSelect();
         expect(serial.connect).not.toHaveBeenCalled();
 
-        // With it on, the same listener connects — and its failure stays silent, which is
-        // what makes the attempt automatic rather than merely unattended.
+        // With it on the same listener connects, and its failure stays silent.
         DeviceHandler.devicePicker.autoConnect = true;
         dialogStore.open.mockClear();
         autoSelect();

--- a/test/js/useMspCliSession_reconnect.test.js
+++ b/test/js/useMspCliSession_reconnect.test.js
@@ -1,22 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
-// Characterization — pins the reconnect behavior of
-// useMspCliSession.scheduleReconnect()/cancelScheduledReconnect(). We mock the
-// collaborators it reaches into (GUI's timeout registry and serial_backend) so
-// we can observe exactly when the reconnect fires.
+// A CLI save/exit has already rebooted the FC, so the wait that follows is the same one a
+// Save & Reboot runs. These pin that it IS the same one: scheduleReconnect hands every
+// transport to serial_backend's reconnect cycle, and cancelScheduledReconnect abandons it.
 //
-// Behavior (what this pins): scheduleReconnect() splits by transport.
-// - Serial (re-enumerating) targets: a single named timeout ("msp_cli_reconnect")
-//   that, after RECONNECT_DELAY_MS (500ms), calls disconnect() exactly once —
-//   NOT a retry loop; reconnection is auto-connect's job on device re-enumeration.
-//   A second scheduleReconnect() replaces (de-bounces) the pending one.
-// - Bluetooth/manual targets (never re-enumerate, so auto-connect would never
-//   fire): delegate to serial_backend.scheduleRebootReconnect(), which drives
-//   the flush -> drop-stale-link -> retry cycle itself.
+// It used to split by transport — serial got a private 500 ms one-shot and a RECONNECTING
+// phase with no window, so a device that never came back left the phase there for good;
+// only BLE/manual reached the cycle.
 // ---------------------------------------------------------------------------
 
-const { GUI, connectDisconnect, disconnect, scheduleRebootReconnect } = vi.hoisted(() => {
+const { GUI, connectDisconnect, disconnect, scheduleRebootReconnect, cancelRebootReconnect } = vi.hoisted(() => {
     return {
         GUI: {
             // Minimal name-keyed timeout registry mirroring gui.js timeout_add/remove.
@@ -42,6 +36,7 @@ const { GUI, connectDisconnect, disconnect, scheduleRebootReconnect } = vi.hoist
         connectDisconnect: vi.fn(),
         disconnect: vi.fn(),
         scheduleRebootReconnect: vi.fn(),
+        cancelRebootReconnect: vi.fn(),
     };
 });
 
@@ -55,8 +50,7 @@ vi.mock("../../src/js/serial_backend", () => ({
     connectDisconnect,
     disconnect,
     scheduleRebootReconnect,
-    // Mirror the real predicate — scheduleReconnect branches on it.
-    isDrivenRebootTarget: (port) => typeof port === "string" && (port.startsWith("bluetooth") || port === "manual"),
+    cancelRebootReconnect,
 }));
 
 // Keep the rest of the import graph light — useMspCliSession also imports MSP and FC.
@@ -72,9 +66,9 @@ vi.mock("../../src/js/fc", () => ({
 import { scheduleReconnect, cancelScheduledReconnect, saveAndReconnect } from "../../src/composables/useMspCliSession";
 import MSP from "../../src/js/msp";
 import DeviceHandler from "../../src/js/device_handler";
-import { getConnectionState, __resetConnectionStateForTests, State } from "../../src/js/connection_state.js";
+import { __resetConnectionStateForTests } from "../../src/js/connection_state.js";
 
-describe("useMspCliSession.scheduleReconnect (characterization)", () => {
+describe("useMspCliSession.scheduleReconnect", () => {
     beforeEach(() => {
         vi.useFakeTimers();
         vi.clearAllMocks();
@@ -90,112 +84,38 @@ describe("useMspCliSession.scheduleReconnect (characterization)", () => {
         vi.useRealTimers();
     });
 
-    it("drops the stale link once after 500ms (one-shot, not a retry loop; reconnect is auto-connect's job)", () => {
-        scheduleReconnect();
+    it.each(["serial_0", "bluetooth_x81jPGap0DdYcGTJyKZWyw==", "manual"])(
+        "hands %s to the one reconnect cycle",
+        (target) => {
+            DeviceHandler.devicePicker.selectedDevice = target;
 
-        // Nothing fires before the 500ms delay.
-        vi.advanceTimersByTime(499);
-        expect(disconnect).not.toHaveBeenCalled();
+            scheduleReconnect();
 
-        // Fires exactly once at the delay boundary.
-        vi.advanceTimersByTime(1);
-        expect(disconnect).toHaveBeenCalledTimes(1);
+            expect(scheduleRebootReconnect).toHaveBeenCalledTimes(1);
+            // No private timer of its own: the cycle owns the drop and the retries.
+            vi.advanceTimersByTime(10000);
+            expect(disconnect).not.toHaveBeenCalled();
+            expect(connectDisconnect).not.toHaveBeenCalled();
+        },
+    );
 
-        // No further calls — it is a single timeout, not an interval. And it never connects
-        // explicitly (that would target the stale pre-reboot id).
-        vi.advanceTimersByTime(10000);
-        expect(disconnect).toHaveBeenCalledTimes(1);
-        expect(connectDisconnect).not.toHaveBeenCalled();
-    });
-
-    it("de-bounces: a second scheduleReconnect replaces the pending one (still one disconnect)", () => {
-        scheduleReconnect();
-        vi.advanceTimersByTime(300);
-
-        // Re-scheduling removes the prior timeout and starts a fresh 500ms window.
-        scheduleReconnect();
-        expect(GUI.timeout_remove).toHaveBeenCalledWith("msp_cli_reconnect");
-
-        // The first (replaced) timer would have fired at 500ms from the start (i.e. 200ms
-        // from now) — prove it does NOT, because it was cancelled.
-        vi.advanceTimersByTime(200);
-        expect(disconnect).not.toHaveBeenCalled();
-
-        // Only the second timer fires, exactly once.
-        vi.advanceTimersByTime(300);
-        expect(disconnect).toHaveBeenCalledTimes(1);
-    });
-
-    it("cancelScheduledReconnect removes the pending timeout so nothing fires", () => {
-        scheduleReconnect();
-        cancelScheduledReconnect();
-
-        vi.advanceTimersByTime(10000);
-        expect(disconnect).not.toHaveBeenCalled();
-        expect(connectDisconnect).not.toHaveBeenCalled();
-    });
-
-    it("cancelScheduledReconnect leaves the reconnect-in-progress window (no sticky reconnect)", () => {
-        DeviceHandler.devicePicker.selectedDevice = "serial_0";
-
-        // scheduleReconnect enters the reconnect window so selectActivePort keeps the device...
-        scheduleReconnect();
-        expect(getConnectionState().isReconnecting).toBe(true);
-
-        // ...and cancelling must leave it so selectActivePort's virtual/manual fallback resumes.
-        cancelScheduledReconnect();
-        expect(getConnectionState().isReconnecting).toBe(false);
-    });
-
-    it("a late cancel (after the timer fired) does NOT abort a live connect", () => {
-        DeviceHandler.devicePicker.selectedDevice = "serial_0";
-
-        scheduleReconnect();
-        expect(getConnectionState().state).toBe(State.RECONNECTING);
-
-        // The timer drops the stale link; auto-connect (external) then reconnects to the
-        // re-enumerated device, advancing the phase (RECONNECTING -> CONNECTING -> HANDSHAKING).
-        // Simulate that transition here.
-        vi.advanceTimersByTime(500);
-        expect(disconnect).toHaveBeenCalledTimes(1);
-        getConnectionState().setPhase(State.CONNECTING);
-
-        // A late cancel (e.g. leaving the Presets tab mid-handshake) must NOT force the live
-        // connect to IDLE — the connect flow owns the phase now and settles it itself.
-        cancelScheduledReconnect();
-        expect(getConnectionState().state).toBe(State.CONNECTING);
-    });
-
-    it("bluetooth target: delegates to serial_backend's driven reboot cycle (BLE never re-enumerates)", () => {
-        // Regression (#5209 follow-up): a BLE device stays on the port list across an FC
-        // reboot — no removedDevice/addedDevice cycle fires — so the passive drop-and-wait
-        // path would never reconnect. scheduleReconnect must hand BLE to the driven
-        // flush/disconnect/retry cycle instead.
-        DeviceHandler.devicePicker.selectedDevice = "bluetooth_x81jPGap0DdYcGTJyKZWyw==";
+    it("hands over with Auto-Connect off too — the cycle reads it live and ends the window", () => {
+        // Previously this path skipped the window entirely when Auto-Connect was off, which
+        // left the dialog and selectActivePort with nothing to settle them.
+        DeviceHandler.devicePicker.autoConnect = false;
 
         scheduleReconnect();
 
         expect(scheduleRebootReconnect).toHaveBeenCalledTimes(1);
-
-        // The passive one-shot must NOT also run — the driven cycle owns the disconnect
-        // (via disconnectForReboot, without the MSP round-trip a rebooting FC can't answer).
-        vi.advanceTimersByTime(10000);
-        expect(disconnect).not.toHaveBeenCalled();
-        expect(connectDisconnect).not.toHaveBeenCalled();
     });
 
-    it("with Auto-Connect OFF: drops the stale link and does NOT reconnect (no reconnect window)", () => {
-        DeviceHandler.devicePicker.autoConnect = false;
-
+    it("cancelScheduledReconnect abandons the cycle", () => {
         scheduleReconnect();
-        // Auto-Connect off means the user opted out of auto-reconnect: no reconnect window.
-        expect(getConnectionState().isReconnecting).toBe(false);
+        cancelScheduledReconnect();
 
-        vi.advanceTimersByTime(500);
-        // It disconnects the stale link but must NOT attempt a reconnect (which would race the
-        // reboot and pop a spurious "failed to open" dialog).
-        expect(disconnect).toHaveBeenCalledTimes(1);
-        expect(connectDisconnect).not.toHaveBeenCalled();
+        expect(cancelRebootReconnect).toHaveBeenCalledTimes(1);
+        vi.advanceTimersByTime(10000);
+        expect(disconnect).not.toHaveBeenCalled();
     });
 
     it("treats a save-reboot connection-closed drain as success, not an error", async () => {


### PR DESCRIPTION
Fixes #5368.

### Problem

"**Failed** to open serial port" appears when a plug-in raises a burst of device events and the port vanishes between the list refresh and `open()`. The app reconnects on the next event, so the modal reports a failure it is already recovering from — and re-arms on every event of the burst.

Separate from #5342, which stopped us connecting to ids the transport no longer lists. This is a port that *was* listed and then vanished.

### The fix

The dialog followed "are we in a reboot window?". It now follows "did the user ask for this attempt?".

`ConnectionState` records who started the attempt (`attemptStarted`) and answers whether a failure reaches the user (`failureIsUserFacing`): yes if they asked for it, or if the link had already opened — a handshake rejected after the open is terminal. The three app-initiated callers pass `{ automatic: true }`; every `ConnectButton` path is unchanged. The reboot-window special case goes, including its `autoConnect` clause — with Auto-Connect off there are no automatic attempts at all. `gui_log()` is untouched, so every failure keeps its log-panel line.

### The reboot lifecycle, which caused it

Tracing that dialog led to the reason the serial path has been flaky: **five owners decided when a reboot was over**, `concludeReboot()` had ten call sites, and up to five timers ran at once — two of them racing to null the same window, as the code admitted. Serial had no owner at all; its reconnect depended on a device event arriving, the selection being re-pointed at the new id, and a listener's tab guard passing.

- **One cycle owns every transport.** It waits, retries while Auto-Connect is on, and concludes on success or timeout. The `addedDevice` listener stays the fast path for serial; the cycle is the backstop and the single owner that ends the window.
- **The dialog observes instead of deciding** — its second timer recomputed the verdict and concluded the window itself. A reboot that never comes back now says so, instead of "Flight Controller is ready" on timeout regardless.
- **The CLI save path shares the cycle.** It had a private timeout and set `RECONNECTING` with no window behind it, so a device that never returned left the phase there for good.
- **The window records what it is waiting for.** `describeDevice()` captures the rebooted device's path and USB ids; `findDescribedDevice()` finds it again under the new path it re-enumerates as. A preference, not a restriction — an unrecognised return still selects normally, so nothing can hang the window.
- **Virtual stops faking a reboot** for a device that does not exist, and `stores/connection.js`'s unread phase read-model goes.

Net across those files: **+200 / −344**.

### Notes

- Behaviour changes: a reboot from the CLI or presets tab now reconnects (nothing reconnected a serial FC there before); the cycle does not connect while the firmware flasher is open, since it owns the port itself.
- Two identical boards remain indistinguishable — Web Serial exposes no serial number. That is now the only ambiguity, rather than "whatever showed up".
- After a synchronous abort `linkOpen` stays true until the transport's close arrives. Pre-existing; clearing it in `abortConnection` would touch the reboot flows that read `isConnected()`.

### Testing

703 passing. New tests cover both halves of the failure rule, both link edges, the settled/failed phases staying outside the in-flight set, device identity, and the reconnect cycle's termination — each checked against a mutant, since a test that passes with the fix reverted pins nothing. Production build verified.

Verified on hardware (4.5.5 and master): plug-in connects, CLI `save` reboot reconnects, leaving the CLI tab for a connected tab works, no modal.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved flight controller reboot and reconnection handling across supported connection types.
  * Automatically reconnects to the same device after re-enumeration when possible.
  * Added cancellation support for in-progress reboot reconnection attempts.
  * Reboot progress, success, and failure status are now displayed directly in the reboot dialog.

* **Bug Fixes**
  * Reduced unnecessary error messages when connection attempts or data requests are cancelled.
  * Improved handling of automatic connection failures and device-selection fallback.
  * Added a localized message when a flight controller fails to reconnect after rebooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->