### PR TITLE
ci: stop building the discarded Capacitor release APK

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -33,12 +33,8 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       debug_build: false
+      build_apk: false
       commit_ref: ${{ github.event.release.target_commitish }}
-    secrets:
-      RELEASE_KEYSTORE: ${{ secrets.RELEASE_KEYSTORE }}
-      RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
-      RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
-      RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
 
   # Build the Tauri desktop bundles (Windows/macOS/Linux) and the signed Tauri
   # Android APK, then attach them to the release. The Tauri APK is the release's

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,11 @@ on:
         default: true
         required: false
         type: boolean
+      build_apk:
+        description: 'Build the Capacitor Android APK (debug or release per debug_build)'
+        default: true
+        required: false
+        type: boolean
 # 📌 2. DEFINE SECRETS THE WORKFLOW ACCEPTS
 #    Only consumed by release builds (debug_build == false). Debug builds run
 #    untrusted PR code and must never receive these, so they are optional.
@@ -75,12 +80,15 @@ jobs:
       - run: npm run build
 
       - name: Generate Capacitor Config
+        if: ${{ inputs.build_apk }}
         run: node capacitor.config.generator.mjs
 
       - name: Sync Capacitor Android Project
+        if: ${{ inputs.build_apk }}
         run: npx cap sync android
 
       - name: Set up Java
+        if: ${{ inputs.build_apk }}
         uses: actions/setup-java@v4
         with:
           distribution: temurin
@@ -91,7 +99,7 @@ jobs:
       # the release signing secrets are never referenced here. The APK is
       # signed with the Android debug keystore, which is enough for test installs.
       - name: Build debug APK
-        if: ${{ inputs.debug_build }}
+        if: ${{ inputs.build_apk && inputs.debug_build }}
         run: |
           pushd android >/dev/null
           ./gradlew clean
@@ -99,7 +107,7 @@ jobs:
           popd >/dev/null
 
       - name: Build and Sign Android APK
-        if: ${{ !inputs.debug_build }}
+        if: ${{ inputs.build_apk && !inputs.debug_build }}
         env:
           RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE }}
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
@@ -124,6 +132,7 @@ jobs:
           popd >/dev/null
 
       - name: Set APK name
+        if: ${{ inputs.build_apk }}
         id: apk_name_set
         env:
           IS_DEBUG: ${{ inputs.debug_build }}
@@ -144,6 +153,7 @@ jobs:
           echo "apk_name=$apk_name" >> $GITHUB_OUTPUT
 
       - name: Upload APK as Artifact
+        if: ${{ inputs.build_apk }}
         id: apk_upload
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
The release build path (`build-release.yml` → `modern_build`) was building and signing a Capacitor release APK that nothing consumes: the release's Android download is the Tauri APK from `tauri-release-assets.yml` (the Capacitor APK is already not attached). `modern_build` is still needed for its `dist-files` artifact, which feeds the Cloudflare web deploy.

This adds an optional `build_apk` input to the reusable `build.yml` (default `true`, so all existing callers are unaffected) gating the Capacitor config/sync/Java/Gradle/APK-sign/upload steps, and sets `build_apk: false` on the release call so it no longer runs the release-APK build or receives the `RELEASE_*` signing secrets.

No user-facing change: the release web deploy, the Tauri release APK, the PR debug APK, the `manual-build` APK, and the nightly Capacitor job all keep the default and are unchanged. The `RELEASE_*` secrets remain in use by `tauri-release-assets.yml`. Validated with actionlint.

Capacitor still backs the runtime Android connectivity layer, so this is a build-side cleanup only, not a step toward removing Capacitor before Tauri Android reaches transport parity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build and Release**
  * Release builds can now skip APK generation when it isn’t needed.
  * APK creation remains enabled by default for standard builds.
  * APK-related build steps and artifacts are omitted when disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->