### PR TITLE
fix(tabs): a blank tab, a crash, and two log lines that were not true

### DIFF
--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -1262,6 +1262,13 @@ const mixerPreviewSvg = ref("");
 
 const updateMixerPreview = async () => {
     const imgSrc = getMixerImageSrc(fcStore.mixerConfig.mixer, fcStore.mixerConfig.reverseMotorDir);
+
+    // No mixer yet: the watcher below runs immediately, and with "Reopen last tab on connect"
+    // this tab mounts before MSP_MIXER_CONFIG arrives. It re-runs when the real id lands.
+    if (!imgSrc) {
+        return;
+    }
+
     try {
         const response = await fetch(imgSrc);
         const text = await response.text();

--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -318,6 +318,7 @@ import { mspHelper } from "../../js/msp/MSPHelper";
 import MSP from "../../js/msp";
 import Model from "../../js/model";
 import MSPCodes from "../../js/msp/MSPCodes";
+import { isMspCancelled } from "@/js/msp/mspErrors";
 import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48 } from "../../js/data_storage";
 import { gui_log } from "../../js/gui_log";
 import { ispConnected } from "../../js/utils/connection";
@@ -533,7 +534,12 @@ async function initialize() {
         await MSP.promise(MSPCodes.MSP_SENSOR_ALIGNMENT, false);
         await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG, false);
     } catch (e) {
-        // preserve behavior but at least log unexpected errors
+        // Switching away mid-sequence clears the MSP queue and cancels these requests. The tab
+        // is being torn down, so there is nothing left to render and nothing to report — going
+        // on to process_html() would only warn that the canvas it wants is already gone.
+        if (isMspCancelled(e)) {
+            return;
+        }
         console.warn("Error during Setup initialize sequence:", e);
     }
 

