### PR TITLE
fix: stop the app scrolling sideways on a phone

### DIFF
--- a/src/components/elements/SettingRow.vue
+++ b/src/components/elements/SettingRow.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="flex items-center gap-2">
         <slot name="default"></slot>
-        <div class="flex items-center" :class="{ 'flex-1': fullWidth }">
+        <div class="flex flex-wrap items-center gap-y-1 min-w-0" :class="{ 'flex-1': fullWidth }">
             <slot name="label"></slot>
             <span v-if="label" v-html="label"></span>
         </div>

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -1117,11 +1117,15 @@ watch(auxChannelValue, (newVal) => {
 
 /* Grid Container */
 .grid-container {
+    /* Pitch is the gPoint box plus its margins; LedGridPoint reads both. */
+    --led-cell: 23px;
+    --led-cell-gap: 3px;
+    --led-cell-pitch: calc(var(--led-cell) + var(--led-cell-gap) * 2);
     position: relative;
     float: inline-start;
     margin-inline-end: 30px;
-    width: calc(29px * 16 + 3px);
-    height: calc(29px * 16 + 3px);
+    width: calc(var(--led-cell-pitch) * 16 + 3px);
+    height: calc(var(--led-cell-pitch) * 16 + 3px);
 }
 
 /* Grid Sections Overlay */
@@ -1130,8 +1134,8 @@ watch(auxChannelValue, (newVal) => {
     top: 0;
     inset-inline-start: 0;
     z-index: 0;
-    width: calc(29px * 16 + 3px);
-    height: calc(29px * 16 + 3px);
+    width: calc(var(--led-cell-pitch) * 16 + 3px);
+    height: calc(var(--led-cell-pitch) * 16 + 3px);
     border: 1px solid var(--surface-500);
     border-radius: 3px;
     pointer-events: none;
@@ -1144,6 +1148,14 @@ watch(auxChannelValue, (newVal) => {
     float: inline-start;
     border: 1px solid var(--surface-500);
     box-sizing: border-box;
+}
+
+@container main-wrapper (max-width: 575px) {
+    .grid-container {
+        --led-cell: 20px;
+        --led-cell-gap: 1px;
+        margin-inline-end: 0;
+    }
 }
 
 /* Controls Panel */

--- a/src/components/tabs/LedStripTab.vue
+++ b/src/components/tabs/LedStripTab.vue
@@ -1152,8 +1152,13 @@ watch(auxChannelValue, (newVal) => {
 
 @container main-wrapper (max-width: 575px) {
     .grid-container {
-        --led-cell: 20px;
         --led-cell-gap: 1px;
+        /* The content wrapper pads 1rem each side: fit 16 pitches plus the grid's 3px
+           allowance into what is left, and never grow past the 22px pitch tuned here.
+           Derived, not fixed, so a small phone or a raised UI scale shrinks the cells
+           instead of clipping the grid. */
+        --led-cell-pitch: min(22px, calc((100cqw - 2rem - 3px) / 16));
+        --led-cell: calc(var(--led-cell-pitch) - var(--led-cell-gap) * 2);
         margin-inline-end: 0;
     }
 }

--- a/src/components/tabs/led_strip/LedGridPoint.vue
+++ b/src/components/tabs/led_strip/LedGridPoint.vue
@@ -110,9 +110,9 @@ const colorStyle = computed(() => {
 .gPoint {
     float: inline-start;
     border: solid 1px var(--surface-500);
-    width: 23px;
-    height: 23px;
-    margin: 3px;
+    width: var(--led-cell, 23px);
+    height: var(--led-cell, 23px);
+    margin: var(--led-cell-gap, 3px);
     border-radius: 7px;
     background: var(--surface-300);
     cursor: pointer;

--- a/src/components/tabs/led_strip/LedGridPoint.vue
+++ b/src/components/tabs/led_strip/LedGridPoint.vue
@@ -219,18 +219,18 @@ const colorStyle = computed(() => {
     font-size: 12px;
     display: block;
     margin-inline-start: -1px;
-    margin-top: -21px;
-    width: 24px;
-    height: 24px;
+    margin-top: calc(2px - var(--led-cell, 23px));
+    width: calc(var(--led-cell, 23px) + 1px);
+    height: calc(var(--led-cell, 23px) + 1px);
     color: white;
     text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
-    line-height: 24px;
+    line-height: calc(var(--led-cell, 23px) + 1px);
 }
 
 /* Direction indicators */
 .indicators {
     position: relative;
-    height: 24px;
+    height: calc(var(--led-cell, 23px) + 1px);
 }
 
 .indicators span {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1443,9 +1443,21 @@ each(range(12), {
         }
     });
     /* A col-span-N child would otherwise spawn a content-sized implicit column
-       in the collapsed single-column grid, pushing the row past the viewport. */
-    .grid-box [class^="col-span-"] {
+       in the collapsed single-column grid, pushing the row past the viewport.
+       Two attribute forms: ^= alone misses elements where col-span-N is not the
+       first class token. */
+    .grid-box [class^="col-span-"],
+    .grid-box [class*=" col-span-"] {
         grid-column: 1 / -1;
+    }
+    /* WebKit zooms the page whenever a focused control computes under 16px, and the
+       viewport meta no longer pins zoom to suppress it. !important and the :not()
+       match the base input rule above, whose font-size: unset !important would
+       otherwise take precedence; .small opts out deliberately. */
+    input:not(.small),
+    select:not(.small),
+    textarea {
+        font-size: 16px !important;
     }
 }
 @media all and (max-width: 575px), all and (max-width: 950px) and (max-height: 500px) and (orientation: landscape) {

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1438,7 +1438,15 @@ each(range(12), {
             margin-inline-start: 0 !important;
             margin-inline-end: 0 !important;
         }
+        .grid-box.col@{value} {
+            grid-template-columns: minmax(0, 1fr);
+        }
     });
+    /* A col-span-N child would otherwise spawn a content-sized implicit column
+       in the collapsed single-column grid, pushing the row past the viewport. */
+    .grid-box [class^="col-span-"] {
+        grid-column: 1 / -1;
+    }
 }
 @media all and (max-width: 575px), all and (max-width: 950px) and (max-height: 500px) and (orientation: landscape) {
     .compact-header-layout();

--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,10 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
+        <meta
+            name="viewport"
+            content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover"
+        />
 
         <script type="module" src="/src/js/utils/common.js"></script>
         <script type="module" src="/src/js/browserMain.js"></script>

--- a/src/index.html
+++ b/src/index.html
@@ -1,10 +1,7 @@
 <!doctype html>
 <html lang="en">
     <head>
-        <meta
-            name="viewport"
-            content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no,viewport-fit=cover"
-        />
+        <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover" />
 
         <script type="module" src="/src/js/utils/common.js"></script>
         <script type="module" src="/src/js/browserMain.js"></script>


### PR DESCRIPTION
Rebased onto the phone shell redesign, which now owns the status bar and the viewport meta, so this has shrunk to the tab content fixes.

Configuration, OSD and LED Strip were wider than a phone viewport and getting clipped by `#content` rather than reflowing. `.grid-box` collapses to one column below 576px, with `col-span-*` children clamped to `1 / -1` (a `col-span-2` would otherwise spawn a content-sized implicit column and blow the width straight back out), and the SettingRow label group can shrink and wrap.

The LED matrix cell size comes off a custom property, and the phone rule derives the pitch from the container, `min(22px, (100cqw - 2rem - 3px) / 16)`, so the 16x16 grid fits from 320px up and across the whole 50-150% UI scale range instead of being cut off at 467px. The wire numbers and direction indicators size off the same variable, so they track the shrunken cells.

WebKit zooms the page in whenever a focused control computes under 16px, which this branch used to suppress by pinning `maximum-scale`. The pin is gone on master, so phone-width layouts raise form controls to the 16px threshold instead: the focus zoom never fires and pinch zoom stays available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * LED strip displays now adapt cell sizing and spacing to narrower screen widths, improving responsiveness.
  * LED indicators and wiring visuals scale consistently with the grid.
  * Setting labels can wrap cleanly with improved spacing.
  * Compact layouts now provide more consistent single-column presentation and larger mobile form text.
  * Improved support for device safe areas and right-to-left layout directions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
