### PR TITLE
feat(connect): bookmark manual connections, with a SITL default

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -140,6 +140,34 @@
         "message": "Enter the serial path or URL to connect to.",
         "description": "Helper text in the connect dialog when choosing the manual port mode."
     },
+    "connectBookmarks": {
+        "message": "Saved connections",
+        "description": "Title of the saved manual connection (bookmark) list in the connect dialog."
+    },
+    "connectBookmarkName": {
+        "message": "Name:",
+        "description": "Label of the input naming a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkNamePlaceholder": {
+        "message": "Name for this connection",
+        "description": "Placeholder of the input naming a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkSave": {
+        "message": "Save",
+        "description": "Button that saves the entered address as a bookmark in the connect dialog."
+    },
+    "connectBookmarkUpdate": {
+        "message": "Update",
+        "description": "Button that renames the bookmark already pointing at the entered address."
+    },
+    "connectBookmarkRemove": {
+        "message": "Remove saved connection",
+        "description": "Button that deletes a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkLimitReached": {
+        "message": "The list of saved connections is full. Remove one to save another.",
+        "description": "Shown in the connect dialog when no more manual connections can be saved."
+    },
     "autoConnect": {
         "message": "Auto-Connect"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -164,10 +164,6 @@
         "message": "Remove saved connection",
         "description": "Button that deletes a saved manual connection in the connect dialog."
     },
-    "connectBookmarkLimitReached": {
-        "message": "The list of saved connections is full. Remove one to save another.",
-        "description": "Shown in the connect dialog when no more manual connections can be saved."
-    },
     "autoConnect": {
         "message": "Auto-Connect"
     },

--- a/src/components/device-picker/ConnectButton.vue
+++ b/src/components/device-picker/ConnectButton.vue
@@ -77,6 +77,31 @@ function connectManual(portOverride) {
     selectAndConnect("manual");
 }
 
+/**
+ * @param {Array<{displayName: string, path: string}>} devices - an enumerated device list
+ * @param {string} icon - the icon for that kind of device
+ * @returns {Array<object>} dropdown items connecting to each device
+ */
+function portItems(devices, icon) {
+    return devices.map((device) => ({
+        label: device.displayName,
+        icon,
+        onSelect: () => selectAndConnect(device.path),
+    }));
+}
+
+/**
+ * @param {Array<{name: string, url: string, builtin?: boolean}>} bookmarks - saved and built-in targets
+ * @returns {Array<object>} dropdown items connecting to each saved address
+ */
+function bookmarkItems(bookmarks) {
+    return bookmarks.map((bookmark) => ({
+        label: bookmark.name,
+        icon: bookmark.builtin ? "i-lucide-flask-conical" : "i-lucide-bookmark",
+        onSelect: () => connectManual(bookmark.url),
+    }));
+}
+
 function onDialogConfirm({ mode, version, portOverride }) {
     if (mode === "virtual") {
         DeviceHandler.devicePicker.virtualMspVersion = version;
@@ -157,60 +182,39 @@ export default defineComponent({
             dialogOpen.value = true;
         }
 
-        function buildDeviceItems() {
-            const expertMode = isExpertModeEnabled();
-            const devices = [];
-            if (DeviceHandler.showSerialOption) {
-                for (const d of serialPorts.value) {
-                    devices.push({
-                        label: d.displayName,
-                        icon: "i-lucide-usb",
-                        onSelect: () => selectAndConnect(d.path),
-                    });
-                }
-            }
-            if (DeviceHandler.showUsbOption) {
-                for (const d of usbPorts.value) {
-                    devices.push({
-                        label: d.displayName,
-                        icon: "i-lucide-cpu",
-                        onSelect: () => selectAndConnect(d.path),
-                    });
-                }
-            }
-            if (DeviceHandler.showBluetoothOption) {
-                for (const d of bluetoothPorts.value) {
-                    devices.push({
-                        label: d.displayName,
-                        icon: "i-lucide-bluetooth",
-                        onSelect: () => selectAndConnect(d.path),
-                    });
-                }
-            }
-            if (expertMode && DeviceHandler.showVirtualMode) {
-                devices.push({
+        function buildVirtualItems() {
+            return [
+                {
                     label: i18n.getMessage("portsSelectVirtual"),
                     icon: "i-lucide-flask-conical",
                     onSelect: () => openConnectDialog("virtual"),
-                });
-            }
-            if (expertMode && DeviceHandler.showManualMode) {
-                // Saved manual targets (and the built-in SITL one) connect in one click;
-                // the dialog is where they are managed.
-                for (const bookmark of bookmarksStore.items) {
-                    devices.push({
-                        label: bookmark.name,
-                        icon: bookmark.builtin ? "i-lucide-flask-conical" : "i-lucide-bookmark",
-                        onSelect: () => connectManual(bookmark.url),
-                    });
-                }
-                devices.push({
+                },
+            ];
+        }
+
+        // Saved manual targets (and the built-in SITL one) connect in one click;
+        // the dialog below them is where they are managed.
+        function buildManualItems() {
+            return [
+                ...bookmarkItems(bookmarksStore.items),
+                {
                     label: i18n.getMessage("portsSelectManual"),
                     icon: "i-lucide-keyboard",
                     onSelect: () => openConnectDialog("manual"),
-                });
-            }
-            return devices;
+                },
+            ];
+        }
+
+        function buildDeviceItems() {
+            const expertMode = isExpertModeEnabled();
+
+            return [
+                ...portItems(DeviceHandler.showSerialOption ? serialPorts.value : [], "i-lucide-usb"),
+                ...portItems(DeviceHandler.showUsbOption ? usbPorts.value : [], "i-lucide-cpu"),
+                ...portItems(DeviceHandler.showBluetoothOption ? bluetoothPorts.value : [], "i-lucide-bluetooth"),
+                ...(expertMode && DeviceHandler.showVirtualMode ? buildVirtualItems() : []),
+                ...(expertMode && DeviceHandler.showManualMode ? buildManualItems() : []),
+            ];
         }
 
         function buildPermissionItems() {

--- a/src/components/device-picker/ConnectButton.vue
+++ b/src/components/device-picker/ConnectButton.vue
@@ -56,6 +56,7 @@
 <script>
 import { defineComponent, computed, ref } from "vue";
 import { useConnectionStore } from "../../stores/connection";
+import { useConnectionBookmarksStore } from "../../stores/connectionBookmarks";
 import DeviceHandler from "../../js/device_handler";
 import { connectDisconnect, disconnect } from "../../js/serial_backend";
 import { i18n } from "../../js/localization";
@@ -68,15 +69,21 @@ function selectAndConnect(path) {
     connectDisconnect();
 }
 
+// A manual target (a serial path, or a tcp://ws:// address such as an ELRS Wi-Fi
+// module) connects through the "manual" pseudo-device, which reads portOverride.
+function connectManual(portOverride) {
+    DeviceHandler.devicePicker.portOverride = portOverride;
+    setConfig({ portOverride });
+    selectAndConnect("manual");
+}
+
 function onDialogConfirm({ mode, version, portOverride }) {
     if (mode === "virtual") {
         DeviceHandler.devicePicker.virtualMspVersion = version;
         setConfig({ virtualMspVersion: version });
         selectAndConnect("virtual");
     } else {
-        DeviceHandler.devicePicker.portOverride = portOverride;
-        setConfig({ portOverride });
-        selectAndConnect("manual");
+        connectManual(portOverride);
     }
 }
 
@@ -90,6 +97,7 @@ export default defineComponent({
     components: { ConnectOptionsDialog },
     setup() {
         const connectionStore = useConnectionStore();
+        const bookmarksStore = useConnectionBookmarksStore();
 
         const isConnected = computed(() => connectionStore.connectionValid);
         const connecting = computed(() => Boolean(connectionStore.connectingTo));
@@ -131,6 +139,11 @@ export default defineComponent({
             }
             if (selectedDevice.value === "virtual") {
                 return i18n.getMessage("connectVirtual");
+            }
+            // "manual" is never in the device lists, so name it by its bookmark or address.
+            if (selectedDevice.value === "manual") {
+                const url = DeviceHandler.devicePicker.portOverride;
+                return bookmarksStore.findItemByUrl(url)?.name || url || i18n.getMessage("connect");
             }
             return selectedDisplayName.value ?? i18n.getMessage("connect");
         });
@@ -182,6 +195,15 @@ export default defineComponent({
                 });
             }
             if (expertMode && DeviceHandler.showManualMode) {
+                // Saved manual targets (and the built-in SITL one) connect in one click;
+                // the dialog is where they are managed.
+                for (const bookmark of bookmarksStore.items) {
+                    devices.push({
+                        label: bookmark.name,
+                        icon: bookmark.builtin ? "i-lucide-flask-conical" : "i-lucide-bookmark",
+                        onSelect: () => connectManual(bookmark.url),
+                    });
+                }
                 devices.push({
                     label: i18n.getMessage("portsSelectManual"),
                     icon: "i-lucide-keyboard",

--- a/src/components/device-picker/ConnectButton.vue
+++ b/src/components/device-picker/ConnectButton.vue
@@ -91,13 +91,13 @@ function portItems(devices, icon) {
 }
 
 /**
- * @param {Array<{name: string, url: string, builtin?: boolean}>} bookmarks - saved and built-in targets
+ * @param {Array<{name: string, url: string}>} bookmarks - the saved targets
  * @returns {Array<object>} dropdown items connecting to each saved address
  */
 function bookmarkItems(bookmarks) {
     return bookmarks.map((bookmark) => ({
         label: bookmark.name,
-        icon: bookmark.builtin ? "i-lucide-flask-conical" : "i-lucide-bookmark",
+        icon: "i-lucide-bookmark",
         onSelect: () => connectManual(bookmark.url),
     }));
 }
@@ -168,7 +168,7 @@ export default defineComponent({
             // "manual" is never in the device lists, so name it by its bookmark or address.
             if (selectedDevice.value === "manual") {
                 const url = DeviceHandler.devicePicker.portOverride;
-                return bookmarksStore.findItemByUrl(url)?.name || url || i18n.getMessage("connect");
+                return bookmarksStore.find(url)?.name || url || i18n.getMessage("connect");
             }
             return selectedDisplayName.value ?? i18n.getMessage("connect");
         });
@@ -192,11 +192,10 @@ export default defineComponent({
             ];
         }
 
-        // Saved manual targets (and the built-in SITL one) connect in one click;
-        // the dialog below them is where they are managed.
+        // Saved targets connect in one click; the dialog below them is where they are managed.
         function buildManualItems() {
             return [
-                ...bookmarkItems(bookmarksStore.items),
+                ...bookmarkItems(bookmarksStore.bookmarks),
                 {
                     label: i18n.getMessage("portsSelectManual"),
                     icon: "i-lucide-keyboard",

--- a/src/components/device-picker/ConnectOptionsDialog.vue
+++ b/src/components/device-picker/ConnectOptionsDialog.vue
@@ -31,12 +31,12 @@
                         <!-- The name box and its save button sit on one row, so the label
                              points at the input by id rather than wrapping the row. -->
                         <label for="connect-bookmark-name">{{ $t("connectBookmarkName") }}</label>
-                        <div class="connect-options__save">
+                        <div class="flex items-center gap-2">
                             <UInput
                                 id="connect-bookmark-name"
                                 v-model="bookmarkName"
                                 size="sm"
-                                class="connect-options__save-input"
+                                class="min-w-0 grow"
                                 :placeholder="portOverride.trim() || $t('connectBookmarkNamePlaceholder')"
                                 :disabled="!canSaveBookmark"
                                 @keydown.enter.prevent="onSaveBookmark"
@@ -47,38 +47,26 @@
                                 size="sm"
                                 icon="i-lucide-bookmark-plus"
                                 :disabled="!canSaveBookmark"
-                                :title="saveBookmarkLabel"
                                 @click="onSaveBookmark"
                             >
                                 {{ saveBookmarkLabel }}
                             </UButton>
                         </div>
-                        <p v-if="bookmarksFull" class="connect-options__hint">
-                            {{ $t("connectBookmarkLimitReached") }}
-                        </p>
                     </div>
                     <div v-if="bookmarks.length" class="connect-options__field">
                         <span>{{ $t("connectBookmarks") }}</span>
-                        <ul class="connect-options__bookmarks">
-                            <li v-for="bookmark in bookmarks" :key="bookmark.id" class="connect-options__bookmark">
+                        <ul class="m-0 flex max-h-48 list-none flex-col gap-0.5 overflow-y-auto p-0">
+                            <li v-for="bookmark in bookmarks" :key="bookmark.url" class="flex items-center gap-1">
                                 <UButton
                                     color="neutral"
                                     variant="ghost"
                                     size="sm"
-                                    :icon="bookmark.builtin ? 'i-lucide-flask-conical' : 'i-lucide-bookmark'"
-                                    class="connect-options__bookmark-pick"
+                                    icon="i-lucide-bookmark"
+                                    class="min-w-0 grow justify-start truncate"
                                     :title="bookmark.url"
                                     @click="applyBookmark(bookmark)"
                                 >
-                                    <span class="connect-options__bookmark-text">
-                                        <span class="connect-options__bookmark-name">{{ bookmark.name }}</span>
-                                        <span
-                                            v-if="bookmark.name !== bookmark.url"
-                                            class="connect-options__bookmark-url"
-                                        >
-                                            {{ bookmark.url }}
-                                        </span>
-                                    </span>
+                                    {{ bookmark.name }}
                                 </UButton>
                                 <UButton
                                     color="error"
@@ -142,14 +130,11 @@ export default defineComponent({
         const bookmarkName = ref("");
 
         const bookmarksStore = useConnectionBookmarksStore();
-        const bookmarks = computed(() => bookmarksStore.items);
+        const bookmarks = computed(() => bookmarksStore.bookmarks);
 
-        // The saved bookmark for whatever address is in the field right now, so the save
-        // button can say "update". A built-in (SITL) match is not one: saving it makes a copy.
-        const matchingBookmark = computed(() => bookmarksStore.findByUrl(portOverride.value));
-        // Any entry for that address, built-ins included, so its name is offered back.
-        const matchingItem = computed(() => bookmarksStore.findItemByUrl(portOverride.value));
-        const bookmarksFull = computed(() => bookmarksStore.isFull && !matchingBookmark.value);
+        // The bookmark for whatever address is in the field right now: its name is offered
+        // back for editing, and the save button becomes an update.
+        const matching = computed(() => bookmarksStore.find(portOverride.value));
 
         watch(
             () => props.modelValue,
@@ -157,15 +142,15 @@ export default defineComponent({
                 if (isOpen) {
                     version.value = props.initialVersion;
                     portOverride.value = props.initialPortOverride;
-                    bookmarkName.value = matchingItem.value?.name ?? "";
+                    bookmarkName.value = matching.value?.name ?? "";
                 }
             },
         );
 
         // Typing a different address must not leave the previous bookmark's name behind,
         // or saving would relabel the wrong target.
-        watch(matchingItem, (entry) => {
-            bookmarkName.value = entry?.name ?? "";
+        watch(matching, (bookmark) => {
+            bookmarkName.value = bookmark?.name ?? "";
         });
 
         const title = computed(() =>
@@ -179,16 +164,13 @@ export default defineComponent({
             return Boolean(version.value);
         });
 
-        const canSaveBookmark = computed(() => portOverride.value.trim().length > 0 && !bookmarksFull.value);
+        const canSaveBookmark = computed(() => portOverride.value.trim().length > 0);
 
         const saveBookmarkLabel = computed(() =>
-            i18n.getMessage(matchingBookmark.value ? "connectBookmarkUpdate" : "connectBookmarkSave"),
+            i18n.getMessage(matching.value ? "connectBookmarkUpdate" : "connectBookmarkSave"),
         );
 
         function onSaveBookmark() {
-            if (!canSaveBookmark.value) {
-                return;
-            }
             bookmarksStore.save(portOverride.value, bookmarkName.value);
         }
 
@@ -197,7 +179,7 @@ export default defineComponent({
         }
 
         function removeBookmark(bookmark) {
-            bookmarksStore.remove(bookmark.id);
+            bookmarksStore.remove(bookmark.url);
         }
 
         function onCancel() {
@@ -222,7 +204,6 @@ export default defineComponent({
             portOverride,
             bookmarkName,
             bookmarks,
-            bookmarksFull,
             canSaveBookmark,
             saveBookmarkLabel,
             firmwareVersions: FIRMWARE_VERSIONS,
@@ -269,65 +250,5 @@ export default defineComponent({
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;
-}
-
-.connect-options__save {
-    display: flex;
-    gap: 0.5rem;
-    align-items: center;
-}
-
-.connect-options__save-input {
-    flex: 1 1 auto;
-    min-width: 0;
-}
-
-.connect-options__hint {
-    margin: 0;
-    font-size: 0.75rem;
-    color: var(--text);
-    opacity: 0.7;
-}
-
-.connect-options__bookmarks {
-    display: flex;
-    flex-direction: column;
-    gap: 0.125rem;
-    margin: 0;
-    padding: 0;
-    list-style: none;
-    max-height: 12rem;
-    overflow-y: auto;
-}
-
-.connect-options__bookmark {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-}
-
-.connect-options__bookmark-pick {
-    flex: 1 1 auto;
-    min-width: 0;
-    justify-content: flex-start;
-    text-align: left;
-}
-
-.connect-options__bookmark-text {
-    display: flex;
-    flex-direction: column;
-    min-width: 0;
-}
-
-.connect-options__bookmark-name,
-.connect-options__bookmark-url {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.connect-options__bookmark-url {
-    font-size: 0.75rem;
-    opacity: 0.7;
 }
 </style>

--- a/src/components/device-picker/ConnectOptionsDialog.vue
+++ b/src/components/device-picker/ConnectOptionsDialog.vue
@@ -102,6 +102,12 @@ import { computed, defineComponent, ref, watch } from "vue";
 import { i18n } from "../../js/localization";
 import { useConnectionBookmarksStore } from "../../stores/connectionBookmarks";
 
+/**
+ * @typedef {object} ConnectionBookmark
+ * @property {string} name - the label shown in the list and the connect menu
+ * @property {string} url - the manual target, e.g. "tcp://192.168.4.1:5761"
+ */
+
 const FIRMWARE_VERSIONS = [
     { value: "1.48.0", label: "MSP: 1.48 | Firmware: 2026.06.*" },
     { value: "1.47.0", label: "MSP: 1.47 | Firmware: 2025.12.*" },
@@ -174,10 +180,16 @@ export default defineComponent({
             bookmarksStore.save(portOverride.value, bookmarkName.value);
         }
 
+        /**
+         * @param {ConnectionBookmark} bookmark - the row the user picked
+         */
         function applyBookmark(bookmark) {
             portOverride.value = bookmark.url;
         }
 
+        /**
+         * @param {ConnectionBookmark} bookmark - the row the user dropped
+         */
         function removeBookmark(bookmark) {
             bookmarksStore.remove(bookmark.url);
         }

--- a/src/components/device-picker/ConnectOptionsDialog.vue
+++ b/src/components/device-picker/ConnectOptionsDialog.vue
@@ -28,9 +28,12 @@
                         />
                     </label>
                     <div class="connect-options__field">
-                        <span>{{ $t("connectBookmarkName") }}</span>
+                        <!-- The name box and its save button sit on one row, so the label
+                             points at the input by id rather than wrapping the row. -->
+                        <label for="connect-bookmark-name">{{ $t("connectBookmarkName") }}</label>
                         <div class="connect-options__save">
                             <UInput
+                                id="connect-bookmark-name"
                                 v-model="bookmarkName"
                                 size="sm"
                                 class="connect-options__save-input"
@@ -256,7 +259,8 @@ export default defineComponent({
     gap: 0.375rem;
 }
 
-.connect-options__field span {
+.connect-options__field > span,
+.connect-options__field > label {
     font-size: 0.875rem;
     color: var(--text);
 }

--- a/src/components/device-picker/ConnectOptionsDialog.vue
+++ b/src/components/device-picker/ConnectOptionsDialog.vue
@@ -14,17 +14,83 @@
                         :ui="{ content: 'max-h-96 z-3002' }"
                     />
                 </label>
-                <label v-else class="connect-options__field">
-                    <span>{{ $t("portOverrideText") }}</span>
-                    <UInput
-                        v-model="portOverride"
-                        size="sm"
-                        autofocus
-                        autocapitalize="none"
-                        autocorrect="off"
-                        spellcheck="false"
-                    />
-                </label>
+                <template v-else>
+                    <label class="connect-options__field">
+                        <span>{{ $t("portOverrideText") }}</span>
+                        <UInput
+                            v-model="portOverride"
+                            size="sm"
+                            autofocus
+                            autocapitalize="none"
+                            autocorrect="off"
+                            spellcheck="false"
+                            @keydown.enter="onConfirm"
+                        />
+                    </label>
+                    <div class="connect-options__field">
+                        <span>{{ $t("connectBookmarkName") }}</span>
+                        <div class="connect-options__save">
+                            <UInput
+                                v-model="bookmarkName"
+                                size="sm"
+                                class="connect-options__save-input"
+                                :placeholder="portOverride.trim() || $t('connectBookmarkNamePlaceholder')"
+                                :disabled="!canSaveBookmark"
+                                @keydown.enter.prevent="onSaveBookmark"
+                            />
+                            <UButton
+                                color="neutral"
+                                variant="soft"
+                                size="sm"
+                                icon="i-lucide-bookmark-plus"
+                                :disabled="!canSaveBookmark"
+                                :title="saveBookmarkLabel"
+                                @click="onSaveBookmark"
+                            >
+                                {{ saveBookmarkLabel }}
+                            </UButton>
+                        </div>
+                        <p v-if="bookmarksFull" class="connect-options__hint">
+                            {{ $t("connectBookmarkLimitReached") }}
+                        </p>
+                    </div>
+                    <div v-if="bookmarks.length" class="connect-options__field">
+                        <span>{{ $t("connectBookmarks") }}</span>
+                        <ul class="connect-options__bookmarks">
+                            <li v-for="bookmark in bookmarks" :key="bookmark.id" class="connect-options__bookmark">
+                                <UButton
+                                    color="neutral"
+                                    variant="ghost"
+                                    size="sm"
+                                    :icon="bookmark.builtin ? 'i-lucide-flask-conical' : 'i-lucide-bookmark'"
+                                    class="connect-options__bookmark-pick"
+                                    :title="bookmark.url"
+                                    @click="applyBookmark(bookmark)"
+                                >
+                                    <span class="connect-options__bookmark-text">
+                                        <span class="connect-options__bookmark-name">{{ bookmark.name }}</span>
+                                        <span
+                                            v-if="bookmark.name !== bookmark.url"
+                                            class="connect-options__bookmark-url"
+                                        >
+                                            {{ bookmark.url }}
+                                        </span>
+                                    </span>
+                                </UButton>
+                                <UButton
+                                    color="error"
+                                    variant="ghost"
+                                    size="sm"
+                                    square
+                                    icon="i-lucide-trash-2"
+                                    :aria-label="$t('connectBookmarkRemove')"
+                                    :title="$t('connectBookmarkRemove')"
+                                    @click="removeBookmark(bookmark)"
+                                />
+                            </li>
+                        </ul>
+                    </div>
+                </template>
             </div>
         </template>
         <template #footer>
@@ -43,6 +109,7 @@
 <script>
 import { computed, defineComponent, ref, watch } from "vue";
 import { i18n } from "../../js/localization";
+import { useConnectionBookmarksStore } from "../../stores/connectionBookmarks";
 
 const FIRMWARE_VERSIONS = [
     { value: "1.48.0", label: "MSP: 1.48 | Firmware: 2026.06.*" },
@@ -69,6 +136,17 @@ export default defineComponent({
 
         const version = ref(props.initialVersion);
         const portOverride = ref(props.initialPortOverride);
+        const bookmarkName = ref("");
+
+        const bookmarksStore = useConnectionBookmarksStore();
+        const bookmarks = computed(() => bookmarksStore.items);
+
+        // The saved bookmark for whatever address is in the field right now, so the save
+        // button can say "update". A built-in (SITL) match is not one: saving it makes a copy.
+        const matchingBookmark = computed(() => bookmarksStore.findByUrl(portOverride.value));
+        // Any entry for that address, built-ins included, so its name is offered back.
+        const matchingItem = computed(() => bookmarksStore.findItemByUrl(portOverride.value));
+        const bookmarksFull = computed(() => bookmarksStore.isFull && !matchingBookmark.value);
 
         watch(
             () => props.modelValue,
@@ -76,9 +154,16 @@ export default defineComponent({
                 if (isOpen) {
                     version.value = props.initialVersion;
                     portOverride.value = props.initialPortOverride;
+                    bookmarkName.value = matchingItem.value?.name ?? "";
                 }
             },
         );
+
+        // Typing a different address must not leave the previous bookmark's name behind,
+        // or saving would relabel the wrong target.
+        watch(matchingItem, (entry) => {
+            bookmarkName.value = entry?.name ?? "";
+        });
 
         const title = computed(() =>
             i18n.getMessage(props.mode === "virtual" ? "portsSelectVirtual" : "portsSelectManual"),
@@ -90,6 +175,27 @@ export default defineComponent({
             }
             return Boolean(version.value);
         });
+
+        const canSaveBookmark = computed(() => portOverride.value.trim().length > 0 && !bookmarksFull.value);
+
+        const saveBookmarkLabel = computed(() =>
+            i18n.getMessage(matchingBookmark.value ? "connectBookmarkUpdate" : "connectBookmarkSave"),
+        );
+
+        function onSaveBookmark() {
+            if (!canSaveBookmark.value) {
+                return;
+            }
+            bookmarksStore.save(portOverride.value, bookmarkName.value);
+        }
+
+        function applyBookmark(bookmark) {
+            portOverride.value = bookmark.url;
+        }
+
+        function removeBookmark(bookmark) {
+            bookmarksStore.remove(bookmark.id);
+        }
 
         function onCancel() {
             open.value = false;
@@ -111,9 +217,17 @@ export default defineComponent({
             open,
             version,
             portOverride,
+            bookmarkName,
+            bookmarks,
+            bookmarksFull,
+            canSaveBookmark,
+            saveBookmarkLabel,
             firmwareVersions: FIRMWARE_VERSIONS,
             title,
             canConfirm,
+            onSaveBookmark,
+            applyBookmark,
+            removeBookmark,
             onCancel,
             onConfirm,
         };
@@ -151,5 +265,65 @@ export default defineComponent({
     display: flex;
     justify-content: flex-end;
     gap: 0.5rem;
+}
+
+.connect-options__save {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.connect-options__save-input {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
+.connect-options__hint {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--text);
+    opacity: 0.7;
+}
+
+.connect-options__bookmarks {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    max-height: 12rem;
+    overflow-y: auto;
+}
+
+.connect-options__bookmark {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.connect-options__bookmark-pick {
+    flex: 1 1 auto;
+    min-width: 0;
+    justify-content: flex-start;
+    text-align: left;
+}
+
+.connect-options__bookmark-text {
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+}
+
+.connect-options__bookmark-name,
+.connect-options__bookmark-url {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.connect-options__bookmark-url {
+    font-size: 0.75rem;
+    opacity: 0.7;
 }
 </style>

--- a/src/stores/connectionBookmarks.js
+++ b/src/stores/connectionBookmarks.js
@@ -1,190 +1,90 @@
 import { defineStore } from "pinia";
-import { computed, ref } from "vue";
+import { ref } from "vue";
 import { get as getConfig, set as setConfig } from "../js/ConfigStorage";
 import { isAndroid, isTauri } from "../js/utils/checkCompatibility";
 
 const STORAGE_KEY = "connectionBookmarks";
-const HIDDEN_DEFAULTS_KEY = "connectionBookmarksHiddenDefaults";
 
-// A saved manual target is a short string ("tcp://192.168.4.1:5761"), so a generous
-// cap keeps a corrupted or hand-edited localStorage entry from flooding the connect menu.
+// A saved target is a short string ("tcp://192.168.4.1:5761"), so a generous cap keeps a
+// corrupted or hand-edited localStorage entry from flooding the connect menu.
 const MAX_BOOKMARKS = 50;
-const MAX_NAME_LENGTH = 64;
-const MAX_URL_LENGTH = 253;
-
-let idCounter = 0;
+const MAX_LENGTH = 253;
 
 /**
- * crypto.randomUUID() needs a secure context, which the configurator does not have when
- * it is served over plain HTTP from a LAN address, so the counter fallback is a path real
- * users take. It restarts at 1 on every load and therefore cannot be trusted to be unique
- * on its own — always mint ids through createUniqueId().
- * @returns {string} a candidate id
+ * SITL speaks raw TCP on 127.0.0.1:5761 and nothing else. A shell with a raw-TCP transport
+ * (Tauri desktop, Capacitor Android) connects straight to it; a browser has no raw sockets,
+ * so the docs put websockify in front (`websockify 127.0.0.1:6761 127.0.0.1:5761`) and the
+ * app connects to the proxy's own port — a different port, not 5761 with a ws:// scheme.
+ * @see https://betaflight.com/docs/development/autopilot/SITL_Autopilot_Testing_Gazebo#connect-to-the-sitl
  */
-function createId() {
-    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-        return crypto.randomUUID();
-    }
-    idCounter += 1;
-    return `bookmark-${idCounter}`;
+function sitlBookmark() {
+    return {
+        name: "Betaflight SITL",
+        url: isTauri() || isAndroid() ? "tcp://127.0.0.1:5761" : "ws://127.0.0.1:6761",
+    };
 }
 
-/**
- * @param {Set<string>} taken - ids already in use
- * @returns {string} an id that is not in `taken`
- */
-function createUniqueId(taken) {
-    let id = createId();
-
-    while (taken.has(id)) {
-        id = createId();
-    }
-
-    return id;
-}
-
-/**
- * Manual targets are network addresses far more often than serial paths, so compare
- * them case-insensitively: "TCP://Quad.local" and "tcp://quad.local" are one bookmark.
- * @param {string} url
- * @returns {string} the comparison key for an address
- */
-function normalizeUrl(url) {
-    return String(url ?? "")
+const clean = (value) =>
+    String(value ?? "")
         .trim()
-        .toLowerCase();
-}
+        .slice(0, MAX_LENGTH);
 
-function clamp(value, maxLength) {
-    return String(value ?? "")
-        .trim()
-        .slice(0, maxLength);
-}
+// Manual targets are network addresses far more often than serial paths, so they compare
+// case-insensitively: "TCP://Quad.local" and "tcp://quad.local" are one bookmark.
+const key = (url) => clean(url).toLowerCase();
 
 /**
- * Drop anything that is not a usable bookmark and give every survivor a unique id.
- * localStorage is user-writable and survives downgrades, so nothing here is trusted.
- * @param {*} stored - whatever was read back from storage
- * @returns {Array<{id: string, name: string, url: string}>}
+ * localStorage is user-writable and survives downgrades, so nothing read back is trusted.
+ * @param {*} stored - whatever was in storage
+ * @returns {Array<{name: string, url: string}>} usable bookmarks, one per address
  */
 function sanitize(stored) {
-    if (!Array.isArray(stored)) {
-        return [];
-    }
-
-    const seenUrls = new Set();
-    // Built-in ids are reserved: a stored bookmark carrying one would collide with the
-    // entry it is listed next to.
-    const seenIds = new Set(defaultBookmarks().map((entry) => entry.id));
     const bookmarks = [];
+    const seen = new Set();
 
-    for (const entry of stored) {
-        if (!entry || typeof entry !== "object") {
+    for (const entry of Array.isArray(stored) ? stored : []) {
+        const url = clean(entry?.url);
+
+        if (!url || seen.has(key(url)) || bookmarks.length >= MAX_BOOKMARKS) {
             continue;
         }
 
-        const url = clamp(entry.url, MAX_URL_LENGTH);
-        const key = normalizeUrl(url);
-
-        if (!url || seenUrls.has(key)) {
-            continue;
-        }
-
-        const stored = typeof entry.id === "string" && entry.id ? entry.id : null;
-        const id = stored && !seenIds.has(stored) ? stored : createUniqueId(seenIds);
-
-        seenUrls.add(key);
-        seenIds.add(id);
-        bookmarks.push({ id, name: clamp(entry.name, MAX_NAME_LENGTH) || url, url });
-
-        if (bookmarks.length >= MAX_BOOKMARKS) {
-            break;
-        }
+        seen.add(key(url));
+        bookmarks.push({ name: clean(entry?.name) || url, url });
     }
 
     return bookmarks;
 }
 
 /**
- * Betaflight SITL speaks raw TCP on 127.0.0.1:5761 and nothing else. A shell with a
- * raw-TCP transport (Tauri desktop, Capacitor Android) connects to it directly. A
- * browser has no raw sockets, so the docs have the user put websockify in front of it
- * (`websockify 127.0.0.1:6761 127.0.0.1:5761`) and connect to the proxy's own port —
- * hence a different port here, not the same one with a ws:// scheme.
- * @see https://betaflight.com/docs/development/autopilot/SITL_Autopilot_Testing_Gazebo#connect-to-the-sitl
- * @returns {Array<{id: string, name: string, url: string, builtin: boolean}>} targets offered out of the box
- */
-function defaultBookmarks() {
-    const url = isTauri() || isAndroid() ? "tcp://127.0.0.1:5761" : "ws://127.0.0.1:6761";
-
-    return [{ id: "default-sitl", name: "Betaflight SITL", url, builtin: true }];
-}
-
-/**
- * Dismissals are only meaningful for built-ins that still exist, so anything else is
- * dropped rather than kept around forever.
- * @param {*} stored - whatever was read back from storage
- * @returns {string[]} the ids of dismissed built-in bookmarks
- */
-function sanitizeIds(stored) {
-    if (!Array.isArray(stored)) {
-        return [];
-    }
-
-    const known = new Set(defaultBookmarks().map((entry) => entry.id));
-
-    return [...new Set(stored.filter((id) => known.has(id)))];
-}
-
-/**
- * Saved manual-connection targets ("bookmarks"): named addresses such as an ELRS
- * Wi-Fi module's `tcp://192.168.4.1:5761`, so they can be picked from the connect
- * menu instead of being typed again for every quad. Ships with a built-in SITL entry,
- * which the user can rename (saving over it) or dismiss (removing it).
+ * Saved manual-connection targets ("bookmarks"): named addresses such as an ELRS Wi-Fi
+ * module's `tcp://192.168.4.1:5761`, so they can be picked from the connect menu instead of
+ * being typed again for every quad. The address is the identity — one bookmark per target.
  */
 export const useConnectionBookmarksStore = defineStore("connectionBookmarks", () => {
-    const bookmarks = ref(sanitize(getConfig(STORAGE_KEY).connectionBookmarks));
-    const hiddenDefaults = ref(sanitizeIds(getConfig(HIDDEN_DEFAULTS_KEY).connectionBookmarksHiddenDefaults));
+    const stored = getConfig(STORAGE_KEY).connectionBookmarks;
 
-    const count = computed(() => bookmarks.value.length);
-    const isFull = computed(() => bookmarks.value.length >= MAX_BOOKMARKS);
-
-    // A saved bookmark for the same address replaces the built-in one, so renaming SITL
-    // does not leave both entries in the list.
-    const visibleDefaults = computed(() =>
-        defaultBookmarks().filter(
-            (entry) => !hiddenDefaults.value.includes(entry.id) && !findByUrl(entry.url, bookmarks.value),
-        ),
-    );
-
-    /** The list to offer the user: everything they saved, then whatever is left of the built-ins. */
-    const items = computed(() => [...bookmarks.value, ...visibleDefaults.value]);
+    // First run seeds SITL, so a simulator connection needs no typing. It is an ordinary
+    // bookmark from then on: renameable, and gone for good once removed — the seeding
+    // condition is "storage has never been written", not "the list is empty".
+    const bookmarks = ref(stored === undefined ? [sitlBookmark()] : sanitize(stored));
 
     function persist() {
-        setConfig({ [STORAGE_KEY]: bookmarks.value, [HIDDEN_DEFAULTS_KEY]: hiddenDefaults.value });
+        setConfig({ [STORAGE_KEY]: bookmarks.value });
+    }
+
+    if (stored === undefined) {
+        persist();
     }
 
     /**
      * @param {string} url
-     * @param {Array<{url: string}>} [list] - defaults to the saved bookmarks
-     * @returns {?{id: string, name: string, url: string}} the entry pointing at this address
+     * @returns {?{name: string, url: string}} the bookmark pointing at this address
      */
-    function findByUrl(url, list = bookmarks.value) {
-        const key = normalizeUrl(url);
+    function find(url) {
+        const wanted = key(url);
 
-        if (!key) {
-            return null;
-        }
-
-        return list.find((bookmark) => normalizeUrl(bookmark.url) === key) ?? null;
-    }
-
-    /**
-     * @param {string} url
-     * @returns {?{id: string, name: string, url: string}} the saved or built-in entry for this address
-     */
-    function findItemByUrl(url) {
-        return findByUrl(url, items.value);
+        return wanted ? (bookmarks.value.find((bookmark) => key(bookmark.url) === wanted) ?? null) : null;
     }
 
     /**
@@ -192,101 +92,44 @@ export const useConnectionBookmarksStore = defineStore("connectionBookmarks", ()
      * idempotent so the same button works whether or not the target is known.
      * @param {string} url - the manual target, e.g. "tcp://192.168.4.1:5761"
      * @param {string} [name] - a label; the address itself when left empty
-     * @returns {?{id: string, name: string, url: string}} null when the address is empty or the list is full
+     * @returns {?{name: string, url: string}} null when the address is empty or the list is full
      */
     function save(url, name = "") {
-        const cleanUrl = clamp(url, MAX_URL_LENGTH);
+        const address = clean(url);
+        const existing = find(address);
 
-        if (!cleanUrl) {
+        if (!address || (!existing && bookmarks.value.length >= MAX_BOOKMARKS)) {
             return null;
         }
 
-        const cleanName = clamp(name, MAX_NAME_LENGTH) || cleanUrl;
-        const existing = findByUrl(cleanUrl);
+        const bookmark = existing ?? { url: address, name: "" };
+        bookmark.name = clean(name) || address;
 
-        if (existing) {
-            existing.name = cleanName;
-            existing.url = cleanUrl;
-            persist();
-            return existing;
+        if (!existing) {
+            bookmarks.value.push(bookmark);
         }
 
-        if (isFull.value) {
-            return null;
-        }
-
-        // Not just a fresh id: the counter fallback restarts at 1 each load, so a stored
-        // "bookmark-1" would come back as a second one — colliding v-for keys, and a
-        // remove() that takes out whichever entry it finds first.
-        const taken = new Set([
-            ...bookmarks.value.map((entry) => entry.id),
-            ...defaultBookmarks().map((entry) => entry.id),
-        ]);
-        const bookmark = { id: createUniqueId(taken), name: cleanName, url: cleanUrl };
-        bookmarks.value.push(bookmark);
         persist();
 
         return bookmark;
     }
 
     /**
-     * Remove a saved bookmark, or dismiss a built-in one. A dismissed built-in stays
-     * gone until the list is cleared, so removing it is not undone on the next start.
-     * @param {string} id
-     * @returns {boolean} true when the list changed
+     * @param {string} url
+     * @returns {boolean} true when a bookmark was removed
      */
-    function remove(id) {
-        const index = bookmarks.value.findIndex((bookmark) => bookmark.id === id);
+    function remove(url) {
+        const index = bookmarks.value.indexOf(find(url));
 
-        if (index !== -1) {
-            bookmarks.value.splice(index, 1);
-            persist();
-            return true;
+        if (index === -1) {
+            return false;
         }
 
-        if (visibleDefaults.value.some((entry) => entry.id === id)) {
-            hiddenDefaults.value.push(id);
-            persist();
-            return true;
-        }
-
-        return false;
-    }
-
-    function clear() {
-        bookmarks.value = [];
-        hiddenDefaults.value = [];
+        bookmarks.value.splice(index, 1);
         persist();
+
+        return true;
     }
 
-    /**
-     * Re-read storage. Only needed when another context wrote the keys (a second
-     * window, or a settings reset) — every mutation here keeps storage in step.
-     */
-    function reload() {
-        bookmarks.value = sanitize(getConfig(STORAGE_KEY).connectionBookmarks);
-        hiddenDefaults.value = sanitizeIds(getConfig(HIDDEN_DEFAULTS_KEY).connectionBookmarksHiddenDefaults);
-    }
-
-    return {
-        bookmarks,
-        items,
-        count,
-        isFull,
-        findByUrl,
-        findItemByUrl,
-        save,
-        remove,
-        clear,
-        reload,
-    };
+    return { bookmarks, find, save, remove };
 });
-
-export const __testing = {
-    MAX_BOOKMARKS,
-    MAX_NAME_LENGTH,
-    MAX_URL_LENGTH,
-    STORAGE_KEY,
-    HIDDEN_DEFAULTS_KEY,
-    defaultBookmarks,
-};

--- a/src/stores/connectionBookmarks.js
+++ b/src/stores/connectionBookmarks.js
@@ -24,10 +24,9 @@ function sitlBookmark() {
     };
 }
 
-const clean = (value) =>
-    String(value ?? "")
-        .trim()
-        .slice(0, MAX_LENGTH);
+// Non-strings are dropped rather than stringified: a stored `{"url": {}}` would otherwise
+// become the bookmark "[object Object]" and be offered in the connect menu.
+const clean = (value) => (typeof value === "string" ? value.trim().slice(0, MAX_LENGTH) : "");
 
 // Manual targets are network addresses far more often than serial paths, so they compare
 // case-insensitively: "TCP://Quad.local" and "tcp://quad.local" are one bookmark.

--- a/src/stores/connectionBookmarks.js
+++ b/src/stores/connectionBookmarks.js
@@ -14,12 +14,33 @@ const MAX_URL_LENGTH = 253;
 
 let idCounter = 0;
 
+/**
+ * crypto.randomUUID() needs a secure context, which the configurator does not have when
+ * it is served over plain HTTP from a LAN address, so the counter fallback is a path real
+ * users take. It restarts at 1 on every load and therefore cannot be trusted to be unique
+ * on its own — always mint ids through createUniqueId().
+ * @returns {string} a candidate id
+ */
 function createId() {
     if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
         return crypto.randomUUID();
     }
     idCounter += 1;
     return `bookmark-${idCounter}`;
+}
+
+/**
+ * @param {Set<string>} taken - ids already in use
+ * @returns {string} an id that is not in `taken`
+ */
+function createUniqueId(taken) {
+    let id = createId();
+
+    while (taken.has(id)) {
+        id = createId();
+    }
+
+    return id;
 }
 
 /**
@@ -69,10 +90,8 @@ function sanitize(stored) {
             continue;
         }
 
-        let id = typeof entry.id === "string" && entry.id ? entry.id : createId();
-        while (seenIds.has(id)) {
-            id = createId();
-        }
+        const stored = typeof entry.id === "string" && entry.id ? entry.id : null;
+        const id = stored && !seenIds.has(stored) ? stored : createUniqueId(seenIds);
 
         seenUrls.add(key);
         seenIds.add(id);
@@ -196,7 +215,14 @@ export const useConnectionBookmarksStore = defineStore("connectionBookmarks", ()
             return null;
         }
 
-        const bookmark = { id: createId(), name: cleanName, url: cleanUrl };
+        // Not just a fresh id: the counter fallback restarts at 1 each load, so a stored
+        // "bookmark-1" would come back as a second one — colliding v-for keys, and a
+        // remove() that takes out whichever entry it finds first.
+        const taken = new Set([
+            ...bookmarks.value.map((entry) => entry.id),
+            ...defaultBookmarks().map((entry) => entry.id),
+        ]);
+        const bookmark = { id: createUniqueId(taken), name: cleanName, url: cleanUrl };
         bookmarks.value.push(bookmark);
         persist();
 

--- a/src/stores/connectionBookmarks.js
+++ b/src/stores/connectionBookmarks.js
@@ -1,0 +1,266 @@
+import { defineStore } from "pinia";
+import { computed, ref } from "vue";
+import { get as getConfig, set as setConfig } from "../js/ConfigStorage";
+import { isAndroid, isTauri } from "../js/utils/checkCompatibility";
+
+const STORAGE_KEY = "connectionBookmarks";
+const HIDDEN_DEFAULTS_KEY = "connectionBookmarksHiddenDefaults";
+
+// A saved manual target is a short string ("tcp://192.168.4.1:5761"), so a generous
+// cap keeps a corrupted or hand-edited localStorage entry from flooding the connect menu.
+const MAX_BOOKMARKS = 50;
+const MAX_NAME_LENGTH = 64;
+const MAX_URL_LENGTH = 253;
+
+let idCounter = 0;
+
+function createId() {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID();
+    }
+    idCounter += 1;
+    return `bookmark-${idCounter}`;
+}
+
+/**
+ * Manual targets are network addresses far more often than serial paths, so compare
+ * them case-insensitively: "TCP://Quad.local" and "tcp://quad.local" are one bookmark.
+ * @param {string} url
+ * @returns {string} the comparison key for an address
+ */
+function normalizeUrl(url) {
+    return String(url ?? "")
+        .trim()
+        .toLowerCase();
+}
+
+function clamp(value, maxLength) {
+    return String(value ?? "")
+        .trim()
+        .slice(0, maxLength);
+}
+
+/**
+ * Drop anything that is not a usable bookmark and give every survivor a unique id.
+ * localStorage is user-writable and survives downgrades, so nothing here is trusted.
+ * @param {*} stored - whatever was read back from storage
+ * @returns {Array<{id: string, name: string, url: string}>}
+ */
+function sanitize(stored) {
+    if (!Array.isArray(stored)) {
+        return [];
+    }
+
+    const seenUrls = new Set();
+    // Built-in ids are reserved: a stored bookmark carrying one would collide with the
+    // entry it is listed next to.
+    const seenIds = new Set(defaultBookmarks().map((entry) => entry.id));
+    const bookmarks = [];
+
+    for (const entry of stored) {
+        if (!entry || typeof entry !== "object") {
+            continue;
+        }
+
+        const url = clamp(entry.url, MAX_URL_LENGTH);
+        const key = normalizeUrl(url);
+
+        if (!url || seenUrls.has(key)) {
+            continue;
+        }
+
+        let id = typeof entry.id === "string" && entry.id ? entry.id : createId();
+        while (seenIds.has(id)) {
+            id = createId();
+        }
+
+        seenUrls.add(key);
+        seenIds.add(id);
+        bookmarks.push({ id, name: clamp(entry.name, MAX_NAME_LENGTH) || url, url });
+
+        if (bookmarks.length >= MAX_BOOKMARKS) {
+            break;
+        }
+    }
+
+    return bookmarks;
+}
+
+/**
+ * Betaflight SITL speaks raw TCP on 127.0.0.1:5761 and nothing else. A shell with a
+ * raw-TCP transport (Tauri desktop, Capacitor Android) connects to it directly. A
+ * browser has no raw sockets, so the docs have the user put websockify in front of it
+ * (`websockify 127.0.0.1:6761 127.0.0.1:5761`) and connect to the proxy's own port —
+ * hence a different port here, not the same one with a ws:// scheme.
+ * @see https://betaflight.com/docs/development/autopilot/SITL_Autopilot_Testing_Gazebo#connect-to-the-sitl
+ * @returns {Array<{id: string, name: string, url: string, builtin: boolean}>} targets offered out of the box
+ */
+function defaultBookmarks() {
+    const url = isTauri() || isAndroid() ? "tcp://127.0.0.1:5761" : "ws://127.0.0.1:6761";
+
+    return [{ id: "default-sitl", name: "Betaflight SITL", url, builtin: true }];
+}
+
+/**
+ * Dismissals are only meaningful for built-ins that still exist, so anything else is
+ * dropped rather than kept around forever.
+ * @param {*} stored - whatever was read back from storage
+ * @returns {string[]} the ids of dismissed built-in bookmarks
+ */
+function sanitizeIds(stored) {
+    if (!Array.isArray(stored)) {
+        return [];
+    }
+
+    const known = new Set(defaultBookmarks().map((entry) => entry.id));
+
+    return [...new Set(stored.filter((id) => known.has(id)))];
+}
+
+/**
+ * Saved manual-connection targets ("bookmarks"): named addresses such as an ELRS
+ * Wi-Fi module's `tcp://192.168.4.1:5761`, so they can be picked from the connect
+ * menu instead of being typed again for every quad. Ships with a built-in SITL entry,
+ * which the user can rename (saving over it) or dismiss (removing it).
+ */
+export const useConnectionBookmarksStore = defineStore("connectionBookmarks", () => {
+    const bookmarks = ref(sanitize(getConfig(STORAGE_KEY).connectionBookmarks));
+    const hiddenDefaults = ref(sanitizeIds(getConfig(HIDDEN_DEFAULTS_KEY).connectionBookmarksHiddenDefaults));
+
+    const count = computed(() => bookmarks.value.length);
+    const isFull = computed(() => bookmarks.value.length >= MAX_BOOKMARKS);
+
+    // A saved bookmark for the same address replaces the built-in one, so renaming SITL
+    // does not leave both entries in the list.
+    const visibleDefaults = computed(() =>
+        defaultBookmarks().filter(
+            (entry) => !hiddenDefaults.value.includes(entry.id) && !findByUrl(entry.url, bookmarks.value),
+        ),
+    );
+
+    /** The list to offer the user: everything they saved, then whatever is left of the built-ins. */
+    const items = computed(() => [...bookmarks.value, ...visibleDefaults.value]);
+
+    function persist() {
+        setConfig({ [STORAGE_KEY]: bookmarks.value, [HIDDEN_DEFAULTS_KEY]: hiddenDefaults.value });
+    }
+
+    /**
+     * @param {string} url
+     * @param {Array<{url: string}>} [list] - defaults to the saved bookmarks
+     * @returns {?{id: string, name: string, url: string}} the entry pointing at this address
+     */
+    function findByUrl(url, list = bookmarks.value) {
+        const key = normalizeUrl(url);
+
+        if (!key) {
+            return null;
+        }
+
+        return list.find((bookmark) => normalizeUrl(bookmark.url) === key) ?? null;
+    }
+
+    /**
+     * @param {string} url
+     * @returns {?{id: string, name: string, url: string}} the saved or built-in entry for this address
+     */
+    function findItemByUrl(url) {
+        return findByUrl(url, items.value);
+    }
+
+    /**
+     * Save an address, or rename the bookmark that already points at it. Saving is
+     * idempotent so the same button works whether or not the target is known.
+     * @param {string} url - the manual target, e.g. "tcp://192.168.4.1:5761"
+     * @param {string} [name] - a label; the address itself when left empty
+     * @returns {?{id: string, name: string, url: string}} null when the address is empty or the list is full
+     */
+    function save(url, name = "") {
+        const cleanUrl = clamp(url, MAX_URL_LENGTH);
+
+        if (!cleanUrl) {
+            return null;
+        }
+
+        const cleanName = clamp(name, MAX_NAME_LENGTH) || cleanUrl;
+        const existing = findByUrl(cleanUrl);
+
+        if (existing) {
+            existing.name = cleanName;
+            existing.url = cleanUrl;
+            persist();
+            return existing;
+        }
+
+        if (isFull.value) {
+            return null;
+        }
+
+        const bookmark = { id: createId(), name: cleanName, url: cleanUrl };
+        bookmarks.value.push(bookmark);
+        persist();
+
+        return bookmark;
+    }
+
+    /**
+     * Remove a saved bookmark, or dismiss a built-in one. A dismissed built-in stays
+     * gone until the list is cleared, so removing it is not undone on the next start.
+     * @param {string} id
+     * @returns {boolean} true when the list changed
+     */
+    function remove(id) {
+        const index = bookmarks.value.findIndex((bookmark) => bookmark.id === id);
+
+        if (index !== -1) {
+            bookmarks.value.splice(index, 1);
+            persist();
+            return true;
+        }
+
+        if (visibleDefaults.value.some((entry) => entry.id === id)) {
+            hiddenDefaults.value.push(id);
+            persist();
+            return true;
+        }
+
+        return false;
+    }
+
+    function clear() {
+        bookmarks.value = [];
+        hiddenDefaults.value = [];
+        persist();
+    }
+
+    /**
+     * Re-read storage. Only needed when another context wrote the keys (a second
+     * window, or a settings reset) — every mutation here keeps storage in step.
+     */
+    function reload() {
+        bookmarks.value = sanitize(getConfig(STORAGE_KEY).connectionBookmarks);
+        hiddenDefaults.value = sanitizeIds(getConfig(HIDDEN_DEFAULTS_KEY).connectionBookmarksHiddenDefaults);
+    }
+
+    return {
+        bookmarks,
+        items,
+        count,
+        isFull,
+        findByUrl,
+        findItemByUrl,
+        save,
+        remove,
+        clear,
+        reload,
+    };
+});
+
+export const __testing = {
+    MAX_BOOKMARKS,
+    MAX_NAME_LENGTH,
+    MAX_URL_LENGTH,
+    STORAGE_KEY,
+    HIDDEN_DEFAULTS_KEY,
+    defaultBookmarks,
+};

--- a/test/js/connect_button_bookmarks.test.js
+++ b/test/js/connect_button_bookmarks.test.js
@@ -5,8 +5,8 @@ import { effectScope } from "vue";
 // ---------------------------------------------------------------------------
 // The connect dropdown is where a saved address turns into an actual connection:
 // the menu item has to route through the "manual" pseudo-device with portOverride
-// set, or the attempt goes to whatever was selected before. Its collaborators are
-// stubbed, and setup() is driven directly (the repo has no rendering harness).
+// set, or the attempt goes to whatever was selected before. That portOverride is
+// then what serial_backend opens — see serial_backend.test.js.
 // ---------------------------------------------------------------------------
 
 const { DeviceHandler, connectDisconnect, expertMode } = vi.hoisted(() => ({
@@ -42,14 +42,8 @@ import ConnectButton from "../../src/components/device-picker/ConnectButton.vue"
 import { useConnectionBookmarksStore } from "../../src/stores/connectionBookmarks.js";
 import { get as getConfig } from "../../src/js/ConfigStorage.js";
 
-function mountLogic() {
-    const scope = effectScope();
-    return scope.run(() => ConnectButton.setup({}, { emit: vi.fn() }));
-}
-
-function bookmarkItem(api, label) {
-    return api.menuItems.value.find((item) => item.label === label);
-}
+const mountLogic = () => effectScope().run(() => ConnectButton.setup({}, { emit: vi.fn() }));
+const item = (api, label) => api.menuItems.value.find((entry) => entry.label === label);
 
 beforeEach(() => {
     localStorage.clear();
@@ -62,62 +56,37 @@ beforeEach(() => {
 });
 
 describe("connecting to a bookmark from the dropdown", () => {
-    it("points the manual target at the saved address and starts the connection", () => {
-        const store = useConnectionBookmarksStore();
-        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+    it("points the manual target at the saved address, remembers it, and connects", () => {
+        useConnectionBookmarksStore().save("tcp://192.168.4.1:5761", "Wi-Fi quad");
 
         const api = mountLogic();
-        bookmarkItem(api, "Wi-Fi quad").onSelect();
+        item(api, "Wi-Fi quad").onSelect();
 
-        expect(DeviceHandler.devicePicker.portOverride).toBe("tcp://192.168.4.1:5761");
         expect(DeviceHandler.devicePicker.selectedDevice).toBe("manual");
-        expect(connectDisconnect).toHaveBeenCalledTimes(1);
-    });
-
-    // The saved setting is what a fresh start hands back to the manual connect path
-    // (device_handler seeds portOverride from it). That the connect path then opens
-    // that address is pinned in serial_backend.test.js.
-    it("remembers the address, so a later connect without the dialog uses it", () => {
-        const store = useConnectionBookmarksStore();
-        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
-
-        const api = mountLogic();
-        bookmarkItem(api, "Wi-Fi quad").onSelect();
-
+        expect(DeviceHandler.devicePicker.portOverride).toBe("tcp://192.168.4.1:5761");
+        // Persisted, so a restart still has the address to connect to.
         expect(getConfig("portOverride").portOverride).toBe("tcp://192.168.4.1:5761");
+        expect(connectDisconnect).toHaveBeenCalledTimes(1);
+        expect(api.mainLabel.value).toBe("Wi-Fi quad");
     });
 
-    it("offers the built-in SITL target too", () => {
+    it("offers the seeded SITL target too", () => {
         const api = mountLogic();
 
-        const sitl = bookmarkItem(api, "Betaflight SITL");
-        expect(sitl.icon).toBe("i-lucide-flask-conical");
-
-        sitl.onSelect();
+        item(api, "Betaflight SITL").onSelect();
 
         expect(DeviceHandler.devicePicker.portOverride).toBe("ws://127.0.0.1:6761");
         expect(connectDisconnect).toHaveBeenCalledTimes(1);
     });
 
-    it("labels the connect button with the bookmark behind a manual selection", () => {
-        const store = useConnectionBookmarksStore();
-        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
-
-        const api = mountLogic();
-        bookmarkItem(api, "Wi-Fi quad").onSelect();
-
-        expect(api.mainLabel.value).toBe("Wi-Fi quad");
-    });
-
     it("keeps bookmarks out of the menu when manual mode is not available", () => {
-        const store = useConnectionBookmarksStore();
-        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+        useConnectionBookmarksStore().save("tcp://192.168.4.1:5761", "Wi-Fi quad");
 
         expertMode.enabled = false;
-        expect(bookmarkItem(mountLogic(), "Wi-Fi quad")).toBeUndefined();
+        expect(item(mountLogic(), "Wi-Fi quad")).toBeUndefined();
 
         expertMode.enabled = true;
         DeviceHandler.showManualMode = false;
-        expect(bookmarkItem(mountLogic(), "Wi-Fi quad")).toBeUndefined();
+        expect(item(mountLogic(), "Wi-Fi quad")).toBeUndefined();
     });
 });

--- a/test/js/connect_button_bookmarks.test.js
+++ b/test/js/connect_button_bookmarks.test.js
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { effectScope } from "vue";
+
+// ---------------------------------------------------------------------------
+// The connect dropdown is where a saved address turns into an actual connection:
+// the menu item has to route through the "manual" pseudo-device with portOverride
+// set, or the attempt goes to whatever was selected before. Its collaborators are
+// stubbed, and setup() is driven directly (the repo has no rendering harness).
+// ---------------------------------------------------------------------------
+
+const { DeviceHandler, connectDisconnect, expertMode } = vi.hoisted(() => ({
+    DeviceHandler: {
+        devicePicker: { selectedDevice: "noselection", portOverride: "", autoConnect: false },
+        devicePickerDisabled: false,
+        currentSerialPorts: [],
+        currentUsbPorts: [],
+        currentBluetoothPorts: [],
+        showSerialOption: false,
+        showUsbOption: false,
+        showBluetoothOption: false,
+        showVirtualMode: false,
+        showManualMode: true,
+    },
+    connectDisconnect: vi.fn(),
+    expertMode: { enabled: true },
+}));
+
+vi.mock("../../src/js/device_handler", () => ({ __esModule: true, default: DeviceHandler }));
+vi.mock("../../src/js/serial_backend", () => ({ __esModule: true, connectDisconnect, disconnect: vi.fn() }));
+vi.mock("../../src/js/localization", () => ({ __esModule: true, i18n: { getMessage: (key) => key } }));
+vi.mock("../../src/js/utils/isExpertModeEnabled", () => ({
+    __esModule: true,
+    isExpertModeEnabled: () => expertMode.enabled,
+}));
+vi.mock("../../src/stores/connection", () => ({
+    __esModule: true,
+    useConnectionStore: () => ({ connectionValid: false, connectingTo: false, virtualMode: false, connectedTo: false }),
+}));
+
+import ConnectButton from "../../src/components/device-picker/ConnectButton.vue";
+import { useConnectionBookmarksStore } from "../../src/stores/connectionBookmarks.js";
+
+function mountLogic() {
+    const scope = effectScope();
+    return scope.run(() => ConnectButton.setup({}, { emit: vi.fn() }));
+}
+
+function bookmarkItem(api, label) {
+    return api.menuItems.value.find((item) => item.label === label);
+}
+
+beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+    connectDisconnect.mockClear();
+    expertMode.enabled = true;
+    DeviceHandler.showManualMode = true;
+    DeviceHandler.devicePicker.selectedDevice = "noselection";
+    DeviceHandler.devicePicker.portOverride = "";
+});
+
+describe("connecting to a bookmark from the dropdown", () => {
+    it("points the manual target at the saved address and starts the connection", () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+
+        const api = mountLogic();
+        bookmarkItem(api, "Wi-Fi quad").onSelect();
+
+        expect(DeviceHandler.devicePicker.portOverride).toBe("tcp://192.168.4.1:5761");
+        expect(DeviceHandler.devicePicker.selectedDevice).toBe("manual");
+        expect(connectDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("remembers the address, so a later connect without the dialog uses it", () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+
+        const api = mountLogic();
+        bookmarkItem(api, "Wi-Fi quad").onSelect();
+
+        expect(JSON.parse(localStorage.getItem("portOverride")).portOverride).toBe("tcp://192.168.4.1:5761");
+    });
+
+    it("offers the built-in SITL target too", () => {
+        const api = mountLogic();
+
+        const sitl = bookmarkItem(api, "Betaflight SITL");
+        expect(sitl.icon).toBe("i-lucide-flask-conical");
+
+        sitl.onSelect();
+
+        expect(DeviceHandler.devicePicker.portOverride).toBe("ws://127.0.0.1:6761");
+        expect(connectDisconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("labels the connect button with the bookmark behind a manual selection", () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+
+        const api = mountLogic();
+        bookmarkItem(api, "Wi-Fi quad").onSelect();
+
+        expect(api.mainLabel.value).toBe("Wi-Fi quad");
+    });
+
+    it("keeps bookmarks out of the menu when manual mode is not available", () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+
+        expertMode.enabled = false;
+        expect(bookmarkItem(mountLogic(), "Wi-Fi quad")).toBeUndefined();
+
+        expertMode.enabled = true;
+        DeviceHandler.showManualMode = false;
+        expect(bookmarkItem(mountLogic(), "Wi-Fi quad")).toBeUndefined();
+    });
+});

--- a/test/js/connect_button_bookmarks.test.js
+++ b/test/js/connect_button_bookmarks.test.js
@@ -40,6 +40,7 @@ vi.mock("../../src/stores/connection", () => ({
 
 import ConnectButton from "../../src/components/device-picker/ConnectButton.vue";
 import { useConnectionBookmarksStore } from "../../src/stores/connectionBookmarks.js";
+import { get as getConfig } from "../../src/js/ConfigStorage.js";
 
 function mountLogic() {
     const scope = effectScope();
@@ -73,6 +74,9 @@ describe("connecting to a bookmark from the dropdown", () => {
         expect(connectDisconnect).toHaveBeenCalledTimes(1);
     });
 
+    // The saved setting is what a fresh start hands back to the manual connect path
+    // (device_handler seeds portOverride from it). That the connect path then opens
+    // that address is pinned in serial_backend.test.js.
     it("remembers the address, so a later connect without the dialog uses it", () => {
         const store = useConnectionBookmarksStore();
         store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
@@ -80,7 +84,7 @@ describe("connecting to a bookmark from the dropdown", () => {
         const api = mountLogic();
         bookmarkItem(api, "Wi-Fi quad").onSelect();
 
-        expect(JSON.parse(localStorage.getItem("portOverride")).portOverride).toBe("tcp://192.168.4.1:5761");
+        expect(getConfig("portOverride").portOverride).toBe("tcp://192.168.4.1:5761");
     });
 
     it("offers the built-in SITL target too", () => {

--- a/test/js/connect_options_dialog.test.js
+++ b/test/js/connect_options_dialog.test.js
@@ -10,21 +10,20 @@ import { useConnectionBookmarksStore } from "../../src/stores/connectionBookmark
 // The dialog's bookmark handling lives entirely in setup(), so drive setup() directly:
 // the repo has no component-rendering harness, and rendering Nuxt UI would test their
 // widgets rather than this wiring.
-function mountLogic({ mode = "manual", initialPortOverride = "" } = {}) {
-    const props = reactive({ modelValue: false, mode, initialVersion: "1.46.0", initialPortOverride });
+function mountLogic(initialPortOverride = "") {
+    const props = reactive({ modelValue: false, mode: "manual", initialVersion: "1.46.0", initialPortOverride });
     const emitted = [];
-    const scope = effectScope();
-    const api = scope.run(() =>
+    const api = effectScope().run(() =>
         ConnectOptionsDialog.setup(props, { emit: (event, payload) => emitted.push([event, payload]) }),
     );
 
-    // The dialog seeds its fields when it opens, so tests that care about that path open it.
+    // The dialog seeds its fields when it opens.
     const open = async () => {
         props.modelValue = true;
         await nextTick();
     };
 
-    return { api, props, emitted, scope, open };
+    return { api, emitted, open };
 }
 
 beforeEach(() => {
@@ -32,32 +31,26 @@ beforeEach(() => {
     setActivePinia(createPinia());
 });
 
-describe("saving from the connect dialog", () => {
+describe("the connect dialog's bookmark row", () => {
     it("saves the typed address under the typed name", () => {
         const { api } = mountLogic();
-        const store = useConnectionBookmarksStore();
 
         api.portOverride.value = "tcp://192.168.4.1:5761";
         api.bookmarkName.value = "Wi-Fi quad";
         api.onSaveBookmark();
 
-        expect(store.bookmarks).toEqual([
-            expect.objectContaining({ name: "Wi-Fi quad", url: "tcp://192.168.4.1:5761" }),
-        ]);
+        expect(useConnectionBookmarksStore().find("tcp://192.168.4.1:5761")?.name).toBe("Wi-Fi quad");
     });
 
     it("cannot save an empty address", () => {
         const { api } = mountLogic();
-        const store = useConnectionBookmarksStore();
 
         api.portOverride.value = "   ";
 
         expect(api.canSaveBookmark.value).toBe(false);
-        api.onSaveBookmark();
-        expect(store.bookmarks).toHaveLength(0);
     });
 
-    it("offers to update, not duplicate, an address that is already saved", async () => {
+    it("offers the saved name back and updates in place", async () => {
         const store = useConnectionBookmarksStore();
         store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
 
@@ -67,33 +60,22 @@ describe("saving from the connect dialog", () => {
         api.portOverride.value = "tcp://192.168.4.1:5761";
         await nextTick();
 
-        expect(api.saveBookmarkLabel.value).toBe("connectBookmarkUpdate");
-        // The saved name is offered back, so updating cannot silently blank it.
+        // Without the name coming back, saving would blank the label of an existing bookmark.
         expect(api.bookmarkName.value).toBe("Wi-Fi quad");
+        expect(api.saveBookmarkLabel.value).toBe("connectBookmarkUpdate");
 
         api.bookmarkName.value = "Racer";
         api.onSaveBookmark();
 
-        expect(store.bookmarks).toHaveLength(1);
-        expect(store.bookmarks[0].name).toBe("Racer");
-    });
-
-    it("opens on the last manual address with its saved name", async () => {
-        const store = useConnectionBookmarksStore();
-        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
-
-        const { api, open } = mountLogic({ initialPortOverride: "tcp://192.168.4.1:5761" });
-        await open();
-
-        expect(api.portOverride.value).toBe("tcp://192.168.4.1:5761");
-        expect(api.bookmarkName.value).toBe("Wi-Fi quad");
+        expect(store.bookmarks.filter((b) => b.url.includes("192.168"))).toEqual([
+            { name: "Racer", url: "tcp://192.168.4.1:5761" },
+        ]);
     });
 
     it("clears the name box when the address moves off a saved bookmark", async () => {
-        const store = useConnectionBookmarksStore();
-        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+        useConnectionBookmarksStore().save("tcp://192.168.4.1:5761", "Wi-Fi quad");
 
-        const { api, open } = mountLogic({ initialPortOverride: "tcp://192.168.4.1:5761" });
+        const { api, open } = mountLogic("tcp://192.168.4.1:5761");
         await open();
         expect(api.bookmarkName.value).toBe("Wi-Fi quad");
 
@@ -102,72 +84,17 @@ describe("saving from the connect dialog", () => {
 
         expect(api.bookmarkName.value).toBe("");
     });
-});
 
-describe("the built-in SITL target", () => {
-    it("is offered without anything saved, and picking it fills in address and name", async () => {
-        const { api } = mountLogic();
-
-        const sitl = api.bookmarks.value.find((entry) => entry.builtin);
-        expect(sitl).toMatchObject({ name: "Betaflight SITL", url: "ws://127.0.0.1:6761" });
-
-        api.applyBookmark(sitl);
-        await nextTick();
-
-        expect(api.portOverride.value).toBe("ws://127.0.0.1:6761");
-        expect(api.bookmarkName.value).toBe("Betaflight SITL");
-        // Saving it makes the user's own copy, so the button offers to save, not to update.
-        expect(api.saveBookmarkLabel.value).toBe("connectBookmarkSave");
-    });
-
-    it("saving over it renames it in place instead of listing it twice", async () => {
-        const { api } = mountLogic();
-        const store = useConnectionBookmarksStore();
-
-        api.applyBookmark(api.bookmarks.value.find((entry) => entry.builtin));
-        await nextTick();
-        api.bookmarkName.value = "My simulator";
-        api.onSaveBookmark();
-        await nextTick();
-
-        expect(api.bookmarks.value).toEqual([
-            expect.objectContaining({ name: "My simulator", url: "ws://127.0.0.1:6761" }),
-        ]);
-        expect(store.bookmarks).toHaveLength(1);
-    });
-
-    it("can be dismissed", async () => {
-        const { api } = mountLogic();
-
-        api.removeBookmark(api.bookmarks.value.find((entry) => entry.builtin));
-        await nextTick();
-
-        expect(api.bookmarks.value).toHaveLength(0);
-    });
-});
-
-describe("using and removing bookmarks", () => {
-    it("picking a bookmark fills the address field", () => {
+    it("picking one fills the address in, and removing drops it from the list", () => {
         const store = useConnectionBookmarksStore();
         const bookmark = store.save("tcp://quad.local:5761", "Cinewhoop");
 
         const { api } = mountLogic();
         api.applyBookmark(bookmark);
-
         expect(api.portOverride.value).toBe("tcp://quad.local:5761");
-    });
-
-    it("removing drops it from the list the dialog shows", () => {
-        const store = useConnectionBookmarksStore();
-        const bookmark = store.save("tcp://quad.local:5761", "Cinewhoop");
-
-        const { api } = mountLogic();
-        expect(api.bookmarks.value.map((entry) => entry.name)).toContain("Cinewhoop");
 
         api.removeBookmark(bookmark);
-
-        expect(api.bookmarks.value.map((entry) => entry.name)).not.toContain("Cinewhoop");
-        expect(store.bookmarks).toHaveLength(0);
+        expect(api.bookmarks.value.map((b) => b.name)).not.toContain("Cinewhoop");
     });
 
     it("confirming emits the trimmed address for the manual connect path", () => {

--- a/test/js/connect_options_dialog.test.js
+++ b/test/js/connect_options_dialog.test.js
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { effectScope, nextTick, reactive } from "vue";
+
+vi.mock("../../src/js/localization", () => ({ i18n: { getMessage: (key) => key } }));
+
+import ConnectOptionsDialog from "../../src/components/device-picker/ConnectOptionsDialog.vue";
+import { useConnectionBookmarksStore } from "../../src/stores/connectionBookmarks.js";
+
+// The dialog's bookmark handling lives entirely in setup(), so drive setup() directly:
+// the repo has no component-rendering harness, and rendering Nuxt UI would test their
+// widgets rather than this wiring.
+function mountLogic({ mode = "manual", initialPortOverride = "" } = {}) {
+    const props = reactive({ modelValue: false, mode, initialVersion: "1.46.0", initialPortOverride });
+    const emitted = [];
+    const scope = effectScope();
+    const api = scope.run(() =>
+        ConnectOptionsDialog.setup(props, { emit: (event, payload) => emitted.push([event, payload]) }),
+    );
+
+    // The dialog seeds its fields when it opens, so tests that care about that path open it.
+    const open = async () => {
+        props.modelValue = true;
+        await nextTick();
+    };
+
+    return { api, props, emitted, scope, open };
+}
+
+beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+});
+
+describe("saving from the connect dialog", () => {
+    it("saves the typed address under the typed name", () => {
+        const { api } = mountLogic();
+        const store = useConnectionBookmarksStore();
+
+        api.portOverride.value = "tcp://192.168.4.1:5761";
+        api.bookmarkName.value = "Wi-Fi quad";
+        api.onSaveBookmark();
+
+        expect(store.bookmarks).toEqual([
+            expect.objectContaining({ name: "Wi-Fi quad", url: "tcp://192.168.4.1:5761" }),
+        ]);
+    });
+
+    it("cannot save an empty address", () => {
+        const { api } = mountLogic();
+        const store = useConnectionBookmarksStore();
+
+        api.portOverride.value = "   ";
+
+        expect(api.canSaveBookmark.value).toBe(false);
+        api.onSaveBookmark();
+        expect(store.bookmarks).toHaveLength(0);
+    });
+
+    it("offers to update, not duplicate, an address that is already saved", async () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+
+        const { api } = mountLogic();
+        expect(api.saveBookmarkLabel.value).toBe("connectBookmarkSave");
+
+        api.portOverride.value = "tcp://192.168.4.1:5761";
+        await nextTick();
+
+        expect(api.saveBookmarkLabel.value).toBe("connectBookmarkUpdate");
+        // The saved name is offered back, so updating cannot silently blank it.
+        expect(api.bookmarkName.value).toBe("Wi-Fi quad");
+
+        api.bookmarkName.value = "Racer";
+        api.onSaveBookmark();
+
+        expect(store.bookmarks).toHaveLength(1);
+        expect(store.bookmarks[0].name).toBe("Racer");
+    });
+
+    it("opens on the last manual address with its saved name", async () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+
+        const { api, open } = mountLogic({ initialPortOverride: "tcp://192.168.4.1:5761" });
+        await open();
+
+        expect(api.portOverride.value).toBe("tcp://192.168.4.1:5761");
+        expect(api.bookmarkName.value).toBe("Wi-Fi quad");
+    });
+
+    it("clears the name box when the address moves off a saved bookmark", async () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Wi-Fi quad");
+
+        const { api, open } = mountLogic({ initialPortOverride: "tcp://192.168.4.1:5761" });
+        await open();
+        expect(api.bookmarkName.value).toBe("Wi-Fi quad");
+
+        api.portOverride.value = "tcp://10.0.0.7:5761";
+        await nextTick();
+
+        expect(api.bookmarkName.value).toBe("");
+    });
+});
+
+describe("the built-in SITL target", () => {
+    it("is offered without anything saved, and picking it fills in address and name", async () => {
+        const { api } = mountLogic();
+
+        const sitl = api.bookmarks.value.find((entry) => entry.builtin);
+        expect(sitl).toMatchObject({ name: "Betaflight SITL", url: "ws://127.0.0.1:6761" });
+
+        api.applyBookmark(sitl);
+        await nextTick();
+
+        expect(api.portOverride.value).toBe("ws://127.0.0.1:6761");
+        expect(api.bookmarkName.value).toBe("Betaflight SITL");
+        // Saving it makes the user's own copy, so the button offers to save, not to update.
+        expect(api.saveBookmarkLabel.value).toBe("connectBookmarkSave");
+    });
+
+    it("saving over it renames it in place instead of listing it twice", async () => {
+        const { api } = mountLogic();
+        const store = useConnectionBookmarksStore();
+
+        api.applyBookmark(api.bookmarks.value.find((entry) => entry.builtin));
+        await nextTick();
+        api.bookmarkName.value = "My simulator";
+        api.onSaveBookmark();
+        await nextTick();
+
+        expect(api.bookmarks.value).toEqual([
+            expect.objectContaining({ name: "My simulator", url: "ws://127.0.0.1:6761" }),
+        ]);
+        expect(store.bookmarks).toHaveLength(1);
+    });
+
+    it("can be dismissed", async () => {
+        const { api } = mountLogic();
+
+        api.removeBookmark(api.bookmarks.value.find((entry) => entry.builtin));
+        await nextTick();
+
+        expect(api.bookmarks.value).toHaveLength(0);
+    });
+});
+
+describe("using and removing bookmarks", () => {
+    it("picking a bookmark fills the address field", () => {
+        const store = useConnectionBookmarksStore();
+        const bookmark = store.save("tcp://quad.local:5761", "Cinewhoop");
+
+        const { api } = mountLogic();
+        api.applyBookmark(bookmark);
+
+        expect(api.portOverride.value).toBe("tcp://quad.local:5761");
+    });
+
+    it("removing drops it from the list the dialog shows", () => {
+        const store = useConnectionBookmarksStore();
+        const bookmark = store.save("tcp://quad.local:5761", "Cinewhoop");
+
+        const { api } = mountLogic();
+        expect(api.bookmarks.value.map((entry) => entry.name)).toContain("Cinewhoop");
+
+        api.removeBookmark(bookmark);
+
+        expect(api.bookmarks.value.map((entry) => entry.name)).not.toContain("Cinewhoop");
+        expect(store.bookmarks).toHaveLength(0);
+    });
+
+    it("confirming emits the trimmed address for the manual connect path", () => {
+        const { api, emitted } = mountLogic();
+
+        api.portOverride.value = "  tcp://quad.local:5761  ";
+        api.onConfirm();
+
+        expect(emitted).toContainEqual([
+            "confirm",
+            { mode: "manual", version: "1.46.0", portOverride: "tcp://quad.local:5761" },
+        ]);
+    });
+});

--- a/test/js/connection_bookmarks.test.js
+++ b/test/js/connection_bookmarks.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 
 import { useConnectionBookmarksStore, __testing } from "../../src/stores/connectionBookmarks.js";
@@ -86,6 +86,40 @@ describe("saving a manual target", () => {
 
         expect(bookmark.url).toHaveLength(MAX_URL_LENGTH);
         expect(bookmark.name).toHaveLength(MAX_NAME_LENGTH);
+    });
+});
+
+// crypto.randomUUID needs a secure context, which the configurator does not get over plain
+// HTTP on a LAN address. There the store falls back to a counter that restarts at 1 on every
+// load, so these cover the ids it mints without it.
+describe("ids without crypto.randomUUID", () => {
+    let randomUUID;
+
+    beforeEach(() => {
+        randomUUID = crypto.randomUUID;
+        crypto.randomUUID = undefined;
+    });
+
+    afterEach(() => {
+        crypto.randomUUID = randomUUID;
+    });
+
+    it("does not reuse an id already held by a stored bookmark", () => {
+        seed([{ id: "bookmark-1", name: "From last session", url: "tcp://a:5761" }]);
+
+        const store = useConnectionBookmarksStore();
+        const saved = store.save("tcp://b:5761", "New one");
+
+        expect(saved.id).not.toBe("bookmark-1");
+        expect(new Set(store.items.map((entry) => entry.id)).size).toBe(store.items.length);
+    });
+
+    it("does not hand out a built-in id", () => {
+        const store = useConnectionBookmarksStore();
+
+        for (let i = 0; i < 5; i++) {
+            expect(store.save(`tcp://${i}.example:5761`).id).not.toBe("default-sitl");
+        }
     });
 });
 

--- a/test/js/connection_bookmarks.test.js
+++ b/test/js/connection_bookmarks.test.js
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+import { useConnectionBookmarksStore, __testing } from "../../src/stores/connectionBookmarks.js";
+import { get as getConfig, set as setConfig } from "../../src/js/ConfigStorage.js";
+
+const { STORAGE_KEY, HIDDEN_DEFAULTS_KEY, MAX_BOOKMARKS, MAX_NAME_LENGTH, MAX_URL_LENGTH } = __testing;
+
+function storedBookmarks() {
+    return getConfig(STORAGE_KEY).connectionBookmarks;
+}
+
+function seed(bookmarks) {
+    setConfig({ [STORAGE_KEY]: bookmarks });
+}
+
+beforeEach(() => {
+    localStorage.clear();
+    setActivePinia(createPinia());
+});
+
+describe("saving a manual target", () => {
+    it("keeps the address and falls back to it as the name", () => {
+        const store = useConnectionBookmarksStore();
+
+        const bookmark = store.save("tcp://192.168.4.1:5761");
+
+        expect(bookmark).toMatchObject({ name: "tcp://192.168.4.1:5761", url: "tcp://192.168.4.1:5761" });
+        expect(store.bookmarks).toHaveLength(1);
+        expect(storedBookmarks()).toEqual([bookmark]);
+    });
+
+    it("trims the address and the name", () => {
+        const store = useConnectionBookmarksStore();
+
+        const bookmark = store.save("  tcp://quad.local:5761  ", "  Cinewhoop  ");
+
+        expect(bookmark).toMatchObject({ name: "Cinewhoop", url: "tcp://quad.local:5761" });
+    });
+
+    it("renames instead of duplicating when the address is already saved", () => {
+        const store = useConnectionBookmarksStore();
+
+        const first = store.save("tcp://192.168.4.1:5761", "Quad");
+        const second = store.save("TCP://192.168.4.1:5761", "Racer");
+
+        expect(store.bookmarks).toHaveLength(1);
+        expect(second.id).toBe(first.id);
+        expect(store.bookmarks[0].name).toBe("Racer");
+        expect(storedBookmarks()).toHaveLength(1);
+    });
+
+    it("refuses an empty address", () => {
+        const store = useConnectionBookmarksStore();
+
+        expect(store.save("   ", "Nothing")).toBeNull();
+        expect(store.bookmarks).toHaveLength(0);
+    });
+
+    it("stops at the maximum and reports being full", () => {
+        const store = useConnectionBookmarksStore();
+
+        for (let i = 0; i < MAX_BOOKMARKS; i++) {
+            expect(store.save(`tcp://10.0.0.${i}:5761`)).not.toBeNull();
+        }
+
+        expect(store.isFull).toBe(true);
+        expect(store.save("tcp://10.9.9.9:5761")).toBeNull();
+        expect(store.count).toBe(MAX_BOOKMARKS);
+    });
+
+    it("still renames a known address when the list is full", () => {
+        const store = useConnectionBookmarksStore();
+
+        for (let i = 0; i < MAX_BOOKMARKS; i++) {
+            store.save(`tcp://10.0.0.${i}:5761`);
+        }
+
+        expect(store.save("tcp://10.0.0.0:5761", "First quad")?.name).toBe("First quad");
+    });
+
+    it("clamps over-long names and addresses", () => {
+        const store = useConnectionBookmarksStore();
+
+        const bookmark = store.save("t".repeat(MAX_URL_LENGTH + 10), "n".repeat(MAX_NAME_LENGTH + 10));
+
+        expect(bookmark.url).toHaveLength(MAX_URL_LENGTH);
+        expect(bookmark.name).toHaveLength(MAX_NAME_LENGTH);
+    });
+});
+
+describe("looking a target up", () => {
+    it("matches case-insensitively and ignores surrounding space", () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://Quad.local:5761", "Quad");
+
+        expect(store.findByUrl("  tcp://quad.LOCAL:5761 ")?.name).toBe("Quad");
+        expect(store.findByUrl("tcp://other:5761")).toBeNull();
+        expect(store.findByUrl("")).toBeNull();
+        expect(store.findByUrl(undefined)).toBeNull();
+    });
+});
+
+describe("removing", () => {
+    it("removes by id and persists the shortened list", () => {
+        const store = useConnectionBookmarksStore();
+        const keep = store.save("tcp://a:5761", "A");
+        const drop = store.save("tcp://b:5761", "B");
+
+        expect(store.remove(drop.id)).toBe(true);
+        expect(store.bookmarks).toEqual([keep]);
+        expect(storedBookmarks()).toEqual([keep]);
+    });
+
+    it("reports an unknown id", () => {
+        const store = useConnectionBookmarksStore();
+
+        expect(store.remove("nope")).toBe(false);
+    });
+
+    it("clear empties the list and storage", () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://a:5761");
+
+        store.clear();
+
+        expect(store.bookmarks).toEqual([]);
+        expect(storedBookmarks()).toEqual([]);
+    });
+});
+
+describe("the built-in SITL target", () => {
+    // jsdom is neither Tauri nor Capacitor, so the default is the websockify proxy address.
+    const SITL_URL = "ws://127.0.0.1:6761";
+
+    it("is offered when nothing is saved", () => {
+        const store = useConnectionBookmarksStore();
+
+        expect(store.bookmarks).toEqual([]);
+        expect(store.items).toEqual([{ id: "default-sitl", name: "Betaflight SITL", url: SITL_URL, builtin: true }]);
+    });
+
+    it("is not persisted, so a later release can change it", () => {
+        useConnectionBookmarksStore();
+
+        expect(storedBookmarks()).toBeUndefined();
+    });
+
+    it("is listed after the user's own bookmarks", () => {
+        const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Quad");
+
+        expect(store.items.map((entry) => entry.name)).toEqual(["Quad", "Betaflight SITL"]);
+    });
+
+    it("is replaced by a saved bookmark for the same address", () => {
+        const store = useConnectionBookmarksStore();
+        store.save(SITL_URL, "My simulator");
+
+        expect(store.items).toEqual([expect.objectContaining({ name: "My simulator", url: SITL_URL })]);
+        expect(store.items.some((entry) => entry.builtin)).toBe(false);
+    });
+
+    it("stays gone once dismissed, across a reload", () => {
+        const store = useConnectionBookmarksStore();
+
+        expect(store.remove("default-sitl")).toBe(true);
+        expect(store.items).toEqual([]);
+        expect(getConfig(HIDDEN_DEFAULTS_KEY).connectionBookmarksHiddenDefaults).toEqual(["default-sitl"]);
+
+        store.reload();
+        expect(store.items).toEqual([]);
+    });
+
+    it("comes back after the list is cleared", () => {
+        const store = useConnectionBookmarksStore();
+        store.remove("default-sitl");
+
+        store.clear();
+
+        expect(store.items.some((entry) => entry.builtin)).toBe(true);
+    });
+
+    it("keeps its id to itself when storage claims it", () => {
+        seed([{ id: "default-sitl", name: "Impostor", url: "tcp://192.168.4.1:5761" }]);
+
+        const store = useConnectionBookmarksStore();
+
+        expect(store.bookmarks[0].id).not.toBe("default-sitl");
+        expect(new Set(store.items.map((entry) => entry.id)).size).toBe(2);
+    });
+
+    it("honours a stored dismissal and forgets ids that name no built-in", () => {
+        setConfig({ [HIDDEN_DEFAULTS_KEY]: ["default-sitl", "default-gone", 7] });
+
+        const store = useConnectionBookmarksStore();
+        expect(store.items).toEqual([]);
+
+        store.save("tcp://a:5761");
+
+        expect(getConfig(HIDDEN_DEFAULTS_KEY).connectionBookmarksHiddenDefaults).toEqual(["default-sitl"]);
+    });
+
+    it("does not count towards the saved-bookmark limit", () => {
+        const store = useConnectionBookmarksStore();
+
+        expect(store.count).toBe(0);
+        expect(store.findByUrl(SITL_URL)).toBeNull();
+        expect(store.findItemByUrl(SITL_URL)?.builtin).toBe(true);
+    });
+});
+
+describe("reading back what was stored", () => {
+    it("restores saved bookmarks", () => {
+        seed([{ id: "one", name: "Quad", url: "tcp://192.168.4.1:5761" }]);
+
+        const store = useConnectionBookmarksStore();
+
+        expect(store.bookmarks).toEqual([{ id: "one", name: "Quad", url: "tcp://192.168.4.1:5761" }]);
+    });
+
+    it("drops entries with no usable address", () => {
+        seed([{ id: "a", name: "Bad", url: "   " }, { id: "b", url: "tcp://ok:5761" }, null, "nonsense", 42]);
+
+        const store = useConnectionBookmarksStore();
+
+        expect(store.bookmarks).toEqual([{ id: "b", name: "tcp://ok:5761", url: "tcp://ok:5761" }]);
+    });
+
+    it("keeps the first of duplicate addresses and de-duplicates ids", () => {
+        seed([
+            { id: "dup", name: "First", url: "tcp://a:5761" },
+            { id: "dup", name: "Second", url: "tcp://b:5761" },
+            { id: "other", name: "Third", url: "TCP://A:5761" },
+        ]);
+
+        const store = useConnectionBookmarksStore();
+
+        expect(store.bookmarks.map((b) => b.name)).toEqual(["First", "Second"]);
+        expect(new Set(store.bookmarks.map((b) => b.id)).size).toBe(2);
+    });
+
+    it("ignores a stored value that is not a list", () => {
+        seed({ nope: true });
+
+        expect(useConnectionBookmarksStore().bookmarks).toEqual([]);
+    });
+
+    it("reload picks up a write from another context", () => {
+        const store = useConnectionBookmarksStore();
+        expect(store.bookmarks).toEqual([]);
+
+        seed([{ id: "x", name: "Elsewhere", url: "tcp://x:5761" }]);
+        store.reload();
+
+        expect(store.bookmarks).toEqual([{ id: "x", name: "Elsewhere", url: "tcp://x:5761" }]);
+    });
+});

--- a/test/js/connection_bookmarks.test.js
+++ b/test/js/connection_bookmarks.test.js
@@ -103,7 +103,16 @@ describe("the seeded SITL target", () => {
 
 describe("reading back what was stored", () => {
     it("drops entries with no address, repeats of one address, and junk", () => {
-        seed([{ name: "Bad", url: "  " }, { url: "tcp://ok:5761" }, { url: "TCP://OK:5761" }, null, 42]);
+        seed([
+            { name: "Bad", url: "  " },
+            { url: "tcp://ok:5761" },
+            { url: "TCP://OK:5761" },
+            // A non-string address must not be stringified into "[object Object]".
+            { url: {} },
+            { url: ["tcp://sneaky:5761"] },
+            null,
+            42,
+        ]);
 
         expect(useConnectionBookmarksStore().bookmarks).toEqual([{ name: "tcp://ok:5761", url: "tcp://ok:5761" }]);
     });

--- a/test/js/connection_bookmarks.test.js
+++ b/test/js/connection_bookmarks.test.js
@@ -1,18 +1,14 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 
-import { useConnectionBookmarksStore, __testing } from "../../src/stores/connectionBookmarks.js";
+import { useConnectionBookmarksStore } from "../../src/stores/connectionBookmarks.js";
 import { get as getConfig, set as setConfig } from "../../src/js/ConfigStorage.js";
 
-const { STORAGE_KEY, HIDDEN_DEFAULTS_KEY, MAX_BOOKMARKS, MAX_NAME_LENGTH, MAX_URL_LENGTH } = __testing;
+// jsdom is neither Tauri nor Capacitor, so the seeded SITL target is the websockify address.
+const SITL = { name: "Betaflight SITL", url: "ws://127.0.0.1:6761" };
 
-function storedBookmarks() {
-    return getConfig(STORAGE_KEY).connectionBookmarks;
-}
-
-function seed(bookmarks) {
-    setConfig({ [STORAGE_KEY]: bookmarks });
-}
+const stored = () => getConfig("connectionBookmarks").connectionBookmarks;
+const seed = (bookmarks) => setConfig({ connectionBookmarks: bookmarks });
 
 beforeEach(() => {
     localStorage.clear();
@@ -20,273 +16,110 @@ beforeEach(() => {
 });
 
 describe("saving a manual target", () => {
-    it("keeps the address and falls back to it as the name", () => {
+    it("trims, falls back to the address as the name, and persists", () => {
         const store = useConnectionBookmarksStore();
 
-        const bookmark = store.save("tcp://192.168.4.1:5761");
+        const bookmark = store.save("  tcp://quad.local:5761  ");
 
-        expect(bookmark).toMatchObject({ name: "tcp://192.168.4.1:5761", url: "tcp://192.168.4.1:5761" });
-        expect(store.bookmarks).toHaveLength(1);
-        expect(storedBookmarks()).toEqual([bookmark]);
+        expect(bookmark).toEqual({ name: "tcp://quad.local:5761", url: "tcp://quad.local:5761" });
+        expect(stored()).toContainEqual(bookmark);
     });
 
-    it("trims the address and the name", () => {
+    it("renames instead of duplicating, matching the address case-insensitively", () => {
         const store = useConnectionBookmarksStore();
+        store.save("tcp://192.168.4.1:5761", "Quad");
 
-        const bookmark = store.save("  tcp://quad.local:5761  ", "  Cinewhoop  ");
+        store.save("TCP://192.168.4.1:5761", "Racer");
 
-        expect(bookmark).toMatchObject({ name: "Cinewhoop", url: "tcp://quad.local:5761" });
-    });
-
-    it("renames instead of duplicating when the address is already saved", () => {
-        const store = useConnectionBookmarksStore();
-
-        const first = store.save("tcp://192.168.4.1:5761", "Quad");
-        const second = store.save("TCP://192.168.4.1:5761", "Racer");
-
-        expect(store.bookmarks).toHaveLength(1);
-        expect(second.id).toBe(first.id);
-        expect(store.bookmarks[0].name).toBe("Racer");
-        expect(storedBookmarks()).toHaveLength(1);
+        expect(store.bookmarks.filter((b) => b.url.toLowerCase().includes("192.168.4.1"))).toEqual([
+            { name: "Racer", url: "tcp://192.168.4.1:5761" },
+        ]);
     });
 
     it("refuses an empty address", () => {
         const store = useConnectionBookmarksStore();
 
         expect(store.save("   ", "Nothing")).toBeNull();
-        expect(store.bookmarks).toHaveLength(0);
     });
 
-    it("stops at the maximum and reports being full", () => {
+    it("stops at the cap", () => {
+        seed([]);
         const store = useConnectionBookmarksStore();
 
-        for (let i = 0; i < MAX_BOOKMARKS; i++) {
+        for (let i = 0; i < 50; i++) {
             expect(store.save(`tcp://10.0.0.${i}:5761`)).not.toBeNull();
         }
 
-        expect(store.isFull).toBe(true);
         expect(store.save("tcp://10.9.9.9:5761")).toBeNull();
-        expect(store.count).toBe(MAX_BOOKMARKS);
-    });
-
-    it("still renames a known address when the list is full", () => {
-        const store = useConnectionBookmarksStore();
-
-        for (let i = 0; i < MAX_BOOKMARKS; i++) {
-            store.save(`tcp://10.0.0.${i}:5761`);
-        }
-
-        expect(store.save("tcp://10.0.0.0:5761", "First quad")?.name).toBe("First quad");
-    });
-
-    it("clamps over-long names and addresses", () => {
-        const store = useConnectionBookmarksStore();
-
-        const bookmark = store.save("t".repeat(MAX_URL_LENGTH + 10), "n".repeat(MAX_NAME_LENGTH + 10));
-
-        expect(bookmark.url).toHaveLength(MAX_URL_LENGTH);
-        expect(bookmark.name).toHaveLength(MAX_NAME_LENGTH);
+        // A known address is still renameable when the list is full.
+        expect(store.save("tcp://10.0.0.0:5761", "First")?.name).toBe("First");
     });
 });
 
-// crypto.randomUUID needs a secure context, which the configurator does not get over plain
-// HTTP on a LAN address. There the store falls back to a counter that restarts at 1 on every
-// load, so these cover the ids it mints without it.
-describe("ids without crypto.randomUUID", () => {
-    let randomUUID;
-
-    beforeEach(() => {
-        randomUUID = crypto.randomUUID;
-        crypto.randomUUID = undefined;
-    });
-
-    afterEach(() => {
-        crypto.randomUUID = randomUUID;
-    });
-
-    it("does not reuse an id already held by a stored bookmark", () => {
-        seed([{ id: "bookmark-1", name: "From last session", url: "tcp://a:5761" }]);
-
-        const store = useConnectionBookmarksStore();
-        const saved = store.save("tcp://b:5761", "New one");
-
-        expect(saved.id).not.toBe("bookmark-1");
-        expect(new Set(store.items.map((entry) => entry.id)).size).toBe(store.items.length);
-    });
-
-    it("does not hand out a built-in id", () => {
-        const store = useConnectionBookmarksStore();
-
-        for (let i = 0; i < 5; i++) {
-            expect(store.save(`tcp://${i}.example:5761`).id).not.toBe("default-sitl");
-        }
-    });
-});
-
-describe("looking a target up", () => {
-    it("matches case-insensitively and ignores surrounding space", () => {
+describe("finding and removing", () => {
+    it("finds by address, ignoring case and surrounding space", () => {
         const store = useConnectionBookmarksStore();
         store.save("tcp://Quad.local:5761", "Quad");
 
-        expect(store.findByUrl("  tcp://quad.LOCAL:5761 ")?.name).toBe("Quad");
-        expect(store.findByUrl("tcp://other:5761")).toBeNull();
-        expect(store.findByUrl("")).toBeNull();
-        expect(store.findByUrl(undefined)).toBeNull();
+        expect(store.find("  tcp://quad.LOCAL:5761 ")?.name).toBe("Quad");
+        expect(store.find("tcp://other:5761")).toBeNull();
+        expect(store.find("")).toBeNull();
     });
-});
 
-describe("removing", () => {
-    it("removes by id and persists the shortened list", () => {
+    it("removes by address and persists the shortened list", () => {
         const store = useConnectionBookmarksStore();
         const keep = store.save("tcp://a:5761", "A");
-        const drop = store.save("tcp://b:5761", "B");
+        store.save("tcp://b:5761", "B");
 
-        expect(store.remove(drop.id)).toBe(true);
-        expect(store.bookmarks).toEqual([keep]);
-        expect(storedBookmarks()).toEqual([keep]);
-    });
-
-    it("reports an unknown id", () => {
-        const store = useConnectionBookmarksStore();
-
-        expect(store.remove("nope")).toBe(false);
-    });
-
-    it("clear empties the list and storage", () => {
-        const store = useConnectionBookmarksStore();
-        store.save("tcp://a:5761");
-
-        store.clear();
-
-        expect(store.bookmarks).toEqual([]);
-        expect(storedBookmarks()).toEqual([]);
+        expect(store.remove("tcp://b:5761")).toBe(true);
+        expect(store.remove("tcp://b:5761")).toBe(false);
+        expect(stored()).toEqual([SITL, keep]);
     });
 });
 
-describe("the built-in SITL target", () => {
-    // jsdom is neither Tauri nor Capacitor, so the default is the websockify proxy address.
-    const SITL_URL = "ws://127.0.0.1:6761";
-
-    it("is offered when nothing is saved", () => {
+describe("the seeded SITL target", () => {
+    it("is there on a first run, and saved so it is the user's from then on", () => {
         const store = useConnectionBookmarksStore();
 
-        expect(store.bookmarks).toEqual([]);
-        expect(store.items).toEqual([{ id: "default-sitl", name: "Betaflight SITL", url: SITL_URL, builtin: true }]);
+        expect(store.bookmarks).toEqual([SITL]);
+        expect(stored()).toEqual([SITL]);
     });
 
-    it("is not persisted, so a later release can change it", () => {
-        useConnectionBookmarksStore();
+    it("does not come back once removed", () => {
+        useConnectionBookmarksStore().remove(SITL.url);
+        setActivePinia(createPinia());
 
-        expect(storedBookmarks()).toBeUndefined();
+        expect(useConnectionBookmarksStore().bookmarks).toEqual([]);
     });
 
-    it("is listed after the user's own bookmarks", () => {
-        const store = useConnectionBookmarksStore();
-        store.save("tcp://192.168.4.1:5761", "Quad");
-
-        expect(store.items.map((entry) => entry.name)).toEqual(["Quad", "Betaflight SITL"]);
-    });
-
-    it("is replaced by a saved bookmark for the same address", () => {
-        const store = useConnectionBookmarksStore();
-        store.save(SITL_URL, "My simulator");
-
-        expect(store.items).toEqual([expect.objectContaining({ name: "My simulator", url: SITL_URL })]);
-        expect(store.items.some((entry) => entry.builtin)).toBe(false);
-    });
-
-    it("stays gone once dismissed, across a reload", () => {
+    it("can be renamed like any other bookmark", () => {
         const store = useConnectionBookmarksStore();
 
-        expect(store.remove("default-sitl")).toBe(true);
-        expect(store.items).toEqual([]);
-        expect(getConfig(HIDDEN_DEFAULTS_KEY).connectionBookmarksHiddenDefaults).toEqual(["default-sitl"]);
+        store.save(SITL.url, "My simulator");
 
-        store.reload();
-        expect(store.items).toEqual([]);
-    });
-
-    it("comes back after the list is cleared", () => {
-        const store = useConnectionBookmarksStore();
-        store.remove("default-sitl");
-
-        store.clear();
-
-        expect(store.items.some((entry) => entry.builtin)).toBe(true);
-    });
-
-    it("keeps its id to itself when storage claims it", () => {
-        seed([{ id: "default-sitl", name: "Impostor", url: "tcp://192.168.4.1:5761" }]);
-
-        const store = useConnectionBookmarksStore();
-
-        expect(store.bookmarks[0].id).not.toBe("default-sitl");
-        expect(new Set(store.items.map((entry) => entry.id)).size).toBe(2);
-    });
-
-    it("honours a stored dismissal and forgets ids that name no built-in", () => {
-        setConfig({ [HIDDEN_DEFAULTS_KEY]: ["default-sitl", "default-gone", 7] });
-
-        const store = useConnectionBookmarksStore();
-        expect(store.items).toEqual([]);
-
-        store.save("tcp://a:5761");
-
-        expect(getConfig(HIDDEN_DEFAULTS_KEY).connectionBookmarksHiddenDefaults).toEqual(["default-sitl"]);
-    });
-
-    it("does not count towards the saved-bookmark limit", () => {
-        const store = useConnectionBookmarksStore();
-
-        expect(store.count).toBe(0);
-        expect(store.findByUrl(SITL_URL)).toBeNull();
-        expect(store.findItemByUrl(SITL_URL)?.builtin).toBe(true);
+        expect(store.bookmarks).toEqual([{ name: "My simulator", url: SITL.url }]);
     });
 });
 
 describe("reading back what was stored", () => {
-    it("restores saved bookmarks", () => {
-        seed([{ id: "one", name: "Quad", url: "tcp://192.168.4.1:5761" }]);
+    it("drops entries with no address, repeats of one address, and junk", () => {
+        seed([{ name: "Bad", url: "  " }, { url: "tcp://ok:5761" }, { url: "TCP://OK:5761" }, null, 42]);
 
-        const store = useConnectionBookmarksStore();
-
-        expect(store.bookmarks).toEqual([{ id: "one", name: "Quad", url: "tcp://192.168.4.1:5761" }]);
+        expect(useConnectionBookmarksStore().bookmarks).toEqual([{ name: "tcp://ok:5761", url: "tcp://ok:5761" }]);
     });
 
-    it("drops entries with no usable address", () => {
-        seed([{ id: "a", name: "Bad", url: "   " }, { id: "b", url: "tcp://ok:5761" }, null, "nonsense", 42]);
-
-        const store = useConnectionBookmarksStore();
-
-        expect(store.bookmarks).toEqual([{ id: "b", name: "tcp://ok:5761", url: "tcp://ok:5761" }]);
-    });
-
-    it("keeps the first of duplicate addresses and de-duplicates ids", () => {
-        seed([
-            { id: "dup", name: "First", url: "tcp://a:5761" },
-            { id: "dup", name: "Second", url: "tcp://b:5761" },
-            { id: "other", name: "Third", url: "TCP://A:5761" },
-        ]);
-
-        const store = useConnectionBookmarksStore();
-
-        expect(store.bookmarks.map((b) => b.name)).toEqual(["First", "Second"]);
-        expect(new Set(store.bookmarks.map((b) => b.id)).size).toBe(2);
-    });
-
-    it("ignores a stored value that is not a list", () => {
+    it("ignores a stored value that is not a list, without re-seeding", () => {
         seed({ nope: true });
 
         expect(useConnectionBookmarksStore().bookmarks).toEqual([]);
     });
 
-    it("reload picks up a write from another context", () => {
+    it("clamps an over-long name and address", () => {
         const store = useConnectionBookmarksStore();
-        expect(store.bookmarks).toEqual([]);
 
-        seed([{ id: "x", name: "Elsewhere", url: "tcp://x:5761" }]);
-        store.reload();
+        const bookmark = store.save("t".repeat(300), "n".repeat(300));
 
-        expect(store.bookmarks).toEqual([{ id: "x", name: "Elsewhere", url: "tcp://x:5761" }]);
+        expect(bookmark.url).toHaveLength(253);
+        expect(bookmark.name).toHaveLength(253);
     });
 });

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -316,6 +316,28 @@ describe("serial_backend connectDisconnect — attempt already in flight", () =>
     });
 });
 
+// A bookmarked address (an ELRS Wi-Fi module, SITL) reaches the transport only through the
+// "manual" pseudo-device: the picker holds "manual" and the address lives in portOverride.
+// If the connect path stopped reading portOverride, every bookmark would open the last
+// enumerated serial port instead.
+describe("serial_backend connectDisconnect — manual target", () => {
+    beforeEach(() => {
+        resetMocks();
+        DeviceHandler.devicePicker.portOverride = "/dev/rfcomm0";
+    });
+
+    it("opens the remembered address rather than the picker's device path", () => {
+        DeviceHandler.devicePicker.selectedDevice = "manual";
+        DeviceHandler.devicePicker.portOverride = "tcp://192.168.4.1:5761";
+
+        connectDisconnect();
+
+        expect(serial.connect).toHaveBeenCalledTimes(1);
+        expect(serial.connect.mock.calls[0][0]).toBe("tcp://192.168.4.1:5761");
+        expect(GUI.connecting_to).toBe("tcp://192.168.4.1:5761");
+    });
+});
+
 describe("serial_backend disconnect convergence", () => {
     beforeEach(() => {
         setActivePinia(createPinia());


### PR DESCRIPTION
Closes #3432

Configuring a quad through its ELRS Wi-Fi module means typing the module's address into the manual connect box every single time. This adds bookmarks for manual targets: save an address under a name, then pick it from the connect menu.

### Connect dropdown

Saved connections are listed as their own entries, so connecting to a quad over TCP is one click. They sit behind the same expert-mode + "manual mode" gate as the manual option itself. The connect button now names a manual connection by its bookmark (or its address) instead of just showing "Connect".

### Connect dialog (manual mode)

- A name field and a **Save** button next to the address. Saving an address that is already bookmarked renames it in place — the button says **Update** — instead of adding a second entry.
- The list of saved connections below: click one to fill in the address, or remove it with the trash button.
- Picking an entry offers its name back, so an update cannot silently blank the label.

### SITL default

Ships with a built-in **Betaflight SITL** entry, so a simulator connection needs no typing at all:

- `tcp://127.0.0.1:5761` where a raw-TCP transport exists (Tauri desktop, Capacitor Android) — SITL speaks raw TCP and nothing else
- `ws://127.0.0.1:6761` in the browser / PWA — the address of the [websockify proxy the docs describe](https://betaflight.com/docs/development/autopilot/SITL_Autopilot_Testing_Gazebo#connect-to-the-sitl) (`websockify 127.0.0.1:6761 127.0.0.1:5761`), which is a different port, not SITL's own with a `ws://` scheme

It is not persisted, so a later release can change it. Saving over it makes the user's own copy (and replaces it in the list); removing it dismisses it for good.

### Storage

Bookmarks live in a Pinia store (`src/stores/connectionBookmarks.js`) backed by `localStorage`. Addresses match case-insensitively, names and addresses are trimmed and length-clamped, the list is capped at 50, and everything read back from storage is sanitised — malformed entries, duplicate addresses and duplicate or reserved ids are dropped, so a hand-edited or downgraded entry cannot break the connect menu.

### Testing

36 new tests: `test/js/connection_bookmarks.test.js` covers the store (saving, renaming, dedup, limits, sanitising, the SITL default and its dismissal) and `test/js/connect_options_dialog.test.js` drives the dialog's `setup()` logic directly, since the repo has no component-rendering harness.

`npx vitest run` — 72 files, 855 tests pass. ESLint and Prettier clean, `npm run build` succeeds.

Not covered here: the issue's follow-up idea of pinging saved addresses to auto-detect which quads are reachable — that is a separate feature.

Screenshots to follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added saved bookmarks for manual connections.
  * Save, rename, select, and remove bookmarks in the connection dialog.
  * Quickly connect using bookmark names, URLs, and built-in simulator options.
  * Added validation, duplicate handling, capacity limits, URL normalization, and persistent storage.
  * Manual connections now reliably use the selected bookmark address.

* **Localization**
  * Added English text for bookmark controls, fields, actions, and limit warnings.

* **Tests**
  * Added coverage for bookmark management, validation, persistence, and connection interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->