### PR TITLE
feat(ports): configurator-side port validation

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2241,7 +2241,7 @@
         "message": "This port configuration is invalid"
     },
     "portsValidationResetWarning": {
-        "message": "Saving this would make the flight controller silently reset <strong>all</strong> port assignments back to defaults."
+        "message": "Saving this would make the flight controller silently reset ALL port assignments back to defaults."
     },
     "portsValidationExpertOverride": {
         "message": "Expert mode is enabled, so you can save anyway — but be aware the flight controller will still reset the ports."

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2234,6 +2234,42 @@
     "portsVtxTableNotSet": {
         "message": "<span class=\"message-negative\">WARNING:</span> The VTX table has not been set up correctly and without it VTX control will not be possible. Please set up the VTX table in $t(tabVtx.message) tab."
     },
+    "portsValidationBannerTitle": {
+        "message": "This port configuration cannot be saved"
+    },
+    "portsValidationBannerTitleExpert": {
+        "message": "This port configuration is invalid"
+    },
+    "portsValidationResetWarning": {
+        "message": "Saving this would make the flight controller silently reset <strong>all</strong> port assignments back to defaults."
+    },
+    "portsValidationExpertOverride": {
+        "message": "Expert mode is enabled, so you can save anyway — but be aware the flight controller will still reset the ports."
+    },
+    "portsValidationVcpRequiresMsp": {
+        "message": "The USB (VCP) port must have MSP enabled."
+    },
+    "portsValidationVtxMspNotShared": {
+        "message": "VTX (MSP) must share this port with MSP or Serial RX; it cannot be the only function."
+    },
+    "portsValidationTooManyFunctions": {
+        "message": "A port may not have more than {{max}} functions enabled (this port has {{count}})."
+    },
+    "portsValidationInvalidCombination": {
+        "message": "This combination of functions cannot share one port. MSP may be shared with Blackbox, VTX (MSP) or telemetry; Serial RX may be shared with FrSky Hub, LTM or MAVLink telemetry on supported receiver protocols."
+    },
+    "portsValidationNoMspPort": {
+        "message": "At least one port must have MSP enabled, otherwise the flight controller cannot be configured."
+    },
+    "portsValidationTooManyMspPorts": {
+        "message": "At most {{max}} ports may have MSP enabled (currently {{count}})."
+    },
+    "portsNoticeSoftserialFunctionStripped": {
+        "message": "MSP and Serial RX are not supported on softserial ports and will be removed by the flight controller."
+    },
+    "portsNoticeSoftserialBaudClamped": {
+        "message": "Softserial baud rate is limited to 19200 and will be clamped by the flight controller."
+    },
     "portsMSPHelp": {
         "message": "<strong>Note:</strong> Do <span class=\"message-negative\">NOT</span> disable MSP on the first serial port unless you know what you are doing.  You may have to reflash and erase your configuration if you do."
     },

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -173,18 +173,17 @@
 
                 <!-- Validation summary (appended below the ports so it can't shift the table) -->
                 <UiBox v-if="tabReady && !isLoading && !isValid" :type="portSeverity" highlight class="mt-4">
-                    <p class="font-semibold" v-html="$t(bannerTitleKey)"></p>
-                    <p v-html="$t('portsValidationResetWarning')"></p>
-                    <p v-if="expertMode" v-html="$t('portsValidationExpertOverride')"></p>
+                    <p class="font-semibold">{{ $t(bannerTitleKey) }}</p>
+                    <p v-if="expertMode">{{ $t("portsValidationResetWarning") }}</p>
+                    <p v-if="expertMode">{{ $t("portsValidationExpertOverride") }}</p>
                     <ul class="list-disc pl-5">
-                        <li v-for="(msg, i) in configErrors" :key="`cfg-${i}`" v-html="msg"></li>
+                        <li v-for="(msg, i) in configErrors" :key="`cfg-${i}`">{{ msg }}</li>
                         <template v-for="port in ports" :key="`pe-${port.identifier}`">
                             <li
                                 v-for="(msg, i) in portErrors[port.identifier] || []"
                                 :key="`pe-${port.identifier}-${i}`"
                             >
-                                <strong>{{ getPortName(port.identifier) }}:</strong>
-                                <span v-html="msg"></span>
+                                <strong>{{ getPortName(port.identifier) }}:</strong> {{ msg }}
                             </li>
                         </template>
                     </ul>
@@ -193,7 +192,7 @@
                 <!-- Advisory softserial notices (non-blocking). -->
                 <UiBox v-if="tabReady && !isLoading && uniqueNotices.length" type="neutral" highlight class="mt-4">
                     <ul class="list-disc pl-5">
-                        <li v-for="(msg, i) in uniqueNotices" :key="`notice-${i}`" v-html="msg"></li>
+                        <li v-for="(msg, i) in uniqueNotices" :key="`notice-${i}`">{{ msg }}</li>
                     </ul>
                 </UiBox>
             </div>

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -6,7 +6,8 @@
 
             <div class="require-support">
                 <UiBox type="warning" highlight class="mb-4">
-                    <p v-html="$t('portsHelp')"></p>
+                    <!-- Only reachable in Expert mode; otherwise an invalid layout can't be saved -->
+                    <p v-if="expertMode" v-html="$t('portsHelp')"></p>
                     <p v-html="$t('portsMSPHelp')"></p>
                 </UiBox>
 
@@ -35,7 +36,7 @@
                         <!-- Rows -->
                         <template v-for="(port, index) in ports" :key="port.identifier">
                             <!-- Identifier -->
-                            <div class="flex items-center pl-3 font-semibold p-1.5">
+                            <div class="flex items-center pl-3 font-semibold p-1.5" :class="portNameClass(port)">
                                 {{ getPortName(port.identifier) }}
                             </div>
 
@@ -100,7 +101,8 @@
                     <UiBox
                         v-for="port in ports"
                         :key="port.identifier"
-                        type="neutral"
+                        :type="portHasError(port.identifier) ? portSeverity : 'neutral'"
+                        :highlight="portHasError(port.identifier)"
                         collapsible
                         :title="getPortName(port.identifier)"
                     >
@@ -168,19 +170,50 @@
                         </div>
                     </UiBox>
                 </div>
+
+                <!-- Validation summary (appended below the ports so it can't shift the table) -->
+                <UiBox v-if="tabReady && !isLoading && !isValid" :type="portSeverity" highlight class="mt-4">
+                    <p class="font-semibold" v-html="$t(bannerTitleKey)"></p>
+                    <p v-html="$t('portsValidationResetWarning')"></p>
+                    <p v-if="expertMode" v-html="$t('portsValidationExpertOverride')"></p>
+                    <ul class="list-disc pl-5">
+                        <li v-for="(msg, i) in configErrors" :key="`cfg-${i}`" v-html="msg"></li>
+                        <template v-for="port in ports" :key="`pe-${port.identifier}`">
+                            <li
+                                v-for="(msg, i) in portErrors[port.identifier] || []"
+                                :key="`pe-${port.identifier}-${i}`"
+                            >
+                                <strong>{{ getPortName(port.identifier) }}:</strong>
+                                <span v-html="msg"></span>
+                            </li>
+                        </template>
+                    </ul>
+                </UiBox>
+
+                <!-- Advisory softserial notices (non-blocking). -->
+                <UiBox v-if="tabReady && !isLoading && uniqueNotices.length" type="neutral" highlight class="mt-4">
+                    <ul class="list-disc pl-5">
+                        <li v-for="(msg, i) in uniqueNotices" :key="`notice-${i}`" v-html="msg"></li>
+                    </ul>
+                </UiBox>
             </div>
         </div>
 
         <div class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2">
-                <UButton :label="$t('configurationButtonSave')" size="xs" :disabled="!dirty" @click="saveConfig" />
+                <UButton
+                    :label="$t('configurationButtonSave')"
+                    size="xs"
+                    :disabled="!dirty || (!isValid && !expertMode)"
+                    @click="saveConfig"
+                />
             </div>
         </div>
     </BaseTab>
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, onUnmounted, ref } from "vue";
 import { useMediaQuery } from "@vueuse/core";
 import BaseTab from "./BaseTab.vue";
 import UiBox from "@/components/elements/UiBox.vue";
@@ -188,9 +221,12 @@ import HelpIcon from "@/components/elements/HelpIcon.vue";
 import WikiButton from "../elements/WikiButton.vue";
 import TabLoadingState from "@/components/elements/TabLoadingState.vue";
 import { useTranslation } from "i18next-vue";
+import { EventBus } from "@/components/eventBus";
+import { isExpertModeEnabled } from "@/js/utils/isExpertModeEnabled";
 import { usePortsRules } from "../../composables/ports/usePortsRules";
 import { usePortsState } from "../../composables/ports/usePortsState";
 import { usePortsConfiguration } from "../../composables/ports/usePortsConfiguration";
+import { usePortsValidation } from "../../composables/ports/usePortsValidation";
 
 const { t } = useTranslation();
 
@@ -207,14 +243,42 @@ const { saveConfig, onTelemetryChange, onPeripheralChange } = usePortsConfigurat
     functionRules,
 );
 
+const { isValid, portErrors, configErrors, notices, portHasError } = usePortsValidation(ports);
+
+// De-duplicate advisory notices (the same clamp can be reported per field).
+const uniqueNotices = computed(() => [...new Set(notices.value)]);
+
+// Expert mode is validated the same way, but is allowed to save anyway; the
+// summary is then shown as a warning rather than a blocking error.
+const expertMode = ref(isExpertModeEnabled());
+function onExpertModeChange(checked) {
+    expertMode.value = checked;
+}
+
+const portSeverity = computed(() => (expertMode.value ? "warning" : "error"));
+const bannerTitleKey = computed(() =>
+    expertMode.value ? "portsValidationBannerTitleExpert" : "portsValidationBannerTitle",
+);
+function portNameClass(port) {
+    if (!portHasError(port.identifier)) {
+        return "";
+    }
+    return expertMode.value ? "text-warning" : "text-error";
+}
+
 const tabReady = ref(false);
 
 onMounted(() => {
+    EventBus.$on("expert-mode-change", onExpertModeChange);
     requestAnimationFrame(() => {
         requestAnimationFrame(() => {
             tabReady.value = true;
         });
     });
+});
+
+onUnmounted(() => {
+    EventBus.$off("expert-mode-change", onExpertModeChange);
 });
 
 const mspBaudItems = mspBaudRates.map((r) => ({ value: r, label: r }));

--- a/src/composables/ports/usePortsConfiguration.js
+++ b/src/composables/ports/usePortsConfiguration.js
@@ -7,6 +7,8 @@ import { gui_log } from "../../js/gui_log";
 import { i18n } from "../../js/localization";
 import { tracking } from "../../js/Analytics";
 import { useReboot } from "../useReboot";
+import { validatePortsConfig } from "./usePortsValidation";
+import { isExpertModeEnabled } from "../../js/utils/isExpertModeEnabled";
 
 export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
     const { saveAndReboot } = useReboot();
@@ -62,6 +64,14 @@ export function usePortsConfiguration(ports, analyticsChanges, functionRules) {
     };
 
     const saveConfig = () => {
+        // Backstop for the disabled Save button: don't send a layout the firmware
+        // would silently reset to defaults. Expert mode may save anyway.
+        const validation = validatePortsConfig(ports);
+        if (!validation.valid && !isExpertModeEnabled()) {
+            gui_log(i18n.getMessage("portsValidationBannerTitle"));
+            return;
+        }
+
         tracking.sendSaveAndChangeEvents(tracking.EVENT_CATEGORIES.FLIGHT_CONTROLLER, toRaw(analyticsChanges), "ports");
 
         // Clear analytics changes

--- a/src/composables/ports/usePortsValidation.js
+++ b/src/composables/ports/usePortsValidation.js
@@ -1,0 +1,106 @@
+import { computed } from "vue";
+import FC from "../../js/fc";
+import { mspHelper } from "../../js/msp/MSPHelper";
+import { i18n } from "../../js/localization";
+import { validateSerialConfig, SERIAL_VALIDATION_CODE as CODE } from "../../js/utils/serialConfigValidation";
+
+// Maps a reactive Ports-tab port model to the { identifier, functionMask,
+// *_baudrateIndex } shape the validator expects. The function list is built the
+// same way saveConfig builds it, so we validate the mask that would be sent.
+function portModelToRawPort(port) {
+    const functions = [];
+    if (port.msp) {
+        functions.push("MSP");
+    }
+    if (port.rxSerial) {
+        functions.push("RX_SERIAL");
+    }
+    if (port.telemetry) {
+        functions.push(port.telemetry);
+    }
+    if (port.sensor) {
+        functions.push(port.sensor);
+    }
+    if (port.peripheral) {
+        functions.push(port.peripheral);
+    }
+
+    const baudIndex = (value) => {
+        const index = mspHelper.BAUD_RATES.indexOf(value);
+        return index < 0 ? 0 : index;
+    };
+
+    return {
+        identifier: port.identifier,
+        functionMask: mspHelper.serialPortFunctionsToMask(functions),
+        gps_baudrateIndex: baudIndex(port.gps_baudrate),
+        telemetry_baudrateIndex: baudIndex(port.telemetry_baudrate),
+        blackbox_baudrateIndex: baudIndex(port.blackbox_baudrate),
+    };
+}
+
+const CODE_TO_I18N = {
+    [CODE.VCP_REQUIRES_MSP]: "portsValidationVcpRequiresMsp",
+    [CODE.VTX_MSP_NOT_SHARED]: "portsValidationVtxMspNotShared",
+    [CODE.TOO_MANY_FUNCTIONS]: "portsValidationTooManyFunctions",
+    [CODE.INVALID_FUNCTION_COMBINATION]: "portsValidationInvalidCombination",
+    [CODE.NO_MSP_PORT]: "portsValidationNoMspPort",
+    [CODE.TOO_MANY_MSP_PORTS]: "portsValidationTooManyMspPorts",
+    [CODE.SOFTSERIAL_FUNCTION_STRIPPED]: "portsNoticeSoftserialFunctionStripped",
+    [CODE.SOFTSERIAL_BAUD_CLAMPED]: "portsNoticeSoftserialBaudClamped",
+};
+
+function messageFor(entry) {
+    const key = CODE_TO_I18N[entry.code];
+    if (!key) {
+        return entry.code;
+    }
+    return i18n.getMessage(key, entry.params ? { ...entry.params } : undefined);
+}
+
+// Non-reactive validation, shared by the live computed and the save guard.
+// Always validates; whether an invalid layout blocks the save is the caller's
+// decision (Expert mode still sees the errors but may save anyway).
+export function validatePortsConfig(ports) {
+    const rawPorts = ports.map(portModelToRawPort);
+    const serialRxProvider = FC.RX_CONFIG?.serialrx_provider ?? 0;
+
+    // hasTelemetry / hasVtxMsp default to true — matches every standard build;
+    // where wrong it only widens an advisory ceiling (8 vs 3).
+    return validateSerialConfig(rawPorts, serialRxProvider);
+}
+
+export function usePortsValidation(ports) {
+    const validationResult = computed(() => validatePortsConfig(ports));
+
+    const isValid = computed(() => validationResult.value.valid);
+
+    // Errors keyed by port identifier; config-wide errors (null id) are excluded.
+    const portErrors = computed(() => {
+        const map = {};
+        for (const error of validationResult.value.errors) {
+            if (error.identifier === null || error.identifier === undefined) {
+                continue;
+            }
+            (map[error.identifier] ||= []).push(messageFor(error));
+        }
+        return map;
+    });
+
+    const configErrors = computed(() =>
+        validationResult.value.errors.filter((e) => e.identifier === null).map(messageFor),
+    );
+
+    const notices = computed(() => validationResult.value.notices.map(messageFor));
+
+    const portHasError = (identifier) => Boolean(portErrors.value[identifier]?.length);
+
+    return {
+        validationResult,
+        isValid,
+        portErrors,
+        configErrors,
+        notices,
+        portHasError,
+    };
+}

--- a/src/composables/ports/usePortsValidation.js
+++ b/src/composables/ports/usePortsValidation.js
@@ -2,7 +2,21 @@ import { computed } from "vue";
 import FC from "../../js/fc";
 import { mspHelper } from "../../js/msp/MSPHelper";
 import { i18n } from "../../js/localization";
+import { buildOptionsReported } from "../useBuildOptions";
 import { validateSerialConfig, SERIAL_VALIDATION_CODE as CODE } from "../../js/utils/serialConfigValidation";
+
+// The firmware's USE_TELEMETRY umbrella flag is not a reported build option, but
+// it is on whenever any telemetry protocol is compiled in, so we infer it from
+// the protocol options that are reported.
+const TELEMETRY_BUILD_OPTIONS = [
+    "USE_TELEMETRY_FRSKY_HUB",
+    "USE_TELEMETRY_HOTT",
+    "USE_TELEMETRY_IBUS_EXTENDED",
+    "USE_TELEMETRY_LTM",
+    "USE_TELEMETRY_MAVLINK",
+    "USE_TELEMETRY_SMARTPORT",
+    "USE_TELEMETRY_SRXL",
+];
 
 // Maps a reactive Ports-tab port model to the { identifier, functionMask,
 // *_baudrateIndex } shape the validator expects. The function list is built the
@@ -30,13 +44,26 @@ function portModelToRawPort(port) {
         return index < 0 ? 0 : index;
     };
 
+    // saveConfig resolves the GPS/Blackbox "AUTO" rate to a concrete value before
+    // sending, so validate the same rate the FC will actually receive (otherwise
+    // the softserial baud clamp notice disagrees with what gets sent).
     return {
         identifier: port.identifier,
         functionMask: mspHelper.serialPortFunctionsToMask(functions),
-        gps_baudrateIndex: baudIndex(port.gps_baudrate),
+        gps_baudrateIndex: baudIndex(port.gps_baudrate === "AUTO" ? "57600" : port.gps_baudrate),
         telemetry_baudrateIndex: baudIndex(port.telemetry_baudrate),
-        blackbox_baudrateIndex: baudIndex(port.blackbox_baudrate),
+        blackbox_baudrateIndex: baudIndex(port.blackbox_baudrate === "AUTO" ? "115200" : port.blackbox_baudrate),
     };
+}
+
+// Mirror of the firmware's USE_TELEMETRY: present when the build reports any
+// telemetry protocol. Fails open (true) when build options were not reported,
+// which matches every standard build and only ever widens an advisory ceiling.
+function targetHasTelemetry(config) {
+    if (!buildOptionsReported(config)) {
+        return true;
+    }
+    return TELEMETRY_BUILD_OPTIONS.some((name) => config.buildOptions.includes(name));
 }
 
 const CODE_TO_I18N = {
@@ -65,9 +92,11 @@ export function validatePortsConfig(ports) {
     const rawPorts = ports.map(portModelToRawPort);
     const serialRxProvider = FC.RX_CONFIG?.serialrx_provider ?? 0;
 
-    // hasTelemetry / hasVtxMsp default to true — matches every standard build;
-    // where wrong it only widens an advisory ceiling (8 vs 3).
-    return validateSerialConfig(rawPorts, serialRxProvider);
+    // Thread the connected target's telemetry capability through; hasVtxMsp keeps
+    // its default (true) since a no-VTX_MSP build only drops an error, never adds one.
+    return validateSerialConfig(rawPorts, serialRxProvider, {
+        hasTelemetry: targetHasTelemetry(FC.CONFIG),
+    });
 }
 
 export function usePortsValidation(ports) {

--- a/src/js/utils/serialConfigValidation.js
+++ b/src/js/utils/serialConfigValidation.js
@@ -1,0 +1,255 @@
+/**
+ * Pure, DOM-free mirror of the firmware's `isSerialConfigValid()`
+ * (src/main/io/serial.c:510-580), `telemetryCheckRxPortShared()`
+ * (src/main/telemetry/telemetry.c:152-181) and the softserial fixups it applies
+ * first. The firmware SILENTLY wipes the whole serial config back to defaults on
+ * an invalid layout (src/main/config/config.c:231 -> PG_RESET(serialConfig)), on
+ * every save and boot, with no error shown. So we must reject exactly what the
+ * firmware rejects before sending — no stricter, no looser.
+ *
+ * That means replicating the firmware's known permissiveness (the rule-6(a)
+ * loophole below): do NOT tighten it, or the UI blocks layouts the FC accepts.
+ */
+
+export const SERIAL_FUNCTION = {
+    MSP: 1 << 0,
+    GPS: 1 << 1,
+    TELEMETRY_FRSKY_HUB: 1 << 2,
+    TELEMETRY_HOTT: 1 << 3,
+    TELEMETRY_LTM: 1 << 4,
+    TELEMETRY_SMARTPORT: 1 << 5,
+    RX_SERIAL: 1 << 6,
+    BLACKBOX: 1 << 7,
+    TELEMETRY_MAVLINK: 1 << 9,
+    ESC_SENSOR: 1 << 10,
+    VTX_SMARTAUDIO: 1 << 11,
+    TELEMETRY_IBUS: 1 << 12,
+    VTX_TRAMP: 1 << 13,
+    RCDEVICE: 1 << 14,
+    LIDAR: 1 << 15,
+    FRSKY_OSD: 1 << 16,
+    VTX_MSP: 1 << 17,
+    GIMBAL: 1 << 18,
+    OSD_CUSTOM_TEXT: 1 << 19,
+};
+
+const F = SERIAL_FUNCTION;
+
+const TELEMETRY_SHAREABLE_MASK = F.TELEMETRY_FRSKY_HUB | F.TELEMETRY_LTM | F.TELEMETRY_MAVLINK;
+
+const TELEMETRY_PORT_FUNCTIONS_MASK = TELEMETRY_SHAREABLE_MASK | F.TELEMETRY_HOTT | F.TELEMETRY_SMARTPORT;
+
+const ALL_FUNCTIONS_SHARABLE_WITH_MSP = F.BLACKBOX | F.VTX_MSP | TELEMETRY_PORT_FUNCTIONS_MASK;
+
+export const SERIAL_PORT_IDENTIFIER = {
+    USB_VCP: 20,
+    SOFTSERIAL_FIRST: 30,
+    SOFTSERIAL_LAST: 31,
+};
+
+export const MAX_MSP_PORT_COUNT = 3;
+
+// baudRates enum in the firmware: BAUD_AUTO=0, BAUD_9600=1, BAUD_19200=2, ...
+const BAUD_19200_INDEX = 2;
+
+// serialrx_provider values (SerialRXType, src/main/rx/rx.h) for which the
+// firmware permits an RX + telemetry share.
+const RX_TELEMETRY_SHARE_PROVIDERS = new Set([
+    15, // SPEKTRUM1024
+    1, // SPEKTRUM2048
+    2, // SBUS
+    3, // SUMD
+    4, // SUMH
+    5, // XBUS_MODE_B
+    6, // XBUS_MODE_B_RJ01
+    7, // IBUS
+    16, // MAVLINK
+]);
+const SERIALRX_IBUS = 7;
+
+/**
+ * Error / notice codes surfaced to callers. The UI maps these to i18n strings.
+ */
+export const SERIAL_VALIDATION_CODE = {
+    VCP_REQUIRES_MSP: "VCP_REQUIRES_MSP",
+    VTX_MSP_NOT_SHARED: "VTX_MSP_NOT_SHARED",
+    TOO_MANY_FUNCTIONS: "TOO_MANY_FUNCTIONS",
+    INVALID_FUNCTION_COMBINATION: "INVALID_FUNCTION_COMBINATION",
+    NO_MSP_PORT: "NO_MSP_PORT",
+    TOO_MANY_MSP_PORTS: "TOO_MANY_MSP_PORTS",
+    SOFTSERIAL_FUNCTION_STRIPPED: "SOFTSERIAL_FUNCTION_STRIPPED",
+    SOFTSERIAL_BAUD_CLAMPED: "SOFTSERIAL_BAUD_CLAMPED",
+};
+
+export function popcount32(value) {
+    let v = value >>> 0;
+    let count = 0;
+    while (v) {
+        v &= v - 1;
+        count++;
+    }
+    return count;
+}
+
+export function isSoftSerialPort(identifier) {
+    return (
+        identifier >= SERIAL_PORT_IDENTIFIER.SOFTSERIAL_FIRST && identifier <= SERIAL_PORT_IDENTIFIER.SOFTSERIAL_LAST
+    );
+}
+
+// Mirror of telemetryCheckRxPortShared() (src/main/telemetry/telemetry.c:152).
+function isRxTelemetryShareAllowed(mask, serialRxProvider) {
+    if (mask & F.RX_SERIAL && mask & TELEMETRY_SHAREABLE_MASK && RX_TELEMETRY_SHARE_PROVIDERS.has(serialRxProvider)) {
+        return true;
+    }
+    if (mask & F.TELEMETRY_IBUS && mask & F.RX_SERIAL && serialRxProvider === SERIALRX_IBUS) {
+        return true;
+    }
+    if (mask & F.RX_SERIAL && mask & F.VTX_MSP) {
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Mirror of the firmware's softserial fixups (serial.c:526-535). The firmware
+ * MUTATES the config here rather than rejecting it, so we must apply the same
+ * normalisation before counting MSP ports — otherwise our MSP count disagrees
+ * with the firmware's. We return a normalised copy plus notices instead of
+ * mutating, so the caller decides whether to apply and inform.
+ *
+ * @param {Array<object>} ports
+ * @returns {{ports: Array, notices: Array}}
+ */
+export function normalizeSerialConfig(ports) {
+    const notices = [];
+    const normalized = ports.map((port) => {
+        if (!isSoftSerialPort(port.identifier)) {
+            return { ...port };
+        }
+        const next = { ...port };
+
+        if (next.functionMask & (F.MSP | F.RX_SERIAL)) {
+            next.functionMask = (next.functionMask & ~(F.MSP | F.RX_SERIAL)) >>> 0;
+            notices.push({
+                identifier: port.identifier,
+                code: SERIAL_VALIDATION_CODE.SOFTSERIAL_FUNCTION_STRIPPED,
+            });
+        }
+
+        for (const key of ["gps_baudrateIndex", "blackbox_baudrateIndex", "telemetry_baudrateIndex"]) {
+            if (next[key] > BAUD_19200_INDEX) {
+                next[key] = BAUD_19200_INDEX;
+                notices.push({
+                    identifier: port.identifier,
+                    code: SERIAL_VALIDATION_CODE.SOFTSERIAL_BAUD_CLAMPED,
+                    field: key,
+                });
+            }
+        }
+        return next;
+    });
+
+    return { ports: normalized, notices };
+}
+
+/**
+ * Mirror of isSerialConfigValid() (src/main/io/serial.c:510).
+ *
+ * Two deliberate, safe deviations from a literal transcription:
+ *  - The firmware returns false on the first failure; we collect ALL failures
+ *    so the UI can highlight every offending row at once. Same verdict.
+ *  - The firmware mutates softserial config in place; we return a normalised
+ *    copy plus notices instead.
+ *
+ * @param {Array<{identifier:number, functionMask:number,
+ *   gps_baudrateIndex?:number, blackbox_baudrateIndex?:number,
+ *   telemetry_baudrateIndex?:number}>} rawPorts
+ * @param {number} serialRxProvider  FC.RX_CONFIG.serialrx_provider
+ * @param {object} [options]
+ * @param {boolean} [options.hasTelemetry=true]  build has USE_TELEMETRY
+ * @param {boolean} [options.hasVtxMsp=true]     build has USE_VTX_MSP
+ * @returns {{valid:boolean, errors:Array, notices:Array, normalizedPorts:Array}}
+ */
+export function validateSerialConfig(rawPorts, serialRxProvider, options = {}) {
+    const { hasTelemetry = true, hasVtxMsp = true } = options;
+
+    const { ports, notices } = normalizeSerialConfig(rawPorts);
+    const errors = [];
+
+    const sharableWithMsp = hasTelemetry ? ALL_FUNCTIONS_SHARABLE_WITH_MSP : F.BLACKBOX | F.VTX_MSP;
+
+    // 8 with telemetry, 3 without.
+    const maxSharedBits = popcount32(F.MSP | sharableWithMsp);
+
+    let mspPortCount = 0;
+
+    for (const port of ports) {
+        const mask = port.functionMask >>> 0;
+
+        if (mask & F.MSP) {
+            mspPortCount++;
+        }
+
+        // Rule 3 — VCP must carry MSP.
+        if (port.identifier === SERIAL_PORT_IDENTIFIER.USB_VCP && !(mask & F.MSP)) {
+            errors.push({
+                identifier: port.identifier,
+                code: SERIAL_VALIDATION_CODE.VCP_REQUIRES_MSP,
+            });
+        }
+
+        const bitCount = popcount32(mask);
+
+        // Rule 4 — VTX (MSP) cannot be the only function on the port.
+        if (hasVtxMsp && mask & F.VTX_MSP && bitCount === 1) {
+            errors.push({
+                identifier: port.identifier,
+                code: SERIAL_VALIDATION_CODE.VTX_MSP_NOT_SHARED,
+            });
+        }
+
+        if (bitCount > 1) {
+            // Rule 5 — hard ceiling on how many functions may share one port.
+            if (bitCount > maxSharedBits) {
+                errors.push({
+                    identifier: port.identifier,
+                    code: SERIAL_VALIDATION_CODE.TOO_MANY_FUNCTIONS,
+                    params: { max: maxSharedBits, count: bitCount },
+                });
+                continue;
+            }
+
+            // Rule 6 — the share must match one of the two supported patterns.
+            // NOTE (rule-6(a) loophole): the firmware only checks that MSP is
+            // present AND at least one shareable bit is present; it never
+            // verifies the *remaining* bits are shareable. So e.g.
+            // MSP | GPS | BLACKBOX passes. We deliberately keep this loophole.
+            const mspShare = mask & F.MSP && mask & sharableWithMsp;
+            const rxShare = hasTelemetry && isRxTelemetryShareAllowed(mask, serialRxProvider);
+
+            if (!mspShare && !rxShare) {
+                errors.push({
+                    identifier: port.identifier,
+                    code: SERIAL_VALIDATION_CODE.INVALID_FUNCTION_COMBINATION,
+                });
+            }
+        }
+    }
+
+    // Rule 7 — MSP port count.
+    if (mspPortCount === 0) {
+        errors.push({
+            identifier: null,
+            code: SERIAL_VALIDATION_CODE.NO_MSP_PORT,
+        });
+    } else if (mspPortCount > MAX_MSP_PORT_COUNT) {
+        errors.push({
+            identifier: null,
+            code: SERIAL_VALIDATION_CODE.TOO_MANY_MSP_PORTS,
+            params: { max: MAX_MSP_PORT_COUNT, count: mspPortCount },
+        });
+    }
+
+    return { valid: errors.length === 0, errors, notices, normalizedPorts: ports };
+}

--- a/test/js/ports_validation.test.js
+++ b/test/js/ports_validation.test.js
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import FC from "../../src/js/fc";
+import { validatePortsConfig } from "../../src/composables/ports/usePortsValidation";
+import { SERIAL_VALIDATION_CODE as CODE } from "../../src/js/utils/serialConfigValidation";
+
+// Minimal Ports-tab port model, matching what usePortsState produces.
+const port = (identifier, overrides = {}) => ({
+    identifier,
+    msp: false,
+    rxSerial: false,
+    telemetry: "",
+    sensor: "",
+    peripheral: "",
+    gps_baudrate: "AUTO",
+    telemetry_baudrate: "AUTO",
+    blackbox_baudrate: "AUTO",
+    ...overrides,
+});
+
+// VCP(MSP) + a UART sharing Serial RX with LTM telemetry. This is valid only when
+// the RX/telemetry share branch is available, i.e. when the target has telemetry
+// and the provider supports the share (SBUS).
+const rxTelemetrySharePorts = () => [port(20, { msp: true }), port(51, { rxSerial: true, telemetry: "TELEMETRY_LTM" })];
+
+const SBUS = 2;
+
+const codes = (result) => result.errors.map((e) => e.code);
+
+describe("validatePortsConfig — build-option derived telemetry capability", () => {
+    beforeEach(() => {
+        setActivePinia(createPinia());
+        FC.resetState();
+        FC.RX_CONFIG.serialrx_provider = SBUS;
+    });
+
+    it("treats telemetry as present when build options were not reported (RX share valid)", () => {
+        // Fresh FC: no api version / empty build options -> fail open to hasTelemetry:true.
+        const result = validatePortsConfig(rxTelemetrySharePorts());
+        expect(result.valid).toBe(true);
+    });
+
+    it("treats telemetry as present when the build reports a telemetry protocol", () => {
+        FC.CONFIG.apiVersion = "1.47.0";
+        FC.CONFIG.buildOptions = ["USE_GPS", "USE_TELEMETRY_LTM"];
+
+        const result = validatePortsConfig(rxTelemetrySharePorts());
+        expect(result.valid).toBe(true);
+    });
+
+    it("rejects the RX/telemetry share on a reported no-telemetry target", () => {
+        FC.CONFIG.apiVersion = "1.47.0";
+        FC.CONFIG.buildOptions = ["USE_GPS"]; // reported, but no telemetry protocol
+
+        const result = validatePortsConfig(rxTelemetrySharePorts());
+        expect(result.valid).toBe(false);
+        expect(codes(result)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
+    });
+
+    it("still honours serialrx_provider (share rejected for an unsupported provider)", () => {
+        FC.RX_CONFIG.serialrx_provider = 9; // CRSF: not an RX/telemetry share provider
+
+        const result = validatePortsConfig(rxTelemetrySharePorts());
+        expect(result.valid).toBe(false);
+        expect(codes(result)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
+    });
+});

--- a/test/js/utils/serialConfigValidation.test.js
+++ b/test/js/utils/serialConfigValidation.test.js
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import {
+    SERIAL_FUNCTION as F,
+    validateSerialConfig,
+    normalizeSerialConfig,
+    isSoftSerialPort,
+    popcount32,
+    SERIAL_VALIDATION_CODE as CODE,
+} from "../../../src/js/utils/serialConfigValidation";
+
+// serialrx_provider (SerialRXType) values used by the vectors.
+const PROVIDER = {
+    SPEKTRUM1024: 15,
+    SPEKTRUM2048: 1,
+    SBUS: 2,
+    IBUS: 7,
+    CRSF: 9,
+    MAVLINK: 16,
+};
+
+// Convenience: build a raw port from an identifier + function mask.
+const p = (identifier, functionMask = 0, extra = {}) => ({ identifier, functionMask, ...extra });
+
+const codes = (result) => result.errors.map((e) => e.code);
+
+describe("popcount32 / isSoftSerialPort", () => {
+    it("counts bits", () => {
+        expect(popcount32(0)).toBe(0);
+        expect(popcount32(F.MSP)).toBe(1);
+        expect(popcount32(F.MSP | F.BLACKBOX | F.VTX_MSP)).toBe(3);
+    });
+
+    it("identifies softserial ports (30-31 only)", () => {
+        expect(isSoftSerialPort(30)).toBe(true);
+        expect(isSoftSerialPort(31)).toBe(true);
+        expect(isSoftSerialPort(29)).toBe(false);
+        expect(isSoftSerialPort(32)).toBe(false);
+        expect(isSoftSerialPort(51)).toBe(false);
+    });
+});
+
+describe("validateSerialConfig — firmware isSerialConfigValid mirror", () => {
+    // 1
+    it("1: VCP with MSP only is valid", () => {
+        const r = validateSerialConfig([p(20, F.MSP)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+        expect(r.errors).toEqual([]);
+    });
+
+    // 2
+    it("2: VCP MSP + UART GPS is valid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.GPS)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 3
+    it("3: MSP | BLACKBOX share is valid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP | F.BLACKBOX)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 4
+    it("4: MSP | SMARTPORT share is valid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP | F.TELEMETRY_SMARTPORT)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 5
+    it("5: RX_SERIAL | LTM with SBUS provider is valid (RX share)", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_LTM)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 6
+    it("6: RX_SERIAL | LTM with CRSF provider is invalid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_LTM)], PROVIDER.CRSF);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
+    });
+
+    // 7
+    it("7: RX_SERIAL | SMARTPORT is invalid (SMARTPORT not in shareable subset)", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_SMARTPORT)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
+    });
+
+    // 8
+    it("8: RX_SERIAL | IBUS telemetry with IBUS provider is valid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_IBUS)], PROVIDER.IBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 9
+    it("9: RX_SERIAL | IBUS telemetry with SBUS provider is invalid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_IBUS)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
+    });
+
+    // 10
+    it("10: RX_SERIAL | VTX_MSP is valid regardless of provider", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.VTX_MSP)], PROVIDER.CRSF);
+        expect(r.valid).toBe(true);
+    });
+
+    // 11
+    it("11: GPS | BLACKBOX share is invalid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.GPS | F.BLACKBOX)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
+    });
+
+    // 12
+    it("12: VTX_MSP alone on a port is invalid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.VTX_MSP)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.VTX_MSP_NOT_SHARED);
+    });
+
+    // 13
+    it("13: MSP | VTX_MSP on the VCP is valid", () => {
+        const r = validateSerialConfig([p(20, F.MSP | F.VTX_MSP)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 14
+    it("14: VCP without MSP is invalid", () => {
+        const r = validateSerialConfig([p(20, 0), p(51, F.MSP)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.VCP_REQUIRES_MSP);
+    });
+
+    // 15
+    it("15: no MSP port anywhere is invalid", () => {
+        const r = validateSerialConfig([p(51, F.GPS), p(52, F.BLACKBOX)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.NO_MSP_PORT);
+    });
+
+    // 16
+    it("16: four MSP ports is invalid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP), p(52, F.MSP), p(53, F.MSP)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.TOO_MANY_MSP_PORTS);
+    });
+
+    // 17
+    it("17: exactly three MSP ports is valid", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP), p(52, F.MSP)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 18
+    it("18: softserial-only MSP strips MSP first -> NO_MSP_PORT + stripped notice", () => {
+        const r = validateSerialConfig([p(30, F.MSP)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.NO_MSP_PORT);
+        expect(r.notices.map((n) => n.code)).toContain(CODE.SOFTSERIAL_FUNCTION_STRIPPED);
+    });
+
+    // 19
+    it("19: softserial GPS baud > 19200 is clamped to index 2 with a notice", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(30, F.GPS, { gps_baudrateIndex: 5 })], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+        expect(r.notices.map((n) => n.code)).toContain(CODE.SOFTSERIAL_BAUD_CLAMPED);
+        const softserial = r.normalizedPorts.find((port) => port.identifier === 30);
+        expect(softserial.gps_baudrateIndex).toBe(2);
+    });
+
+    // 20 — regression guard for the rule-6(a) loophole.
+    it("20: MSP | GPS | BLACKBOX is valid (documents the rule-6(a) loophole)", () => {
+        const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP | F.GPS | F.BLACKBOX)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 21
+    it("21: eight shared bits (exactly at the ceiling) is valid", () => {
+        const eightBits =
+            F.MSP |
+            F.BLACKBOX |
+            F.VTX_MSP |
+            F.TELEMETRY_FRSKY_HUB |
+            F.TELEMETRY_HOTT |
+            F.TELEMETRY_LTM |
+            F.TELEMETRY_SMARTPORT |
+            F.TELEMETRY_MAVLINK;
+        expect(popcount32(eightBits)).toBe(8);
+        const r = validateSerialConfig([p(20, F.MSP), p(51, eightBits)], PROVIDER.SBUS);
+        expect(r.valid).toBe(true);
+    });
+
+    // 22
+    it("22: nine shared bits exceeds the ceiling -> TOO_MANY_FUNCTIONS", () => {
+        const nineBits =
+            F.MSP |
+            F.BLACKBOX |
+            F.VTX_MSP |
+            F.TELEMETRY_FRSKY_HUB |
+            F.TELEMETRY_HOTT |
+            F.TELEMETRY_LTM |
+            F.TELEMETRY_SMARTPORT |
+            F.TELEMETRY_MAVLINK |
+            F.GPS;
+        const r = validateSerialConfig([p(20, F.MSP), p(51, nineBits)], PROVIDER.SBUS);
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.TOO_MANY_FUNCTIONS);
+    });
+
+    // 23
+    it("23: with hasTelemetry:false the ceiling drops to 3", () => {
+        const eightBits =
+            F.MSP |
+            F.BLACKBOX |
+            F.VTX_MSP |
+            F.TELEMETRY_FRSKY_HUB |
+            F.TELEMETRY_HOTT |
+            F.TELEMETRY_LTM |
+            F.TELEMETRY_SMARTPORT |
+            F.TELEMETRY_MAVLINK;
+        const r = validateSerialConfig([p(20, F.MSP), p(51, eightBits)], PROVIDER.SBUS, {
+            hasTelemetry: false,
+        });
+        expect(r.valid).toBe(false);
+        expect(codes(r)).toContain(CODE.TOO_MANY_FUNCTIONS);
+    });
+});
+
+describe("normalizeSerialConfig", () => {
+    it("does not mutate the input ports", () => {
+        const input = [p(30, F.MSP | F.GPS, { gps_baudrateIndex: 5 })];
+        const snapshot = JSON.parse(JSON.stringify(input));
+        normalizeSerialConfig(input);
+        expect(input).toEqual(snapshot);
+    });
+
+    it("leaves non-softserial ports untouched", () => {
+        const { ports, notices } = normalizeSerialConfig([p(51, F.MSP | F.RX_SERIAL, { gps_baudrateIndex: 5 })]);
+        expect(ports[0].functionMask).toBe(F.MSP | F.RX_SERIAL);
+        expect(ports[0].gps_baudrateIndex).toBe(5);
+        expect(notices).toEqual([]);
+    });
+});

--- a/test/js/utils/serialConfigValidation.test.js
+++ b/test/js/utils/serialConfigValidation.test.js
@@ -40,118 +40,100 @@ describe("popcount32 / isSoftSerialPort", () => {
 });
 
 describe("validateSerialConfig — firmware isSerialConfigValid mirror", () => {
-    // 1
     it("1: VCP with MSP only is valid", () => {
         const r = validateSerialConfig([p(20, F.MSP)], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
         expect(r.errors).toEqual([]);
     });
 
-    // 2
     it("2: VCP MSP + UART GPS is valid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.GPS)], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
     });
 
-    // 3
     it("3: MSP | BLACKBOX share is valid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP | F.BLACKBOX)], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
     });
 
-    // 4
     it("4: MSP | SMARTPORT share is valid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP | F.TELEMETRY_SMARTPORT)], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
     });
 
-    // 5
     it("5: RX_SERIAL | LTM with SBUS provider is valid (RX share)", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_LTM)], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
     });
 
-    // 6
     it("6: RX_SERIAL | LTM with CRSF provider is invalid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_LTM)], PROVIDER.CRSF);
         expect(r.valid).toBe(false);
         expect(codes(r)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
     });
 
-    // 7
     it("7: RX_SERIAL | SMARTPORT is invalid (SMARTPORT not in shareable subset)", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_SMARTPORT)], PROVIDER.SBUS);
         expect(r.valid).toBe(false);
         expect(codes(r)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
     });
 
-    // 8
     it("8: RX_SERIAL | IBUS telemetry with IBUS provider is valid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_IBUS)], PROVIDER.IBUS);
         expect(r.valid).toBe(true);
     });
 
