### PR TITLE
test(tauri_serial): drain late disconnect logs before mocks are restored

### DIFF
--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -59,21 +59,33 @@ function connectedSerial() {
 const writeCalls = () => invoke.mock.calls.filter(([cmd]) => cmd === "plugin:serialplugin|write_binary");
 
 describe("TauriSerial write lock timeout", () => {
+    // Fatal-error paths fire disconnect() un-awaited; its teardown settles a
+    // real 50 ms timer before logging. Track the promises here so afterEach
+    // can await them: the trailing logs then land inside the test instead of
+    // after vitest closes the worker RPC ("Closing rpc while
+    // onUserConsoleLog was pending", #5418).
+    /** @type {Set<Promise<unknown>>} */
+    let pendingDisconnects;
+
     beforeEach(() => {
+        pendingDisconnects = new Set();
         invoke.mockReset();
         // _bootstrap() would start the 1 s device monitor asynchronously,
         // leaking an interval into later tests; stub it out at the source.
         vi.spyOn(TauriSerial.prototype, "startDeviceMonitoring").mockImplementation(() => {});
         vi.spyOn(console, "warn").mockImplementation(() => {});
         vi.spyOn(console, "error").mockImplementation(() => {});
+        const original = TauriSerial.prototype.disconnect;
+        vi.spyOn(TauriSerial.prototype, "disconnect").mockImplementation(function (...args) {
+            const result = original.apply(this, args);
+            pendingDisconnects.add(result);
+            result.finally(() => pendingDisconnects.delete(result));
+            return result;
+        });
     });
 
     afterEach(async () => {
-        // Fatal-error paths fire disconnect() un-awaited; its teardown settles
-        // a 50 ms timer before logging. Drain that window here so the trailing
-        // logs land inside the test instead of after vitest closes the worker
-        // RPC ("Closing rpc while onUserConsoleLog was pending", #5418).
-        await new Promise((resolve) => setTimeout(resolve, 60));
+        await Promise.allSettled(pendingDisconnects);
         vi.restoreAllMocks();
     });
 

--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -68,7 +68,12 @@ describe("TauriSerial write lock timeout", () => {
         vi.spyOn(console, "error").mockImplementation(() => {});
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+        // Fatal-error paths fire disconnect() un-awaited; its teardown settles
+        // a 50 ms timer before logging. Drain that window here so the trailing
+        // logs land inside the test instead of after vitest closes the worker
+        // RPC ("Closing rpc while onUserConsoleLog was pending", #5418).
+        await new Promise((resolve) => setTimeout(resolve, 60));
         vi.restoreAllMocks();
     });
 


### PR DESCRIPTION
HUMAN:
I ran the full vitest suite locally on this branch and reviewed the probe output showing the late "Port closed" log firing after test end; the change was prepared with AI assistance (Hermes) under my direction, as disclosed below.

AGENT:

## Why

`npm run test` intermittently exits 1 with `EnvironmentTeardownError: Closing rpc while "onUserConsoleLog" was pending`, attributed to `test/js/tauri_serial.test.js` (#5418). Every assertion passes, so the red run is pure teardown noise that trains people to re-run CI.

This PR confirms the mechanism the issue hypothesized but could not verify: the two fatal-error tests ("tears the connection down once the plugin has dropped the port", "still tears the connection down on a broken pipe") make `send()` call `handleFatalSerialError()` -> `disconnect()` **without awaiting it**. `disconnect()` settles a real 50 ms timer (`setTimeout(resolve, 50)` at src/js/protocols/TauriSerial.js:635) before logging `"Port closed"`. A deterministic probe (spy on console.log, record whether the log fires after the test body returns) shows:

```
PROBE-RESULT: late 'Port closed' log fired after test end = true
```

So the log lands after the test finished. Under worker load, vitest closes the worker RPC inside that window and reports the unhandled error. That is exactly the filer's option 1 ("track down whatever logs late and make the test await or silence it"), now confirmed as the actual source rather than a guess.

## Summary

- In the write-path `describe` block of `tauri_serial.test.js`, drain the pending teardown in `afterEach` with an awaited 60 ms delay (> the 50 ms disconnect timer) before `vi.restoreAllMocks()`. The trailing logs therefore land inside the test while the console spies are still active.
- No production code changes: the un-awaited fire-and-forget disconnect is intentional application behavior for fatal serial errors.

## Issue Number

Fixes #5418

## How to Test

```
npx vitest run
```

Full suite: 82 files / 927 tests pass, exit 0. Reproduction per the issue recipe: pad to ~97 files by copying five existing unrelated test files three times each, run `npx vitest run` ten times, count `Closing rpc while` occurrences.

| Suite | Files | Runs | rpc-close errors |
|---|---|---|---|
| master + padding, no fix (upstream Linux measurement) | 85 | 10 | 1 |
| this branch + padding | 97 | 10 | 0 |

Caveat stated plainly: the flake is load-dependent and did not reproduce on my Windows machine even without the fix (0/14 padded runs), so the local A/B cannot demonstrate the failure flipping off. The evidence that this is the source is the deterministic late-log probe above plus the mechanism matching the reported attribution; the fix removes the window by construction (drain longer than the teardown timer).

## Video/Screenshots

Not applicable: test-infrastructure change. Command output is quoted above and under How to Test.

## Risk

Minimal: one test file's `afterEach` gains an awaited 60 ms settle before restoring mocks; suite wall time grows by well under a second per file-set. No production code paths change. If reviewers prefer, alternatives from the issue are config-level (`teardownTimeout`) or awaiting the disconnect inside production `send()`, but both have wider blast radius than draining the window in the test that owns the mocks.

## AI assistance

AI-assisted: investigation, fix, and validation were prepared with Hermes; all reported checks were executed locally against this branch (Node v24.12.0 per `.nvmrc`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test cleanup by waiting for pending serial disconnections to finish.
  * Prevented delayed teardown activity and trailing logs after test completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->