### PR TITLE
feat(ble): move native BLE to tauri-plugin-blec and enable Android

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -121,12 +121,11 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 name = "betaflight-app"
 version = "2026.12.0"
 dependencies = [
- "btleplug",
- "futures",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-blec",
  "tauri-plugin-serialplugin",
  "tauri-plugin-shell",
  "tauri-plugin-window-state",
@@ -252,30 +251,31 @@ dependencies = [
 
 [[package]]
 name = "btleplug"
-version = "0.11.8"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a11621cb2c8c024e444734292482b1ad86fb50ded066cf46252e46643c8748"
+checksum = "52c3264dbe2c8e29381e4e95aa2d2783ad0b9192b511240f3755b7e5e3cee87e"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",
  "bluez-async",
- "dashmap 6.2.1",
+ "dashmap",
  "dbus",
  "futures",
  "jni 0.19.0",
- "jni-utils",
  "log",
  "objc2 0.5.2",
  "objc2-core-bluetooth",
  "objc2-foundation 0.2.2",
  "once_cell",
+ "serde",
+ "serde_bytes",
  "static_assertions",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "uuid",
- "windows",
- "windows-future",
+ "windows 0.62.2",
+ "windows-future 0.3.2",
 ]
 
 [[package]]
@@ -628,19 +628,6 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown 0.14.5",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
-name = "dashmap"
 version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
@@ -897,6 +884,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1593,7 +1601,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -1911,21 +1919,6 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "jni-utils"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "259e9f2c3ead61de911f147000660511f07ab00adeed1d84f5ac4d0386e7a6c4"
-dependencies = [
- "dashmap 5.5.3",
- "futures",
- "jni 0.19.0",
- "log",
- "once_cell",
- "static_assertions",
- "uuid",
 ]
 
 [[package]]
@@ -3393,6 +3386,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3882,8 +3885,8 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]
@@ -3953,7 +3956,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4036,6 +4039,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-blec"
+version = "0.12.0"
+source = "git+https://github.com/MnlPhlp/tauri-plugin-blec?rev=fbade6ca37941b53d26c0cfebe39ccbf37ff8bc2#fbade6ca37941b53d26c0cfebe39ccbf37ff8bc2"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "btleplug",
+ "enumflags2",
+ "futures",
+ "once_cell",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-build",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "tauri-plugin-serialplugin"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4109,7 +4135,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4134,7 +4160,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -4502,7 +4528,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -4928,8 +4966,8 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
 ]
@@ -4952,8 +4990,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -5008,11 +5046,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
+ "windows-collections 0.2.0",
+ "windows-core 0.61.2",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -5021,7 +5071,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -5033,8 +5092,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -5043,9 +5115,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -5088,8 +5171,18 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5102,12 +5195,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5210,6 +5321,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -5525,8 +5645,8 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
- "windows-core",
+ "windows 0.61.3",
+ "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -30,13 +30,19 @@ tauri-plugin-serialplugin = "3.0"
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-window-state = "2"
 
-# Native BLE via btleplug's CoreBluetooth backend (shared by macOS and iOS). Scoped to Apple
-# targets so Linux (libdbus) and Windows (WinRT) desktop builds/CI are untouched by the spike.
-[target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
-btleplug = "0.11"
-futures = "0.3"
+# Native BLE for the platforms whose webview has no Web Bluetooth. blec uses a Kotlin
+# backend on Android and btleplug elsewhere; raw btleplug can't serve Android because its
+# droidplug JNI half needs gradle wiring Tauri regenerates, and R8 strips it on release.
+#
+# Not compiled on Linux/Windows: btleplug pulls dbus there, which would add libdbus-1-dev to
+# desktop builds and CI for a path the frontend doesn't use (they keep Web Bluetooth).
+#
+# Pinned to a commit rather than 0.12.0: that release drops every device from an Android scan
+# when the per-device is_bonded() IPC fails. Revisit once a fixed version is published.
+[target.'cfg(any(target_os = "ios", target_os = "macos", target_os = "android"))'.dependencies]
+tauri-plugin-blec = { git = "https://github.com/MnlPhlp/tauri-plugin-blec", rev = "fbade6ca37941b53d26c0cfebe39ccbf37ff8bc2" }
 uuid = "1"
-tokio = { version = "1", features = ["time"] }
+tokio = { version = "1", features = ["sync", "time"] }
 
 [features]
 default = ["custom-protocol"]

--- a/src-tauri/Info.plist
+++ b/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Betaflight connects to your flight controller over Bluetooth Low Energy.</string>
+</dict>
+</plist>

--- a/src-tauri/capabilities/android.json
+++ b/src-tauri/capabilities/android.json
@@ -6,6 +6,7 @@
     "windows": ["*"],
     "permissions": [
         "core:default",
-        "serialplugin:default"
+        "serialplugin:default",
+        "blec:allow-check-permissions"
     ]
 }

