### PR TITLE
Add Export Video to the Blackbox tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -194,7 +194,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1722,7 +1721,6 @@
       "resolved": "https://registry.npmjs.org/@capacitor/core/-/core-8.3.4.tgz",
       "integrity": "sha512-CqRQCkb6HXxcx/N7s+hHTN6ef2CmamFiRMITwm4qB840ph56mS42bzUgn6tKCP+RZjdDweiRHj9ytDDeN6jFag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -1823,7 +1821,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -1870,9 +1867,39 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
+      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
+      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2499,7 +2526,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz",
       "integrity": "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.8.0",
         "@floating-ui/utils": "^0.2.12"
@@ -5927,7 +5953,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -5988,7 +6013,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.28.0.tgz",
       "integrity": "sha512-gUuD5WAYfbDxNSSJya/emh2KSzXZXLUYKW4fEnc1AQ5FE2twzh4LJ9UlKFIawigrUCAksWI5Fy1hRbv+5m4ZdQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6086,7 +6110,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-collaboration/-/extension-collaboration-3.28.0.tgz",
       "integrity": "sha512-4RUyRPhieqPD7fvCeniIE0QBSwb1exOWJlYvF8s8wWTwc5uywa95gUhRbnHwgTReeG0WW+177eFSEr9xZaUseg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6116,7 +6139,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-drag-handle/-/extension-drag-handle-3.28.0.tgz",
       "integrity": "sha512-Ta/ZmyFcbUGmxb/OtfJ+znWPTtSNPC0Z7diMkbg3aOo387qtrVEtbq/8w2+6PayOQGEiQN8xYU1ZjCdOhwmVAQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/dom": "^1.6.13"
       },
@@ -6277,7 +6299,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.28.0.tgz",
       "integrity": "sha512-zQ66i5DuhVOndmZ0d7H475Y5Yb+BMx+zfCjFkCzEc6WVef5MumtxBVTkGLQ0ibxUaD71s4QQZbjHWagpaTg0eQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6333,7 +6354,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-node-range/-/extension-node-range-3.28.0.tgz",
       "integrity": "sha512-bH2rxZgSVk/qeFCcJC3Fjl7CYqp1TYjx5fXLtyL+r5qz/KR8qCItLZWndfH+POVD5D9RvEwNnJHBD8Sa2hDI4w==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6426,7 +6446,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.28.0.tgz",
       "integrity": "sha512-DJT1khCK+O/pT1gQlAnoKAx6zwDkgv7GtnhSfkqm1/4KHC3x+SSJnBIgBl9oGHymA+DxWbW1EULU4V3d/kT2uQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6470,7 +6489,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.28.0.tgz",
       "integrity": "sha512-ALcpwZMUdat9gjJKlpscpoqXStoLhU246LPEVBDvJdIsoUKvUu3MrzfXik2Y8mtSGfhjtm9O2TRkWxQiFVMwsQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.4.1",
         "prosemirror-commands": "^1.7.1",
@@ -6532,7 +6550,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/suggestion/-/suggestion-3.28.0.tgz",
       "integrity": "sha512-24k0CvvazBeHAK2+WrV1n0uDBZBHNbDAq1K8b5KkWSxcAU7zSCytmApS1u7clRW5wg2xKNBdDhNhvk7KSm1kIA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -6548,7 +6565,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/vue-3/-/vue-3-3.28.0.tgz",
       "integrity": "sha512-twb3T6hofM0ajncCSgrLYIjfn86WfR2NVXteurdNOcnkJCIMTij5OhO/xn0z7y8+lp3TMkF6H5kajUpivBpnzw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -7180,7 +7196,6 @@
       "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-14.3.0.tgz",
       "integrity": "sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/web-bluetooth": "^0.0.21",
         "@vueuse/metadata": "14.3.0",
@@ -7312,7 +7327,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7783,7 +7797,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -8734,7 +8747,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -9160,8 +9172,7 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/embla-carousel-auto-height": {
       "version": "8.6.0",
@@ -9546,7 +9557,6 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9607,7 +9617,6 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -10319,7 +10328,6 @@
       "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.5.0.tgz",
       "integrity": "sha512-sQtrEfA+ez/3G0cCZecF70oqpCRttCexYUG4mUrtWL49ULUzUyxokt5kyqwtKzj1270RaKih+hcP3qLcumccow==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -10762,7 +10770,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.10"
       },
@@ -11551,6 +11558,7 @@
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -11814,8 +11822,7 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "license": "BSD-2-Clause",
-      "peer": true
+      "license": "BSD-2-Clause"
     },
     "node_modules/leaflet-marker-rotation": {
       "version": "0.4.0",
@@ -11843,7 +11850,6 @@
       "integrity": "sha512-o3UxHBPPVY1HtCXx15/z1NlknQiWyafRNbtLEv+6xFaDRI2g2xPKIH43do9dSwt8bGLTsjNSaifa48N3d6odsQ==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "copy-anything": "^3.0.5",
         "parse-node-version": "^1.0.1"
@@ -11892,6 +11898,7 @@
       "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
       "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
@@ -13684,7 +13691,6 @@
       "integrity": "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -13862,7 +13868,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.11.tgz",
       "integrity": "sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -13883,7 +13888,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -13917,7 +13921,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.42.1.tgz",
       "integrity": "sha512-rRqzZnRgkyh69XoOMrfFJHwauHscLBmHbq772kwbic1ymQAM8gXjzEbJse5j1ep2UO2HRIAQL0bY3kZ/RoqjVw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.25.8",
         "prosemirror-state": "^1.0.0",
@@ -14147,7 +14150,6 @@
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -14158,7 +14160,6 @@
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -14499,7 +14500,6 @@
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
       "integrity": "sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.139.0",
         "@rolldown/pluginutils": "^1.0.0"
@@ -14542,7 +14542,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
       "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.9"
       },
@@ -14985,8 +14984,7 @@
       "version": "1.15.7",
       "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.7.tgz",
       "integrity": "sha512-Kk8wLQPlS+yi1ZEf48a4+fzHa4yxjC30M/Sr2AnQu+f/MPwvvX9XjZ6OWejiz8crBsLwSq8GHqaxaET7u6ux0A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -15067,7 +15065,6 @@
       "integrity": "sha512-zkYxVZoDMj8njzZc3EH5UyY7885wpi9a1mmWVwFiNHSo+i5r2Go84E2OI1cdOctRymLkNvgs1j5jqAKA0ftBqg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@storybook/icons": "^2.0.2",
@@ -15463,7 +15460,6 @@
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
       "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"
@@ -15492,8 +15488,7 @@
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
       "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tapable": {
       "version": "2.3.3",
@@ -15930,7 +15925,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -16635,7 +16629,6 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
       "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -17030,7 +17023,6 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.40.tgz",
       "integrity": "sha512-+8PJ4SJXdn/cHGImF4CKdxlWHIN5Dkt7DoufRREM6h6uVCx2m7QxgcEQmmzyOK8A9mcafg7sFbJFYsdFVubTig==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.40",
         "@vue/compiler-sfc": "3.5.40",
@@ -17205,7 +17197,6 @@
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.6.4.tgz",
       "integrity": "sha512-Hz9q5sa33Yhduglwz6g9skT8OBPii+4bFn88w6J+J4MfEo4KRRpmiNG/hHHkdbRFlLBOqxN8y8gf2Fb0MTUgVg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/devtools-api": "^6.6.4"
       },
@@ -17533,7 +17524,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "Leaflet.MultiOptionsPolyline": "github:hgoebl/Leaflet.MultiOptionsPolyline",
         "lodash.debounce": "^4.0.8",
         "marked": "^15.0.7",
+        "mediabunny": "^1.55.2",
         "multicast-dns": "^7.2.5",
         "ol": "^10.4.0",
         "pinia": "^3.0.4",
@@ -1872,27 +1873,6 @@
       "peer": true,
       "engines": {
         "node": ">=20.19.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.3.tgz",
-      "integrity": "sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.3",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/core/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.3.tgz",
-      "integrity": "sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -6653,6 +6633,21 @@
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-transform": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-transform/-/dom-mediacapture-transform-0.1.12.tgz",
+      "integrity": "sha512-d7/QsLRwF864A5mgIM/YrfiglHoYn7zgCcAoJgW404r+2DwnNr7EBbLnCWpmOMgH8y0te73L1AV6H1bmauaWFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/dom-webcodecs": "*"
+      }
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -12645,6 +12640,24 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
       "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
       "license": "CC0-1.0"
