### PR TITLE
fix(ports): preserve serial function bits the app cannot name

### DIFF
--- a/src/composables/ports/usePortsConfiguration.js
+++ b/src/composables/ports/usePortsConfiguration.js
@@ -8,6 +8,13 @@ import { i18n } from "../../js/localization";
 import { tracking } from "../../js/Analytics";
 import { useReboot } from "../useReboot";
 
+/** @typedef {import("./usePortsState").PortRow} PortRow */
+
+/**
+ * @param {PortRow[]} ports - the rows the Ports tab is editing
+ * @param {Record<string, string>} analyticsChanges - accumulated for the save event
+ * @param {object[]} functionRules - the serial function rules for this API version
+ */
 export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
     const { saveAndReboot } = useReboot();
 
@@ -87,9 +94,13 @@ export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
             if (p.peripheral) {
                 functions.push(p.peripheral);
             }
+            // Functions the FC reported that no slot could hold; the bits this build cannot
+            // name ride along in functionMask and are restored by serialPortFunctionsToMask.
+            functions.push(...(p.reservedFunctions ?? []));
 
             return {
                 identifier: p.identifier,
+                functionMask: p.functionMask ?? 0,
                 msp_baudrate: p.msp_baudrate,
                 telemetry_baudrate: p.telemetry_baudrate,
                 gps_baudrate: p.gps_baudrate === "AUTO" ? "57600" : p.gps_baudrate,
@@ -117,6 +128,11 @@ export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
     const findRule = (name) => functionRules.find((r) => r.name === name);
     const isMspShareable = (rule) => rule?.sharableWith?.includes("msp") === true;
 
+    // A preserved function is written back on save, and VTX_MSP is the one peripheral firmware
+    // lets share a port with MSP. Clearing MSP under it would produce a combination
+    // serialPortFunctionsConflict() refuses, so the enable stays.
+    const reservedRequiresMsp = (port) => (port.reservedFunctions ?? []).some((name) => name.includes("MSP"));
+
     const onTelemetryChange = (port) => {
         if (port.telemetry) {
             const rule = findRule(port.telemetry);
@@ -124,7 +140,7 @@ export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
                 analyticsChanges["Telemetry"] = rule.displayName;
             }
 
-            if (!isMspShareable(rule)) {
+            if (!isMspShareable(rule) && !reservedRequiresMsp(port)) {
                 port.msp = false;
             }
 
@@ -143,7 +159,9 @@ export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
             port.msp = true;
             analyticsChanges["MspControl"] = port.peripheral;
         } else if (port.peripheral && !isMspShareable(rule)) {
-            port.msp = false;
+            if (!reservedRequiresMsp(port)) {
+                port.msp = false;
+            }
             delete analyticsChanges["MspControl"];
         }
 

--- a/src/composables/ports/usePortsState.js
+++ b/src/composables/ports/usePortsState.js
@@ -52,8 +52,8 @@ export function usePortsState(getRules) {
         // A port has one slot per group (see functionRules), so a decoded function that no slot
         // claimed - a second peripheral, or a named function with no rule on this API version -
         // would be dropped on save. Park it here and re-emit it verbatim instead.
-        const claimed = [msp && "MSP", rxSerial && "RX_SERIAL", telemetry, sensor, peripheral].filter(Boolean);
-        const reservedFunctions = fcPort.functions.filter((f) => !claimed.includes(f));
+        const claimed = new Set([msp && "MSP", rxSerial && "RX_SERIAL", telemetry, sensor, peripheral].filter(Boolean));
+        const reservedFunctions = fcPort.functions.filter((f) => !claimed.has(f));
 
         return {
             identifier: fcPort.identifier,

--- a/src/composables/ports/usePortsState.js
+++ b/src/composables/ports/usePortsState.js
@@ -7,6 +7,30 @@ import { mspHelper } from "../../js/msp/MSPHelper";
 import { useDirtyState } from "../useDirtyState";
 import { getPortDisplayName as getPortName } from "./portNames";
 
+/**
+ * A serial port as the FC reported it, decoded from MSP2_COMMON_SERIAL_CONFIG.
+ *
+ * @typedef {object} FcSerialPort
+ * @property {number} identifier
+ * @property {number} functionMask - the raw mask, including bits this build cannot name
+ * @property {string[]} functions - only the bits it could name
+ */
+
+/**
+ * A port as the Ports tab edits it: one slot per function group, plus whatever the save has to
+ * put back untouched.
+ *
+ * @typedef {object} PortRow
+ * @property {number} identifier
+ * @property {number} functionMask - the raw mask as received
+ * @property {string[]} reservedFunctions - decoded functions no slot could hold
+ * @property {boolean} msp
+ * @property {boolean} rxSerial
+ * @property {string} telemetry
+ * @property {string} sensor
+ * @property {string} peripheral
+ */
+
 export function usePortsState(getRules) {
     const ports = reactive([]);
     const analyticsChanges = reactive({});
@@ -14,18 +38,37 @@ export function usePortsState(getRules) {
 
     const { dirty, markClean } = useDirtyState(() => JSON.stringify(ports));
 
+    /**
+     * @param {FcSerialPort} fcPort
+     * @returns {PortRow}
+     */
     const transformPortData = (fcPort) => {
+        const msp = fcPort.functions.includes("MSP");
+        const rxSerial = fcPort.functions.includes("RX_SERIAL");
+        const telemetry = fcPort.functions.find((f) => getRules("telemetry").some((r) => r.name === f)) || "";
+        const sensor = fcPort.functions.find((f) => getRules("sensors").some((r) => r.name === f)) || "";
+        const peripheral = fcPort.functions.find((f) => getRules("peripherals").some((r) => r.name === f)) || "";
+
+        // A port has one slot per group (see functionRules), so a decoded function that no slot
+        // claimed - a second peripheral, or a named function with no rule on this API version -
+        // would be dropped on save. Park it here and re-emit it verbatim instead.
+        const claimed = [msp && "MSP", rxSerial && "RX_SERIAL", telemetry, sensor, peripheral].filter(Boolean);
+        const reservedFunctions = fcPort.functions.filter((f) => !claimed.includes(f));
+
         return {
             identifier: fcPort.identifier,
+            // Raw mask as received. MSPHelper ORs the bits it cannot name back in on write.
+            functionMask: fcPort.functionMask || 0,
+            reservedFunctions,
             msp_baudrate: fcPort.msp_baudrate,
             telemetry_baudrate: fcPort.telemetry_baudrate,
             gps_baudrate: fcPort.gps_baudrate === "AUTO" ? "AUTO" : fcPort.gps_baudrate || "AUTO",
             blackbox_baudrate: fcPort.blackbox_baudrate === "AUTO" ? "AUTO" : fcPort.blackbox_baudrate || "AUTO",
-            msp: fcPort.functions.includes("MSP"),
-            rxSerial: fcPort.functions.includes("RX_SERIAL"),
-            telemetry: fcPort.functions.find((f) => getRules("telemetry").some((r) => r.name === f)) || "",
-            sensor: fcPort.functions.find((f) => getRules("sensors").some((r) => r.name === f)) || "",
-            peripheral: fcPort.functions.find((f) => getRules("peripherals").some((r) => r.name === f)) || "",
+            msp,
+            rxSerial,
+            telemetry,
+            sensor,
+            peripheral,
         };
     };
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -65,6 +65,14 @@ function MspHelper() {
         "2470000",
     ];
     // needs to be identical to 'serialPortFunction_e' in 'src/main/io/serial.h' in betaflight
+    //
+    // This list is incomplete, and that is not a bug to fix by filling it in. Firmware adds
+    // serial functions faster than the app learns their names, and the app cannot always tell
+    // which layout it is talking to: 2026.6.1 has LIDAR_NL on bit 19, while a master build
+    // flashed before the API 1.49 bump has OSD_CUSTOM_TEXT there, and both answer API 1.48.
+    //
+    // Bits absent from this list are not lost: they are round-tripped verbatim by
+    // serialPortUnknownFunctionMask() / serialPortFunctionsToMask() below.
     self.SERIAL_PORT_FUNCTIONS = {
         MSP: 0,
         GPS: 1,
@@ -1006,9 +1014,13 @@ MspHelper.prototype.process_data = function (dataHandler) {
                     const portConfigSize = data.remaining() / count;
                     for (let ii = 0; ii < count; ii++) {
                         const start = data.remaining();
+                        const identifier = data.readU8();
+                        const functionMask = data.readU32();
                         const serialPort = {
-                            identifier: data.readU8(),
-                            functions: self.serialPortFunctionMaskToFunctions(data.readU32()),
+                            identifier,
+                            // retained so bits this build cannot name survive the next write
+                            functionMask,
+                            functions: self.serialPortFunctionMaskToFunctions(functionMask),
                             msp_baudrate: self.BAUD_RATES[data.readU8()],
                             gps_baudrate: self.BAUD_RATES[data.readU8()],
                             telemetry_baudrate: self.BAUD_RATES[data.readU8()],
@@ -2137,7 +2149,10 @@ MspHelper.prototype.crunch = function (code, modifierCode = undefined) {
 
                 buffer.push8(serialPort.identifier);
 
-                const functionMask = self.serialPortFunctionsToMask(serialPort.functions);
+                const functionMask = self.serialPortFunctionsToMask(
+                    serialPort.functions,
+                    self.serialPortUnknownFunctionMask(serialPort.functionMask),
+                );
                 buffer
                     .push32(functionMask)
                     .push8(self.BAUD_RATES.indexOf(serialPort.msp_baudrate))
@@ -2797,7 +2812,42 @@ MspHelper.prototype.serialPortFunctionMaskToFunctions = function (functionMask) 
     return functions;
 };
 
-MspHelper.prototype.serialPortFunctionsToMask = function (functions) {
+/**
+ * Every bit this configurator build knows how to name, as a mask.
+ *
+ * @returns {number} bitmask of the serialPortFunction_e bits in SERIAL_PORT_FUNCTIONS
+ */
+MspHelper.prototype.serialPortKnownFunctionMask = function () {
+    let mask = 0;
+    for (const bit of Object.values(this.SERIAL_PORT_FUNCTIONS)) {
+        mask = bit_set(mask, bit);
+    }
+    return mask >>> 0;
+};
+
+/**
+ * The bits of `functionMask` this build cannot name, round-tripped untouched rather than
+ * decoded. Without this, opening the Ports tab and saving anything drops a user's gimbal,
+ * Nooploop rangefinder or OSD custom text assignment - every firmware since 2025.12.
+ *
+ * Decoding them instead would need the app to know which layout the FC uses, and below API
+ * 1.49 it cannot: 2026.6.1 and a pre-bump master build disagree about bit 19 while both
+ * answering 1.48.
+ *
+ * @param {number} [functionMask] - the mask as the FC reported it
+ * @returns {number} the bits of `functionMask` absent from SERIAL_PORT_FUNCTIONS
+ */
+MspHelper.prototype.serialPortUnknownFunctionMask = function (functionMask) {
+    return ((functionMask || 0) & ~this.serialPortKnownFunctionMask()) >>> 0;
+};
+
+/**
+ * @param {string[]} functions - named functions to encode
+ * @param {number} [reservedMask=0] - bits to carry through verbatim, from
+ *        {@link MspHelper.prototype.serialPortUnknownFunctionMask}
+ * @returns {number} the mask to send to the FC
+ */
+MspHelper.prototype.serialPortFunctionsToMask = function (functions, reservedMask = 0) {
     const self = this;
     let mask = 0;
 
@@ -2809,7 +2859,7 @@ MspHelper.prototype.serialPortFunctionsToMask = function (functions) {
         }
     }
 
-    return mask;
+    return (mask | reservedMask) >>> 0;
 };
 
 MspHelper.prototype.sendRxFailConfig = function (onCompleteCallback) {

--- a/test/js/msp/serialPortFunctions.test.js
+++ b/test/js/msp/serialPortFunctions.test.js
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import MspHelper from "../../../src/js/msp/MSPHelper";
+import MSPCodes from "../../../src/js/msp/MSPCodes";
+import "../../../src/js/injected_methods";
+import FC from "../../../src/js/fc";
+
+/**
+ * The app names a subset of the firmware's serial function bits and must round-trip the rest
+ * untouched, because it cannot always tell which layout the FC uses: c18421eb moved
+ * OSD_CUSTOM_TEXT into bit 19 without bumping API_VERSION_MINOR, so a released 2026.6.1 board
+ * (bit 19 = LIDAR_NL) and a pre-1.49 master build (bit 19 = OSD_CUSTOM_TEXT) both answer
+ * "1.48". Writing a bit whose meaning cannot be resolved would reassign a user's rangefinder.
+ */
+
+const mspHelper = new MspHelper();
+
+// serialPortFunction_e in src/main/io/serial.h, firmware master (API 1.49), keyed by the
+// configurator's name for each bit. A superset on purpose: the app names only some of these,
+// and what matters is that the ones it does name carry the firmware's value.
+const FIRMWARE_BITS = {
+    MSP: 0,
+    GPS: 1,
+    TELEMETRY_FRSKY: 2, // FUNCTION_TELEMETRY_FRSKY_HUB
+    TELEMETRY_HOTT: 3,
+    TELEMETRY_LTM: 4,
+    TELEMETRY_SMARTPORT: 5,
+    RX_SERIAL: 6,
+    BLACKBOX: 7,
+    TELEMETRY_MAVLINK: 9,
+    ESC_SENSOR: 10,
+    TBS_SMARTAUDIO: 11, // FUNCTION_VTX_SMARTAUDIO
+    TELEMETRY_IBUS: 12,
+    IRC_TRAMP: 13, // FUNCTION_VTX_TRAMP
+    RUNCAM_DEVICE_CONTROL: 14, // FUNCTION_RCDEVICE
+    LIDAR_TF: 15, // FUNCTION_LIDAR, the unified serial rangefinder bit
+    FRSKY_OSD: 16,
+    VTX_MSP: 17,
+    GIMBAL: 18,
+    OSD_CUSTOM_TEXT: 19,
+};
+
+// Bits no firmware defines yet, standing in for whatever it adds next. The live instance today
+// is bit 19 on a board that reports API 1.48, which this build cannot name for the reason above.
+const RESERVED_BIT = 1 << 25;
+const OTHER_RESERVED_BIT = 1 << 30;
+
+function serialConfigBuffer(ports) {
+    const buffer = [];
+    buffer.push8(ports.length);
+    for (const port of ports) {
+        buffer
+            .push8(port.identifier)
+            .push32(port.functionMask)
+            .push8(mspHelper.BAUD_RATES.indexOf("115200"))
+            .push8(mspHelper.BAUD_RATES.indexOf("57600"))
+            .push8(mspHelper.BAUD_RATES.indexOf("AUTO"))
+            .push8(mspHelper.BAUD_RATES.indexOf("115200"));
+    }
+    return buffer;
+}
+
+/** Decode a MSP2_COMMON_SERIAL_CONFIG reply into FC.SERIAL_CONFIG.ports. */
+function readSerialConfig(ports) {
+    mspHelper.process_data({
+        code: MSPCodes.MSP2_COMMON_SERIAL_CONFIG,
+        dataView: new DataView(new Uint8Array(serialConfigBuffer(ports)).buffer),
+        crcError: false,
+        callbacks: [],
+    });
+}
+
+/** Re-encode FC.SERIAL_CONFIG.ports and pull each port's function mask back out. */
+function writtenMasks() {
+    const buffer = mspHelper.crunch(MSPCodes.MSP2_COMMON_SET_SERIAL_CONFIG);
+    const view = new DataView(new Uint8Array(buffer).buffer);
+    const masks = [];
+
+    const count = view.getUint8(0);
+    for (let i = 0; i < count; i++) {
+        masks.push(view.getUint32(1 + i * 9 + 1, true));
+    }
+    return masks;
+}
+
+describe("serial port function bits", () => {
+    beforeEach(() => {
+        FC.resetState();
+    });
+
+    describe("SERIAL_PORT_FUNCTIONS layout", () => {
+        it("gives every named function the bit the firmware gives it", () => {
+            for (const [name, bit] of Object.entries(mspHelper.SERIAL_PORT_FUNCTIONS)) {
+                expect(FIRMWARE_BITS, `${name} is not a firmware serial function`).toHaveProperty(name);
+                expect(bit, `${name} is on the wrong bit`).toEqual(FIRMWARE_BITS[name]);
+            }
+        });
+
+        it("assigns each bit to exactly one function", () => {
+            const bits = Object.values(mspHelper.SERIAL_PORT_FUNCTIONS);
+            expect(new Set(bits).size).toEqual(bits.length);
+        });
+
+        it("reports exactly the named bits in the known mask", () => {
+            const known = mspHelper.serialPortKnownFunctionMask();
+            let expected = 0;
+            for (const bit of Object.values(mspHelper.SERIAL_PORT_FUNCTIONS)) {
+                expected |= 1 << bit;
+            }
+            expect(known).toEqual(expected >>> 0);
+        });
+    });
+
+    describe("serialPortUnknownFunctionMask", () => {
+        it("returns only the bits this build cannot name", () => {
+            const mask = (1 << 1) | RESERVED_BIT | OTHER_RESERVED_BIT;
+            expect(mspHelper.serialPortUnknownFunctionMask(mask)).toEqual(RESERVED_BIT | OTHER_RESERVED_BIT);
+        });
+
+        it("returns zero for a fully known mask", () => {
+            expect(mspHelper.serialPortUnknownFunctionMask((1 << 0) | (1 << 1))).toEqual(0);
+        });
+
+        it("treats a missing mask as nothing to preserve", () => {
+            expect(mspHelper.serialPortUnknownFunctionMask(undefined)).toEqual(0);
+        });
+    });
+
+    describe("decoding a serial config", () => {
+        it("retains the raw mask alongside the names it could decode", () => {
+            const mask = (1 << 1) | RESERVED_BIT;
+            readSerialConfig([{ identifier: 3, functionMask: mask }]);
+
+            expect(FC.SERIAL_CONFIG.ports[0].functionMask).toEqual(mask);
+            expect(FC.SERIAL_CONFIG.ports[0].functions).toEqual(["GPS"]);
+        });
+    });
+
+    describe("decode -> encode round-trip", () => {
+        it("preserves unnamed bits through an unchanged save", () => {
+            const masks = [(1 << 0) | RESERVED_BIT, (1 << 1) | OTHER_RESERVED_BIT];
+
+            readSerialConfig([
+                { identifier: 0, functionMask: masks[0] },
+                { identifier: 1, functionMask: masks[1] },
+            ]);
+
+            expect(writtenMasks()).toEqual(masks);
+        });
+
+        it("preserves unnamed bits on a port the user edited", () => {
+            readSerialConfig([{ identifier: 3, functionMask: (1 << 1) | RESERVED_BIT }]);
+
+            // user swaps GPS for ESC_SENSOR on this port
+            FC.SERIAL_CONFIG.ports[0].functions = ["ESC_SENSOR"];
+
+            expect(writtenMasks()).toEqual([(1 << 10) | RESERVED_BIT]);
+        });
+
+        it("preserves unnamed bits on a port whose functions were all cleared", () => {
+            readSerialConfig([{ identifier: 5, functionMask: (1 << 7) | RESERVED_BIT }]);
+
+            FC.SERIAL_CONFIG.ports[0].functions = [];
+
+            expect(writtenMasks()).toEqual([RESERVED_BIT]);
+        });
+
+        it("preserves an unnamed bit on one port while another port is edited", () => {
+            readSerialConfig([
+                { identifier: 0, functionMask: 1 << 0 },
+                { identifier: 4, functionMask: RESERVED_BIT },
+            ]);
+
+            FC.SERIAL_CONFIG.ports[0].functions = ["MSP", "TELEMETRY_MAVLINK"];
+
+            expect(writtenMasks()).toEqual([(1 << 0) | (1 << 9), RESERVED_BIT]);
+        });
+
+        it("encodes nothing extra when the FC port carries no mask (virtual mode)", () => {
+            FC.SERIAL_CONFIG.ports = [
+                {
+                    identifier: 0,
+                    functions: ["MSP"],
+                    msp_baudrate: "115200",
+                    gps_baudrate: "57600",
+                    telemetry_baudrate: "AUTO",
+                    blackbox_baudrate: "115200",
+                },
+            ];
+
+            expect(writtenMasks()).toEqual([1 << 0]);
+        });
+    });
+});

--- a/test/js/ports_save.test.js
+++ b/test/js/ports_save.test.js
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const sendSerialConfig = vi.fn();
+const crunch = vi.fn(() => []);
+const sendMessage = vi.fn();
+const saveAndReboot = vi.fn(() => Promise.resolve());
+const guiLog = vi.fn();
+
+vi.mock("../../src/js/msp/MSPHelper", () => ({
+    mspHelper: {
+        sendSerialConfig: (...args) => sendSerialConfig(...args),
+        crunch: (...args) => crunch(...args),
+    },
+}));
+
+vi.mock("../../src/js/msp", () => ({
+    default: { send_message: (...args) => sendMessage(...args) },
+}));
+
+vi.mock("../../src/composables/useReboot", () => ({
+    useReboot: () => ({ saveAndReboot }),
+}));
+
+vi.mock("../../src/js/gui_log", () => ({
+    gui_log: (...args) => guiLog(...args),
+}));
+
+vi.mock("../../src/js/localization", () => ({
+    i18n: { getMessage: (key) => key },
+}));
+
+vi.mock("../../src/js/Analytics", () => ({
+    tracking: {
+        EVENT_CATEGORIES: { FLIGHT_CONTROLLER: "fc" },
+        sendSaveAndChangeEvents: vi.fn(),
+    },
+}));
+
+const { usePortsConfiguration } = await import("../../src/composables/ports/usePortsConfiguration");
+const FC = (await import("../../src/js/fc")).default;
+const Features = (await import("../../src/js/Features")).default;
+
+function makePort(overrides = {}) {
+    return {
+        identifier: 0,
+        functionMask: 0,
+        reservedFunctions: [],
+        msp: false,
+        rxSerial: false,
+        telemetry: "",
+        sensor: "",
+        peripheral: "",
+        msp_baudrate: "115200",
+        telemetry_baudrate: "AUTO",
+        gps_baudrate: "AUTO",
+        blackbox_baudrate: "AUTO",
+        ...overrides,
+    };
+}
+
+/** Run saveConfig and let the serial write complete. */
+function save(ports) {
+    const { saveConfig } = usePortsConfiguration(ports, {}, []);
+    saveConfig();
+    expect(sendSerialConfig).toHaveBeenCalledTimes(1);
+    sendSerialConfig.mock.calls[0][0]();
+}
+
+describe("ports save", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        FC.resetState();
+        FC.CONFIG.apiVersion = "1.48.0";
+        FC.FEATURE_CONFIG.features = new Features(FC.CONFIG);
+    });
+
+    describe("reconstructed port array", () => {
+        it("carries the raw function mask through so unnamed bits can be restored", () => {
+            const reservedBit = 1 << 25;
+            save([makePort({ identifier: 3, sensor: "GPS", functionMask: (1 << 1) | reservedBit })]);
+
+            expect(FC.SERIAL_CONFIG.ports[0].functionMask).toEqual((1 << 1) | reservedBit);
+        });
+
+        it("re-emits named functions that no slot could hold", () => {
+            // A port has one peripheral slot, so a second peripheral the FC reported lands in
+            // reservedFunctions rather than being silently dropped on save.
+            save([makePort({ identifier: 4, peripheral: "VTX_MSP", reservedFunctions: ["FRSKY_OSD"] })]);
+
+            expect(FC.SERIAL_CONFIG.ports[0].functions).toEqual(["VTX_MSP", "FRSKY_OSD"]);
+        });
+
+        it("keeps every slot's function", () => {
+            save([
+                makePort({
+                    identifier: 2,
+                    msp: true,
+                    rxSerial: true,
+                    telemetry: "TELEMETRY_MAVLINK",
+                    sensor: "GPS",
+                    peripheral: "BLACKBOX",
+                }),
+            ]);
+
+            expect(FC.SERIAL_CONFIG.ports[0].functions).toEqual([
+                "MSP",
+                "RX_SERIAL",
+                "TELEMETRY_MAVLINK",
+                "GPS",
+                "BLACKBOX",
+            ]);
+        });
+
+        it("tolerates a port with no reserved data", () => {
+            const port = makePort({ identifier: 1, sensor: "GPS" });
+            delete port.functionMask;
+            delete port.reservedFunctions;
+
+            save([port]);
+
+            expect(FC.SERIAL_CONFIG.ports[0].functionMask).toEqual(0);
+            expect(FC.SERIAL_CONFIG.ports[0].functions).toEqual(["GPS"]);
+        });
+    });
+
+    describe("MSP under a preserved function", () => {
+        // VTX_MSP is the peripheral firmware lets share a port with MSP. When the FC reports it
+        // alongside another peripheral, only one fits the row's slot and the other is preserved -
+        // and the save writes it back, so clearing MSP under it would produce a combination
+        // serialPortFunctionsConflict() refuses.
+        const rules = [
+            { name: "FRSKY_OSD", groups: ["peripherals"], maxPorts: 1, displayName: "FrSky OSD" },
+            { name: "TELEMETRY_HOTT", groups: ["telemetry"], maxPorts: 1, displayName: "HoTT" },
+        ];
+
+        it("keeps MSP when a preserved peripheral needs it", () => {
+            const port = makePort({ msp: true, peripheral: "FRSKY_OSD", reservedFunctions: ["VTX_MSP"] });
+            const { onPeripheralChange } = usePortsConfiguration([port], {}, rules);
+
+            onPeripheralChange(port);
+
+            expect(port.msp).toBe(true);
+        });
+
+        it("still clears MSP when nothing preserved needs it", () => {
+            const port = makePort({ msp: true, peripheral: "FRSKY_OSD" });
+            const { onPeripheralChange } = usePortsConfiguration([port], {}, rules);
+
+            onPeripheralChange(port);
+
+            expect(port.msp).toBe(false);
+        });
+
+        it("keeps MSP when a telemetry pick would otherwise clear it", () => {
+            const port = makePort({ msp: true, telemetry: "TELEMETRY_HOTT", reservedFunctions: ["VTX_MSP"] });
+            const { onTelemetryChange } = usePortsConfiguration([port], {}, rules);
+
+            onTelemetryChange(port);
+
+            expect(port.msp).toBe(true);
+        });
+
+        it("still clears MSP for a telemetry function that cannot share it", () => {
+            const port = makePort({ msp: true, telemetry: "TELEMETRY_HOTT" });
+            const { onTelemetryChange } = usePortsConfiguration([port], {}, rules);
+
+            onTelemetryChange(port);
+
+            expect(port.msp).toBe(false);
+        });
+    });
+
+    describe("feature bits", () => {
+        it("enables RX_SERIAL, ESC_SENSOR and GPS from port assignments", () => {
+            save([
+                makePort({ identifier: 0, rxSerial: true }),
+                makePort({ identifier: 2, sensor: "ESC_SENSOR" }),
+                makePort({ identifier: 3, sensor: "GPS" }),
+            ]);
+
+            const features = FC.FEATURE_CONFIG.features;
+            expect(features.isEnabled("RX_SERIAL")).toBe(true);
+            expect(features.isEnabled("ESC_SENSOR")).toBe(true);
+            expect(features.isEnabled("GPS")).toBe(true);
+        });
+
+        it("does not enable a feature from a reserved function it cannot interpret", () => {
+            save([makePort({ identifier: 4, reservedFunctions: ["FRSKY_OSD"] })]);
+
+            expect(FC.FEATURE_CONFIG.features.isEnabled("RX_SERIAL")).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
Opening the Ports tab and saving anything silently dropped every serial function bit this build has no name for. `serialPortFunctionMaskToFunctions` iterates only known keys, so unknown bits were lost on read, and `serialPortFunctionsToMask` rebuilt the mask from that same list, so they were lost on write. **A user with a gimbal on UART4 who opened the Ports tab and saved anything lost it** — on every firmware since 2025.12.

## The fix

Preservation, not naming. The raw `functionMask` is retained on read and every unrecognised bit is ORed back on write. That is version-independent and needs no API gate.

Naming the bits cannot work below API 1.49. `c18421eb` moved `OSD_CUSTOM_TEXT` from bit 20 into bit 19 two days after 2026.6.1 shipped and **without bumping `API_VERSION_MINOR`**, so bit 19 is `LIDAR_NL` on a released 2026.6.1 board and `OSD_CUSTOM_TEXT` on any master build flashed before the 1.49 bump — and both answer API 1.48. Writing bit 19 to a 2026.6.1 board silently reassigns the user's Nooploop rangefinder; corrupting a config is worse than dropping an assignment.

The one-slot-per-group port model is a second drop point: a port has one telemetry slot, one sensor slot and one peripheral slot, so a decoded function no slot claimed — a second peripheral, for instance — was dropped on save even though the app could name it. Those are parked in `reservedFunctions` and re-emitted verbatim.

That write-back has one consequence worth naming. `VTX_MSP` is the peripheral firmware lets share a port with MSP, so it can be the preserved one; the exclusion callbacks would clear MSP under it and the save would then write a combination `serialPortFunctionsConflict()` refuses. The MSP enable now stays when a preserved function needs it, so preserving cannot itself produce an invalid config.

## Scope

Three source files, no UI. Earlier revisions of this PR carried the contextual per-feature port controls and a handful of adjacent correctness fixes; both are gone:

- **Per-feature port assignment** is #5451's, on the API 1.49 path.
- **No new Ports tab UI.** The tab is read-only from 1.49, so a "reserved function" badge, `maxPorts` picker gating and the corrected MSP port count would all be decoration on a control surface that is going away. Left out.
- **Naming `GIMBAL` (bit 18) and `OSD_CUSTOM_TEXT` (bit 19)** is #5451's too. Nothing here writes either.
- The save-rejection handling, the `portsEepromSaved` key fix and the bit 15 relabel are real but unrelated to this bug, so they are out of this PR.

## Where it applies

Firmware master is at API 1.49 with `MSP_SET_CF_SERIAL_CONFIG` and `MSP2_COMMON_SET_SERIAL_CONFIG` both retired, and the Ports tab is read-only from 1.49. So the write half of this fix runs on **1.48 and below** — every released firmware today, and exactly the range where bits 19 and 20 are ambiguous. The read half keeps the raw mask on every version.

## Testing

942 unit tests pass, `npm run lint` and `npm run build` are clean. 23 of those tests are new: decode → encode round-trips for unchanged, edited and cleared ports, the reserved-function parking and write-back, and the MSP-under-a-preserved-function guard.

The layout test checks each bit the app names against the firmware's `serialPortFunction_e` rather than pinning the set of names, so it keeps working — and keeps checking — once #5451 adds `GIMBAL` and `OSD_CUSTOM_TEXT`. Reserved-bit tests use bits no firmware defines yet, for the same reason.

**Not tested on hardware.**

## Todo

- [ ] Hardware verification:
  - [ ] 2026.6.1 board with a Nooploop rangefinder on bit 19: edit an unrelated port, save, confirm the assignment survives. This is the corruption path the PR exists to avoid.
  - [ ] The same check on a pre-1.49 master build carrying OSD custom text on bit 19.

## Related

| PR | State | Why it matters here |
|---|---|---|
| [betaflight#15573](https://github.com/betaflight/betaflight/pull/15573) | merged | Retired both serial-config write commands and reduced `serialConfig_t` to the update rate and reboot character; from API 1.49 the mask is synthesised read-only from the feature PGs. |
| [betaflight#15571](https://github.com/betaflight/betaflight/pull/15571) | merged | Bumped `API_VERSION_MINOR` to 49, which is what makes bit 19 nameable at all. Nothing here writes it. |
| [#5451](https://github.com/betaflight/betaflight-configurator/pull/5451) | open | Assigns every serial port from its own tab on the 1.49 path, and adds `GIMBAL` and `OSD_CUSTOM_TEXT` to the function table. Independent of this fix. |
| [#5420](https://github.com/betaflight/betaflight-configurator/pull/5420) | merged | Ports tab read-only from API 1.49. This fix applies below that, where the tab still writes the mask. |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved serial-port assignments, including uncommon or firmware-specific functions, when saving configuration changes.
  * Prevented existing port settings from being lost when editing, clearing, or updating multiple ports.
  * Kept MSP support enabled when required by telemetry or peripheral configurations.
  * Improved handling of virtual ports and unsupported function mappings.
* **Reliability**
  * Added broader validation to ensure port configurations survive updates and firmware compatibility differences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->