### PR TITLE
fix: wizards height on WebKit

### DIFF
--- a/src/components/EscDshotDirection/Styles.css
+++ b/src/components/EscDshotDirection/Styles.css
@@ -1,6 +1,8 @@
+/* No `height: 100%` on the flex containers below: the dialog they live in is sized
+   `height: fit-content` (see main.less), and WebKit resolves a percentage height against
+   that intrinsic height as 0 instead of auto, collapsing the whole modal on macOS. */
 .escDshotDirection-Component {
     display: flex;
-    height: 100%;
     flex-flow: column;
 }
 
@@ -16,13 +18,11 @@
 
 #escDshotDirectionDialog-MainContent {
     display: flex;
-    height: 100%;
     flex-flow: column;
 }
 
 #escDshotDirectionDialog-Warning {
     display: flex;
-    height: 100%;
     flex-flow: column;
     border-top: 1px solid var(--superSubtleAccent);
     padding-top: 16px;

--- a/src/components/MotorOutputReordering/Styles.css
+++ b/src/components/MotorOutputReordering/Styles.css
@@ -1,6 +1,8 @@
+/* No `height: 100%` on the flex containers below: the dialog they live in is sized
+   `height: fit-content` (see main.less), and WebKit resolves a percentage height against
+   that intrinsic height as 0 instead of auto, collapsing the whole modal on macOS. */
 .motorOutputReorderComponent {
     display: flex;
-    height: 100%;
     flex-flow: column;
 }
 
@@ -10,13 +12,11 @@
 
 #dialogMotorOutputReorderMainContent {
     display: flex;
-    height: 100%;
     flex-flow: column;
 }
 
 #dialogMotorOutputReorderWarning {
     display: flex;
-    height: 100%;
     flex-flow: column;
 }
 


### PR DESCRIPTION
Fixes #5427

WebKit interprets intrinsic heights in a different way, causing wizards to be collapsed.

## Screenshots

<table>
<tr>
 <td><code>master</code>
 <td>Fix
<tr>
 <td><img width="500" src="https://github.com/user-attachments/assets/c5a46978-d3f6-48dc-b693-33a85218cead" />
 <td><img width="500" src="https://github.com/user-attachments/assets/9b9af6b3-5e01-446f-8364-67d526b92eae" />
</table>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dialog sizing on macOS and WebKit-based browsers.
  * Prevented content from collapsing in ESC DShot direction and motor output reordering dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->