### PR TITLE
fix: Allow version strings in isMspCliSupported to contain underscores

### DIFF
--- a/src/composables/useMspCliSession.js
+++ b/src/composables/useMspCliSession.js
@@ -18,7 +18,9 @@ export function isMspCliSupported() {
     if (!version) {
         return false;
     }
-    return semver.gte(version, MIN_FC_VERSION_FOR_MSP_CLI);
+
+    const normalizedVersion = version.replaceAll("_", "-");
+    return semver.valid(normalizedVersion) ? semver.gte(normalizedVersion, MIN_FC_VERSION_FOR_MSP_CLI) : false;
 }
 
 function wait(ms) {

--- a/test/js/useMspCliSession.test.js
+++ b/test/js/useMspCliSession.test.js
@@ -209,6 +209,17 @@ describe("useMspCliSession", () => {
             FC.CONFIG.flightControllerVersion = "4.6.0";
             expect(isMspCliSupported()).toBe(true);
         });
+
+        it("supports vendor firmware versions with underscore prerelease identifiers", () => {
+            FC.CONFIG.flightControllerVersion = "2025.12.3-alpha.KAACK_V19";
+            expect(isMspCliSupported()).toBe(true);
+        });
+
+        it("returns false for an invalid firmware version without throwing", () => {
+            FC.CONFIG.flightControllerVersion = "not-a-version";
+            expect(() => isMspCliSupported()).not.toThrow();
+            expect(isMspCliSupported()).toBe(false);
+        });
     });
 });
 


### PR DESCRIPTION
## Issue 
On Discord it was reported that KAACK Firmware Versions cannot use Presets, Save or Load Backup Buttons and few other features linked to the function `isMspCliSupported`. 
KAACK currently installs as `2025.12.3-alpha.KAACK_V19`. The underscore causes `semver.gte()` to throw and also stops the error dialog from showing.

## FIX
I modified the `isMspCliSupported` Function to allow underscores and transform them to hyphens. 
Additionally, I added `semver.valid(version)` to avoid throwing on invalid version strings.

## Comment

The fix could be narrowed down to target KAACK Versions specifically. 

Additionally, the KAACK Firmwares should be made semver compliant. This fix would still be needed for backwards compatibility with older versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility checks for flight-controller firmware versions using underscore-based prerelease identifiers.
  - Invalid firmware version values are now rejected gracefully without causing errors.

- **Tests**
  - Added coverage for underscore-formatted prerelease versions and invalid version inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->