### PR TITLE
fix: retire references to the standalone Blackbox viewer

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -991,7 +991,7 @@
         "message": "Software"
     },
     "defaultSoftwareText": {
-        "message": "Our <a href=\"https://blackbox.betaflight.com\" target=\"_blank\" rel=\"noopener noreferrer\">Blackbox Log Viewer</a> is available as an online app.<br /><br />Our collection of <a href=\"https://github.com/betaflight/betaflight-tx-lua-scripts/releases\" target=\"_blank\" rel=\"noopener noreferrer\">TX Lua Scripts</a> are available on GitHub.<br /><br />Our <a href=\"https://github.com/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">source code</a> for the firmware, this app, and the blackbox viewer can be downloaded from GitHub."
+        "message": "Our Blackbox log viewer is built into this app. Open the <strong>Blackbox Viewer</strong> tab to analyse your flight logs.<br /><br />Our collection of <a href=\"https://github.com/betaflight/betaflight-tx-lua-scripts/releases\" target=\"_blank\" rel=\"noopener noreferrer\">TX Lua Scripts</a> are available on GitHub.<br /><br />Our <a href=\"https://github.com/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">source code</a> for the firmware and this app can be downloaded from GitHub."
     },
     "defaultContributingHead": {
         "message": "Contributing"

--- a/src/js/webworkers/gpx-export-worker.js
+++ b/src/js/webworkers/gpx-export-worker.js
@@ -2,11 +2,11 @@ onmessage = function (event) {
     const header = `<?xml version="1.0" encoding="UTF-8"?>
 <gpx xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd http://www.topografix.com/GPX/gpx_style/0/2 http://www.topografix.com/GPX/gpx_style/0/2/gpx_style.xsd" xmlns:gpx_style="http://www.topografix.com/GPX/gpx_style/0/2" 
   version="1.1" 
-  creator="https://github.com/betaflight/blackbox-log-viewer">
+  creator="https://github.com/betaflight/betaflight-configurator">
   <metadata>
     <author>
-      <name>Betaflight Blackbox Explorer</name>
-      <link href="https://github.com/betaflight/blackbox-log-viewer"></link>
+      <name>Betaflight App</name>
+      <link href="https://github.com/betaflight/betaflight-configurator"></link>
     </author>
   </metadata>`;
 


### PR DESCRIPTION
The Welcome tab still told people the Blackbox log viewer was an online app elsewhere and linked to blackbox.betaflight.com, which is now a frozen build of a repository that is feature frozen and due to be archived on 1 December 2026. It now points at the Blackbox Viewer tab in this app instead, and the source-code sentence drops the separate mention of the viewer since it is part of the app.

Only locales/en/messages.json is touched, as that is the Crowdin source; the translations follow from there.

Exported GPX files also stamped the old repository into their creator and author metadata, so those now point at betaflight-configurator.

Related: betaflight/blackbox-log-viewer#939, betaflight/betaflight.com#755.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Updated the software information text to highlight the built-in Blackbox Viewer tab.
  - Continued linking to TX Lua Scripts and Betaflight source code.
  - Updated exported GPX metadata to identify the Betaflight Configurator/App as the creator and author.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->