-    // 9
     it("9: RX_SERIAL | IBUS telemetry with SBUS provider is invalid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.TELEMETRY_IBUS)], PROVIDER.SBUS);
         expect(r.valid).toBe(false);
         expect(codes(r)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
     });
 
-    // 10
     it("10: RX_SERIAL | VTX_MSP is valid regardless of provider", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.RX_SERIAL | F.VTX_MSP)], PROVIDER.CRSF);
         expect(r.valid).toBe(true);
     });
 
-    // 11
     it("11: GPS | BLACKBOX share is invalid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.GPS | F.BLACKBOX)], PROVIDER.SBUS);
         expect(r.valid).toBe(false);
         expect(codes(r)).toContain(CODE.INVALID_FUNCTION_COMBINATION);
     });
 
-    // 12
     it("12: VTX_MSP alone on a port is invalid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.VTX_MSP)], PROVIDER.SBUS);
         expect(r.valid).toBe(false);
         expect(codes(r)).toContain(CODE.VTX_MSP_NOT_SHARED);
     });
 
-    // 13
     it("13: MSP | VTX_MSP on the VCP is valid", () => {
         const r = validateSerialConfig([p(20, F.MSP | F.VTX_MSP)], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
     });
 
-    // 14
     it("14: VCP without MSP is invalid", () => {
         const r = validateSerialConfig([p(20, 0), p(51, F.MSP)], PROVIDER.SBUS);
         expect(r.valid).toBe(false);
         expect(codes(r)).toContain(CODE.VCP_REQUIRES_MSP);
     });
 
-    // 15
     it("15: no MSP port anywhere is invalid", () => {
         const r = validateSerialConfig([p(51, F.GPS), p(52, F.BLACKBOX)], PROVIDER.SBUS);
         expect(r.valid).toBe(false);
         expect(codes(r)).toContain(CODE.NO_MSP_PORT);
     });
 
-    // 16
     it("16: four MSP ports is invalid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP), p(52, F.MSP), p(53, F.MSP)], PROVIDER.SBUS);
         expect(r.valid).toBe(false);
         expect(codes(r)).toContain(CODE.TOO_MANY_MSP_PORTS);
     });
 
