### PR TITLE
Keep Download from FC available while a Blackbox log is loaded

### DIFF
--- a/src/blackbox-viewer/App.vue
+++ b/src/blackbox-viewer/App.vue
@@ -2,11 +2,12 @@
     <div id="blackbox-app">
         <!-- Teleported into legacy DOM layout -->
         <Teleport to="#vue-welcome">
-            <WelcomePage @files-selected="onFilesSelected" />
+            <WelcomePage @files-selected="onFilesSelected" @download-from-fc="onDownloadFromFc" />
         </Teleport>
         <Teleport to="#vue-navbar">
             <AppToolbar
                 @files-selected="onFilesSelected"
+                @download-from-fc="onDownloadFromFc"
                 @open-settings="onOpenSettings"
                 @open-keys="onOpenKeys"
                 @export-csv="onExportCsv"
@@ -151,6 +152,11 @@ const workspaceStore = useWorkspaceStore();
 // Embedded: a ref to the tab root, null until the tab mounts. Standalone: nothing injected.
 const injectedRoot = inject("bbvRoot", null);
 
+// FC dataflash pull capability, shared with WelcomePage.vue/AppToolbar.vue via injection so
+// the download control (and its available/pulling/progress state) works from either surface,
+// independent of whether a log is already loaded in the viewer.
+const dataflash = inject("bbvDataflash", null);
+
 // Centralized CSS class binding — replaces 27 imperative html.classList calls in main.js
 watchEffect(() => {
     // Only fall back to <html> when running standalone (no root injected); when embedded, wait
@@ -194,6 +200,20 @@ const sysConfig = computed(() => {
 
 function onFilesSelected(files) {
     appStore.loadFiles?.(files);
+}
+
+// Pulling replaces the active viewer log the same way opening another local file does — it
+// does not depend on, and is not blocked by, logStore.hasLog (see #5415).
+async function onDownloadFromFc() {
+    if (!dataflash || !dataflash.available.value || dataflash.pulling.value) {
+        return;
+    }
+    try {
+        const buffer = await dataflash.pull();
+        appStore.loadLogBuffer?.(buffer, "FC dataflash.BBL");
+    } catch (e) {
+        alert(`Could not download the log from the flight controller:\n\n${e.message}`);
+    }
 }
 
 function onOpenSettings() {

--- a/src/blackbox-viewer/components/AppToolbar.vue
+++ b/src/blackbox-viewer/components/AppToolbar.vue
@@ -3,6 +3,24 @@
     <div class="toolbar-bar">
         <div class="toolbar-group toolbar-group--start">
             <LogFileInput size="xs" label="Open log file" @files-selected="$emit('files-selected', $event)" />
+            <UTooltip
+                :text="
+                    downloadAvailable
+                        ? 'Download the onboard log from the connected flight controller'
+                        : 'Connect a flight controller that has a recorded log'
+                "
+            >
+                <UButton
+                    size="xs"
+                    color="primary"
+                    variant="soft"
+                    icon="i-lucide-download"
+                    :loading="pulling"
+                    :disabled="!downloadAvailable || pulling"
+                    :label="pulling ? `Downloading… ${Math.round(progress)}%` : 'Download from FC'"
+                    @click="$emit('download-from-fc')"
+                />
+            </UTooltip>
             <span v-if="appStore.logFilename" class="toolbar-filename" :title="appStore.logFilename">
                 {{ appStore.logFilename }}
             </span>
@@ -88,7 +106,7 @@
 </template>
 
 <script setup>
-import { computed, ref, watch } from "vue";
+import { computed, inject, ref, watch } from "vue";
 import { useLogStore } from "../stores/log.js";
 import { useAppStore } from "../stores/app.js";
 import { useGraphStore } from "../stores/graph.js";
@@ -97,6 +115,7 @@ import LogFileInput from "./LogFileInput.vue";
 
 defineEmits([
     "files-selected",
+    "download-from-fc",
     "export-csv",
     "export-gpx",
     "export-workspaces",
@@ -144,6 +163,13 @@ watch(
     },
     { immediate: true },
 );
+
+// Host-provided FC dataflash pull capability (null when not embedded / unavailable). Shared
+// with WelcomePage.vue via the same injection so both surfaces reflect one source of truth.
+const dataflash = inject("bbvDataflash", null);
+const downloadAvailable = computed(() => !!dataflash?.available?.value);
+const pulling = computed(() => !!dataflash?.pulling?.value);
+const progress = computed(() => dataflash?.progress?.value ?? 0);
 </script>
 
 <style scoped>

--- a/src/blackbox-viewer/components/WelcomePage.vue
+++ b/src/blackbox-viewer/components/WelcomePage.vue
@@ -54,12 +54,10 @@
 <script setup>
 import { computed, inject } from "vue";
 import { useLogStore } from "../stores/log.js";
-import { useAppStore } from "../stores/app.js";
 import LogFileInput from "./LogFileInput.vue";
 
-defineEmits(["files-selected"]);
+const emit = defineEmits(["files-selected", "download-from-fc"]);
 const logStore = useLogStore();
-const appStore = useAppStore();
 
 // Host-provided FC dataflash pull capability (null when not embedded / unavailable).
 // Its fields are refs nested in a plain object, so unwrap them via local computeds
@@ -69,16 +67,8 @@ const downloadAvailable = computed(() => !!dataflash?.available?.value);
 const pulling = computed(() => !!dataflash?.pulling?.value);
 const progress = computed(() => dataflash?.progress?.value ?? 0);
 
-async function onDownload() {
-    if (!dataflash || !downloadAvailable.value || dataflash.pulling.value) {
-        return;
-    }
-    try {
-        const buffer = await dataflash.pull();
-        appStore.loadLogBuffer?.(buffer, "FC dataflash.BBL");
-    } catch (e) {
-        alert(`Could not download the log from the flight controller:\n\n${e.message}`);
-    }
+function onDownload() {
+    emit("download-from-fc");
 }
 </script>
 

--- a/test/js/blackbox_download_from_fc.test.js
+++ b/test/js/blackbox_download_from_fc.test.js
@@ -1,0 +1,100 @@
+import { createApp, effectScope } from "vue";
+import { createPinia, setActivePinia } from "pinia";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import AppToolbar from "../../src/blackbox-viewer/components/AppToolbar.vue";
+import WelcomePage from "../../src/blackbox-viewer/components/WelcomePage.vue";
+import { useLogStore } from "../../src/blackbox-viewer/stores/log.js";
+
+// Regression coverage for #5415: "Download from FC is unavailable if there is an active log
+// loaded". AppToolbar.vue (visible whenever logStore.hasLog is true) previously had no download
+// control at all — only WelcomePage.vue (visible when hasLog is false) did, so the option
+// disappeared the moment a log was loaded. The FC pull itself (useDataflashPull) never depended
+// on hasLog; this was a UI-only gap. These tests drive each component's setup() directly rather
+// than fully rendering it, matching this repo's existing approach for components built on Nuxt
+// UI widgets (see connect_options_dialog.test.js): rendering Nuxt UI would exercise their
+// widgets' own provider wiring rather than this component's logic.
+
+function fakeDataflash({ available = true, pulling = false } = {}) {
+    return {
+        available: { value: available },
+        pulling: { value: pulling },
+        progress: { value: 0 },
+        pull: async () => new Uint8Array([1, 2, 3]),
+    };
+}
+
+// Runs `component.setup()` with a real reactive/injection context: an app supplies
+// `bbvDataflash` via provide(), and app.runWithContext() lets inject() see it without a full
+// component mount (and therefore without needing to render Nuxt UI's own components).
+function runSetup(component, dataflash) {
+    const app = createApp({});
+    app.provide("bbvDataflash", dataflash);
+    const emitted = [];
+    const scope = effectScope();
+    const api = app.runWithContext(() =>
+        scope.run(() =>
+            component.setup({}, { emit: (event, ...args) => emitted.push([event, ...args]), expose: () => {} }),
+        ),
+    );
+    return { api, emitted, stop: () => scope.stop() };
+}
+
+describe("Download from FC availability (#5415)", () => {
+    let scope;
+
+    beforeEach(() => {
+        setActivePinia(createPinia());
+    });
+
+    afterEach(() => {
+        scope?.stop();
+        scope = null;
+    });
+
+    it("AppToolbar exposes an available download control while a log is loaded", () => {
+        const logStore = useLogStore();
+        logStore.hasLog = true; // an active log is already loaded in the viewer
+
+        const { api, stop } = runSetup(AppToolbar, fakeDataflash({ available: true }));
+        scope = { stop };
+
+        expect(api.downloadAvailable.value).toBe(true);
+    });
+
+    it("AppToolbar's availability does not depend on logStore.hasLog", () => {
+        const logStore = useLogStore();
+        const dataflash = fakeDataflash({ available: true });
+
+        logStore.hasLog = false;
+        const withoutLog = runSetup(AppToolbar, dataflash);
+        expect(withoutLog.api.downloadAvailable.value).toBe(true);
+        withoutLog.stop();
+
+        logStore.hasLog = true;
+        const withLog = runSetup(AppToolbar, dataflash);
+        scope = { stop: withLog.stop };
+        expect(withLog.api.downloadAvailable.value).toBe(true);
+    });
+
+    it("AppToolbar still reports unavailable when the FC has no dataflash log, independent of hasLog", () => {
+        const logStore = useLogStore();
+        logStore.hasLog = true;
+
+        const { api, stop } = runSetup(AppToolbar, fakeDataflash({ available: false }));
+        scope = { stop };
+
+        expect(api.downloadAvailable.value).toBe(false);
+    });
+
+    it("WelcomePage (no-log state) keeps working after the fix", () => {
+        const logStore = useLogStore();
+        logStore.hasLog = false;
+
+        const { api, emitted, stop } = runSetup(WelcomePage, fakeDataflash({ available: true }));
+        scope = { stop };
+
+        expect(api.downloadAvailable.value).toBe(true);
+        api.onDownload();
+        expect(emitted).toEqual([["download-from-fc"]]);
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes #5415: "Download from FC" disappeared once a log was loaded in the Blackbox Viewer, because the control only existed on the no-log welcome screen (`WelcomePage.vue`); the toolbar shown while a log is active (`AppToolbar.vue`) never had one.
- The FC dataflash pull itself (`useDataflashPull`) never depended on whether a log was loaded, so this was a UI-only gap, not a state/MSP issue.
- Adds the same download control to the toolbar, sharing the existing `bbvDataflash` injection (no new/duplicated download logic). Centralizes the pull-and-load handler in `App.vue`, matching the existing pattern already used for `files-selected`.

## Test plan
- [x] `npx vitest run` — 930/930 tests passing, including a new regression test (`test/js/blackbox_download_from_fc.test.js`) that fails without the fix and passes with it
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Download from FC” action to both the toolbar and welcome page.
  * The control displays availability, loading, and download progress states.
  * Downloaded dataflash logs are automatically opened for viewing.
  * Clear alerts are shown when downloads fail.

* **Bug Fixes**
  * The download action remains available while another log is open.

* **Tests**
  * Added coverage for download availability and event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->