+    },
+    "node_modules/mediabunny": {
+      "version": "1.55.2",
+      "resolved": "https://registry.npmjs.org/mediabunny/-/mediabunny-1.55.2.tgz",
+      "integrity": "sha512-EEx4O6qYddAdCyWPMZNDwI7uc5hewNHrPAf9jLcVhIbXoPsiqNQ+D9i1pfadmGkjN2V318jSrZljkpoziYm6Lg==",
+      "license": "MPL-2.0",
+      "workspaces": [
+        ".",
+        "packages/*"
+      ],
+      "dependencies": {
+        "@types/dom-mediacapture-transform": "^0.1.11",
+        "@types/dom-webcodecs": "0.1.13"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/Vanilagy"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "Leaflet.MultiOptionsPolyline": "github:hgoebl/Leaflet.MultiOptionsPolyline",
     "lodash.debounce": "^4.0.8",
     "marked": "^15.0.7",
+    "mediabunny": "^1.55.2",
     "multicast-dns": "^7.2.5",
     "ol": "^10.4.0",
     "pinia": "^3.0.4",

--- a/src/blackbox-viewer/App.vue
+++ b/src/blackbox-viewer/App.vue
@@ -12,6 +12,7 @@
                 @export-csv="onExportCsv"
                 @export-gpx="onExportGpx"
                 @export-workspaces="onExportWorkspaces"
+                @export-video="appStore.videoExportDialogOpen = true"
                 @toggle-fullscreen="onToggleFullscreen"
             />
         </Teleport>
@@ -95,6 +96,7 @@
         <!-- Dialogs -->
         <KeysDialog v-model:open="appStore.keysDialogOpen" />
         <UserSettingsDialog v-model:open="appStore.settingsDialogOpen" @save="onSaveSettings" />
+        <VideoExportDialog v-model:open="appStore.videoExportDialogOpen" />
         <GraphConfigDialog
             v-model:open="appStore.graphConfigDialogOpen"
             :flightLog="logStore.flightLog"
@@ -116,6 +118,7 @@ import { usePlaybackStore } from "./stores/playback.js";
 import { useSettingsStore } from "./stores/settings.js";
 import { useWorkspaceStore } from "./stores/workspace.js";
 import AppToolbar from "./components/AppToolbar.vue";
+import VideoExportDialog from "./components/VideoExportDialog.vue";
 import WelcomePage from "./components/WelcomePage.vue";
 import ViewControls from "./components/ViewControls.vue";
 import PlaybackControls from "./components/PlaybackControls.vue";

--- a/src/blackbox-viewer/components/AppToolbar.vue
+++ b/src/blackbox-viewer/components/AppToolbar.vue
@@ -41,8 +41,8 @@
                     label="Export Video"
                     icon="i-lucide-video"
                     size="xs"
-                    :disabled="!logStore.hasLog"
-                    title="Render the marked range to a video file"
+                    :disabled="!videoCapability?.canEncode"
+                    :title="videoExportTitle"
                     @click="$emit('export-video')"
                 />
                 <USeparator orientation="vertical" class="h-4" />
@@ -77,9 +77,11 @@
 </template>
 
 <script setup>
+import { computed, ref, watch } from "vue";
 import { useLogStore } from "../stores/log.js";
 import { useAppStore } from "../stores/app.js";
 import { useGraphStore } from "../stores/graph.js";
+import { probeVideoExport } from "../video_export.js";
 import LogFileInput from "./LogFileInput.vue";
 
 defineEmits([
@@ -96,6 +98,35 @@ defineEmits([
 const logStore = useLogStore();
 const appStore = useAppStore();
 const graphStore = useGraphStore();
+const videoCapability = ref(null);
+let probeGeneration = 0;
+
+const videoExportTitle = computed(() => {
+    if (!videoCapability.value) return "Checking video export support…";
+    return videoCapability.value.canEncode ? "Render the marked range to a video file" : videoCapability.value.reason;
+});
+
+watch(
+    () => logStore.hasLog,
+    async (hasLog) => {
+        const generation = ++probeGeneration;
+        videoCapability.value = null;
+        if (!hasLog) return;
+        let result;
+        try {
+            result = await probeVideoExport({ width: 1280, height: 720 });
+        } catch (error) {
+            result = {
+                canEncode: false,
+                reason: `Video capability detection failed: ${error?.message ?? String(error)}`,
+            };
+        }
+        if (generation === probeGeneration) {
+            videoCapability.value = result;
+        }
+    },
+    { immediate: true },
+);
 </script>
 
 <style scoped>

--- a/src/blackbox-viewer/components/AppToolbar.vue
+++ b/src/blackbox-viewer/components/AppToolbar.vue
@@ -35,6 +35,16 @@
                     title="Export your workspace configurations to file"
                     @click="$emit('export-workspaces')"
                 />
+                <UButton
+                    variant="ghost"
+                    color="neutral"
+                    label="Export Video"
+                    icon="i-lucide-video"
+                    size="xs"
+                    :disabled="!logStore.hasLog"
+                    title="Render the marked range to a video file"
+                    @click="$emit('export-video')"
+                />
                 <USeparator orientation="vertical" class="h-4" />
             </template>
             <UButton
@@ -77,6 +87,7 @@ defineEmits([
     "export-csv",
     "export-gpx",
     "export-workspaces",
+    "export-video",
     "open-settings",
     "open-keys",
     "toggle-fullscreen",

--- a/src/blackbox-viewer/components/AppToolbar.vue
+++ b/src/blackbox-viewer/components/AppToolbar.vue
@@ -35,16 +35,27 @@
                     title="Export your workspace configurations to file"
                     @click="$emit('export-workspaces')"
                 />
-                <UButton
-                    variant="ghost"
-                    color="neutral"
-                    label="Export Video"
-                    icon="i-lucide-video"
-                    size="xs"
-                    :disabled="!videoCapability?.canEncode"
-                    :title="videoExportTitle"
-                    @click="$emit('export-video')"
-                />
+                <UTooltip :text="videoExportTitle" :delay-duration="300">
+                    <span
+                        data-testid="video-export-capability"
+                        class="inline-flex"
+                        :role="videoExportDisabled ? 'group' : undefined"
+                        :aria-disabled="videoExportDisabled || undefined"
+                        :aria-label="videoExportDisabled ? `Export Video unavailable: ${videoExportTitle}` : undefined"
+                        :tabindex="videoExportDisabled ? 0 : undefined"
+                    >
+                        <UButton
+                            variant="ghost"
+                            color="neutral"
+                            label="Export Video"
+                            icon="i-lucide-video"
+                            size="xs"
+                            :disabled="videoExportDisabled"
+                            :class="{ 'pointer-events-none': videoExportDisabled }"
+                            @click="$emit('export-video')"
+                        />
+                    </span>
+                </UTooltip>
                 <USeparator orientation="vertical" class="h-4" />
             </template>
             <UButton
@@ -100,6 +111,8 @@ const appStore = useAppStore();
 const graphStore = useGraphStore();
 const videoCapability = ref(null);
 let probeGeneration = 0;
+
+const videoExportDisabled = computed(() => !videoCapability.value?.canEncode);
 
 const videoExportTitle = computed(() => {
     if (!videoCapability.value) {

--- a/src/blackbox-viewer/components/AppToolbar.vue
+++ b/src/blackbox-viewer/components/AppToolbar.vue
@@ -102,7 +102,9 @@ const videoCapability = ref(null);
 let probeGeneration = 0;
 
 const videoExportTitle = computed(() => {
-    if (!videoCapability.value) return "Checking video export support…";
+    if (!videoCapability.value) {
+        return "Checking video export support…";
+    }
     return videoCapability.value.canEncode ? "Render the marked range to a video file" : videoCapability.value.reason;
 });
 
@@ -111,7 +113,9 @@ watch(
     async (hasLog) => {
         const generation = ++probeGeneration;
         videoCapability.value = null;
-        if (!hasLog) return;
+        if (!hasLog) {
+            return;
+        }
         let result;
         try {
             result = await probeVideoExport({ width: 1280, height: 720 });

--- a/src/blackbox-viewer/components/VideoExportDialog.vue
+++ b/src/blackbox-viewer/components/VideoExportDialog.vue
@@ -1,10 +1,14 @@
 <script setup>
-import { computed, ref, watch } from "vue";
+import { computed, onUnmounted, ref, toRaw, watch } from "vue";
+import FileSystem from "@/js/FileSystem.js";
 import { useLogStore } from "../stores/log.js";
 import { usePlaybackStore } from "../stores/playback.js";
 import { useAppStore } from "../stores/app.js";
 import { useGraphStore } from "../stores/graph.js";
+import { useSettingsStore } from "../stores/settings.js";
+import { PrefStorage } from "../pref_storage.js";
 import {
+    cancelActiveVideoExport,
     estimateFrameCount,
     estimateOutputBytes,
     probeVideoExport,
@@ -12,32 +16,33 @@ import {
     suggestedName,
 } from "../video_export.js";
 
+const FRAMERATES = [30, 50, 60];
+const RESOLUTIONS = [
+    { label: "720p (1280 × 720)", value: "1280x720", width: 1280, height: 720 },
+    { label: "1080p (1920 × 1080)", value: "1920x1080", width: 1920, height: 1080 },
+];
+
+const open = defineModel("open", { type: Boolean, default: false });
 const appStore = useAppStore();
 const logStore = useLogStore();
 const playbackStore = usePlaybackStore();
+const graphStore = useGraphStore();
+const settingsStore = useSettingsStore();
+const prefs = new PrefStorage();
 
-const FRAMERATES = [30, 50, 60];
-const RESOLUTIONS = [
-    { label: "720p", width: 1280, height: 720 },
-    { label: "1080p", width: 1920, height: 1080 },
-];
-
-const mode = ref("settings"); // settings | rendering | done | error
+const mode = ref("settings");
+const phase = ref("rendering");
 const frameRate = ref(30);
-const resolution = ref(RESOLUTIONS[0]);
-const probeResult = ref(null);
+const resolutionValue = ref(RESOLUTIONS[0].value);
+const probes = ref({});
+const probesLoading = ref(false);
 const progress = ref({ frame: 0, totalFrames: 0, bytesWritten: 0, etaSecs: 0 });
 const resultInfo = ref(null);
 const errorMessage = ref("");
 let cancelRequested = false;
 
-const open = computed({
-    get: () => appStore.videoExportDialogOpen,
-    set: (value) => {
-        appStore.videoExportDialogOpen = value;
-    },
-});
-
+const resolution = computed(() => RESOLUTIONS.find((item) => item.value === resolutionValue.value) ?? RESOLUTIONS[0]);
+const probeResult = computed(() => probes.value[resolution.value.value] ?? null);
 const estimatedFrames = computed(() =>
     estimateFrameCount({
         inTime: playbackStore.videoExportInTime,
@@ -47,7 +52,6 @@ const estimatedFrames = computed(() =>
         getMaxTime: () => logStore.flightLog?.getMaxTime?.() ?? 0,
     }),
 );
-
 const estimatedBytes = computed(() =>
     estimateOutputBytes({
         frameCount: estimatedFrames.value,
@@ -56,74 +60,123 @@ const estimatedBytes = computed(() =>
         codec: probeResult.value?.codec,
     }),
 );
+const progressPercent = computed(() =>
+    progress.value.totalFrames > 0 ? Math.round((progress.value.frame / progress.value.totalFrames) * 100) : 0,
+);
+const canStart = computed(
+    () =>
+        !probesLoading.value && probeResult.value?.canEncode && estimatedFrames.value > 0 && mode.value === "settings",
+);
 
-const bufferedWarning = computed(() => probeResult.value?.saveMode === "buffered");
+async function warmAllProbes() {
+    probesLoading.value = true;
+    try {
+        const results = await Promise.all(
+            RESOLUTIONS.map(async (item) => [
+                item.value,
+                await probeVideoExport({ width: item.width, height: item.height }),
+            ]),
+        );
+        probes.value = Object.fromEntries(results);
+    } catch (error) {
+        const failure = {
+            canEncode: false,
+            reason: `Video capability detection failed: ${error?.message ?? String(error)}`,
+        };
+        probes.value = Object.fromEntries(RESOLUTIONS.map((item) => [item.value, failure]));
+    } finally {
+        probesLoading.value = false;
+    }
+}
 
-watch(open, async (isOpen) => {
+function seedForm() {
+    const config = playbackStore.videoConfig ?? {};
+    const savedResolution = `${config.width}x${config.height}`;
+    resolutionValue.value = RESOLUTIONS.some((item) => item.value === savedResolution)
+        ? savedResolution
+        : RESOLUTIONS[0].value;
+    frameRate.value = FRAMERATES.includes(Number(config.frameRate)) ? Number(config.frameRate) : 30;
+}
+
+watch(open, (isOpen) => {
     if (isOpen) {
         cancelRequested = false;
         mode.value = "settings";
+        phase.value = "rendering";
+        resultInfo.value = null;
         errorMessage.value = "";
-        probeResult.value = await probeVideoExport({
-            width: resolution.value.width,
-            height: resolution.value.height,
-        });
+        progress.value = { frame: 0, totalFrames: estimatedFrames.value, bytesWritten: 0, etaSecs: 0 };
+        seedForm();
+        void warmAllProbes();
+    } else if (mode.value === "rendering") {
+        cancelExport();
     }
 });
 
-function onResolutionChange(option) {
-    resolution.value = option;
-    probeVideoExport({
-        width: option.width,
-        height: option.height,
-    }).then((result) => {
-        probeResult.value = result;
-    });
-}
+watch(
+    () => appStore.viewerActive,
+    (viewerActive) => {
+        if (!viewerActive) {
+            cancelExport();
+        }
+    },
+);
 
 function humanSize(bytes) {
     if (!bytes) return "0 MB";
     const mb = bytes / (1024 * 1024);
-    return mb >= 1 ? `${mb.toFixed(0)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
+    return mb >= 1 ? `${mb.toFixed(1)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+function humanTime(seconds) {
+    const total = Math.max(0, Math.ceil(seconds || 0));
+    const minutes = Math.floor(total / 60);
+    return `${minutes}:${String(total % 60).padStart(2, "0")}`;
 }
 
 async function startExport() {
-    const exportCanvas = document.createElement("canvas");
-    exportCanvas.width = resolution.value.width;
-    exportCanvas.height = resolution.value.height;
+    if (!canStart.value) return;
 
-    const fileName = suggestedName(logStore.getFilename?.() || "blackbox", probeResult.value.extension);
-
+    const selectedProbe = probeResult.value;
+    const fileName = suggestedName(appStore.logFilename || "blackbox", selectedProbe.extension);
     let file;
     try {
-        file = await window.FileSystem.pickSaveFile(
-            fileName,
-            probeResult.value.description,
-            `.${probeResult.value.extension}`,
-        );
-        if (!file) {
-            return; // user dismissed the dialog; stay in settings
-        }
+        file = await FileSystem.pickSaveFile(fileName, selectedProbe.description, `.${selectedProbe.extension}`);
+        if (!file) return;
     } catch (error) {
         if (error?.name === "AbortError") return;
-        throw error;
+        errorMessage.value = error?.message ?? String(error);
+        mode.value = "error";
+        return;
     }
 
+    playbackStore.videoConfig = {
+        ...playbackStore.videoConfig,
+        width: resolution.value.width,
+        height: resolution.value.height,
+        frameRate: frameRate.value,
+    };
+    prefs.set("videoConfig", playbackStore.videoConfig);
+
+    const exportCanvas = document.createElement("canvas");
     mode.value = "rendering";
+    phase.value = graphStore.hasAnalyser ? "preparing" : "rendering";
     cancelRequested = false;
+    progress.value = { frame: 0, totalFrames: estimatedFrames.value, bytesWritten: 0, etaSecs: 0 };
 
     try {
-        // The engine borrows the live grapher and blocks resize/rAF traffic.
-        const graphStore = useGraphStore();
         const outcome = await runVideoExport({
             canvas: exportCanvas,
+            canvasRefs: graphStore.canvasRefs,
             graph: graphStore.graph,
             log: logStore.flightLog,
-            renderFrame: (timeMicros) => {
-                graphStore.graph.draw(timeMicros, true);
-                // Composite craft + sticks + analyser exactly as the live view.
-                graphStore.graph.renderOverlay?.(exportCanvas.getContext("2d"));
-            },
+            userSettings: toRaw(settingsStore.userSettings),
+            includeSticks: graphStore.hasSticks,
+            includeCraft: graphStore.hasCraft,
+            includeAnalyser: graphStore.hasAnalyser,
+            getAnalyserLayout: () => graphStore.analyserLayout,
+            restoreCanvasSize: graphStore.updateCanvasSize,
+            invalidateGraph: graphStore.invalidateGraph,
             inTime: playbackStore.videoExportInTime,
             outTime: playbackStore.videoExportOutTime,
             frameRate: frameRate.value,
@@ -131,29 +184,16 @@ async function startExport() {
             height: resolution.value.height,
             file,
             shouldCancel: () => cancelRequested,
+            onPhase: (value) => {
+                phase.value = value;
+            },
             onProgress: (value) => {
                 progress.value = value;
             },
         });
 
-        if (outcome.cancelled) {
-            mode.value = "done";
-            resultInfo.value = {
-                cancelled: true,
-                frames: outcome.frames,
-                bytes: outcome.bytes,
-                name: fileName,
-            };
-        } else {
-            await window.FileSystem.closeFile(file);
-            mode.value = "done";
-            resultInfo.value = {
-                cancelled: false,
-                frames: outcome.frames,
-                bytes: outcome.bytes,
-                name: fileName,
-            };
-        }
+        resultInfo.value = { ...outcome, name: fileName };
+        mode.value = "done";
     } catch (error) {
         errorMessage.value = error?.message ?? String(error);
         mode.value = "error";
@@ -162,78 +202,113 @@ async function startExport() {
 
 function cancelExport() {
     cancelRequested = true;
+    cancelActiveVideoExport();
 }
+
+onUnmounted(cancelExport);
 </script>
 
 <template>
-    <UModal v-model:open="open" :title="'Export Video'" :dismissible="mode !== 'rendering'">
+    <UModal
+        v-model:open="open"
+        title="Export Video"
+        :close="mode !== 'rendering'"
+        :dismissible="mode !== 'rendering'"
+        :ui="{ content: 'sm:max-w-xl' }"
+    >
         <template #body>
-            <div v-if="mode === 'settings'" class="flex flex-col gap-3">
+            <div v-if="mode === 'settings'" class="flex flex-col gap-4">
                 <p class="text-sm">
-                    Renders the marked range (set with <kbd>I</kbd> / <kbd>O</kbd>) offscreen, frame by frame, exactly
-                    as shown in the viewer.
+                    Exports the range marked with <kbd>I</kbd> and <kbd>O</kbd>. With no markers, the whole log is used.
                 </p>
-                <div v-if="probeResult && !probeResult.canEncode" role="alert">
-                    {{ probeResult.reason }}
+
+                <UAlert
+                    v-if="logStore.hasVideo"
+                    color="neutral"
+                    variant="subtle"
+                    title="The background flight video is not included in this export."
+                />
+                <UAlert
+                    v-if="probeResult && !probeResult.canEncode"
+                    color="error"
+                    variant="subtle"
+                    title="Video export is unavailable"
+                    :description="probeResult.reason"
+                />
+
+                <div class="grid grid-cols-2 gap-3">
+                    <UFormField label="Framerate">
+                        <USelect v-model="frameRate" :items="FRAMERATES" class="w-full" />
+                    </UFormField>
+                    <UFormField label="Resolution">
+                        <USelect v-model="resolutionValue" :items="RESOLUTIONS" class="w-full" />
+                    </UFormField>
                 </div>
-                <div v-else class="grid grid-cols-2 gap-3">
-                    <label class="flex flex-col gap-1 text-sm">
-                        Framerate
-                        <USelect v-model.number="frameRate" :items="FRAMERATES" />
-                    </label>
-                    <label class="flex flex-col gap-1 text-sm">
-                        Resolution
-                        <USelect :items="RESOLUTIONS" :value="resolution" @change="onResolutionChange" />
-                    </label>
-                </div>
-                <p v-if="probeResult?.canEncode" class="text-sm">
-                    {{ estimatedFrames }} frames, about {{ humanSize(estimatedBytes) }}.
+
+                <p class="text-sm text-muted">
+                    {{ estimatedFrames }} frames · estimated {{ humanSize(estimatedBytes) }}
                 </p>
                 <UAlert
-                    v-if="bufferedWarning && probeResult?.canEncode"
+                    v-if="probeResult?.saveMode === 'buffered'"
                     color="warning"
                     variant="subtle"
-                    title="This browser cannot save directly to disk."
-                    :description="
-                        'The whole video (' +
-                        humanSize(estimatedBytes) +
-                        ') is held in memory until the export finishes. Keep the export short.'
-                    "
+                    title="This browser cannot stream the video directly to disk."
+                    :description="`The complete file (about ${humanSize(estimatedBytes)}) is held until export finishes. Keep the export short.`"
+                />
+                <UAlert
+                    v-if="probeResult?.androidBridge"
+                    color="warning"
+                    variant="subtle"
+                    title="Video export can be slow on Android."
+                    description="Keep the app in the foreground and start with a short 720p export."
                 />
             </div>
 
             <div v-else-if="mode === 'rendering'" class="flex flex-col gap-3">
-                <p class="text-sm">Rendering frame {{ progress.frame }} of {{ progress.totalFrames }}...</p>
-                <span>{{ humanSize(progress.bytesWritten) }} written</span>
-                <span>ETA {{ Math.ceil(progress.etaSecs) }}s</span>
-                <UButton variant="outline" label="Cancel" @click="cancelExport" />
+                <p class="text-sm">
+                    {{
+                        phase === "preparing"
+                            ? "Preparing analyser…"
+                            : `Rendering frame ${progress.frame} of ${progress.totalFrames}`
+                    }}
+                </p>
+                <UProgress :model-value="progressPercent" />
+                <div class="flex justify-between text-sm text-muted">
+                    <span>{{ progressPercent }}% · {{ humanSize(progress.bytesWritten) }} written</span>
+                    <span v-if="phase === 'rendering'">About {{ humanTime(progress.etaSecs) }} remaining</span>
+                </div>
             </div>
 
             <div v-else-if="mode === 'done'" class="flex flex-col gap-3">
-                <template v-if="resultInfo?.cancelled">
-                    <p class="text-sm">
-                        Export cancelled after {{ resultInfo.frames }} frames. The partly-written file was left on disk,
-                        may be unplayable, and can be deleted.
-                    </p>
-                </template>
-                <template v-else>
-                    <p class="text-sm">
-                        Saved {{ resultInfo?.name }} ({{ resultInfo?.frames }} frames,
-                        {{ humanSize(resultInfo?.bytes) }}).
-                    </p>
-                </template>
-                <UButton label="Close" @click="open = false" />
+                <UAlert
+                    v-if="resultInfo?.cancelled"
+                    color="warning"
+                    variant="subtle"
+                    title="Export cancelled"
+                    description="A partly-written file may remain on disk. It may be unplayable and can be deleted."
+                />
+                <p v-else class="text-sm">
+                    Saved {{ resultInfo?.name }} — {{ resultInfo?.frames }} frames, {{ humanSize(resultInfo?.bytes) }}.
+                </p>
             </div>
 
-            <div v-else class="flex flex-col gap-3">
-                <p class="text-sm text-(--ui-error)">The export failed: {{ errorMessage }}</p>
-                <UButton label="Close" @click="open = false" />
-            </div>
+            <UAlert v-else color="error" variant="subtle" title="Video export failed" :description="errorMessage" />
         </template>
+
         <template #footer>
-            <div v-if="mode === 'settings'" class="flex w-full justify-end gap-2">
-                <UButton variant="outline" label="Cancel" :disabled="!probeResult?.canEncode" @click="open = false" />
-                <UButton label="Start Export" :disabled="!probeResult?.canEncode" @click="startExport" />
+            <div class="flex w-full justify-end gap-2">
+                <template v-if="mode === 'settings'">
+                    <UButton color="neutral" variant="outline" label="Cancel" @click="open = false" />
+                    <UButton label="Start Export" :loading="probesLoading" :disabled="!canStart" @click="startExport" />
+                </template>
+                <UButton
+                    v-else-if="mode === 'rendering'"
+                    color="neutral"
+                    variant="outline"
+                    label="Cancel export"
+                    @click="cancelExport"
+                />
+                <UButton v-else label="Close" @click="open = false" />
             </div>
         </template>
     </UModal>

--- a/src/blackbox-viewer/components/VideoExportDialog.vue
+++ b/src/blackbox-viewer/components/VideoExportDialog.vue
@@ -247,10 +247,20 @@ onUnmounted(cancelExport);
 
                 <div class="grid grid-cols-2 gap-3">
                     <UFormField label="Framerate">
-                        <USelect v-model="frameRate" :items="FRAMERATE_OPTIONS" class="w-full" />
+                        <USelect
+                            v-model="frameRate"
+                            :items="FRAMERATE_OPTIONS"
+                            :ui="{ content: 'z-[3002]' }"
+                            class="w-full"
+                        />
                     </UFormField>
                     <UFormField label="Resolution">
-                        <USelect v-model="resolutionValue" :items="RESOLUTIONS" class="w-full" />
+                        <USelect
+                            v-model="resolutionValue"
+                            :items="RESOLUTIONS"
+                            :ui="{ content: 'z-[3002]' }"
+                            class="w-full"
+                        />
                     </UFormField>
                 </div>
 

--- a/src/blackbox-viewer/components/VideoExportDialog.vue
+++ b/src/blackbox-viewer/components/VideoExportDialog.vue
@@ -1,0 +1,240 @@
+<script setup>
+import { computed, ref, watch } from "vue";
+import { useLogStore } from "../stores/log.js";
+import { usePlaybackStore } from "../stores/playback.js";
+import { useAppStore } from "../stores/app.js";
+import { useGraphStore } from "../stores/graph.js";
+import {
+    estimateFrameCount,
+    estimateOutputBytes,
+    probeVideoExport,
+    runVideoExport,
+    suggestedName,
+} from "../video_export.js";
+
+const appStore = useAppStore();
+const logStore = useLogStore();
+const playbackStore = usePlaybackStore();
+
+const FRAMERATES = [30, 50, 60];
+const RESOLUTIONS = [
+    { label: "720p", width: 1280, height: 720 },
+    { label: "1080p", width: 1920, height: 1080 },
+];
+
+const mode = ref("settings"); // settings | rendering | done | error
+const frameRate = ref(30);
+const resolution = ref(RESOLUTIONS[0]);
+const probeResult = ref(null);
+const progress = ref({ frame: 0, totalFrames: 0, bytesWritten: 0, etaSecs: 0 });
+const resultInfo = ref(null);
+const errorMessage = ref("");
+let cancelRequested = false;
+
+const open = computed({
+    get: () => appStore.videoExportDialogOpen,
+    set: (value) => {
+        appStore.videoExportDialogOpen = value;
+    },
+});
+
+const estimatedFrames = computed(() =>
+    estimateFrameCount({
+        inTime: playbackStore.videoExportInTime,
+        outTime: playbackStore.videoExportOutTime,
+        frameRate: frameRate.value,
+        getMinTime: () => logStore.flightLog?.getMinTime?.() ?? 0,
+        getMaxTime: () => logStore.flightLog?.getMaxTime?.() ?? 0,
+    }),
+);
+
+const estimatedBytes = computed(() =>
+    estimateOutputBytes({
+        frameCount: estimatedFrames.value,
+        width: resolution.value.width,
+        height: resolution.value.height,
+        codec: probeResult.value?.codec,
+    }),
+);
+
+const bufferedWarning = computed(() => probeResult.value?.saveMode === "buffered");
+
+watch(open, async (isOpen) => {
+    if (isOpen) {
+        cancelRequested = false;
+        mode.value = "settings";
+        errorMessage.value = "";
+        probeResult.value = await probeVideoExport({
+            width: resolution.value.width,
+            height: resolution.value.height,
+        });
+    }
+});
+
+function onResolutionChange(option) {
+    resolution.value = option;
+    probeVideoExport({
+        width: option.width,
+        height: option.height,
+    }).then((result) => {
+        probeResult.value = result;
+    });
+}
+
+function humanSize(bytes) {
+    if (!bytes) return "0 MB";
+    const mb = bytes / (1024 * 1024);
+    return mb >= 1 ? `${mb.toFixed(0)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
+}
+
+async function startExport() {
+    const exportCanvas = document.createElement("canvas");
+    exportCanvas.width = resolution.value.width;
+    exportCanvas.height = resolution.value.height;
+
+    const fileName = suggestedName(logStore.getFilename?.() || "blackbox", probeResult.value.extension);
+
+    let file;
+    try {
+        file = await window.FileSystem.pickSaveFile(
+            fileName,
+            probeResult.value.description,
+            `.${probeResult.value.extension}`,
+        );
+        if (!file) {
+            return; // user dismissed the dialog; stay in settings
+        }
+    } catch (error) {
+        if (error?.name === "AbortError") return;
+        throw error;
+    }
+
+    mode.value = "rendering";
+    cancelRequested = false;
+
+    try {
+        // The engine borrows the live grapher and blocks resize/rAF traffic.
+        const graphStore = useGraphStore();
+        const outcome = await runVideoExport({
+            canvas: exportCanvas,
+            graph: graphStore.graph,
+            log: logStore.flightLog,
+            renderFrame: (timeMicros) => {
+                graphStore.graph.draw(timeMicros, true);
+                // Composite craft + sticks + analyser exactly as the live view.
+                graphStore.graph.renderOverlay?.(exportCanvas.getContext("2d"));
+            },
+            inTime: playbackStore.videoExportInTime,
+            outTime: playbackStore.videoExportOutTime,
+            frameRate: frameRate.value,
+            width: resolution.value.width,
+            height: resolution.value.height,
+            file,
+            shouldCancel: () => cancelRequested,
+            onProgress: (value) => {
+                progress.value = value;
+            },
+        });
+
+        if (outcome.cancelled) {
+            mode.value = "done";
+            resultInfo.value = {
+                cancelled: true,
+                frames: outcome.frames,
+                bytes: outcome.bytes,
+                name: fileName,
+            };
+        } else {
+            await window.FileSystem.closeFile(file);
+            mode.value = "done";
+            resultInfo.value = {
+                cancelled: false,
+                frames: outcome.frames,
+                bytes: outcome.bytes,
+                name: fileName,
+            };
+        }
+    } catch (error) {
+        errorMessage.value = error?.message ?? String(error);
+        mode.value = "error";
+    }
+}
+
+function cancelExport() {
+    cancelRequested = true;
+}
+</script>
+
+<template>
+    <UModal v-model:open="open" :title="'Export Video'" :dismissible="mode !== 'rendering'">
+        <template #body>
+            <div v-if="mode === 'settings'" class="flex flex-col gap-3">
+                <p class="text-sm">
+                    Renders the marked range (set with <kbd>I</kbd> / <kbd>O</kbd>) offscreen, frame by frame, exactly
+                    as shown in the viewer.
+                </p>
+                <div v-if="probeResult && !probeResult.canEncode" role="alert">
+                    {{ probeResult.reason }}
+                </div>
+                <div v-else class="grid grid-cols-2 gap-3">
+                    <label class="flex flex-col gap-1 text-sm">
+                        Framerate
+                        <USelect v-model.number="frameRate" :items="FRAMERATES" />
+                    </label>
+                    <label class="flex flex-col gap-1 text-sm">
+                        Resolution
+                        <USelect :items="RESOLUTIONS" :value="resolution" @change="onResolutionChange" />
+                    </label>
+                </div>
+                <p v-if="probeResult?.canEncode" class="text-sm">
+                    {{ estimatedFrames }} frames, about {{ humanSize(estimatedBytes) }}.
+                </p>
+                <UAlert
+                    v-if="bufferedWarning && probeResult?.canEncode"
+                    color="warning"
+                    variant="subtle"
+                    title="This browser cannot save directly to disk."
+                    :description="
+                        'The whole video (' +
+                        humanSize(estimatedBytes) +
+                        ') is held in memory until the export finishes. Keep the export short.'
+                    "
+                />
+            </div>
+
+            <div v-else-if="mode === 'rendering'" class="flex flex-col gap-3">
+                <p class="text-sm">Rendering frame {{ progress.frame }} of {{ progress.totalFrames }}...</p>
+                <span>{{ humanSize(progress.bytesWritten) }} written</span>
+                <span>ETA {{ Math.ceil(progress.etaSecs) }}s</span>
+                <UButton variant="outline" label="Cancel" @click="cancelExport" />
+            </div>
+
+            <div v-else-if="mode === 'done'" class="flex flex-col gap-3">
+                <template v-if="resultInfo?.cancelled">
+                    <p class="text-sm">
+                        Export cancelled after {{ resultInfo.frames }} frames. The partly-written file was left on disk,
+                        may be unplayable, and can be deleted.
+                    </p>
+                </template>
+                <template v-else>
+                    <p class="text-sm">
+                        Saved {{ resultInfo?.name }} ({{ resultInfo?.frames }} frames,
+                        {{ humanSize(resultInfo?.bytes) }}).
+                    </p>
+                </template>
+                <UButton label="Close" @click="open = false" />
+            </div>
+
+            <div v-else class="flex flex-col gap-3">
+                <p class="text-sm text-(--ui-error)">The export failed: {{ errorMessage }}</p>
+                <UButton label="Close" @click="open = false" />
+            </div>
+        </template>
+        <template #footer>
+            <div v-if="mode === 'settings'" class="flex w-full justify-end gap-2">
+                <UButton variant="outline" label="Cancel" :disabled="!probeResult?.canEncode" @click="open = false" />
+                <UButton label="Start Export" :disabled="!probeResult?.canEncode" @click="startExport" />
+            </div>
+        </template>
+    </UModal>
+</template>

--- a/src/blackbox-viewer/components/VideoExportDialog.vue
+++ b/src/blackbox-viewer/components/VideoExportDialog.vue
@@ -16,7 +16,8 @@ import {
     suggestedName,
 } from "../video_export.js";
 
-const FRAMERATES = [30, 50, 60];
+const FRAMERATE_OPTIONS = [30, 50, 60];
+const ALLOWED_FRAMERATES = new Set(FRAMERATE_OPTIONS);
 const RESOLUTIONS = [
     { label: "720p (1280 × 720)", value: "1280x720", width: 1280, height: 720 },
     { label: "1080p (1920 × 1080)", value: "1920x1080", width: 1920, height: 1080 },
@@ -95,7 +96,7 @@ function seedForm() {
     resolutionValue.value = RESOLUTIONS.some((item) => item.value === savedResolution)
         ? savedResolution
         : RESOLUTIONS[0].value;
-    frameRate.value = FRAMERATES.includes(Number(config.frameRate)) ? Number(config.frameRate) : 30;
+    frameRate.value = ALLOWED_FRAMERATES.has(Number(config.frameRate)) ? Number(config.frameRate) : 30;
 }
 
 watch(open, (isOpen) => {
@@ -123,7 +124,9 @@ watch(
 );
 
 function humanSize(bytes) {
-    if (!bytes) return "0 MB";
+    if (!bytes) {
+        return "0 MB";
+    }
     const mb = bytes / (1024 * 1024);
     return mb >= 1 ? `${mb.toFixed(1)} MB` : `${(bytes / 1024).toFixed(0)} KB`;
 }
@@ -135,16 +138,22 @@ function humanTime(seconds) {
 }
 
 async function startExport() {
-    if (!canStart.value) return;
+    if (!canStart.value) {
+        return;
+    }
 
     const selectedProbe = probeResult.value;
     const fileName = suggestedName(appStore.logFilename || "blackbox", selectedProbe.extension);
     let file;
     try {
         file = await FileSystem.pickSaveFile(fileName, selectedProbe.description, `.${selectedProbe.extension}`);
-        if (!file) return;
+        if (!file) {
+            return;
+        }
     } catch (error) {
-        if (error?.name === "AbortError") return;
+        if (error?.name === "AbortError") {
+            return;
+        }
         errorMessage.value = error?.message ?? String(error);
         mode.value = "error";
         return;
@@ -238,7 +247,7 @@ onUnmounted(cancelExport);
 
                 <div class="grid grid-cols-2 gap-3">
                     <UFormField label="Framerate">
-                        <USelect v-model="frameRate" :items="FRAMERATES" class="w-full" />
+                        <USelect v-model="frameRate" :items="FRAMERATE_OPTIONS" class="w-full" />
                     </UFormField>
                     <UFormField label="Resolution">
                         <USelect v-model="resolutionValue" :items="RESOLUTIONS" class="w-full" />

--- a/src/blackbox-viewer/grapher.js
+++ b/src/blackbox-viewer/grapher.js
@@ -63,6 +63,7 @@ export function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, cr
         graphs = [],
         inTime = false,
         outTime = false,
+        drawInOutRegionEnabled = true,
         lastMouseX,
         sticks = null,
         craft3D = null,
@@ -967,7 +968,9 @@ export function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, cr
             }
         }
 
-        drawInOutRegion();
+        if (drawInOutRegionEnabled) {
+            drawInOutRegion();
+        }
     };
 
     this.refreshGraphConfig = function () {
@@ -1100,6 +1103,10 @@ export function FlightLogGrapher(flightLog, graphConfig, canvas, stickCanvas, cr
             inTime = false;
             analyser.setInTime(inTime);
         }
+    };
+
+    this.setDrawInOutRegion = function (state) {
+        drawInOutRegionEnabled = Boolean(state);
     };
 
     // New function to return the current window scale.

--- a/src/blackbox-viewer/keyboard_handler.js
+++ b/src/blackbox-viewer/keyboard_handler.js
@@ -1,5 +1,6 @@
 import { formatTime } from "./tools.js";
 import { GRAPH_MIN_ZOOM } from "./stores/graph.js";
+import { isExportInProgress } from "./playback_controls.js";
 
 /**
  * Create a keydown event handler for the document.
@@ -306,7 +307,7 @@ export function createKeydownHandler(ctx) {
 
     return function (e) {
         // Dormant behind other tabs (embedded): don't hijack keys the user means for the host.
-        if (!appStore.viewerActive) {
+        if (!appStore.viewerActive || isExportInProgress()) {
             return;
         }
         const shifted = e.altKey || e.shiftKey || e.ctrlKey || e.metaKey;
@@ -358,7 +359,7 @@ export function createDropdownSpaceGuard(ctx) {
     const { appStore, hasGraph, logPlayPause } = ctx;
 
     return function (e) {
-        if (e.code !== "Space" || !appStore.viewerActive || !hasGraph()) {
+        if (e.code !== "Space" || !appStore.viewerActive || isExportInProgress() || !hasGraph()) {
             return;
         }
         // Match a reka-ui dropdown-menu trigger (aria-haspopup="menu") or select

--- a/src/blackbox-viewer/main.js
+++ b/src/blackbox-viewer/main.js
@@ -13,6 +13,7 @@ import { restorePenDefaults, changePenSmoothing, changePenZoom, changePenExpo } 
 import { createKeydownHandler, createDropdownSpaceGuard } from "./keyboard_handler.js";
 import { upgradeWorkspaceFormat, saveWorkspaces, loadWorkspaces } from "./workspace_io.js";
 import { exportCsv, exportGpx, exportSpectrumToCsv } from "./export_utils.js";
+import { cancelActiveVideoExport } from "./video_export.js";
 import {
     syncLogToVideo,
     setVideoOffset,
@@ -780,6 +781,8 @@ export function bootstrapViewer() {
 
     // Teardown: reverse every global side-effect so the tab can be re-mounted cleanly.
     return function teardown() {
+        // Stop the export loop before the shared grapher and canvases are released.
+        cancelActiveVideoExport();
         // Nulling the graph makes the requestAnimationFrame loop bail on its next tick.
         if (graph) {
             try {

--- a/src/blackbox-viewer/playback_controls.js
+++ b/src/blackbox-viewer/playback_controls.js
@@ -35,7 +35,18 @@ function ensureThrottles() {
     }
 }
 
+// While a blackbox video export is borrowing the live grapher offscreen,
+// window resizes and stray re-renders must not resize or repaint it mid-frame
+// (that would letterbox exported frames); see video_export.js and #5396.
+let exportInProgress = false;
+export function setExportInProgress(value) {
+    exportInProgress = value;
+}
+
 export function animationLoop() {
+    if (exportInProgress) {
+        return;
+    }
     ensureThrottles();
     const now = Date.now();
     const graphStore = useGraphStore(pinia);
@@ -99,6 +110,9 @@ export function invalidateGraph() {
 }
 
 export function updateCanvasSize() {
+    if (exportInProgress) {
+        return;
+    }
     const graphStore = useGraphStore(pinia);
     const logStore = useLogStore(pinia);
     const canvas = graphStore.canvasRefs?.canvas;

--- a/src/blackbox-viewer/playback_controls.js
+++ b/src/blackbox-viewer/playback_controls.js
@@ -40,11 +40,18 @@ function ensureThrottles() {
 // (that would letterbox exported frames); see video_export.js and #5396.
 let exportInProgress = false;
 export function setExportInProgress(value) {
-    exportInProgress = value;
+    exportInProgress = Boolean(value);
+}
+
+export function isExportInProgress() {
+    return exportInProgress;
 }
 
 export function animationLoop() {
     if (exportInProgress) {
+        // invalidateGraph() set this before queuing us. Clear it even though no
+        // frame is drawn so the post-export redraw can schedule a fresh rAF.
+        animationFrameIsQueued = false;
         return;
     }
     ensureThrottles();

--- a/src/blackbox-viewer/playback_controls.js
+++ b/src/blackbox-viewer/playback_controls.js
@@ -47,6 +47,10 @@ export function isExportInProgress() {
     return exportInProgress;
 }
 
+export function getGraphState() {
+    return usePlaybackStore(pinia).graphState;
+}
+
 export function animationLoop() {
     if (exportInProgress) {
         // invalidateGraph() set this before queuing us. Clear it even though no

--- a/src/blackbox-viewer/stores/app.js
+++ b/src/blackbox-viewer/stores/app.js
@@ -31,6 +31,7 @@ export const useAppStore = defineStore("app", () => {
     const headerDialogOpen = ref(false);
     const settingsDialogOpen = ref(false);
     const keysDialogOpen = ref(false);
+    const videoExportDialogOpen = ref(false);
 
     // Callbacks registered by main.js (closure-dependent operations)
     const loadFiles = shallowRef(null);
@@ -69,6 +70,7 @@ export const useAppStore = defineStore("app", () => {
         headerDialogOpen,
         settingsDialogOpen,
         keysDialogOpen,
+        videoExportDialogOpen,
         loadFiles,
         newGraphConfig,
         exportCsv,

--- a/src/blackbox-viewer/video_export.js
+++ b/src/blackbox-viewer/video_export.js
@@ -62,6 +62,21 @@ function yieldToBrowser() {
     return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+function evictFailedProbe(cacheKey, pending) {
+    pending.then(
+        (result) => {
+            if (!result?.canEncode && probeCache.get(cacheKey) === pending) {
+                probeCache.delete(cacheKey);
+            }
+        },
+        () => {
+            if (probeCache.get(cacheKey) === pending) {
+                probeCache.delete(cacheKey);
+            }
+        },
+    );
+}
+
 /** Check encoder and save capabilities, cached per output resolution. */
 export async function probeVideoExport({ width, height } = {}) {
     const cacheKey = `${width || 0}x${height || 0}`;
@@ -111,6 +126,7 @@ export async function probeVideoExport({ width, height } = {}) {
     })();
 
     probeCache.set(cacheKey, pending);
+    evictFailedProbe(cacheKey, pending);
     return pending;
 }
 
@@ -176,6 +192,7 @@ export function createFileSystemTarget(writableToken, options = {}) {
     });
 
     const target = new StreamTarget(writable, { chunked: true, chunkSize });
+    target.exportWritable = writable;
     target.bytesWritten = () => bytesWritten;
     target.closeFile = closeFile;
     return target;

--- a/src/blackbox-viewer/video_export.js
+++ b/src/blackbox-viewer/video_export.js
@@ -8,6 +8,8 @@ import {
     QUALITY_MEDIUM,
 } from "mediabunny";
 
+import { setExportInProgress } from "./playback_controls.js";
+
 // Offscreen video export for the blackbox viewer (design: #5396).
 //
 // This module owns the capability probe, the frame maths, and the
@@ -172,4 +174,118 @@ export function suggestedName(logName, extension) {
             ? logName.slice(0, logName.lastIndexOf("."))
             : String(logName || "blackbox");
     return `${base}.${extension}`;
+}
+
+/**
+ * Run the export: borrow the live grapher offscreen, render every frame in
+ * the marked range into the encoder, and stream the result to FileSystem.
+ *
+ * The grapher is borrowed by resizing its backing store to the export
+ * resolution (CSS layout keeps the on-screen size), so updateCanvasSize()
+ * and animationLoop() must be suppressed by the caller for the duration
+ * via setExportInProgress(); both are restored in the finally block here.
+ *
+ * Options bag (all required unless noted):
+ *   - canvas:        offscreen export canvas (width/height set to target)
+ *   - graph:         live FlightLogGrapher instance to borrow
+ *   - log:           flight log object (has getMinTime/getMaxTime)
+ *   - renderFrame:   callback rendering `timeMicros` onto the canvas
+ *   - inTime/outTime marker bounds in microseconds (falsy = whole log)
+ *   - frameRate, width, height
+ *   - file:          FileSystem file descriptor from pickSaveFile
+ *   - onProgress:    optional ({ frame, totalFrames, bytesWritten, etaSecs })
+ *
+ * Returns { frames, bytes }. Cancels cleanly if options.shouldCancel()
+ * turns true between frames; the partial file stays on disk and is
+ * reported to the user by the dialog.
+ */
+export async function runVideoExport(options) {
+    const { canvas, graph, renderFrame, inTime, outTime, frameRate, width, height, file, onProgress, shouldCancel } =
+        options;
+
+    const probe = await probeVideoExport({ width, height });
+    if (!probe.canEncode) {
+        throw new Error(probe.reason);
+    }
+
+    const totalFrames = estimateFrameCount({
+        inTime,
+        outTime,
+        frameRate,
+        getMinTime: () => options.log.getMinTime(),
+        getMaxTime: () => options.log.getMaxTime(),
+    });
+
+    // Borrow window opens: block resize/re-render interference for real.
+    setExportInProgress(true);
+
+    let output;
+    try {
+        canvas.width = width;
+        canvas.height = height;
+
+        const target = createFileSystemTarget(file);
+        output = new Output({
+            target,
+            format:
+                probe.container === "mp4"
+                    ? new Mp4OutputFormat({ fastStart: "fragmented" })
+                    : new WebMOutputFormat({ appendOnly: true }),
+        });
+        const source = createCanvasSource(canvas, probe.codec, frameRate);
+        output.addVideoTrack(source, { frameRate });
+        await output.start();
+
+        const startMicros = inTime ?? (typeof options.log.getMinTime === "function" ? options.log.getMinTime() : 0);
+        const frameDurationMicros = MICROSECONDS_PER_SECOND / frameRate;
+
+        let lastFrameAt = Date.now();
+        let smoothedFps = 0;
+
+        for (let frame = 0; frame < totalFrames; frame += 1) {
+            if (shouldCancel?.()) {
+                await output.cancel();
+                return { frames: frame, bytes: target.bytesWritten(), cancelled: true };
+            }
+
+            renderFrame(startMicros + frame * frameDurationMicros);
+            await source.add(frame / frameRate, 1 / frameRate);
+
+            const now = Date.now();
+            const instantFps = 1000 / Math.max(1, now - lastFrameAt);
+            smoothedFps = smoothedFps ? smoothedFps * 0.9 + instantFps * 0.1 : instantFps;
+            lastFrameAt = now;
+
+            onProgress?.({
+                frame: frame + 1,
+                totalFrames,
+                bytesWritten: target.bytesWritten(),
+                etaSecs: (totalFrames - frame - 1) / Math.max(1, smoothedFps),
+            });
+        }
+
+        await output.finalize();
+        return { frames: totalFrames, bytes: target.bytesWritten() };
+    } catch (error) {
+        // Never finalize a broken muxer; cancel leaves the partial file which
+        // the dialog reports as unplayable-but-deletable.
+        if (output) {
+            try {
+                await output.cancel();
+            } catch {
+                // already torn down; nothing further to do
+            }
+        }
+        throw error;
+    } finally {
+        // Restore the borrowed grapher on every path.
+        try {
+            graph.updateCanvasSize();
+        } catch {
+            // graph may already be gone after tab teardown
+        }
+        canvas.width = width;
+        canvas.height = height;
+        setExportInProgress(false);
+    }
 }

--- a/src/blackbox-viewer/video_export.js
+++ b/src/blackbox-viewer/video_export.js
@@ -29,6 +29,63 @@ const ANDROID_CHUNK_SIZE = 256 * 1024;
 const YIELD_BUDGET_MS = 12;
 const HIDDEN_YIELD_BUDGET_MS = 250;
 
+/**
+ * @typedef {object} VideoExportProgress
+ * @property {number} frame
+ * @property {number} totalFrames
+ * @property {number} bytesWritten
+ * @property {number} etaSecs
+ */
+
+/**
+ * @typedef {object} VideoExportResult
+ * @property {number} frames
+ * @property {number} bytes
+ * @property {boolean} cancelled
+ */
+
+/**
+ * @typedef {object} VideoExportFileSystem
+ * @property {(file: unknown) => Promise<unknown>} openFile
+ * @property {(writable: unknown, data: Blob) => Promise<void>} writeChunck
+ * @property {(writable: unknown) => Promise<void>} closeFile
+ */
+
+/**
+ * @typedef {StreamTarget & {
+ *   exportWritable: WritableStream,
+ *   bytesWritten: () => number,
+ *   closeFile: () => Promise<void>
+ * }} VideoExportTarget
+ */
+
+/**
+ * @typedef {object} VideoExportOptions
+ * @property {HTMLCanvasElement} canvas Private encoder canvas.
+ * @property {{canvas: HTMLCanvasElement, stickCanvas?: HTMLCanvasElement,
+ *   craftCanvas?: HTMLCanvasElement, analyserCanvas?: HTMLCanvasElement}} canvasRefs
+ * @property {{render: (time: number) => void, resize: (width: number, height: number) => void,
+ *   setDrawInOutRegion?: (enabled: boolean) => void}} graph
+ * @property {{getMinTime: () => number, getMaxTime: () => number}} log
+ * @property {unknown} file Picked FileSystem descriptor.
+ * @property {VideoExportFileSystem} [fileSystem]
+ * @property {number} frameRate
+ * @property {number} width
+ * @property {number} height
+ * @property {number | false | null} [inTime]
+ * @property {number | false | null} [outTime]
+ * @property {object} [userSettings]
+ * @property {boolean} [includeSticks]
+ * @property {boolean} [includeCraft]
+ * @property {boolean} [includeAnalyser]
+ * @property {() => {left?: number, top?: number}} [getAnalyserLayout]
+ * @property {() => void} [restoreCanvasSize]
+ * @property {() => void} [invalidateGraph]
+ * @property {() => boolean} [shouldCancel]
+ * @property {(phase: "preparing" | "rendering") => void} [onPhase]
+ * @property {(progress: VideoExportProgress) => void} [onProgress]
+ */
+
 const probeCache = new Map();
 let activeExport = null;
 
@@ -158,6 +215,7 @@ export function videoExportChunkSize(android = isAndroid()) {
  * Adapt an already-open FileSystem writable to mediabunny's positioned stream contract.
  * The selected container is append-only, so any non-sequential write is a hard error.
  */
+/** @returns {VideoExportTarget} */
 export function createFileSystemTarget(writableToken, options = {}) {
     const fileSystem = options.fileSystem ?? FileSystem;
     const chunkSize = options.chunkSize ?? videoExportChunkSize();
@@ -199,6 +257,7 @@ export function createFileSystemTarget(writableToken, options = {}) {
 }
 
 /** Open a picked descriptor before adapting its production writable token. */
+/** @returns {Promise<VideoExportTarget>} */
 export async function openFileSystemTarget(file, options = {}) {
     const fileSystem = options.fileSystem ?? FileSystem;
     const writableToken = await fileSystem.openFile(file);
@@ -269,6 +328,7 @@ export function cancelActiveVideoExport() {
     }
 }
 
+/** @param {VideoExportOptions} options */
 function validateVideoExportOptions(options) {
     if (activeExport) {
         throw new Error("A video export is already running");
@@ -278,6 +338,7 @@ function validateVideoExportOptions(options) {
     }
 }
 
+/** @param {VideoExportOptions} options */
 async function buildVideoExportPlan(options) {
     const probe = await probeVideoExport({ width: options.width, height: options.height });
     if (!probe.canEncode) {
@@ -341,6 +402,7 @@ function reportVideoExportProgress({ options, target, frame, totalFrames, smooth
     });
 }
 
+/** @returns {Promise<VideoExportResult>} */
 async function renderVideoFrames({ options, output, source, target, exportState, start, totalFrames }) {
     const frameDurationMicros = MICROSECONDS_PER_SECOND / options.frameRate;
     let lastFrameAt = performance.now();
@@ -393,11 +455,11 @@ async function cancelFailedVideoOutput(output) {
     }
 }
 
-async function closeAndRestoreVideoExport({ options, target, exportState, viewerState, failedError }) {
+async function closeAndRestoreVideoExport({ options, target, exportState, viewerState, failed }) {
     try {
         await target?.closeFile();
     } catch (error) {
-        if (!failedError) {
+        if (!failed) {
             throw error;
         }
         // Preserve the original encoder or render failure.
@@ -422,6 +484,8 @@ async function closeAndRestoreVideoExport({ options, target, exportState, viewer
 /**
  * Borrow the live grapher, render the selected range, and stream the encoded file.
  * The writable and viewer state are restored on success, cancellation, and failure.
+ * @param {VideoExportOptions} options
+ * @returns {Promise<VideoExportResult>}
  */
 export async function runVideoExport(options) {
     validateVideoExportOptions(options);
@@ -430,7 +494,7 @@ export async function runVideoExport(options) {
 
     let target = null;
     let output = null;
-    let failedError = null;
+    let failed = false;
     const viewerState = { borrowed: false, graphState: GRAPH_STATE_PAUSED };
     try {
         const { probe, start, totalFrames } = await buildVideoExportPlan(options);
@@ -443,10 +507,10 @@ export async function runVideoExport(options) {
         await startVideoOutput(options, output);
         return await renderVideoFrames({ options, output, source: started.source, target, exportState, start, totalFrames });
     } catch (error) {
-        failedError = error;
+        failed = true;
         await cancelFailedVideoOutput(output);
         throw error;
     } finally {
-        await closeAndRestoreVideoExport({ options, target, exportState, viewerState, failedError });
+        await closeAndRestoreVideoExport({ options, target, exportState, viewerState, failed });
     }
 }

--- a/src/blackbox-viewer/video_export.js
+++ b/src/blackbox-viewer/video_export.js
@@ -252,18 +252,16 @@ export function cancelActiveVideoExport() {
     }
 }
 
-/**
- * Borrow the live grapher, render the selected range, and stream the encoded file.
- * The writable and viewer state are restored on success, cancellation, and failure.
- */
-export async function runVideoExport(options) {
+function validateVideoExportOptions(options) {
     if (activeExport) {
         throw new Error("A video export is already running");
     }
     if (!options.graph || !options.canvasRefs?.canvas || !options.file || !options.log) {
         throw new Error("The blackbox viewer is not ready to export video");
     }
+}
 
+async function buildVideoExportPlan(options) {
     const probe = await probeVideoExport({ width: options.width, height: options.height });
     if (!probe.canEncode) {
         throw new Error(probe.reason);
@@ -280,116 +278,144 @@ export async function runVideoExport(options) {
         throw new Error("The selected video range contains no frames");
     }
 
+    return { probe, start, totalFrames };
+}
+
+async function borrowExportGrapher(options, start) {
+    setExportInProgress(true);
+    setGraphState(GRAPH_STATE_PAUSED);
+
+    options.canvas.width = options.width;
+    options.canvas.height = options.height;
+    options.graph.setDrawInOutRegion?.(false);
+    options.graph.resize(options.width, options.height);
+
+    if (options.includeAnalyser) {
+        options.onPhase?.("preparing");
+        options.graph.render(start);
+        await yieldToBrowser();
+    }
+}
+
+function createVideoOutput({ options, target, probe }) {
+    const format =
+        probe.container === "mp4"
+            ? new Mp4OutputFormat({ fastStart: "fragmented" })
+            : new WebMOutputFormat({ appendOnly: true });
+    const output = new Output({ target, format });
+    const source = createCanvasSource(options.canvas, probe.codec);
+    output.addVideoTrack(source, { frameRate: options.frameRate });
+    return { output, source };
+}
+
+async function startVideoOutput(options, output) {
+    await output.start();
+    options.onPhase?.("rendering");
+}
+
+function reportVideoExportProgress({ options, target, frame, totalFrames, smoothedFrameMs }) {
+    options.onProgress?.({
+        frame: frame + 1,
+        totalFrames,
+        bytesWritten: target.bytesWritten(),
+        etaSecs: ((totalFrames - frame - 1) * smoothedFrameMs) / 1000,
+    });
+}
+
+async function renderVideoFrames({ options, output, source, target, exportState, start, totalFrames }) {
+    const frameDurationMicros = MICROSECONDS_PER_SECOND / options.frameRate;
+    let lastFrameAt = performance.now();
+    let lastYieldAt = lastFrameAt;
+    let smoothedFrameMs = 0;
+
+    for (let frame = 0; frame < totalFrames; frame += 1) {
+        if (exportState.cancelled || options.shouldCancel?.()) {
+            await output.cancel();
+            return { frames: frame, bytes: target.bytesWritten(), cancelled: true };
+        }
+
+        options.graph.render(start + frame * frameDurationMicros);
+        compositeVideoFrame({
+            canvas: options.canvas,
+            canvasRefs: options.canvasRefs,
+            userSettings: options.userSettings,
+            includeSticks: options.includeSticks,
+            includeCraft: options.includeCraft,
+            includeAnalyser: options.includeAnalyser,
+            analyserLayout: options.getAnalyserLayout?.(),
+        });
+        await source.add(frame / options.frameRate, 1 / options.frameRate);
+
+        const now = performance.now();
+        const frameMs = Math.max(0.1, now - lastFrameAt);
+        smoothedFrameMs = smoothedFrameMs ? smoothedFrameMs * 0.8 + frameMs * 0.2 : frameMs;
+        lastFrameAt = now;
+        reportVideoExportProgress({ options, target, frame, totalFrames, smoothedFrameMs });
+
+        const budget = typeof document !== "undefined" && document.hidden ? HIDDEN_YIELD_BUDGET_MS : YIELD_BUDGET_MS;
+        if (now - lastYieldAt >= budget) {
+            await yieldToBrowser();
+            lastYieldAt = performance.now();
+        }
+    }
+
+    await output.finalize();
+    return { frames: totalFrames, bytes: target.bytesWritten(), cancelled: false };
+}
+
+async function cancelFailedVideoOutput(output) {
+    if (!output || output.state === "canceled" || output.state === "finalized") {
+        return;
+    }
+    try {
+        await output.cancel();
+    } catch {
+        // The original error remains the useful failure to report.
+    }
+}
+
+async function closeAndRestoreVideoExport({ options, target, exportState }) {
+    try {
+        await target.closeFile();
+    } finally {
+        options.graph.setDrawInOutRegion?.(true);
+        setExportInProgress(false);
+        try {
+            options.restoreCanvasSize?.();
+            (options.invalidateGraph ?? invalidateGraph)?.();
+        } catch {
+            // The tab may already have torn down its graph and canvases.
+        }
+        if (activeExport === exportState) {
+            activeExport = null;
+        }
+    }
+}
+
+/**
+ * Borrow the live grapher, render the selected range, and stream the encoded file.
+ * The writable and viewer state are restored on success, cancellation, and failure.
+ */
+export async function runVideoExport(options) {
+    validateVideoExportOptions(options);
+    const { probe, start, totalFrames } = await buildVideoExportPlan(options);
+
     const fileSystem = options.fileSystem ?? FileSystem;
     const target = await openFileSystemTarget(options.file, { fileSystem });
     const exportState = { cancelled: false };
     activeExport = exportState;
 
     let output = null;
-    let exportGuardSet = false;
-    let drawRegionDisabled = false;
-
     try {
-        setExportInProgress(true);
-        exportGuardSet = true;
-        setGraphState(GRAPH_STATE_PAUSED);
-
-        options.canvas.width = options.width;
-        options.canvas.height = options.height;
-        options.graph.setDrawInOutRegion?.(false);
-        drawRegionDisabled = true;
-        options.graph.resize(options.width, options.height);
-
-        if (options.includeAnalyser) {
-            options.onPhase?.("preparing");
-            options.graph.render(start);
-            await yieldToBrowser();
-        }
-
-        output = new Output({
-            target,
-            format:
-                probe.container === "mp4"
-                    ? new Mp4OutputFormat({ fastStart: "fragmented" })
-                    : new WebMOutputFormat({ appendOnly: true }),
-        });
-        const source = createCanvasSource(options.canvas, probe.codec);
-        output.addVideoTrack(source, { frameRate: options.frameRate });
-        await output.start();
-        options.onPhase?.("rendering");
-
-        const frameDurationMicros = MICROSECONDS_PER_SECOND / options.frameRate;
-        let lastFrameAt = performance.now();
-        let lastYieldAt = lastFrameAt;
-        let smoothedFrameMs = 0;
-
-        for (let frame = 0; frame < totalFrames; frame += 1) {
-            if (exportState.cancelled || options.shouldCancel?.()) {
-                await output.cancel();
-                return { frames: frame, bytes: target.bytesWritten(), cancelled: true };
-            }
-
-            options.graph.render(start + frame * frameDurationMicros);
-            compositeVideoFrame({
-                canvas: options.canvas,
-                canvasRefs: options.canvasRefs,
-                userSettings: options.userSettings,
-                includeSticks: options.includeSticks,
-                includeCraft: options.includeCraft,
-                includeAnalyser: options.includeAnalyser,
-                analyserLayout: options.getAnalyserLayout?.(),
-            });
-            await source.add(frame / options.frameRate, 1 / options.frameRate);
-
-            const now = performance.now();
-            const frameMs = Math.max(0.1, now - lastFrameAt);
-            smoothedFrameMs = smoothedFrameMs ? smoothedFrameMs * 0.8 + frameMs * 0.2 : frameMs;
-            lastFrameAt = now;
-            options.onProgress?.({
-                frame: frame + 1,
-                totalFrames,
-                bytesWritten: target.bytesWritten(),
-                etaSecs: ((totalFrames - frame - 1) * smoothedFrameMs) / 1000,
-            });
-
-            const budget =
-                typeof document !== "undefined" && document.hidden ? HIDDEN_YIELD_BUDGET_MS : YIELD_BUDGET_MS;
-            if (now - lastYieldAt >= budget) {
-                await yieldToBrowser();
-                lastYieldAt = performance.now();
-            }
-        }
-
-        await output.finalize();
-        return { frames: totalFrames, bytes: target.bytesWritten(), cancelled: false };
+        await borrowExportGrapher(options, start);
+        const started = createVideoOutput({ options, target, probe });
+        output = started.output;
+        await startVideoOutput(options, output);
+        return await renderVideoFrames({ options, output, source: started.source, target, exportState, start, totalFrames });
     } catch (error) {
-        if (output && output.state !== "canceled" && output.state !== "finalized") {
-            try {
-                await output.cancel();
-            } catch {
-                // The original error remains the useful failure to report.
-            }
-        }
+        await cancelFailedVideoOutput(output);
         throw error;
     } finally {
-        try {
-            await target.closeFile();
-        } finally {
-            if (drawRegionDisabled) {
-                options.graph.setDrawInOutRegion?.(true);
-            }
-            if (exportGuardSet) {
-                setExportInProgress(false);
-            }
-            try {
-                options.restoreCanvasSize?.();
-                (options.invalidateGraph ?? invalidateGraph)?.();
-            } catch {
-                // The tab may already have torn down its graph and canvases.
-            }
-            if (activeExport === exportState) {
-                activeExport = null;
-            }
-        }
+        await closeAndRestoreVideoExport({ options, target, exportState });
     }
 }

--- a/src/blackbox-viewer/video_export.js
+++ b/src/blackbox-viewer/video_export.js
@@ -393,9 +393,14 @@ async function cancelFailedVideoOutput(output) {
     }
 }
 
-async function closeAndRestoreVideoExport({ options, target, exportState, viewerState }) {
+async function closeAndRestoreVideoExport({ options, target, exportState, viewerState, failedError }) {
     try {
         await target?.closeFile();
+    } catch (error) {
+        if (!failedError) {
+            throw error;
+        }
+        // Preserve the original encoder or render failure.
     } finally {
         if (viewerState.borrowed) {
             setExportInProgress(false);
@@ -425,6 +430,7 @@ export async function runVideoExport(options) {
 
     let target = null;
     let output = null;
+    let failedError = null;
     const viewerState = { borrowed: false, graphState: GRAPH_STATE_PAUSED };
     try {
         const { probe, start, totalFrames } = await buildVideoExportPlan(options);
@@ -437,9 +443,10 @@ export async function runVideoExport(options) {
         await startVideoOutput(options, output);
         return await renderVideoFrames({ options, output, source: started.source, target, exportState, start, totalFrames });
     } catch (error) {
+        failedError = error;
         await cancelFailedVideoOutput(output);
         throw error;
     } finally {
-        await closeAndRestoreVideoExport({ options, target, exportState, viewerState });
+        await closeAndRestoreVideoExport({ options, target, exportState, viewerState, failedError });
     }
 }

--- a/src/blackbox-viewer/video_export.js
+++ b/src/blackbox-viewer/video_export.js
@@ -11,7 +11,7 @@ import {
 import FileSystem from "@/js/FileSystem.js";
 import { isAndroid, isTauriDesktop } from "@/js/utils/checkCompatibility.js";
 import { ThemeColors } from "./theme_colors.js";
-import { invalidateGraph, setExportInProgress, setGraphState } from "./playback_controls.js";
+import { getGraphState, invalidateGraph, setExportInProgress, setGraphState } from "./playback_controls.js";
 import { GRAPH_STATE_PAUSED } from "./stores/playback.js";
 
 const MICROSECONDS_PER_SECOND = 1e6;
@@ -298,7 +298,9 @@ async function buildVideoExportPlan(options) {
     return { probe, start, totalFrames };
 }
 
-async function borrowExportGrapher(options, start) {
+async function borrowExportGrapher(options, start, viewerState) {
+    viewerState.graphState = getGraphState();
+    viewerState.borrowed = true;
     setExportInProgress(true);
     setGraphState(GRAPH_STATE_PAUSED);
 
@@ -391,17 +393,20 @@ async function cancelFailedVideoOutput(output) {
     }
 }
 
-async function closeAndRestoreVideoExport({ options, target, exportState }) {
+async function closeAndRestoreVideoExport({ options, target, exportState, viewerState }) {
     try {
-        await target.closeFile();
+        await target?.closeFile();
     } finally {
-        options.graph.setDrawInOutRegion?.(true);
-        setExportInProgress(false);
-        try {
-            options.restoreCanvasSize?.();
-            (options.invalidateGraph ?? invalidateGraph)?.();
-        } catch {
-            // The tab may already have torn down its graph and canvases.
+        if (viewerState.borrowed) {
+            setExportInProgress(false);
+            try {
+                options.graph.setDrawInOutRegion?.(true);
+                options.restoreCanvasSize?.();
+                setGraphState(viewerState.graphState);
+                (options.invalidateGraph ?? invalidateGraph)?.();
+            } catch {
+                // The tab may already have torn down its graph and canvases.
+            }
         }
         if (activeExport === exportState) {
             activeExport = null;
@@ -415,16 +420,18 @@ async function closeAndRestoreVideoExport({ options, target, exportState }) {
  */
 export async function runVideoExport(options) {
     validateVideoExportOptions(options);
-    const { probe, start, totalFrames } = await buildVideoExportPlan(options);
-
-    const fileSystem = options.fileSystem ?? FileSystem;
-    const target = await openFileSystemTarget(options.file, { fileSystem });
     const exportState = { cancelled: false };
     activeExport = exportState;
 
+    let target = null;
     let output = null;
+    const viewerState = { borrowed: false, graphState: GRAPH_STATE_PAUSED };
     try {
-        await borrowExportGrapher(options, start);
+        const { probe, start, totalFrames } = await buildVideoExportPlan(options);
+        const fileSystem = options.fileSystem ?? FileSystem;
+        target = await openFileSystemTarget(options.file, { fileSystem });
+
+        await borrowExportGrapher(options, start, viewerState);
         const started = createVideoOutput({ options, target, probe });
         output = started.output;
         await startVideoOutput(options, output);
@@ -433,6 +440,6 @@ export async function runVideoExport(options) {
         await cancelFailedVideoOutput(output);
         throw error;
     } finally {
-        await closeAndRestoreVideoExport({ options, target, exportState });
+        await closeAndRestoreVideoExport({ options, target, exportState, viewerState });
     }
 }

--- a/src/blackbox-viewer/video_export.js
+++ b/src/blackbox-viewer/video_export.js
@@ -8,20 +8,14 @@ import {
     QUALITY_MEDIUM,
 } from "mediabunny";
 
-import { setExportInProgress } from "./playback_controls.js";
-
-// Offscreen video export for the blackbox viewer (design: #5396).
-//
-// This module owns the capability probe, the frame maths, and the
-// append-only FileSystem sink. The render loop that drives them lives in
-// runVideoExport(); the dialog only reads stores and calls in here.
+import FileSystem from "@/js/FileSystem.js";
+import { isAndroid, isTauriDesktop } from "@/js/utils/checkCompatibility.js";
+import { ThemeColors } from "./theme_colors.js";
+import { invalidateGraph, setExportInProgress, setGraphState } from "./playback_controls.js";
+import { GRAPH_STATE_PAUSED } from "./stores/playback.js";
 
 const MICROSECONDS_PER_SECOND = 1e6;
-
-// Probe order per design doc 1/5 §4: H.264 first (hardware on every
-// WebCodecs implementation that has one), then the free containers.
 const CODEC_PROBE_ORDER = ["avc", "vp9", "vp8", "av1"];
-
 const CODEC_CONTAINERS = {
     avc: { container: "mp4", extension: "mp4", description: "MP4 video" },
     hevc: { container: "mp4", extension: "mp4", description: "MP4 video" },
@@ -29,145 +23,220 @@ const CODEC_CONTAINERS = {
     vp8: { container: "webm", extension: "webm", description: "WebM video" },
     av1: { container: "webm", extension: "webm", description: "WebM video" },
 };
-
-// Measured constant used by estimateOutputBytes; see the calibration note
-// in runVideoExport() — recalibrate after a real export if needed.
 const ESTIMATED_BITS_PER_PIXEL_PER_FRAME = 0.12;
+const DEFAULT_CHUNK_SIZE = 4 * 1024 * 1024;
+const ANDROID_CHUNK_SIZE = 256 * 1024;
+const YIELD_BUDGET_MS = 12;
+const HIDDEN_YIELD_BUDGET_MS = 250;
 
 const probeCache = new Map();
+let activeExport = null;
 
-/**
- * Check whether this environment can encode + save an export.
- *
- * Returns both halves of the capability question: can we encode (WebCodecs
- * with a supported codec) and how will saving behave ("stream" = direct to
- * disk via showSaveFilePicker, "buffered" = whole file held in memory).
- * Results are cached per canvas size because codec negotiation is not free.
- */
+function saveMode() {
+    return typeof globalThis.showSaveFilePicker === "function" || isAndroid() || isTauriDesktop()
+        ? "stream"
+        : "buffered";
+}
+
+function normalizeBound(value, fallback) {
+    return value === false || value == null ? fallback() : value;
+}
+
+function exportRange({ inTime, outTime, getMinTime, getMaxTime }) {
+    return {
+        start: normalizeBound(inTime, typeof getMinTime === "function" ? getMinTime : () => 0),
+        end: normalizeBound(outTime, typeof getMaxTime === "function" ? getMaxTime : () => 0),
+    };
+}
+
+function sizeEnabled(settings) {
+    return Number.parseInt(settings?.size, 10) > 0;
+}
+
+function canvasPosition(value) {
+    const parsed = Number.parseFloat(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function yieldToBrowser() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** Check encoder and save capabilities, cached per output resolution. */
 export async function probeVideoExport({ width, height } = {}) {
     const cacheKey = `${width || 0}x${height || 0}`;
     if (probeCache.has(cacheKey)) {
         return probeCache.get(cacheKey);
     }
 
-    let result;
-    if (typeof globalThis.VideoEncoder !== "function") {
-        result = {
-            canEncode: false,
-            reason: "This browser cannot encode video (WebCodecs unavailable)",
-        };
-    } else {
-        const codec = await getFirstEncodableVideoCodec(
-            CODEC_PROBE_ORDER,
-            width && height ? { width, height, quality: QUALITY_MEDIUM } : { quality: QUALITY_MEDIUM },
-        );
+    const pending = (async () => {
+        if (typeof globalThis.VideoEncoder !== "function") {
+            return {
+                canEncode: false,
+                reason: "This browser cannot encode video (WebCodecs unavailable)",
+            };
+        }
+
+        let codec;
+        try {
+            codec = await getFirstEncodableVideoCodec(
+                CODEC_PROBE_ORDER,
+                width && height ? { width, height, quality: QUALITY_MEDIUM } : { quality: QUALITY_MEDIUM },
+            );
+        } catch (error) {
+            return {
+                canEncode: false,
+                reason: `Video codec detection failed: ${error?.message ?? String(error)}`,
+            };
+        }
         if (!codec) {
-            result = {
+            return {
                 canEncode: false,
                 reason: "No supported video codec found — on Linux, install the GStreamer H.264 or VP9 plugins",
             };
-        } else {
-            const { container, extension, description } = CODEC_CONTAINERS[codec];
-            result = {
-                canEncode: true,
-                codec,
-                container,
-                extension,
-                description,
-                saveMode: typeof globalThis.showSaveFilePicker === "function" ? "stream" : "buffered",
-            };
         }
-    }
 
-    probeCache.set(cacheKey, result);
-    return result;
+        const format = CODEC_CONTAINERS[codec];
+        if (!format) {
+            return { canEncode: false, reason: `Unsupported video codec returned by the encoder: ${codec}` };
+        }
+
+        return {
+            canEncode: true,
+            codec,
+            ...format,
+            saveMode: saveMode(),
+            androidBridge: isAndroid(),
+        };
+    })();
+
+    probeCache.set(cacheKey, pending);
+    return pending;
 }
 
-/**
- * Frames in the marked range at the chosen framerate. Falsy in/out bounds
- * fall back to the log's own extent so a marker-less range exports whole.
- */
+/** Frames in the marked range at the selected framerate. */
 export function estimateFrameCount({ inTime, outTime, frameRate, getMinTime, getMaxTime }) {
-    const start = inTime ?? (typeof getMinTime === "function" ? getMinTime() : 0);
-    const end = outTime ?? (typeof getMaxTime === "function" ? getMaxTime() : 0);
+    if (!Number.isFinite(frameRate) || frameRate <= 0) {
+        return 0;
+    }
+    const { start, end } = exportRange({ inTime, outTime, getMinTime, getMaxTime });
     const durationMicros = Math.max(0, end - start);
     return Math.round(durationMicros / (MICROSECONDS_PER_SECOND / frameRate));
 }
 
-/** Rough output size so buffered-save users can decide before rendering. */
+/** Rough output size shown before a buffered export starts. */
 export function estimateOutputBytes({ frameCount, width, height, codec }) {
     if (!frameCount || frameCount <= 0 || !width || !height) {
         return 0;
     }
-    // VP8/VP9 have no hardware path in most desktop stacks; their output is
-    // measurably larger than H.264 at QUALITY_MEDIUM.
     const codecFactor = codec === "vp8" || codec === "vp9" ? 1.6 : 1;
     return Math.ceil((frameCount * width * height * ESTIMATED_BITS_PER_PIXEL_PER_FRAME * codecFactor) / 8);
 }
 
+/** Chunk size tuned to avoid the Android hex-bridge allocation spike documented in #5396. */
+export function videoExportChunkSize(android = isAndroid()) {
+    return android ? ANDROID_CHUNK_SIZE : DEFAULT_CHUNK_SIZE;
+}
+
 /**
- * Build the mediabunny output wired to FileSystem's append-only contract.
- *
- * Every chunk is handed to FileSystem.writeChunck as a Blob; a non-sequential
- * position would silently corrupt the file downstream, so it throws here where
- * the cause is visible instead of in the muxer where it is not.
+ * Adapt an already-open FileSystem writable to mediabunny's positioned stream contract.
+ * The selected container is append-only, so any non-sequential write is a hard error.
  */
-export function createFileSystemTarget(file) {
+export function createFileSystemTarget(writableToken, options = {}) {
+    const fileSystem = options.fileSystem ?? FileSystem;
+    const chunkSize = options.chunkSize ?? videoExportChunkSize();
     let bytesWritten = 0;
     let nextPosition = 0;
+    let closePromise = null;
+
+    const closeFile = () => {
+        closePromise ??= Promise.resolve(fileSystem.closeFile(writableToken));
+        return closePromise;
+    };
 
     const writable = new WritableStream({
         async write(chunk) {
-            const data = chunk instanceof Blob ? chunk : new Blob([chunk.data ?? chunk]);
-            await window.FileSystem.writeChunck(file._downloadWritable ?? file.writable, data);
-            bytesWritten += data.size;
-        },
-    });
-
-    const target = new StreamTarget(writable, { chunked: true, chunkSize: 4 * 1024 * 1024 });
-    // Wrap so byte accounting stays exact even when mediabunny batches writes.
-    const originalWrite = target.write.bind(target);
-    target.write = async (chunk) => {
-        if (chunk.type === "write") {
+            if (chunk?.type !== "write" || !(chunk.data instanceof Uint8Array)) {
+                throw new TypeError("Video export received an invalid muxer write");
+            }
             if (chunk.position !== nextPosition) {
                 throw new Error(
                     `Non-sequential write at offset ${chunk.position} (expected ${nextPosition}); ` +
                         "the export sink is append-only",
                 );
             }
+
+            const data = new Blob([chunk.data]);
+            await fileSystem.writeChunck(writableToken, data);
             nextPosition += chunk.data.byteLength;
-        }
-        await originalWrite(chunk);
-    };
+            bytesWritten += data.size;
+        },
+        close: closeFile,
+        abort: closeFile,
+    });
+
+    const target = new StreamTarget(writable, { chunked: true, chunkSize });
     target.bytesWritten = () => bytesWritten;
+    target.closeFile = closeFile;
     return target;
 }
 
-/** Create the mediabunny Output for the probed codec. */
-export function createOutputForCodec(codec) {
-    const { container } = CODEC_CONTAINERS[codec];
-    const format =
-        container === "mp4"
-            ? new Mp4OutputFormat({ fastStart: "fragmented" })
-            : new WebMOutputFormat({ appendOnly: true });
-    return new Output({ target: null, format });
+/** Open a picked descriptor before adapting its production writable token. */
+export async function openFileSystemTarget(file, options = {}) {
+    const fileSystem = options.fileSystem ?? FileSystem;
+    const writableToken = await fileSystem.openFile(file);
+    return createFileSystemTarget(writableToken, { ...options, fileSystem });
 }
 
-/** Build the CanvasSource for the offscreen export canvas. */
-export function createCanvasSource(canvas, codec, frameRate) {
+/** Create a mediabunny source that rejects unexpected canvas size changes. */
+export function createCanvasSource(canvas, codec) {
     return new CanvasSource(canvas, {
         codec,
         quality: QUALITY_MEDIUM,
         keyFrameInterval: 2,
-        // Any size change reaching the encoder means the live grapher escaped
-        // its borrow window; fail loudly rather than letterbox silently.
         sizeChangeBehavior: "deny",
-        bitrate: undefined,
-        frameRate,
     });
 }
 
-/** Replace the log's extension with the export container's. */
+/** Composite the live grapher canvases into the private encoder canvas. */
+export function compositeVideoFrame({
+    canvas,
+    canvasRefs,
+    userSettings,
+    includeSticks,
+    includeCraft,
+    includeAnalyser,
+    analyserLayout,
+}) {
+    const context = canvas.getContext("2d");
+    if (!context) {
+        throw new Error("A 2D canvas is required to export video");
+    }
+
+    context.fillStyle = ThemeColors.getGraphBackground();
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.drawImage(canvasRefs.canvas, 0, 0);
+
+    if (includeSticks && sizeEnabled(userSettings?.sticks)) {
+        context.drawImage(
+            canvasRefs.stickCanvas,
+            canvasPosition(canvasRefs.stickCanvas.style.left),
+            canvasPosition(canvasRefs.stickCanvas.style.top),
+        );
+    }
+    if (includeCraft && sizeEnabled(userSettings?.craft)) {
+        context.drawImage(
+            canvasRefs.craftCanvas,
+            canvasPosition(canvasRefs.craftCanvas.style.left),
+            canvasPosition(canvasRefs.craftCanvas.style.top),
+        );
+    }
+    if (includeAnalyser && sizeEnabled(userSettings?.analyser)) {
+        context.drawImage(canvasRefs.analyserCanvas, analyserLayout?.left ?? 0, analyserLayout?.top ?? 0);
+    }
+}
+
+/** Replace a log extension with the selected video container extension. */
 export function suggestedName(logName, extension) {
     const base =
         typeof logName === "string" && logName.includes(".")
@@ -176,55 +245,67 @@ export function suggestedName(logName, extension) {
     return `${base}.${extension}`;
 }
 
+/** Ask the active loop to stop at its next frame boundary. Safe to call repeatedly. */
+export function cancelActiveVideoExport() {
+    if (activeExport) {
+        activeExport.cancelled = true;
+    }
+}
+
 /**
- * Run the export: borrow the live grapher offscreen, render every frame in
- * the marked range into the encoder, and stream the result to FileSystem.
- *
- * The grapher is borrowed by resizing its backing store to the export
- * resolution (CSS layout keeps the on-screen size), so updateCanvasSize()
- * and animationLoop() must be suppressed by the caller for the duration
- * via setExportInProgress(); both are restored in the finally block here.
- *
- * Options bag (all required unless noted):
- *   - canvas:        offscreen export canvas (width/height set to target)
- *   - graph:         live FlightLogGrapher instance to borrow
- *   - log:           flight log object (has getMinTime/getMaxTime)
- *   - renderFrame:   callback rendering `timeMicros` onto the canvas
- *   - inTime/outTime marker bounds in microseconds (falsy = whole log)
- *   - frameRate, width, height
- *   - file:          FileSystem file descriptor from pickSaveFile
- *   - onProgress:    optional ({ frame, totalFrames, bytesWritten, etaSecs })
- *
- * Returns { frames, bytes }. Cancels cleanly if options.shouldCancel()
- * turns true between frames; the partial file stays on disk and is
- * reported to the user by the dialog.
+ * Borrow the live grapher, render the selected range, and stream the encoded file.
+ * The writable and viewer state are restored on success, cancellation, and failure.
  */
 export async function runVideoExport(options) {
-    const { canvas, graph, renderFrame, inTime, outTime, frameRate, width, height, file, onProgress, shouldCancel } =
-        options;
+    if (activeExport) {
+        throw new Error("A video export is already running");
+    }
+    if (!options.graph || !options.canvasRefs?.canvas || !options.file || !options.log) {
+        throw new Error("The blackbox viewer is not ready to export video");
+    }
 
-    const probe = await probeVideoExport({ width, height });
+    const probe = await probeVideoExport({ width: options.width, height: options.height });
     if (!probe.canEncode) {
         throw new Error(probe.reason);
     }
 
-    const totalFrames = estimateFrameCount({
-        inTime,
-        outTime,
-        frameRate,
+    const { start, end } = exportRange({
+        inTime: options.inTime,
+        outTime: options.outTime,
         getMinTime: () => options.log.getMinTime(),
         getMaxTime: () => options.log.getMaxTime(),
     });
+    const totalFrames = estimateFrameCount({ inTime: start, outTime: end, frameRate: options.frameRate });
+    if (totalFrames <= 0) {
+        throw new Error("The selected video range contains no frames");
+    }
 
-    // Borrow window opens: block resize/re-render interference for real.
-    setExportInProgress(true);
+    const fileSystem = options.fileSystem ?? FileSystem;
+    const target = await openFileSystemTarget(options.file, { fileSystem });
+    const exportState = { cancelled: false };
+    activeExport = exportState;
 
-    let output;
+    let output = null;
+    let exportGuardSet = false;
+    let drawRegionDisabled = false;
+
     try {
-        canvas.width = width;
-        canvas.height = height;
+        setExportInProgress(true);
+        exportGuardSet = true;
+        setGraphState(GRAPH_STATE_PAUSED);
 
-        const target = createFileSystemTarget(file);
+        options.canvas.width = options.width;
+        options.canvas.height = options.height;
+        options.graph.setDrawInOutRegion?.(false);
+        drawRegionDisabled = true;
+        options.graph.resize(options.width, options.height);
+
+        if (options.includeAnalyser) {
+            options.onPhase?.("preparing");
+            options.graph.render(start);
+            await yieldToBrowser();
+        }
+
         output = new Output({
             target,
             format:
@@ -232,60 +313,83 @@ export async function runVideoExport(options) {
                     ? new Mp4OutputFormat({ fastStart: "fragmented" })
                     : new WebMOutputFormat({ appendOnly: true }),
         });
-        const source = createCanvasSource(canvas, probe.codec, frameRate);
-        output.addVideoTrack(source, { frameRate });
+        const source = createCanvasSource(options.canvas, probe.codec);
+        output.addVideoTrack(source, { frameRate: options.frameRate });
         await output.start();
+        options.onPhase?.("rendering");
 
-        const startMicros = inTime ?? (typeof options.log.getMinTime === "function" ? options.log.getMinTime() : 0);
-        const frameDurationMicros = MICROSECONDS_PER_SECOND / frameRate;
-
-        let lastFrameAt = Date.now();
-        let smoothedFps = 0;
+        const frameDurationMicros = MICROSECONDS_PER_SECOND / options.frameRate;
+        let lastFrameAt = performance.now();
+        let lastYieldAt = lastFrameAt;
+        let smoothedFrameMs = 0;
 
         for (let frame = 0; frame < totalFrames; frame += 1) {
-            if (shouldCancel?.()) {
+            if (exportState.cancelled || options.shouldCancel?.()) {
                 await output.cancel();
                 return { frames: frame, bytes: target.bytesWritten(), cancelled: true };
             }
 
-            renderFrame(startMicros + frame * frameDurationMicros);
-            await source.add(frame / frameRate, 1 / frameRate);
+            options.graph.render(start + frame * frameDurationMicros);
+            compositeVideoFrame({
+                canvas: options.canvas,
+                canvasRefs: options.canvasRefs,
+                userSettings: options.userSettings,
+                includeSticks: options.includeSticks,
+                includeCraft: options.includeCraft,
+                includeAnalyser: options.includeAnalyser,
+                analyserLayout: options.getAnalyserLayout?.(),
+            });
+            await source.add(frame / options.frameRate, 1 / options.frameRate);
 
-            const now = Date.now();
-            const instantFps = 1000 / Math.max(1, now - lastFrameAt);
-            smoothedFps = smoothedFps ? smoothedFps * 0.9 + instantFps * 0.1 : instantFps;
+            const now = performance.now();
+            const frameMs = Math.max(0.1, now - lastFrameAt);
+            smoothedFrameMs = smoothedFrameMs ? smoothedFrameMs * 0.8 + frameMs * 0.2 : frameMs;
             lastFrameAt = now;
-
-            onProgress?.({
+            options.onProgress?.({
                 frame: frame + 1,
                 totalFrames,
                 bytesWritten: target.bytesWritten(),
-                etaSecs: (totalFrames - frame - 1) / Math.max(1, smoothedFps),
+                etaSecs: ((totalFrames - frame - 1) * smoothedFrameMs) / 1000,
             });
+
+            const budget =
+                typeof document !== "undefined" && document.hidden ? HIDDEN_YIELD_BUDGET_MS : YIELD_BUDGET_MS;
+            if (now - lastYieldAt >= budget) {
+                await yieldToBrowser();
+                lastYieldAt = performance.now();
+            }
         }
 
         await output.finalize();
-        return { frames: totalFrames, bytes: target.bytesWritten() };
+        return { frames: totalFrames, bytes: target.bytesWritten(), cancelled: false };
     } catch (error) {
-        // Never finalize a broken muxer; cancel leaves the partial file which
-        // the dialog reports as unplayable-but-deletable.
-        if (output) {
+        if (output && output.state !== "canceled" && output.state !== "finalized") {
             try {
                 await output.cancel();
             } catch {
-                // already torn down; nothing further to do
+                // The original error remains the useful failure to report.
             }
         }
         throw error;
     } finally {
-        // Restore the borrowed grapher on every path.
         try {
-            graph.updateCanvasSize();
-        } catch {
-            // graph may already be gone after tab teardown
+            await target.closeFile();
+        } finally {
+            if (drawRegionDisabled) {
+                options.graph.setDrawInOutRegion?.(true);
+            }
+            if (exportGuardSet) {
+                setExportInProgress(false);
+            }
+            try {
+                options.restoreCanvasSize?.();
+                (options.invalidateGraph ?? invalidateGraph)?.();
+            } catch {
+                // The tab may already have torn down its graph and canvases.
+            }
+            if (activeExport === exportState) {
+                activeExport = null;
+            }
         }
-        canvas.width = width;
-        canvas.height = height;
-        setExportInProgress(false);
     }
 }

--- a/src/blackbox-viewer/video_export.js
+++ b/src/blackbox-viewer/video_export.js
@@ -1,0 +1,175 @@
+import {
+    Output,
+    Mp4OutputFormat,
+    WebMOutputFormat,
+    StreamTarget,
+    CanvasSource,
+    getFirstEncodableVideoCodec,
+    QUALITY_MEDIUM,
+} from "mediabunny";
+
+// Offscreen video export for the blackbox viewer (design: #5396).
+//
+// This module owns the capability probe, the frame maths, and the
+// append-only FileSystem sink. The render loop that drives them lives in
+// runVideoExport(); the dialog only reads stores and calls in here.
+
+const MICROSECONDS_PER_SECOND = 1e6;
+
+// Probe order per design doc 1/5 §4: H.264 first (hardware on every
+// WebCodecs implementation that has one), then the free containers.
+const CODEC_PROBE_ORDER = ["avc", "vp9", "vp8", "av1"];
+
+const CODEC_CONTAINERS = {
+    avc: { container: "mp4", extension: "mp4", description: "MP4 video" },
+    hevc: { container: "mp4", extension: "mp4", description: "MP4 video" },
+    vp9: { container: "webm", extension: "webm", description: "WebM video" },
+    vp8: { container: "webm", extension: "webm", description: "WebM video" },
+    av1: { container: "webm", extension: "webm", description: "WebM video" },
+};
+
+// Measured constant used by estimateOutputBytes; see the calibration note
+// in runVideoExport() — recalibrate after a real export if needed.
+const ESTIMATED_BITS_PER_PIXEL_PER_FRAME = 0.12;
+
+const probeCache = new Map();
+
+/**
+ * Check whether this environment can encode + save an export.
+ *
+ * Returns both halves of the capability question: can we encode (WebCodecs
+ * with a supported codec) and how will saving behave ("stream" = direct to
+ * disk via showSaveFilePicker, "buffered" = whole file held in memory).
+ * Results are cached per canvas size because codec negotiation is not free.
+ */
+export async function probeVideoExport({ width, height } = {}) {
+    const cacheKey = `${width || 0}x${height || 0}`;
+    if (probeCache.has(cacheKey)) {
+        return probeCache.get(cacheKey);
+    }
+
+    let result;
+    if (typeof globalThis.VideoEncoder !== "function") {
+        result = {
+            canEncode: false,
+            reason: "This browser cannot encode video (WebCodecs unavailable)",
+        };
+    } else {
+        const codec = await getFirstEncodableVideoCodec(
+            CODEC_PROBE_ORDER,
+            width && height ? { width, height, quality: QUALITY_MEDIUM } : { quality: QUALITY_MEDIUM },
+        );
+        if (!codec) {
+            result = {
+                canEncode: false,
+                reason: "No supported video codec found — on Linux, install the GStreamer H.264 or VP9 plugins",
+            };
+        } else {
+            const { container, extension, description } = CODEC_CONTAINERS[codec];
+            result = {
+                canEncode: true,
+                codec,
+                container,
+                extension,
+                description,
+                saveMode: typeof globalThis.showSaveFilePicker === "function" ? "stream" : "buffered",
+            };
+        }
+    }
+
+    probeCache.set(cacheKey, result);
+    return result;
+}
+
+/**
+ * Frames in the marked range at the chosen framerate. Falsy in/out bounds
+ * fall back to the log's own extent so a marker-less range exports whole.
+ */
+export function estimateFrameCount({ inTime, outTime, frameRate, getMinTime, getMaxTime }) {
+    const start = inTime ?? (typeof getMinTime === "function" ? getMinTime() : 0);
+    const end = outTime ?? (typeof getMaxTime === "function" ? getMaxTime() : 0);
+    const durationMicros = Math.max(0, end - start);
+    return Math.round(durationMicros / (MICROSECONDS_PER_SECOND / frameRate));
+}
+
+/** Rough output size so buffered-save users can decide before rendering. */
+export function estimateOutputBytes({ frameCount, width, height, codec }) {
+    if (!frameCount || frameCount <= 0 || !width || !height) {
+        return 0;
+    }
+    // VP8/VP9 have no hardware path in most desktop stacks; their output is
+    // measurably larger than H.264 at QUALITY_MEDIUM.
+    const codecFactor = codec === "vp8" || codec === "vp9" ? 1.6 : 1;
+    return Math.ceil((frameCount * width * height * ESTIMATED_BITS_PER_PIXEL_PER_FRAME * codecFactor) / 8);
+}
+
+/**
+ * Build the mediabunny output wired to FileSystem's append-only contract.
+ *
+ * Every chunk is handed to FileSystem.writeChunck as a Blob; a non-sequential
+ * position would silently corrupt the file downstream, so it throws here where
+ * the cause is visible instead of in the muxer where it is not.
+ */
+export function createFileSystemTarget(file) {
+    let bytesWritten = 0;
+    let nextPosition = 0;
+
+    const writable = new WritableStream({
+        async write(chunk) {
+            const data = chunk instanceof Blob ? chunk : new Blob([chunk.data ?? chunk]);
+            await window.FileSystem.writeChunck(file._downloadWritable ?? file.writable, data);
+            bytesWritten += data.size;
+        },
+    });
+
+    const target = new StreamTarget(writable, { chunked: true, chunkSize: 4 * 1024 * 1024 });
+    // Wrap so byte accounting stays exact even when mediabunny batches writes.
+    const originalWrite = target.write.bind(target);
+    target.write = async (chunk) => {
+        if (chunk.type === "write") {
+            if (chunk.position !== nextPosition) {
+                throw new Error(
+                    `Non-sequential write at offset ${chunk.position} (expected ${nextPosition}); ` +
+                        "the export sink is append-only",
+                );
+            }
+            nextPosition += chunk.data.byteLength;
+        }
+        await originalWrite(chunk);
+    };
+    target.bytesWritten = () => bytesWritten;
+    return target;
+}
+
+/** Create the mediabunny Output for the probed codec. */
+export function createOutputForCodec(codec) {
+    const { container } = CODEC_CONTAINERS[codec];
+    const format =
+        container === "mp4"
+            ? new Mp4OutputFormat({ fastStart: "fragmented" })
+            : new WebMOutputFormat({ appendOnly: true });
+    return new Output({ target: null, format });
+}
+
+/** Build the CanvasSource for the offscreen export canvas. */
+export function createCanvasSource(canvas, codec, frameRate) {
+    return new CanvasSource(canvas, {
+        codec,
+        quality: QUALITY_MEDIUM,
+        keyFrameInterval: 2,
+        // Any size change reaching the encoder means the live grapher escaped
+        // its borrow window; fail loudly rather than letterbox silently.
+        sizeChangeBehavior: "deny",
+        bitrate: undefined,
+        frameRate,
+    });
+}
+
+/** Replace the log's extension with the export container's. */
+export function suggestedName(logName, extension) {
+    const base =
+        typeof logName === "string" && logName.includes(".")
+            ? logName.slice(0, logName.lastIndexOf("."))
+            : String(logName || "blackbox");
+    return `${base}.${extension}`;
+}

--- a/src/js/FileSystem.js
+++ b/src/js/FileSystem.js
@@ -18,6 +18,8 @@ const EXTENSION_MIME_MAP = {
     ".gpx": "application/gpx+xml",
     ".lua": "text/plain",
     ".csv": "text/csv",
+    ".mp4": "video/mp4",
+    ".webm": "video/webm",
 };
 
 function mimeForExtension(ext) {

--- a/test/js/blackbox_video_export.test.js
+++ b/test/js/blackbox_video_export.test.js
@@ -137,6 +137,32 @@ describe("probeVideoExport", () => {
         await fresh.probeVideoExport({ width: 1920, height: 1080 });
         expect(codecSpy).toHaveBeenCalledTimes(1);
     });
+
+    it("retries a failed probe instead of disabling the resolution for the session", async () => {
+        const codecSpy = vi.fn().mockResolvedValueOnce(null).mockResolvedValueOnce("avc");
+        vi.stubGlobal(
+            "VideoEncoder",
+            class VideoEncoder {
+                static isConfigSupported() {
+                    return Promise.resolve({ supported: true });
+                }
+            },
+        );
+        vi.doMock("mediabunny", () => ({
+            Output: class {},
+            Mp4OutputFormat: class {},
+            WebMOutputFormat: class {},
+            StreamTarget: class {},
+            CanvasSource: class {},
+            getFirstEncodableVideoCodec: codecSpy,
+            QUALITY_MEDIUM: "medium",
+        }));
+        const fresh = await import("../../src/blackbox-viewer/video_export");
+
+        expect((await fresh.probeVideoExport({ width: 1280, height: 720 })).canEncode).toBe(false);
+        expect((await fresh.probeVideoExport({ width: 1280, height: 720 })).canEncode).toBe(true);
+        expect(codecSpy).toHaveBeenCalledTimes(2);
+    });
 });
 
 describe("createFileSystemTarget", () => {
@@ -144,7 +170,7 @@ describe("createFileSystemTarget", () => {
         const writableToken = { id: "production-writable" };
         const fileSystem = { writeChunck: vi.fn(), closeFile: vi.fn() };
         const target = mod.createFileSystemTarget(writableToken, { fileSystem, chunkSize: 1024 });
-        const writer = target._writable.getWriter();
+        const writer = target.exportWritable.getWriter();
 
         await writer.write({ type: "write", data: new Uint8Array([1, 2]), position: 0 });
         await writer.write({ type: "write", data: new Uint8Array([3, 4, 5]), position: 2 });
@@ -165,7 +191,7 @@ describe("createFileSystemTarget", () => {
     it("throws on a non-sequential position instead of corrupting downstream", async () => {
         const fileSystem = { writeChunck: vi.fn(), closeFile: vi.fn() };
         const target = mod.createFileSystemTarget({}, { fileSystem, chunkSize: 1024 });
-        const writer = target._writable.getWriter();
+        const writer = target.exportWritable.getWriter();
 
         await writer.write({ type: "write", data: new Uint8Array(4), position: 0 });
         await expect(writer.write({ type: "write", data: new Uint8Array(4), position: 8 })).rejects.toThrow(
@@ -188,7 +214,7 @@ describe("createFileSystemTarget", () => {
             closeFile: vi.fn(),
         };
         const target = await mod.openFileSystemTarget(descriptor, { fileSystem, chunkSize: 1024 });
-        const writer = target._writable.getWriter();
+        const writer = target.exportWritable.getWriter();
 
         await writer.write({ type: "write", data: new Uint8Array([9]), position: 0 });
         await writer.close();

--- a/test/js/blackbox_video_export.test.js
+++ b/test/js/blackbox_video_export.test.js
@@ -254,6 +254,116 @@ describe("compositeVideoFrame", () => {
     });
 });
 
+describe("runVideoExport lifecycle", () => {
+    afterEach(() => {
+        vi.doUnmock("mediabunny");
+        vi.doUnmock("../../src/blackbox-viewer/playback_controls.js");
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.resetModules();
+    });
+
+    async function loadRuntime({ codec, graphState = 1 }) {
+        vi.resetModules();
+        const controls = {
+            getGraphState: vi.fn(() => graphState),
+            invalidateGraph: vi.fn(),
+            setExportInProgress: vi.fn(),
+            setGraphState: vi.fn(),
+        };
+
+        class FakeOutput {
+            constructor() {
+                this.state = "pending";
+            }
+
+            addVideoTrack() {}
+
+            async start() {
+                this.state = "started";
+            }
+
+            async finalize() {
+                this.state = "finalized";
+            }
+
+            async cancel() {
+                this.state = "canceled";
+            }
+        }
+
+        vi.stubGlobal("VideoEncoder", class VideoEncoder {});
+        vi.doMock("mediabunny", () => ({
+            Output: FakeOutput,
+            Mp4OutputFormat: class {},
+            WebMOutputFormat: class {},
+            StreamTarget: class {},
+            CanvasSource: class {
+                async add() {}
+            },
+            getFirstEncodableVideoCodec: vi.fn(() => codec),
+            QUALITY_MEDIUM: "medium",
+        }));
+        vi.doMock("../../src/blackbox-viewer/playback_controls.js", () => controls);
+
+        return { fresh: await import("../../src/blackbox-viewer/video_export"), controls };
+    }
+
+    function runtimeOptions(overrides = {}) {
+        const context = { fillRect: vi.fn(), drawImage: vi.fn(), fillStyle: "" };
+        const graphCanvas = {};
+        return {
+            canvas: { width: 0, height: 0, getContext: () => context },
+            canvasRefs: { canvas: graphCanvas },
+            graph: { render: vi.fn(), resize: vi.fn(), setDrawInOutRegion: vi.fn() },
+            log: { getMinTime: () => 0, getMaxTime: () => 1e6 },
+            file: { name: "flight.mp4" },
+            fileSystem: {
+                openFile: vi.fn().mockResolvedValue({ id: "writable" }),
+                writeChunck: vi.fn(),
+                closeFile: vi.fn(),
+            },
+            frameRate: 30,
+            width: 1280,
+            height: 720,
+            ...overrides,
+        };
+    }
+
+    it("reserves the grapher before codec planning and releases it after planning fails", async () => {
+        let resolveCodec;
+        const codec = new Promise((resolve) => {
+            resolveCodec = resolve;
+        });
+        const { fresh } = await loadRuntime({ codec });
+        const options = runtimeOptions();
+
+        const first = fresh.runVideoExport(options);
+        await expect(fresh.runVideoExport(options)).rejects.toThrow(/already running/);
+
+        resolveCodec(null);
+        await expect(first).rejects.toThrow(/No supported video codec/);
+        await expect(fresh.runVideoExport(options)).rejects.toThrow(/No supported video codec/);
+    });
+
+    it("restores playback state after returning the grapher", async () => {
+        const { fresh, controls } = await loadRuntime({ codec: Promise.resolve("avc") });
+        const restoreCanvasSize = vi.fn();
+        const invalidateGraph = vi.fn();
+        const options = runtimeOptions({ restoreCanvasSize, invalidateGraph });
+
+        const result = await fresh.runVideoExport(options);
+
+        expect(result).toMatchObject({ frames: 30, cancelled: false });
+        expect(controls.getGraphState).toHaveBeenCalledOnce();
+        expect(controls.setGraphState.mock.calls).toEqual([[0], [1]]);
+        expect(controls.setExportInProgress.mock.calls).toEqual([[true], [false]]);
+        expect(restoreCanvasSize).toHaveBeenCalledOnce();
+        expect(invalidateGraph).toHaveBeenCalledOnce();
+        expect(options.fileSystem.closeFile).toHaveBeenCalledOnce();
+    });
+});
+
 describe("suggestedName", () => {
     it("replaces the log extension with the export container's", () => {
         expect(mod.suggestedName("FOO.BBL", "mp4")).toBe("FOO.mp4");

--- a/test/js/blackbox_video_export.test.js
+++ b/test/js/blackbox_video_export.test.js
@@ -1,0 +1,189 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mod = await import("../../src/blackbox-viewer/video_export");
+
+describe("estimateFrameCount", () => {
+    it("rounds the marker range at the chosen framerate", () => {
+        // 1e6 micros / 30 fps = 33_333.3 micros per frame
+        expect(mod.estimateFrameCount({ inTime: 0, outTime: 1e6, frameRate: 30 })).toBe(30);
+        expect(mod.estimateFrameCount({ inTime: 0, outTime: 500000, frameRate: 60 })).toBe(30);
+    });
+
+    it("falls back to the log extent when a bound is unset", () => {
+        expect(
+            mod.estimateFrameCount({
+                inTime: null,
+                outTime: undefined,
+                frameRate: 30,
+                getMinTime: () => 100000,
+                getMaxTime: () => 3100000,
+            }),
+        ).toBe(90);
+    });
+
+    it("treats false like an unset bound", () => {
+        expect(
+            mod.estimateFrameCount({
+                inTime: false,
+                outTime: 2e6,
+                frameRate: 50,
+                getMinTime: () => 0,
+            }),
+        ).toBe(100);
+    });
+
+    it("clamps inverted ranges to zero", () => {
+        expect(mod.estimateFrameCount({ inTime: 5e6, outTime: 1e6, frameRate: 30 })).toBe(0);
+    });
+});
+
+describe("estimateOutputBytes", () => {
+    it("returns zero for empty ranges", () => {
+        expect(mod.estimateOutputBytes({ frameCount: 0, width: 1280, height: 720 })).toBe(0);
+        expect(mod.estimateOutputBytes({ frameCount: 10, width: 0, height: 0 })).toBe(0);
+    });
+
+    it("scales with frames and pixels", () => {
+        const small = mod.estimateOutputBytes({ frameCount: 30, width: 640, height: 360, codec: "avc" });
+        const big = mod.estimateOutputBytes({ frameCount: 300, width: 1920, height: 1080, codec: "avc" });
+        expect(big).toBeGreaterThan(small * 20);
+    });
+
+    it("charges a factor for software-codec containers", () => {
+        const avc = mod.estimateOutputBytes({ frameCount: 100, width: 1280, height: 720, codec: "avc" });
+        const vp9 = mod.estimateOutputBytes({ frameCount: 100, width: 1280, height: 720, codec: "vp9" });
+        expect(vp9).toBeGreaterThan(avc);
+    });
+});
+
+describe("probeVideoExport", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.unstubAllGlobals();
+        vi.resetModules();
+    });
+
+    async function loadWithCodec(codec) {
+        vi.stubGlobal(
+            "VideoEncoder",
+            class VideoEncoder {
+                static isConfigSupported() {
+                    return Promise.resolve({ supported: true });
+                }
+            },
+        );
+        vi.doMock("mediabunny", () => ({
+            getFirstEncodableVideoCodec: vi.fn().mockResolvedValue(codec),
+            QUALITY_MEDIUM: "medium",
+        }));
+        return import("../../src/blackbox-viewer/video_export");
+    }
+
+    it("reports WebCodecs absence with its reason", async () => {
+        const fresh = await import("../../src/blackbox-viewer/video_export");
+        const result = await fresh.probeVideoExport({ width: 1280, height: 720 });
+        expect(result.canEncode).toBe(false);
+        expect(result.reason).toMatch(/WebCodecs/i);
+    });
+
+    it("threads a supported codec through to container + extension + saveMode", async () => {
+        vi.stubGlobal("showSaveFilePicker", () => {});
+        const fresh = await loadWithCodec("avc");
+        const result = await fresh.probeVideoExport({ width: 1280, height: 720 });
+        expect(result).toMatchObject({
+            canEncode: true,
+            codec: "avc",
+            container: "mp4",
+            extension: "mp4",
+            description: "MP4 video",
+            saveMode: "stream",
+        });
+    });
+
+    it("reports buffered save mode without showSaveFilePicker", async () => {
+        const fresh = await loadWithCodec("vp9");
+        const result = await fresh.probeVideoExport({ width: 1280, height: 720 });
+        expect(result.saveMode).toBe("buffered");
+        expect(result.extension).toBe("webm");
+    });
+
+    it("caches per canvas size", async () => {
+        const codecSpy = vi.fn().mockResolvedValue("avc");
+        vi.stubGlobal("showSaveFilePicker", () => {});
+        vi.stubGlobal(
+            "VideoEncoder",
+            class VideoEncoder {
+                static isConfigSupported() {
+                    return Promise.resolve({ supported: true });
+                }
+            },
+        );
+        vi.doMock("mediabunny", () => ({
+            getFirstEncodableVideoCodec: codecSpy,
+            QUALITY_MEDIUM: "medium",
+        }));
+        const fresh = await import("../../src/blackbox-viewer/video_export");
+        await fresh.probeVideoExport({ width: 1920, height: 1080 });
+        await fresh.probeVideoExport({ width: 1920, height: 1080 });
+        expect(codecSpy).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("createFileSystemTarget", () => {
+    afterEach(() => {
+        vi.resetModules();
+        delete window.FileSystem;
+    });
+
+    async function loadWithFakeTarget() {
+        vi.doMock("mediabunny", () => ({
+            // Mimics the real StreamTarget contract: write() feeds the
+            // WritableStream the module handed us.
+            StreamTarget: class FakeStreamTarget {
+                constructor(writable) {
+                    this._writer = writable.getWriter();
+                    this.write = vi.fn(async (chunk) => {
+                        await this._writer.write(chunk);
+                    });
+                }
+            },
+        }));
+        return import("../../src/blackbox-viewer/video_export");
+    }
+
+    it("hands every muxer chunk to FileSystem as a Blob, in order", async () => {
+        const fresh = await loadWithFakeTarget();
+        window.FileSystem = { writeChunck: vi.fn() };
+        const target = fresh.createFileSystemTarget({});
+
+        await target.write({ type: "write", data: new Uint8Array([1, 2]), position: 0 });
+        await target.write({ type: "write", data: new Uint8Array([3, 4, 5]), position: 2 });
+
+        const calls = window.FileSystem.writeChunck.mock.calls;
+        expect(calls).toHaveLength(2);
+        expect(calls[0][1]).toBeInstanceOf(Blob);
+        expect(await calls[0][1].arrayBuffer()).toEqual(new Uint8Array([1, 2]).buffer);
+        expect(await calls[1][1].arrayBuffer()).toEqual(new Uint8Array([3, 4, 5]).buffer);
+        expect(target.bytesWritten()).toBe(5);
+    });
+
+    it("throws on a non-sequential position instead of corrupting downstream", async () => {
+        const fresh = await loadWithFakeTarget();
+        window.FileSystem = { writeChunck: vi.fn() };
+        const target = fresh.createFileSystemTarget({});
+
+        await target.write({ type: "write", data: new Uint8Array(4), position: 0 });
+        await expect(target.write({ type: "write", data: new Uint8Array(4), position: 8 })).rejects.toThrow(
+            /append-only/,
+        );
+        expect(window.FileSystem.writeChunck).toHaveBeenCalledTimes(1);
+    });
+});
+
+describe("suggestedName", () => {
+    it("replaces the log extension with the export container's", () => {
+        expect(mod.suggestedName("FOO.BBL", "mp4")).toBe("FOO.mp4");
+        expect(mod.suggestedName("no-ext", "webm")).toBe("no-ext.webm");
+        expect(mod.suggestedName("", "mp4")).toBe("blackbox.mp4");
+    });
+});

--- a/test/js/blackbox_video_export.test.js
+++ b/test/js/blackbox_video_export.test.js
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GRAPH_STATE_PAUSED, GRAPH_STATE_PLAY } from "../../src/blackbox-viewer/stores/playback.js";
 
 const mod = await import("../../src/blackbox-viewer/video_export");
 
@@ -263,7 +264,7 @@ describe("runVideoExport lifecycle", () => {
         vi.resetModules();
     });
 
-    async function loadRuntime({ codec, graphState = 1 }) {
+    async function loadRuntime({ codec, graphState = GRAPH_STATE_PLAY }) {
         vi.resetModules();
         const controls = {
             getGraphState: vi.fn(() => graphState),
@@ -356,11 +357,28 @@ describe("runVideoExport lifecycle", () => {
 
         expect(result).toMatchObject({ frames: 30, cancelled: false });
         expect(controls.getGraphState).toHaveBeenCalledOnce();
-        expect(controls.setGraphState.mock.calls).toEqual([[0], [1]]);
+        expect(controls.setGraphState.mock.calls).toEqual([[GRAPH_STATE_PAUSED], [GRAPH_STATE_PLAY]]);
         expect(controls.setExportInProgress.mock.calls).toEqual([[true], [false]]);
         expect(restoreCanvasSize).toHaveBeenCalledOnce();
         expect(invalidateGraph).toHaveBeenCalledOnce();
         expect(options.fileSystem.closeFile).toHaveBeenCalledOnce();
+    });
+
+    it("does not let a close failure hide the original export error", async () => {
+        const { fresh } = await loadRuntime({ codec: Promise.resolve("avc") });
+        const renderError = new Error("frame render failed");
+        const options = runtimeOptions({
+            graph: {
+                render: vi.fn(() => {
+                    throw renderError;
+                }),
+                resize: vi.fn(),
+                setDrawInOutRegion: vi.fn(),
+            },
+        });
+        options.fileSystem.closeFile.mockRejectedValue(new Error("file close failed"));
+
+        await expect(fresh.runVideoExport(options)).rejects.toBe(renderError);
     });
 });
 

--- a/test/js/blackbox_video_export.test.js
+++ b/test/js/blackbox_video_export.test.js
@@ -3,6 +3,14 @@ import { GRAPH_STATE_PAUSED, GRAPH_STATE_PLAY } from "../../src/blackbox-viewer/
 
 const mod = await import("../../src/blackbox-viewer/video_export");
 
+/** @typedef {Parameters<typeof mod.runVideoExport>[0]} VideoExportOptions */
+/**
+ * @typedef {object} RuntimeHarness
+ * @property {typeof mod} fresh
+ * @property {{getGraphState: import("vitest").Mock, invalidateGraph: import("vitest").Mock,
+ *   setExportInProgress: import("vitest").Mock, setGraphState: import("vitest").Mock}} controls
+ */
+
 describe("estimateFrameCount", () => {
     it("rounds the marker range at the chosen framerate", () => {
         // 1e6 micros / 30 fps = 33_333.3 micros per frame
@@ -264,6 +272,10 @@ describe("runVideoExport lifecycle", () => {
         vi.resetModules();
     });
 
+    /**
+     * @param {{codec: Promise<string | null>, graphState?: number}} settings
+     * @returns {Promise<RuntimeHarness>}
+     */
     async function loadRuntime({ codec, graphState = GRAPH_STATE_PLAY }) {
         vi.resetModules();
         const controls = {
@@ -310,6 +322,10 @@ describe("runVideoExport lifecycle", () => {
         return { fresh: await import("../../src/blackbox-viewer/video_export"), controls };
     }
 
+    /**
+     * @param {Partial<VideoExportOptions>} [overrides]
+     * @returns {VideoExportOptions}
+     */
     function runtimeOptions(overrides = {}) {
         const context = { fillRect: vi.fn(), drawImage: vi.fn(), fillStyle: "" };
         const graphCanvas = {};
@@ -379,6 +395,32 @@ describe("runVideoExport lifecycle", () => {
         options.fileSystem.closeFile.mockRejectedValue(new Error("file close failed"));
 
         await expect(fresh.runVideoExport(options)).rejects.toBe(renderError);
+    });
+
+    it("preserves an undefined export rejection when closing also fails", async () => {
+        const { fresh } = await loadRuntime({ codec: Promise.resolve("avc") });
+        const options = runtimeOptions({
+            graph: {
+                render: vi.fn(() => {
+                    throw undefined;
+                }),
+                resize: vi.fn(),
+                setDrawInOutRegion: vi.fn(),
+            },
+        });
+        options.fileSystem.closeFile.mockRejectedValue(new Error("file close failed"));
+
+        let rejected = false;
+        let reason = "not rejected";
+        try {
+            await fresh.runVideoExport(options);
+        } catch (error) {
+            rejected = true;
+            reason = error;
+        }
+
+        expect(rejected).toBe(true);
+        expect(reason).toBeUndefined();
     });
 });
 

--- a/test/js/blackbox_video_export.test.js
+++ b/test/js/blackbox_video_export.test.js
@@ -73,6 +73,11 @@ describe("probeVideoExport", () => {
             },
         );
         vi.doMock("mediabunny", () => ({
+            Output: class {},
+            Mp4OutputFormat: class {},
+            WebMOutputFormat: class {},
+            StreamTarget: class {},
+            CanvasSource: class {},
             getFirstEncodableVideoCodec: vi.fn().mockResolvedValue(codec),
             QUALITY_MEDIUM: "medium",
         }));
@@ -119,6 +124,11 @@ describe("probeVideoExport", () => {
             },
         );
         vi.doMock("mediabunny", () => ({
+            Output: class {},
+            Mp4OutputFormat: class {},
+            WebMOutputFormat: class {},
+            StreamTarget: class {},
+            CanvasSource: class {},
             getFirstEncodableVideoCodec: codecSpy,
             QUALITY_MEDIUM: "medium",
         }));
@@ -130,53 +140,91 @@ describe("probeVideoExport", () => {
 });
 
 describe("createFileSystemTarget", () => {
-    afterEach(() => {
-        vi.resetModules();
-        delete window.FileSystem;
-    });
+    it("hands every muxer chunk to the opened writable as a Blob and closes once", async () => {
+        const writableToken = { id: "production-writable" };
+        const fileSystem = { writeChunck: vi.fn(), closeFile: vi.fn() };
+        const target = mod.createFileSystemTarget(writableToken, { fileSystem, chunkSize: 1024 });
+        const writer = target._writable.getWriter();
 
-    async function loadWithFakeTarget() {
-        vi.doMock("mediabunny", () => ({
-            // Mimics the real StreamTarget contract: write() feeds the
-            // WritableStream the module handed us.
-            StreamTarget: class FakeStreamTarget {
-                constructor(writable) {
-                    this._writer = writable.getWriter();
-                    this.write = vi.fn(async (chunk) => {
-                        await this._writer.write(chunk);
-                    });
-                }
-            },
-        }));
-        return import("../../src/blackbox-viewer/video_export");
-    }
+        await writer.write({ type: "write", data: new Uint8Array([1, 2]), position: 0 });
+        await writer.write({ type: "write", data: new Uint8Array([3, 4, 5]), position: 2 });
+        await writer.close();
+        await target.closeFile();
 
-    it("hands every muxer chunk to FileSystem as a Blob, in order", async () => {
-        const fresh = await loadWithFakeTarget();
-        window.FileSystem = { writeChunck: vi.fn() };
-        const target = fresh.createFileSystemTarget({});
-
-        await target.write({ type: "write", data: new Uint8Array([1, 2]), position: 0 });
-        await target.write({ type: "write", data: new Uint8Array([3, 4, 5]), position: 2 });
-
-        const calls = window.FileSystem.writeChunck.mock.calls;
+        const calls = fileSystem.writeChunck.mock.calls;
         expect(calls).toHaveLength(2);
+        expect(calls[0][0]).toBe(writableToken);
         expect(calls[0][1]).toBeInstanceOf(Blob);
         expect(await calls[0][1].arrayBuffer()).toEqual(new Uint8Array([1, 2]).buffer);
         expect(await calls[1][1].arrayBuffer()).toEqual(new Uint8Array([3, 4, 5]).buffer);
         expect(target.bytesWritten()).toBe(5);
+        expect(fileSystem.closeFile).toHaveBeenCalledOnce();
+        expect(fileSystem.closeFile).toHaveBeenCalledWith(writableToken);
     });
 
     it("throws on a non-sequential position instead of corrupting downstream", async () => {
-        const fresh = await loadWithFakeTarget();
-        window.FileSystem = { writeChunck: vi.fn() };
-        const target = fresh.createFileSystemTarget({});
+        const fileSystem = { writeChunck: vi.fn(), closeFile: vi.fn() };
+        const target = mod.createFileSystemTarget({}, { fileSystem, chunkSize: 1024 });
+        const writer = target._writable.getWriter();
 
-        await target.write({ type: "write", data: new Uint8Array(4), position: 0 });
-        await expect(target.write({ type: "write", data: new Uint8Array(4), position: 8 })).rejects.toThrow(
+        await writer.write({ type: "write", data: new Uint8Array(4), position: 0 });
+        await expect(writer.write({ type: "write", data: new Uint8Array(4), position: 8 })).rejects.toThrow(
             /append-only/,
         );
-        expect(window.FileSystem.writeChunck).toHaveBeenCalledTimes(1);
+        expect(fileSystem.writeChunck).toHaveBeenCalledTimes(1);
+    });
+
+    it("uses small Android bridge chunks", () => {
+        expect(mod.videoExportChunkSize(true)).toBe(256 * 1024);
+        expect(mod.videoExportChunkSize(false)).toBe(4 * 1024 * 1024);
+    });
+
+    it("uses the production pick → open → write → close lifecycle", async () => {
+        const descriptor = { name: "flight.mp4", _fileHandle: {} };
+        const writableToken = { id: "opened-token" };
+        const fileSystem = {
+            openFile: vi.fn().mockResolvedValue(writableToken),
+            writeChunck: vi.fn(),
+            closeFile: vi.fn(),
+        };
+        const target = await mod.openFileSystemTarget(descriptor, { fileSystem, chunkSize: 1024 });
+        const writer = target._writable.getWriter();
+
+        await writer.write({ type: "write", data: new Uint8Array([9]), position: 0 });
+        await writer.close();
+
+        expect(fileSystem.openFile).toHaveBeenCalledWith(descriptor);
+        expect(fileSystem.writeChunck).toHaveBeenCalledWith(writableToken, expect.any(Blob));
+        expect(fileSystem.closeFile).toHaveBeenCalledWith(writableToken);
+    });
+});
+
+describe("compositeVideoFrame", () => {
+    it("draws the graph and enabled overlays at their export-scale positions", () => {
+        const context = { fillRect: vi.fn(), drawImage: vi.fn(), fillStyle: "" };
+        const graphCanvas = {};
+        const stickCanvas = { style: { left: "12.5px", top: "24px" } };
+        const craftCanvas = { style: { left: "30px", top: "40px" } };
+        const analyserCanvas = {};
+        const canvas = { width: 1280, height: 720, getContext: () => context };
+
+        mod.compositeVideoFrame({
+            canvas,
+            canvasRefs: { canvas: graphCanvas, stickCanvas, craftCanvas, analyserCanvas },
+            userSettings: { sticks: { size: "30%" }, craft: { size: "40%" }, analyser: { size: "35%" } },
+            includeSticks: true,
+            includeCraft: true,
+            includeAnalyser: true,
+            analyserLayout: { left: 50, top: 60 },
+        });
+
+        expect(context.fillRect).toHaveBeenCalledWith(0, 0, 1280, 720);
+        expect(context.drawImage.mock.calls).toEqual([
+            [graphCanvas, 0, 0],
+            [stickCanvas, 12.5, 24],
+            [craftCanvas, 30, 40],
+            [analyserCanvas, 50, 60],
+        ]);
     });
 });
 

--- a/test/js/blackbox_video_export_guard.test.js
+++ b/test/js/blackbox_video_export_guard.test.js
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+    animationLoop,
+    invalidateGraph,
+    isExportInProgress,
+    setExportInProgress,
+} from "../../src/blackbox-viewer/playback_controls.js";
+import { createKeydownHandler } from "../../src/blackbox-viewer/keyboard_handler.js";
+
+afterEach(() => {
+    setExportInProgress(false);
+    vi.unstubAllGlobals();
+});
+
+describe("video export playback guard", () => {
+    it("releases the queued-frame latch when an animation frame is suppressed", () => {
+        const callbacks = [];
+        const requestAnimationFrame = vi.fn((callback) => callbacks.push(callback));
+        vi.stubGlobal("requestAnimationFrame", requestAnimationFrame);
+
+        setExportInProgress(true);
+        invalidateGraph();
+        expect(requestAnimationFrame).toHaveBeenCalledTimes(1);
+        callbacks.shift()();
+
+        setExportInProgress(false);
+        invalidateGraph();
+        expect(requestAnimationFrame).toHaveBeenCalledTimes(2);
+
+        // Reset the module latch without entering the store-dependent render path.
+        setExportInProgress(true);
+        callbacks.shift()();
+        expect(isExportInProgress()).toBe(true);
+    });
+
+    it("blocks viewer shortcuts while the live grapher is borrowed", () => {
+        const logPlayPause = vi.fn();
+        const handler = createKeydownHandler({
+            appStore: { viewerActive: true },
+            hasGraph: () => true,
+            logPlayPause,
+        });
+        const event = {
+            code: "Space",
+            key: " ",
+            target: { type: "", closest: () => null },
+            preventDefault: vi.fn(),
+        };
+
+        setExportInProgress(true);
+        handler(event);
+
+        expect(logPlayPause).not.toHaveBeenCalled();
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+});

--- a/test/js/blackbox_video_export_guard.test.js
+++ b/test/js/blackbox_video_export_guard.test.js
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-    animationLoop,
     invalidateGraph,
     isExportInProgress,
     setExportInProgress,

--- a/test/js/blackbox_video_export_toolbar.test.js
+++ b/test/js/blackbox_video_export_toolbar.test.js
@@ -1,0 +1,101 @@
+import { createApp, h, nextTick } from "vue";
+import { createPinia, setActivePinia } from "pinia";
+import { TooltipProvider } from "reka-ui";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import AppToolbar from "../../src/blackbox-viewer/components/AppToolbar.vue";
+import { useLogStore } from "../../src/blackbox-viewer/stores/log.js";
+import { probeVideoExport } from "../../src/blackbox-viewer/video_export.js";
+
+vi.mock("../../src/blackbox-viewer/video_export.js", () => ({
+    probeVideoExport: vi.fn(),
+}));
+
+async function flushProbe() {
+    await Promise.resolve();
+    await nextTick();
+    await Promise.resolve();
+    await nextTick();
+}
+
+describe("blackbox video export toolbar", () => {
+    let app;
+    let host;
+
+    afterEach(() => {
+        app?.unmount();
+        host?.remove();
+        app = null;
+        host = null;
+        vi.resetAllMocks();
+    });
+
+    it("exposes an unavailable encoder reason from the disabled Export Video control", async () => {
+        const reason = "No supported video codec found; install the required Linux encoder plugins";
+        probeVideoExport.mockResolvedValue({ canEncode: false, reason });
+
+        const pinia = createPinia();
+        setActivePinia(pinia);
+        useLogStore().setFlightLog({});
+
+        host = document.createElement("div");
+        document.body.appendChild(host);
+        app = createApp({
+            render: () => h(TooltipProvider, null, () => h(AppToolbar)),
+        });
+        app.use(pinia);
+        app.mount(host);
+        await flushProbe();
+
+        const button = [...host.querySelectorAll("button")].find((element) =>
+            element.textContent.includes("Export Video"),
+        );
+        expect(button).toBeTruthy();
+        expect(button.disabled).toBe(true);
+
+        const explanationTrigger = button.closest('[data-testid="video-export-capability"]');
+        expect(explanationTrigger).toBeTruthy();
+        expect(explanationTrigger.getAttribute("role")).toBe("group");
+        expect(explanationTrigger.getAttribute("aria-disabled")).toBe("true");
+        expect(explanationTrigger.getAttribute("aria-label")).toBe(`Export Video unavailable: ${reason}`);
+        expect(explanationTrigger.getAttribute("tabindex")).toBe("0");
+        expect(button.classList.contains("pointer-events-none")).toBe(true);
+
+        explanationTrigger.focus();
+        await new Promise((resolve) => setTimeout(resolve, 350));
+        await nextTick();
+        expect(document.body.textContent).toContain(reason);
+    });
+
+    it("keeps Export Video interactive when an encoder is available", async () => {
+        probeVideoExport.mockResolvedValue({ canEncode: true, codec: "avc" });
+
+        const pinia = createPinia();
+        const onExportVideo = vi.fn();
+        setActivePinia(pinia);
+        useLogStore().setFlightLog({});
+
+        host = document.createElement("div");
+        document.body.appendChild(host);
+        app = createApp({
+            render: () => h(TooltipProvider, null, () => h(AppToolbar, { onExportVideo })),
+        });
+        app.use(pinia);
+        app.mount(host);
+        await flushProbe();
+
+        const button = [...host.querySelectorAll("button")].find((element) =>
+            element.textContent.includes("Export Video"),
+        );
+        const explanationTrigger = button.closest('[data-testid="video-export-capability"]');
+
+        expect(button.disabled).toBe(false);
+        expect(button.classList.contains("pointer-events-none")).toBe(false);
+        expect(explanationTrigger.hasAttribute("role")).toBe(false);
+        expect(explanationTrigger.hasAttribute("aria-disabled")).toBe(false);
+        expect(explanationTrigger.hasAttribute("aria-label")).toBe(false);
+        expect(explanationTrigger.hasAttribute("tabindex")).toBe(false);
+
+        button.click();
+        expect(onExportVideo).toHaveBeenCalledOnce();
+    });
+});

--- a/test/js/fileSystem.test.js
+++ b/test/js/fileSystem.test.js
@@ -55,6 +55,13 @@ describe("buildAcceptTypes", () => {
         });
     });
 
+    it("maps video extensions to their video MIME types", () => {
+        const [mp4] = buildAcceptTypes("video", ".mp4");
+        expect(mp4.accept).toEqual({ "video/mp4": [".mp4", ".MP4"] });
+        const [webm] = buildAcceptTypes("video", ["webm"]);
+        expect(webm.accept).toEqual({ "video/webm": [".webm", ".WEBM"] });
+    });
+
     it("falls back to application/octet-stream for unknown extensions (never */*)", () => {
         const [type] = buildAcceptTypes("custom", ".xyz");
         expect(type.accept).toEqual({ "application/octet-stream": [".xyz", ".XYZ"] });


### PR DESCRIPTION
## Why

The Blackbox tab has no **Export Video** feature; the standalone viewer had one and the Vue port dropped it (#5396). This ports the feature following the design documents in that issue: borrow the live grapher, render the selected range frame by frame, composite the graph and enabled overlays, encode with WebCodecs through mediabunny, and stream an MP4 (or WebM fallback) through the existing `FileSystem` abstraction.

## Summary

- Adds `.mp4` and `.webm` MIME support to `FileSystem`.
- Adds a video-export engine with codec probing, frame and size estimation, append-only streaming, progress/ETA, and cancellation.
- Composites the graph, sticks, craft, and analyser canvases into a private encoder canvas.
- Uses the complete log when I/O markers are unset and preserves a marker explicitly set at time zero.
- Borrows and restores the live grapher safely: resize and animation traffic are guarded, viewer shortcuts are suppressed, the in/out region is hidden without clearing markers, analyser rendering is prewarmed, and teardown cancels an active export.
- Uses 256 KiB chunks on Android and 4 MiB elsewhere.
- Adds a four-state settings/rendering/done/error dialog, capability-aware toolbar button, buffered-save warning, Android warning, and honest partial-file cancellation message.

## Issue Number

Implements #5396

## How to Test

Using the repository's Node 24 runtime:

```text
npm ci
npm run test
npm run lint
npm run build
```

Local results for this revision:

- 87 test files / 1,008 tests passed.
- 24 focused video-export and export-guard tests passed.
- ESLint passed.
- SonarCloud Quality Gate passed with zero open issues attributed to this pull request.
- Production PWA build passed. The main JavaScript chunk is approximately 3.59 MB, below the 5 MB Workbox precache limit.
- Clean `npm ci` completed successfully.

Windows Chromium end-to-end checks with a real Blackbox log:

- Whole-log H.264 MP4: 1280×720, approximately 4.3 seconds, 1.35 MB. Chromium decoded sampled frames throughout the file; frames were opaque, nonblank, and changed over time.
- I/O-marked H.264 MP4: exactly 60 frames over 2.0 seconds, approximately 603 KB, decoded at 1280×720.
- Analyser-enabled export completed without an exception.
- Cancellation produced the expected cancelled state and an immediate retry succeeded.
- A resize event during export did not interrupt or corrupt the export.
- Playback advanced normally after export, confirming viewer restoration.

The browser verification used a File System Access-compatible test writable so the exact muxed bytes could be retained and decoded in-page. The production pick → open → Blob writes → exactly-once close lifecycle is separately covered by tests against the real `FileSystem` contract.

## Video/Screenshots

Not attached. The generated files were decoded and inspected during the end-to-end checks described above.

## Risk and remaining validation

The implementation is contained primarily within the Blackbox viewer. The shared `FileSystem` change is limited to the two MIME entries.

Known v1 limitations from the design documents remain explicit in the UI: background flight video is not composited; non-streaming browsers buffer the completed file in memory; and cancellation may leave a partial file that the user can delete.

The following rows have **not** been claimed as locally verified and would benefit from maintainer/platform testing:

- 1080p and 50/60 fps combinations.
- Tauri on macOS and Linux.
- Android SAF export on a physical device.
- Firefox/WebM fallback where WebCodecs and codecs are available.
- VLC and NLE compatibility (for example DaVinci Resolve or Adobe Premiere).

## AI assistance

AI-assisted: implementation and testing were performed with Codex against the issue's design documents. All validation results reported above were executed against this branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added video export with MP4 and WebM support.
  * Choose output resolution and frame rate, estimate export size, monitor progress, and cancel exports.
  * Added export status indicators, file selection, success/error feedback, and mobile save warnings.
  * Added controls to show or hide in/out regions during export.
* **Bug Fixes**
  * Prevented keyboard shortcuts and unnecessary viewer rendering while exporting.
  * Improved video file type handling and cleanup when exports are cancelled or fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->