### PR TITLE
fix(serial): make Tauri Android serial work

### DIFF
--- a/scripts/android-devtools.sh
+++ b/scripts/android-devtools.sh
@@ -12,17 +12,17 @@ PACKAGE="${PACKAGE:-com.betaflight.app}"
 PORT="${PORT:-9222}"
 
 DEVICE_ARGS=()
-if [ -n "${ANDROID_SERIAL:-}" ]; then
+if [[ -n "${ANDROID_SERIAL:-}" ]]; then
     DEVICE_ARGS=(-s "$ANDROID_SERIAL")
 fi
 
-if [ "${1:-}" = "console" ]; then
+if [[ "${1:-}" == "console" ]]; then
     echo "Tailing the webview console for $PACKAGE (Ctrl-C to stop)…" >&2
     exec adb "${DEVICE_ARGS[@]}" logcat -s Tauri/Console
 fi
 
 PID="$(adb "${DEVICE_ARGS[@]}" shell pidof "$PACKAGE" | tr -d '\r')"
-if [ -z "$PID" ]; then
+if [[ -z "$PID" ]]; then
     echo "$PACKAGE is not running — start it first." >&2
     exit 1
 fi
@@ -32,4 +32,13 @@ adb "${DEVICE_ARGS[@]}" forward "tcp:$PORT" "localabstract:webview_devtools_remo
 
 echo "DevTools for $PACKAGE (pid $PID) is on http://localhost:$PORT"
 echo "Open chrome://inspect#devices in Chrome and click 'inspect', or use the target list:"
-curl -s "http://localhost:$PORT/json/list" | grep -E '"(title|url|webSocketDebuggerUrl)"' || true
+
+# Bounded, and loud when it fails: a forward left over from a previous run of the
+# app points at a pid that is gone, and an unbounded request there just hangs.
+if targets="$(curl --fail --silent --show-error --connect-timeout 2 --max-time 5 \
+    "http://localhost:$PORT/json/list")"; then
+    printf '%s\n' "$targets" | grep -E '"(title|url|webSocketDebuggerUrl)"' || true
+else
+    echo "Could not read the DevTools target list on port $PORT — is the app still running?" >&2
+    exit 1
+fi

--- a/scripts/android-devtools.sh
+++ b/scripts/android-devtools.sh
@@ -21,8 +21,9 @@ if [[ "${1:-}" == "console" ]]; then
     exec adb "${DEVICE_ARGS[@]}" logcat -s Tauri/Console
 fi
 
-PID="$(adb "${DEVICE_ARGS[@]}" shell pidof "$PACKAGE" | tr -d '\r')"
-if [[ -z "$PID" ]]; then
+# pidof exits non-zero when nothing matches, which under `set -e` would abort
+# here and swallow the message below, so take its status as part of the test.
+if ! PID="$(adb "${DEVICE_ARGS[@]}" shell pidof "$PACKAGE" | tr -d '\r')" || [[ -z "$PID" ]]; then
     echo "$PACKAGE is not running — start it first." >&2
     exit 1
 fi

--- a/scripts/android-devtools.sh
+++ b/scripts/android-devtools.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Attach to the Tauri Android webview on a connected device.
+#
+#   ./scripts/android-devtools.sh          # forward DevTools, then open chrome://inspect
+#   ./scripts/android-devtools.sh console  # just tail the JS console in this terminal
+#
+# The DevTools socket is named after the app's pid, so this has to be re-run
+# after the app restarts.
+set -euo pipefail
+
+PACKAGE="${PACKAGE:-com.betaflight.app}"
+PORT="${PORT:-9222}"
+
+DEVICE_ARGS=()
+if [ -n "${ANDROID_SERIAL:-}" ]; then
+    DEVICE_ARGS=(-s "$ANDROID_SERIAL")
+fi
+
+if [ "${1:-}" = "console" ]; then
+    echo "Tailing the webview console for $PACKAGE (Ctrl-C to stop)…" >&2
+    exec adb "${DEVICE_ARGS[@]}" logcat -s Tauri/Console
+fi
+
+PID="$(adb "${DEVICE_ARGS[@]}" shell pidof "$PACKAGE" | tr -d '\r')"
+if [ -z "$PID" ]; then
+    echo "$PACKAGE is not running — start it first." >&2
+    exit 1
+fi
+
+adb "${DEVICE_ARGS[@]}" forward --remove "tcp:$PORT" 2>/dev/null || true
+adb "${DEVICE_ARGS[@]}" forward "tcp:$PORT" "localabstract:webview_devtools_remote_$PID" >/dev/null
+
+echo "DevTools for $PACKAGE (pid $PID) is on http://localhost:$PORT"
+echo "Open chrome://inspect#devices in Chrome and click 'inspect', or use the target list:"
+curl -s "http://localhost:$PORT/json/list" | grep -E '"(title|url|webSocketDebuggerUrl)"' || true

