### PR TITLE
Esp32 reboot fix

### DIFF
--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -79,6 +79,18 @@ const REBOOT_RECONNECT_RETRY_MS = 1000;
 // it is dropped for the next retry. Short because the normal 10s handshake timeout would
 // consume the whole reboot window (the retry loop skips ticks while a connection is open).
 const REBOOT_HANDSHAKE_STALL_MS = 3000;
+// How long (from the start of the reboot window) a serial link must stay open before we treat
+// it as having SURVIVED the reboot rather than being about to drop. A soft-resetting ESP32
+// keeps its USB serial enumerated (USB-UART bridge or native USB-JTAG), so the link never
+// drops and the transport-reconnect branch — gated on !isConnected() — never fires. Once past
+// this settle (~flush 1.5s + ~1s FC boot) we drop the stale link ourselves so the reconnect
+// runs a fresh handshake. Short enough for a fast recovery, long enough not to tear down an
+// STM32 link whose OS-level drop the platform has not reported yet.
+const REBOOT_FORCED_RELINK_SETTLE_MS = 2500;
+// A reboot's link survived past the settle above and we forced a single reconnect for it.
+// Guards the forced drop to one attempt per reboot; after it, the normal stall/reconnect
+// machinery owns the rest. Reset at the start of every reboot cycle (rebootReconnect).
+let rebootForcedRelinkTried = false;
 // The BLE link was kept open across the current reboot (softResetForReboot). While true,
 // a stalled handshake keeps riding the known-good GATT session instead of dropping it.
 // Cleared on any real transport close.
