### PR TITLE
fix(logging): avoid disconnect warning during flash erase

### DIFF
--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -338,6 +338,7 @@ import { useSaving } from "../../composables/useSaving";
 import { useReboot } from "../../composables/useReboot";
 import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import { runTabLoad } from "../../composables/useTabLoad";
+import { useDataflashErase } from "../../composables/useDataflashErase";
 
 const BLOCK_SIZE = 4096;
 
@@ -410,8 +411,6 @@ export default defineComponent({
         const debugFieldsEnabled = ref(debugStore.enableFields ? debugStore.enableFields.map(() => true) : []);
         const saveProgress = ref(0);
         const saveCancelled = ref(false);
-        const eraseCancelled = ref(false);
-        const isErasing = ref(false);
         const blockSize = ref(BLOCK_SIZE);
         const writeError = ref(false);
 
@@ -600,6 +599,35 @@ export default defineComponent({
 
         const { dirty, markClean, takeSnapshot } = useDirtyState(serializeOnboardLoggingState);
 
+        const {
+            isErasing,
+            start: startFlashErase,
+            cancel: cancelFlashErase,
+        } = useDataflashErase({
+            onComplete: () => {
+                if (
+                    getConfig("showNotifications").showNotifications &&
+                    NotificationManager.checkPermission() === "granted"
+                ) {
+                    NotificationManager.showNotification("Betaflight App", {
+                        body: i18n.getMessage("flashEraseDoneNotification"),
+                        icon: "/images/pwa/favicon.ico",
+                    });
+                }
+            },
+            onError: (error) => {
+                console.error("Dataflash erase failed", error);
+                gui_log(
+                    `<strong><span class="message-negative">${i18n.getMessage("error", {
+                        errorMessage: error,
+                    })}</span></strong>`,
+                );
+            },
+            onFinish: () => {
+                eraseOpen.value = false;
+            },
+        });
+
         function updateDebugField(index, value) {
             // Use splice to ensure Vue 3 reactivity
             debugFieldsEnabled.value.splice(index, 1, value);
@@ -654,79 +682,16 @@ export default defineComponent({
             if (dataflashUsedSize.value === 0) {
                 return;
             }
-            eraseCancelled.value = false;
             eraseOpen.value = true;
         }
 
-        async function flashErase() {
-            try {
-                connectionStore.pauseLiveData();
-                // Await the drain: clearMspQueue() resolves callbacks_cleanup() asynchronously, so
-                // firing it unawaited would wipe the pollForEraseCompletion callback we register just
-                // below (the erase send is non-errorAware and cleanup drops it silently) — leaving the
-                // dialog stuck forever even though the FC does erase. Drain first, then register.
-                await connectionStore.clearMspQueue();
-                isErasing.value = true;
-                MSP.send_message(MSPCodes.MSP_DATAFLASH_ERASE, false, false, pollForEraseCompletion);
-            } catch (error) {
-                // Startup failed before the erase poll could take over: restore the UI and
-                // live-data pump so the dialog doesn't strand, and surface the failure.
-                console.error("Failed to start dataflash erase", error);
-                isErasing.value = false;
-                eraseOpen.value = false;
-                connectionStore.resumeLiveData();
-                gui_log(
-                    `<strong><span class="message-negative">${i18n.getMessage("error", {
-                        errorMessage: error,
-                    })}</span></strong>`,
-                );
-            }
+        function flashErase() {
+            return startFlashErase();
         }
 
         function flashEraseCancel() {
-            eraseCancelled.value = true;
-            isErasing.value = false;
             eraseOpen.value = false;
-            connectionStore.resumeLiveData();
-        }
-
-        async function pollForEraseCompletion() {
-            if (!connectionStore.connectionValid || eraseCancelled.value) {
-                return;
-            }
-
-            try {
-                // errorAware request so a timeout settles instead of stranding a legacy
-                // callback: the flash chip can stop answering MSP mid-erase, and we must
-                // keep polling rather than abandon the dialog on a single missed summary.
-                await MSP.promise(MSPCodes.MSP_DATAFLASH_SUMMARY);
-            } catch {
-                // Summary timed out/cancelled (flash unresponsive mid-erase). Re-poll without
-                // reading the stale cached ready flag — it still holds the pre-erase value and
-                // would otherwise close the dialog before the erase has actually finished.
-                if (connectionStore.connectionValid && !eraseCancelled.value) {
-                    setTimeout(pollForEraseCompletion, 500);
-                }
-                return;
-            }
-
-            if (!connectionStore.connectionValid || eraseCancelled.value) {
-                return;
-            }
-
-            if (fcStore.dataflash?.ready) {
-                isErasing.value = false;
-                eraseOpen.value = false;
-                connectionStore.resumeLiveData();
-                if (getConfig("showNotifications").showNotifications) {
-                    NotificationManager.showNotification("Betaflight App", {
-                        body: i18n.getMessage("flashEraseDoneNotification"),
-                        icon: "/images/pwa/favicon.ico",
-                    });
-                }
-            } else {
-                setTimeout(pollForEraseCompletion, 500);
-            }
+            cancelFlashErase();
         }
 
         function flashUpdateSummary(onDone) {
@@ -792,11 +757,8 @@ export default defineComponent({
 
         function conditionallyEraseFlash(maxBytes, nextAddress) {
             if (Number.isFinite(maxBytes) && nextAddress >= maxBytes) {
-                connectionStore.pauseLiveData();
-                eraseCancelled.value = false;
-                isErasing.value = true;
                 eraseOpen.value = true;
-                MSP.send_message(MSPCodes.MSP_DATAFLASH_ERASE, false, false, pollForEraseCompletion);
+                void startFlashErase({ clearQueue: false });
             } else {
                 gui_log(
                     i18n.getMessage("dataflashSaveIncompleteWarning") ||

--- a/src/composables/useDataflashErase.ts
+++ b/src/composables/useDataflashErase.ts
@@ -1,0 +1,237 @@
+import { onScopeDispose, ref, watch, type Ref } from "vue";
+import MSP from "../js/msp";
+import MSPCodes from "../js/msp/MSPCodes";
+import FC from "../js/fc";
+import { useConnectionStore } from "../stores/connection";
+
+const ERASE_POLL_INTERVAL_MS = 500;
+export const DATAFLASH_ERASE_TIMEOUT_MS = 60000;
+
+type EraseFinishReason = "complete" | "error" | "disconnected" | "cancelled" | "disposed";
+
+interface DataflashEraseCallbacks {
+    onComplete?: () => void;
+    onError?: (error: unknown) => void;
+    onFinish?: (reason: EraseFinishReason) => void;
+}
+
+interface DataflashEraseStartOptions {
+    clearQueue?: boolean;
+}
+
+interface DataflashEraseApi {
+    isErasing: Ref<boolean>;
+    start: (options?: DataflashEraseStartOptions) => Promise<void>;
+    cancel: () => void;
+}
+
+/**
+ * Manage dataflash erase polling and connection liveness as one operation.
+ *
+ * Some flash implementations legitimately stop servicing MSP while erasing. Summary polls
+ * therefore suppress the global connection watchdog until the bounded erase window expires.
+ * After that window, one normal poll restores dead-link detection before the operation exits.
+ *
+ * @param callbacks lifecycle callbacks
+ * @returns reactive erase state and lifecycle actions
+ */
+export function useDataflashErase({
+    onComplete,
+    onError,
+    onFinish,
+}: DataflashEraseCallbacks = {}): DataflashEraseApi {
+    const connectionStore = useConnectionStore();
+    const isErasing = ref(false);
+
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+    let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+    let deadlineExpired = false;
+    let pollInFlight = false;
+    let operationSequence = 0;
+
+    /** Clear every timer owned by the current erase operation. */
+    function clearTimers(): void {
+        if (pollTimer !== null) {
+            clearTimeout(pollTimer);
+            pollTimer = null;
+        }
+        if (deadlineTimer !== null) {
+            clearTimeout(deadlineTimer);
+            deadlineTimer = null;
+        }
+    }
+
+    /** Return whether an asynchronous continuation still belongs to the active erase. */
+    function isCurrentOperation(sequence: number): boolean {
+        return isErasing.value && sequence === operationSequence;
+    }
+
+    /** Complete one operation and restore shared connection/UI state exactly once. */
+    function finish(sequence: number, reason: EraseFinishReason, error?: unknown): void {
+        if (!isCurrentOperation(sequence)) {
+            return;
+        }
+
+        clearTimers();
+        operationSequence++;
+        isErasing.value = false;
+        pollInFlight = false;
+        connectionStore.resumeLiveData();
+        onFinish?.(reason);
+
+        if (reason === "complete") {
+            onComplete?.();
+        } else if (reason === "error") {
+            onError?.(error);
+        }
+    }
+
+    /** Schedule a sequence-scoped completion poll. */
+    function schedulePoll(sequence: number, delay = ERASE_POLL_INTERVAL_MS): void {
+        if (!isCurrentOperation(sequence) || pollTimer !== null) {
+            return;
+        }
+        pollTimer = setTimeout(() => {
+            pollTimer = null;
+            if (isCurrentOperation(sequence)) {
+                void pollForCompletion(sequence);
+            }
+        }, delay);
+    }
+
+    /** Handle a failed summary request without letting stale operations mutate new ones. */
+    function handlePollFailure(sequence: number, notifyTimeout: boolean, error: unknown): void {
+        if (!isCurrentOperation(sequence)) {
+            return;
+        }
+        pollInFlight = false;
+
+        if (!connectionStore.connectionValid) {
+            finish(sequence, "disconnected");
+            return;
+        }
+        if (notifyTimeout) {
+            finish(sequence, "error", error);
+            return;
+        }
+
+        // If the deadline expired while this suppressed poll was in flight, immediately issue
+        // the final watchdog-enabled probe. Otherwise continue normal erase polling.
+        schedulePoll(sequence, deadlineExpired ? 0 : ERASE_POLL_INTERVAL_MS);
+    }
+
+    /** Handle a successful summary response and choose the next terminal or polling state. */
+    function handlePollResponse(sequence: number, notifyTimeout: boolean): void {
+        if (!isCurrentOperation(sequence)) {
+            return;
+        }
+        pollInFlight = false;
+
+        if (!connectionStore.connectionValid) {
+            finish(sequence, "disconnected");
+        } else if (FC.DATAFLASH?.ready) {
+            finish(sequence, "complete");
+        } else if (deadlineExpired && notifyTimeout) {
+            finish(sequence, "error", new Error("Dataflash erase did not complete within the allowed time"));
+        } else {
+            // A deadline that expired during a suppressed request requires the promised normal
+            // liveness probe; before the deadline, continue at the regular polling cadence.
+            schedulePoll(sequence, deadlineExpired ? 0 : ERASE_POLL_INTERVAL_MS);
+        }
+    }
+
+    /** Request the current dataflash summary for one operation sequence. */
+    async function pollForCompletion(sequence: number): Promise<void> {
+        if (!isCurrentOperation(sequence)) {
+            return;
+        }
+        if (!connectionStore.connectionValid) {
+            finish(sequence, "disconnected");
+            return;
+        }
+
+        // Expected erase-time silence must not trip the global watchdog. Once the operation's
+        // own deadline expires, the next request becomes a normal liveness probe so a genuinely
+        // dead FC still follows the standard disconnect-and-warning path.
+        const notifyTimeout = deadlineExpired;
+        pollInFlight = true;
+        try {
+            await MSP.promise(MSPCodes.MSP_DATAFLASH_SUMMARY, false, { notifyTimeout });
+        } catch (error: unknown) {
+            handlePollFailure(sequence, notifyTimeout, error);
+            return;
+        }
+
+        handlePollResponse(sequence, notifyTimeout);
+    }
+
+    /** Mark the bounded erase window expired and start its final liveness probe when idle. */
+    function expireDeadline(sequence: number): void {
+        if (!isCurrentOperation(sequence)) {
+            return;
+        }
+        deadlineTimer = null;
+        deadlineExpired = true;
+        if (!pollInFlight) {
+            schedulePoll(sequence, 0);
+        }
+    }
+
+    /**
+     * Start erasing dataflash.
+     * @param options operation startup options
+     */
+    async function start({ clearQueue = true }: DataflashEraseStartOptions = {}): Promise<void> {
+        if (isErasing.value) {
+            return;
+        }
+
+        isErasing.value = true;
+        deadlineExpired = false;
+        pollInFlight = false;
+        const sequence = ++operationSequence;
+        connectionStore.pauseLiveData();
+
+        try {
+            if (clearQueue) {
+                // Await the dynamic queue drain before registering the erase callback, or its
+                // asynchronous cleanup can remove that callback and strand the operation.
+                await connectionStore.clearMspQueue();
+            }
+            if (!isCurrentOperation(sequence)) {
+                return;
+            }
+            if (!connectionStore.connectionValid) {
+                finish(sequence, "disconnected");
+                return;
+            }
+
+            deadlineTimer = setTimeout(() => expireDeadline(sequence), DATAFLASH_ERASE_TIMEOUT_MS);
+            MSP.send_message(MSPCodes.MSP_DATAFLASH_ERASE, false, false, () => {
+                if (isCurrentOperation(sequence)) {
+                    void pollForCompletion(sequence);
+                }
+            });
+        } catch (error: unknown) {
+            finish(sequence, "error", error);
+        }
+    }
+
+    /** Cancel the active erase operation, if any. */
+    function cancel(): void {
+        finish(operationSequence, "cancelled");
+    }
+
+    watch(
+        () => connectionStore.connectionValid,
+        (connectionValid) => {
+            if (!connectionValid) {
+                finish(operationSequence, "disconnected");
+            }
+        },
+    );
+
+    onScopeDispose(() => finish(operationSequence, "disposed"));
+
+    return { isErasing, start, cancel };
+}

--- a/src/js/msp.js
+++ b/src/js/msp.js
@@ -518,7 +518,17 @@ const MSP = {
         }
         return true;
     },
-    _transmit(code, data, callback_sent, callback_msp, errorAware) {
+    /**
+     * Transmit an MSP request and register its response callback.
+     * @param {number} code MSP command code
+     * @param {ArrayBuffer|Array<number>|false|undefined} data optional command payload
+     * @param {Function|false|undefined} callback_sent callback invoked after the bytes are sent
+     * @param {Function|false|undefined} callback_msp callback invoked with the MSP response
+     * @param {boolean} errorAware whether timeout and cancellation errors settle the request
+     * @param {boolean} [notifyTimeout=true] whether timeout exhaustion invokes MSP.onTimeout
+     * @returns {boolean} true when the request is queued
+     */
+    _transmit(code, data, callback_sent, callback_msp, errorAware, notifyTimeout = true) {
         const bufferOut = code <= 254 ? this.encode_message_v1(code, data) : this.encode_message_v2(code, data);
         const view = new Uint8Array(bufferOut);
 
@@ -536,6 +546,7 @@ const MSP = {
                     callback: callback_msp,
                     callbackSent: callback_sent,
                     errorAware: true,
+                    notifyTimeout,
                 });
                 return true;
             }
@@ -549,6 +560,7 @@ const MSP = {
             callback: callback_msp,
             callbackSent: callback_sent,
             errorAware,
+            notifyTimeout,
             attempts: 1,
             start: performance.now(),
         };
@@ -621,9 +633,12 @@ const MSP = {
         }
         this._release_parked(obj.code);
 
-        // Notify the liveness hook after a full errorAware exhaustion. It — not this per-request
-        // failure — classifies the link as dead or merely slow (see handleConnectionTimeout).
-        this.onTimeout?.(obj.code);
+        // Notify the liveness hook after a full errorAware exhaustion unless the caller expects
+        // the FC to be temporarily silent (for example while erasing dataflash). The request still
+        // rejects normally so that operation-specific retry or failure handling can proceed.
+        if (obj.notifyTimeout) {
+            this.onTimeout?.(obj.code);
+        }
     },
     _park(code, entry) {
         let queue = this.parked.get(code);
@@ -659,10 +674,14 @@ const MSP = {
         });
     },
     /**
-     * resolves: {command: code, data: data, length: message_length}
-     * rejects: MspTimeoutError, MspCancelledError or MspCrcError
+     * @param {number} code MSP command code
+     * @param {ArrayBuffer|Array<number>|false} data optional command payload
+     * @param {{notifyTimeout?: boolean}} options set notifyTimeout false when request silence is
+     * expected and must not trigger the connection-liveness watchdog
+     * @returns {Promise<object|undefined>} resolves with {command, data, length}; rejects with
+     * MspTimeoutError, MspCancelledError or MspCrcError
      */
-    async promise(code, data) {
+    async promise(code, data, { notifyTimeout = true } = {}) {
         if (code === undefined || CONFIGURATOR.virtualMode) {
             return undefined;
         }
@@ -684,6 +703,7 @@ const MSP = {
                     }
                 },
                 true,
+                notifyTimeout,
             );
         });
     },

--- a/test/js/msp_promise.test.js
+++ b/test/js/msp_promise.test.js
@@ -89,6 +89,25 @@ describe("MSP promise semantics", () => {
                 MSP.onTimeout = null;
             }
         });
+
+        it("can reject without notifying the connection timeout hook when silence is expected", async () => {
+            const onTimeout = vi.fn();
+            const previousOnTimeout = MSP.onTimeout;
+            MSP.onTimeout = onTimeout;
+            try {
+                const rejection = expect(
+                    MSP.promise(EEPROM_WRITE_CODE, false, { notifyTimeout: false }),
+                ).rejects.toBeInstanceOf(MspTimeoutError);
+
+                await vi.advanceTimersByTimeAsync(MSP.TIMEOUT * MSP.MAX_RETRIES);
+                await rejection;
+
+                expect(onTimeout).not.toHaveBeenCalled();
+                expect(MSP.callbacks).toHaveLength(0);
+            } finally {
+                MSP.onTimeout = previousOnTimeout;
+            }
+        });
     });
 
     describe("disconnect_cleanup", () => {

--- a/test/js/useDataflashErase.test.js
+++ b/test/js/useDataflashErase.test.js
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { effectScope, nextTick } from "vue";
+import { useDataflashErase, DATAFLASH_ERASE_TIMEOUT_MS } from "../../src/composables/useDataflashErase";
+import { useConnectionStore } from "../../src/stores/connection";
+import CONFIGURATOR from "../../src/js/data_storage";
+import FC from "../../src/js/fc";
+import MSP from "../../src/js/msp";
+import MSPCodes from "../../src/js/msp/MSPCodes";
+import { MspTimeoutError } from "../../src/js/msp/mspErrors";
+
+describe("useDataflashErase", () => {
+    let scope;
+    let erase;
+    let connectionStore;
+    let eraseAcknowledgements;
+    let callbacks;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        setActivePinia(createPinia());
+        FC.resetState();
+        CONFIGURATOR.connectionValid = true;
+        connectionStore = useConnectionStore();
+        callbacks = {
+            onComplete: vi.fn(),
+            onError: vi.fn(),
+            onFinish: vi.fn(),
+        };
+        eraseAcknowledgements = [];
+
+        vi.spyOn(MSP, "send_message").mockImplementation((code, data, callbackSent, callbackMsp) => {
+            if (code === MSPCodes.MSP_DATAFLASH_ERASE) {
+                eraseAcknowledgements.push(callbackMsp);
+            }
+            return true;
+        });
+        vi.spyOn(MSP, "promise");
+
+        scope = effectScope();
+        scope.run(() => {
+            erase = useDataflashErase(callbacks);
+        });
+    });
+
+    afterEach(() => {
+        scope.stop();
+        CONFIGURATOR.connectionValid = false;
+        vi.runAllTimers();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+    });
+
+    it("completes and resumes live data when dataflash reports ready", async () => {
+        MSP.promise.mockResolvedValue({});
+        FC.DATAFLASH.ready = true;
+
+        await erase.start({ clearQueue: false });
+        expect(connectionStore.liveDataPaused).toBe(true);
+        eraseAcknowledgements[0]();
+        await vi.runAllTicks();
+
+        expect(erase.isErasing.value).toBe(false);
+        expect(connectionStore.liveDataPaused).toBe(false);
+        expect(callbacks.onComplete).toHaveBeenCalledOnce();
+        expect(callbacks.onFinish).toHaveBeenCalledWith("complete");
+    });
+
+    it("uses a watchdog-enabled final probe after the bounded erase window", async () => {
+        MSP.promise.mockRejectedValue(new MspTimeoutError("timed out", MSPCodes.MSP_DATAFLASH_SUMMARY));
+
+        await erase.start({ clearQueue: false });
+        eraseAcknowledgements[0]();
+        await vi.advanceTimersByTimeAsync(DATAFLASH_ERASE_TIMEOUT_MS + 500);
+
+        expect(MSP.promise.mock.calls.at(-1)).toEqual([
+            MSPCodes.MSP_DATAFLASH_SUMMARY,
+            false,
+            { notifyTimeout: true },
+        ]);
+        expect(erase.isErasing.value).toBe(false);
+        expect(connectionStore.liveDataPaused).toBe(false);
+        expect(callbacks.onError).toHaveBeenCalledOnce();
+        expect(callbacks.onFinish).toHaveBeenCalledWith("error");
+    });
+
+    it("cleans up immediately when the physical connection closes", async () => {
+        await erase.start({ clearQueue: false });
+        CONFIGURATOR.connectionValid = false;
+        await nextTick();
+
+        expect(erase.isErasing.value).toBe(false);
+        expect(connectionStore.liveDataPaused).toBe(false);
+        expect(callbacks.onError).not.toHaveBeenCalled();
+        expect(callbacks.onFinish).toHaveBeenCalledWith("disconnected");
+    });
+
+    it("ignores a cancelled poll that settles after a new erase starts", async () => {
+        let resolveCancelledPoll;
+        MSP.promise
+            .mockImplementationOnce(
+                () =>
+                    new Promise((resolve) => {
+                        resolveCancelledPoll = resolve;
+                    }),
+            )
+            .mockResolvedValueOnce({});
+
+        await erase.start({ clearQueue: false });
+        eraseAcknowledgements[0]();
+        await vi.runAllTicks();
+
+        erase.cancel();
+        await erase.start({ clearQueue: false });
+        FC.DATAFLASH.ready = true;
+
+        resolveCancelledPoll({});
+        await vi.runAllTicks();
+
+        expect(erase.isErasing.value).toBe(true);
+        expect(callbacks.onComplete).not.toHaveBeenCalled();
+
+        eraseAcknowledgements[1]();
+        await vi.runAllTicks();
+
+        expect(erase.isErasing.value).toBe(false);
+        expect(callbacks.onComplete).toHaveBeenCalledOnce();
+    });
+});


### PR DESCRIPTION
## Summary
- allow individual error-aware MSP requests to suppress global connection-timeout notification while still rejecting normally
- move dataflash erase MSP handling into a typed TypeScript composable
- tolerate expected MSP silence during erase, then restore normal dead-link detection with a bounded final liveness probe
- scope every timer, callback, and async continuation to its erase operation so cancelled work cannot affect a restart
- centralize completion, cancellation, physical-disconnect, timeout, and unmount cleanup so live-data polling always resumes
- guard completion notifications when browser permission is not granted
- add regression coverage for timeout suppression and the complete erase lifecycle, including cancel-then-restart

## Why
Some flash implementations stop servicing MSP while erasing dataflash. The erase poll intentionally catches summary timeouts and retries, but the global five-second dead-link watchdog disconnected first and displayed an inappropriate Connection lost warning.

## Testing
- Full Vitest suite: 86 test files, 988 tests passed
- Full ESLint passed
- TypeScript composable check passed
- Production Vite build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dataflash erase handling with clearer progress, cancellation, completion, timeout, and disconnection behavior.
  * Live connection data is managed automatically during erase operations.
  * Added configurable timeout notifications for MSP requests.

* **Bug Fixes**
  * Prevented canceled or outdated erase operations from affecting newer operations.
  * Added a final connection check before reporting erase completion.

* **Tests**
  * Added coverage for erase success, timeouts, disconnections, cancellation, and silent request timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->