### PR TITLE
feat(android): enable USB serial on the Tauri Android build

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "android-usb-serial"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca4442188d2b56ad9b37696fd8de549f32271b486d87c94a1c81b4dd2caa712"
+dependencies = [
+ "libc",
+ "log",
+ "nusb",
+ "serialport",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1757,7 +1769,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
 dependencies = [
  "core-foundation-sys",
- "mach2",
+ "mach2 0.4.3",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d3a048d09fbb6597dbf7c69f40d14df4a49487db1487191618c893fc3b1c26"
+dependencies = [
+ "core-foundation-sys",
+ "mach2 0.5.0",
 ]
 
 [[package]]
@@ -2048,6 +2070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2079,6 +2107,15 @@ name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
 dependencies = [
  "libc",
 ]
@@ -2270,6 +2307,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "nusb"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18ef13beb3b3a8fc16fd7aea912ebd3d45dde00a9a5b968d0742297468065845"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "futures-core",
+ "io-kit-sys 0.5.0",
+ "js-sys",
+ "linux-raw-sys",
+ "log",
+ "once_cell",
+ "rustix",
+ "slab",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3168,6 +3227,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3457,9 +3529,9 @@ dependencies = [
  "cfg-if",
  "core-foundation",
  "core-foundation-sys",
- "io-kit-sys",
+ "io-kit-sys 0.4.1",
  "libudev",
- "mach2",
+ "mach2 0.4.3",
  "nix",
  "scopeguard",
  "unescaper",
@@ -3965,16 +4037,18 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-serialplugin"
-version = "2.22.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f12b210ee10e56cfa3f724ee1bff7eeae21f3616ace6de27d54727493c96e92"
+checksum = "4c5073b8ad71cf1c1c31db72169e8723902d0c58e32c54be774b567f38b8bfd2"
 dependencies = [
+ "android-usb-serial",
+ "jni 0.21.1",
+ "log",
  "serde",
  "serde_json",
  "serialport",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = "1.0"
 # USB serial is desktop + Android only. iOS has no USB serial API, and
 # tauri-plugin-serialplugin's iOS build path doesn't compile, so exclude it there.
 [target.'cfg(not(target_os = "ios"))'.dependencies]
-tauri-plugin-serialplugin = "2.21"
+tauri-plugin-serialplugin = "3.0"
 
 # Window size/position/maximized persistence is a desktop-only concept.
 # Cargo can't evaluate tauri's `desktop` cfg here, so spell the platforms out.

--- a/src-tauri/capabilities/android.json
+++ b/src-tauri/capabilities/android.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "../gen/schemas/android-schema.json",
+    "identifier": "android",
+    "description": "Android capability: core APIs and USB serial access.",
+    "platforms": ["android"],
+    "windows": ["*"],
+    "permissions": [
+        "core:default",
+        "serialplugin:default"
+    ]
+}

--- a/src-tauri/gen/android/app/src/main/res/xml/device_filter.xml
+++ b/src-tauri/gen/android/app/src/main/res/xml/device_filter.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Overrides the serial plugin's generic filter so USB attach only fires for
+         Betaflight-compatible devices. Includes the DFU bootloader IDs, which the
+         plugin's own filter omits. -->
+
+    <!-- FT232R USB UART -->
+    <usb-device vendor-id="1027" product-id="24577" />
+
+    <!-- STM32 devices -->
+    <usb-device vendor-id="1155" product-id="12886" /> <!-- STM32 in HID mode -->
+    <usb-device vendor-id="1155" product-id="14158" /> <!-- STLink Virtual COM Port (NUCLEO boards) -->
+    <usb-device vendor-id="1155" product-id="22336" /> <!-- STM Electronics Virtual COM Port -->
+    <usb-device vendor-id="1155" product-id="57105" /> <!-- STM Device in DFU Mode -->
+
+    <!-- CP210x devices -->
+    <usb-device vendor-id="4292" product-id="60000" />
+    <usb-device vendor-id="4292" product-id="60001" />
+    <usb-device vendor-id="4292" product-id="60002" />
+
+    <!-- GD32 devices -->
+    <usb-device vendor-id="10473" product-id="394" /> <!-- GD32 VCP -->
+    <usb-device vendor-id="10473" product-id="393" /> <!-- GD32 DFU Bootloader -->
+
+    <!-- AT32 devices -->
+    <usb-device vendor-id="11836" product-id="22336" /> <!-- AT32 VCP -->
+    <usb-device vendor-id="11836" product-id="57105" /> <!-- AT32F435 DFU Bootloader -->
+
+    <!-- APM32 devices -->
+    <usb-device vendor-id="12619" product-id="22336" /> <!-- APM32 VCP -->
+    <usb-device vendor-id="12619" product-id="262" /> <!-- APM32 DFU Bootloader -->
+
+    <!-- Raspberry Pi Pico devices -->
+    <usb-device vendor-id="11914" product-id="9" /> <!-- Raspberry Pi Pico VCP -->
+    <usb-device vendor-id="11914" product-id="15" /> <!-- Raspberry Pi Pico in Bootloader mode -->
+
+    <!-- WCH (QinHeng Electronics) devices -->
+    <usb-device vendor-id="6790" product-id="29986" /> <!-- CH340 USB-to-Serial (variant) -->
+    <usb-device vendor-id="6790" product-id="29987" /> <!-- CH340 USB-to-Serial -->
+    <usb-device vendor-id="6790" product-id="21795" /> <!-- CH341 USB-to-Serial -->
+    <usb-device vendor-id="6790" product-id="30084" /> <!-- CH340S USB-to-Serial -->
+
+    <!-- X32 devices -->
+    <usb-device vendor-id="14743" product-id="22336" /> <!-- X32 VCP -->
+    <usb-device vendor-id="14743" product-id="57105" /> <!-- X32 DFU Bootloader -->
+</resources>

--- a/src-tauri/gen/android/build.gradle.kts
+++ b/src-tauri/gen/android/build.gradle.kts
@@ -13,8 +13,6 @@ allprojects {
     repositories {
         google()
         mavenCentral()
-        // tauri-plugin-serialplugin pulls com.github.mik3y:usb-serial-for-android from JitPack
-        maven { url = uri("https://jitpack.io") }
     }
 }
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,8 @@
         "security": {
             "csp": null,
             "capabilities": [
-                "default"
+                "default",
+                "android"
             ]
         },
         "windows": [

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -2,7 +2,7 @@ import WebSerial from "./protocols/WebSerial.js";
 import WebBluetooth from "./protocols/WebBluetooth.js";
 import Websocket from "./protocols/WebSocket.js";
 import VirtualSerial from "./protocols/VirtualSerial.js";
-import { isAndroid, isTauri, isTauriIOS } from "./utils/checkCompatibility.js";
+import { isAndroid, isTauri, isTauriAndroid, isTauriIOS } from "./utils/checkCompatibility.js";
 import CapacitorSerial from "./protocols/CapacitorSerial.js";
 import CapacitorBle from "./protocols/CapacitorBle.js";
 import CapacitorTcp from "./protocols/CapacitorTcp.js";
@@ -54,8 +54,12 @@ class Serial extends EventTarget {
             this._protocols = [
                 ...(isTauriIOS() ? [] : [{ name: "serial", instance: new TauriSerial() }]),
                 // iOS WKWebView has no Web Bluetooth, so use the native btleplug transport there;
-                // desktop Tauri keeps the webview's Web Bluetooth.
-                { name: "bluetooth", instance: isTauriIOS() ? new TauriBle() : new WebBluetooth() },
+                // desktop Tauri keeps the webview's Web Bluetooth. The Android System WebView has
+                // no Web Bluetooth either and has no native transport yet, so it registers no
+                // bluetooth slot rather than a dead one.
+                ...(isTauriAndroid()
+                    ? []
+                    : [{ name: "bluetooth", instance: isTauriIOS() ? new TauriBle() : new WebBluetooth() }]),
                 { name: "tcp", instance: new TauriTcp() },
                 { name: "websocket", instance: new Websocket() },
             ];

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -84,7 +84,7 @@ export function isEmbeddedDeployment() {
 }
 
 /**
- * @returns {boolean} Whether running inside a Tauri shell (desktop or iOS).
+ * @returns {boolean} Whether running inside a Tauri shell (desktop, Android or iOS).
  */
 export function isTauri() {
     return typeof globalThis !== "undefined" && "__TAURI_INTERNALS__" in globalThis;
@@ -101,6 +101,13 @@ export function isTauriIOS() {
     // iPad in desktop mode reports "Macintosh" but still exposes touch points.
     const ua = navigator.userAgent ?? "";
     return /iPad|iPhone|iPod/.test(ua) || (/Macintosh/.test(ua) && navigator.maxTouchPoints > 1);
+}
+
+/**
+ * @returns {boolean} Whether running inside a Tauri shell on Android.
+ */
+export function isTauriAndroid() {
+    return isTauri() && getOS() === "Android";
 }
 
 /**

--- a/test/js/serial.test.js
+++ b/test/js/serial.test.js
@@ -2,10 +2,14 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 
 // Force the Tauri shell so the protocol list registers both the Rust-backed raw-TCP
 // slot and the WebSocket slot — the case the ws/wss vs tcp routing fix is about.
+// Mutable so a second block can pin the Tauri Android slot table.
+const platform = vi.hoisted(() => ({ isTauriIOS: true, isTauriAndroid: false }));
+
 vi.mock("../../src/js/utils/checkCompatibility.js", () => ({
     isAndroid: () => false,
     isTauri: () => true,
-    isTauriIOS: () => true,
+    isTauriIOS: () => platform.isTauriIOS,
+    isTauriAndroid: () => platform.isTauriAndroid,
 }));
 
 // Replace each protocol with a tiny EventTarget stub so construction is side-effect free
@@ -24,13 +28,23 @@ vi.mock("../../src/js/protocols/CapacitorBle.js", () => ({ default: stub("Capaci
 vi.mock("../../src/js/protocols/CapacitorTcp.js", () => ({ default: stub("CapacitorTcp") }));
 vi.mock("../../src/js/protocols/TauriSerial.js", () => ({ default: stub("TauriSerial") }));
 vi.mock("../../src/js/protocols/TauriTcp.js", () => ({ default: stub("TauriTcp") }));
+vi.mock("../../src/js/protocols/TauriBle.js", () => ({ default: stub("TauriBle") }));
 
 let serial;
-beforeEach(async () => {
+// The singleton builds its slot table at module load, so reset the registry to pick up
+// a changed platform.
+async function loadSerial() {
+    vi.resetModules();
     ({ serial } = await import("../../src/js/serial.js"));
-});
+}
 
 describe("serial.selectProtocol — Tauri transport routing", () => {
+    beforeEach(async () => {
+        platform.isTauriIOS = true;
+        platform.isTauriAndroid = false;
+        await loadSerial();
+    });
+
     it("routes wss:// to the WebSocket protocol, not raw TCP", () => {
         expect(serial.selectProtocol("wss://example.com:5761").constructor.name).toBe("Websocket");
     });
@@ -71,5 +85,34 @@ describe("serial.selectProtocol — Tauri transport routing", () => {
         expect(serial.selectProtocol("elrs_rx.local:5761").constructor.name).toBe("TauriTcp");
         expect(serial.selectProtocol("[fe80::1]").constructor.name).toBe("TauriTcp");
         expect(serial.selectProtocol("[fe80::1]:5761").constructor.name).toBe("TauriTcp");
+    });
+});
+
+describe("serial protocol slots — Tauri Android", () => {
+    beforeEach(async () => {
+        platform.isTauriIOS = false;
+        platform.isTauriAndroid = true;
+        await loadSerial();
+    });
+
+    it("uses the native serial transport", () => {
+        expect(serial.selectProtocol("/dev/bus/usb/001/002").constructor.name).toBe("TauriSerial");
+    });
+
+    it("keeps the Rust-backed TCP and WebSocket slots distinct", () => {
+        expect(serial.selectProtocol("tcp://192.168.0.10:5761").constructor.name).toBe("TauriTcp");
+        expect(serial.selectProtocol("manual").constructor.name).toBe("TauriTcp");
+        expect(serial.selectProtocol("wss://example.com:5761").constructor.name).toBe("Websocket");
+    });
+
+    it("registers no bluetooth slot", () => {
+        // The Android System WebView has no Web Bluetooth and there is no native transport
+        // yet, so nothing must be registered rather than a dead WebBluetooth instance.
+        expect(serial._protocols.some((p) => p.name === "bluetooth")).toBe(false);
+        expect(serial.selectProtocol("bluetooth-AA:BB:CC:DD:EE:FF")).toBeUndefined();
+    });
+
+    it("still registers the virtual transport", () => {
+        expect(serial.selectProtocol("virtual").constructor.name).toBe("VirtualSerial");
     });
 });

--- a/test/js/serial.test.js
+++ b/test/js/serial.test.js
@@ -33,6 +33,7 @@ vi.mock("../../src/js/protocols/TauriBle.js", () => ({ default: stub("TauriBle")
 let serial;
 // The singleton builds its slot table at module load, so reset the registry to pick up
 // a changed platform.
+/** @returns {Promise<void>} */
 async function loadSerial() {
     vi.resetModules();
     ({ serial } = await import("../../src/js/serial.js"));
@@ -108,7 +109,6 @@ describe("serial protocol slots — Tauri Android", () => {
     it("registers no bluetooth slot", () => {
         // The Android System WebView has no Web Bluetooth and there is no native transport
         // yet, so nothing must be registered rather than a dead WebBluetooth instance.
-        expect(serial._protocols.some((p) => p.name === "bluetooth")).toBe(false);
         expect(serial.selectProtocol("bluetooth-AA:BB:CC:DD:EE:FF")).toBeUndefined();
     });
 


### PR DESCRIPTION
First step towards Android on Tauri. Capacitor is untouched and keeps shipping; this only makes the Tauri Android build able to talk to a flight controller over USB serial.

`capabilities/default.json` restricts to `["linux","windows","macOS"]`, so no permissions were granted on any mobile target and serialplugin's commands were unreachable from the webview even though the plugin was registered. This adds an Android-only capability granting `core:default` and `serialplugin:default`. iOS is deliberately left alone, since that path currently works.

Also bumps `tauri-plugin-serialplugin` 2.21 to 3.0, which replaces the vendored usb-serial-for-android Java stack with a pure Rust nusb driver and moves USB I/O off the Android main thread, so the JitPack repository is no longer needed. The six commands `TauriSerial.js` uses (`available_ports`, `open`, `set_timeout`, `read_binary`, `write_binary`, `close`) are unaffected by the 3.0 removals. 3.x expects the app to supply its own `device_filter.xml`, so the curated Betaflight VID/PID list is ported over from the Capacitor project (it also carries the DFU bootloader IDs, which the plugin's generic filter omits).

On the JS side, `isAndroid()` is Capacitor-only, so a Tauri Android build falls into the `isTauri()` branch and was handed `WebBluetooth`, which is inert because the Android System WebView exposes no `navigator.bluetooth`. Adds `isTauriAndroid()` and registers no bluetooth slot there rather than a dead one. `checkBluetoothSupport()` and `checkUsbSupport()` still report false for Tauri Android on purpose: BLE and DFU have no transport yet, so those entry points should stay hidden until the implementations land.

Verified: `cargo check` on desktop and `aarch64-linux-android`, full vitest suite, Android debug APK builds with no JitPack, and the curated device filter confirmed present in the built APK. Not yet verified on hardware, so I would like an on-device check before merge (FC over USB-OTG, plus a desktop serial smoke test since the serialplugin bump affects desktop too).

Follow-ups, not in this PR: BLE via tauri-plugin-blec, a USB DFU transport, and SAF file I/O. Capacitor can only be retired once those land.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Android support for serial plugin access.
  * Improved platform detection and serial transport routing across Android, iOS, and desktop environments.
  * Android now uses native serial communication without Bluetooth protocol registration.

* **Bug Fixes**
  * Preserved correct separation between native serial, Bluetooth, TCP/WebSocket, and virtual transports.

* **Tests**
  * Expanded coverage for Android-specific routing, Bluetooth behavior, and transport compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->