### PR TITLE
feat(ports): assign every remaining serial port from its own tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1648,6 +1648,12 @@
     "featureRX_SPI": {
         "message": "SPI Rx (e.g. built-in Rx)"
     },
+    "escSensorSerialPort": {
+        "message": "ESC Telemetry Serial Port"
+    },
+    "escSensorSerialPortHelp": {
+        "message": "UART the ESC telemetry is read on. Set on the ESC sensor itself from API 1.49; the Ports tab only shows it."
+    },
     "featureESC_SENSOR": {
         "message": "Use KISS/BLHeli_32 ESC telemetry <b>over a separate wire</b>"
     },
@@ -7766,6 +7772,12 @@
         "message": "Frequency at which the Pit Mode changes when enabled.",
         "description": "Help text for the pit mode field of the VTX tab"
     },
+    "vtxSerialPort": {
+        "message": "Serial Port"
+    },
+    "vtxSerialPortHelp": {
+        "message": "UART the VTX control protocol runs on. Set on the VTX itself from API 1.49; the Ports tab only shows it."
+    },
     "vtxLowPowerDisarm": {
         "message": "Low Power Disarm",
         "description": "Text of one of the fields of the VTX tab"
@@ -8311,6 +8323,18 @@
     },
     "onboardLoggingBlackbox": {
         "message": "Blackbox logging device"
+    },
+    "onboardLoggingSerialPort": {
+        "message": "Serial Port"
+    },
+    "onboardLoggingSerialPortHelp": {
+        "message": "UART used when the logging device is Serial. Set on the blackbox itself from API 1.49; the Ports tab only shows it."
+    },
+    "onboardLoggingSerialBaud": {
+        "message": "Serial Baud Rate"
+    },
+    "onboardLoggingSerialBaudHelp": {
+        "message": "Baud rate for the serial logging port."
     },
     "onboardLoggingRateOfLogging": {
         "message": "Blackbox logging rate"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1693,6 +1693,21 @@
     "configurationTelemetry": {
         "message": "Telemetry"
     },
+    "telemetryInstanceProtocol": {
+        "message": "Telemetry $1 Protocol"
+    },
+    "telemetryInstancePort": {
+        "message": "Telemetry $1 Serial Port"
+    },
+    "telemetryInstanceBaud": {
+        "message": "Telemetry $1 Baud Rate"
+    },
+    "rcdeviceSerialPort": {
+        "message": "Camera Control Serial Port"
+    },
+    "rcdeviceSerialPortHelp": {
+        "message": "UART a RunCam protocol camera is wired to. Set on the device itself from API 1.49; the Ports tab only shows it."
+    },
     "configurationTelemetryHelp": {
         "message": "Telemetry output from receiver"
     },
@@ -6271,6 +6286,24 @@
     "osdSetupVideoFormatOptionHd": {
         "message": "HD",
         "description": "Option for the video format in the OSD"
+    },
+    "osdSerialPort": {
+        "message": "OSD Serial Port"
+    },
+    "osdSerialPortHelp": {
+        "message": "UART a serial OSD is wired to. Set on the OSD itself from API 1.49; the Ports tab only shows it."
+    },
+    "osdCustomTextSerialPort": {
+        "message": "Custom Text Serial Port"
+    },
+    "osdCustomTextSerialPortHelp": {
+        "message": "UART custom OSD text is received on."
+    },
+    "osdCustomTextSerialBaud": {
+        "message": "Custom Text Baud Rate"
+    },
+    "osdCustomTextSerialBaudHelp": {
+        "message": "Baud rate for the custom OSD text port."
     },
     "osdSetupUnitsTitle": {
         "message": "Units"

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2307,6 +2307,18 @@
     "portsHelp": {
         "message": "<strong>Note:</strong> not all combinations are valid.  When the flight controller firmware detects this the serial port configuration will be reset."
     },
+    "portsMspSectionTitle": {
+        "message": "MSP Ports"
+    },
+    "portsMspSectionHelp": {
+        "message": "MSP has no tab of its own, so its ports are assigned here. The table below is a read-only view of what every feature has claimed."
+    },
+    "portsMspInstancePort": {
+        "message": "MSP $1 Serial Port"
+    },
+    "portsMspInstanceBaud": {
+        "message": "MSP $1 Baud Rate"
+    },
     "portsVtxTableNotSet": {
         "message": "<span class=\"message-negative\">WARNING:</span> The VTX table has not been set up correctly and without it VTX control will not be possible. Please set up the VTX table in $t(tabVtx.message) tab."
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -2352,6 +2352,12 @@
     "portsFunction_VTX_MSP": {
         "message": "VTX (MSP + Displayport)"
     },
+    "portsFunction_GIMBAL": {
+        "message": "Gimbal"
+    },
+    "portsFunction_OSD_CUSTOM_TEXT": {
+        "message": "OSD Custom Text"
+    },
     "pidTuningProfileOption": {
         "message": "Profile $1"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -1739,6 +1739,18 @@
     "configurationRangefinderType": {
         "message": "Type"
     },
+    "rangefinderSerialPort": {
+        "message": "Rangefinder Serial Port"
+    },
+    "rangefinderSerialPortHelp": {
+        "message": "UART the rangefinder is wired to. Set on the rangefinder itself from API 1.49; the Ports tab only shows it."
+    },
+    "opticalflowSerialPort": {
+        "message": "Optical Flow Serial Port"
+    },
+    "opticalflowSerialPortHelp": {
+        "message": "UART the optical flow sensor is wired to. A module reporting both flow and range needs each set separately."
+    },
     "configurationOpticalflow": {
         "message": "Optical Flow",
         "description": "Don't translate!!!"

--- a/src/components/tabs/MotorsTab.vue
+++ b/src/components/tabs/MotorsTab.vue
@@ -98,6 +98,19 @@
                                 </template>
                             </SettingRow>
                             <SettingRow
+                                v-if="digitalProtocolConfigured && escSensorPortAvailable"
+                                :label="$t('escSensorSerialPort')"
+                                :help="$t('escSensorSerialPortHelp')"
+                            >
+                                <USelect
+                                    v-model="escSensorPortIdentifier"
+                                    :items="escSensorPortOptions"
+                                    :disabled="!escSensorPortWritable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                            <SettingRow
                                 v-if="digitalProtocolConfigured"
                                 :label="$t('configurationDshotBidir')"
                                 :help="$t('configurationDshotBidirHelp')"
@@ -558,6 +571,7 @@ import { useMotorConfiguration } from "@/composables/motors/useMotorConfiguratio
 import { useMotorDataPolling } from "@/composables/motors/useMotorDataPolling";
 import { useSaving } from "@/composables/useSaving";
 import { useReboot } from "@/composables/useReboot";
+import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import { useBuildOptions } from "@/composables/useBuildOptions";
 
 const API_VERSION_1_47 = "1.47.0";
@@ -573,6 +587,17 @@ const { configHasChanged, resetChanges } = motorsState;
 // Shared save discipline: runSave owns isSaving and swallows benign MspCancelledError.
 const { isSaving, runSave } = useSaving();
 const { saveToEeprom, saveAndReboot } = useReboot();
+
+// From API 1.49 the ESC telemetry port lives on the ESC sensor parameter group rather than the
+// shared port function mask, so it is assigned beside the feature that uses it.
+const {
+    available: escSensorPortAvailable,
+    writable: escSensorPortWritable,
+    options: escSensorPortOptions,
+    selectedIdentifier: escSensorPortIdentifier,
+    load: loadEscSensorPort,
+    write: writeEscSensorPort,
+} = useFeaturePort({ setting: "esc_sensor_uart", functionName: "ESC_SENSOR" });
 
 // Warning dialog
 const settingsChangedOpen = ref(false);
@@ -812,6 +837,8 @@ onMounted(async () => {
     await MSP.promise(MSPCodes.MSP_ADVANCED_CONFIG);
     await MSP.promise(MSPCodes.MSP_FILTER_CONFIG);
     await MSP.promise(MSPCodes.MSP_ARMING_CONFIG);
+
+    await loadEscSensorPort();
 
     // Initialize motors state (CRITICAL: must be after MSP data loaded)
     motorsState.initializeDefaults();
@@ -1424,6 +1451,10 @@ const handleSave = (reboot = true) => {
             await MSP.promise(MSPCodes.MSP_SET_ADVANCED_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_ARMING_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_ARMING_CONFIG));
             await MSP.promise(MSPCodes.MSP_SET_FILTER_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FILTER_CONFIG));
+
+            // Between the parameter group writes and the persist that serialises them, so a
+            // refused port throws before anything reaches EEPROM.
+            await writeEscSensorPort();
 
             // Persist to EEPROM, rebooting when requested.
             if (reboot) {

--- a/src/components/tabs/OnboardLoggingTab.vue
+++ b/src/components/tabs/OnboardLoggingTab.vue
@@ -42,6 +42,32 @@
                                     class="min-w-40"
                                 />
                             </SettingRow>
+                            <SettingRow
+                                v-if="blackboxPortAvailable"
+                                :label="$t('onboardLoggingSerialPort')"
+                                :help="$t('onboardLoggingSerialPortHelp')"
+                            >
+                                <USelect
+                                    v-model="blackboxPortIdentifier"
+                                    :items="blackboxPortOptions"
+                                    :disabled="!blackboxPortWritable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                            <SettingRow
+                                v-if="blackboxPortAvailable"
+                                :label="$t('onboardLoggingSerialBaud')"
+                                :help="$t('onboardLoggingSerialBaudHelp')"
+                            >
+                                <USelect
+                                    v-model="blackboxBaud"
+                                    :items="blackboxBaudOptions"
+                                    :disabled="!blackboxPortWritable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
                             <SettingRow v-show="blackboxDevice !== 0" :label="$t('onboardLoggingRateOfLogging')">
                                 <USelect v-model="blackboxRate" :items="loggingRates" size="xs" class="min-w-40" />
                             </SettingRow>
@@ -310,6 +336,7 @@ import { bit_check, bit_set } from "../../js/bit";
 import { useDirtyState } from "../../composables/useDirtyState";
 import { useSaving } from "../../composables/useSaving";
 import { useReboot } from "../../composables/useReboot";
+import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import { runTabLoad } from "../../composables/useTabLoad";
 
 const BLOCK_SIZE = 4096;
@@ -408,6 +435,23 @@ export default defineComponent({
             const index = types.gyro.elements.indexOf("VIRTUAL");
             virtualGyro.value = fcStore.sensorConfigActive?.gyro_hardware === index;
         };
+
+        // From API 1.49 the serial-logging port and its baud live on the blackbox parameter group
+        // rather than the shared port function mask, so they are assigned here.
+        const {
+            available: blackboxPortAvailable,
+            writable: blackboxPortWritable,
+            options: blackboxPortOptions,
+            selectedIdentifier: blackboxPortIdentifier,
+            baudOptions: blackboxBaudOptions,
+            selectedBaud: blackboxBaud,
+            load: loadBlackboxPort,
+            write: writeBlackboxPort,
+        } = useFeaturePort({
+            setting: "blackbox_uart",
+            functionName: "BLACKBOX",
+            baud: { setting: "blackbox_baud" },
+        });
 
         const blackboxDeviceOptions = computed(() => {
             const options = [{ label: i18n.getMessage("blackboxLoggingNone"), value: 0 }];
@@ -550,6 +594,8 @@ export default defineComponent({
                 blackboxRate: blackboxRate.value,
                 debugMode: debugMode.value,
                 debugFieldsEnabled: [...debugFieldsEnabled.value],
+                blackboxPortIdentifier: blackboxPortIdentifier.value,
+                blackboxBaud: blackboxBaud.value,
             });
 
         const { dirty, markClean, takeSnapshot } = useDirtyState(serializeOnboardLoggingState);
@@ -591,6 +637,10 @@ export default defineComponent({
                         MSPCodes.MSP_SET_ADVANCED_CONFIG,
                         mspHelper.crunch(MSPCodes.MSP_SET_ADVANCED_CONFIG),
                     );
+
+                    // Between the parameter group write and the persist that serialises it, so a
+                    // refused port throws before anything reaches EEPROM.
+                    await writeBlackboxPort();
 
                     await saveAndReboot();
 
@@ -949,6 +999,8 @@ export default defineComponent({
                         }
 
                         // Populate UI state
+                        await loadBlackboxPort();
+
                         blackboxDevice.value = fcStore.blackbox?.blackboxDevice || 0;
                         blackboxRate.value = fcStore.blackbox?.blackboxSampleRate || 0;
                         debugMode.value = fcStore.pidAdvancedConfig?.debugMode || 0;
@@ -1001,6 +1053,12 @@ export default defineComponent({
             isExpertMode,
             virtualGyro,
             blackboxDeviceOptions,
+            blackboxPortAvailable,
+            blackboxPortWritable,
+            blackboxPortOptions,
+            blackboxPortIdentifier,
+            blackboxBaudOptions,
+            blackboxBaud,
             blackboxSupport,
             loggingRates,
             debugModes,

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -263,6 +263,45 @@
                                     size="xs"
                                 />
                             </SettingRow>
+                            <SettingRow
+                                v-if="osdPortAvailable"
+                                :label="$t('osdSerialPort')"
+                                :help="$t('osdSerialPortHelp')"
+                            >
+                                <USelect
+                                    v-model="osdPortIdentifier"
+                                    :items="osdPortOptions"
+                                    :disabled="!osdPortWritable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                            <SettingRow
+                                v-if="customTextPortAvailable"
+                                :label="$t('osdCustomTextSerialPort')"
+                                :help="$t('osdCustomTextSerialPortHelp')"
+                            >
+                                <USelect
+                                    v-model="customTextPortIdentifier"
+                                    :items="customTextPortOptions"
+                                    :disabled="!customTextPortWritable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                            <SettingRow
+                                v-if="customTextPortAvailable"
+                                :label="$t('osdCustomTextSerialBaud')"
+                                :help="$t('osdCustomTextSerialBaudHelp')"
+                            >
+                                <USelect
+                                    v-model="customTextBaud"
+                                    :items="customTextBaudOptions"
+                                    :disabled="!customTextPortWritable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
                         </UiBox>
 
                         <!-- Units -->
@@ -549,7 +588,35 @@ import { useOsdRuler } from "@/composables/useOsdRuler";
 import { useBuildOptions } from "@/composables/useBuildOptions";
 import { useTransientLabel } from "@/composables/useTransientLabel";
 import { useSaving } from "@/composables/useSaving";
+import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import { runTabLoad } from "@/composables/useTabLoad";
+
+// From API 1.49 both live on the OSD parameter group. osd_uart only shows up in the synthesised
+// mask when the display port device is FrSky OSD, and sets no bit at all on MSP DisplayPort, so
+// the setting is the only reliable read either way.
+const {
+    available: osdPortAvailable,
+    writable: osdPortWritable,
+    options: osdPortOptions,
+    selectedIdentifier: osdPortIdentifier,
+    load: loadOsdPort,
+    write: writeOsdPort,
+} = useFeaturePort({ setting: "osd_uart", functionName: "FRSKY_OSD" });
+
+const {
+    available: customTextPortAvailable,
+    writable: customTextPortWritable,
+    options: customTextPortOptions,
+    selectedIdentifier: customTextPortIdentifier,
+    baudOptions: customTextBaudOptions,
+    selectedBaud: customTextBaud,
+    load: loadCustomTextPort,
+    write: writeCustomTextPort,
+} = useFeaturePort({
+    setting: "osd_custom_text_uart",
+    functionName: "OSD_CUSTOM_TEXT",
+    baud: { setting: "osd_custom_text_baud" },
+});
 import BaseTab from "./BaseTab.vue";
 import WikiButton from "@/components/elements/WikiButton.vue";
 import UiBox from "@/components/elements/UiBox.vue";
@@ -1295,6 +1362,9 @@ async function loadConfig() {
             // Fetch OSD config via Store
             await osdStore.fetchOsdConfig();
 
+            await loadOsdPort();
+            await loadCustomTextPort();
+
             // Set initial profile from store state
             previewProfile.value = osdStore.osdProfiles.selected || 0;
             activeProfile.value = osdStore.osdProfiles.selected || 0;
@@ -1334,7 +1404,10 @@ const saveConfig = () =>
             osdStore.syncToLegacy();
 
             // Send all OSD config to FC and write EEPROM.
-            await osdStore.saveAllConfig();
+            await osdStore.saveAllConfig(async () => {
+                await writeOsdPort();
+                await writeCustomTextPort();
+            });
 
             // Track analytics
             const changes = analyticsChanges.value;

--- a/src/components/tabs/PortsTab.vue
+++ b/src/components/tabs/PortsTab.vue
@@ -18,6 +18,37 @@
                     <p v-html="$t('portsVtxTableNotSet')"></p>
                 </UiBox>
 
+                <UiBox
+                    v-if="anyMspAvailable"
+                    :title="$t('portsMspSectionTitle')"
+                    :help="$t('portsMspSectionHelp')"
+                    type="neutral"
+                    class="mb-4"
+                >
+                    <template v-for="(msp, index) in mspPorts" :key="index">
+                        <template v-if="msp.available">
+                            <SettingRow :label="$t('portsMspInstancePort', [index + 1])">
+                                <USelect
+                                    v-model="msp.selectedIdentifier"
+                                    :items="msp.options"
+                                    :disabled="!msp.writable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                            <SettingRow :label="$t('portsMspInstanceBaud', [index + 1])">
+                                <USelect
+                                    v-model="msp.selectedBaud"
+                                    :items="msp.baudOptions"
+                                    :disabled="!msp.writable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                        </template>
+                    </template>
+                </UiBox>
+
                 <TabLoadingState v-if="!tabReady || isLoading" size="size-8" color-class="text-muted">
                     <span class="ml-2 text-dimmed">{{ $t("dataWaitingForData") }}</span>
                 </TabLoadingState>
@@ -224,20 +255,34 @@
             </div>
         </div>
 
-        <div v-if="!readOnly" class="content_toolbar toolbar_fixed_bottom">
+        <div v-if="!readOnly || anyMspAvailable" class="content_toolbar toolbar_fixed_bottom">
             <div class="flex gap-2">
-                <UButton :label="$t('configurationButtonSave')" size="xs" :disabled="!dirty" @click="saveConfig" />
+                <UButton
+                    v-if="!readOnly"
+                    :label="$t('configurationButtonSave')"
+                    size="xs"
+                    :disabled="!dirty"
+                    @click="saveConfig"
+                />
+                <UButton
+                    v-else
+                    :label="$t('configurationButtonSave')"
+                    size="xs"
+                    :disabled="!mspDirty || isSavingMsp"
+                    @click="saveMspPorts"
+                />
             </div>
         </div>
     </BaseTab>
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from "vue";
+import { computed, onMounted, reactive, ref } from "vue";
 import { useMediaQuery } from "@vueuse/core";
 import BaseTab from "./BaseTab.vue";
 import UiBox from "@/components/elements/UiBox.vue";
 import HelpIcon from "@/components/elements/HelpIcon.vue";
+import SettingRow from "@/components/elements/SettingRow.vue";
 import WikiButton from "../elements/WikiButton.vue";
 import TabLoadingState from "@/components/elements/TabLoadingState.vue";
 import { useTranslation } from "i18next-vue";
@@ -245,6 +290,9 @@ import { usePortsRules } from "../../composables/ports/usePortsRules";
 import { usePortsState } from "../../composables/ports/usePortsState";
 import { usePortsConfiguration } from "../../composables/ports/usePortsConfiguration";
 import { usePortsReadOnly } from "../../composables/ports/usePortsReadOnly";
+import { useFeaturePort } from "../../composables/ports/useFeaturePort";
+import { useReboot } from "@/composables/useReboot";
+import { useSaving } from "@/composables/useSaving";
 
 const { t } = useTranslation();
 
@@ -265,12 +313,47 @@ const { saveConfig, onTelemetryChange, onPeripheralChange } = usePortsConfigurat
 
 const tabReady = ref(false);
 
+// The MSP ports have no feature tab of their own, so from API 1.49 they are assigned here even
+// though the mask grid above is read-only. All three instances set the same FUNCTION_MSP bit, so
+// none of them can be read back from it. MAX_MSP_PORT_COUNT is compile-time, so each is probed.
+const mspPorts = [1, 2, 3].map((instance) =>
+    reactive(
+        useFeaturePort({
+            setting: `msp_uart_${instance}`,
+            functionName: "MSP",
+            baud: { setting: `msp_baud_${instance}` },
+        }),
+    ),
+);
+
+const anyMspAvailable = computed(() => mspPorts.some((port) => port.available));
+const mspDirty = computed(() => mspPorts.some((port) => port.changed));
+
+const { saveAndReboot } = useReboot();
+const { isSaving: isSavingMsp, runSave: runMspSave } = useSaving();
+
+// A reassigned MSP port only takes effect once the firmware opens it, so this always reboots.
+const saveMspPorts = () =>
+    runMspSave(
+        async () => {
+            for (const port of mspPorts) {
+                await port.write();
+            }
+            await saveAndReboot();
+        },
+        { onError: (error) => console.error("Failed to save MSP ports", error) },
+    );
+
 onMounted(() => {
     requestAnimationFrame(() => {
         requestAnimationFrame(() => {
             tabReady.value = true;
         });
     });
+
+    Promise.all(mspPorts.map((port) => port.load())).catch((error) =>
+        console.error("Failed to read the MSP ports", error),
+    );
 });
 
 const mspBaudItems = mspBaudRates.map((r) => ({ value: r, label: r }));

--- a/src/components/tabs/ReceiverTab.vue
+++ b/src/components/tabs/ReceiverTab.vue
@@ -173,6 +173,54 @@
                                     @update:model-value="(checked) => toggleTelemetry(checked)"
                                 />
                             </SettingRow>
+                            <template v-for="(telemetry, index) in telemetryPorts" :key="index">
+                                <template v-if="telemetry.available">
+                                    <SettingRow :label="$t('telemetryInstanceProtocol', [index + 1])">
+                                        <USelect
+                                            v-model="telemetry.selectedProtocol"
+                                            :items="telemetry.protocolOptions"
+                                            :disabled="!telemetry.writable"
+                                            size="xs"
+                                            class="min-w-40"
+                                            @update:model-value="onSerialDeviceChange"
+                                        />
+                                    </SettingRow>
+                                    <SettingRow :label="$t('telemetryInstancePort', [index + 1])">
+                                        <USelect
+                                            v-model="telemetry.selectedIdentifier"
+                                            :items="telemetry.options"
+                                            :disabled="!telemetry.writable"
+                                            size="xs"
+                                            class="min-w-40"
+                                            @update:model-value="onSerialDeviceChange"
+                                        />
+                                    </SettingRow>
+                                    <SettingRow :label="$t('telemetryInstanceBaud', [index + 1])">
+                                        <USelect
+                                            v-model="telemetry.selectedBaud"
+                                            :items="telemetry.baudOptions"
+                                            :disabled="!telemetry.writable"
+                                            size="xs"
+                                            class="min-w-40"
+                                            @update:model-value="onSerialDeviceChange"
+                                        />
+                                    </SettingRow>
+                                </template>
+                            </template>
+                            <SettingRow
+                                v-if="rcdevicePortAvailable"
+                                :label="$t('rcdeviceSerialPort')"
+                                :help="$t('rcdeviceSerialPortHelp')"
+                            >
+                                <USelect
+                                    v-model="rcdevicePortIdentifier"
+                                    :items="rcdevicePortOptions"
+                                    :disabled="!rcdevicePortWritable"
+                                    size="xs"
+                                    class="min-w-40"
+                                    @update:model-value="onSerialDeviceChange"
+                                />
+                            </SettingRow>
                         </UiBox>
 
                         <!-- RSSI -->
@@ -544,7 +592,7 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, nextTick, watch } from "vue";
+import { ref, reactive, computed, onMounted, onUnmounted, nextTick, watch } from "vue";
 import { useFlightControllerStore } from "@/stores/fc";
 import { useConnectionStore } from "@/stores/connection";
 import { useDirtyState } from "@/composables/useDirtyState";
@@ -673,6 +721,41 @@ const {
     write: writeRxPort,
 } = useFeaturePort({ setting: "rx_uart", functionName: "RX_SERIAL" });
 
+// Every protocol a telemetry instance may claim in the synthesised mask. Which one it sets depends
+// on its configured protocol, and the three instances collapse into the same bits, so none of them
+// can be read back from the mask.
+const TELEMETRY_FUNCTIONS = [
+    "TELEMETRY_FRSKY",
+    "TELEMETRY_HOTT",
+    "TELEMETRY_LTM",
+    "TELEMETRY_SMARTPORT",
+    "TELEMETRY_MAVLINK",
+    "TELEMETRY_IBUS",
+];
+
+// MAX_TELEMETRY_PROVIDERS is a compile-time constant that never reaches the app, so each instance
+// is probed and only the ones this build has report themselves available. reactive() rather than a
+// destructure because the template iterates them.
+const telemetryPorts = [1, 2, 3].map((instance) =>
+    reactive(
+        useFeaturePort({
+            setting: `telemetry_${instance}_uart`,
+            functionName: TELEMETRY_FUNCTIONS,
+            baud: { setting: `telemetry_${instance}_baud` },
+            protocol: { setting: `telemetry_${instance}_protocol` },
+        }),
+    ),
+);
+
+const {
+    available: rcdevicePortAvailable,
+    writable: rcdevicePortWritable,
+    options: rcdevicePortOptions,
+    selectedIdentifier: rcdevicePortIdentifier,
+    load: loadRcdevicePort,
+    write: writeRcdevicePort,
+} = useFeaturePort({ setting: "rcdevice_uart", functionName: "RUNCAM_DEVICE_CONTROL" });
+
 // Dirty state tracking
 /** @returns {string} serialized receiver state for dirty comparison */
 function serializeReceiverState() {
@@ -681,6 +764,12 @@ function serializeReceiverState() {
         rxMode: selectedRxMode.value,
         serialrxProvider: rxConfig.value?.serialrx_provider,
         rxPortIdentifier: rxPortIdentifier.value,
+        rcdevicePortIdentifier: rcdevicePortIdentifier.value,
+        telemetryPorts: telemetryPorts.map((port) => [
+            port.selectedProtocol,
+            port.selectedIdentifier,
+            port.selectedBaud,
+        ]),
         rxSpiProtocol: rxConfig.value?.rxSpiProtocol,
         elrsModelId: rxConfig.value?.elrsModelId,
         stickMin: rxConfig.value?.stick_min,
@@ -1008,6 +1097,11 @@ function onRxPortChange() {
     needReboot.value = true;
 }
 
+// A telemetry or camera port only takes effect once the firmware opens it.
+function onSerialDeviceChange() {
+    needReboot.value = true;
+}
+
 // Actions
 function resetRefreshRate() {
     refreshRate.value = 50;
@@ -1079,6 +1173,10 @@ async function loadConfig() {
             await MSP.promise(MSPCodes.MSP_RX_CONFIG);
             await MSP.promise(MSPCodes.MSP_MIXER_CONFIG);
             await loadRxPort();
+            await loadRcdevicePort();
+            for (const port of telemetryPorts) {
+                await port.load();
+            }
 
             // Update local state from FC
             updateChannelMapFromRcMap();
@@ -1157,13 +1255,20 @@ const saveConfig = (withReboot = false) =>
             // Throwing skips the persist, so a refused port leaves nothing written to EEPROM.
             try {
                 await writeRxPort();
+                await writeRcdevicePort();
+                for (const port of telemetryPorts) {
+                    await port.write();
+                }
             } catch (error) {
                 gui_log(t("receiverSerialPortSaveFailed"));
                 throw error;
             }
 
+            // Unconditional: the telemetry feature switch lives on this tab, and a mask change has
+            // to reach the FC whether or not the save also reboots.
+            await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
+
             if (withReboot) {
-                await MSP.promise(MSPCodes.MSP_SET_FEATURE_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_FEATURE_CONFIG));
                 await saveAndReboot();
             } else {
                 await saveToEeprom();

--- a/src/components/tabs/SensorsTab.vue
+++ b/src/components/tabs/SensorsTab.vue
@@ -73,6 +73,19 @@
                                 size="xs"
                             />
                         </SettingRow>
+                        <SettingRow
+                            v-if="showRangefinder && sonarHardwareEnabled && rangefinderPortAvailable"
+                            :label="$t('rangefinderSerialPort')"
+                            :help="$t('rangefinderSerialPortHelp')"
+                        >
+                            <USelect
+                                v-model="rangefinderPortIdentifier"
+                                :items="rangefinderPortOptions"
+                                :disabled="!rangefinderPortWritable"
+                                class="min-w-40"
+                                size="xs"
+                            />
+                        </SettingRow>
                         <SettingRow v-if="showOpticalFlow" :label="$t('configurationOpticalflow')" fullWidth>
                             <USwitch v-model="opticalFlowHardwareEnabled" />
                             <USelect
@@ -83,6 +96,19 @@
                                         .filter((_, i) => i > 0)
                                         .map((label, i) => ({ label, value: i + 1 }))
                                 "
+                                class="min-w-40"
+                                size="xs"
+                            />
+                        </SettingRow>
+                        <SettingRow
+                            v-if="showOpticalFlow && opticalFlowHardwareEnabled && opticalFlowPortAvailable"
+                            :label="$t('opticalflowSerialPort')"
+                            :help="$t('opticalflowSerialPortHelp')"
+                        >
+                            <USelect
+                                v-model="opticalFlowPortIdentifier"
+                                :items="opticalFlowPortOptions"
+                                :disabled="!opticalFlowPortWritable"
                                 class="min-w-40"
                                 size="xs"
                             />
@@ -762,6 +788,7 @@ import { useFlightControllerStore } from "@/stores/fc";
 import { useReboot } from "@/composables/useReboot";
 import { useIsMounted } from "@/composables/useIsMounted";
 import { useDirtyState } from "@/composables/useDirtyState";
+import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import { useSaving } from "@/composables/useSaving";
 import { runTabLoad } from "@/composables/useTabLoad";
 import MSP from "../../js/msp";
@@ -808,6 +835,27 @@ import LiveSensorPanel from "./sensors/LiveSensorPanel.vue";
 
 const fcStore = useFlightControllerStore();
 const { saveAndReboot } = useReboot();
+
+// From API 1.49 each of these owns its own UART. Both still set the same FUNCTION_LIDAR bit in the
+// synthesised mask, which is why neither can be read back from it — the setting is the only thing
+// that says which port belongs to which sensor.
+const {
+    available: rangefinderPortAvailable,
+    writable: rangefinderPortWritable,
+    options: rangefinderPortOptions,
+    selectedIdentifier: rangefinderPortIdentifier,
+    load: loadRangefinderPort,
+    write: writeRangefinderPort,
+} = useFeaturePort({ setting: "rangefinder_uart", functionName: "LIDAR_TF" });
+
+const {
+    available: opticalFlowPortAvailable,
+    writable: opticalFlowPortWritable,
+    options: opticalFlowPortOptions,
+    selectedIdentifier: opticalFlowPortIdentifier,
+    load: loadOpticalFlowPort,
+    write: writeOpticalFlowPort,
+} = useFeaturePort({ setting: "opticalflow_uart", functionName: "LIDAR_TF" });
 
 const { isSaving, runSave } = useSaving();
 const isMounted = useIsMounted();
@@ -1985,6 +2033,8 @@ const serializeState = () =>
         accelTrims: { ...accelTrims },
         sensorAlignment: snapshotSensorAlignment(),
         magDeclination: magDeclination.value,
+        rangefinderPort: rangefinderPortIdentifier.value,
+        opticalFlowPort: opticalFlowPortIdentifier.value,
     });
 
 const { dirty, markClean, takeSnapshot } = useDirtyState(serializeState);
@@ -2132,6 +2182,9 @@ const loadConfig = async () => {
                 console.warn("Failed to load sensor types", error);
             }
 
+            await loadRangefinderPort();
+            await loadOpticalFlowPort();
+
             hydrateSensorConfig();
             hydrateAlignment();
             resolveSensorNames();
@@ -2231,6 +2284,11 @@ const saveConfig = () =>
             if (isApi146.value) {
                 await MSP.promise(MSPCodes.MSP_SET_COMPASS_CONFIG, mspHelper.crunch(MSPCodes.MSP_SET_COMPASS_CONFIG));
             }
+
+            // Between the parameter group writes and the persist that serialises them, so a
+            // refused port throws before anything reaches EEPROM.
+            await writeRangefinderPort();
+            await writeOpticalFlowPort();
 
             gui_log(i18n.getMessage("sensorConfigSaved"));
 

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -87,6 +87,19 @@
                                 />
                             </SettingRow>
 
+                            <SettingRow
+                                v-if="vtxPortAvailable"
+                                :label="$t('vtxSerialPort')"
+                                :help="$t('vtxSerialPortHelp')"
+                            >
+                                <USelect
+                                    v-model="vtxPortIdentifier"
+                                    :items="vtxPortOptions"
+                                    :disabled="!vtxPortWritable"
+                                    class="w-36"
+                                />
+                            </SettingRow>
+
                             <!-- Low power disarm -->
                             <SettingRow :label="$t('vtxLowPowerDisarm')" :help="$t('vtxLowPowerDisarmHelp')">
                                 <USelect
@@ -387,6 +400,7 @@ import { i18n } from "../../js/localization";
 import { useVtx } from "../../composables/useVtx";
 import { useInterval } from "../../composables/useInterval";
 import { useSaving } from "../../composables/useSaving";
+import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import { useTranslation } from "i18next-vue";
 
 export default defineComponent({
@@ -437,6 +451,19 @@ export default defineComponent({
 
         const { addInterval } = useInterval();
         const { isSaving, runSave } = useSaving();
+
+        // The mask bit a VTX claims is chosen by its protocol, so all three are its own.
+        const {
+            available: vtxPortAvailable,
+            writable: vtxPortWritable,
+            options: vtxPortOptions,
+            selectedIdentifier: vtxPortIdentifier,
+            load: loadVtxPort,
+            write: writeVtxPort,
+        } = useFeaturePort({
+            setting: "vtx_uart",
+            functionName: ["TBS_SMARTAUDIO", "IRC_TRAMP", "VTX_MSP"],
+        });
 
         const lowPowerDisarmOptions = computed(() => [
             { value: 0, label: t("vtxLowPowerDisarmOption_0") },
@@ -497,6 +524,7 @@ export default defineComponent({
 
         onMounted(async () => {
             await loadVtxConfig();
+            await loadVtxPort();
             addInterval("vtx_device_status_pull", updateDeviceStatus, 1000);
             i18n.localizePage();
             GUI.content_ready();
@@ -505,8 +533,9 @@ export default defineComponent({
         const handleSave = () =>
             runSave(
                 async () => {
-                    await saveVtx();
+                    await saveVtx(writeVtxPort);
                     await loadVtxConfig();
+                    await loadVtxPort();
                 },
                 {
                     onError: (error) => {
@@ -647,6 +676,10 @@ export default defineComponent({
 
         return {
             // State
+            vtxPortAvailable,
+            vtxPortWritable,
+            vtxPortOptions,
+            vtxPortIdentifier,
             savePending,
             factoryBandsSupported,
             frequencyMode,

--- a/src/composables/ports/portNames.js
+++ b/src/composables/ports/portNames.js
@@ -72,6 +72,36 @@ export function getPortDisplayName(identifier) {
 }
 
 /**
+ * The identifier a CLI port name refers to on this board.
+ *
+ * The name alone is ambiguous — the two UART identifier blocks share their names — so only the
+ * ports the FC reported can settle it. A name this board does not report reads as unassigned,
+ * which is also what the firmware does with an assignment naming a port it has no driver for.
+ *
+ * @param {Array<{identifier: number}>} ports FC.SERIAL_CONFIG.ports
+ * @param {string|null} name as the CLI prints it, e.g. "UART3", "VCP", "NONE"
+ * @returns {number} identifier, or PORT_NONE
+ */
+export function findPortIdentifierByCliName(ports, name) {
+    const wanted = (name ?? "").trim().toUpperCase();
+
+    if (!wanted || wanted === PORT_NAME_NONE) {
+        return PORT_NONE;
+    }
+
+    const reported = (ports ?? []).find((port) => getPortCliName(port.identifier) === wanted);
+    if (reported) {
+        return reported.identifier;
+    }
+
+    const candidates = Object.keys(portCliNames)
+        .map(Number)
+        .filter((identifier) => portCliNames[identifier] === wanted);
+
+    return candidates.length === 1 ? candidates[0] : PORT_NONE;
+}
+
+/**
  * Builds the CLI command that assigns a port to a feature.
  *
  * Throws rather than falling back to the raw identifier: the firmware resolves this setting by

--- a/src/composables/ports/useFeaturePort.js
+++ b/src/composables/ports/useFeaturePort.js
@@ -3,27 +3,22 @@ import { useFlightControllerStore } from "@/stores/fc";
 import MSP from "../../js/msp";
 import MSPCodes from "../../js/msp/MSPCodes";
 import { i18n } from "../../js/localization";
-import { findCliError, findCliSettingValue, isMspCliSupported, send as cliSend } from "../useMspCliSession";
+import {
+    findCliError,
+    findCliSettingAllowedValues,
+    findCliSettingValue,
+    isMspCliSupported,
+    send as cliSend,
+} from "../useMspCliSession";
 import { serialPortsAreReadOnly } from "./usePortsReadOnly";
-import { PORT_NONE, formatPortSetCommand, getPortDisplayName } from "./portNames";
-
-/**
- * The port a feature is currently assigned to, read from the per-port function mask.
- *
- * @param {Array<{identifier: number, functions: string[]}>} ports FC.SERIAL_CONFIG.ports
- * @param {string} functionName e.g. "RX_SERIAL"
- * @returns {number} identifier, or PORT_NONE when unassigned
- */
-export function findFeaturePortIdentifier(ports, functionName) {
-    const port = (ports ?? []).find((candidate) => (candidate.functions ?? []).includes(functionName));
-
-    return port ? port.identifier : PORT_NONE;
-}
+import { PORT_NONE, findPortIdentifierByCliName, formatPortSetCommand, getPortDisplayName } from "./portNames";
 
 /**
  * @param {Array<{identifier: number, functions: string[]}>} ports
  * @param {object} options
- * @param {string} options.functionName the feature's own function, left out of the annotations
+ * @param {string|string[]} options.functionName the feature's own function(s), left out of the
+ *   annotations. An array where the bit the firmware sets depends on the configured protocol,
+ *   as it does for a VTX.
  * @param {number} [options.currentIdentifier] kept in the list even if the FC did not report it
  * @param {string} [options.noneLabel]
  * @param {(functionName: string) => string} [options.describeFunction]
@@ -34,9 +29,10 @@ export function buildPortOptions(
     { functionName, currentIdentifier = PORT_NONE, noneLabel = "None", describeFunction = (name) => name } = {},
 ) {
     const options = [{ value: PORT_NONE, label: noneLabel }];
+    const own = Array.isArray(functionName) ? functionName : [functionName];
 
     for (const port of ports ?? []) {
-        const claimedElsewhere = (port.functions ?? []).filter((name) => name !== functionName);
+        const claimedElsewhere = (port.functions ?? []).filter((name) => !own.includes(name));
         const displayName = getPortDisplayName(port.identifier);
 
         options.push({
@@ -76,33 +72,48 @@ function describePortFunction(functionName) {
 /**
  * Serial port assignment for one feature, owned by that feature's own tab.
  *
- * From API 1.49 the port lives on the feature's parameter group and the per-port function mask
- * is a read-only view synthesised from those, so the assignment is read over MSP with the rest
- * of the serial config but written through the CLI.
+ * From API 1.49 the port lives on the feature's parameter group, so it is read and written
+ * through that setting rather than through the per-port function mask. The mask is only a
+ * synthesised view and cannot answer "which port is this feature on" in general: the three MSP
+ * and three telemetry instances share a bit, a rangefinder and an optical flow sensor share one,
+ * a VTX sets a bit chosen by its protocol, and an OSD on MSP DisplayPort sets none at all. The
+ * mask is still what builds the port list and its "claimed by" annotations.
  *
- * Features that also own their baud rate pass `baud`; the port and the baud are two settings on
- * the same parameter group, so they load and persist together.
+ * Whether a build has the setting at all is discovered the same way — a `get` for a setting the
+ * firmware was not built with answers INVALID NAME, which is how the instance count for MSP and
+ * telemetry reaches the app (MAX_MSP_PORT_COUNT and MAX_TELEMETRY_PROVIDERS never do).
  *
  * @param {object} options
  * @param {string} options.setting CLI setting name, e.g. "rx_uart"
- * @param {string} options.functionName port function the feature claims, e.g. "RX_SERIAL"
- * @param {{setting: string, rates: string[]}} [options.baud] omit for a feature with no baud of
- *   its own, such as a serial receiver, whose rate follows the protocol
+ * @param {string|string[]} options.functionName port function(s) the feature claims in the mask,
+ *   used only to keep its own claim out of the annotations
+ * @param {{setting: string, rates?: string[]}} [options.baud] omit for a feature with no baud of
+ *   its own, such as a serial receiver, whose rate follows the protocol. Without `rates` the
+ *   values the firmware prints for the setting are offered.
+ * @param {{setting: string}} [options.protocol] a lookup setting the feature carries beside its
+ *   port, as a telemetry instance carries its protocol
  */
-export function useFeaturePort({ setting, functionName, baud = null }) {
+export function useFeaturePort({ setting, functionName, baud = null, protocol = null }) {
     const fcStore = useFlightControllerStore();
 
-    const available = computed(() => serialPortsAreReadOnly(fcStore.config.apiVersion));
+    const apiSupported = computed(() => serialPortsAreReadOnly(fcStore.config.apiVersion));
+    const supported = ref(true);
+    const available = computed(() => apiSupported.value && supported.value);
     const writable = computed(() => available.value && isMspCliSupported());
 
     const selectedIdentifier = ref(PORT_NONE);
     const assignedIdentifier = ref(PORT_NONE);
     const selectedBaud = ref(null);
     const assignedBaud = ref(null);
+    const baudRates = ref(baud?.rates ?? null);
+    const selectedProtocol = ref(null);
+    const assignedProtocol = ref(null);
+    const protocolValues = ref(null);
 
     const portChanged = computed(() => selectedIdentifier.value !== assignedIdentifier.value);
     const baudChanged = computed(() => Boolean(baud) && selectedBaud.value !== assignedBaud.value);
-    const changed = computed(() => portChanged.value || baudChanged.value);
+    const protocolChanged = computed(() => Boolean(protocol) && selectedProtocol.value !== assignedProtocol.value);
+    const changed = computed(() => portChanged.value || baudChanged.value || protocolChanged.value);
 
     const options = computed(() =>
         buildPortOptions(fcStore.serialConfig?.ports, {
@@ -113,24 +124,71 @@ export function useFeaturePort({ setting, functionName, baud = null }) {
         }),
     );
 
-    const baudOptions = computed(() => buildBaudOptions(baud?.rates, selectedBaud.value));
+    const baudOptions = computed(() => buildBaudOptions(baudRates.value, selectedBaud.value));
+    const protocolOptions = computed(() => (protocolValues.value ?? []).map((value) => ({ value, label: value })));
+
+    // Returns null when the firmware does not have the setting, so the caller can tell an absent
+    // instance from one that is simply unassigned.
+    async function readSetting(name, { discoverValues = false } = {}) {
+        const lines = await cliSend(`get ${name}`);
+        if (findCliError(lines)) {
+            return null;
+        }
+
+        const value = findCliSettingValue(lines, name);
+        if (value === null) {
+            return null;
+        }
+
+        return { value, allowed: discoverValues ? findCliSettingAllowedValues(lines) : null };
+    }
 
     async function load() {
-        if (!available.value) {
+        supported.value = true;
+        selectedIdentifier.value = PORT_NONE;
+        assignedIdentifier.value = PORT_NONE;
+        selectedBaud.value = null;
+        assignedBaud.value = null;
+        selectedProtocol.value = null;
+        assignedProtocol.value = null;
+
+        if (!apiSupported.value) {
             return;
         }
 
         await MSP.promise(MSPCodes.MSP2_COMMON_SERIAL_CONFIG);
 
-        assignedIdentifier.value = findFeaturePortIdentifier(fcStore.serialConfig?.ports, functionName);
+        if (!isMspCliSupported()) {
+            return;
+        }
+
+        const port = await readSetting(setting);
+        if (!port) {
+            supported.value = false;
+            return;
+        }
+
+        assignedIdentifier.value = findPortIdentifierByCliName(fcStore.serialConfig?.ports, port.value);
         selectedIdentifier.value = assignedIdentifier.value;
 
-        // Not read from the port entry alongside the mask: the synthesised baud only appears on the
-        // port that owns the function, so an unassigned feature would report the firmware default
-        // instead of what is stored, and a save would then skip a write it owed.
-        if (baud && writable.value) {
-            assignedBaud.value = findCliSettingValue(await cliSend(`get ${baud.setting}`), baud.setting);
-            selectedBaud.value = assignedBaud.value;
+        if (baud) {
+            const stored = await readSetting(baud.setting, { discoverValues: !baud.rates });
+            if (stored) {
+                if (!baud.rates && stored.allowed) {
+                    baudRates.value = stored.allowed;
+                }
+                assignedBaud.value = stored.value;
+                selectedBaud.value = stored.value;
+            }
+        }
+
+        if (protocol) {
+            const stored = await readSetting(protocol.setting, { discoverValues: true });
+            if (stored) {
+                protocolValues.value = stored.allowed;
+                assignedProtocol.value = stored.value;
+                selectedProtocol.value = stored.value;
+            }
         }
     }
 
@@ -146,6 +204,11 @@ export function useFeaturePort({ setting, functionName, baud = null }) {
             return;
         }
 
+        if (protocolChanged.value) {
+            await sendSetting(`set ${protocol.setting} = ${selectedProtocol.value}`);
+            assignedProtocol.value = selectedProtocol.value;
+        }
+
         if (portChanged.value) {
             await sendSetting(formatPortSetCommand(setting, selectedIdentifier.value));
             assignedIdentifier.value = selectedIdentifier.value;
@@ -157,5 +220,18 @@ export function useFeaturePort({ setting, functionName, baud = null }) {
         }
     }
 
-    return { available, writable, options, selectedIdentifier, baudOptions, selectedBaud, changed, load, write };
+    return {
+        available,
+        supported,
+        writable,
+        options,
+        selectedIdentifier,
+        baudOptions,
+        selectedBaud,
+        protocolOptions,
+        selectedProtocol,
+        changed,
+        load,
+        write,
+    };
 }

--- a/src/composables/useMspCliSession.js
+++ b/src/composables/useMspCliSession.js
@@ -119,6 +119,23 @@ export function findCliSettingValue(lines, setting) {
     return null;
 }
 
+// A MODE_LOOKUP setting is printed with the names it accepts, so the app can offer exactly those
+// rather than carrying its own copy of a firmware table. NULL table entries are skipped by the
+// firmware, so the list is not positionally aligned with the enum — names only.
+export function findCliSettingAllowedValues(lines) {
+    for (const line of lines ?? []) {
+        const match = /^Allowed values:\s*(.+)$/.exec(line.trim());
+        if (match) {
+            return match[1]
+                .split(",")
+                .map((value) => value.trim())
+                .filter(Boolean);
+        }
+    }
+
+    return null;
+}
+
 export async function saveAndReconnect() {
     let saveError = null;
     try {

--- a/src/composables/useVtx.js
+++ b/src/composables/useVtx.js
@@ -364,7 +364,11 @@ export function useVtx() {
     // (useSaving); this only marshals data and issues the MSP writes. Persist is EEPROM-only
     // (no reboot), matching the previous writeConfiguration(false) behavior. The exact set and
     // order of MSP_SET_VTX* writes is preserved: VTX config, then each power level, then each band.
-    async function saveVtx() {
+    /**
+     * @param {() => Promise<void>} [beforePersist] runs after the parameter groups are written and
+     *   before the persist that serialises them, which is where a CLI `set` has to sit
+     */
+    async function saveVtx(beforePersist) {
         const { saveToEeprom } = useReboot();
 
         syncStateToFC();
@@ -383,6 +387,8 @@ export function useVtx() {
             FC.VTXTABLE_BAND = { ...bandList[index] };
             await MSP.promise(MSPCodes.MSP_SET_VTXTABLE_BAND, mspHelper.crunch(MSPCodes.MSP_SET_VTXTABLE_BAND));
         }
+
+        await beforePersist?.();
 
         await saveToEeprom();
 

--- a/src/js/msp/MSPHelper.js
+++ b/src/js/msp/MSPHelper.js
@@ -83,6 +83,8 @@ function MspHelper() {
         LIDAR_TF: 15,
         FRSKY_OSD: 16,
         VTX_MSP: 17,
+        GIMBAL: 18,
+        OSD_CUSTOM_TEXT: 19,
     };
 
     self.REBOOT_TYPES = {

--- a/src/stores/osd.js
+++ b/src/stores/osd.js
@@ -367,7 +367,11 @@ export const useOsdStore = defineStore("osd", () => {
         return buffer;
     }
 
-    const saveAllConfig = async () => {
+    /**
+     * @param {() => Promise<void>} [beforePersist] runs after the config is written and before the
+     *   EEPROM write that serialises it, which is where a CLI `set` has to sit
+     */
+    const saveAllConfig = async (beforePersist) => {
         const savedSnapshot = takeSnapshot();
 
         await MSP.promise(MSPCodes.MSP_SET_OSD_CONFIG, encodeOther());
@@ -386,6 +390,8 @@ export const useOsdStore = defineStore("osd", () => {
                 encodeStatisticsPayload(stat, CONFIGURATOR.virtualMode, OSD.virtualMode),
             );
         }
+
+        await beforePersist?.();
 
         await MSP.promise(MSPCodes.MSP_EEPROM_WRITE);
         captureSnapshot(savedSnapshot);

--- a/test/js/ports_feature_port.test.js
+++ b/test/js/ports_feature_port.test.js
@@ -7,12 +7,7 @@ import MSPCodes from "../../src/js/msp/MSPCodes";
 import { API_VERSION_1_48, API_VERSION_1_49 } from "../../src/js/data_storage";
 import { GPS_BAUD_RATES } from "../../src/composables/ports/featureBaudRates";
 import { PORT_NONE } from "../../src/composables/ports/portNames";
-import {
-    buildBaudOptions,
-    buildPortOptions,
-    findFeaturePortIdentifier,
-    useFeaturePort,
-} from "../../src/composables/ports/useFeaturePort";
+import { buildBaudOptions, buildPortOptions, useFeaturePort } from "../../src/composables/ports/useFeaturePort";
 
 vi.mock("../../src/js/localization", () => ({
     __esModule: true,
@@ -30,32 +25,6 @@ const ports = [
     { identifier: 51, functions: [] },
     { identifier: 53, functions: ["RX_SERIAL"] },
 ];
-
-describe("findFeaturePortIdentifier", () => {
-    it("finds the port the feature is assigned to", () => {
-        expect(findFeaturePortIdentifier(ports, "RX_SERIAL")).toBe(53);
-        expect(findFeaturePortIdentifier(ports, "MSP")).toBe(20);
-    });
-
-    it("reports no port when the feature is unassigned", () => {
-        expect(findFeaturePortIdentifier(ports, "GPS")).toBe(PORT_NONE);
-    });
-
-    it("survives a port list the FC has not filled in", () => {
-        expect(findFeaturePortIdentifier([], "RX_SERIAL")).toBe(PORT_NONE);
-        expect(findFeaturePortIdentifier(undefined, "RX_SERIAL")).toBe(PORT_NONE);
-        expect(findFeaturePortIdentifier([{ identifier: 51 }], "RX_SERIAL")).toBe(PORT_NONE);
-    });
-
-    it("takes the first claimant when two ports carry the function", () => {
-        const duplicated = [
-            { identifier: 51, functions: ["RX_SERIAL"] },
-            { identifier: 53, functions: ["RX_SERIAL"] },
-        ];
-
-        expect(findFeaturePortIdentifier(duplicated, "RX_SERIAL")).toBe(51);
-    });
-});
 
 describe("buildPortOptions", () => {
     const options = () => buildPortOptions(ports, { functionName: "RX_SERIAL", noneLabel: "None" });
@@ -107,8 +76,17 @@ describe("buildPortOptions", () => {
 describe("useFeaturePort", () => {
     let scope;
     let port;
+    let replies;
 
-    function withApiVersion(apiVersion) {
+    // A `get` for a setting the firmware was not built with is refused; a `set` just succeeds.
+    function reply(command) {
+        if (replies[command]) {
+            return replies[command];
+        }
+        return command.startsWith("get ") ? ["###ERROR IN get: INVALID NAME###"] : [];
+    }
+
+    function withFeature(options, apiVersion = API_VERSION_1_49) {
         FC.CONFIG.apiVersion = apiVersion;
         FC.CONFIG.flightControllerVersion = "4.6.0";
         FC.SERIAL_CONFIG = { ports: [...ports] };
@@ -116,17 +94,18 @@ describe("useFeaturePort", () => {
         scope?.stop();
         scope = effectScope();
         scope.run(() => {
-            port = useFeaturePort({ setting: "rx_uart", functionName: "RX_SERIAL" });
+            port = useFeaturePort(options);
         });
     }
 
     beforeEach(() => {
         setActivePinia(createPinia());
         FC.resetState();
+        replies = { "get rx_uart": ["rx_uart = UART3"] };
         cliSend.mockReset();
-        cliSend.mockResolvedValue([]);
+        cliSend.mockImplementation((command) => Promise.resolve(reply(command)));
         vi.spyOn(MSP, "promise").mockResolvedValue(undefined);
-        withApiVersion(API_VERSION_1_49);
+        withFeature({ setting: "rx_uart", functionName: "RX_SERIAL" });
     });
 
     afterEach(() => {
@@ -136,7 +115,7 @@ describe("useFeaturePort", () => {
     });
 
     it("does nothing on firmware that still owns the port through the mask", async () => {
-        withApiVersion(API_VERSION_1_48);
+        withFeature({ setting: "rx_uart", functionName: "RX_SERIAL" }, API_VERSION_1_48);
 
         expect(port.available.value).toBe(false);
 
@@ -148,12 +127,40 @@ describe("useFeaturePort", () => {
         expect(cliSend).not.toHaveBeenCalled();
     });
 
-    it("reads the current assignment out of the serial config", async () => {
+    it("reads the port from the feature's own setting, not from the mask", async () => {
+        // the mask would answer 53 for RX_SERIAL either way, so point the setting somewhere else
+        replies["get rx_uart"] = ["rx_uart = UART1"];
+
         await port.load();
 
         expect(MSP.promise).toHaveBeenCalledWith(MSPCodes.MSP2_COMMON_SERIAL_CONFIG);
-        expect(port.selectedIdentifier.value).toBe(53);
+        expect(cliSend).toHaveBeenCalledWith("get rx_uart");
+        expect(port.selectedIdentifier.value).toBe(51);
         expect(port.changed.value).toBe(false);
+    });
+
+    it("resolves the port name against the ports this board reported", async () => {
+        // UART3 is both identifier 2 and 53; only the reported list settles which
+        await port.load();
+
+        expect(port.selectedIdentifier.value).toBe(53);
+    });
+
+    it("reads an unassigned feature as no port", async () => {
+        replies["get rx_uart"] = ["rx_uart = NONE"];
+
+        await port.load();
+
+        expect(port.selectedIdentifier.value).toBe(PORT_NONE);
+    });
+
+    it("reports itself unsupported when the build has no such setting", async () => {
+        withFeature({ setting: "msp_uart_3", functionName: "MSP" });
+
+        await port.load();
+
+        expect(port.supported.value).toBe(false);
+        expect(port.available.value).toBe(false);
     });
 
     it("writes the selection as a CLI set and settles the dirty state", async () => {
@@ -179,6 +186,7 @@ describe("useFeaturePort", () => {
 
     it("writes nothing when the selection has not moved", async () => {
         await port.load();
+        cliSend.mockClear();
 
         await port.write();
 
@@ -186,13 +194,84 @@ describe("useFeaturePort", () => {
     });
 
     it("keeps the change pending when the firmware rejects the set", async () => {
-        cliSend.mockResolvedValue(["###ERROR: invalid name###"]);
-
         await port.load();
         port.selectedIdentifier.value = 51;
+        cliSend.mockResolvedValue(["###ERROR IN set: INVALID NAME###"]);
 
         await expect(port.write()).rejects.toThrow(/ERROR/);
         expect(port.changed.value).toBe(true);
+    });
+
+    it("offers the baud rates the firmware prints when the feature has no curated list", async () => {
+        replies = {
+            "get blackbox_uart": ["blackbox_uart = UART3"],
+            "get blackbox_baud": [
+                "blackbox_baud = 115200",
+                "Allowed values: AUTO, 9600, 115200, 230400",
+                "Default value: AUTO",
+            ],
+        };
+        withFeature({ setting: "blackbox_uart", functionName: "BLACKBOX", baud: { setting: "blackbox_baud" } });
+
+        await port.load();
+
+        expect(port.selectedBaud.value).toBe("115200");
+        expect(port.baudOptions.value.map((option) => option.value)).toEqual(["AUTO", "9600", "115200", "230400"]);
+    });
+
+    it("keeps a curated rate list rather than the firmware's", async () => {
+        replies = {
+            "get gps_uart": ["gps_uart = UART3"],
+            "get gps_baud": ["gps_baud = 57600", "Allowed values: AUTO, 9600, 57600"],
+        };
+        withFeature({
+            setting: "gps_uart",
+            functionName: "GPS",
+            baud: { setting: "gps_baud", rates: GPS_BAUD_RATES },
+        });
+
+        await port.load();
+
+        expect(port.baudOptions.value.map((option) => option.value)).not.toContain("AUTO");
+    });
+
+    it("carries a protocol beside the port and writes it first", async () => {
+        replies = {
+            "get telemetry_1_uart": ["telemetry_1_uart = UART3"],
+            "get telemetry_1_baud": ["telemetry_1_baud = AUTO", "Allowed values: AUTO, 115200"],
+            "get telemetry_1_protocol": [
+                "telemetry_1_protocol = SMARTPORT",
+                "Allowed values: NONE, FRSKY_HUB, SMARTPORT, MAVLINK",
+            ],
+        };
+        withFeature({
+            setting: "telemetry_1_uart",
+            functionName: ["TELEMETRY_SMARTPORT", "TELEMETRY_MAVLINK"],
+            baud: { setting: "telemetry_1_baud" },
+            protocol: { setting: "telemetry_1_protocol" },
+        });
+
+        await port.load();
+
+        expect(port.selectedProtocol.value).toBe("SMARTPORT");
+        expect(port.protocolOptions.value.map((option) => option.value)).toContain("MAVLINK");
+
+        port.selectedProtocol.value = "MAVLINK";
+        port.selectedIdentifier.value = 51;
+        cliSend.mockClear();
+
+        await port.write();
+
+        const sent = cliSend.mock.calls.map((call) => call[0]);
+        expect(sent).toEqual(["set telemetry_1_protocol = MAVLINK", "set telemetry_1_uart = UART1"]);
+    });
+
+    it("leaves a shared bit off its own annotations for every protocol it may claim", async () => {
+        const labels = buildPortOptions([{ identifier: 53, functions: ["TELEMETRY_SMARTPORT"] }], {
+            functionName: ["TELEMETRY_SMARTPORT", "TELEMETRY_MAVLINK"],
+        }).map((option) => option.label);
+
+        expect(labels).toContain("UART3");
     });
 });
 

--- a/test/js/ports_feature_port.test.js
+++ b/test/js/ports_feature_port.test.js
@@ -163,6 +163,18 @@ describe("useFeaturePort", () => {
         expect(port.available.value).toBe(false);
     });
 
+    it("writes nothing for an instance the build does not have", async () => {
+        // the tabs loop write() over all three instances, so an absent one has to be inert
+        withFeature({ setting: "msp_uart_3", functionName: "MSP", baud: { setting: "msp_baud_3" } });
+
+        await port.load();
+        expect(port.supported.value).toBe(false);
+
+        cliSend.mockClear();
+        await expect(port.write()).resolves.toBeUndefined();
+        expect(cliSend).not.toHaveBeenCalled();
+    });
+
     it("writes the selection as a CLI set and settles the dirty state", async () => {
         await port.load();
         port.selectedIdentifier.value = 51;

--- a/test/js/ports_port_names.test.js
+++ b/test/js/ports_port_names.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
     PORT_NONE,
+    findPortIdentifierByCliName,
     formatPortSetCommand,
     getPortCliName,
     getPortDisplayName,
@@ -53,5 +54,43 @@ describe("port names", () => {
 
     it("refuses to fall back to the raw identifier, which the firmware would reject", () => {
         expect(() => formatPortSetCommand("rx_uart", 99)).toThrow(/99/);
+    });
+});
+
+describe("findPortIdentifierByCliName", () => {
+    // UART3 is identifier 2 in the legacy block and 53 in the current one; only the ports the FC
+    // reported say which block this board populates.
+    const legacy = [{ identifier: 2 }, { identifier: 20 }];
+    const current = [{ identifier: 53 }, { identifier: 20 }];
+
+    it("resolves an ambiguous UART name against the board's own ports", () => {
+        expect(findPortIdentifierByCliName(legacy, "UART3")).toBe(2);
+        expect(findPortIdentifierByCliName(current, "UART3")).toBe(53);
+    });
+
+    it("reads NONE and an empty reply as unassigned", () => {
+        expect(findPortIdentifierByCliName(current, "NONE")).toBe(PORT_NONE);
+        expect(findPortIdentifierByCliName(current, null)).toBe(PORT_NONE);
+        expect(findPortIdentifierByCliName(current, "")).toBe(PORT_NONE);
+    });
+
+    it("is case and whitespace insensitive, as the CLI is", () => {
+        expect(findPortIdentifierByCliName(current, " uart3 ")).toBe(53);
+    });
+
+    it("resolves an unambiguous name the board did not report", () => {
+        expect(findPortIdentifierByCliName([], "VCP")).toBe(20);
+        expect(findPortIdentifierByCliName([], "SOFTSERIAL2")).toBe(31);
+    });
+
+    it("reads an unreported ambiguous name as unassigned rather than guessing a block", () => {
+        expect(findPortIdentifierByCliName([], "UART3")).toBe(PORT_NONE);
+    });
+
+    it("round trips every name it can build a command from", () => {
+        for (const identifier of [2, 20, 31, 40, 53, 65, 70]) {
+            const name = getPortCliName(identifier);
+            expect(findPortIdentifierByCliName([{ identifier }], name)).toBe(identifier);
+        }
     });
 });


### PR DESCRIPTION
Completes the app half of the per-feature serial port migration. Firmware master is at API 1.49 with all 17 `*_uart` settings, and the ports tab is read-only from 1.49, so until this lands only RX and GPS can be assigned from the GUI at all.

**Stacked on #5451** (the GPS re-land), which carries the baud axis this depends on. Retarget to master once that merges. Worth squash-merging #5451 and this in order rather than merging this into #5451's branch, which is how the last stack got stranded.

What goes where: blackbox on Onboard Logging, OSD and its custom text on OSD, VTX on VTX, ESC telemetry on Motors, rangefinder and optical flow on Sensors, telemetry 1-3 and camera control on Receiver, MSP 1-3 in a new section on Ports. `gimbal_uart` stays CLI only.

The read path had to change. `useFeaturePort` previously reversed the synthesised function mask, which works for RX and GPS but not for most of the rest: the three MSP and three telemetry instances each share a bit, a rangefinder and an optical flow sensor share `FUNCTION_LIDAR`, a VTX sets a bit chosen by its protocol, and an OSD on MSP DisplayPort sets no bit at all. Every feature now reads its own setting and resolves the returned name against the ports the FC reported, which is what settles the two UART identifier blocks sharing their names. The mask stays as the source of the port list and its claimed-by annotations.

That read also reports whether the build has the setting, so an absent MSP or telemetry instance renders as unsupported instead of erroring. `MAX_MSP_PORT_COUNT` and `MAX_TELEMETRY_PROVIDERS` never reach the app.

A lookup setting prints the values it accepts, so the app offers those rather than carrying a copy of the firmware's baud table. GPS keeps its curated list, which is deliberately narrower than what the firmware allows.

Two things reviewers should look at. RX and GPS moved onto the new read path as well: the read lives in the shared composable, so leaving them behind meant two code paths in one place. And `MSP_SET_FEATURE_CONFIG` on the receiver tab moved out of the reboot-only branch, because the TELEMETRY switch lives there and a mask change on a no-reboot save was never reaching the FC.

`findFeaturePortIdentifier` is deleted: once nothing read the mask for an assignment it had no production consumer, since the ports tab reads `port.functions` directly.

Not verified on hardware or SITL. Unit tests, lint and build only.