### PR TITLE
Allow dragging and dropping a log file onto the Blackbox Viewer tab

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,8 @@
                 "minWidth": 1024,
                 "minHeight": 550,
                 "resizable": true,
-                "fullscreen": false
+                "fullscreen": false,
+                "dragDropEnabled": false
             }
         ]
     },

--- a/src/blackbox-viewer/App.vue
+++ b/src/blackbox-viewer/App.vue
@@ -350,11 +350,17 @@ function onDrop(e) {
     if (!appStore.viewerActive) {
         return;
     }
-    const item = e.dataTransfer.items?.[0];
-    const entry = item?.webkitGetAsEntry?.();
-    if (entry?.isFile) {
-        appStore.loadFiles?.([e.dataTransfer.files[0]]);
+    const file = e.dataTransfer.files?.[0];
+    if (!file) {
+        return;
     }
+    // Skip directory drops where the webview can tell us; not every webview implements
+    // webkitGetAsEntry, so a null entry must not block loading the file.
+    const entry = e.dataTransfer.items?.[0]?.webkitGetAsEntry?.();
+    if (entry && !entry.isFile) {
+        return;
+    }
+    appStore.loadFiles?.([file]);
 }
 onMounted(() => {
     document.addEventListener("dragover", onDragOver);

--- a/src/blackbox-viewer/components/WelcomePage.vue
+++ b/src/blackbox-viewer/components/WelcomePage.vue
@@ -34,6 +34,8 @@
                     </UTooltip>
                 </div>
 
+                <p class="welcome-drop-hint">…or drag and drop a log file anywhere in this tab</p>
+
                 <div class="welcome-help">
                     <UIcon name="i-lucide-help-circle" class="welcome-help-icon" />
                     <ULink
@@ -140,6 +142,12 @@ async function onDownload() {
     gap: 0.75rem;
     flex-wrap: wrap;
     justify-content: center;
+}
+
+.welcome-drop-hint {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+    margin: 0;
 }
 
 .welcome-help {


### PR DESCRIPTION
The viewer already registered window-level drop handlers, but dropping a log file did nothing in the desktop app: Tauri intercepts native file drops by default, so the HTML5 `drop` event never reaches the page. Nothing in the app uses Tauri's native drag-drop events, so this disables the interceptor (`dragDropEnabled: false`), which also unblocks the legend panel's drag reordering on Windows.

The drop handler now loads from `dataTransfer.files` directly and only uses `webkitGetAsEntry` to reject directory drops when the webview can report that (it previously discarded the file whenever no entry was returned). The welcome card also mentions the drop affordance now.

Verified in the browser build by dropping a 10 MB `.bbl` onto the tab (log parses and renders fully).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for loading the first log file dropped onto the tab, including broader browser compatibility.
  * Added guidance on the welcome page explaining that log files can be dragged and dropped anywhere in the tab.

* **Bug Fixes**
  * Directory drops are now rejected consistently.
  * Disabled fullscreen mode and drag-and-drop support for the application window configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->