### PR TITLE
refactor(dfu): share the USB descriptor layer between DFU transports

### DIFF
--- a/src/js/protocols/UsbDfuDescriptors.js
+++ b/src/js/protocols/UsbDfuDescriptors.js
@@ -266,7 +266,7 @@ class UsbDfuDescriptors extends EventTarget {
     }
 
     /**
-     * True if `buf` at `offset` is a complete (9-byte) DFU functional descriptor with a
+     * True if `buf` at `offset` holds a complete DFU functional descriptor with a
      * usable, non-zero wTransferSize. Rejects HID descriptors (same 0x21 type) that are
      * shorter or that decode to a zero transfer size.
      * @param {Uint8Array} buf
@@ -278,7 +278,8 @@ class UsbDfuDescriptors extends EventTarget {
         if (buf[offset + 1] !== DFU) {
             return false;
         }
-        // DFU functional descriptor is exactly 9 bytes.
+        // The fields we read occupy the first 9 bytes. A device may declare a longer
+        // descriptor, so require at least that much rather than exactly that much.
         if (buf[offset] < 9 || offset + 9 > buf.length) {
             return false;
         }

--- a/src/js/protocols/UsbDfuDescriptors.js
+++ b/src/js/protocols/UsbDfuDescriptors.js
@@ -1,0 +1,341 @@
+/**
+ * USB descriptor reading for DFU transports.
+ *
+ * Everything here is plain parsing on top of control transfers, so it is shared by
+ * every DFU transport regardless of how the bytes are moved. A subclass supplies
+ * `_rawControlTransferIn` and sets `logHead`, and must call
+ * `_invalidateDescriptorCache()` whenever the underlying device changes.
+ */
+class UsbDfuDescriptors extends EventTarget {
+    // DFU functional descriptor bDescriptorType. NOTE: 0x21 is shared with the HID
+    // descriptor type, so a bare type match is ambiguous on composite devices — it must
+    // be qualified by a preceding DFU interface descriptor (see getFunctionalDescriptor).
+    static get DFU_FUNCTIONAL_DESCRIPTOR_TYPE() {
+        return 0x21;
+    }
+
+    /**
+     * Perform a control transfer IN, returning the raw bytes.
+     * @abstract
+     * @param {{requestType: string, recipient: string, request: number, value: number, index: number}} _setup
+     * @param {number} _length - Maximum bytes to read.
+     * @returns {Promise<{status: string, data: Uint8Array}>}
+     */
+    async _rawControlTransferIn(_setup, _length) {
+        throw new Error("_rawControlTransferIn must be implemented by the transport");
+    }
+
+    /** Drops descriptors cached against the previous device. */
+    _invalidateDescriptorCache() {
+        this._langId = undefined;
+        this._configDescriptor = undefined;
+    }
+
+    /**
+     * Reject a USB operation that never settles, so a wedged device surfaces an
+     * error instead of hanging the flash forever. Control transfers normally
+     * complete in milliseconds, so this never fires during healthy operation.
+     * @template T
+     * @param {Promise<T>} promise - The USB operation to guard.
+     * @param {number} timeoutMs - Timeout in milliseconds.
+     * @param {string} label - Human-readable operation name for the timeout error.
+     * @returns {Promise<T>} Resolves with the operation result, or rejects on timeout.
+     */
+    _withTimeout(promise, timeoutMs, label) {
+        let timer;
+        const timeout = new Promise((_, reject) => {
+            timer = setTimeout(
+                () => reject(new Error(`${this.logHead} USB ${label} timed out after ${timeoutMs}ms`)),
+                timeoutMs,
+            );
+        });
+        // Promise.race already attaches a rejection reaction to `promise`, so a late USB
+        // rejection (after the timeout won) is technically "handled" and won't surface as an
+        // unhandledrejection. This explicit no-op catch documents that intent and keeps the
+        // guarantee independent of Promise.race internals.
+        promise.catch(() => {});
+        return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+    }
+
+    /**
+     * Fetch the first supported LANGID from string descriptor 0.
+     * Cached after the first successful read.
+     * Falls back to 0x0409 (English US) on failure.
+     */
+    async getLangId() {
+        if (this._langId !== undefined) {
+            return this._langId;
+        }
+
+        try {
+            const setup = {
+                requestType: "standard",
+                recipient: "device",
+                request: 6,
+                value: 0x300,
+                index: 0,
+            };
+
+            const result = await this._withTimeout(this._rawControlTransferIn(setup, 255), 5000, "getLangId");
+            if (result.status === "ok" && result.data.length >= 4) {
+                this._langId = (result.data[3] << 8) | result.data[2];
+                return this._langId;
+            }
+        } catch (error) {
+            console.warn(`${this.logHead} Failed to read LANGID, falling back to 0x0409:`, error);
+        }
+
+        this._langId = 0x0409;
+        return this._langId;
+    }
+
+    async getString(index) {
+        if (index === 0) {
+            return "";
+        }
+
+        const langId = await this.getLangId();
+        const setup = {
+            requestType: "standard",
+            recipient: "device",
+            request: 6,
+            value: 0x300 | index,
+            index: langId,
+        };
+
+        const result = await this._withTimeout(this._rawControlTransferIn(setup, 255), 5000, `getString(${index})`);
+        if (result.status === "ok") {
+            const buf = result.data;
+            const length = Math.min(buf[0], buf.length);
+            let descriptor = "";
+            for (let i = 2; i + 1 < length; i += 2) {
+                descriptor += String.fromCodePoint((buf[i + 1] << 8) | buf[i]);
+            }
+            return descriptor;
+        }
+        throw new Error(`USB getString failed: ${result.status}`);
+    }
+
+    /**
+     * Fetch the full configuration descriptor blob.
+     * Cached for the lifetime of the current device connection.
+     */
+    async getConfigDescriptor() {
+        if (this._configDescriptor) {
+            return this._configDescriptor;
+        }
+
+        const setup = {
+            requestType: "standard",
+            recipient: "device",
+            request: 6,
+            value: 0x200,
+            index: 0,
+        };
+
+        // First read the 9-byte config header to learn the total length
+        const header = await this._withTimeout(
+            this._rawControlTransferIn(setup, 9),
+            5000,
+            "getConfigDescriptor(header)",
+        );
+        if (header.status !== "ok") {
+            throw new Error(`USB getConfigDescriptor failed: ${header.status}`);
+        }
+
+        const totalLength = (header.data[3] << 8) | header.data[2];
+
+        // Now fetch the entire configuration descriptor blob
+        const result = await this._withTimeout(
+            this._rawControlTransferIn(setup, totalLength),
+            5000,
+            "getConfigDescriptor",
+        );
+        if (result.status !== "ok") {
+            throw new Error(`USB getConfigDescriptor failed: ${result.status}`);
+        }
+
+        this._configDescriptor = result.data;
+        return this._configDescriptor;
+    }
+
+    async getInterfaceDescriptor(interfaceIndex) {
+        const buf = await this.getConfigDescriptor();
+
+        // Walk the descriptor chain looking for the Nth interface descriptor (type 4)
+        let offset = 9; // skip the 9-byte configuration descriptor header
+        let seenInterfaces = 0;
+
+        while (offset + 1 < buf.length) {
+            const bLength = buf[offset];
+            const bDescriptorType = buf[offset + 1];
+
+            if (bDescriptorType === 4) {
+                if (seenInterfaces === interfaceIndex) {
+                    return {
+                        bLength: buf[offset],
+                        bDescriptorType: buf[offset + 1],
+                        bInterfaceNumber: buf[offset + 2],
+                        bAlternateSetting: buf[offset + 3],
+                        bNumEndpoints: buf[offset + 4],
+                        bInterfaceClass: buf[offset + 5],
+                        bInterfaceSubclass: buf[offset + 6],
+                        bInterfaceProtocol: buf[offset + 7],
+                        iInterface: buf[offset + 8],
+                    };
+                }
+                seenInterfaces++;
+            }
+
+            offset += bLength || 1; // guard against zero-length descriptors
+        }
+
+        throw new Error(`USB interface descriptor ${interfaceIndex} not found`);
+    }
+
+    /**
+     * Count the interface descriptors (type 4) in the configuration blob. Alternate
+     * settings each get their own descriptor, so this counts them individually, which
+     * is what getInterfaceDescriptor indexes over.
+     * @param {Uint8Array} buf
+     * @returns {number}
+     */
+    _countInterfaceDescriptors(buf) {
+        let offset = 9;
+        let count = 0;
+        while (offset + 1 < buf.length) {
+            if (buf[offset + 1] === 4) {
+                count++;
+            }
+            offset += buf[offset] || 1;
+        }
+        return count;
+    }
+
+    /**
+     * Read all interface descriptor strings for a given interface number.
+     * @returns {Promise<string[]>}
+     */
+    async getInterfaceDescriptors(interfaceNum) {
+        const descriptorStringArray = [];
+        const descriptorCount = this._countInterfaceDescriptors(await this.getConfigDescriptor());
+
+        for (let i = 0; i < descriptorCount; i++) {
+            try {
+                const descriptor = await this.getInterfaceDescriptor(i);
+                if (descriptor.bInterfaceNumber === interfaceNum) {
+                    const str = await this.getString(descriptor.iInterface);
+                    descriptorStringArray.push(str);
+                }
+            } catch (error) {
+                console.warn(`${this.logHead} Error reading interface descriptor ${i}:`, error);
+                break;
+            }
+        }
+
+        return descriptorStringArray;
+    }
+
+    /**
+     * Decode a DFU functional descriptor from `buf` at `offset`.
+     * @param {Uint8Array} buf - Buffer containing the descriptor.
+     * @param {number} [offset=0] - Byte offset of the descriptor's bLength field.
+     * @returns {{bLength:number,bDescriptorType:number,bmAttributes:number,wDetachTimeOut:number,wTransferSize:number,bcdDFUVersion:number}}
+     */
+    _parseFunctionalDescriptor(buf, offset = 0) {
+        return {
+            bLength: buf[offset],
+            bDescriptorType: buf[offset + 1],
+            bmAttributes: buf[offset + 2],
+            wDetachTimeOut: (buf[offset + 4] << 8) | buf[offset + 3],
+            wTransferSize: (buf[offset + 6] << 8) | buf[offset + 5],
+            bcdDFUVersion: (buf[offset + 8] << 8) | buf[offset + 7],
+        };
+    }
+
+    /**
+     * True if `buf` at `offset` is a complete (9-byte) DFU functional descriptor with a
+     * usable, non-zero wTransferSize. Rejects HID descriptors (same 0x21 type) that are
+     * shorter or that decode to a zero transfer size.
+     * @param {Uint8Array} buf
+     * @param {number} offset
+     * @returns {boolean}
+     */
+    _isValidFunctionalDescriptor(buf, offset) {
+        const DFU = UsbDfuDescriptors.DFU_FUNCTIONAL_DESCRIPTOR_TYPE;
+        if (buf[offset + 1] !== DFU) {
+            return false;
+        }
+        // DFU functional descriptor is exactly 9 bytes.
+        if (buf[offset] < 9 || offset + 9 > buf.length) {
+            return false;
+        }
+        const wTransferSize = (buf[offset + 6] << 8) | buf[offset + 5];
+        return wTransferSize > 0;
+    }
+
+    /**
+     * Read the DFU functional descriptor.
+     *
+     * The descriptor (bDescriptorType 0x21) is embedded in the configuration descriptor,
+     * so we parse it from the blob we already fetched. Some ST ROM bootloaders (confirmed
+     * on the STM32C5) never answer a standalone GET_DESCRIPTOR for it and the request
+     * hangs indefinitely; reading it from the config descriptor avoids that request and
+     * yields the real wTransferSize.
+     *
+     * Because 0x21 is also the HID descriptor type, a match is only accepted when it sits
+     * inside a DFU interface (bInterfaceClass 0xFE / bInterfaceSubClass 0x01) and is a
+     * complete 9-byte descriptor with a non-zero wTransferSize.
+     * @returns {Promise<{bLength:number,bDescriptorType:number,bmAttributes:number,wDetachTimeOut:number,wTransferSize:number,bcdDFUVersion:number}>}
+     */
+    async getFunctionalDescriptor() {
+        try {
+            const buf = await this.getConfigDescriptor();
+            let offset = 0;
+            let inDfuInterface = false;
+            while (offset + 1 < buf.length) {
+                const bLength = buf[offset];
+                const bDescriptorType = buf[offset + 1];
+
+                if (bDescriptorType === 4 && offset + 9 <= buf.length) {
+                    // Interface descriptor: Application-Specific class 0xFE, DFU subclass 0x01.
+                    inDfuInterface = buf[offset + 5] === 0xfe && buf[offset + 6] === 0x01;
+                } else if (
+                    inDfuInterface &&
+                    bDescriptorType === UsbDfuDescriptors.DFU_FUNCTIONAL_DESCRIPTOR_TYPE &&
+                    this._isValidFunctionalDescriptor(buf, offset)
+                ) {
+                    const descriptor = this._parseFunctionalDescriptor(buf, offset);
+                    console.log(
+                        `${this.logHead} DFU functional descriptor from config: wTransferSize=${descriptor.wTransferSize}`,
+                    );
+                    return descriptor;
+                }
+                offset += bLength || 1;
+            }
+            console.warn(`${this.logHead} DFU functional descriptor not in config blob; trying standalone request`);
+        } catch (error) {
+            console.warn(`${this.logHead} Could not read config descriptor for functional descriptor: ${error}`);
+        }
+
+        // Fallback: request it directly (works on classic ST/AT32/GD32 bootloaders).
+        const setup = {
+            requestType: "standard",
+            recipient: "interface",
+            request: 6,
+            value: 0x2100,
+            index: 0,
+        };
+
+        const result = await this._withTimeout(this._rawControlTransferIn(setup, 255), 5000, "getFunctionalDescriptor");
+        if (result.status === "ok") {
+            if (!this._isValidFunctionalDescriptor(result.data, 0)) {
+                throw new Error(`${this.logHead} Invalid DFU functional descriptor in standalone response`);
+            }
+            return this._parseFunctionalDescriptor(result.data, 0);
+        }
+        throw new Error(`USB getFunctionalDescriptor failed: ${result.status}`);
+    }
+}
+
+export default UsbDfuDescriptors;

