### PR TITLE
Scale the blackbox curve spinner step to the curve

### DIFF
--- a/src/blackbox-viewer/components/GraphConfigDialog.vue
+++ b/src/blackbox-viewer/components/GraphConfigDialog.vue
@@ -289,7 +289,7 @@ import Sortable from "sortablejs";
 import UiBox from "./UiBox.vue";
 import { GraphConfig } from "../graph_config.js";
 import { FlightLogFieldPresenter } from "../flightlog_fields_presenter.js";
-import { coarseMinMaxStep, FINE_MIN_MAX_STEP } from "../curve_step.js";
+import { coarseMinMaxStep, FINE_MIN_MAX_STEP, needsFineStep } from "../curve_step.js";
 
 const open = defineModel("open", { type: Boolean, default: false });
 
@@ -595,7 +595,7 @@ function onFieldChange(graph, field) {
         const defaults = getDefaults(field.name);
         const minMax = { ...defaults.MinMax };
         field.smoothing = defaults.smoothing;
-        field.curve = { power: defaults.power, MinMax: minMax, highPrecise: isHighPrecise(minMax) };
+        field.curve = { power: defaults.power, MinMax: minMax, highPrecise: needsFineStep(minMax) };
     }
 }
 
@@ -608,7 +608,7 @@ function makeField(name, existing, color) {
         curve: {
             power: existing?.curve?.power ?? defaults.power,
             MinMax: minMax,
-            highPrecise: isHighPrecise(minMax),
+            highPrecise: needsFineStep(minMax),
         },
         color: color || existing?.color || palette[0].color,
         lineWidth: existing?.lineWidth ?? 1,
@@ -715,20 +715,12 @@ watch(open, (val) => {
 // The spinner step follows the size of the curve, see coarseMinMaxStep. Ctrl forces the fine step
 // for a field, and those inputs are shown in italics.
 
-function isHighPrecise(minMax) {
-    if (!Number.isFinite(minMax?.min) || !Number.isFinite(minMax?.max)) {
-        return false;
-    }
-    const step = coarseMinMaxStep(minMax);
-    return minMax.min % step !== 0 || minMax.max % step !== 0;
-}
-
 function defineFieldsResolution() {
     for (const graph of localGraphs.value) {
         for (const field of graph.fields) {
             const minMax = field?.curve?.MinMax;
             if (minMax?.min != null && minMax?.max != null) {
-                field.curve.highPrecise = isHighPrecise(minMax);
+                field.curve.highPrecise = needsFineStep(minMax);
             }
         }
     }

--- a/src/blackbox-viewer/components/GraphConfigDialog.vue
+++ b/src/blackbox-viewer/components/GraphConfigDialog.vue
@@ -190,7 +190,11 @@
                                     <div style="display: contents" @contextmenu="(e) => onContextMenu(e, graph, field)">
                                         <UInputNumber
                                             :model-value="field.curve?.MinMax?.min ?? -500"
-                                            :step="field.curve?.highPrecise ? smallMinMaxStep : normalMinMaxStep"
+                                            :step="
+                                                field.curve?.highPrecise
+                                                    ? FINE_MIN_MAX_STEP
+                                                    : coarseMinMaxStep(field.curve?.MinMax)
+                                            "
                                             :step-snapping="false"
                                             :class="{ italic: field.curve?.highPrecise }"
                                             :format-options="noGrouping"
@@ -215,7 +219,11 @@
                                         />
                                         <UInputNumber
                                             :model-value="field.curve?.MinMax?.max ?? 500"
-                                            :step="field.curve?.highPrecise ? smallMinMaxStep : normalMinMaxStep"
+                                            :step="
+                                                field.curve?.highPrecise
+                                                    ? FINE_MIN_MAX_STEP
+                                                    : coarseMinMaxStep(field.curve?.MinMax)
+                                            "
                                             :step-snapping="false"
                                             :class="{ italic: field.curve?.highPrecise }"
                                             :format-options="noGrouping"
@@ -281,6 +289,7 @@ import Sortable from "sortablejs";
 import UiBox from "./UiBox.vue";
 import { GraphConfig } from "../graph_config.js";
 import { FlightLogFieldPresenter } from "../flightlog_fields_presenter.js";
+import { coarseMinMaxStep, FINE_MIN_MAX_STEP } from "../curve_step.js";
 
 const open = defineModel("open", { type: Boolean, default: false });
 
@@ -703,17 +712,15 @@ watch(open, (val) => {
     }
 });
 
-// Set curves min-max values changes step. Switch between normal 10 or precesion 0.1 step by using Ctrl key.
-// The precesion value input has italic font.
-
-const normalMinMaxStep = 10;
-const smallMinMaxStep = 0.1;
+// The spinner step follows the size of the curve, see coarseMinMaxStep. Ctrl forces the fine step
+// for a field, and those inputs are shown in italics.
 
 function isHighPrecise(minMax) {
     if (!Number.isFinite(minMax?.min) || !Number.isFinite(minMax?.max)) {
         return false;
     }
-    return minMax.min % normalMinMaxStep !== 0 || minMax.max % normalMinMaxStep !== 0;
+    const step = coarseMinMaxStep(minMax);
+    return minMax.min % step !== 0 || minMax.max % step !== 0;
 }
 
 function defineFieldsResolution() {

--- a/src/blackbox-viewer/curve_step.js
+++ b/src/blackbox-viewer/curve_step.js
@@ -1,0 +1,27 @@
+// The curve min/max spinners used a fixed increment of 10, which is unusable once a field is
+// scaled to a small range: stepping a +/-10 velocity curve in tens only ever reaches 0 or 20.
+// The coarse step follows the size of the range instead, and Ctrl still forces the fine step.
+
+export const FINE_MIN_MAX_STEP = 0.1;
+
+/**
+ * Spinner increment for a curve whose bounds span the given range.
+ *
+ * @param {{min: number, max: number}} minMax Curve bounds.
+ * @returns {number} Increment to step the bounds by.
+ */
+export function coarseMinMaxStep(minMax) {
+    // Missing bounds show as the +/-500 placeholder, which wants the widest step.
+    if (!Number.isFinite(minMax?.min) || !Number.isFinite(minMax?.max)) {
+        return 10;
+    }
+
+    const span = Math.abs(minMax.max - minMax.min);
+    if (span >= 100) {
+        return 10;
+    }
+    if (span >= 10) {
+        return 1;
+    }
+    return FINE_MIN_MAX_STEP;
+}

--- a/src/blackbox-viewer/curve_step.js
+++ b/src/blackbox-viewer/curve_step.js
@@ -7,7 +7,8 @@ export const FINE_MIN_MAX_STEP = 0.1;
 /**
  * Spinner increment for a curve whose bounds span the given range.
  *
- * @param {{min: number, max: number}} minMax Curve bounds.
+ * @param {{min?: number, max?: number}} [minMax] Curve bounds, which may be absent or unset while a
+ *     field is still being picked.
  * @returns {number} Increment to step the bounds by.
  */
 export function coarseMinMaxStep(minMax) {
@@ -24,4 +25,36 @@ export function coarseMinMaxStep(minMax) {
         return 1;
     }
     return FINE_MIN_MAX_STEP;
+}
+
+/**
+ * Whether a bound sits on a whole multiple of the step.
+ *
+ * Compares the quotient rather than taking a remainder: 0.3 % 0.1 is 0.09999999999999998, so a
+ * remainder test rejects bounds that are perfectly well aligned.
+ *
+ * @param {number} value Bound to check.
+ * @param {number} step Increment it should sit on.
+ * @returns {boolean} True when the bound lands on the step.
+ */
+function isAlignedToStep(value, step) {
+    const quotient = value / step;
+    const tolerance = 1e-9 * Math.max(1, Math.abs(quotient));
+    return Math.abs(quotient - Math.round(quotient)) <= tolerance;
+}
+
+/**
+ * Whether a curve wants the fine step, because a bound falls between two coarse steps and could
+ * not otherwise be reached. Inputs in this state are shown in italics.
+ *
+ * @param {{min?: number, max?: number}} [minMax] Curve bounds.
+ * @returns {boolean} True when the coarse step cannot express the bounds.
+ */
+export function needsFineStep(minMax) {
+    if (!Number.isFinite(minMax?.min) || !Number.isFinite(minMax?.max)) {
+        return false;
+    }
+
+    const step = coarseMinMaxStep(minMax);
+    return !isAlignedToStep(minMax.min, step) || !isAlignedToStep(minMax.max, step);
 }

--- a/src/blackbox-viewer/curve_step.js
+++ b/src/blackbox-viewer/curve_step.js
@@ -39,7 +39,10 @@ export function coarseMinMaxStep(minMax) {
  */
 function isAlignedToStep(value, step) {
     const quotient = value / step;
-    const tolerance = 1e-9 * Math.max(1, Math.abs(quotient));
+    // One ULP of the quotient. A fixed tolerance would be far too generous at large bounds: at a
+    // quotient near 1e12 an absolute 1e-9 slack works out to about 1000, which would swallow bounds
+    // that are a whole step out. Measured worst case for genuinely aligned bounds is 0.8 ULP.
+    const tolerance = Number.EPSILON * Math.max(1, Math.abs(quotient));
     return Math.abs(quotient - Math.round(quotient)) <= tolerance;
 }
 

--- a/test/js/blackbox_curve_step.test.js
+++ b/test/js/blackbox_curve_step.test.js
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { coarseMinMaxStep, FINE_MIN_MAX_STEP } from "../../src/blackbox-viewer/curve_step.js";
+
+describe("curve min/max spinner step", () => {
+    it("keeps tens for wide ranges", () => {
+        expect(coarseMinMaxStep({ min: -500, max: 500 })).toBe(10);
+        expect(coarseMinMaxStep({ min: 0, max: 4000 })).toBe(10);
+        expect(coarseMinMaxStep({ min: -50, max: 50 })).toBe(10);
+    });
+
+    it("drops to ones where tens would overshoot the range", () => {
+        // The autopilot velocity curves sit at +/-10, where a step of 10 only reaches 0 or 20.
+        expect(coarseMinMaxStep({ min: -10, max: 10 })).toBe(1);
+        expect(coarseMinMaxStep({ min: -5, max: 5 })).toBe(1);
+        expect(coarseMinMaxStep({ min: 0, max: 20 })).toBe(1);
+    });
+
+    it("drops to the fine step for very small ranges", () => {
+        expect(coarseMinMaxStep({ min: -2, max: 2 })).toBe(FINE_MIN_MAX_STEP);
+        expect(coarseMinMaxStep({ min: 0, max: 1 })).toBe(FINE_MIN_MAX_STEP);
+    });
+
+    it("falls back to tens when the bounds are missing or not finite", () => {
+        expect(coarseMinMaxStep(undefined)).toBe(10);
+        expect(coarseMinMaxStep({})).toBe(10);
+        expect(coarseMinMaxStep({ min: Number.NaN, max: 10 })).toBe(10);
+    });
+});

--- a/test/js/blackbox_curve_step.test.js
+++ b/test/js/blackbox_curve_step.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { coarseMinMaxStep, FINE_MIN_MAX_STEP } from "../../src/blackbox-viewer/curve_step.js";
+import { coarseMinMaxStep, FINE_MIN_MAX_STEP, needsFineStep } from "../../src/blackbox-viewer/curve_step.js";
 
 describe("curve min/max spinner step", () => {
     it("keeps tens for wide ranges", () => {
@@ -24,5 +24,37 @@ describe("curve min/max spinner step", () => {
         expect(coarseMinMaxStep(undefined)).toBe(10);
         expect(coarseMinMaxStep({})).toBe(10);
         expect(coarseMinMaxStep({ min: Number.NaN, max: 10 })).toBe(10);
+    });
+});
+
+describe("curve min/max fine step", () => {
+    it("leaves bounds that sit on the coarse step alone", () => {
+        expect(needsFineStep({ min: -500, max: 500 })).toBe(false);
+        expect(needsFineStep({ min: -10, max: 10 })).toBe(false);
+        expect(needsFineStep({ min: 0, max: 4000 })).toBe(false);
+    });
+
+    it("asks for the fine step when a bound falls between two coarse steps", () => {
+        expect(needsFineStep({ min: -15.5, max: 15.5 })).toBe(true);
+        expect(needsFineStep({ min: -505, max: 505 })).toBe(true);
+    });
+
+    it("does not trip over decimal bounds that are actually aligned", () => {
+        // 0.3 % 0.1 is 0.09999999999999998, so a remainder test would call these misaligned.
+        expect(needsFineStep({ min: -0.3, max: 0.7 })).toBe(false);
+        expect(needsFineStep({ min: 0.1, max: 0.3 })).toBe(false);
+        expect(needsFineStep({ min: -2, max: 2 })).toBe(false);
+        expect(needsFineStep({ min: 0, max: 0.7 })).toBe(false);
+    });
+
+    it("still spots decimal bounds that are genuinely off the step", () => {
+        expect(needsFineStep({ min: -0.25, max: 0.7 })).toBe(true);
+        expect(needsFineStep({ min: 0, max: 0.05 })).toBe(true);
+    });
+
+    it("says no when the bounds are missing or not finite", () => {
+        expect(needsFineStep(undefined)).toBe(false);
+        expect(needsFineStep({})).toBe(false);
+        expect(needsFineStep({ min: Number.NaN, max: 10 })).toBe(false);
     });
 });

--- a/test/js/blackbox_curve_step.test.js
+++ b/test/js/blackbox_curve_step.test.js
@@ -52,6 +52,31 @@ describe("curve min/max fine step", () => {
         expect(needsFineStep({ min: 0, max: 0.05 })).toBe(true);
     });
 
+    it("stays honest at bounds large enough for a loose tolerance to swallow a whole step", () => {
+        expect(needsFineStep({ min: 0, max: 1e10 })).toBe(false);
+        expect(needsFineStep({ min: 0, max: 1e10 + 1 })).toBe(true);
+        expect(needsFineStep({ min: 0, max: 1e13 })).toBe(false);
+        expect(needsFineStep({ min: 0, max: 1e13 + 1 })).toBe(true);
+    });
+
+    it("accepts aligned bounds across the range each step covers", () => {
+        // The step comes from the span, so each case has to stay inside the band that selects it.
+        // Worst measured drift for an aligned bound is 0.8 ULP of the quotient, and the tolerance
+        // is a full ULP, so none of these should want the fine step.
+        const bands = [
+            { step: 0.1, bounds: [0.1, 0.3, 0.7, 1.1, 2.9, 4.9] },
+            { step: 1, bounds: [5, 7, 13, 27, 49] },
+            { step: 10, bounds: [50, 130, 1280, 16380, 1e6, 1e10] },
+        ];
+        for (const { step, bounds } of bands) {
+            for (const bound of bounds) {
+                const minMax = { min: -bound, max: bound };
+                expect(coarseMinMaxStep(minMax), `step for +/-${bound}`).toBe(step);
+                expect(needsFineStep(minMax), `+/-${bound}`).toBe(false);
+            }
+        }
+    });
+
     it("says no when the bounds are missing or not finite", () => {
         expect(needsFineStep(undefined)).toBe(false);
         expect(needsFineStep({})).toBe(false);


### PR DESCRIPTION
Follow-up to #5454, which stopped the curve min/max inputs rounding typed values onto the spinner step. The other half of the same report is the step itself: it was fixed at 10, which is useless once a field is scaled small.

The autopilot velocity channels default to +/-10, where stepping in tens only ever reaches 0 or 20, so the arrows could not get near the +/-2 or +/-5 range those channels actually want. The coarse step now follows the size of the range: tens from 100 wide, ones from 10 wide, and 0.1 below that. Wide curves such as +/-500 keep the step they already had, and Ctrl in the field still forces the fine step.

Reported by @ctzsnooze in #5450.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Min/max controls now automatically select practical increment sizes based on the configured value range.
  * Small ranges use finer increments, while wider ranges use larger increments for faster adjustment.
  * High-precision fields continue to support fine-grained adjustments.
  * Missing or invalid range limits receive a reliable default increment.

* **Bug Fixes**
  * Improved curve-bound editing for small-scale and decimal values.
  * Increased accuracy when handling decimal increments and very large values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->