### PR TITLE
ci(nightly): one Android heading, runtime token in the filename

### DIFF
--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -297,7 +297,7 @@ jobs:
         run: |
           mkdir -p staging
           SHA_SHORT=$(echo "$COMMIT_SHA" | head -c 8)
-          APK_NAME="betaflight-app-${VERSION}-${SHA_SHORT}.apk"
+          APK_NAME="betaflight-${VERSION}-${SHA_SHORT}-capacitor.apk"
           cp android/app/build/outputs/apk/release/app-release.apk "staging/${APK_NAME}"
           echo "APK_NAME=${APK_NAME}" >> "$GITHUB_ENV"
 
@@ -320,7 +320,7 @@ jobs:
           mkdir -p manifest-fragments
           BASE="${PUBLIC_BASE%/}"
           SIZE=$(stat -c %s "staging/${APK_NAME}")
-          jq -n --arg label "Android APK" --arg url "${BASE}/${PREFIX}/${APK_NAME}" --argjson size "$SIZE" \
+          jq -n --arg label "Android (Capacitor)" --arg url "${BASE}/${PREFIX}/${APK_NAME}" --argjson size "$SIZE" \
             '{label: $label, url: $url, size: $size}' > manifest-fragments/android.json
 
       - name: Upload manifest fragment
@@ -409,7 +409,7 @@ jobs:
         run: |
           mkdir -p staging
           SHA_SHORT=$(echo "$COMMIT_SHA" | head -c 8)
-          APK_NAME="betaflight-app-tauri-${VERSION}-${SHA_SHORT}.apk"
+          APK_NAME="betaflight-${VERSION}-${SHA_SHORT}-tauri.apk"
           APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -path '*release*' | grep -iv unsigned | grep -i universal | head -1)
           if [ -z "$APK" ]; then
             APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -path '*release*' | grep -iv unsigned | head -1)
@@ -440,7 +440,7 @@ jobs:
           mkdir -p manifest-fragments
           BASE="${PUBLIC_BASE%/}"
           SIZE=$(stat -c %s "staging/${APK_NAME}")
-          jq -n --arg label "Android APK (Tauri)" --arg url "${BASE}/${PREFIX}/${APK_NAME}" --argjson size "$SIZE" \
+          jq -n --arg label "Android (Tauri)" --arg url "${BASE}/${PREFIX}/${APK_NAME}" --argjson size "$SIZE" \
             '{label: $label, url: $url, size: $size}' > manifest-fragments/tauri-android.json
 
       - name: Upload manifest fragment

--- a/.github/workflows/tauri-release-assets.yml
+++ b/.github/workflows/tauri-release-assets.yml
@@ -258,7 +258,7 @@ jobs:
         run: |
           mkdir -p staging
           VERSION=$(jq -r '.version' package.json)
-          APK_NAME="betaflight-app-${VERSION}.apk"
+          APK_NAME="betaflight-${VERSION}-tauri.apk"
           APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -path '*release*' | grep -iv unsigned | grep -i universal | head -1)
           if [ -z "$APK" ]; then
             APK=$(find src-tauri/gen/android/app/build/outputs/apk -name '*.apk' -path '*release*' | grep -iv unsigned | head -1)

--- a/scripts/generate-downloads-index.mjs
+++ b/scripts/generate-downloads-index.mjs
@@ -228,11 +228,10 @@ function renderNightlySection(nightly) {
         { key: "linux", title: "Linux" },
     ];
     const hasDesktop = platforms.some((p) => Array.isArray(desktop[p.key]) && desktop[p.key].length > 0);
-    const hasAndroid = Boolean(nightly?.android);
-    const tauriMobile = [nightly?.tauriAndroid].filter(Boolean);
-    const hasTauriMobile = tauriMobile.length > 0;
+    const android = [nightly?.android, nightly?.tauriAndroid].filter(Boolean);
+    const hasAndroid = android.length > 0;
 
