### PR TITLE
downloads page: call it the app, not the configurator

### DIFF
--- a/scripts/templates/downloads-index.html
+++ b/scripts/templates/downloads-index.html
@@ -6,7 +6,7 @@
         <title>Betaflight downloads</title>
         <meta
             name="description"
-            content="Download Betaflight Configurator nightly builds, stable releases, and the web app."
+            content="Download the Betaflight app: nightly builds, stable releases, and the web app."
         />
         <link rel="icon" type="image/png" href="favicon.png" />
         <style>


### PR DESCRIPTION
The downloads page named the product "Betaflight Configurator" in its meta description, which is the text search engines and link previews show. We only ever call it the app.

That description was the only authored prose on the page using the old name. Checked against the live page at downloads.betaflight.com and a local render of the full release history; the only other matches are the footer's source link, which correctly carries the repo's current path, and the fixed asset filenames on the 10.9.0/10.10.0 era releases.

Both of those follow the repo name rather than the product name, so a future repo rename picks them up on its own.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the downloads page description to refer to the Betaflight app instead of Betaflight Configurator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->