--- a/src/js/protocols/TauriSerial.js
+++ b/src/js/protocols/TauriSerial.js
@@ -108,15 +108,22 @@ function isLockTimeoutError(error) {
  * @returns {number|undefined} The numeric ID, or undefined when absent/unparseable.
  */
 function parseId(value) {
-    if (value === undefined || value === null) {
-        return undefined;
-    }
     if (typeof value === "number") {
         return value;
     }
-    const text = String(value).trim();
-    const parsed = Number.parseInt(text, /^0x/i.test(text) ? 16 : 10);
-    return Number.isNaN(parsed) ? undefined : parsed;
+    // Anything that is not a string cannot be an ID from either backend, and
+    // stringifying it would only produce "[object Object]" to fail on below.
+    if (typeof value !== "string") {
+        return undefined;
+    }
+    const text = value.trim();
+    // Match the whole string, because parseInt stops at the first invalid
+    // character: "1155unknown" would otherwise read as 1155 and promote an
+    // unrecognised device into the known-device list.
+    if (!/^(?:0x[0-9a-f]+|[0-9]+)$/i.test(text)) {
+        return undefined;
+    }
+    return Number.parseInt(text, /^0x/i.test(text) ? 16 : 10);
 }
 
 /**

--- a/src/js/protocols/TauriSerial.js
+++ b/src/js/protocols/TauriSerial.js
@@ -5,6 +5,49 @@ import GUI from "../gui";
 const logHead = "[TAURI SERIAL]";
 
 /**
+ * Bytes to request per `read_binary` poll.
+ *
+ * This is a correctness bound, not a tuning knob. The plugin's RX hub reads the
+ * port into a 1024-byte buffer and hands the whole chunk to the pending read
+ * slot, which keeps only what fits in the requested size and DROPS the rest —
+ * the remainder is not pushed back onto its idle buffer. Asking for less than a
+ * hub chunk therefore silently loses the tail of every burst above that size,
+ * which corrupts any MSP response longer than the request (MSP_BOXNAMES fails
+ * its CRC first) and then desynchronises the stream.
+ *
+ * Staying well above the 1024-byte chunk keeps a poll that arrives mid-burst
+ * from ever being the shorter side, and staying under the hub's 64 KiB idle cap
+ * keeps the "idle already full" fast path reachable while a CLI dump streams.
+ */
+const READ_CHUNK_SIZE = 16384;
+
+/**
+ * Timeout handed to `read_binary`, in milliseconds.
+ *
+ * Zero, so the call returns whatever the RX hub has already buffered instead of
+ * waiting for more. Any non-zero value is a wait held *inside* the plugin, and
+ * on Android that wait is not free: wry bridges the webview to Rust through a
+ * synchronous JavascriptInterface, so a command blocks the webview's JavaScript
+ * thread for its whole duration. Polling with a 10 ms wait sixty times a second
+ * parked that thread for most of every second, starving rendering and input.
+ *
+ * The loop paces itself with its own sleep instead, which yields to the event
+ * loop rather than blocking it.
+ */
+const READ_TIMEOUT_MS = 0;
+
+/**
+ * Pause between read polls, in milliseconds.
+ *
+ * With a non-blocking read the loop sets its own pace, and on Android every poll
+ * is a round trip across the synchronous webview bridge, so the pace is a real
+ * cost rather than a free spin. 20 ms keeps receive latency far inside the MSP
+ * status cadence while asking roughly a third as many round trips per second as
+ * the 5 ms spin this replaced.
+ */
+const READ_POLL_INTERVAL_MS = 20;
+
+/**
  * Extract a best-effort message string from an error value of unknown shape
  * (string | Error | plugin-returned object). Flattened from a nested ternary
  * so the sequence is easier to follow.
@@ -30,6 +73,22 @@ function isBrokenPipeError(error) {
 }
 
 /**
+ * Detects the plugin having dropped the port from its registry, which it does
+ * as soon as the device leaves the bus.
+ *
+ * A flight controller re-enumerates on every reboot — "Save and Reboot", exiting
+ * the bootloader — and on Android the port path is the USB device node, so the
+ * old path is gone for good rather than reappearing. Treating this as fatal
+ * stops the read loop and the MSP queue from hammering a dead path for the
+ * second or so it takes the hotplug poll to notice.
+ * @param {unknown} error - Rejection value from the plugin (string, Error or object).
+ * @returns {boolean} Whether the port no longer exists.
+ */
+function isPortGoneError(error) {
+    return /not found|is not open|disconnected|detached/i.test(extractErrorMessage(error));
+}
+
+/**
  * Detects a lost race for the port lock against the plugin's RX hub thread.
  * The plugin returns this before touching the port, so no bytes reached the
  * device and the chunk is safe to resend.
@@ -41,14 +100,23 @@ function isLockTimeoutError(error) {
 }
 
 /**
- * Parse a vendor/product ID from the plugin response (may arrive as number or
- * string depending on OS backend).
+ * Parse a vendor/product ID from the plugin response. The shape depends on the
+ * backend: the desktop serialport enumerator stringifies the numbers as decimal
+ * ("1155"), while the Android USB bridge formats them as hex ("0x0483"). Ports
+ * with no USB descriptor report the literal "Unknown".
+ * @param {unknown} value - Raw `vid`/`pid` field from `available_ports`.
+ * @returns {number|undefined} The numeric ID, or undefined when absent/unparseable.
  */
 function parseId(value) {
     if (value === undefined || value === null) {
         return undefined;
     }
-    return typeof value === "number" ? value : Number.parseInt(value, 10);
+    if (typeof value === "number") {
+        return value;
+    }
+    const text = String(value).trim();
+    const parsed = Number.parseInt(text, /^0x/i.test(text) ? 16 : 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
 }
 
 /**
@@ -111,8 +179,9 @@ class TauriSerial extends EventTarget {
     }
 
     handleFatalSerialError() {
-        // On fatal errors (broken pipe, etc.) just disconnect cleanly.
-        // The monitor loop will surface the removal as a removedDevice event.
+        // On fatal errors (broken pipe, port gone) just disconnect cleanly. The
+        // monitor loop resumes once we are disconnected and surfaces the removal
+        // as a removedDevice event, which is what the reconnect cycle waits for.
         if (this.connected) {
             this.disconnect();
         }
@@ -129,6 +198,17 @@ class TauriSerial extends EventTarget {
         // emit duplicate/missed hotplug events.
         this.deviceMonitorInterval = setInterval(async () => {
             if (this.deviceCheckInFlight) {
+                return;
+            }
+            // Enumeration is for finding a device to connect to, so it has no job
+            // while one is open — and on Android it is actively harmful there.
+            // `available_ports` crosses into Kotlin and queries the USB service on
+            // a single-threaded executor with an unbounded wait, over the same
+            // synchronous bridge the reads and writes use. Running it once a second
+            // underneath a live MSP session is what wedged that bridge and froze
+            // the app. Loss of the device is noticed by the read/write path
+            // instead, which is both safe and an order of magnitude quicker.
+            if (this.connected || this.openRequested) {
                 return;
             }
             this.deviceCheckInFlight = true;
@@ -227,6 +307,40 @@ class TauriSerial extends EventTarget {
         }
     }
 
+    /**
+     * Whether the transport still enumerates `path`, asked fresh rather than read
+     * from the cached list.
+     *
+     * Opening a path that has gone away is not a harmless failure on Android. The
+     * plugin's Kotlin bridge throws `device not found` for a vanished USB node,
+     * and its JNI wrapper leaks that exception: `with_env` only clears a pending
+     * exception after the call succeeds, so a throw returns early and leaves the
+     * exception set on the thread. Every later call over that bridge is then
+     * undefined — in practice the webview's JavaScript thread blocks inside
+     * `postMessage` and never comes back, which reads as the whole app freezing.
+     *
+     * This matters most straight after "Save and Reboot": the flight controller
+     * re-enumerates under a new device node, so the remembered path is dead while
+     * the reconnect cycle is retrying against it.
+     *
+     * Checked against the raw port map, not the known-device list, so this only
+     * ever answers "does this path exist".
+     * @param {string} path - Port path about to be opened.
+     * @returns {Promise<boolean>} Whether the transport still lists it.
+     * @private
+     */
+    async _portExists(path) {
+        try {
+            const portsMap = await invoke("plugin:serialplugin|available_ports");
+            return Object.hasOwn(portsMap ?? {}, path);
+        } catch (error) {
+            // An enumeration failure is not evidence the port is gone; let the
+            // open proceed and report the real error.
+            console.warn(`${logHead} Could not verify port ${path}:`, error);
+            return true;
+        }
+    }
+
     getDisplayName(path, vendorId, productId) {
         if (vendorId && productId) {
             const vendorName = vendorIdNames[vendorId] || `VID:${vendorId} PID:${productId}`;
@@ -243,6 +357,15 @@ class TauriSerial extends EventTarget {
 
         this.openRequested = true;
         this.openCanceled = false;
+
+        // Never hand the plugin a path it no longer enumerates — see _portExists.
+        if (!(await this._portExists(path))) {
+            console.log(`${logHead} Port ${path} is no longer present, not opening`);
+            this.openRequested = false;
+            this.openCanceled = false;
+            this.dispatchEvent(new CustomEvent("connect", { detail: false }));
+            return false;
+        }
 
         try {
             const openOptions = { path, baudRate };
@@ -358,8 +481,8 @@ class TauriSerial extends EventTarget {
         if (msg.includes("no data received")) {
             return "continue";
         }
-        if (isBrokenPipeError(error)) {
-            console.error(`${logHead} Fatal poll error (broken pipe) on ${this.connectionId}:`, error);
+        if (isBrokenPipeError(error) || isPortGoneError(error)) {
+            console.error(`${logHead} Fatal poll error on ${this.connectionId}:`, error);
             return "fatal";
         }
         console.warn(`${logHead} Poll error:`, error);
@@ -372,8 +495,8 @@ class TauriSerial extends EventTarget {
                 try {
                     const result = await invoke("plugin:serialplugin|read_binary", {
                         path: this.connectionId,
-                        size: 256,
-                        timeout: 10,
+                        size: READ_CHUNK_SIZE,
+                        timeout: READ_TIMEOUT_MS,
                     });
 
                     if (result && result.length > 0) {
@@ -381,12 +504,12 @@ class TauriSerial extends EventTarget {
                         this.dispatchEvent(new CustomEvent("receive", { detail: bytes }));
                     }
 
-                    await new Promise((resolve) => setTimeout(resolve, 5));
+                    await new Promise((resolve) => setTimeout(resolve, READ_POLL_INTERVAL_MS));
                 } catch (error) {
                     if (this._classifyReadError(error) === "fatal") {
                         throw error;
                     }
-                    await new Promise((resolve) => setTimeout(resolve, 5));
+                    await new Promise((resolve) => setTimeout(resolve, READ_POLL_INTERVAL_MS));
                 }
             }
         } catch (error) {
@@ -464,7 +587,7 @@ class TauriSerial extends EventTarget {
         } catch (error) {
             console.error(`${logHead} Error sending data:`, error);
             this.transmitting = false;
-            if (isBrokenPipeError(error)) {
+            if (isBrokenPipeError(error) || isPortGoneError(error)) {
                 this.handleFatalSerialError(error);
             }
             const res = { bytesSent: 0 };

--- a/src/js/protocols/TauriSerial.js
+++ b/src/js/protocols/TauriSerial.js
@@ -120,7 +120,7 @@ function parseId(value) {
     // Match the whole string, because parseInt stops at the first invalid
     // character: "1155unknown" would otherwise read as 1155 and promote an
     // unrecognised device into the known-device list.
-    if (!/^(?:0x[0-9a-f]+|[0-9]+)$/i.test(text)) {
+    if (!/^(?:0x[\da-f]+|\d+)$/i.test(text)) {
         return undefined;
     }
     return Number.parseInt(text, /^0x/i.test(text) ? 16 : 10);

--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -218,6 +218,15 @@ describe("TauriSerial port enumeration", () => {
 
         expect(ports).toEqual([]);
     });
+
+    it("drops a port whose IDs are only partly numeric", async () => {
+        // parseInt stops at the first invalid character, so a lenient parse would
+        // read "1155unknown" as 1155 and promote an unrecognised device into the
+        // known-device list.
+        const ports = await listPorts({ "/dev/ttyS0": { ...STM32_VCP, vid: "1155unknown", pid: "22336" } });
+
+        expect(ports).toEqual([]);
+    });
 });
 
 describe("TauriSerial connect", () => {

--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -18,8 +18,8 @@ const invoke = vi.hoisted(() => vi.fn());
 vi.mock("@tauri-apps/api/core", () => ({ invoke }));
 
 vi.mock("../../src/js/protocols/devices", () => ({
-    serialDevices: [],
-    vendorIdNames: { 0x2e3c: "AT32" },
+    serialDevices: [{ vendorId: 0x0483, productId: 0x5740 }],
+    vendorIdNames: { 0x2e3c: "AT32", 0x0483: "STM32" },
 }));
 
 vi.mock("../../src/js/gui", () => ({
@@ -100,13 +100,29 @@ describe("TauriSerial write lock timeout", () => {
     });
 
     it("does not retry an unrelated write error", async () => {
-        mockWrites("Port '/dev/ttyACM0' not found");
+        mockWrites("Failed to write binary data: Input/output error");
         const serial = connectedSerial();
 
         const result = await serial.send(new Uint8Array([1, 2, 3]));
 
         expect(result).toEqual({ bytesSent: 0 });
         expect(writeCalls()).toHaveLength(1);
+        // Not a dead link — an I/O hiccup leaves the port open.
+        expect(serial.connected).toBe(true);
+    });
+
+    it("tears the connection down once the plugin has dropped the port", async () => {
+        // A flight controller re-enumerates on every reboot, and on Android the
+        // path is the USB device node, so it never comes back. Without this the
+        // MSP queue keeps writing to a dead path until the 1 s hotplug poll
+        // catches up, which reads as a hang.
+        mockWrites("Port '/dev/ttyACM0' not found");
+        const serial = connectedSerial();
+
+        const result = await serial.send(new Uint8Array([1, 2, 3]));
+
+        expect(result).toEqual({ bytesSent: 0 });
+        expect(serial.connected).toBe(false);
     });
 
     it("still tears the connection down on a broken pipe", async () => {
@@ -153,6 +169,57 @@ describe("TauriSerial write lock timeout", () => {
     });
 });
 
+describe("TauriSerial port enumeration", () => {
+    // The plugin's two backends format the USB IDs differently: the desktop
+    // serialport enumerator stringifies them as decimal, the Android USB bridge
+    // as hex. Both must survive into the known-device filter, or the transport
+    // reports no ports at all on that platform.
+    const STM32_VCP = { type: "Usb", manufacturer: "Betaflight", product: "SPEEDYBEEF405MINI" };
+
+    beforeEach(() => {
+        invoke.mockReset();
+        vi.spyOn(TauriSerial.prototype, "startDeviceMonitoring").mockImplementation(() => {});
+        vi.spyOn(console, "log").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /** Resolve available_ports with `portsMap` and return the filtered port list. */
+    async function listPorts(portsMap) {
+        invoke.mockImplementation((cmd) =>
+            Promise.resolve(cmd === "plugin:serialplugin|available_ports" ? portsMap : undefined),
+        );
+        return new TauriSerial().getDevices();
+    }
+
+    it("parses the decimal IDs the desktop backend reports", async () => {
+        const ports = await listPorts({ "/dev/ttyACM0": { ...STM32_VCP, vid: "1155", pid: "22336" } });
+
+        expect(ports).toHaveLength(1);
+        expect(ports[0]).toMatchObject({ path: "/dev/ttyACM0", vendorId: 0x0483, productId: 0x5740 });
+    });
+
+    it("parses the hex IDs the Android backend reports", async () => {
+        const ports = await listPorts({ "/dev/bus/usb/002/003": { ...STM32_VCP, vid: "0x0483", pid: "0x5740" } });
+
+        expect(ports).toHaveLength(1);
+        expect(ports[0]).toMatchObject({
+            path: "/dev/bus/usb/002/003",
+            vendorId: 0x0483,
+            productId: 0x5740,
+            displayName: "Betaflight STM32",
+        });
+    });
+
+    it("drops a port whose IDs are unknown rather than reading them as zero", async () => {
+        const ports = await listPorts({ "/dev/ttyS0": { type: "Unknown", vid: "Unknown", pid: "Unknown" } });
+
+        expect(ports).toEqual([]);
+    });
+});
+
 describe("TauriSerial connect", () => {
     beforeEach(() => {
         invoke.mockReset();
@@ -164,6 +231,43 @@ describe("TauriSerial connect", () => {
         vi.restoreAllMocks();
     });
 
+    it("refuses to open a path the transport no longer lists", async () => {
+        // Opening a vanished USB node makes the plugin's Kotlin bridge throw, and
+        // its JNI wrapper leaves that exception pending, wedging every later call
+        // over the bridge. The reconnect after "Save and Reboot" aims at exactly
+        // such a stale path, so the open must not be attempted at all.
+        invoke.mockImplementation((cmd) =>
+            Promise.resolve(cmd === "plugin:serialplugin|available_ports" ? {} : undefined),
+        );
+        const serial = new TauriSerial();
+
+        const connected = await serial.connect(PORT, { baudRate: 115200 });
+
+        expect(connected).toBe(false);
+        expect(invoke.mock.calls.map(([cmd]) => cmd)).not.toContain("plugin:serialplugin|open");
+        // The flag must clear, or every later connect is refused as "already requested".
+        expect(serial.openRequested).toBe(false);
+    });
+
+    it("opens a path that is still present", async () => {
+        invoke.mockImplementation((cmd) => {
+            if (cmd === "plugin:serialplugin|available_ports") {
+                return Promise.resolve({ [PORT]: { type: "Usb", vid: "1155", pid: "22336" } });
+            }
+            if (cmd === "plugin:serialplugin|read_binary") {
+                return Promise.resolve([]);
+            }
+            return Promise.resolve(undefined);
+        });
+        const serial = new TauriSerial();
+
+        const connected = await serial.connect(PORT, { baudRate: 115200 });
+        serial.reading = false;
+
+        expect(connected).toBe(true);
+        expect(invoke.mock.calls.map(([cmd]) => cmd)).toContain("plugin:serialplugin|open");
+    });
+
     it("does not call the inert set_timeout command", async () => {
         // set_timeout is a no-op on 3.x: the RX hub owns the fd and every
         // command re-applies its own timeout to the guard before each op.
@@ -172,7 +276,7 @@ describe("TauriSerial connect", () => {
                 return Promise.resolve([]);
             }
             if (cmd === "plugin:serialplugin|available_ports") {
-                return Promise.resolve({});
+                return Promise.resolve({ [PORT]: { type: "Usb", vid: "1155", pid: "22336" } });
             }
             return Promise.resolve(undefined);
         });
@@ -183,5 +287,31 @@ describe("TauriSerial connect", () => {
 
         expect(connected).toBe(true);
         expect(invoke.mock.calls.map(([cmd]) => cmd)).not.toContain("plugin:serialplugin|set_timeout");
+    });
+
+    it("polls for more bytes than the plugin's RX chunk can hold", async () => {
+        // The plugin's RX hub reads the port into a 1024-byte buffer and hands
+        // the whole chunk to the pending read slot, which keeps only what fits
+        // in the requested size and drops the remainder instead of buffering
+        // it. A request below one hub chunk therefore truncates every burst
+        // above it — MSP_BOXNAMES (~500 bytes) fails its CRC and the stream
+        // never resynchronises.
+        invoke.mockImplementation((cmd) => {
+            if (cmd === "plugin:serialplugin|read_binary") {
+                return Promise.resolve([]);
+            }
+            if (cmd === "plugin:serialplugin|available_ports") {
+                return Promise.resolve({ [PORT]: { type: "Usb", vid: "1155", pid: "22336" } });
+            }
+            return Promise.resolve(undefined);
+        });
+        const serial = new TauriSerial();
+
+        await serial.connect(PORT, { baudRate: 115200 });
+        serial.reading = false;
+
+        const read = invoke.mock.calls.find(([cmd]) => cmd === "plugin:serialplugin|read_binary");
+        expect(read).toBeDefined();
+        expect(read[1].size).toBeGreaterThan(1024);
     });
 });


### PR DESCRIPTION
Serial (VCP) did not work at all in the Tauri Android build. Three separate defects were in the way. Each was found and verified on hardware — a SpeedyBee F405 Mini on USB OTG, driven over ADB with the webview console and `logcat` side by side.

Bluetooth and DFU were unaffected because they never touch this code path, which is why serial was the odd one out.

## 1. No port was ever offered

`tauri-plugin-serialplugin` formats the USB IDs differently per backend. The desktop enumerator stringifies them as decimal, the Android USB bridge as hex:

```
enumerateJson: 1 device(s) json={"ports":{"/dev/bus/usb/002/003":
  {"type":"Usb","vid":"0x0483","pid":"0x5740","manufacturer":"Betaflight",
   "product":"Betaflight - SPEEDYBEEF405MINI",...}}}
```

`parseId()` parsed both with radix 10, so `Number.parseInt("0x0483", 10)` returned `0`. Every Android port arrived with `vendorId: 0` and was dropped by the known-device filter — the native side had been working the whole time, the port list just never survived the filter.

The radix now comes from the string, and an unparseable value (a port with no USB descriptor reports the literal `"Unknown"`) returns `undefined` rather than `NaN`.

## 2. Connecting corrupted the stream

The plugin's RX hub reads the port into a 1024-byte buffer and hands the whole chunk to the pending read slot. That slot keeps only what fits in the requested size and **discards the remainder** — it is not pushed back onto the hub's idle buffer:

```rust
// tauri-plugin-serialplugin-3.0.2/src/hub/shared.rs:601
let take = chunk.len().min(remaining);
slot.buffer.extend_from_slice(&chunk[..take]);   // chunk[take..] is dropped
```

The read loop asked for 256 bytes, so every burst above that lost its tail. `MSP_BOXNAMES` (~500 bytes) failed its CRC on every single connect and the stream never resynchronised, leaving MSP queueing requests that were never answered:

```
code: 116 (MSP_BOXNAMES) - crc failed
MSP: data request timed-out: 108 QUEUE: 32 (108,108,108,...)
```

Requesting 16 KiB — comfortably above one hub chunk — fixes it. After the change the connect sequence completes clean, System info is fully populated and the error counter reads 0 where it previously showed 3–5.

## 3. Rebooting the board froze the app

On Android the port path *is* the USB device node, so "Save and Reboot" brings the board back under a new one (`/dev/bus/usb/002/013` → `.../014`) while the reconnect still aims at the old, dead path.

Opening a vanished node makes the Kotlin bridge throw, and the plugin's JNI wrapper leaks that exception:

```rust
// tauri-plugin-serialplugin-3.0.2/src/android/fd_bridge.rs:46
env.with_local_frame(32, |env| {
    let out = f(env)?;                              // early-returns on Err…
    map_exception(env, "USB fd operation failed")?; // …so this never runs
    Ok(out)
})
```

`map_exception` holds the only `env.exception_clear()`. When Kotlin throws `device not found`, jni-rs returns `Err(JavaException)`, `?` bails out, and the pending exception stays set on the thread. Everything crossing that bridge afterwards is undefined — in practice the webview's JavaScript thread blocks inside `postMessage` and never returns:

```
[SERIAL-BACKEND] Connecting to: /dev/bus/usb/002/012
[TAURI SERIAL] Error connecting: Error invoking postMessage:
               Java exception was raised during method invocation
```

The trigger was ours to remove: the reconnect opened that path three seconds after the app had already logged `Found 0 serial ports`. `connect()` now confirms the path is still enumerated first, and a `not found` from the plugin is treated as fatal so the read loop and the MSP queue stop writing to a path that is gone, instead of spending a second hammering it.

After this, a full Save-and-Reboot cycle survives:

```
Configuration saved to EEPROM
[TAURI SERIAL] Polling stopped for /dev/bus/usb/002/013
[TAURI SERIAL] Port /dev/bus/usb/002/013 is no longer present, not opening
[TAURI SERIAL] Device added: /dev/bus/usb/002/014
[TAURI SERIAL] Connected to /dev/bus/usb/002/014
```

## Also here

- **Enumeration pauses while a port is open.** `available_ports` crosses into Kotlin and queries the USB service on a single-threaded executor with an unbounded wait, over the same synchronous bridge the reads and writes use. It has no job during a session — device loss is noticed by the read/write path, which is far quicker.
- **The read no longer asks the plugin to wait.** That wait is held across wry's synchronous JavascriptInterface, so it parked the webview's JavaScript thread for most of every second. The loop paces itself instead.
- **`scripts/android-devtools.sh`** attaches DevTools or tails the webview console on a connected device, which is what made any of this diagnosable.

## Known issue, not fixed here

A second freeze remains, and it is below this layer. It is silent — no Java exception, no Rust panic, no renderer crash, and USB is healthy to the last millisecond (`status=0` completions, a fresh read URB submitted, then nothing). `Runtime.evaluate` never returns and `Debugger.pause` never fires, with `CrRendererMain` in state `S`, so the thread is blocked in a native call rather than spinning in JS.

wry bridges Android IPC through a synchronous JavascriptInterface and every serialplugin command is a sync `#[tauri::command]`, so the renderer's JS thread is parked inside `postMessage` for the duration of each call, and one eventually does not come back. The changes here push it from 4–25 s out to 40–65 s but do not remove it. Already on the newest compatible wry 0.55.1 / tauri 2.11.1.

Fixing it properly needs the plugin itself:

1. `with_env` must clear a pending exception on the error path, not only after success.
2. RX needs a route that is not one synchronous IPC per poll. `watch` already pushes over a Tauri Channel, but is unusable for binary because `route_streaming` runs the bytes through `String::from_utf8_lossy` and line-trimming — fine for AT modems, fatal for MSP.

Vendoring a patched plugin behind a git rev, as is already done for `tauri-plugin-blec`, is the obvious route if upstream is slow.

## Testing

- SpeedyBee F405 Mini (BTFL 4.5.5, `0483:5740`) over USB OTG on Android, Tauri build.
- Port enumerates, auto-connect works, live telemetry at 126 Hz, Ports/Configuration/Setup all populate, 0 MSP errors.
- Disconnect/reconnect and a full Save-and-Reboot cycle both recover onto the new device node.
- `npm run test`: 758 passing, including new coverage for hex and decimal ID parsing, the read size bound, the fatal port-gone classification, and the refusal to open a path that is no longer listed.
- Desktop paths are unchanged in behaviour: decimal IDs still parse, and the larger read size is a strict superset of the old one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a utility for connecting Chrome DevTools to a running Android app and viewing console logs.
  * Added support for identifying serial ports using hexadecimal or decimal USB IDs.

* **Bug Fixes**
  * Improved handling when serial ports are removed or disconnected.
  * Prevented attempts to open stale or unavailable ports.
  * Improved non-blocking serial reads and error handling during connection loss.
  * Improved detection and validation of serial port identifiers.
  * Improved serial read performance with larger data buffers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->