### PR TITLE
fix: repair the radio emulator popup and finish its Nuxt UI migration

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,7 +73,9 @@ export default [
     {
         // Build and release tooling: real Node scripts, not browser code. Without this
         // block `.mjs` matches no `files` pattern and is linted with zero rules.
-        files: ["**/*.mjs"],
+        // The root config files are `.js` but equally Node-side; Vite bundles its config to
+        // CJS before executing it, so `__dirname` and friends are genuinely available there.
+        files: ["**/*.mjs", "*.config.js", "nuxt-ui.vite.js"],
         languageOptions: {
             ecmaVersion: "latest",
             sourceType: "module",

--- a/src/blackbox-viewer/leaflet-global.js
+++ b/src/blackbox-viewer/leaflet-global.js
@@ -5,6 +5,10 @@
 // alone does not guarantee.
 import L from "leaflet";
 
-globalThis.L ??= L;
+// Bind unconditionally. graph_map.js reads the bare global rather than importing Leaflet,
+// so leaving a pre-existing `globalThis.L` in place would silently hand the viewer, and the
+// plugins patching it, some other page's Leaflet instead of the version pinned here.
+// Leaflet's own UMD build assigns `window.L` the same way.
+globalThis.L = L;
 
 export default L;

--- a/src/blackbox-viewer/leaflet-global.js
+++ b/src/blackbox-viewer/leaflet-global.js
@@ -1,0 +1,10 @@
+// The Leaflet plugins loaded alongside this module are UMD bundles that patch the global
+// `L` instead of importing Leaflet, so nothing links them to Leaflet's own initialisation.
+// Import Leaflet here and publish the global before they run: referencing the imported
+// value is what forces the bundler to emit Leaflet's initialiser call, which chunk layout
+// alone does not guarantee.
+import L from "leaflet";
+
+globalThis.L ??= L;
+
+export default L;

--- a/src/blackbox-viewer/vendor.js
+++ b/src/blackbox-viewer/vendor.js
@@ -1,3 +1,4 @@
-import "leaflet";
+// Must stay first: publishes the global `L` the two plugins below patch.
+import "./leaflet-global.js";
 import "leaflet-marker-rotation";
 import "Leaflet.MultiOptionsPolyline";

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1019,8 +1019,10 @@ function sendBind() {
 }
 
 function openSticksWindow() {
-    const windowWidth = 410;
-    const windowHeight = 550;
+    const windowWidth = 430;
+    // Sized to the tallest state: gimbals + aux sliders + the arming warning box, which is
+    // the popup's initial content. Dismissing the warning leaves the controls centred.
+    const windowHeight = 570;
 
     const rxFunction = (channels) => {
         if (connectionStore.connectionValid && GUI.active_tab !== "cli") {

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1019,10 +1019,11 @@ function sendBind() {
 }
 
 function openSticksWindow() {
-    const windowWidth = 430;
-    // Sized to the tallest state: gimbals + aux sliders + the arming warning box, which is
-    // the popup's initial content. Dismissing the warning leaves the controls centred.
-    const windowHeight = 570;
+    const windowWidth = 420;
+    // Minimum that fits the initial state: gimbals + aux sliders + the expanded arming
+    // warning. Collapsing the warning or dismissing it leaves slack; resizing from there
+    // is left to the user rather than driven from the app.
+    const windowHeight = 600;
 
     const rxFunction = (channels) => {
         if (connectionStore.connectionValid && GUI.active_tab !== "cli") {

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1019,7 +1019,7 @@ function sendBind() {
 }
 
 function openSticksWindow() {
-    const windowWidth = 370;
+    const windowWidth = 410;
     const windowHeight = 550;
 
     const rxFunction = (channels) => {

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1030,8 +1030,13 @@ function openSticksWindow() {
         return false;
     };
 
+    // Resolve against the document base rather than the server root: the build uses
+    // `base: "./"`, so the app can be served from a sub-path (PR previews) or from a
+    // custom scheme (Tauri/Capacitor), where an absolute "/..." path would miss.
+    const stickWindowUrl = new URL("components/tabs/receiver-msp/receiver_msp.html", document.baseURI).href;
+
     const createdWindow = globalThis.open(
-        "/components/tabs/receiver-msp/receiver_msp.html",
+        stickWindowUrl,
         "receiver_msp",
         `location=no,width=${windowWidth},height=${windowHeight + (screen.height - screen.availHeight)}`,
     );

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -1042,6 +1042,10 @@ function openSticksWindow() {
     );
     if (createdWindow) {
         createdWindow.setRawRx = rxFunction;
+        // The popup is a separate document with its own module graph, so it cannot import the
+        // initialised i18n instance — hand it over the same way as setRawRx above. This used to
+        // reach the popup as a `window.i18n` global, dropped in 58e84750 during the ESM cleanup.
+        createdWindow.i18n = i18n;
         DarkTheme.isDarkThemeEnabled((isEnabled) => {
             windowWatcherUtil.passValue(createdWindow, "darkTheme", isEnabled);
         });

--- a/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
+++ b/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
@@ -22,28 +22,23 @@
             </div>
         </div>
 
-        <div class="control-sliders">
-            <div v-for="i in 4" :key="i" class="control-slider">
-                <span class="slider-label">{{ t(`controlAxisAux${i}`) }}</span>
-                <input
-                    type="range"
+        <div class="flex w-full flex-col gap-3">
+            <div v-for="i in 4" :key="i" class="flex items-center gap-3">
+                <span class="w-10 shrink-0 text-right">{{ t(`controlAxisAux${i}`) }}</span>
+                <USlider
+                    v-model="stickValues[`Aux${i}`]"
                     :min="CHANNEL_MIN_VALUE"
                     :max="CHANNEL_MAX_VALUE"
-                    v-model.number="stickValues[`Aux${i}`]"
                     :aria-label="t(`controlAxisAux${i}`)"
-                    class="slider"
+                    class="flex-1"
                 />
-                <span class="tooltip">{{ stickValues[`Aux${i}`] }}</span>
+                <span class="w-9 shrink-0 tabular-nums">{{ stickValues[`Aux${i}`] }}</span>
             </div>
         </div>
 
-        <div v-if="!enableTX" class="warning">
-            <p v-html="t('receiverMspWarningText')"></p>
-            <div class="button-enable">
-                <a class="btn" href="#" @click.prevent="enableControls">
-                    {{ t("receiverMspEnableButton") }}
-                </a>
-            </div>
+        <div v-if="!enableTX" class="flex w-full flex-col items-center gap-6">
+            <p class="warning-text text-center" v-html="t('receiverMspWarningText')"></p>
+            <UButton class="w-fit" :label="t('receiverMspEnableButton')" @click="enableControls" />
         </div>
     </div>
 </template>
@@ -176,24 +171,32 @@ body {
     font-size: 12px;
     background-color: var(--surface-100);
     color: var(--text);
-    overflow: hidden;
+    /* The safety warning makes the initial state nearly fill the popup, so scroll rather than
+       clip it. `safe center` centres the short armed state (warning hidden) but falls back to
+       top-anchored when the content is tall — plain `center` would push the first line out of
+       reach above the scroll origin. */
+    overflow-y: auto;
     user-select: none;
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    justify-content: safe center;
     align-items: center;
-    padding: 2rem;
+    min-height: 100vh;
+    box-sizing: border-box;
+    padding: 1.5rem;
+    margin: 0;
 }
 
 .receiver-msp {
     display: flex;
     flex-direction: column;
     align-items: center;
+    width: 100%;
+    gap: 1.5rem;
 }
 
 .control-gimbals {
-    padding: 1.5rem;
-    padding-bottom: 0;
+    padding: 0.5rem 1.5rem 0;
     text-align: center;
     display: inline-flex;
 }
@@ -259,72 +262,9 @@ body {
     cursor: pointer;
 }
 
-.control-sliders {
-    width: 100%;
-}
-
-.control-slider {
-    margin: 20px;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.slider-label {
-    flex-shrink: 0;
-    width: 40px;
-    text-align: right;
-}
-
-.slider {
-    flex: 1;
-    margin-left: 10px;
-    margin-right: 10px;
-    accent-color: var(--primary-500);
-}
-
-.tooltip {
-    flex-shrink: 0;
-    width: 35px;
-}
-
-.warning {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
-.button-enable {
-    width: fit-content;
-}
-
-.button-enable a {
-    width: fit-content;
-    margin-top: 20px;
-    background-color: var(--primary-500);
-    border-radius: 3px;
-    border: 1px solid var(--primary-600);
-    color: var(--surface-50);
-    font-size: 12px;
-    display: block;
-    cursor: pointer;
-    transition: all ease 0.2s;
-    padding: 0px 9px;
-    line-height: 28px;
-    text-decoration: none;
-    font-weight: bold;
-}
-
-.button-enable a:hover {
-    background-color: var(--primary-400);
-    transition: all ease 0.2s;
-}
-
-.button-enable a:active {
-    background-color: var(--success-500);
-    border: 1px solid var(--success-600);
-    transition: all ease 0s;
-    box-shadow: inset 0px 1px 5px rgba(0, 0, 0, 0.35);
+.warning-text {
+    line-height: 1.7;
+    margin: 0;
 }
 
 @media all and (max-width: 575px) {

--- a/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
+++ b/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
@@ -37,7 +37,7 @@
         </div>
 
         <div v-if="!enableTX" class="flex w-full flex-1 flex-col items-center gap-4">
-            <UiBox :title="t('warningTitle')" type="error" highlight class="w-full">
+            <UiBox :title="t('warningTitle')" type="error" highlight collapsible class="w-full">
                 <p class="warning-text" v-html="t('receiverMspWarningText')"></p>
             </UiBox>
             <UButton class="mt-auto w-fit" :label="t('receiverMspEnableButton')" @click="enableControls" />
@@ -188,6 +188,15 @@ body {
     box-sizing: border-box;
     padding: 1.5rem;
     margin: 0;
+}
+
+#app {
+    display: flex;
+    flex-direction: column;
+    justify-content: safe center;
+    align-items: center;
+    flex: 1;
+    width: 100%;
 }
 
 .receiver-msp {

--- a/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
+++ b/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
@@ -52,8 +52,8 @@
 import { ref, reactive, onMounted, onUnmounted } from "vue";
 import { clamp } from "@/js/utils/common";
 
-// i18n from parent window
-const i18n = globalThis.opener?.i18n;
+// i18n instance handed to this window by the opener (see openSticksWindow in ReceiverTab.vue).
+const i18n = globalThis.i18n ?? globalThis.opener?.i18n;
 const t = (key) => i18n?.getMessage(key) ?? key;
 
 const CHANNEL_MIN_VALUE = 1000;

--- a/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
+++ b/src/components/tabs/receiver-msp/ReceiverMspWindow.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="receiver-msp">
+    <div class="receiver-msp" :class="{ 'flex-1': !enableTX }">
         <div class="control-gimbals">
             <div
                 v-for="(gimbal, index) in gimbals"
@@ -36,9 +36,11 @@
             </div>
         </div>
 
-        <div v-if="!enableTX" class="flex w-full flex-col items-center gap-6">
-            <p class="warning-text text-center" v-html="t('receiverMspWarningText')"></p>
-            <UButton class="w-fit" :label="t('receiverMspEnableButton')" @click="enableControls" />
+        <div v-if="!enableTX" class="flex w-full flex-1 flex-col items-center gap-4">
+            <UiBox :title="t('warningTitle')" type="error" highlight class="w-full">
+                <p class="warning-text" v-html="t('receiverMspWarningText')"></p>
+            </UiBox>
+            <UButton class="mt-auto w-fit" :label="t('receiverMspEnableButton')" @click="enableControls" />
         </div>
     </div>
 </template>
@@ -46,6 +48,7 @@
 <script setup>
 import { ref, reactive, onMounted, onUnmounted } from "vue";
 import { clamp } from "@/js/utils/common";
+import UiBox from "@/components/elements/UiBox.vue";
 
 // i18n instance handed to this window by the opener (see openSticksWindow in ReceiverTab.vue).
 const i18n = globalThis.i18n ?? globalThis.opener?.i18n;
@@ -263,7 +266,7 @@ body {
 }
 
 .warning-text {
-    line-height: 1.7;
+    line-height: 1.6;
     margin: 0;
 }
 

--- a/src/components/tabs/receiver-msp/receiverMspApp.js
+++ b/src/components/tabs/receiver-msp/receiverMspApp.js
@@ -1,6 +1,8 @@
 import { createApp } from "vue";
+import ui from "@nuxt/ui/vue-plugin";
 import ReceiverMspWindow from "./ReceiverMspWindow.vue";
 import windowWatcherUtil from "../../../js/utils/window_watchers";
+import { getNuxtUiRouter } from "../../../js/nuxt_ui_router";
 
 // Import styles for the popup window
 import "../../../css/opensans_webfontkit/fonts.css";
@@ -14,6 +16,9 @@ windowWatcherUtil.bindWatchers(globalThis, {
     },
 });
 
-// Create and mount Vue app
+// Create and mount Vue app. This popup is a separate document with its own Vue
+// instance, so it has to register Nuxt UI itself; the router is required because
+// UButton/ULink call vue-router's useRoute().
 const app = createApp(ReceiverMspWindow);
+app.use(getNuxtUiRouter()).use(ui);
 app.mount("#app");

--- a/vite.config.js
+++ b/vite.config.js
@@ -118,6 +118,32 @@ function serveLocalesPlugin() {
     };
 }
 
+/**
+ * The radio-emulator popup is a secondary MPA entry, not an installable page.
+ * VitePWA injects `<link rel="manifest" href="./manifest.webmanifest">` into every
+ * HTML entry, which resolves relative to the popup's own directory and 404s.
+ * Strip it from everything except the main entry.
+ * Registered after VitePWA so its `post` hook runs last.
+ * @returns {import("vite").Plugin}
+ */
+function stripManifestFromSecondaryEntriesPlugin() {
+    return {
+        name: "strip-manifest-from-secondary-entries",
+        // `enforce`/`order` post so this runs after vite-plugin-pwa:build has injected the link.
+        enforce: "post",
+        apply: "build",
+        transformIndexHtml: {
+            order: "post",
+            handler(html, ctx) {
+                if (ctx.path === "/index.html") {
+                    return html;
+                }
+                return html.replace(/<link rel="manifest"[^>]*>/g, "");
+            },
+        },
+    };
+}
+
 export default defineConfig({
     base: "./", // Important for production APK asset paths
     define: {
@@ -151,12 +177,16 @@ export default defineConfig({
         // Vite root, matching the previous rollup-plugin-copy behaviour).
         // `src` globs are absolute because the Vite root is `src/`, so
         // repo-root-relative patterns would otherwise resolve under `src/`.
+        // Only assets that are fetched by URL at runtime belong here. Never add
+        // `src/components`: those files are bundled, and copying them raw runs on
+        // `writeBundle` — after the bundle is emitted — so the raw
+        // `receiver-msp/receiver_msp.html` would overwrite the built MPA entry and
+        // leave the popup loading an untransformed module (bare `vue` specifier).
         ...viteStaticCopy({
             targets: [
                 { src: normalizePath(path.resolve(__dirname, "locales")), dest: "." },
                 { src: normalizePath(path.resolve(__dirname, "resources")), dest: "." },
                 { src: normalizePath(path.resolve(__dirname, "src/images")), dest: "." },
-                { src: normalizePath(path.resolve(__dirname, "src/components")), dest: "." },
             ],
         }).filter((plugin) => plugin.name === "vite-plugin-static-copy:build"),
         VitePWA({
@@ -186,6 +216,7 @@ export default defineConfig({
                 ],
             },
         }),
+        stripManifestFromSecondaryEntriesPlugin(),
     ],
     // Absolute root so @nuxt/ui's template aliases (#build/ui.css, etc.) resolve to
     // absolute paths; a relative root yields relative aliases and Vite warns about duplicated modules.


### PR DESCRIPTION
## Preview

<img width="422" height="662" alt="image" src="https://github.com/user-attachments/assets/706150a1-67f6-45dd-9b10-418adf29a299" />


## Summary

The radio emulator popup ("Sticks" on the Receiver tab) was blank in every production build, failing with:

```
Uncaught TypeError: Failed to resolve module specifier "vue". Relative references must start with either "/", "./", or "../".
```

Reproducible on `master.app.betaflight.com` and in any local `npm run build`. It worked under `npm run dev` only because the dev server transforms the module on the fly.

This fixes the build bug, restores the popup's translations (separately broken), and finishes its migration to Vue + Nuxt UI.

## The build bug

`src/components/tabs/receiver-msp/receiver_msp.html` is an MPA entry, so the build correctly emitted it alongside a hashed `assets/receiver_msp-*.js` bundle. But `vite-plugin-static-copy` also copied the whole `src/components` source tree into the output, and it copies on `writeBundle` — *after* the bundle is emitted. The raw source HTML overwrote the built entry, leaving the popup loading an untransformed module with a bare `vue` specifier, an uncompiled `.vue` import and a raw `.less` import.

That copy target is a leftover from the pre-Vite nwjs layout. Nothing reads raw component files from `dist/components/` at runtime — the tree holds only `.vue`, `.js`, `.css` and the one MPA `.html`, all of which the bundler handles — so it is dropped outright rather than filtered. This also stops ~2.3 MB of raw source, including Storybook stories, being shipped and PWA-precached.

## The i18n regression

Every string in the popup rendered as its raw key — axis and aux labels, warning text, button and window title.

The popup is a separate document with its own module graph, so it cannot import the initialised i18n instance and has always read it off the opener. In 2025.12 that worked because `localization.js` published it as a `window.i18n` global. 58e84750 removed that global during the ESM cleanup — correctly, as nothing in the main app still needed it — but the popup had no other route to it. Because the lookup falls back to `?? key` it degraded silently, and the popup was separately blank in production, so it went unnoticed.

The instance is now handed to the popup the same way `setRawRx` already is, rather than reinstating an app-wide global. The keys themselves were never missing: all are present and translated across the locales.

## UI unification

The popup still carried its pre-Vue markup: a hand-rolled `<a class="btn">` with a private copy of the old yellow button CSS, and native `<input type="range">` sliders coloured with `accent-color`. Neither tracked the app theme.

- `UButton` (solid primary, matching the Sensors tab) and `USlider` replace them, dropping ~78 lines of bespoke CSS. The popup registers the Nuxt UI plugin itself, with the router, since `UButton` calls `useRoute()`.
- The arming warning now uses the shared `UiBox` (`type="error"`, collapsible), the same treatment the firmware flasher uses for its pre-flash warning.
- Layout: `overflow: hidden` plus `justify-content: center` meant content taller than the window was clipped at both ends with no way to scroll to it. Now `overflow-y: auto` with `justify-content: safe center`.
- The enable button is pinned to the bottom. This needed `#app` — the plain block box Vue mounts into, between `body` and the component — to become the growing flex column; without it the `flex-1` below had no flex container and the button floated.
- Popup resized to 420x600, the minimum that fits the initial state.

## Verification

Against a served production build:

| Check | Result |
|---|---|
| `grep -c 'assets/receiver_msp'` in built HTML | 2 |
| Raw `src="./receiverMspApp.js"` in built HTML | 0 |
| Raw sources (`*.vue`, `*.stories.js`) under `src/dist` | none |
| All referenced popup assets over HTTP | 200 |
| Bare import specifiers in the popup bundle | none |
| Popup HTML + assets in the service-worker precache | present |

In headless Chrome the raw source HTML reproduces the reported error with an empty `#app`; the built output mounts and renders with a clean console. Button position verified at 520 (content overflows and scrolls), 570, 650 and 800px tall — 24px above the bottom padding at every height. Light and dark mode checked, warning expanded, collapsed and dismissed.

Every large chunk the popup pulls in is shared with the main app, which is always loaded first since the popup opens from the Receiver tab, so the popup-only payload stays at ~4 KB.

`npm run lint` clean; `npm run test` 911 passed (78 files).

## Note on the ESLint change

The pre-commit hook lints staged files, but the root config files are Node-side `.js` and fell into the browser ESLint block, so every `__dirname` was a `no-undef` error. `npm run lint` never surfaced this (it only covers `src scripts *.mjs`), but the hook did — blocking any commit touching `vite.config.js`. They are now in the existing Node block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable camera controls and support for up to three telemetry serial ports in receiver settings.
  * Updated the receiver MSP popup with improved sliders, buttons, warnings, responsive layout, and translation support.
  * Increased the receiver sticks popup size for better usability.

* **Bug Fixes**
  * Improved popup positioning, scrolling, and loading across different app base URLs.
  * Prevented incorrect PWA installation prompts on secondary pages.
  * Improved production build reliability and Leaflet plugin compatibility in the blackbox viewer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->