--- a/src/js/protocols/UsbDfuDescriptors.js
+++ b/src/js/protocols/UsbDfuDescriptors.js
@@ -142,8 +142,17 @@ class UsbDfuDescriptors extends EventTarget {
         if (header.status !== "ok") {
             throw new Error(`USB getConfigDescriptor failed: ${header.status}`);
         }
+        // A transfer can succeed and still return fewer bytes than asked for. Without
+        // this the length below reads past the end, comes out as 0, and an empty blob
+        // gets cached as if it were the whole configuration.
+        if (header.data.length < 4) {
+            throw new Error(`USB getConfigDescriptor returned a ${header.data.length}-byte header`);
+        }
 
         const totalLength = (header.data[3] << 8) | header.data[2];
+        if (totalLength < 9) {
+            throw new Error(`USB getConfigDescriptor reported an implausible length of ${totalLength}`);
+        }
 
         // Now fetch the entire configuration descriptor blob
         const result = await this._withTimeout(
@@ -153,6 +162,9 @@ class UsbDfuDescriptors extends EventTarget {
         );
         if (result.status !== "ok") {
             throw new Error(`USB getConfigDescriptor failed: ${result.status}`);
+        }
+        if (result.data.length < totalLength) {
+            throw new Error(`USB getConfigDescriptor returned ${result.data.length} of ${totalLength} bytes`);
         }
 
         this._configDescriptor = result.data;

--- a/src/js/protocols/WebUsbDfuTransport.js
+++ b/src/js/protocols/WebUsbDfuTransport.js
@@ -1,4 +1,5 @@
 import { usbDevices } from "./devices";
+import UsbDfuDescriptors from "./UsbDfuDescriptors.js";
 
 /**
  * WebUSB transport for DFU protocol.
@@ -6,7 +7,7 @@ import { usbDevices } from "./devices";
  *
  * Events: "addedDevice", "removedDevice"
  */
-class WebUsbDfuTransport extends EventTarget {
+class WebUsbDfuTransport extends UsbDfuDescriptors {
     constructor() {
         super();
         this.logHead = "[WebUSB Transport]";
@@ -35,8 +36,7 @@ class WebUsbDfuTransport extends EventTarget {
             const port = this.createPort(e.device);
             if (this.usbDevice === e.device) {
                 this.usbDevice = null;
-                this._langId = undefined;
-                this._configDescriptor = undefined;
+                this._invalidateDescriptorCache();
             }
             this.dispatchEvent(new CustomEvent("removedDevice", { detail: port }));
         });
@@ -125,8 +125,7 @@ class WebUsbDfuTransport extends EventTarget {
         if (device.configuration === null) {
             await device.selectConfiguration(1);
         }
-        this._langId = undefined;
-        this._configDescriptor = undefined;
+        this._invalidateDescriptorCache();
         this.usbDevice = device;
         console.log(`${this.logHead} USB Device opened: ${this.usbDevice.productName}`);
     }
@@ -158,8 +157,7 @@ class WebUsbDfuTransport extends EventTarget {
         } finally {
             if (this.usbDevice === device) {
                 this.usbDevice = null;
-                this._langId = undefined;
-                this._configDescriptor = undefined;
+                this._invalidateDescriptorCache();
             }
         }
     }
@@ -177,33 +175,6 @@ class WebUsbDfuTransport extends EventTarget {
         }
         const identifier = this.usbDevice.serialNumber ?? `${this.usbDevice.vendorId}_${this.usbDevice.productId}`;
         return `usb_${identifier}`;
-    }
-
-    /**
-     * Race a USB operation against a timeout so a device that never answers a
-     * descriptor request (seen on some brand-new ST ROM bootloaders) surfaces as an
-     * error instead of hanging the flash forever. WebUSB control transfers normally
-     * complete in milliseconds, so this never fires during healthy operation.
-     * @template T
-     * @param {Promise<T>} promise - The USB operation to guard.
-     * @param {number} timeoutMs - Timeout in milliseconds.
-     * @param {string} label - Human-readable operation name for the timeout error.
-     * @returns {Promise<T>} Resolves with the operation result, or rejects on timeout.
-     */
-    _withTimeout(promise, timeoutMs, label) {
-        let timer;
-        const timeout = new Promise((_, reject) => {
-            timer = setTimeout(
-                () => reject(new Error(`${this.logHead} USB ${label} timed out after ${timeoutMs}ms`)),
-                timeoutMs,
-            );
-        });
-        // Promise.race already attaches a rejection reaction to `promise`, so a late USB
-        // rejection (after the timeout won) is technically "handled" and won't surface as an
-        // unhandledrejection. This explicit no-op catch documents that intent and keeps the
-        // guarantee independent of Promise.race internals.
-        promise.catch(() => {});
-        return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
     }
 
     // ===== Control Transfers =====
@@ -224,6 +195,14 @@ class WebUsbDfuTransport extends EventTarget {
     }
 
     /**
+     * The descriptor layer reads through this; WebUSB already normalises for us.
+     * @returns {Promise<{status: string, data: Uint8Array}>}
+     */
+    async _rawControlTransferIn(setup, length) {
+        return this.controlTransferIn(setup, length);
+    }
+
+    /**
      * Perform a USB control transfer OUT (host -> device).
      * @returns {Promise<{status: string}>}
      */
@@ -234,291 +213,6 @@ class WebUsbDfuTransport extends EventTarget {
             return { status: "ok" };
         }
         throw new Error(`USB controlTransferOut failed: ${result.status}`);
-    }
-
-    // ===== Descriptor Reading =====
-
-    /**
-     * Fetch the first supported LANGID from string descriptor 0.
-     * Cached after the first successful read.
-     * Falls back to 0x0409 (English US) on failure.
-     */
-    async getLangId() {
-        if (this._langId !== undefined) {
-            return this._langId;
-        }
-
-        try {
-            const setup = {
-                requestType: "standard",
-                recipient: "device",
-                request: 6,
-                value: 0x300,
-                index: 0,
-            };
-
-            const result = await this._withTimeout(this.usbDevice.controlTransferIn(setup, 255), 5000, "getLangId");
-            if (result.status === "ok" && result.data.byteLength >= 4) {
-                this._langId = result.data.getUint16(2, true);
-                return this._langId;
-            }
-        } catch (error) {
-            console.warn(`${this.logHead} Failed to read LANGID, falling back to 0x0409:`, error);
-        }
-
-        this._langId = 0x0409;
-        return this._langId;
-    }
-
-    async getString(index) {
-        if (index === 0) {
-            return "";
-        }
-
-        const langId = await this.getLangId();
-        const setup = {
-            requestType: "standard",
-            recipient: "device",
-            request: 6,
-            value: 0x300 | index,
-            index: langId,
-        };
-
-        const result = await this._withTimeout(
-            this.usbDevice.controlTransferIn(setup, 255),
-            5000,
-            `getString(${index})`,
-        );
-        if (result.status === "ok") {
-            const length = Math.min(result.data.getUint8(0), result.data.byteLength);
-            let descriptor = "";
-            for (let i = 2; i + 1 < length; i += 2) {
-                const charCode = result.data.getUint16(i, true);
-                descriptor += String.fromCodePoint(charCode);
-            }
-            return descriptor;
-        }
-        throw new Error(`USB getString failed: ${result.status}`);
-    }
-
-    /**
-     * Fetch the full configuration descriptor blob.
-     * Cached for the lifetime of the current device connection.
-     */
-    async getConfigDescriptor() {
-        if (this._configDescriptor) {
-            return this._configDescriptor;
-        }
-
-        const setup = {
-            requestType: "standard",
-            recipient: "device",
-            request: 6,
-            value: 0x200,
-            index: 0,
-        };
-
-        // First read the 9-byte config header to learn the total length
-        const header = await this._withTimeout(
-            this.usbDevice.controlTransferIn(setup, 9),
-            5000,
-            "getConfigDescriptor(header)",
-        );
-        if (header.status !== "ok") {
-            throw new Error(`USB getConfigDescriptor failed: ${header.status}`);
-        }
-
-        const totalLength = header.data.getUint16(2, true);
-
-        // Now fetch the entire configuration descriptor blob
-        const result = await this._withTimeout(
-            this.usbDevice.controlTransferIn(setup, totalLength),
-            5000,
-            "getConfigDescriptor",
-        );
-        if (result.status !== "ok") {
-            throw new Error(`USB getConfigDescriptor failed: ${result.status}`);
-        }
-
-        this._configDescriptor = new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength);
-        return this._configDescriptor;
-    }
-
-    async getInterfaceDescriptor(interfaceIndex) {
-        const buf = await this.getConfigDescriptor();
-
-        // Walk the descriptor chain looking for the Nth interface descriptor (type 4)
-        let offset = 9; // skip the 9-byte configuration descriptor header
-        let seenInterfaces = 0;
-
-        while (offset + 1 < buf.length) {
-            const bLength = buf[offset];
-            const bDescriptorType = buf[offset + 1];
-
-            if (bDescriptorType === 4) {
-                if (seenInterfaces === interfaceIndex) {
-                    return {
-                        bLength: buf[offset],
-                        bDescriptorType: buf[offset + 1],
-                        bInterfaceNumber: buf[offset + 2],
-                        bAlternateSetting: buf[offset + 3],
-                        bNumEndpoints: buf[offset + 4],
-                        bInterfaceClass: buf[offset + 5],
-                        bInterfaceSubclass: buf[offset + 6],
-                        bInterfaceProtocol: buf[offset + 7],
-                        iInterface: buf[offset + 8],
-                    };
-                }
-                seenInterfaces++;
-            }
-
-            offset += bLength || 1; // guard against zero-length descriptors
-        }
-
-        throw new Error(`USB interface descriptor ${interfaceIndex} not found`);
-    }
-
-    /**
-     * Read all interface descriptor strings for a given interface number.
-     * @returns {Promise<string[]>}
-     */
-    async getInterfaceDescriptors(interfaceNum) {
-        const descriptorStringArray = [];
-        const interfaces = this.usbDevice.configuration.interfaces;
-
-        if (interfaces.length === 0) {
-            return [];
-        }
-
-        const descriptorCount = interfaces.reduce((count, iface) => count + iface.alternates.length, 0);
-
-        for (let i = 0; i < descriptorCount; i++) {
-            try {
-                const descriptor = await this.getInterfaceDescriptor(i);
-                if (descriptor.bInterfaceNumber === interfaceNum) {
-                    const str = await this.getString(descriptor.iInterface);
-                    descriptorStringArray.push(str);
-                }
-            } catch (error) {
-                console.warn(`${this.logHead} Error reading interface descriptor ${i}:`, error);
-                break;
-            }
-        }
-
-        return descriptorStringArray;
-    }
-
-    // DFU functional descriptor bDescriptorType. NOTE: 0x21 is shared with the HID
-    // descriptor type, so a bare type match is ambiguous on composite devices — it must
-    // be qualified by a preceding DFU interface descriptor (see getFunctionalDescriptor).
-    static get DFU_FUNCTIONAL_DESCRIPTOR_TYPE() {
-        return 0x21;
-    }
-
-    /**
-     * Decode a DFU functional descriptor from `buf` at `offset`.
-     * @param {Uint8Array} buf - Buffer containing the descriptor.
-     * @param {number} [offset=0] - Byte offset of the descriptor's bLength field.
-     * @returns {{bLength:number,bDescriptorType:number,bmAttributes:number,wDetachTimeOut:number,wTransferSize:number,bcdDFUVersion:number}}
-     */
-    _parseFunctionalDescriptor(buf, offset = 0) {
-        return {
-            bLength: buf[offset],
-            bDescriptorType: buf[offset + 1],
-            bmAttributes: buf[offset + 2],
-            wDetachTimeOut: (buf[offset + 4] << 8) | buf[offset + 3],
-            wTransferSize: (buf[offset + 6] << 8) | buf[offset + 5],
-            bcdDFUVersion: (buf[offset + 8] << 8) | buf[offset + 7],
-        };
-    }
-
-    /**
-     * True if `buf` at `offset` is a complete (9-byte) DFU functional descriptor with a
-     * usable, non-zero wTransferSize. Rejects HID descriptors (same 0x21 type) that are
-     * shorter or that decode to a zero transfer size.
-     * @param {Uint8Array} buf
-     * @param {number} offset
-     * @returns {boolean}
-     */
-    _isValidFunctionalDescriptor(buf, offset) {
-        const DFU = WebUsbDfuTransport.DFU_FUNCTIONAL_DESCRIPTOR_TYPE;
-        if (buf[offset + 1] !== DFU) {
-            return false;
-        }
-        // DFU functional descriptor is exactly 9 bytes.
-        if (buf[offset] < 9 || offset + 9 > buf.length) {
-            return false;
-        }
-        const wTransferSize = (buf[offset + 6] << 8) | buf[offset + 5];
-        return wTransferSize > 0;
-    }
-
-    /**
-     * Read the DFU functional descriptor.
-     *
-     * The descriptor (bDescriptorType 0x21) is embedded in the configuration descriptor,
-     * so we parse it from the blob we already fetched. Some ST ROM bootloaders (confirmed
-     * on the STM32C5) never answer a standalone GET_DESCRIPTOR for it and the request
-     * hangs indefinitely; reading it from the config descriptor avoids that request and
-     * yields the real wTransferSize.
-     *
-     * Because 0x21 is also the HID descriptor type, a match is only accepted when it sits
-     * inside a DFU interface (bInterfaceClass 0xFE / bInterfaceSubClass 0x01) and is a
-     * complete 9-byte descriptor with a non-zero wTransferSize.
-     * @returns {Promise<{bLength:number,bDescriptorType:number,bmAttributes:number,wDetachTimeOut:number,wTransferSize:number,bcdDFUVersion:number}>}
-     */
-    async getFunctionalDescriptor() {
-        try {
-            const buf = await this.getConfigDescriptor();
-            let offset = 0;
-            let inDfuInterface = false;
-            while (offset + 1 < buf.length) {
-                const bLength = buf[offset];
-                const bDescriptorType = buf[offset + 1];
-
-                if (bDescriptorType === 4 && offset + 9 <= buf.length) {
-                    // Interface descriptor: Application-Specific class 0xFE, DFU subclass 0x01.
-                    inDfuInterface = buf[offset + 5] === 0xfe && buf[offset + 6] === 0x01;
-                } else if (
-                    inDfuInterface &&
-                    bDescriptorType === WebUsbDfuTransport.DFU_FUNCTIONAL_DESCRIPTOR_TYPE &&
-                    this._isValidFunctionalDescriptor(buf, offset)
-                ) {
-                    const descriptor = this._parseFunctionalDescriptor(buf, offset);
-                    console.log(
-                        `${this.logHead} DFU functional descriptor from config: wTransferSize=${descriptor.wTransferSize}`,
-                    );
-                    return descriptor;
-                }
-                offset += bLength || 1;
-            }
-            console.warn(`${this.logHead} DFU functional descriptor not in config blob; trying standalone request`);
-        } catch (error) {
-            console.warn(`${this.logHead} Could not read config descriptor for functional descriptor: ${error}`);
-        }
-
-        // Fallback: request it directly (works on classic ST/AT32/GD32 bootloaders).
-        const setup = {
-            requestType: "standard",
-            recipient: "interface",
-            request: 6,
-            value: 0x2100,
-            index: 0,
-        };
-
-        const result = await this._withTimeout(
-            this.usbDevice.controlTransferIn(setup, 255),
-            5000,
-            "getFunctionalDescriptor",
-        );
-        if (result.status === "ok") {
-            const buf = new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength);
-            if (!this._isValidFunctionalDescriptor(buf, 0)) {
-                throw new Error(`${this.logHead} Invalid DFU functional descriptor in standalone response`);
-            }
-            return this._parseFunctionalDescriptor(buf, 0);
-        }
-        throw new Error(`USB getFunctionalDescriptor failed: ${result.status}`);
     }
 }
 

