### PR TITLE
Fix typed blackbox curve min/max values below the step

### DIFF
--- a/src/blackbox-viewer/components/GraphConfigDialog.vue
+++ b/src/blackbox-viewer/components/GraphConfigDialog.vue
@@ -191,6 +191,7 @@
                                         <UInputNumber
                                             :model-value="field.curve?.MinMax?.min ?? -500"
                                             :step="field.curve?.highPrecise ? smallMinMaxStep : normalMinMaxStep"
+                                            :step-snapping="false"
                                             :class="{ italic: field.curve?.highPrecise }"
                                             :format-options="noGrouping"
                                             size="xs"
@@ -215,6 +216,7 @@
                                         <UInputNumber
                                             :model-value="field.curve?.MinMax?.max ?? 500"
                                             :step="field.curve?.highPrecise ? smallMinMaxStep : normalMinMaxStep"
+                                            :step-snapping="false"
                                             :class="{ italic: field.curve?.highPrecise }"
                                             :format-options="noGrouping"
                                             size="xs"
@@ -582,19 +584,22 @@ function onFieldChange(graph, field) {
     } else {
         // Apply defaults for the selected field
         const defaults = getDefaults(field.name);
+        const minMax = { ...defaults.MinMax };
         field.smoothing = defaults.smoothing;
-        field.curve = { power: defaults.power, MinMax: { ...defaults.MinMax } };
+        field.curve = { power: defaults.power, MinMax: minMax, highPrecise: isHighPrecise(minMax) };
     }
 }
 
 function makeField(name, existing, color) {
     const defaults = getDefaults(name);
+    const minMax = existing?.curve?.MinMax ? { ...existing.curve.MinMax } : { ...defaults.MinMax };
     return {
         name,
         smoothing: existing?.smoothing ?? defaults.smoothing,
         curve: {
             power: existing?.curve?.power ?? defaults.power,
-            MinMax: existing?.curve?.MinMax ? { ...existing.curve.MinMax } : { ...defaults.MinMax },
+            MinMax: minMax,
+            highPrecise: isHighPrecise(minMax),
         },
         color: color || existing?.color || palette[0].color,
         lineWidth: existing?.lineWidth ?? 1,
@@ -704,13 +709,19 @@ watch(open, (val) => {
 const normalMinMaxStep = 10;
 const smallMinMaxStep = 0.1;
 
+function isHighPrecise(minMax) {
+    if (!Number.isFinite(minMax?.min) || !Number.isFinite(minMax?.max)) {
+        return false;
+    }
+    return minMax.min % normalMinMaxStep !== 0 || minMax.max % normalMinMaxStep !== 0;
+}
+
 function defineFieldsResolution() {
     for (const graph of localGraphs.value) {
         for (const field of graph.fields) {
-            const min = field?.curve?.MinMax?.min;
-            const max = field?.curve?.MinMax?.max;
-            if (min != null && max != null) {
-                field.curve.highPrecise = min % normalMinMaxStep !== 0 || max % normalMinMaxStep !== 0;
+            const minMax = field?.curve?.MinMax;
+            if (minMax?.min != null && minMax?.max != null) {
+                field.curve.highPrecise = isHighPrecise(minMax);
             }
         }
     }

--- a/test/js/blackbox_minmax_step.test.js
+++ b/test/js/blackbox_minmax_step.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { createApp, h, nextTick, ref } from "vue";
+import { NumberFieldInput, NumberFieldRoot } from "reka-ui";
+
+// The blackbox graph config dialog sets a coarse step of 10 on the curve min/max inputs so the
+// spinner moves in useful jumps. reka-ui snaps typed values onto that step unless snapping is
+// turned off, which silently rewrote anything finer: typing 5 landed on 10, and 3 landed on 0.
+// UInputNumber only forwards stepSnapping when it is passed explicitly, because the prop has no
+// default of its own, so leaving it off means reka's default of true applies. Pinned here because
+// a dependency bump could quietly bring the snapping back.
+async function commitTypedValue(rootProps, typed) {
+    const model = ref(rootProps.modelValue);
+    const app = createApp({
+        render: () =>
+            h(
+                NumberFieldRoot,
+                {
+                    ...rootProps,
+                    modelValue: model.value,
+                    "onUpdate:modelValue": (value) => {
+                        model.value = value;
+                    },
+                },
+                () => h(NumberFieldInput),
+            ),
+    });
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    app.mount(host);
+    await nextTick();
+
+    const input = host.querySelector("input");
+    input.value = String(typed);
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    await nextTick();
+
+    const committed = model.value;
+    app.unmount();
+    host.remove();
+    return committed;
+}
+
+const COARSE_STEP = 10;
+const FINE_STEP = 0.1;
+
+describe("blackbox curve min/max inputs", () => {
+    it("keeps a typed value finer than the coarse step", async () => {
+        expect(await commitTypedValue({ modelValue: -50, step: COARSE_STEP, stepSnapping: false }, 5)).toBe(5);
+        expect(await commitTypedValue({ modelValue: -50, step: COARSE_STEP, stepSnapping: false }, 3)).toBe(3);
+        expect(await commitTypedValue({ modelValue: -50, step: COARSE_STEP, stepSnapping: false }, 2.5)).toBe(2.5);
+        expect(await commitTypedValue({ modelValue: 50, step: COARSE_STEP, stepSnapping: false }, -5)).toBe(-5);
+    });
+
+    it("would round the same values away with snapping left on", async () => {
+        expect(await commitTypedValue({ modelValue: -50, step: COARSE_STEP }, 5)).toBe(10);
+        expect(await commitTypedValue({ modelValue: -50, step: COARSE_STEP }, 3)).toBe(0);
+    });
+
+    it("leaves the fine step alone either way", async () => {
+        expect(await commitTypedValue({ modelValue: -50, step: FINE_STEP, stepSnapping: false }, 2.5)).toBe(2.5);
+        expect(await commitTypedValue({ modelValue: -50, step: FINE_STEP }, 2.5)).toBe(2.5);
+    });
+});


### PR DESCRIPTION
The curve min/max inputs in the blackbox graph config carry a step of 10 so the spinner moves in useful jumps, but reka-ui snaps typed values onto the step unless snapping is explicitly turned off. Typing 5 landed on 10 and 3 landed on 0, so the scale could not be set any finer than the step. Setting the values through the context menu instead, "make all fields like this one" and friends, writes straight to the field and skips the input, which is why the two disagreed.

The reason it was on at all is subtle: `UInputNumber` declares `stepSnapping` with no default of its own, and `useComponentProps` only returns a value for props that were actually passed, so leaving it off means reka's own default of `true` applies.

Separately, a field's step was only resolved when the dialog opened, so anything picked from the field dropdown afterwards kept the coarse step and no italic hint no matter what its range was. Barometer is an easy one to hit that way. The resolution rule now lives in one place and is applied wherever a curve gets built.

The test pins the reka behaviour the fix relies on, in both directions, so a dependency bump can't quietly bring the snapping back.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Min/max values in graph configuration now preserve user-entered precision when they fall between standard step increments.
  - Component step snapping is disabled when needed, preventing unintended rounding of precise boundary values.
  - Graph curve precision is automatically enabled when configured bounds require it.
  - Invalid or non-finite min/max values are handled safely during precision detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->