--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -235,8 +235,11 @@ export function usePower() {
 
         syncingFromFc = true;
         try {
-            await loadData();
-            gui_log(i18n.getMessage("powerReceivedBatteryProfile", [FC.CONFIG.batteryProfile + 1]));
+            // Only announce the profile the FC actually sent. The load resolves either way,
+            // so without this a cancelled or failed read still logged a successful sync.
+            if (await loadData()) {
+                gui_log(i18n.getMessage("powerReceivedBatteryProfile", [FC.CONFIG.batteryProfile + 1]));
+            }
         } finally {
             syncingFromFc = false;
         }
@@ -252,6 +255,10 @@ export function usePower() {
     );
 
     // Load data from flight controller
+    /**
+     * Read the power configuration from the FC into reactive state.
+     * @returns {Promise<boolean>} true when the data actually arrived
+     */
     const loadData = async () => {
         isLoading.value = true;
         try {
@@ -268,13 +275,14 @@ export function usePower() {
 
             // Update reactive state
             updateStateFromFC();
+            return true;
         } catch (error) {
             // Switching away mid-load clears the MSP queue and cancels the chain. Expected —
             // the tab is being torn down — so don't report it, same as the live poller below.
-            if (isMspCancelled(error)) {
-                return;
+            if (!isMspCancelled(error)) {
+                console.error("Error loading power data:", error);
             }
-            console.error("Error loading power data:", error);
+            return false;
         } finally {
             isLoading.value = false;
         }

--- a/src/composables/usePower.js
+++ b/src/composables/usePower.js
@@ -269,6 +269,11 @@ export function usePower() {
             // Update reactive state
             updateStateFromFC();
         } catch (error) {
+            // Switching away mid-load clears the MSP queue and cancels the chain. Expected —
+            // the tab is being torn down — so don't report it, same as the live poller below.
+            if (isMspCancelled(error)) {
+                return;
+            }
             console.error("Error loading power data:", error);
         } finally {
             isLoading.value = false;

--- a/src/js/utils/common.js
+++ b/src/js/utils/common.js
@@ -41,10 +41,24 @@ export function isInt(n) {
     return n % 1 === 0;
 }
 
+/**
+ * Image for a mixer, by its 1-based FC id. Empty when there is no such mixer — the id is 0
+ * until MSP_MIXER_CONFIG arrives, and a tab can render before that. model.js guards the same
+ * lookup the same way.
+ * @param {number} mixerIndex - FC.MIXER_CONFIG.mixer (1-based)
+ * @param {boolean} reverseMotorDir - reversed-motor variant
+ * @returns {string} the image path, or "" when the mixer is not known yet
+ */
 export function getMixerImageSrc(mixerIndex, reverseMotorDir) {
+    const mixer = mixerList[mixerIndex - 1];
+
+    if (!mixer) {
+        return "";
+    }
+
     const reverse = reverseMotorDir ? "_reversed" : "";
 
-    return `./resources/motor_order/${mixerList[mixerIndex - 1].image}${reverse}.svg`;
+    return `./resources/motor_order/${mixer.image}${reverse}.svg`;
 }
 
 export function getTextWidth(text) {

--- a/src/js/vue_tab_mounter.js
+++ b/src/js/vue_tab_mounter.js
@@ -99,7 +99,12 @@ export function completeVueTabMount(componentInstance) {
  * Clear the active Vue tab so the root app can unmount it naturally.
  */
 export function unmountVueTab() {
+    // An unmount cancels whatever mount was in flight, and the callback dropped on the next
+    // line is the only thing that clears tab_switch_in_progress. Leaving that flag set makes
+    // every later switchTab() a silent no-op — blank content, no error — until something else
+    // happens to clear it, which is why the disconnect/connect dance appeared to fix it.
     pendingContentReadyCallback = null;
+    GUI.tab_switch_in_progress = false;
     clearTabAdapter(vueTabState.activeTabName ?? GUI.active_tab);
     vueTabState.activeTabName = null;
     vueTabState.activeTabKey += 1;

--- a/test/js/common.test.js
+++ b/test/js/common.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { getMixerImageSrc } from "../../src/js/utils/common.js";
+import { mixerList } from "../../src/js/model.js";
+
+// FC.MIXER_CONFIG.mixer is 0 until MSP_MIXER_CONFIG arrives, and a tab can render before that
+// — "Reopen last tab on connect" mounts the Motors tab straight after the handshake. The
+// lookup is 1-based into a 0-based list, so an unset id reaches mixerList[-1].
+describe("getMixerImageSrc", () => {
+    it("returns the image for a known mixer", () => {
+        const quadX = mixerList.findIndex((mixer) => mixer.image === "quad_x") + 1;
+
+        expect(getMixerImageSrc(quadX, false)).toBe("./resources/motor_order/quad_x.svg");
+        expect(getMixerImageSrc(quadX, true)).toBe("./resources/motor_order/quad_x_reversed.svg");
+    });
+
+    it.each([0, -1, undefined, mixerList.length + 1])("returns nothing for id %s", (id) => {
+        expect(getMixerImageSrc(id, false)).toBe("");
+    });
+});

--- a/test/js/vue_tab_mounter.test.js
+++ b/test/js/vue_tab_mounter.test.js
@@ -24,9 +24,21 @@ vi.mock("../../src/js/pinia_instance.js", () => ({
     pinia: {},
 }));
 
-import { buildTabAdapter } from "../../src/js/vue_tab_mounter.js";
-import { TABS } from "../../src/js/gui.js";
+import { buildTabAdapter, unmountVueTab } from "../../src/js/vue_tab_mounter.js";
+import GUI, { TABS } from "../../src/js/gui.js";
 import { useNavigationStore } from "../../src/stores/navigation.js";
+
+describe("unmountVueTab", () => {
+    it("clears tab_switch_in_progress — an unmount cancels the mount that would have cleared it", () => {
+        // Otherwise teardownConnectionUi's unmount + switchTab("landing") leaves the content
+        // blank: the switch is silently refused and the flag never falls.
+        GUI.tab_switch_in_progress = true;
+
+        unmountVueTab();
+
+        expect(GUI.tab_switch_in_progress).toBe(false);
+    });
+});
 
 describe("buildTabAdapter", () => {
     let navigationStore;


### PR DESCRIPTION
Four faults that show up when a tab mounts or unmounts around a connect, a reboot or a tab switch. Found while testing #5369 on hardware; none of them is caused by it, and none touches the connection layer.

### A blank tab after leaving the CLI

Intermittent, no error, and only a disconnect/reconnect brought it back.

`switchTab()` refuses to run while `GUI.tab_switch_in_progress` is set, and the only thing that clears that flag is the `contentReady` callback of the mount in flight. `unmountVueTab()` drops that callback on its first line but left the flag standing — so when the FC's reboot tore the connection down mid-switch, `teardownConnectionUi()` unmounted the tab and its `switchTab("landing")` was silently refused, along with every switch after it. The disconnect that appeared to fix it was `prepareDisconnect()` clearing the flag by hand.

An unmount cancels the mount that would have cleared it, so it clears it now. `teardownConnectionUi` already carries two comments about this same class of silent refusal — `connect_lock` and `allowedTabs`, both cleared before it navigates. This was the third reason a switch could be refused and the only one nothing handled.

### A crash opening the Motors tab directly

With "Reopen last tab on connect":

```
TypeError: Cannot read properties of undefined (reading 'image')
    at getMixerImageSrc (common.js:47)
```

`FC.MIXER_CONFIG.mixer` is 0 until `MSP_MIXER_CONFIG` arrives and the lookup is 1-based into a 0-based list, so an unset id reads `mixerList[-1]`. Landing on Setup first hid it. `getMixerImageSrc` now returns nothing for an id it does not know — `model.js:77` already guards the same lookup the same way — and the preview waits for the watcher to re-run with the real id.

### Two log lines that were not true

- Clicking a tab while a freshly-opened one is still loading clears the MSP queue, so its requests reject with `MspCancelledError`. Setup and Power reported that as an error; the tab that asked is being torn down. Both now use `isMspCancelled()`, the convention already followed in six places — including the live poller eighty lines below the Power catch that was missing it. Setup also returns before `process_html()`, which is what produced the "Model canvas or wrapper not found" line straight after.
- `usePower.loadData()` resolves whether or not the read succeeded, so `syncBatteryProfileFromFc()` logged `powerReceivedBatteryProfile` regardless. It now returns whether the data arrived. Not a cancellation issue: the original catch already swallowed genuine errors and fell through to the same log.

### Testing

709 passing, including a new `common.test.js` for the mixer lookup and a case pinning that an unmount clears the switch flag; both mutation-checked. Lint, Prettier and a production build clean.

Verified on hardware: the blank tab after CLI, and the Motors crash, both reproduced and confirmed fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of cancelled setup and power requests during teardown.
  * Prevented misleading battery profile change notifications when data loading fails or is cancelled.
  * Reduced unnecessary error logging for expected request cancellations.
  * Ensured tab switching state resets when an in-progress tab mount is cancelled.
  * Prevented mixer preview loading before configuration is available.
  * Improved handling of unavailable mixer configurations and images.

* **Tests**
  * Added coverage for tab switching cleanup and mixer image handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->