### PR TITLE
feat(receiver): assign the serial rx port from the receiver tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2175,6 +2175,18 @@
     "configurationSerialRX": {
         "message": "Serial Receiver Provider"
     },
+    "portsPortNone": {
+        "message": "None"
+    },
+    "receiverSerialPort": {
+        "message": "Serial Port"
+    },
+    "receiverSerialPortHelp": {
+        "message": "The UART the serial receiver is wired to. The baud rate follows the provider, so there is nothing to set here. Changing the port requires a reboot."
+    },
+    "receiverSerialPortSaveFailed": {
+        "message": "Could not set the receiver serial port, so nothing was saved."
+    },
     "someRXTypesDisabled": {
         "message": "Some Receiver Providers are not supported by current Build Configuration."
     },

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -89,6 +89,19 @@
                                         :ui="{ content: 'max-h-72' }"
                                     />
                                 </SettingRow>
+                                <SettingRow
+                                    v-if="rxPortAvailable"
+                                    :label="$t('receiverSerialPort')"
+                                    :help="$t('receiverSerialPortHelp')"
+                                >
+                                    <USelect
+                                        v-model="rxPortIdentifier"
+                                        :items="rxPortOptions"
+                                        :disabled="!rxPortWritable"
+                                        class="min-w-52"
+                                        @update:model-value="onRxPortChange"
+                                    />
+                                </SettingRow>
                                 <UiBox highlight v-if="showSomeRxTypesDisabled">
                                     <p v-html="$t('someRXTypesDisabled')"></p>
                                 </UiBox>
@@ -560,6 +573,7 @@ import CryptoES from "crypto-es";
 import semver from "semver";
 import * as THREE from "three";
 import * as d3 from "d3";
+import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import UiBox from "../elements/UiBox.vue";
 import SettingRow from "../elements/SettingRow.vue";
 import SettingColumn from "../elements/SettingColumn.vue";
@@ -648,6 +662,17 @@ const rcDeadbandConfig = computed(() => fcStore.rcDeadbandConfig);
 // RX link, so the banner/tint warn that channel values are failsafe output.
 const failsafeActive = computed(() => fcStore.failsafeActive);
 