--- a/src-tauri/gen/android/app/build.gradle.kts
+++ b/src-tauri/gen/android/app/build.gradle.kts
@@ -27,7 +27,8 @@ android {
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = "com.betaflight.app"
-        minSdk = 24
+        // 26 is the floor imposed by the BLE plugin's Android library.
+        minSdk = 26
         targetSdk = 36
         // versionCode = <calendar year>000000 + CI build number (github.run_number) so it tracks the
         // year and every upload outranks the last. The 2026006000 floor grandfathers the first build

--- a/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- The BLE plugin merges in the Bluetooth permissions, but declares BLE as required, which
+         would hide the app from non-BLE devices that can still use USB serial. -->
+    <uses-feature
+        android:name="android.hardware.bluetooth_le"
+        android:required="false"
+        tools:replace="android:required" />
 
     <!-- USB host required: serial to the flight controller is the only transport on Android -->
     <uses-feature android:name="android.hardware.usb.host" android:required="true" />

--- a/src-tauri/src/ble.rs
+++ b/src-tauri/src/ble.rs
@@ -16,6 +16,7 @@ use std::sync::{Arc, Mutex};
 
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
+use tokio::sync::Mutex as TokioMutex;
 use uuid::Uuid;
 
 use tauri_plugin_blec::models::{BleDevice, CharProps, ScanFilter, Service, WriteType};
@@ -66,6 +67,11 @@ struct WriteTarget {
 pub struct BleState {
     write_target: Mutex<Option<WriteTarget>>,
     generation: Arc<AtomicU64>,
+    /// The plugin exposes one process-wide connection, so a connect and a disconnect
+    /// that overlap act on the same link: a losing connect's cleanup would otherwise
+    /// tear down the winner. Held across each whole transition, not just the state
+    /// writes. Not taken by `ble_send`, which must not block behind a scan.
+    transition: TokioMutex<()>,
 }
 
 /// blec substitutes an identifier for the advertised name when a peripheral has
@@ -189,6 +195,10 @@ pub async fn ble_connect(
     id: String,
     devices: Vec<BleDeviceDescriptor>,
 ) -> Result<BleConnectResult, String> {
+    // Serialise the whole attempt against other transitions, so a cleanup here can
+    // never tear down a link that a concurrent connect established.
+    let _transition = state.transition.lock().await;
+
     // Reserve this attempt's generation before any await, so an attempt superseded
     // by a later connect or disconnect can no longer emit.
     let generation = state.generation.clone();
@@ -271,6 +281,8 @@ pub async fn ble_send(state: State<'_, BleState>, data: Vec<u8>) -> Result<(), S
 
 #[tauri::command]
 pub async fn ble_disconnect(state: State<'_, BleState>) -> Result<(), String> {
+    let _transition = state.transition.lock().await;
+
     // Bump first so the disconnect callback doesn't emit a spurious ble-disconnected
     // after an intentional teardown.
     state.generation.fetch_add(1, Ordering::SeqCst);

--- a/src-tauri/src/ble.rs
+++ b/src-tauri/src/ble.rs
@@ -87,15 +87,13 @@ fn is_nameless(device: &BleDevice) -> bool {
 /// last message is the full result. The receiver must stay alive for the whole
 /// window: the scan task panics if it can no longer send.
 async fn scan_devices() -> Result<Vec<BleDevice>, String> {
-    // blec never asks for the Android runtime permissions on its own, and its
-    // scan hard-rejects without them. A no-op on every other platform.
+    // blec never asks for the Android runtime permissions on its own, and its scan
+    // hard-rejects without them. A no-op on every other platform.
     //
-    // Below API 31 this only grants BLUETOOTH/BLUETOOTH_ADMIN, which are install-time
-    // permissions, so the scan runs but Android returns no results until location is
-    // also granted. blec requests location only for iBeacon scanning, which asking for
-    // would put a location prompt in front of every user on API 31+, where the
-    // neverForLocation scan permission makes it unnecessary. Left as-is pending an
-    // upstream fix: BLE discovery does not work on Android 8-11.
+    // This covers the Bluetooth permissions only. Below API 31 Android also withholds
+    // scan results until location is granted, and this wrapper cannot ask for it — it
+    // does not forward the flag the plugin gates that on. TauriBle requests it directly
+    // on the versions that need it, before calling this.
     tauri_plugin_blec::check_permissions(true).map_err(|e| e.to_string())?;
 
     let handler = get_handler().map_err(|e| e.to_string())?;

--- a/src-tauri/src/ble.rs
+++ b/src-tauri/src/ble.rs
@@ -1,39 +1,35 @@
 //! Native BLE (GATT central) commands for the configurator.
 //!
-//! The Tauri webview exposes no usable Web Bluetooth on iOS (WKWebView has no
-//! `navigator.bluetooth`), so the JS `TauriBle` protocol drives these commands
-//! instead. Backed by btleplug, whose CoreBluetooth backend is shared between
-//! macOS and iOS — hence this module is gated to Apple targets (Linux would pull
-//! in libdbus and Windows a separate WinRT path; neither is needed for the iOS
-//! spike and both would touch desktop CI).
+//! Used wherever the webview exposes no usable Web Bluetooth: iOS and macOS
+//! (WKWebView) and Android (System WebView). The JS `TauriBle` protocol drives
+//! these commands and receives notification bytes via the `ble-data` event, with
+//! `ble-disconnected` when the link drops.
 //!
-//! A single connection is held in managed state. Notifications from the read
-//! characteristic are forwarded to the frontend via the `ble-data` event, and
-//! `ble-disconnected` fires when the link drops. An epoch counter fences each
-//! connection so a stale notification task (left over from a reconnect or
-//! disconnect) can never emit against the live peripheral.
+//! Backed by `tauri-plugin-blec`, which speaks to a Kotlin GATT client on Android
+//! and to btleplug/CoreBluetooth on Apple. The plugin owns the connection state;
+//! this module keeps only the write target chosen at connect time, plus a
+//! generation counter so a superseded attempt's notifications can never be
+//! emitted against a newer connection.
 
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Duration;
 
-use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use tauri::{AppHandle, Emitter, State};
 use uuid::Uuid;
 
-use btleplug::api::{Central, CharPropFlags, Characteristic, Manager as _, Peripheral as _, ScanFilter, WriteType};
-use btleplug::platform::{Adapter, Manager, Peripheral};
+use tauri_plugin_blec::models::{BleDevice, CharProps, ScanFilter, Service, WriteType};
+use tauri_plugin_blec::{get_handler, OnDisconnectHandler};
 
 /// How long a scan runs before returning the peripherals seen so far. BLE
 /// advertisements arrive every few hundred ms, so a couple of seconds catches
 /// the modules in range without making the picker feel stuck.
-const SCAN_DURATION: Duration = Duration::from_secs(3);
+const SCAN_DURATION_MS: u64 = 3000;
 
 /// A discovered peripheral, surfaced to the device picker.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct BleDevice {
+pub struct ScannedDevice {
     id: String,
     name: String,
     services: Vec<String>,
@@ -58,60 +54,132 @@ pub struct BleConnectResult {
     service_uuid: String,
 }
 
-#[derive(Default)]
-pub struct BleState {
-    adapter: Mutex<Option<Adapter>>,
-    peripheral: Mutex<Option<Peripheral>>,
-    write_char: Mutex<Option<Characteristic>>,
-    epoch: Arc<AtomicU64>,
+/// The characteristic `ble_send` writes to, resolved once at connect time.
+#[derive(Clone)]
+struct WriteTarget {
+    service: Uuid,
+    characteristic: Uuid,
+    write_type: WriteType,
 }
 
-/// Lazily create and cache the first BLE adapter. The same adapter instance must
-/// serve both scan and connect: it holds the discovered-peripheral map that
-/// `peripheral()` lookups resolve against.
-async fn get_adapter(state: &State<'_, BleState>) -> Result<Adapter, String> {
-    if let Some(adapter) = state.adapter.lock().unwrap().clone() {
-        return Ok(adapter);
-    }
-    let manager = Manager::new().await.map_err(|e| e.to_string())?;
-    let adapter = manager
-        .adapters()
+#[derive(Default)]
+pub struct BleState {
+    write_target: Mutex<Option<WriteTarget>>,
+    generation: Arc<AtomicU64>,
+}
+
+/// blec substitutes an identifier for the advertised name when a peripheral has
+/// none: the empty string on Android, and the CoreBluetooth UUID (i.e. the
+/// address) on Apple. Such a peripheral is almost never a user-selectable FC
+/// bridge and only clutters the picker.
+fn is_nameless(device: &BleDevice) -> bool {
+    device.name.is_empty() || device.name == device.address
+}
+
+/// Runs a scan and returns the peripherals seen. `discover` returns as soon as it
+/// has spawned its task and then pushes the *cumulative* list every 200 ms, so the
+/// last message is the full result. The receiver must stay alive for the whole
+/// window: the scan task panics if it can no longer send.
+async fn scan_devices() -> Result<Vec<BleDevice>, String> {
+    // blec never asks for the Android runtime permissions on its own, and its
+    // scan hard-rejects without them. A no-op on every other platform.
+    //
+    // Below API 31 this only grants BLUETOOTH/BLUETOOTH_ADMIN, which are install-time
+    // permissions, so the scan runs but Android returns no results until location is
+    // also granted. blec requests location only for iBeacon scanning, which asking for
+    // would put a location prompt in front of every user on API 31+, where the
+    // neverForLocation scan permission makes it unnecessary. Left as-is pending an
+    // upstream fix: BLE discovery does not work on Android 8-11.
+    tauri_plugin_blec::check_permissions(true).map_err(|e| e.to_string())?;
+
+    let handler = get_handler().map_err(|e| e.to_string())?;
+    let (tx, mut rx) = tokio::sync::mpsc::channel(8);
+    handler
+        .discover(Some(tx), SCAN_DURATION_MS, ScanFilter::None, false)
         .await
-        .map_err(|e| e.to_string())?
-        .into_iter()
-        .next()
-        .ok_or_else(|| "no Bluetooth adapter available".to_string())?;
-    *state.adapter.lock().unwrap() = Some(adapter.clone());
-    Ok(adapter)
+        .map_err(|e| e.to_string())?;
+
+    let mut devices = Vec::new();
+    while let Some(batch) = rx.recv().await {
+        devices = batch;
+    }
+    Ok(devices)
 }
 
 #[tauri::command]
-pub async fn ble_scan(state: State<'_, BleState>) -> Result<Vec<BleDevice>, String> {
-    let adapter = get_adapter(&state).await?;
+pub async fn ble_scan() -> Result<Vec<ScannedDevice>, String> {
+    let devices = scan_devices().await?;
+    Ok(devices
+        .into_iter()
+        .filter(|device| !is_nameless(device))
+        .map(|device| ScannedDevice {
+            id: device.address,
+            name: device.name,
+            services: device.services.iter().map(Uuid::to_string).collect(),
+        })
+        .collect())
+}
 
-    // Empty filter = discover everything, mirroring Web Bluetooth's acceptAllDevices;
-    // service matching happens at connect time against the JS descriptor table.
-    adapter.start_scan(ScanFilter::default()).await.map_err(|e| e.to_string())?;
-    tokio::time::sleep(SCAN_DURATION).await;
-    let _ = adapter.stop_scan().await;
+/// The GATT profile resolved against a connected peripheral.
+struct MatchedProfile {
+    /// As written in the JS table, so the frontend can look the entry back up.
+    service_uuid: String,
+    service: Uuid,
+    write: Uuid,
+    read: Uuid,
+    write_type: WriteType,
+}
 
-    let peripherals = adapter.peripherals().await.map_err(|e| e.to_string())?;
-    let mut devices = Vec::new();
-    for peripheral in peripherals {
-        let props = peripheral.properties().await.ok().flatten();
-        // A peripheral with no advertised name is almost never a user-selectable FC
-        // bridge and only clutters the picker, so drop it.
-        let Some(name) = props.as_ref().and_then(|p| p.local_name.clone()) else {
+/// Picks the first descriptor whose service and both characteristics resolve on
+/// the connected peripheral. Order matters: the JS table lists device variants
+/// most-specific first, which is what lets a family like SpeedyBee fall through
+/// to the profile it actually implements.
+fn match_descriptor(services: &[Service], descriptors: &[BleDeviceDescriptor]) -> Option<MatchedProfile> {
+    for descriptor in descriptors {
+        let (Ok(service_uuid), Ok(write_uuid), Ok(read_uuid)) = (
+            Uuid::parse_str(&descriptor.service_uuid),
+            Uuid::parse_str(&descriptor.write_characteristic),
+            Uuid::parse_str(&descriptor.read_characteristic),
+        ) else {
             continue;
         };
-        let services = props.map(|p| p.services.iter().map(|u| u.to_string()).collect()).unwrap_or_default();
-        devices.push(BleDevice {
-            id: peripheral.id().to_string(),
-            name,
-            services,
+
+        let Some(service) = services.iter().find(|s| s.uuid == service_uuid) else {
+            continue;
+        };
+        let Some(write) = service.characteristics.iter().find(|c| c.uuid == write_uuid) else {
+            continue;
+        };
+        if !service.characteristics.iter().any(|c| c.uuid == read_uuid) {
+            continue;
+        }
+
+        // Prefer acknowledged writes when the characteristic supports them (matching
+        // the Web Bluetooth path), falling back to write-without-response otherwise.
+        let write_type = if write.properties.contains(CharProps::Write) {
+            WriteType::WithResponse
+        } else {
+            WriteType::WithoutResponse
+        };
+        return Some(MatchedProfile {
+            service_uuid: descriptor.service_uuid.clone(),
+            service: service_uuid,
+            write: write_uuid,
+            read: read_uuid,
+            write_type,
         });
     }
-    Ok(devices)
+    None
+}
+
+/// Reports the link dropping, unless a later connect or disconnect superseded this
+/// attempt. `OnDisconnectHandler` is a one-shot, so each connect needs a fresh one.
+fn disconnect_emitter(app: AppHandle, generation: Arc<AtomicU64>, my_generation: u64) -> OnDisconnectHandler {
+    OnDisconnectHandler::from_sync(move || {
+        if generation.load(Ordering::SeqCst) == my_generation {
+            let _ = app.emit("ble-disconnected", ());
+        }
+    })
 }
 
 #[tauri::command]
@@ -121,142 +189,96 @@ pub async fn ble_connect(
     id: String,
     devices: Vec<BleDeviceDescriptor>,
 ) -> Result<BleConnectResult, String> {
-    // Reserve this attempt's epoch before any await, so a slower attempt that gets
-    // superseded by a later connect/disconnect refuses to install its peripheral.
-    let epoch = state.epoch.clone();
-    let my_epoch = epoch.fetch_add(1, Ordering::SeqCst) + 1;
+    // Reserve this attempt's generation before any await, so an attempt superseded
+    // by a later connect or disconnect can no longer emit.
+    let generation = state.generation.clone();
+    let my_generation = generation.fetch_add(1, Ordering::SeqCst) + 1;
 
-    let adapter = get_adapter(&state).await?;
-    let peripherals = adapter.peripherals().await.map_err(|e| e.to_string())?;
-    let peripheral = peripherals
-        .into_iter()
-        .find(|p| p.id().to_string() == id)
-        .ok_or_else(|| "device not found — rescan and try again".to_string())?;
+    let handler = get_handler().map_err(|e| e.to_string())?;
 
-    peripheral.connect().await.map_err(|e| e.to_string())?;
-    // From here the peripheral is connected, so every early return must disconnect it
-    // first or it leaks a live link the state never tracks.
-    if let Err(e) = peripheral.discover_services().await {
-        let _ = peripheral.disconnect().await;
-        return Err(e.to_string());
+    // blec resolves the address against the peripherals cached by its last scan, so
+    // a reconnect to a remembered device on a cold start finds nothing. Scan once
+    // and retry rather than making the frontend care.
+    let emit_disconnect = || disconnect_emitter(app.clone(), generation.clone(), my_generation);
+    if let Err(err) = handler.connect(&id, emit_disconnect(), false).await {
+        scan_devices().await?;
+        handler
+            .connect(&id, emit_disconnect(), false)
+            .await
+            .map_err(|retry_err| format!("{err} (after rescan: {retry_err})"))?;
     }
 
-    let characteristics = peripheral.characteristics();
-    let mut matched: Option<(String, Characteristic, Characteristic)> = None;
-    for descriptor in &devices {
-        let (Ok(service_uuid), Ok(write_uuid), Ok(read_uuid)) = (
-            Uuid::parse_str(&descriptor.service_uuid),
-            Uuid::parse_str(&descriptor.write_characteristic),
-            Uuid::parse_str(&descriptor.read_characteristic),
-        ) else {
-            continue;
-        };
-        let write = characteristics.iter().find(|c| c.service_uuid == service_uuid && c.uuid == write_uuid);
-        let read = characteristics.iter().find(|c| c.service_uuid == service_uuid && c.uuid == read_uuid);
-        if let (Some(write), Some(read)) = (write, read) {
-            matched = Some((descriptor.service_uuid.clone(), write.clone(), read.clone()));
-            break;
-        }
-    }
-
-    let (service_uuid, write_char, read_char) = match matched {
-        Some(found) => found,
-        None => {
-            let _ = peripheral.disconnect().await;
-            return Err("device exposes no supported Betaflight GATT service".to_string());
+    // Must happen before any later scan: blec clears its peripheral cache when a new
+    // discover starts, and this call resolves the address against that cache.
+    let services = match handler.discover_services(&id).await {
+        Ok(services) => services,
+        Err(e) => {
+            let _ = handler.disconnect().await;
+            return Err(e.to_string());
         }
     };
 
-    if let Err(e) = peripheral.subscribe(&read_char).await {
-        let _ = peripheral.disconnect().await;
-        return Err(e.to_string());
-    }
-
-    // Install only if nothing superseded us while connecting; check and install under
-    // the same lock so a concurrent disconnect can't race the store.
-    let previous = {
-        let mut guard = state.peripheral.lock().unwrap();
-        if epoch.load(Ordering::SeqCst) != my_epoch {
-            drop(guard);
-            let _ = peripheral.disconnect().await;
-            return Err("connection attempt superseded".to_string());
-        }
-        let previous = guard.replace(peripheral.clone());
-        *state.write_char.lock().unwrap() = Some(write_char);
-        previous
+    let Some(profile) = match_descriptor(&services, &devices) else {
+        let _ = handler.disconnect().await;
+        return Err("device exposes no supported Betaflight GATT service".to_string());
     };
-    // Drop any peripheral we replaced (a reconnect without an intervening disconnect)
-    // after releasing the lock, so its link doesn't linger.
-    if let Some(previous) = previous {
-        let _ = previous.disconnect().await;
-    }
 
-    spawn_notifications(app, epoch, my_epoch, peripheral, read_char.uuid);
-
-    Ok(BleConnectResult { service_uuid })
-}
-
-/// Forwards notifications from the read characteristic to the frontend until the
-/// peripheral drops the link or `epoch` no longer matches (a later reconnect or
-/// disconnect superseded it). The stream ending is treated as a disconnect.
-fn spawn_notifications(app: AppHandle, epoch: Arc<AtomicU64>, my_epoch: u64, peripheral: Peripheral, read_uuid: Uuid) {
-    tauri::async_runtime::spawn(async move {
-        let mut stream = match peripheral.notifications().await {
-            Ok(stream) => stream,
-            Err(_) => {
-                if epoch.load(Ordering::SeqCst) == my_epoch {
-                    let _ = app.emit("ble-disconnected", ());
+    let subscribe_result = {
+        let app = app.clone();
+        let generation = generation.clone();
+        handler
+            .subscribe(profile.read, Some(profile.service), move |data: Vec<u8>| {
+                if generation.load(Ordering::SeqCst) == my_generation {
+                    let _ = app.emit("ble-data", data);
                 }
-                return;
-            }
-        };
+            })
+            .await
+    };
+    if let Err(e) = subscribe_result {
+        let _ = handler.disconnect().await;
+        return Err(e.to_string());
+    }
 
-        while let Some(notification) = stream.next().await {
-            if epoch.load(Ordering::SeqCst) != my_epoch {
-                return;
-            }
-            if notification.uuid == read_uuid {
-                let _ = app.emit("ble-data", notification.value);
-            }
-        }
-
-        // Stream ended: the link is gone. Only report it if we are still the live epoch.
-        if epoch.load(Ordering::SeqCst) == my_epoch {
-            let _ = app.emit("ble-disconnected", ());
-        }
+    // Refuse to install if something superseded us while connecting.
+    if generation.load(Ordering::SeqCst) != my_generation {
+        let _ = handler.disconnect().await;
+        return Err("connection attempt superseded".to_string());
+    }
+    *state.write_target.lock().unwrap() = Some(WriteTarget {
+        service: profile.service,
+        characteristic: profile.write,
+        write_type: profile.write_type,
     });
+
+    Ok(BleConnectResult {
+        service_uuid: profile.service_uuid,
+    })
 }
 
 #[tauri::command]
 pub async fn ble_send(state: State<'_, BleState>, data: Vec<u8>) -> Result<(), String> {
-    // Clone the handles out from under the locks before awaiting; btleplug's
-    // Peripheral/Characteristic are cheap Arc-backed clones.
-    let peripheral = state.peripheral.lock().unwrap().clone();
-    let write_char = state.write_char.lock().unwrap().clone();
-    let (Some(peripheral), Some(write_char)) = (peripheral, write_char) else {
+    let target = state.write_target.lock().unwrap().clone();
+    let Some(target) = target else {
         return Err("BLE peripheral is not connected".to_string());
     };
 
-    // Prefer acknowledged writes when the characteristic supports them (matching the
-    // Web Bluetooth path), falling back to write-without-response otherwise.
-    let write_type = if write_char.properties.contains(CharPropFlags::WRITE) {
-        WriteType::WithResponse
-    } else {
-        WriteType::WithoutResponse
-    };
-
-    peripheral.write(&write_char, &data, write_type).await.map_err(|e| e.to_string())
+    get_handler()
+        .map_err(|e| e.to_string())?
+        .send_data(target.characteristic, Some(target.service), &data, target.write_type)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 #[tauri::command]
 pub async fn ble_disconnect(state: State<'_, BleState>) -> Result<(), String> {
-    // Fence the notification task first so its stream-end doesn't emit a spurious
-    // ble-disconnected after an intentional teardown.
-    state.epoch.fetch_add(1, Ordering::SeqCst);
-    let peripheral = state.peripheral.lock().unwrap().take();
-    *state.write_char.lock().unwrap() = None;
-    if let Some(peripheral) = peripheral {
-        let _ = peripheral.disconnect().await;
-    }
-    Ok(())
+    // Bump first so the disconnect callback doesn't emit a spurious ble-disconnected
+    // after an intentional teardown.
+    state.generation.fetch_add(1, Ordering::SeqCst);
+    *state.write_target.lock().unwrap() = None;
+
+    get_handler()
+        .map_err(|e| e.to_string())?
+        .disconnect()
+        .await
+        .map_err(|e| e.to_string())
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,9 @@
 mod tcp;
 
-// Native BLE (btleplug/CoreBluetooth) is Apple-only: it shares the macOS/iOS backend and
-// avoids the libdbus (Linux) and WinRT (Windows) paths, which the iOS spike doesn't need.
-#[cfg(any(target_os = "ios", target_os = "macos"))]
+// Native BLE covers the platforms whose webview has no Web Bluetooth: Apple (WKWebView) and
+// Android (System WebView). Linux and Windows keep the webview's own Web Bluetooth, which also
+// keeps btleplug's libdbus/WinRT paths out of desktop builds and CI.
+#[cfg(any(target_os = "ios", target_os = "macos", target_os = "android"))]
 mod ble;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -28,19 +29,22 @@ pub fn run() {
 
     let builder = builder.manage(tcp::TcpState::default());
 
-    // On Apple targets register the native BLE transport alongside TCP; elsewhere only TCP
-    // exists, so the handler lists diverge.
-    #[cfg(any(target_os = "ios", target_os = "macos"))]
-    let builder = builder.manage(ble::BleState::default()).invoke_handler(tauri::generate_handler![
-        tcp::tcp_connect,
-        tcp::tcp_send,
-        tcp::tcp_disconnect,
-        ble::ble_scan,
-        ble::ble_connect,
-        ble::ble_send,
-        ble::ble_disconnect
-    ]);
-    #[cfg(not(any(target_os = "ios", target_os = "macos")))]
+    // Registering blec is what populates the handler its Rust API resolves, and what registers
+    // the Android native plugin — the ble_* commands are dead without it.
+    #[cfg(any(target_os = "ios", target_os = "macos", target_os = "android"))]
+    let builder = builder
+        .plugin(tauri_plugin_blec::init())
+        .manage(ble::BleState::default())
+        .invoke_handler(tauri::generate_handler![
+            tcp::tcp_connect,
+            tcp::tcp_send,
+            tcp::tcp_disconnect,
+            ble::ble_scan,
+            ble::ble_connect,
+            ble::ble_send,
+            ble::ble_disconnect
+        ]);
+    #[cfg(not(any(target_os = "ios", target_os = "macos", target_os = "android")))]
     let builder = builder.invoke_handler(tauri::generate_handler![
         tcp::tcp_connect,
         tcp::tcp_send,

--- a/src/js/protocols/TauriBle.js
+++ b/src/js/protocols/TauriBle.js
@@ -3,6 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { i18n } from "../localization";
 import { gui_log } from "../gui_log";
 import { bluetoothDevices } from "./devices";
+import { androidScanNeedsLocation } from "../utils/checkCompatibility";
 
 /**
  * Native BLE transport for the Tauri shells whose webview has no Web Bluetooth:
@@ -93,8 +94,23 @@ class TauriBle extends EventTarget {
     // A BLE scan doubles as the permission gate: it raises the iOS Bluetooth prompt on
     // first CoreBluetooth use, and the runtime scan/connect permission request on
     // Android. The picker renders whatever this returns.
+    // The Rust side asks for the Bluetooth permissions, but the plugin only requests
+    // location when told to scan for iBeacons, and its Rust wrapper never passes that
+    // through. Older Android needs location regardless, so ask the plugin directly.
+    async _requestScanLocationPermission() {
+        try {
+            await invoke("plugin:blec|check_permissions", { askIfDenied: true, allowIbeacons: true });
+        } catch (e) {
+            // Fall through and scan anyway: the permission may already be granted.
+            console.error(`${this.logHead} Location permission request failed: ${e}`);
+        }
+    }
+
     async getDevices() {
         try {
+            if (androidScanNeedsLocation()) {
+                await this._requestScanLocationPermission();
+            }
             const found = await invoke("ble_scan");
             this.devices = found.map((device) => this.createPort(device));
         } catch (e) {

--- a/src/js/protocols/TauriBle.js
+++ b/src/js/protocols/TauriBle.js
@@ -108,7 +108,7 @@ class TauriBle extends EventTarget {
 
     async getDevices() {
         try {
-            if (androidScanNeedsLocation()) {
+            if (await androidScanNeedsLocation()) {
                 await this._requestScanLocationPermission();
             }
             const found = await invoke("ble_scan");

--- a/src/js/protocols/TauriBle.js
+++ b/src/js/protocols/TauriBle.js
@@ -5,12 +5,12 @@ import { gui_log } from "../gui_log";
 import { bluetoothDevices } from "./devices";
 
 /**
- * Native BLE transport for the Tauri iOS shell.
+ * Native BLE transport for the Tauri shells whose webview has no Web Bluetooth:
+ * iOS and macOS (WKWebView) and Android (System WebView).
  *
- * WKWebView exposes no Web Bluetooth, so this drives the Rust `ble_*` commands
- * (btleplug/CoreBluetooth) and receives notification bytes via the `ble-data` /
- * `ble-disconnected` events. Presents the same EventTarget interface as
- * `WebBluetooth`, so serial.js and serial_backend treat it identically.
+ * Drives the Rust `ble_*` commands and receives notification bytes via the
+ * `ble-data` / `ble-disconnected` events. Presents the same EventTarget interface
+ * as `WebBluetooth`, so serial.js and serial_backend treat it identically.
  */
 class TauriBle extends EventTarget {
     constructor() {
@@ -47,7 +47,8 @@ class TauriBle extends EventTarget {
 
     // Mirrors WebBluetooth/CapacitorBle: a stable `bluetooth_`-prefixed path keeps
     // serial.js selectProtocol routing to the BLE slot, and the id (a CoreBluetooth
-    // UUID on iOS) is stable across scans so a pinned path re-resolves to the same device.
+    // UUID on Apple, a MAC address on Android) is stable across scans so a pinned
+    // path re-resolves to the same device.
     createPort(device) {
         return {
             path: `bluetooth_${device.id}`,
@@ -89,8 +90,9 @@ class TauriBle extends EventTarget {
         return false;
     }
 
-    // A BLE scan doubles as the permission gate: the first CoreBluetooth use raises the
-    // iOS Bluetooth prompt. The picker renders whatever this returns.
+    // A BLE scan doubles as the permission gate: it raises the iOS Bluetooth prompt on
+    // first CoreBluetooth use, and the runtime scan/connect permission request on
+    // Android. The picker renders whatever this returns.
     async getDevices() {
         try {
             const found = await invoke("ble_scan");

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -35,11 +35,13 @@ const defaultBluetoothDevices = [
         writeCharacteristic: "6e400003-b5a3-f393-e0a9-e50e24dcca9e",
         readCharacteristic: "6e400002-b5a3-f393-e0a9-e50e24dcca9e",
     },
+    // A board exposing more than one SpeedyBee service is matched in this order,
+    // which is the preference the Android native implementation applies.
     {
-        name: "SpeedyBee V1",
-        serviceUuid: "00001000-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "00001001-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "00001002-0000-1000-8000-00805f9b34fb",
+        name: "SpeedyBee FF00",
+        serviceUuid: "000000ff-0000-1000-8000-00805f9b34fb",
+        writeCharacteristic: "0000ff01-0000-1000-8000-00805f9b34fb",
+        readCharacteristic: "0000ff02-0000-1000-8000-00805f9b34fb",
     },
     {
         name: "SpeedyBee V2",
@@ -48,10 +50,10 @@ const defaultBluetoothDevices = [
         readCharacteristic: "0000abf2-0000-1000-8000-00805f9b34fb",
     },
     {
-        name: "SpeedyBee FF00",
-        serviceUuid: "000000ff-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "0000ff01-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "0000ff02-0000-1000-8000-00805f9b34fb",
+        name: "SpeedyBee V1",
+        serviceUuid: "00001000-0000-1000-8000-00805f9b34fb",
+        writeCharacteristic: "00001001-0000-1000-8000-00805f9b34fb",
+        readCharacteristic: "00001002-0000-1000-8000-00805f9b34fb",
     },
     {
         name: "DroneBridge",

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -3,64 +3,42 @@ import { get as getConfig, set as setConfig } from "../ConfigStorage.js";
 
 const STORAGE_KEY = "device-filters";
 
+// A 16-bit Bluetooth SIG identifier expanded against the Base UUID.
+const bt16 = (id) => `0000${id}-0000-1000-8000-00805f9b34fb`;
+
+/**
+ * @param {string} name
+ * @param {[string, string, string]} uuids - service, write and read, in that order.
+ * @param {object} [extra] - additional per-profile flags.
+ */
+const profile = (name, [service, write, read], extra = {}) => ({
+    name,
+    serviceUuid: service,
+    writeCharacteristic: write,
+    readCharacteristic: read,
+    ...extra,
+});
+
+// Nordic UART is a vendor 128-bit service rather than a SIG identifier.
+const NORDIC_UART = [
+    "6e400001-b5a3-f393-e0a9-e50e24dcca9e",
+    "6e400003-b5a3-f393-e0a9-e50e24dcca9e",
+    "6e400002-b5a3-f393-e0a9-e50e24dcca9e",
+];
+
+// Order matters: a board exposing more than one of these services matches the first
+// entry that resolves, so the SpeedyBee variants are listed in the order the Android
+// native implementation prefers them.
 const defaultBluetoothDevices = [
-    {
-        name: "CC2541",
-        serviceUuid: "0000ffe0-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "0000ffe1-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "0000ffe2-0000-1000-8000-00805f9b34fb",
-        susceptibleToCrcCorruption: true,
-    },
-    {
-        name: "HC-05",
-        serviceUuid: "00001101-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "00001101-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "00001101-0000-1000-8000-00805f9b34fb",
-    },
-    {
-        name: "HM-10",
-        serviceUuid: "0000ffe1-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "0000ffe1-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "0000ffe1-0000-1000-8000-00805f9b34fb",
-    },
-    {
-        name: "HM-11",
-        serviceUuid: "6e400001-b5a3-f393-e0a9-e50e24dcca9e",
-        writeCharacteristic: "6e400003-b5a3-f393-e0a9-e50e24dcca9e",
-        readCharacteristic: "6e400002-b5a3-f393-e0a9-e50e24dcca9e",
-    },
-    {
-        name: "Nordic NRF",
-        serviceUuid: "6e400001-b5a3-f393-e0a9-e50e24dcca9e",
-        writeCharacteristic: "6e400003-b5a3-f393-e0a9-e50e24dcca9e",
-        readCharacteristic: "6e400002-b5a3-f393-e0a9-e50e24dcca9e",
-    },
-    // A board exposing more than one SpeedyBee service is matched in this order,
-    // which is the preference the Android native implementation applies.
-    {
-        name: "SpeedyBee FF00",
-        serviceUuid: "000000ff-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "0000ff01-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "0000ff02-0000-1000-8000-00805f9b34fb",
-    },
-    {
-        name: "SpeedyBee V2",
-        serviceUuid: "0000abf0-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "0000abf1-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "0000abf2-0000-1000-8000-00805f9b34fb",
-    },
-    {
-        name: "SpeedyBee V1",
-        serviceUuid: "00001000-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "00001001-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "00001002-0000-1000-8000-00805f9b34fb",
-    },
-    {
-        name: "DroneBridge",
-        serviceUuid: "0000db32-0000-1000-8000-00805f9b34fb",
-        writeCharacteristic: "0000db33-0000-1000-8000-00805f9b34fb",
-        readCharacteristic: "0000db34-0000-1000-8000-00805f9b34fb",
-    },
+    profile("CC2541", [bt16("ffe0"), bt16("ffe1"), bt16("ffe2")], { susceptibleToCrcCorruption: true }),
+    profile("HC-05", [bt16("1101"), bt16("1101"), bt16("1101")]),
+    profile("HM-10", [bt16("ffe1"), bt16("ffe1"), bt16("ffe1")]),
+    profile("HM-11", NORDIC_UART),
+    profile("Nordic NRF", NORDIC_UART),
+    profile("SpeedyBee FF00", [bt16("00ff"), bt16("ff01"), bt16("ff02")]),
+    profile("SpeedyBee V2", [bt16("abf0"), bt16("abf1"), bt16("abf2")]),
+    profile("SpeedyBee V1", [bt16("1000"), bt16("1001"), bt16("1002")]),
+    profile("DroneBridge", [bt16("db32"), bt16("db33"), bt16("db34")]),
 ];
 
 const defaultSerialDevices = [

--- a/src/js/protocols/devices.js
+++ b/src/js/protocols/devices.js
@@ -48,6 +48,12 @@ const defaultBluetoothDevices = [
         readCharacteristic: "0000abf2-0000-1000-8000-00805f9b34fb",
     },
     {
+        name: "SpeedyBee FF00",
+        serviceUuid: "000000ff-0000-1000-8000-00805f9b34fb",
+        writeCharacteristic: "0000ff01-0000-1000-8000-00805f9b34fb",
+        readCharacteristic: "0000ff02-0000-1000-8000-00805f9b34fb",
+    },
+    {
         name: "DroneBridge",
         serviceUuid: "0000db32-0000-1000-8000-00805f9b34fb",
         writeCharacteristic: "0000db33-0000-1000-8000-00805f9b34fb",

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -2,7 +2,7 @@ import WebSerial from "./protocols/WebSerial.js";
 import WebBluetooth from "./protocols/WebBluetooth.js";
 import Websocket from "./protocols/WebSocket.js";
 import VirtualSerial from "./protocols/VirtualSerial.js";
-import { isAndroid, isTauri, isTauriAndroid, isTauriIOS } from "./utils/checkCompatibility.js";
+import { isAndroid, isTauri, isTauriAndroid, isTauriIOS, isTauriMacOS } from "./utils/checkCompatibility.js";
 import CapacitorSerial from "./protocols/CapacitorSerial.js";
 import CapacitorBle from "./protocols/CapacitorBle.js";
 import CapacitorTcp from "./protocols/CapacitorTcp.js";
@@ -53,13 +53,13 @@ class Serial extends EventTarget {
             // is desktop + Android only — iOS has no USB serial.
             this._protocols = [
                 ...(isTauriIOS() ? [] : [{ name: "serial", instance: new TauriSerial() }]),
-                // iOS WKWebView has no Web Bluetooth, so use the native btleplug transport there;
-                // desktop Tauri keeps the webview's Web Bluetooth. The Android System WebView has
-                // no Web Bluetooth either and has no native transport yet, so it registers no
-                // bluetooth slot rather than a dead one.
-                ...(isTauriAndroid()
-                    ? []
-                    : [{ name: "bluetooth", instance: isTauriIOS() ? new TauriBle() : new WebBluetooth() }]),
+                // Neither WKWebView (iOS, macOS) nor the Android System WebView exposes Web
+                // Bluetooth, so those use the native transport; Linux and Windows keep the
+                // webview's own Web Bluetooth.
+                {
+                    name: "bluetooth",
+                    instance: isTauriIOS() || isTauriMacOS() || isTauriAndroid() ? new TauriBle() : new WebBluetooth(),
+                },
                 { name: "tcp", instance: new TauriTcp() },
                 { name: "websocket", instance: new Websocket() },
             ];

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -113,6 +113,33 @@ export function isTauriAndroid() {
 }
 
 /**
+ * The major Android release, read from the user agent ("… Android 14; Pixel 8 …").
+ *
+ * @returns {number|null} The major version, or null when it can't be determined.
+ */
+export function getAndroidVersion() {
+    const match = /Android\s+(\d+)/.exec(globalThis.navigator?.userAgent ?? "");
+    return match ? Number(match[1]) : null;
+}
+
+/**
+ * Android returns no BLE scan results unless location is granted, until Android 12
+ * (API 31) where the scan permission is declared neverForLocation and stands alone.
+ * Asking only where it is required keeps the prompt away from everyone else.
+ *
+ * @returns {boolean} Whether a BLE scan here needs location permission first.
+ */
+export function androidScanNeedsLocation() {
+    if (!isTauriAndroid()) {
+        return false;
+    }
+    const version = getAndroidVersion();
+    // An unrecognised agent is treated as old: a redundant prompt beats a scan that
+    // silently finds nothing.
+    return version === null || version < 12;
+}
+
+/**
  * @returns {boolean} Whether running inside a Tauri shell on macOS.
  */
 export function isTauriMacOS() {

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -111,6 +111,14 @@ export function isTauriAndroid() {
 }
 
 /**
+ * @returns {boolean} Whether running inside a Tauri shell on macOS.
+ */
+export function isTauriMacOS() {
+    // isTauriIOS() claims an iPad in desktop mode, which also reports "Macintosh".
+    return isTauri() && !isTauriIOS() && getOS() === "MacOS";
+}
+
+/**
  * True only when running as a genuine web/PWA build, i.e. not inside a natively
  * packaged shell (Capacitor Android/iOS, Tauri desktop/iOS) and not an embedded
  * deployment identified by the WebSocket transport metadata. Use this to gate
@@ -231,8 +239,9 @@ export function checkBluetoothSupport() {
     let result = false;
     if (isAndroid()) {
         result = true;
-    } else if (isTauriIOS()) {
-        // Native btleplug transport — WKWebView has no navigator.bluetooth.
+    } else if (isTauriIOS() || isTauriMacOS() || isTauriAndroid()) {
+        // Native BLE transport — neither WKWebView nor the Android System WebView
+        // exposes navigator.bluetooth.
         result = true;
     } else if (navigator.bluetooth) {
         result = true;

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -10,7 +10,9 @@ import { Capacitor } from "@capacitor/core";
 export function getOS() {
     let os = "unknown";
     const userAgent = globalThis.navigator.userAgent;
-    const platform = globalThis.navigator?.userAgentData?.platform;
+    // userAgentData is Chromium-only: WKWebView (Tauri macOS/iOS) and Safari never
+    // expose it, so fall back to the legacy navigator.platform ("MacIntel", "iPhone").
+    const platform = globalThis.navigator?.userAgentData?.platform ?? globalThis.navigator?.platform;
     const macosPlatforms = ["Macintosh", "MacIntel", "MacPPC", "Mac68K", "macOS"];
     const windowsPlatforms = ["Win32", "Win64", "Windows", "WinCE"];
     const iosPlatforms = ["iPhone", "iPad", "iPod"];

--- a/src/js/utils/checkCompatibility.js
+++ b/src/js/utils/checkCompatibility.js
@@ -113,7 +113,10 @@ export function isTauriAndroid() {
 }
 
 /**
- * The major Android release, read from the user agent ("… Android 14; Pixel 8 …").
+ * The major Android release as it appears in the user agent.
+ *
+ * Unreliable on its own: Chrome's user-agent reduction pins this at "Android 10" on
+ * every modern release, so treat it only as a fallback for `getAndroidRelease()`.
  *
  * @returns {number|null} The major version, or null when it can't be determined.
  */
@@ -123,20 +126,41 @@ export function getAndroidVersion() {
 }
 
 /**
- * Android returns no BLE scan results unless location is granted, until Android 12
- * (API 31) where the scan permission is declared neverForLocation and stands alone.
- * Asking only where it is required keeps the prompt away from everyone else.
+ * The real major Android release, preferring client hints over the frozen user agent.
  *
- * @returns {boolean} Whether a BLE scan here needs location permission first.
+ * @returns {Promise<number|null>} The major version, or null when it can't be determined.
  */
-export function androidScanNeedsLocation() {
+export async function getAndroidRelease() {
+    const uaData = globalThis.navigator?.userAgentData;
+    if (uaData?.getHighEntropyValues) {
+        try {
+            const { platformVersion } = await uaData.getHighEntropyValues(["platformVersion"]);
+            const major = Number.parseInt(platformVersion, 10);
+            if (Number.isFinite(major)) {
+                return major;
+            }
+        } catch (error) {
+            console.warn("Could not read the platform version from client hints:", error);
+        }
+    }
+    return getAndroidVersion();
+}
+
+/**
+ * Android returns no BLE scan results unless location is granted, until Android 12
+ * where the scan permission is declared neverForLocation and stands alone. Asking
+ * only where it is required keeps the prompt away from everyone else.
+ *
+ * @returns {Promise<boolean>} Whether a BLE scan here needs location permission first.
+ */
+export async function androidScanNeedsLocation() {
     if (!isTauriAndroid()) {
         return false;
     }
-    const version = getAndroidVersion();
-    // An unrecognised agent is treated as old: a redundant prompt beats a scan that
+    const release = await getAndroidRelease();
+    // An indeterminate release is treated as old: a redundant prompt beats a scan that
     // silently finds nothing.
-    return version === null || version < 12;
+    return release === null || release < 12;
 }
 
 /**

--- a/test/js/checkCompatibility.test.js
+++ b/test/js/checkCompatibility.test.js
@@ -84,6 +84,47 @@ describe("isTauriAndroid", () => {
     });
 });
 
+describe("androidScanNeedsLocation", () => {
+    const androidUA = (version) =>
+        `Mozilla/5.0 (Linux; Android ${version}; Pixel 8) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36`;
+
+    it("is true below Android 12, where a scan finds nothing without location", async () => {
+        globalThis[TAURI] = {};
+        for (const version of [8, 9, 10, 11]) {
+            setUserAgent(androidUA(version));
+            const { androidScanNeedsLocation } = await loadCompatibility();
+            expect(androidScanNeedsLocation()).toBe(true);
+            restoreNavigator();
+        }
+    });
+
+    it("is false from Android 12, where the scan permission stands alone", async () => {
+        globalThis[TAURI] = {};
+        for (const version of [12, 14, 16]) {
+            setUserAgent(androidUA(version));
+            const { androidScanNeedsLocation } = await loadCompatibility();
+            expect(androidScanNeedsLocation()).toBe(false);
+            restoreNavigator();
+        }
+    });
+
+    it("assumes location is needed when the version can't be read", async () => {
+        globalThis[TAURI] = {};
+        // A redundant prompt beats a scan that silently returns nothing.
+        setUserAgent("Mozilla/5.0 (Linux; Android; Pixel) AppleWebKit/537.36 Mobile");
+        const { androidScanNeedsLocation, getAndroidVersion } = await loadCompatibility();
+        expect(getAndroidVersion()).toBeNull();
+        expect(androidScanNeedsLocation()).toBe(true);
+    });
+
+    it("is false off Android entirely", async () => {
+        globalThis[TAURI] = {};
+        setUserAgent(UA.mac, { legacyPlatform: "MacIntel" });
+        const { androidScanNeedsLocation } = await loadCompatibility();
+        expect(androidScanNeedsLocation()).toBe(false);
+    });
+});
+
 describe("isTauriMacOS", () => {
     it("is true for a Tauri shell on macOS", async () => {
         globalThis[TAURI] = {};

--- a/test/js/checkCompatibility.test.js
+++ b/test/js/checkCompatibility.test.js
@@ -88,12 +88,21 @@ describe("androidScanNeedsLocation", () => {
     const androidUA = (version) =>
         `Mozilla/5.0 (Linux; Android ${version}; Pixel 8) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36`;
 
+    /** Stubs the client hints an Android WebView answers with. */
+    function setClientHints(platformVersion) {
+        stubNavigator("userAgentData", {
+            platform: "Android",
+            getHighEntropyValues: async () => ({ platformVersion }),
+        });
+    }
+
     it("is true below Android 12, where a scan finds nothing without location", async () => {
         globalThis[TAURI] = {};
         for (const version of [8, 9, 10, 11]) {
             setUserAgent(androidUA(version));
+            setClientHints(`${version}.0.0`);
             const { androidScanNeedsLocation } = await loadCompatibility();
-            expect(androidScanNeedsLocation()).toBe(true);
+            expect(await androidScanNeedsLocation()).toBe(true);
             restoreNavigator();
         }
     });
@@ -102,26 +111,46 @@ describe("androidScanNeedsLocation", () => {
         globalThis[TAURI] = {};
         for (const version of [12, 14, 16]) {
             setUserAgent(androidUA(version));
+            setClientHints(`${version}.0.0`);
             const { androidScanNeedsLocation } = await loadCompatibility();
-            expect(androidScanNeedsLocation()).toBe(false);
+            expect(await androidScanNeedsLocation()).toBe(false);
             restoreNavigator();
         }
     });
 
-    it("assumes location is needed when the version can't be read", async () => {
+    it("trusts client hints over a user agent frozen at Android 10", async () => {
+        // Chrome's user-agent reduction reports "Android 10; K" on every modern release,
+        // so the agent alone would drag a current device onto the legacy path.
+        globalThis[TAURI] = {};
+        setUserAgent("Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 Chrome/131 Mobile Safari/537.36");
+        setClientHints("15.0.0");
+
+        const { androidScanNeedsLocation, getAndroidVersion } = await loadCompatibility();
+        expect(getAndroidVersion()).toBe(10);
+        expect(await androidScanNeedsLocation()).toBe(false);
+    });
+
+    it("falls back to the agent when client hints are unavailable", async () => {
+        globalThis[TAURI] = {};
+        setUserAgent(androidUA(13));
+        const { androidScanNeedsLocation } = await loadCompatibility();
+        expect(await androidScanNeedsLocation()).toBe(false);
+    });
+
+    it("assumes location is needed when the release can't be determined", async () => {
         globalThis[TAURI] = {};
         // A redundant prompt beats a scan that silently returns nothing.
         setUserAgent("Mozilla/5.0 (Linux; Android; Pixel) AppleWebKit/537.36 Mobile");
         const { androidScanNeedsLocation, getAndroidVersion } = await loadCompatibility();
         expect(getAndroidVersion()).toBeNull();
-        expect(androidScanNeedsLocation()).toBe(true);
+        expect(await androidScanNeedsLocation()).toBe(true);
     });
 
     it("is false off Android entirely", async () => {
         globalThis[TAURI] = {};
         setUserAgent(UA.mac, { legacyPlatform: "MacIntel" });
         const { androidScanNeedsLocation } = await loadCompatibility();
-        expect(androidScanNeedsLocation()).toBe(false);
+        expect(await androidScanNeedsLocation()).toBe(false);
     });
 });
 

--- a/test/js/checkCompatibility.test.js
+++ b/test/js/checkCompatibility.test.js
@@ -21,11 +21,14 @@ function restoreNavigator() {
     stubbed.clear();
 }
 
-function setUserAgent(userAgent, { maxTouchPoints = 0, platform } = {}) {
+function setUserAgent(userAgent, { maxTouchPoints = 0, platform, legacyPlatform } = {}) {
     stubNavigator("userAgent", userAgent);
     stubNavigator("maxTouchPoints", maxTouchPoints);
     // getOS() prefers userAgentData.platform when present, so pin it too.
     stubNavigator("userAgentData", platform ? { platform } : undefined);
+    if (legacyPlatform !== undefined) {
+        stubNavigator("platform", legacyPlatform);
+    }
 }
 
 async function loadCompatibility() {
@@ -47,6 +50,20 @@ beforeEach(() => {
 afterEach(() => {
     restoreNavigator();
     delete globalThis[TAURI];
+});
+
+describe("getOS", () => {
+    // userAgentData is Chromium-only. WKWebView exposes navigator.platform alone, which is
+    // the shape the Tauri macOS and iOS shells actually present.
+    it("identifies a webview that exposes only the legacy platform", async () => {
+        setUserAgent(UA.mac, { legacyPlatform: "MacIntel" });
+        const { getOS } = await loadCompatibility();
+        expect(getOS()).toBe("MacOS");
+
+        restoreNavigator();
+        setUserAgent(UA.iphone, { legacyPlatform: "iPhone" });
+        expect(getOS()).toBe("iOS");
+    });
 });
 
 describe("isTauriAndroid", () => {
@@ -96,6 +113,8 @@ describe("checkBluetoothSupport", () => {
             [UA.android, {}],
             [UA.iphone, {}],
             [UA.mac, { platform: "macOS" }],
+            // The real WKWebView shell: no userAgentData at all.
+            [UA.mac, { legacyPlatform: "MacIntel" }],
         ]) {
             globalThis[TAURI] = {};
             setUserAgent(ua, extra);

--- a/test/js/checkCompatibility.test.js
+++ b/test/js/checkCompatibility.test.js
@@ -1,0 +1,119 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
+
+// Exercises the real predicates rather than mocking them, by driving the inputs they
+// read: the Tauri global, the user agent and touch points.
+
+const TAURI = "__TAURI_INTERNALS__";
+
+// jsdom leaves maxTouchPoints, userAgentData and bluetooth undefined, so they have to be
+// defined rather than spied on. Recorded here so each test can drop them again.
+const stubbed = new Set();
+
+function stubNavigator(property, value) {
+    Object.defineProperty(navigator, property, { value, configurable: true, writable: true });
+    stubbed.add(property);
+}
+
+function restoreNavigator() {
+    for (const property of stubbed) {
+        delete navigator[property];
+    }
+    stubbed.clear();
+}
+
+function setUserAgent(userAgent, { maxTouchPoints = 0, platform } = {}) {
+    stubNavigator("userAgent", userAgent);
+    stubNavigator("maxTouchPoints", maxTouchPoints);
+    // getOS() prefers userAgentData.platform when present, so pin it too.
+    stubNavigator("userAgentData", platform ? { platform } : undefined);
+}
+
+async function loadCompatibility() {
+    vi.resetModules();
+    return import("../../src/js/utils/checkCompatibility.js");
+}
+
+const UA = {
+    android: "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Chrome/120 Mobile Safari/537.36",
+    iphone: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Mobile/15E148",
+    mac: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Safari/605.1.15",
+    linux: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36",
+};
+
+beforeEach(() => {
+    delete globalThis[TAURI];
+});
+
+afterEach(() => {
+    restoreNavigator();
+    delete globalThis[TAURI];
+});
+
+describe("isTauriAndroid", () => {
+    it("is true only inside a Tauri shell on Android", async () => {
+        setUserAgent(UA.android);
+        const { isTauriAndroid } = await loadCompatibility();
+        expect(isTauriAndroid()).toBe(false);
+
+        globalThis[TAURI] = {};
+        expect(isTauriAndroid()).toBe(true);
+    });
+
+    it("is false for a Tauri shell on another platform", async () => {
+        globalThis[TAURI] = {};
+        setUserAgent(UA.linux, { platform: "Linux" });
+        const { isTauriAndroid } = await loadCompatibility();
+        expect(isTauriAndroid()).toBe(false);
+    });
+});
+
+describe("isTauriMacOS", () => {
+    it("is true for a Tauri shell on macOS", async () => {
+        globalThis[TAURI] = {};
+        setUserAgent(UA.mac, { platform: "macOS" });
+        const { isTauriMacOS } = await loadCompatibility();
+        expect(isTauriMacOS()).toBe(true);
+    });
+
+    it("is false outside Tauri", async () => {
+        setUserAgent(UA.mac, { platform: "macOS" });
+        const { isTauriMacOS } = await loadCompatibility();
+        expect(isTauriMacOS()).toBe(false);
+    });
+
+    it("does not claim an iPad in desktop mode, which also reports Macintosh", async () => {
+        globalThis[TAURI] = {};
+        setUserAgent(UA.mac, { platform: "macOS", maxTouchPoints: 5 });
+        const { isTauriMacOS, isTauriIOS } = await loadCompatibility();
+        expect(isTauriIOS()).toBe(true);
+        expect(isTauriMacOS()).toBe(false);
+    });
+});
+
+describe("checkBluetoothSupport", () => {
+    it("reports support on the native-BLE Tauri platforms", async () => {
+        for (const [ua, extra] of [
+            [UA.android, {}],
+            [UA.iphone, {}],
+            [UA.mac, { platform: "macOS" }],
+        ]) {
+            globalThis[TAURI] = {};
+            setUserAgent(ua, extra);
+            const { checkBluetoothSupport } = await loadCompatibility();
+            expect(checkBluetoothSupport()).toBe(true);
+            restoreNavigator();
+        }
+    });
+
+    it("falls back to the webview's Web Bluetooth on Tauri desktop", async () => {
+        globalThis[TAURI] = {};
+        setUserAgent(UA.linux, { platform: "Linux" });
+        const { checkBluetoothSupport } = await loadCompatibility();
+
+        // WebKitGTK exposes no navigator.bluetooth, so nothing claims support.
+        expect(checkBluetoothSupport()).toBe(false);
+
+        stubNavigator("bluetooth", {});
+        expect(checkBluetoothSupport()).toBe(true);
+    });
+});

--- a/test/js/serial.test.js
+++ b/test/js/serial.test.js
@@ -3,13 +3,14 @@ import { describe, expect, it, vi, beforeEach } from "vitest";
 // Force the Tauri shell so the protocol list registers both the Rust-backed raw-TCP
 // slot and the WebSocket slot — the case the ws/wss vs tcp routing fix is about.
 // Mutable so a second block can pin the Tauri Android slot table.
-const platform = vi.hoisted(() => ({ isTauriIOS: true, isTauriAndroid: false }));
+const platform = vi.hoisted(() => ({ isTauriIOS: true, isTauriAndroid: false, isTauriMacOS: false }));
 
 vi.mock("../../src/js/utils/checkCompatibility.js", () => ({
     isAndroid: () => false,
     isTauri: () => true,
     isTauriIOS: () => platform.isTauriIOS,
     isTauriAndroid: () => platform.isTauriAndroid,
+    isTauriMacOS: () => platform.isTauriMacOS,
 }));
 
 // Replace each protocol with a tiny EventTarget stub so construction is side-effect free
@@ -43,6 +44,7 @@ describe("serial.selectProtocol — Tauri transport routing", () => {
     beforeEach(async () => {
         platform.isTauriIOS = true;
         platform.isTauriAndroid = false;
+        platform.isTauriMacOS = false;
         await loadSerial();
     });
 
@@ -93,6 +95,7 @@ describe("serial protocol slots — Tauri Android", () => {
     beforeEach(async () => {
         platform.isTauriIOS = false;
         platform.isTauriAndroid = true;
+        platform.isTauriMacOS = false;
         await loadSerial();
     });
 
@@ -106,13 +109,42 @@ describe("serial protocol slots — Tauri Android", () => {
         expect(serial.selectProtocol("wss://example.com:5761").constructor.name).toBe("Websocket");
     });
 
-    it("registers no bluetooth slot", () => {
-        // The Android System WebView has no Web Bluetooth and there is no native transport
-        // yet, so nothing must be registered rather than a dead WebBluetooth instance.
-        expect(serial.selectProtocol("bluetooth-AA:BB:CC:DD:EE:FF")).toBeUndefined();
+    it("uses the native BLE transport", () => {
+        // The Android System WebView has no navigator.bluetooth, so WebBluetooth would be inert.
+        expect(serial.selectProtocol("bluetooth_AA:BB:CC:DD:EE:FF").constructor.name).toBe("TauriBle");
     });
 
     it("still registers the virtual transport", () => {
         expect(serial.selectProtocol("virtual").constructor.name).toBe("VirtualSerial");
+    });
+});
+
+describe("serial protocol slots — Tauri macOS", () => {
+    beforeEach(async () => {
+        platform.isTauriIOS = false;
+        platform.isTauriAndroid = false;
+        platform.isTauriMacOS = true;
+        await loadSerial();
+    });
+
+    it("uses the native BLE transport, since WKWebView has no Web Bluetooth", () => {
+        expect(serial.selectProtocol("bluetooth_1B2C3D4E").constructor.name).toBe("TauriBle");
+    });
+
+    it("keeps the native serial transport", () => {
+        expect(serial.selectProtocol("/dev/cu.usbmodem1").constructor.name).toBe("TauriSerial");
+    });
+});
+
+describe("serial protocol slots — Tauri desktop (Linux/Windows)", () => {
+    beforeEach(async () => {
+        platform.isTauriIOS = false;
+        platform.isTauriAndroid = false;
+        platform.isTauriMacOS = false;
+        await loadSerial();
+    });
+
+    it("keeps the webview's Web Bluetooth", () => {
+        expect(serial.selectProtocol("bluetooth_AA:BB:CC:DD:EE:FF").constructor.name).toBe("WebBluetooth");
     });
 });

--- a/test/js/serial.test.js
+++ b/test/js/serial.test.js
@@ -32,21 +32,26 @@ vi.mock("../../src/js/protocols/TauriTcp.js", () => ({ default: stub("TauriTcp")
 vi.mock("../../src/js/protocols/TauriBle.js", () => ({ default: stub("TauriBle") }));
 
 let serial;
-// The singleton builds its slot table at module load, so reset the registry to pick up
-// a changed platform.
-/** @returns {Promise<void>} */
-async function loadSerial() {
-    vi.resetModules();
-    ({ serial } = await import("../../src/js/serial.js"));
+
+/**
+ * Rebuilds the serial singleton on the given Tauri platform. It builds its slot table at
+ * module load, so the registry has to be reset for a changed platform to take effect.
+ * @param {{ios?: boolean, android?: boolean, macos?: boolean}} on - the platform to report;
+ *   everything omitted is false, which is desktop Linux/Windows.
+ * @returns {void}
+ */
+function usePlatform(on = {}) {
+    beforeEach(async () => {
+        platform.isTauriIOS = on.ios ?? false;
+        platform.isTauriAndroid = on.android ?? false;
+        platform.isTauriMacOS = on.macos ?? false;
+        vi.resetModules();
+        ({ serial } = await import("../../src/js/serial.js"));
+    });
 }
 
 describe("serial.selectProtocol — Tauri transport routing", () => {
-    beforeEach(async () => {
-        platform.isTauriIOS = true;
-        platform.isTauriAndroid = false;
-        platform.isTauriMacOS = false;
-        await loadSerial();
-    });
+    usePlatform({ ios: true });
 
     it("routes wss:// to the WebSocket protocol, not raw TCP", () => {
         expect(serial.selectProtocol("wss://example.com:5761").constructor.name).toBe("Websocket");
@@ -92,12 +97,7 @@ describe("serial.selectProtocol — Tauri transport routing", () => {
 });
 
 describe("serial protocol slots — Tauri Android", () => {
-    beforeEach(async () => {
-        platform.isTauriIOS = false;
-        platform.isTauriAndroid = true;
-        platform.isTauriMacOS = false;
-        await loadSerial();
-    });
+    usePlatform({ android: true });
 
     it("uses the native serial transport", () => {
         expect(serial.selectProtocol("/dev/bus/usb/001/002").constructor.name).toBe("TauriSerial");
@@ -120,12 +120,7 @@ describe("serial protocol slots — Tauri Android", () => {
 });
 
 describe("serial protocol slots — Tauri macOS", () => {
-    beforeEach(async () => {
-        platform.isTauriIOS = false;
-        platform.isTauriAndroid = false;
-        platform.isTauriMacOS = true;
-        await loadSerial();
-    });
+    usePlatform({ macos: true });
 
     it("uses the native BLE transport, since WKWebView has no Web Bluetooth", () => {
         expect(serial.selectProtocol("bluetooth_1B2C3D4E").constructor.name).toBe("TauriBle");
@@ -137,12 +132,7 @@ describe("serial protocol slots — Tauri macOS", () => {
 });
 
 describe("serial protocol slots — Tauri desktop (Linux/Windows)", () => {
-    beforeEach(async () => {
-        platform.isTauriIOS = false;
-        platform.isTauriAndroid = false;
-        platform.isTauriMacOS = false;
-        await loadSerial();
-    });
+    usePlatform();
 
     it("keeps the webview's Web Bluetooth", () => {
         expect(serial.selectProtocol("bluetooth_AA:BB:CC:DD:EE:FF").constructor.name).toBe("WebBluetooth");


### PR DESCRIPTION
Stacked on #5373 (review that first; this branches off it).

Android had no BLE transport at all, which is the biggest single blocker to retiring Capacitor. btleplug can't provide it: its Android backend needs the droidplug JNI half, whose Gradle wiring Tauri regenerates and whose JNI-only Java R8 strips on our release builds. btleplug's own README points at `tauri-plugin-blec`, which uses a Kotlin GATT client on Android and btleplug everywhere else.

`ble.rs` is rewritten on blec's Rust `Handler`, keeping the same four commands and two events, so `TauriBle.js` needs no functional change and the GATT profile table stays authoritative in JS. We call blec purely from Rust, so no npm package and no `blec` capability entry are needed.

macOS was being routed to `WebBluetooth` even though WKWebView has no `navigator.bluetooth`, so `ble.rs` was compiled for macOS but never reachable and BLE was silently dead there. macOS now uses the native transport like iOS. Linux and Windows keep the webview's Web Bluetooth, and blec is not compiled for them, so desktop builds and CI are untouched (verified: neither blec nor btleplug appears in the desktop dependency graph).

Two things worth calling out. The dependency is pinned to a commit rather than 0.12.0 because that release drops every device from an Android scan when the per-device `is_bonded()` IPC fails; the fix is merged upstream but unreleased. And `minSdk` moves 24 to 26, which the plugin's Android library requires, so the Tauri APK drops Android 7.x (Capacitor still ships at 24 meanwhile). The app also overrides blec's `bluetooth_le required="true"` so USB-serial-only devices can still install. Adds the SpeedyBee FF00 profile that the Capacitor plugin supports but the JS table lacked, which would otherwise regress those devices on the move to Tauri.

Known gap, documented in the code: below API 31 blec only requests the install-time Bluetooth permissions, so Android returns no scan results until location is granted, meaning discovery does not work on Android 8-11. Requesting location unconditionally would put a location prompt in front of every Android 12+ user where `neverForLocation` makes it unnecessary, so this needs an upstream fix rather than a workaround here.

Verified: cargo check and clippy for aarch64-linux-android, desktop cargo check with blec absent from the graph, vitest, and a debug APK whose merged manifest shows minSdk 26, the Bluetooth permissions, and `bluetooth_le` not-required. Not yet verified on hardware. Android needs an on-device scan/connect/MSP run plus a probe of two known upstream defects (#46 empty service discovery, #15 writes hanging after reconnect). Apple cannot be built here at all, and since this swaps a working iOS BLE backend it needs TestFlight before merge; macOS BLE should also be exercised for the first time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added native Bluetooth Low Energy support for Android, alongside iOS and macOS.
  - Added support for SpeedyBee FF00 Bluetooth devices and improved Bluetooth profile matching.
  - Added platform-aware transport selection for native BLE and Web Bluetooth.
  - Added Android Bluetooth capability and Apple Bluetooth permission configuration.

- **Bug Fixes**
  - Improved Bluetooth scanning, connection, subscription, writing, and disconnect behavior.
  - Improved device discovery reliability and handling of stale connection events.
  - Added Android location-permission handling where required for Bluetooth scans.

- **Documentation**
  - Clarified platform support, device identifiers, and Android Bluetooth permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->