### PR TITLE
feat(blackbox-viewer): full screen mode

### DIFF
--- a/src/blackbox-viewer/App.vue
+++ b/src/blackbox-viewer/App.vue
@@ -12,6 +12,7 @@
                 @export-csv="onExportCsv"
                 @export-gpx="onExportGpx"
                 @export-workspaces="onExportWorkspaces"
+                @toggle-fullscreen="onToggleFullscreen"
             />
         </Teleport>
         <Teleport to="#vue-statusbar">
@@ -198,6 +199,10 @@ function onOpenSettings() {
 
 function onOpenKeys() {
     appStore.keysDialogOpen = true;
+}
+
+function onToggleFullscreen() {
+    graphStore.toggleFullscreen();
 }
 
 function onExportCsv() {

--- a/src/blackbox-viewer/components/AppToolbar.vue
+++ b/src/blackbox-viewer/components/AppToolbar.vue
@@ -53,6 +53,15 @@
                 title="Keyboard Shortcuts"
                 @click="$emit('open-keys')"
             />
+            <UButton
+                variant="ghost"
+                color="neutral"
+                :icon="graphStore.isFullscreen ? 'i-lucide-minimize' : 'i-lucide-maximize'"
+                size="xs"
+                :title="graphStore.isFullscreen ? 'Exit Full Screen (F)' : 'Full Screen (F)'"
+                :aria-pressed="graphStore.isFullscreen"
+                @click="$emit('toggle-fullscreen')"
+            />
         </div>
     </div>
 </template>
@@ -60,12 +69,22 @@
 <script setup>
 import { useLogStore } from "../stores/log.js";
 import { useAppStore } from "../stores/app.js";
+import { useGraphStore } from "../stores/graph.js";
 import LogFileInput from "./LogFileInput.vue";
 
-defineEmits(["files-selected", "export-csv", "export-gpx", "export-workspaces", "open-settings", "open-keys"]);
+defineEmits([
+    "files-selected",
+    "export-csv",
+    "export-gpx",
+    "export-workspaces",
+    "open-settings",
+    "open-keys",
+    "toggle-fullscreen",
+]);
 
 const logStore = useLogStore();
 const appStore = useAppStore();
+const graphStore = useGraphStore();
 </script>
 
 <style scoped>

--- a/src/blackbox-viewer/components/KeysDialog.vue
+++ b/src/blackbox-viewer/components/KeysDialog.vue
@@ -84,6 +84,8 @@ const layout = [
                 { keys: ["G"], action: "QuickGrid — hide all grids" },
                 { keys: ["T"], action: "Toggle field values table" },
                 { keys: ["C"], action: "Toggle configuration dump" },
+                { keys: ["F"], action: "Toggle full screen" },
+                { keys: ["Esc"], action: "Leave full screen" },
             ],
         },
         {

--- a/src/blackbox-viewer/keyboard_handler.js
+++ b/src/blackbox-viewer/keyboard_handler.js
@@ -226,6 +226,12 @@ export function createKeydownHandler(ctx) {
                 workspaceStore.showDefaultMenu = true;
             }
         },
+        KeyF(e, shifted) {
+            if (!shifted) {
+                graphStore.toggleFullscreen();
+                e.preventDefault();
+            }
+        },
         KeyZ: handleKeyZoom,
         KeyS: handleKeySave,
         KeyX(e, shifted) {
@@ -275,6 +281,14 @@ export function createKeydownHandler(ctx) {
                 break;
             case "End":
                 logJumpEnd();
+                break;
+            case "Escape":
+                // Leave fullscreen, unless Escape is already busy dismissing a dialog, dropdown
+                // menu or select — those trap focus inside themselves, so the target tells us.
+                if (!graphStore.isFullscreen || e.target.closest?.("[role='dialog'],[role='menu'],[role='listbox']")) {
+                    return false;
+                }
+                graphStore.toggleFullscreen();
                 break;
             default:
                 return false;

--- a/src/blackbox-viewer/keyboard_handler.js
+++ b/src/blackbox-viewer/keyboard_handler.js
@@ -283,9 +283,10 @@ export function createKeydownHandler(ctx) {
                 logJumpEnd();
                 break;
             case "Escape":
-                // Leave fullscreen, unless Escape is already busy dismissing a dialog, dropdown
-                // menu or select — those trap focus inside themselves, so the target tells us.
-                if (!graphStore.isFullscreen || e.target.closest?.("[role='dialog'],[role='menu'],[role='listbox']")) {
+                // Leave fullscreen, unless Escape is already busy dismissing a dialog — that
+                // traps focus inside itself, so the target tells us. Open popups never get
+                // here; they are filtered out before dispatch.
+                if (!graphStore.isFullscreen || e.target.closest?.("[role='dialog']")) {
                     return false;
                 }
                 graphStore.toggleFullscreen();
@@ -297,6 +298,12 @@ export function createKeydownHandler(ctx) {
         return true;
     }
 
+    // An open reka-ui dropdown menu or select owns the keyboard: it runs its own type-ahead
+    // and arrow navigation, which every shortcut below would otherwise double up on. Only the
+    // open popup is matched, never its trigger, so the shortcuts keep working while a closed
+    // trigger holds focus — the same distinction createDropdownSpaceGuard draws below.
+    const OPEN_POPUP = "[role='menu'],[role='listbox']";
+
     return function (e) {
         // Dormant behind other tabs (embedded): don't hijack keys the user means for the host.
         if (!appStore.viewerActive) {
@@ -306,7 +313,7 @@ export function createKeydownHandler(ctx) {
         if (e.key === "Enter" && e.target.type === "text" && !e.target.closest(".modal")) {
             e.target.blur();
         }
-        if (hasGraph() && e.target.type !== "text" && !e.target.closest(".modal")) {
+        if (hasGraph() && e.target.type !== "text" && !e.target.closest(".modal") && !e.target.closest?.(OPEN_POPUP)) {
             if (e.code.startsWith("Digit")) {
                 try {
                     handleDigitKey(e);

--- a/src/blackbox-viewer/main.js
+++ b/src/blackbox-viewer/main.js
@@ -108,6 +108,8 @@ export function bootstrapViewer() {
     logStore.hasVideo = false;
     logStore.flightLog = null;
     graphStore.graph = null;
+    // A fresh mount lands on the welcome page, which has no toolbar to leave fullscreen with.
+    graphStore.isFullscreen = false;
 
     graphStore.invalidateGraph = invalidateGraph;
     graphStore.updateCanvasSize = updateCanvasSize;

--- a/src/blackbox-viewer/stores/graph.js
+++ b/src/blackbox-viewer/stores/graph.js
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { ref, shallowRef, computed } from "vue";
+import { ref, shallowRef, computed, nextTick } from "vue";
 import { useSettingsStore } from "./settings.js";
 import { useLogStore } from "./log.js";
 import { PrefStorage } from "../pref_storage.js";
@@ -157,6 +157,17 @@ export const useGraphStore = defineStore("graph", () => {
         invalidateGraph.value?.();
     }
 
+    /**
+     * Grow the viewer over the host configurator's chrome (sidebar menu and status bar).
+     * The `is-fullscreen` class that drives the layout is applied by App.vue on the next
+     * flush, so the canvases can only be re-measured once that has landed and the browser
+     * has laid the enlarged viewer out.
+     */
+    function toggleFullscreen() {
+        isFullscreen.value = !isFullscreen.value;
+        nextTick(() => requestAnimationFrame(() => updateCanvasSize.value?.()));
+    }
+
     function toggleMap() {
         hasMap.value = !hasMap.value;
         prefs.set("hasMap", hasMap.value);
@@ -231,6 +242,7 @@ export const useGraphStore = defineStore("graph", () => {
         legendVisibilityChange,
         toggleAnalyser,
         toggleAnalyserFullscreen,
+        toggleFullscreen,
         toggleMap,
         setGraphZoom,
         quickZoomToggle,

--- a/src/components/tabs/BlackboxViewerTab.vue
+++ b/src/components/tabs/BlackboxViewerTab.vue
@@ -47,12 +47,13 @@
 </template>
 
 <script setup>
-import { nextTick, onActivated, onDeactivated, onMounted, onBeforeUnmount, provide, ref } from "vue";
+import { nextTick, onActivated, onDeactivated, onMounted, onBeforeUnmount, provide, ref, watch } from "vue";
 import BaseTab from "./BaseTab.vue";
 import GUI from "../../js/gui";
 import BlackboxViewerApp from "../../blackbox-viewer/App.vue";
 import { bootstrapViewer } from "../../blackbox-viewer/main.js";
 import { setBlackboxViewerDark, setViewerActive } from "../../blackbox-viewer/vue_init.js";
+import { useGraphStore } from "../../blackbox-viewer/stores/graph.js";
 import { useDataflashPull } from "../../composables/useDataflashPull";
 
 // Named so <keep-alive :include> in App.vue can target this tab (and only this tab) for caching.
@@ -63,6 +64,19 @@ const viewerReady = ref(false);
 let themeObserver = null;
 let teardownViewer = null;
 const dataflash = useDataflashPull();
+const graphStore = useGraphStore();
+
+// Going fullscreen means painting over the configurator's own chrome, which is outside this
+// tab: #content isolates its stacking context, so the viewer's z-index can never escape it.
+// Marking the body lets the rule below lift #content itself instead. Only the class lives on
+// the host document — the layout state stays on the viewer root (see App.vue).
+const FULLSCREEN_BODY_CLASS = "blackbox-viewer-fullscreen";
+
+function markHostFullscreen(on) {
+    document.body.classList.toggle(FULLSCREEN_BODY_CLASS, on);
+}
+
+watch(() => graphStore.isFullscreen, markHostFullscreen);
 
 // The viewer renders as a child of this tab, on the host's Vue app and pinia. Hand it the
 // root element (for its scoped state classes) and the FC dataflash pull via provide/inject.
@@ -92,10 +106,19 @@ onMounted(async () => {
 });
 
 // Kept alive across tab switches: pause/resume instead of unmounting so the loaded log survives.
-onActivated(() => setViewerActive(true));
-onDeactivated(() => setViewerActive(false));
+// The fullscreen mode is part of that surviving state, but the class that widens #content must
+// not outlive the tab being on screen.
+onActivated(() => {
+    setViewerActive(true);
+    markHostFullscreen(graphStore.isFullscreen);
+});
+onDeactivated(() => {
+    setViewerActive(false);
+    markHostFullscreen(false);
+});
 
 onBeforeUnmount(() => {
+    markHostFullscreen(false);
     themeObserver?.disconnect();
     themeObserver = null;
     try {
@@ -121,5 +144,32 @@ onBeforeUnmount(() => {
        on this root makes those fixed descendants resolve against the tab pane instead of the
        window, so the viewer stays inside the content area and never covers the sidebar. */
     transform: translateZ(0);
+}
+
+/* Fullscreen: the viewer covers the sidebar menu and the status bar. Everything inside it
+   already lays out with `position: fixed` against this root (see the transform above), so
+   pinning the root to #main-wrapper's box is all it takes to grow the whole viewer with it.
+   Gated on a log being open: the welcome page has no toolbar to leave fullscreen from. */
+.blackbox-viewer-root.is-fullscreen:is(.has-log, .has-video) {
+    position: fixed;
+    inset: 0;
+    background-color: var(--surface-100);
+}
+
+/* The mobile top bar paints above the viewer, so keep the toolbar clear of it. */
+@media all and (max-width: 575px), all and (max-width: 950px) and (max-height: 500px) and (orientation: landscape) {
+    .blackbox-viewer-root.is-fullscreen:is(.has-log, .has-video) {
+        top: calc(3rem + env(safe-area-inset-top, 0px));
+    }
+}
+</style>
+
+<style>
+/* Host-side half of the viewer's fullscreen mode (see the tab's own styles above). #content
+   is `isolation: isolate`, so lift #content itself to let the viewer paint over the sidebar
+   and the status bar. Kept well below the Nuxt UI portal layer rooted at #main-wrapper, so
+   dialogs, dropdowns and the mobile sidebar still land on top of the viewer. */
+body.blackbox-viewer-fullscreen #content {
+    z-index: 40;
 }
 </style>


### PR DESCRIPTION
## Summary

The blackbox-viewer tab can now run full screen, expanding over the sidebar menu and the status bar.

The toggle sits at the top right of the viewer toolbar, directly after the keyboard shortcuts icon, and flips between the maximize and minimize corner brackets. `F` toggles it, `Esc` leaves it, and both are listed in the shortcuts dialog. Escape is ignored while it is already dismissing a dialog, menu or select, so it never doubles up.

| | normal | full screen |
|---|---|---|
| viewer root | x:256 w:1340 h:860 | x:0 y:0 **w:1600 h:900** |
| over sidebar (120,400) | `.tab_container` | viewer canvas |
| over status bar (120,880) | `#status-bar` | viewer status bar |
| graph canvas | 1139×667 | **1394×707** |

## How it works

State reuses `graphStore.isFullscreen`, which was already bound to an `is-fullscreen` class on the viewer root but was never toggled by anything.

The vendored viewer lays its whole UI out with `position: fixed` against the tab root (which carries a transform for exactly that reason), so pinning that root to `#main-wrapper`'s box grows every part of the viewer with it. The canvases are re-measured once the enlarged layout has landed.

`#content` is `isolation: isolate`, so the viewer's own z-index can never escape it. The tab marks `document.body` instead, and one rule lifts `#content` itself — kept well below the Nuxt UI portal layer rooted at `#main-wrapper`, so dialogs, dropdowns and the mobile sidebar still land on top of the viewer. That mark is dropped while the tab is off screen and restored on return, and full screen is reset on a fresh mount, where the welcome page has no toolbar to leave it from.

## Notes

While full screen the viewer covers the sidebar, so the tab menu is not clickable until you leave it via the toolbar button or `Esc`. That is the point of the feature rather than a side effect, but worth calling out.

## Testing

Driven in the running app with a real log:

- Toggle on/off from the toolbar button, with `F`, and with `Esc`.
- Escape with the shortcuts dialog open closes only the dialog and stays full screen; a second Escape exits.
- Dialogs render above the full screen viewer.
- Switching to another tab drops the body mark and returns `#content` to `z-index: auto` (other tabs render untouched); returning to the viewer restores full screen.
- `npm run test` 881/881, lint and prettier clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fullscreen viewing for graph content through the toolbar button.
  * Added keyboard shortcuts: `F` to toggle fullscreen and `Esc` to exit.
  * Fullscreen state is preserved while the viewer tab is active and cleared when leaving it.
  * Added accessible button labels and state indicators.
  * Added mobile-friendly fullscreen layout adjustments.

* **Bug Fixes**
  * Improved canvas resizing when entering or exiting fullscreen.
  * Prevented shortcuts from triggering inside open menus and listboxes.
  * Ensured each viewer session starts outside fullscreen mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->