### PR TITLE
fix(serial): retry a Tauri write that lost the port lock

### DIFF
--- a/src/js/protocols/TauriSerial.js
+++ b/src/js/protocols/TauriSerial.js
@@ -30,6 +30,15 @@ function isBrokenPipeError(error) {
 }
 
 /**
+ * Detects a lost race for the port lock against the plugin's RX hub thread.
+ * The plugin returns this before touching the port, so no bytes reached the
+ * device and the chunk is safe to resend.
+ */
+function isLockTimeoutError(error) {
+    return /lock timeout/i.test(extractErrorMessage(error));
+}
+
+/**
  * Parse a vendor/product ID from the plugin response (may arrive as number or
  * string depending on OS backend).
  */
@@ -261,19 +270,6 @@ class TauriSerial extends EventTarget {
                 return await this._abortOpen(path);
             }
 
-            try {
-                await invoke("plugin:serialplugin|set_timeout", {
-                    path,
-                    timeout: 100,
-                });
-            } catch (e) {
-                console.debug(`${logHead} Could not set timeout:`, e);
-            }
-
-            if (this.openCanceled) {
-                return await this._abortOpen(path);
-            }
-
             const activePort = this.ports.find((p) => p.path === path);
             this.connected = true;
             this.connectionId = path;
@@ -425,10 +421,16 @@ class TauriSerial extends EventTarget {
             this.transmitting = true;
 
             const writeChunk = async (chunk) => {
-                await invoke("plugin:serialplugin|write_binary", {
-                    path: this.connectionId,
-                    value: Array.from(chunk),
-                });
+                const value = Array.from(chunk);
+                try {
+                    await invoke("plugin:serialplugin|write_binary", { path: this.connectionId, value });
+                } catch (error) {
+                    if (!isLockTimeoutError(error)) {
+                        throw error;
+                    }
+                    console.warn(`${logHead} Write lock timeout, resending chunk`);
+                    await invoke("plugin:serialplugin|write_binary", { path: this.connectionId, value });
+                }
             };
 
             if (this.isNeedBatchWrite) {

--- a/src/js/protocols/TauriSerial.js
+++ b/src/js/protocols/TauriSerial.js
@@ -33,6 +33,8 @@ function isBrokenPipeError(error) {
  * Detects a lost race for the port lock against the plugin's RX hub thread.
  * The plugin returns this before touching the port, so no bytes reached the
  * device and the chunk is safe to resend.
+ * @param {unknown} error - Rejection value from the plugin (string, Error or object).
+ * @returns {boolean} Whether the write failed on the port lock without transmitting.
  */
 function isLockTimeoutError(error) {
     return /lock timeout/i.test(extractErrorMessage(error));
@@ -422,14 +424,24 @@ class TauriSerial extends EventTarget {
 
             const writeChunk = async (chunk) => {
                 const value = Array.from(chunk);
+                const path = this.connectionId;
+                const session = this.connectionInfo;
                 try {
-                    await invoke("plugin:serialplugin|write_binary", { path: this.connectionId, value });
+                    await invoke("plugin:serialplugin|write_binary", { path, value });
                 } catch (error) {
                     if (!isLockTimeoutError(error)) {
                         throw error;
                     }
+                    // A disconnect (even one followed by a reconnect to the
+                    // same path) while the plugin held the write means this
+                    // chunk belongs to a dead session; resending would inject
+                    // it into the new one. connect() builds a fresh
+                    // connectionInfo per session, so identity is the check.
+                    if (this.connectionInfo !== session) {
+                        throw error;
+                    }
                     console.warn(`${logHead} Write lock timeout, resending chunk`);
-                    await invoke("plugin:serialplugin|write_binary", { path: this.connectionId, value });
+                    await invoke("plugin:serialplugin|write_binary", { path, value });
                 }
             };
 

--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// TauriSerial write path under tauri-plugin-serialplugin 3.x.
+//
+// 3.x spawns a background RX hub thread on open() that becomes the sole reader
+// of the fd and holds the port mutex through each 10 ms poll. A write that
+// loses that race fails with "serial port lock timeout after 250 ms" — a real,
+// rare failure measured against a PTY pair, and one that cannot happen on 2.x.
+//
+// The plugin returns that error before it touches the port, so no bytes reached
+// the device and the chunk can be resent. These tests pin that one retry, and
+// pin that it stays bounded and does not swallow other write errors.
+// ---------------------------------------------------------------------------
+
+const invoke = vi.hoisted(() => vi.fn());
+
+vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+
+vi.mock("../../src/js/protocols/devices", () => ({
+    serialDevices: [],
+    vendorIdNames: { 0x2e3c: "AT32" },
+}));
+
+vi.mock("../../src/js/gui", () => ({
+    default: { operating_system: "Linux" },
+}));
+
+const { default: TauriSerial } = await import("../../src/js/protocols/TauriSerial");
+
+const LOCK_TIMEOUT = "serial port lock timeout after 250 ms";
+const PORT = "/dev/ttyACM0";
+
+/**
+ * Queue outcomes for write_binary only. The constructor starts device
+ * monitoring, which issues its own invokes, so call-order mocking would hand
+ * the port-poll a write's result. The last outcome repeats.
+ */
+function mockWrites(...outcomes) {
+    let call = 0;
+    invoke.mockImplementation((cmd) => {
+        if (cmd !== "plugin:serialplugin|write_binary") {
+            return Promise.resolve(cmd === "plugin:serialplugin|available_ports" ? {} : undefined);
+        }
+        const outcome = outcomes[Math.min(call++, outcomes.length - 1)];
+        return typeof outcome === "string" ? Promise.reject(outcome) : Promise.resolve(outcome);
+    });
+}
+
+/** A TauriSerial already past connect(), with no read or monitor loop running. */
+function connectedSerial() {
+    const serial = new TauriSerial();
+    serial.stopDeviceMonitoring();
+    serial.connected = true;
+    serial.connectionId = PORT;
+    return serial;
+}
+
+const writeCalls = () => invoke.mock.calls.filter(([cmd]) => cmd === "plugin:serialplugin|write_binary");
+
+describe("TauriSerial write lock timeout", () => {
+    beforeEach(() => {
+        invoke.mockReset();
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("resends the chunk once and reports the full length", async () => {
+        mockWrites(LOCK_TIMEOUT, 4);
+        const serial = connectedSerial();
+        const callback = vi.fn();
+
+        const result = await serial.send(new Uint8Array([1, 2, 3, 4]), callback);
+
+        expect(result).toEqual({ bytesSent: 4 });
+        expect(callback).toHaveBeenCalledWith({ bytesSent: 4 });
+        expect(writeCalls()).toHaveLength(2);
+        // The resend must carry the same bytes, not a rebuilt or empty buffer.
+        expect(writeCalls()[1][1]).toEqual({ path: PORT, value: [1, 2, 3, 4] });
+        expect(serial.transmitting).toBe(false);
+    });
+
+    it("gives up after one retry rather than looping", async () => {
+        mockWrites(LOCK_TIMEOUT);
+        const serial = connectedSerial();
+
+        const result = await serial.send(new Uint8Array([1, 2, 3]));
+
+        expect(result).toEqual({ bytesSent: 0 });
+        expect(writeCalls()).toHaveLength(2);
+        // A lock timeout is contention, not a dead link — the port stays open.
+        expect(serial.connected).toBe(true);
+    });
+
+    it("does not retry an unrelated write error", async () => {
+        mockWrites("Port '/dev/ttyACM0' not found");
+        const serial = connectedSerial();
+
+        const result = await serial.send(new Uint8Array([1, 2, 3]));
+
+        expect(result).toEqual({ bytesSent: 0 });
+        expect(writeCalls()).toHaveLength(1);
+    });
+
+    it("still tears the connection down on a broken pipe", async () => {
+        mockWrites("Serial port disconnected: Broken pipe");
+        const serial = connectedSerial();
+
+        const result = await serial.send(new Uint8Array([1, 2, 3]));
+
+        expect(result).toEqual({ bytesSent: 0 });
+        expect(writeCalls()).toHaveLength(1);
+        expect(serial.connected).toBe(false);
+    });
+
+    it("retries only the failing chunk in batch write mode", async () => {
+        // AT32 on macOS splits writes into 63-byte chunks; a retry must not
+        // resend chunks that already reached the device.
+        mockWrites(63, LOCK_TIMEOUT, 63);
+        const serial = connectedSerial();
+        serial.isNeedBatchWrite = true;
+
+        const result = await serial.send(new Uint8Array(126).fill(7));
+
+        expect(result).toEqual({ bytesSent: 126 });
+        expect(writeCalls()).toHaveLength(3);
+        expect(writeCalls()[1][1].value).toEqual(writeCalls()[2][1].value);
+    });
+});
+
+describe("TauriSerial connect", () => {
+    beforeEach(() => {
+        invoke.mockReset();
+        vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    it("does not call the inert set_timeout command", async () => {
+        // set_timeout is a no-op on 3.x: the RX hub owns the fd and every
+        // command re-applies its own timeout to the guard before each op.
+        invoke.mockImplementation((cmd) => {
+            if (cmd === "plugin:serialplugin|read_binary") {
+                return Promise.resolve([]);
+            }
+            return Promise.resolve(undefined);
+        });
+        const serial = new TauriSerial();
+
+        const connected = await serial.connect(PORT, { baudRate: 115200 });
+        serial.reading = false;
+
+        expect(connected).toBe(true);
+        expect(invoke.mock.calls.map(([cmd]) => cmd)).not.toContain("plugin:serialplugin|set_timeout");
+    });
+});

--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // ---------------------------------------------------------------------------
 // TauriSerial write path under tauri-plugin-serialplugin 3.x.
@@ -50,9 +50,9 @@ function mockWrites(...outcomes) {
 /** A TauriSerial already past connect(), with no read or monitor loop running. */
 function connectedSerial() {
     const serial = new TauriSerial();
-    serial.stopDeviceMonitoring();
     serial.connected = true;
     serial.connectionId = PORT;
+    serial.connectionInfo = { connectionId: PORT, bitrate: 115200 };
     return serial;
 }
 
@@ -61,8 +61,15 @@ const writeCalls = () => invoke.mock.calls.filter(([cmd]) => cmd === "plugin:ser
 describe("TauriSerial write lock timeout", () => {
     beforeEach(() => {
         invoke.mockReset();
+        // _bootstrap() would start the 1 s device monitor asynchronously,
+        // leaking an interval into later tests; stub it out at the source.
+        vi.spyOn(TauriSerial.prototype, "startDeviceMonitoring").mockImplementation(() => {});
         vi.spyOn(console, "warn").mockImplementation(() => {});
         vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it("resends the chunk once and reports the full length", async () => {
@@ -126,12 +133,35 @@ describe("TauriSerial write lock timeout", () => {
         expect(writeCalls()).toHaveLength(3);
         expect(writeCalls()[1][1].value).toEqual(writeCalls()[2][1].value);
     });
+
+    it("does not resend into a new session after a disconnect and reconnect", async () => {
+        const serial = connectedSerial();
+        invoke.mockImplementation((cmd) => {
+            if (cmd !== "plugin:serialplugin|write_binary") {
+                return Promise.resolve(cmd === "plugin:serialplugin|available_ports" ? {} : undefined);
+            }
+            // While the plugin held the write, the user disconnected and
+            // reconnected to the same path: a fresh session, same connectionId.
+            serial.connectionInfo = { connectionId: PORT, bitrate: 115200 };
+            return Promise.reject(LOCK_TIMEOUT);
+        });
+
+        const result = await serial.send(new Uint8Array([1, 2, 3]));
+
+        expect(result).toEqual({ bytesSent: 0 });
+        expect(writeCalls()).toHaveLength(1);
+    });
 });
 
 describe("TauriSerial connect", () => {
     beforeEach(() => {
         invoke.mockReset();
+        vi.spyOn(TauriSerial.prototype, "startDeviceMonitoring").mockImplementation(() => {});
         vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it("does not call the inert set_timeout command", async () => {
@@ -140,6 +170,9 @@ describe("TauriSerial connect", () => {
         invoke.mockImplementation((cmd) => {
             if (cmd === "plugin:serialplugin|read_binary") {
                 return Promise.resolve([]);
+            }
+            if (cmd === "plugin:serialplugin|available_ports") {
+                return Promise.resolve({});
             }
             return Promise.resolve(undefined);
         });


### PR DESCRIPTION
Follow-up to #5373. That PR bumped `tauri-plugin-serialplugin` 2.21 to 3.0 for the Android nusb driver, and flagged that a desktop serial check was still outstanding. I have now done that check by measurement rather than by reading the source, and it turned up two things worth acting on.

The harness drives the real plugin command functions under `tauri::test::mock_app()` against a socat PTY pair, compiled against both 2.22 and 3.0.2. Unchanged between the two: the `available_ports` map shape and its value keys, write round-trip integrity, `close` semantics and error strings, and all six commands' argument names. 3.0.2 spawns a background RX hub thread on every `open()` that becomes the sole reader of the fd and holds the port mutex through each 10 ms poll, which accounts for all three deltas:

- Reads are roughly 10x faster (empty poll and partial read both 100 ms to 10 ms), taking an idle read loop from about 9 to about 66 IPC round trips per second.
- `set_timeout` is inert. Empty-read latency tracked it on 2.22 (100 ms to 1001 ms) and ignores it entirely on 3.0.2 (10.1 ms either way). It is inert on Android too, since the hub is not cfg-gated. So this drops the call we make after `open`.
- Writes pay a lock tax under inbound traffic (0.0 ms mean on 2.22 against 8.6 ms mean and 19.7 ms max on 3.0.2, at a saturated 115200) and can rarely fail outright with `serial port lock timeout after 250 ms`, seen once in about 7 runs of 50 writes under a 128 KB/s stream. Net per MSP request and response is still a clear win, roughly 19 ms against 100 ms.

That last failure is what this PR fixes. It cannot happen on 2.x, so it arrived with the bump. `write_binary` reaches the port through `with_port_try_lock`, which returns the timeout error before it invokes the closure that touches the port, so no bytes reached the device and the chunk is safe to resend. Without a retry the write reports `bytesSent: 0`, which nothing above the transport inspects, so recovery falls to MSP's 1 s reply timeout at 3 attempts; three consecutive failures abort a blackbox download, or for legacy `send_message()` callers leave the queue entry stranded with no callback. Retrying per chunk rather than per send keeps the AT32 batch path from resending bytes already on the wire. There is no JS backoff because the Rust helper already spins for 250 ms at 1 ms intervals.

`test/js/tauri_serial.test.js` is new and is the first `@tauri-apps/api/core` invoke mock in the suite, so it establishes that pattern. One trap for anyone extending it: the mock has to dispatch per command rather than per call order, because the `TauriSerial` constructor bootstraps device monitoring and will otherwise consume the values queued for a write. I checked the tests fail against the pre-change file (4 of the 6; the other 2 are regression guards asserting behaviour that should not change), so they are not trivially green.

Untested, and I would still like a hardware check: the retry path has never met a real lock timeout from a real flight controller, only a mocked `invoke`. The measurements are Linux only. macOS shares the serialport-rs POSIX path so most should carry, but its enumeration and the AT32 batch-write quirk are unexercised, and Windows now shells out to `wmic` per `available_ports` call. Real USB unplug is also untested, since only a PTY master close was tried, so an unplug could produce an errno the disconnect classifier does not recognise; a master close does yield a broken pipe error that the JS regex matches on both versions, and fatal teardown fires.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved serial data transfers by retrying once when a temporary port-lock timeout occurs.
  - Preserved active connections during recoverable lock contention.
  - Continued handling broken-pipe and other unexpected write errors appropriately.
  - Removed an ineffective serial timeout operation during connection setup.

- **Tests**
  - Added coverage for retry behavior, payload integrity, byte counts, failed chunks, connection retention, and disconnection handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->