### PR TITLE
fix(android): sync the Capacitor APK version and give it its own id (2026.6-maintenance backport)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,8 @@ jobs:
       # signed with the Android debug keystore, which is enough for test installs.
       - name: Build debug APK
         if: ${{ inputs.debug_build }}
+        env:
+          ANDROID_BUILD_NUMBER: ${{ github.run_number }}
         run: |
           pushd android >/dev/null
           ./gradlew clean
@@ -105,6 +107,7 @@ jobs:
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
+          ANDROID_BUILD_NUMBER: ${{ github.run_number }}
         run: |
           : "${RELEASE_KEYSTORE_BASE64:?Set the RELEASE_KEYSTORE secret with your base64-encoded keystore}"
           : "${RELEASE_KEYSTORE_PASSWORD:?Set the RELEASE_KEYSTORE_PASSWORD secret with your keystore password}"

--- a/.github/workflows/tauri-nightly.yml
+++ b/.github/workflows/tauri-nightly.yml
@@ -272,6 +272,7 @@ jobs:
           RELEASE_KEYSTORE_PASSWORD: ${{ secrets.RELEASE_KEYSTORE_PASSWORD }}
           RELEASE_KEY_ALIAS: ${{ secrets.RELEASE_KEY_ALIAS }}
           RELEASE_KEY_ALIAS_PASSWORD: ${{ secrets.RELEASE_KEY_ALIAS_PASSWORD }}
+          ANDROID_BUILD_NUMBER: ${{ github.run_number }}
         run: |
           : "${RELEASE_KEYSTORE_BASE64:?Set the RELEASE_KEYSTORE secret with your base64-encoded keystore}"
           : "${RELEASE_KEYSTORE_PASSWORD:?Set the RELEASE_KEYSTORE_PASSWORD secret with your keystore password}"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,14 +1,26 @@
+import groovy.json.JsonSlurper
+import java.time.Year
+
 apply plugin: 'com.android.application'
 
+def appVersion = new JsonSlurper().parseText(file("../../package.json").text).version
+def buildNumberEnv = System.getenv("ANDROID_BUILD_NUMBER")
+def buildNumber = buildNumberEnv?.isInteger() ? buildNumberEnv.toInteger() : 0
+
 android {
+    // namespace stays betaflight.app because the Java sources live in that
+    // package; only applicationId identifies the installed app.
     namespace = "betaflight.app"
     compileSdk = rootProject.ext.compileSdkVersion
     defaultConfig {
-        applicationId "betaflight.app"
+        applicationId "com.betaflight.app.capacitor"
         minSdk = rootProject.ext.minSdkVersion
         targetSdk = rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0"
+        // Mirrors the Tauri Android scheme in src-tauri/gen/android/app/build.gradle.kts:
+        // <calendar year>000000 + CI build number, floored at 2026006000, so every
+        // build outranks the last. Valid until 2099 (< 2.1e9 cap).
+        versionCode Math.max(Year.now().value * 1000000, 2026006000) + buildNumber
+        versionName buildNumber > 0 ? "${appVersion}.${buildNumber}" : appVersion
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -2,6 +2,6 @@
 <resources>
     <string name="app_name">Betaflight App</string>
     <string name="title_activity_main">Betaflight App</string>
-    <string name="package_name">betaflight.app</string>
-    <string name="custom_url_scheme">betaflight.app</string>
+    <string name="package_name">com.betaflight.app.capacitor</string>
+    <string name="custom_url_scheme">com.betaflight.app.capacitor</string>
 </resources>

--- a/capacitor.config.base.json
+++ b/capacitor.config.base.json
@@ -1,5 +1,5 @@
 {
-  "appId": "betaflight.app",
+  "appId": "com.betaflight.app.capacitor",
   "appName": "Betaflight App",
   "webDir": "src/dist"
 }


### PR DESCRIPTION
Backport of #5389 to 2026.6-maintenance.

Every Capacitor APK we have shipped went out as `versionCode 1` / `versionName "1.0"`, hardcoded in `android/app/build.gradle` and never synced from `package.json`, so a newer release cannot upgrade over an older one. versionCode and versionName now follow the same scheme as the Tauri Android build:

```
versionCode = max(year * 1_000_000, 2026006000) + ANDROID_BUILD_NUMBER
versionName = <package.json version>[.<build number>]
```

`build.yml` and the nightly pass `github.run_number`; unset or non-numeric falls back to 0 and the floor.

applicationId moves to `com.betaflight.app.capacitor` so it no longer collides with the Tauri app's `com.betaflight.app`. `namespace` stays `betaflight.app` because the Java sources live there.

Verified against the real Gradle evaluation on this branch (package.json 2026.6.1):

```
ANDROID_BUILD_NUMBER unset -> versionCode=2026006000 versionName=2026.6.1
ANDROID_BUILD_NUMBER=6123  -> versionCode=2026012123 versionName=2026.6.1.6123
```

The only difference from #5389 is the `build.yml` step guards, which on this branch have no `build_apk` input.

Note for anyone sideloading: because the package id changes, an existing Capacitor install will not upgrade in place, it appears as a separate app.