### PR TITLE
fix(serial): invoke the send callback once, not twice

### DIFF
--- a/src/js/protocols/WebBluetooth.js
+++ b/src/js/protocols/WebBluetooth.js
@@ -467,7 +467,7 @@ class WebBluetooth extends EventTarget {
                 });
             }
             console.error(`${this.logHead} No write characteristic available or characteristic is invalid`);
-            return;
+            return { bytesSent: 0 };
         }
         if (!this.device?.gatt?.connected) {
             if (cb) {
@@ -477,11 +477,13 @@ class WebBluetooth extends EventTarget {
                 });
             }
             console.error(`${this.logHead} GATT Server is disconnected. Cannot perform GATT operations.`);
-            return;
+            return { bytesSent: 0 };
         }
 
         // There is no writable stream in the bluetooth API
         const dataBuffer = new Uint8Array(data);
+
+        let bytesSent = 0;
 
         // Serialize writes to prevent concurrent access
         this.writeQueue = this.writeQueue
@@ -489,6 +491,7 @@ class WebBluetooth extends EventTarget {
                 try {
                     await this.writeCharacteristic.writeValue(dataBuffer);
                     this.bytesSent += data.byteLength;
+                    bytesSent = data.byteLength;
 
                     if (cb) {
                         cb({
@@ -512,6 +515,7 @@ class WebBluetooth extends EventTarget {
             });
 
         await this.writeQueue;
+        return { bytesSent };
     }
 }
 

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -252,7 +252,9 @@ class Serial extends EventTarget {
     async send(data, callback) {
         let result;
         try {
-            result = (await this._protocol?.send(data)) ?? { bytesSent: 0 };
+            // Guard the method too: virtual mode has no send(), and that is a
+            // normal path, not an error to log.
+            result = (await this._protocol?.send?.(data)) ?? { bytesSent: 0 };
         } catch (error) {
             result = { bytesSent: 0 };
             console.error(`${this.logHead} Error sending data:`, error);

--- a/src/js/serial.js
+++ b/src/js/serial.js
@@ -244,12 +244,15 @@ class Serial extends EventTarget {
     }
 
     /**
-     * Send data through the serial connection
+     * Send data through the serial connection.
+     *
+     * The callback is invoked here and only here. Protocols must not be handed
+     * it, or every transport that fires it internally would deliver it twice.
      */
     async send(data, callback) {
         let result;
         try {
-            result = (await this._protocol?.send(data, callback)) ?? { bytesSent: 0 };
+            result = (await this._protocol?.send(data)) ?? { bytesSent: 0 };
         } catch (error) {
             result = { bytesSent: 0 };
             console.error(`${this.logHead} Error sending data:`, error);

--- a/test/js/serial_send_callback.test.js
+++ b/test/js/serial_send_callback.test.js
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// serial.send() callback contract.
+//
+// The facade used to pass `callback` down into the protocol AND invoke it
+// itself. Every transport fires the callback on each of its own exit paths, so
+// the caller's callback ran twice per send. That is not cosmetic: AutoBackup
+// passes `onClose` as a send callback, so a double call disconnected twice and
+// logged "serial port closed" twice.
+//
+// The contract pinned here: the facade is the single owner of the callback.
+// Protocols are handed no callback and are the single source of the byte count.
+// ---------------------------------------------------------------------------
+
+vi.mock("../../src/js/utils/checkCompatibility.js", () => ({
+    isAndroid: () => false,
+    isTauri: () => false,
+    isTauriIOS: () => false,
+    isTauriAndroid: () => false,
+}));
+
+const stub = (tag) =>
+    ({
+        [tag]: class extends EventTarget {},
+    })[tag];
+
+vi.mock("../../src/js/protocols/WebSerial.js", () => ({ default: stub("WebSerial") }));
+vi.mock("../../src/js/protocols/WebBluetooth.js", () => ({ default: stub("WebBluetooth") }));
+vi.mock("../../src/js/protocols/WebSocket.js", () => ({ default: stub("Websocket") }));
+vi.mock("../../src/js/protocols/VirtualSerial.js", () => ({ default: stub("VirtualSerial") }));
+vi.mock("../../src/js/protocols/CapacitorSerial.js", () => ({ default: stub("CapacitorSerial") }));
+vi.mock("../../src/js/protocols/CapacitorBle.js", () => ({ default: stub("CapacitorBle") }));
+vi.mock("../../src/js/protocols/CapacitorTcp.js", () => ({ default: stub("CapacitorTcp") }));
+vi.mock("../../src/js/protocols/TauriSerial.js", () => ({ default: stub("TauriSerial") }));
+vi.mock("../../src/js/protocols/TauriTcp.js", () => ({ default: stub("TauriTcp") }));
+vi.mock("../../src/js/protocols/TauriBle.js", () => ({ default: stub("TauriBle") }));
+
+let serial;
+// The singleton builds its slot table at module load.
+async function loadSerial() {
+    vi.resetModules();
+    ({ serial } = await import("../../src/js/serial.js"));
+}
+
+/**
+ * A transport that behaves like the real ones: it fires whatever callback it is
+ * handed, on every exit path. If the facade still passed one down, that is what
+ * would produce the second invocation.
+ */
+function fakeProtocol({ bytesSent = 0, throws = false, hasSend = true } = {}) {
+    const proto = { receivedCallbacks: [] };
+    if (hasSend) {
+        proto.send = vi.fn(async (data, cb) => {
+            proto.receivedCallbacks.push(cb);
+            cb?.({ error: null, bytesSent });
+            if (throws) {
+                throw new Error("write failed");
+            }
+            return { bytesSent };
+        });
+    }
+    return proto;
+}
+
+describe("serial.send callback contract", () => {
+    beforeEach(async () => {
+        await loadSerial();
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("invokes the callback exactly once on a successful send", async () => {
+        serial._protocol = fakeProtocol({ bytesSent: 12 });
+        const callback = vi.fn();
+
+        await serial.send(new Uint8Array(12), callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+    });
+
+    it("hands the protocol no callback, so it cannot fire a second one", async () => {
+        const proto = fakeProtocol({ bytesSent: 4 });
+        serial._protocol = proto;
+
+        await serial.send(new Uint8Array(4), vi.fn());
+
+        expect(proto.receivedCallbacks).toEqual([undefined]);
+    });
+
+    it("reports the protocol's real byte count, not zero", async () => {
+        serial._protocol = fakeProtocol({ bytesSent: 64 });
+        const callback = vi.fn();
+
+        const result = await serial.send(new Uint8Array(64), callback);
+
+        expect(result).toEqual({ bytesSent: 64 });
+        expect(callback).toHaveBeenCalledWith({ bytesSent: 64 });
+    });
+
+    it("invokes the callback exactly once when the protocol throws", async () => {
+        serial._protocol = fakeProtocol({ bytesSent: 8, throws: true });
+        const callback = vi.fn();
+
+        const result = await serial.send(new Uint8Array(8), callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith({ bytesSent: 0 });
+        expect(result).toEqual({ bytesSent: 0 });
+    });
+
+    it("invokes the callback exactly once in virtual mode, which has no send method", async () => {
+        // VirtualSerial defines no send(), so `?.` does not guard it and the call
+        // throws a TypeError the facade swallows. The facade is then the only
+        // thing that can fire the callback at all.
+        serial._protocol = fakeProtocol({ hasSend: false });
+        const callback = vi.fn();
+
+        const result = await serial.send(new Uint8Array(3), callback);
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({ bytesSent: 0 });
+    });
+});
+
+describe("WebBluetooth.send return value", () => {
+    // The facade's `?? { bytesSent: 0 }` is now the only value the caller sees,
+    // so a transport that returns undefined would silently report every send as
+    // zero bytes and break the msp.js bytesSent === byteLength check.
+    beforeEach(() => {
+        vi.resetModules();
+        vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    it("returns the byte count written, not undefined", async () => {
+        const { default: WebBluetooth } = await vi.importActual("../../src/js/protocols/WebBluetooth.js");
+        const ble = new WebBluetooth();
+        ble.writeCharacteristic = { writeValue: vi.fn().mockResolvedValue(undefined) };
+        ble.device = { gatt: { connected: true } };
+        ble.writeQueue = Promise.resolve();
+
+        const result = await ble.send(new Uint8Array(20));
+
+        expect(result).toEqual({ bytesSent: 20 });
+    });
+
+    it("returns zero bytes when there is no write characteristic", async () => {
+        const { default: WebBluetooth } = await vi.importActual("../../src/js/protocols/WebBluetooth.js");
+        const ble = new WebBluetooth();
+        ble.writeCharacteristic = null;
+
+        expect(await ble.send(new Uint8Array(5))).toEqual({ bytesSent: 0 });
+    });
+});

--- a/test/js/serial_send_callback.test.js
+++ b/test/js/serial_send_callback.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 
 // ---------------------------------------------------------------------------
 // serial.send() callback contract.
@@ -69,6 +69,10 @@ describe("serial.send callback contract", () => {
         vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
     it("invokes the callback exactly once on a successful send", async () => {
         serial._protocol = fakeProtocol({ bytesSent: 12 });
         const callback = vi.fn();
@@ -109,9 +113,9 @@ describe("serial.send callback contract", () => {
     });
 
     it("invokes the callback exactly once in virtual mode, which has no send method", async () => {
-        // VirtualSerial defines no send(), so `?.` does not guard it and the call
-        // throws a TypeError the facade swallows. The facade is then the only
-        // thing that can fire the callback at all.
+        // VirtualSerial defines no send(); the guarded call yields undefined and
+        // the facade reports zero bytes quietly. Virtual mode sends constantly,
+        // so this path must not log an error per send.
         serial._protocol = fakeProtocol({ hasSend: false });
         const callback = vi.fn();
 
@@ -119,6 +123,7 @@ describe("serial.send callback contract", () => {
 
         expect(callback).toHaveBeenCalledTimes(1);
         expect(result).toEqual({ bytesSent: 0 });
+        expect(console.error).not.toHaveBeenCalled();
     });
 });
 
@@ -129,6 +134,10 @@ describe("WebBluetooth.send return value", () => {
     beforeEach(() => {
         vi.resetModules();
         vi.spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
     });
 
     it("returns the byte count written, not undefined", async () => {
@@ -149,5 +158,15 @@ describe("WebBluetooth.send return value", () => {
         ble.writeCharacteristic = null;
 
         expect(await ble.send(new Uint8Array(5))).toEqual({ bytesSent: 0 });
+    });
+
+    it("returns zero bytes without writing when the GATT server is disconnected", async () => {
+        const { default: WebBluetooth } = await vi.importActual("../../src/js/protocols/WebBluetooth.js");
+        const ble = new WebBluetooth();
+        ble.writeCharacteristic = { writeValue: vi.fn() };
+        ble.device = { gatt: { connected: false } };
+
+        expect(await ble.send(new Uint8Array(5))).toEqual({ bytesSent: 0 });
+        expect(ble.writeCharacteristic.writeValue).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
`serial.send()` passed the caller's callback down into `this._protocol.send(data, callback)` and then invoked it again itself. Every registered transport already fires the callback on each of its own exit paths, so the caller's callback ran twice per send.

That is not just noise. `AutoBackup` passes `this.onClose.bind(this)` as a send callback, so running it twice calls `serial.disconnect()` twice and registers a second `disconnect` listener while overwriting `this.boundHandleDisconnect`, which leaves the first one unreachable for `cleanupListeners()`. `handleDisconnect` then fires twice and the "serial port closed" message is logged to the UI twice. MSP is the other consumer and gets off lighter: it just runs `callback_sent()` twice, and most callers pass `false` for it.

The fix makes the facade the single owner of the callback and hands the protocol none. It has to be that direction rather than the reverse, because dropping the facade's call would break three things that rely on it: `VirtualSerial` has no `send` method at all, so the optional chain does not guard it and the resulting `TypeError` is swallowed by the facade, which is then the only thing that can deliver the callback in virtual mode; and the not-connected paths in `WebSocket` and both TCP transports never fire the callback themselves.

`WebBluetooth.send()` needed one change to go with it. It fell off the end after awaiting its write queue and returned `undefined` on every path, which was harmless while its own callback ran first with the real count and the facade's second call merely overwrote it. Once the facade's return value is the only one the caller sees, `?? { bytesSent: 0 }` would have reported every BLE write as zero bytes and broken the `sendInfo.bytesSent === bufferOut.byteLength` check in `msp.js`. It now returns the byte count like every other transport.

The nine protocols keep their `callback` parameter, which is simply no longer passed anything. Stripping it would touch several transports that have no test or hardware coverage here, and three of them are Capacitor classes due for deletion, so that is left for the Capacitor removal.

`test/js/serial_send_callback.test.js` is new and pins the contract, which nothing did before: the callback fires exactly once on success, once when the protocol throws, and once in virtual mode, the protocol receives no callback, and the real byte count reaches the caller. I checked the tests fail against the pre-change code (5 of the 7; the other 2 assert behaviour that should not change), so they are not trivially green.

Not verified on hardware: no flight controller and no phone here. The AutoBackup double-disconnect is traced from source rather than observed, and BLE, TCP, WebSocket and the three Capacitor transports are all unexercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed serial send callbacks so they are invoked exactly once, including when errors occur or virtual transports are used.
  * Improved Bluetooth send results by accurately reporting bytes sent.
  * Added a safe zero-byte result when Bluetooth is disconnected or no write characteristic is available.

* **Documentation**
  * Clarified callback behavior for serial send operations.

* **Tests**
  * Added coverage for callback handling, byte counts, errors, and unavailable Bluetooth connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->