### PR TITLE
feat(osd): pick the OSD display port protocol from its own tab

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6402,6 +6402,9 @@
     "osdSetupUploadingFontFailed": {
         "message": "Upload failed"
     },
+    "osdSetupSaveReboot": {
+        "message": "Save and Reboot"
+    },
     "osdSetupSave": {
         "message": "Save"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -6293,6 +6293,12 @@
         "message": "HD",
         "description": "Option for the video format in the OSD"
     },
+    "osdProtocol": {
+        "message": "OSD Protocol"
+    },
+    "osdProtocolHelp": {
+        "message": "Protocol the OSD is drawn with. MAX7456 and FrSky OSD drive an analogue chip or module; MSP sends the OSD over the UART below, as DJI, HDZero and Walksnail goggles expect."
+    },
     "osdSerialPort": {
         "message": "OSD Serial Port"
     },

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7841,6 +7841,9 @@
     "vtxSerialPortHelp": {
         "message": "UART the VTX control protocol runs on. Set on the VTX itself from API 1.49; the Ports tab only shows it."
     },
+    "vtxSerialPortMspHelp": {
+        "message": "An MSP VTX answers on the same MSP link the goggles are drawn over, so it follows the OSD Serial Port on the OSD tab and cannot be set here."
+    },
     "vtxLowPowerDisarm": {
         "message": "Low Power Disarm",
         "description": "Text of one of the fields of the VTX tab"

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -601,6 +601,7 @@ import { useOsdRuler } from "@/composables/useOsdRuler";
 import { useBuildOptions } from "@/composables/useBuildOptions";
 import { useTransientLabel } from "@/composables/useTransientLabel";
 import { useSaving } from "@/composables/useSaving";
+import { useReboot } from "@/composables/useReboot";
 import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import { PORT_NONE } from "@/composables/ports/portNames";
 import { runTabLoad } from "@/composables/useTabLoad";
@@ -684,6 +685,7 @@ const selectedFontPreset = ref(selectedFont.value);
 const uploadProgress = ref(0);
 const uploadProgressLabel = ref("");
 const { isSaving, runSave } = useSaving();
+const { reboot } = useReboot();
 const logoImageSizeParams = {
     logoWidthPx: FONT.constants.SIZES.CHAR_WIDTH * 24,
     logoHeightPx: FONT.constants.SIZES.CHAR_HEIGHT * 4,
@@ -696,6 +698,12 @@ const saveMenuItems = computed(() => [
             icon: "i-lucide-save",
             disabled: !portsOrConfigDirty.value || isSaving.value,
             onSelect: saveConfig,
+        },
+        {
+            label: i18n.getMessage("osdSetupSaveReboot"),
+            icon: "i-lucide-rotate-cw",
+            disabled: !portsOrConfigDirty.value || isSaving.value,
+            onSelect: saveAndRebootConfig,
         },
         {
             label: i18n.getMessage("osdSetupRefresh"),
@@ -1454,6 +1462,12 @@ const saveConfig = () =>
             },
         },
     );
+
+// A UART assignment only takes effect at serial init, so the port rows need a reboot to bite.
+const saveAndRebootConfig = async () => {
+    await saveConfig();
+    await reboot();
+};
 
 // Font Manager
 const fontCharacterUrls = computed(() => {

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -264,6 +264,19 @@
                                 />
                             </SettingRow>
                             <SettingRow
+                                v-if="osdProtocolOptions.length"
+                                :label="$t('osdProtocol')"
+                                :help="$t('osdProtocolHelp')"
+                            >
+                                <USelect
+                                    v-model="osdProtocol"
+                                    :items="osdProtocolOptions"
+                                    :disabled="!osdPortWritable"
+                                    size="xs"
+                                    class="min-w-40"
+                                />
+                            </SettingRow>
+                            <SettingRow
                                 v-if="osdPortAvailable"
                                 :label="$t('osdSerialPort')"
                                 :help="$t('osdSerialPortHelp')"
@@ -591,9 +604,9 @@ import { useSaving } from "@/composables/useSaving";
 import { useFeaturePort } from "@/composables/ports/useFeaturePort";
 import { runTabLoad } from "@/composables/useTabLoad";
 
-// From API 1.49 both live on the OSD parameter group. osd_uart only shows up in the synthesised
-// mask when the display port device is FrSky OSD, and sets no bit at all on MSP DisplayPort, so
-// the setting is the only reliable read either way.
+// From API 1.49 both live on the OSD parameter group. The bit osd_uart sets in the synthesised
+// mask follows the display port device, and on MSP DisplayPort it is the shared MSP bit, so the
+// setting is the only reliable read either way.
 const {
     available: osdPortAvailable,
     writable: osdPortWritable,
@@ -602,7 +615,13 @@ const {
     changed: osdPortChanged,
     load: loadOsdPort,
     write: writeOsdPort,
-} = useFeaturePort({ setting: "osd_uart", functionName: "FRSKY_OSD" });
+    selectedProtocol: osdProtocol,
+    protocolOptions: osdProtocolOptions,
+} = useFeaturePort({
+    setting: "osd_uart",
+    functionName: "FRSKY_OSD",
+    protocol: { setting: "osd_displayport_device" },
+});
 
 const {
     available: customTextPortAvailable,

--- a/src/components/tabs/OsdTab.vue
+++ b/src/components/tabs/OsdTab.vue
@@ -310,7 +310,7 @@
                                 <USelect
                                     v-model="customTextBaud"
                                     :items="customTextBaudOptions"
-                                    :disabled="!customTextPortWritable"
+                                    :disabled="!customTextPortWritable || !customTextPortAssigned"
                                     size="xs"
                                     class="min-w-40"
                                 />
@@ -602,6 +602,7 @@ import { useBuildOptions } from "@/composables/useBuildOptions";
 import { useTransientLabel } from "@/composables/useTransientLabel";
 import { useSaving } from "@/composables/useSaving";
 import { useFeaturePort } from "@/composables/ports/useFeaturePort";
+import { PORT_NONE } from "@/composables/ports/portNames";
 import { runTabLoad } from "@/composables/useTabLoad";
 
 // From API 1.49 both live on the OSD parameter group. The bit osd_uart sets in the synthesised
@@ -638,6 +639,8 @@ const {
     functionName: "OSD_CUSTOM_TEXT",
     baud: { setting: "osd_custom_text_baud" },
 });
+
+const customTextPortAssigned = computed(() => customTextPortIdentifier.value !== PORT_NONE);
 
 // A port-only change still has to enable Save; the OSD store's dirty state cannot see these.
 const portsOrConfigDirty = computed(() => osdStore.dirty || osdPortChanged.value || customTextPortChanged.value);

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -98,12 +98,13 @@
                             <SettingRow
                                 v-if="vtxPortAvailable"
                                 :label="$t('vtxSerialPort')"
-                                :help="$t('vtxSerialPortHelp')"
+                                :help="mspVtx ? $t('vtxSerialPortMspHelp') : $t('vtxSerialPortHelp')"
                             >
                                 <USelect
-                                    v-model="vtxPortIdentifier"
+                                    :model-value="vtxPortShown"
+                                    @update:model-value="(v) => (vtxPortIdentifier = v)"
                                     :items="vtxPortOptions"
-                                    :disabled="!vtxPortWritable"
+                                    :disabled="!vtxPortWritable || mspVtx"
                                     class="w-36"
                                 />
                             </SettingRow>
@@ -409,6 +410,7 @@ import { useVtx } from "../../composables/useVtx";
 import { useInterval } from "../../composables/useInterval";
 import { useSaving } from "../../composables/useSaving";
 import { useFeaturePort } from "@/composables/ports/useFeaturePort";
+import { PORT_NONE } from "@/composables/ports/portNames";
 import { useTranslation } from "i18next-vue";
 
 export default defineComponent({
@@ -477,6 +479,18 @@ export default defineComponent({
             protocol: { setting: "vtx_type" },
         });
 
+        // An MSP VTX answers on the goggles' MSP link rather than a port of its own, so the
+        // firmware falls back to the OSD's UART and the row follows the OSD tab, read-only.
+        const { selectedIdentifier: osdPortIdentifier, load: loadOsdPort } = useFeaturePort({
+            setting: "osd_uart",
+            functionName: "FRSKY_OSD",
+        });
+
+        const mspVtx = computed(() => vtxProtocol.value === "MSP");
+        const vtxPortShown = computed(() =>
+            mspVtx.value && vtxPortIdentifier.value === PORT_NONE ? osdPortIdentifier.value : vtxPortIdentifier.value,
+        );
+
         // vtxDevType_e keeps index 2 open, so the firmware lookup names it RESERVED.
         const vtxProtocolOptions = computed(() => vtxProtocolValues.value.filter(({ value }) => value !== "RESERVED"));
 
@@ -543,6 +557,7 @@ export default defineComponent({
         onMounted(async () => {
             await loadVtxConfig();
             await loadVtxPort();
+            await loadOsdPort();
             addInterval("vtx_device_status_pull", updateDeviceStatus, 1000);
             i18n.localizePage();
             GUI.content_ready();
@@ -554,6 +569,7 @@ export default defineComponent({
                     await saveVtx(writeVtxPort);
                     await loadVtxConfig();
                     await loadVtxPort();
+                    await loadOsdPort();
                 },
                 {
                     onError: (error) => {
@@ -700,6 +716,8 @@ export default defineComponent({
             vtxPortIdentifier,
             vtxProtocol,
             vtxProtocolOptions,
+            mspVtx,
+            vtxPortShown,
             savePending,
             factoryBandsSupported,
             frequencyMode,

--- a/src/composables/ports/useFeaturePort.js
+++ b/src/composables/ports/useFeaturePort.js
@@ -114,7 +114,7 @@ async function sendSetting(command) {
  * through that setting rather than through the per-port function mask. The mask is only a
  * synthesised view and cannot answer "which port is this feature on" in general: the three MSP
  * and three telemetry instances share a bit, a rangefinder and an optical flow sensor share one,
- * a VTX sets a bit chosen by its protocol, and an OSD on MSP DisplayPort sets none at all. The
+ * and a VTX or an OSD sets a bit chosen by its protocol, which on MSP is the shared MSP bit. The
  * mask is still what builds the port list and its "claimed by" annotations.
  *
  * Whether a build has the setting at all is discovered the same way — a `get` for a setting the


### PR DESCRIPTION
Follow-up to #5451.

osd_displayport_device was not exposed anywhere in the app, so the only protocol select that reached an MSP link was the VTX tab's, and a DJI, HDZero or Walksnail user had to configure a VTX to get an OSD. It now sits above the port it applies to and reads its values from the firmware.

An MSP VTX answers on that same link, so the VTX tab's port row is read-only for it and shows the OSD's UART, with the help text saying where to set it. Needs betaflight/betaflight#15628 for the firmware fallback.

Also disables the OSD custom text baud when no port is assigned.

![OSD tab](https://raw.githubusercontent.com/blckmn/betaflight-configurator/screenshots/osd-protocol-osd.png)

![VTX tab](https://raw.githubusercontent.com/blckmn/betaflight-configurator/screenshots/osd-protocol-vtx.png)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable serial ports, protocols, and baud rates for OSD display and custom-text output.
  * Added VTX protocol and serial-port settings, including automatic OSD UART selection for MSP VTX devices.
  * Added a **Save and Reboot** option for applying UART assignments.
* **Bug Fixes**
  * Port-only changes are now detected, saved, and reloaded correctly alongside OSD and VTX settings.
* **Documentation**
  * Added guidance explaining MSP VTX serial-port behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->