### PR TITLE
Allow the blackbox legend list to scroll on unmodified wheel

### DIFF
--- a/src/blackbox-viewer/components/LegendPanel.vue
+++ b/src/blackbox-viewer/components/LegendPanel.vue
@@ -39,7 +39,7 @@
                     class="graph-legend-group"
                     @click="onGraphClick($event, gi)"
                     @mousedown.middle.prevent="onResetPen(gi, null)"
-                    @wheel.prevent="onFieldWheel($event, gi, null)"
+                    @wheel="onFieldWheel($event, gi, null)"
                 >
                     <UIcon name="i-lucide-trash-2" class="size-3.5 mr-1 inline-block align-middle" />
                     {{ graph.label }}
@@ -54,7 +54,7 @@
                         @mouseenter="onFieldHover(gi, fi)"
                         @mouseleave="onFieldLeave"
                         @mousedown.middle.prevent="onResetPen(gi, fi)"
-                        @wheel.prevent="onFieldWheel($event, gi, fi)"
+                        @wheel="onFieldWheel($event, gi, fi)"
                     >
                         <span class="graph-legend-field-name" @click="onFieldClick($event, gi, fi, field)">{{
                             field.friendlyName
@@ -309,10 +309,13 @@ function onResetPen(gi, fi) {
 }
 
 function onFieldWheel(e, gi, fi) {
-    if (e.shiftKey || e.altKey || e.ctrlKey) {
-        const delta = e.deltaY < 0 ? 1 : -1;
-        graphStore.fieldWheel?.(gi, fi, delta, e.shiftKey, e.altKey, e.ctrlKey);
+    // Without a modifier key the wheel scrolls the legend list natively.
+    if (!e.shiftKey && !e.altKey && !e.ctrlKey) {
+        return;
     }
+    e.preventDefault();
+    const delta = e.deltaY < 0 ? 1 : -1;
+    graphStore.fieldWheel?.(gi, fi, delta, e.shiftKey, e.altKey, e.ctrlKey);
 }
 
 // --- Override toggles ---


### PR DESCRIPTION
### Description

The legend wheel handlers in `LegendPanel.vue` used `@wheel.prevent`, which swallowed *every* wheel event over the graph titles and fields — including unmodified ones. Because `.log-graph-legend` is an `overflow-y: auto` container, that meant the legend list could never be scrolled when more graphs were configured than fit the panel.

`onFieldWheel` now calls `preventDefault()` itself, and only when Shift, Alt or Ctrl is held — i.e. when the wheel is actually adjusting the pen. Without a modifier the event falls through to the browser and scrolls the legend natively.

Modifier behaviour (Shift / Alt / Ctrl + wheel to adjust pen scale/offset) is unchanged.

### Testing

Load a log with enough graphs configured to overflow the legend panel:

- Wheel with no modifier over a graph title or field → the legend list scrolls.
- Shift / Alt / Ctrl + wheel → pen adjustment as before, page does not scroll.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved legend panel scrolling behavior.
  * Standard mouse-wheel scrolling now works naturally, while modifier-key scrolling continues to adjust field values without scrolling the page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->