--- a/src/js/protocols/WebUsbDfuTransport.js
+++ b/src/js/protocols/WebUsbDfuTransport.js
@@ -180,26 +180,30 @@ class WebUsbDfuTransport extends UsbDfuDescriptors {
     // ===== Control Transfers =====
 
     /**
-     * Perform a USB control transfer IN (device -> host).
-     * @returns {Promise<{status: string, data: Uint8Array}>}
-     */
-    async controlTransferIn(setup, length) {
-        const result = await this.usbDevice.controlTransferIn(setup, length);
-        if (result.status === "ok") {
-            return {
-                status: "ok",
-                data: new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength),
-            };
-        }
-        throw new Error(`USB controlTransferIn failed: ${result.status}`);
-    }
-
-    /**
-     * The descriptor layer reads through this; WebUSB already normalises for us.
+     * Perform a USB control transfer IN (device -> host), reporting the transfer status
+     * rather than throwing, so the descriptor layer can decide what a stall means for a
+     * given request (an unsupported LANGID read is recoverable; a truncated
+     * configuration descriptor is not).
      * @returns {Promise<{status: string, data: Uint8Array}>}
      */
     async _rawControlTransferIn(setup, length) {
-        return this.controlTransferIn(setup, length);
+        const result = await this.usbDevice.controlTransferIn(setup, length);
+        const data = result.data
+            ? new Uint8Array(result.data.buffer, result.data.byteOffset, result.data.byteLength)
+            : new Uint8Array(0);
+        return { status: result.status, data };
+    }
+
+    /**
+     * Perform a USB control transfer IN (device -> host), throwing on a failed transfer.
+     * @returns {Promise<{status: string, data: Uint8Array}>}
+     */
+    async controlTransferIn(setup, length) {
+        const result = await this._rawControlTransferIn(setup, length);
+        if (result.status === "ok") {
+            return result;
+        }
+        throw new Error(`USB controlTransferIn failed: ${result.status}`);
     }
 
     /**

--- a/test/js/usbDfuDescriptors.test.js
+++ b/test/js/usbDfuDescriptors.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach, vi } from "vitest";
+import { describe, expect, it, afterEach, beforeEach, vi } from "vitest";
 import UsbDfuDescriptors from "../../src/js/protocols/UsbDfuDescriptors.js";
 
 // The descriptor layer is pure parsing over control transfers, so it can be driven
@@ -98,6 +98,10 @@ beforeEach(() => {
     vi.spyOn(console, "log").mockImplementation(() => {});
 });
 
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
 describe("getLangId", () => {
     it("reads the first supported LANGID and caches it", async () => {
         const transport = new ScriptedTransport();
@@ -139,6 +143,25 @@ describe("getConfigDescriptor", () => {
 
         await transport.getConfigDescriptor();
         expect(transport.calls.filter((c) => c.value === CONFIG)).toHaveLength(2);
+    });
+
+    it("rejects a header too short to hold the length", async () => {
+        // An "ok" transfer can still come back short; reading past the end would yield
+        // a zero length and cache an empty blob as if it were the configuration.
+        const transport = new ScriptedTransport({ config: [9, 2] });
+        await expect(transport.getConfigDescriptor()).rejects.toThrow(/2-byte header/);
+    });
+
+    it("rejects an implausible total length", async () => {
+        const transport = new ScriptedTransport({ config: [9, 2, 4, 0, 1, 1, 0, 0x80, 50] });
+        await expect(transport.getConfigDescriptor()).rejects.toThrow(/implausible length of 4/);
+    });
+
+    it("rejects a body shorter than the advertised length", async () => {
+        // Claims 64 bytes but only ever returns the 18 it has.
+        const short = [9, 2, 64, 0, 1, 1, 0, 0x80, 50, ...interfaceDescriptor()];
+        const transport = new ScriptedTransport({ config: short });
+        await expect(transport.getConfigDescriptor()).rejects.toThrow(/returned 18 of 64 bytes/);
     });
 });
 

--- a/test/js/usbDfuDescriptors.test.js
+++ b/test/js/usbDfuDescriptors.test.js
@@ -1,0 +1,210 @@
+import { describe, expect, it, beforeEach, vi } from "vitest";
+import UsbDfuDescriptors from "../../src/js/protocols/UsbDfuDescriptors.js";
+
+// The descriptor layer is pure parsing over control transfers, so it can be driven
+// entirely through a scripted _rawControlTransferIn with no USB backend at all.
+
+const CONFIG = 0x200;
+const STRING = 0x300;
+
+/** @returns {number[]} a 9-byte configuration descriptor header */
+const configHeader = (totalLength) => [9, 2, totalLength & 0xff, totalLength >> 8, 1, 1, 0, 0x80, 50];
+
+/** @returns {number[]} a 9-byte interface descriptor */
+const interfaceDescriptor = ({ number = 0, alternate = 0, cls = 0xfe, subclass = 0x01, iInterface = 0 } = {}) => [
+    9,
+    4,
+    number,
+    alternate,
+    0,
+    cls,
+    subclass,
+    0x02,
+    iInterface,
+];
+
+/** @returns {number[]} a 9-byte DFU functional descriptor */
+const functionalDescriptor = (transferSize) => [
+    9,
+    0x21,
+    0x0b,
+    0xff,
+    0x00,
+    transferSize & 0xff,
+    transferSize >> 8,
+    0x1a,
+    0x01,
+];
+
+/** @returns {number[]} a USB string descriptor holding `text` as UTF-16LE */
+function stringDescriptor(text) {
+    const bytes = [0, 3];
+    for (const char of text) {
+        const code = char.codePointAt(0);
+        bytes.push(code & 0xff, code >> 8);
+    }
+    bytes[0] = bytes.length;
+    return bytes;
+}
+
+function buildConfig(parts) {
+    const body = parts.flat();
+    const total = 9 + body.length;
+    return [...configHeader(total), ...body];
+}
+
+class ScriptedTransport extends UsbDfuDescriptors {
+    constructor({ config = [], strings = {}, langId = [4, 3, 0x09, 0x04], standalone } = {}) {
+        super();
+        this.logHead = "[test]";
+        this.config = config;
+        this.strings = strings;
+        this.langId = langId;
+        this.standalone = standalone;
+        this.calls = [];
+    }
+
+    async _rawControlTransferIn(setup, length) {
+        this.calls.push({ value: setup.value, length });
+
+        if (setup.value === STRING) {
+            return this.respond(this.langId, length);
+        }
+        if ((setup.value & 0xff00) === STRING) {
+            const text = this.strings[setup.value & 0xff];
+            return text === undefined
+                ? { status: "stall", data: new Uint8Array(0) }
+                : this.respond(stringDescriptor(text), length);
+        }
+        if (setup.value === CONFIG) {
+            return this.respond(this.config, length);
+        }
+        if (setup.value === 0x2100) {
+            if (!this.standalone) {
+                throw new Error("device never answers the standalone request");
+            }
+            return this.respond(this.standalone, length);
+        }
+        return { status: "stall", data: new Uint8Array(0) };
+    }
+
+    respond(bytes, length) {
+        return { status: "ok", data: new Uint8Array(bytes.slice(0, length)) };
+    }
+}
+
+beforeEach(() => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+describe("getLangId", () => {
+    it("reads the first supported LANGID and caches it", async () => {
+        const transport = new ScriptedTransport();
+        expect(await transport.getLangId()).toBe(0x0409);
+
+        await transport.getLangId();
+        expect(transport.calls.filter((c) => c.value === STRING)).toHaveLength(1);
+    });
+
+    it("falls back to English US when the descriptor is short", async () => {
+        const transport = new ScriptedTransport({ langId: [2, 3] });
+        expect(await transport.getLangId()).toBe(0x0409);
+    });
+});
+
+describe("getString", () => {
+    it("decodes UTF-16LE", async () => {
+        const transport = new ScriptedTransport({ strings: { 4: "@Internal Flash /0x08000000" } });
+        expect(await transport.getString(4)).toBe("@Internal Flash /0x08000000");
+    });
+
+    it("returns empty for index 0 without a transfer", async () => {
+        const transport = new ScriptedTransport();
+        expect(await transport.getString(0)).toBe("");
+        expect(transport.calls).toHaveLength(0);
+    });
+});
+
+describe("getConfigDescriptor", () => {
+    it("reads the header first, then the whole blob, then caches", async () => {
+        const config = buildConfig([interfaceDescriptor(), functionalDescriptor(2048)]);
+        const transport = new ScriptedTransport({ config });
+
+        const blob = await transport.getConfigDescriptor();
+        expect(blob).toHaveLength(config.length);
+
+        const lengths = transport.calls.filter((c) => c.value === CONFIG).map((c) => c.length);
+        expect(lengths).toEqual([9, config.length]);
+
+        await transport.getConfigDescriptor();
+        expect(transport.calls.filter((c) => c.value === CONFIG)).toHaveLength(2);
+    });
+});
+
+describe("getInterfaceDescriptors", () => {
+    it("counts interface descriptors from the blob and returns strings for the requested interface", async () => {
+        const config = buildConfig([
+            interfaceDescriptor({ number: 0, alternate: 0, iInterface: 4 }),
+            interfaceDescriptor({ number: 0, alternate: 1, iInterface: 5 }),
+            interfaceDescriptor({ number: 1, alternate: 0, iInterface: 6 }),
+        ]);
+        const transport = new ScriptedTransport({
+            config,
+            strings: { 4: "@Internal Flash", 5: "@Option Bytes", 6: "@OTP" },
+        });
+
+        expect(await transport.getInterfaceDescriptors(0)).toEqual(["@Internal Flash", "@Option Bytes"]);
+        expect(await transport.getInterfaceDescriptors(1)).toEqual(["@OTP"]);
+    });
+
+    it("returns nothing when the configuration exposes no interfaces", async () => {
+        const transport = new ScriptedTransport({ config: buildConfig([]) });
+        expect(await transport.getInterfaceDescriptors(0)).toEqual([]);
+    });
+});
+
+describe("getFunctionalDescriptor", () => {
+    it("parses it out of the configuration blob without a standalone request", async () => {
+        const config = buildConfig([interfaceDescriptor(), functionalDescriptor(2048)]);
+        const transport = new ScriptedTransport({ config });
+
+        const descriptor = await transport.getFunctionalDescriptor();
+        expect(descriptor.wTransferSize).toBe(2048);
+        expect(descriptor.bcdDFUVersion).toBe(0x011a);
+        // The STM32C5 ROM never answers this, so it must not be attempted.
+        expect(transport.calls.some((c) => c.value === 0x2100)).toBe(false);
+    });
+
+    it("ignores a HID descriptor that shares type 0x21 outside a DFU interface", async () => {
+        // Interface class 3 is HID, so its 0x21 descriptor must not be mistaken for DFU.
+        const config = buildConfig([
+            interfaceDescriptor({ cls: 0x03, subclass: 0x00 }),
+            functionalDescriptor(64),
+            interfaceDescriptor({ number: 1 }),
+            functionalDescriptor(1024),
+        ]);
+        const transport = new ScriptedTransport({ config });
+
+        expect((await transport.getFunctionalDescriptor()).wTransferSize).toBe(1024);
+    });
+
+    it("falls back to the standalone request when the blob has no functional descriptor", async () => {
+        const transport = new ScriptedTransport({
+            config: buildConfig([interfaceDescriptor()]),
+            standalone: functionalDescriptor(4096),
+        });
+
+        expect((await transport.getFunctionalDescriptor()).wTransferSize).toBe(4096);
+        expect(transport.calls.some((c) => c.value === 0x2100)).toBe(true);
+    });
+
+    it("rejects a standalone response that is not a usable descriptor", async () => {
+        const transport = new ScriptedTransport({
+            config: buildConfig([interfaceDescriptor()]),
+            standalone: functionalDescriptor(0),
+        });
+
+        await expect(transport.getFunctionalDescriptor()).rejects.toThrow(/Invalid DFU functional descriptor/);
+    });
+});


### PR DESCRIPTION
Groundwork for Android USB DFU. Independent of the other Tauri PRs and safe on its own: no behaviour change, no native code.

Every descriptor method in `WebUsbDfuTransport` turned out to be plain parsing on top of control transfers, but it lived inside the WebUSB transport, so a second transport would have had to duplicate it or push the same logic into native code. That is exactly what the Capacitor Android plugin had to do, and why it carries four descriptor commands in Java.

This moves LANGID negotiation, UTF-16LE string decoding, the two-phase configuration fetch, the descriptor-chain walk, and the functional-descriptor lookup (including the STM32C5 workaround and the HID disambiguation for the shared 0x21 type) onto a `UsbDfuDescriptors` base class that reads through a single `_rawControlTransferIn` primitive. `WebUsbDfuTransport` keeps only what genuinely needs `navigator.usb` and shrinks from 525 to 219 lines.

One real fix falls out. `getInterfaceDescriptors` counted interfaces via `usbDevice.configuration.interfaces` while `getInterfaceDescriptor` indexed into the raw configuration blob, so the count and the indexing came from two different views of the device. The count now comes from walking the blob for type 4 descriptors, which removes the layer's last dependency on WebUSB and makes the two consistent.

The consequence for the follow-up is that the Android native surface shrinks to open, claim, release, close, reset and raw control transfers, with no descriptor parsing in Kotlin or Rust at all. The one requirement is that its `controlTransferIn` accepts arbitrary `requestType`/`recipient`, since GET_DESCRIPTOR needs `standard`/`device`, which is precisely what the Capacitor plugin could not do.

Verified: the three existing DFU suites pass untouched, which matters because they drive the real `UsbDfuProtocol` against fake transports and also instantiate the real `WebUsbDfuTransport` with a stubbed `usbDevice` returning `DataView`s. Adds `usbDfuDescriptors.test.js`, which drives the new base class through a scripted primitive and covers LANGID fallback, string decoding, the two-phase fetch and caching, the interface count including alternate settings, and all three functional-descriptor paths.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added USB DFU descriptor support for configuration, interface, language, string, and functional descriptors.
  * Added descriptor caching with automatic refresh when the connection state changes.
  * Added timeout handling and fallback behavior to improve descriptor retrieval reliability.
* **Bug Fixes**
  * Improved descriptor validation to prevent HID descriptors from being misidentified as DFU descriptors.
* **Tests**
  * Added coverage for descriptor parsing, caching, fallbacks, string decoding, and invalid responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->