@@ -1453,9 +1465,13 @@ export function cancelRebootReconnect() {
 // as the FC restarts, and no single disconnect event marks "FC ready". Runs whether or not the
 // reboot dialog is shown.
 function rebootReconnect() {
+    console.log("rebootReconnect");
     // Cancel any prior reboot cycle (e.g. a second Save-and-Reboot within the window) so we
     // never run two overlapping retry loops.
     stopRebootReconnect();
+
+    // Fresh cycle: allow one forced relink for a link that survives the reboot (see the loop).
+    rebootForcedRelinkTried = false;
 
     rebootReconnectTimerId = setTimeout(() => {
         const driven = isDrivenRebootTarget(DeviceHandler.devicePicker.selectedDevice);
@@ -1524,15 +1540,51 @@ function rebootReconnect() {
             // which is exactly what stops the flasher from picking up the board.
             const waitedOut = !mayConnect && (driven || flasherOwnsPort() || ourDeviceBack);
 
-            if (CONFIGURATOR.connectionValid || timedOut || waitedOut) {
+            // Success, or the window truly ran out.
+            if (CONFIGURATOR.connectionValid || timedOut) {
                 stopRebootReconnect();
-                // The reboot window has closed (reconnected, timed out, or nothing left to wait
-                // for): concludeReboot settles to IDLE so normal selection resumes. A kept BLE
-                // link that never made it back to connected is dropped for real here.
+                // Reconnected, or timed out: concludeReboot settles to CONNECTED/IDLE so normal
+                // selection resumes. A kept BLE link that never made it back to connected is
+                // dropped for real here.
                 getConnectionState().concludeReboot(CONFIGURATOR.connectionValid);
                 releaseKeptRebootLink();
                 return;
             }
+
+            // A link that SURVIVED the reboot (e.g. an ESP32 soft-reset keeps its USB serial
+            // enumerated — USB-UART bridge or native USB-JTAG) never drops, so no transport
+            // reconnect fires and connectionValid stays false. The FC came back and answers MSP,
+            // but nothing re-runs the handshake. Force it: once the link has stayed open past a
+            // short settle, drop it ONCE and then drive the reconnect to completion. This runs
+            // regardless of Auto-Connect — it finishes the reboot the user asked for on the link
+            // we already own, it is NOT an auto-grab of a re-enumerated device — but still yields
+            // the port to the flasher.
+            const settled = Date.now() - state.rebootWindowStartedAt >= REBOOT_FORCED_RELINK_SETTLE_MS;
+            if (isConnected() && settled && !GUI.connecting_to && !rebootForcedRelinkTried && !flasherOwnsPort()) {
+                console.log(`${logHead} Link survived reboot past settle — dropping once to force reconnect`);
+                rebootForcedRelinkTried = true;
+                dropStalledRebootConnection(); // closes the transport WITHOUT stopping this loop
+                return;
+            }
+            // Drive the forced relink's reconnect: the link we dropped above is now closed, so
+            // re-open it and run a fresh handshake (-> finishOpen -> connectionValid), Auto-Connect
+            // aside. The reboot window bounds the retries.
+            if (rebootForcedRelinkTried && !isConnected() && !GUI.connecting_to && !flasherOwnsPort()) {
+                MSP.disconnect_cleanup();
+                connectDisconnect({ automatic: true });
+                return;
+            }
+
+            // Auto-Connect off and nothing left to wait for: end the window. Skip while a link is
+            // still open (its forced relink above owns it) or while a forced relink is in flight —
+            // those conclude on connectionValid or the window timeout, not here.
+            if (waitedOut && !rebootForcedRelinkTried && !isConnected()) {
+                stopRebootReconnect();
+                getConnectionState().concludeReboot(CONFIGURATOR.connectionValid);
+                releaseKeptRebootLink();
+                return;
+            }
+
             if (mayConnect && !isConnected() && !GUI.connecting_to) {
                 // Re-derive the kept-link flag from protocol truth before reconnecting.
                 // A real transport close normally clears it via onClosed, but between

--- a/src/js/serial_backend.js
+++ b/src/js/serial_backend.js
@@ -1465,7 +1465,6 @@ export function cancelRebootReconnect() {
 // as the FC restarts, and no single disconnect event marks "FC ready". Runs whether or not the
 // reboot dialog is shown.
 function rebootReconnect() {
-    console.log("rebootReconnect");
     // Cancel any prior reboot cycle (e.g. a second Save-and-Reboot within the window) so we
     // never run two overlapping retry loops.
     stopRebootReconnect();

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -792,7 +792,7 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
         resetMocks();
     });
 
-    it("sends MSP_SET_REBOOT, forces connectionValid false, and leaves a live serial link alone", () => {
+    it("sends MSP_SET_REBOOT, forces connectionValid false, and does not drop the link during the flush", () => {
         vi.useFakeTimers();
         try {
             // Plain USB/serial path: not bluetooth, not manual, not virtual.
@@ -812,13 +812,83 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             // The reboot forces the connection invalid so the cycle waits for a real reconnect.
             expect(CONFIGURATOR.connectionValid).toBe(false);
 
-            // A serial link that is still open after the flush means the FC did not reboot, or
-            // the OS has not noticed yet. Dropping it would tear down a working connection and
-            // throw the user off the tab they just opened — the CLI-tab exit path does exactly
-            // this. The transport owns that link; only driven targets are dropped here.
+            // A serial link that is still open right after the flush means the FC did not reboot
+            // yet, or the OS has not noticed the drop. We give it a short settle before touching
+            // it (a genuinely re-enumerating STM32 drops within this window and takes the normal
+            // reconnect path); the flush itself never drops a live serial link.
             vi.advanceTimersByTime(1500);
             expect(serial.disconnect).not.toHaveBeenCalled();
         } finally {
+            vi.advanceTimersByTime(30000); // drain the window
+            vi.useRealTimers();
+        }
+    });
+
+    // A soft-resetting ESP32 keeps its USB serial enumerated (USB-UART bridge or native
+    // USB-JTAG), so the link never drops and the transport-reconnect branch — gated on
+    // !isConnected() — never fires. The FC comes back and answers MSP, but connectionValid was
+    // forced false at reboot and nothing re-runs the handshake, so the window used to time out
+    // as FAILED. Once the link has stayed open past the settle, we drop it ONCE and the next
+    // tick reconnects it with a fresh handshake.
+    it("drops a link that survives the reboot once past the settle, then reconnects", () => {
+        vi.useFakeTimers();
+        try {
+            DeviceHandler.devicePicker.selectedDevice = "/dev/ttyACM0";
+            DeviceHandler.devicePicker.autoConnect = true;
+            CONFIGURATOR.virtualMode = false;
+            CONFIGURATOR.connectionValid = true;
+            establishConnection();
+
+            serial.disconnect.mockClear();
+            serial.connect.mockClear();
+
+            reinitializeConnection();
+
+            // Flush (1500) + first retry tick (1000) = 2500ms of window elapsed, at/after the
+            // 2500ms settle. The link is still open, so the loop forces a single drop.
+            vi.advanceTimersByTime(1500 + 1000);
+            expect(serial.disconnect).toHaveBeenCalledTimes(1);
+
+            // Next tick: the link is now closed, so the normal reconnect branch opens it again
+            // (-> onOpen -> fresh handshake). The forced drop is one-shot.
+            vi.advanceTimersByTime(1000);
+            expect(serial.connect).toHaveBeenCalledTimes(1);
+        } finally {
+            vi.advanceTimersByTime(30000); // drain the window
+            vi.useRealTimers();
+        }
+    });
+
+    // The reboot the user asked for must complete on a survived link even with Auto-Connect OFF:
+    // the link is the one we already own, not a device to auto-grab. Without this, the loop would
+    // conclude via waitedOut (Auto-Connect off + our device "back" because the link never dropped)
+    // and the dialog would report failure while the FC is up and answering — the ESP32-S3 case.
+    it("forces the relink on a survived link with Auto-Connect OFF, then reconnects", () => {
+        vi.useFakeTimers();
+        DeviceHandler.findDescribedDevice.mockReturnValue({ path: "serial_9" }); // our device stays listed
+        try {
+            DeviceHandler.devicePicker.selectedDevice = "/dev/ttyACM0";
+            DeviceHandler.devicePicker.autoConnect = false; // Auto-Connect OFF (waitedOut would fire)
+            CONFIGURATOR.virtualMode = false;
+            CONFIGURATOR.connectionValid = true;
+            establishConnection();
+
+            serial.disconnect.mockClear();
+            serial.connect.mockClear();
+
+            reinitializeConnection();
+
+            // Past the settle: the survived link is dropped once even though Auto-Connect is off
+            // (waitedOut does not preempt it), and the reboot window stays open.
+            vi.advanceTimersByTime(1500 + 1000);
+            expect(serial.disconnect).toHaveBeenCalledTimes(1);
+            expect(getConnectionState().isRebootWindowOpen).toBe(true);
+
+            // The forced relink drives the reconnect itself, Auto-Connect notwithstanding.
+            vi.advanceTimersByTime(1000);
+            expect(serial.connect).toHaveBeenCalledTimes(1);
+        } finally {
+            DeviceHandler.findDescribedDevice.mockReturnValue(undefined);
             vi.advanceTimersByTime(30000); // drain the window
             vi.useRealTimers();
         }

--- a/test/js/serial_backend.test.js
+++ b/test/js/serial_backend.test.js
@@ -849,10 +849,16 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             vi.advanceTimersByTime(1500 + 1000);
             expect(serial.disconnect).toHaveBeenCalledTimes(1);
 
-            // Next tick: the link is now closed, so the normal reconnect branch opens it again
-            // (-> onOpen -> fresh handshake). The forced drop is one-shot.
+            // Next tick: the link is now closed, so the normal reconnect branch opens it again.
+            // The forced drop is one-shot.
             vi.advanceTimersByTime(1000);
             expect(serial.connect).toHaveBeenCalledTimes(1);
+
+            // The reconnect must start a FRESH handshake, not merely open the transport. Drive
+            // the mocked open event and assert onOpen issues MSP_API_VERSION as its first request.
+            MSP.send_message.mockClear();
+            serialHandlers.connect({ detail: true });
+            expect(MSP.send_message).toHaveBeenCalledWith(MSPCodes.MSP_API_VERSION, false, false, expect.any(Function));
         } finally {
             vi.advanceTimersByTime(30000); // drain the window
             vi.useRealTimers();
@@ -887,6 +893,12 @@ describe("serial_backend reinitializeConnection — serial/USB reboot path", () 
             // The forced relink drives the reconnect itself, Auto-Connect notwithstanding.
             vi.advanceTimersByTime(1000);
             expect(serial.connect).toHaveBeenCalledTimes(1);
+
+            // And it runs a fresh handshake, not just a transport open: driving the mocked open
+            // event issues MSP_API_VERSION.
+            MSP.send_message.mockClear();
+            serialHandlers.connect({ detail: true });
+            expect(MSP.send_message).toHaveBeenCalledWith(MSPCodes.MSP_API_VERSION, false, false, expect.any(Function));
         } finally {
             DeviceHandler.findDescribedDevice.mockReturnValue(undefined);
             vi.advanceTimersByTime(30000); // drain the window


### PR DESCRIPTION
Problem:
A soft-resetting ESP32 keeps its USB serial enumerated (USB-UART bridge or native USB-JTAG), so the link never drops and the transport-reconnect branch never fires. In effect configurator hangs and page must be reloaded.

Fix:
General, board-agnostic behaviour: if a link is still open past a short settle after the reboot, it must have survived the reset. Drop it once and drive a fresh reconnect + handshake.

Tests:
- bare ESP32S3 with BMI160 spi gyro
- OmnibusF4SD as regression
- Unittests added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved serial/USB reconnection after device reboots.
  * Added a brief settle period before handling links that remain open.
  * Automatically refreshes surviving connections once and performs a fresh handshake, including when Auto-Connect is disabled.
  * Improved handling of reconnect timeouts and interrupted links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->