### PR TITLE
fix(cli): keep autocomplete builder traffic out of CLI output

### DIFF
--- a/src/composables/useCli.js
+++ b/src/composables/useCli.js
@@ -140,6 +140,7 @@ export function useCli() {
 
     let outputHistory = "";
     let cliBuffer = "";
+    let outputSuppressed = false;
 
     // Refs for DOM elements
     const windowWrapperRef = ref(null);
@@ -207,9 +208,9 @@ export function useCli() {
     };
 
     const writeLineToOutput = (text) => {
-        if (CliAutoComplete.isBuilding()) {
-            CliAutoComplete.builderParseLine(text);
-            return; // suppress output if in building state
+        if (CliAutoComplete.isSuppressingOutput()) {
+            CliAutoComplete.parseSuppressedLine(text);
+            return; // suppress output while the cache builder owns the channel
         }
 
         if (text.startsWith("###ERROR")) {
@@ -574,6 +575,16 @@ export function useCli() {
                 continue;
             }
 
+            // snapshot first: processing this character can end suppression, and the character that
+            // ends it still belongs to the builder
+            const suppressed = CliAutoComplete.isSuppressingOutput();
+
+            if (outputSuppressed && !suppressed) {
+                // drop whatever half of a builder line was already buffered
+                cliBuffer = "";
+            }
+            outputSuppressed = suppressed;
+
             if (CONFIGURATOR.cliValid) {
                 const shouldContinue = processCharacterInCliMode(byte, currentChar);
                 if (shouldContinue) {
@@ -581,8 +592,7 @@ export function useCli() {
                 }
             }
 
-            if (!CliAutoComplete.isBuilding()) {
-                // do not include the building dialog into the history
+            if (!suppressed) {
                 outputHistory += currentChar;
             }
 
@@ -594,7 +604,7 @@ export function useCli() {
         validateCliEntry(validateText);
 
         // fallback to native autocomplete
-        if (!CliAutoComplete.isEnabled()) {
+        if (!CliAutoComplete.isEnabled() && !CliAutoComplete.isSuppressingOutput()) {
             setPrompt(removePromptHash(cliBuffer));
         }
     };
@@ -602,6 +612,7 @@ export function useCli() {
     const initialize = async () => {
         outputHistory = "";
         cliBuffer = "";
+        outputSuppressed = false;
         state.startProcessing = false;
 
         CONFIGURATOR.cliActive = true;

--- a/src/js/CliAutoComplete.js
+++ b/src/js/CliAutoComplete.js
@@ -3,6 +3,12 @@ import CONFIGURATOR from "./data_storage";
 import FC from "./fc";
 import { EventBus } from "../components/eventBus";
 
+const BUILDER_TIMEOUT_MS = 3000;
+
+// The builder gives up while the FC still owes it the tail of a dump/get response, so output stays
+// suppressed until the last sentinel we sent comes back, or this cap expires on a link gone quiet.
+const DRAIN_TIMEOUT_MS = 2 * BUILDER_TIMEOUT_MS;
+
 /**
  * Encapsulates the AutoComplete cache-building logic.
  *
@@ -11,7 +17,7 @@ import { EventBus } from "../components/eventBus";
  */
 const CliAutoComplete = {
     configEnabled: false,
-    builder: { state: "reset", numFails: 0 },
+    builder: { state: "reset", numFails: 0, draining: false },
 };
 
 CliAutoComplete.isEnabled = function () {
@@ -23,6 +29,18 @@ CliAutoComplete.isEnabled = function () {
 
 CliAutoComplete.isBuilding = function () {
     return this.builder.state !== "reset" && this.builder.state !== "done" && this.builder.state !== "fail";
+};
+
+CliAutoComplete.isSuppressingOutput = function () {
+    return this.isBuilding() || this.builder.draining;
+};
+
+CliAutoComplete.parseSuppressedLine = function (line) {
+    if (this.builder.draining) {
+        this._drainParseLine(line);
+    } else {
+        this.builderParseLine(line);
+    }
 };
 
 CliAutoComplete.setEnabled = function (enable) {
@@ -55,9 +73,26 @@ CliAutoComplete.initialize = function (sendLine, writeToOutput, isIdle) {
 
 CliAutoComplete.cleanup = function () {
     this._builderWatchdogStop();
+    this._drainStop();
     GUI.timeout_remove("autocomplete_builder_defer");
     this.builder.state = "reset";
     this.builder.numFails = 0;
+};
+
+CliAutoComplete._drainStart = function () {
+    this.builder.draining = true;
+    GUI.timeout_add("autocomplete_builder_drain", () => this._drainStop(), DRAIN_TIMEOUT_MS);
+};
+
+CliAutoComplete._drainParseLine = function (line) {
+    if (line.indexOf(this.builder.sentinel) !== -1) {
+        this._drainStop();
+    }
+};
+
+CliAutoComplete._drainStop = function () {
+    GUI.timeout_remove("autocomplete_builder_drain");
+    this.builder.draining = false;
 };
 
 CliAutoComplete._builderWatchdogTouch = function () {
@@ -71,6 +106,7 @@ CliAutoComplete._builderWatchdogTouch = function () {
             if (self.builder.numFails) {
                 self.builder.numFails++;
                 self.builder.state = "fail";
+                self._drainStart();
                 self.writeToOutput("Failed!<br># ");
                 EventBus.$emit("autocomplete:build:stop");
             } else {
@@ -80,7 +116,7 @@ CliAutoComplete._builderWatchdogTouch = function () {
                 self.builderStart();
             }
         },
-        3000,
+        BUILDER_TIMEOUT_MS,
     );
 };
 

--- a/test/js/cli_autocomplete_output_suppression.test.js
+++ b/test/js/cli_autocomplete_output_suppression.test.js
@@ -1,0 +1,144 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { useCli } from "../../src/composables/useCli";
+import CliAutoComplete from "../../src/js/CliAutoComplete";
+import CONFIGURATOR from "../../src/js/data_storage";
+import FC from "../../src/js/fc";
+import GUI from "../../src/js/gui";
+import BFClipboard from "../../src/js/Clipboard";
+
+function bytes(str) {
+    return new TextEncoder().encode(str);
+}
+
+// The cache builder's own help/dump/get traffic must never reach the CLI window or the saved/copied
+// history, including the tail that keeps arriving after the watchdog has given up on a slow FC.
+describe("useCli output suppression around CliAutoComplete", () => {
+    let cli;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        CONFIGURATOR.cliActive = true;
+        CONFIGURATOR.cliValid = true;
+        FC.CONFIG.flightControllerIdentifier = "BTFL";
+        CliAutoComplete.builder = { state: "reset", numFails: 0, draining: false };
+        CliAutoComplete.configEnabled = true;
+        GUI.operating_system = "Linux";
+
+        cli = useCli();
+        cli.windowWrapperRef.value = document.createElement("div");
+        cli.cliWindowRef.value = document.createElement("div");
+
+        CliAutoComplete.initialize(
+            vi.fn(),
+            () => {},
+            () => true,
+        );
+    });
+
+    afterEach(() => {
+        CliAutoComplete.cleanup();
+        vi.useRealTimers();
+        vi.restoreAllMocks();
+        CONFIGURATOR.cliActive = false;
+        CONFIGURATOR.cliValid = false;
+    });
+
+    function historyText() {
+        const spy = vi.spyOn(BFClipboard, "writeText").mockImplementation(() => {});
+        cli.copyToClipboard();
+        const text = spy.mock.calls[0][0];
+        spy.mockRestore();
+        return text;
+    }
+
+    function visibleText() {
+        vi.advanceTimersByTime(100); // let the buffered output flush
+        return cli.windowWrapperRef.value.textContent;
+    }
+
+    function startBuildAndReachHelp() {
+        CliAutoComplete.builderStart();
+        cli.read(bytes(`${CliAutoComplete.builder.sentinel}\r`));
+        expect(CliAutoComplete.builder.state).toBe("parse-help");
+    }
+
+    function failWatchdog() {
+        vi.advanceTimersByTime(3000); // first timeout retries
+        vi.advanceTimersByTime(3000); // second timeout gives up
+        expect(CliAutoComplete.builder.state).toBe("fail");
+    }
+
+    it("keeps the response tail that lands after the watchdog gives up out of history and window", () => {
+        startBuildAndReachHelp();
+        cli.read(bytes("adjrange\rbeeper\r"));
+        failWatchdog();
+
+        cli.read(bytes("set gyro_lpf1_static_hz = 250\rset dyn_notch_count = 3\r"));
+
+        expect(historyText()).not.toContain("gyro_lpf1_static_hz");
+        expect(visibleText()).not.toContain("gyro_lpf1_static_hz");
+    });
+
+    it("resumes normal output once the trailing sentinel arrives", () => {
+        startBuildAndReachHelp();
+        failWatchdog();
+
+        // the retry regenerated the sentinel; that last one sent is what ends the drain
+        const sentinel = CliAutoComplete.builder.sentinel;
+        cli.read(bytes(`set dyn_notch_count = 3\r${sentinel}\r`));
+        expect(CliAutoComplete.isSuppressingOutput()).toBe(false);
+
+        cli.read(bytes("REAL_USER_OUTPUT\r"));
+
+        expect(historyText()).toContain("REAL_USER_OUTPUT");
+        expect(historyText()).not.toContain("dyn_notch_count");
+    });
+
+    it("stops suppressing after the drain cap when the sentinel never comes back", () => {
+        startBuildAndReachHelp();
+        failWatchdog();
+        expect(CliAutoComplete.isSuppressingOutput()).toBe(true);
+
+        vi.advanceTimersByTime(6000);
+
+        expect(CliAutoComplete.isSuppressingOutput()).toBe(false);
+        cli.read(bytes("REAL_USER_OUTPUT\r"));
+        expect(historyText()).toContain("REAL_USER_OUTPUT");
+    });
+
+    it("discards a line left half-received when the builder gave up mid-line", () => {
+        startBuildAndReachHelp();
+
+        cli.read(bytes("set gyro_lpf1_st")); // chunk boundary lands mid-line
+        failWatchdog();
+        cli.read(bytes(`atic_hz = 250\r${CliAutoComplete.builder.sentinel}\r`));
+        expect(CliAutoComplete.isSuppressingOutput()).toBe(false);
+
+        expect(historyText()).toBe("");
+        expect(visibleText()).not.toContain("atic_hz");
+    });
+
+    it("does not splice a stale builder half-line onto output resuming after the drain cap", () => {
+        startBuildAndReachHelp();
+        cli.read(bytes("set gyro_lpf1_st")); // FC goes silent mid-line and never sends the sentinel
+        failWatchdog();
+
+        vi.advanceTimersByTime(6000);
+        cli.read(bytes("REAL_USER_OUTPUT\r"));
+
+        expect(visibleText()).not.toContain("gyro_lpf1_st");
+        expect(historyText()).toContain("REAL_USER_OUTPUT");
+    });
+
+    it("does not leak the character that completes the build into history", () => {
+        CliAutoComplete.builderStart();
+        const sentinel = CliAutoComplete.builder.sentinel;
+
+        for (let i = 0; i < 5; i++) {
+            cli.read(bytes(`${sentinel}\r`));
+        }
+
+        expect(CliAutoComplete.builder.state).toBe("done");
+        expect(historyText()).toBe("");
+    });
+});


### PR DESCRIPTION
Fixes #5444

When the autocomplete cache builder's watchdog gives up on a slow FC, it hands the channel straight back to normal output while the FC still owes it the tail of a `help`/`dump`/`get` response. Those late lines get rendered in the CLI window and appended to the history that Save to file and Copy to clipboard read from. The fail path now keeps output suppressed until the last sentinel it sent comes back (the FC's own terminator for that backlog), with a cap so a dead link cannot suppress forever. `builder.state` still goes to `fail` immediately, so `isBuilding()`/`isEnabled()` and the dropdown are unchanged, draining only governs who owns the output.

Separately, the history append read the builder state *after* processing the character, so the character that ended the build leaked into every saved log as a leading blank line. It now snapshots the state beforehand, and drops a half received builder line so it cannot be spliced onto the output that resumes.

Worth noting for reviewers: the fix direction suggested in the issue (snapshotting before the character) only addresses that second, cosmetic half. In the headline case the state flips inside a timer between serial chunks, so the snapshot is already stale and the late lines still land in the history.

The new tests were mutation checked rather than just run green: disabling the drain fails 4, reverting the snapshot fails 2, removing the half line discard fails 1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI output handling during autocomplete processing.
  * Prevented stale or suppressed builder output from appearing in the CLI window or copied history.
  * Restored normal output reliably after completion signals or timeout.
  * Preserved the character that completes autocomplete processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->