+// From API 1.49 the port lives on the RX parameter group rather than the shared port function
+// mask, so it is assigned here instead of on the (by then read-only) ports tab.
+const {
+    available: rxPortAvailable,
+    writable: rxPortWritable,
+    options: rxPortOptions,
+    selectedIdentifier: rxPortIdentifier,
+    load: loadRxPort,
+    write: writeRxPort,
+} = useFeaturePort({ setting: "rx_uart", functionName: "RX_SERIAL" });
+
 // Dirty state tracking
 /** @returns {string} serialized receiver state for dirty comparison */
 function serializeReceiverState() {
@@ -655,6 +680,7 @@ function serializeReceiverState() {
         channelMap: channelMapString.value,
         rxMode: selectedRxMode.value,
         serialrxProvider: rxConfig.value?.serialrx_provider,
+        rxPortIdentifier: rxPortIdentifier.value,
         rxSpiProtocol: rxConfig.value?.rxSpiProtocol,
         elrsModelId: rxConfig.value?.elrsModelId,
         stickMin: rxConfig.value?.stick_min,
@@ -976,6 +1002,12 @@ function onRxModeChange() {
     }
 }
 
+// Deliberately a change handler rather than a watcher: seeding the selection during load would
+// trip a watcher and leave the tab asking for a reboot every time it is opened.
+function onRxPortChange() {
+    needReboot.value = true;
+}
+
 // Actions
 function resetRefreshRate() {
     refreshRate.value = 50;
@@ -1046,6 +1078,7 @@ async function loadConfig() {
             await MSP.promise(MSPCodes.MSP_RC_DEADBAND);
             await MSP.promise(MSPCodes.MSP_RX_CONFIG);
             await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
+            await loadRxPort();
 
             // Update local state from FC
             updateChannelMapFromRcMap();
@@ -1118,6 +1151,16 @@ const saveConfig = (withReboot = false) =>
             await MSP.promise(MSPCodes.MSP_SET_RSSI_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RSSI_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_RC_DEADBAND, mspHelper.crunch(MSPCodes.MSP_SET_RC_DEADBAND));
             await MSP.promise(MSPCodes.MSP_SET_RX_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_RX_CONFIG));
+
+            // rx_uart shares the RX parameter group with everything MSP_SET_RX_CONFIG just wrote,
+            // and the persist below serialises that group, so this has to sit between the two.
+            // Throwing skips the persist, so a refused port leaves nothing written to EEPROM.
+            try {
+                await writeRxPort();
+            } catch (error) {
+                gui_log(t("receiverSerialPortSaveFailed"));
+                throw error;
+            }
 
             if (withReboot) {
                 await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));

--- a/src/composables/ports/portNames.js
+++ b/src/composables/ports/portNames.js
@@ -1,0 +1,96 @@
+export const PORT_NONE = -1;
+export const PORT_NAME_NONE = "NONE";
+
+// Keyed by serialPortIdentifier_e. The UART block appears twice because the identifier base
+// moved; only one of the two blocks is ever populated on a given target, so a name round trip
+// is unambiguous in practice.
+const portCliNames = {
+    0: "UART1",
+    1: "UART2",
+    2: "UART3",
+    3: "UART4",
+    4: "UART5",
+    5: "UART6",
+    6: "UART7",
+    7: "UART8",
+    8: "UART9",
+    9: "UART10",
+    20: "VCP",
+    30: "SOFTSERIAL1",
+    31: "SOFTSERIAL2",
+    40: "LPUART1",
+    50: "UART0",
+    51: "UART1",
+    52: "UART2",
+    53: "UART3",
+    54: "UART4",
+    55: "UART5",
+    56: "UART6",
+    57: "UART7",
+    58: "UART8",
+    59: "UART9",
+    60: "UART10",
+    61: "UART11",
+    62: "UART12",
+    63: "UART13",
+    64: "UART14",
+    65: "UART15",
+    70: "PIOUART0",
+    71: "PIOUART1",
+    72: "PIOUART2",
+    73: "PIOUART3",
+    74: "PIOUART4",
+    75: "PIOUART5",
+    76: "PIOUART6",
+    77: "PIOUART7",
+    78: "PIOUART8",
+    79: "PIOUART9",
+};
+
+// The configurator has always shown the USB port as "USB VCP"; the firmware CLI knows it as "VCP".
+const portDisplayNames = {
+    20: "USB VCP",
+};
+
+/**
+ * The name the firmware CLI accepts and prints for a port, or null when the identifier is
+ * unknown to us.
+ *
+ * @param {number} identifier
+ * @returns {string|null}
+ */
+export function getPortCliName(identifier) {
+    return portCliNames[identifier] ?? null;
+}
+
+/**
+ * @param {number} identifier
+ * @returns {string}
+ */
+export function getPortDisplayName(identifier) {
+    return portDisplayNames[identifier] ?? portCliNames[identifier] ?? `UART (${identifier})`;
+}
+
+/**
+ * Builds the CLI command that assigns a port to a feature.
+ *
+ * Throws rather than falling back to the raw identifier: the firmware resolves this setting by
+ * name only and rejects a number, so an unmappable identifier has to surface here instead of
+ * failing on the board.
+ *
+ * @param {string} setting CLI setting name, e.g. "rx_uart"
+ * @param {number} identifier
+ * @returns {string}
+ */
+export function formatPortSetCommand(setting, identifier) {
+    if (identifier === PORT_NONE) {
+        return `set ${setting} = ${PORT_NAME_NONE}`;
+    }
+
+    const name = getPortCliName(identifier);
+    if (!name) {
+        throw new Error(`No serial port name for identifier ${identifier}`);
+    }
+
+    return `set ${setting} = ${name}`;
+}

--- a/src/composables/ports/useFeaturePort.js
+++ b/src/composables/ports/useFeaturePort.js
@@ -1,0 +1,118 @@
+import { computed, ref } from "vue";
+import { useFlightControllerStore } from "@/stores/fc";
+import MSP from "../../js/msp";
+import MSPCodes from "../../js/msp/MSPCodes";
+import { i18n } from "../../js/localization";
+import { findCliError, isMspCliSupported, send as cliSend } from "../useMspCliSession";
+import { serialPortsAreReadOnly } from "./usePortsReadOnly";
+import { PORT_NONE, formatPortSetCommand, getPortDisplayName } from "./portNames";
+
+/**
+ * The port a feature is currently assigned to, read from the per-port function mask.
+ *
+ * @param {Array<{identifier: number, functions: string[]}>} ports FC.SERIAL_CONFIG.ports
+ * @param {string} functionName e.g. "RX_SERIAL"
+ * @returns {number} identifier, or PORT_NONE when unassigned
+ */
+export function findFeaturePortIdentifier(ports, functionName) {
+    const port = (ports ?? []).find((candidate) => (candidate.functions ?? []).includes(functionName));
+
+    return port ? port.identifier : PORT_NONE;
+}
+
+/**
+ * @param {Array<{identifier: number, functions: string[]}>} ports
+ * @param {object} options
+ * @param {string} options.functionName the feature's own function, left out of the annotations
+ * @param {number} [options.currentIdentifier] kept in the list even if the FC did not report it
+ * @param {string} [options.noneLabel]
+ * @param {(functionName: string) => string} [options.describeFunction]
+ * @returns {Array<{value: number, label: string}>}
+ */
+export function buildPortOptions(
+    ports,
+    { functionName, currentIdentifier = PORT_NONE, noneLabel = "None", describeFunction = (name) => name } = {},
+) {
+    const options = [{ value: PORT_NONE, label: noneLabel }];
+
+    for (const port of ports ?? []) {
+        const claimedElsewhere = (port.functions ?? []).filter((name) => name !== functionName);
+        const displayName = getPortDisplayName(port.identifier);
+
+        options.push({
+            value: port.identifier,
+            label: claimedElsewhere.length
+                ? `${displayName} (${claimedElsewhere.map(describeFunction).join(", ")})`
+                : displayName,
+        });
+    }
+
+    if (currentIdentifier !== PORT_NONE && !options.some((option) => option.value === currentIdentifier)) {
+        options.push({ value: currentIdentifier, label: getPortDisplayName(currentIdentifier) });
+    }
+
+    return options;
+}
+
+function describePortFunction(functionName) {
+    return i18n.getMessage(`portsFunction_${functionName}`) || functionName;
+}
+
+/**
+ * Serial port assignment for one feature, owned by that feature's own tab.
+ *
+ * From API 1.49 the port lives on the feature's parameter group and the per-port function mask
+ * is a read-only view synthesised from those, so the assignment is read over MSP with the rest
+ * of the serial config but written through the CLI.
+ *
+ * @param {object} options
+ * @param {string} options.setting CLI setting name, e.g. "rx_uart"
+ * @param {string} options.functionName port function the feature claims, e.g. "RX_SERIAL"
+ */
+export function useFeaturePort({ setting, functionName }) {
+    const fcStore = useFlightControllerStore();
+
+    const available = computed(() => serialPortsAreReadOnly(fcStore.config.apiVersion));
+    const writable = computed(() => available.value && isMspCliSupported());
+
+    const selectedIdentifier = ref(PORT_NONE);
+    const assignedIdentifier = ref(PORT_NONE);
+
+    const changed = computed(() => selectedIdentifier.value !== assignedIdentifier.value);
+
+    const options = computed(() =>
+        buildPortOptions(fcStore.serialConfig?.ports, {
+            functionName,
+            currentIdentifier: selectedIdentifier.value,
+            noneLabel: i18n.getMessage("portsPortNone"),
+            describeFunction: describePortFunction,
+        }),
+    );
+
+    async function load() {
+        if (!available.value) {
+            return;
+        }
+
+        await MSP.promise(MSPCodes.MSP2_COMMON_SERIAL_CONFIG);
+
+        assignedIdentifier.value = findFeaturePortIdentifier(fcStore.serialConfig?.ports, functionName);
+        selectedIdentifier.value = assignedIdentifier.value;
+    }
+
+    async function write() {
+        if (!available.value || !changed.value) {
+            return;
+        }
+
+        const lines = await cliSend(formatPortSetCommand(setting, selectedIdentifier.value));
+        const error = findCliError(lines);
+        if (error) {
+            throw new Error(error);
+        }
+
+        assignedIdentifier.value = selectedIdentifier.value;
+    }
+
+    return { available, writable, options, selectedIdentifier, changed, load, write };
+}

--- a/src/composables/ports/usePortsState.js
+++ b/src/composables/ports/usePortsState.js
@@ -5,6 +5,7 @@ import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
 import { mspHelper } from "../../js/msp/MSPHelper";
 import { useDirtyState } from "../useDirtyState";
+import { getPortDisplayName as getPortName } from "./portNames";
 
 export function usePortsState(getRules) {
     const ports = reactive([]);
@@ -12,51 +13,6 @@ export function usePortsState(getRules) {
     const isLoading = ref(true);
 
     const { dirty, markClean } = useDirtyState(() => JSON.stringify(ports));
-
-    const portIdentifierToNameMapping = {
-        0: "UART1",
-        1: "UART2",
-        2: "UART3",
-        3: "UART4",
-        4: "UART5",
-        5: "UART6",
-        6: "UART7",
-        7: "UART8",
-        8: "UART9",
-        9: "UART10",
-        20: "USB VCP",
-        30: "SOFTSERIAL1",
-        31: "SOFTSERIAL2",
-        40: "LPUART1",
-        50: "UART0",
-        51: "UART1",
-        52: "UART2",
-        53: "UART3",
-        54: "UART4",
-        55: "UART5",
-        56: "UART6",
-        57: "UART7",
-        58: "UART8",
-        59: "UART9",
-        60: "UART10",
-        61: "UART11",
-        62: "UART12",
-        63: "UART13",
-        64: "UART14",
-        65: "UART15",
-        70: "PIOUART0",
-        71: "PIOUART1",
-        72: "PIOUART2",
-        73: "PIOUART3",
-        74: "PIOUART4",
-        75: "PIOUART5",
-        76: "PIOUART6",
-        77: "PIOUART7",
-        78: "PIOUART8",
-        79: "PIOUART9",
-    };
-
-    const getPortName = (id) => portIdentifierToNameMapping[id] || `UART (${id})`;
 
     const transformPortData = (fcPort) => {
         return {

--- a/src/composables/useMspCliSession.js
+++ b/src/composables/useMspCliSession.js
@@ -86,6 +86,13 @@ export function isConnectionClosedError(error) {
     return error?.connectionClosed === true;
 }
 
+// `send` resolves with whatever the FC replied, and a command the FC refused replies normally —
+// the refusal is a line in the response, not a transport error. Callers that need to know whether
+// a command took effect have to look for it.
+export function findCliError(lines) {
+    return parseErrors(lines ?? [])[0] ?? null;
+}
+
 export async function saveAndReconnect() {
     let saveError = null;
     try {

--- a/test/js/ports_feature_port.test.js
+++ b/test/js/ports_feature_port.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { buildPortOptions, findFeaturePortIdentifier } from "../../src/composables/ports/useFeaturePort";
+import { PORT_NONE } from "../../src/composables/ports/portNames";
+
+const ports = [
+    { identifier: 20, functions: ["MSP"] },
+    { identifier: 51, functions: [] },
+    { identifier: 53, functions: ["RX_SERIAL"] },
+];
+
+describe("findFeaturePortIdentifier", () => {
+    it("finds the port the feature is assigned to", () => {
+        expect(findFeaturePortIdentifier(ports, "RX_SERIAL")).toBe(53);
+        expect(findFeaturePortIdentifier(ports, "MSP")).toBe(20);
+    });
+
+    it("reports no port when the feature is unassigned", () => {
+        expect(findFeaturePortIdentifier(ports, "GPS")).toBe(PORT_NONE);
+    });
+
+    it("survives a port list the FC has not filled in", () => {
+        expect(findFeaturePortIdentifier([], "RX_SERIAL")).toBe(PORT_NONE);
+        expect(findFeaturePortIdentifier(undefined, "RX_SERIAL")).toBe(PORT_NONE);
+        expect(findFeaturePortIdentifier([{ identifier: 51 }], "RX_SERIAL")).toBe(PORT_NONE);
+    });
+
+    it("takes the first claimant when two ports carry the function", () => {
+        const duplicated = [
+            { identifier: 51, functions: ["RX_SERIAL"] },
+            { identifier: 53, functions: ["RX_SERIAL"] },
+        ];
+
+        expect(findFeaturePortIdentifier(duplicated, "RX_SERIAL")).toBe(51);
+    });
+});
+
+describe("buildPortOptions", () => {
+    const options = () => buildPortOptions(ports, { functionName: "RX_SERIAL", noneLabel: "None" });
+
+    it("offers None first, then the FC's ports in order", () => {
+        expect(options().map((option) => option.value)).toEqual([PORT_NONE, 20, 51, 53]);
+        expect(options()[0].label).toBe("None");
+    });
+
+    it("annotates a port another feature has claimed", () => {
+        expect(options().find((option) => option.value === 20).label).toBe("USB VCP (MSP)");
+    });
+
+    it("leaves the feature's own claim out of the annotation", () => {
+        expect(options().find((option) => option.value === 53).label).toBe("UART3");
+        expect(options().find((option) => option.value === 51).label).toBe("UART1");
+    });
+
+    it("runs the annotation through the caller's translator", () => {
+        const translated = buildPortOptions(ports, {
+            functionName: "RX_SERIAL",
+            describeFunction: (name) => name.toLowerCase(),
+        });
+
+        expect(translated.find((option) => option.value === 20).label).toBe("USB VCP (msp)");
+    });
+
+    it("keeps a current assignment the FC did not report, so the select never blanks", () => {
+        const withMissing = buildPortOptions(ports, { functionName: "RX_SERIAL", currentIdentifier: 57 });
+
+        expect(withMissing.map((option) => option.value)).toContain(57);
+        expect(withMissing.find((option) => option.value === 57).label).toBe("UART7");
+    });
+
+    it("does not duplicate a current assignment that is already listed", () => {
+        const values = buildPortOptions(ports, { functionName: "RX_SERIAL", currentIdentifier: 53 }).map(
+            (option) => option.value,
+        );
+
+        expect(values.filter((value) => value === 53)).toHaveLength(1);
+        expect(values.filter((value) => value === PORT_NONE)).toHaveLength(1);
+    });
+
+    it("copes with no ports at all", () => {
+        expect(buildPortOptions(undefined, { functionName: "RX_SERIAL" })).toHaveLength(1);
+    });
+});

--- a/test/js/ports_port_names.test.js
+++ b/test/js/ports_port_names.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import {
+    PORT_NONE,
+    formatPortSetCommand,
+    getPortCliName,
+    getPortDisplayName,
+} from "../../src/composables/ports/portNames";
+
+describe("port names", () => {
+    it("calls the USB port VCP for the firmware and USB VCP for the user", () => {
+        expect(getPortCliName(20)).toBe("VCP");
+        expect(getPortDisplayName(20)).toBe("USB VCP");
+    });
+
+    it("resolves both UART identifier blocks to the same names", () => {
+        expect(getPortCliName(2)).toBe("UART3");
+        expect(getPortCliName(53)).toBe("UART3");
+        expect(getPortCliName(50)).toBe("UART0");
+        expect(getPortCliName(65)).toBe("UART15");
+    });
+
+    it("names the soft and PIO ports", () => {
+        expect(getPortCliName(30)).toBe("SOFTSERIAL1");
+        expect(getPortCliName(40)).toBe("LPUART1");
+        expect(getPortCliName(79)).toBe("PIOUART9");
+    });
+
+    it("reports an unknown identifier as unmappable but still shows the user something", () => {
+        expect(getPortCliName(99)).toBeNull();
+        expect(getPortDisplayName(99)).toBe("UART (99)");
+    });
+
+    // The firmware resolves this setting by name, so a display string ("USB VCP") leaking into the
+    // CLI table would be sent verbatim and refused by the board.
+    it("keeps every CLI name free of the spaces a display name would carry", () => {
+        for (let identifier = -1; identifier <= 100; identifier++) {
+            const name = getPortCliName(identifier);
+            if (name !== null) {
+                expect(name).toMatch(/^[A-Z0-9]+$/);
+            }
+        }
+    });
+
+    it("builds the assignment command from the CLI name", () => {
+        expect(formatPortSetCommand("rx_uart", 2)).toBe("set rx_uart = UART3");
+        expect(formatPortSetCommand("gps_uart", 53)).toBe("set gps_uart = UART3");
+        expect(formatPortSetCommand("rx_uart", 20)).toBe("set rx_uart = VCP");
+    });
+
+    it("clears an assignment with NONE", () => {
+        expect(formatPortSetCommand("rx_uart", PORT_NONE)).toBe("set rx_uart = NONE");
+    });
+
+    it("refuses to fall back to the raw identifier, which the firmware would reject", () => {
+        expect(() => formatPortSetCommand("rx_uart", 99)).toThrow(/99/);
+    });
+});


### PR DESCRIPTION
Second of the series that moves serial port assignment onto the tab that owns each feature, following #5420 which made the ports tab read-only from API 1.49. Stacked on that branch, so retarget to master once it merges.

From API 1.49 `rx_uart` lives on the RX parameter group and the per-port function mask survives only as a read-only view synthesised from it, so the ports tab can no longer assign the receiver's port. The receiver tab picks it up, next to the serial receiver provider it already owns. The current assignment is read from the function mask alongside the rest of the serial config (one MSP round trip, which is needed anyway to populate the port list), and a change is written with `set rx_uart = <PORT>` over the MSP CLI before the tab's existing EEPROM write persists the parameter group. There is no baud to set, since the RX baud follows the provider.

Below 1.49 the selector is hidden and no extra MSP traffic is issued, so the ports tab keeps ownership there and nothing changes for currently shipping firmware.

`useFeaturePort` and `portNames` are deliberately generic rather than inlined, since the remaining device tabs each need the same read/select/write against their own setting. `portNames` also becomes the single identifier-to-name table, replacing the private copy in `usePortsState`: the firmware resolves these settings by name and rejects a number, so two tables disagreeing on VCP (the configurator shows "USB VCP", the CLI wants "VCP") would have written the wrong port. A test asserts no display string can leak into the CLI table.

One pre-existing bug surfaced on the way. `useMspCliSession.send()` resolves when the FC refuses a command, because the refusal comes back as a `###ERROR` line in the response rather than a transport error. Left alone, a rejected port would have reached the EEPROM write and reported success. `findCliError` is new for that, and `useMagCalibration.writeCalValues` has the same latent bug and should get it in a follow-up.

Ports already claimed by another feature are offered and annotated with the claim rather than disabled, since from 1.49 the configurator no longer owns a mask to enforce exclusivity and conflicts are resolved on the owning tab.

Changing the port sets the existing reboot flag, so a port change always takes the save-and-reboot path.

Not yet exercised on hardware: an actual reassignment plus reboot. Firmware betaflight/betaflight#15571 (the API bump to 1.49) is still unmerged, so the gate is inert until it lands.