### PR TITLE
Update blackbox debug names for 2026.12

### DIFF
--- a/src/blackbox-viewer/flightlog_parser.js
+++ b/src/blackbox-viewer/flightlog_parser.js
@@ -25,6 +25,7 @@ import {
     API_VERSION_1_46,
     API_VERSION_1_47,
     API_VERSION_1_48,
+    API_VERSION_1_49,
 } from "../js/data_storage";
 
 /**
@@ -66,6 +67,9 @@ function firmwareToApiVersion(firmwareType, firmwareVersion) {
 
     // Betaflight switched from 4.x to a year-based scheme (2025.12, 2026.x),
     // so a calendar version always compares greater than any 4.x version.
+    if (semver.gte(version, "2026.12.0")) {
+        return API_VERSION_1_49;
+    }
     if (semver.gte(version, "2026.0.0")) {
         return API_VERSION_1_48;
     }

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -1490,8 +1490,10 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
-
                 case "AUTOPILOT_ALTITUDE":
+                    if (!semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                        return getCurveForMinMaxFields(fieldName);
+                    }
                     switch (fieldName) {
                         case "debug[1]": // Target Altitude
                         case "debug[2]": // Current Altitude
@@ -1525,8 +1527,10 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
-
                 case "AUTOPILOT_PID":
+                    if (!semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                        return getCurveForMinMaxFields(fieldName);
+                    }
                     switch (fieldName) {
                         case "debug[0]": // XY Velocity
                         case "debug[1]": // XY Distance Error
@@ -1560,8 +1564,10 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
-
                 case "AUTOPILOT_STOP":
+                    if (!semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                        return getCurveForMinMaxFields(fieldName);
+                    }
                     switch (fieldName) {
                         case "debug[0]": // Velocity Error East
                         case "debug[1]": // Velocity Error North
@@ -1595,7 +1601,6 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
-
                 case "POSITION_EST":
                     switch (fieldName) {
                         case "debug[0]": // Position

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -281,8 +281,19 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
         };
     };
 
+    const minMaxPower1 = function (min, max) {
+        return {
+            power: 1,
+            MinMax: {
+                min,
+                max,
+            },
+        };
+    };
+
     const gyroScaleMargin = 1.2; // Give a 20% margin for gyro graphs
     const highResolutionScale = sysConfig.blackbox_high_resolution > 0 ? 10 : 1;
+
     try {
         if (
             fieldName.match(/^motor\[/) ||
@@ -1466,13 +1477,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                 case "MAVLINK_TELEMETRY":
                     switch (fieldName) {
                         case "debug[0]":
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 1,
-                                },
-                            };
+                            return minMaxPower1(0, 1);
                         case "debug[1]":
                         case "debug[2]":
                         case "debug[3]":
@@ -1480,16 +1485,11 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         case "debug[5]":
                         case "debug[6]":
                         case "debug[7]":
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 100,
-                                },
-                            };
+                            return minMaxPower1(0, 100);
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
+
                 case "AUTOPILOT_ALTITUDE":
                     if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);
@@ -1497,36 +1497,22 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                     switch (fieldName) {
                         case "debug[1]": // Target Altitude
                         case "debug[2]": // Current Altitude
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -10,
-                                    max: 10,
-                                },
-                            };
+                            return minMaxPower1(-10, 10);
+
                         case "debug[0]": // New Throttle
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 1000,
-                                    max: 2000,
-                                },
-                            };
+                            return minMaxPower1(1000, 2000);
+
                         case "debug[3]": // P
                         case "debug[4]": // I
                         case "debug[5]": // D
                         case "debug[6]": // A
                         case "debug[7]": // F
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -500,
-                                    max: 500,
-                                },
-                            };
+                            return minMaxPower1(-500, 500);
+
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
+
                 case "AUTOPILOT_PID":
                     if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);
@@ -1534,36 +1520,22 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                     switch (fieldName) {
                         case "debug[0]": // XY Velocity
                         case "debug[1]": // XY Distance Error
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -10,
-                                    max: 10,
-                                },
-                            };
+                            return minMaxPower1(-10, 10);
+
                         case "debug[2]": // XY P
                         case "debug[3]": // XY I
                         case "debug[4]": // XY D
                         case "debug[5]": // XY A
                         case "debug[6]": // XY F
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -500,
-                                    max: 500,
-                                },
-                            };
+                            return minMaxPower1(-500, 500);
+
                         case "debug[7]": // Status
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 500,
-                                },
-                            };
+                            return minMaxPower1(0, 500);
+
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
+
                 case "AUTOPILOT_NAV":
                     if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);
@@ -1572,35 +1544,21 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         case "debug[0]": // Target Velocity
                         case "debug[1]": // Velocity
                         case "debug[2]": // Velocity Error
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -10,
-                                    max: 10,
-                                },
-                            };
+                            return minMaxPower1(-10, 10);
+
                         case "debug[3]": // P
                         case "debug[4]": // I
                         case "debug[5]": // D
                         case "debug[6]": // A
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -500,
-                                    max: 500,
-                                },
-                            };
+                            return minMaxPower1(-500, 500);
+
                         case "debug[7]": // Status
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 500,
-                                },
-                            };
+                            return minMaxPower1(0, 500);
+
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
+
                 case "AUTOPILOT_STOP":
                     if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);
@@ -1608,36 +1566,22 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                     switch (fieldName) {
                         case "debug[0]": // Velocity Error East
                         case "debug[1]": // Velocity Error North
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -5,
-                                    max: 5,
-                                },
-                            };
+                            return minMaxPower1(-5, 5);
+
                         case "debug[2]": // PID Sum East
                         case "debug[3]": // PID Sum North
                         case "debug[4]": // Roll Angle Command
                         case "debug[5]": // Pitch Angle Command
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -500,
-                                    max: 500,
-                                },
-                            };
+                            return minMaxPower1(-500, 500);
+
                         case "debug[6]": // Status Flags East
                         case "debug[7]": // Status Flags North
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 500,
-                                },
-                            };
+                            return minMaxPower1(0, 500);
+
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
+
                 case "POSITION_EST":
                     switch (fieldName) {
                         case "debug[0]": // Position
@@ -1646,22 +1590,12 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         case "debug[3]": // Velocity East
                         case "debug[4]": // Velocity North
                         case "debug[5]": // Raw Acceleration
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -10,
-                                    max: 10,
-                                },
-                            };
+                            return minMaxPower1(-10, 10);
+
                         case "debug[6]": // GPS R Pos
                         case "debug[7]": // GPS R Vel
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 1000,
-                                },
-                            };
+                            return minMaxPower1(0, 1000);
+
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -534,7 +534,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         },
                     };
                 case "ALTITUDE":
-                    if (semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                    if (sysConfig.apiVersion && semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         switch (fieldName) {
                             case "debug[0]": // RangeFinder Alt
                             case "debug[1]": // Baro Alt
@@ -1038,7 +1038,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                             return getCurveForMinMaxFields(fieldName);
                     }
                 case "GPS_RESCUE_VELOCITY":
-                    if (semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                    if (sysConfig.apiVersion && semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         switch (fieldName) {
                             case "debug[0]": // Target Velocity
                             case "debug[1]": // Velocity / Phase
@@ -1080,7 +1080,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                     }
 
                 case "GPS_RESCUE_HEADING":
-                    if (semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                    if (sysConfig.apiVersion && semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         switch (fieldName) {
                             case "debug[0]": // Ground Speed
                                 return {
@@ -1163,7 +1163,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                     }
 
                 case "GPS_RESCUE_TRACKING":
-                    if (semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                    if (sysConfig.apiVersion && semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         switch (fieldName) {
                             case "debug[0]": // Velocity
                             case "debug[2]": // Altitude

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -1564,6 +1564,43 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
+                case "AUTOPILOT_NAV":
+                    if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                        return getCurveForMinMaxFields(fieldName);
+                    }
+                    switch (fieldName) {
+                        case "debug[0]": // Target Velocity
+                        case "debug[1]": // Velocity
+                        case "debug[2]": // Velocity Error
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -10,
+                                    max: 10,
+                                },
+                            };
+                        case "debug[3]": // P
+                        case "debug[4]": // I
+                        case "debug[5]": // D
+                        case "debug[6]": // A
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -500,
+                                    max: 500,
+                                },
+                            };
+                        case "debug[7]": // Status
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: 0,
+                                    max: 500,
+                                },
+                            };
+                        default:
+                            return getCurveForMinMaxFields(fieldName);
+                    }
                 case "AUTOPILOT_STOP":
                     if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -534,34 +534,56 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         },
                     };
                 case "ALTITUDE":
-                    switch (fieldName) {
-                        case "debug[0]": // GPS Trust
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -200,
-                                    max: 200,
-                                },
-                            };
-                        case "debug[1]": // Baro Alt
-                        case "debug[2]": // GPS Alt
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -50,
-                                    max: 50,
-                                },
-                            };
-                        case "debug[3]": // vario
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -5,
-                                    max: 5,
-                                },
-                            };
-                        default:
-                            return getCurveForMinMaxFields(fieldName);
+                    if (semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                        switch (fieldName) {
+                            case "debug[0]": // RangeFinder Alt
+                            case "debug[1]": // Baro Alt
+                            case "debug[2]": // GPS Alt
+                            case "debug[3]": // Kalman Alt
+                            case "debug[4]": // GPS Vel Up
+                            case "debug[5]": // Kalman Vel Up
+                            case "debug[6]": // Accelerometer Up
+                            case "debug[7]": // Kalman Accel Up
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -5,
+                                        max: 5,
+                                    },
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                        }
+                    } else {
+                        switch (fieldName) {
+                            case "debug[0]": // GPS Trust
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -200,
+                                        max: 200,
+                                    },
+                                };
+                            case "debug[1]": // Baro Alt
+                            case "debug[2]": // GPS Alt
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -50,
+                                        max: 50,
+                                    },
+                                };
+                            case "debug[3]": // Vario
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -5,
+                                        max: 5,
+                                    },
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                        }
                     }
                 case "FFT":
                     switch (fieldName) {
@@ -1016,128 +1038,178 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                             return getCurveForMinMaxFields(fieldName);
                     }
                 case "GPS_RESCUE_VELOCITY":
-                    switch (fieldName) {
-                        case "debug[0]": // Pitch P deg * 100
-                        case "debug[1]": // Pitch D deg * 100
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -20,
-                                    max: 20,
-                                },
-                            };
-                        case "debug[2]": // Velocity in cm/s
-                        case "debug[3]": // Velocity to home in cm/s
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -5,
-                                    max: 5,
-                                },
-                            };
-                        default:
-                            return getCurveForMinMaxFields(fieldName);
+                    if (semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                        switch (fieldName) {
+                            case "debug[0]": // Target Velocity
+                            case "debug[1]": // Velocity / Phase
+                            case "debug[2]": // Step East * 100
+                            case "debug[3]": // Step North * 100
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -1000,
+                                        max: 1000,
+                                    },
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                        }
+                    } else {
+                        switch (fieldName) {
+                            case "debug[0]": // Pitch P deg * 100
+                            case "debug[1]": // Pitch D deg * 100
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -20,
+                                        max: 20,
+                                    },
+                                };
+                            case "debug[2]": // Velocity in cm/s
+                            case "debug[3]": // Velocity to home in cm/s
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -5,
+                                        max: 5,
+                                    },
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                        }
                     }
+
                 case "GPS_RESCUE_HEADING":
-                    switch (fieldName) {
-                        case "debug[0]": // Groundspeed cm/s
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -100,
-                                    max: 100,
-                                },
-                            };
-                        case "debug[1]": // GPS GroundCourse
-                        case "debug[2]": // Yaw attitude * 10
-                        case "debug[3]": // Angle to home * 10
-                        case "debug[4]": // magYaw * 10
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 360,
-                                },
-                            };
-                        case "debug[5]": // magYaw * 10
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 20,
-                                },
-                            };
-                        case "debug[6]": // roll angle *100
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 180,
-                                },
-                            };
-                        case "debug[7]": // yaw rate deg/s
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 200,
-                                },
-                            };
-                        default:
-                            return getCurveForMinMaxFields(fieldName);
+                    if (semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                        switch (fieldName) {
+                            case "debug[0]": // Ground Speed
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -20,
+                                        max: 20,
+                                    },
+                                };
+                            case "debug[1]": // GPS Ground Course
+                            case "debug[2]": // Yaw Attitude
+                            case "debug[3]": // Direction To Home
+                            case "debug[4]": // Mag Yaw
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: 0,
+                                        max: 360,
+                                    },
+                                };
+                            case "debug[7]": // Rescue Yaw Rate
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -100,
+                                        max: 100,
+                                    },
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                        }
+                    } else {
+                        switch (fieldName) {
+                            case "debug[0]": // Groundspeed cm/s
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -100,
+                                        max: 100,
+                                    },
+                                };
+                            case "debug[1]": // GPS GroundCourse
+                            case "debug[2]": // Yaw attitude * 10
+                            case "debug[3]": // Angle to home * 10
+                            case "debug[4]": // magYaw * 10
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: 0,
+                                        max: 360,
+                                    },
+                                };
+                            case "debug[5]": // magYaw * 10
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: 0,
+                                        max: 20,
+                                    },
+                                };
+                            case "debug[6]": // roll angle * 100
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: 0,
+                                        max: 180,
+                                    },
+                                };
+                            case "debug[7]": // yaw rate deg/s
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: 0,
+                                        max: 200,
+                                    },
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                        }
                     }
-                case "RTH":
-                    switch (fieldName) {
-                        case "debug[0]": // Pitch angle, deg * 100
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -4000,
-                                    max: 4000,
-                                },
-                            };
-                        case "debug[1]": // Rescue Phase
-                        case "debug[2]": // Failure code
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 20,
-                                },
-                            };
-                        case "debug[3]": // Failure counters coded
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: 0,
-                                    max: 4000,
-                                },
-                            };
-                        default:
-                            return getCurveForMinMaxFields(fieldName);
-                    }
+
                 case "GPS_RESCUE_TRACKING":
-                    switch (fieldName) {
-                        case "debug[0]": // velocity to home cm/s
-                        case "debug[1]": // target velocity cm/s
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -10,
-                                    max: 10,
-                                },
-                            };
-                        case "debug[2]": // altitude m
-                        case "debug[3]": // Target altitude m
-                            return {
-                                power: 1,
-                                MinMax: {
-                                    min: -50,
-                                    max: 50,
-                                },
-                            };
-                        default:
-                            return getCurveForMinMaxFields(fieldName);
+                    if (semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                        switch (fieldName) {
+                            case "debug[0]": // Velocity
+                            case "debug[2]": // Altitude
+                            case "debug[3]": // Target Altitude
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -10,
+                                        max: 10,
+                                    },
+                                };
+                            case "debug[4]": // Aircraft Heading
+                            case "debug[5]": // Bearing To Home
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: 0,
+                                        max: 360,
+                                    },
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                        }
+                    } else {
+                        switch (fieldName) {
+                            case "debug[0]": // velocity to home cm/s
+                            case "debug[1]": // target velocity cm/s
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -10,
+                                        max: 10,
+                                    },
+                                };
+                            case "debug[2]": // altitude m
+                            case "debug[3]": // Target altitude m
+                                return {
+                                    power: 1,
+                                    MinMax: {
+                                        min: -50,
+                                        max: 50,
+                                    },
+                                };
+                            default:
+                                return getCurveForMinMaxFields(fieldName);
+                        }
                     }
                 case "GPS_CONNECTION":
                     switch (fieldName) {
@@ -1199,6 +1271,36 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                                 MinMax: {
                                     min: -200,
                                     max: 200,
+                                },
+                            };
+                        default:
+                            return getCurveForMinMaxFields(fieldName);
+                    }
+                case "RTH":
+                    switch (fieldName) {
+                        case "debug[0]": // Pitch angle, deg * 100
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -4000,
+                                    max: 4000,
+                                },
+                            };
+                        case "debug[1]": // Rescue Phase
+                        case "debug[2]": // Failure code
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: 0,
+                                    max: 20,
+                                },
+                            };
+                        case "debug[3]": // Failure counters coded
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: 0,
+                                    max: 4000,
                                 },
                             };
                         default:
@@ -1388,8 +1490,142 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                         default:
                             return getCurveForMinMaxFields(fieldName);
                     }
+
+                case "AUTOPILOT_ALTITUDE":
+                    switch (fieldName) {
+                        case "debug[1]": // Target Altitude
+                        case "debug[2]": // Current Altitude
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -10,
+                                    max: 10,
+                                },
+                            };
+                        case "debug[0]": // New Throttle
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: 1000,
+                                    max: 2000,
+                                },
+                            };
+                        case "debug[3]": // P
+                        case "debug[4]": // I
+                        case "debug[5]": // D
+                        case "debug[6]": // A
+                        case "debug[7]": // F
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -500,
+                                    max: 500,
+                                },
+                            };
+                        default:
+                            return getCurveForMinMaxFields(fieldName);
+                    }
+
+                case "AUTOPILOT_PID":
+                    switch (fieldName) {
+                        case "debug[0]": // XY Velocity
+                        case "debug[1]": // XY Distance Error
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -10,
+                                    max: 10,
+                                },
+                            };
+                        case "debug[2]": // XY P
+                        case "debug[3]": // XY I
+                        case "debug[4]": // XY D
+                        case "debug[5]": // XY A
+                        case "debug[6]": // XY F
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -500,
+                                    max: 500,
+                                },
+                            };
+                        case "debug[7]": // Status
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: 0,
+                                    max: 500,
+                                },
+                            };
+                        default:
+                            return getCurveForMinMaxFields(fieldName);
+                    }
+
+                case "AUTOPILOT_STOP":
+                    switch (fieldName) {
+                        case "debug[0]": // Velocity Error East
+                        case "debug[1]": // Velocity Error North
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -5,
+                                    max: 5,
+                                },
+                            };
+                        case "debug[2]": // PID Sum East
+                        case "debug[3]": // PID Sum North
+                        case "debug[4]": // Roll Angle Command
+                        case "debug[5]": // Pitch Angle Command
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -500,
+                                    max: 500,
+                                },
+                            };
+                        case "debug[6]": // Status Flags East
+                        case "debug[7]": // Status Flags North
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: 0,
+                                    max: 500,
+                                },
+                            };
+                        default:
+                            return getCurveForMinMaxFields(fieldName);
+                    }
+
+                case "POSITION_EST":
+                    switch (fieldName) {
+                        case "debug[0]": // Position
+                        case "debug[1]": // Velocity
+                        case "debug[2]": // Kalman Acceleration
+                        case "debug[3]": // Velocity East
+                        case "debug[4]": // Velocity North
+                        case "debug[5]": // Raw Acceleration
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: -10,
+                                    max: 10,
+                                },
+                            };
+                        case "debug[6]": // GPS R Pos
+                        case "debug[7]": // GPS R Vel
+                            return {
+                                power: 1,
+                                MinMax: {
+                                    min: 0,
+                                    max: 1000,
+                                },
+                            };
+                        default:
+                            return getCurveForMinMaxFields(fieldName);
+                    }
             }
         }
+
         // if not found above then
         // Scale and center the field based on the whole-log observed ranges for that field
         return getCurveForMinMaxFields(fieldName);

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -547,8 +547,8 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                                 return {
                                     power: 1,
                                     MinMax: {
-                                        min: -5,
-                                        max: 5,
+                                        min: -10,
+                                        max: 10,
                                     },
                                 };
                             default:

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -1491,7 +1491,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                             return getCurveForMinMaxFields(fieldName);
                     }
                 case "AUTOPILOT_ALTITUDE":
-                    if (!semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                    if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);
                     }
                     switch (fieldName) {
@@ -1528,7 +1528,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                             return getCurveForMinMaxFields(fieldName);
                     }
                 case "AUTOPILOT_PID":
-                    if (!semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                    if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);
                     }
                     switch (fieldName) {
@@ -1565,7 +1565,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                             return getCurveForMinMaxFields(fieldName);
                     }
                 case "AUTOPILOT_STOP":
-                    if (!semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
+                    if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);
                     }
                     switch (fieldName) {

--- a/src/blackbox-viewer/graph_config.js
+++ b/src/blackbox-viewer/graph_config.js
@@ -1536,7 +1536,7 @@ GraphConfig.getDefaultCurveForField = function (flightLog, fieldName) {
                             return getCurveForMinMaxFields(fieldName);
                     }
 
-                case "AUTOPILOT_NAV":
+                case "POSITION_NAV":
                     if (sysConfig.apiVersion && !semver.gte(sysConfig.apiVersion, API_VERSION_1_49)) {
                         return getCurveForMinMaxFields(fieldName);
                     }

--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -1234,7 +1234,7 @@ export function getDebugFieldNames(apiVersion) {
             "XY F",
             "Status",
         );
-        result.AUTOPILOT_NAV = debugFields(
+        result.POSITION_NAV = debugFields(
             "Autopilot Nav",
             "Target Velocity",
             "Velocity Error",
@@ -1421,7 +1421,7 @@ const autopilotPidDecode = (v, ctx, fieldName) => {
             return f0(v);
     }
 };
-const autopilotNavDecode = (v, ctx, fieldName) => {
+const positionNavDecode = (v, ctx, fieldName) => {
     if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
         return f0(v);
     }
@@ -1589,7 +1589,7 @@ const DEBUG_DECODE = {
     ALTITUDE: altitudeDecode,
     AUTOPILOT_ALTITUDE: autopilotAltitudeDecode,
     AUTOPILOT_PID: autopilotPidDecode,
-    AUTOPILOT_NAV: autopilotNavDecode,
+    POSITION_NAV: positionNavDecode,
     AUTOPILOT_STOP: autopilotStopDecode,
 
     POSITION_EST: {
@@ -2008,7 +2008,7 @@ const DEBUG_CONVERT = {
     ALTITUDE: cAltitude,
     AUTOPILOT_ALTITUDE: cAutopilotAltitude,
     AUTOPILOT_PID: cAutopilotPid,
-    AUTOPILOT_NAV: cPositionNav,
+    POSITION_NAV: cPositionNav,
     AUTOPILOT_STOP: cAutopilotStop,
 
     POSITION_EST: {

--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -1347,6 +1347,8 @@ export function getDebugFieldNames(apiVersion) {
 // ---------------------------------------------------------------------------
 
 const f0 = (v) => v.toFixed(0);
+const isApiAtLeast = (ctx, version) => Boolean(ctx?.apiVersion) && semver.gte(ctx.apiVersion, version);
+
 const gyroDps = (v, ctx) => `${Math.round(ctx.gyroRawToDegreesPerSecond(v))} °/s`;
 const gyroDecode = (v, ctx, fieldName) => (fieldName === "debug[4]" ? `${v.toFixed(0)} %` : gyroDps(v, ctx));
 const fftFreqDecode = (v, ctx, fieldName) => {
@@ -1362,7 +1364,7 @@ const opticalflowDecode = (v, ctx, fieldName) => {
     return (v / 1000).toFixed(1);
 };
 const altitudeDecode = (v, ctx, fieldName) => {
-    if (semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
         switch (fieldName) {
             case "debug[0]":
             case "debug[1]":
@@ -1510,7 +1512,7 @@ const gpsRescueHeadingDecode = (v, ctx, fieldName) => {
 };
 
 const gpsRescueTrackingDecode = (v, ctx, fieldName) => {
-    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (!isApiAtLeast(ctx, API_VERSION_1_49)) {
         switch (fieldName) {
             case "debug[0]":
             case "debug[1]":
@@ -1829,79 +1831,91 @@ const cOpticalflow = (toFriendly, v, ctx, fieldName) => {
 };
 
 const cAltitude = (toFriendly, v, ctx, fieldName) => {
-    if (semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
         return cScale100(toFriendly, v);
-    }
-
-    switch (fieldName) {
-        case "debug[1]":
-        case "debug[2]":
-        case "debug[3]":
-            return cScale100(toFriendly, v);
-        default:
-            return v;
+    } else {
+        switch (fieldName) {
+            case "debug[1]":
+            case "debug[2]":
+            case "debug[3]":
+                return cScale100(toFriendly, v);
+            default:
+                return v;
+        }
     }
 };
 
 const cAutopilotAltitude = (toFriendly, v, ctx, fieldName) => {
-    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[1]": // Target Altitude
+            case "debug[2]": // Current Altitude
+                return cScale100(toFriendly, v);
+            default:
+                return v;
+        }
+    } else {
         return v;
-    }
-
-    switch (fieldName) {
-        case "debug[1]": // Target Altitude
-        case "debug[2]": // Current Altitude
-            return cScale100(toFriendly, v);
-        default:
-            return v;
     }
 };
 
 const cAutopilotPid = (toFriendly, v, ctx, fieldName) => {
-    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]": // Velocity
+            case "debug[1]": // Distance Error
+                return cScale100(toFriendly, v);
+            default:
+                return v;
+        }
+    } else {
         return v;
     }
-
-    switch (fieldName) {
-        case "debug[0]": // Velocity
-        case "debug[1]": // Distance Error
-            return cScale100(toFriendly, v);
-        default:
-            return v;
-    }
 };
+
 const cPositionNav = (toFriendly, v, ctx, fieldName) => {
-    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]": // Target Velocity
+            case "debug[1]": // Velocity
+            case "debug[2]": // Velocity Error
+                return cScale100(toFriendly, v);
+            default: // PIDs and status pass through unchanged
+                return v;
+        }
+    } else {
         return v;
     }
-
-    switch (fieldName) {
-        case "debug[0]": // Target Velocity
-        case "debug[1]": // Velocity
-        case "debug[2]": // Velocity Error
-            return cScale100(toFriendly, v);
-        default: // PIDs and status pass through unchanged
-            return v;
-    }
 };
+
 const cAutopilotStop = (toFriendly, v, ctx, fieldName) => {
-    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]": // Velocity Error East
+            case "debug[1]": // Velocity Error North
+                return cScale100(toFriendly, v);
+            case "debug[4]": // Roll Angle
+            case "debug[5]": // Pitch Angle
+                return cScale10(toFriendly, v);
+            default:
+                return v;
+        }
+    } else {
         return v;
     }
-
-    switch (fieldName) {
-        case "debug[0]": // Velocity Error East
-        case "debug[1]": // Velocity Error North
-            return cScale100(toFriendly, v);
-        case "debug[4]": // Roll Angle
-        case "debug[5]": // Pitch Angle
-            return cScale10(toFriendly, v);
-        default:
-            return v;
-    }
 };
+
 const cGpsRescueVelocity = (toFriendly, v, ctx, fieldName) => {
-    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]": // Target Velocity
+            case "debug[2]": // Step East * 100
+            case "debug[3]": // Step North * 100
+                return cScale100(toFriendly, v);
+            default:
+                return v;
+        }
+    } else {
         switch (fieldName) {
             case "debug[0]":
             case "debug[1]":
@@ -1915,19 +1929,22 @@ const cGpsRescueVelocity = (toFriendly, v, ctx, fieldName) => {
                 return v;
         }
     }
-
-    switch (fieldName) {
-        case "debug[0]": // Target Velocity
-        case "debug[2]": // Step East * 100
-        case "debug[3]": // Step North * 100
-            return cScale100(toFriendly, v);
-        default:
-            return v;
-    }
 };
 
 const cGpsRescueHeading = (toFriendly, v, ctx, fieldName) => {
-    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]": // Ground Speed
+                return cScale100(toFriendly, v);
+            case "debug[1]": // GPS Ground Course
+            case "debug[2]": // Yaw Attitude
+            case "debug[3]": // Direction To Home
+            case "debug[4]": // Mag Yaw
+                return cScale10(toFriendly, v);
+            default:
+                return v;
+        }
+    } else {
         switch (fieldName) {
             case "debug[0]":
             case "debug[6]":
@@ -1940,22 +1957,19 @@ const cGpsRescueHeading = (toFriendly, v, ctx, fieldName) => {
                 return v;
         }
     }
-
-    switch (fieldName) {
-        case "debug[0]": // Ground Speed
-            return cScale100(toFriendly, v);
-        case "debug[1]": // GPS Ground Course
-        case "debug[2]": // Yaw Attitude
-        case "debug[3]": // Direction To Home
-        case "debug[4]": // Mag Yaw
-            return cScale10(toFriendly, v);
-        default:
-            return v;
-    }
 };
-
 const cGpsRescueTracking = (toFriendly, v, ctx, fieldName) => {
-    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+    if (isApiAtLeast(ctx, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]": // Velocity
+            case "debug[2]": // Altitude
+            case "debug[3]": // Target Altitude
+                return cScale100(toFriendly, v);
+            default:
+                // Heading/Bearing are already in degrees.
+                return v;
+        }
+    } else {
         switch (fieldName) {
             case "debug[0]":
             case "debug[1]":
@@ -1970,18 +1984,7 @@ const cGpsRescueTracking = (toFriendly, v, ctx, fieldName) => {
                 return v;
         }
     }
-
-    switch (fieldName) {
-        case "debug[0]": // Velocity
-        case "debug[2]": // Altitude
-        case "debug[3]": // Target Altitude
-            return cScale100(toFriendly, v);
-        default:
-            // Heading/Bearing are already in degrees.
-            return v;
-    }
 };
-
 const DEBUG_CONVERT = {
     NONE: {
         "debug[2]": cScale100,

--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -157,6 +157,17 @@ export function getDebugModes(apiVersion) {
 
     return result;
 }
+
+const debugFields = (all, ...fields) => {
+    const result = { "debug[all]": all };
+
+    fields.forEach((field, index) => {
+        result[`debug[${index}]`] = field;
+    });
+
+    return result;
+};
+
 /**
  * Returns the numeric debug_mode value for a given name in the firmware
  * identified by `apiVersion`, or -1 if the name is not defined in that
@@ -1119,182 +1130,183 @@ export function getDebugFieldNames(apiVersion) {
     }
 
     if (semver.gte(apiVersion, API_VERSION_1_48)) {
-        result.AUTOPILOT_PID = {
-            "debug[all]": "Autopilot PID",
-            "debug[0]": "Velocity Error [dbg-axis]",
-            "debug[1]": "Distance Error [dbg-axis]",
-            "debug[2]": "P Term [dbg-axis] * 10",
-            "debug[3]": "I Term [dbg-axis] * 10",
-            "debug[4]": "D Term [dbg-axis] * 10",
-            "debug[5]": "A Term [dbg-axis] * 10",
-            "debug[6]": "F Term [dbg-axis] * 10",
-            "debug[7]": "Status Flags [dbg-axis]",
-        };
+        result.AUTOPILOT_PID = debugFields(
+            "Autopilot PID",
+            "Velocity Error [dbg-axis]",
+            "Distance Error [dbg-axis]",
+            "P Term [dbg-axis] * 10",
+            "I Term [dbg-axis] * 10",
+            "D Term [dbg-axis] * 10",
+            "A Term [dbg-axis] * 10",
+            "F Term [dbg-axis] * 10",
+            "Status Flags [dbg-axis]",
+        );
 
-        result.AUTOPILOT_STOP = {
-            "debug[all]": "Autopilot Stop",
-            "debug[0]": "Velocity Error [East]",
-            "debug[1]": "Velocity Error [North]",
-            "debug[2]": "PID Sum [East] * 10",
-            "debug[3]": "PID Sum [North] * 10",
-            "debug[4]": "Roll Angle Command * 10",
-            "debug[5]": "Pitch Angle Command * 10",
-            "debug[6]": "Status Flags [East]",
-            "debug[7]": "Status Flags [North]",
-        };
+        result.AUTOPILOT_STOP = debugFields(
+            "Autopilot Stop",
+            "Velocity Error [East]",
+            "Velocity Error [North]",
+            "PID Sum [East] * 10",
+            "PID Sum [North] * 10",
+            "Roll Angle Command * 10",
+            "Pitch Angle Command * 10",
+            "Status Flags [East]",
+            "Status Flags [North]",
+        );
 
-        result.GYRO_SAMPLE = {
-            "debug[all]": "Gyro Sample",
-            "debug[0]": "Gyro before downsampling [dbg-axis]",
-            "debug[1]": "Gyro after downsampling [dbg-axis]",
-            "debug[2]": "Gyro after RPM [dbg-axis]",
-            "debug[3]": "Gyro after all filtering [dbg-axis]",
-            "debug[4]": "CPU Load at Sample",
-        };
-
+        result.GYRO_SAMPLE = debugFields(
+            "Gyro Sample",
+            "Gyro before downsampling [dbg-axis]",
+            "Gyro after downsampling [dbg-axis]",
+            "Gyro after RPM [dbg-axis]",
+            "Gyro after all filtering [dbg-axis]",
+            "CPU Load at Sample",
+        );
         // Flow-processing pipeline replaced the quality/raw/processed/delta-time
         // layout used prior to 1.48 (opticalflow.c rewrite).
-        result.OPTICALFLOW = {
-            "debug[all]": "Optical Flow",
-            "debug[0]": "Rotated Flow Rate X",
-            "debug[1]": "Rotated Flow Rate Y",
-            "debug[2]": "Gyro Compensation X",
-            "debug[3]": "Gyro Compensation Y",
-            "debug[4]": "Compensated Flow Rate X",
-            "debug[5]": "Compensated Flow Rate Y",
-            "debug[6]": "Filtered Flow Rate X",
-            "debug[7]": "Filtered Flow Rate Y",
-        };
+        result.OPTICALFLOW = debugFields(
+            "Optical Flow",
+            "Rotated Flow Rate X",
+            "Rotated Flow Rate Y",
+            "Gyro Compensation X",
+            "Gyro Compensation Y",
+            "Compensated Flow Rate X",
+            "Compensated Flow Rate Y",
+            "Filtered Flow Rate X",
+            "Filtered Flow Rate Y",
+        );
 
         // POSITION_NAV is a reserved firmware enum slot with no fields yet,
         // so it intentionally has no fieldNames entry.
         delete result.AUTOPILOT_POSITION;
 
-        result.RANGEFINDER = {
-            "debug[all]": "Rangefinder",
-            "debug[0]": "not used",
-            "debug[1]": "Raw Altitude",
-            "debug[2]": "Calc Altitude",
-            "debug[3]": "SNR",
-            "debug[4]": "Cos Tilt Angle * 1000",
-            "debug[5]": "Max Tilt Cos * 1000",
-        };
+        result.RANGEFINDER = debugFields(
+            "Rangefinder",
+            "not used",
+            "Raw Altitude",
+            "Calc Altitude",
+            "SNR",
+            "Cos Tilt Angle * 1000",
+            "Max Tilt Cos * 1000",
+        );
 
         // debug[3] ("Axis Error [roll]") was removed by "Remove absolute control" (#15023).
-        result.ITERM_RELAX = {
-            "debug[all]": "I-term Relax",
-            "debug[0]": "Setpoint HPF [roll]",
-            "debug[1]": "I Relax Factor [roll]",
-            "debug[2]": "Relaxed I Error [roll]",
-        };
+        result.ITERM_RELAX = debugFields(
+            "I-term Relax",
+            "Setpoint HPF [roll]",
+            "I Relax Factor [roll]",
+            "Relaxed I Error [roll]",
+        );
     }
+
     if (semver.gte(apiVersion, API_VERSION_1_49)) {
-        result.ALTITUDE = {
-            "debug[all]": "Altitude",
-            "debug[0]": "RangeFinder Altitude",
-            "debug[1]": "Baro Altitude",
-            "debug[2]": "GPS Altitude",
-            "debug[3]": "Kalman Altitude",
-            "debug[4]": "GPS Velocity",
-            "debug[5]": "Kalman Velocity",
-            "debug[6]": "Accelerometer",
-            "debug[7]": "Kalman Acceleration",
-        };
+        result.ALTITUDE = debugFields(
+            "Altitude",
+            "RangeFinder Altitude",
+            "Baro Altitude",
+            "GPS Altitude",
+            "Kalman Altitude",
+            "GPS Velocity",
+            "Kalman Velocity",
+            "Accelerometer",
+            "Kalman Acceleration",
+        );
 
-        result.AUTOPILOT_ALTITUDE = {
-            "debug[all]": "Autopilot Altitude",
-            "debug[0]": "newThrottle",
-            "debug[1]": "Target Altitude",
-            "debug[2]": "Current Altitude",
-            "debug[3]": "Alt P",
-            "debug[4]": "Alt I",
-            "debug[5]": "Alt D",
-            "debug[6]": "Alt A",
-            "debug[7]": "Alt F",
-        };
+        result.AUTOPILOT_ALTITUDE = debugFields(
+            "Autopilot Altitude",
+            "newThrottle",
+            "Target Altitude",
+            "Current Altitude",
+            "Alt P",
+            "Alt I",
+            "Alt D",
+            "Alt A",
+            "Alt F",
+        );
 
-        result.AUTOPILOT_PID = {
-            "debug[all]": "Autopilot PID",
-            "debug[0]": "XY Velocity",
-            "debug[1]": "XY Distance Error",
-            "debug[2]": "XY P",
-            "debug[3]": "XY I",
-            "debug[4]": "XY D",
-            "debug[5]": "XY A",
-            "debug[6]": "XY F",
-            "debug[7]": "Status",
-        };
+        result.AUTOPILOT_PID = debugFields(
+            "Autopilot PID",
+            "XY Velocity",
+            "XY Distance Error",
+            "XY P",
+            "XY I",
+            "XY D",
+            "XY A",
+            "XY F",
+            "Status",
+        );
 
-        result.AUTOPILOT_STOP = {
-            "debug[all]": "Autopilot Stop",
-            "debug[0]": "East Vel Error",
-            "debug[1]": "North Vel Error",
-            "debug[2]": "East PIDsum",
-            "debug[3]": "North PIDsum",
-            "debug[4]": "Roll Angle",
-            "debug[5]": "Pitch Angle",
-            "debug[6]": "Status",
-            "debug[7]": "-",
-        };
-        result.GPS_RESCUE_VELOCITY = {
-            "debug[all]": "GPS Rescue Velocity",
-            "debug[0]": "Target Velocity",
-            "debug[1]": "Velocity / Phase",
-            "debug[2]": "Step East",
-            "debug[3]": "Step North",
-            "debug[4]": "Not Used",
-            "debug[5]": "Not Used",
-            "debug[6]": "Not Used",
-            "debug[7]": "Not Used",
-        };
+        result.AUTOPILOT_STOP = debugFields(
+            "Autopilot Stop",
+            "East Vel Error",
+            "North Vel Error",
+            "East PIDsum",
+            "North PIDsum",
+            "Roll Angle",
+            "Pitch Angle",
+            "Status",
+            "-",
+        );
 
-        result.GPS_RESCUE_HEADING = {
-            "debug[all]": "GPS Rescue Heading",
-            "debug[0]": "Ground Speed",
-            "debug[1]": "GPS Ground Course",
-            "debug[2]": "Yaw Attitude",
-            "debug[3]": "Direction To Home",
-            "debug[4]": "Mag Yaw",
-            "debug[5]": "Not Used",
-            "debug[6]": "Not Used",
-            "debug[7]": "Rescue Yaw Rate",
-        };
+        result.GPS_RESCUE_VELOCITY = debugFields(
+            "GPS Rescue Velocity",
+            "Target Velocity",
+            "Velocity / Phase",
+            "Step East",
+            "Step North",
+            "Not Used",
+            "Not Used",
+            "Not Used",
+            "Not Used",
+        );
 
-        result.GPS_RESCUE_TRACKING = {
-            "debug[all]": "GPS Rescue Tracking",
-            "debug[0]": "Velocity",
-            "debug[1]": "Not Used",
-            "debug[2]": "Altitude",
-            "debug[3]": "Target Altitude",
-            "debug[4]": "Aircraft Heading",
-            "debug[5]": "Bearing To Home",
-            "debug[6]": "Not Used",
-            "debug[7]": "Not Used",
-        };
+        result.GPS_RESCUE_HEADING = debugFields(
+            "GPS Rescue Heading",
+            "Ground Speed",
+            "GPS Ground Course",
+            "Yaw Attitude",
+            "Direction To Home",
+            "Mag Yaw",
+            "Not Used",
+            "Not Used",
+            "Rescue Yaw Rate",
+        );
 
-        result.PITOT = {
-            "debug[all]": "Pitot",
-            "debug[0]": "Airspeed",
-            "debug[1]": "Diff Pressure",
-            "debug[2]": "Pressure Pa",
-            "debug[3]": "Temperature",
-            "debug[4]": "-",
-            "debug[5]": "-",
-            "debug[6]": "-",
-            "debug[7]": "-",
-        };
+        result.GPS_RESCUE_TRACKING = debugFields(
+            "GPS Rescue Tracking",
+            "Velocity",
+            "Not Used",
+            "Altitude",
+            "Target Altitude",
+            "Aircraft Heading",
+            "Bearing To Home",
+            "Not Used",
+            "Not Used",
+        );
 
-        result.POSITION_EST = {
-            "debug[all]": "Position Estimate",
-            "debug[0]": "Position",
-            "debug[1]": "Velocity",
-            "debug[2]": "Acceleration",
-            "debug[3]": "velEast",
-            "debug[4]": "velNorth",
-            "debug[5]": "AccelRaw",
-            "debug[6]": "RGpsPos",
-            "debug[7]": "RGpsVel",
-        };
+        result.PITOT = debugFields(
+            "Pitot",
+            "Airspeed",
+            "Diff Pressure",
+            "Pressure Pa",
+            "Temperature",
+            "-",
+            "-",
+            "-",
+            "-",
+        );
+
+        result.POSITION_EST = debugFields(
+            "Position Estimate",
+            "Position",
+            "Velocity",
+            "Acceleration",
+            "velEast",
+            "velNorth",
+            "AccelRaw",
+            "RGpsPos",
+            "RGpsVel",
+        );
     }
 
     return result;

--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -1,5 +1,5 @@
 import semver from "semver";
-import { API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48 } from "../data_storage";
+import { API_VERSION_1_46, API_VERSION_1_47, API_VERSION_1_48, API_VERSION_1_49 } from "../data_storage";
 import { addArrayElement, addArrayElementAfter, removeArrayElement, replaceArrayElement } from "./array";
 
 /**
@@ -150,9 +150,13 @@ export function getDebugModes(apiVersion) {
         addArrayElement(result, "AUTOPILOT_STOP");
     }
 
+    if (semver.gte(apiVersion, API_VERSION_1_49)) {
+        addArrayElement(result, "PITOT");
+        addArrayElement(result, "POSITION_EST");
+    }
+
     return result;
 }
-
 /**
  * Returns the numeric debug_mode value for a given name in the firmware
  * identified by `apiVersion`, or -1 if the name is not defined in that
@@ -1184,6 +1188,114 @@ export function getDebugFieldNames(apiVersion) {
             "debug[2]": "Relaxed I Error [roll]",
         };
     }
+    if (semver.gte(apiVersion, API_VERSION_1_49)) {
+        result.ALTITUDE = {
+            "debug[all]": "Altitude",
+            "debug[0]": "RangeFinder Altitude",
+            "debug[1]": "Baro Altitude",
+            "debug[2]": "GPS Altitude",
+            "debug[3]": "Kalman Altitude",
+            "debug[4]": "GPS Velocity",
+            "debug[5]": "Kalman Velocity",
+            "debug[6]": "Accelerometer",
+            "debug[7]": "Kalman Acceleration",
+        };
+
+        result.AUTOPILOT_ALTITUDE = {
+            "debug[all]": "Autopilot Altitude",
+            "debug[0]": "newThrottle",
+            "debug[1]": "Target Altitude",
+            "debug[2]": "Current Altitude",
+            "debug[3]": "Alt P",
+            "debug[4]": "Alt I",
+            "debug[5]": "Alt D",
+            "debug[6]": "Alt A",
+            "debug[7]": "Alt F",
+        };
+
+        result.AUTOPILOT_PID = {
+            "debug[all]": "Autopilot PID",
+            "debug[0]": "XY Velocity",
+            "debug[1]": "XY Distance Error",
+            "debug[2]": "XY P",
+            "debug[3]": "XY I",
+            "debug[4]": "XY D",
+            "debug[5]": "XY A",
+            "debug[6]": "XY F",
+            "debug[7]": "Status",
+        };
+
+        result.AUTOPILOT_STOP = {
+            "debug[all]": "Autopilot Stop",
+            "debug[0]": "East Vel Error",
+            "debug[1]": "North Vel Error",
+            "debug[2]": "East PIDsum",
+            "debug[3]": "North PIDsum",
+            "debug[4]": "Roll Angle",
+            "debug[5]": "Pitch Angle",
+            "debug[6]": "Status",
+            "debug[7]": "-",
+        };
+        result.GPS_RESCUE_VELOCITY = {
+            "debug[all]": "GPS Rescue Velocity",
+            "debug[0]": "Target Velocity",
+            "debug[1]": "Velocity / Phase",
+            "debug[2]": "Step East",
+            "debug[3]": "Step North",
+            "debug[4]": "Not Used",
+            "debug[5]": "Not Used",
+            "debug[6]": "Not Used",
+            "debug[7]": "Not Used",
+        };
+
+        result.GPS_RESCUE_HEADING = {
+            "debug[all]": "GPS Rescue Heading",
+            "debug[0]": "Ground Speed",
+            "debug[1]": "GPS Ground Course",
+            "debug[2]": "Yaw Attitude",
+            "debug[3]": "Direction To Home",
+            "debug[4]": "Mag Yaw",
+            "debug[5]": "Not Used",
+            "debug[6]": "Not Used",
+            "debug[7]": "Rescue Yaw Rate",
+        };
+
+        result.GPS_RESCUE_TRACKING = {
+            "debug[all]": "GPS Rescue Tracking",
+            "debug[0]": "Velocity",
+            "debug[1]": "Not Used",
+            "debug[2]": "Altitude",
+            "debug[3]": "Target Altitude",
+            "debug[4]": "Aircraft Heading",
+            "debug[5]": "Bearing To Home",
+            "debug[6]": "Not Used",
+            "debug[7]": "Not Used",
+        };
+
+        result.PITOT = {
+            "debug[all]": "Pitot",
+            "debug[0]": "Airspeed",
+            "debug[1]": "Diff Pressure",
+            "debug[2]": "Pressure Pa",
+            "debug[3]": "Temperature",
+            "debug[4]": "-",
+            "debug[5]": "-",
+            "debug[6]": "-",
+            "debug[7]": "-",
+        };
+
+        result.POSITION_EST = {
+            "debug[all]": "Position Estimate",
+            "debug[0]": "Position",
+            "debug[1]": "Velocity",
+            "debug[2]": "Acceleration",
+            "debug[3]": "velEast",
+            "debug[4]": "velNorth",
+            "debug[5]": "AccelRaw",
+            "debug[6]": "RGpsPos",
+            "debug[7]": "RGpsVel",
+        };
+    }
 
     return result;
 }
@@ -1230,6 +1342,173 @@ const opticalflowDecode = (v, ctx, fieldName) => {
     }
     return (v / 1000).toFixed(1);
 };
+const altitudeDecode = (v, ctx, fieldName) => {
+    if (semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]":
+            case "debug[1]":
+            case "debug[2]":
+            case "debug[3]":
+                return `${(v / 100).toFixed(2)} m`;
+            case "debug[4]":
+            case "debug[5]":
+                return `${(v / 100).toFixed(2)} m/s`;
+            case "debug[6]":
+            case "debug[7]":
+                return `${(v / 100).toFixed(2)} m/s/s`;
+            default:
+                return f0(v);
+        }
+    }
+
+    switch (fieldName) {
+        case "debug[1]":
+        case "debug[2]":
+        case "debug[3]":
+            return `${(v / 100).toFixed(2)} m`;
+        default:
+            return f0(v);
+    }
+};
+
+const autopilotAltitudeDecode = (v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return f0(v);
+    }
+
+    switch (fieldName) {
+        case "debug[1]": // Target Altitude
+        case "debug[2]": // Current Altitude
+            return `${(v / 100).toFixed(2)} m`;
+        default:
+            return f0(v);
+    }
+};
+
+const autopilotPidDecode = (v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return f0(v);
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Velocity
+            return `${(v / 100).toFixed(2)} m/s`;
+        case "debug[1]": // Distance Error
+            return `${(v / 100).toFixed(2)} m`;
+        default:
+            return f0(v);
+    }
+};
+
+const autopilotStopDecode = (v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return f0(v);
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Velocity Error East
+        case "debug[1]": // Velocity Error North
+            return `${(v / 100).toFixed(2)} m/s`;
+        case "debug[4]": // Roll Angle
+        case "debug[5]": // Pitch Angle
+            return `${(v / 10).toFixed(1)} °`;
+        default:
+            return f0(v);
+    }
+};
+
+const gpsRescueVelocityDecode = (v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]":
+            case "debug[1]":
+                return `${(v / 100).toFixed(1)} °`;
+            case "debug[2]":
+            case "debug[3]":
+                return `${(v / 100).toFixed(1)} m/s`;
+            case "debug[4]":
+            case "debug[5]":
+            case "debug[7]":
+                return `${(v / 100).toFixed(1)} °`;
+            default:
+                return f0(v);
+        }
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Target Velocity
+            return `${(v / 100).toFixed(2)} m/s`;
+        case "debug[1]": // Velocity / Phase - provisional mixed-use field
+            return f0(v);
+        case "debug[2]": // Step East * 100
+        case "debug[3]": // Step North * 100
+            return (v / 100).toFixed(2);
+        default:
+            return f0(v);
+    }
+};
+
+const gpsRescueHeadingDecode = (v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]":
+                return `${(v / 100).toFixed(2)} m/s`;
+            case "debug[1]":
+            case "debug[2]":
+            case "debug[3]":
+                return `${(v / 10).toFixed(1)} °`;
+            case "debug[6]":
+                return `${(v / 100).toFixed(1)} °`;
+            default:
+                return f0(v);
+        }
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Ground Speed
+            return `${(v / 100).toFixed(2)} m/s`;
+        case "debug[1]": // GPS Ground Course
+        case "debug[2]": // Yaw Attitude
+        case "debug[3]": // Direction To Home
+        case "debug[4]": // Mag Yaw
+            return `${(v / 10).toFixed(1)} °`;
+        default:
+            return f0(v);
+    }
+};
+
+const gpsRescueTrackingDecode = (v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]":
+            case "debug[1]":
+                return `${(v / 100).toFixed(1)} m/s`;
+            case "debug[2]":
+            case "debug[3]":
+                return `${(v / 100).toFixed(1)} m`;
+            case "debug[4]":
+            case "debug[5]":
+                return `${(v / 10).toFixed(1)} °`;
+            case "debug[7]":
+                return `${(v / 100).toFixed(1)} °`;
+            default:
+                return f0(v);
+        }
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Velocity
+            return `${(v / 100).toFixed(1)} m/s`;
+        case "debug[2]": // Altitude
+        case "debug[3]": // Target Altitude
+            return `${(v / 100).toFixed(1)} m`;
+        case "debug[4]": // Aircraft Heading
+        case "debug[5]": // Bearing To Home
+            return `${v.toFixed(0)} °`;
+        default:
+            return f0(v);
+    }
+};
 
 const DEBUG_DECODE = {
     NONE: {
@@ -1272,10 +1551,18 @@ const DEBUG_DECODE = {
     SCHEDULER: (v) => `${v.toFixed(0)} μS`,
     ESC_SENSOR_RPM: (v) => `${v.toFixed(0)} rpm`,
     ESC_SENSOR_TMP: (v) => `${v.toFixed(0)} °C`,
-    ALTITUDE: {
-        "debug[1]": (v) => `${(v / 100).toFixed(2)} m`,
-        "debug[2]": (v) => `${(v / 100).toFixed(2)} m`,
-        "debug[3]": (v) => `${(v / 100).toFixed(2)} m`,
+    ALTITUDE: altitudeDecode,
+    AUTOPILOT_ALTITUDE: autopilotAltitudeDecode,
+    AUTOPILOT_PID: autopilotPidDecode,
+    AUTOPILOT_STOP: autopilotStopDecode,
+
+    POSITION_EST: {
+        "debug[0]": (v) => `${(v / 100).toFixed(2)} m`,
+        "debug[1]": (v) => `${(v / 100).toFixed(2)} m/s`,
+        "debug[2]": (v) => `${(v / 100).toFixed(2)} m/s/s`,
+        "debug[3]": (v) => `${(v / 100).toFixed(2)} m/s`,
+        "debug[4]": (v) => `${(v / 100).toFixed(2)} m/s`,
+        "debug[5]": (v) => `${(v / 100).toFixed(2)} m/s/s`,
         _default: f0,
     },
     FFT: {
@@ -1377,34 +1664,9 @@ const DEBUG_DECODE = {
         "debug[3]": (v) => `${(v / 100).toFixed(1)} m`,
         _default: f0,
     },
-    GPS_RESCUE_VELOCITY: {
-        "debug[0]": (v) => `${(v / 100).toFixed(1)} °`,
-        "debug[1]": (v) => `${(v / 100).toFixed(1)} °`,
-        "debug[2]": (v) => `${(v / 100).toFixed(1)} m/s`,
-        "debug[3]": (v) => `${(v / 100).toFixed(1)} m/s`,
-        "debug[4]": (v) => `${(v / 100).toFixed(1)} °`,
-        "debug[5]": (v) => `${(v / 100).toFixed(1)} °`,
-        "debug[7]": (v) => `${(v / 100).toFixed(1)} °`,
-        _default: f0,
-    },
-    GPS_RESCUE_HEADING: {
-        "debug[0]": (v) => `${(v / 100).toFixed(2)} m/s`,
-        "debug[1]": (v) => `${(v / 10).toFixed(1)} °`,
-        "debug[2]": (v) => `${(v / 10).toFixed(1)} °`,
-        "debug[3]": (v) => `${(v / 10).toFixed(1)} °`,
-        "debug[6]": (v) => `${(v / 100).toFixed(1)} °`,
-        _default: f0,
-    },
-    GPS_RESCUE_TRACKING: {
-        "debug[0]": (v) => `${(v / 100).toFixed(1)} m/s`,
-        "debug[1]": (v) => `${(v / 100).toFixed(1)} m/s`,
-        "debug[2]": (v) => `${(v / 100).toFixed(1)} m`,
-        "debug[3]": (v) => `${(v / 100).toFixed(1)} m`,
-        "debug[4]": (v) => `${(v / 10).toFixed(1)} °`,
-        "debug[5]": (v) => `${(v / 10).toFixed(1)} °`,
-        "debug[7]": (v) => `${(v / 100).toFixed(1)} °`,
-        _default: f0,
-    },
+    GPS_RESCUE_VELOCITY: gpsRescueVelocityDecode,
+    GPS_RESCUE_HEADING: gpsRescueHeadingDecode,
+    GPS_RESCUE_TRACKING: gpsRescueTrackingDecode,
     GPS_CONNECTION: {
         "debug[3]": (v) => (v * 100).toFixed(0),
         _default: f0,
@@ -1513,15 +1775,158 @@ const cFftFreq = (toFriendly, v, ctx, fieldName) => {
     const gyroField = semver.gte(ctx.apiVersion, API_VERSION_1_47) ? "debug[0]" : "debug[3]";
     return fieldName === gyroField ? cGyro(toFriendly, v, ctx) : v;
 };
+
 const cScale100 = cScale(100);
 const cScale10 = cScale(10);
 const cScale1000 = cScale(1000);
+
 // Pre-1.48: debug[0]/debug[5] (quality/deltaTimeUs) pass through unscaled.
 const cOpticalflow = (toFriendly, v, ctx, fieldName) => {
     if (!semver.gte(ctx.apiVersion, API_VERSION_1_48) && (fieldName === "debug[0]" || fieldName === "debug[5]")) {
         return v;
     }
     return cScale1000(toFriendly, v);
+};
+
+const cAltitude = (toFriendly, v, ctx, fieldName) => {
+    if (semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return cScale100(toFriendly, v);
+    }
+
+    switch (fieldName) {
+        case "debug[1]":
+        case "debug[2]":
+        case "debug[3]":
+            return cScale100(toFriendly, v);
+        default:
+            return v;
+    }
+};
+
+const cAutopilotAltitude = (toFriendly, v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return v;
+    }
+
+    switch (fieldName) {
+        case "debug[1]": // Target Altitude
+        case "debug[2]": // Current Altitude
+            return cScale100(toFriendly, v);
+        default:
+            return v;
+    }
+};
+
+const cAutopilotPid = (toFriendly, v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return v;
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Velocity
+        case "debug[1]": // Distance Error
+            return cScale100(toFriendly, v);
+        default:
+            return v;
+    }
+};
+
+const cAutopilotStop = (toFriendly, v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return v;
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Velocity Error East
+        case "debug[1]": // Velocity Error North
+            return cScale100(toFriendly, v);
+        case "debug[4]": // Roll Angle
+        case "debug[5]": // Pitch Angle
+            return cScale10(toFriendly, v);
+        default:
+            return v;
+    }
+};
+const cGpsRescueVelocity = (toFriendly, v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]":
+            case "debug[1]":
+            case "debug[2]":
+            case "debug[3]":
+            case "debug[4]":
+            case "debug[5]":
+            case "debug[7]":
+                return cScale100(toFriendly, v);
+            default:
+                return v;
+        }
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Target Velocity
+        case "debug[2]": // Step East * 100
+        case "debug[3]": // Step North * 100
+            return cScale100(toFriendly, v);
+        default:
+            return v;
+    }
+};
+
+const cGpsRescueHeading = (toFriendly, v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]":
+            case "debug[6]":
+                return cScale100(toFriendly, v);
+            case "debug[1]":
+            case "debug[2]":
+            case "debug[3]":
+                return cScale10(toFriendly, v);
+            default:
+                return v;
+        }
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Ground Speed
+            return cScale100(toFriendly, v);
+        case "debug[1]": // GPS Ground Course
+        case "debug[2]": // Yaw Attitude
+        case "debug[3]": // Direction To Home
+        case "debug[4]": // Mag Yaw
+            return cScale10(toFriendly, v);
+        default:
+            return v;
+    }
+};
+
+const cGpsRescueTracking = (toFriendly, v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        switch (fieldName) {
+            case "debug[0]":
+            case "debug[1]":
+            case "debug[2]":
+            case "debug[3]":
+            case "debug[7]":
+                return cScale100(toFriendly, v);
+            case "debug[4]":
+            case "debug[5]":
+                return cScale10(toFriendly, v);
+            default:
+                return v;
+        }
+    }
+
+    switch (fieldName) {
+        case "debug[0]": // Velocity
+        case "debug[2]": // Altitude
+        case "debug[3]": // Target Altitude
+            return cScale100(toFriendly, v);
+        default:
+            // Heading/Bearing are already in degrees.
+            return v;
+    }
 };
 
 const DEBUG_CONVERT = {
@@ -1543,11 +1948,23 @@ const DEBUG_CONVERT = {
         "debug[4]": cScale1000,
     },
     MIXER: (toFriendly, v, ctx) => (toFriendly ? ctx.rcCommandRawToThrottle(v) : ctx.throttleToRcCommandRaw(v)),
-    ALTITUDE: {
-        "debug[1]": cScale100,
-        "debug[2]": cScale100,
-        "debug[3]": cScale100,
+
+    ALTITUDE: cAltitude,
+    AUTOPILOT_ALTITUDE: cAutopilotAltitude,
+    AUTOPILOT_PID: cAutopilotPid,
+    AUTOPILOT_STOP: cAutopilotStop,
+
+    POSITION_EST: {
+        "debug[0]": cScale100, // Position
+        "debug[1]": cScale100, // Velocity
+        "debug[2]": cScale100, // Kalman Acceleration
+        "debug[3]": cScale100, // Velocity East
+        "debug[4]": cScale100, // Velocity North
+        "debug[5]": cScale100, // Raw Acceleration
+        // debug[6] = GPS R Pos
+        // debug[7] = GPS R Vel
     },
+
     FFT: {
         "debug[0]": cGyro,
         "debug[1]": cGyro,
@@ -1595,31 +2012,9 @@ const DEBUG_CONVERT = {
         "debug[2]": cScale100,
         "debug[3]": cScale100,
     },
-    GPS_RESCUE_VELOCITY: {
-        "debug[0]": cScale100,
-        "debug[1]": cScale100,
-        "debug[2]": cScale100,
-        "debug[3]": cScale100,
-        "debug[4]": cScale100,
-        "debug[5]": cScale100,
-        "debug[7]": cScale100,
-    },
-    GPS_RESCUE_HEADING: {
-        "debug[0]": cScale100,
-        "debug[1]": cScale10,
-        "debug[2]": cScale10,
-        "debug[3]": cScale10,
-        "debug[6]": cScale100,
-    },
-    GPS_RESCUE_TRACKING: {
-        "debug[0]": cScale100,
-        "debug[1]": cScale100,
-        "debug[2]": cScale100,
-        "debug[3]": cScale100,
-        "debug[4]": cScale10,
-        "debug[5]": cScale10,
-        "debug[7]": cScale100,
-    },
+    GPS_RESCUE_VELOCITY: cGpsRescueVelocity,
+    GPS_RESCUE_HEADING: cGpsRescueHeading,
+    GPS_RESCUE_TRACKING: cGpsRescueTracking,
     GPS_CONNECTION: {
         "debug[3]": cInvScale(100),
     },
@@ -1654,6 +2049,7 @@ const DEBUG_CONVERT = {
         "debug[6]": cScale(1000),
     },
 };
+
 for (const m of [
     "GYRO",
     "GYRO_FILTERED",
@@ -1670,6 +2066,7 @@ for (const m of [
 ]) {
     DEBUG_CONVERT[m] = cGyroGroup;
 }
+
 // NONE/AIRMODE/BARO share one block (firmware groups them).
 DEBUG_CONVERT.AIRMODE = DEBUG_CONVERT.NONE;
 DEBUG_CONVERT.BARO = DEBUG_CONVERT.NONE;
@@ -1693,6 +2090,7 @@ export function convertDebugFieldValue(debugModeName, fieldName, toFriendly, val
     if (typeof entry === "function") {
         return entry(toFriendly, value, ctx, fieldName);
     }
+
     // `null` field entries are explicit passthroughs that override `_default`.
     const fn = fieldName in entry ? entry[fieldName] : entry._default;
     return fn ? fn(toFriendly, value, ctx) : value;

--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -1724,6 +1724,13 @@ const DEBUG_DECODE = {
         "debug[7]": (v) => `${v.toFixed(0)} Hz`,
         _default: f0,
     },
+    PITOT: {
+        "debug[0]": (v) => `${(v / 100).toFixed(2)} m/s`,
+        "debug[1]": (v) => `${v.toFixed(0)} Pa`,
+        "debug[2]": (v) => `${v.toFixed(0)} Pa`,
+        "debug[3]": (v) => `${v.toFixed(0)} °C`,
+        _default: f0,
+    },
     VELOCITY: () => "",
     DFILTER: () => "",
 };

--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -144,8 +144,7 @@ export function getDebugModes(apiVersion) {
     if (semver.gte(apiVersion, API_VERSION_1_48)) {
         removeArrayElement(result, "AUTOPILOT_POSITION");
         addArrayElement(result, "AUTOPILOT_PID");
-        // POSITION_NAV is a reserved enum slot in firmware (no name/fields yet);
-        // it must occupy its index so AUTOPILOT_STOP decodes correctly.
+        // POSITION_NAV  had no debug name/fields in 1.48, but existed in the enum
         addArrayElement(result, "POSITION_NAV");
         addArrayElement(result, "AUTOPILOT_STOP");
     }
@@ -1176,8 +1175,8 @@ export function getDebugFieldNames(apiVersion) {
             "Filtered Flow Rate Y",
         );
 
-        // POSITION_NAV is a reserved firmware enum slot with no fields yet,
-        // so it intentionally has no fieldNames entry.
+        // POSITION_NAV had no names or fields set in 1.48
+        // AUTOPILOT_POSITION was deprecated in 1.48
         delete result.AUTOPILOT_POSITION;
 
         result.RANGEFINDER = debugFields(
@@ -1234,6 +1233,17 @@ export function getDebugFieldNames(apiVersion) {
             "XY A",
             "XY F",
             "Status",
+        );
+        result.AUTOPILOT_NAV = debugFields(
+            "Autopilot Nav",
+            "Target Velocity",
+            "Velocity Error",
+            "Nav P ",
+            "Nav I",
+            "Nav D",
+            "Nav A",
+            "Status",
+            "-",
         );
 
         result.AUTOPILOT_STOP = debugFields(
@@ -1411,7 +1421,20 @@ const autopilotPidDecode = (v, ctx, fieldName) => {
             return f0(v);
     }
 };
+const autopilotNavDecode = (v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return f0(v);
+    }
 
+    switch (fieldName) {
+        case "debug[0]": // Target Velocity
+        case "debug[1]": // Velocity
+        case "debug[2]": // Velocity Error
+            return `${(v / 100).toFixed(2)} m/s`;
+        default:
+            return f0(v);
+    }
+};
 const autopilotStopDecode = (v, ctx, fieldName) => {
     if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
         return f0(v);
@@ -1566,6 +1589,7 @@ const DEBUG_DECODE = {
     ALTITUDE: altitudeDecode,
     AUTOPILOT_ALTITUDE: autopilotAltitudeDecode,
     AUTOPILOT_PID: autopilotPidDecode,
+    AUTOPILOT_NAV: autopilotNavDecode,
     AUTOPILOT_STOP: autopilotStopDecode,
 
     POSITION_EST: {
@@ -1849,7 +1873,20 @@ const cAutopilotPid = (toFriendly, v, ctx, fieldName) => {
             return v;
     }
 };
+const cPositionNav = (toFriendly, v, ctx, fieldName) => {
+    if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
+        return v;
+    }
 
+    switch (fieldName) {
+        case "debug[0]": // Target Velocity
+        case "debug[1]": // Velocity
+        case "debug[2]": // Velocity Error
+            return cScale100(toFriendly, v);
+        default: // PIDs and status pass through unchanged
+            return v;
+    }
+};
 const cAutopilotStop = (toFriendly, v, ctx, fieldName) => {
     if (!semver.gte(ctx.apiVersion, API_VERSION_1_49)) {
         return v;
@@ -1971,6 +2008,7 @@ const DEBUG_CONVERT = {
     ALTITUDE: cAltitude,
     AUTOPILOT_ALTITUDE: cAutopilotAltitude,
     AUTOPILOT_PID: cAutopilotPid,
+    AUTOPILOT_NAV: cPositionNav,
     AUTOPILOT_STOP: cAutopilotStop,
 
     POSITION_EST: {

--- a/src/js/utils/debugModes.js
+++ b/src/js/utils/debugModes.js
@@ -144,7 +144,6 @@ export function getDebugModes(apiVersion) {
     if (semver.gte(apiVersion, API_VERSION_1_48)) {
         removeArrayElement(result, "AUTOPILOT_POSITION");
         addArrayElement(result, "AUTOPILOT_PID");
-        // POSITION_NAV  had no debug name/fields in 1.48, but existed in the enum
         addArrayElement(result, "POSITION_NAV");
         addArrayElement(result, "AUTOPILOT_STOP");
     }
@@ -153,7 +152,6 @@ export function getDebugModes(apiVersion) {
         addArrayElement(result, "PITOT");
         addArrayElement(result, "POSITION_EST");
     }
-
     return result;
 }
 
@@ -1237,15 +1235,14 @@ export function getDebugFieldNames(apiVersion) {
         result.POSITION_NAV = debugFields(
             "Autopilot Nav",
             "Target Velocity",
+            "Velocity",
             "Velocity Error",
-            "Nav P ",
+            "Nav P",
             "Nav I",
             "Nav D",
             "Nav A",
             "Status",
-            "-",
         );
-
         result.AUTOPILOT_STOP = debugFields(
             "Autopilot Stop",
             "East Vel Error",


### PR DESCRIPTION
This PR should show the correct Debug name, field names, scalings and units, for the debugs that are active in 2026.12 logs, when using the Configurator blackbox display. The changes should not adversely affect logs from earlier firmware. Some logs during crossover phases may not align perfectly in content with a particular release and may show incorrect names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Betaflight API version 1.49 and versions 2026.12.0 and later.
  * Added PITOT, POSITION_EST, and AUTOPILOT_NAV debug modes.
  * Added airspeed, pressure, and temperature measurements for PITOT data.
  * Added API-version-specific field labels and mappings for altitude, GPS Rescue, autopilot, PID, navigation, position estimation, and related telemetry.
* **Bug Fixes**
  * Improved decoding, unit conversion, graph scaling, and displayed ranges for newer flight logs.
  * Preserved compatibility with earlier API versions and flight-log formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->