-    if (!nightly || (!hasDesktop && !hasAndroid && !hasTauriMobile)) {
+    if (!nightly || (!hasDesktop && !hasAndroid)) {
         return `
             <section>
                 <h2>Nightly build</h2>
@@ -245,8 +244,7 @@ function renderNightlySection(nightly) {
         .map((p) => `<h3>${escapeHtml(p.title)}</h3>${fileList(desktop[p.key])}`)
         .join("");
 
-    const androidBlock = hasAndroid ? `<h3>Android</h3>${fileList([nightly.android])}` : "";
-    const tauriMobileBlock = hasTauriMobile ? `<h3>Mobile (Tauri)</h3>${fileList(tauriMobile)}` : "";
+    const androidBlock = hasAndroid ? `<h3>Android</h3>${fileList(android)}` : "";
 
     const commitShort = nightly.commit ? nightly.commit.slice(0, 8) : "";
     const metaParts = [];
@@ -269,7 +267,6 @@ function renderNightlySection(nightly) {
                 ${meta}
                 ${platformBlocks}
                 ${androidBlock}
-                ${tauriMobileBlock}
             </section>`;
 }
 

--- a/scripts/rename-tauri-bundles.mjs
+++ b/scripts/rename-tauri-bundles.mjs
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 /*
  * Normalises Tauri bundle filenames in a directory so they use a consistent
- * kebab-cased form: "Betaflight App" collapses to "betaflight-app", spaces
- * and underscores become dashes, and the x86_64 architecture token is left
- * intact. Optionally rewrites the version segment for nightly builds.
+ * kebab-cased form: the leading product token collapses to "betaflight",
+ * spaces and underscores become dashes, and the x86_64 architecture token is
+ * left intact. Optionally rewrites the version segment for nightly builds.
  *
  * Usage:
  *   node rename-tauri-bundles.mjs --dir <path>
@@ -12,6 +12,10 @@
 import { readdirSync, renameSync, statSync } from "node:fs";
 import { join } from "node:path";
 
+// Tauri derives bundle names from productName, whose casing (and any " App"
+// suffix) varies by bundle target; anchor the rewrite so only the leading
+// product token is touched and extensions such as .AppImage keep their case.
+const PRODUCT_TOKEN = /^betaflight(?:[ _-]app)?/i;
 const ARCH_TOKEN = "x86_64";
 const ARCH_PLACEHOLDER = "\u0000ARCH\u0000";
 const ALLOWED_FLAGS = new Set(["dir", "from-version", "to-version"]);
@@ -37,7 +41,7 @@ function parseArgs(argv) {
 }
 
 function normalise(name) {
-    let next = name.replaceAll("Betaflight App", "betaflight-app");
+    let next = name.replace(PRODUCT_TOKEN, "betaflight");
     next = next.replaceAll(ARCH_TOKEN, ARCH_PLACEHOLDER);
     next = next.replaceAll(" ", "-");
     next = next.replaceAll("_", "-");


### PR DESCRIPTION
The nightly downloads index split the two Android builds across separate `Android` and `Mobile (Tauri)` headings. Both are Android, so they now share one heading, and the filename carries the runtime instead of the heading (the file list renders the filename, not the manifest label, so the names had to become self-describing).

APK names follow the desktop bundles, with the runtime sitting where the architecture token does: `betaflight-<version>-<sha>-capacitor.apk` and `-tauri.apk`.

While there, `rename-tauri-bundles.mjs` was matching the literal `Betaflight App`, which stopped matching when productName became `Betaflight`. NSIS and DMG bundles kept a capital B while deb and rpm did not, so listings were mixed case. The rewrite is now anchored to the leading product token, which leaves `.AppImage` and `x86_64` intact.

Release assets get the same treatment, so a release differs from a nightly only by the absent commit segment:

```
betaflight-2026.12.0-d87f6ac8-x64-setup.exe    betaflight-2026.6.1-x64-setup.exe
betaflight-2026.12.0-d87f6ac8-aarch64.dmg      betaflight-2026.6.1-aarch64.dmg
betaflight-2026.12.0-d87f6ac8-amd64.deb        betaflight-2026.6.1-amd64.deb
betaflight-2026.12.0-d87f6ac8-capacitor.apk
betaflight-2026.12.0-d87f6ac8-tauri.apk        betaflight-2026.6.1-tauri.apk
```

The downloads page classifies assets by extension and arch on a lowercased name, so the renames do not disturb the release history grouping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Android APK filenames for nightly and release builds.
  * Improved build labels to distinguish Capacitor and Tauri packages.
  * Combined nightly Android downloads into a single Android section.
  * Improved handling of bundle names with varied capitalization, separators, and file extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->