-    // 17
     it("17: exactly three MSP ports is valid", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP), p(52, F.MSP)], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
     });
 
-    // 18
     it("18: softserial-only MSP strips MSP first -> NO_MSP_PORT + stripped notice", () => {
         const r = validateSerialConfig([p(30, F.MSP)], PROVIDER.SBUS);
         expect(r.valid).toBe(false);
@@ -159,7 +141,6 @@ describe("validateSerialConfig — firmware isSerialConfigValid mirror", () => {
         expect(r.notices.map((n) => n.code)).toContain(CODE.SOFTSERIAL_FUNCTION_STRIPPED);
     });
 
-    // 19
     it("19: softserial GPS baud > 19200 is clamped to index 2 with a notice", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(30, F.GPS, { gps_baudrateIndex: 5 })], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
@@ -168,13 +149,11 @@ describe("validateSerialConfig — firmware isSerialConfigValid mirror", () => {
         expect(softserial.gps_baudrateIndex).toBe(2);
     });
 
-    // 20 — regression guard for the rule-6(a) loophole.
     it("20: MSP | GPS | BLACKBOX is valid (documents the rule-6(a) loophole)", () => {
         const r = validateSerialConfig([p(20, F.MSP), p(51, F.MSP | F.GPS | F.BLACKBOX)], PROVIDER.SBUS);
         expect(r.valid).toBe(true);
     });
 
-    // 21
     it("21: eight shared bits (exactly at the ceiling) is valid", () => {
         const eightBits =
             F.MSP |
@@ -190,7 +169,6 @@ describe("validateSerialConfig — firmware isSerialConfigValid mirror", () => {
         expect(r.valid).toBe(true);
     });
 
-    // 22
     it("22: nine shared bits exceeds the ceiling -> TOO_MANY_FUNCTIONS", () => {
         const nineBits =
             F.MSP |
@@ -207,7 +185,6 @@ describe("validateSerialConfig — firmware isSerialConfigValid mirror", () => {
         expect(codes(r)).toContain(CODE.TOO_MANY_FUNCTIONS);
     });
 
-    // 23
     it("23: with hasTelemetry:false the ceiling drops to 3", () => {
         const eightBits =
             F.MSP |


### PR DESCRIPTION
Block saving invalid Ports configurations _(allow in Expert mode, showing warning card)_.

## Problem

When the serial port config is invalid, Betaflight firmware silently wipes every port back to target defaults - a full [`PG_RESET(serialConfig)` (`config.c:231`)](https://github.com/betaflight/betaflight/blob/087699dba08e3f518edef05770dea5ad8e054ac7/src/main/config/config.c#L232), on every save and every boot, with no error. The MSP write handlers don't run this check, so the FC happily ACKs the layout the user just built and then destroys it on reboot. From the user's side: "I set my ports, hit Save, and they all reverted to defaults with no message."

The Configurator now catches these cases client-side before sending and refuses to save, explaining which port is wrong and why.

## What's included

- `serialConfigValidation.js`: a pure, DOM-free validator that mirrors the firmware's `isSerialConfigValid()`, `telemetryCheckRxPortShared()`, and the softserial fixups. It intentionally replicates the firmware exactly, including its known permissiveness (e.g. the rule-6(a) loophole where MSP | GPS | BLACKBOX passes) - being stricter than the FC would block valid layouts, which is a different, worse bug. A regression test guards this.
- Ports tab integration: live validation on every change; per-port rows highlighted; a consolidated summary appended below the table (so it never shifts the layout); the redundant standing "combinations may be reset" note now only shows in Expert mode, where it's still reachable.
- Expert mode: still validates and shows the warnings, but is allowed to save anyway (styled as a warning rather than a hard block).
- i18n: all new strings in locales/en/messages.json.
- Tests: 27 unit tests covering all 23 spec vectors plus edges.

## Save paths covered

The Ports tab (`MSP2_COMMON_SET_SERIAL_CONFIG`) and its defensive save-guard.

Not covered: Presets/backup-restore/CLI paths that apply raw serial diff lines - they bypass the Ports model and would need CLI-line parsing.

## Notes

- `hasTelemetry` / `hasVtxMsp` default to true (matches every standard build); where wrong it only widens an advisory bit-count ceiling (8 vs 3), never a hard-stop rule.
- Softserial fixups surface as advisory notices, not blocking errors - the firmware accepts and normalises them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation for serial-port configurations, including port/function conflicts, MSP/VCP requirements, function limits, and softserial restrictions.
  * Invalid ports are highlighted with clear error messages and advisory notices.
  * Saving invalid configurations is blocked unless Expert mode is enabled.
  * Expert mode reveals additional guidance and allows advanced overrides.
  * Validation now accounts for target telemetry capabilities and applicable automatic baud rates.

* **Tests**
  * Added comprehensive coverage for validation rules, normalization, limits, and provider-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->