### PR TITLE
perf(tauri): push serial bytes instead of polling for them

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -35,8 +35,7 @@ dependencies = [
 [[package]]
 name = "android-usb-serial"
 version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca4442188d2b56ad9b37696fd8de549f32271b486d87c94a1c81b4dd2caa712"
+source = "git+https://github.com/blckmn/tauri-plugin-serialplugin?rev=68a58a74fb5fa9cbf41b17c419f0136748d56a50#68a58a74fb5fa9cbf41b17c419f0136748d56a50"
 dependencies = [
  "libc",
  "log",
@@ -4147,8 +4146,7 @@ dependencies = [
 [[package]]
 name = "tauri-plugin-serialplugin"
 version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c5073b8ad71cf1c1c31db72169e8723902d0c58e32c54be774b567f38b8bfd2"
+source = "git+https://github.com/blckmn/tauri-plugin-serialplugin?rev=68a58a74fb5fa9cbf41b17c419f0136748d56a50#68a58a74fb5fa9cbf41b17c419f0136748d56a50"
 dependencies = [
  "android-usb-serial",
  "jni 0.21.1",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -27,7 +27,12 @@ tauri-plugin-dfu = { path = "plugins/dfu" }
 # USB serial is desktop + Android only. iOS has no USB serial API, and
 # tauri-plugin-serialplugin's iOS build path doesn't compile, so exclude it there.
 [target.'cfg(not(target_os = "ios"))'.dependencies]
-tauri-plugin-serialplugin = "3.0"
+# Pinned to a fork rather than 3.0 for its `raw` watch mode. Upstream's watch
+# routes every chunk through its AT line router, which decodes the bytes with
+# from_utf8_lossy, splits them on newlines and trims each line, so MSP loses its
+# non-UTF-8 bytes and its 0x09/0x0A/0x0D/0x20 payload bytes. Raw streams them
+# verbatim. Revisit once the change is upstream and released.
+tauri-plugin-serialplugin = { git = "https://github.com/blckmn/tauri-plugin-serialplugin", rev = "68a58a74fb5fa9cbf41b17c419f0136748d56a50" }
 
 # Window size/position/maximized persistence is a desktop-only concept.
 # Cargo can't evaluate tauri's `desktop` cfg here, so spell the platforms out.

--- a/src/js/protocols/TauriSerial.js
+++ b/src/js/protocols/TauriSerial.js
@@ -151,6 +151,7 @@ class TauriSerial extends EventTarget {
         // open port, and port-list changes for hotplug.
         this.dataChannelId = null;
         this.portListChannelId = null;
+        this.portListChannel = null;
         this.monitoringDevices = false;
         this.portListSubscription = null;
 
@@ -197,7 +198,13 @@ class TauriSerial extends EventTarget {
 
         this.monitoringDevices = true;
         const channel = new Channel();
-        channel.onmessage = (event) => this._handlePortListEvent(event);
+        this.portListChannel = channel;
+        channel.onmessage = (event) => {
+            if (this.portListChannel !== channel) {
+                return;
+            }
+            this._handlePortListEvent(event);
+        };
 
         this.portListSubscription = invoke("plugin:serialplugin|watch_ports", {
             options: { pollIntervalMs: PORT_LIST_POLL_INTERVAL_MS },
@@ -209,6 +216,7 @@ class TauriSerial extends EventTarget {
             })
             .catch((error) => {
                 this.monitoringDevices = false;
+                this.portListChannel = null;
                 console.error(`${logHead} Could not start device monitoring:`, error);
             });
 
@@ -222,6 +230,7 @@ class TauriSerial extends EventTarget {
         await this.portListSubscription;
 
         this.monitoringDevices = false;
+        this.portListChannel = null;
         const channelId = this.portListChannelId;
         this.portListChannelId = null;
         if (channelId === null) {
@@ -238,6 +247,10 @@ class TauriSerial extends EventTarget {
 
     /**
      * Apply one `PortListEvent` from the monitor.
+     *
+     * Only the current subscription's events are applied: a channel already in
+     * flight when `stopDeviceMonitoring` unsubscribed would otherwise report a
+     * device removal underneath an open port, which the reconnect cycle acts on.
      *
      * A `snapshot` is a full reconciliation, not just an initial state: the
      * monitor sends one on every subscribe, and this transport unsubscribes for

--- a/src/js/protocols/TauriSerial.js
+++ b/src/js/protocols/TauriSerial.js
@@ -1,51 +1,40 @@
-import { invoke } from "@tauri-apps/api/core";
+import { Channel, invoke } from "@tauri-apps/api/core";
 import { serialDevices, vendorIdNames } from "./devices";
 import GUI from "../gui";
 
 const logHead = "[TAURI SERIAL]";
 
 /**
- * Bytes to request per `read_binary` poll.
+ * Options handed to the plugin's `watch` command.
  *
- * This is a correctness bound, not a tuning knob. The plugin's RX hub reads the
- * port into a 1024-byte buffer and hands the whole chunk to the pending read
- * slot, which keeps only what fits in the requested size and DROPS the rest —
- * the remainder is not pushed back onto its idle buffer. Asking for less than a
- * hub chunk therefore silently loses the tail of every burst above that size,
- * which corrupts any MSP response longer than the request (MSP_BOXNAMES fails
- * its CRC first) and then desynchronises the stream.
+ * `raw` is a correctness requirement, not a tuning knob. Without it the plugin
+ * routes every chunk through its AT line router, which decodes the bytes as
+ * UTF-8, splits them on newlines, trims each line and can reclassify one as an
+ * out-of-band `urc` event. MSP is binary: that path replaces every non-UTF-8
+ * byte, eats 0x09/0x0A/0x0D/0x20 payload bytes and silently drops whole frames.
  *
- * Staying well above the 1024-byte chunk keeps a poll that arrives mid-burst
- * from ever being the shorter side, and staying under the hub's 64 KiB idle cap
- * keeps the "idle already full" fast path reachable while a CLI dump streams.
+ * `serialDataFlushIntervalMs` of 0 makes the hub flush its batch buffer on every
+ * pass of its read loop, so a frame is dispatched as soon as the OS hands it
+ * over rather than waiting out a batching window.
+ *
+ * `size` is only the hub thread's read buffer. Unlike the `read_binary` path it
+ * cannot truncate: the watch route appends whole chunks, so a burst larger than
+ * this arrives as consecutive events instead of losing its tail.
  */
-const READ_CHUNK_SIZE = 16384;
+const WATCH_OPTIONS = {
+    size: 4096,
+    serialDataFlushIntervalMs: 0,
+    raw: true,
+};
 
 /**
- * Timeout handed to `read_binary`, in milliseconds.
+ * Poll interval for the plugin's port-list monitor, in milliseconds.
  *
- * Zero, so the call returns whatever the RX hub has already buffered instead of
- * waiting for more. Any non-zero value is a wait held *inside* the plugin, and
- * on Android that wait is not free: wry bridges the webview to Rust through a
- * synchronous JavascriptInterface, so a command blocks the webview's JavaScript
- * thread for its whole duration. Polling with a 10 ms wait sixty times a second
- * parked that thread for most of every second, starving rendering and input.
- *
- * The loop paces itself with its own sleep instead, which yields to the event
- * loop rather than blocking it.
+ * The monitor runs on a Rust thread rather than over the webview bridge, so this
+ * is not a cost paid on the JavaScript thread. It matches the cadence of the
+ * hotplug poll it replaces.
  */
-const READ_TIMEOUT_MS = 0;
-
-/**
- * Pause between read polls, in milliseconds.
- *
- * With a non-blocking read the loop sets its own pace, and on Android every poll
- * is a round trip across the synchronous webview bridge, so the pace is a real
- * cost rather than a free spin. 20 ms keeps receive latency far inside the MSP
- * status cadence while asking roughly a third as many round trips per second as
- * the 5 ms spin this replaced.
- */
-const READ_POLL_INTERVAL_MS = 20;
+const PORT_LIST_POLL_INTERVAL_MS = 1000;
 
 /**
  * Extract a best-effort message string from an error value of unknown shape
@@ -150,7 +139,6 @@ class TauriSerial extends EventTarget {
 
         this.ports = [];
         this.connectionId = null;
-        this.reading = false;
 
         this.connect = this.connect.bind(this);
         this.disconnect = this.disconnect.bind(this);
@@ -159,11 +147,12 @@ class TauriSerial extends EventTarget {
         // macOS AT32 batch-write workaround flag (driver quirk).
         this.isNeedBatchWrite = false;
 
-        // Device hotplug monitoring — poll-based since the plugin doesn't
-        // expose a native event stream.
+        // Channel ids for the plugin's two push streams: received bytes for the
+        // open port, and port-list changes for hotplug.
+        this.dataChannelId = null;
+        this.portListChannelId = null;
         this.monitoringDevices = false;
-        this.deviceMonitorInterval = null;
-        this.deviceCheckInFlight = false;
+        this.portListSubscription = null;
 
         // Fire-and-forget init; wrapped in a sync helper so the constructor
         // body contains no async operation (Sonar S7059). The promise
@@ -194,48 +183,113 @@ class TauriSerial extends EventTarget {
         }
     }
 
-    startDeviceMonitoring() {
+    /**
+     * Subscribe to the plugin's port-list monitor.
+     *
+     * The monitor enumerates on its own Rust thread and pushes only the changes,
+     * so unlike the `available_ports` poll this replaces, nothing is spent on the
+     * JavaScript thread between events.
+     */
+    async startDeviceMonitoring() {
         if (this.monitoringDevices) {
             return;
         }
 
         this.monitoringDevices = true;
-        // Reentrancy-guarded poll: skip the tick if the previous check hasn't
-        // returned yet, so overlapping runs can't race on `this.ports` and
-        // emit duplicate/missed hotplug events.
-        this.deviceMonitorInterval = setInterval(async () => {
-            if (this.deviceCheckInFlight) {
-                return;
-            }
-            // Enumeration is for finding a device to connect to, so it has no job
-            // while one is open — and on Android it is actively harmful there.
-            // `available_ports` crosses into Kotlin and queries the USB service on
-            // a single-threaded executor with an unbounded wait, over the same
-            // synchronous bridge the reads and writes use. Running it once a second
-            // underneath a live MSP session is what wedged that bridge and froze
-            // the app. Loss of the device is noticed by the read/write path
-            // instead, which is both safe and an order of magnitude quicker.
-            if (this.connected || this.openRequested) {
-                return;
-            }
-            this.deviceCheckInFlight = true;
-            try {
-                await this.checkDeviceChanges();
-            } finally {
-                this.deviceCheckInFlight = false;
-            }
-        }, 1000);
+        const channel = new Channel();
+        channel.onmessage = (event) => this._handlePortListEvent(event);
 
-        console.log(`${logHead} Device monitoring started`);
+        this.portListSubscription = invoke("plugin:serialplugin|watch_ports", {
+            options: { pollIntervalMs: PORT_LIST_POLL_INTERVAL_MS },
+            channel,
+        })
+            .then((channelId) => {
+                this.portListChannelId = channelId;
+                console.log(`${logHead} Device monitoring started`);
+            })
+            .catch((error) => {
+                this.monitoringDevices = false;
+                console.error(`${logHead} Could not start device monitoring:`, error);
+            });
+
+        await this.portListSubscription;
     }
 
-    stopDeviceMonitoring() {
-        if (this.deviceMonitorInterval) {
-            clearInterval(this.deviceMonitorInterval);
-            this.deviceMonitorInterval = null;
-        }
+    async stopDeviceMonitoring() {
+        // A subscribe still in flight would otherwise store its channel id after
+        // this teardown had read it, leaving the monitor running for the whole
+        // connection — the very thing connect() stops it to avoid.
+        await this.portListSubscription;
+
         this.monitoringDevices = false;
-        console.log(`${logHead} Device monitoring stopped`);
+        const channelId = this.portListChannelId;
+        this.portListChannelId = null;
+        if (channelId === null) {
+            return;
+        }
+
+        try {
+            await invoke("plugin:serialplugin|unwatch_ports", { channelId });
+            console.log(`${logHead} Device monitoring stopped`);
+        } catch (error) {
+            console.warn(`${logHead} Error stopping device monitoring:`, error);
+        }
+    }
+
+    /**
+     * Apply one `PortListEvent` from the monitor.
+     *
+     * A `snapshot` is a full reconciliation, not just an initial state: the
+     * monitor sends one on every subscribe, and this transport unsubscribes for
+     * the duration of a connection, so the snapshot that arrives on reconnect is
+     * what reports a device that vanished while the port was open.
+     * @param {{kind: string, ports?: object, path?: string, info?: object}} event - Event from the monitor.
+     * @private
+     */
+    _handlePortListEvent(event) {
+        switch (event?.kind) {
+            case "snapshot":
+                this._reconcilePorts(this._filterToKnownDevices(this._convertPortsMapToArray(event.ports ?? {})));
+                break;
+            case "added":
+                this._reconcilePorts([
+                    ...this.ports.filter((port) => port.path !== event.path),
+                    ...this._filterToKnownDevices(this._convertPortsMapToArray({ [event.path]: event.info ?? {} })),
+                ]);
+                break;
+            case "removed":
+                this._reconcilePorts(this.ports.filter((port) => port.path !== event.path));
+                break;
+            default:
+                console.warn(`${logHead} Unknown port list event:`, event);
+        }
+    }
+
+    /**
+     * Diff `currentPorts` against the cached list and emit the difference.
+     *
+     * Kept as a diff rather than trusting each event verbatim so a duplicate
+     * `added` or a `removed` for a path already gone stays silent.
+     * @param {Array<object>} currentPorts - The known-device ports as they now stand.
+     * @private
+     */
+    _reconcilePorts(currentPorts) {
+        const removedPorts = this.ports.filter(
+            (oldPort) => !currentPorts.some((newPort) => newPort.path === oldPort.path),
+        );
+        const addedPorts = currentPorts.filter((newPort) => !this.ports.some((old) => old.path === newPort.path));
+
+        this.ports = currentPorts;
+
+        for (const removed of removedPorts) {
+            this.dispatchEvent(new CustomEvent("removedDevice", { detail: removed }));
+            console.log(`${logHead} Device removed: ${removed.path}`);
+        }
+
+        for (const added of addedPorts) {
+            this.dispatchEvent(new CustomEvent("addedDevice", { detail: added }));
+            console.log(`${logHead} Device added: ${added.path}`);
+        }
     }
 
     /**
@@ -269,35 +323,6 @@ class TauriSerial extends EventTarget {
             }
             return serialDevices.some((d) => d.vendorId === port.vendorId && d.productId === port.productId);
         });
-    }
-
-    async checkDeviceChanges() {
-        try {
-            const portsMap = await invoke("plugin:serialplugin|available_ports");
-            const allPorts = this._convertPortsMapToArray(portsMap);
-            const currentPorts = this._filterToKnownDevices(allPorts);
-
-            const removedPorts = this.ports.filter(
-                (oldPort) => !currentPorts.some((newPort) => newPort.path === oldPort.path),
-            );
-            const addedPorts = currentPorts.filter(
-                (newPort) => !this.ports.some((oldPort) => oldPort.path === newPort.path),
-            );
-
-            for (const removed of removedPorts) {
-                this.dispatchEvent(new CustomEvent("removedDevice", { detail: removed }));
-                console.log(`${logHead} Device removed: ${removed.path}`);
-            }
-
-            for (const added of addedPorts) {
-                this.dispatchEvent(new CustomEvent("addedDevice", { detail: added }));
-                console.log(`${logHead} Device added: ${added.path}`);
-            }
-
-            this.ports = currentPorts;
-        } catch (error) {
-            console.warn(`${logHead} Error checking device changes:`, error);
-        }
     }
 
     async loadDevices() {
@@ -423,8 +448,19 @@ class TauriSerial extends EventTarget {
 
             this.addEventListener("receive", this.handleReceiveBytes);
 
-            this.reading = true;
-            this.readLoop();
+            // Enumeration has no job while a port is open, and on Android it is
+            // actively harmful: `available_ports` crosses into Kotlin and queries
+            // the USB service on a single-threaded executor with an unbounded
+            // wait. Running that underneath a live MSP session is what wedged the
+            // bridge and froze the app. Loss of the device is noticed by the read
+            // and write paths instead, which is both safe and quicker.
+            await this.stopDeviceMonitoring();
+
+            // Nothing reads the port without the watch, so a failure here is a
+            // failed connection rather than a degraded one.
+            if (!(await this._startWatch(path))) {
+                return await this._abortConnect(path);
+            }
 
             this.dispatchEvent(new CustomEvent("connect", { detail: true }));
             console.log(`${logHead} Connected to ${path}`);
@@ -456,6 +492,23 @@ class TauriSerial extends EventTarget {
         return false;
     }
 
+    /**
+     * Undo a connection whose port opened but whose byte stream would not start.
+     * Mirrors `_abortOpen`, plus the state `connect` had already committed.
+     * @param {string} path - The port to close again.
+     * @private
+     */
+    async _abortConnect(path) {
+        this.removeEventListener("receive", this.handleReceiveBytes);
+        this.connected = false;
+        this.connectionId = null;
+        this.connectionInfo = null;
+        this.bitrate = 0;
+        await this._abortOpen(path);
+        await this.startDeviceMonitoring();
+        return false;
+    }
+
     checkIsNeedBatchWrite() {
         const isMac = GUI.operating_system === "MacOS";
         const vendorId = this.connectionInfo?.vendorId;
@@ -478,52 +531,75 @@ class TauriSerial extends EventTarget {
     }
 
     /**
-     * Classify a read error as fatal (rethrow and tear the loop down) or
-     * transient (log + continue). Extracted from readLoop to keep its
-     * cognitive complexity under the Sonar limit.
+     * Subscribe to the open port's byte stream.
+     *
+     * The plugin's RX hub thread is the sole reader of the fd either way; this
+     * asks it to push what it reads instead of holding it in an idle buffer for
+     * the next poll to collect. A failure here is fatal to the connection: the
+     * port would be open with nothing reading it.
+     * @param {string} path - The open port's path.
      * @private
      */
-    _classifyReadError(error) {
-        const msg = extractErrorMessage(error).toLowerCase();
-        if (msg.includes("no data received")) {
-            return "continue";
+    async _startWatch(path) {
+        const channel = new Channel();
+        channel.onmessage = (event) => this._handleSerialEvent(event);
+
+        try {
+            this.dataChannelId = await invoke("plugin:serialplugin|watch", {
+                path,
+                options: WATCH_OPTIONS,
+                channel,
+            });
+            return true;
+        } catch (error) {
+            console.error(`${logHead} Could not watch ${path}:`, error);
+            return false;
         }
-        if (isBrokenPipeError(error) || isPortGoneError(error)) {
-            console.error(`${logHead} Fatal poll error on ${this.connectionId}:`, error);
-            return "fatal";
-        }
-        console.warn(`${logHead} Poll error:`, error);
-        return "continue";
     }
 
-    async readLoop() {
+    async _stopWatch() {
+        const channelId = this.dataChannelId;
+        this.dataChannelId = null;
+        if (channelId === null) {
+            return;
+        }
+
         try {
-            while (this.reading) {
-                try {
-                    const result = await invoke("plugin:serialplugin|read_binary", {
-                        path: this.connectionId,
-                        size: READ_CHUNK_SIZE,
-                        timeout: READ_TIMEOUT_MS,
-                    });
-
-                    if (result && result.length > 0) {
-                        const bytes = new Uint8Array(result);
-                        this.dispatchEvent(new CustomEvent("receive", { detail: bytes }));
-                    }
-
-                    await new Promise((resolve) => setTimeout(resolve, READ_POLL_INTERVAL_MS));
-                } catch (error) {
-                    if (this._classifyReadError(error) === "fatal") {
-                        throw error;
-                    }
-                    await new Promise((resolve) => setTimeout(resolve, READ_POLL_INTERVAL_MS));
-                }
-            }
+            await invoke("plugin:serialplugin|unwatch", { channelId });
         } catch (error) {
-            console.error(`${logHead} Error in read loop:`, error);
-            this.handleFatalSerialError(error);
-        } finally {
-            console.log(`${logHead} Polling stopped for ${this.connectionId || "<no-port>"}`);
+            // `close` also drops every watch registered for the path, so losing
+            // the race with it leaves nothing to report.
+            console.debug(`${logHead} Unwatch failed:`, error);
+        }
+    }
+
+    /**
+     * Apply one `SerialEvent` from the open port.
+     *
+     * Late events are dropped rather than dispatched: a channel already in flight
+     * when the port closed would otherwise inject bytes into whatever session
+     * comes next.
+     * @param {{kind: string, data?: Array<number>, reason?: string, message?: string}} event - Event from the plugin.
+     * @private
+     */
+    _handleSerialEvent(event) {
+        if (!this.connected) {
+            return;
+        }
+
+        switch (event?.kind) {
+            case "data":
+                this.dispatchEvent(new CustomEvent("receive", { detail: new Uint8Array(event.data) }));
+                break;
+            case "disconnect":
+                console.error(`${logHead} Port ${this.connectionId} disconnected: ${event.reason}`);
+                this.handleFatalSerialError(event.reason);
+                break;
+            case "error":
+                console.warn(`${logHead} Read error on ${this.connectionId}: ${event.message}`);
+                break;
+            default:
+                console.warn(`${logHead} Unknown serial event:`, event);
         }
     }
 
@@ -626,13 +702,11 @@ class TauriSerial extends EventTarget {
         this.closeRequested = true;
         this.connected = false;
         this.transmitting = false;
-        this.reading = false;
 
         try {
             this.removeEventListener("receive", this.handleReceiveBytes);
 
-            // Small delay to allow read loop to notice the state change.
-            await new Promise((resolve) => setTimeout(resolve, 50));
+            await this._stopWatch();
 
             if (this.connectionId) {
                 try {
@@ -647,6 +721,12 @@ class TauriSerial extends EventTarget {
             this.bitrate = 0;
             this.connectionInfo = null;
             this.closeRequested = false;
+
+            // Resume hotplug monitoring, which connect() suspended. The snapshot
+            // the monitor sends on subscribe is what reports a device that went
+            // away while the port was open, and the reconnect cycle waits on the
+            // removedDevice event that comes out of it.
+            await this.startDeviceMonitoring();
 
             this.dispatchEvent(new CustomEvent("disconnect", { detail: true }));
             return true;

--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -369,6 +369,19 @@ describe("TauriSerial connect", () => {
 
         expect(stop).toHaveBeenCalled();
     });
+
+    it("resumes port enumeration after disconnecting", async () => {
+        // The snapshot the monitor sends on subscribe is what reports a device
+        // unplugged while the port was open, which the reconnect cycle waits on.
+        mockPresentPort();
+        const serial = new TauriSerial();
+        await serial.connect(PORT, { baudRate: 115200 });
+        const start = vi.spyOn(serial, "startDeviceMonitoring");
+
+        await serial.disconnect();
+
+        expect(start).toHaveBeenCalled();
+    });
 });
 
 describe("TauriSerial receive", () => {
@@ -537,6 +550,30 @@ describe("TauriSerial hotplug", () => {
         channel.onmessage({ kind: "added", path: PORT, info: STM32 });
 
         expect(serial.ports.map((port) => port.path)).toEqual([PORT]);
+    });
+
+    it("drops a port-list event that arrives after the monitor was torn down", async () => {
+        // connect() suspends the monitor. A channel still in flight would
+        // otherwise report a removal underneath the open port, which the
+        // reconnect cycle acts on.
+        const { serial, channel, events } = await monitored({ [PORT]: STM32 });
+
+        await serial.stopDeviceMonitoring();
+        channel.onmessage({ kind: "removed", path: PORT });
+
+        expect(events).toEqual([]);
+        expect(serial.ports.map((port) => port.path)).toEqual([PORT]);
+    });
+
+    it("ignores the previous subscription once the monitor has restarted", async () => {
+        const { serial, channel, events } = await monitored({ [PORT]: STM32 });
+
+        await serial.stopDeviceMonitoring();
+        await serial.startDeviceMonitoring();
+        channel.onmessage({ kind: "snapshot", ports: {} });
+
+        expect(events).toEqual([]);
+        expect(lastChannel()).not.toBe(channel);
     });
 
     it("waits for an in-flight subscribe before tearing the monitor down", async () => {

--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -15,7 +15,18 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const invoke = vi.hoisted(() => vi.fn());
 
-vi.mock("@tauri-apps/api/core", () => ({ invoke }));
+/** Every Channel the transport constructed, newest last. */
+const channels = vi.hoisted(() => []);
+
+vi.mock("@tauri-apps/api/core", () => ({
+    invoke,
+    Channel: class {
+        constructor() {
+            this.onmessage = () => {};
+            channels.push(this);
+        }
+    },
+}));
 
 vi.mock("../../src/js/protocols/devices", () => ({
     serialDevices: [{ vendorId: 0x0483, productId: 0x5740 }],
@@ -58,11 +69,34 @@ function connectedSerial() {
 
 const writeCalls = () => invoke.mock.calls.filter(([cmd]) => cmd === "plugin:serialplugin|write_binary");
 
+const commands = () => invoke.mock.calls.map(([cmd]) => cmd);
+const argsFor = (cmd) => invoke.mock.calls.find(([name]) => name === cmd)?.[1];
+
+/** The most recently constructed Channel — the one the call under test just handed the plugin. */
+const lastChannel = () => channels.at(-1);
+
+/**
+ * Resolve every command as if PORT were present and openable. `watch` and
+ * `watch_ports` resolve to channel ids, which the transport stores to unwatch.
+ */
+function mockPresentPort() {
+    invoke.mockImplementation((cmd) => {
+        if (cmd === "plugin:serialplugin|available_ports") {
+            return Promise.resolve({ [PORT]: { type: "Usb", vid: "1155", pid: "22336" } });
+        }
+        if (cmd === "plugin:serialplugin|watch" || cmd === "plugin:serialplugin|watch_ports") {
+            return Promise.resolve(1);
+        }
+        return Promise.resolve(undefined);
+    });
+}
+
 describe("TauriSerial write lock timeout", () => {
     beforeEach(() => {
         invoke.mockReset();
-        // _bootstrap() would start the 1 s device monitor asynchronously,
-        // leaking an interval into later tests; stub it out at the source.
+        channels.length = 0;
+        // _bootstrap() would subscribe to the port monitor asynchronously,
+        // leaking a subscription into later tests; stub it out at the source.
         vi.spyOn(TauriSerial.prototype, "startDeviceMonitoring").mockImplementation(() => {});
         vi.spyOn(console, "warn").mockImplementation(() => {});
         vi.spyOn(console, "error").mockImplementation(() => {});
@@ -178,6 +212,7 @@ describe("TauriSerial port enumeration", () => {
 
     beforeEach(() => {
         invoke.mockReset();
+        channels.length = 0;
         vi.spyOn(TauriSerial.prototype, "startDeviceMonitoring").mockImplementation(() => {});
         vi.spyOn(console, "log").mockImplementation(() => {});
     });
@@ -232,6 +267,7 @@ describe("TauriSerial port enumeration", () => {
 describe("TauriSerial connect", () => {
     beforeEach(() => {
         invoke.mockReset();
+        channels.length = 0;
         vi.spyOn(TauriSerial.prototype, "startDeviceMonitoring").mockImplementation(() => {});
         vi.spyOn(console, "log").mockImplementation(() => {});
     });
@@ -259,68 +295,270 @@ describe("TauriSerial connect", () => {
     });
 
     it("opens a path that is still present", async () => {
-        invoke.mockImplementation((cmd) => {
-            if (cmd === "plugin:serialplugin|available_ports") {
-                return Promise.resolve({ [PORT]: { type: "Usb", vid: "1155", pid: "22336" } });
-            }
-            if (cmd === "plugin:serialplugin|read_binary") {
-                return Promise.resolve([]);
-            }
-            return Promise.resolve(undefined);
-        });
+        mockPresentPort();
         const serial = new TauriSerial();
 
         const connected = await serial.connect(PORT, { baudRate: 115200 });
-        serial.reading = false;
 
         expect(connected).toBe(true);
-        expect(invoke.mock.calls.map(([cmd]) => cmd)).toContain("plugin:serialplugin|open");
+        expect(commands()).toContain("plugin:serialplugin|open");
     });
 
     it("does not call the inert set_timeout command", async () => {
         // set_timeout is a no-op on 3.x: the RX hub owns the fd and every
         // command re-applies its own timeout to the guard before each op.
-        invoke.mockImplementation((cmd) => {
-            if (cmd === "plugin:serialplugin|read_binary") {
-                return Promise.resolve([]);
-            }
-            if (cmd === "plugin:serialplugin|available_ports") {
-                return Promise.resolve({ [PORT]: { type: "Usb", vid: "1155", pid: "22336" } });
-            }
-            return Promise.resolve(undefined);
-        });
+        mockPresentPort();
         const serial = new TauriSerial();
 
         const connected = await serial.connect(PORT, { baudRate: 115200 });
-        serial.reading = false;
 
         expect(connected).toBe(true);
-        expect(invoke.mock.calls.map(([cmd]) => cmd)).not.toContain("plugin:serialplugin|set_timeout");
+        expect(commands()).not.toContain("plugin:serialplugin|set_timeout");
     });
 
-    it("polls for more bytes than the plugin's RX chunk can hold", async () => {
-        // The plugin's RX hub reads the port into a 1024-byte buffer and hands
-        // the whole chunk to the pending read slot, which keeps only what fits
-        // in the requested size and drops the remainder instead of buffering
-        // it. A request below one hub chunk therefore truncates every burst
-        // above it — MSP_BOXNAMES (~500 bytes) fails its CRC and the stream
-        // never resynchronises.
+    it("subscribes to the byte stream rather than polling for it", async () => {
+        mockPresentPort();
+        const serial = new TauriSerial();
+
+        await serial.connect(PORT, { baudRate: 115200 });
+
+        expect(commands()).not.toContain("plugin:serialplugin|read_binary");
+        expect(argsFor("plugin:serialplugin|watch")).toMatchObject({
+            path: PORT,
+            // raw keeps MSP out of the plugin's AT line router, which would
+            // decode the bytes as UTF-8 and trim them; a zero flush interval
+            // stops the hub holding a frame back for its batching window.
+            options: { raw: true, serialDataFlushIntervalMs: 0 },
+        });
+    });
+
+    it("fails the connection when the byte stream will not start", async () => {
+        // The port would otherwise be left open with nothing reading it, and the
+        // caller told the connection succeeded.
         invoke.mockImplementation((cmd) => {
-            if (cmd === "plugin:serialplugin|read_binary") {
-                return Promise.resolve([]);
-            }
             if (cmd === "plugin:serialplugin|available_ports") {
                 return Promise.resolve({ [PORT]: { type: "Usb", vid: "1155", pid: "22336" } });
+            }
+            if (cmd === "plugin:serialplugin|watch") {
+                return Promise.reject("watch already active");
+            }
+            return Promise.resolve(1);
+        });
+        const serial = new TauriSerial();
+        const outcomes = [];
+        serial.addEventListener("connect", (event) => outcomes.push(event.detail));
+
+        const connected = await serial.connect(PORT, { baudRate: 115200 });
+
+        expect(connected).toBe(false);
+        expect(outcomes).toEqual([false]);
+        expect(serial.connected).toBe(false);
+        expect(serial.connectionId).toBe(null);
+        expect(commands()).toContain("plugin:serialplugin|close");
+    });
+
+    it("suspends port enumeration for the life of the connection", async () => {
+        // available_ports crosses into Kotlin and queries the USB service on a
+        // single-threaded executor over the same bridge the reads and writes
+        // use. Leaving it running underneath a live session wedged the bridge.
+        mockPresentPort();
+        const serial = new TauriSerial();
+        const stop = vi.spyOn(serial, "stopDeviceMonitoring");
+
+        await serial.connect(PORT, { baudRate: 115200 });
+
+        expect(stop).toHaveBeenCalled();
+    });
+});
+
+describe("TauriSerial receive", () => {
+    beforeEach(() => {
+        invoke.mockReset();
+        channels.length = 0;
+        vi.spyOn(TauriSerial.prototype, "startDeviceMonitoring").mockImplementation(() => {});
+        vi.spyOn(console, "log").mockImplementation(() => {});
+        vi.spyOn(console, "error").mockImplementation(() => {});
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /** A connected TauriSerial plus the channel the plugin would push events on. */
+    async function watched() {
+        mockPresentPort();
+        const serial = new TauriSerial();
+        await serial.connect(PORT, { baudRate: 115200 });
+        return { serial, channel: lastChannel() };
+    }
+
+    it("dispatches the bytes verbatim", async () => {
+        // The bytes the plugin's text path would have eaten: a NUL, the
+        // whitespace its trim strips, and a pair that is not valid UTF-8.
+        const payload = [0x24, 0x4d, 0x3e, 0x00, 0x09, 0x0d, 0x0a, 0x20, 0xff, 0xfe];
+        const { serial, channel } = await watched();
+        const received = [];
+        serial.addEventListener("receive", (event) => received.push(event.detail));
+
+        channel.onmessage({ kind: "data", path: PORT, data: payload, size: payload.length });
+
+        expect(received).toHaveLength(1);
+        expect([...received[0]]).toEqual(payload);
+    });
+
+    it("counts the bytes it received", async () => {
+        const { serial, channel } = await watched();
+
+        channel.onmessage({ kind: "data", path: PORT, data: [1, 2, 3], size: 3 });
+
+        expect(serial.bytesReceived).toBe(3);
+    });
+
+    it("drops an event that arrives after the port closed", async () => {
+        // A channel still in flight when the port closed would otherwise inject
+        // its bytes into whatever session comes next.
+        const { serial, channel } = await watched();
+        const received = [];
+        serial.addEventListener("receive", (event) => received.push(event.detail));
+        await serial.disconnect();
+
+        channel.onmessage({ kind: "data", path: PORT, data: [1, 2, 3], size: 3 });
+
+        expect(received).toEqual([]);
+    });
+
+    it("tears the connection down on a disconnect event", async () => {
+        const { serial, channel } = await watched();
+
+        channel.onmessage({ kind: "disconnect", path: PORT, reason: "Serial port disconnected" });
+
+        // disconnect() is not awaited from the event handler, so the teardown
+        // lands over the following microtasks.
+        await vi.waitFor(() => expect(commands()).toContain("plugin:serialplugin|close"));
+        expect(serial.connected).toBe(false);
+    });
+
+    it("keeps the connection on a transient read error", async () => {
+        const { serial, channel } = await watched();
+
+        channel.onmessage({ kind: "error", path: PORT, message: "Serial read error: temporary" });
+
+        expect(serial.connected).toBe(true);
+    });
+
+    it("unwatches the stream when disconnecting", async () => {
+        const { serial } = await watched();
+        const channelId = serial.dataChannelId;
+
+        await serial.disconnect();
+
+        expect(argsFor("plugin:serialplugin|unwatch")).toEqual({ channelId });
+        expect(serial.dataChannelId).toBe(null);
+    });
+});
+
+describe("TauriSerial hotplug", () => {
+    const STM32 = { type: "Usb", vid: "1155", pid: "22336" };
+
+    beforeEach(() => {
+        invoke.mockReset();
+        channels.length = 0;
+        vi.spyOn(console, "log").mockImplementation(() => {});
+        vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    /** A TauriSerial subscribed to the port monitor, with the events it emitted. */
+    async function monitored(initialPorts = {}) {
+        invoke.mockImplementation((cmd) =>
+            Promise.resolve(cmd === "plugin:serialplugin|available_ports" ? initialPorts : 7),
+        );
+        const serial = new TauriSerial();
+        await vi.waitFor(() => expect(serial.portListChannelId).toBe(7));
+
+        const events = [];
+        for (const name of ["addedDevice", "removedDevice"]) {
+            serial.addEventListener(name, (event) => events.push([name, event.detail.path]));
+        }
+        return { serial, channel: lastChannel(), events };
+    }
+
+    it("reports a device that appeared", async () => {
+        const { channel, events } = await monitored();
+
+        channel.onmessage({ kind: "added", path: PORT, info: STM32 });
+
+        expect(events).toEqual([["addedDevice", PORT]]);
+    });
+
+    it("reports a device that went away", async () => {
+        const { channel, events } = await monitored({ [PORT]: STM32 });
+
+        channel.onmessage({ kind: "removed", path: PORT });
+
+        expect(events).toEqual([["removedDevice", PORT]]);
+    });
+
+    it("reconciles a snapshot against the ports it knew about", async () => {
+        // The monitor sends a snapshot on every subscribe, and the transport
+        // resubscribes on disconnect. That snapshot is what reports a device
+        // unplugged while the port was open, which the reconnect cycle waits on.
+        const { channel, events } = await monitored({ [PORT]: STM32 });
+
+        channel.onmessage({ kind: "snapshot", ports: {} });
+
+        expect(events).toEqual([["removedDevice", PORT]]);
+    });
+
+    it("stays silent for a device it does not recognise", async () => {
+        const { channel, events } = await monitored();
+
+        channel.onmessage({ kind: "added", path: "/dev/ttyS0", info: { vid: "Unknown", pid: "Unknown" } });
+
+        expect(events).toEqual([]);
+    });
+
+    it("stays silent when a snapshot changes nothing", async () => {
+        const { channel, events } = await monitored({ [PORT]: STM32 });
+
+        channel.onmessage({ kind: "snapshot", ports: { [PORT]: STM32 } });
+
+        expect(events).toEqual([]);
+    });
+
+    it("does not list a port twice when told it was added twice", async () => {
+        const { serial, channel } = await monitored();
+
+        channel.onmessage({ kind: "added", path: PORT, info: STM32 });
+        channel.onmessage({ kind: "added", path: PORT, info: STM32 });
+
+        expect(serial.ports.map((port) => port.path)).toEqual([PORT]);
+    });
+
+    it("waits for an in-flight subscribe before tearing the monitor down", async () => {
+        // Otherwise the subscribe stores its channel id after the teardown read
+        // it, and the monitor keeps enumerating for the whole connection.
+        let resolveWatch;
+        invoke.mockImplementation((cmd) => {
+            if (cmd === "plugin:serialplugin|watch_ports") {
+                return new Promise((resolve) => {
+                    resolveWatch = resolve;
+                });
             }
             return Promise.resolve(undefined);
         });
         const serial = new TauriSerial();
+        await vi.waitFor(() => expect(resolveWatch).toBeDefined());
 
-        await serial.connect(PORT, { baudRate: 115200 });
-        serial.reading = false;
+        const stopped = serial.stopDeviceMonitoring();
+        resolveWatch(7);
+        await stopped;
 
-        const read = invoke.mock.calls.find(([cmd]) => cmd === "plugin:serialplugin|read_binary");
-        expect(read).toBeDefined();
-        expect(read[1].size).toBeGreaterThan(1024);
+        expect(argsFor("plugin:serialplugin|unwatch_ports")).toEqual({ channelId: 7 });
+        expect(serial.portListChannelId).toBe(null);
     });
 });

--- a/test/js/tauri_serial.test.js
+++ b/test/js/tauri_serial.test.js
@@ -376,11 +376,15 @@ describe("TauriSerial connect", () => {
         mockPresentPort();
         const serial = new TauriSerial();
         await serial.connect(PORT, { baudRate: 115200 });
-        const start = vi.spyOn(serial, "startDeviceMonitoring");
+        // The describe-level stub keeps _bootstrap() from subscribing; from here
+        // the real subscribe path is the behaviour under test.
+        TauriSerial.prototype.startDeviceMonitoring.mockRestore();
+        invoke.mockClear();
 
         await serial.disconnect();
 
-        expect(start).toHaveBeenCalled();
+        expect(commands()).toContain("plugin:serialplugin|watch_ports");
+        expect(serial.portListChannelId).toBe(1);
     });
 });
 


### PR DESCRIPTION
TauriSerial polled `read_binary` every 20 ms, so every inbound MSP frame waited 0-20 ms before JS saw it and a tab load of ~25 sequential requests paid ~250 ms of pure poll latency. Receive and hotplug now arrive as push events over IPC channels: the plugin's RX hub thread dispatches what it reads instead of parking it for the next poll, and `watch_ports` enumerates on a Rust thread instead of over the webview bridge. Enumeration stays suspended while a port is open, since `available_ports` crosses the same single-threaded Kotlin bridge the reads and writes use.

The plugin's `watch` is not binary safe (its AT line router decodes chunks as UTF-8, splits on newlines and trims), so this pins a fork of tauri-plugin-serialplugin that adds a `raw` mode.

This fixes latency, not throughput: data still crosses IPC as a JSON number array, so if a CLI dump is still slow the encoding is the next thing to look at.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved USB serial communication reliability by preserving incoming bytes accurately.
  * Improved connection and disconnection handling, including transient errors and cleanup.
  * Prevented stale device events from causing incorrect connection or removal notifications.
  * Improved detection of connected and disconnected serial devices without duplicate notifications.

* **Performance**
  * Replaced periodic polling with responsive event-based serial data and device monitoring.
  * Reduced unnecessary device checks while maintaining accurate hotplug updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
