### PR TITLE
fix(configuration): gate gyro cal on first arm behind API 1.47

### DIFF
--- a/src/components/tabs/ConfigurationTab.vue
+++ b/src/components/tabs/ConfigurationTab.vue
@@ -240,7 +240,7 @@ import { mspHelper } from "../../js/msp/MSPHelper.js";
 import { gui_log } from "../../js/gui_log";
 import { i18n } from "../../js/localization";
 import semver from "semver";
-import { API_VERSION_1_45, API_VERSION_1_46 } from "../../js/data_storage";
+import { API_VERSION_1_45, API_VERSION_1_46, API_VERSION_1_47 } from "../../js/data_storage";
 import { updateTabList } from "../../js/utils/updateTabList";
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "../elements/WikiButton.vue";
@@ -483,9 +483,12 @@ export default defineComponent({
             // Arming Config
             armingConfig.small_angle = fcStore.armingConfig.small_angle;
 
-            if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_46)) {
+            if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_47)) {
                 showGyroCalOnFirstArm.value = true;
                 armingConfig.gyro_cal_on_first_arm_bool = fcStore.armingConfig.gyro_cal_on_first_arm === 1;
+            }
+
+            if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_46)) {
                 armingConfig.auto_disarm_delay = fcStore.armingConfig.auto_disarm_delay;
             }
 
@@ -544,8 +547,11 @@ export default defineComponent({
                     }
 
                     fcStore.armingConfig.small_angle = armingConfig.small_angle;
-                    if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_46)) {
+                    if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_47)) {
                         fcStore.armingConfig.gyro_cal_on_first_arm = armingConfig.gyro_cal_on_first_arm_bool ? 1 : 0;
+                    }
+
+                    if (semver.gte(fcStore.config.apiVersion, API_VERSION_1_46)) {
                         fcStore.armingConfig.auto_disarm_delay = armingConfig.auto_disarm_delay;
                     }
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -522,7 +522,7 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     FC.ARMING_CONFIG.auto_disarm_delay = data.readU8();
                     data.readU8(); // was FC.ARMING_CONFIG.auto_disarm_kill_switch
                     FC.ARMING_CONFIG.small_angle = data.readU8();
-                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+                    if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
                         FC.ARMING_CONFIG.gyro_cal_on_first_arm = data.readU8();
                     }
                     break;
@@ -1949,7 +1949,7 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
                 .push8(FC.ARMING_CONFIG.auto_disarm_delay)
                 .push8(0) // was disarm_kill_switch
                 .push8(FC.ARMING_CONFIG.small_angle);
-            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_46)) {
+            if (semver.gte(FC.CONFIG.apiVersion, API_VERSION_1_47)) {
                 buffer.push8(FC.ARMING_CONFIG.gyro_cal_on_first_arm);
             }
             break;


### PR DESCRIPTION
### Problem

"Calibrate gyro on first arm" is offered on 4.5.x, but toggling it does nothing — confirmed by testing: the setting works on 2026.x and is silently ignored on 4.5.x.

### Cause

Not a regression from the Vue migration — the gate has been wrong since the feature was added in dfc04a21, which used `API_VERSION_1_46`.

The firmware side (betaflight/betaflight#13626, `e60224395`, 2024-05-22) landed while master still declared API 1.46; master only bumped to 1.47 on 2024-06-13, *after* 4.5 was released. So 4.5.x reports API 1.46 but has no fourth byte in `MSP_ARMING_CONFIG`. The configurator read a byte that isn't there and pushed one the firmware ignores. The field only exists from API 1.47 onwards.

### Fix

`API_VERSION_1_46` → `API_VERSION_1_47` for `gyro_cal_on_first_arm`:

- `MSPHelper.js` — read and write sides of `MSP_ARMING_CONFIG`
- `ConfigurationTab.vue` — `showGyroCalOnFirstArm` visibility, value load, and save path

`auto_disarm_delay` was bundled into the same conditional in the tab's load and save paths, but it is a genuine 1.46 field (and `showAutoDisarmDelay` still gates on 1.46), so it is split into its own 1.46 block and keeps working on 4.5.x.

### Result

- 4.5.x (API 1.46): the toggle is hidden instead of shown-but-inert; auto disarm delay unaffected.
- 2026.x (API 1.48): unchanged.

Lint clean, 819 tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for API version 1.47.
  * Gyro calibration on first arm is now available when supported by the connected flight controller.
  * Auto-disarm delay remains available from API version 1.46.

* **Bug Fixes**
  * Improved loading and saving of arming configuration settings for API version compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->