### PR TITLE
don't fill markers, make the status text legible in daylight mode

### DIFF
--- a/src/blackbox-viewer/components/StatusBar.vue
+++ b/src/blackbox-viewer/components/StatusBar.vue
@@ -55,7 +55,7 @@ const workspaceStore = useWorkspaceStore();
     padding: 0 0.75rem;
     height: 1.5rem;
     font-size: 0.65rem;
-    color: var(--text-secondary);
+    color: var(--graph-text-secondary);
     background: var(--surface-200, hsl(0, 0%, 92%));
     border-top: 1px solid var(--border-color, #ccc);
 }

--- a/src/blackbox-viewer/grapher.js
+++ b/src/blackbox-viewer/grapher.js
@@ -512,12 +512,10 @@ export function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, cr
             canvasContext.lineTo(x + labelDirection * margin, labelY + drawingParams.fontSizeEventLabel / 2);
             canvasContext.lineTo(x + labelDirection * (width - 1), labelY - drawingParams.fontSizeEventLabel / 2);
 
-            canvasContext.fillStyle = color || "rgba(255,255,255,0.5)";
-            canvasContext.fill();
+            canvasContext.strokeStyle = color || "rgba(255,255,255,0.5)";
             canvasContext.stroke();
             canvasContext.fillStyle = labelColor || "rgba(200,200,200,0.9)";
             canvasContext.closePath();
-
             canvasContext.fillText(label, x + labelDirection * (width + 8), labelY);
         }
     }


### PR DESCRIPTION
Simple PR to:
- make the fill inside a marker box (flightmode, time, etc) transparent, so that the underlying waveforms are not obscured
- set the status text at the bottom to be a paler color in daylight mode, so that it is legible.
<img width="512" height="357" alt="Screenshot 2026-08-21 at 9 17 10 pm" src="https://github.com/user-attachments/assets/f17ce2fb-90b3-42ed-a949-d5005384afa5" />
vs 
<img width="596" height="267" alt="Screenshot 2026-08-21 at 9 18 10 pm" src="https://github.com/user-attachments/assets/0f09eae6-21f5-4122-bf88-1e27abf54d89" />

and at the bottom, in daylight mode, the text is legible
<img width="867" height="138" alt="Screenshot 2026-08-21 at 9 19 14 pm" src="https://github.com/user-attachments/assets/680bb693-1637-461a-9dc3-4e500f56140c" />

vs being too dark to read...
<img width="1093" height="136" alt="Screenshot 2026-08-21 at 9 18 51 pm" src="https://github.com/user-attachments/assets/74544391-c2d0-4889-a837-e5543f93a967" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated status bar text coloring for improved visual consistency.
  * Refined event labels so their callout outlines use the event color without filling the shape.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->