### PR TITLE
RPM filter weights are added into config data

### DIFF
--- a/src/blackbox-viewer/components/HeaderDialog.vue
+++ b/src/blackbox-viewer/components/HeaderDialog.vue
@@ -684,10 +684,10 @@ const rpmFilterParams = computed(() => {
     }
     return [
         param("Harmonics", fmtVal(s.gyro_rpm_notch_harmonics, 0)),
+        param("Weights", s.rpm_filter_weights ? String(s.rpm_filter_weights) : null),
         param("Q", fmtVal(s.gyro_rpm_notch_q, 0)),
         param("Min Hz", fmtVal(s.gyro_rpm_notch_min, 0)),
         param("Fade Range Hz", fmtVal(s.rpm_filter_fade_range_hz, 0)),
-        param("Weights", s.rpm_filter_weights ? String(s.rpm_filter_weights) : null),
         param("Notch LPF", fmtVal(s.rpm_notch_lpf, 0)),
         param("D-Term Harmonics", fmtVal(s.dterm_rpm_notch_harmonics, 0)),
         param("D-Term Q", fmtVal(s.dterm_rpm_notch_q, 0)),

--- a/src/blackbox-viewer/flightlog_parser.js
+++ b/src/blackbox-viewer/flightlog_parser.js
@@ -409,6 +409,7 @@ export function FlightLogParser(logData) {
         rc_smoothing_rx_smoothed: null,
         dyn_notch_count: null, // Number of dynamic notches 4.3
         rpm_filter_fade_range_hz: null, // Fade range for RPM notch filters in Hz
+        rpm_filter_weights: null, // RPM filter weights as simple string
         dyn_idle_p_gain: null,
         dyn_idle_i_gain: null,
         dyn_idle_d_gain: null,
@@ -774,6 +775,7 @@ export function FlightLogParser(logData) {
         "chirp_frequency_end_deci_hz",
         "chirp_time_seconds",
         "dterm_lpf_dyn_hz",
+        "rpm_filter_weights",
     ]);
 
     // Fields where parseInt value is divided by 100 on older firmware, raw on newer


### PR DESCRIPTION
RPM filter weights are added into config data to show it at the log header parameters table.
These data are useful by tuning filters.
<img width="365" height="356" alt="rpm_weights" src="https://github.com/user-attachments/assets/99fbea51-4619-4b61-91da-672a0ec1edb5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reading RPM filter weight settings from flight logs.
  * Added RPM filter weights to the displayed system configuration.
  * Reordered RPM filter settings so “Weights” appears prominently near the top of the list.

* **Bug Fixes**
  * Improved consistency between RPM filter settings available in parsed logs and those shown in the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->