### PR TITLE
Add Serbian language to the UI

### DIFF
--- a/.github/workflows/translations-pr.yml
+++ b/.github/workflows/translations-pr.yml
@@ -33,7 +33,7 @@ jobs:
         upload_translations: false
 
         download_translations: true
-        download_translations_args: '-l ar -l ca -l da -l de -l es-ES -l eu -l fr -l gl -l it -l ja -l ka -l ko -l nl -l pt-PT -l pt-BR -l pl -l ru -l uk -l uz -l zh-CN -l zh-TW'
+        download_translations_args: '-l ar -l ca -l da -l de -l es-ES -l eu -l fr -l gl -l it -l ja -l ka -l ko -l nl -l pt-PT -l pt-BR -l pl -l ru -l sr -l sr-CS -l uk -l uz -l zh-CN -l zh-TW'
         localization_branch_name: update_translations_crowdin
         push_translations: true
         commit_message: 'Update translations'

--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -355,6 +355,14 @@
         "message": "\u0420\u0443\u0441\u0441\u043A\u0438\u0439",
         "description": "Don't translate!!!"
     },
+    "language_sr": {
+        "message": "Srpski (latinica)",
+        "description": "Don't translate!!!"
+    },
+    "language_sr_Cyrl": {
+        "message": "\u0421\u0440\u043f\u0441\u043a\u0438 (\u045b\u0438\u0440\u0438\u043b\u0438\u0446\u0430)",
+        "description": "Don't translate!!!"
+    },
     "language_uk": {
         "message": "\u0423\u043A\u0440\u0430\u0457\u043D\u0441\u044C\u043A\u0430",
         "description": "Don't translate!!!"

--- a/locales/sr/messages.json
+++ b/locales/sr/messages.json
@@ -1,0 +1,9947 @@
+{
+    "yes": {
+        "message": "Da",
+        "description": "General Yes message to be used across the application"
+    },
+    "no": {
+        "message": "Ne",
+        "description": "General No message to be used across the application"
+    },
+    "on": {
+        "message": "Uključeno"
+    },
+    "off": {
+        "message": "Isključeno"
+    },
+    "auto": {
+        "message": "Automatski"
+    },
+    "error": {
+        "message": "Greška: {{errorMessage}}"
+    },
+    "errorTitle": {
+        "message": "Greška"
+    },
+    "warningTitle": {
+        "message": "Upozorenje"
+    },
+    "noticeTitle": {
+        "message": "Obaveštenje"
+    },
+    "search": {
+        "message": "Pretraži"
+    },
+    "dontShowAgain": {
+        "message": "Ne prikazuj ponovo"
+    },
+    "pwaOnNeedRefreshTitle": {
+        "message": "Aplikacija mora da se ažurira",
+        "description": "Title of the window that appears when the app needs to be refreshed to get the latest changes"
+    },
+    "pwaOnNeedRefreshText": {
+        "message": "Morate da osvežite stranicu da biste dobili najnovije promene. Osvežavanje će ponovo učitati stranicu i izgubićete sve nesačuvane promene i prekinućete sve operacije u toku.<br><br>Želite li da osvežite stranicu sada? Takođe možete da odbacite ovu poruku i ručno osvežite stranicu kasnije.",
+        "description": "Text of the window that appears when the app needs to be refreshed to get the latest changes"
+    },
+    "pwaOnOfflineReadyTitle": {
+        "message": "Aplikacija je spremna za korišćenje van mreže",
+        "description": "Title of the window that appears when the app is ready to be installed and used offline"
+    },
+    "pwaOnOfflineReadyText": {
+        "message": "Možete je instalirati kao samostalnu aplikaciju na Vaš uređaj ako želite. Potražite opciju u adresnoj traci pretraživača ili meniju.",
+        "description": "Text of the window that appears when the app is ready to be installed and used offline"
+    },
+    "operationNotSupported": {
+        "message": "Ova operacija nije podržana na Vašem hardveru."
+    },
+    "storageDeviceNotReady": {
+        "message": "Uređaj za skladištenje nije spreman. U slučaju microSD kartice, proverite da li je pravilno prepoznata od strane Vašeg flight kontrolera."
+    },
+    "connect": {
+        "message": "Poveži"
+    },
+    "connecting": {
+        "message": "Povezivanje"
+    },
+    "disconnect": {
+        "message": "Prekini vezu"
+    },
+    "disconnectVirtual": {
+        "message": "Prekini vezu (virtuelno)",
+        "description": "Disconnect button label shown when connected in virtual mode."
+    },
+    "disconnectManual": {
+        "message": "Prekini vezu (ručno)",
+        "description": "Disconnect button label shown when connected via manual port override."
+    },
+    "disconnectBluetooth": {
+        "message": "Prekini vezu (Bluetooth)",
+        "description": "Disconnect button label shown when connected via Bluetooth."
+    },
+    "portsSelectNoSelection": {
+        "message": "Izaberite Vaš uređaj",
+        "description": "Text for the option to select a device in the port selection dropdown"
+    },
+    "portsSelectManual": {
+        "message": "Ručni odabir"
+    },
+    "portsSelectNone": {
+        "message": "Nema dostupne veze"
+    },
+    "portsSelectVirtual": {
+        "message": "Virtuelni mod (eksperimentalno)",
+        "description": "Configure a Virtual Flight Controller without the need of a physical FC."
+    },
+    "portsSelectPermission": {
+        "message": "--- Ne mogu da pronađem svoj USB uređaj ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access the device."
+    },
+    "portsSelectPermissionBluetooth": {
+        "message": "--- Ne mogu da pronađem svoj Bluetooth uređaj ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access a Bluetooth device."
+    },
+    "portsSelectPermissionDFU": {
+        "message": "--- Ne mogu da pronađem svoj DFU uređaj ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access a DFU device."
+    },
+    "bluetoothConnected": {
+        "message": "Povezano sa Bluetooth uređajem: $1"
+    },
+    "bluetoothConnectionType": {
+        "message": "Vrsta Bluetooth veze: $1"
+    },
+    "bluetoothConnectionError": {
+        "message": "Bluetooth greška: $1"
+    },
+    "virtualMode": {
+        "message": "Virtuelni mod"
+    },
+    "virtualMSPVersion": {
+        "message": "Virtuelna verzija firmvera"
+    },
+    "portOverrideText": {
+        "message": "Port:"
+    },
+    "connectVirtualDescription": {
+        "message": "Simulirajte flight kontroler bez hardvera.",
+        "description": "Helper text in the connect dialog when choosing the virtual FC mode."
+    },
+    "connectVirtual": {
+        "message": "Poveži se (virtuelno)",
+        "description": "Connect button label shown when virtual mode port is selected."
+    },
+    "connectManualDescription": {
+        "message": "Unesite serijsku putanju ili URL za povezivanje.",
+        "description": "Helper text in the connect dialog when choosing the manual port mode."
+    },
+    "connectBookmarks": {
+        "message": "Sačuvane veze",
+        "description": "Title of the saved manual connection (bookmark) list in the connect dialog."
+    },
+    "connectBookmarkName": {
+        "message": "Naziv:",
+        "description": "Label of the input naming a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkNamePlaceholder": {
+        "message": "Naziv za ovu vezu",
+        "description": "Placeholder of the input naming a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkSave": {
+        "message": "Sačuvaj",
+        "description": "Button that saves the entered address as a bookmark in the connect dialog."
+    },
+    "connectBookmarkUpdate": {
+        "message": "Ažuriraj",
+        "description": "Button that renames the bookmark already pointing at the entered address."
+    },
+    "connectBookmarkRemove": {
+        "message": "Ukloni sačuvanu vezu",
+        "description": "Button that deletes a saved manual connection in the connect dialog."
+    },
+    "autoConnect": {
+        "message": "Automatsko povezivanje"
+    },
+    "close": {
+        "message": "Zatvori"
+    },
+    "openSidebarMenu": {
+        "message": "Otvori bočni meni",
+        "description": "Accessible label for the floating hamburger button shown on narrow viewports."
+    },
+    "OK": {
+        "message": "U redu"
+    },
+    "cancel": {
+        "message": "Otkaži"
+    },
+    "submit": {
+        "message": "Pošalji"
+    },
+    "delete": {
+        "message": "Obriši"
+    },
+    "edit": {
+        "message": "Izmeni"
+    },
+    "add": {
+        "message": "Dodaj"
+    },
+    "update": {
+        "message": "Ažuriraj"
+    },
+    "save": {
+        "message": "Sačuvaj"
+    },
+    "autoConnectEnabled": {
+        "message": "Automatsko povezivanje: Uključeno - Aplikacija automatski pokušava da se poveže kada se detektuje novi port"
+    },
+    "autoConnectDisabled": {
+        "message": "Automatsko povezivanje: Isključeno - Korisnik mora sam da izabere ispravan serijski port i klikne na dugme \"Poveži se\""
+    },
+    "expertMode": {
+        "message": "Uključi ekspertski mod"
+    },
+    "expertModeDescription": {
+        "message": "Prikaz opcija ekspertskog moda"
+    },
+    "warningSettings": {
+        "message": "Prikaži upozorenja"
+    },
+    "rememberLastTab": {
+        "message": "Ponovo otvori poslednju karticu pri povezivanju"
+    },
+    "meteredConnection": {
+        "message": "Bez pristupa internetu (za ograničene ili spore veze)",
+        "description": "Text for the option to disable internet access for metered connection or to disable data over slow connections"
+    },
+    "analyticsOptOut": {
+        "message": "Bez anonimnog prikupljanja statističkih podataka"
+    },
+    "connectionTimeout": {
+        "message": "Podesite vremensko ograničenje veze kako biste omogućili dužu inicijalizaciju prilikom priključivanja uređaja ili ponovnog pokretanja",
+        "description": "Change timeout on auto-connect and reboot so the bus has more time to initialize after being detected by the system"
+    },
+    "languageAndAppearanceSettings": {
+        "message": "Jezik i izgled",
+        "description": "Title for the language and appearance settings section"
+    },
+    "developmentSettings": {
+        "message": "Podešavanja za razvoj",
+        "description": "Title for the development settings section"
+    },
+    "showAllSerialDevices": {
+        "message": "Prikaži sve serijske uređaje (za proizvođače ili razvoj)",
+        "description": "Do not filter serial devices using VID\/PID values (for manufacturers or development)"
+    },
+    "cliOnlyMode": {
+        "message": "Uključi samo CLI mod",
+        "description": "Text for the option to enable or disable CLI only mode"
+    },
+    "automaticDevOptions": {
+        "message": "Automatski uključi podešavanja za razvoj za preview verzije",
+        "description": "Text for the option to automatically enable development settings for preview builds"
+    },
+    "showManualMode": {
+        "message": "Prikaz moda ručnog povezivanja",
+        "description": "Text for the option to enable or disable manual connection mode"
+    },
+    "showVirtualMode": {
+        "message": "Prikaz moda virtuelnog povezivanja",
+        "description": "Text for the option to enable or disable the virtual FC"
+    },
+    "useLegacyRenderingModel": {
+        "message": "Stari način renderovanja za 3D model (za uređaje slabijih performansi)",
+        "description": "Text for the option to enable or disable legacy rendering of the 3D model"
+    },
+    "cordovaForceComputerUI": {
+        "message": "Interfejs za računare umesto interfejsa za telefone"
+    },
+    "language_changed": {
+        "message": "Promena jezika je sačuvana"
+    },
+    "language_choice_message": {
+        "message": "Promenite jezik:",
+        "description": "Try and be brief"
+    },
+    "userLanguageSelect": {
+        "message": "Izaberite podrazumevani jezik"
+    },
+    "language_default": {
+        "message": "Podrazumevano sistemski"
+    },
+    "sensorDataFlashNotFound": {
+        "message": "Nije pronađen <br>dataflash čip",
+        "description": "Text of the dataflash image in the header of the page."
+    },
+    "sensorDataFlashFreeSpace": {
+        "message": "Dataflash: slobodan prostor",
+        "description": "Text of the dataflash image in the header of the page."
+    },
+    "sensorStatusGyro": {
+        "message": "Žiroskop"
+    },
+    "configurationGyroRequired": {
+        "message": "Mora biti uključen bar jedan žiroskop"
+    },
+    "sensorStatusGyroShort": {
+        "message": "Žiroskop",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusAccel": {
+        "message": "Akcelerometar"
+    },
+    "sensorStatusAccelShort": {
+        "message": "Akcel",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusMag": {
+        "message": "Magnetometar"
+    },
+    "sensorStatusMagShort": {
+        "message": "Mag",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusBaro": {
+        "message": "Barometar"
+    },
+    "sensorStatusBaroShort": {
+        "message": "Baro",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusGPS": {
+        "message": "GPS"
+    },
+    "sensorStatusGPSShort": {
+        "message": "GPS",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusSonar": {
+        "message": "Sonar \/ Merač dometa"
+    },
+    "sensorStatusSonarShort": {
+        "message": "Sonar",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "checkForConfiguratorUnstableVersions": {
+        "message": "Prikaži obaveštenja o ažuriranju za nestabilne verzije aplikacije"
+    },
+    "configuratorUpdateNotice": {
+        "message": "Koristite zastarelu verziju <b>Betaflight aplikacije<\/b>.<br>$t(configuratorUpdateHelp.message)"
+    },
+    "configuratorUpdateHelp": {
+        "message": "Korišćenje novijeg firmvera sa zastarelom verzijom programa znači da menjanje nekih podešavanja može dovesti do <strong>neispravnih podešavanja firmvera i drona koji ne leti<\/strong>.<br \/>Uz to, neke mogućnosti firmvera moći ćete da podesite samo kroz CLI.<br g\/><br \/><strong>Verzija Betaflight programa <b>$1<\/b> dostupna je za preuzimanje<\/strong>.<br \/>Preuzmite i instalirajte najnoviju verziju sa ispravkama i poboljšanjima <a href=\"$2\" target=\"_blank\" rel=\"noopener noreferrer\">ovde<\/a><br>Prozor programa mora biti zatvoren pre ažuriranja."
+    },
+    "rebootFlightController": {
+        "message": "Ponovno pokretanje flight kontrolera, ponovo se povežite kada bude spreman"
+    },
+    "rebootFlightControllerReady": {
+        "message": "Flight kontroler je spreman"
+    },
+    "rebootFlightControllerFailed": {
+        "message": "Flight kontroler se nije ponovo povezao"
+    },
+    "deviceRebooting": {
+        "message": "Uređaj - <span class=\"message-negative\">Ponovno pokretanje<\/span>"
+    },
+    "deviceRebooting_flashBootloader": {
+        "message": "Uređaj - <span class=\"message-negative\">Ponovno pokretanje u FLASH BOOTLOADER<\/span>"
+    },
+    "deviceRebooting_romBootloader": {
+        "message": "Uređaj - <span class=\"message-negative\">Ponovno pokretanje u ROM BOOTLOADER<\/span>"
+    },
+    "deviceReady": {
+        "message": "Uređaj - <span class=\"message-positive\">Spreman<\/span>"
+    },
+    "tabFirmwareFlasher": {
+        "message": "Upis firmvera"
+    },
+    "tabLanding": {
+        "message": "Dobrodošli"
+    },
+    "tabPrivacyPolicy": {
+        "message": "Politika privatnosti"
+    },
+    "tabHelp": {
+        "message": "Uputstva i podrška"
+    },
+    "tabOptions": {
+        "message": "Opcije"
+    },
+    "sidebarOpenOptions": {
+        "message": "Opcije",
+        "description": "Tooltip for the options icon button in the sidebar footer."
+    },
+    "sidebarToggleDarkMode": {
+        "message": "Prebaci na tamni \/ svetli mod",
+        "description": "Tooltip for the dark mode toggle icon button in the sidebar footer."
+    },
+    "sidebarToggleExpertMode": {
+        "message": "Prebaci na ekspertski mod",
+        "description": "Tooltip for the expert mode toggle icon button in the sidebar footer."
+    },
+    "tabSetup": {
+        "message": "Početno podešavanje"
+    },
+    "tabSetupOSD": {
+        "message": "OSD podešavanje"
+    },
+    "tabSensorConfig": {
+        "message": "Senzori"
+    },
+    "sensorConfigHardware": {
+        "message": "Hardver senzora"
+    },
+    "sensorConfigGyroLabel": {
+        "message": "Žiroskop $1"
+    },
+    "sensorConfigSaved": {
+        "message": "Konfiguracija senzora sačuvana"
+    },
+    "sensorConfigSaveFailed": {
+        "message": "Čuvanje konfiguracije senzora nije uspelo"
+    },
+    "sensorConfigMagnetometer": {
+        "message": "Magnetometar"
+    },
+    "sensorConfigAccelerometer": {
+        "message": "Akcelerometar"
+    },
+    "sensorConfigAccCalibrateHelp": {
+        "message": "Postavite letelicu na ravnu površinu pre kalibracije"
+    },
+    "sensorConfigAccNeedsCalibration": {
+        "message": "Akcelerometar nije kalibrisan. Molimo kalibrišite pre letenja."
+    },
+    "sensorConfigMagNeedsCalibration": {
+        "message": "Ofseti kalibracije magnetometra su nula. Molimo kalibrišite za precizno određivanje smera."
+    },
+    "sensorConfigCalibrate": {
+        "message": "Kalibriši"
+    },
+    "sensorConfig3dPreview": {
+        "message": "3D pregled položaja"
+    },
+    "sensorConfigLiveData": {
+        "message": "Podaci senzora uživo"
+    },
+    "sensorConfigShowLiveData": {
+        "message": "Prikaži podatke senzora uživo"
+    },
+    "sensorConfigLiveStop": {
+        "message": "Zaustavi podatke uživo"
+    },
+    "tabConfiguration": {
+        "message": "Konfiguracija"
+    },
+    "tabPorts": {
+        "message": "Portovi"
+    },
+    "tabPidTuning": {
+        "message": "PID podešavanje"
+    },
+    "tabAutotune": {
+        "message": "Autotune"
+    },
+    "tabBlackboxViewer": {
+        "message": "Blackbox pregledač",
+        "description": "Navigation sidebar label for the Blackbox log viewer tab"
+    },
+    "autotuneImportTitle": {
+        "message": "Blackbox analiza cvrkuta"
+    },
+    "autotuneImportButton": {
+        "message": "Uvezi Blackbox log"
+    },
+    "autotuneImportDescription": {
+        "message": "Uvezite blackbox log snimljen sa debug_mode = CHIRP da biste analizirali frekventni odziv i izračunali PID preporuke."
+    },
+    "autotuneSelectingFile": {
+        "message": "Odabir fajla..."
+    },
+    "autotuneAnalyzing": {
+        "message": "Analiziranje podataka cvrkuta..."
+    },
+    "autotuneBandwidth": {
+        "message": "Propusni opseg"
+    },
+    "autotunePhaseMargin": {
+        "message": "Fazna margina"
+    },
+    "autotuneResonantPeak": {
+        "message": "Rezonantni vrh"
+    },
+    "autotuneCoherence": {
+        "message": "Koherencija"
+    },
+    "autotuneParameter": {
+        "message": "Parametar"
+    },
+    "autotuneCurrent": {
+        "message": "Struja"
+    },
+    "autotuneProposed": {
+        "message": "Predloženo"
+    },
+    "autotuneChange": {
+        "message": "Promeni"
+    },
+    "autotuneApplying": {
+        "message": "Primenjuje se..."
+    },
+    "autotuneApplied": {
+        "message": "Pojačanja primenjena i sačuvana."
+    },
+    "autotuneApplyFailed": {
+        "message": "Primena pojačanja neuspešna"
+    },
+    "autotuneConnectRequired": {
+        "message": "Povežite se sa flight kontrolerom da biste primenili pojačanja."
+    },
+    "autotuneNoLogs": {
+        "message": "Nema važećih Blackbox logova u ovom fajlu."
+    },
+    "autotuneNoChirpData": {
+        "message": "Nema chirp podataka. Proverite da li je log snimljen sa debug_mode = CHIRP i da li je chirp mod bio aktiviran."
+    },
+    "autotuneSampleCount": {
+        "message": "{{count}} uzoraka"
+    },
+    "autotuneSampleRate": {
+        "message": "Brzina uzorkovanja: {{rate}} Hz"
+    },
+    "autotuneImportAnother": {
+        "message": "Uvezi drugi"
+    },
+    "autotuneImportRetry": {
+        "message": "Pokušajte ponovo"
+    },
+    "autotuneFile": {
+        "message": "Fajl"
+    },
+    "autotuneAxesDetected": {
+        "message": "Detektovane ose"
+    },
+    "autotuneApplyGains": {
+        "message": "Primeni pojačanja"
+    },
+    "autotuneGainTitle": {
+        "message": "Preporuka pojačanja"
+    },
+    "autotuneAxisSelector": {
+        "message": "Izaberite osu"
+    },
+    "autotuneAxisRoll": {
+        "message": "Roll"
+    },
+    "autotuneAxisPitch": {
+        "message": "Pitch"
+    },
+    "autotuneAxisYaw": {
+        "message": "Yaw"
+    },
+    "autotuneBodePlotTitle": {
+        "message": "Frekventni odziv"
+    },
+    "autotuneSectionCurrentPids": {
+        "message": "Trenutni PID-ovi (iz loga)"
+    },
+    "autotuneSectionAnalysis": {
+        "message": "Analiza"
+    },
+    "autotuneSectionProposedSliders": {
+        "message": "Predloženi slajderi"
+    },
+    "autotuneSliderMasterMultiplier": {
+        "message": "Glavni množilac"
+    },
+    "autotuneSliderPIGain": {
+        "message": "P \/ I pojačanje"
+    },
+    "autotuneSliderIGain": {
+        "message": "I pojačanje"
+    },
+    "autotuneSliderDGain": {
+        "message": "D pojačanje"
+    },
+    "autotuneSliderFeedforward": {
+        "message": "Feedforward"
+    },
+    "autotuneSliderDTermFilter": {
+        "message": "D-Term filter"
+    },
+    "autotuneApplyFromAxis": {
+        "message": "Primenite pojačanja sa ose"
+    },
+    "autotuneSensitivityPeak": {
+        "message": "Vrhunac osetljivosti"
+    },
+    "autotuneOvershoot": {
+        "message": "Preletanje"
+    },
+    "autotuneRiseTime": {
+        "message": "Vreme uspona"
+    },
+    "autotuneSettlingTime": {
+        "message": "Vreme smirivanja"
+    },
+    "autotuneSpectrogramTitle": {
+        "message": "Spektrogram (žiroskop)"
+    },
+    "tabReceiver": {
+        "message": "Prijemnik"
+    },
+    "tabModeSelection": {
+        "message": "Izbor moda"
+    },
+    "tabServos": {
+        "message": "Servoi"
+    },
+    "tabFailsafe": {
+        "message": "Failsafe"
+    },
+    "tabOsd": {
+        "message": "OSD"
+    },
+    "tabVtx": {
+        "message": "Video-predajnik"
+    },
+    "tabPower": {
+        "message": "Napajanje i baterija"
+    },
+    "tabGPS": {
+        "message": "GPS"
+    },
+    "tabFlightPlan": {
+        "message": "Plan leta"
+    },
+    "tabMotorTesting": {
+        "message": "Motori"
+    },
+    "tabLedStrip": {
+        "message": "LED traka"
+    },
+    "tabCLI": {
+        "message": "CLI"
+    },
+    "tabLogging": {
+        "message": "Snimanje preko kabla"
+    },
+    "tabOnboardLogging": {
+        "message": "Blackbox"
+    },
+    "tabAdjustments": {
+        "message": "Podešavanje u letu"
+    },
+    "tabAuxiliary": {
+        "message": "Modovi"
+    },
+    "logActionHide": {
+        "message": "Sakrij dnevnik"
+    },
+    "logActionShow": {
+        "message": "Prikaži dnevnik"
+    },
+    "tabLog": {
+        "message": "Dnevnik"
+    },
+    "i2cErrorDetected": {
+        "message": "I2C greška detektovana (+{{delta}}, ukupno {{total}})",
+        "description": "Logged when the flight controller reports new I2C bus errors. {{delta}} is how many errors since the last poll; {{total}} is the running total."
+    },
+    "logActionClear": {
+        "message": "Očisti"
+    },
+    "logAutoScroll": {
+        "message": "Automatsko skrolovanje"
+    },
+    "fileSystemPickerFiles": {
+        "message": "{{typeof}} fajl",
+        "description": "Text for the file picker dialog, showing the type of files selected. The parameter can be HEX, TXT, etc."
+    },
+    "fileSystemPickerFirmwareFiles": {
+        "message": "Firmver fajla"
+    },
+    "serialErrorFrameError": {
+        "message": "Greška serijske veze: loše kadriranje"
+    },
+    "serialErrorParityError": {
+        "message": "Greška serijske veze: loš paritet"
+    },
+    "serialPortOpened": {
+        "message": "Serijski port <span class=\"message-positive\">uspešno<\/span> otvoren sa ID-om: $1"
+    },
+    "serialPortOpenFail": {
+        "message": "<span class=\"message-negative\">Neuspešno<\/span> otvaranje serijskog porta"
+    },
+    "connectionFailedTitle": {
+        "message": "Veza neuspešna"
+    },
+    "connectionFailed": {
+        "message": "<span class=\"message-negative\">Neuspešno<\/span> povezivanje na izabrani port. Proverite da li je uređaj dostupan i da li su podešavanja veze ispravna, pa pokušajte ponovo."
+    },
+    "connectionFailedLocalNetworkIOS": {
+        "message": "Na iOS-u, dozvolite pristup <strong>Lokalnoj mreži<\/strong> za Betaflight u Podešavanjima &rarr; Privatnost &amp; Bezbednost &rarr; Lokalna mreža, pa pokušajte ponovo."
+    },
+    "connectionLostTitle": {
+        "message": "Veza izgubljena"
+    },
+    "connectionLostUnresponsive": {
+        "message": "Flight kontroler <span class=\"message-negative\">je prestao da reaguje<\/span> i veza je prekinuta. Ponovo povežite pločicu i pokušajte ponovo; ako se problem nastavi, isključite i ponovo uključite flight kontroler."
+    },
+    "serialPortClosedOk": {
+        "message": "Serijski port <span class=\"message-positive\">uspešno<\/span> zatvoren"
+    },
+    "serialPortClosedFail": {
+        "message": "<span class=\"message-negative\">Neuspešno<\/span> zatvaranje serijskog porta"
+    },
+    "serialUnrecoverable": {
+        "message": "Nepopravljiv <span class=\"message-negative\">kvar<\/span> serijske veze, prekidanje veze..."
+    },
+    "serialPortLoading": {
+        "message": "Učitavanje…"
+    },
+    "usbDeviceOpened": {
+        "message": "USB uređaj <span class=\"message-positive\">uspešno<\/span> otvoren sa ID-om: $1"
+    },
+    "usbDeviceOpenFail": {
+        "message": "<span class=\"message-negative\">Neuspešno<\/span> otvaranje USB uređaja!"
+    },
+    "usbDeviceClosed": {
+        "message": "USB uređaj <span class=\"message-positive\">uspešno<\/span> zatvoren"
+    },
+    "usbDeviceCloseFail": {
+        "message": "<span class=\"message-negative\">Neuspešno<\/span> zatvaranje USB uređaja"
+    },
+    "usbDeviceUdevNotice": {
+        "message": "Da li su <strong>udev pravila<\/strong> ispravno instalirana? Pogledajte dokumentaciju za uputstva"
+    },
+    "stm32UsbDfuNotFound": {
+        "message": "USB DFU nije pronađen"
+    },
+    "stm32DfuPermissionRequired": {
+        "message": "Uređaj se ponovo pokrenuo u DFU mod.<br><br>Vaš pregledač zahteva USB dozvolu za pristup DFU uređaju. Kliknite na dugme ispod da biste ga izabrali iz birača uređaja."
+    },
+    "stm32RebootingToBootloader": {
+        "message": "Pokretanje ponovnog pokretanja u bootloader ..."
+    },
+    "stm32RebootingToBootloaderFailed": {
+        "message": "Ponovno pokretanje uređaja u bootloader: NEUSPEŠNO"
+    },
+    "stm32TimedOut": {
+        "message": "STM32 - isteklo vreme, programiranje: NEUSPEŠNO"
+    },
+    "stm32WrongResponse": {
+        "message": "STM32 komunikacija neuspešna, pogrešan odgovor, očekivano: $1 (0x$2) primljeno: $3 (0x$4)"
+    },
+    "stm32ContactingBootloader": {
+        "message": "Kontaktiranje bootloadera ..."
+    },
+    "stm32ContactingBootloaderFailed": {
+        "message": "Komunikacija sa bootloaderom neuspešna"
+    },
+    "stm32ResponseBootloaderFailed": {
+        "message": "Nema odgovora od bootloadera, programiranje: NEUSPEŠNO"
+    },
+    "stm32GlobalEraseExtended": {
+        "message": "Izvršavanje globalnog brisanja čipa (preko proširenog brisanja) ..."
+    },
+    "stm32LocalEraseExtended": {
+        "message": "Izvršavanje lokalnog brisanja (preko proširenog brisanja) ..."
+    },
+    "stm32GlobalErase": {
+        "message": "Izvršavanje globalnog brisanja čipa ..."
+    },
+    "stm32LocalErase": {
+        "message": "Izvršavanje lokalnog brisanja ..."
+    },
+    "stm32InvalidHex": {
+        "message": "Nevažeći heksadecimalni kod"
+    },
+    "stm32Erase": {
+        "message": "Brisanje ..."
+    },
+    "stm32Flashing": {
+        "message": "Flešovanje ..."
+    },
+    "stm32Verifying": {
+        "message": "Provera ..."
+    },
+    "stm32ProgrammingSuccessful": {
+        "message": "Programiranje: USPEŠNO"
+    },
+    "stm32ProgrammingFailed": {
+        "message": "Programiranje: NEUSPEŠNO"
+    },
+    "stm32AddressLoadFailed": {
+        "message": "Učitavanje adrese za sektor opcionalnih bajtova nije uspelo. Vrlo verovatno zbog zaštite od čitanja."
+    },
+    "stm32AddressLoadSuccess": {
+        "message": "Učitavanje adrese za sektor opcionalnih bajtova je uspelo."
+    },
+    "stm32AddressLoadUnknown": {
+        "message": "Učitavanje adrese za sektor opcionalnih bajtova nije uspelo zbog nepoznate greške. Prekidam."
+    },
+    "stm32NotReadProtected": {
+        "message": "Zaštita od čitanja nije aktivna"
+    },
+    "stm32ReadProtected": {
+        "message": "Pločica je izgleda zaštićena od čitanja. Uklanjam zaštitu. Ne isključujte\/otkačinjite!"
+    },
+    "stm32UnprotectSuccessful": {
+        "message": "Uklanjanje zaštite uspešno."
+    },
+    "stm32UnprotectUnplug": {
+        "message": "POTREBNA AKCIJA: Isključite i ponovo povežite flight kontroler u DFU modu da biste pokušali ponovo da flešujete!"
+    },
+    "stm32UnprotectFailed": {
+        "message": "Nije uspelo uklanjanje zaštite pločice"
+    },
+    "stm32UnprotectInitFailed": {
+        "message": "Nije uspelo pokretanje rutine za uklanjanje zaštite"
+    },
+    "noConfigurationReceived": {
+        "message": "Nije primljena konfiguracija u roku od <span class=\"message-negative\">10 sekundi<\/span>, komunikacija <span class=\"message-negative\">nije uspela<\/span>"
+    },
+    "firmwareVersionNotSupported": {
+        "message": "Ova verzija firmvera <span class=\"message-negative\">nije podržana<\/span>. Molimo Vas da nadogradite na firmver koji podržava API verziju <strong>$1<\/strong> ili noviju. Koristite CLI za pravljenje rezervne kopije pre flešovanja. Procedura za pravljenje\/vraćanje rezervne kopije putem CLI-ja je u dokumentaciji.<br \/>Alternativno, preuzmite i koristite staru verziju aplikacije ako niste spremni za nadogradnju."
+    },
+    "firmwareTypeNotSupported": {
+        "message": "Firmver koji nije Betaflight <span class=\"message-negative\">nije podržan<\/span>, osim za CLI mod."
+    },
+    "firmwareUpgradeRequired": {
+        "message": "Firmver na ovom uređaju treba ažurirati na noviju verziju. Pre upisa napravite rezervnu kopiju kroz CLI — postupak stoji u uputstvima.<br \/>Ako niste spremni za ažuriranje, preuzmite i koristite stariju verziju programa."
+    },
+    "resetToCustomDefaultsDialog": {
+        "message": "Dostupna su prilagođena fabrička podešavanja za ovu pločicu. Normalno, pločica neće raditi ispravno ako se ne primene prilagođena fabrička podešavanja.<br \/>Da li želite da primenite prilagođena fabrička podešavanja za ovu pločicu?"
+    },
+    "resetToCustomDefaultsAccept": {
+        "message": "Primeni prilagođena fabrička podešavanja"
+    },
+    "reportProblemsDialogHeader": {
+        "message": "Otkriveni su sledeći <strong>problemi sa Vašom konfiguracijom<\/strong>:"
+    },
+    "reportProblemsDialogFooter": {
+        "message": "<span class=\"message-negative\"><strong>Morate rešiti ove probleme pre nego što pokušate da letite Vašom letelicom<\/span><\/strong>."
+    },
+    "reportProblemsDialogAPI_VERSION_MAX_SUPPORTED": {
+        "message": "<span class=\"message-negative\"><strong>Verzija programa koju koristite ($3) ne podržava firmver $4<\/strong><\/span>.<br>$t(configuratorUpdateHelp.message)"
+    },
+    "reportProblemsDialogMOTOR_PROTOCOL_DISABLED": {
+        "message": "<strong>nije izabran protokol za izlaz motora<\/strong>.<br>Molimo Vas da izaberete protokol za izlaz motora odgovarajući za Vaše ESC-ove u '$t(configurationEscFeatures.message)' na kartici '$t(tabMotorTesting.message)'.<br>$t(escProtocolDisabledMessage.message)"
+    },
+    "reportProblemsDialogACC_NEEDS_CALIBRATION": {
+        "message": "<strong>akcelerometar je uključen, ali nije kalibrisan<\/strong>.<br>Ako planirate da koristite akcelerometar, molimo Vas da pratite uputstva za '$t(initialSetupButtonCalibrateAccel.message)' na kartici '$t(tabSetup.message)'. Ako je bilo koja funkcija koja zahteva akcelerometar (modovi automatskog nivelisanja, GPS rescue, ...) uključena, armovanje letelice će biti isključeno dok se akcelerometar ne kalibriše.<br>Ako ne planirate da koristite akcelerometar, preporučuje se da ga isključite u '$t(configurationSystem.message)' na kartici '$t(tabConfiguration.message)'."
+    },
+    "infoVersionOs": {
+        "message": "OS: <strong>{{operatingSystem}}<\/strong>",
+        "description": "Message that appears in the GUI log panel indicating operating system"
+    },
+    "infoVersionConfigurator": {
+        "message": "Verzija aplikacije: <strong>{{configuratorVersion}}<\/strong>",
+        "description": "Message that appears in the GUI log panel indicating application version"
+    },
+    "buildServerSuccess": {
+        "message": "Uspeh: $1"
+    },
+    "buildServerFailure": {
+        "message": "<b>Greška build servera: $1 <code>$2<\/code><\/b>"
+    },
+    "buildServerUsingCached": {
+        "message": "Koriste se keširane informacije o izradama za $1."
+    },
+    "buildServerSupportRequestSubmission": {
+        "message": "<br>*** Podaci za podršku su poslati *** <br>ID: $1<br><br><br># kopirajte ID i prosledite ga Betaflight timu."
+    },
+    "buildKey": {
+        "message": "Ključ izrade: <strong>$1<\/strong>"
+    },
+    "supportWarningDialogTitle": {
+        "message": "Potvrdite slanje podataka"
+    },
+    "supportWarningDialogText": {
+        "message": "Potvrdite slanje podataka Betaflight timu.<br><br>Ovaj proces će pokrenuti neke komande i poslati izlazne podatke na build server.<br><br>Zatim ćete dobiti jedinstveni identifikator za Vaše slanje podataka.<br><br>Obavezno prosledite ovaj jedinstveni identifikator Betaflight timu kada koristite Discord ili otvarate problem na GitHub-u."
+    },
+    "supportWarningDialogInputPlaceHolder": {
+        "message": "Opišite problem"
+    },
+    "releaseCheckLoaded": {
+        "message": "Učitane su informacije o izdanju za $1 sa GitHub-a."
+    },
+    "releaseCheckFailed": {
+        "message": "<b>Upit ka GitHub-u za izdanja $1 nije uspeo, koriste se keširane informacije. Razlog: <code>$2<\/code><\/b>"
+    },
+    "releaseCheckCached": {
+        "message": "Koriste se keširane informacije o izdanjima za $1."
+    },
+    "releaseCheckNoInfo": {
+        "message": "Nema dostupnih informacija o izdanju za $1."
+    },
+    "tabSwitchConnectionRequired": {
+        "message": "Morate se <strong>povezati<\/strong> pre nego što možete da otvorite bilo koju karticu."
+    },
+    "tabSwitchWaitForOperation": {
+        "message": "Ovo <span class=\"message-negative\">ne možete<\/span> sada da uradite, sačekajte da se trenutna radnja završi…"
+    },
+    "tabSwitchUpgradeRequired": {
+        "message": "Morate <strong>ažurirati<\/strong> firmver na najnoviju verziju Betaflight-a da biste koristili karticu $1."
+    },
+    "firmwareVersion": {
+        "message": "Verzija firmvera: <strong>$1<\/strong>"
+    },
+    "apiVersionReceived": {
+        "message": "MultiWii API verzija: <strong>$1<\/strong>"
+    },
+    "uniqueDeviceIdReceived": {
+        "message": "Jedinstveni ID uređaja: <strong>0x$1<\/strong>"
+    },
+    "craftNameReceived": {
+        "message": "Naziv letelice: <strong>$1<\/strong>"
+    },
+    "armingDisabled": {
+        "message": "<strong>Armovanje je isključeno<\/strong>"
+    },
+    "armingEnabled": {
+        "message": "<strong>Armovanje je uključeno<\/strong>"
+    },
+    "runawayTakeoffPreventionDisabled": {
+        "message": "<strong>Zaštita od nekontrolisanog poletanja je privremeno isključena<\/strong>"
+    },
+    "runawayTakeoffPreventionEnabled": {
+        "message": "<strong>Zaštita od nekontrolisanog poletanja je uključena<\/strong>"
+    },
+    "boardInfoReceived": {
+        "message": "Pločica: <strong>$1<\/strong>, verzija: <strong>$2<\/strong>"
+    },
+    "buildInfoReceived": {
+        "message": "Pokrenuti firmver je objavljen: <strong>$1<\/strong>"
+    },
+    "fcInfoReceived": {
+        "message": "Informacije o flight kontroleru, identifikator: <strong>$1<\/strong>, verzija: <strong>$2<\/strong>"
+    },
+    "versionLabelTarget": {
+        "message": "Target"
+    },
+    "versionLabelFirmware": {
+        "message": "Verzija firmvera"
+    },
+    "versionLabelConfigurator": {
+        "message": "Verzija aplikacije"
+    },
+    "notifications_app_just_updated_to_version": {
+        "message": "Aplikacija je upravo ažurirana na verziju: $1"
+    },
+    "notifications_click_here_to_start_app": {
+        "message": "Kliknite ovde da pokrenete aplikaciju"
+    },
+    "statusbar_port_utilization": {
+        "message": "Iskorišćenost porta:",
+        "description": "Port utilization text shown in the status bar"
+    },
+    "statusbar_usage_download": {
+        "message": "D:",
+        "description": "References 'Download' in the status bar, port utilization. Keep one character long if possible"
+    },
+    "statusbar_usage_upload": {
+        "message": "U:",
+        "description": "References 'Upload' in the status bar, port utilization. Keep one character long if possible"
+    },
+    "statusbar_packet_error": {
+        "message": "Greške paketa:",
+        "description": "Packet error text shown in the status bar"
+    },
+    "statusbar_i2c_error": {
+        "message": "I2C greške:",
+        "description": "CPU load text shown in the status bar"
+    },
+    "statusbar_cycle_time": {
+        "message": "Vreme ciklusa:",
+        "description": "Cycle time text shown in the status bar"
+    },
+    "statusbar_cpu_load": {
+        "message": "Opterećenje CPU-a:",
+        "description": "CPU load text shown in the status bar"
+    },
+    "statusbar_connection_time": {
+        "message": "Trajanje veze:",
+        "description": "Connection time text shown in the status bar"
+    },
+    "dfu_connect_message": {
+        "message": "Koristite karticu za flešovanje firmvera za pristup DFU uređajima"
+    },
+    "dfu_erased_kilobytes": {
+        "message": "Obrisano $1 kB fleš memorije <span class=\"message-positive\">uspešno<\/span>"
+    },
+    "dfu_device_flash_info": {
+        "message": "Detektovan je uređaj sa ukupnom veličinom fleš memorije od $1 KiB"
+    },
+    "dfu_hex_address_errors": {
+        "message": "Slika firmvera sadrži adrese koje ne postoje na izabranom uređaju"
+    },
+    "dfu_error_image_size": {
+        "message": "<span class=\"message-negative\">Greška<\/span>: Izabrana slika je veća od dostupne fleš memorije na čipu! Slika: $1 KiB, granica = $2 KiB"
+    },
+    "eeprom_saved_ok": {
+        "message": "EEPROM je <span class=\"message-positive\">sačuvan<\/span>"
+    },
+    "defaultWelcomeIntro": {
+        "message": "Dobro došli u <strong>Betaflight App<\/strong>, alat namenjen za lakše ažuriranje, podešavanje i fino podešavanje Vašeg flight kontrolera."
+    },
+    "defaultHardwareHead": {
+        "message": "Hardver"
+    },
+    "defaultHardwareText": {
+        "message": "Aplikacija podržava sav hardver koji može da pokrene Betaflight. Pogledajte karticu Flešovanje firmvera za kompletnu listu hardvera.<br \/><br \/>Korisni alatke i drajveri za hardver:<ul><li>Za stariji hardver koji koristi CP210x USB na serijski čip, najnovije <b>CP210x drajvere<\/b> možete preuzeti <a href=\"https:\/\/www.silabs.com\/software-and-tools\/usb-to-uart-bridge-vcp-drivers\" target=\"_blank\" rel=\"noopener noreferrer\">ovde<\/a><\/li><li>Najnoviji <b>Zadig<\/b> za instalaciju USB drajvera na Windows-u možete preuzeti <a href=\"https:\/\/zadig.akeo.ie\/\" target=\"_blank\" rel=\"noopener noreferrer\">ovde<\/a><\/li><li><b>ImpulseRC Driver Fixer<\/b> možete preuzeti <a href=\"https:\/\/github.com\/ImpulseRC\/ImpulseRC_Driver_Fixer\" target=\"_blank\" rel=\"noopener noreferrer\">ovde<\/a><\/li><\/ul>"
+    },
+    "defaultSoftwareHead": {
+        "message": "Softver"
+    },
+    "defaultSoftwareText": {
+        "message": "Naš Blackbox pregledač dnevnika je ugrađen u ovu aplikaciju. Otvorite karticu <strong>Blackbox Viewer<\/strong> za analizu Vaših dnevnika letenja.<br \/><br \/>Naša kolekcija <a href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/releases\" target=\"_blank\" rel=\"noopener noreferrer\">TX Lua skripti<\/a> je dostupna na GitHub-u.<br \/><br \/>Naš <a href=\"https:\/\/github.com\/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">izvorni kod<\/a> za firmver i ovu aplikaciju možete preuzeti sa GitHub-a."
+    },
+    "defaultContributingHead": {
+        "message": "Doprinos zajednici"
+    },
+    "defaultContributingText": {
+        "message": "Ako želite da pomognete da Betaflight bude još bolji, možete pomoći na mnogo načina, uključujući:<br \/><ul><li>korišćenje Vašeg znanja o Betaflight-u za kreiranje ili ažuriranje sadržaja na <a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">našem Wiki-ju<\/a>, ili odgovaranje na pitanja drugih korisnika na onlajn forumima;<\/li><li><a href=\"https:\/\/betaflight.com\/docs\/development\" target=\"_blank\" rel=\"noopener noreferrer\">doprinos koda<\/a> za firmver i aplikaciju — nove funkcije, popravke, poboljšanja;<\/li><li>testiranje <a href=\"https:\/\/github.com\/Betaflight\/betaflight\/pulls\" target=\"_blank\" rel=\"noopener noreferrer\">novih funkcija i popravki<\/a> i davanje povratnih informacija;<\/li><li>pomaganje drugim korisnicima da reše probleme koje prijave u <a href=\"https:\/\/github.com\/betaflight\/betaflight\/issues\" target=\"_blank\" rel=\"noopener noreferrer\">našem sistemu za praćenje problema<\/a> i učešće u raspravama o zahtevima za nove funkcije;<\/li><li><a href=\"https:\/\/github.com\/betaflight\/betaflight\/blob\/master\/README.md#translators\" target=\"_blank\" rel=\"noopener noreferrer\">prevođenje<\/a> Betaflight App-a na novi jezik ili pomoć u održavanju postojećih prevoda.<\/li><\/ul>"
+    },
+    "defaultFacebookText": {
+        "message": "Takođe imamo i <a href=\"https:\/\/www.facebook.com\/groups\/betaflightgroup\/\" target=\"_blank\" rel=\"noopener noreferrer\">Facebook grupu<\/a>.<br \/>Pridružite nam se da biste razgovarali o Betaflight-u, postavljali pitanja o podešavanju ili se jednostavno družili sa drugim pilotima."
+    },
+    "defaultDiscordText": {
+        "message": "Betaflight <a href=\"https:\/\/discord.betaflight.com\/invite\" target=\"_blank\" rel=\"noopener noreferrer\">Discord server<\/a>.<br \/>Podelite svoje iskustvo u letenju, pričajte o Betaflight-u, pomozite drugima ili potražite pomoć za sebe od zajednice."
+    },
+    "defaultRedditText": {
+        "message": "Pridružite se našem <a href=\"https:\/\/www.reddit.com\/r\/Betaflight\/\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight Reddit podforumu<\/a>.<br \/>Diskutujte o funkcijama, postavljajte pitanja i povežite se sa Betaflight zajednicom na Reddit-u."
+    },
+    "defaultCommunityHead": {
+        "message": "Zajednica"
+    },
+    "statisticsDisclaimerHead": {
+        "message": "Vaša privatnost"
+    },
+    "statisticsDisclaimer": {
+        "message": "Ova Betaflight aplikacija prikuplja anonimnu statistiku korišćenja. Ovi podaci o korišćenju mogu obuhvatati broj pokretanja, geografski region korisnika, tipove flight kontrolera, verzije firmvera, korišćenje UI elemenata i kartica, itd. Prikupljamo ove podatke kako bismo bolje razumeli kako se aplikacija koristi i trendove u zajednici. Ovo radimo kako bismo razvili poboljšani UI i celokupno iskustvo. Korisnici mogu isključiti prikupljanje podataka u kartici Opcije. Za informacije o tome kako prikupljamo i koristimo Vaše podatke, pogledajte našu <a href=\"https:\/\/www.betaflight.com\/privacy\" rel=\"noopener noreferrer\" target=\"_blank\">politiku privatnosti<\/a>."
+    },
+    "defaultButtonFirmwareFlasher": {
+        "message": "Upis firmvera"
+    },
+    "defaultDonateHead": {
+        "message": "Donacije za otvoren kod"
+    },
+    "defaultDonateText": {
+        "message": "<p><strong>Betaflight<\/strong> je softver <strong>otvorenog koda<\/strong> i dostupan je besplatno <strong>bez garancije<\/strong> svim korisnicima.<\/p><p>Ako smatrate da je Betaflight koristan, razmislite o <strong>podršci<\/strong> njegovom razvoju putem donacije.<\/p>"
+    },
+    "defaultDonateBottom": {
+        "message": "<p>Ako želite da redovno finansijski doprinosite, razmislite o tome da postanete naš patron na $t(patreonLink.message).<\/p>"
+    },
+    "patreonLink": {
+        "message": "<a href=\"https:\/\/www.patreon.com\/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">Patreon<\/a>",
+        "description": "Patreon is name, and should not require translation"
+    },
+    "defaultDonate": {
+        "message": "Donirajte"
+    },
+    "defaultSponsorsHead": {
+        "message": "Sponzori"
+    },
+    "defaultDocumentationHead": {
+        "message": "Dokumentacija \/ uputstvo"
+    },
+    "defaultDocumentation": {
+        "message": "Betaflight dokumentacija je dostupna u beleškama o izdanju i na wiki stranici.<br \/><br \/>"
+    },
+    "defaultDocumentation1": {
+        "message": "Betaflight wiki je odličan izvor informacija i možete ga pronaći <a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">ovde<\/a>."
+    },
+    "defaultDocumentation2": {
+        "message": "Beleške o izdanju za firmver možete pročitati na GitHub stranici sa izdanjima, <a href=\"https:\/\/github.com\/Betaflight\/Betaflight\/releases\" target=\"_blank\" rel=\"noopener noreferrer\">ovde<\/a>."
+    },
+    "defaultSupportHead": {
+        "message": "Podrška"
+    },
+    "defaultSupportSubline1": {
+        "message": "Izvori podrške"
+    },
+    "defaultSupportSubline2": {
+        "message": "Programeri"
+    },
+    "defaultSupport": {
+        "message": "Za podršku prvo pretražite forume i wiki ili kontaktirajte svog prodavca.<br \/><br \/>"
+    },
+    "defaultSupport1": {
+        "message": "<a href=\"http:\/\/www.rcgroups.com\/forums\/showthread.php?t=2464844&page=1\" target=\"_blank\" rel=\"noopener noreferrer\">RC Groups tema<\/a>"
+    },
+    "defaultSupport2": {
+        "message": "<a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight Wiki<\/a>"
+    },
+    "defaultSupport3": {
+        "message": "<a href=\"https:\/\/www.youtube.com\/playlist?list=PLwoDb7WF6c8nT4jjsE4VENEmwu9x8zDiE\" target=\"_blank\" rel=\"noopener noreferrer\">Joshua Bardwell Betaflight 4.3 video snimci<\/a>"
+    },
+    "defaultSupport4": {
+        "message": "<a href=\"https:\/\/github.com\/Betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub<\/a>"
+    },
+    "defaultSupport5": {
+        "message": "<a href=\"https:\/\/discord.betaflight.com\/invite\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight programeri na Discord-u<\/a>"
+    },
+    "initialSetupButtonCalibrateAccel": {
+        "message": "Kalibriši akcelerometar"
+    },
+    "initialSetupCalibrateMagText": {
+        "message": "Pomerajte multirotor za najmanje <strong>360<\/strong> stepeni po svim osama rotacije, imate 30 sekundi da obavite ovaj zadatak"
+    },
+    "initialSetupButtonCalibratingText": {
+        "message": "Kalibrisanje..."
+    },
+    "initialSetupButtonReset": {
+        "message": "Obriši podešavanja"
+    },
+    "initialSetupResetText": {
+        "message": "Vratite flight kontroler u <strong>nekonfigurisano stanje.<\/strong>"
+    },
+    "initialSetupButtonBackup": {
+        "message": "Sačuvaj rezervnu kopiju (JSON)"
+    },
+    "initialSetupButtonRestore": {
+        "message": "Vrati iz rezervne kopije (JSON)"
+    },
+    "initialSetupButtonRebootBootloader": {
+        "message": "Aktiviraj Boot Loader \/ DFU"
+    },
+    "initialSetupBackupRestoreHeader": {
+        "message": "Eksperimentalno pravljenje i vraćanje rezervne kopije"
+    },
+    "initialSetupBackupRestoreText": {
+        "message": "<strong>Sačuvajte bekap<\/strong> svoje konfiguracije u slučaju nezgode, <strong>CLI<\/strong> podešavanja <span class=\"message-negative\">nisu<\/span> uključena - koristite komandu 'diff all' u CLI-ju za ovo."
+    },
+    "initialSetupRebootBootloaderText": {
+        "message": "Ponovo pokrenite u <strong>boot loader \/ DFU<\/strong> mod."
+    },
+    "initialSetupButtonResetZaxis": {
+        "message": "Resetuj Z osu, odstupanje: 0 deg"
+    },
+    "initialSetupButtonResetZaxisValue": {
+        "message": "Resetuj Z osu, odstupanje: $1 deg"
+    },
+    "initialSetupHeading": {
+        "message": "Yaw:",
+        "description": "Heading [yaw] attitude value shown on Setup tab when no magnetometer is active"
+    },
+    "initialSetupMagHeading": {
+        "message": "Mag pravac:",
+        "description": "Heading value shown on Setup tab when magnetometer is active"
+    },
+    "initialSetupMixerHead": {
+        "message": "Vrsta miksera"
+    },
+    "initialSetupThrottleHead": {
+        "message": "Podešavanja gasa"
+    },
+    "initialSetupMinimum": {
+        "message": "Minimum:"
+    },
+    "initialSetupMaximum": {
+        "message": "Maksimum:"
+    },
+    "initialSetupFailsafe": {
+        "message": "Failsafe:"
+    },
+    "initialSetupMinCommand": {
+        "message": "MinCommand:"
+    },
+    "initialSetupBatteryHead": {
+        "message": "Baterija"
+    },
+    "initialSetupMinCellV": {
+        "message": "Minimalni napon ćelije:"
+    },
+    "initialSetupMaxCellV": {
+        "message": "Maksimalni napon ćelije:"
+    },
+    "initialSetupVoltageScale": {
+        "message": "Skala napona:"
+    },
+    "initialSetupAccelTrimsHead": {
+        "message": "Trimovi akcelerometra"
+    },
+    "initialSetupPitch": {
+        "message": "Pitch:"
+    },
+    "initialSetupRoll": {
+        "message": "Roll:"
+    },
+    "initialSetupMagHead": {
+        "message": "Magnetometar"
+    },
+    "initialSetupMagDeclination": {
+        "message": "Magnetska deklinacija:"
+    },
+    "initialSetupInfoHead": {
+        "message": "Informacije o sistemu"
+    },
+    "initialSetupInfoHeadHelp": {
+        "message": "Prikazuje FC flegove za razoružavanje, informacije o bateriji, RSSI nivo.",
+        "description": "Message that pops up to describe the System info section"
+    },
+    "initialSensorInfoHead": {
+        "message": "Informacije o senzorima"
+    },
+    "initialSensorInfoHeadHelp": {
+        "message": "Prikazuje hardver senzora",
+        "description": "Message that pops up to describe the Sensor info section"
+    },
+    "initialSetupBattery": {
+        "message": "Napon baterije:"
+    },
+    "initialSetupBatteryValue": {
+        "message": "$1 V"
+    },
+    "initialSetupDrawn": {
+        "message": "Potrošeni kapacitet:"
+    },
+    "initialSetupDrawing": {
+        "message": "Potrošnja struje:"
+    },
+    "initialSetupBatteryMahValue": {
+        "message": "$1 mAh"
+    },
+    "initialSetupBatteryAValue": {
+        "message": "$1 A"
+    },
+    "initialSetupCpuLoad": {
+        "message": "Opterećenje CPU-a:"
+    },
+    "initialSetupLoopTime": {
+        "message": "Brzina ciklusa:"
+    },
+    "initialSetupCpuTemp": {
+        "message": "Temperatura CPU-a:"
+    },
+    "initialSetupCpuTempNotSupported": {
+        "message": "Nije podržano u MSP API pre verzije 1.46"
+    },
+    "initialSetupRSSI": {
+        "message": "RSSI:"
+    },
+    "initialSetupNotInBuild": {
+        "message": "Nije uključeno u build",
+        "description": "Message that pops up when hardware support is not included in build"
+    },
+    "initialSetupNotDetected": {
+        "message": "Nije detektovan ili je isključen",
+        "description": "Message that pops up when hardware is not detected or disabled"
+    },
+    "initialSetupRSSIValue": {
+        "message": "$1 dBm"
+    },
+    "initialSetupMCU": {
+        "message": "MCU:"
+    },
+    "initialSetupSensorHardware": {
+        "message": "Senzori:"
+    },
+    "initialSetupSensorGyro": {
+        "message": "Žiroskop:"
+    },
+    "initialSetupSensorAcc": {
+        "message": "Akcelerometar:"
+    },
+    "initialSetupSensorMag": {
+        "message": "Magnetometar:"
+    },
+    "initialSetupSensorBaro": {
+        "message": "Baro:"
+    },
+    "initialSetupSensorGPS": {
+        "message": "GPS:"
+    },
+    "initialSetupSensorSonar": {
+        "message": "Sonar:"
+    },
+    "initialSetupSensorOpticalflow": {
+        "message": "Optički protok:"
+    },
+    "initialSetupSensorRadar": {
+        "message": "Radar:"
+    },
+    "initialSetupArmingDisableFlags": {
+        "message": "Zastavice za onemogućavanje armovanja:"
+    },
+    "initialSetupArmingAllowed": {
+        "message": "Armovanje je dozvoljeno"
+    },
+    "initialSetupArmingDisableFlagsTooltip": {
+        "message": "Lista zastavica koje ukazuju na to zašto armovanje trenutno nije dozvoljeno. Pređite mišem preko zastavice ili pogledajte Wiki (stranicu 'Arming Sequence & Safety') za više informacija."
+    },
+    "initialSetupArmingDisableFlagsTooltipNO_GYRO": {
+        "message": "Žiroskop nije detektovan",
+        "description": "Message that pops up to describe the NO_GYRO arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipFAILSAFE": {
+        "message": "Failsafe je aktivan",
+        "description": "Message that pops up to describe the FAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRX_FAILSAFE": {
+        "message": "Nije detektovan validan signal prijemnika",
+        "description": "Message that pops up to describe the RX_FAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNOT_DISARMED": {
+        "message": "Vaš prijemnik se upravo oporavio od Failsafe-a, ali je prekidač za ARM uključen",
+        "description": "Message that pops up to describe the NOT_DISARMED arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBOXFAILSAFE": {
+        "message": "Prekidač 'FAILSAFE' je aktiviran",
+        "description": "Message that pops up to describe the BOXFAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRUNAWAY_TAKEOFF": {
+        "message": "Aktivirana je zaštita od nekontrolisanog poletanja",
+        "description": "Message that pops up to describe the RUNAWAY_TAKEOFF arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCRASH_DETECTED": {
+        "message": "Detekcija sudara je aktivna",
+        "description": "Message that pops up to describe the CRASH_DETECTED arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCALIBRATING": {
+        "message": "Letelica se trenutno kalibriše",
+        "description": "Message that pops up to describe the CALIBRATING arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipTHROTTLE": {
+        "message": "Kanal za gas je previsok",
+        "description": "Message that pops up to describe the THROTTLE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipANGLE": {
+        "message": "Letelica nije (dovoljno) poravnata",
+        "description": "Message that pops up to describe the ANGLE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBOOT_GRACE_TIME": {
+        "message": "Armovanje je prerano nakon uključivanja",
+        "description": "Message that pops up to describe the BOOT_GRACE_TIME arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNOPREARM": {
+        "message": "PREARM prekidač nije aktiviran ili PREARM nije ponovo preklopljen nakon razoružavanja",
+        "description": "Message that pops up to describe the NOPREARM arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipLOAD": {
+        "message": "Opterećenje sistema je preveliko za bezbedan let",
+        "description": "Message that pops up to describe the LOAD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipACC_CALIBRATION": {
+        "message": "Kalibracija akcelerometra je i dalje u toku",
+        "description": "Message that pops up to describe the ACC_CALIBRATION arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCLI": {
+        "message": "CLI je aktivan",
+        "description": "Message that pops up to describe the CLI arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCMS_MENU": {
+        "message": "CMS (meni za podešavanje) je aktivan - preko OSD-a ili drugog ekrana -",
+        "description": "Message that pops up to describe the CMS_MENU arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipOSD_MENU": {
+        "message": "OSD meni je aktivan",
+        "description": "Message that pops up to describe the OSD_MENU arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBST": {
+        "message": "Black Sheep Telemetry uređaj (TBS Core Pro na primer) je razoružao letelicu i sprečava armovanje",
+        "description": "Message that pops up to describe the BST arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipMSP": {
+        "message": "MSP veza je aktivna, verovatno sa aplikacijom Betaflight",
+        "description": "Message that pops up to describe the MSP arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipPARALYZE": {
+        "message": "Aktiviran je Paralyze mod",
+        "description": "Message that pops up to describe the PARALYZE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipGPS": {
+        "message": "GPS Rescue mod je podešen, ali potreban broj satelita još nije pronađen",
+        "description": "Message that pops up to describe the GPS arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRESC": {
+        "message": "Prekidač za 'GPS Rescue' je aktiviran",
+        "description": "Message that pops up to describe the RESC arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRPMFILTER": {
+        "message": "Filtriranje zasnovano na RPM je uključeno, ali jedan ili više ESC-ova ne šalju ispravnu DSHOT telemetriju. Proverite da li ESC-ovi podržavaju dvosmernu DSHOT telemetriju i da li imaju instaliran odgovarajući firmver.",
+        "description": "Message that pops up to describe the RPMFILTER arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipDSHOT_TELEM": {
+        "message": "DShot telemetrija je uključena, ali jedan ili više ESC-ova ne šalju ispravnu DSHOT telemetriju. Proverite da li ESC-ovi podržavaju dvosmernu DSHOT telemetriju i da li imaju instaliran odgovarajući firmver.",
+        "description": "Message that pops up to describe the DSHOT_TELEM arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipREBOOT_REQUIRED": {
+        "message": "Izmena podešavanja zahteva ponovno pokretanje",
+        "description": "Message that pops up to describe the REBOOT_REQD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipDSHOT_BITBANG": {
+        "message": "Bitbang DSHOT ne radi ispravno i motori se ne mogu kontrolisati. Verovatno je došlo do konflikta tajmera sa drugim funkcijama uključenim na flight kontroleru.",
+        "description": "Message that pops up to describe the DSHOT_BBANG arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNO_ACC_CALIBRATION": {
+        "message": "Akcelerometar nije kalibrisan, a uključene su funkcije koje zavise od njega. Kalibrišite akcelerometar.",
+        "description": "Message that pops up to describe the NO_ACC_CAL arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipMOTOR_PROTOCOL": {
+        "message": "Nije izabran protokol za izlaz motora",
+        "description": "Message that pops up to describe the MOTOR_PROTO arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCRASHFLIP": {
+        "message": "Prekidač za Crash Flip je aktivan",
+        "description": "Message that pops to describe the CRASHFLIP arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipALTHOLD": {
+        "message": "Altitude Hold je aktivan",
+        "description": "Message that pops up to describe the ALTHOLD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipPOSHOLD": {
+        "message": "Position Hold je aktivan",
+        "description": "Message that pops up to describe the POSHOLD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipAUTOPILOT": {
+        "message": "Prekidač za Autopilot mod je aktivan",
+        "description": "Message that pops up to describe the AUTOPILOT arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipARM_SWITCH": {
+        "message": "Neka druga zastavica za razoružavanje je aktivna prilikom armovanja",
+        "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"
+    },
+    "initialSetupGPSHead": {
+        "message": "GPS"
+    },
+    "initialSetupGPSHeadHelp": {
+        "message": "Prikazuje GPS informacije ako je ispravno uključen na karticama Ports, Configuration i GPS",
+        "description": "Message that pops up to describe the GPS section"
+    },
+    "initialSetupSonarHead": {
+        "message": "Sonar"
+    },
+    "initialSetupSonarHeadHelp": {
+        "message": "Prikazuje informacije o sonaru ako je ispravno uključen na kartici Configuration",
+        "description": "Message that pops up to describe the Sonar section"
+    },
+    "initialSetupAltitudeSonar": {
+        "message": "Visina"
+    },
+    "initialSetupInstrumentsHead": {
+        "message": "Instrumenti"
+    },
+    "initialSetupInstrumentsHeadHelp": {
+        "message": "Prikazuje Heading, Pitch i Roll na instrumentima",
+        "description": "Message that pops up to describe the Instruments section"
+    },
+    "initialSetupInfoBoardName": {
+        "message": "Pločica:"
+    },
+    "initialSetupInfoFirmwareVersion": {
+        "message": "Firmver:"
+    },
+    "initialSetupInfoAPIversion": {
+        "message": "MSP API:"
+    },
+    "initialSetupInfoBuild": {
+        "message": "Informacije o firmveru"
+    },
+    "initialSetupInfoFirmwareHelp": {
+        "message": "Prikazuje informacije o izradi firmvera, zahteva internet vezu sa serverom za izradu.<br>Opcije prikazuju definisane opcije korišćene u izradi u oblaku.<br>Veze Log i Config prikazuju informacije u oblaku pomoću ključa sačuvanog u firmveru.<br>Kod lokalne izrade, ove sekcije su prazne.",
+        "description": "Message that pops up to describe the Build \/ Firmware section"
+    },
+    "initialSetupInfoBuildDate": {
+        "message": "Datum izrade:"
+    },
+    "initialSetupInfoBuildInfo": {
+        "message": "Informacije o izradi:"
+    },
+    "initialSetupInfoBuildInfoKey": {
+        "message": "Ključ izrade"
+    },
+    "initialSetupInfoBuildConfig": {
+        "message": "Config"
+    },
+    "initialSetupInfoBuildDownload": {
+        "message": "Preuzmi"
+    },
+    "initialSetupInfoBuildFirmware": {
+        "message": "Firmver:"
+    },
+    "initialSetupInfoBuildLog": {
+        "message": "Dnevnik"
+    },
+    "initialSetupInfoBuildOptions": {
+        "message": "Opcije"
+    },
+    "initialSetupInfoBuildOptionList": {
+        "message": "Opcije definisane u izradi firmvera"
+    },
+    "initialSetupInfoBuildEmpty": {
+        "message": "Lokalna izrada – nema informacija u oblaku"
+    },
+    "initialSetupInfoBuildType": {
+        "message": "Vrsta izrade:"
+    },
+    "initialSetupInfoBuildLocal": {
+        "message": "Lokalna izrada"
+    },
+    "initialSetupInfoBuildCloud": {
+        "message": "Izrada u oblaku"
+    },
+    "initialSetupNoBuildInfo": {
+        "message": "Nema dostupnih informacija o izradi"
+    },
+    "initialSetupNotOnline": {
+        "message": "Server nije dostupan"
+    },
+    "initialSetupButtonSave": {
+        "message": "Sačuvaj"
+    },
+    "initialSetupModel": {
+        "message": "Model: $1"
+    },
+    "initialSetupAttitude": {
+        "message": "$1 deg"
+    },
+    "initialSetupAccelCalibStarted": {
+        "message": "Kalibracija akcelerometra je započeta"
+    },
+    "initialSetupAccelCalibEnded": {
+        "message": "Kalibracija akcelerometra je <span class=\"message-positive\">završena<\/span>"
+    },
+    "initialSetupMagCalibStarted": {
+        "message": "Kalibracija magnetometra je započeta"
+    },
+    "initialSetupMagCalibEnded": {
+        "message": "Kalibracija magnetometra je <span class=\"message-positive\">završena<\/span>"
+    },
+    "initialSetupSettingsRestored": {
+        "message": "Podešavanja su vraćena na <strong>fabrička<\/strong>"
+    },
+    "initialSetupNetworkInfo": {
+        "message": "Mrežne informacije"
+    },
+    "initialSetupNetworkInfoHelp": {
+        "message": "Prikazuje status mrežne veze",
+        "description": "Message that pops up to describe the Network Connection section"
+    },
+    "initialSetupNetworkInfoStatus": {
+        "message": "Status:"
+    },
+    "initialSetupNetworkInfoStatusOnline": {
+        "message": "Na mreži"
+    },
+    "initialSetupNetworkInfoStatusOffline": {
+        "message": "Van mreže"
+    },
+    "initialSetupNetworkInfoStatusSlow": {
+        "message": "Sporo"
+    },
+    "initialSetupNetworkType": {
+        "message": "Tip:"
+    },
+    "initialSetupNetworkRtt": {
+        "message": "RTT:"
+    },
+    "initialSetupNetworkDownlink": {
+        "message": "Silazna veza:"
+    },
+    "featureNone": {
+        "message": "&lt;Izaberite jedno&gt;"
+    },
+    "featureRX_PPM": {
+        "message": "PPM\/CPPM (jedna žica)"
+    },
+    "featureINFLIGHT_ACC_CAL": {
+        "message": "Kalibracija nivelisanja u letu"
+    },
+    "featureRX_SERIAL": {
+        "message": "Serijski (putem UART-a)"
+    },
+    "featureMOTOR_STOP": {
+        "message": "Ne pokreći motore prilikom armovanja"
+    },
+    "featureMOTOR_STOPTip": {
+        "message": "Ova funkcija je isključena kada je uključen AIRMODE"
+    },
+    "featureSERVO_TILT": {
+        "message": "Servo gimbal"
+    },
+    "featureSERVO_TILTTip": {
+        "message": "Ova funkcija uključuje CAMSTAB mod, koji se može koristiti za održavanje stabilnosti do dve ose pomoću akcelerometra"
+    },
+    "featureSOFTSERIAL": {
+        "message": "Serijski portovi zasnovani na procesoru"
+    },
+    "featureSOFTSERIALTip": {
+        "message": "Podesite portove na kartici Ports nakon uključivanja."
+    },
+    "featureGPS": {
+        "message": "GPS za navigaciju i telemetriju"
+    },
+    "featureGPSTip": {
+        "message": "Uključi \/ isključi GPS podatke. Ako se GPS ne može uključiti, proverite da li je port dodeljen GPS-u na kartici Ports",
+        "description": "Message that pops up to describe the GPS feature"
+    },
+    "featureSONAR": {
+        "message": "Sonar"
+    },
+    "featureSONARTip": {
+        "message": "Uključuje Sonar merač udaljenosti za merenje visine od tla u cm"
+    },
+    "featureTELEMETRY": {
+        "message": "Telemetrijski izlaz"
+    },
+    "featureTELEMETRYTip": {
+        "message": "Uključuje telemetrijski izlaz za slanje na predajnik"
+    },
+    "feature3D": {
+        "message": "3D mod (za upotrebu sa reverzibilnim ESC-ovima)"
+    },
+    "feature3DTip": {
+        "message": "Uključi 3D mod za upotrebu sa reverzibilnim ESC-ovima, podesite na kartici Motors"
+    },
+    "featureRX_PARALLEL_PWM": {
+        "message": "PWM (jedna žica po kanalu)"
+    },
+    "featureRX_MSP": {
+        "message": "MSP (upravljanje putem MSP porta)"
+    },
+    "featureRSSI_ADC": {
+        "message": "Analogni RSSI ulaz"
+    },
+    "featureLED_STRIP": {
+        "message": "Podrška za višebojnu RGB LED traku"
+    },
+    "featureLED_STRIPTip": {
+        "message": "Uključite podršku za višebojnu RGB LED traku, konfigurišite na kartici LED traka"
+    },
+    "featureDISPLAY": {
+        "message": "OLED ekran"
+    },
+    "featureDISPLAYTip": {
+        "message": "Ako je ova funkcija uključena, a nijedan uređaj za prikaz nije povezan (ili uređaj za prikaz nije uključen), doći će do kašnjenja od približno 10 sekundi pri svakom ponovnom pokretanju flight kontrolera."
+    },
+    "featureOSD": {
+        "message": "On Screen Display"
+    },
+    "featureOSDTip": {
+        "message": "Uključite OSD, konfigurišite na kartici OSD"
+    },
+    "featureCHANNEL_FORWARDING": {
+        "message": "Prosleđivanje pomoćnih kanala na servo izlaze"
+    },
+    "featureTRANSPONDER": {
+        "message": "Transponder za trke"
+    },
+    "featureTRANSPONDERTip": {
+        "message": "Podesite ga na kartici Transponder za trke pošto ga uključite."
+    },
+    "featureAIRMODE": {
+        "message": "Trajno uključi Airmode"
+    },
+    "featureRX_SPI": {
+        "message": "SPI Rx (npr. ugrađeni Rx)"
+    },
+    "escSensorSerialPort": {
+        "message": "Serijski port za telemetriju ESC-a"
+    },
+    "escSensorSerialPortHelp": {
+        "message": "UART na kom se čita telemetrija ESC-a. Od API-ja 1.49 zadaje se na samom ESC senzoru; kartica Ports ga samo prikazuje."
+    },
+    "featureESC_SENSOR": {
+        "message": "Koristite KISS\/BLHeli_32 ESC telemetriju <b>preko zasebne žice<\/b>"
+    },
+    "featureANTI_GRAVITY": {
+        "message": "Trajno uključi"
+    },
+    "featureANTI_GRAVITYTip": {
+        "message": "Ako je ovo isključeno, mod 'ANTI GRAVITY' se može koristiti za uključivanje Anti Gravity pomoću prekidača."
+    },
+    "featureDYNAMIC_FILTER": {
+        "message": "Dinamičko žiroskopsko notch filtriranje"
+    },
+    "configurationFeatureEnabled": {
+        "message": "Uključeno"
+    },
+    "configurationFeatureName": {
+        "message": "Funkcija"
+    },
+    "configurationFeatureDescription": {
+        "message": "Opis"
+    },
+    "configurationMixer": {
+        "message": "Mikser"
+    },
+    "configurationFeatures": {
+        "message": "Ostale funkcije"
+    },
+    "configurationFeatureHelp": {
+        "message": "Pomoć"
+    },
+    "configurationReceiver": {
+        "message": "Prijemnik"
+    },
+    "configurationReceiverMode": {
+        "message": "Mod prijemnika"
+    },
+    "configurationTelemetry": {
+        "message": "Telemetrija"
+    },
+    "telemetryInstanceTitle": {
+        "message": "Telemetrija $1"
+    },
+    "telemetryInstanceProtocol": {
+        "message": "Protokol"
+    },
+    "telemetryInstancePort": {
+        "message": "Serijski port"
+    },
+    "telemetryInstanceBaud": {
+        "message": "Brzina prenosa"
+    },
+    "rcdeviceSectionTitle": {
+        "message": "Kontrola kamere"
+    },
+    "rcdeviceSerialPort": {
+        "message": "Serijski port"
+    },
+    "rcdeviceSerialPortHelp": {
+        "message": "UART na koji je povezana kamera sa RunCam protokolom. Od API-ja 1.49 zadaje se na samom uređaju; kartica Ports ga samo prikazuje."
+    },
+    "configurationTelemetryHelp": {
+        "message": "Telemetrijski izlaz iz prijemnika"
+    },
+    "configurationRSSI": {
+        "message": "RSSI"
+    },
+    "configurationRSSIHelp": {
+        "message": "RSSI je mera jačine signala i vrlo je koristan da biste znali kada dron izlazi iz dometa ili kada trpi radio-smetnje."
+    },
+    "configurationEscFeatures": {
+        "message": "Regulatori i motori"
+    },
+    "configurationFeaturesHelp": {
+        "message": "<strong>Napomena:<\/strong> ne mogu se sve mogućnosti kombinovati. Kada firmver otkrije nedozvoljenu kombinaciju, sukobljene mogućnosti se isključuju.<br \/><strong>Napomena:<\/strong> podesite serijske portove <span class=\"message-negative\">pre<\/span> nego što uključite mogućnosti koje te portove koriste."
+    },
+    "configurationSerialRXHelp": {
+        "message": "&#8226; UART na koji je vezan prijemnik mora biti postavljen na „Serial Rx“ (na kartici <i>Portovi<\/i>)<br>&#8226; Ispod, iz padajuće liste, izaberite ispravan način zapisa podataka:"
+    },
+    "configurationSpiRxHelp": {
+        "message": "<strong>Napomena:<\/strong> SPI prijemnik radi samo ako je odgovarajući uređaj ugrađen na pločicu ili vezan na SPI magistralu."
+    },
+    "configurationActiveImu": {
+        "message": "Aktivni IMU"
+    },
+    "configurationMagAlignmentHelp": {
+        "message": "Poravnanje magnetometra je položaj tog senzora na pločici flight kontrolera. Fabrička vrednost je obično ispravna, ali ako imate sopstveni sklop ili flight kontroler sa drugačije postavljenim magnetometrom, ovo možda treba prilagoditi."
+    },
+    "configurationMagDeclination": {
+        "message": "Magnetna deklinacija"
+    },
+    "configurationMagDeclinationInput": {
+        "message": "Deklinacija u stepenima"
+    },
+    "configurationMagDeclinationHelp": {
+        "message": "Magnetna deklinacija je ugao između magnetnog i pravog severa. Razlikuje se za svako mesto na zemlji. Vrednost za svoje mesto možete naći na internetu."
+    },
+    "configurationRangefinder": {
+        "message": "Merač visine",
+        "description": "Don't translate!!!"
+    },
+    "configurationRangefinderHelp": {
+        "message": "Uključuje merač koji meri rastojanje do tla u centimetrima."
+    },
+    "configurationRangefinderType": {
+        "message": "Tip"
+    },
+    "rangefinderSerialPort": {
+        "message": "Serijski port za merač udaljenosti"
+    },
+    "rangefinderSerialPortHelp": {
+        "message": "UART na koji je povezan merač udaljenosti. Od API-ja 1.49 zadaje se na samom meraču; kartica Ports ga samo prikazuje."
+    },
+    "opticalflowSerialPort": {
+        "message": "Serijski port za optički protok"
+    },
+    "opticalflowSerialPortHelp": {
+        "message": "UART na koji je povezan senzor optičkog protoka. Modulu koji javlja i protok i udaljenost svaki se zadaje posebno."
+    },
+    "configurationOpticalflow": {
+        "message": "Optički senzor kretanja",
+        "description": "Don't translate!!!"
+    },
+    "configurationOpticalflowHelp": {
+        "message": "Uključuje optički senzor kretanja."
+    },
+    "configurationBoardAlignment": {
+        "message": "Board and Sensor Alignment"
+    },
+    "configurationBoardAlignmentRoll": {
+        "message": "Roll°"
+    },
+    "configurationBoardAlignmentPitch": {
+        "message": "Pitch°"
+    },
+    "configurationBoardAlignmentYaw": {
+        "message": "Yaw°"
+    },
+    "configurationMagAlignment": {
+        "message": "Poravnanje magnetometra"
+    },
+    "configurationBoardAlignmentHelp": {
+        "message": "Proizvoljno okretanje pločice u stepenima, da bi mogla da se ugradi bočno, naopako, zakrenuto i slično. Kada koristite spoljne senzore, njihov položaj zadajte kroz poravnanje senzora (žiroskop, akcelerometar, magnetometar), nezavisno od položaja same pločice."
+    },
+    "boardAlignmentWizard-Launch": {
+        "message": "Automatsko prepoznavanje orijentacije pločice"
+    },
+    "boardAlignmentWizard-DialogTitle": {
+        "message": "Čarobnjak za orijentaciju pločice"
+    },
+    "boardAlignmentWizard-Intro": {
+        "message": "Ovaj čarobnjak prepoznaje kako je Vaš flight kontroler montiran vodeći Vas kroz četiri jednostavna pokreta. Postavite dron na ravnu površinu tako da je kamera okrenuta od Vas (prema ekranu), a zatim pratite uputstva."
+    },
+    "boardAlignmentWizard-Start": {
+        "message": "Pokreni"
+    },
+    "boardAlignmentWizard-Step": {
+        "message": "Korak"
+    },
+    "boardAlignmentWizard-HintFlat": {
+        "message": "Postavite dron na ravno sa kamerom okrenutom od Vas (prema ekranu)."
+    },
+    "boardAlignmentWizard-HintPitchDown": {
+        "message": "Nagnite nos nadole za oko 45°, tako da kamera bude usmerena ka zemlji."
+    },
+    "boardAlignmentWizard-HintRollRight": {
+        "message": "Nagnite desnu stranu nadole za oko 45°, spuštajući desne krakove i podižući leve."
+    },
+    "boardAlignmentWizard-HintYawCW": {
+        "message": "Rotirajte dron za oko 45° u smeru kazaljke na satu (gledano odozgo)."
+    },
+    "boardAlignmentWizard-HintLevel": {
+        "message": "Vratite dron u ravni položaj."
+    },
+    "boardAlignmentWizard-HoldSteady": {
+        "message": "Držite mirno..."
+    },
+    "boardAlignmentWizard-Settling": {
+        "message": "Smirivanje"
+    },
+    "boardAlignmentWizard-Tilting": {
+        "message": "Nastavite da naginjete"
+    },
+    "boardAlignmentWizard-LevelOut": {
+        "message": "Vratite u ravni položaj"
+    },
+    "boardAlignmentWizard-AxisDetected": {
+        "message": "Osa je prepoznata — držite mirno"
+    },
+    "boardAlignmentWizard-YawProgress": {
+        "message": "Rotacija"
+    },
+    "boardAlignmentWizard-Computing": {
+        "message": "Izračunavanje orijentacije..."
+    },
+    "boardAlignmentWizard-ResultTitle": {
+        "message": "Prepoznata orijentacija"
+    },
+    "boardAlignmentWizard-ResultNoChange": {
+        "message": "Orijentacija Vaše pločice deluje ispravno — promene nisu potrebne."
+    },
+    "boardAlignmentWizard-ResultCurrent": {
+        "message": "Struja"
+    },
+    "boardAlignmentWizard-ResultDetected": {
+        "message": "Prepoznato"
+    },
+    "boardAlignmentWizard-Back": {
+        "message": "Nazad"
+    },
+    "boardAlignmentWizard-Apply": {
+        "message": "Primeni"
+    },
+    "boardAlignmentWizard-Cancel": {
+        "message": "Otkaži"
+    },
+    "boardAlignmentWizard-Retry": {
+        "message": "Pokušajte ponovo"
+    },
+    "boardAlignmentWizard-CaptureNow": {
+        "message": "Zabeleži sada"
+    },
+    "boardAlignmentWizard-LowConfidence": {
+        "message": "Pouzdanost prepoznavanja je smanjena — proverite rezultat u odnosu na živi prikaz položaja pre primene."
+    },
+    "boardAlignmentWizard-NoAccelerometer": {
+        "message": "Akcelerometar je neophodan za pokretanje ovog čarobnjaka."
+    },
+    "boardAlignmentWizard-AccNeedsCalibration": {
+        "message": "Kalibrišite akcelerometar pre pokretanja ovog čarobnjaka."
+    },
+    "boardAlignmentWizard-Error-missing_samples": {
+        "message": "Neki uzorci nisu prikupljeni. Pokušajte ponovo."
+    },
+    "boardAlignmentWizard-Error-no_gravity": {
+        "message": "Akcelerometar ne očitava gravitaciju. Proverite da li je FC povezan i da se ne krece."
+    },
+    "boardAlignmentWizard-Error-no_pitch_tilt": {
+        "message": "Pokret za Pitch nije detektovan. Molimo Vas pokušajte ponovo i nagnite nos još više naniže."
+    },
+    "boardAlignmentWizard-Error-no_roll_tilt": {
+        "message": "Pokret za Roll nije detektovan. Molimo Vas pokušajte ponovo i nagnite desnu stranu još više naniže."
+    },
+    "boardAlignmentWizard-Error-gesture_direction_mismatch": {
+        "message": "Jedan od pokreta naginjanja je bio u pogrešnom smeru. Proverite smerove za Pitch i Roll i pokušajte ponovo."
+    },
+    "boardAlignmentWizard-StepFlat": {
+        "message": "Ravno"
+    },
+    "boardAlignmentWizard-StepPitch": {
+        "message": "Pitch"
+    },
+    "boardAlignmentWizard-StepRoll": {
+        "message": "Roll"
+    },
+    "boardAlignmentWizard-StepYaw": {
+        "message": "Yaw"
+    },
+    "boardAlignmentWizard-Confirmed": {
+        "message": "Zabeleženo"
+    },
+    "configurationSensorGyroToUse": {
+        "message": "Žiroskop i akcelerometar"
+    },
+    "configurationSensorGyroToUseFirst": {
+        "message": "Prvi"
+    },
+    "configurationSensorGyroToUseSecond": {
+        "message": "Drugi"
+    },
+    "configurationSensorGyroToUseBoth": {
+        "message": "Oba"
+    },
+    "configurationSensorAlignmentGyro1": {
+        "message": "Prvi žiroskop"
+    },
+    "configurationSensorAlignmentGyro2": {
+        "message": "Drugi žiroskop"
+    },
+    "configurationSensorAlignmentDefaultOption": {
+        "message": "Fabričko"
+    },
+    "configurationSensorAlignmentCustom": {
+        "message": "Prilagođeno"
+    },
+    "configurationAccelTrimRoll": {
+        "message": "Fino podešavanje akcelerometra — Roll"
+    },
+    "configurationAccelTrimPitch": {
+        "message": "Fino podešavanje akcelerometra — Pitch"
+    },
+    "configurationArming": {
+        "message": "Armovanje"
+    },
+    "configurationArmingHelp": {
+        "message": "Neke mogućnosti armovanja traže da akcelerometar bude uključen."
+    },
+    "configurationReverseMotorSwitch": {
+        "message": "Smer obrtanja motora je obrnut"
+    },
+    "configurationReverseMotorSwitchHelp": {
+        "message": "Ovom postavkom se rasporedu motora javlja da je smer obrtanja obrnut i da su propeleri postavljeni u skladu s tim. <strong>Pažnja:<\/strong> ovo NE obrće smer motora. Za to koristite program za svoje regulatore ili zamenite redosled žica između regulatora i motora. Takođe, sa skinutim propelerima proverite da se motori okreću u smerovima prikazanim na slici iznad, pre nego što pokušate da armujete."
+    },
+    "configurationAutoDisarmDelay": {
+        "message": "Razoružavanje motora posle zadatog vremena [sekunde] (zahteva MOTOR_STOP)"
+    },
+    "configurationAutoDisarmDelayHelp": {
+        "message": "Razoružava motore posle zadatog vremena u sekundama (traži uključen MOTOR_STOP)."
+    },
+    "configurationGyroCalOnFirstArm": {
+        "message": "Kalibracija žiroskopa pri prvom armovanju"
+    },
+    "configurationGyroCalOnFirstArmHelp": {
+        "message": "Kada je uključeno, žiroskop se kalibriše pri prvom armovanju posle uključivanja. To pomaže da se smanji odstupanje žiroskopa tokom leta."
+    },
+    "configurationMotorIdle": {
+        "message": "Prazan hod motora (%)"
+    },
+    "configurationMotorIdleHelp": {
+        "message": "Zadaje brzinu praznog hoda motora dok je dron armovan a gas nizak (ispod `min_check`).<br\/><br\/><strong class=\"message-positive\">Dinamički prazan hod isključen<\/strong><br\/><br\/>Svaki motor dobija `min_command` uvećan za procenat praznog hoda.<br\/><br\/><b>Prazan hod prenizak<\/b>: motori možda neće pouzdano krenuti, sporo se pokreću ili gube korak pri prevrtajima.<br\/><br\/><b>Prazan hod previsok<\/b>: dron deluje kao da lebdi.<br\/><br\/><b>Napomena<\/b>: analogni regulatori moraju biti kalibrisani tako da motori krenu tek malo iznad `min_command`.<br\/><br\/><strong class=\"message-positive\">Dinamički prazan hod uključen<\/strong><br\/><br\/>Pri armovanju se svakom motoru šalje uobičajena vrednost praznog hoda dok se ne pokrene.<br\/><br\/>Kada se okrene, signal motora se prilagođava da bi se postigla zadata brzina obrtanja.<br\/><br\/>Pre poletanja signal je ograničen na zadati procenat praznog hoda, pa zadata brzina možda neće biti postignuta. To je u redu. Kada gas pređe procenat zadat kroz `airmode_motor_start_throttle`, granica je znatno viša i zadata brzina se postiže.<br\/><br\/><b>Prazan hod prenizak<\/b>: motori možda neće pouzdano krenuti<br\/><br\/><b>Prazan hod previsok<\/b>: podrhtavanje pre poletanja, ali samo ako je i dinamički prazan hod visok<br\/><br\/><b>Napomena<\/b>: dinamički prazan hod traži DShot i DShot telemetriju."
+    },
+    "configurationMotorPoles": {
+        "message": "Broj polova motora",
+        "description": "One of the fields of the ESC\/Motor configuration"
+    },
+    "configurationMotorPolesLong": {
+        "message": "$t(configurationMotorPoles.message) (broj magneta na zvonu motora)",
+        "description": "One of the fields of the ESC\/Motor configuration"
+    },
+    "configurationMotorPolesHelp": {
+        "message": "Broj polova je broj magneta na zvonu motora. NE brojte statore na kojima su namotaji. Motori za petice obično imaju četrnaest magneta, a trojke i manji često dvanaest.",
+        "description": "Help text for the Motor poles field of the ESC\/Motor configuration"
+    },
+    "configurationMotorIdleRpmHelp": {
+        "message": "Ovo je vrednost dinamičkog praznog hoda iz aktivnog PID profila. Kada je dinamički prazan hod postavljen na nulu, važi samo stalni prazan hod motora. Dinamički prazan hod menja se na kartici PID podešavanje.",
+        "description": "Help text for dynamic idle setting"
+    },
+    "configurationThrottleMinimum": {
+        "message": "Najmanji gas (najniža vrednost regulatora dok je armovan)"
+    },
+    "configurationThrottleMinimumHelp": {
+        "message": "Ovo je vrednost praznog hoda koja se šalje regulatorima kada je dron armovan a ručica gasa u najnižem položaju. Povećajte je za brži prazan hod. Povećajte je i ako motori gube korak."
+    },
+    "configurationThrottleMaximum": {
+        "message": "Najveći gas (najviša vrednost regulatora dok je armovan)"
+    },
+    "configurationThrottleMinimumCommand": {
+        "message": "Najmanja komanda (vrednost regulatora dok je razoružan)"
+    },
+    "configurationThrottleMinimumCommandHelp": {
+        "message": "Ovo je vrednost koja se šalje regulatorima dok je dron razoružan. Postavite je tako da motori stoje (kod većine regulatora to je hiljadu)."
+    },
+    "configurationEscProtocolDisabled": {
+        "message": "Izaberite protokol motora koji odgovara Vašim regulatorima. $t(escProtocolDisabledMessage.message)"
+    },
+    "escProtocolDisabledMessage": {
+        "message": "<strong>Oprez:<\/strong> Izbor protokola izlaza motora koji Vaši ESC-ovi ne podržavaju može dovesti do toga da se <strong>ESC-ovi zavrte čim se poveže baterija<\/strong>. Iz tog razloga, <strong>uvek proverite da li ste skinuli propelere pre prvog povezivanja baterije nakon promene protokola izlaza motora<\/strong>."
+    },
+    "configurationDshotBeeper": {
+        "message": "Podešavanje DShot pištanja"
+    },
+    "configurationUseDshotBeeper": {
+        "message": "DShot pištanje (motori pište dok je dron razoružan)"
+    },
+    "configurationDshotBeaconTone": {
+        "message": "Ton pištanja"
+    },
+    "configurationDshotBeaconHelp": {
+        "message": "DShot pištanje koristi regulatore i motore da proizvedu zvuk. Zato se ne može koristiti dok se motori okreću. Na Betaflight-u 3.4 i novijem, ako pokušate da armujete dok je DShot pištanje aktivno, armovanje se odlaže dve sekunde od poslednjeg tona. Time se sprečava da pištanje smeta komandama koje se šalju pri armovanju.<br\/><strong>Pažnja:<\/strong> pošto DShot pištanje propušta struju kroz motore, prejako podešena jačina može da izazove pregrevanje i da ošteti motore ili regulatore. Jačinu podešavajte i proveravajte kroz BLHeli Configurator ili BLHeli Suite."
+    },
+    "configurationBeeper": {
+        "message": "Podešavanje piskalice"
+    },
+    "beeperGYRO_CALIBRATED": {
+        "message": "Oglasi se kada je žiroskop kalibrisan"
+    },
+    "beeperRX_LOST": {
+        "message": "Oglasi se kada je TX isključen ili je signal izgubljen (ponavlja se dok TX ne bude u redu)"
+    },
+    "beeperRX_LOST_LANDING": {
+        "message": "Oglasi SOS kada je armovan a TX je isključen ili je signal izgubljen (automatsko sletanje \/ automatsko razoružavanje)"
+    },
+    "beeperDISARMING": {
+        "message": "Oglasi se pri razoružavanju flight kontrolera"
+    },
+    "beeperARMING": {
+        "message": "Oglasi se pri armovanju flight kontrolera"
+    },
+    "beeperARMING_GPS_FIX": {
+        "message": "Oglasi se posebnim tonom pri armovanju pločice kada GPS ima signal"
+    },
+    "beeperBAT_CRIT_LOW": {
+        "message": "Duži zvučni signali upozorenja kada je baterija kritično prazna (ponavlja se)"
+    },
+    "beeperBAT_LOW": {
+        "message": "Zvučni signali upozorenja kada je baterija pri kraju (ponavlja se)"
+    },
+    "beeperGPS_STATUS": {
+        "message": "Brojem zvučnih signala prikazuje koliko je GPS satelita pronađeno"
+    },
+    "beeperRX_SET": {
+        "message": "Oglasi se kada je AUX kanal podešen za zvučni signal"
+    },
+    "beeperACC_CALIBRATION": {
+        "message": "Potvrda da je kalibracija akcelerometra u letu završena"
+    },
+    "beeperACC_CALIBRATION_FAIL": {
+        "message": "Kalibracija akcelerometra u letu nije uspela"
+    },
+    "beeperREADY_BEEP": {
+        "message": "Oglasi se kada je GPS zaključan i spreman"
+    },
+    "beeperDISARM_REPEAT": {
+        "message": "Zvučni signali dok se ručica drži u poziciji za razoružavanje"
+    },
+    "beeperARMED": {
+        "message": "Zvučni signali upozorenja kada je pločica armovana a motori ne rade u mirovanju (ponavlja se dok se pločica ne razoruža ili se ne poveća gas)"
+    },
+    "beeperSYSTEM_INIT": {
+        "message": "Zvučni signali inicijalizacije kada se pločica uključi"
+    },
+    "beeperUSB": {
+        "message": "Zvučni signal kada se flight kontroler napaja preko USB-a. Isključite ovo ako ne želite da piskalica radi dok je letelica na radnom stolu"
+    },
+    "beeperBLACKBOX_ERASE": {
+        "message": "Zvučni signal kada se završi brisanje Blackbox-a"
+    },
+    "beeperCRASH_FLIP": {
+        "message": "Zvučni signal kada je aktivan crash flip mod"
+    },
+    "beeperCAM_CONNECTION_OPEN": {
+        "message": "Zvučni signal kada se uđe u kontrolu kamere pomoću 5 tastera"
+    },
+    "beeperCAM_CONNECTION_CLOSE": {
+        "message": "Zvučni signal kada se izađe iz kontrole kamere pomoću 5 tastera"
+    },
+    "beeperRC_SMOOTHING_INIT_FAIL": {
+        "message": "Zvučni signal kada je letelica armovana a RC ublažavanje nije inicijalizovalo filtere"
+    },
+    "configurationBeeperEnableAll": {
+        "message": "Uključi sve"
+    },
+    "configurationBeeperDisableAll": {
+        "message": "Isključi sve"
+    },
+    "configuration3d": {
+        "message": "Rad motora u oba smera"
+    },
+    "configuration3dDeadbandLow": {
+        "message": "Donja mrtva zona"
+    },
+    "configuration3dDeadbandHigh": {
+        "message": "Gornja mrtva zona"
+    },
+    "configuration3dNeutral": {
+        "message": "Neutralni položaj"
+    },
+    "configuration3dDeadbandThrottle": {
+        "message": "Mrtva zona gasa"
+    },
+    "configurationSystem": {
+        "message": "Podešavanje sistema"
+    },
+    "configurationLoopTime": {
+        "message": "Vreme ciklusa flight kontrolera"
+    },
+    "configurationCalculatedCyclesSec": {
+        "message": "Ciklusa u sekundi [Hz]"
+    },
+    "configurationSpeedGyroNoGyro": {
+        "message": "Nema žiroskopa",
+        "description": "When no gyro is configured this appears in place of the speed of the gyro in kHz"
+    },
+    "configurationSpeedPidNoGyro": {
+        "message": "Žiroskop \/ {{value}}",
+        "description": "When no gyro is configured this appears in place of the speed of the PID in kHz. Try to keep it short."
+    },
+    "configurationKHzUnitLabel": {
+        "message": "{{value}} kHz",
+        "description": "Value for some options that show the speed of gyro, pid, etc. in kHz"
+    },
+    "configurationLoopTimeHelp": {
+        "message": "<strong>Napomena:<\/strong> proverite da Vaš flight kontroler može da radi na ovim brzinama. Pratite opterećenje procesora i postojanost vremena ciklusa. Posle ove izmene možda će biti potrebno ponovo podesiti PID. SAVET: isključivanjem akcelerometra i drugih senzora dobija se više snage."
+    },
+    "configurationGPS": {
+        "message": "Konfiguracija"
+    },
+    "configurationGPSHelp": {
+        "message": "Podesite protokol za GPS uređaj (ne zaboravite da podesite port na kartici Portovi), koristite automatsku brzinu prenosa ili je zadajte na kartici Portovi, uz ostala podešavanja.",
+        "description": "Help text GPS configuration"
+    },
+    "configurationGPSProtocol": {
+        "message": "Protokol"
+    },
+    "configurationGPSBaudrate": {
+        "message": "Brzina prenosa"
+    },
+    "configurationGPSubxSbas": {
+        "message": "Vrsta zemaljske podrške"
+    },
+    "gpsSerialPort": {
+        "message": "Serijski port"
+    },
+    "gpsSerialPortHelp": {
+        "message": "UART na koji je povezan GPS modul. Promena zahteva restart."
+    },
+    "gpsSerialBaud": {
+        "message": "Brzina prenosa"
+    },
+    "gpsSerialBaudHelp": {
+        "message": "Brzina na kojoj se očekuje da GPS modul radi. Kada ne uspe da uspostavi vezu, Betaflight proba i ostale brzine, pa je ovo polazna vrednost, a ne čvrsto podešavanje."
+    },
+    "gpsSerialPortSaveFailed": {
+        "message": "Serijski port za GPS nije mogao da se postavi, pa ništa nije sačuvano."
+    },
+    "gpsCanDevice": {
+        "message": "CAN magistrala"
+    },
+    "gpsCanDeviceHelp": {
+        "message": "CAN magistrala na koju su povezani DroneCAN moduli. Ona pripada celom DroneCAN sistemu, pa njena promena pomera svaki DroneCAN uređaj, ne samo GPS. Promena zahteva restart."
+    },
+    "gpsCanDeviceSaveFailed": {
+        "message": "CAN magistrala nije mogla da se postavi, pa ništa nije sačuvano."
+    },
+    "configurationGPSAutoBaud": {
+        "message": "Automatska brzina prenosa"
+    },
+    "configurationGPSAutoConfig": {
+        "message": "Automatsko podešavanje"
+    },
+    "configurationGPSGalileo": {
+        "message": "Koristi Galileo",
+        "description": "Option to use Galileo in the GPS configuration"
+    },
+    "configurationGPSGalileoHelp": {
+        "message": "Kada je uključeno, GPS modul prati i sistem Galileo, što obično daje više uhvaćenih satelita. Na Betaflight-u 4.2.x i starijim istovremeno isključuje QZSS dopunski sistem.",
+        "description": "Help text for the option to use Galileo in the GPS configuration"
+    },
+    "configurationGPSHomeOnce": {
+        "message": "Zabeleži mesto poletanja samo jednom",
+        "description": "Option to set the Home Point with the first arm only, not with each arm in the GPS Configuration"
+    },
+    "configurationGPSHomeOnceHelp": {
+        "message": "Kada je uključeno, kao mesto poletanja pamti se samo prvo armovanje posle priključivanja baterije. Ako nije uključeno, mesto poletanja se osvežava pri svakom armovanju.",
+        "description": "Help text for the option to set the Home Point with the first arm only, not with each arm in the GPS Configuration"
+    },
+    "configurationGPSNotInBuild": {
+        "message": "Podrška za GPS nije uključena u ovu verziju firmvera. Ponovo napravite firmver sa uključenom GPS opcijom da biste mogli da ga podesite i koristite.",
+        "description": "Shown in the GPS Configuration box when the connected firmware was built without the GPS build option"
+    },
+    "configurationSerialRX": {
+        "message": "Vrsta serijskog prijemnika"
+    },
+    "portsPortNone": {
+        "message": "Ništa"
+    },
+    "receiverSerialPort": {
+        "message": "Serijski port"
+    },
+    "receiverSerialPortHelp": {
+        "message": "UART na koji je povezan serijski prijemnik. Brzina prenosa podataka prati provajdera, tako da ovde nema šta da se podešava. Promena porta zahteva ponovno pokretanje."
+    },
+    "receiverSerialPortSaveFailed": {
+        "message": "Nije bilo moguće podesiti serijski port prijemnika, tako da ništa nije sačuvano."
+    },
+    "someRXTypesDisabled": {
+        "message": "Neki provajderi prijemnika nisu podržani u trenutnoj konfiguraciji izrade."
+    },
+    "serialRXNotSupported": {
+        "message": "Izabrani provajder prijemnika nije podržan u trenutnoj konfiguraciji izrade. Izaberite drugog provajdera ili ažurirajte firmver sa izabranim odgovarajućim radio protokolom u konfiguraciji izrade."
+    },
+    "configurationSpiRX": {
+        "message": "Vrsta SPI prijemnika"
+    },
+    "configurationSaved": {
+        "message": "Podešavanja sačuvana"
+    },
+    "configurationButtonSave": {
+        "message": "Sačuvaj i restartuj"
+    },
+    "dialogClose": {
+        "message": "Zatvori"
+    },
+    "dialogDynFiltersChangeTitle": {
+        "message": "Promena Dynamic Notch vrednosti"
+    },
+    "dialogDynFiltersChangeNote": {
+        "message": "<span class=\"message-negative\"><b>UPOZORENJE: Ova promena će uključiti\/isključiti RPM filtriranje, čime se povećava\/smanjuje kašnjenje\/efikasnost filtera.<\/b><\/span><br><br>Vratiti dinamičke notch filtere na preporučene vrednosti?"
+    },
+    "portsIdentifier": {
+        "message": "Identifikator"
+    },
+    "portsConfiguration": {
+        "message": "Konfiguracija\/MSP"
+    },
+    "portsSerialRx": {
+        "message": "Serial Rx"
+    },
+    "portsSerialRxHelp": {
+        "message": "Uključite ili isključite serijski prijemnik (RX) na navedenom UART-u. Dozvoljen je samo jedan."
+    },
+    "portsSensorIn": {
+        "message": "Ulaz senzora"
+    },
+    "portsTelemetryOut": {
+        "message": "Izlaz telemetrije"
+    },
+    "portsPeripherals": {
+        "message": "Periferije"
+    },
+    "portsHelp": {
+        "message": "<strong>Napomena:<\/strong> nisu sve kombinacije važeće. Kada firmver flight kontrolera ovo detektuje, konfiguracija serijskih portova će biti resetovana."
+    },
+    "portsVtxTableNotSet": {
+        "message": "<span class=\"message-negative\">UPOZORENJE:<\/span> VTX tabela nije ispravno podešena i bez nje VTX kontrola neće biti moguća. Molimo podesite VTX tabelu u kartici $t(tabVtx.message)."
+    },
+    "portsMSPHelp": {
+        "message": "<strong>Napomena:<\/strong> NE <span class=\"message-negative\">isključujte<\/span> MSP na prvom serijskom portu osim ako ne znate šta radite. U suprotnom ćete možda morati ponovo da instalirate firmver i obrišete konfiguraciju."
+    },
+    "portsReadOnlyHelp": {
+        "message": "<strong>Napomena:<\/strong> ovaj firmver dodeljuje serijske portove na sopstvenoj kartici svake funkcije, tako da je ovaj prikaz samo za čitanje. Prikazuje koji port trenutno koristi svaka funkcija; promenite dodelu na kartici koja sadrži tu funkciju."
+    },
+    "portsFirmwareUpgradeRequired": {
+        "message": "Nadogradnja firmvera je <span class=\"message-negative\">obavezna<\/span>. Konfiguracija serijskih portova za firmver &lt; 1.8.0 nije podržana."
+    },
+    "portsButtonSave": {
+        "message": "Sačuvaj i restartuj"
+    },
+    "portsTelemetryDisabled": {
+        "message": "Isključeno"
+    },
+    "portsFunction_MSP": {
+        "message": "MSP"
+    },
+    "portsFunction_GPS": {
+        "message": "GPS"
+    },
+    "portsFunction_TELEMETRY_FRSKY": {
+        "message": "FrSky"
+    },
+    "portsFunction_TELEMETRY_HOTT": {
+        "message": "HoTT"
+    },
+    "portsFunction_TELEMETRY_LTM": {
+        "message": "LTM"
+    },
+    "portsFunction_TELEMETRY_MAVLINK": {
+        "message": "MAVLink"
+    },
+    "portsFunction_TELEMETRY_MSP": {
+        "message": "MSP"
+    },
+    "portsFunction_TELEMETRY_SMARTPORT": {
+        "message": "SmartPort"
+    },
+    "portsFunction_TELEMETRY_IBUS": {
+        "message": "iBUS"
+    },
+    "portsFunction_TELEMETRY_JETIXBUS": {
+        "message": "JETIXBUS"
+    },
+    "portsFunction_TELEMETRY_CRSF": {
+        "message": "CRSF"
+    },
+    "portsFunction_TELEMETRY_SRXL": {
+        "message": "SRXL"
+    },
+    "portsFunction_ESC_SENSOR": {
+        "message": "ESC"
+    },
+    "portsFunction_RX_SERIAL": {
+        "message": "Serial RX"
+    },
+    "portsFunction_BLACKBOX": {
+        "message": "Blackbox snimanje"
+    },
+    "portsFunction_TBS_SMARTAUDIO": {
+        "message": "VTX (TBS SmartAudio)"
+    },
+    "portsFunction_IRC_TRAMP": {
+        "message": "VTX (IRC Tramp)"
+    },
+    "portsFunction_RUNCAM_DEVICE_CONTROL": {
+        "message": "Kamera (RunCam protokol)"
+    },
+    "portsFunction_FRSKY_OSD": {
+        "message": "OSD (FrSky protokol)"
+    },
+    "portsFunction_VTX_MSP": {
+        "message": "VTX (MSP + Displayport)"
+    },
+    "portsFunction_GIMBAL": {
+        "message": "Gimbal"
+    },
+    "portsFunction_OSD_CUSTOM_TEXT": {
+        "message": "Proizvoljni OSD tekst"
+    },
+    "pidTuningProfileOption": {
+        "message": "Profil $1"
+    },
+    "pidTuningRateProfileOption": {
+        "message": "Rateprofile $1"
+    },
+    "portsFunction_LIDAR_TF": {
+        "message": "Benewake LIDAR"
+    },
+    "pidTuningUpgradeFirmwareToChangePidController": {
+        "message": "<span class=\"message-negative\">Promena PID kontrolera je onemogućena - možete je promeniti putem CLI-ja.<\/span> Imate firmver sa verzijom API-ja <span class=\"message-negative\">$1<\/span>, ali ova funkcionalnost zahteva <span class=\"message-positive\">$2<\/span>."
+    },
+    "pidTuningSubTabPid": {
+        "message": "Podešavanja PID profila"
+    },
+    "pidTuningSubTabRates": {
+        "message": "Podešavanja Rate profila"
+    },
+    "pidTuningSubTabFilter": {
+        "message": "Podešavanja filtera"
+    },
+    "pidProfileName": {
+        "message": "Naziv PID profila"
+    },
+    "pidProfileNameHelp": {
+        "message": "Naziv PID profila koji može opisati za kakve je uslove ovaj profil podešen: lakša\/teža baterija, akciona kamera \/ bez akcione kamere, veća nadmorska visina itd."
+    },
+    "rateProfileName": {
+        "message": "Naziv Rate profila"
+    },
+    "rateProfileNameHelp": {
+        "message": "Naziv Rate profila koji može opisati za koju vrstu letenja je ovaj profil namenjen: filmsko snimanje, trke, freestyle itd."
+    },
+    "pidTuningShowAllPids": {
+        "message": "Prikaži sve PID-ove"
+    },
+    "pidTuningHideUnusedPids": {
+        "message": "Sakrij neiskorišćene PID-ove"
+    },
+    "pidTuningNonProfilePidSettings": {
+        "message": "Podešavanja PID kontrolera nezavisna od profila"
+    },
+    "pidTuningAntiGravity": {
+        "message": "Anti Gravity"
+    },
+    "pidTuningAntiGravityMode": {
+        "message": "Mod",
+        "description": "Anti Gravity mode selection parameter"
+    },
+    "pidTuningAntiGravityModeOptionSmooth": {
+        "message": "Ublaženo",
+        "description": "One of the modes of anti gravity"
+    },
+    "pidTuningAntiGravityModeOptionStep": {
+        "message": "Korak",
+        "description": "One of the modes of anti gravity"
+    },
+    "pidTuningAntiGravityGain": {
+        "message": "Gain",
+        "description": "Anti Gravity Gain Parameter"
+    },
+    "pidTuningAntiGravityGainHelp": {
+        "message": "Povećava iTerm i povećava P tokom brzih promena gasa.<br><br>8.0 znači oko 8x pojačanje iTerm-a",
+        "description": "Anti Gravity Gain Parameter Help Icon"
+    },
+    "pidTuningAntiGravityThres": {
+        "message": "Prag",
+        "description": "Anti Gravity Threshold Parameter"
+    },
+    "pidTuningAntiGravityHelp": {
+        "message": "Anti Gravity povećava I (i, u verziji 4.3, P) tokom i ubrzo nakon brzih promena gasa, povećavajući stabilnost položaja tokom naglog davanja gasa.<br><br>Veće vrednosti pojačanja mogu poboljšati stabilnost na letelicama sa slabijim odzivom ili onima sa pomerenim težištem."
+    },
+    "pidTuningDerivative": {
+        "message": "Derivativni",
+        "description": "Table header of the Derivative feature in the PIDs tab"
+    },
+    "pidTuningDMaxFeatureTitle": {
+        "message": "Dinamičko prigušenje \/ D Max podešavanja",
+        "description": "Title for the options panel for the D Max feature"
+    },
+    "pidTuningDMaxSettingTitle": {
+        "message": "Dinamičko<br>prigušenje",
+        "description": "Sidebar title for the options panel for the D Max feature"
+    },
+    "pidTuningDMaxGain": {
+        "message": "Gain",
+        "description": "Gain of the D Max feature"
+    },
+    "pidTuningDMaxGainHelp": {
+        "message": "D Max Gain povećava osetljivost sistema koji povećava D kada se letelica brzo okreće ili trese u vrtloženju propeler (propwash).<br><br>Veće vrednosti za Gain podižu D lakše nego manje vrednosti, brže približavajući D prema D Max. Vrednosti od 40 ili čak 50 mogu dobro raditi za čiste freestyle letelice.<br><br>Manje vrednosti neće podizati D prema D Max osim pri veoma brzim potezima, i mogu više odgovarati trkačkim podešavanjima smanjujući kašnjenje D parametra.<br><br>UPOZORENJE: Gain ili Advance mora biti podešen iznad oko 20, inače se D neće povećavati kako bi trebalo. Podešavanje oba na nulu zaključaće D na osnovnu vrednost.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningDMaxAdvance": {
+        "message": "Advance",
+        "description": "Advance of the D Max feature"
+    },
+    "pidTuningDMaxAdvanceHelp": {
+        "message": "D Max Advance dodaje osetljivost na Gain faktor kada se ručice brzo pomeraju.<br><br>Advance ne reaguje na žiroskop ili propwash. Deluje ranije od Gain faktora i povremeno je koristan za letelice sa slabim odzivom koje su sklone velikom kašnjenju na početku poteza.<br><br>Uglavnom ga je najbolje ostaviti na nuli.<br><br>UPOZORENJE: Advance ili Gain mora biti podešen iznad oko 20, inače se D neće povećavati kako bi trebalo. Podešavanje oba na nulu zaključaće D na osnovnu vrednost.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningDMaxFeatureHelp": {
+        "message": "D Max povećava D tokom bržih pokreta žiroskopa i\/ili komandi sa daljinskog.<br><br>Faktor 'Gain' povećava D kada se letelica brzo okreće ili trese u vrtloženju propeler (propwash). Obično je potreban samo 'Gain'.<br><br>Faktor 'Advance' povećava D prema D Max tokom komandi sa daljinskog. Obično nije potreban i treba ga podesiti na nulu. Advance može biti koristan za letelice sa slabim odzivom koje imaju tendenciju velikog prebacivanja (overshoot).<br><br>Veće vrednosti za Gain (npr. 40) mogu biti prikladnije za freestyle jer lakše podižu D.<br><br>UPOZORENJE: Jedan od parametara Gain ili Advance mora biti podešen iznad oko 20, inače se D neće povećavati kako bi trebalo. Podešavanje oba na nulu zaključaće D na osnovnu vrednost.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningPidSettings": {
+        "message": "Podešavanja PID kontrolera"
+    },
+    "pidTuningMotorSettings": {
+        "message": "Podešavanja gasa i motora"
+    },
+    "pidTuningMiscSettings": {
+        "message": "Razna podešavanja"
+    },
+    "receiverRcSmoothing": {
+        "message": "RC ublažavanje"
+    },
+    "receiverRcSmoothingAuto": {
+        "message": "Automatski"
+    },
+    "receiverRcSmoothingManual": {
+        "message": "Ručno"
+    },
+    "receiverRcSmoothingAutoFactor": {
+        "message": "Setpoint Auto faktor",
+        "description": "Setpoint Auto Factor parameter for RC smoothing"
+    },
+    "receiverRcSmoothingAutoFactorHelp": {
+        "message": "Podešava izračunavanje Setpoint Auto faktora, 10 je fabrički odnos faktora i kašnjenja. Povećanje broja će više ublažiti komande sa daljinskog, istovremeno dodajući kašnjenje. Ovo može biti korisno za nepouzdane RC veze ili za filmsko snimanje.<br>Budite oprezni sa brojevima koji se približavaju 50, kašnjenje unosa će postati primetno.<br>Koristite CLI komandu rc_smoothing_info dok su TX i RX uključeni da biste videli automatski izračunate granične frekvencije RC ublažavanja.",
+        "description": "Setpoint Auto Factor parameter help message"
+    },
+    "receiverRcSmoothingAutoFactorHelp2": {
+        "message": "Podešava Setpoint RC ublažavanje. 30 je fabričko. Veće vrednosti više ublažavaju komande sa daljinskog – npr. 60 za HD freestyle ili 90-120 za filmsko snimanje. Napomena: Vrednosti preko 50 će izazvati primetno kašnjenje ručice. Niže vrednosti, npr. 20-25, preneće neke od koraka RC kontrole u signale motora, blago povećavajući toplotu motora, ali će blago smanjiti RC kašnjenje. Ovo može biti korisno za trke.",
+        "description": "Setpoint Auto Factor parameter help message"
+    },
+    "receiverRcSmoothingAutoFactorThrottle": {
+        "message": "Throttle Auto faktor",
+        "description": "Throttle Auto Factor parameter for RC smoothing"
+    },
+    "receiverRcSmoothingAutoFactorThrottleHelp": {
+        "message": "Podešava izračunavanje Throttle faktora, 10 je fabrički odnos faktora i kašnjenja. Povećanje broja će više ublažiti komande gasa, istovremeno dodajući kašnjenje. Ovo može biti korisno za nepouzdane RC veze ili za filmsko snimanje.<br>Budite oprezni sa brojevima koji se približavaju 50, kašnjenje unosa će postati primetno.<br>Koristite CLI komandu rc_smoothing_info dok su TX i RX uključeni da biste videli automatski izračunate granične frekvencije RC ublažavanja.",
+        "description": "Throttle Auto Factor parameter help message"
+    },
+    "receiverRcFeedforwardTypeSelect": {
+        "message": "Feedforward vrsta graničnika"
+    },
+    "receiverRcSetpointTypeSelect": {
+        "message": "Setpoint vrsta graničnika"
+    },
+    "receiverThrottleTypeSelect": {
+        "message": "Throttle vrsta graničnika"
+    },
+    "receiverRcSmoothingInterpolation": {
+        "message": "Interpolacija"
+    },
+    "receiverRcSmoothingFilter": {
+        "message": "Filter"
+    },
+    "rcSmoothingSetpointCutoffHelp": {
+        "message": "Granična frekvencija u Hz koju koristi filter Setpoint-a. Korišćenje manjih vrednosti rezultiraće ublaženijim komandama sa daljinskog i pogodnije je za sporije protokole prijemnika. Većina korisnika treba da ostavi ovo na 0 što odgovara opciji „Auto”."
+    },
+    "rcSmoothingFeedforwardCutoffHelp": {
+        "message": "Granična frekvencija u Hz koju koristi Feedforward filter. Korišćenje manjih vrednosti rezultiraće ublaženijim komandama sa daljinskog i pogodnije je za sporije protokole prijemnika. Većina korisnika treba da ostavi ovo na 0 što odgovara opciji „Auto”."
+    },
+    "rcSmoothingChannelsSmoothedHelp": {
+        "message": "Kanali na koje se primenjuje ublažavanje"
+    },
+    "receiverRcSmoothingSetpointManual": {
+        "message": "Određuje da li se granična frekvencija Setpoint filtera automatski izračunava (preporučeno) ili je korisnik ručno bira. Korišćenje „Ručno“ se ne preporučuje za protokole prijemnika kao što je Crossfire koji se mogu menjati tokom leta."
+    },
+    "receiverRcSmoothingFeedforwardManual": {
+        "message": "Određuje da li se granična frekvencija Feedforward filtera automatski izračunava (preporučeno) ili je korisnik ručno bira. Korišćenje „Ručno“ se ne preporučuje za protokole prijemnika kao što je Crossfire koji se mogu menjati tokom leta."
+    },
+    "receiverRcSmoothingThrottleManual": {
+        "message": "Određuje da li se RC ublažavanje automatski izračunava (preporučeno) ili je korisnik ručno bira. Korišćenje „Ručno“ se ne preporučuje za protokole prijemnika kao što je Crossfire koji se mogu menjati tokom leta."
+    },
+    "rcSmoothingThrottleCutoffHelp": {
+        "message": "Granična frekvencija u Hz koju koristi filter za ublažavanje gasa. Korišćenje manjih vrednosti rezultiraće ublaženijim komandama gasa i pogodnije je za sporije protokole prijemnika. Većina korisnika treba da ostavi ovo na 0 što odgovara opciji „Auto”."
+    },
+    "receiverRcSmoothingSetpointHz": {
+        "message": "Setpoint granična frekvencija"
+    },
+    "receiverRcSmoothingThrottleCutoffHz": {
+        "message": "Throttle granična frekvencija"
+    },
+    "receiverRcSmoothingFeedforwardCutoff": {
+        "message": "Feedforward granična frekvencija"
+    },
+    "receiverRcFeedforwardType": {
+        "message": "Feedforward vrsta filtera"
+    },
+    "receiverRcSmoothingFeedforwardTypeAuto": {
+        "message": "Automatski"
+    },
+    "pidTuningDtermSetpointTransition": {
+        "message": "D Setpoint prelaz"
+    },
+    "pidTuningDtermSetpoint": {
+        "message": "D Setpoint težina"
+    },
+    "pidTuningDtermSetpointTransitionHelp": {
+        "message": "Pomoću ovog parametra, D Setpoint težina se može smanjiti blizu centra ručica, što rezultira ublaženijim završetkom okreta (flips i rolls).<br> Vrednost predstavlja tačku otklona ručice: 0 – ručica u centru, 1 – pun otklon. Kada je ručica iznad te tačke, Setpoint težina ostaje konstantna na svojoj podešenoj vrednosti. Kada je ručica ispod te tačke, Setpoint težina se proporcionalno smanjuje i dostiže 0 u centralnom položaju ručice.<br>Vrednost 1 daje maksimalan efekat ublažavanja, dok vrednost 0 zadržava fiksnu Setpoint težinu na podešenoj vrednosti tokom celog opsega ručice."
+    },
+    "pidTuningDtermSetpointHelp": {
+        "message": "Ovaj parametar određuje efekat ubrzanja ručice unutar izvodne komponente.<br> Vrednost 0 je stara Measurement metoda gde D prati samo žiroskop. Vrednost 1 je stara Error metoda, koja koristi jednak odnos praćenja žiroskopa i ručice.<br> Manje vrednosti daju sporiji, ublaženiji odziv ručice, dok veće vrednosti pružaju veći odziv na ubrzanje ručice.<br>Imajte na umu da se preporučuje RC interpolacija kada koristite veće vrednosti kako bi se sprečili trzaji komandi koji stvaraju šum."
+    },
+    "pidTuningDtermSetpointTransitionWarning": {
+        "message": "<span class=\"message-negative\"><strong>$t(warningTitle.message):<\/strong> Upotreba D Setpoint prelaza većeg od 0 i manjeg od 0.1 se izričito ne preporučuje. To može dovesti do nestabilnosti i smanjene odzivnosti ručica kada prelaze preko centralne tačke.<\/span>"
+    },
+    "pidTuningFeedforwardGroup": {
+        "message": "Feed-<br>forward"
+    },
+    "pidTuningFeedforwardGroupHelp": {
+        "message": "Feedforward prilagođava odzivnost ručica.<br \/><br \/> Ove opcije Vam omogućavaju da ga podesite za bilo šta, od oštrog i trenutnog odziva ručica za trke, do mekog i ublaženog odziva za filmsko snimanje \/ HD svrhe."
+    },
+    "pidTuningFeedforwardJitter": {
+        "message": "Redukcija podrhtavanja"
+    },
+    "pidTuningFeedforwardJitterHelp": {
+        "message": "Redukcija podrhtavanja smanjuje Feedforward kada se ručice pomeraju polako, bez obzira na njihov položaj.<br><br>Ovo omogućava ublažen let bez podrhtavanja pri pravljenju blagih i sporih lukova, dok pruža pun Feedforward bez ikakvog kašnjenja kada se ručice brzo pomere. Prelaz nije potreban i treba ga postaviti na nulu kada je redukcija podrhtavanja aktivna.<br><br>Fabrička vrednost je 7. Veće vrednosti, npr. 10–12, dobre su za filmsko snimanje ili HD freestyle svrhe, dok 5 može biti bolje za trke sa brzim RC vezama."
+    },
+    "pidTuningFeedforwardSmoothFactor": {
+        "message": "Ublaženost"
+    },
+    "pidTuningFeedforwardSmoothnessHelp": {
+        "message": "Ublažavanje Feedforward-a je ključno za prigušivanje šuma u Feedforward liniji.<br><br>Najmanja vrednost koja daje glatku liniju je najbolja.<br><br>Fabrička vrednost od 25 je dobra za RC veze od 50–150 Hz. Za RC veze od 250 Hz koristite 40–50. Za veze od 500 Hz koristite 60–65."
+    },
+    "pidTuningFeedforwardAveraging": {
+        "message": "Izračunavanje proseka"
+    },
+    "pidTuningFeedforwardAveragingHelp": {
+        "message": "Izračunavanje proseka Feedforward-a uzima prosečnu vrednost poslednja 2 ili 3 Feedforward koraka. Ovo ublažava Feedforward liniju, ali dodaje malo kašnjenja.<br><br>Najefikasnije je kada postoji sekvencijalno podrhtavanje gore\/dole u signalu, što je uobičajeno kod bržih RC veza.<br><br>Prosek od 2 tačke je potreban za veze od 500 Hz i bučne veze od 250 Hz, ili za letenje radi filmskog snimanja \/ HD-a. Crossfire (pre CRSFShot-a) zahteva prosek od 3 tačke u režimu od 150 Hz."
+    },
+    "pidTuningOptionOff": {
+        "message": "Isključeno"
+    },
+    "pidTuningOptionOn": {
+        "message": "Uključeno"
+    },
+    "pidTuningFeedforwardAveragingOption2Point": {
+        "message": "2 tačke"
+    },
+    "pidTuningFeedforwardAveragingOption3Point": {
+        "message": "3 tačke"
+    },
+    "pidTuningFeedforwardAveragingOption4Point": {
+        "message": "4 tačke"
+    },
+    "pidTuningFeedforwardBoost": {
+        "message": "Boost"
+    },
+    "pidTuningFeedforwardBoostHelp": {
+        "message": "Feedforward boost dodaje dodatni potisak kao odgovor na ubrzanje ili usporenje ručice.<br><br>Ovo smanjuje kašnjenje žiroskopa uzrokovano kašnjenjem ubrzanja motora i smanjuje overshoot kada se ručice usporavaju snažnim povlačenjem motora.<br><br>Fabrički boost radi za većinu konfiguracija. Trkački piloti možda više vole da ga malo povećaju. Boost se može fino podesiti pažljivom analizom logova."
+    },
+    "pidTuningFeedforwardMaxRateLimit": {
+        "message": "Max Rate Limit"
+    },
+    "pidTuningFeedforwardMaxRateLimitHelp": {
+        "message": "Smanjuje Feedforward kako se ručice približavaju maksimalnom otklonu, kako bi se smanjio overshoot na početku flipa ili rolla.<br><br>Ne radi ništa na kraju flipa ili rolla. Niže vrednosti uzrokuju da slabljenje počne ranije.<br><br>Obično ova vrednost ne zahteva izmene. Najbolja je najviša vrednost koja daje prihvatljiv overshoot na početku roll-ova ili flip-ova."
+    },
+    "pidTuningFeedforwardTransition": {
+        "message": "Prelaz"
+    },
+    "pidTuningFeedforwardTransitionHelp": {
+        "message": "Linearno smanjuje Feedforward kada su ručice blizu centra.<br><br>U verziji 4.2 i ranijim, transition se može koristiti za glađi odziv ručice oko centralnog položaja.<br><br>U verziji 4.3, transition se ne preporučuje, jer je 'zamenjen' funkcijom za smanjenje podrhtavanja (jitter).<br><br>Vrednost 0 isključuje transition. Vrednost 0.3 smanjuje Feedforward na nulu kada su ručice tačno u centru, ali se povećava na punu normalnu vrednost kada su ručice >30% van centra."
+    },
+    "pidTuningProportional": {
+        "message": "<b>P<\/b>roportional"
+    },
+    "pidTuningProportionalHelp": {
+        "message": "Koliko čvrsto letelica prati ručice (Setpoint).<br \/><br \/>Više vrednosti (pojačanja) pružaju preciznije praćenje, ali mogu izazvati overshoot ako su prevelike u odnosu na D, i mogu izazvati oscilacije u zaokretima sa velikim gasom. Zamislite P kao oprugu na automobilu.",
+        "description": "Proportional Term helpicon message on PID table titlebar"
+    },
+    "pidTuningIntegral": {
+        "message": "<b>I<\/b>ntegral"
+    },
+    "pidTuningIntegralHelp": {
+        "message": "Kontroliše trajna mala odstupanja.<br><br>Slično kao P, ali se akumulira postepeno i polako dok greška ne bude nula. Važno za dugotrajnije uticaje kao što su pomeren težište ili stalni spoljni uticaji poput vetra.<br \/><br \/>Veća pojačanja pružaju preciznije praćenje, posebno u zaokretima, ali letelica može delovati kruto.<br><br>Može izazvati spore oscilacije kod letelica sa slabijim odzivom ili ako je visoko u odnosu na P.",
+        "description": "Integral Term helpicon message on PID table titlebar"
+    },
+    "pidTuningDMax": {
+        "message": "<b>D<\/b> Max"
+    },
+    "pidTuningDMaxHelp": {
+        "message": "Pruža jače prigušenje za brze manevre koji bi inače mogli izazvati overshoot.<br><br>Omogućava nižu osnovnu D min vrednost nego obično, čineći da se motori manje greju i da ulazak u zaokret bude brži, ali podiže D radi kontrole overshoot-a pri flipovima ili brzim promenama smera.<br><br>Najkorisnije za trkače, bučne letelice ili letelice sa slabim odzivom.",
+        "description": "D Max Term helpicon message on PID table titlebar"
+    },
+    "pidTuningDerivativeHelp": {
+        "message": "Kontroliše jačinu prigušenja BILO KOG kretanja letelice. Za pomeranje ručica, D-član prigušuje komandu. Za spoljne uticaje (propwash ILI udar vetra) D-član prigušuje taj uticaj.<br><br>Veća pojačanja daju više prigušenja i smanjuju overshoot izazvan P-članom i FF-om.<br>Međutim, D-član je VEOMA osetljiv na visokofrekventne vibracije žiroskopa (šum | uvećava ih 10x do 100x).<br><br>Visokofrekventni šum može izazvati grejanje motora i pregorevanje motora ako su D-pojačanja previsoka ili ako šum žiroskopa nije dobro filtriran (pogledajte karticu Filteri).<br><br>Zamislite D-član kao amortizer na automobilu, ali sa negativnim svojstvom da uvećava visokofrekventni šum žiroskopa.",
+        "description": "Derivative Term helpicon message on PID table titlebar"
+    },
+    "pidTuningFeedforward": {
+        "message": "<b>F<\/b>eedforward"
+    },
+    "pidTuningFeedforwardHelp": {
+        "message": "Dodatni faktor upravljanja, izveden isključivo iz komandi sa ručice, koji pomaže da se letelica brzo pokrene pri brzim pomeranjima ručice.<br><br>FF ne može izazvati oscilacije, omogućava niži P za sličan odziv ručice i kompenzuje prirodno protivljenje D-člana komandama sa ručice.<br><br>Niske ili nulte vrednosti rezultiraće blažim, ali odloženijim odzivom na komande sa ručice.",
+        "description": "Feedforward Term helpicon message on PID table titlebar"
+    },
+    "pidTuningMaxRateWarning": {
+        "message": "<span class=\"message-negative\"><b>Upozorenje:<\/b><\/span> veoma visoki rates mogu dovesti do desinhronizacije usled naglih usporenja."
+    },
+    "pidTuningRcRate": {
+        "message": "RC Rate"
+    },
+    "pidTuningMaxVel": {
+        "message": "Max Vel [deg\/s]"
+    },
+    "pidTuningRate": {
+        "message": "Rate"
+    },
+    "pidTuningSuperRate": {
+        "message": "Super Rate"
+    },
+    "pidTuningRatesPreview": {
+        "message": "Pregled rejtova"
+    },
+    "pidTuningRatesModelPreview": {
+        "message": "Pregled modela rejtova"
+    },
+    "pidTuningRatesTuningHelp": {
+        "message": "<b>Rates i Expo<\/b>: Odredite osećaj na ručici na osnovu ovih parametara. Koristite grafik i 3D model uživo da pronađete Vaša omiljena rate podešavanja."
+    },
+    "pidTuningRcExpo": {
+        "message": "RC Expo"
+    },
+    "pidTuningTpaGroup": {
+        "message": "TPA"
+    },
+    "pidTuningTPAMode": {
+        "message": "TPA Mode"
+    },
+    "pidTuningTPA": {
+        "message": "TPA"
+    },
+    "pidTuningTPARate": {
+        "message": "TPA Rate (%)"
+    },
+    "pidTuningTPABreakPoint": {
+        "message": "TPA Breakpoint (μs)"
+    },
+    "pidTuningTPAPD": {
+        "message": "PD"
+    },
+    "pidTuningTPAD": {
+        "message": "D"
+    },
+    "pidTuningThrottleCurvePreview": {
+        "message": "Pregled krive gasa"
+    },
+    "pidTuningThrottleLimitType": {
+        "message": "Ograničenje gasa"
+    },
+    "pidTuningThrottleLimitPercent": {
+        "message": "Ograničenje gasa %"
+    },
+    "pidTuningThrottleLimitTypeOff": {
+        "message": "Isključeno"
+    },
+    "pidTuningThrottleLimitTypeScale": {
+        "message": "SCALE"
+    },
+    "pidTuningThrottleLimitTypeClip": {
+        "message": "CLIP"
+    },
+    "pidTuningThrottleLimitTypeTip": {
+        "message": "Izaberite vrstu ograničenja gasa. <b>ISKLJUČENO<\/b> isključuje funkciju, <b>SCALE<\/b> transformiše opseg gasa od 0 do izabranog procenta koristeći pun hod ručice, <b>CLIP<\/b> postavlja maksimalni procenat gasa, a hod ručice preko toga neće imati dodatnog efekta"
+    },
+    "pidTuningThrottleLimitPercentTip": {
+        "message": "Podesite željeni procenat ograničenja gasa. Postavljanje na 100% isključuje funkciju."
+    },
+    "pidTuningFilter": {
+        "message": "Filter"
+    },
+    "pidTuningFilterFrequency": {
+        "message": "Frekvencija"
+    },
+    "pidTuningRatesCurve": {
+        "message": "Pregled rejtova"
+    },
+    "throttle": {
+        "message": "Gas"
+    },
+    "pidTuningButtonSave": {
+        "message": "Sačuvaj"
+    },
+    "pidTuningButtonRefresh": {
+        "message": "Osveži"
+    },
+    "pidTuningProfileHead": {
+        "message": "Profil"
+    },
+    "pidTuningControllerHead": {
+        "message": "PID kontroler"
+    },
+    "pidTuningCopyProfile": {
+        "message": "Kopiraj profil"
+    },
+    "pidTuningCopyRateProfile": {
+        "message": "Kopiraj rateprofile"
+    },
+    "dialogCopyProfileText": {
+        "message": "Kopiraj vrednosti iz trenutnog profila u"
+    },
+    "dialogCopyRateProfileText": {
+        "message": "Kopiraj vrednosti iz trenutnog rateprofile-a u"
+    },
+    "dialogCopyProfileTitle": {
+        "message": "Kopiranje vrednosti profila"
+    },
+    "dialogCopyProfileNote": {
+        "message": "Sve vrednosti na ciljnom profilu biće obrisane i presnimljene"
+    },
+    "dialogCopyProfileConfirm": {
+        "message": "Kopiraj"
+    },
+    "dialogCopyProfileClose": {
+        "message": "Otkaži"
+    },
+    "pidTuningResetPidProfile": {
+        "message": "Resetuj ovaj profil"
+    },
+    "pidTuningPidProfileReset": {
+        "message": "Učitane su fabričke vrednosti za trenutni PID profil."
+    },
+    "pidTuningReceivedProfile": {
+        "message": "Flight kontroler je postavio profil: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningReceivedRateProfile": {
+        "message": "Flight kontroler je postavio Rateprofile: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningLoadedProfile": {
+        "message": "Učitan profil: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningLoadedRateProfile": {
+        "message": "Učitan Rateprofile: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningDataRefreshed": {
+        "message": "PID podaci su <strong>osveženi<\/strong>"
+    },
+    "tuningHelp": {
+        "message": "<b>Saveti za podešavanje<\/b><br \/><span class=\"message-negative\">VAŽNO:<\/span> Važno je proveriti temperaturu motora tokom prvih letova. Što je vrednost filtera veća, letelica može bolje leteti, ali ćete takođe uneti više šuma u motore. <br>Fabrička vrednost od 100Hz je optimalna, ali za bučnije sisteme možete pokušati sa smanjenjem Dterm filtera na 50Hz i eventualno žiroskopskog filtera."
+    },
+    "tuningHelpSliders": {
+        "message": "Koristite klizače za prilagođavanje Vaših filtera. Klizači moraju biti isključeni da biste vršili ručne izmene.<br>Pomeranje klizača udesno daje više granične vrednosti i može poboljšati propwash, ali će propustiti više šuma do motora, čineći ih toplijim.<br>Većina čistih izrada sa RPM filtriranjem biće u redu sa klizačem za gyro lowpass sasvim udesno, ili sa samo aktivnim lowpass 2 i klizačima u sredini.<br><strong>UPOZORENJE:<\/strong> Budite VEOMA oprezni kada pomerate D klizače udesno. Proverite temperaturu motora nakon svake promene.<br><strong>Napomena:<\/strong> Promena profila menja samo podešavanja D-term filtera. Podešavanja žiroskopskog filtera su ista za sve profile.",
+        "description": "Filter tuning subtab note"
+    },
+    "filterWarning": {
+        "message": "<span class=\"message-negative\"><b>Upozorenje:<\/b><\/span> Količina filtriranja koju koristite je opasno niska. Ovo verovatno može otežati upravljanje letelicom i može dovesti do nekontrolisanog odletanja. Izuzetno se preporučuje da <b>uključite bar jedan od Gyro Dynamic Lowpass ili Gyro Lowpass 1 i bar jedan od D-Term Dynamic Lowpass ili D Term Lowpass 1<\/b>."
+    },
+    "pidTuningSliders": {
+        "message": "Klizači za PID podešavanje"
+    },
+    "pidTuningSliderPidsMode": {
+        "message": "Mod:",
+        "description": "Pidtuning slider mode can be OFF, RP or RPY"
+    },
+    "pidTuningSliderModeHelp": {
+        "message": "<strong>Mod klizača za PID podešavanje<\/strong><br><br>Mod klizača za PID podešavanje može biti:<br><br>&bull; ISKLJUČENO - bez klizača, unesite vrednosti ručno<br>&bull; RP - klizači kontrolišu samo Roll i Pitch, unesite Yaw vrednosti ručno<br>&bull; RPY - klizači kontrolišu sve PID vrednosti<br><br><span class=\"message-negative\"><b>Upozorenje:<\/b><\/span> Prelazak sa RP na RPY mod će prepisati Yaw podešavanja podešavanjima firmvera."
+    },
+    "receiverHelpModelId": {
+        "message": "Ako podesite Model Match ispod na broj različit od 255, možete navesti broj prijemnika na stranici za podešavanje modela u OpenTX\/EdgeTX i uključiti Model Match u ELRS LUA skripti za taj model. Model match je između 0 i 63, uključujući oba.<br \/>Pogledajte ELRS dokumentaciju za više informacija."
+    },
+    "receiverModelId": {
+        "message": "Model Match ID"
+    },
+    "receiverHelp": {
+        "message": "&#8226;  <b><strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Failsafe#testing-failsafe\" target=\"_blank\" rel=\"noopener noreferrer\">Uvek proverite da li Vam Failsafe radi ispravno!<\/a><\/strong><\/b> Podešavanja su na kartici Failsafe, za koju je potreban Ekspertski mod.<br> &#8226; <b>Koristite najnoviji firmver za predajnik!<\/b><br> &#8226; <strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Rx#disabling-the-opentxedgetx-adc-filter\" target=\"_blank\" rel=\"noopener noreferrer\">Isključite hardverski ADC filter<\/a><\/strong> u predajniku ako koristite OpenTx ili EdgeTx.<br>Osnovno podešavanje: Ispravno konfigurišite podešavanja 'Prijemnika'. Izaberite ispravnu 'Mapu kanala' za Vaš radio. Proverite da li se grafici za Roll, Pitch i ostale komande pomeraju ispravno. Podesite krajnje tačke kanala ili vrednosti opsega u predajniku na ~1000 do ~2000, i podesite središnju tačku na 1500. Za više informacija, pročitajte <strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Rx\" target=\"_blank\" rel=\"noopener noreferrer\">dokumentaciju<\/a><\/strong>."
+    },
+    "receiverFailsafeActiveTitle": {
+        "message": "Failsafe aktivan"
+    },
+    "receiverFailsafeActiveWarning": {
+        "message": "Flight kontroler je u failsafe režimu. Vrednosti kanala prikazane ispod su failsafe izlaz, a ne žive vrednosti koje dolaze sa Vašeg prijemnika. Proverite vezu prijemnika i failsafe podešavanja."
+    },
+    "receiverThrottleMid": {
+        "message": "Throttle MID"
+    },
+    "receiverThrottleExpo": {
+        "message": "Throttle EXPO"
+    },
+    "receiverThrottleHover": {
+        "message": "Tačka lebdenja"
+    },
+    "receiverStickRange": {
+        "message": "Opseg ručice"
+    },
+    "receiverStickMin": {
+        "message": "Prag 'ručica nisko'"
+    },
+    "receiverHelpStickMin": {
+        "message": "Maksimalna vrednost (u us) da bi se ručica prepoznala kao niska \/ leva za komandni unos (MIN_CHECK)."
+    },
+    "receiverStickCenter": {
+        "message": "Centar ručice"
+    },
+    "receiverHelpStickCenter": {
+        "message": "Vrednost (u us) koja se koristi za određivanje da li je ručica centrirana (MID_RC)."
+    },
+    "receiverStickMax": {
+        "message": "Prag 'ručica visoko'"
+    },
+    "receiverHelpStickMax": {
+        "message": "Minimalna vrednost (u us) da bi se ručica prepoznala kao visoka \/ desna za komandni unos (MAX_CHECK)."
+    },
+    "receiverDeadband": {
+        "message": "RC mrtva zona"
+    },
+    "receiverHelpDeadband": {
+        "message": "Ovo su vrednosti (u us) za koliko se RC komanda može razlikovati pre nego što se smatra validnom. Za predajnike sa podrhtavanjem na izlazima, ova vrednost se može povećati ako se RC komande trzaju dok su u mirovanju."
+    },
+    "receiverYawDeadband": {
+        "message": "Yaw mrtva zona"
+    },
+    "receiverHelpYawDeadband": {
+        "message": "Ovo su vrednosti (u us) za koliko se RC komanda može razlikovati pre nego što se smatra validnom. Za predajnike sa podrhtavanjem na izlazima, ova vrednost se može povećati ako se RC komande trzaju dok su u mirovanju. <strong>Ovo podešavanje je samo za Yaw.<\/strong>"
+    },
+    "recevier3dDeadbandThrottle": {
+        "message": "3D Throttle mrtva zona"
+    },
+    "receiverHelp3dDeadbandThrottle": {
+        "message": "Ovo su vrednosti (u us). Da biste proširili neutralnu zonu, povećajte vrednost. <strong>Ovo podešavanje je samo za 3D gas.<\/strong>"
+    },
+    "receiverChannelMap": {
+        "message": "Mapa kanala"
+    },
+    "receiverChannelDefaultOption": {
+        "message": "Fabričko"
+    },
+    "receiverChannelMapTitle": {
+        "message": "Možete definisati sopstvenu mapu kanala klikom unutar polja"
+    },
+    "receiverRssiChannel": {
+        "message": "RSSI kanal"
+    },
+    "receiverRssiChannelDisabledOption": {
+        "message": "Isključeno"
+    },
+    "receiverRefreshRateTitle": {
+        "message": "Brzina osvežavanja grafika"
+    },
+    "receiverResetRefreshRate": {
+        "message": "Vrati na fabričko"
+    },
+    "receiverResetRefreshRateTitle": {
+        "message": "Vrati učestanost osvežavanja na fabričko"
+    },
+    "receiverRowContainerRoll": {
+        "message": "Roll [A]:",
+        "description": "Roll label in signal graph"
+    },
+    "receiverRowContainerPitch": {
+        "message": "Pitch [E]:",
+        "description": "Pitch label in signal graph"
+    },
+    "receiverRowContainerYaw": {
+        "message": "Yaw [R]:",
+        "description": "Yaw label in signal graph"
+    },
+    "receiverRowContainerThrottle": {
+        "message": "Throttle [T]:",
+        "description": "Throttle label in signal graph"
+    },
+    "receiverButtonSave": {
+        "message": "Sačuvaj"
+    },
+    "receiverButtonRefresh": {
+        "message": "Osveži"
+    },
+    "receiverButtonBind": {
+        "message": "Bindovanje prijemnika"
+    },
+    "receiverButtonBindMessage": {
+        "message": "Zahtev za bindovanje poslat flight kontroleru."
+    },
+    "receiverButtonBindingPhrase": {
+        "message": "Bind fraza"
+    },
+    "receiverButtonSticks": {
+        "message": "Simulator daljinskog",
+        "description": "Button that opens a window with a radio emulator on the receiver tab. Actually only enabled for MSP protocol"
+    },
+    "receiverDataRefreshed": {
+        "message": "Podaci o podešavanju komandi su <strong>osveženi<\/strong>"
+    },
+    "receiverModelPreview": {
+        "message": "Pregled"
+    },
+    "receiverMspWarningText": {
+        "message": "Ove ručice omogućavaju da se Betaflight armuje i isproba bez daljinskog i prijemnika. Ipak, <strong>ovo nije namenjeno za let i propeleri ne smeju biti postavljeni.<\/strong><br \/><br \/>Ova mogućnost ne jemči pouzdano upravljanje dronom. <strong>Ako propeleri ostanu na dronu, vrlo verovatno će doći do ozbiljne povrede.<\/strong>"
+    },
+    "receiverMspEnableButton": {
+        "message": "Uključi upravljanje"
+    },
+    "auxiliaryHelp": {
+        "message": "Modove podešavate opsegom ili vezom ka drugom modu (veze rade od Betaflight-a 4.0 naviše). <strong>Opsegom<\/strong> zadajete koji prekidač na daljinskom uključuje koji mod: kada vrednost kanala padne unutar zadatog opsega, mod se uključuje. <strong>Vezom<\/strong> uključujete jedan mod onda kada se uključi drugi. <strong>Izuzeci:<\/strong> ARM se ne može vezati ni na jedan mod ni sa jednog moda, i mod se ne može vezati na mod koji je i sam zadat vezom. Za isti mod može se zadati više opsega ili veza. Kada ih ima više, svaki se označava sa <strong>I<\/strong> ili <strong>ILI<\/strong>. Mod se uključuje kada:<br \/>- su aktivni SVI opsezi i veze označeni sa <strong>I<\/strong>; ili<br \/>- je aktivan bar jedan opseg ili veza označen sa <strong>ILI<\/strong>.<br \/><br \/>Ne zaboravite da sačuvate podešavanja dugmetom Sačuvaj."
+    },
+    "auxiliaryToggleUnused": {
+        "message": "Sakrij nekorišćene modove"
+    },
+    "auxiliaryMin": {
+        "message": "Min"
+    },
+    "auxiliaryMax": {
+        "message": "Maks"
+    },
+    "auxiliaryDisabled": {
+        "message": "(ISKLJUČENO)",
+        "description": "Text to add to the ARM mode (maybe others in the future) in the MODES TAB when it has been disabled for some external reason"
+    },
+    "auxiliaryAddRange": {
+        "message": "Add Range"
+    },
+    "auxiliaryAddLink": {
+        "message": "Add Link"
+    },
+    "auxiliaryButtonSave": {
+        "message": "Sačuvaj"
+    },
+    "auxiliaryAutoChannelSelect": {
+        "message": "AUTO"
+    },
+    "auxiliaryLinkNone": {
+        "message": "Ništa"
+    },
+    "auxiliaryModeLogicOR": {
+        "message": "ILI"
+    },
+    "auxiliaryModeLogicAND": {
+        "message": "I"
+    },
+    "auxiliaryHelpMode_3DDISABLE": {
+        "message": "Omogućava obrtanje motora u oba smera, za negativan potisak i let naopako. Gas prelazi u opseg od −100 do +100 umesto od 0 do 100.",
+        "description": "Help text to 3D mode"
+    },
+    "auxiliaryHelpMode_ACROTRAINER": {
+        "message": "Ograničava koliko dron sme da se nagne dok letite u akro modu — za uvežbavanje.",
+        "description": "Help text to ACRO TRAINER mode"
+    },
+    "auxiliaryHelpMode_ARM": {
+        "message": "Uključuje motore i omogućava letenje",
+        "description": "Help text to ARM mode"
+    },
+    "auxiliaryHelpMode_ANGLE": {
+        "message": "Samonivelišući mod: ručice za nagib određuju ugao između drona i vodoravne ravni, a dron se sam vraća u ravan položaj kada ručice pustite.",
+        "description": "Help text to ANGLE mode"
+    },
+    "auxiliaryHelpMode_ANTIGRAVITY": {
+        "message": "Režim leta koji povećava P i I član pri naglim promenama gasa, da bi se poboljšalo praćenje ručice i sprečilo zanošenje nosa.",
+        "description": "Help text to ANTIGRAVITY mode"
+    },
+    "auxiliaryHelpMode_AIRMODE": {
+        "message": "U uobičajenom rasporedu motora, kada se izračunaju komande za nagibe i okretanje pa jedan motor dođe do svog gornjeg ograničenja, svim motorima se snaga smanjuje podjednako. Kada motor padne ispod najmanje vrednosti, biva odsečen. Zamislite da je gas tek malo iznad dna a Vi zatražite brz prevrtaj: pošto dva motora ne mogu niže, dobijate upola manju snagu, dakle upola slabije dejstvo regulatora. Ako bi Vaša komanda tražila razliku veću od sto posto između najbržeg i najsporijeg motora, sporiji bi bili odsečeni, čime se ravnoteža motora narušava jer se dejstvo smanjuje neravnomerno",
+        "description": "Help text to AIRMODE mode"
+    },
+    "auxiliaryHelpMode_ALTHOLD": {
+        "message": "<a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Position-Hold-2025-12#altitude-hold\" target=\"_blank\" rel=\"noopener noreferrer\">Zadržavanje visine<\/a> aktivno drži dron na istoj visini, koristeći spoljne senzore zajedno sa ANGLE modom.",
+        "description": "Help text for ALTITUDE HOLD mode"
+    },
+    "auxiliaryHelpMode_AUTOPILOT": {
+        "message": "Samostalno upravljanje letom: spaja zadržavanje visine i zadržavanje položaja, radi mirnog lebdenja u mestu ili praćenja unapred zadate putanje leta.",
+        "description": "Help text for AUTOPILOT mode"
+    },
+    "auxiliaryHelpMode_BEEPER": {
+        "message": "Uključuje piskalicu — korisno za pronalaženje drona posle pada.",
+        "description": "Help text to BEEPER mode"
+    },
+    "auxiliaryHelpMode_BEEPERMUTE": {
+        "message": "Isključuje ili uključuje piskalicu, zajedno sa upozorenjima i obaveštenjima.",
+        "description": "Help text to BEEPERMUTE mode"
+    },
+    "auxiliaryHelpMode_BEEPERON": {
+        "message": "Uključuje mod stalnog pištanja.",
+        "description": "Help text to BEEPER ON mode"
+    },
+    "auxiliaryHelpMode_BEEPGPSSATELLITECOUNT": {
+        "message": "Piskalicom javlja broj pronađenih satelita.",
+        "description": "Help text to BEEP GPS SATELLITE COUNT mode"
+    },
+    "auxiliaryHelpMode_BLACKBOX": {
+        "message": "Uključuje snimanje u Blackbox.",
+        "description": "Help text to BLACKBOX mode"
+    },
+    "auxiliaryHelpMode_BLACKBOXERASE": {
+        "message": "Briše Blackbox zapis.",
+        "description": "Help text to BLACKBOX ERASE mode"
+    },
+    "auxiliaryHelpMode_BOXPREARM": {
+        "message": "Uključuje PREARM, dodatnu bravu ispred armovanja.",
+        "description": "Help text to BOXPREARM mode"
+    },
+    "auxiliaryHelpMode_CALIB": {
+        "message": "Pokreće kalibraciju u letu.",
+        "description": "Help text to CALIB mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL1": {
+        "message": "Uključuje i isključuje CAMERA CONTROL 1 — pogledajte uputstvo proizvođača.",
+        "description": "Help text to customized CAMERA CONTROL 1 mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL2": {
+        "message": "Uključuje i isključuje CAMERA CONTROL 2 — pogledajte uputstvo proizvođača.",
+        "description": "Help text to customized CAMERA CONTROL 2 mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL3": {
+        "message": "Uključuje i isključuje CAMERA CONTROL 3 — pogledajte uputstvo proizvođača.",
+        "description": "Help text to customized CAMERA CONTROL 3 mode"
+    },
+    "auxiliaryHelpMode_CAMSTAB": {
+        "message": "Uključuje stabilizaciju kamere.",
+        "description": "Help text to CAMSTAB mode"
+    },
+    "auxiliaryHelpMode_CHIRP": {
+        "message": "Uključuje Chirp mod.",
+        "description": "Help text for CHIRP mode"
+    },
+    "auxiliaryHelpMode_FAILSAFE": {
+        "message": "Ručno pokreće drugu fazu Failsafe-a.",
+        "description": "Help text to FAILSAFE mode"
+    },
+    "auxiliaryHelpMode_FLIPOVERAFTERCRASH": {
+        "message": "Okreće motore unazad da bi prevrnuti dron vratio na noge posle pada (zahteva DShot).",
+        "description": "Help text to FLIP OVER AFTER CRASH mode"
+    },
+    "auxiliaryHelpMode_FPVANGLEMIX": {
+        "message": "Prilagođava okretanje u mestu nagibu pod kojim je kamera postavljena.",
+        "description": "Help text to FPV ANGLE MIX mode"
+    },
+    "auxiliaryHelpMode_GPSBEEPSATELLITECOUNT": {
+        "message": "Označava broj pronađenih satelita tako što toliko puta zapišti.",
+        "description": "Help text to GPS BEEP SATELLITE COUNT mode"
+    },
+    "auxiliaryHelpMode_GPSRESCUE": {
+        "message": "Uključuje GPS Rescue, povratak drona na mesto gde je poslednji put armovan.",
+        "description": "Help text to GPS RESCUE mode"
+    },
+    "auxiliaryHelpMode_HEADADJ": {
+        "message": "Postavlja novu polaznu tačku okretanja za HEADFREE mod.",
+        "description": "Help text to HEAD ADJ mode"
+    },
+    "auxiliaryHelpMode_HEADFREE": {
+        "message": "Režim leta u kome je skretanje (yaw) vezano za spoljašnju tačku oslonca — najčešće za smer u kome je pilot okrenut — umesto za samu letelicu. Namenjen početnicima, ali se retko koristi; preporučuje se ANGLE režim.",
+        "description": "Help text to HEADFREE mode"
+    },
+    "auxiliaryHelpMode_HORIZON": {
+        "message": "Mešoviti mod: dok su ručice u sredini ponaša se kao ANGLE i sam se niveliše, a pri punom otklonu dozvoljava potpuni prevrtaj.",
+        "description": "Help text to HORIZON mode"
+    },
+    "auxiliaryHelpMode_LAUNCHCONTROL": {
+        "message": "Pomoć pri startu na trci.",
+        "description": "Help text to LAUNCH CONTROL mode"
+    },
+    "auxiliaryHelpMode_LEDLOW": {
+        "message": "Gasi LED traku.",
+        "description": "Help text to LEDLOW mode"
+    },
+    "auxiliaryHelpMode_MAG": {
+        "message": "Zadržava pravac prema magnetometru, dakle prema kompasu.",
+        "description": "Help text to MAG mode"
+    },
+    "auxiliaryHelpMode_MSPOVERRIDE": {
+        "message": "Uključuje MSP Override mod.",
+        "description": "Help text to MSP OVERRIDE mode"
+    },
+    "auxiliaryHelpMode_OSDDISABLE": {
+        "message": "Uključuje ili isključuje prikaz preko slike (OSD).",
+        "description": "Help text to OSD mode"
+    },
+    "auxiliaryHelpMode_PASSTHRU": {
+        "message": "Prosleđuje komande sa prijemnika pravo na servoe, kod avionskog rasporeda.",
+        "description": "Help text to PASSTHRU mode"
+    },
+    "auxiliaryHelpMode_PARALYZE": {
+        "message": "Trajno onesposobljava dron posle pada, dok mu se ne prekine napajanje.",
+        "description": "Help text to PARALYZE mode"
+    },
+    "auxiliaryHelpMode_PIDAUDIO": {
+        "message": "Uključuje i isključuje PIDAUDIO.",
+        "description": "Help text to PIDAUDIO mode"
+    },
+    "auxiliaryHelpMode_POSHOLD": {
+        "message": "Zadržavanje položaja u mestu.",
+        "description": "Help text to POSHOLD mode"
+    },
+    "auxiliaryHelpMode_PREARM": {
+        "message": "Pri armovanju dron čeka da prvo uključite ovaj prekidač, pa tek onda dozvoljava armovanje.",
+        "description": "Help text to PREARM mode"
+    },
+    "auxiliaryHelpMode_READY": {
+        "message": "Prikazuje oznaku READY na ekranu u naočarima, preko prekidača.",
+        "description": "Help text to READY mode"
+    },
+    "auxiliaryHelpMode_STICKCOMMANDSDISABLE": {
+        "message": "Isključuje ili uključuje komande koje se zadaju ručicama.",
+        "description": "Help text to STICK COMMANDS DISABLE mode"
+    },
+    "auxiliaryHelpMode_SERVO1": {
+        "message": "Uključuje i isključuje SERVO1.",
+        "description": "Help text to SERVO1 mode"
+    },
+    "auxiliaryHelpMode_SERVO2": {
+        "message": "Uključuje i isključuje SERVO2.",
+        "description": "Help text to SERVO2 mode"
+    },
+    "auxiliaryHelpMode_SERVO3": {
+        "message": "Uključuje i isključuje SERVO3.",
+        "description": "Help text to SERVO3 mode"
+    },
+    "auxiliaryHelpMode_TELEMETRY": {
+        "message": "Uključuje slanje podataka nazad ka daljinskom, preko prekidača.",
+        "description": "Help text to TELEMETRY mode"
+    },
+    "auxiliaryHelpMode_USER1": {
+        "message": "Uključuje i isključuje USER1 — upravlja izlazom preko PINIO.",
+        "description": "Help text to customized USER1 mode"
+    },
+    "auxiliaryHelpMode_USER2": {
+        "message": "Uključuje i isključuje USER2 — upravlja izlazom preko PINIO.",
+        "description": "Help text to customized USER2 mode"
+    },
+    "auxiliaryHelpMode_USER3": {
+        "message": "Uključuje i isključuje USER3 — upravlja izlazom preko PINIO.",
+        "description": "Help text to customized USER3 mode"
+    },
+    "auxiliaryHelpMode_USER4": {
+        "message": "Uključuje i isključuje USER4 — upravlja izlazom preko PINIO.",
+        "description": "Help text to customized USER4 mode"
+    },
+    "auxiliaryHelpMode_VTXCONTROLDISABLE": {
+        "message": "Onemogućava menjanje podešavanja video-predajnika preko OSD-a.",
+        "description": "Help text to VTX CONTROL DISABLE mode"
+    },
+    "auxiliaryHelpMode_VTXPOWER": {
+        "message": "Kruži kroz nivoe snage video-predajnika, ako ih predajnik podržava.",
+        "description": "Help text to VTX POWER mode"
+    },
+    "auxiliaryHelpMode_VTXPITMODE": {
+        "message": "Prebacuje video-predajnik u pit mod, na vrlo malu snagu, ako to podržava.",
+        "description": "Help text to VTX PIT MODE mode"
+    },
+    "auxiliaryHelpMode_LAPTIMERRESET": {
+        "message": "Poništava merač krugova na transponderu.",
+        "description": "Help text to LAP TIMER RESET mode"
+    },
+    "adjustmentsHelp": {
+        "message": "Podesite prekidače za prilagođavanje. Pogledajte odeljak uputstva 'prilagođavanja tokom leta' za detalje. Promene koje funkcije prilagođavanja naprave ne čuvaju se automatski."
+    },
+    "adjustmentsColumnEnable": {
+        "message": "Ako je uključeno"
+    },
+    "adjustmentsColumnUsingSlot": {
+        "message": "koristi slot"
+    },
+    "adjustmentsColumnWhenChannel": {
+        "message": "kada je kanal"
+    },
+    "adjustmentsColumnIsInRange": {
+        "message": "u opsegu"
+    },
+    "adjustmentsColumnThenApplyFunction": {
+        "message": "onda primeni"
+    },
+    "adjustmentsColumnViaChannel": {
+        "message": "preko kanala"
+    },
+    "adjustmentsColumnMode": {
+        "message": "mod"
+    },
+    "adjustmentsModeStep": {
+        "message": "Korak"
+    },
+    "adjustmentsModeAbsolute": {
+        "message": "Apsolutno"
+    },
+    "adjustmentsModeSelection": {
+        "message": "Izbor"
+    },
+    "adjustmentsColumnAdjustmentCenter": {
+        "message": "centar (vred.)"
+    },
+    "adjustmentsColumnAdjustmentScale": {
+        "message": "skala (vred.|%)"
+    },
+    "adjustmentsCenterHelp": {
+        "message": "Podešava srednju tačku ili referentnu vrednost koju koristi funkcija prilagođavanja.<br \/><br \/><strong>Prilagođavanje klizačem:<\/strong><br \/>Za prilagođavanje klizačem, postavite Adjustment Center na 0. Trenutna pozicija klizača koristiće se za prilagođavanje gore\/dole.<br \/><br \/><strong>Prilagođavanje izborom:<\/strong><br \/>Postavite Adjustment Center na 0, ili na određenu vrednost u mikrosekundama (uS) ako želite da pomerite referentnu tačku prekidača u odnosu na 1500uS prilikom pokretanja RC prilagođavanja.<br \/><br \/><strong>Postepeno prilagođavanje:<\/strong><br \/>Postavite Adjustment Center na 0 kako bi se koristila trenutna vrednost stavke koja se prilagođava.<br \/><br \/><strong>Apsolutno prilagođavanje:<\/strong><br \/>Da biste koristili metod apsolutnog prilagođavanja, morate podesiti i Adjustment Center i Scale kako biste odredili željenu vrednost i opseg. Opseg se računa kao: Centar ± Skala. Na primer, postavljanje Adjustment Center na 50 i Adjustment Scale na 25 pravi opseg od 25 do 75, gde je srednja pozicija (prekidač ili POT) preslikana na 50.<br \/><br \/>Posetite <a href=\"https:\/\/www.betaflight.com\/docs\/wiki\/guides\/current\/Inflight-Adjustments\" target=\"_blank\" rel=\"noopener noreferrer\">ovu stranicu<\/a> za više informacija.",
+        "description": "Tooltip help text for the Adjustment Center column"
+    },
+    "adjustmentsScaleHelp": {
+        "message": "Kontroliše skaliranje ili opseg podešavanja; veće vrednosti povećavaju opseg podešavanja ili osetljivost.<br \/><br \/><strong>Podešavanja klizačem:<\/strong><br \/>Za podešavanja klizačem, Adjustment Scale kontroliše skaliranje\/osetljivost podešavanja. Vrednost 50 odgovara 50% opsega klizača. Postavljanje na 0 koristi fabričku skalu za klizače.<br \/><br \/><strong>Podešavanja izborom:<\/strong><br \/>Za podešavanja izborom, postavite Adjustment Scale na 0 za fabričko ponašanje, ili navedite vrednost u mikrosekundama (uS) da biste ograničili opseg. Na primer: postavite Adjustment Center na 1000 (uS) i Adjustment Scale na 500 (uS) da biste koristili prekidač sa 3 položaja kao prekidač sa 2 položaja.<br \/><br \/><strong>Podešavanja u koracima i apsolutna podešavanja:<\/strong><br \/>Za podešavanja u koracima i apsolutna podešavanja, Adjustment Scale definisuje opseg iznad i ispod Adjustment Center. Na primer, vrednost 25 pravi opseg podešavanja od ±25 od vrednosti Adjustment Center, ili od trenutne vrednosti ako je Adjustment Center postavljen na 0.<br \/><strong>Napomena:<\/strong> Da biste koristili metod apsolutnog podešavanja sa potencijometrom, mora biti navedena vrednost za Adjustment Scale.<br \/><br \/>Posetite <a href=\"https:\/\/www.betaflight.com\/docs\/wiki\/guides\/current\/Inflight-Adjustments\" target=\"_blank\" rel=\"noopener noreferrer\">ovu stranicu<\/a> za više informacija.",
+        "description": "Tooltip help text for the Adjustment Scale column"
+    },
+    "adjustmentsSlot0": {
+        "message": "Slot 1"
+    },
+    "adjustmentsSlot1": {
+        "message": "Slot 2"
+    },
+    "adjustmentsSlot2": {
+        "message": "Slot 3"
+    },
+    "adjustmentsSlot3": {
+        "message": "Slot 4"
+    },
+    "adjustmentsMin": {
+        "message": "Min"
+    },
+    "adjustmentsMax": {
+        "message": "Maks"
+    },
+    "adjustmentsFunction0": {
+        "message": "Bez promena"
+    },
+    "adjustmentsFunction1": {
+        "message": "Podešavanje za RC Rate"
+    },
+    "adjustmentsFunction2": {
+        "message": "Podešavanje za RC Expo"
+    },
+    "adjustmentsFunction3": {
+        "message": "Podešavanje za Expo gasa"
+    },
+    "adjustmentsFunction4": {
+        "message": "Podešavanje za Pitch & Roll Rate"
+    },
+    "adjustmentsFunction5": {
+        "message": "Podešavanje za Yaw Rate"
+    },
+    "adjustmentsFunction6": {
+        "message": "Podešavanje za Pitch & Roll P"
+    },
+    "adjustmentsFunction7": {
+        "message": "Podešavanje za Pitch & Roll I"
+    },
+    "adjustmentsFunction8": {
+        "message": "Podešavanje za Pitch & Roll D"
+    },
+    "adjustmentsFunction9": {
+        "message": "Podešavanje za Yaw P"
+    },
+    "adjustmentsFunction10": {
+        "message": "Podešavanje za Yaw I"
+    },
+    "adjustmentsFunction11": {
+        "message": "Podešavanje za Yaw D"
+    },
+    "adjustmentsFunction12": {
+        "message": "Izbor Rate profila"
+    },
+    "adjustmentsFunction13": {
+        "message": "Pitch Rate"
+    },
+    "adjustmentsFunction14": {
+        "message": "Roll Rate"
+    },
+    "adjustmentsFunction15": {
+        "message": "Podešavanje za Pitch P"
+    },
+    "adjustmentsFunction16": {
+        "message": "Podešavanje za Pitch I"
+    },
+    "adjustmentsFunction17": {
+        "message": "Podešavanje za Pitch D"
+    },
+    "adjustmentsFunction18": {
+        "message": "Podešavanje Roll P"
+    },
+    "adjustmentsFunction19": {
+        "message": "Podešavanje Roll I"
+    },
+    "adjustmentsFunction20": {
+        "message": "Podešavanje Roll D"
+    },
+    "adjustmentsFunction21": {
+        "message": "RC Rate Yaw"
+    },
+    "adjustmentsFunction22": {
+        "message": "Podešavanje Pitch & Roll F"
+    },
+    "adjustmentsFunction23": {
+        "message": "Feedforward prelaz"
+    },
+    "adjustmentsFunction24": {
+        "message": "Podešavanje Horizon jačine"
+    },
+    "adjustmentsFunction25": {
+        "message": "Izbor PID-Audio"
+    },
+    "adjustmentsFunction26": {
+        "message": "Podešavanje Pitch F"
+    },
+    "adjustmentsFunction27": {
+        "message": "Podešavanje Roll F"
+    },
+    "adjustmentsFunction28": {
+        "message": "Podešavanje Yaw F"
+    },
+    "adjustmentsFunction29": {
+        "message": "Izbor OSD profila"
+    },
+    "adjustmentsFunction30": {
+        "message": "Izbor LED profila"
+    },
+    "adjustmentsFunction31": {
+        "message": "Podešavanje LED osvetljenosti"
+    },
+    "adjustmentsFunction32": {
+        "message": "Glavni množilac klizača"
+    },
+    "adjustmentsFunction33": {
+        "message": "Izbor profila baterije",
+        "description": "Allows switching battery profiles via RC channel"
+    },
+    "adjustmentsSave": {
+        "message": "Sačuvaj"
+    },
+    "adjustmentsShowAll": {
+        "message": "Prikaži sve slotove"
+    },
+    "adjustmentsHideEmpty": {
+        "message": "Sakrij prazne slotove"
+    },
+    "adjustmentsSlotsActive": {
+        "message": "{{active}} od {{total}} slotova aktivno"
+    },
+    "servosFirmwareUpgradeRequired": {
+        "message": "Servoi zahtevaju firmver &gt;= 1.10.0. i podršku za pločicu."
+    },
+    "servosChangeDirection": {
+        "message": "Promenite smer na TX radi usklađivanja"
+    },
+    "servosForwardChannel": {
+        "message": "Prosledi kanal {{channel}} na servo {{servo}}"
+    },
+    "servosName": {
+        "message": "Naziv"
+    },
+    "servosMid": {
+        "message": "Sredina"
+    },
+    "servosMin": {
+        "message": "Min"
+    },
+    "servosMax": {
+        "message": "MAX"
+    },
+    "servosAngleAtMin": {
+        "message": "Ugao pri min"
+    },
+    "servosAngleAtMax": {
+        "message": "Ugao pri maks"
+    },
+    "servosRateAndDirection": {
+        "message": "Odziv i smer"
+    },
+    "servosRate": {
+        "message": "Odziv:",
+        "description": "Label for 'Rate:' direction"
+    },
+    "servosLiveMode": {
+        "message": "Uključi Live mod"
+    },
+    "servosButtonSave": {
+        "message": "Sačuvaj"
+    },
+    "servosNormal": {
+        "message": "Normalno"
+    },
+    "servosReverse": {
+        "message": "Obrnuto"
+    },
+    "gpsHead": {
+        "message": "Opšte"
+    },
+    "gpsHeadHelp": {
+        "message": "Prikazuje razne GPS informacije. Smerovi se prikazuju samo kada se koristi magnetometar.",
+        "description": "Help text for gpsHead"
+    },
+    "gpsMapHead": {
+        "message": "Trenutna lokacija"
+    },
+    "gpsMapSatelliteView": {
+        "message": "Satelitski prikaz"
+    },
+    "gpsMapHybridView": {
+        "message": "Hibridni prikaz"
+    },
+    "gpsMapStreetView": {
+        "message": "Prikaz ulica"
+    },
+    "gpsMapZoomIn": {
+        "message": "Uvećaj"
+    },
+    "gpsMapZoomOut": {
+        "message": "Umanji"
+    },
+    "gpsMapToggleFullscreen": {
+        "message": "Uključi ili isključi ceo ekran"
+    },
+    "gpsMapRetry": {
+        "message": "Pokušaj ponovo"
+    },
+    "gpsMapMessage1": {
+        "message": "Proverite Vašu internet vezu"
+    },
+    "gpsMapMessage2": {
+        "message": "Čeka se GPS 3D fiks…"
+    },
+    "gps3dFix": {
+        "message": "3D fiks:"
+    },
+    "gpsFixTrue": {
+        "message": "Da"
+    },
+    "gpsFixFalse": {
+        "message": "Ne"
+    },
+    "gpsPositionUnit": {
+        "message": "deg",
+        "description": "Unit for GPS position."
+    },
+    "gpsAltitude": {
+        "message": "Nadmorska visina:"
+    },
+    "gpsLatitude": {
+        "message": "Geografska širina:",
+        "description": "Show GPS position - Latitude"
+    },
+    "gpsLongitude": {
+        "message": "Geografska dužina:",
+        "description": "Show GPS position - Longitude"
+    },
+    "gpsHeading": {
+        "message": "Pravac IMU \/ GPS:",
+        "description": "Show IMU \/ GPS heading - Attitude \/ GPS course over ground"
+    },
+    "gpsSpeed": {
+        "message": "Brzina:"
+    },
+    "gpsSats": {
+        "message": "Broj satelita:",
+        "description": "Show number of fixed GPS Satellites"
+    },
+    "gpsDistToHome": {
+        "message": "Udaljenost od početne tačke:"
+    },
+    "gpsPositionalDop": {
+        "message": "Pozicioni DOP:"
+    },
+    "gpsMagneticDeclination": {
+        "message": "$t(configurationMagDeclination):",
+        "description": "Do not translate"
+    },
+    "gpsSignalStrHead": {
+        "message": "Informacije o signalu"
+    },
+    "gpsSignalStrHeadHelp": {
+        "message": "Prikazuje jačinu, kvalitet i status signala za svaki pronađeni GPS izvor",
+        "description": "Help text for gpsSignalStrHead"
+    },
+    "gpsSignalStr": {
+        "message": "Jačina signala"
+    },
+    "gpsSignalLost": {
+        "message": "GPS ikonica svetli samo kada je potvrđena veza sa GPS modulom.<br \/><br \/>Prvo će biti crvena, a promeniće se u žutu kada se postigne 3D fix.<br \/><br \/>Ako GPS ikonica ne svetli, proverite Vaše ožičenje i podešavanja i potvrdite da GPS modul dobija napajanje.<br \/><br \/>CLI komanda 'status' pruža više informacija o stanju GPS veze."
+    },
+    "gpsSignalGnssId": {
+        "message": "GNSS ID"
+    },
+    "gpsSignalSatId": {
+        "message": "Sat ID"
+    },
+    "gpsSignalQuality": {
+        "message": "Kvalitet"
+    },
+    "gnssQualityNoSignal": {
+        "message": "nema signala"
+    },
+    "gnssQualitySearching": {
+        "message": "pretraživanje"
+    },
+    "gnssQualityAcquired": {
+        "message": "pronađen"
+    },
+    "gnssQualityUnusable": {
+        "message": "neupotrebljiv"
+    },
+    "gnssQualityLocked": {
+        "message": "zaključan"
+    },
+    "gnssQualityFullyLocked": {
+        "message": "potpuno zaključan"
+    },
+    "gnssUsedUnused": {
+        "message": "nekorišćen"
+    },
+    "gnssUsedUsed": {
+        "message": "KORIŠĆEN"
+    },
+    "gnssHealthyUnknown": {
+        "message": "nepoznato"
+    },
+    "gnssHealthyHealthy": {
+        "message": "ispravan"
+    },
+    "gnssHealthyUnhealthy": {
+        "message": "neispravan"
+    },
+    "flightPlanWaypointList": {
+        "message": "Lista tačaka puta"
+    },
+    "flightPlanNoWaypoints": {
+        "message": "Nisu definisane tačke puta. Kliknite na mapu ili upotrebite obrazac da dodate tačke puta."
+    },
+    "flightPlanAddWaypoint": {
+        "message": "Dodaj tačku puta"
+    },
+    "flightPlanEditWaypoint": {
+        "message": "Uredi tačku puta"
+    },
+    "flightPlanLatitude": {
+        "message": "Geografska širina <span class=\"units\">°<\/span>"
+    },
+    "flightPlanLongitude": {
+        "message": "Geografska dužina <span class=\"units\">°<\/span>"
+    },
+    "flightPlanAltitude": {
+        "message": "Visina <span class=\"units\">ft AMSL<\/span>"
+    },
+    "flightPlanSpeed": {
+        "message": "Brzina <span class=\"units\">čvorova<\/span>"
+    },
+    "flightPlanType": {
+        "message": "Vrsta tačke puta"
+    },
+    "flightPlanTypeFlyover": {
+        "message": "Prelet"
+    },
+    "flightPlanTypeFlyby": {
+        "message": "Prolaz"
+    },
+    "flightPlanTypeHold": {
+        "message": "Zadržavanje"
+    },
+    "flightPlanTypeLand": {
+        "message": "Sletanje"
+    },
+    "flightPlanTypeTakeoff": {
+        "message": "Poletanje"
+    },
+    "flightPlanTypeAltChange": {
+        "message": "Promena visine",
+        "description": "Modifier waypoint type: changes the altitude of the next positional waypoint"
+    },
+    "flightPlanTypeDelay": {
+        "message": "Pauza",
+        "description": "Modifier waypoint type: pauses traversal for a duration"
+    },
+    "flightPlanTypeYawRate": {
+        "message": "Ograničenje Yaw brzine",
+        "description": "Modifier waypoint type: caps the yaw rate of the next positional waypoint"
+    },
+    "flightPlanDuration": {
+        "message": "Trajanje zadržavanja <span class=\"units\">min<\/span>"
+    },
+    "flightPlanDurationAria": {
+        "message": "Trajanje zadržavanja u minutima",
+        "description": "Plain-text aria-label variant of flightPlanDuration for screen readers"
+    },
+    "flightPlanDelayDuration": {
+        "message": "Trajanje pauze <span class=\"units\">min<\/span>"
+    },
+    "flightPlanDelayDurationAria": {
+        "message": "Trajanje pauze u minutima",
+        "description": "Plain-text aria-label variant of flightPlanDelayDuration for screen readers"
+    },
+    "flightPlanYawRate": {
+        "message": "Yaw brzina <span class=\"units\">°\/s<\/span>"
+    },
+    "flightPlanYawRateAria": {
+        "message": "Yaw brzina u stepenima u sekundi",
+        "description": "Plain-text aria-label variant of flightPlanYawRate for screen readers"
+    },
+    "flightPlanPattern": {
+        "message": "Šablon zadržavanja"
+    },
+    "flightPlanPatternCircle": {
+        "message": "Krug"
+    },
+    "flightPlanPatternFigure8": {
+        "message": "Osmica"
+    },
+    "flightPlanPatternOrbit": {
+        "message": "Orbita"
+    },
+    "flightPlanMap": {
+        "message": "Mapa plana leta"
+    },
+    "flightPlanMapInstructions": {
+        "message": "Kliknite da dodate tačke puta. Prevlačite oznake tačaka puta da ih pomerite."
+    },
+    "flightPlanLoading": {
+        "message": "Molimo sačekajte..."
+    },
+    "flightPlanClear": {
+        "message": "Očisti"
+    },
+    "flightPlanLoad": {
+        "message": "Učitaj"
+    },
+    "flightPlanSaveToFC": {
+        "message": "Sačuvaj na FC"
+    },
+    "flightPlanLoaded": {
+        "message": "Plan leta je uspešno učitan"
+    },
+    "flightPlanSaved": {
+        "message": "Plan leta je uspešno sačuvan"
+    },
+    "flightPlanCleared": {
+        "message": "Plan leta je obrisan"
+    },
+    "flightPlanLoadFromFC": {
+        "message": "Učitaj sa FC"
+    },
+    "flightPlanLoadedFromFC": {
+        "message": "Plan leta je učitan sa flight kontrolera"
+    },
+    "flightPlanSavedToFC": {
+        "message": "Plan leta je sačuvan na flight kontroleru"
+    },
+    "flightPlanFCLoadError": {
+        "message": "Neuspešno učitavanje plana leta sa flight kontrolera"
+    },
+    "flightPlanFCSaveError": {
+        "message": "Neuspešno čuvanje plana leta na flight kontroleru"
+    },
+    "flightPlanFCEmpty": {
+        "message": "Nisu pronađene tačke puta na flight kontroleru"
+    },
+    "flightPlanClearedFC": {
+        "message": "Plan leta je obrisan na flight kontroleru"
+    },
+    "flightPlanLoadError": {
+        "message": "Neuspešno učitavanje plana leta"
+    },
+    "flightPlanSaveError": {
+        "message": "Neuspešno čuvanje plana leta"
+    },
+    "flightPlanInvalidLatitude": {
+        "message": "Nevažeća geografska širina (mora biti između -90 i 90)"
+    },
+    "flightPlanInvalidLongitude": {
+        "message": "Nevažeća geografska dužina (mora biti između -180 i 180)"
+    },
+    "flightPlanInvalidAltitude": {
+        "message": "Nevažeća visina (mora biti nula ili pozitivna)"
+    },
+    "flightPlanInvalidDuration": {
+        "message": "Nevažeće trajanje (mora biti nula ili pozitivno)"
+    },
+    "flightPlanInvalidYawRate": {
+        "message": "Nevažeća Yaw brzina (mora biti nula ili pozitivna)"
+    },
+    "flightPlanConfirmDelete": {
+        "message": "Da li ste sigurni da želite da obrišete ovu tačku puta?"
+    },
+    "flightPlanDeleteWaypointTitle": {
+        "message": "Obriši tačku rute"
+    },
+    "flightPlanDeleteWaypointConfirm": {
+        "message": "Da li ste sigurni da želite da obrišete ovu tačku rute? Ova radnja se ne može opozvati."
+    },
+    "flightPlanConfirmClear": {
+        "message": "Da li ste sigurni da želite da obrišete sve tačke rute? Ova radnja se ne može opozvati."
+    },
+    "flightPlanClearTitle": {
+        "message": "Obriši plan leta"
+    },
+    "flightPlanLoadPromptTitle": {
+        "message": "Učitati plan leta sa flight kontrolera?"
+    },
+    "flightPlanLoadPromptBody": {
+        "message": "Flight kontroler je povezan. Da li želite da zamenite trenutni plan leta onim koji je sačuvan na flight kontroleru? Ako izaberete „Ne“, zadržaće se Vaš trenutni plan kako biste mogli da ga sačuvate na flight kontroleru."
+    },
+    "flightPlanKeepLocal": {
+        "message": "Zadrži trenutni"
+    },
+    "flightPlanElevationProfile": {
+        "message": "Profil visine"
+    },
+    "flightPlanDistance": {
+        "message": "Ukupna udaljenost"
+    },
+    "flightPlanFlightTime": {
+        "message": "Vreme leta"
+    },
+    "flightPlanMinAlt": {
+        "message": "Min. visina"
+    },
+    "flightPlanMaxAlt": {
+        "message": "Maks. visina"
+    },
+    "flightPlanNoWaypointsForProfile": {
+        "message": "Dodajte tačke rute da biste videli profil visine"
+    },
+    "flightPlanGroundElev": {
+        "message": "Visina terena"
+    },
+    "flightPlanMaxGroundElev": {
+        "message": "Maks. visina terena"
+    },
+    "flightPlanAvgGround": {
+        "message": "Prosečna visina terena"
+    },
+    "flightPlanMaxGround": {
+        "message": "Maks. visina terena"
+    },
+    "flightPlanAlt": {
+        "message": "Visina"
+    },
+    "flightPlanDist": {
+        "message": "Udaljenost"
+    },
+    "motorsVoltage": {
+        "message": "Napon:"
+    },
+    "motorsADrawing": {
+        "message": "Jačina struje:"
+    },
+    "motorsmAhDrawn": {
+        "message": "Potrošeno:"
+    },
+    "motorsVoltageValue": {
+        "message": "$1 V"
+    },
+    "motorsADrawingValue": {
+        "message": "$1 A"
+    },
+    "motorsmAhDrawnValue": {
+        "message": "$1 mAh"
+    },
+    "motorsText": {
+        "message": "Motori"
+    },
+    "motorNumber1": {
+        "message": "Motor - 1"
+    },
+    "motorNumber2": {
+        "message": "Motor - 2"
+    },
+    "motorNumber3": {
+        "message": "Motor - 3"
+    },
+    "motorNumber4": {
+        "message": "Motor - 4"
+    },
+    "motorNumber5": {
+        "message": "Motor - 5"
+    },
+    "motorNumber6": {
+        "message": "Motor - 6"
+    },
+    "motorNumber7": {
+        "message": "Motor - 7"
+    },
+    "motorNumber8": {
+        "message": "Motor - 8"
+    },
+    "servosText": {
+        "message": "Servoi"
+    },
+    "servoNumber1": {
+        "message": "Servo - 1"
+    },
+    "servoNumber2": {
+        "message": "Servo - 2"
+    },
+    "servoNumber3": {
+        "message": "Servo - 3"
+    },
+    "servoNumber4": {
+        "message": "Servo - 4"
+    },
+    "servoNumber5": {
+        "message": "Servo - 5"
+    },
+    "servoNumber6": {
+        "message": "Servo - 6"
+    },
+    "servoNumber7": {
+        "message": "Servo - 7"
+    },
+    "servoNumber8": {
+        "message": "Servo - 8"
+    },
+    "motorsResetMaximumButton": {
+        "message": "Vrati na fabričko"
+    },
+    "motorsResetMaximum": {
+        "message": "Poništi najveću zabeleženu vrednost"
+    },
+    "motorsSensorAccelSelect": {
+        "message": "akcelerometar"
+    },
+    "motorsTelemetryHelp": {
+        "message": "Ovi brojevi prikazuju podatke koje regulatori šalju nazad, ako to podržavaju. Mogu da pokažu stvarnu brzinu obrtanja motora (R, u obrtajima u minuti), udeo grešaka u toj vezi (E) i temperaturu regulatora (T).",
+        "description": "Help text for the telemetry values in the motors tab."
+    },
+    "motorsRPM": {
+        "message": "R: {{motorsRpmValue}}",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Keep the letters as prefix. Shows the RPM of the motor if telemetry is available."
+    },
+    "motorsRPMError": {
+        "message": "E: {{motorsErrorValue}}%",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the error of motor telemetry if available."
+    },
+    "motorsESCTemperature": {
+        "message": "T: {{motorsESCTempValue}}&deg;C",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the ESC temperature if available."
+    },
+    "motorsMaster": {
+        "message": "Svi zajedno"
+    },
+    "motorsNotice": {
+        "message": "<strong>Provera motora i armovanje — upozorenje:<\/strong><br \/><br \/><strong class=\"message-negative\">PAŽNJA: Ozbiljna opasnost od povrede! Skinite sve propelere!<\/strong><br \/><br \/><ul><li>&#x2022; Motori će se pokrenuti kada dron bude armovan ili kada podignete klizače<\/li><li>&#x2022; Režim provere motora ostaje uključen i kada pređete na drugu karticu<\/li><li>&#x2022; Pritisak na bilo koji taster zaustavlja motore, ali samo dok ste na kartici Motori<\/li><li>&#x2022; Isključivanje USB kabla možda neće zaustaviti motore!<\/li><\/ul>"
+    },
+    "motorsEnableControl": {
+        "message": "<strong>Razumem opasnost<\/strong>, propeleri su skinuti — uključi upravljanje motorima i armovanje, i isključi zaštitu od nekontrolisanog poletanja."
+    },
+    "motorsDialogMixerReset": {
+        "message": "<strong>Otkriven je problem sa rasporedom motora<\/strong><br \/><br \/>Model {{mixerName}} traži <strong class=\"message-positive\">{{mixerMotors}}<\/strong> izlaza za motore, a trenutna podešavanja firmvera nude <strong class=\"message-positive\">{{outputs}}<\/strong> upotrebljivih izlaza za izabrani raspored.<br \/><br \/>Ako koristite sopstveni raspored, morate ga zadati komandom mmix pre nego što promenite raspored.<br \/><br \/>Proverite podešavanja i dodajte potrebne izlaze za motore."
+    },
+    "motorsDialogSettingsChanged": {
+        "message": "Otkrivene su izmene u podešavanjima.<br \/><br \/><strong class=\"message-negative-italic\">Režim provere motora je isključen dok se podešavanja ne sačuvaju.<\/strong>"
+    },
+    "motorsDialogSettingsChangedOk": {
+        "message": "U redu"
+    },
+    "motorOutputReorderDialogClose": {
+        "message": "Otkaži"
+    },
+    "motorOutputReorderDialogAgree": {
+        "message": "Pokreni"
+    },
+    "motorsRemapDialogTitle": {
+        "message": "Preuredi redosled motora"
+    },
+    "motorOutputReorderDialogOpen": {
+        "message": "Preuredi redosled motora"
+    },
+    "motorOutputReorderDialogSelectSpinningMotor": {
+        "message": "Kliknite na motor koji se okreće..."
+    },
+    "motorOutputReorderDialogRemapIsDone": {
+        "message": "Spremni! Proverite redosled okretanja motora klikom na sliku."
+    },
+    "motorsRemapDialogUnderstandRisks": {
+        "message": "<strong>Razumem opasnost<\/strong>,<br \/>propeleri su skinuti."
+    },
+    "motorsRemapDialogRiskNotice": {
+        "message": "<strong>Bezbednosno upozorenje<\/strong><br \/><strong class=\"message-negative\">Skinite sve propelere da ne bi došlo do povrede!<\/strong><br \/>Motori će se <strong>pokrenuti!<\/strong>"
+    },
+    "motorsRemapDialogExplanations": {
+        "message": "<strong>Obaveštenje<\/strong><br \/>Motori će se pokretati jedan po jedan i moći ćete da izaberete koji se motor okreće. Baterija mora biti priključena, a protokol regulatora ispravno izabran. Ovaj alat može samo da preuredi motore koji su trenutno aktivni. Za složenije preuređenje potrebna je komanda Resource u CLI-ju. Pogledajte ovu <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Remapping-Motors-with-Resource-Command\" target=\"_blank\" rel=\"noopener noreferrer\">stranicu uputstava<\/a>."
+    },
+    "motorsRemapDialogSave": {
+        "message": "Sačuvaj"
+    },
+    "motorsRemapDialogStartOver": {
+        "message": "Počni ispočetka"
+    },
+    "motorsButtonReset": {
+        "message": "Vrati na fabričko"
+    },
+    "motorsButtonSave": {
+        "message": "Sačuvaj i restartuj"
+    },
+    "escDshotDirectionDialog-Title": {
+        "message": "Smer motora - <strong class=\"message-negative-italic\">Upozorenje: Proverite da li su propelere skinute!<\/strong>"
+    },
+    "escDshotDirectionDialog-SelectMotor": {
+        "message": "Izaberite jedan ili sve motore"
+    },
+    "escDshotDirectionDialog-SelectMotorSafety": {
+        "message": "Motori će se okretati kada ih izaberete!"
+    },
+    "escDshotDirectionDialog-RiskNotice": {
+        "message": "<strong>Bezbednosno obaveštenje<\/strong><br \/><strong class=\"message-negative-italic\">Skinite sve propelere da biste sprečili povrede!<\/strong><br \/>Motori će <strong>odmah početi da se okreću<\/strong> čim ih izaberete!"
+    },
+    "escDshotDirectionDialog-UnderstandRisks": {
+        "message": "<strong>Razumem rizike<\/strong>,<br \/>sve propelere su skinute."
+    },
+    "escDshotDirectionDialog-InformationNotice": {
+        "message": "<strong>Informativno obaveštenje<\/strong><br \/>Da biste promenili smer motora, baterija mora biti priključena i ispravan ESC protokol mora biti podešen na kartici $t(tabMotorTesting.message). Imajte u vidu da neće svi Dshot ESC-ovi raditi sa ovim dijalogom. Proverite firmver Vašeg ESC-a."
+    },
+    "escDshotDirectionDialog-NormalInformationNotice": {
+        "message": "Podesite smer okretanja motora izborom i pokretanjem svakog motora pojedinačno."
+    },
+    "escDshotDirectionDialog-WizardInformationNotice": {
+        "message": "Poništava sve smerove okretanja motora, a zatim omogućava korisniku da izabere koje treba obrnuti."
+    },
+    "escDshotDirectionDialog-Open": {
+        "message": "Smer motora"
+    },
+    "escDshotDirectionDialog-CommandNormal": {
+        "message": "Normalno"
+    },
+    "escDshotDirectionDialog-CommandReverse": {
+        "message": "Obrnuto"
+    },
+    "escDshotDirectionDialog-CommandSpin": {
+        "message": "Testiraj motor"
+    },
+    "escDshotDirectionDialog-ReleaseButtonToStop": {
+        "message": "Pustite dugme da biste zaustavili"
+    },
+    "escDshotDirectionDialog-ReleaseToStop": {
+        "message": "Pustite da biste zaustavili"
+    },
+    "escDshotDirectionDialog-Start": {
+        "message": "Pojedinačno"
+    },
+    "escDshotDirectionDialog-StartWizard": {
+        "message": "Čarobnjak"
+    },
+    "escDshotDirectionDialog-SetDirectionHint": {
+        "message": "Promenite smer izabranog(ih) motora"
+    },
+    "escDshotDirectionDialog-SetDirectionHintSafety": {
+        "message": "Motori će se okretati prilikom podešavanja smera"
+    },
+    "escDshotDirectionDialog-SettingsAutoSaved": {
+        "message": "Smer motora se čuva odmah po izboru"
+    },
+    "escDshotDirectionDialog-WrongProtocolText": {
+        "message": "Funkcija radi samo sa DSHOT ESC-ovima.<br \/>Proverite da li Vaš ESC (elektronski kontroler brzine) podržava DSHOT protokol i promenite ga na kartici $t(tabMotorTesting.message)."
+    },
+    "escDshotDirectionDialog-WrongMixerText": {
+        "message": "Broj motora je 0.<br \/>Proverite trenutni Mixer na kartici $t(tabMotorTesting.message) ili podesite prilagođeni putem CLI-ja. Pogledajte ovu <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Mixer\" target=\"_blank\" rel=\"noopener noreferrer\">Wiki stranicu<\/a>."
+    },
+    "escDshotDirectionDialog-WrongFirmwareText": {
+        "message": "Ažurirajte firmver.<br \/> Proverite da li koristite najnoviji firmver: Betaflight 4.3 ili noviji."
+    },
+    "escDshotDirectionDialog-WizardActionHint": {
+        "message": "Kliknite pojedinačno na brojeve motora da biste promenili smer obrtanja"
+    },
+    "escDshotDirectionDialog-WizardActionHintSecondLine": {
+        "message": "Proverite da li se svi motori obrću ispravno"
+    },
+    "escDshotDirectionDialog-SpinWizard": {
+        "message": "Pokreni \/ obrći motore"
+    },
+    "escDshotDirectionDialog-StopWizard": {
+        "message": "Zaustavi motore"
+    },
+    "sensorsInfo": {
+        "message": "Imajte na umu da korišćenje kratkih perioda osvežavanja i prikazivanje više grafikona u isto vreme troši dosta resursa i brže će isprazniti bateriju ako koristite laptop.<br \/>Preporučujemo da prikazujete samo grafikone za senzore koji Vas zanimaju uz razumne periode osvežavanja."
+    },
+    "sensorsRefresh": {
+        "message": "Osvežavanje:"
+    },
+    "sensorsGlobalRefresh": {
+        "message": "Osveži sve:"
+    },
+    "sensorsScale": {
+        "message": "Razmera:"
+    },
+    "sensorsScaleAuto": {
+        "message": "Automatski"
+    },
+    "sensorsGyroSelect": {
+        "message": "Žiroskop"
+    },
+    "sensorsAccelSelect": {
+        "message": "Akcelerometar"
+    },
+    "sensorsMagSelect": {
+        "message": "Magnetometar"
+    },
+    "sensorsAltitudeSelect": {
+        "message": "Visina"
+    },
+    "sensorsSonarSelect": {
+        "message": "Sonar"
+    },
+    "sensorsDebugSelect": {
+        "message": "Debug"
+    },
+    "sensorsGyroTitle": {
+        "message": "Žiroskop - deg\/s"
+    },
+    "sensorsAccelTitle": {
+        "message": "Akcelerometar - g"
+    },
+    "sensorsMagTitle": {
+        "message": "Magnetometar"
+    },
+    "sensorsAltitudeTitle": {
+        "message": "Visina - metri"
+    },
+    "sensorsAltitudeHint": {
+        "message": "Visina se izračunava kombinovanjem očitavanja barometra (ako je dostupan) i visine sa GPS-a (ako je dostupan). Ako je GPS povezan i ima signal, apsolutna visina iznad nivoa mora biće prikazana dok je letelica razoružana. Kada je armovana, biće prikazana visina u odnosu na poziciju pri armovanju."
+    },
+    "sensorsSonarTitle": {
+        "message": "Sonar - cm"
+    },
+    "sensorsDebugTitle": {
+        "message": "Debug"
+    },
+    "cliInfo": {
+        "message": "<strong>Napomena:<\/strong> Napuštanje CLI kartice ili pritisak na Prekini vezu će <strong>automatski<\/strong> poslati \"<strong>exit<\/strong>\" pločici. Sa najnovijim firmverom ovo će <strong>restartovati<\/strong> kontroler i nesačuvane izmene će biti <strong>izgubljene<\/strong>.<p><strong><span class=\"message-negative\">Upozorenje:<\/span><\/strong> Neke komande u CLI-ju mogu izazvati slanje proizvoljnih signala na izlazne pinove motora. Ovo može uzrokovati pokretanje motora ako je baterija povezana. Zato se strogo preporučuje da se uverite da <strong>baterija nije povezana pre unosa komandi u CLI<\/strong>."
+    },
+    "cliInputPlaceholder": {
+        "message": "Napišite Vašu komandu ovde. Pritisnite Tab za automatsko dovršavanje."
+    },
+    "cliInputPlaceholderBuilding": {
+        "message": "Sačekajte dok se kreira keš za automatsko dovršavanje..."
+    },
+    "cliEnter": {
+        "message": "Prepoznat je CLI mod"
+    },
+    "cliDevEnter": {
+        "message": "Prepoznat je samo CLI razvojni mod"
+    },
+    "cliReboot": {
+        "message": "Prepoznato je CLI ponovno pokretanje"
+    },
+    "cliSaveToFileBtn": {
+        "message": "Sačuvaj u fajl"
+    },
+    "cliClearOutputHistoryBtn": {
+        "message": "Očisti istoriju izlaza"
+    },
+    "cliCopyToClipboardBtn": {
+        "message": "Kopiraj u ostavu"
+    },
+    "cliCopySuccessful": {
+        "message": "Kopirano"
+    },
+    "cliLoadFromFileBtn": {
+        "message": "Učitaj iz fajla"
+    },
+    "cliSupportRequestBtn": {
+        "message": "Pošalji podatke za podršku"
+    },
+    "cliConfirmSnippetDialogTitle": {
+        "message": "Učitana je fajl <strong>{{fileName}}<\/strong>. Pregledajte učitane komande"
+    },
+    "cliConfirmSnippetNote": {
+        "message": "<strong>Napomena<\/strong>: Možete pregledati i izmeniti komande pre izvršavanja."
+    },
+    "cliConfirmSnippetBtn": {
+        "message": "Izvrši"
+    },
+    "cliSnippetPreviewLabel": {
+        "message": "Pregled isečka"
+    },
+    "cliPanelTitle": {
+        "message": "Interfejs komandne linije"
+    },
+    "cliCommand": {
+        "message": "Unesite komandu ovde"
+    },
+    "loggingNote": {
+        "message": "Podaci se zapisuju <span class=\"message-negative\">samo<\/span> dok ste na ovoj kartici; izlaskom sa nje zapisivanje se <span class=\"message-negative\">prekida<\/span> i program se vraća u uobičajeno <strong>„configurator“<\/strong> stanje.<br \/> Možete sami izabrati učestanost osvežavanja, a podaci se radi brzine upisuju u fajl svake <strong>1<\/strong> sekunde."
+    },
+    "loggingPropertiesTitle": {
+        "message": "Svojstva dnevnika"
+    },
+    "loggingSamplingInterval": {
+        "message": "Interval uzorkovanja:"
+    },
+    "loggingSamplesSaved": {
+        "message": "Sačuvani uzorci:"
+    },
+    "loggingLogSize": {
+        "message": "Veličina dnevnika:"
+    },
+    "loggingLogName": {
+        "message": "Naziv dnevnika:"
+    },
+    "loggingButtonLogFile": {
+        "message": "Izaberite fajl dnevnika"
+    },
+    "loggingStart": {
+        "message": "Započni beleženje"
+    },
+    "loggingStop": {
+        "message": "Zaustavi beleženje"
+    },
+    "loggingBack": {
+        "message": "Napusti beleženje \/ Prekini vezu"
+    },
+    "loggingErrorNotConnected": {
+        "message": "Morate se prvo <strong>povezati<\/strong>"
+    },
+    "loggingErrorLogFile": {
+        "message": "Molimo izaberite fajl dnevnika"
+    },
+    "loggingErrorOneProperty": {
+        "message": "Molimo izaberite bar jedno svojstvo za beleženje"
+    },
+    "loggingAutomaticallyRetained": {
+        "message": "Automatski je učitan prethodni fajl dnevnika: <strong>$1<\/strong>"
+    },
+    "blackboxNotSupported": {
+        "message": "Firmver Vašeg flight kontrolera ne podržava Blackbox beleženje."
+    },
+    "blackboxMaybeSupported": {
+        "message": "Firmver Vašeg flight kontrolera je suviše star da bi podržao ovu karticu ili je opcija Blackbox isključena na kartici Configuration."
+    },
+    "blackboxConfiguration": {
+        "message": "Blackbox podešavanje"
+    },
+    "blackboxButtonSave": {
+        "message": "Sačuvaj i ponovo pokreni"
+    },
+    "blackboxLoggingNone": {
+        "message": "Bez beleženja"
+    },
+    "blackboxLoggingFlash": {
+        "message": "Ugrađena Flash memorija"
+    },
+    "blackboxLoggingSdCard": {
+        "message": "SD kartica"
+    },
+    "blackboxLoggingSerial": {
+        "message": "Serijski port"
+    },
+    "blackboxLoggingVirtual": {
+        "message": "U fajl"
+    },
+    "serialLoggingSupportedNote": {
+        "message": "Možete vršiti beleženje na spoljni uređaj za beleženje (kao što je OpenLager) pomoću serijskog porta. Podesite port na kartici Ports."
+    },
+    "sdcardNote": {
+        "message": "Dnevnici leta mogu se snimati na ugrađeni slot za SD karticu na Vašem flight kontroleru."
+    },
+    "dataflashUsedSpace": {
+        "message": "Iskorišćeni prostor"
+    },
+    "dataflashFreeSpace": {
+        "message": "Slobodan prostor"
+    },
+    "dataflashUnavSpace": {
+        "message": "Nedostupan prostor"
+    },
+    "dataflashLogsSpace": {
+        "message": "Slobodan prostor za dnevnike"
+    },
+    "dataflashNote": {
+        "message": "Dnevnici leta mogu se snimati na ugrađeni dataflash čip Vašeg flight kontrolera."
+    },
+    "dataflashNotPresentNote": {
+        "message": "Vaš flight kontroler nema dostupan kompatibilan dataflash čip."
+    },
+    "dataflashButtonSaveFile": {
+        "message": "Sačuvaj flash u fajl..."
+    },
+    "dataflashSavetoFileNote": {
+        "message": "Direktno čuvanje flash memorije u fajl je sporo i podložno greškama \/ oštećenju fajla.<br>U nekim slučajevima će raditi za male fajlove, ali ovo nije podržano i zahtevi za podršku će biti zatvoreni bez komentara – umesto toga koristite Mass Storage mod."
+    },
+    "dataflashSaveFileDepreciationHint": {
+        "message": "Ovaj metod je spor i podložan greškama \/ oštećenju fajlova, jer sama MSP veza ima osnovna, fundamentalna ograničenja koja je čine neprikladnom za prenos fajlova. Može raditi samo za male log fajlove. Nemojte otvarati zahteve za podršku ako prenos fajlova ne uspe kada koristite ovaj metod. Preporučeni metod je da koristite '<b>$t(onboardLoggingRebootMscText.message)<\/b>' (ispod) kako biste aktivirali Mass Storage mod i pristupili Vašem flight kontroleru kao uređaju za skladištenje radi preuzimanja log fajlova."
+    },
+    "dataflashButtonSaveAndErase": {
+        "message": "Sačuvaj i obriši",
+        "description": "Button text to save blackbox logs to file and then erase the flash"
+    },
+    "dataflashButtonErase": {
+        "message": "Obriši flash"
+    },
+    "dataflashConfirmEraseTitle": {
+        "message": "Potvrdite brisanje dataflash memorije"
+    },
+    "dataflashConfirmEraseNote": {
+        "message": "Ovo će obrisati sve Blackbox logove ili druge podatke sa dataflash memorije. Trajaće oko 20 sekundi, da li ste sigurni?"
+    },
+    "dataflashSavingTitle": {
+        "message": "Čuvanje dataflash memorije u fajl"
+    },
+    "dataflashSavingNote": {
+        "message": "Čuvanje može trajati nekoliko minuta, sačekajte."
+    },
+    "dataflashSavingNoteAfter": {
+        "message": "Čuvanje je završeno. Pritisnite \"OK\" za nastavak."
+    },
+    "dataflashButtonSaveCancel": {
+        "message": "Otkaži"
+    },
+    "dataflashButtonSaveDismiss": {
+        "message": "OK"
+    },
+    "dataflashButtonEraseConfirm": {
+        "message": "Da, obriši dataflash"
+    },
+    "dataflashButtonEraseCancel": {
+        "message": "Otkaži"
+    },
+    "dataflashFileWriteFailed": {
+        "message": "Pisanje u izabrani fajl nije uspelo, da li su dozvole za taj folder u redu?"
+    },
+    "sdcardStatusNoCard": {
+        "message": "Kartica nije ubačena"
+    },
+    "sdcardStatusReboot": {
+        "message": "Kritična greška<br>Ponovo pokrenite za novi pokušaj"
+    },
+    "sdcardStatusReady": {
+        "message": "Kartica je spremna"
+    },
+    "sdcardStatusStarting": {
+        "message": "Pokretanje kartice..."
+    },
+    "sdcardStatusFileSystem": {
+        "message": "Pokretanje fajl sistema..."
+    },
+    "sdcardStatusUnknown": {
+        "message": "Nepoznato stanje $1"
+    },
+    "firmwareFlasherPleaseWait": {
+        "message": "Sačekajte"
+    },
+    "firmwareFlasherBoardSelectionHead": {
+        "message": "Izbor pločice"
+    },
+    "firmwareFlasherBranch": {
+        "message": "Izaberite Pull Request ili Commit"
+    },
+    "firmwareFlasherReleaseSummaryHead": {
+        "message": "Informacije o verziji i izradi"
+    },
+    "firmwareFlasherReleaseManufacturer": {
+        "message": "ID proizvođača:"
+    },
+    "firmwareFlasherReleaseVersion": {
+        "message": "Verzija:"
+    },
+    "firmwareFlasherReleaseVersionUrl": {
+        "message": "Posetite stranicu izdanja."
+    },
+    "firmwareFlasherReleaseNotes": {
+        "message": "Beleške o izdanju:"
+    },
+    "firmwareFlasherReleaseDate": {
+        "message": "Datum:"
+    },
+    "firmwareFlasherReleaseTarget": {
+        "message": "Target:"
+    },
+    "firmwareFlasherTargetWikiUrlInfo": {
+        "message": "Saznajte više informacija o targetu na Betaflight Wiki stranici",
+        "description": "Link to Betaflight support for target"
+    },
+    "firmwareFlasherReleaseMCU": {
+        "message": "MCU:"
+    },
+    "firmwareFlasherCloudBuildDetails": {
+        "message": "Detalji Cloud Build-a:"
+    },
+    "firmwareFlasherCloudBuildLogUrl": {
+        "message": "Prikaži dnevnik"
+    },
+    "firmwareFlasherCloudBuildStatus": {
+        "message": "Status build-a:"
+    },
+    "firmwareFlasherFlashStatus": {
+        "message": "Status flešovanja:"
+    },
+    "firmwareFlasherCloudBuildQueued": {
+        "message": "u redu čekanja"
+    },
+    "firmwareFlasherCloudBuildPending": {
+        "message": "na čekanju"
+    },
+    "firmwareFlasherCloudBuildProcessing": {
+        "message": "u obradi"
+    },
+    "firmwareFlasherCloudBuildSuccessCached": {
+        "message": "uspešno (keširano)"
+    },
+    "firmwareFlasherCloudBuildSuccess": {
+        "message": "uspešno"
+    },
+    "firmwareFlasherCloudBuildFailCancel": {
+        "message": "otkazano"
+    },
+    "firmwareFlasherCloudBuildFailTimeOut": {
+        "message": "isteklo je vreme (pokušajte ponovo)"
+    },
+    "firmwareFlasherCloudBuildFailRequest": {
+        "message": "greška u zahtevu za build (proverite konfiguraciju build-a, npr. prilagođene definicije)"
+    },
+    "firmwareFlasherCloudBuildFail": {
+        "message": "neuspešno (proverite log)"
+    },
+    "firmwareFlasherReleaseFileUrl": {
+        "message": "Preuzmite ručno."
+    },
+    "firmwareFlasherTargetWarning": {
+        "message": "<span class=\"message-negative\">VAŽNO<\/span>: Proverite da li flešujete fajl koji odgovara Vašem targetu. Flešovanje binarnog fajla za pogrešan target može izazvati <span class=\"message-negative\">loše<\/span> stvari."
+    },
+    "firmwareFlasherPath": {
+        "message": "Putanja:"
+    },
+    "firmwareFlasherSize": {
+        "message": "Veličina:"
+    },
+    "firmwareFlasherStatus": {
+        "message": "Status:"
+    },
+    "firmwareFlasherProgress": {
+        "message": "Napredak:"
+    },
+    "firmwareFlasherLoadFirmwareFile": {
+        "message": "Molimo učitajte fajl firmvera"
+    },
+    "firmwareFlasherLoadedConfig": {
+        "message": "Meta je učitana, molimo učitajte fajl firmvera"
+    },
+    "firmwareFlasherNoReboot": {
+        "message": "Bez sekvence ponovnog pokretanja"
+    },
+    "firmwareFlasherOnlineSelectBuildType": {
+        "message": "Izaberite tip verzije da biste videli dostupne pločice."
+    },
+    "firmwareFlasherOnlineSelectBoardDescription": {
+        "message": "Izaberite ili detektujte Vašu pločicu da biste videli dostupne verzije firmvera na mreži - Izaberite odgovarajući firmver za Vašu pločicu."
+    },
+    "firmwareFlasherOnlineSelectBoardHint": {
+        "message": "Betaflight aplikacija podržava flešovanje unificiranih meta sa odgovarajućim specifičnim podešavanjima za pločicu u jednom koraku.<br><br>Koncept unificiranih meta znači da se ista .hex fajl firmvera može koristiti za sve pločice koje koriste isti MCU.<br><br>Betaflight 4.4 uvodi <strong>Cloud Build<\/strong><br><br>Sa opcijom <strong>Cloud Build<\/strong> potrebno je definisati hardverske opcije prisutne na Vašoj letelici.<br><br>Da bi različite pločice radile sa istim firmverom, specifična fajl podešavanja se primenjuje zajedno sa firmverom kada se flešuje unificirana meta.<br><br>Sa lokalnim pravljenjem možete učitati fajl podešavanja unificirane mete ili izabrati pločicu pre učitavanja .hex fajla firmvera.<br><br>Ako naiđete na probleme prilikom korišćenja firmvera, razmislite o pridruživanju Discord-u ili otvorite <a href=\"https:\/\/github.com\/betaflight\/betaflight\/issues\" target=\"_blank\" rel=\"noopener noreferrer\">problem (issue)<\/a>."
+    },
+    "firmwareFlasherOnlineSelectFirmwareVersionDescription": {
+        "message": "Izaberite verziju firmvera za Vašu pločicu."
+    },
+    "firmwareFlasherNoRebootDescription": {
+        "message": "Uključite ako je Vaš flight kontroler u boot modu, tj. ako ste uključili flight kontroler sa prespojenim pinovima za bootloader ili dok ste držali dugme BOOT na flight kontroleru."
+    },
+    "firmwareFlasherFlashOnConnect": {
+        "message": "Flešuj pri povezivanju"
+    },
+    "firmwareFlasherFlashOnConnectDescription": {
+        "message": "Pokušaj automatskog flešovanja pločice (pokreće se kada se detektuje novi serijski port).<br \/><br \/><span class=\"message-negative\">UPOZORENJE<\/span>: ova funkcija isključuje funkcije detekcije i rezervne kopije."
+    },
+    "firmwareFlasherFullChipErase": {
+        "message": "Potpuno brisanje čipa"
+    },
+    "firmwareFlasherFullChipEraseDescription": {
+        "message": "Briše sve podatke podešavanja koji su trenutno sačuvani na pločici."
+    },
+    "firmwareFlasherFlashDevelopmentFirmware": {
+        "message": "Koristi razvojni firmver"
+    },
+    "firmwareFlasherFlashDevelopmentFirmwareDescription": {
+        "message": "Flešuj najnoviji (netestirani) razvojni firmver."
+    },
+    "firmwareFlasherManualPort": {
+        "message": "Port"
+    },
+    "firmwareFlasherManualBaud": {
+        "message": "Ručni baud rate"
+    },
+    "firmwareFlasherManualBaudDescription": {
+        "message": "Ručni izbor baud rate-a za pločice koje ne podržavaju fabričku brzinu ili za flešovanje putem Bluetooth-a.<br \/><span class=\"message-negative\">Napomena:<\/span> Ne koristi se prilikom flešovanja putem USB DFU"
+    },
+    "firmwareFlasherBaudRate": {
+        "message": "Baud rate"
+    },
+    "firmwareFlasherShowDevelopmentReleases": {
+        "message": "Prikaži kandidate za izdanje"
+    },
+    "firmwareFlasherShowDevelopmentReleasesDescription": {
+        "message": "Prikaži kandidate za izdanje pored stabilnih izdanja"
+    },
+    "firmwareFlasherOptionLoading": {
+        "message": "Učitavanje…"
+    },
+    "firmwareFlasherOptionLabelBuildTypeRelease": {
+        "message": "Zvanično izdanje"
+    },
+    "firmwareFlasherOptionLabelBuildTypeReleaseCandidate": {
+        "message": "Zvanično izdanje i kandidat za izdanje"
+    },
+    "firmwareFlasherOptionLabelBuildTypeDevelopment": {
+        "message": "Razvojna verzija"
+    },
+    "firmwareFlasherOptionLabelBuildTypeAKK3_3": {
+        "message": "3.3 AKK & RDQ VTX zakrpa"
+    },
+    "firmwareFlasherOptionLabelBuildTypeAKK3_4": {
+        "message": "3.4 AKK & RDQ VTX zakrpa"
+    },
+    "firmwareFlasherOptionLabelSelectFirmware": {
+        "message": "Izaberite firmver \/ pločicu"
+    },
+    "firmwareFlasherOptionLabelSelectBoard": {
+        "message": "Izaberite pločicu"
+    },
+    "firmwareFlasherOptionLabelSelectFirmwareVersion": {
+        "message": "Izaberite verziju firmvera"
+    },
+    "firmwareFlasherOptionLabelSelectFirmwareVersionFor": {
+        "message": "Izaberite verziju firmvera za"
+    },
+    "firmwareFlasherButtonLoadLocal": {
+        "message": "Učitaj firmver [Lokalno]"
+    },
+    "firmwareFlasherButtonLoadOnline": {
+        "message": "Učitaj firmver [Onlajn]"
+    },
+    "firmwareFlasherButtonDownloading": {
+        "message": "Preuzimanje..."
+    },
+    "firmwareFlasherExitDfu": {
+        "message": "Napusti DFU mod"
+    },
+    "firmwareFlasherFindDfuDevice": {
+        "message": "Pronađi DFU uređaj"
+    },
+    "firmwareFlasherFlashFirmware": {
+        "message": "Flešuj firmver"
+    },
+    "firmwareFlasherFlashFirmwareOptions": {
+        "message": "Opcije flešovanja firmvera"
+    },
+    "firmwareFlasherLoadFirmwareOptions": {
+        "message": "Opcije učitavanja firmvera"
+    },
+    "firmwareFlasherFlashingProgress": {
+        "message": "Napredak flešovanja",
+        "description": "Accessible label for the circular progress ring shown during firmware flashing."
+    },
+    "firmwareFlasherGithubInfoHead": {
+        "message": "Informacije o firmveru sa GitHub-a"
+    },
+    "firmwareFlasherCommiter": {
+        "message": "Autor izmene:"
+    },
+    "firmwareFlasherDate": {
+        "message": "Datum:"
+    },
+    "firmwareFlasherHash": {
+        "message": "Heš:"
+    },
+    "firmwareFlasherUrl": {
+        "message": "Otvorite GitHub da biste pregledali ovu izmenu..."
+    },
+    "firmwareFlasherMessage": {
+        "message": "Poruka:"
+    },
+    "firmwareFlasherWarningText": {
+        "message": "<span class=\"message-negative\">Ne<\/span> pokušavajte da ovim alatom upišete firmver na uređaj koji <strong>nije Betaflight<\/strong>.<br \/><span class=\"message-negative\">Ne<\/span> <strong>isključujte<\/strong> pločicu i ne <strong>gasite<\/strong> računar dok traje upis.<br \/><br \/><strong>Napomena: <\/strong>STM32 bootloader je u ROM memoriji i ne može se pokvariti.<br \/><strong>Napomena: <\/strong><span class=\"message-negative\">Automatsko povezivanje<\/span> je uvek isključeno dok ste u alatu za upis firmvera.<br \/><strong>Napomena: <\/strong>Napravite rezervnu kopiju — neka ažuriranja brišu sva Vaša podešavanja.<br \/><strong>Napomena:<\/strong> Ako imate problema pri upisu, <strong>prvo isključite sve kablove sa flight kontrolera<\/strong>, pa restartujte računar i ažurirajte upravljačke programe.<br \/><strong>Napomena:<\/strong> Kod pločica sa direktno vezanim USB priključkom, a to su skoro sve novije, obavezno pročitajte deo uputstva o upisu preko USB-a i proverite da imate ispravne upravljačke programe"
+    },
+    "firmwareFlasherWarningShort": {
+        "message": "Nemojte flešovati hardver koji nije Betaflight. Nemojte odspajati pločicu tokom flešovanja. STM32 bootloader je u ROM-u i ne može se uništiti. Uvek napravite rezervnu kopiju konfiguracije pre nadogradnje."
+    },
+    "firmwareFlasherRecoveryHead": {
+        "message": "<strong>Oporavak \/ izgubljena veza<\/strong>"
+    },
+    "firmwareFlasherRecoveryText": {
+        "message": "Ako ste izgubili komunikaciju sa pločicom, pratite ove korake da biste je obnovili:<ul><li>Isključite napajanje<\/li><li>Uključite 'No reboot sequence' i 'Full chip erase'.<\/li><li>Spojite BOOT pinove kratkospojnikom ili držite dugme BOOT.<\/li><li>Uključite napajanje (LED indikator aktivnosti NEĆE trepereti ako je urađeno ispravno).<\/li><li>Instalirajte sve STM32 drajvere i Zadig ako je potrebno (pogledajte odeljak <a href=\"https:\/\/betaflight.com\/docs\/wiki\/getting-started\/firmware-installation\" target=\"_blank\" rel=\"noopener noreferrer\">USB Flashing<\/a> u Betaflight uputstvu).<\/li><li>Zatvorite aplikaciju, a zatim je ponovo pokrenite.<\/li><li>Otpustite dugme BOOT ako ga Vaš FC ima.<\/li><li>Flešujte odgovarajući firmver (koristeći ručno podešenu brzinu prenosa ako je navedeno u uputstvu za Vaš FC).<\/li><li>Isključite napajanje.<\/li><li>Uklonite BOOT kratkospojnik.<\/li><li>Uključite napajanje (LED indikator aktivnosti bi trebalo da treperi).<\/li><li>Povežite se normalno.<\/li><\/ul>"
+    },
+    "firmwareFlasherRecoveryShort": {
+        "message": "Ako ste izgubili komunikaciju: isključite napajanje, uključite No Reboot Sequence i Full Chip Erase, spojite BOOT pinove, a zatim uključite napajanje. Instalirajte drajvere ako je potrebno."
+    },
+    "firmwareFlasherReadMore": {
+        "message": "Pročitajte više →"
+    },
+    "firmwareFlasherSubTabBoardBuild": {
+        "message": "Pločica i izrada"
+    },
+    "firmwareFlasherAdvancedTitle": {
+        "message": "Napredno"
+    },
+    "firmwareFlasherSubTabFlash": {
+        "message": "Flešovanje"
+    },
+    "firmwareFlasherButtonLeave": {
+        "message": "Napustite flešovanje firmvera"
+    },
+    "firmwareFlasherFirmwareNotLoaded": {
+        "message": "Firmver nije učitan"
+    },
+    "firmwareFlasherFirmwareLoaded": {
+        "message": "Firmver"
+    },
+    "firmwareFlasherFirmwareSize": {
+        "message": "{{bytes}} bajtova"
+    },
+    "firmwareFlasherFirmwareLocalLoaded": {
+        "message": "Učitan lokalni firmver: {{filename}} ({{bytes}} bajtova)"
+    },
+    "firmwareFlasherFirmwareOnlineLoaded": {
+        "message": "Učitan mrežni firmver: {{filename}} ({{bytes}} bajtova)"
+    },
+    "firmwareFlasherTooltipSaveFirmware": {
+        "message": "Sačuvaj firmver"
+    },
+    "firmwareFlasherInvalidFileFormat": {
+        "message": "Neispravan format fajla"
+    },
+    "firmwareFlasherUf2Corrupted": {
+        "message": "Izgleda da je UF2 fajl oštećena"
+    },
+    "firmwareFlasherHexCorrupted": {
+        "message": "Izgleda da je HEX fajl oštećena"
+    },
+    "firmwareFlasherUF2SaveSuccess": {
+        "message": "UF2 je uspešno sačuvan (upisan)"
+    },
+    "firmwareFlasherUF2SaveFailed": {
+        "message": "Čuvanje (upisivanje) UF2 fajla nije uspelo"
+    },
+    "firmwareFlasherEsp32Connecting": {
+        "message": "Povezivanje sa ESP32 bootloader-om..."
+    },
+    "firmwareFlasherEsp32Detected": {
+        "message": "Detektovan $1"
+    },
+    "firmwareFlasherEsp32Flashing": {
+        "message": "Flešovanje ESP32..."
+    },
+    "firmwareFlasherEsp32Rebooting": {
+        "message": "Flešovanje je završeno, ponovno pokretanje..."
+    },
+    "firmwareFlasherEsp32Complete": {
+        "message": "ESP32 je uspešno flešovan"
+    },
+    "firmwareFlasherEsp32Failed": {
+        "message": "Flešovanje ESP32 nije uspelo: $1"
+    },
+    "firmwareFlasherEsp32NotSupported": {
+        "message": "Za flešovanje ESP32 potrebna je verzija za pregledač (Web Serial)"
+    },
+    "firmwareFlasherEsp32NoPort": {
+        "message": "Izaberite serijski port pre flešovanja ESP32"
+    },
+    "firmwareFlasherClickToConnectDfu": {
+        "message": "Kliknite za povezivanje sa DFU uređajem"
+    },
+    "firmwareFlasherConfigCorrupted": {
+        "message": "Izgleda da je konfiguraciona fajl oštećena, prihvata se ASCII (karakteri 0-255)",
+        "description": "shown in the progress bar at the bottom, be brief"
+    },
+    "firmwareFlasherConfigCorruptedLogMessage": {
+        "message": "Izgleda da je konfiguraciona fajl oštećena, prihvata se ASCII (karakteri 0-255), karakteri izvan ovog opsega su dozvoljeni kao komentari",
+        "description": "shown in the log, more wordy"
+    },
+    "firmwareFlasherRemoteFirmwareLoaded": {
+        "message": "<span class=\"message-positive\">Udaljeni firmver je učitan, spremno za flešovanje<\/span>"
+    },
+    "firmwareFlasherFailedToLoadOnlineFirmware": {
+        "message": "Neuspešno učitavanje udaljenog firmvera"
+    },
+    "firmwareFlasherFailedToLoadUnifiedConfig": {
+        "message": "Neuspešno učitavanje udaljene konfiguracije za {{remote_file}}"
+    },
+    "firmwareFlasherCanceledBackup": {
+        "message": "Pravljenje rezervne kopije je otkazano, flešovanje je prekinuto"
+    },
+    "firmwareFlasherBackupInvalidData": {
+        "message": "Neuspešna rezervna kopija: primljeni su nevažeći podaci sa uređaja (nije u CLI modu), flešovanje je prekinuto"
+    },
+    "firmwareFlasherLegacyLabel": {
+        "message": "{{target}} (Legacy)",
+        "description": "If we have a Unified target and a old style target available, we are labeling the older one"
+    },
+    "firmwareFlasherNoFirmwareSelected": {
+        "message": "<b>Nije izabran firmver za učitavanje<\/b>"
+    },
+    "firmwareFlasherNoTargetsLoaded": {
+        "message": "Nije učitana nijedna meta"
+    },
+    "firmwareFlasherNoValidPort": {
+        "message": "<span class=\"message-negative\">Molimo izaberite važeći serijski port<\/span>"
+    },
+    "firmwareFlasherWritePermissions": {
+        "message": "Nemate <span class=\"message-negative\">dozvolu za pisanje<\/span> za ovu fajl"
+    },
+    "firmwareFlasherFlashTrigger": {
+        "message": "Detektovano: <strong>$1<\/strong> - pokreće se flešovanje pri povezivanju"
+    },
+    "firmwareFlasherVerifyBoard": {
+        "message": "<h3>Firmver se ne poklapa<\/h3><br \/>Povezana pločica je <strong>{{verified_board}}<\/strong>, dok ste Vi izabrali <strong>{{selected_board}}<\/strong>.<br \/><br \/>Da li želite da nastavite flešovanje?",
+        "description": "Make a quick connection to read firmware target and never flash a wrong target again"
+    },
+    "firmwareFlasherBoardVerificationSuccess": {
+        "message": "Aplikacija je <span class=\"message-positive\">uspešno<\/span> detektovala i potvrdila pločicu: <strong>{{boardName}}<\/strong>",
+        "description": "Board verification has succeeded."
+    },
+    "firmwareFlasherBoardVerficationTargetNotAvailable": {
+        "message": "Aplikacija je detektovala pločicu: <strong>{{boardName}}<\/strong>, ali nije pronađena zvanična Betaflight meta",
+        "description": "Board verification has succeeded, but the target is not available as official Betaflight target."
+    },
+    "firmwareFlasherBoardVerificationFail": {
+        "message": "Aplikacija <span class=\"message-negative\">nije uspela<\/span> da potvrdi pločicu. Ako se ovo nastavi, pokušajte da promenite karticu i pokušate ponovo, ponovo povežete USB ili se prvo povežite ako ste možda zaboravili da primenite prilagođena fabrička podešavanja.",
+        "description": "Sometimes MSP values cannot be read from firmware correctly"
+    },
+    "firmwareFlasherButtonAbort": {
+        "message": "Prekini"
+    },
+    "firmwareFlasherButtonContinue": {
+        "message": "Nastavi"
+    },
+    "firmwareFlasherDetectBoardButton": {
+        "message": "Detektuj"
+    },
+    "firmwareFlasherDetectBoardDescriptionHint": {
+        "message": "Detekcija radi samo kada niste u DFU modu i kada MSP komunikacija funkcioniše. Ponekad morate pokušati nekoliko puta ili čak ponovo povezati USB. Pokušajte prvo da se povežete normalno, jer ste možda zaboravili da primenite prilagođena fabrička podešavanja. Molimo ponovo pokrenite uređaj nakon flešovanja - ponovo priključite USB."
+    },
+    "firmwareFlasherDetectBoardQuery": {
+        "message": "Očitajte informacije o pločici radi izbora odgovarajućeg firmvera"
+    },
+    "unstableFirmwareAcknowledgementDialog": {
+        "message": "Spremate se da flešujete <strong>razvojnu verziju firmvera<\/strong>. Ove verzije su u procesu izrade i bilo šta od sledećeg može biti slučaj:<strong><ul><li>firmver uopšte ne radi;<\/li><li>sa firmverom se ne može leteti;<\/li><li>postoje bezbednosni problemi sa firmverom, na primer odletanje letelice;<\/li><li>firmver može uzrokovati da flight kontroler postane neodzivan ili da se ošteti<\/li><\/ul><\/strong>Ako nastavite sa flešovanjem ovog firmvera, <strong>preuzimate punu odgovornost za rizik od bilo kog od gore navedenih događaja<\/strong>. Takođe potvrđujete da je neophodno izvršiti <strong>temeljna testiranja na stolu bez propeler<\/strong> pre bilo kakvog pokušaja letenja sa ovim firmverom."
+    },
+    "unstableFirmwareAcknowledgement": {
+        "message": "Pročitao sam gore navedeno i <strong>preuzimam punu odgovornost<strong> za upis nestabilnog firmvera"
+    },
+    "unstableFirmwareAcknowledgementFlash": {
+        "message": "Flešuj"
+    },
+    "firmwareFlasherRemindBackupTitle": {
+        "message": "Brisanje podešavanja",
+        "description": "Warning message title before actual flashing takes place"
+    },
+    "firmwareFlasherRemindBackup": {
+        "message": "Flešovanje novog firmvera će obrisati sva podešavanja. Preporučujemo da sačuvate rezervnu kopiju pre nego što nastavite.",
+        "description": "Warning message before actual flashing takes place"
+    },
+    "firmwareFlasherBackup": {
+        "message": "Napravi rezervnu kopiju",
+        "description": "Create a backup before actual flashing takes place"
+    },
+    "firmwareFlasherBackupIgnore": {
+        "message": "Zanemari rizik",
+        "description": "Ignore creating a backup before actual flashing takes place"
+    },
+    "firmwareBackupEnabled": {
+        "message": "Pravljenje rezervne kopije uključeno"
+    },
+    "firmwareBackupDisabled": {
+        "message": "Pravljenje rezervne kopije isključeno"
+    },
+    "firmwareBackupAsk": {
+        "message": "Pitaj pre pravljenja rezervne kopije"
+    },
+    "ledStripHelp": {
+        "message": "Flight kontroler može upravljati bojama i efektima pojedinačnih LED lampica na traci.<br \/>Podesite LED lampice na mreži, podesite redosled povezivanja, a zatim pričvrstite LED lampice na Vašu letelicu prema pozicijama na mreži. LED lampice bez rednog broja žice neće biti sačuvane.<br \/>Dvaput kliknite na boju da biste izmenili HSV vrednosti."
+    },
+    "ledStripButtonSave": {
+        "message": "Sačuvaj"
+    },
+    "ledStripColorSetupTitle": {
+        "message": "Podešavanje boja",
+        "description": "Color setup title of the led strip"
+    },
+    "ledStripH": {
+        "message": "H",
+        "description": "Abbreviation of Hue in HSV (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripS": {
+        "message": "S",
+        "description": "Abbreviation of Saturation in HSV  (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripV": {
+        "message": "V",
+        "description": "Abbreviation of Brightness in HSV  (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripRemainingText": {
+        "message": "Preostalo",
+        "description": "In the LED STRIP, text next the counter of leds remaining"
+    },
+    "ledStripClearSelectedButton": {
+        "message": "Obriši izabrano",
+        "description": "In the LED STRIP, clear selected leds"
+    },
+    "ledStripClearAllButton": {
+        "message": "Očisti SVE",
+        "description": "In the LED STRIP, clear all leds"
+    },
+    "ledStripVtxOverlay": {
+        "message": "VTX (koristi VTX frekvenciju za dodelu boje)"
+    },
+    "ledStripBrightnessSliderTitle": {
+        "message": "Osvetljenost",
+        "description": "Brightness of the LED Strip"
+    },
+    "ledStripBrightnessSliderHelp": {
+        "message": "Maksimalni procenat osvetljenosti LED lampica."
+    },
+    "ledStripRainbowDeltaSliderTitle": {
+        "message": "Delta",
+        "description": "LED Strip rainbow effect delta"
+    },
+    "ledStripRainbowDeltaSliderHelp": {
+        "message": "Razlika u nijansi između LED lampica.",
+        "description": "Hint on LED Strip tab for rainbow delta"
+    },
+    "ledStripRainbowFreqSliderTitle": {
+        "message": "Frekvencija",
+        "description": "LED Strip rainbow effect frequency"
+    },
+    "ledStripRainbowFreqSliderHelp": {
+        "message": "Frekvencija promene boje, odnosno brzina efekta.",
+        "description": "Hint on LED Strip tab for rainbow frequency"
+    },
+    "ledStripFunctionSection": {
+        "message": "LED funkcije"
+    },
+    "ledStripFunctionTitle": {
+        "message": "Funkcija"
+    },
+    "ledStripFunctionNoneOption": {
+        "message": "Ništa",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionColorOption": {
+        "message": "Boja",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionModesOption": {
+        "message": "Modovi &amp; orijentacija",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionArmOption": {
+        "message": "ARM stanje",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionBatteryOption": {
+        "message": "Baterija",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionRSSIOption": {
+        "message": "RSSI",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionGPSOption": {
+        "message": "GPS",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionGPSBarOption": {
+        "message": "GPS traka",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionBatteryBarOption": {
+        "message": "Indikator baterije",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionAltitudeOption": {
+        "message": "Visina",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionRingOption": {
+        "message": "Prsten",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripColorModifierTitle": {
+        "message": "Modifikator boje"
+    },
+    "ledStripModeColorsTitle": {
+        "message": "Boje modova"
+    },
+    "ledStripModeColorsModeOrientation": {
+        "message": "Orijentacija",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeHeadfree": {
+        "message": "Headfree",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeHorizon": {
+        "message": "Horizon",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeAngle": {
+        "message": "Angle",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeMag": {
+        "message": "Mag",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeBaro": {
+        "message": "Baro",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripDirN": {
+        "message": "N",
+        "description": "North direction in Color Mode in Led Strip"
+    },
+    "ledStripDirE": {
+        "message": "E",
+        "description": "East direction in Color Mode in Led Strip"
+    },
+    "ledStripDirS": {
+        "message": "S",
+        "description": "South direction in Color Mode in Led Strip"
+    },
+    "ledStripDirW": {
+        "message": "W",
+        "description": "West direction in Color Mode in Led Strip"
+    },
+    "ledStripDirU": {
+        "message": "U",
+        "description": "Up direction in Color Mode in Led Strip"
+    },
+    "ledStripDirD": {
+        "message": "D",
+        "description": "Down direction in Color Mode in Led Strip"
+    },
+    "ledStripModesOrientationTitle": {
+        "message": "LED orijentacija ('Modes &amp; Orientation') i boja",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModesSpecialColorsTitle": {
+        "message": "Posebne boje",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeDisarmed": {
+        "message": "Razoružan",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeArmed": {
+        "message": "Armovan",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeAnimation": {
+        "message": "Animacija",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeBlinkBg": {
+        "message": "Treptanje pozadine",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSNoSats": {
+        "message": "GPS: nema satelita",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSNoLock": {
+        "message": "GPS: nije zaključan",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSLocked": {
+        "message": "GPS: zaključan",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeGpsDefault": {
+        "message": "Fabričko",
+        "description": "One of the modes in GPS Mode in Led Strip"
+    },
+    "ledStripModeGpsBar": {
+        "message": "Traka",
+        "description": "One of the modes in GPS Mode in Led Strip"
+    },
+    "ledStripWiring": {
+        "message": "Povezivanje LED trake",
+        "description": "One of the modes in Led Strip"
+    },
+    "ledStripWiringMode": {
+        "message": "Mod redosleda povezivanja",
+        "description": "One of the wiring modes in Led Strip"
+    },
+    "ledStripWiringClearControl": {
+        "message": "Obriši izabrano",
+        "description": "Control button in the wiring modes in Led Strip"
+    },
+    "ledStripWiringClearAllControl": {
+        "message": "Obriši SVO povezivanje",
+        "description": "Control button in the wiring modes in Led Strip"
+    },
+    "ledStripWiringMessage": {
+        "message": "LED diode bez broja redosleda neće biti sačuvane.",
+        "description": "Message in the wiring modes in Led Strip"
+    },
+    "ledStripLarsonOverlay": {
+        "message": "Larson skener",
+        "description": "Larson effect switch label on LED Strip tab"
+    },
+    "ledStripBlinkAlwaysOverlay": {
+        "message": "Stalno treperenje"
+    },
+    "ledStripThrottleHue": {
+        "message": "Nijansa prema gasu",
+        "description": "Label of throttle hue modifier switch on LED Strip tab"
+    },
+    "ledStripThrottleHueChannel": {
+        "message": "Kanal nijanse gasa",
+        "description": "Accessible label for the aux-channel select next to the throttle hue switch"
+    },
+    "ledStripRainbowOverlay": {
+        "message": "Duga",
+        "description": "Label of rainbow effect switch on LED Strip tab"
+    },
+    "ledStripOverlayTitle": {
+        "message": "Preklapanje"
+    },
+    "ledStripWarningsOverlay": {
+        "message": "Upozorenja"
+    },
+    "ledStripIndecatorOverlay": {
+        "message": "Indikator (koristi poziciju na matrici)"
+    },
+    "colorBlack": {
+        "message": "crna"
+    },
+    "colorWhite": {
+        "message": "bela"
+    },
+    "colorRed": {
+        "message": "crvena"
+    },
+    "colorOrange": {
+        "message": "narandžasta"
+    },
+    "colorYellow": {
+        "message": "žuta"
+    },
+    "colorLimeGreen": {
+        "message": "limeta zelena"
+    },
+    "colorGreen": {
+        "message": "zelena"
+    },
+    "colorMintGreen": {
+        "message": "menta zelena"
+    },
+    "colorCyan": {
+        "message": "cijan"
+    },
+    "colorLightBlue": {
+        "message": "svetloplava"
+    },
+    "colorBlue": {
+        "message": "plava"
+    },
+    "colorDarkViolet": {
+        "message": "Tamnoljubičasta"
+    },
+    "colorMagenta": {
+        "message": "Magenta"
+    },
+    "colorDeepPink": {
+        "message": "Tamnoružičasta"
+    },
+    "controlAxisRoll": {
+        "message": "Roll [A]"
+    },
+    "controlAxisPitch": {
+        "message": "Pitch [E]"
+    },
+    "controlAxisYaw": {
+        "message": "Yaw [R]"
+    },
+    "controlAxisThrottle": {
+        "message": "Gas [T]"
+    },
+    "controlAxisAux1": {
+        "message": "AUX 1"
+    },
+    "controlAxisAux2": {
+        "message": "AUX 2"
+    },
+    "controlAxisAux3": {
+        "message": "AUX 3"
+    },
+    "controlAxisAux4": {
+        "message": "AUX 4"
+    },
+    "controlAxisAux5": {
+        "message": "AUX 5"
+    },
+    "controlAxisAux6": {
+        "message": "AUX 6"
+    },
+    "controlAxisAux7": {
+        "message": "AUX 7"
+    },
+    "controlAxisAux8": {
+        "message": "AUX 8"
+    },
+    "controlAxisAux9": {
+        "message": "AUX 9"
+    },
+    "controlAxisAux10": {
+        "message": "AUX 10"
+    },
+    "controlAxisAux11": {
+        "message": "AUX 11"
+    },
+    "controlAxisAux12": {
+        "message": "AUX 12"
+    },
+    "controlAxisAux13": {
+        "message": "AUX 13"
+    },
+    "controlAxisAux14": {
+        "message": "AUX 14"
+    },
+    "controlAxisAux15": {
+        "message": "AUX 15"
+    },
+    "controlAxisAux16": {
+        "message": "AUX 16"
+    },
+    "pidTuningBasic": {
+        "message": "Osnovno\/Acro"
+    },
+    "pidTuningYawJumpPrevention": {
+        "message": "Yaw Jump Prevention"
+    },
+    "pidTuningYawJumpPreventionHelp": {
+        "message": "Sprečava odskakanje letelice na kraju Yaw rotacije. Veća vrednost daje jače prigušenje na kraju Yaw pokreta (radi kao stari Yaw D, koji nije bio pravi D kao na ostalim osama)"
+    },
+    "pidTuningRcExpoPower": {
+        "message": "RC Expo Power"
+    },
+    "pidTuningRcExpoPowerHelp": {
+        "message": "Eksponent koji se koristi pri izračunavanju RC Expo-a. U verzijama Betaflight-a pre 3.0, vrednost je fiksirana na 3."
+    },
+    "pidTuningLevel": {
+        "message": "Angle\/Horizon"
+    },
+    "pidTuningAltitude": {
+        "message": "Barometar i sonar \/ visina"
+    },
+    "pidTuningMag": {
+        "message": "Magnetometar \/ Heading"
+    },
+    "pidTuningGps": {
+        "message": "GPS navigacija"
+    },
+    "pidTuningStrength": {
+        "message": "Jačina"
+    },
+    "pidTuningTransition": {
+        "message": "Prelaz"
+    },
+    "pidTuningHorizon": {
+        "message": "Horizon"
+    },
+    "pidTuningAngle": {
+        "message": "Angle"
+    },
+    "pidTuningLevelAngleLimit": {
+        "message": "Angle limit"
+    },
+    "pidTuningLevelSensitivity": {
+        "message": "Osetljivost"
+    },
+    "pidTuningLevelHelp": {
+        "message": "Vrednosti ispod menjaju ponašanje ANGLE i HORIZON modova leta. Različiti PID kontroleri obrađuju vrednosti na različite načine. Molimo Vas da proverite dokumentaciju."
+    },
+    "pidTuningMotorOutputLimit": {
+        "message": "Ograničenje izlaza motora"
+    },
+    "pidTuningMotorLimit": {
+        "message": "Faktor skaliranja [%]"
+    },
+    "pidTuningMotorLimitHelp": {
+        "message": "Procenat smanjenja pogonskog signala po motoru.<br><br>Smanjuje struju ESC-a i grejanje motora kada koristite baterije sa većim brojem ćelija na motorima sa visokim KV.<br><br>Kada koristite 6S bateriju na letelici sa 4S motorima, propelerima i podešavanjem, pokušajte sa 66%; kada koristite 4S bateriju na letelici namenjenoj za 3S, pokušajte sa 75%.<br><br>Proverite da li sve Vaše komponente mogu da podrže napon baterije koju koristite."
+    },
+    "pidTuningCellCount": {
+        "message": "Broj ćelija — za automatsko menjanje profila"
+    },
+    "pidTuningCellCountHelp": {
+        "message": "Automatski aktivira prvi profil koji ima broj ćelija jednak povezanoj bateriji.<br><br><ul><li><b>Prebaci<\/b>: Uvek prebaci na profil sa odgovarajućim brojem ćelija ako postoji.<\/li><li><b>Isključi<\/b>: Isključi automatsko menjanje profila<\/li><b>1S-8S<\/b>: Izaberite broj ćelija za ovaj profil<\/li><\/ul>"
+    },
+    "pidTuningCellCountChange": {
+        "message": "Prebaci",
+        "description": "Switch profile if there are no profiles matching cell count"
+    },
+    "pidTuningCellCountStay": {
+        "message": "Isključi",
+        "description": "Disable cell count for this profile"
+    },
+    "pidTuningCellCount1S": {
+        "message": "1S"
+    },
+    "pidTuningCellCount2S": {
+        "message": "2S"
+    },
+    "pidTuningCellCount3S": {
+        "message": "3S"
+    },
+    "pidTuningCellCount4S": {
+        "message": "4S"
+    },
+    "pidTuningCellCount5S": {
+        "message": "5S"
+    },
+    "pidTuningCellCount6S": {
+        "message": "6S"
+    },
+    "pidTuningCellCount7S": {
+        "message": "7S"
+    },
+    "pidTuningCellCount8S": {
+        "message": "8S"
+    },
+    "pidTuningNonProfileFilterSettings": {
+        "message": "Podešavanja filtera nezavisna od profila"
+    },
+    "pidTuningFilterSlidersHelp": {
+        "message": "Ovi klizači prilagođavaju žiroskop i D-term filtere.<br \/><br \/>Za jače filtriranje:<br \/> - Klizači ulevo<br> - Niže granične frekvencije.<br \/><br \/> Jače filtriranje održava motore hladnijim uklanjanjem više šuma, ali više kasni signal žiroskopa i može pogoršati propwash ili izazvati rezonantne oscilacije. Manje odzivne letelice, npr. X-Class, najbolje rade sa jačim filtriranjem. <br><br>Za slabije filtriranje:<br \/> - Klizači udesno<br \/> - Više granične frekvencije <br><br>Slabije filtriranje smanjuje kašnjenje signala žiroskopa i često poboljšava propwash. Pomeranje lowpass filtera žiroskopa udesno je obično u redu, ali pomeranje D filtera udesno obično nije potrebno i može lako dovesti do veoma vrućih motora.",
+        "description": "Overall helpicon message for filter tuning sliders"
+    },
+    "pidTuningSliderLowFiltering": {
+        "message": "Slabije filtriranje",
+        "description": "Filter tuning slider low header"
+    },
+    "pidTuningSliderDefaultFiltering": {
+        "message": "Fabričko filtriranje",
+        "description": "Filter tuning slider default header"
+    },
+    "pidTuningSliderHighFiltering": {
+        "message": "Jače filtriranje",
+        "description": "Filter tuning slider high header"
+    },
+    "pidTuningGyroFilterSlider": {
+        "message": "Množilac filtera žiroskopa",
+        "description": "Gyro filter tuning slider label"
+    },
+    "pidTuningGyroFilterSliderHelp": {
+        "message": "Menja granične frekvencije lowpass filtera žiroskopa.<br \/><br \/>Pomeranje klizača ulevo daje jače filtriranje žiroskopa (niža granična frekvencija).<br \/><br \/>Pomeranje klizača udesno daje slabije filtriranje žiroskopa (viša granična frekvencija).<br \/><br \/>Kada pomerate klizač udesno radi boljeg ponašanja pri propwash-u, BUDITE OPREZNI da ne odete predaleko. Propustićete više šuma u P i D i možete dobiti odletanje letelice ili pregorevanje motora.<br \/><br \/>Možda ćete morati da pomerite klizač ulevo ako imate problema sa rezonancijom rama, lošim ležajevima, oštećenim propelerima, vrućim motorima itd.<br \/><br \/>Filtriranje žiroskopa se primenjuje pre i pored D filtriranja.",
+        "description": "Gyro filter tuning slider helpicon message"
+    },
+    "pidTuningDTermFilterSlider": {
+        "message": "Množilac D-term filtera",
+        "description": "D Term filter tuning slider label"
+    },
+    "pidTuningDTermFilterSliderHelp": {
+        "message": "Menja granične frekvencije D-term lowpass filtera.<br \/><br \/>Pomeranje klizača ulevo daje jače D filtriranje (niža granična frekvencija).<br \/><br \/>Pomeranje klizača udesno daje slabije filtriranje (viša granična frekvencija).<br \/><br \/>D-term je najosetljiviji PID element na šum i rezonanciju. Može pojačati visokofrekventni šum od 10 do 100 puta. Zato su granične frekvencije D filtera mnogo niže od filtera žiroskopa.<br \/><br \/>D-term filtriranje se primenjuje nakon i pored filtriranja žiroskopa. Fabričko D filtriranje je optimalno za većinu letelica i retko ga treba menjati.<br \/><br \/>Pomeranje ovog klizača ulevo smanjuje grejanje motora kod bučnih letelica i kod visokih PID 'D' vrednosti, ali se može javiti više propwash-a i rezonancije D niže frekvencije.<br \/><br \/>Pomeranje klizača udesno se ne preporučuje, ali može poboljšati propwash na čistim izradama. Može izazvati struganje motora pri armovanju, iznenadne rezonancije u letu i ozbiljno pregrevanje motora.",
+        "description": "D Term filter tuning slider helpicon message"
+    },
+    "pidTuningPidSlidersHelp": {
+        "message": "Klizači za podešavanje letačkih karakteristika letelice (PID pojačanja)<br \/><br \/>Prigušenje (D pojačanje): Odupire se brzom kretanju, smanjuje P oscilacije.<br \/><br \/>Praćenje (P i I pojačanje): Poboljšava odziv letelice; ako je previsoko, može izazvati podrhtavanje ili oscilacije.<br \/><br \/>Odziv ručice (Feedforward): Povećava odziv letelice na brže pokrete ručice.<br \/><br \/>Zanošenje - Lelujanje (I pojačanje, ekspert): Fino podešavanje I.<br \/><br \/>Dinamički D (D Max, ekspert): Podešava maksimalan iznos za koji D može biti povećan tokom brzih pokreta.<br \/><br \/>Pitch prigušenje (Pitch:Roll D odnos, ekspert): Povećava iznos prigušenja na Pitch-u u odnosu na Roll.<br \/><br \/>Pitch praćenje (Pitch:Roll P, I i F odnos, ekspert): Povećava snagu stabilizacije na Pitch-u u odnosu na Roll.<br \/><br \/>Glavni množilac (sva pojačanja, ekspert): Povećava ili smanjuje sva PID pojačanja, održavajući njihove proporcije konstantnim.",
+        "description": "Overall helpicon message for PID tuning sliders"
+    },
+    "pidTuningSliderWarning": {
+        "message": "<span class=\"message-negative\">OPREZ<\/span>: Trenutne pozicije klizača mogu izazvati odletanje letelice, oštećenje motora ili nebezbedno ponašanje letelice. Nastavite sa oprezom.",
+        "description": "Warning shown when tuning slider are above safe limits"
+    },
+    "pidTuningSlidersDisabled": {
+        "message": "<strong>Napomena:<\/strong> Klizači su isključeni jer su vrednosti ručno promenjene. Klikom na dugme '$t(pidTuningSliderEnableButton.message)' ponovo ćete ih aktivirati. Ovo će resetovati vrednosti i sve nesačuvane izmene će biti izgubljene.",
+        "description": "Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningGyroSliderDisabled": {
+        "message": "<strong>Napomena:<\/strong> Klizač žiroskopa je isključen jer su vrednosti ručno promenjene. Klikom na dugme '$t(pidTuningGyroSliderEnableButton.message)' ponovo ćete ga aktivirati. Ovo će resetovati vrednosti i sve nesačuvane izmene će biti izgubljene.",
+        "description": "Gyro Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningDTermSliderDisabled": {
+        "message": "<strong>Napomena:<\/strong> Klizač DTerm-a je isključen jer su vrednosti ručno promenjene. Klikom na dugme '$t(pidTuningDTermSliderEnableButton.message)' ponovo ćete ga aktivirati. Ovo će resetovati vrednosti i sve nesačuvane izmene će biti izgubljene.",
+        "description": "DTerm Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningPidSlidersDisabled": {
+        "message": "<strong>Napomena:<\/strong> Klizači su isključeni. Klikom na dugme '$t(pidTuningSliderEnableButton.message)' promenićete PID vrednosti kako bi odgovarale Vašoj prethodno sačuvanoj poziciji klizača.",
+        "description": "Tuning sliders disabled note"
+    },
+    "pidTuningSliderEnableButton": {
+        "message": "Uključi klizače",
+        "description": "Button label for enabling sliders"
+    },
+    "pidTuningSlidersNonExpertMode": {
+        "message": "<strong>Napomena:<\/strong> Opseg klizača je ograničen jer niste u ekspertskom modu. Ovaj opseg bi trebalo da odgovara većini izrada i početnicima.",
+        "description": "Sliders restricted message"
+    },
+    "pidTuningPidSlidersNonExpertMode": {
+        "message": "<strong>Napomena:<\/strong> Pristup i opseg klizača su ograničeni jer niste u ekspertskom modu. Osnovni mod bi trebalo da odgovara većini izrada i početnicima.",
+        "description": "Firmware Pid sliders restricted message"
+    },
+    "pidTuningFilterSlidersNonExpertMode": {
+        "message": "<strong>Napomena:<\/strong> Opseg klizača je ograničen jer niste u ekspertskom modu. Ovaj opseg bi trebalo da odgovara većini izrada i početnicima.",
+        "description": "Firmware filter sliders restricted message"
+    },
+    "pidTuningSlidersExpertSettingsDetectedNote": {
+        "message": "<strong>Napomena:<\/strong> Klizač(i) su isključeni jer su trenutne vrednosti izvan opsega podešavanja u osnovnom modu. Pređite na ekspertski mod da biste napravili izmene",
+        "description": "Slider expert settings detected while in non-expert mode"
+    },
+    "pidTuningSliderLow": {
+        "message": "Nisko",
+        "description": "Tuning Slider Low header"
+    },
+    "pidTuningSliderDefault": {
+        "message": "Fabričko",
+        "description": "Tuning Slider Default header"
+    },
+    "pidTuningSliderHigh": {
+        "message": "Visoko",
+        "description": "Tuning Slider High header"
+    },
+    "pidTuningMasterSlider": {
+        "message": "Glavni množilac:",
+        "description": "Master tuning slider label"
+    },
+    "pidTuningMasterSliderHelp": {
+        "message": "Jednako povećava sve PID parametre. Nemojte menjati ovaj klizač osim ako ne potrošite opseg podešavanja na ostalim klizačima. Obično je ovo potrebno samo za letelice sa malim autoritetom ili velikim momentom inercije (MoI) kao što su X-Class ili cinelifter izrade. Preveliko glavno pojačanje može izazvati podrhtavanje, oscilacije ili vruće motore.",
+        "description": "Master Gain tuning slider helpicon message"
+    },
+    "pidTuningDGainSlider": {
+        "message": "Prigušenje:<br \/><i><small>D Gains<\/small><\/i>",
+        "description": "D Gain (Damping) tuning slider label"
+    },
+    "pidTuningDGainSliderHelp": {
+        "message": "Relativno visoke D vrednosti će prigušiti odziv ručice i mogu zagrejati motore, ali bi trebalo da pomognu u kontroli brzih oscilacija i poboljšaju ponašanje u propwash-u.<br \/><br \/>Relativno nizak D-term daje brži odziv ručice, ali će oslabiti performanse u propwash-u i reakciju na spoljne uticaje (vetar).",
+        "description": "D gain balance tuning slider helpicon message"
+    },
+    "pidTuningPIGainSlider": {
+        "message": "Praćenje:<br \/><i><small>P & I Gains<\/small><\/i>",
+        "description": "P and I Gain (Stability) tuning slider label"
+    },
+    "pidTuningPIGainSliderHelp": {
+        "message": "Povećajte klizač Praćenje da biste pojačali reakciju letelice na Vaše komande i spoljne uticaje, sprečavajući da nos letelice skrene sa putanje u bilo kom trenutku.<br \/><br \/>Niže vrednosti za „Praćenje” uzrokuju dosta lelujanja i letelica će skretati sa putanje pri pomeranju ručice i u propwash-u. Visoke vrednosti mogu dovesti do oscilacija i brzog povratnog udarca (teško se vidi, ali se čuje). Prekomerno praćenje može rezultirati oscilacijama i vrućim motorima.",
+        "description": "P and I gain tuning slider helpicon message"
+    },
+    "pidTuningResponseSlider": {
+        "message": "Odziv ručice:<br \/><i><small>FF Gains<\/small><\/i>",
+        "description": "Response tuning slider label"
+    },
+    "pidTuningResponseSliderHelp": {
+        "message": "Niži odziv ručice povećava kašnjenje pokreta letelice u odnosu na komande i može izazvati spor povratni udarac na kraju izvođenja flip-a ili roll-a.<br><br>Veći odziv ručice daje oštriju reakciju letelice na brze pokrete ručice. Prevelik odziv ručice može izazvati prelaženje željene pozicije na kraju flip-a ili roll-a.<br \/><br \/><strong>Napomena:<\/strong><br \/>Opcija „I-term Relax” može smanjiti povratni udarac za letelice sa manjom snagom ili ako se koriste niske vrednosti za odziv ručice.",
+        "description": "Stick response gain tuning slider helpicon message"
+    },
+    "pidTuningIGainSlider": {
+        "message": "Zanošenje - Lelujanje:<br \/><i><small>I Gains<\/small><\/i>",
+        "description": "I-term slider label"
+    },
+    "pidTuningIGainSliderHelp": {
+        "message": "Povećava ili smanjuje I vrednosti. Veće I može poboljšati praćenje u spiralnim zaokretima, kruženju ili pri komandama sa 0% gasa. Previše I, naročito uz nedovoljno P, može izazvati lelujanje ili povratni udarac nakon flip-a\/roll-a ili pri naglom oduzimanju gasa na 0%.<br \/><br \/>Uopšteno, želite da klizač „Zanošenje – Lelujanje” bude što je moguće viši kako bi letelica pratila putanju u spiralnim zaokretima, kruženju itd... ali ne toliko visok da počne lelujanje pri naglom oduzimanju gasa na 0%.<br \/><br \/><strong>Napomena:<\/strong><br \/>Ako primetite jasne povratne udarce u bilo kom trenutku, uverite se da je opcija „I-term Relax” uključena i pokušajte sa smanjenjem vrednosti iterm_relax_cutoff.",
+        "description": "I-gain Gain tuning slider helpicon message"
+    },
+    "pidTuningDMaxGainSlider": {
+        "message": "Dinamičko prigušenje:<br \/><i><small>D Max<\/small><\/i>",
+        "description": "D Max slider label"
+    },
+    "pidTuningDMaxGainSliderHelp": {
+        "message": "Povećava D max, odnosno maksimalnu vrednost do koje D može porasti tokom brzih pokreta.<br \/><br \/>Za trkačke letelice, gde je glavni klizač za Prigušenje postavljen nisko radi smanjenja grejanja motora, pomeranje ovog klizača udesno će poboljšati kontrolu prelaženja željene pozicije pri brzoj promeni smera.<br \/><br \/>Za HD letelice ili letelice za filmsko snimanje, nestabilnost u letu unapred se najbolje rešava pomeranjem klizača Prigušenje (a ne klizača Dinamičko prigušenje) udesno. Proverite grejanje motora i slušajte ima li čudnih zvukova tokom brzih komandi sa daljinskog dok pomerate ovaj klizač udesno.<br \/><br \/>Za freestyle letelice, posebno teže izrade, pomeranje ovog klizača udesno može pomoći u kontroli prelaženja željene pozicije u flip-ovima i roll-ovima.<br \/><br \/><strong>Napomena:<\/strong><br \/>Prelaženje željene pozicije u flip-ovima i roll-ovima je obično uzrokovano nedovoljnim „I-term Relax” podešavanjem, desinhronizacijom motora ili nedovoljnom snagom (tzv. zasićenje motora). Ako pomeranje klizača za dinamičko prigušenje udesno ne poboljša stanje, vratite ga u normalan položaj i potražite stvarni uzrok lelujanja.",
+        "description": "D Max slider helpicon message"
+    },
+    "pidTuningRollPitchRatioSlider": {
+        "message": "Pitch prigušenje:<br \/><i><small>Pitch:Roll D<\/small><\/i>",
+        "description": "Pitch-Roll Ratio slider label"
+    },
+    "pidTuningRollPitchRatioSliderHelp": {
+        "message": "Povećava prigušenje (D) SAMO na Pitch osi, odnosno za Pitch u odnosu na Roll. Pomaže u kontroli prelaženja pozicije ili povratnog udarca specifičnog za Pitch.<br \/><br \/>Letelice sa „težim” momentom inercije na Pitch osi uglavnom zahtevaju jače prigušenje (pošto Pitch ima veću inerciju i akumulira više zamaha).<br \/><br \/>Prvo podesite glavne klizače „Prigušenje” i\/ili „Praćenje” dok ne dobijete dobro ponašanje na Roll osi. Zatim koristite klizače za Pitch (povećajte ili smanjite) za fino podešavanje Pitch ose bez uticaja na Roll.",
+        "description": "Pitch-Roll Ratio tuning slider helpicon message"
+    },
+    "pidTuningPitchPIGainSlider": {
+        "message": "Pitch praćenje:<br><i><small>Pitch:Roll P, I & FF<\/small><\/i>",
+        "description": "Pitch P & I slider label"
+    },
+    "pidTuningPitchPIGainSliderHelp": {
+        "message": "Povećava jačinu praćenja SAMO na Pitch osi promenom Pitch P i I vrednosti u odnosu na Roll. Omogućava jače praćenje na Pitch osi u odnosu na Roll.<br \/><br \/>Povećajte da biste stabilizovali lelujanje nosa pri oštrim Pitch komandama ili naglom oduzimanju gasa. Takođe razmotrite povećanje Anti-Gravity vrednosti.<br \/><br \/>Prvo podesite glavne klizače „Prigušenje” i\/ili „Praćenje” dok ne dobijete dobro ponašanje na Roll osi. Zatim koristite klizače za Pitch (povećajte ili smanjite) za fino podešavanje Pitch ose bez uticaja na Roll.",
+        "description": "Pitch P & I Gain tuning slider helpicon message"
+    },
+    "pidTuningGyroLowpassFiltersGroup": {
+        "message": "Niskopropusni žiroskopski filteri"
+    },
+    "pidTuningGyroLowpassType": {
+        "message": "Vrsta 1. niskopropusnog žiroskopskog filtera"
+    },
+    "pidTuningGyroLowpass": {
+        "message": "Gyro Lowpass 1"
+    },
+    "pidTuningGyroLowpassHelp": {
+        "message": "Prvi od dva niskopropusna žiroskopska filtera.<br \/><br \/>Upotreba prvog niskopropusnog žiroskopskog filtera u dinamičkom modu bila je važna sa starijim kodom dinamičkog notch filtera. Prvi niskopropusni filter se obično može potpuno isključiti u firmveru 4.3 kada se koristi RPM filtriranje, osim ako žiroskop nema interno hardversko filtriranje.<br \/><br \/>U dinamičkom modu, filtriranje će biti jače na niskom gasu, sa manje filtriranja i manjim kašnjenjem kako se gas povećava. Prelaz sa niske na visoku graničnu frekvenciju dešavaće se ranije pri povećanju gasa ako su više eksponencijalne vrednosti niskopropusnog žiroskopskog filtera.<br \/><br \/>U statičkom modu, granična frekvencija je fiksna.<br \/><br \/>Vrsta filtera je fabrički postavljena na PT1. Filtriranje višeg reda je retko potrebno.",
+        "description": "Help icon for the Gyro Lowpass 1 Filter"
+    },
+    "pidTuningGyroLowpassMode": {
+        "message": "Mod"
+    },
+    "pidTuningLowpassStatic": {
+        "message": "STATIČKI"
+    },
+    "pidTuningLowpassDynamic": {
+        "message": "DINAMIČKI"
+    },
+    "pidTuningLowpassFilterType": {
+        "message": "Vrsta filtera"
+    },
+    "pidTuningMinCutoffFrequency": {
+        "message": "Minimalna granična frekvencija [Hz]"
+    },
+    "pidTuningMaxCutoffFrequency": {
+        "message": "Maksimalna granična frekvencija [Hz]"
+    },
+    "pidTuningGyroLowpass2": {
+        "message": "Gyro Lowpass 2"
+    },
+    "pidTuningGyroLowpass2Help": {
+        "message": "Drugi od dva niskopropusna žiroskopska filtera.<br \/><br \/>Ovaj filter radi u petlji žiroskopa, filtrirajući signal pre nego što uđe u PID petlju. Uvek je u statičkom modu (sa fiksnom graničnom frekvencijom).<br \/><br \/>Ako je frekvencija PID petlje manja od frekvencije petlje žiroskopa (npr. PID petlja od 4kHz sa petljom žiroskopa od 8kHz), ovaj filter treba zadržati kako bi se sprečili problemi sa preslikavanjem frekvencija usled smanjenja učestalosti odabiranja sa 8kHz na 4kHz.<br \/><br \/>Pojedinačna konfiguracija drugog niskopropusnog žiroskopskog filtera, podešeno negde između 500 i 1000Hz, radi dobro za Betaflight 4.3 ili noviji, za čiste izrade sa aktivnim RPM filtriranjem i bar fabričkim D filtriranjem.",
+        "description": "Gyro lowpass filter helpicon message"
+    },
+    "pidTuningGyroLowpassFilterHelp": {
+        "message": "Žiroskopski niskopropusni filteri prigušuju šum viših frekvencija kako ne bi ušao u PID petlju. Postoje dva žiroskopska filtera koja se mogu nezavisno podešavati; fabrički su oba aktivna.<br \/><br \/>Uz RPM filtriranje, klizač žiroskopskog filtera se često može pomeriti malo udesno, ili jedan statički žiroskopski niskopropusni filter na 500 Hz može biti dovoljan.<br \/><br \/>Letelica će imati manje propwash-a uz najmanje kašnjenje žiroskopskog filtera.<br \/><br \/>Uvek proverite zagrevanje motora kada pomerate klizače udesno. Uz minimalno žiroskopsko filtriranje, od ključne je važnosti imati dovoljno D filtriranja. Budite oprezni.",
+        "description": "Gyro lowpass filter helpicon message"
+    },
+    "pidTuningDTermLowpassFilterHelp": {
+        "message": "D-term niskopropusni filteri prigušuju šum viših frekvencija i rezonance koje bi inače bile pojačane D pojačanjem.<br \/><br \/>Postoje dva D filtera i njihovi efekti se sabiraju. Oba su potrebna u skoro svim letelicama, iako se jedan PT2 može koristiti umesto dva PT1 filtera.<br \/><br \/>Uopšteno, letelica će leteti najbolje i imati najmanje propwash-a kada je podešena na najmanje kašnjenje filtera (klizači udesno, više granične vrednosti). Međutim, posebno sa D filterima, klizači udesno mogu znatno povećati šansu za pregrevanje motora.<br \/><br \/>Veoma je lako spaliti motore ako nemate dovoljno D filtriranja, budite oprezni.",
+        "description": "D-term lowpass filter helpicon message"
+    },
+    "pidTuningGyroNotchFiltersGroup": {
+        "message": "Žiroskopski notch filteri"
+    },
+    "pidTuningGyroNotchFilter": {
+        "message": "Žiroskopski notch filter 1"
+    },
+    "pidTuningGyroNotchFilterHelp": {
+        "message": "Primenjuje statički (konstantna frekvencija) notch filter na žiroskop, na navedenoj centralnoj frekvenciji.<br \/><br \/>Može biti koristan za izolovane rezonance konstantne frekvencije koje utiču i na P i na D.<br \/><br \/>Da bi bio koristan, rezonantna frekvencija mora biti konstantna u celom opsegu gasa.<br \/><br \/>Širina notch filtera se podešava graničnom frekvencijom. Granična frekvencija bi obično trebalo da bude podešena između 10% i 40% ispod centralne frekvencije. Koristite najuži opseg filtera koji kontroliše rezonancu. Izbegavajte podešavanje notch filtera ispod 100 Hz, osim u posebnim okolnostima.<br \/><br \/>Statički notch filteri su retko potrebni u verziji 4.3."
+    },
+    "pidTuningGyroNotchFilter2": {
+        "message": "Žiroskopski notch filter 2"
+    },
+    "pidTuningGyroNotchFilter2Help": {
+        "message": "Primenjuje drugi statički (konstantna frekvencija) notch filter na žiroskop.<br \/><br \/>Ovo je retko potrebno i treba ga koristiti samo kao poslednju opciju za borbu protiv druge linije rezonance fiksne frekvencije koja se ne može kontrolisati drugim sredstvima."
+    },
+    "pidTuningCenterFrequency": {
+        "message": "Centralna frekvencija [Hz]"
+    },
+    "pidTuningCutoffFrequency": {
+        "message": "Granična frekvencija [Hz]"
+    },
+    "pidTuningNotchFilterHelp": {
+        "message": "Notch filter je simetrični, uski filter sa parametrima za centralnu i graničnu frekvenciju.<br \/><br \/>Centralna vrednost je centralna frekvencija filtera. Granična vrednost je donja -3 dB granična frekvencija.<br \/><br \/>Na primer, Notch Cutoff od 160 sa Notch Center od 260 daje široki notch sa opsegom od -3 dB od 160-360 Hz i najjačim prigušenjem oko 260 Hz.",
+        "description": "Notch filter helpicon message"
+    },
+    "pidTuningDynamicNotchFilterGroup": {
+        "message": "Dynamic Notch filter"
+    },
+    "pidTuningDynamicNotchFilterHelp": {
+        "message": "Dynamic Notch filter prati vrhunce frekvencije šuma motora i postavlja notch filtere na te frekvencije, nezavisno za svaku osu."
+    },
+    "pidTuningMultiDynamicNotchFilterHelp": {
+        "message": "Dynamic Notch filter prati vrhunce frekvencije šuma žiroskopa i postavlja od jedan do pet notch filtera sa njihovim centrom na tim frekvencijama na svakoj osi."
+    },
+    "pidTuningDynamicNotchFilterDisabledWarning": {
+        "message": "<strong>Napomena:<\/strong> Dynamic notch filter je isključen. Da biste ga podesili i koristili, uključite opciju 'DYNAMIC_FILTER' u odeljku '$t(configurationFeatures.message)' na kartici '$t(tabConfiguration.message)'. Takođe se uverite da je PID looprate najmanje 2kHz."
+    },
+    "pidTuningDynamicNotchFilterNyquistWarning": {
+        "message": "Dynamic notch filter je isključen. Da biste ga koristili, uverite se da je učestanost PID petlje podešena na najmanje 2kHz na kartici '$t(tabConfiguration.message)'."
+    },
+    "pidTuningDynamicNotchRange": {
+        "message": "Opseg Dynamic Notch filtera"
+    },
+    "pidTuningDynamicNotchQ": {
+        "message": "Q faktor (x100)"
+    },
+    "pidTuningDynamicNotchMinHz": {
+        "message": "Min frekvencija [Hz]"
+    },
+    "pidTuningDynamicNotchMaxHz": {
+        "message": "Maks frekvencija [Hz]"
+    },
+    "pidTuningDynamicNotchCount": {
+        "message": "Broj notch filtera"
+    },
+    "pidTuningDynamicNotchRangeHelp": {
+        "message": "Dynamic notch ima tri frekventna opsega u kojima može da radi: LOW (80-330 Hz) za letelice sa nižim brojem obrtaja poput 6+ inča, MEDIUM (140-550 Hz) za standardne letelice od 5 inča, HIGH (230-800 Hz) za letelice sa veoma visokim brojem obrtaja od 2,5-3 inča. Opcija AUTO bira opseg u zavisnosti od vrednosti maksimalne granične frekvencije filtera Gyro Dynamic Lowpass 1."
+    },
+    "pidTuningDynamicNotchQHelp": {
+        "message": "Q faktor podešava koliko su uski ili široki dynamic notch filteri. Sačuvana vrednost je Q faktor × 100 (npr. 300 = Q 3,0). Veća vrednost ga čini užim i preciznijim, a manja vrednost ga čini širim. Veoma niska vrednost će znatno povećati kašnjenje filtera."
+    },
+    "pidTuningDynamicNotchMinHzHelp": {
+        "message": "Podesite ovo na najnižu frekvenciju ulaznog šuma koju je potrebno kontrolisati pomoću dynamic notch filtera."
+    },
+    "pidTuningDynamicNotchMaxHzHelp": {
+        "message": "Podesite ovo na najvišu frekvenciju ulaznog šuma koju je potrebno kontrolisati pomoću dynamic notch filtera."
+    },
+    "pidTuningDynamicNotchCountHelp": {
+        "message": "Podešava broj dynamic notch filtera po osi. Sa uključenim RPM filterom preporučuje se vrednost 1 ili 2. Bez RPM filtera preporučuje se vrednost 4 ili 5. Manji brojevi će smanjiti kašnjenje filtera, ali mogu povećati temperaturu motora."
+    },
+    "pidTuningRpmFilterGroup": {
+        "message": "Gyro RPM filter",
+        "description": "Header text for the RPM Filter group"
+    },
+    "pidTuningRpmFilterHelp": {
+        "message": "RPM filtriranje je skup notch filtera na žiroskopu koji koriste RPM telemetrijske podatke za uklanjanje šuma motora sa hirurškom preciznošću.<br \/><br \/><b><span class=\"message-positive\">VAŽNO<\/span>: ESC mora podržavati Bidirectional DShot protokol i vrednost $t(configurationMotorPoles.message) u kartici $t(tabMotorTesting.message) mora biti tačna da bi ovaj filter radio.<\/b>",
+        "description": "Header text for the RPM Filter group"
+    },
+    "pidTuningRpmHarmonics": {
+        "message": "Harmonici",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmHarmonicsHelp": {
+        "message": "Broj harmonika po motoru. Vrednost 3 (preporučeno za većinu letelica) generiše 3 notch filtera po motoru za svaku osu, što je ukupno 36 notch filtera. Jedan na osnovnoj frekvenciji motora i dva harmonika na umnošcima te osnovne frekvencije.",
+        "description": "Help text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmMinHz": {
+        "message": "Min frekvencija [Hz]",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmMinHzHelp": {
+        "message": "Minimalna frekvencija koju će koristiti RPM filter.",
+        "description": "Help text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmFadeRangeHz": {
+        "message": "Opseg slabljenja [Hz]",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmQ": {
+        "message": "Q faktor (x100)",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmQHelp": {
+        "message": "Q faktor podešava koliko su uski ili široki RPM notch filteri. Zapamćena vrednost je Q faktor × 100, dozvoljeni opseg je 250–3000 (Q 2,5 do Q 30,0), fabrički 500 (Q 5,0). Veće vrednosti čine svaki notch užim i preciznijim; manje vrednosti ih čine širim. Veoma niske vrednosti značajno povećavaju kašnjenje filtera."
+    },
+    "pidTuningRpmWeight": {
+        "message": "Težina {{index}}",
+        "description": "Text for the per-harmonic weight parameter of the RPM Filter"
+    },
+    "pidTuningFilterSettings": {
+        "message": "Podešavanja filtera zavisna od profila"
+    },
+    "pidTuningDTermLowpass": {
+        "message": "D Term lowpass 1"
+    },
+    "pidTuningDTermLowpassHelp": {
+        "message": "Prvi od dva D-term lowpass filtera.<br \/><br \/>U dinamičkom modu, filtriranje će biti jače na niskom gasu, sa manje filtriranja i manje kašnjenja kako se gas povećava. Ovo pomaže u kontroli škripanja motora ili neočekivanog odletanja pri armovanju, dok smanjuje kašnjenje i propwash nakon poletanja. Prelazak sa niske na visoku graničnu frekvenciju dešavaće se ranije kako se gas povećava, sa višim vrednostima D-term lowpass expo.<br \/><br \/>U statičkom modu, granična frekvencija je fiksna. Ovo se ne preporučuje za D filtriranje.<br \/><br \/>Vrsta filtera je fabrički PT1, iako su neki korisnici ovde koristili samo jedan dinamički Biquad filter, bez drugog PT1.<br \/><br \/>Promene koje rezultiraju manjim D filtriranjem mogu izazvati ozbiljno pregrevanje motora ili odletanje letelice pri armovanju.",
+        "description": "Help icon for the DTerm Lowpass 1 Filter"
+    },
+    "pidTuningDTermLowpassMode": {
+        "message": "Mod"
+    },
+    "pidTuningDTermLowpass2": {
+        "message": "D Term lowpass 2"
+    },
+    "pidTuningDTermLowpass2Help": {
+        "message": "Drugi od dva D-term lowpass filtera.<br \/><br \/>Ovaj filter je uvek u statičkom modu (fiksna granična frekvencija). Za D filtriranje su potrebna najmanje dva PT1 lowpass filtera ili jedan filter drugog reda.<br \/><br \/>Obično je ova granična frekvencija podešena na višu vrednost opsega dinamičkog lowpass 1 filtera. Ovo obezbeđuje kontrolu šuma drugog reda iznad te frekvencije.<br \/><br \/>Promene koje rezultiraju manjim D filtriranjem mogu izazvati ozbiljno pregrevanje motora ili odletanje letelice pri armovanju.",
+        "description": "Help icon for the DTerm Lowpass 2 Filter"
+    },
+    "pidTuningDTermLowpassFiltersGroup": {
+        "message": "D Term lowpass filteri"
+    },
+    "pidTuningDTermLowpassType": {
+        "message": "Vrsta filtera"
+    },
+    "pidTuningStaticCutoffFrequency": {
+        "message": "Statička granična frekvencija [Hz]"
+    },
+    "pidTuningDTermLowpass2Type": {
+        "message": "Vrsta filtera"
+    },
+    "pidTuningDTermLowpassDynExpo": {
+        "message": "Expo dinamičke krive"
+    },
+    "pidTuningDTermNotchFiltersGroup": {
+        "message": "D Term notch filter"
+    },
+    "pidTuningDTermNotchFiltersGroupHelp": {
+        "message": "Primenjuje statički notch filter (konstantne frekvencije) na D-Term podatke, na navedenoj centralnoj frekvenciji.<br \/><br \/>Širina notch filtera se podešava graničnom frekvencijom.<br \/><br \/>Može biti korisno za izolovane rezonance konstantne frekvencije koje D pojačava.<br \/><br \/>Držite graničnu frekvenciju što bliže centru. Izbegavajte podešavanje notch filtera ispod 100 Hz, osim na letelicama sa niskim RPM-om."
+    },
+    "pidTuningYawLowpassFiltersGroup": {
+        "message": "Yaw lowpass filter"
+    },
+    "pidTuningYawLowpassFiltersGroupHelp": {
+        "message": "Primenjuje PT1 filter na navedenoj graničnoj frekvenciji na podatke sa žiroskopa po Yaw osi."
+    },
+    "pidTuningVbatPidCompensation": {
+        "message": "Vbat PID kompenzacija"
+    },
+    "pidTuningVbatPidCompensationHelp": {
+        "message": "Povećava PID vrednosti radi kompenzacije kada opadne Vbat napon. Ovo daje ujednačenije karakteristike leta tokom celog trajanja baterije. Količina kompenzacije koja se primenjuje izračunava se na osnovu $t(powerBatteryMaximum.message) podešenog na stranici $t(tabPower.message), pa se uverite da je ta vrednost odgovarajuća."
+    },
+    "pidTuningVbatSagCompensation": {
+        "message": "Vbat sag kompenzacija %"
+    },
+    "pidTuningVbatSagCompensationHelp": {
+        "message": "Pruža ujednačene performanse gasa i PID-a tokom celog opsega radnog napona baterije povećavanjem snage motora kako napon opada.<br \/><br \/>Količina kompenzacije se može menjati između 0 i 100%. Preporučuje se potpuna kompenzacija (100%).<br \/><br \/>Posetite <a href=\"https:\/\/betaflight.com\/docs\/wiki\/tuning\/4-2-Tuning-Notes#dynamic-battery-sag-compensation\" target=\"_blank\" rel=\"noopener noreferrer\">ovaj wiki članak<\/a> za više informacija."
+    },
+    "pidTuningVbatSagValue": {
+        "message": "%"
+    },
+    "pidTuningThrustLinearization": {
+        "message": "Linearizacija potiska %"
+    },
+    "pidTuningThrustLinearizationHelp": {
+        "message": "Poboljšava odziv i kontrolu na niskom gasu.<br><br>Naročito korisno za whoop letelice i ESC-ove na 48kHz. Nema uticaja pri većem gasu.<br><br>Količina kompenzacije se može menjati između 0 i 150%. Obično je dovoljno 30-40%."
+    },
+    "pidTuningThrustLinearValue": {
+        "message": "%"
+    },
+    "pidTuningItermRotation": {
+        "message": "I Term rotacija"
+    },
+    "pidTuningItermRotationHelp": {
+        "message": "Pravilno rotira trenutni vektor I Term-a na druge ose kako se letelica okreće pri neprekidnom Yaw okretanju tokom Roll manevara, pri izvođenju funel-a i drugih trikova. Izuzetno korisno za LOS akro pilote."
+    },
+    "pidTuningItermRelax": {
+        "message": "I Term Relax"
+    },
+    "pidTuningItermRelaxHelp": {
+        "message": "Potiskuje nakupljanje I Term-a pri brzim pokretima, smanjujući povratni trzaj na kraju okretaja po Roll, Flip i drugim brzim komandama.<br><br>Setpoint mod reaguje na ublažene komande sa daljinskog i najbolje funkcioniše na odzivnim letelicama.<br><br>Gyro mod može biti koristan za izuzetno spore letelice.<br><br>Obično iTerm Relax ne treba primenjivati na Yaw."
+    },
+    "pidTuningItermRelaxAxes": {
+        "message": "Ose",
+        "description": "Iterm Relax Axes selection"
+    },
+    "pidTuningOptionRP": {
+        "message": "RP"
+    },
+    "pidTuningOptionRPY": {
+        "message": "RPY"
+    },
+    "pidTuningItermRelaxAxesOptionRPInc": {
+        "message": "RP (samo povećanje)"
+    },
+    "pidTuningItermRelaxAxesOptionRPYInc": {
+        "message": "RPY (samo povećanje)"
+    },
+    "pidTuningItermRelaxType": {
+        "message": "Tip",
+        "description": "Iterm Relax Type selection"
+    },
+    "pidTuningItermRelaxTypeOptionSetpoint": {
+        "message": "Setpoint"
+    },
+    "pidTuningItermRelaxCutoff": {
+        "message": "Granična frekvencija",
+        "description": "Cutoff value of the I Term Relax"
+    },
+    "pidTuningItermRelaxCutoffHelp": {
+        "message": "Niže vrednosti znače jače potiskivanje povratnog trzaja nakon Flip manevara kod manje odzivnih letelica. Više vrednosti povećavaju preciznost skretanja pri velikim brzinama rotacije za trke.<br><br>Podesite na 30-40 za trke, 15 za odzivne freestyle letelice, 10 za teže freestyle letelice, 3-5 za X-klasu."
+    },
+    "pidTuningAbsoluteControlGain": {
+        "message": "Absolute Control"
+    },
+    "pidTuningAbsoluteControlGainHelp": {
+        "message": "Ova funkcija rešava neke od osnovnih problema funkcije $t(pidTuningItermRotation.message) i u nekom trenutku je može zameniti. Ona akumulira apsolutnu grešku žiroskopa u koordinatama letelice i meša proporcionalnu korekciju u setpoint.<br><br>AirMode mora biti uključen, kao i $t(pidTuningItermRelax.message) (za $t(pidTuningOptionRP.message)). Kada se kombinuje sa $t(pidTuningIntegratedYaw.message), možete uključiti $t(pidTuningItermRelax.message) za $t(pidTuningOptionRPY.message)."
+    },
+    "pidTuningThrottleBoost": {
+        "message": "Throttle Boost"
+    },
+    "pidTuningThrottleBoostHelp": {
+        "message": "Trenutno pojačava gas pri bržim komandama gasa, pružajući neposredniji odziv gasa."
+    },
+    "pidTuningIdleMinRpm": {
+        "message": "Vrednost Dynamic Idle [* 100 RPM]"
+    },
+    "pidTuningIdleMinRpmHelp": {
+        "message": "Dynamic Idle poboljšava kontrolu na niskom RPM-u i smanjuje rizik od desinhronizacije motora. <br \/><br \/> Poboljšava PID autoritet, stabilnost na nultom gasu, vreme lebdenja naglavačke i kočenje motora.<br \/><br \/>Minimalni RPM za Dynamic Idle treba podesiti na oko 3000 - 3500 RPM. <br \/><br \/>Posetite <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Dynamic-Idle\" target=\"_blank\" rel=\"noopener noreferrer\">ovaj wiki članak<\/a> za više informacija."
+    },
+    "pidTuningIdleMinRpmDisabled": {
+        "message": "Dynamic Idle je isključen jer je DShot telemetrija isključena"
+    },
+    "pidTuningAcroTrainerAngleLimit": {
+        "message": "Ograničenje ugla za Acro Trainer"
+    },
+    "pidTuningAcroTrainerAngleLimitHelp": {
+        "message": "Pomaže pilotima da nauče da lete u acro modu ograničavanjem ugla koji letelica može da postigne. Važeća ograničenja su 10-80 stepeni. Mod mora biti aktiviran prekidačem u kartici $t(tabAuxiliary.message)."
+    },
+    "pidTuningIntegratedYaw": {
+        "message": "Integrated Yaw"
+    },
+    "pidTuningIntegratedYawCaution": {
+        "message": "<span class=\"message-negative\">OPREZ<\/span>: ako uključite ovu funkciju, morate shodno tome prilagoditi YAW PID. Više informacija <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Integrated-Yaw\" target=\"_blank\" rel=\"noopener noreferrer\">ovde<\/a>"
+    },
+    "pidTuningIntegratedYawHelp": {
+        "message": "Integrated Yaw integriše Yaw P, I i D vrednosti, omogućavajući da se Yaw P, I i D podešavaju slično kao Pitch i Roll.<br><br>Potrebno je vrlo malo I vrednosti, jer integrisani P deluje kao I, a integrisani D deluje kao P.<br><br>NAPOMENA: Integrated Yaw zahteva korišćenje funkcije Absolute Control, pošto I nije potreban uz Integrated Yaw."
+    },
+    "failsafeFeaturesHelpOld": {
+        "message": "Podešavanje Failsafe-a je znatno izmenjeno. Koristite Betaflight <strong>v1.12.0+<\/strong> da biste dobili poboljšani prozor za podešavanje."
+    },
+    "failsafePaneTitleOld": {
+        "message": "Failsafe prijemnika"
+    },
+    "failsafeFeaturesHelpNew": {
+        "message": "Failsafe ima dve faze. U <strong>fazu 1<\/strong> se ulazi kada neki od letačkih kanala ima neispravnu dužinu impulsa, kada prijemnik javi da je u Failsafe stanju, ili kada signala uopšte nema. Tada se zadato postupanje sa kanalima primenjuje na <span class=\"message-negative\">sve kanale<\/span> i ostavlja se kratko vreme da se signal vrati. U <strong>fazu 2<\/strong> se ulazi ako stanje greške potraje duže od zadatog zaštitnog vremena dok je dron <span class=\"message-negative\">armovan<\/span>. Svi kanali tada ostaju na zadatoj vrednosti, osim ako izabrani postupak ne odredi drugačije.<br \/><strong>Napomena:<\/strong> i pre ulaska u fazu 1, zadato postupanje primenjuje se na pojedinačne AUX kanale koji imaju neispravne impulse."
+    },
+    "failsafePulsrangeTitle": {
+        "message": "Podešavanje ispravnog opsega impulsa"
+    },
+    "failsafePulsrangeHelp": {
+        "message": "Impulsi kraći od najmanje ili duži od najveće dužine smatraju se neispravnim. Za AUX kanale tada se primenjuje zadato postupanje sa tim kanalom, a za letačke kanale se ulazi u fazu 1."
+    },
+    "failsafeRxMinUsecItem": {
+        "message": "Najmanja dužina"
+    },
+    "failsafeRxMaxUsecItem": {
+        "message": "Najveća dužina"
+    },
+    "failsafeChannelFallbackSettingsTitle": {
+        "message": "Faza 1 — postupanje sa kanalima"
+    },
+    "failsafeChannelFallbackSettingsHelp": {
+        "message": "Ova podešavanja primenjuju se na pojedinačne neispravne AUX kanale, ili na sve kanale pri ulasku u fazu 1. <strong>Napomena:<\/strong> vrednosti se čuvaju u koracima od dvadeset pet mikrosekundi, pa se sitne izmene gube."
+    },
+    "failsafeChannelFallbackSettingsAuto": {
+        "message": "<strong>Auto<\/strong> znači da Roll, Pitch i Yaw idu u sredinu, a Throttle na nisko. <strong>Hold<\/strong> znači da se zadržava poslednja ispravna primljena vrednost."
+    },
+    "failsafeChannelFallbackSettingsHold": {
+        "message": "<strong>Hold<\/strong> znači da se zadržava poslednja ispravna primljena vrednost. <strong>Set<\/strong> znači da se koristi vrednost koju ovde zadate."
+    },
+    "failsafeChannelFallbackSettingsValueAuto": {
+        "message": "Automatski",
+        "description": "Text for Auto option"
+    },
+    "failsafeChannelFallbackSettingsValueHold": {
+        "message": "Zadrži",
+        "description": "Text for Hold option"
+    },
+    "failsafeChannelFallbackSettingsValueSet": {
+        "message": "Postavi",
+        "description": "Text for Set option"
+    },
+    "failsafeStageTwoSettingsTitle": {
+        "message": "Faza 2 — podešavanja"
+    },
+    "failsafeDelayItem": {
+        "message": "Trajanje faze 1 posle gubitka signala [sekunde]"
+    },
+    "failsafeDelayHelp": {
+        "message": "Zadajte koliko traje faza 1 posle gubitka signala. Ako to vreme istekne a signal se ne vrati, pokreće se faza 2."
+    },
+    "failsafeThrottleLowItem": {
+        "message": "Odlaganje pri niskom gasu [sekunde]"
+    },
+    "failsafeThrottleLowHelp": {
+        "message": "Ako je gas bio nizak ovoliko dugo, dron se samo razoružava umesto da izvrši izabrani Failsafe postupak."
+    },
+    "failsafeThrottleItem": {
+        "message": "Vrednost gasa pri spuštanju"
+    },
+    "failsafeOffDelayItem": {
+        "message": "Odlaganje gašenja motora tokom Failsafe-a [sekunde]"
+    },
+    "failsafeOffDelayHelp": {
+        "message": "Koliko dugo dron ostaje u režimu spuštanja pre nego što se motori ugase i dron razoruža."
+    },
+    "failsafeSubTitle1": {
+        "message": "Faza 2 — postupak"
+    },
+    "failsafeProcedureItemSelect1": {
+        "message": "Land"
+    },
+    "failsafeProcedureItemSelect2": {
+        "message": "Drop"
+    },
+    "failsafeProcedureItemSelect4": {
+        "message": "GPS Rescue"
+    },
+    "failsafeGpsRescueItemAltitudeMode": {
+        "message": "Način određivanja visine"
+    },
+    "failsafeGpsRescueItemAltitudeModeMaxAlt": {
+        "message": "Najveća dostignuta visina"
+    },
+    "failsafeGpsRescueItemAltitudeModeFixedAlt": {
+        "message": "Zadata visina"
+    },
+    "failsafeGpsRescueItemAltitudeModeCurrentAlt": {
+        "message": "Trenutna visina"
+    },
+    "failsafeGpsRescueInitialClimb": {
+        "message": "Početno penjanje (metara)"
+    },
+    "failsafeGpsRescueInitialClimbHelp": {
+        "message": "Koliko će se dron popeti iznad trenutne visine kada povratak počne, ako je način određivanja visine postavljen na trenutnu visinu. Dodaje se i u režimu najveće visine."
+    },
+    "failsafeGpsRescueItemReturnAltitude": {
+        "message": "Visina povratka (metara) — <strong>važi samo u režimu zadate visine<\/strong>"
+    },
+    "failsafeGpsRescueItemAscendRate": {
+        "message": "Brzina penjanja (metara u sekundi)"
+    },
+    "failsafeGpsRescueItemGroundSpeed": {
+        "message": "Brzina povratka nad zemljom (metara u sekundi)"
+    },
+    "failsafeGpsRescueItemAngle": {
+        "message": "Najveći ugao nagiba unapred"
+    },
+    "failsafeGpsRescueAngleHelp": {
+        "message": "Veći najveći ugao znači brži i odlučniji povratak. Može biti koristan za teže dronove, one sa velikim otporom ili slabijim odzivom, kao i pri jačem vetru. PAŽNJA: uz povećanje ugla obično treba povećati i gas za povratak. U suprotnom dron može da izgubi visinu i padne."
+    },
+    "failsafeGpsRescueItemDescentDistance": {
+        "message": "Rastojanje na kom počinje spuštanje (metara)"
+    },
+    "failsafeGpsRescueItemDescendRate": {
+        "message": "Brzina spuštanja (metara u sekundi)"
+    },
+    "failsafeGpsRescueDescendRateHelp": {
+        "message": "Početna brzina spuštanja je tri puta veća od ove vrednosti i smanjuje se do zadate vrednosti na visini sletanja."
+    },
+    "failsafeGpsRescueItemMinStartDistHelp": {
+        "message": "Ako povratak počne preblizu mestu poletanja, unutar ovog najmanjeg rastojanja, dron će prvo odleteti pravo napred dok se ne udalji bar toliko, pa tek onda kreće uobičajen postupak povratka.",
+        "description": "Updated help text for the minimum start distance needed for GPS rescue to activate"
+    },
+    "failsafeGpsRescueItemThrottleMin": {
+        "message": "Najmanji gas"
+    },
+    "failsafeGpsRescueItemThrottleMax": {
+        "message": "Najveći gas"
+    },
+    "failsafeGpsRescueThrottleMaxHelp": {
+        "message": "Treba povećati za teže dronove, one sa velikim otporom ili slabijim odzivom, ako se očekuje povratak protiv jakog vetra, ili ako je povećan najveći ugao nagiba."
+    },
+    "failsafeGpsRescueItemThrottleHover": {
+        "message": "Gas za lebdenje — <span class=\"message-negative\">VAŽNO: postavite ovu vrednost tačno<\/span>"
+    },
+    "failsafeGpsRescueThrottleHoverHelp": {
+        "message": "Da biste našli pravu vrednost, postavite radnju Failsafe prekidača na fazu 2, postupak faze 2 na Land, pa menjajte vrednost gasa pri spuštanju dok dron ne počne da lebdi ili da se spušta polako. Tu vrednost zatim upišite kao gas za lebdenje pri GPS Rescue-u, i kao vrednost gasa u postupanju sa kanalima u fazi 1."
+    },
+    "failsafeGpsRescueItemMinDth": {
+        "message": "Najmanje rastojanje od mesta poletanja (metara)"
+    },
+    "failsafeGpsRescueItemMinDthHelp": {
+        "message": "Najmanje rastojanje od mesta poletanja potrebno da bi se GPS Rescue uopšte pokrenuo."
+    },
+    "failsafeGpsRescueItemMinSats": {
+        "message": "Najmanji broj satelita"
+    },
+    "failsafeGpsRescueItemAllowArmingWithoutFix": {
+        "message": "Dozvoli armovanje bez satelitskog položaja — <span class=\"message-negative\">PAŽNJA: bez položaja dron se razoružava pri Failsafe-u!<\/span>"
+    },
+    "failsafeGpsRescueArmWithoutFixHelp": {
+        "message": "Ne preporučuje se. Dozvoljava armovanje bez zabeleženog mesta poletanja, ali će se dron pri stvarnom gubitku signala razoružati i pasti. Ako se proba prekidačem, pre razoružavanja postoji kratak period u kom dron ne radi ništa."
+    },
+    "failsafeGpsRescueItemSanityChecks": {
+        "message": "Provere ispravnosti"
+    },
+    "failsafeGpsRescueItemSanityChecksOff": {
+        "message": "Isključeno"
+    },
+    "failsafeGpsRescueItemSanityChecksOn": {
+        "message": "Uključeno"
+    },
+    "failsafeGpsRescueItemSanityChecksFSOnly": {
+        "message": "Samo pri Failsafe-u"
+    },
+    "failsafeKillSwitchItem": {
+        "message": "Failsafe prekidač za trenutno gašenje (podesite Failsafe na kartici Modovi)"
+    },
+    "failsafeKillSwitchHelp": {
+        "message": "Ovom postavkom Failsafe prekidač sa kartice Modovi postaje prekidač za trenutno gašenje, koji zaobilazi izabrani Failsafe postupak. <strong>Napomena:<\/strong> dok je taj prekidač uključen, armovanje je onemogućeno."
+    },
+    "failsafeSwitchTitle": {
+        "message": "Failsafe prekidač"
+    },
+    "failsafeSwitchModeItem": {
+        "message": "Radnja Failsafe prekidača"
+    },
+    "failsafeSwitchModeHelp": {
+        "message": "Ova postavka određuje šta se dešava kada se Failsafe pokrene preko AUX prekidača:<br\/><strong>Faza 1<\/strong> pokreće fazu 1. Korisno je kada želite da isprobate kako se dron tačno ponaša pri gubitku signala.<br\/><strong>Faza 2<\/strong> preskače fazu 1 i odmah pokreće postupak faze 2.<br\/><strong>Trenutno gašenje<\/strong> razoružava dron istog trenutka, pa će dron pasti."
+    },
+    "failsafeSwitchOptionStage1": {
+        "message": "Faza 1"
+    },
+    "failsafeSwitchOptionStage2": {
+        "message": "Faza 2"
+    },
+    "failsafeSwitchOptionKill": {
+        "message": "Trenutno gašenje"
+    },
+    "powerButtonSave": {
+        "message": "Sačuvaj"
+    },
+    "powerFirmwareUpgradeRequired": {
+        "message": "Potrebno je <span class=\"message-negative\">ažuriranje firmvera<\/span>. Podešavanja baterije, napona i struje sa API-jem &lt; 1.33.0 (Betaflight &lt;= 3.17) nisu podržana."
+    },
+    "powerBatteryVoltageMeterSource": {
+        "message": "Izvor merenja napona"
+    },
+    "powerBatteryVoltageMeterTypeNone": {
+        "message": "Ništa"
+    },
+    "powerBatteryVoltageMeterTypeAdc": {
+        "message": "Merač na pločici"
+    },
+    "powerBatteryVoltageMeterTypeEsc": {
+        "message": "Senzor u regulatoru"
+    },
+    "powerBatteryCurrentMeterSource": {
+        "message": "Izvor merenja struje"
+    },
+    "powerBatteryCurrentMeterTypeNone": {
+        "message": "Ništa"
+    },
+    "powerBatteryCurrentMeterTypeAdc": {
+        "message": "Merač na pločici"
+    },
+    "powerBatteryCurrentMeterTypeVirtual": {
+        "message": "Računski"
+    },
+    "powerBatteryCurrentMeterTypeEsc": {
+        "message": "Senzor u regulatoru"
+    },
+    "powerBatteryCurrentMeterTypeMsp": {
+        "message": "MSP senzor \/ spoljni OSD"
+    },
+    "powerBatteryMinimum": {
+        "message": "Najniži napon ćelije"
+    },
+    "powerBatteryMaximum": {
+        "message": "Najviši napon ćelije"
+    },
+    "powerBatteryWarning": {
+        "message": "Napon ćelije za upozorenje"
+    },
+    "powerBatteryMinimumHelp": {
+        "message": "Napon koji se smatra kritično niskim i koji pokreće odgovarajuća upozorenja: „LAND NOWˮ na OSD-u i zvučni signal ako je piskalica zalemljena. Koristi se i pri računanju broja ćelija."
+    },
+    "powerBatteryMaximumHelp": {
+        "message": "Napon pune ćelije. Pomaže programu da izračuna broj ćelija u bateriji."
+    },
+    "powerBatteryWarningHelp": {
+        "message": "Napon koji se smatra niskim i koji pokreće odgovarajuće upozorenje: „LOW BATTERYˮ na OSD-u."
+    },
+    "powerCalibrationManagerButton": {
+        "message": "Kalibracija"
+    },
+    "powerCalibrationManagerTitle": {
+        "message": "Kalibracija merača"
+    },
+    "powerCalibrationManagerHelp": {
+        "message": "Za kalibraciju izmerite multimetrom stvarni napon i stvarnu jačinu struje na dronu, sa priključenom baterijom, pa te vrednosti upišite ispod. Zatim, sa istom baterijom i dalje priključenom, kliknite [Kalibriši]."
+    },
+    "powerCalibrationManagerNote": {
+        "message": "<strong>Napomena:<\/strong> pre kalibracije razmere proverite da su delilac i množilac za napon, kao i pomeraj za struju, ispravno postavljeni.<br>Ako ostanu na nuli, kalibracija se neće primeniti.<\/br><strong>Ne zaboravite da skinete propelere pre nego što priključite bateriju!<\/strong>"
+    },
+    "powerCalibrationManagerWarning": {
+        "message": "<span class=\"message-negative\">Pažnja:<\/span> baterija <span class=\"message-negative\">nije priključena<\/span> ili izvori merenja napona i struje <span class=\"message-negative\">nisu ispravno postavljeni.<\/span> Proverite da napon i jačina struje pokazuju vrednost veću od nule. U suprotnom kalibracija ovim alatom nije moguća."
+    },
+    "powerCalibrationManagerSourceNote": {
+        "message": "<span class=\"message-negative\">Pažnja:<\/span> izvori merenja napona i struje <strong>su promenjeni ali nisu sačuvani.<\/strong> Postavite ispravne izvore i sačuvajte ih pre nego što pokušate kalibraciju."
+    },
+    "powerCalibrationManagerConfirmationTitle": {
+        "message": "Potvrda kalibracije"
+    },
+    "powerCalibrationSave": {
+        "message": "Kalibriši"
+    },
+    "powerCalibrationApply": {
+        "message": "Primeni kalibraciju"
+    },
+    "powerCalibrationDiscard": {
+        "message": "Odbaci kalibraciju"
+    },
+    "powerCalibrationConfirmHelp": {
+        "message": "Ovde su prikazane nove kalibrisane razmere. <br>Primenom se razmere postavljaju, ali <strong>se ne čuvaju.<\/strong><\/br> <br>Posle čuvanja proverite da su novi napon i struja tačni.<\/br>"
+    },
+    "powerVoltageHead": {
+        "message": "Merač napona"
+    },
+    "powerVoltageWarning": {
+        "message": "<span class=\"message-negative\">Pažnja:<\/span> vrednosti su ograničene na 25,5 V."
+    },
+    "powerVoltageValue": {
+        "message": "$1 V"
+    },
+    "powerVoltageCalibration": {
+        "message": "Izmereni napon"
+    },
+    "powerVoltageCalibratedScale": {
+        "message": "Kalibrisana razmera napona:"
+    },
+    "powerVoltageId10": {
+        "message": "Baterija"
+    },
+    "powerVoltageId20": {
+        "message": "5V"
+    },
+    "powerVoltageId30": {
+        "message": "9V"
+    },
+    "powerVoltageId40": {
+        "message": "12V"
+    },
+    "powerVoltageId50": {
+        "message": "Svi regulatori zajedno"
+    },
+    "powerVoltageId60": {
+        "message": "Regulator motora 1"
+    },
+    "powerVoltageId61": {
+        "message": "Regulator motora 2"
+    },
+    "powerVoltageId62": {
+        "message": "Regulator motora 3"
+    },
+    "powerVoltageId63": {
+        "message": "Regulator motora 4"
+    },
+    "powerVoltageId64": {
+        "message": "Regulator motora 5"
+    },
+    "powerVoltageId65": {
+        "message": "Regulator motora 6"
+    },
+    "powerVoltageId66": {
+        "message": "Regulator motora 7"
+    },
+    "powerVoltageId67": {
+        "message": "Regulator motora 8"
+    },
+    "powerVoltageId68": {
+        "message": "Regulator motora 9"
+    },
+    "powerVoltageId69": {
+        "message": "Regulator motora 10"
+    },
+    "powerVoltageId70": {
+        "message": "Regulator motora 11"
+    },
+    "powerVoltageId71": {
+        "message": "Regulator motora 12"
+    },
+    "powerVoltageId80": {
+        "message": "Ćelija 1"
+    },
+    "powerVoltageId81": {
+        "message": "Ćelija 2"
+    },
+    "powerVoltageId82": {
+        "message": "Ćelija 3"
+    },
+    "powerVoltageId83": {
+        "message": "Ćelija 4"
+    },
+    "powerVoltageId84": {
+        "message": "Ćelija 5"
+    },
+    "powerVoltageId85": {
+        "message": "Ćelija 6"
+    },
+    "powerVoltageScale": {
+        "message": "Razmera"
+    },
+    "powerVoltageDivider": {
+        "message": "Vrednost delioca"
+    },
+    "powerVoltageMultiplier": {
+        "message": "Vrednost množioca"
+    },
+    "powerAmperageHead": {
+        "message": "Merač jačine struje"
+    },
+    "powerAmperageWarning": {
+        "message": "<span class=\"message-negative\">Pažnja:<\/span> vrednosti su ograničene na 63,5 A."
+    },
+    "powerAmperageValue": {
+        "message": "$1 A"
+    },
+    "powerAmperageId10": {
+        "message": "Baterija"
+    },
+    "powerAmperageId50": {
+        "message": "Svi regulatori zajedno"
+    },
+    "powerAmperageId60": {
+        "message": "Regulator motora 1"
+    },
+    "powerAmperageId61": {
+        "message": "Regulator motora 2"
+    },
+    "powerAmperageId62": {
+        "message": "Regulator motora 3"
+    },
+    "powerAmperageId63": {
+        "message": "Regulator motora 4"
+    },
+    "powerAmperageId64": {
+        "message": "Regulator motora 5"
+    },
+    "powerAmperageId65": {
+        "message": "Regulator motora 6"
+    },
+    "powerAmperageId66": {
+        "message": "Regulator motora 7"
+    },
+    "powerAmperageId67": {
+        "message": "Regulator motora 8"
+    },
+    "powerAmperageId68": {
+        "message": "Regulator motora 9"
+    },
+    "powerAmperageId69": {
+        "message": "Regulator motora 10"
+    },
+    "powerAmperageId70": {
+        "message": "Regulator motora 11"
+    },
+    "powerAmperageId71": {
+        "message": "Regulator motora 12"
+    },
+    "powerAmperageId80": {
+        "message": "Računski"
+    },
+    "powerAmperageId90": {
+        "message": "MSP"
+    },
+    "powerMahValue": {
+        "message": "$1 mAh"
+    },
+    "powerAmperageScale": {
+        "message": "Razmera [desetinke mV po A]"
+    },
+    "powerAmperageOffset": {
+        "message": "Pomeraj [mA]"
+    },
+    "powerAmperageCalibration": {
+        "message": "Izmerena jačina struje"
+    },
+    "powerAmperageCalibratedScale": {
+        "message": "Kalibrisana razmera struje:"
+    },
+    "powerBatteryProfile": {
+        "message": "Profil baterije"
+    },
+    "powerBatteryProfileOption": {
+        "message": "Profil baterije $1"
+    },
+    "powerReceivedBatteryProfile": {
+        "message": "Flight kontroler je postavio profil baterije: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "powerBatteryProfileNamePlaceholder": {
+        "message": "na primer LiPo, Li-Ion"
+    },
+    "powerBatteryProfileNameLabel": {
+        "message": "Naziv profila"
+    },
+    "powerBatteryHead": {
+        "message": "Baterija"
+    },
+    "powerStateHead": {
+        "message": "Stanje napajanja"
+    },
+    "powerBatteryConnected": {
+        "message": "Povezano"
+    },
+    "powerBatteryConnectedValueYes": {
+        "message": "Da (ćelija: $1)"
+    },
+    "powerBatteryConnectedValueNo": {
+        "message": "Ne"
+    },
+    "powerBatteryVoltage": {
+        "message": "Napon"
+    },
+    "powerBatteryCurrentDrawn": {
+        "message": "potrošeno mAh"
+    },
+    "powerBatteryAmperage": {
+        "message": "Jačina struje"
+    },
+    "powerBatteryPowerDraw": {
+        "message": "Potrošnja"
+    },
+    "powerWattValue": {
+        "message": "$1 W"
+    },
+    "powerBatteryVoltageDrop": {
+        "message": "Prosedanje napona"
+    },
+    "powerBatteryCapacity": {
+        "message": "Kapacitet (mAh)"
+    },
+    "osdSetupTitle": {
+        "message": "OSD"
+    },
+    "osdToggleElementVisibility": {
+        "message": "Uključi ili isključi prikaz elementa {{element}} za profil {{profile}}"
+    },
+    "osdSetupNoOsdChipDetectWarning": {
+        "message": "<span class=\"message-negative\"><b>PAŽNJA:<\/b><\/span> OSD čip nije pronađen. Neki flight kontroleri ne napajaju OSD čip dok baterija nije priključena. Priključite bateriju pre USB kabla (PROPELERI SKINUTI!)."
+    },
+    "osdSetupPreviewHelp": {
+        "message": "<strong>Napomena:<\/strong> pregled OSD-a možda ne prikazuje slova koja su stvarno upisana u flight kontroler. Raspored pojedinih elemenata može izgledati drugačije na starijim verzijama firmvera — proverite izgled kroz naočare pre leta."
+    },
+    "osdSetupUnsupportedNote1": {
+        "message": "Vaš flight kontroler ne odgovara na OSD komande. To najverovatnije znači da nema ugrađen Betaflight OSD."
+    },
+    "osdSetupUnsupportedNote2": {
+        "message": "Neki flight kontroleri imaju ugrađen <a href=\"https:\/\/www.youtube.com\/watch?v=ikKH_6SQ-Tk\" target=\"_blank\" rel=\"noopener noreferrer\">MinimOSD<\/a>, koji se može upisati i podesiti kroz <a href=\"https:\/\/github.com\/ShikOfTheRa\/scarab-osd\/releases\/latest\" target='_blank'>scarab-osd<\/a>, ali se MinimOSD ne može podesiti kroz ovaj program."
+    },
+    "osdSetupProfilesTitle": {
+        "message": "Broj OSD profila",
+        "description": "Description of the header of the OSD elements column associated to each profile"
+    },
+    "osdSetupElementsTitle": {
+        "message": "Elementi"
+    },
+    "osdSetupPreviewTitle": {
+        "message": "Prevucite elemente da im promenite položaj",
+        "description": "Indicates in the preview window of the OSD that the user can drag the elements to reorder them"
+    },
+    "osdSetupPreviewSelectProfileTitle": {
+        "message": "Pregled za",
+        "description": "Label of the selector for the OSD Profile in the preview. KEEP IT SHORT!!!"
+    },
+    "osdSetupPreviewForTitle": {
+        "message": "Promena profila ili slova ovde NEĆE promeniti profil ni slova u flight kontroleru — menja se samo prozor za pregled. Ako želite stvarnu promenu, koristite '$t(osdSetupSelectedProfileTitle.message)' odnosno dugme '$t(osdSetupFontManager.message)'.",
+        "description": "Help content for the OSD profile and font PREVIEW"
+    },
+    "osdSetupSelectedProfileTitle": {
+        "message": "Aktivan OSD profil",
+        "description": "Title of the box to select the current active OSD profile"
+    },
+    "osdSetupSelectedProfileLabel": {
+        "message": "Trenutno:",
+        "description": "Label for the selection of the curren active OSD profile"
+    },
+    "osdSetupPreviewSelectProfileElement": {
+        "message": "OSD profil {{profileNumber}}",
+        "description": "Content of the selector for the OSD Profile in the preview"
+    },
+    "osdSetupPreviewSelectFont": {
+        "message": "Slova",
+        "description": "Content of the selector for the OSD Font in the preview"
+    },
+    "osdSetupFontManagerTitle": {
+        "message": "Upravljanje slovima za OSD",
+        "description": "Dialog title"
+    },
+    "osdSetupFontTypeDefault": {
+        "message": "Fabričko",
+        "description": "Font Default"
+    },
+    "osdSetupFontTypeBold": {
+        "message": "Podebljana",
+        "description": "Font Bold"
+    },
+    "osdSetupFontTypeLarge": {
+        "message": "Velika",
+        "description": "Font Large"
+    },
+    "osdSetupFontTypeLargeExtra": {
+        "message": "Vrlo velika",
+        "description": "Font Large Extra"
+    },
+    "osdSetupFontTypeBetaflight": {
+        "message": "Betaflight",
+        "description": "Font Betaflight"
+    },
+    "osdSetupFontTypeDigital": {
+        "message": "Digital",
+        "description": "Font Digital"
+    },
+    "osdSetupFontTypeClarity": {
+        "message": "Clarity",
+        "description": "Font Clarity"
+    },
+    "osdSetupFontTypeVision": {
+        "message": "Vision",
+        "description": "Font Vision"
+    },
+    "osdSetupFontTypeImpact": {
+        "message": "Impact",
+        "description": "Font Impact"
+    },
+    "osdSetupFontTypeImpactMini": {
+        "message": "Impact Mini",
+        "description": "Font Impact Mini"
+    },
+    "osdSetupPreviewCheckZoom": {
+        "message": "Uvećanje",
+        "description": "Check to select a bigger display of the OSD preview in small screens"
+    },
+    "osdSetupVideoFormatTitle": {
+        "message": "Video standard"
+    },
+    "osdSetupVideoFormatOptionAuto": {
+        "message": "Automatski",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionPal": {
+        "message": "PAL",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionNtsc": {
+        "message": "NTSC",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionHd": {
+        "message": "HD",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSerialPort": {
+        "message": "Serijski port za OSD"
+    },
+    "osdSerialPortHelp": {
+        "message": "UART na koji je povezan serijski OSD. Od API-ja 1.49 zadaje se na samom OSD-u; kartica Ports ga samo prikazuje."
+    },
+    "osdCustomTextSerialPort": {
+        "message": "Serijski port za proizvoljni tekst"
+    },
+    "osdCustomTextSerialPortHelp": {
+        "message": "UART na kom se prima proizvoljni OSD tekst."
+    },
+    "osdCustomTextSerialBaud": {
+        "message": "Brzina prenosa za proizvoljni tekst"
+    },
+    "osdCustomTextSerialBaudHelp": {
+        "message": "Brzina prenosa za port proizvoljnog OSD teksta."
+    },
+    "osdSetupUnitsTitle": {
+        "message": "Jedinice"
+    },
+    "osdSetupUnitsOptionImperial": {
+        "message": "Imperijalne",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupUnitsOptionMetric": {
+        "message": "Metričke",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupUnitsOptionBritish": {
+        "message": "Britanske",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupTimersTitle": {
+        "message": "Merači vremena"
+    },
+    "osdSetupAlarmsTitle": {
+        "message": "Alarmi"
+    },
+    "osdSetupStatsTitle": {
+        "message": "Podaci posle leta"
+    },
+    "osdSetupVtxTitle": {
+        "message": "Podešavanja video-predajnika"
+    },
+    "osdSetupCraftNameTitle": {
+        "message": "Naziv drona"
+    },
+    "osdSetupWarningsTitle": {
+        "message": "Upozorenja"
+    },
+    "osdSetupFontPresets": {
+        "message": "Gotovi skupovi slova:"
+    },
+    "osdSetupFontPresetsSelector": {
+        "message": "Izaberite skup slova:"
+    },
+    "osdSetupFontPresetsSelectorCustomOption": {
+        "message": "Sopstvena slova",
+        "description": "Option to show as selected when the user selects a custom local font"
+    },
+    "osdSetupFontPresetsSelectorOr": {
+        "message": "ili"
+    },
+    "osdSetupOpenFont": {
+        "message": "Otvori fajl sa slovima"
+    },
+    "osdSetupCustomLogoTitle": {
+        "message": "Slika pri pokretanju:"
+    },
+    "osdSetupCustomLogoOpenImageButton": {
+        "message": "Izaberite sopstvenu sliku&hellip;"
+    },
+    "osdSetupCustomLogoInfoTitle": {
+        "message": "Sopstvena slika:"
+    },
+    "osdSetupCustomLogoInfoImageSize": {
+        "message": "Veličina mora biti $t(logoWidthPx)x$t(logoHeightPx) tačaka"
+    },
+    "osdSetupCustomLogoInfoColorMap": {
+        "message": "Mora da sadrži zelene, crne i bele tačke"
+    },
+    "osdSetupCustomLogoInfoUploadHint": {
+        "message": "Kliknite <b>$t(osdSetupUploadFont.message)<\/b> da bi sopstvena slika ostala trajno upisana"
+    },
+    "osdSetupCustomLogoImageSizeError": {
+        "message": "Neispravna veličina slike: {{width}}x{{height}} (očekivano $t(logoWidthPx)×$t(logoHeightPx))"
+    },
+    "osdSetupCustomLogoColorMapError": {
+        "message": "Slika sadrži neispravnu tačku: rgb({{valueR}}, {{valueG}}, {{valueB}}) na položaju {{posX}}×{{posY}}"
+    },
+    "osdSetupUploadFont": {
+        "message": "Pošalji slova"
+    },
+    "osdSetupUploadingFont": {
+        "message": "Šaljem…"
+    },
+    "osdSetupUploadingFontEnd": {
+        "message": "Poslato svih {{length}} znakova na OSD"
+    },
+    "osdSetupUploadingFontFailed": {
+        "message": "Slanje nije uspelo"
+    },
+    "osdSetupSave": {
+        "message": "Sačuvaj"
+    },
+    "osdSetupRefresh": {
+        "message": "Osveži"
+    },
+    "osdSetupFontManager": {
+        "message": "Upravljanje slovima"
+    },
+    "osdSetupUncheckAll": {
+        "message": "Poništi sve"
+    },
+    "osdSetupHead": {
+        "message": "Podatak"
+    },
+    "osdSetupVideoMode": {
+        "message": "Video režim"
+    },
+    "osdSetupCameraConnected": {
+        "message": "Kamera povezana"
+    },
+    "osdSetupResetText": {
+        "message": "Vrati OSD na fabričko"
+    },
+    "osdSetupButtonReset": {
+        "message": "Vrati podešavanja"
+    },
+    "osdTextElementMainBattVoltage": {
+        "message": "Napon baterije",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMainBattVoltage": {
+        "message": "Trenutni napon glavne baterije (treperi kada padne ispod praga upozorenja)"
+    },
+    "osdTextElementRssiValue": {
+        "message": "RSSI vrednost",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRssiValue": {
+        "message": "Trenutna RSSI vrednost (treperi kada padne ispod praga upozorenja). Kod današnjih protokola koristite RSSI u dBm."
+    },
+    "osdTextElementRssiDbmValue": {
+        "message": "RSSI u dBm",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRssiDbmValue": {
+        "message": "Pokazatelj jačine primljenog signala — govori koliko je prijem jak, u dBm"
+    },
+    "osdTextElementTimer": {
+        "message": "Merač vremena",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer": {
+        "message": "Merač vremena leta"
+    },
+    "osdTextElementThrottlePosition": {
+        "message": "Položaj gasa",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementThrottlePosition": {
+        "message": "Trenutna vrednost kanala gasa"
+    },
+    "osdTextElementCpuLoad": {
+        "message": "Opterećenje procesora",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCpuLoad": {
+        "message": "Trenutno opterećenje procesora"
+    },
+    "osdTextElementVtxChannel": {
+        "message": "Kanal video-predajnika",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementVtxChannel": {
+        "message": "Trenutni kanal i snaga video-predajnika"
+    },
+    "osdTextElementVTXchannelVariantPower": {
+        "message": "Snaga video-predajnika",
+        "description": "One of the variants of the VTX channel element of the OSD"
+    },
+    "osdTextElementVTXchannelVariantFull": {
+        "message": "Opseg:Kanal:Snaga:Pit",
+        "description": "One of the variants of the VTX channel element of the OSD"
+    },
+    "osdTextElementVoltageWarning": {
+        "message": "Upozorenje o naponu baterije",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementVoltageWarning": {
+        "message": "Prikazuje upozorenje kada napon padne ispod zadate vrednosti"
+    },
+    "osdTextElementArmed": {
+        "message": "Armovan",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArmed": {
+        "message": "Tekstualna poruka o armovanju"
+    },
+    "osdTextElementDisarmed": {
+        "message": "Razoružan",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDisarmed": {
+        "message": "Tekstualna poruka o razoružavanju"
+    },
+    "osdTextElementCrosshairs": {
+        "message": "Nišan",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCrosshairs": {
+        "message": "Nišan na sredini ekrana"
+    },
+    "osdTextElementArtificialHorizon": {
+        "message": "Veštački horizont",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArtificialHorizon": {
+        "message": "Grafički prikaz veštačkog horizonta"
+    },
+    "osdTextElementHorizonSidebars": {
+        "message": "Bočne oznake horizonta",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHorizonSidebars": {
+        "message": "Oznake sa strane veštačkog horizonta"
+    },
+    "osdTextElementCurrentDraw": {
+        "message": "Trenutna potrošnja struje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCurrentDraw": {
+        "message": "Trenutna jačina struje iz baterije"
+    },
+    "osdTextElementMahDrawn": {
+        "message": "Potrošeno mAh",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMahDrawn": {
+        "message": "Ukupno potrošen kapacitet baterije"
+    },
+    "osdTextElementWhDrawn": {
+        "message": "Potrošeno Wh",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWhDrawn": {
+        "message": "Ukupno potrošen kapacitet baterije u Wh"
+    },
+    "osdDescElementAuxValue": {
+        "message": "Vrednost AUX kanala",
+        "description": "Displays a receiver AUX channel see PR 10789"
+    },
+    "osdTextElementAuxValue": {
+        "message": "Vrednost AUX kanala",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementSysGoggleVoltage": {
+        "message": "Napon naočara",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysGoggleVoltage": {
+        "message": "Napon na naočarima, prikazan od strane naočara"
+    },
+    "osdTextElementSysVtxVoltage": {
+        "message": "VTX napon",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxVoltage": {
+        "message": "VTX napon, prikazan od strane naočara"
+    },
+    "osdTextElementSysBitrate": {
+        "message": "VTX bitrate",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysBitrate": {
+        "message": "Video bitrate, prikazan od strane naočara"
+    },
+    "osdTextElementSysDelay": {
+        "message": "VTX kašnjenje",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysDelay": {
+        "message": "Video kašnjenje, prikazano od strane naočara"
+    },
+    "osdTextElementSysDistance": {
+        "message": "VTX udaljenost",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysDistance": {
+        "message": "Udaljenost video prenosa, prikazana od strane naočara"
+    },
+    "osdTextElementSysLQ": {
+        "message": "Kvalitet veze naočara",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysLQ": {
+        "message": "Kvalitet video veze, prikazan od strane naočara"
+    },
+    "osdTextElementSysGoggleDVR": {
+        "message": "Status DVR-a naočara",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysGoggleDVR": {
+        "message": "Status DVR-a naočara, prikazan od strane naočara"
+    },
+    "osdTextElementSysVtxDVR": {
+        "message": "Status VTX DVR-a",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxDVR": {
+        "message": "Status VTX DVR-a, prikazan od strane naočara"
+    },
+    "osdTextElementSysWarnings": {
+        "message": "Sistemska upozorenja naočara",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysWarnings": {
+        "message": "Sistemska video upozorenja, prikazana od strane naočara"
+    },
+    "osdTextElementSysVtxTemp": {
+        "message": "VTX temperatura",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxTemp": {
+        "message": "VTX temperatura, prikazana od strane naočara"
+    },
+    "osdTextElementSysFanSpeed": {
+        "message": "Brzina ventilatora naočara",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysFanSpeed": {
+        "message": "Brzina ventilatora naočara, prikazana od strane naočara"
+    },
+    "osdTextElementLapTimeCurrent": {
+        "message": "Trenutno vreme GPS kruga",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimeCurrent": {
+        "message": "Trenutno vreme GPS kruga"
+    },
+    "osdTextElementLapTimePrevious": {
+        "message": "Prethodno vreme GPS kruga",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimePrevious": {
+        "message": "Prethodno vreme GPS kruga"
+    },
+    "osdTextElementLapTimeBest3": {
+        "message": "GPS: najbolja tri kruga",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimeBest3": {
+        "message": "Najbolja tri vremena kruga po GPS-u"
+    },
+    "osdTextElementCraftName": {
+        "message": "Naziv letelice",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCraftName": {
+        "message": "Naziv drona zadat na kartici Konfiguracija.<\/br>Može se zadati i promenljivom „craft_name“ u CLI-ju."
+    },
+    "osdTextElementAltitude": {
+        "message": "Visina",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAltitude": {
+        "message": "Trenutna visina (treperi kada pređe prag upozorenja)"
+    },
+    "osdTextElementAltitudeVariant1DecimalAGL": {
+        "message": "Iznad tla, sa jednom decimalom",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariantNoDecimalAGL": {
+        "message": "Iznad tla, bez decimala",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariant1DecimalASL": {
+        "message": "Iznad mora, sa jednom decimalom",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariantNoDecimalASL": {
+        "message": "Iznad mora, bez decimala",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementCustomMsg0": {
+        "message": "Sopstvena poruka 1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg1": {
+        "message": "Sopstvena poruka 2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg2": {
+        "message": "Sopstvena poruka 3",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg3": {
+        "message": "Sopstvena poruka 4",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCustomMsg0": {
+        "message": "Sopstvena poruka 1 sa spoljnog uređaja",
+        "description": "Description of the custom message 1 element of the OSD"
+    },
+    "osdDescElementCustomMsg1": {
+        "message": "Sopstvena poruka 2 sa spoljnog uređaja",
+        "description": "Description of the custom message 2 element of the OSD"
+    },
+    "osdDescElementCustomMsg2": {
+        "message": "Sopstvena poruka 3 sa spoljnog uređaja",
+        "description": "Description of the custom message 3 element of the OSD"
+    },
+    "osdDescElementCustomMsg3": {
+        "message": "Sopstvena poruka 4 sa spoljnog uređaja",
+        "description": "Description of the custom message 4 element of the OSD"
+    },
+    "osdTextElementOnTime": {
+        "message": "Vreme uključenosti",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementOnTime": {
+        "message": "Ukupno vreme otkako je dron uključen"
+    },
+    "osdTextElementFlyTime": {
+        "message": "Vreme leta",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlyTime": {
+        "message": "Ukupno vreme koje je dron proveo armovan od uključivanja (treperi kada pređe prag upozorenja)"
+    },
+    "osdTextElementFlyMode": {
+        "message": "Mod leta",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlyMode": {
+        "message": "Trenutni mod leta"
+    },
+    "osdTextElementGPSSpeed": {
+        "message": "GPS brzina",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSSpeed": {
+        "message": "Brzina po GPS-u"
+    },
+    "osdTextElementGPSSats": {
+        "message": "GPS sateliti",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSSats": {
+        "message": "Broj satelita koji daju položaj"
+    },
+    "osdTextElementGPSLon": {
+        "message": "GPS geografska dužina",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSLon": {
+        "message": "Koordinata geografske dužine"
+    },
+    "osdTextElementGPSLat": {
+        "message": "GPS geografska širina",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSLat": {
+        "message": "Koordinata geografske širine"
+    },
+    "osdTextElementGPSVariant7Decimals": {
+        "message": "Sa sedam decimala",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariant4Decimals": {
+        "message": "Sa četiri decimale",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariantDegMinSec": {
+        "message": "U stepenima, minutima i sekundama",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariantOpenLocation": {
+        "message": "Preko Open Location Code oznake",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementDebug": {
+        "message": "Debug",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDebug": {
+        "message": "Debug promenljive"
+    },
+    "osdTextElementDebug2": {
+        "message": "Debug2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDebug2": {
+        "message": "Debug promenljive za debug 4 do 7"
+    },
+    "osdTextElementPIDRoll": {
+        "message": "PID roll",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDRoll": {
+        "message": "PID pojačanja za osu roll"
+    },
+    "osdTextElementPIDPitch": {
+        "message": "PID pitch",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDPitch": {
+        "message": "PID pojačanja za osu pitch"
+    },
+    "osdTextElementPIDYaw": {
+        "message": "PID yaw",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDYaw": {
+        "message": "PID pojačanja za osu yaw"
+    },
+    "osdTextElementPower": {
+        "message": "Snaga",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPower": {
+        "message": "Trenutna električna potrošnja"
+    },
+    "osdTextElementPIDRateProfile": {
+        "message": "Profil: PID i rejt",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDRateProfile": {
+        "message": "Brojčani prikaz aktivnog PID i rejt profila"
+    },
+    "osdTextElementBatteryWarning": {
+        "message": "Upozorenje o bateriji",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementBatteryWarning": {
+        "message": "Tekst upozorenja koji se pojavljuje kada napon baterije padne ispod praga"
+    },
+    "osdTextElementAvgCellVoltage": {
+        "message": "Prosečan napon ćelije",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAvgCellVoltage": {
+        "message": "Prosečan napon ćelije (napon baterije podeljen brojem ćelija)"
+    },
+    "osdTextElementPitchAngle": {
+        "message": "Ugao: pitch",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPitchAngle": {
+        "message": "Brojčani ugao nagiba napred-nazad u stepenima"
+    },
+    "osdTextElementRollAngle": {
+        "message": "Ugao: roll",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRollAngle": {
+        "message": "Brojčani ugao nagiba levo-desno u stepenima"
+    },
+    "osdTextElementMainBattUsage": {
+        "message": "Potrošnja baterije",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMainBattUsage": {
+        "message": "Grafički prikaz potrošenog kapaciteta baterije"
+    },
+    "osdTextElementMainBattUsageVariantGraphrRemain": {
+        "message": "Grafički, preostalo",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantGraphUsage": {
+        "message": "Grafički, potrošeno",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantValueRemain": {
+        "message": "Procenat preostalog",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantValueUsage": {
+        "message": "Procenat potrošenog",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementArmedTime": {
+        "message": "Merač: vreme od armovanja",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArmedTime": {
+        "message": "Vreme od poslednjeg armovanja drona"
+    },
+    "osdTextElementHomeDirection": {
+        "message": "Pravac ka mestu poletanja",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHomeDirection": {
+        "message": "Strelica koja pokazuje pravac ka mestu poletanja"
+    },
+    "osdTextElementHomeDistance": {
+        "message": "Rastojanje do mesta poletanja",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHomeDistance": {
+        "message": "Rastojanje do mesta poletanja (u metrima ili stopama, prema izabranim jedinicama)"
+    },
+    "osdTextElementNumericalHeading": {
+        "message": "Brojčani pravac",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNumericalHeading": {
+        "message": "Brojčani prikaz trenutnog pravca u stepenima"
+    },
+    "osdTextElementNumericalVario": {
+        "message": "Brojčani variometar",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNumericalVario": {
+        "message": "Brojčani prikaz brzine penjanja i spuštanja (u metrima ili stopama, prema izabranim jedinicama)"
+    },
+    "osdTextElementCompassBar": {
+        "message": "Traka kompasa",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCompassBar": {
+        "message": "Grafička traka kompasa sa trenutnim pravcem"
+    },
+    "osdTextElementWarnings": {
+        "message": "Upozorenja",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWarnings": {
+        "message": "Obaveštenja (na primer slaba baterija), upozorenja (razlozi zašto armovanje nije moguće, kritično slaba baterija) i vidljiva piskalica (četiri zvezdice koje trepere)"
+    },
+    "osdTextElementEscTemperature": {
+        "message": "Temperatura regulatora",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscTemperature": {
+        "message": "Temperatura koju javlja regulator, bilo preko jednožične serijske telemetrije, bilo preko dvosmernog DShota sa EDT, ako to firmver regulatora podržava."
+    },
+    "osdTextElementEscRpm": {
+        "message": "Obrtaji regulatora",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscRpm": {
+        "message": "Broj obrtaja koji javlja regulator"
+    },
+    "osdTextElementRemainingTimeEstimate": {
+        "message": "Merač: procena preostalog vremena",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRemainingTimeEstimate": {
+        "message": "Procena koliko još leta preostaje"
+    },
+    "osdTextElementRtcDateTime": {
+        "message": "Datum i vreme",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantFullDate": {
+        "message": "Pun datum",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantShortDate": {
+        "message": "Skraćen datum",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantTimeOnly": {
+        "message": "Samo vreme",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdDescElementRtcDateTime": {
+        "message": "Datum i vreme sa časovnika"
+    },
+    "osdTextElementAdjustmentRange": {
+        "message": "Opseg podešavanja u letu",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAdjustmentRange": {
+        "message": "Trenutno aktivno podešavanje u letu i njegova vrednost"
+    },
+    "osdTextElementTimer1": {
+        "message": "Merač 1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer1": {
+        "message": "Prikazuje vrednost merača 1"
+    },
+    "osdTextElementTimer2": {
+        "message": "Merač 2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer2": {
+        "message": "Prikazuje vrednost merača 2"
+    },
+    "osdTextElementCoreTemperature": {
+        "message": "Temperatura procesora",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCoreTemperature": {
+        "message": "Temperatura jezgra STM32 procesora"
+    },
+    "osdTextAntiGravity": {
+        "message": "Anti-Gravity",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescAntiGravity": {
+        "message": "Uključuje oznaku koja se pojavljuje dok je Anti-Gravity aktivan"
+    },
+    "osdTextGForce": {
+        "message": "Preopterećenje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescGForce": {
+        "message": "Prikazuje koliko preopterećenje dron trpi"
+    },
+    "osdTextElementMotorDiag": {
+        "message": "Prikaz rada motora",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMotorDiag": {
+        "message": "Prikazuje grafikon izlaza svakog motora"
+    },
+    "osdTextElementLogStatus": {
+        "message": "Stanje Blackbox zapisa",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLogStatus": {
+        "message": "Broj zapisa i upozorenja"
+    },
+    "osdTextElementFlipArrow": {
+        "message": "Strelica za prevrtanje posle pada",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlipArrow": {
+        "message": "Strelica koja pokazuje na kojoj su strani motori okrenuti nagore u Turtle modu (akcelerometar mora biti uključen)"
+    },
+    "osdTextElementLinkQuality": {
+        "message": "Kvalitet veze",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLinkQuality": {
+        "message": "Zamenski pokazatelj „kvaliteta veze“, zasnovan na gubitku paketa — koristiti oprezno"
+    },
+    "osdTextElementLinkQualityVariantRfMode": {
+        "message": "Režim veze : kvalitet veze",
+        "description": "One of the variants of the Link Quality element of the OSD"
+    },
+    "osdTextElementLinkQualityVariantQualityOnly": {
+        "message": "Samo kvalitet veze",
+        "description": "One of the variants of the Link Quality element of the OSD"
+    },
+    "osdTextElementFlightDist": {
+        "message": "Pređeno rastojanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlightDist": {
+        "message": "Rastojanje pređeno tokom ovog leta."
+    },
+    "osdTextElementStickOverlayLeft": {
+        "message": "Prikaz leve ručice",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementStickOverlayLeft": {
+        "message": "Prikaz položaja leve ručice daljinskog."
+    },
+    "osdTextElementStickOverlayRight": {
+        "message": "Prikaz desne ručice",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementStickOverlayRight": {
+        "message": "Prikaz položaja desne ručice daljinskog."
+    },
+    "osdTextElementDisplayName": {
+        "message": "Prikazano ime",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDisplayName": {
+        "message": "Može se zadati i promenljivom „display_name“ u CLI-ju."
+    },
+    "osdTextElementPilotName": {
+        "message": "Ime pilota",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPilotName": {
+        "message": "Ime pilota zadato na kartici Konfiguracija.<\/br>Može se zadati i promenljivom „pilot_name“ u CLI-ju."
+    },
+    "osdTextElementEscRpmFreq": {
+        "message": "Frekvencija obrtaja regulatora",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscRpmFreq": {
+        "message": "Frekvencija obrtaja koju javlja regulator"
+    },
+    "osdTextElementRateProfileName": {
+        "message": "Profil: naziv rejt profila",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRateProfileName": {
+        "message": "Prikazuje naziv trenutnog rejt profila"
+    },
+    "osdTextElementPidProfileName": {
+        "message": "Profil: naziv PID profila",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPidProfileName": {
+        "message": "Prikazuje naziv trenutnog PID profila"
+    },
+    "osdTextElementOsdProfileName": {
+        "message": "Profil: OSD profil ime",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementOsdProfileName": {
+        "message": "Ime OSD profila kao što je podešeno u CLI varijablama \"osd_profile_1_name\", \"osd_profile_2_name\" i \"osd_profile_3_name\""
+    },
+    "osdTextElementRcChannels": {
+        "message": "RC kanali",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRcChannels": {
+        "message": "Prikazuje najviše 4 vrednosti kanala. Kanali moraju biti navedeni u CLI varijabli 'osd_rcchannels'"
+    },
+    "osdTextElementCameraFrame": {
+        "message": "Okvir kamere",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCameraFrame": {
+        "message": "Dodaje podesivi element okvira dizajniran da predstavlja vidno polje pilotove HD kamere za vizuelno kadriranje.<br \/><br \/>Možete podesiti širinu i visinu u CLI-ju sa 'osd_camera_frame_width' i 'osd_camera_frame_height'"
+    },
+    "osdTextElementEfficiency": {
+        "message": "Efikasnost baterije",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEfficiency": {
+        "message": "Trenutna potrošnja baterije u mAh\/udaljenosti. (Zahteva ispravan GPS signal)"
+    },
+    "osdTextTotalFlights": {
+        "message": "Ukupno letova",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescTotalFlights": {
+        "message": "Približan ukupan broj letova"
+    },
+    "osdTextElementUpDownReference": {
+        "message": "Gore (Pitch 90 deg)\/Dole (Pitch -90 deg) Referenca",
+        "description": "OSD Symbol to show when pitch is approaching vertical (90 deg, U) and D for nose down (-90 deg, D)"
+    },
+    "osdDescUpDownReference": {
+        "message": "OSD simbol koji se prikazuje kada se Pitch približava vertikali (90 deg, U) i D za nos nadole (-90 deg, D)"
+    },
+    "osdTextElementTxUplinkPower": {
+        "message": "Tx uplink snaga",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescTxUplinkPower": {
+        "message": "Prikazuje vrednost Tx snage (mW ili W). Korisno kada je <i>Dynamic Power<\/i> uključen za podržane radio uređaje"
+    },
+    "osdTextElementReadyMode": {
+        "message": "Mod spremnosti",
+        "description": "When active READY will be displayed until flying"
+    },
+    "osdDescElementReadyMode": {
+        "message": "Kada je aktivan, prikazaće se READY dok se ne poleti"
+    },
+    "osdTextElementRSNRValue": {
+        "message": "RSNR vrednost",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRSNRValue": {
+        "message": "RSNR vrednost"
+    },
+    "osdTextElementUnknown": {
+        "message": "Nepoznato $1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementUnknown": {
+        "message": "Nepoznat element (detalji će biti dodati u budućem izdanju)"
+    },
+    "osdTextStatMaxSpeed": {
+        "message": "Maksimalna brzina",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxSpeed": {
+        "message": "Maksimalna zabeležena brzina"
+    },
+    "osdTextStatMinBattery": {
+        "message": "Minimalni napon baterije",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinBattery": {
+        "message": "Minimalni zabeleženi napon glavne baterije"
+    },
+    "osdTextStatMinRssi": {
+        "message": "RSSI minimum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRssi": {
+        "message": "Minimalni zabeleženi RSSI"
+    },
+    "osdTextStatMaxCurrent": {
+        "message": "Maksimalna potrošnja struje iz baterije",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxCurrent": {
+        "message": "Maksimalna zabeležena potrošnja struje"
+    },
+    "osdTextStatUsedMah": {
+        "message": "Potrošeno mAh iz baterije",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUsedMah": {
+        "message": "Potrošen kapacitet baterije"
+    },
+    "osdTextStatUsedWh": {
+        "message": "Potrošeno Wh iz baterije",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUsedWh": {
+        "message": "Potrošen kapacitet baterije u Wh"
+    },
+    "osdTextStatMaxAltitude": {
+        "message": "Maksimalna visina",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxAltitude": {
+        "message": "Maksimalna zabeležena visina"
+    },
+    "osdTextStatBlackbox": {
+        "message": "Upotreba Blackbox-a",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBlackbox": {
+        "message": "Procenat ukupne upotrebe Blackbox-a"
+    },
+    "osdTextStatEndBattery": {
+        "message": "Krajnji napon baterije",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEndBattery": {
+        "message": "Napon baterije u trenutku razoružavanja"
+    },
+    "osdTextStatFlyTime": {
+        "message": "Ukupno vreme leta",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFlyTime": {
+        "message": "Ukupno vreme tokom kojeg je letelica bila armovana u trenutnom ciklusu napajanja"
+    },
+    "osdTextStatArmedTime": {
+        "message": "Vreme leta od poslednjeg armovanja",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatArmedTime": {
+        "message": "Vreme od kada je letelica poslednji put armovana"
+    },
+    "osdTextStatMaxDistance": {
+        "message": "Maksimalna udaljenost od kuće",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxDistance": {
+        "message": "Maksimalna udaljenost od početne lokacije"
+    },
+    "osdTextStatBlackboxLogNumber": {
+        "message": "Broj Blackbox loga",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBlackboxLogNumber": {
+        "message": "Broj loga za Blackbox log ovog leta"
+    },
+    "osdTextStatTimer1": {
+        "message": "Merač 1",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTimer1": {
+        "message": "Vrednost tajmera 1 u trenutku razoružavanja"
+    },
+    "osdTextStatTimer2": {
+        "message": "Merač 2",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTimer2": {
+        "message": "Vrednost tajmera 2 u trenutku razoružavanja"
+    },
+    "osdTextStatRtcDateTime": {
+        "message": "Datum i vreme",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatRtcDateTime": {
+        "message": "Datum i vreme sa sata u realnom vremenu"
+    },
+    "osdTextStatBattery": {
+        "message": "Napon baterije",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBattery": {
+        "message": "Napon baterije u realnom vremenu"
+    },
+    "osdTextStatGForce": {
+        "message": "Maksimalna G sila",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatGForce": {
+        "message": "Maksimalna G-sila koju je letelica iskusila"
+    },
+    "osdTextStatEscTemperature": {
+        "message": "Maksimalna temperatura ESC-a",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEscTemperature": {
+        "message": "Maksimalna temperatura ESC-a"
+    },
+    "osdTextStatEscRpm": {
+        "message": "Maksimalni RPM ESC-a",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEscRpm": {
+        "message": "Maksimalni RPM ESC-a"
+    },
+    "osdTextStatMinLinkQuality": {
+        "message": "Minimalni kvalitet veze",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinLinkQuality": {
+        "message": "Minimum alternativnog indikatora za 'kvalitet veze' zasnovanog na gubitku frejmova"
+    },
+    "osdTextStatFlightDistance": {
+        "message": "Pređeno rastojanje",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFlightDistance": {
+        "message": "Ukupna udaljenost pređena tokom leta"
+    },
+    "osdTextStatMaxFFT": {
+        "message": "Maksimalni FFT",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxFFT": {
+        "message": "Vršna FFT frekvencija"
+    },
+    "osdTextStatTotalFlights": {
+        "message": "Ukupan broj letova",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlights": {
+        "message": "Ukupan broj letova"
+    },
+    "osdTextStatTotalFlightTime": {
+        "message": "Ukupno vreme leta",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlightTime": {
+        "message": "Ukupno vreme provedeno u letu"
+    },
+    "osdTextStatTotalFlightDistance": {
+        "message": "Ukupna pređena udaljenost",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlightDistance": {
+        "message": "Ukupna pređena udaljenost"
+    },
+    "osdTextStatMinRssiDbm": {
+        "message": "Minimalni RSSI dBm",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRssiDbm": {
+        "message": "Minimalna RSSI dBm vrednost"
+    },
+    "osdTextStatMinRSNR": {
+        "message": "Minimalna RSNR vrednost",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRSNR": {
+        "message": "Minimalna RSNR vrednost"
+    },
+    "osdTextStatBest3ConsecLaps": {
+        "message": "Najbolja 3 uzastopna kruga",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBest3ConsecLaps": {
+        "message": "Najbolja 3 uzastopna kruga"
+    },
+    "osdTextStatBestLap": {
+        "message": "Najbolji krug",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBestLap": {
+        "message": "Najbolji krug"
+    },
+    "osdTextStatFullThrottleTime": {
+        "message": "Tajmer punog gasa",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFullThrottleTime": {
+        "message": "Tajmer punog gasa"
+    },
+    "osdTextStatFullThrottleCounter": {
+        "message": "Brojač punog gasa",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFullThrottleCounter": {
+        "message": "Brojač punog gasa"
+    },
+    "osdTextStatAvgThrottle": {
+        "message": "Prosečan gas",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatAvgThrottle": {
+        "message": "Prosečan gas"
+    },
+    "osdTextStatUnknown": {
+        "message": "Nepoznato $1",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUnknown": {
+        "message": "Nepoznata statistika (detalji će biti dodati u budućem izdanju)"
+    },
+    "osdDescribeFontVersion1": {
+        "message": "Verzija fonta: 1 (Betaflight 4.0 ili stariji)"
+    },
+    "osdDescribeFontVersion2": {
+        "message": "Verzija fonta: 2 (Betaflight 4.1 ili noviji)"
+    },
+    "osdDescribeFontVersionCUSTOM": {
+        "message": "Verzija fonta: korisnički definisana"
+    },
+    "osdTimerSource": {
+        "message": "Izvor:"
+    },
+    "osdTimerSourceTooltip": {
+        "message": "Izaberite izvor tajmera, ovo kontroliše trajanje\/događaj koji tajmer meri"
+    },
+    "osdTimerSourceOptionOnTime": {
+        "message": "Vreme uključenosti",
+        "description": "One of the options for the source timer. This options shows the amount of time has passed since the battery was plugged"
+    },
+    "osdTimerSourceOptionTotalArmedTime": {
+        "message": "Ukupno armovano vreme",
+        "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed since the battery was plugged"
+    },
+    "osdTimerSourceOptionLastArmedTime": {
+        "message": "Poslednje armovano vreme",
+        "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed the latest time"
+    },
+    "osdTimerSourceOptionOnArmTime": {
+        "message": "Vreme uključeno\/armovano",
+        "description": "One of the options for the source timer. This option shows On time when aircraft is disarmed, and Armed time when armed"
+    },
+    "osdTimerPrecision": {
+        "message": "Preciznost:"
+    },
+    "osdTimerPrecisionTooltip": {
+        "message": "Izaberite preciznost tajmera, ovo kontroliše sa kojom preciznošću se vreme prikazuje"
+    },
+    "osdTimerPrecisionOptionSecond": {
+        "message": "Sekunda",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerPrecisionOptionHundredth": {
+        "message": "Stotinka",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerPrecisionOptionTenth": {
+        "message": "Desetinka",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerAlarm": {
+        "message": "Alarm:"
+    },
+    "osdTimerAlarmTooltip": {
+        "message": "Izaberite prag alarma tajmera u minutima. Kada vreme pređe ovu vrednost, OSD element će treptati. Postavljanje na 0 isključuje alarm."
+    },
+    "osdTimerAlarmOptionRssi": {
+        "message": "RSSI",
+        "description": "Text of the RSSI alarm"
+    },
+    "osdTimerAlarmOptionCapacity": {
+        "message": "Kapacitet",
+        "description": "Text of the capacity alarm"
+    },
+    "osdTimerAlarmOptionAltitude": {
+        "message": "Visina",
+        "description": "Text of the altitude alarm"
+    },
+    "osdTimerAlarmOptionLinkQuality": {
+        "message": "Kvalitet veze",
+        "description": "Text of the link quality alarm"
+    },
+    "osdTimerAlarmOptionRssiDbm": {
+        "message": "RSSI dBm",
+        "description": "Text of the RSSI dBm alarm"
+    },
+    "osdWarningTextArmingDisabled": {
+        "message": "Armovanje isključeno",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningArmingDisabled": {
+        "message": "Prikazuje najozbiljniji razlog zašto armovanje nije moguće"
+    },
+    "osdWarningTextBatteryNotFull": {
+        "message": "Baterija nije puna",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryNotFull": {
+        "message": "Upozorava kada je povezana baterija koja nije potpuno napunjena"
+    },
+    "osdWarningTextBatteryWarning": {
+        "message": "Upozorenje o bateriji",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryWarning": {
+        "message": "Upozorava kada napon baterije padne ispod praga upozorenja"
+    },
+    "osdWarningTextBatteryCritical": {
+        "message": "Baterija kritična",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryCritical": {
+        "message": "Upozorava kada napon baterije padne ispod minimalnog prosečnog napona ćelije"
+    },
+    "osdWarningTextVisualBeeper": {
+        "message": "Vizuelni piskalica",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningVisualBeeper": {
+        "message": "Prikazuje vizualizaciju piskalice (prikazuje se kao 4 zvezdice)"
+    },
+    "osdWarningTextCrashFlipMode": {
+        "message": "Mod za prevrtanje nakon pada",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningCrashFlipMode": {
+        "message": "Upozorava kada je aktiviran mod za prevrtanje nakon pada"
+    },
+    "osdWarningTextEscFail": {
+        "message": "ESC greška",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningEscFail": {
+        "message": "Navodi listu ESC-ova\/motora koji otkazuju (RPM ili temperatura su izvan konfigurisanog praga)"
+    },
+    "osdWarningTextCoreTemperature": {
+        "message": "Temperatura procesora",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningCoreTemperature": {
+        "message": "Upozorava kada temperatura jezgra MCU-a pređe konfigurisan prag"
+    },
+    "osdWarningTextRcSmoothingFailure": {
+        "message": "RC ublažavanje neuspešno",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRcSmoothingFailure": {
+        "message": "Upozorava kada inicijalizacija RC ublažavanja nije uspela"
+    },
+    "osdWarningTextFailsafe": {
+        "message": "Failsafe",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningFailsafe": {
+        "message": "Upozorava kada dođe do Failsafe-a"
+    },
+    "osdWarningTextLaunchControl": {
+        "message": "Launch control",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLaunchControl": {
+        "message": "Upozorava kada je aktiviran mod Launch Control"
+    },
+    "osdWarningTextGpsRescueUnavailable": {
+        "message": "GPS Rescue nedostupan",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningGpsRescueUnavailable": {
+        "message": "Upozorava kada GPS Rescue nije dostupan i ne može se aktivirati"
+    },
+    "osdWarningTextGpsRescueDisabled": {
+        "message": "GPS Rescue isključen",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningGpsRescueDisabled": {
+        "message": "Upozorava kada je GPS Rescue isključen"
+    },
+    "osdWarningTextRSSI": {
+        "message": "RSSI",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRSSI": {
+        "message": "Upozorava kada je RSSI ispod podešene vrednosti alarma"
+    },
+    "osdWarningTextLinkQuality": {
+        "message": "Kvalitet veze",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLinkQuality": {
+        "message": "Upozorava kada je kvalitet veze ispod podešene vrednosti alarma"
+    },
+    "osdWarningTextRssiDbm": {
+        "message": "RSSI dBm",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRssiDbm": {
+        "message": "Upozorava kada je vrednost RSSI dBm ispod podešene vrednosti alarma"
+    },
+    "osdWarningTextOverCap": {
+        "message": "Baterija preko kapaciteta",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningOverCap": {
+        "message": "Upozorava kada potrošeni mAh premaši konfigurisano ograničenje kapaciteta"
+    },
+    "osdWarningTextRSNR": {
+        "message": "RSNR",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRSNR": {
+        "message": "Upozorava kada je vrednost RSNR ispod podešene vrednosti alarma"
+    },
+    "osdWarningTextLoad": {
+        "message": "OPTEREĆENJE",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLoad": {
+        "message": "Upozorava ako je opterećenje CPU-a flight kontrolera previsoko",
+        "description": "Description of one of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdTextElementPosHoldFailed": {
+        "message": "Zadržavanje pozicije neuspešno",
+        "description": "One of the elements of the OSD that can be enabled to show a warning when position hold fails (e.g. in GPS mode)"
+    },
+    "osdDescElementPosHoldFailed": {
+        "message": "Prikazuje upozorenje kada zadržavanje pozicije ne uspe (npr. u GPS modu)"
+    },
+    "osdWarningTextPosHoldFailed": {
+        "message": "Zadržavanje pozicije neuspešno",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningPosHoldFailed": {
+        "message": "Zadržavanje pozicije neuspešno",
+        "description": "Warns when the position hold fails (e.g. in GPS mode)"
+    },
+    "osdWarningTextAutopilotAbort": {
+        "message": "Misija autopilota prekinuta",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningAutopilotAbort": {
+        "message": "Misija autopilota prekinuta",
+        "description": "Warns when a waypoint mission aborts (GPS lost, stalled or flyaway)"
+    },
+    "osdWarningTextUnknown": {
+        "message": "Nepoznato $1"
+    },
+    "osdWarningUnknown": {
+        "message": "Nepoznato upozorenje (detalji će biti dodati u budućem izdanju)"
+    },
+    "osdSectionHelpElements": {
+        "message": "Uključite ili isključite OSD elemente."
+    },
+    "osdSectionHelpVideoMode": {
+        "message": "Podesite očekivani video mod kamere (obično ovo možete ostaviti na AUTO, ako imate poteškoća, podesite ovo da odgovara izlazu kamere)."
+    },
+    "osdSectionHelpUnits": {
+        "message": "Podešava sistem jedinica koji se koristi za numeričke prikaze."
+    },
+    "osdSectionHelpTimers": {
+        "message": "Konfigurišite tajmere leta."
+    },
+    "osdSectionHelpAlarms": {
+        "message": "Podesite pragove koji se koriste za OSD elemente sa stanjima alarma."
+    },
+    "osdSectionHelpStats": {
+        "message": "Podesite vrednosti prikazane na ekranu statistike nakon leta."
+    },
+    "osdSectionHelpWarnings": {
+        "message": "Uključite ili isključite upozorenja koja se prikazuju na elementu UPOZORENJA."
+    },
+    "osdSettingsSaved": {
+        "message": "OSD podešavanja sačuvana"
+    },
+    "osdWritePermissions": {
+        "message": "Nemate <span class=\"message-negative\">dozvole za pisanje<\/span> za ovu fajl"
+    },
+    "osdButtonSaved": {
+        "message": "Sačuvano"
+    },
+    "vtxHelp": {
+        "message": "Ovde možete konfigurisati vrednosti za Vaš Video predajnik (VTX). Možete pregledati i promeniti vrednosti prenosa, uključujući VTX tabele, ako flight kontroler i VTX to podržavaju.<br>Da biste podesili Vaš VTX, koristite sledeće korake:<br>1. Idite na <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/VTX#vtx-tables\">ovu<\/a> stranicu;<br>2. Pronađite odgovarajuću VTX konfiguracionu fajl za Vašu zemlju i Vaš VTX model i preuzmite je;<br>3. Kliknite na '$t(vtxButtonLoadFile.message)' ispod, izaberite VTX konfiguracionu fajl, učitajte je;<br>4. Proverite da li su podešavanja tačna;<br>5. Kliknite na '$t(vtxButtonSave.message)' da biste sačuvali VTX podešavanja na flight kontroleru.<br>6. Opciono kliknite na '$t(vtxButtonSaveLua.message)' da biste sačuvali lua konfiguracionu fajl koju možete koristiti sa betaflight lua skriptama (Više pogledajte <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/\">ovde<\/a>.)",
+        "description": "Introduction message in the VTX tab"
+    },
+    "vtxMessageNotSupported": {
+        "message": "<span class=\"message-negative\">Pažnja:<\/span> Vaš VTX nije konfigurisan ili nije podržan. Stoga ne možete menjati VTX vrednosti odavde. Ovo će biti moguće samo ako je flight kontroler povezan sa VTX-om koristeći neki protokol kao što su Tramp ili SmartAudio i ako je ispravno konfigurisan na kartici $t(tabPorts.message) ako je potrebno.",
+        "description": "Message to show when the VTX is not supported in the VTX tab"
+    },
+    "vtxMessageTableNotConfigured": {
+        "message": "<span class=\"message-negative\">Pažnja:<\/span> Morate PRVO konfigurisati i sačuvati VTX tabelu na dnu pre nego što možete koristiti polja $t(vtxSelectedMode.message).",
+        "description": "Message to show when the VTX is not supported in the VTX tab"
+    },
+    "vtxMessageFactoryBandsNotSupported": {
+        "message": "<span class=\"message-negative\">Pažnja:<\/span> Izabrani tip VTX-a ne podržava 'fabričko' podešavanje za opsege, ali neki od Vaših opsega imaju ovo podešavanje. Kliknite na '$t(vtxButtonSave.message)' da biste ovo popravili.",
+        "description": "Message to show when the configured VTX type does not support factory bands, but one or more of the configured bands are of this type"
+    },
+    "vtxMessageVerifyTable": {
+        "message": "<span class=\"message-negative\">Pažnja:<\/span> Vrednosti VTX tabele su učitane, ali još nisu sačuvane na flight kontroleru. Morate proveriti i izmeniti vrednosti da biste bili sigurni da su validne i legalne u Vašoj zemlji, a zatim pritisnite dugme $t(vtxButtonSave.message) da biste ih sačuvali na flight kontroleru.",
+        "description": "Message to show when the VTX Table has been loaded from a external source"
+    },
+    "vtxFrequencyChannel": {
+        "message": "Unesite frekvenciju direktno",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxFrequencyChannelHelp": {
+        "message": "Ako ovo omogućite, aplikacija će Vam omogućiti da izaberete frekvenciju umesto uobičajenog opsega\/kanala. Da bi ovo funkcionisalo, Vaš VTX mora podržavati ovu funkciju.",
+        "description": "Help text for the frequency or channel select field of the VTX tab"
+    },
+    "vtxSelectedMode": {
+        "message": "Izabrani mod",
+        "description": "Title for the actual mode header of the VTX"
+    },
+    "vtxActualState": {
+        "message": "Trenutne vrednosti",
+        "description": "Title for the actual values header of the VTX"
+    },
+    "vtxType": {
+        "message": "VTX tip",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxType_0": {
+        "message": "Nije podržano",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_1": {
+        "message": "RTC607",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_3": {
+        "message": "SmartAudio",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_4": {
+        "message": "Tramp",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_5": {
+        "message": "MSP",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_255": {
+        "message": "Nepoznato",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxBand": {
+        "message": "Opseg",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxBandHelp": {
+        "message": "Ovde birate opseg za svoj video-predajnik.",
+        "description": "Help text for the band field of the VTX tab"
+    },
+    "vtxBand_0": {
+        "message": "Ništa",
+        "description": "Text of one of the options for the band field of the VTX tab"
+    },
+    "vtxBand_X": {
+        "message": "Opseg {{bandName}}",
+        "description": "Text of one of the options for the band field of the VTX tab"
+    },
+    "vtxChannel_0": {
+        "message": "Ništa",
+        "description": "Text of one of the options for the channel field of the VTX tab"
+    },
+    "vtxChannel_X": {
+        "message": "Kanal {{channelName}}",
+        "description": "Text of one of the options for the channel field of the VTX tab"
+    },
+    "vtxPower_0": {
+        "message": "Ništa",
+        "description": "Text of one of the options for the power field of the VTX tab"
+    },
+    "vtxPower_X": {
+        "message": "Nivo {{powerLevel}}",
+        "description": "Text of one of the options for the power field of the VTX tab"
+    },
+    "vtxChannel": {
+        "message": "Kanal",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxChannelHelp": {
+        "message": "Ovde birate kanal za svoj video-predajnik.",
+        "description": "Help text for the channel field of the VTX tab"
+    },
+    "vtxFrequency": {
+        "message": "Frekvencija",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxFrequencyHelp": {
+        "message": "Ovde birate frekvenciju za svoj video-predajnik, ako je podržana.",
+        "description": "Help text for the frequency field of the VTX tab"
+    },
+    "vtxReadyTrue": {
+        "message": "Da",
+        "description": "vtx device are ready"
+    },
+    "vtxReadyFalse": {
+        "message": "Ne",
+        "description": "vtx device are not ready"
+    },
+    "vtxDeviceReady": {
+        "message": "Uređaj spreman",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPower": {
+        "message": "Snaga",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPowerHelp": {
+        "message": "Ovo je izabrana snaga video-predajnika. Može se menjati ako je uključen $t(vtxPitMode.message) ili $t(vtxLowPowerDisarm.message).",
+        "description": "Help text for the power field of the VTX tab"
+    },
+    "vtxPitMode": {
+        "message": "Pit mod",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPitModeHelp": {
+        "message": "Kada je uključen, video-predajnik prelazi na vrlo malu snagu, da bi dron mogao da bude uključen na stolu a da ne smeta drugim pilotima. Domet u tom režimu obično je manji od pet metara.<br \/><br \/>NAPOMENA: kod nekih protokola, kao što je SmartAudio, pit mod se ne može uključiti kroz program pošto je predajnik već upaljen.",
+        "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxPitModeFrequency": {
+        "message": "Frekvencija u pit modu",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPitModeFrequencyHelp": {
+        "message": "Frekvencija na koju se prelazi kada je pit mod uključen.",
+        "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxProtocol": {
+        "message": "Protokol"
+    },
+    "vtxProtocolHelp": {
+        "message": "Upravljački protokol kojim VTX govori. SmartAudio i Tramp rade preko UART-a ispod; MSP ga deli sa MSP-om, kao što to rade i DJI, HDZero i Walksnail."
+    },
+    "vtxSerialPort": {
+        "message": "Serijski port"
+    },
+    "vtxSerialPortHelp": {
+        "message": "UART na kom radi upravljački protokol VTX-a. Od API-ja 1.49 zadaje se na samom VTX-u; kartica Ports ga samo prikazuje."
+    },
+    "vtxLowPowerDisarm": {
+        "message": "Mala snaga dok je razoružan",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxLowPowerDisarmHelp": {
+        "message": "Kada je uključeno, video-predajnik koristi najmanju dostupnu snagu dok dron nije armovan, osim ako je nastupio Failsafe.",
+        "description": "Help text for the low power disarm field of the VTX tab"
+    },
+    "vtxLowPowerDisarmOption_0": {
+        "message": "Isključeno",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxLowPowerDisarmOption_1": {
+        "message": "Uključeno",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxLowPowerDisarmOption_2": {
+        "message": "Do prvog armovanja",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxTable": {
+        "message": "Tabela video-predajnika",
+        "description": "Text of the header of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevels": {
+        "message": "Broj nivoa snage",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsHelp": {
+        "message": "Ovim se zadaje koliko nivoa snage Vaš video-predajnik podržava.",
+        "description": "Help for the number of power levels field of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsTableHelp": {
+        "message": "Ova tabela prikazuje različite vrednosti snage koje se mogu koristiti za video-predajnik. Dele se na dve stvari: <br><b>- $t(vtxTablePowerLevelsValue.message):<\/b> svaki nivo snage traži vrednost koju određuje proizvođač uređaja. Tačnu vrednost potražite kod proizvođača ili u Betaflight uputstvima o tabelama video-predajnika, gde ima primera. <br><b>- $t(vtxTablePowerLevelsLabel.message):<\/b> ovde upisujete oznaku koju želite za svaki nivo snage. Mogu biti brojevi (25, 200, 600, 1.2), slova (OFF, MIN, MAX) ili kombinacija.<br \/><br \/>Podesite <b>samo<\/b> one nivoe snage koji su dozvoljeni u Vašoj zemlji.",
+        "description": "Help for the table of power levels (value-label) that appears in the VTX tab"
+    },
+    "vtxTablePowerLevelsValue": {
+        "message": "Vrednost",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsLabel": {
+        "message": "Oznaka",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBands": {
+        "message": "Broj opsega",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsHelp": {
+        "message": "Ovim se zadaje koliko opsega video-predajnik traži.",
+        "description": "Help for the number of bands field of the VTX Table element in the VTX tab"
+    },
+    "vtxTableChannels": {
+        "message": "Broj kanala po opsegu",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsChannelsHelp": {
+        "message": "Ovim se zadaje koliko opsega i koliko kanala po opsegu želite za svoj video-predajnik.",
+        "description": "Help for the number of bands and channels field of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleName": {
+        "message": "Naziv",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleLetter": {
+        "message": "Slovo",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleFactory": {
+        "message": "Fabrički",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsChannelsTableHelp": {
+        "message": "Ova tabela prikazuje sve frekvencije koje se mogu koristiti za Vaš video-predajnik. Možete imati više opsega, a za svaki opseg podešavate:<br><b>- $t(vtxTableBandTitleName.message):<\/b> naziv koji želite da date opsegu, na primer BOSCAM_A, FATSHARK ili RACEBAND.<br><b>- $t(vtxTableBandTitleLetter.message):<\/b> kratko slovo koje označava taj opseg.<br><b>- $t(vtxTableBandTitleFactory.message):<\/b> označava da li je opseg fabrički. Ako jeste, Betaflight šalje predajniku broj opsega i kanala, pa predajnik koristi svoju ugrađenu tabelu frekvencija, a ove ovde služe samo za prikaz na ekranu. Ako nije, Betaflight šalje predajniku stvarnu frekvenciju zadatu ovde.<br><b>- Frekvencije:<\/b> frekvencije za taj opseg.<br \/><br \/>Imajte na umu da nisu sve frekvencije dozvoljene u Vašoj zemlji. Svakoj frekvenciji koju ne smete da koristite upišite <b>nulu<\/b> da biste je isključili.",
+        "description": "Help for the table of bands-channels that appears in the VTX tab"
+    },
+    "vtxSavedFileOk": {
+        "message": "Fajl sa podešavanjima video-predajnika je <span class=\"message-positive\">sačuvan<\/span>",
+        "description": "Message in the GUI log when the VTX Config file is saved"
+    },
+    "vtxSavedFileKo": {
+        "message": "<span class=\"message-negative\">Greška<\/span> pri čuvanju fajla sa podešavanjima video-predajnika",
+        "description": "Message in the GUI log when the VTX Config file is saved"
+    },
+    "vtxSavedLuaFileOk": {
+        "message": "Lua fajl sa podešavanjima video-predajnika je <span class=\"message-positive\">sačuvan<\/span>",
+        "description": "Message in the GUI log when the lua VTX Config file is saved"
+    },
+    "vtxSavedLuaFileKo": {
+        "message": "<span class=\"message-negative\">Greška<\/span> pri čuvanju lua fajla sa podešavanjima video-predajnika",
+        "description": "Message in the GUI log when the lua VTX Config file saving has failed"
+    },
+    "vtxLoadFileOk": {
+        "message": "Fajl sa podešavanjima video-predajnika je <span class=\"message-positive\">učitan<\/span>",
+        "description": "Message in the GUI log when the VTX Config file is loaded"
+    },
+    "vtxLoadFileKo": {
+        "message": "<span class=\"message-negative\">Greška<\/span> pri učitavanju fajla sa podešavanjima video-predajnika",
+        "description": "Message in the GUI log when the VTX Config file is loaded"
+    },
+    "vtxLoadClipboardOk": {
+        "message": "Podešavanja video-predajnika su <span class=\"message-positive\">učitana<\/span> iz privremene memorije",
+        "description": "Message in the GUI log when the VTX Config file is pasted from clipboard"
+    },
+    "vtxLoadClipboardKo": {
+        "message": "<span class=\"message-negative\">Greška<\/span> pri učitavanju podešavanja video-predajnika iz privremene memorije",
+        "description": "Message in the GUI log when the VTX Config file is pasted from clipboard"
+    },
+    "vtxButtonSaveFile": {
+        "message": "Sačuvaj u fajl",
+        "description": "Save to file button in the VTX tab"
+    },
+    "vtxButtonSaveLua": {
+        "message": "Sačuvaj Lua skriptu",
+        "description": "Save Lua script button in the VTX tab"
+    },
+    "vtxLuaFileHelp": {
+        "message": "Dugme „$t(vtxButtonSaveLua.message)“ omogućava da sačuvate <i>mcuid<\/i>.lua fajl sa podešavanjima tabele video-predajnika, koji se koristi uz <a href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight Lua skripte za daljinski<\/a>.<br><br>Verzija 1.6.0 i novije koriste fajl takav kakav jeste, a kod starijih verzija skripti treba ga preimenovati tako da se poklapa sa nazivom modela na daljinskom.",
+        "description": "Tooltip message for the Save Lua script button in the VTX tab"
+    },
+    "vtxButtonLoadFile": {
+        "message": "Učitaj iz fajla",
+        "description": "Load to file button in the VTX tab"
+    },
+    "vtxButtonLoadClipboard": {
+        "message": "Učitaj iz privremene memorije",
+        "description": "Paste from clipboard button in the VTX tab"
+    },
+    "vtxButtonSave": {
+        "message": "Sačuvaj",
+        "description": "Save button in the VTX tab"
+    },
+    "buttonSaving": {
+        "message": "Čuvanje",
+        "description": "Show state of the Save button in the VTX\/LED tab"
+    },
+    "buttonSaved": {
+        "message": "Sačuvano",
+        "description": "Saved action button in the VTX\/LED tab"
+    },
+    "vtxSmartAudioUnlocked": {
+        "message": "{{version}} otključan",
+        "description": "Indicates if SA device is unlocked"
+    },
+    "mainHelpArmed": {
+        "message": "Armovanje motora"
+    },
+    "mainHelpFailsafe": {
+        "message": "Failsafe mod"
+    },
+    "mainHelpLink": {
+        "message": "Status serijske veze"
+    },
+    "configurationEscProtocol": {
+        "message": "Protokol regulatora i motora"
+    },
+    "configurationEscProtocolHelp": {
+        "message": "Izaberite protokol motora. <br>Proverite da ga Vaši regulatori podržavaju — taj podatak stoji na stranici proizvođača. <br> <b>Oprezno sa DSHOT900 i DSHOT1200 — malo regulatora ih podržava!<\/b>"
+    },
+    "configurationunsyndePwm": {
+        "message": "PWM brzina motora odvojena od brzine PID petlje"
+    },
+    "configurationUnsyncedPWMFreq": {
+        "message": "PWM frekvencija motora"
+    },
+    "configurationDshotBidir": {
+        "message": "Dvosmerni DShot (traži odgovarajući firmver regulatora)",
+        "description": "Feature for the ESC\/Motor"
+    },
+    "configurationDshotBidirHelp": {
+        "message": "Šalje podatke sa regulatora nazad flight kontroleru kroz DShot. Neophodno je za RPM filter i za dinamički prazan hod. <br> <br>Napomena: traži odgovarajući regulator sa prikladnim firmverom, na primer JESC, Jazzmac ili BLHeli-32.",
+        "description": "Description of the Bidirectional DShot feature of the ESC\/Motor"
+    },
+    "configurationGyroFrequency": {
+        "message": "Učestanost osvežavanja žiroskopa"
+    },
+    "configurationPidProcessDenom": {
+        "message": "Učestanost PID petlje"
+    },
+    "configurationPidProcessDenomHelp": {
+        "message": "Najveća učestanost PID petlje ograničena je najvećom učestanošću kojom izabrani protokol motora može da šalje komande."
+    },
+    "configurationGyroUse32kHz": {
+        "message": "Uzorkovanje žiroskopa na 32 kHz"
+    },
+    "configurationGyroUse32kHzHelp": {
+        "message": "Učestanost žiroskopa od 32 kHz moguća je samo ako je čip podržava (trenutno MPU6500, MPU9250 i ICM20xxx ako su vezani preko SPI). Ako niste sigurni, pogledajte specifikaciju svoje pločice."
+    },
+    "configurationAccHardware": {
+        "message": "Akcelerometar"
+    },
+    "configurationBaroHardware": {
+        "message": "Barometar"
+    },
+    "configurationMagHardware": {
+        "message": "Magnetometar (ako je podržan)"
+    },
+    "configurationMagDeclinationNoGps": {
+        "message": "Nije bilo moguće odrediti položaj. Priključite GPS modul ili dozvolite pregledaču pristup položaju."
+    },
+    "configurationMagDeclinationSet": {
+        "message": "Magnetna deklinacija postavljena na {{declination}}° prema otkrivenom položaju."
+    },
+    "configurationMagInclination": {
+        "message": "Inklinacija"
+    },
+    "configurationMagInclinationHelp": {
+        "message": "Ugao između magnetnog polja zemlje i vodoravne ravni na Vašem mestu. Pozitivne vrednosti znače da polje pokazuje nadole, dakle severna polulopta."
+    },
+    "configurationMagFieldStrengthLabel": {
+        "message": "Jačina polja"
+    },
+    "configurationMagFieldStrengthHelp": {
+        "message": "Ukupna jačina magnetnog polja zemlje na Vašem mestu, u nanoteslama. Uobičajene vrednosti kreću se od dvadeset pet hiljada do šezdeset pet hiljada."
+    },
+    "sensorConfigMagDetect": {
+        "message": "Detektuj"
+    },
+    "sensorConfigMagUpdate": {
+        "message": "Ažuriraj"
+    },
+    "sensorConfigDeclinationAutoSet": {
+        "message": "Magnetna deklinacija je automatski detektovana kao {{value}}° za Vašu lokaciju."
+    },
+    "sensorConfigDeclinationDrift": {
+        "message": "Deklinacija je {{saved}}°, ali GPS detektuje {{detected}}° za ovu lokaciju. Kliknite na Ažuriraj da biste ispravili."
+    },
+    "magCalibrationCancel": {
+        "message": "Otkaži"
+    },
+    "magCalibrationClear": {
+        "message": "Očisti"
+    },
+    "magCalibrationModeOptions": {
+        "message": "Opcije moda kalibracije"
+    },
+    "magCalibrationRetry": {
+        "message": "Pokušaj ponovo"
+    },
+    "magCalibrationWaiting": {
+        "message": "Čekanje na pomeranje... Protresite letelicu da biste započeli."
+    },
+    "magCalibrationCollecting": {
+        "message": "Polako rotirajte letelicu u svim pravcima."
+    },
+    "magCalibrationComplete": {
+        "message": "Kalibracija je završena."
+    },
+    "magCalibrationError": {
+        "message": "Kalibracija nije uspela. Pokušajte ponovo u području sa manje magnetnih smetnji."
+    },
+    "magCalibrationNoMovement": {
+        "message": "Pomeranje nije detektovano 30 sekundi. Kalibracija je otkazana."
+    },
+    "magCalibrationSamples": {
+        "message": "Uzorci"
+    },
+    "magCalibrationQualityGood": {
+        "message": "Dobar"
+    },
+    "magCalibrationQualityFair": {
+        "message": "Prosečan"
+    },
+    "magCalibrationQualityPoor": {
+        "message": "Loš"
+    },
+    "magCalibrationFirmwareOffsets": {
+        "message": "Firmver pomeraji"
+    },
+    "magCalibrationUnguided": {
+        "message": "Kalibracija firmvera (zastarelo)"
+    },
+    "magCalibrationUnguidedDesc": {
+        "message": "Rotirajte slobodno — firmver automatski čuva nakon 30s"
+    },
+    "magCalibrationUnguidedTitle": {
+        "message": "Kalibracija firmvera"
+    },
+    "magCalibrationUnguidedInstruction": {
+        "message": "Imate 30 sekundi da rotirate letelicu u svim smerovima. Firmver će automatski sačuvati vrednosti kalibracije kada vreme istekne."
+    },
+    "magCalibrationUnguidedDone": {
+        "message": "Kalibracija firmvera je završena"
+    },
+    "magCalibrationCheck": {
+        "message": "Proveri"
+    },
+    "magCalibrationCheckDesc": {
+        "message": "Prikaz uživo podataka kompasa sa trenutnom kalibracijom"
+    },
+    "magCalibrationCheckTitle": {
+        "message": "Provera kalibracije"
+    },
+    "magCalibrationCheckInstruction": {
+        "message": "Potvrdite orijentaciju i kalibraciju magnetometra. Postavite Vašu letelicu ravno u odnosu na horizont, usmerite nos ka poznatoj tački na kompasu (telefon se može koristiti za određivanje severa) i potvrdite da se nove tačke pojavljuju na očekivanom mestu na 3D prikazu. Vrednosti jačine polja za svaku osu i sferičnost tačaka ukazuju na tačnost kalibracije. Ako se tačke pojavljuju na potpuno pogrešnim mestima, orijentacija magnetometra je verovatno pogrešna."
+    },
+    "magCalibrationCalValues": {
+        "message": "Vrednosti kalibracije"
+    },
+    "magCalibrationSaveValues": {
+        "message": "Sačuvaj vrednosti"
+    },
+    "magCalibrationSaveSuccess": {
+        "message": "Vrednosti kalibracije su sačuvane"
+    },
+    "magCalibrationSaveError": {
+        "message": "Neuspešno čuvanje vrednosti kalibracije"
+    },
+    "magCalibrationFull": {
+        "message": "Kalibriši i detektuj orijentaciju"
+    },
+    "magCalibrationFullDesc": {
+        "message": "Rotirajte letelicu u svim smerovima da biste kalibrisali senzor i automatski detektovali njegovu orijentaciju ugradnje."
+    },
+    "magCalibrationFullTitle": {
+        "message": "Kalibracija i detekcija orijentacije"
+    },
+    "magCalibrationFullInstruction": {
+        "message": "Pratite korake ispod, držeći letelicu stabilno tokom svakog punog kruga. Broj zona raste kako dostižete nove uglove — cilj je pokriti svih 20."
+    },
+    "magCalibrationFullStepCounter": {
+        "message": "Korak {{n}} od {{total}}"
+    },
+    "magCalibrationFullStep1": {
+        "message": "Držite letelicu ravno i polako je rotirajte za punih 360°."
+    },
+    "magCalibrationFullStep2": {
+        "message": "Okrenite je naopako i polako rotirajte za još jednih punih 360°."
+    },
+    "magCalibrationFullStep3": {
+        "message": "Usmerite nos pravo nagore i napravite pun krug oko njega."
+    },
+    "magCalibrationFullStep4": {
+        "message": "Okrenite nos letelice nadole i napravite pun krug."
+    },
+    "magCalibrationFullStep5": {
+        "message": "Postavite je na levi bok i napravite pun krug."
+    },
+    "magCalibrationFullStep6": {
+        "message": "Postavite je na desni bok i napravite pun krug."
+    },
+    "magCalibrationFullStep7": {
+        "message": "Napravite nekoliko sporih prevrtaja napred, svaki put okrenuti u drugom pravcu."
+    },
+    "magCalibrationFullStep8": {
+        "message": "Napravite nekoliko sporih prevrtaja nazad, ponovo svaki put okrenuti u drugom pravcu."
+    },
+    "magCalibrationFullZones": {
+        "message": "{{covered}} \/ {{total}} pokrivenih zona"
+    },
+    "magCalibrationFullCompute": {
+        "message": "Završi kalibraciju"
+    },
+    "magCalibrationFullCoverageHint": {
+        "message": "Više pokrivenih zona daje veću preciznost — težite ka 20 \/ 20 za najbolju kalibraciju i detekciju poravnanja."
+    },
+    "magCalibrationFullCoverage": {
+        "message": "Pokrivenost:"
+    },
+    "magCalibrationFullAlignment": {
+        "message": "Poravnanje:"
+    },
+    "magCalibrationFullCustomAngles": {
+        "message": "roll {{roll}}° pitch {{pitch}}° yaw {{yaw}}°"
+    },
+    "magCalibrationFullOffsets": {
+        "message": "Kalibracija:"
+    },
+    "magCalibrationFullResidual": {
+        "message": "Rezidual:"
+    },
+    "magCalibrationFullCopyCli": {
+        "message": "Kopiraj CLI"
+    },
+    "magCalibrationFullApply": {
+        "message": "Primeni"
+    },
+    "magCalibrationFullExport": {
+        "message": "Izvezi model"
+    },
+    "magCalibrationFullInsufficientSamples": {
+        "message": "Nedovoljno uzoraka — rotirajte duže"
+    },
+    "magCalibrationFullNoGeo": {
+        "message": "Nema GPS-a, lokacije pregledača ili IP adrese — unesite koordinate ručno da biste nastavili"
+    },
+    "magCalibrationManualLocationTitle": {
+        "message": "Lokacija je potrebna za kalibraciju"
+    },
+    "magCalibrationManualLocationPrompt": {
+        "message": "Ručno unesite geografsku širinu i dužinu izborom sa Google Maps-a. Vaš dron nema satelitski položaj i Vaš uređaj nije dostavio podatke o lokaciji. Lokacija je potrebna za kalibraciju magnetometra."
+    },
+    "magCalibrationManualLocationPlaceholder": {
+        "message": "npr. 63.728263, -68.446117"
+    },
+    "magCalibrationManualLocationInvalid": {
+        "message": "Neispravan format koordinata. Unesite u obliku: geografska širina, geografska dužina (npr. 63.728263, -68.446117)"
+    },
+    "magCalibrationManualLocationFailed": {
+        "message": "Nije moguće izračunati magnetsku referencu za te koordinate. Proverite ih i pokušajte ponovo."
+    },
+    "magCalibrationFullCliCopied": {
+        "message": "CLI komande su kopirane u clipboard"
+    },
+    "magCalibrationFullCliCopyFailed": {
+        "message": "Kopiranje u clipboard nije uspelo"
+    },
+    "magCalibrationFullCustomUnsupported": {
+        "message": "Firmver {{version}} je suviše star za CUSTOM poravnanje magnetometra (potreban je {{min}}+). Ažurirajte firmver, pa primenite."
+    },
+    "magCalibrationFullApplied": {
+        "message": "Kalibracija je primenjena i sačuvana"
+    },
+    "magCalibrationDiscard": {
+        "message": "Odbaci"
+    },
+    "magVizPointCloud": {
+        "message": "Oblak tačaka"
+    },
+    "magVizHeatmap": {
+        "message": "Voksel toplotna mapa"
+    },
+    "magVizProjection": {
+        "message": "Trostruka projekcija"
+    },
+    "magVizPolar": {
+        "message": "Polarna gustina"
+    },
+    "magVizWaitingForData": {
+        "message": "Čekanje na podatke…"
+    },
+    "magVizAxisField": {
+        "message": "Polje"
+    },
+    "magVizAgeLegendOld": {
+        "message": "Staro"
+    },
+    "magVizAgeLegendNew": {
+        "message": "Novo"
+    },
+    "configurationSmallAngle": {
+        "message": "Maximum ARM Angle [stepeni]"
+    },
+    "configurationSmallAngleHelp": {
+        "message": "Dron se neće armovati ako je nagnut više od zadatog broja stepeni. Važi samo ako je akcelerometar uključen. Postavljanjem na sto osamdeset ova provera se praktično isključuje."
+    },
+    "configurationBatteryVoltage": {
+        "message": "Napon baterije"
+    },
+    "configurationBatteryCurrent": {
+        "message": "Struja baterije"
+    },
+    "configurationBatteryMeterType": {
+        "message": "Vrsta merača baterije"
+    },
+    "configurationBatteryMinimum": {
+        "message": "Najniži napon ćelije"
+    },
+    "configurationBatteryMaximum": {
+        "message": "Najviši napon ćelije"
+    },
+    "configurationBatteryWarning": {
+        "message": "Napon ćelije za upozorenje"
+    },
+    "configurationBatteryScale": {
+        "message": "Razmera napona"
+    },
+    "configurationCurrentMeterType": {
+        "message": "Vrsta merača struje"
+    },
+    "configurationCurrent": {
+        "message": "Senzor struje"
+    },
+    "configurationCurrentScale": {
+        "message": "Razmera izlaznog napona u miliampere [desetinke mV po A]"
+    },
+    "configurationCurrentOffset": {
+        "message": "Pomeraj u koracima od milivolta"
+    },
+    "configurationBatteryMultiwiiCurrent": {
+        "message": "Podrška za stari Multiwii MSP izlaz struje"
+    },
+    "pidTuningProfile": {
+        "message": "Profil"
+    },
+    "pidTuningProfileTip": {
+        "message": "Do 3 (2 za neke kontrolere) različita PID profila mogu se sačuvati na flight kontroleru. PID profili obuhvataju PID, D setpoint i angle\/horizon podešavanja na ovoj kartici. Kada ste na terenu, jednostavne komande ručicom (pogledajte uputstva na internetu) mogu se koristiti za prebacivanje između profila."
+    },
+    "pidTuningRateProfile": {
+        "message": "Rateprofile"
+    },
+    "pidTuningRateProfileTip": {
+        "message": "Do 3 različita Rateprofile profila po profilu mogu se sačuvati na flight kontroleru. Rateprofile obuhvata podešavanja za 'RC Rate', 'Rate', 'RC Expo', 'Throttle' i 'TPA'. Prebacivanje između Rateprofile profila je moguće tokom leta, podešavanjem tropoložajnog prekidača za 'Rate Profile Selection' na kartici 'Adjustments'."
+    },
+    "pidTuningRateSetup": {
+        "message": "Osnovni\/Acro Rates"
+    },
+    "pidTuningRateSetupHelp": {
+        "message": "Podesite ove vrednosti da biste podesili Vaše brzine odziva. Koristite RC Rate da povećate ukupnu maksimalnu brzinu odziva, koristite Super Rate za veće brzine na kraju hoda ručice, i koristite RC Expo da ublažite osećaj na sredini ručice.",
+        "description": "Rate table helpicon message"
+    },
+    "pidTuningDelta": {
+        "message": "Metoda izvoda"
+    },
+    "pidTuningDeltaError": {
+        "message": "Greška"
+    },
+    "pidTuningDeltaMeasurement": {
+        "message": "Merenje"
+    },
+    "pidTuningDeltaTip": {
+        "message": "<b>Derivative from Error<\/b> pruža direktniji odziv ručice i uglavnom se više koristi za trke.<br \/><br \/><b>Derivative from Measurement<\/b> pruža blaži odziv ručice što je korisnije za freestyle"
+    },
+    "pidTuningPidControllerTip": {
+        "message": "<b>Legacy vs Betaflight (float):<\/b> PID skaliranje i PID logika su potpuno isti. Ponovno podešavanje nije nužno potrebno. Legacy je stariji Betaflight algoritam baziran na celobrojnoj matematici. Betaflight PID kontroler koristi matematiku sa pokretnim zarezom i ima mnogo novih funkcija posebno dizajniranih za multirotore.<br><b>Float vs Integer:<\/b> PID skaliranje i PID logika su potpuno isti. Nije potrebno ponovno podešavanje. F1 pločice nemaju ugrađeni FPU, pa matematika sa pokretnim zarezom povećava opterećenje CPU-a dok celobrojna matematika poboljšava performanse, ali float matematika može doneti malo veću preciznost."
+    },
+    "pidTuningFilterTip": {
+        "message": "<b>Gyro Soft Filter:<\/b> Niskopropusni filter za žiroskop. Koristite manju vrednost za jače filtriranje.<br><b>D Term Filter:<\/b> Niskopropusni filter za Dterm. Može uticati na podešavanje D parametra. Koristite manju vrednost za jače filtriranje.<br><b>Yaw Filter:<\/b> Filtrira Yaw izlaz. Može pomoći na letelicama sa šumom na Yaw osi."
+    },
+    "pidTuningRatesTip": {
+        "message": "Igrajte se sa brzinama odziva i vidite kako one utiču na krivu ručice"
+    },
+    "configurationCamera": {
+        "message": "Kamera"
+    },
+    "configurationPersonalization": {
+        "message": "Lične postavke"
+    },
+    "craftName": {
+        "message": "Naziv letelice"
+    },
+    "configurationCraftNameHelp": {
+        "message": "Može se prikazati u zapisima, u nazivima rezervnih kopija i na ekranu u naočarima.<\/br>Može se zadati i promenljivom <b>craft_name<\/b> u CLI-ju."
+    },
+    "configurationPilotName": {
+        "message": "Ime pilota"
+    },
+    "configurationPilotNameHelp": {
+        "message": "Može se prikazati na ekranu u naočarima.<\/br>Može se zadati i promenljivom <b>pilot_name<\/b> u CLI-ju."
+    },
+    "configurationFpvCamAngleDegrees": {
+        "message": "Ugao FPV kamere [stepeni]"
+    },
+    "onboardLoggingBlackbox": {
+        "message": "Uređaj za Blackbox snimanje"
+    },
+    "onboardLoggingSerialPort": {
+        "message": "Serijski port"
+    },
+    "onboardLoggingSerialPortHelp": {
+        "message": "UART koji se koristi kada je uređaj za zapisivanje serijski. Od API-ja 1.49 zadaje se na samom Blackbox-u; kartica Ports ga samo prikazuje."
+    },
+    "onboardLoggingSerialBaud": {
+        "message": "Brzina prenosa serijskog porta"
+    },
+    "onboardLoggingSerialBaudHelp": {
+        "message": "Brzina prenosa za serijski port za zapisivanje."
+    },
+    "onboardLoggingRateOfLogging": {
+        "message": "Brzina Blackbox snimanja"
+    },
+    "onboardLoggingDebugFields": {
+        "message": "Uključena debug polja"
+    },
+    "onboardLoggingDebugMode": {
+        "message": "Blackbox debug mod"
+    },
+    "onboardLoggingDebugModeUnknown": {
+        "message": "NEPOZNATO"
+    },
+    "onboardLoggingSerialLogger": {
+        "message": "Spoljašnji serijski uređaj za beleženje"
+    },
+    "onboardLoggingFlashLogger": {
+        "message": "Ugrađeni dataflash čip"
+    },
+    "onboardLoggingEraseInProgress": {
+        "message": "Brisanje je u toku, molimo sačekajte..."
+    },
+    "onboardLoggingOnboardSDCard": {
+        "message": "SD kartica na pločici"
+    },
+    "onboardLoggingMsc": {
+        "message": "Mod masovne memorije"
+    },
+    "onboardLoggingMscNote": {
+        "message": "Ponovo pokrenite u modu <strong>uređaja masovne memorije (MSC)<\/strong>. Kada se aktivira, ugrađeni Flash ili SD kartica na Vašem flight kontroleru biće prepoznati kao uređaj za skladištenje na Vašem računaru i omogućiće Vam preuzimanje log fajlova. Izbacite uređaj i ponovo uključite napajanje Vašeg flight kontrolera kako biste napustili mod uređaja masovne memorije."
+    },
+    "onboardLoggingRebootMscText": {
+        "message": "Aktivirajte mod uređaja masovne memorije"
+    },
+    "onboardLoggingMscNotReady": {
+        "message": "Mod masovne memorije ne može se aktivirati jer uređaj za skladištenje nije spreman."
+    },
+    "dialogConfirmResetTitle": {
+        "message": "Potvrdi"
+    },
+    "dialogConfirmResetNote": {
+        "message": "UPOZORENJE: Da li ste sigurni da želite da vratite <strong>SVA PODEŠAVANJA<\/strong> na nekonfigurisano stanje? Ovo <strong>nije<\/strong> \"fabričko resetovanje\". Može prouzrokovati neočekivane probleme i možda će biti potrebno ponovo flešovati Vaš firmver da biste se ponovo povezali."
+    },
+    "dialogConfirmResetConfirm": {
+        "message": "Vrati na fabričko"
+    },
+    "dialogConfirmResetClose": {
+        "message": "Otkaži"
+    },
+    "modeCameraWifi": {
+        "message": "Dugme za Wi-Fi kamere"
+    },
+    "modeCameraPower": {
+        "message": "Dugme za napajanje kamere"
+    },
+    "modeCameraChangeMode": {
+        "message": "Dugme za promenu moda kamere"
+    },
+    "flashTab": {
+        "message": "Ažuriranje firmvera"
+    },
+    "cliAutoComplete": {
+        "message": "Napredno CLI automatsko dopunjavanje"
+    },
+    "firmwareBackupOnFlash": {
+        "message": "Napravite rezervnu kopiju pre flešovanja novog cilja"
+    },
+    "darkTheme": {
+        "message": "Uključi tamnu temu"
+    },
+    "colorTheme": {
+        "message": "Tema boja",
+        "description": "Color theme settings"
+    },
+    "colorThemeYellow": {
+        "message": "Žuta (fabrički)",
+        "description": "Default yellow color theme"
+    },
+    "colorThemeAmber": {
+        "message": "Ćilibar",
+        "description": "Amber color theme"
+    },
+    "colorThemeContrast": {
+        "message": "Visoki kontrast",
+        "description": "Contrast color theme"
+    },
+    "uiScale": {
+        "message": "Skaliranje interfejsa",
+        "description": "Scale the entire user interface up or down"
+    },
+    "pidTuningRatesType": {
+        "message": "Vrsta Rates-a"
+    },
+    "pidTuningRatesTypeTip": {
+        "message": "Promena vrste rejtova menja krivu i način na koji je zadajete"
+    },
+    "pidTuningRcRateRaceflight": {
+        "message": "Rate"
+    },
+    "pidTuningRcExpoRaceflight": {
+        "message": "Expo"
+    },
+    "pidTuningRateRaceflight": {
+        "message": "Acro+"
+    },
+    "pidTuningRcExpoKISS": {
+        "message": "RC kriva"
+    },
+    "pidTuningRateQuickRates": {
+        "message": "Max Rate"
+    },
+    "pidTuningRcRateActual": {
+        "message": "Osetljivost u centru"
+    },
+    "pidTuningAcroCenterSensitiviy": {
+        "message": "Osetljivost centar-maksimum"
+    },
+    "dialogRatesTypeTitle": {
+        "message": "Promena vrste Rate-a"
+    },
+    "dialogRatesTypeNote": {
+        "message": "<span class=\"message-negative\"><b>UPOZORENJE: Menjate vrstu Rate-a.<\/b><\/span> Ako promenite vrstu Rate-a, Vaši Rate-ovi će biti podešeni na fabričku krivu."
+    },
+    "dialogRatesTypeConfirm": {
+        "message": "Promeni"
+    },
+    "gpsSbasAutoDetect": {
+        "message": "Automatsko prepoznavanje",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasEuropeanEGNOS": {
+        "message": "Evropski EGNOS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasNorthAmericanWAAS": {
+        "message": "Severnoamerički WAAS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasJapaneseMSAS": {
+        "message": "Japanski MSAS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasIndianGAGAN": {
+        "message": "Indijski GAGAN",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasNone": {
+        "message": "Ništa",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "dialogFileNameTitle": {
+        "message": "Naziv fajla"
+    },
+    "dialogFileNameDescription": {
+        "message": "Fajl će biti sačuvan u fascikli 'Android\/data\/betaflight-app\/{{folder}}' u Vašoj internoj memoriji."
+    },
+    "dialogFileAlreadyExistsTitle": {
+        "message": "Ovaj fajl već postoji"
+    },
+    "dialogFileAlreadyExistsDescription": {
+        "message": "Da li želite da ga presnimite?"
+    },
+    "cordovaCheckingWebview": {
+        "message": "Provera webview aplikacija..."
+    },
+    "cordovaIncompatibleWebview": {
+        "message": "Nekompatibilan webview"
+    },
+    "cordovaWebviewTroubleshootingMsg": {
+        "message": "Morate ažurirati webview na Vašem uređaju da biste koristili aplikaciju Betaflight."
+    },
+    "cordovaWebviewTroubleshootingMsg2": {
+        "message": "Alat ispod je namenjen da Vam pomogne pri instalaciji novog webview-a ili ažuriranju već instaliranog."
+    },
+    "cordovaAvailableWebviews": {
+        "message": "Dostupne webview aplikacije na Vašem uređaju"
+    },
+    "cordovaWebviewInstall": {
+        "message": "Instalacija aplikacije <b>{{app}}<\/b> može rešiti ovaj problem sa kompatibilnošću."
+    },
+    "cordovaWebviewInstallBtn": {
+        "message": "Instaliraj sa Google Play prodavnice"
+    },
+    "cordovaWebviewUninstall": {
+        "message": "Deinstalacija aplikacije <b>{{app}}<\/b> može rešiti ovaj problem sa kompatibilnošću. Ako ne možete da je deinstalirate, pokušajte da je isključite u podešavanjima."
+    },
+    "cordovaWebviewUninstallBtn1": {
+        "message": "Deinstaliraj sa Google Play prodavnice"
+    },
+    "cordovaWebviewUninstallBtn2": {
+        "message": "Deinstaliraj \/ isključi iz podešavanja"
+    },
+    "cordovaWebviewUpdate": {
+        "message": "Ažuriranje aplikacije <b>{{app}}<\/b> može rešiti ovaj problem sa kompatibilnošću."
+    },
+    "cordovaWebviewUpdateBtn": {
+        "message": "Ažuriraj sa Google Play prodavnice"
+    },
+    "cordovaWebviewEnable": {
+        "message": "Idite na odeljak O uređaju u Podešavanjima i dodirnite broj izrade 10 puta da biste uključili 'Opcije za programere'. Zatim otvorite Opcije za programere i izaberite <b>{{app}}<\/b> kao WebView provajdera."
+    },
+    "cordovaWebviewEnableBtn": {
+        "message": "Otvori podešavanja"
+    },
+    "cordovaWebviewIncompatible": {
+        "message": "Izgleda da Vaš uređaj nije kompatibilan. Pokušajte da pronađete druge načine za ažuriranje WebView-a"
+    },
+    "cordovaNoWebview": {
+        "message": "Nije instalirana \/ uključena nijedna WebView aplikacija"
+    },
+    "cordovaWebviewUsed": {
+        "message": "korišćeno"
+    },
+    "cordovaExitAppTitle": {
+        "message": "Potvrda"
+    },
+    "cordovaExitAppMessage": {
+        "message": "Da li zaista želite da zatvorite aplikaciju?"
+    },
+    "dropDownSelectAll": {
+        "message": "[Izaberi\/poništi sve]",
+        "description": "Select all item in the drop down\/multiple select"
+    },
+    "dropDownFilterDisabled": {
+        "message": "Izaberite...",
+        "description": "Text indicating nothing is selected in the drop down\/multiple select (filter disabled)"
+    },
+    "dropDownAll": {
+        "message": "Sve",
+        "description": "Text indicating everything is selected in the drop down\/multiple select"
+    },
+    "tabPresets": {
+        "message": "Gotova podešavanja",
+        "description": "Presets tab title"
+    },
+    "presetsReload": {
+        "message": "Ponovo učitaj",
+        "description": "Text on the reload button that appears when there in an error loading presets index"
+    },
+    "presetsAuthor": {
+        "message": "Autor:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsKeywords": {
+        "message": "Ključne reči:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsSourceRepository": {
+        "message": "Izvor:",
+        "description": "Text prefixing user defined name of the preset repository containing a preset"
+    },
+    "presetsVersions": {
+        "message": "Firmver:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsOfficial": {
+        "message": "Zvanično",
+        "description": "Hint text in the presets detailed dialog indication preset is official"
+    },
+    "presetsCommunity": {
+        "message": "Zajednica",
+        "description": "Hint text in the presets detailed dialog indication preset is not official but community"
+    },
+    "presetsExperimental": {
+        "message": "Eksperimentalno",
+        "description": "Hint text in the presets detailed dialog indication preset is not official but experimental"
+    },
+    "presetsApply": {
+        "message": "Izaberi",
+        "description": "Button to pick a preset"
+    },
+    "presetsViewOnline": {
+        "message": "Pogledaj na internetu&hellip;",
+        "description": "Link text for opening preset file online"
+    },
+    "presetsOpenDiscussion": {
+        "message": "Diskusija&hellip;",
+        "description": "Link text for opening preset discussion"
+    },
+    "presetsShowCli": {
+        "message": "Prikaži CLI",
+        "description": "Button to show CLI code of a preset"
+    },
+    "presetsHideCli": {
+        "message": "Sakrij CLI",
+        "description": "Button to hide CLI code of a preset"
+    },
+    "presetsOptions": {
+        "message": "Opcije",
+        "description": "Text label for Options drop down select"
+    },
+    "presetsFilterCategory": {
+        "message": "Kategorije",
+        "description": "UI filter name"
+    },
+    "presetsFilterKeyword": {
+        "message": "Ključne reči",
+        "description": "UI filter name"
+    },
+    "presetsFilterAuthor": {
+        "message": "Autori",
+        "description": "UI filter name"
+    },
+    "presetsFilterFirmware": {
+        "message": "Firmveri",
+        "description": "UI filter name"
+    },
+    "presetsFilterStatus": {
+        "message": "Stanje",
+        "description": "UI filter name - official\/community\/experimental"
+    },
+    "presetsLoadError": {
+        "message": "Greška pri učitavanju preset-a sa interneta",
+        "description": "Error report when failed to load presets index or a specific preset"
+    },
+    "presetsButtonSave": {
+        "message": "Sačuvaj i restartuj",
+        "description": "A button that saves all applied presets - analogous to 'save' command in CLI"
+    },
+    "presetsButtonCancel": {
+        "message": "Otkaži",
+        "description": "A button that restarts FC without saving applied presets - analogous to 'exit' command in CLI"
+    },
+    "presetsApplyingPresets": {
+        "message": "Primenjivanje konfiguracije...",
+        "description": "First label in the progress dialog when applying configuration (presets or user config)"
+    },
+    "presetsPleaseWait": {
+        "message": "Molimo sačekajte.",
+        "description": "Second label in the progress dialog when applying presets"
+    },
+    "presetsCliErrorsWarning": {
+        "message": "<span class='message-negative'>UPOZORENJE<\/span><br\/>Konfiguracija je primenjena sa CLI greškama.",
+        "description": "Text to show when there are CLI errors after applying presets or user configuration"
+    },
+    "presetsSaveAnyway": {
+        "message": "Ipak sačuvaj",
+        "description": "Save anyway button on the CLI errors presets dialog"
+    },
+    "presetsWarningDialogTitle": {
+        "message": "UPOZORENJE",
+        "description": "Warning title in the warning dialog in the presets"
+    },
+    "presetsWarningDialogYesButton": {
+        "message": "Prihvatam",
+        "description": "Agree button in the presets warning dialog"
+    },
+    "presetsWarningDialogNoButton": {
+        "message": "Otkaži",
+        "description": "Cancel button in the presets warning dialog"
+    },
+    "presetsFavoriteAddAriaLabel": {
+        "message": "Dodaj omiljeni preset",
+        "description": "Accessible label for the button that favorites a preset"
+    },
+    "presetsFavoriteRemoveAriaLabel": {
+        "message": "Ukloni omiljeni preset",
+        "description": "Accessible label for the button that removes a preset from favorites"
+    },
+    "presetsWiki": {
+        "message": "Presets Wiki",
+        "description": "Button to open Presets Wiki link"
+    },
+    "presetsBackupSave": {
+        "message": "Sačuvaj rezervnu kopiju",
+        "description": "Button to backup current configuration to file"
+    },
+    "presetsBackupLoad": {
+        "message": "Učitaj rezervnu kopiju",
+        "description": "Button to load backup from the file"
+    },
+    "presetsVirtualModeCliUnsupported": {
+        "message": "Primenjivanje preset-a i radnje sa rezervnom kopijom zahtevaju CLI, koji nije dostupan u virtualnom modu.",
+        "description": "Warning shown when a presets CLI action is attempted in Virtual Mode"
+    },
+    "mspCliFirmwareTooOld": {
+        "message": "Ova radnja zahteva Betaflight firmver {{required}} ili noviji (trenutno je povezan {{current}}). Molimo ažurirajte firmver Vašeg flight kontrolera pre nego što nastavite.",
+        "description": "Warning shown when an MSP CLI action is attempted on firmware that does not support MSP CLI"
+    },
+    "firmwareFlasherRestoreBackup": {
+        "message": "Vrati rezervnu kopiju",
+        "description": "Button to restore pre-flash backup from flasher tab"
+    },
+    "firmwareFlasherRestoreBackupTitle": {
+        "message": "Vrati rezervnu kopiju napravljenu pre flešovanja",
+        "description": "Title for the restore backup confirmation dialog"
+    },
+    "firmwareFlasherRestoreBackupConfirm": {
+        "message": "Ovo će vratiti rezervnu kopiju konfiguracije napravljenu pre flešovanja. Da li želite da nastavite?",
+        "description": "Confirmation message before restoring a pre-flash backup"
+    },
+    "firmwareFlasherRestoreBackupSuccess": {
+        "message": "Rezervna kopija konfiguracije je uspešno vraćena.",
+        "description": "Success message after restoring a pre-flash backup"
+    },
+    "firmwareFlasherRestoreBackupSuccessSkipped": {
+        "message": "Rezervna kopija konfiguracije je vraćena, {{count}} linija je preskočeno.",
+        "description": "Success message after restoring a pre-flash backup when some CLI lines were skipped"
+    },
+    "firmwareFlasherRestoreBackupFailed": {
+        "message": "Vraćanje nije uspelo: {{1}}",
+        "description": "Error message when restoring a pre-flash backup fails"
+    },
+    "firmwareFlasherRestoreConnectionFailed": {
+        "message": "Nije moguće povezivanje sa flight kontrolerom radi vraćanja.",
+        "description": "Error message when connection fails during restore"
+    },
+    "firmwareFlasherNoBackupAvailable": {
+        "message": "Nema dostupne rezervne kopije za vraćanje.",
+        "description": "Error message when no backup data is cached for restore"
+    },
+    "presetsLoadingDumpAll": {
+        "message": "Učitavanje trenutne konfiguracije sa flight kontrolera",
+        "description": "Title for the waiting dialog when loading dump all into a file"
+    },
+    "dumpAllNotSavedWarning": {
+        "message": "Došlo je do greške prilikom čuvanja trenutne konfiguracije",
+        "description": "Message appears on presets tab when saving current diff all into a file has failed"
+    },
+    "presetSources": {
+        "message": "Izvori preseta...",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogTitle": {
+        "message": "Izvori preseta",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogAddNew": {
+        "message": "Dodaj novi izvor",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogDefaultSourceName": {
+        "message": "Novi prilagođeni izvor preseta",
+        "description": "A default preset source (repo) name"
+    },
+    "presetsSourcesDialogSaveSource": {
+        "message": "Sačuvaj",
+        "description": "Presets tab, sources dialog, button to save new or editable source"
+    },
+    "presetsSourcesDialogResetSource": {
+        "message": "Vrati na fabričko",
+        "description": "Presets tab, sources dialog, button to reset source after modifications"
+    },
+    "presetsSourcesDialogMakeSourceActive": {
+        "message": "Aktiviraj",
+        "description": "Presets tab, sources dialog, button to make selected source active"
+    },
+    "presetsSourcesDialogMakeSourceDisable": {
+        "message": "Isključi",
+        "description": "Presets tab, sources dialog, button to make selected source disabled"
+    },
+    "presetsSourcesDialogDeleteSource": {
+        "message": "Obriši",
+        "description": "Presets tab, sources dialog, button to delete selected source"
+    },
+    "presetsWarningNotOfficialSource": {
+        "message": "<span class=\"message-negative\">UPOZORENJE!<\/span> Izabran je izvor preseta treće strane.",
+        "description": "Warning message that shows up when a third party preset source is selected"
+    },
+    "presetsFailedToLoadRepositories": {
+        "message": "<span class=\"message-negative\">UPOZORENJE!<\/span> Učitavanje sledećih repozitorijuma nije uspelo: <b>{{repos}}<\/b>",
+        "description": "Warning message that shows up when we fail to load some repositories"
+    },
+    "presetsWarningBackup": {
+        "message": "Molimo Vas da napravite rezervnu kopiju trenutne konfiguracije (dugme „$t(presetsBackupSave.message)“ ili putem CLI ako je dugme isključeno) <strong>pre<\/strong> izbora i primene preseta. U suprotnom neće biti moguće vraćanje na prethodnu konfiguraciju nakon primene preseta.",
+        "description": "Warning message that shows up at the top of the presets tab"
+    },
+    "presets_sources_dialog_warning": {
+        "message": "<span class=\"message-negative\">UPOZORENJE!<\/span> Korišćenje izvora preseta trećih strana može biti opasno.<br\/>Proverite da li dodajete i koristite samo pouzdane izvore. Zlonamerni ili loši izvori preseta pokvariće konfiguraciju Vaše letelice i mogu potencijalno oštetiti Vaše uređaje.",
+        "description": "Warning message that shows up at the top of the preset sources dialog"
+    },
+    "presetsWarningWrongVersionConfirmation": {
+        "message": "Izabrani preset zahteva verziju firmvera $1<br\/> Trenutna verzija firmvera je $2",
+        "description": "Warning message that shows up at the top of the preset sources dialog"
+    },
+    "presetsNoPresetsFound": {
+        "message": "Nije pronađen nijedan preset za zadate parametre pretrage",
+        "description": "Message that appears on presets tab if no presets were found"
+    },
+    "presetsTooManyPresetsFound": {
+        "message": "Dostignuta je maksimalna granica broja prikazanih preseta",
+        "description": "Message that appears on presets tab if too many presets found"
+    },
+    "presetsOptionsPlaceholder": {
+        "message": "PAŽNJA! Pregledajte listu opcija",
+        "description": "Placeholder for the options list dropdown"
+    },
+    "presetsVersionMismatch": {
+        "message": "Verzija izvora preseta se ne poklapa.<br\/>Potrebna verzija: {{versionRequired}}<br\/>Verzija izvora preseta: {{versionSource}}<br\/>Korišćenje ovog izvora preseta može biti opasno.<br\/>Da li želite da nastavite?",
+        "description": "Placeholder for the options list dropdown"
+    },
+    "presetsReviewOptionsWarning": {
+        "message": "Molimo Vas da pregledate listu opcija pre izbora ovog preseta.",
+        "description": "Dialog text to prompt user to review options for the preset"
+    },
+    "firmwareFlasherBuildConfigurationHead": {
+        "message": "Konfiguracija izrade"
+    },
+    "firmwareFlasherBuildOptions": {
+        "message": "Ostale opcije"
+    },
+    "firmwareFlasherRemoveBuildOption": {
+        "message": "Ukloni {{option}}",
+        "description": "Accessible label for the remove button on a selected build option badge."
+    },
+    "firmwareFlasherSelectProtocol": {
+        "message": "Izaberite protokol"
+    },
+    "firmwareFlasherSelectOptions": {
+        "message": "Izaberite opcije"
+    },
+    "firmwareFlasherSelectBranch": {
+        "message": "Izaberite granu ili unesite PR # \/ heš komita"
+    },
+    "firmwareFlasherSearchBoard": {
+        "message": "Pretražite pločicu..."
+    },
+    "firmwareFlasherBuildRadioProtocols": {
+        "message": "Radio-protokol"
+    },
+    "firmwareFlasherBuildTelemetryProtocols": {
+        "message": "Telemetrijski protokol"
+    },
+    "firmwareFlasherBuildMotorProtocols": {
+        "message": "Protokol motora"
+    },
+    "firmwareFlasherBuildOsdProtocols": {
+        "message": "OSD protokol"
+    },
+    "firmwareFlasherConfigurationFile": {
+        "message": "Naziv konfiguracionog fajla:"
+    },
+    "firmwareFlasherRadioProtocolDescription": {
+        "message": "Izaberite radio-protokol koji želite da uključite u ovu verziju. Imajte na umu da je ovo padajući meni, ali se može izabrati samo jedna stavka."
+    },
+    "firmwareFlasherTelemetryProtocolDescription": {
+        "message": "Izaberite telemetrijski protokol koji želite da uključite u ovu verziju. Imajte na umu da je ovo padajući meni, ali se može izabrati samo jedna stavka. Takođe, neki telemetrijski protokoli će biti uključeni bez obzira na Vaš izbor na osnovu izabranog radio-protokola, npr. CRSF."
+    },
+    "firmwareFlasherOptionLabelTelemetryProtocolIncluded": {
+        "message": "Automatski uključeno"
+    },
+    "firmwareFlasherOptionsDescription": {
+        "message": "Izaberite opšte opcije koje želite da uključite u ovu verziju. Imajte na umu da je ovo padajući meni i da se može izabrati više stavki. Stavke poput ispravki, npr. AKK VTX, nalaze se ovde."
+    },
+    "firmwareFlasherMotorProtocolDescription": {
+        "message": "Izaberite protokol motora (ESC) koji želite da uključite u ovu verziju. Imajte na umu da je ovo padajući meni, ali se može izabrati samo jedna stavka."
+    },
+    "firmwareFlasherOsdProtocolDescription": {
+        "message": "Izaberite OSD protokol koji želite da uključite u ovu verziju. Imajte na umu da je ovo padajući meni, ali se može izabrati samo jedna stavka."
+    },
+    "firmwareFlasherBranchDescription": {
+        "message": "Posebno korisno za programere: možete izabrati spojeni PR, navesti SHA komita ili navesti PR koji još nije spojen kucanjem znaka # ispred broja PR-a, npr. #1234 (ovo je skraćeni zapis za granu 'pull\/1234\/head')."
+    },
+    "firmwareFlasherCustomDefinesDescription": {
+        "message": "Za programere: možete dodati sve potrebne definicije odvojene razmakom (`space`), ali bez prefiksa `USE_`, on će biti automatski dodat."
+    },
+    "firmwareFlasherBuildCustomDefines": {
+        "message": "Prilagođene definicije"
+    },
+    "firmwareFlasherOSDProtocolNotSelected": {
+        "message": "OSD protokol nije izabran"
+    },
+    "firmwareFlasherOSDProtocolNotSelectedDescription": {
+        "message": "Morate izabrati OSD protokol da biste napravili firmver."
+    },
+    "firmwareFlasherOSDProtocolSelect": {
+        "message": "Izaberite OSD protokol"
+    },
+    "firmwareFlasherOSDProtocolNotSelectedContinue": {
+        "message": "Nastavi bez OSD protokola"
+    },
+    "firmwareFlasherOptionLabelVerifiedPartner": {
+        "message": "✅ Potvrđeni partner"
+    },
+    "firmwareFlasherOptionLabelVendorCommunity": {
+        "message": "⚠️ Proizvođač \/ Zajednica"
+    },
+    "firmwareFlasherOptionLabelLegacy": {
+        "message": "Zastarelo"
+    },
+    "firmwareFlasherOptionLabelNotQualified": {
+        "message": "Target koji podržava zajednica \/ proizvođač — nije zvanično podržan"
+    },
+    "coreBuild": {
+        "message": "Samo jezgro"
+    },
+    "coreBuildModeDescription": {
+        "message": "Ova opcija pravi firmver koji sadrži drajvere za hardver (i neke ograničene funkcije). Služi kao pomoć pri detekciji hardvera na flight kontroleru i pružena je samo radi pogodnosti. Neće sve funkcije biti dostupne (samo hardver) kada koristite ovu opciju."
+    },
+    "showDevToolsOnStartup": {
+        "message": "Automatski otvori DevTools u razvojnom režimu",
+        "description": "Text for the option to enable automatic opening of DevTools in debug mode"
+    },
+    "betaflightSupportButton": {
+        "message": "Wiki",
+        "description": "Text for the button to open the support URL"
+    },
+    "showNotifications": {
+        "message": "Prikaži obaveštenja za dugotrajne operacije"
+    },
+    "notificationsDeniedTitle": {
+        "message": "Obaveštenja su blokirana",
+        "description": "Title when Notifications has no or denied permissions"
+    },
+    "notificationsDenied": {
+        "message": "Obaveštenja su blokirana. Molimo Vas da ih uključite u podešavanjima pregledača. U suprotnom nećete primati obaveštenja o dugotrajnim operacijama. Ako koristite Chrome, obaveštenja možete uključiti klikom na ikonicu katanca u adresnoj traci i izborom opcije „Podešavanja sajta“.",
+        "description": "Message when Notifications has no or denied permissions"
+    },
+    "flashEraseDoneNotification": {
+        "message": "Brisanje Dataflash memorije je završeno",
+        "description": "Notification message when flash erase is done"
+    },
+    "flashDownloadDoneNotification": {
+        "message": "Dnevnici iz Dataflash memorije su preuzeti",
+        "description": "Notification message when flash logs are done downloading"
+    },
+    "programmingSuccessfulNotification": {
+        "message": "FC je uspešno programiran",
+        "description": "Notification message when programming is successful"
+    },
+    "programmingFailedNotification": {
+        "message": "Programiranje FC-a nije uspelo",
+        "description": "Notification message when programming is unsuccessful"
+    },
+    "osdTextElementLidar": {
+        "message": "Sonar",
+        "description": "Displays distance from sonar sensor in cm"
+    },
+    "osdTextElementCustomSerialText": {
+        "message": "Sopstveni tekst sa serijskog porta",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCustomSerialText": {
+        "message": "Prikazuje sopstveni tekst primljen sa serijskog porta"
+    },
+    "osdTextElementBatteryProfileName": {
+        "message": "Profil: naziv profila baterije",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementBatteryProfileName": {
+        "message": "Prikazuje naziv ili broj aktivnog profila baterije"
+    },
+    "osdTextElementWpNumber": {
+        "message": "Broj tačke putanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNumber": {
+        "message": "Prikazuje redni broj trenutne i ukupan broj tačaka u aktivnom planu leta"
+    },
+    "osdTextElementWpCurrentLat": {
+        "message": "Geografska širina tačke putanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLat": {
+        "message": "Prikazuje geografsku širinu trenutne tačke putanje"
+    },
+    "osdTextElementWpCurrentLon": {
+        "message": "Geografska dužina tačke putanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLon": {
+        "message": "Prikazuje geografsku dužinu trenutne tačke putanje"
+    },
+    "osdTextElementWpCurrentAlt": {
+        "message": "Visina tačke putanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentAlt": {
+        "message": "Prikazuje visinu trenutne tačke putanje"
+    },
+    "osdTextElementWpDistance": {
+        "message": "Rastojanje do tačke putanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDistance": {
+        "message": "Prikazuje rastojanje do trenutne tačke putanje"
+    },
+    "osdTextElementWpDirection": {
+        "message": "Pravac ka tački putanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDirection": {
+        "message": "Prikazuje strelicu koja pokazuje ka trenutnoj tački putanje"
+    },
+    "osdTextElementWpNextNumber": {
+        "message": "Broj sledeće tačke putanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNextNumber": {
+        "message": "Prikazuje broj sledeće tačke u aktivnom planu leta"
+    },
+    "osdTextElementWpEta": {
+        "message": "Procenjeno vreme do tačke putanje",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpEta": {
+        "message": "Prikazuje procenjeno vreme dolaska do trenutne tačke putanje"
+    },
+    "osdTextElementNavMap": {
+        "message": "Navigaciona karta",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNavMap": {
+        "message": "Mala karta sa mestom poletanja, planom leta i pređenim putem"
+    },
+    "osdTextElementPosHoldReady": {
+        "message": "Zadržavanje položaja spremno",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPosHoldReady": {
+        "message": "Pokazuje da li su ispunjeni uslovi za zadržavanje položaja, pre nego što se prekidač uključi"
+    },
+    "osdSetupPreviewCheckRulers": {
+        "message": "Lenjiri",
+        "description": "Label for the checkbox to toggle OSD preview rulers around the preview"
+    },
+    "tabUserProfile": {
+        "message": "Korisnički profil"
+    },
+    "labelEmail": {
+        "message": "E-pošta"
+    },
+    "placeholderEmailAddress": {
+        "message": "Unesite adresu e-pošte"
+    },
+    "userEmailRequired": {
+        "message": "Adresa e-pošte je obavezna"
+    },
+    "profileLoginMessage": {
+        "message": "Molimo Vas da se prijavite da biste videli svoj profil."
+    },
+    "tabBackups": {
+        "message": "Rezervne kopije"
+    },
+    "userPasskeyDeleteSuccess": {
+        "message": "Pristupni ključ je uspešno izbrisan"
+    },
+    "userPasskeyDeleteFailed": {
+        "message": "Brisanje pristupnog ključa nije uspelo"
+    },
+    "userTokenDeleteSuccess": {
+        "message": "Token je uspešno izbrisan"
+    },
+    "userTokenDeleteFailed": {
+        "message": "Brisanje tokena nije uspelo"
+    },
+    "userProfileLoadFailed": {
+        "message": "Učitavanje korisničkog profila nije uspelo"
+    },
+    "userTokenLoadFailed": {
+        "message": "Učitavanje korisničkih tokena nije uspelo"
+    },
+    "userPasskeyLoadFailed": {
+        "message": "Učitavanje korisničkih pristupnih ključeva nije uspelo"
+    },
+    "userProfileUpdateSuccess": {
+        "message": "Profil je uspešno ažuriran"
+    },
+    "userProfileUpdateFailed": {
+        "message": "Ažuriranje profila nije uspelo"
+    },
+    "userBackupsLoadFailed": {
+        "message": "Nije uspelo učitavanje rezervnih kopija"
+    },
+    "userBackupDownloadFailed": {
+        "message": "Nije uspelo preuzimanje rezervne kopije"
+    },
+    "userBackupFileEmpty": {
+        "message": "Fajl rezervne kopije je prazna"
+    },
+    "userBackupUpdateSuccess": {
+        "message": "Rezervna kopija je uspešno ažurirana"
+    },
+    "userBackupUpdateFailed": {
+        "message": "Nije uspelo ažuriranje rezervne kopije"
+    },
+    "userBackupDeleteSuccess": {
+        "message": "Rezervna kopija je uspešno obrisana"
+    },
+    "userBackupDeleteFailed": {
+        "message": "Nije uspelo brisanje rezervne kopije"
+    },
+    "actionRestore": {
+        "message": "Vrati iz kopije"
+    },
+    "titleRestoreBackup": {
+        "message": "Vrati rezervnu kopiju"
+    },
+    "userBackupRestoreConfirm": {
+        "message": "Želite li da primenite rezervnu kopiju \"{{name}}\" na povezani flight kontroler? Trenutna konfiguracija će biti presnimljena."
+    },
+    "userBackupRestoreInProgress": {
+        "message": "Vraćanje rezervne kopije..."
+    },
+    "userBackupRestoreSuccess": {
+        "message": "Rezervna kopija je uspešno vraćena"
+    },
+    "userBackupRestoreFailed": {
+        "message": "Nije uspelo vraćanje rezervne kopije"
+    },
+    "userBackupRestoreErrors": {
+        "message": "<span class='message-negative'>UPOZORENJE<\/span><br\/>Rezervna kopija je primenjena uz CLI greške."
+    },
+    "userPasskeyNoPasskeys": {
+        "message": "Nema dostupnih pristupnih ključeva"
+    },
+    "userTokenNoTokens": {
+        "message": "Nema dostupnih tokena"
+    },
+    "profileBackupSuccess": {
+        "message": "Uspešno pravljenje rezervne kopije"
+    },
+    "profileBackupApiSuccess": {
+        "message": "Rezervna kopija je uspešno sačuvana na API"
+    },
+    "profileBackupApiFail": {
+        "message": "Nije uspelo čuvanje rezervne kopije na API"
+    },
+    "profileBackupEmptyResult": {
+        "message": "Pravljenje rezervne kopije nije uspelo"
+    },
+    "labelLogin": {
+        "message": "Prijava"
+    },
+    "labelSignOut": {
+        "message": "Odjava"
+    },
+    "labelAvatarUrl": {
+        "message": "URL avatara"
+    },
+    "placeholderAvatarUrl": {
+        "message": "Unesite URL slike za Vaš avatar"
+    },
+    "labelCreatePasskey": {
+        "message": "Napravi pristupni ključ"
+    },
+    "labelUsePasskey": {
+        "message": "Upotrebi pristupni ključ"
+    },
+    "labelSignInWithPasskey": {
+        "message": "Prijavite se pomoću Passkey-a"
+    },
+    "labelSendVerificationCode": {
+        "message": "Pošaljite verifikacioni kod"
+    },
+    "labelSignInWithEmailCode": {
+        "message": "Prijavite se umesto toga kodom iz e-pošte"
+    },
+    "labelBackToPasskey": {
+        "message": "Nazad na prijavu pomoću Passkey-a"
+    },
+    "labelBack": {
+        "message": "Nazad"
+    },
+    "labelNoPasskeyPrompt": {
+        "message": "Nemate Passkey?"
+    },
+    "labelSetOnePasskeyUp": {
+        "message": "Podesite ga"
+    },
+    "descriptionPasskeyLogin": {
+        "message": "Upotrebite Vaš Passkey za prijavu"
+    },
+    "descriptionCodeRequest": {
+        "message": "Poslaćemo Vam verifikacioni kod na e-poštu"
+    },
+    "descriptionCodeEntered": {
+        "message": "Unesite kod koji smo poslali na $1"
+    },
+    "titleEnterVerificationCode": {
+        "message": "Unesite verifikacioni kod"
+    },
+    "labelVerificationCode": {
+        "message": "Verifikacioni kod"
+    },
+    "labelCode": {
+        "message": "Kod"
+    },
+    "userLoggingIn": {
+        "message": "Prijava u toku..."
+    },
+    "userSignedOut": {
+        "message": "Odjavljeni ste"
+    },
+    "userSignOutFailed": {
+        "message": "Odjava nije uspela"
+    },
+    "userLoginSuccess": {
+        "message": "Prijava je uspešna"
+    },
+    "userLoginFailed": {
+        "message": "Prijava nije uspela"
+    },
+    "userCreatePasskeyFailed": {
+        "message": "Kreiranje Passkey-a nije uspelo"
+    },
+    "userCreatePasskeySuccess": {
+        "message": "Passkey je uspešno kreiran"
+    },
+    "userVerifyingCode": {
+        "message": "Provera koda u toku..."
+    },
+    "userCreatingPasskey": {
+        "message": "Kreiranje Passkey-a u toku..."
+    },
+    "userCodeRequired": {
+        "message": "Verifikacioni kod je obavezan"
+    },
+    "userSendingCode": {
+        "message": "Slanje verifikacionog koda u toku..."
+    },
+    "userSendCodeFailed": {
+        "message": "Slanje verifikacionog koda nije uspelo"
+    },
+    "dataWaitingForData": {
+        "message": "Čekanje na podatke..."
+    },
+    "labelId": {
+        "message": "ID"
+    },
+    "labelCreated": {
+        "message": "Kreirano"
+    },
+    "labelLastUsed": {
+        "message": "Poslednji put korišćeno"
+    },
+    "labelActions": {
+        "message": "Akcije"
+    },
+    "labelDetails": {
+        "message": "Detalji"
+    },
+    "labelExpiry": {
+        "message": "Istek"
+    },
+    "labelDescription": {
+        "message": "Opis"
+    },
+    "labelDate": {
+        "message": "Datum"
+    },
+    "actionDownload": {
+        "message": "Preuzmi"
+    },
+    "actionBackup": {
+        "message": "Rezervna kopija"
+    },
+    "actionEdit": {
+        "message": "Izmeni"
+    },
+    "actionDelete": {
+        "message": "Obriši"
+    },
+    "actionSave": {
+        "message": "Sačuvaj"
+    },
+    "titleEditProfile": {
+        "message": "Uredi profil"
+    },
+    "titleLogin": {
+        "message": "Prijava"
+    },
+    "labelName": {
+        "message": "Naziv"
+    },
+    "labelAddress": {
+        "message": "Adresa"
+    },
+    "labelCountry": {
+        "message": "Država"
+    },
+    "confirmDelete": {
+        "message": "Da li ste sigurni da želite da izbrišete ovaj {{item}}?"
+    },
+    "itemBackup": {
+        "message": "rezervna kopija"
+    },
+    "itemToken": {
+        "message": "token"
+    },
+    "itemPasskey": {
+        "message": "pristupni ključ"
+    },
+    "notLoggedIn": {
+        "message": "Niste prijavljeni"
+    },
+    "backupNoBackupsAvailable": {
+        "message": "Nema dostupnih rezervnih kopija"
+    },
+    "backupRequiresConnection": {
+        "message": "Povežite flight kontroler da biste uključili ovu akciju",
+        "description": "Tooltip shown on disabled backup and restore buttons when no flight controller is connected"
+    },
+    "titleEditBackup": {
+        "message": "Uredi rezervnu kopiju"
+    },
+    "backupMcuUnknown": {
+        "message": "MCU nepoznat"
+    },
+    "sectionUserTokens": {
+        "message": "Korisnički tokeni"
+    },
+    "sectionUserPasskeys": {
+        "message": "Korisnički passkey-ovi"
+    },
+    "osdPresetPositionAlignTitle": {
+        "message": "Poravnaj prema položaju",
+        "description": "Label for the preset position alignment menu in the OSD elements list"
+    },
+    "osdPresetPositionChooseTitle": {
+        "message": "Izaberite položaj",
+        "description": "Title for the preset position grid popup in the OSD elements list"
+    },
+    "tabPreflight": {
+        "message": "Pre poletanja"
+    },
+    "preflightTitle": {
+        "message": "Provera okruženja pre leta"
+    },
+    "preflightLocation": {
+        "message": "Lokacija leta"
+    },
+    "preflightUseMyLocation": {
+        "message": "Koristi moju lokaciju"
+    },
+    "preflightDetecting": {
+        "message": "Detektovanje..."
+    },
+    "preflightOr": {
+        "message": "ili unesite koordinate:"
+    },
+    "preflightLatitude": {
+        "message": "Geografska širina"
+    },
+    "preflightLongitude": {
+        "message": "Geografska dužina"
+    },
+    "preflightApply": {
+        "message": "Primeni"
+    },
+    "preflightLaunchStatus": {
+        "message": "Status poletanja"
+    },
+    "preflightStatusGo": {
+        "message": "SPREMAN"
+    },
+    "preflightStatusCaution": {
+        "message": "OPREZ"
+    },
+    "preflightStatusWarning": {
+        "message": "UPOZORENJE"
+    },
+    "preflightStatusNoGo": {
+        "message": "NIJE SPREMAN"
+    },
+    "preflightStatusNoData": {
+        "message": "Nema podataka"
+    },
+    "preflightCheckWind": {
+        "message": "Vetar"
+    },
+    "preflightCheckVisibility": {
+        "message": "Vidljivost"
+    },
+    "preflightCheckPrecipitation": {
+        "message": "Padavine"
+    },
+    "preflightCheckSolar": {
+        "message": "Sunčeva aktivnost"
+    },
+    "preflightLevelUnknown": {
+        "message": "Nepoznato"
+    },
+    "preflightWmoClearSky": {
+        "message": "Vedro"
+    },
+    "preflightWmoMainlyClear": {
+        "message": "Pretežno vedro"
+    },
+    "preflightWmoPartlyCloudy": {
+        "message": "Delimično oblačno"
+    },
+    "preflightWmoOvercast": {
+        "message": "Potpuno oblačno"
+    },
+    "preflightWmoFog": {
+        "message": "Magla"
+    },
+    "preflightWmoRimeFog": {
+        "message": "Magla sa injem"
+    },
+    "preflightWmoLightDrizzle": {
+        "message": "Slaba rosulja"
+    },
+    "preflightWmoModerateDrizzle": {
+        "message": "Umerena rosulja"
+    },
+    "preflightWmoDenseDrizzle": {
+        "message": "Gusta rosulja"
+    },
+    "preflightWmoLightFreezingDrizzle": {
+        "message": "Slaba ledena rosulja"
+    },
+    "preflightWmoDenseFreezingDrizzle": {
+        "message": "Gusta ledena rosulja"
+    },
+    "preflightWmoSlightRain": {
+        "message": "Slaba kiša"
+    },
+    "preflightWmoModerateRain": {
+        "message": "Umerena kiša"
+    },
+    "preflightWmoHeavyRain": {
+        "message": "Jaka kiša"
+    },
+    "preflightWmoLightFreezingRain": {
+        "message": "Slaba ledena kiša"
+    },
+    "preflightWmoHeavyFreezingRain": {
+        "message": "Jaka ledena kiša"
+    },
+    "preflightWmoSlightSnow": {
+        "message": "Slab sneg"
+    },
+    "preflightWmoModerateSnow": {
+        "message": "Umeren sneg"
+    },
+    "preflightWmoHeavySnow": {
+        "message": "Jak sneg"
+    },
+    "preflightWmoSnowGrains": {
+        "message": "Zrnast sneg"
+    },
+    "preflightWmoSlightRainShowers": {
+        "message": "Slab pljusak"
+    },
+    "preflightWmoModerateRainShowers": {
+        "message": "Umeren pljusak"
+    },
+    "preflightWmoViolentRainShowers": {
+        "message": "Silovit pljusak"
+    },
+    "preflightWmoSlightSnowShowers": {
+        "message": "Slab snežni pljusak"
+    },
+    "preflightWmoHeavySnowShowers": {
+        "message": "Jak snežni pljusak"
+    },
+    "preflightWmoThunderstorm": {
+        "message": "Grmljavina"
+    },
+    "preflightWmoThunderstormSlightHail": {
+        "message": "Grmljavina sa slabim gradom"
+    },
+    "preflightWmoThunderstormHeavyHail": {
+        "message": "Grmljavina sa jakim gradom"
+    },
+    "preflightKpLow": {
+        "message": "Nisko"
+    },
+    "preflightKpModerate": {
+        "message": "Umereno"
+    },
+    "preflightKpElevated": {
+        "message": "Povišen"
+    },
+    "preflightKpStorm": {
+        "message": "Oluja"
+    },
+    "preflightWindCalm": {
+        "message": "Bez vetra"
+    },
+    "preflightWindLight": {
+        "message": "Slab"
+    },
+    "preflightWindModerate": {
+        "message": "Umereno"
+    },
+    "preflightWindStrong": {
+        "message": "Jak"
+    },
+    "preflightWindDangerous": {
+        "message": "Opasan"
+    },
+    "preflightVisExcellent": {
+        "message": "Odlična"
+    },
+    "preflightVisGood": {
+        "message": "Dobra"
+    },
+    "preflightVisReduced": {
+        "message": "Smanjena"
+    },
+    "preflightVisPoor": {
+        "message": "Loša"
+    },
+    "preflightPrecipNone": {
+        "message": "Ništa"
+    },
+    "preflightPrecipLight": {
+        "message": "Slabe"
+    },
+    "preflightPrecipModerate": {
+        "message": "Umereno"
+    },
+    "preflightPrecipHeavy": {
+        "message": "Jake"
+    },
+    "preflightDewNoRisk": {
+        "message": "Bez rizika"
+    },
+    "preflightDewLowRisk": {
+        "message": "Nizak rizik"
+    },
+    "preflightDewFogLikely": {
+        "message": "Verovatna magla\/kondenzacija"
+    },
+    "preflightDewFogExpected": {
+        "message": "Očekuje se magla\/zamagljivanje objektiva"
+    },
+    "preflightUvLow": {
+        "message": "Nisko"
+    },
+    "preflightUvModerate": {
+        "message": "Umereno"
+    },
+    "preflightUvHigh": {
+        "message": "Visoko"
+    },
+    "preflightUvVeryHigh": {
+        "message": "Veoma visok"
+    },
+    "preflightBatteryRisk": {
+        "message": "Rizik za bateriju"
+    },
+    "preflightBatteryOk": {
+        "message": "Normalan opseg"
+    },
+    "preflightBatteryCool": {
+        "message": "Smanjene performanse, zagrejte baterije"
+    },
+    "preflightBatteryCold": {
+        "message": "Znatno smanjen kapacitet"
+    },
+    "preflightBatteryHot": {
+        "message": "Rizik od bubrenja, držite u hladu"
+    },
+    "preflightBatteryExtreme": {
+        "message": "Ne letite, ekstremna toplota"
+    },
+    "preflightCheckBattery": {
+        "message": "Baterija"
+    },
+    "preflightCheckDensityAlt": {
+        "message": "Visina po gustini"
+    },
+    "preflightFeelsLike": {
+        "message": "Subjektivni osećaj"
+    },
+    "preflightFogRisk": {
+        "message": "Rizik od magle"
+    },
+    "preflightFogUnlikely": {
+        "message": "Malo verovatno"
+    },
+    "preflightFogLow": {
+        "message": "Nizak rizik"
+    },
+    "preflightFogModerate": {
+        "message": "Umeren rizik"
+    },
+    "preflightFogHigh": {
+        "message": "Visok rizik"
+    },
+    "preflightElevation": {
+        "message": "Nadmorska visina"
+    },
+    "preflightDensityAlt": {
+        "message": "Visina po gustini"
+    },
+    "preflightDaNormal": {
+        "message": "Normalne performanse"
+    },
+    "preflightDaReduced": {
+        "message": "Blago smanjen uzgon"
+    },
+    "preflightDaLow": {
+        "message": "Osetno smanjene performanse"
+    },
+    "preflightDaPoor": {
+        "message": "Znatno smanjenje uzgona"
+    },
+    "preflightCivilTwilight": {
+        "message": "Prozor građanskog sumraka"
+    },
+    "preflightRefresh": {
+        "message": "Osveži"
+    },
+    "preflightCurrentWeather": {
+        "message": "Trenutne vremenske prilike"
+    },
+    "preflightWind": {
+        "message": "Brzina vetra"
+    },
+    "preflightGusts": {
+        "message": "Udari vetra"
+    },
+    "preflightVisibility": {
+        "message": "Vidljivost"
+    },
+    "preflightPrecipitation": {
+        "message": "Padavine"
+    },
+    "preflightCloudCover": {
+        "message": "Oblačnost"
+    },
+    "preflightHumidity": {
+        "message": "Vlažnost vazduha"
+    },
+    "preflightPressure": {
+        "message": "Pritisak"
+    },
+    "preflightDewPoint": {
+        "message": "Tačka rose"
+    },
+    "preflightFlightWindow": {
+        "message": "Prozor za letenje"
+    },
+    "preflightSunrise": {
+        "message": "Izlazak sunca"
+    },
+    "preflightSunset": {
+        "message": "Zalazak sunca"
+    },
+    "preflightDaylight": {
+        "message": "Dnevna svetlost"
+    },
+    "preflightUvIndex": {
+        "message": "UV indeks"
+    },
+    "preflightTempRange": {
+        "message": "Temperaturni opseg"
+    },
+    "preflightCurrentlyDay": {
+        "message": "Trenutno"
+    },
+    "preflightDaytime": {
+        "message": "Dan"
+    },
+    "preflightNighttime": {
+        "message": "Noć"
+    },
+    "preflightWindForecast": {
+        "message": "Prognoza vetra po visini"
+    },
+    "preflightWindForecastHelp": {
+        "message": "Brzina vetra na različitim visinama je ključna za FPV letove velikog dometa i na velikim visinama. Na većim visinama vetar je obično jači."
+    },
+    "preflightTime": {
+        "message": "Vreme"
+    },
+    "preflightWind10m": {
+        "message": "10m"
+    },
+    "preflightWind80m": {
+        "message": "80m"
+    },
+    "preflightWind120m": {
+        "message": "120m"
+    },
+    "preflightGustsShort": {
+        "message": "Udari vetra"
+    },
+    "preflightRainProb": {
+        "message": "Kiša %"
+    },
+    "preflightWindUnit": {
+        "message": "Brzine vetra u m\/s. Visine iznad nivoa terena (AGL)."
+    },
+    "preflightSolarActivity": {
+        "message": "Sunčeva aktivnost"
+    },
+    "preflightSolarHelp": {
+        "message": "Visoka sunčeva aktivnost (Kp > 5) izaziva smetnje u jonosferi, što može smanjiti preciznost GPS-a i uticati na pouzdanost funkcije GPS Rescue."
+    },
+    "preflightGeoStorm": {
+        "message": "Geomagnetna oluja"
+    },
+    "preflightSolarRadiation": {
+        "message": "Sunčevo zračenje"
+    },
+    "preflightRadioBlackout": {
+        "message": "Radio-blokada"
+    },
+    "preflightLastMeasurement": {
+        "message": "Poslednje merenje"
+    },
+    "preflightLoadingSolar": {
+        "message": "Učitavanje podataka o Sunčevoj aktivnosti..."
+    },
+    "preflightGNSS": {
+        "message": "GNSS \/ GPS status"
+    },
+    "preflightGNSSHelp": {
+        "message": "Sunčeva aktivnost utiče na kvalitet signala GNSS satelita. Visoke Kp vrednosti mogu smanjiti preciznost GPS pozicije i smanjiti pouzdanost funkcije GPS Rescue."
+    },
+    "preflightGNSSNote": {
+        "message": "Sunčevi i geomagnetni uslovi utiču na preciznost GPS-a. Povežite Vaš dron za uživo prikaz satelitskih podataka na kartici GPS."
+    },
+    "preflightKpEffect": {
+        "message": "Uticaj jonosfere"
+    },
+    "preflightGPSRescue": {
+        "message": "GPS Rescue status"
+    },
+    "preflightMagDeclination": {
+        "message": "Magnetna deklinacija"
+    },
+    "preflightMagInclination": {
+        "message": "Magnetna inklinacija"
+    },
+    "preflightGNSSPlanner": {
+        "message": "Alat za planiranje GNSS satelita"
+    },
+    "preflightAirspace": {
+        "message": "Vazdušni prostor i zone zabrane letenja"
+    },
+    "preflightAirspaceNote": {
+        "message": "Uvek proverite lokalna ograničenja u vazdušnom prostoru i NOTAM obaveštenja pre letenja. Pravila se razlikuju po državama i regionima."
+    },
+    "preflightDroneSafetyMap": {
+        "message": "Karta bezbednosti za dronove (Altitude Angel)"
+    },
+    "preflightAirspaceExplorer": {
+        "message": "SkyVector karta vazdušnog prostora"
+    },
+    "preflightNOTAMs": {
+        "message": "FAA NOTAM obaveštenja (SAD)"
+    },
+    "preflightNOTAMsEU": {
+        "message": "EUROCONTROL NOTAM-i (EU)"
+    },
+    "preflightMap": {
+        "message": "Mapa lokacije"
+    },
+    "preflightNoData": {
+        "message": "Podesite lokaciju za učitavanje podataka o okruženju"
+    },
+    "preflightAttribution": {
+        "message": "Vremenski podaci: Open-Meteo.com (CC BY 4.0) | Solarni podaci: NOAA Space Weather Prediction Center"
+    },
+    "preflightSavedLocationsPlaceholder": {
+        "message": "Sačuvane lokacije..."
+    },
+    "preflightLoadLocation": {
+        "message": "Učitaj"
+    },
+    "preflightSaveLocation": {
+        "message": "Sačuvaj"
+    },
+    "preflightSavedLocationsFull": {
+        "message": "Dostignut je maksimum od 5 sačuvanih lokacija"
+    },
+    "preflightLocationLabel": {
+        "message": "Naziv lokacije (maks. 20 znakova)"
+    },
+    "preflightDeleteLocation": {
+        "message": "Izbrišite izabranu lokaciju"
+    },
+    "preflightRenameLocation": {
+        "message": "Preimenujte izabranu lokaciju"
+    },
+    "preflightRenameLocationBtn": {
+        "message": "Preimenuj"
+    },
+    "preflightCoordinates": {
+        "message": "Koordinate"
+    },
+    "preflightSaveLocationBtn": {
+        "message": "Sačuvaj lokaciju"
+    },
+    "preflightConfirmSave": {
+        "message": "Sačuvaj"
+    },
+    "preflightCancel": {
+        "message": "Otkaži"
+    },
+    "preflightGeolocationFailed": {
+        "message": "Nije moguće detektovati lokaciju. Unesite koordinate ručno."
+    },
+    "preflightIpConsentMessage": {
+        "message": "Lociranje putem pregledača nije uspelo. Vaša približna lokacija može se odrediti pomoću Vaše IP adrese putem usluge treće strane ipapi.co."
+    },
+    "preflightIpConsentAllow": {
+        "message": "Dozvoli"
+    },
+    "preflightIpConsentDeny": {
+        "message": "Ne, hvala"
+    },
+    "preflightMapSatellite": {
+        "message": "Satelitski prikaz"
+    },
+    "preflightMapHybrid": {
+        "message": "Hibridni satelitski i ulični prikaz"
+    },
+    "preflightMapStreet": {
+        "message": "Prikaz mape ulica"
+    },
+    "preflightMapZoomIn": {
+        "message": "Uvećaj"
+    },
+    "preflightMapZoomOut": {
+        "message": "Umanji"
+    },
+    "preflightMapFullscreen": {
+        "message": "Uključi ili isključi ceo ekran"
+    },
+    "preflightKpMinimal": {
+        "message": "Minimalan uticaj na GPS"
+    },
+    "preflightKpDegraded": {
+        "message": "Moguće smanjenje preciznosti GPS-a"
+    },
+    "preflightKpSevere": {
+        "message": "Očekuju se značajne smetnje na GPS-u"
+    },
+    "preflightGpsRescueUnknown": {
+        "message": "Prvo proverite sunčevu aktivnost"
+    },
+    "preflightGpsRescueReliable": {
+        "message": "GPS Rescue je pouzdan"
+    },
+    "preflightGpsRescueUnreliable": {
+        "message": "GPS Rescue možda nije pouzdan"
+    },
+    "preflightGpsRescueNotRecommended": {
+        "message": "GPS Rescue se NE preporučuje"
+    },
+    "preflightForecast": {
+        "message": "Petodnevna prognoza"
+    },
+    "preflightForecastHelp": {
+        "message": "Dnevni pregled vremena koji Vam pomaže u planiranju letenja"
+    },
+    "preflightForecastDay": {
+        "message": "Dan"
+    },
+    "preflightForecastWeather": {
+        "message": "Vremenske prilike"
+    },
+    "preflightNotamProvider": {
+        "message": "NOTAM izvor"
+    },
+    "preflightNotamProviderNone": {
+        "message": "Isključeno"
+    },
+    "preflightNotamProviderFaa": {
+        "message": "FAA NOTAM API (SAD, potreban API ključ)"
+    },
+    "preflightNotamProviderOpenaip": {
+        "message": "OpenAIP (globalni vazdušni prostor, potreban API ključ)"
+    },
+    "preflightNotamFaaApiKeyLabel": {
+        "message": "FAA API ključ (client_id:client_secret)"
+    },
+    "preflightNotamOpenAipApiKeyLabel": {
+        "message": "OpenAIP API ključ"
+    },
+    "preflightNotamRadius": {
+        "message": "Poluprečnik pretrage"
+    },
+    "preflightNotamRadiusUnitNm": {
+        "message": "NM"
+    },
+    "preflightNotamRadiusUnitKm": {
+        "message": "km"
+    },
+    "preflightNotamSettings": {
+        "message": "Podešavanja podataka o vazdušnom prostoru"
+    },
+    "preflightNotamPrivacyNote": {
+        "message": "Podaci o vazdušnom prostoru šalju Vaše koordinate izabranom izvoru. Nikakvi dodatni lični podaci se ne šalju."
+    },
+    "preflightNotamLoading": {
+        "message": "Preuzimanje podataka o vazdušnom prostoru..."
+    },
+    "preflightNotamEmpty": {
+        "message": "Nisu pronađena obaveštenja za ovu lokaciju i poluprečnik"
+    },
+    "preflightNotamApiKeyRequired": {
+        "message": "Za izabrani izvor je potreban API ključ. Unesite Vaš ključ u podešavanjima iznad."
+    },
+    "preflightNotamFetchError": {
+        "message": "Neuspešno preuzimanje podataka o vazdušnom prostoru"
+    },
+    "preflightNotamActiveNow": {
+        "message": "Trenutno aktivno"
+    },
+    "preflightNotamPermanent": {
+        "message": "Trajno"
+    },
+    "preflightNotamExpired": {
+        "message": "Isteklo"
+    },
+    "preflightNotamTypeTfr": {
+        "message": "TFR"
+    },
+    "preflightNotamTypeSua": {
+        "message": "SUA"
+    },
+    "preflightNotamTypeSnow": {
+        "message": "SNOWTAM"
+    },
+    "preflightNotamTypeAsh": {
+        "message": "ASHTAM"
+    },
+    "preflightNotamTypeNotam": {
+        "message": "NOTAM"
+    },
+    "preflightNotamAltFrom": {
+        "message": "Donja"
+    },
+    "preflightNotamAltTo": {
+        "message": "Gornja"
+    },
+    "preflightNotamShowMore": {
+        "message": "Prikaži više"
+    },
+    "preflightNotamShowLess": {
+        "message": "Prikaži manje"
+    },
+    "preflightNotamLastFetched": {
+        "message": "Poslednje preuzeto"
+    }
+}

--- a/locales/sr_Cyrl/messages.json
+++ b/locales/sr_Cyrl/messages.json
@@ -1,0 +1,9947 @@
+{
+    "yes": {
+        "message": "Да",
+        "description": "General Yes message to be used across the application"
+    },
+    "no": {
+        "message": "Не",
+        "description": "General No message to be used across the application"
+    },
+    "on": {
+        "message": "Укључено"
+    },
+    "off": {
+        "message": "Искључено"
+    },
+    "auto": {
+        "message": "Аутоматски"
+    },
+    "error": {
+        "message": "Грешка: {{errorMessage}}"
+    },
+    "errorTitle": {
+        "message": "Грешка"
+    },
+    "warningTitle": {
+        "message": "Упозорење"
+    },
+    "noticeTitle": {
+        "message": "Обавештење"
+    },
+    "search": {
+        "message": "Претражи"
+    },
+    "dontShowAgain": {
+        "message": "Не приказуј поново"
+    },
+    "pwaOnNeedRefreshTitle": {
+        "message": "Апликација мора да се ажурира",
+        "description": "Title of the window that appears when the app needs to be refreshed to get the latest changes"
+    },
+    "pwaOnNeedRefreshText": {
+        "message": "Морате да освежите страницу да бисте добили најновије промене. Освежавање ће поново учитати страницу и изгубићете све несачуване промене и прекинућете све операције у току.<br><br>Желите ли да освежите страницу сада? Такође можете да одбаците ову поруку и ручно освежите страницу касније.",
+        "description": "Text of the window that appears when the app needs to be refreshed to get the latest changes"
+    },
+    "pwaOnOfflineReadyTitle": {
+        "message": "Апликација је спремна за коришћење ван мреже",
+        "description": "Title of the window that appears when the app is ready to be installed and used offline"
+    },
+    "pwaOnOfflineReadyText": {
+        "message": "Можете је инсталирати као самосталну апликацију на Ваш уређај ако желите. Потражите опцију у адресној траци претраживача или менију.",
+        "description": "Text of the window that appears when the app is ready to be installed and used offline"
+    },
+    "operationNotSupported": {
+        "message": "Ова операција није подржана на Вашем хардверу."
+    },
+    "storageDeviceNotReady": {
+        "message": "Уређај за складиштење није спреман. У случају microSD картице, проверите да ли је правилно препозната од стране Вашег flight контролера."
+    },
+    "connect": {
+        "message": "Повежи"
+    },
+    "connecting": {
+        "message": "Повезивање"
+    },
+    "disconnect": {
+        "message": "Прекини везу"
+    },
+    "disconnectVirtual": {
+        "message": "Прекини везу (виртуелно)",
+        "description": "Disconnect button label shown when connected in virtual mode."
+    },
+    "disconnectManual": {
+        "message": "Прекини везу (ручно)",
+        "description": "Disconnect button label shown when connected via manual port override."
+    },
+    "disconnectBluetooth": {
+        "message": "Прекини везу (Bluetooth)",
+        "description": "Disconnect button label shown when connected via Bluetooth."
+    },
+    "portsSelectNoSelection": {
+        "message": "Изаберите Ваш уређај",
+        "description": "Text for the option to select a device in the port selection dropdown"
+    },
+    "portsSelectManual": {
+        "message": "Ручни одабир"
+    },
+    "portsSelectNone": {
+        "message": "Нема доступне везе"
+    },
+    "portsSelectVirtual": {
+        "message": "Виртуелни мод (експериментално)",
+        "description": "Configure a Virtual Flight Controller without the need of a physical FC."
+    },
+    "portsSelectPermission": {
+        "message": "--- Не могу да пронађем свој USB уређај ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access the device."
+    },
+    "portsSelectPermissionBluetooth": {
+        "message": "--- Не могу да пронађем свој Bluetooth уређај ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access a Bluetooth device."
+    },
+    "portsSelectPermissionDFU": {
+        "message": "--- Не могу да пронађем свој DFU уређај ---",
+        "description": "Option in the port selection dropdown to allow the user to give permissions to the system to access a DFU device."
+    },
+    "bluetoothConnected": {
+        "message": "Повезано са Bluetooth уређајем: $1"
+    },
+    "bluetoothConnectionType": {
+        "message": "Врста Bluetooth везе: $1"
+    },
+    "bluetoothConnectionError": {
+        "message": "Bluetooth грешка: $1"
+    },
+    "virtualMode": {
+        "message": "Виртуелни мод"
+    },
+    "virtualMSPVersion": {
+        "message": "Виртуелна верзија фирмвера"
+    },
+    "portOverrideText": {
+        "message": "Port:"
+    },
+    "connectVirtualDescription": {
+        "message": "Симулирајте flight контролер без хардвера.",
+        "description": "Helper text in the connect dialog when choosing the virtual FC mode."
+    },
+    "connectVirtual": {
+        "message": "Повежи се (виртуелно)",
+        "description": "Connect button label shown when virtual mode port is selected."
+    },
+    "connectManualDescription": {
+        "message": "Унесите серијску путању или URL за повезивање.",
+        "description": "Helper text in the connect dialog when choosing the manual port mode."
+    },
+    "connectBookmarks": {
+        "message": "Сачуване везе",
+        "description": "Title of the saved manual connection (bookmark) list in the connect dialog."
+    },
+    "connectBookmarkName": {
+        "message": "Назив:",
+        "description": "Label of the input naming a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkNamePlaceholder": {
+        "message": "Назив за ову везу",
+        "description": "Placeholder of the input naming a saved manual connection in the connect dialog."
+    },
+    "connectBookmarkSave": {
+        "message": "Сачувај",
+        "description": "Button that saves the entered address as a bookmark in the connect dialog."
+    },
+    "connectBookmarkUpdate": {
+        "message": "Ажурирај",
+        "description": "Button that renames the bookmark already pointing at the entered address."
+    },
+    "connectBookmarkRemove": {
+        "message": "Уклони сачувану везу",
+        "description": "Button that deletes a saved manual connection in the connect dialog."
+    },
+    "autoConnect": {
+        "message": "Аутоматско повезивање"
+    },
+    "close": {
+        "message": "Затвори"
+    },
+    "openSidebarMenu": {
+        "message": "Отвори бочни мени",
+        "description": "Accessible label for the floating hamburger button shown on narrow viewports."
+    },
+    "OK": {
+        "message": "У реду"
+    },
+    "cancel": {
+        "message": "Откажи"
+    },
+    "submit": {
+        "message": "Пошаљи"
+    },
+    "delete": {
+        "message": "Обриши"
+    },
+    "edit": {
+        "message": "Измени"
+    },
+    "add": {
+        "message": "Додај"
+    },
+    "update": {
+        "message": "Ажурирај"
+    },
+    "save": {
+        "message": "Сачувај"
+    },
+    "autoConnectEnabled": {
+        "message": "Аутоматско повезивање: Укључено - Апликација аутоматски покушава да се повеже када се детектује нови порт"
+    },
+    "autoConnectDisabled": {
+        "message": "Аутоматско повезивање: Искључено - Корисник мора сам да изабере исправан серијски порт и кликне на дугме \"Повежи се\""
+    },
+    "expertMode": {
+        "message": "Укључи експертски мод"
+    },
+    "expertModeDescription": {
+        "message": "Приказ опција експертског мода"
+    },
+    "warningSettings": {
+        "message": "Прикажи упозорења"
+    },
+    "rememberLastTab": {
+        "message": "Поново отвори последњу картицу при повезивању"
+    },
+    "meteredConnection": {
+        "message": "Без приступа интернету (за ограничене или споре везе)",
+        "description": "Text for the option to disable internet access for metered connection or to disable data over slow connections"
+    },
+    "analyticsOptOut": {
+        "message": "Без анонимног прикупљања статистичких података"
+    },
+    "connectionTimeout": {
+        "message": "Подесите временско ограничење везе како бисте омогућили дужу иницијализацију приликом прикључивања уређаја или поновног покретања",
+        "description": "Change timeout on auto-connect and reboot so the bus has more time to initialize after being detected by the system"
+    },
+    "languageAndAppearanceSettings": {
+        "message": "Језик и изглед",
+        "description": "Title for the language and appearance settings section"
+    },
+    "developmentSettings": {
+        "message": "Подешавања за развој",
+        "description": "Title for the development settings section"
+    },
+    "showAllSerialDevices": {
+        "message": "Прикажи све серијске уређаје (за произвођаче или развој)",
+        "description": "Do not filter serial devices using VID\/PID values (for manufacturers or development)"
+    },
+    "cliOnlyMode": {
+        "message": "Укључи само CLI мод",
+        "description": "Text for the option to enable or disable CLI only mode"
+    },
+    "automaticDevOptions": {
+        "message": "Аутоматски укључи подешавања за развој за preview верзије",
+        "description": "Text for the option to automatically enable development settings for preview builds"
+    },
+    "showManualMode": {
+        "message": "Приказ мода ручног повезивања",
+        "description": "Text for the option to enable or disable manual connection mode"
+    },
+    "showVirtualMode": {
+        "message": "Приказ мода виртуелног повезивања",
+        "description": "Text for the option to enable or disable the virtual FC"
+    },
+    "useLegacyRenderingModel": {
+        "message": "Стари начин рендеровања за 3D модел (за уређаје слабијих перформанси)",
+        "description": "Text for the option to enable or disable legacy rendering of the 3D model"
+    },
+    "cordovaForceComputerUI": {
+        "message": "Интерфејс за рачунаре уместо интерфејса за телефоне"
+    },
+    "language_changed": {
+        "message": "Промена језика је сачувана"
+    },
+    "language_choice_message": {
+        "message": "Промените језик:",
+        "description": "Try and be brief"
+    },
+    "userLanguageSelect": {
+        "message": "Изаберите подразумевани језик"
+    },
+    "language_default": {
+        "message": "Подразумевано системски"
+    },
+    "sensorDataFlashNotFound": {
+        "message": "Није пронађен <br>dataflash чип",
+        "description": "Text of the dataflash image in the header of the page."
+    },
+    "sensorDataFlashFreeSpace": {
+        "message": "Dataflash: слободан простор",
+        "description": "Text of the dataflash image in the header of the page."
+    },
+    "sensorStatusGyro": {
+        "message": "Жироскоп"
+    },
+    "configurationGyroRequired": {
+        "message": "Мора бити укључен бар један жироскоп"
+    },
+    "sensorStatusGyroShort": {
+        "message": "Жироскоп",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusAccel": {
+        "message": "Акцелерометар"
+    },
+    "sensorStatusAccelShort": {
+        "message": "Акцел",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusMag": {
+        "message": "Магнетометар"
+    },
+    "sensorStatusMagShort": {
+        "message": "Mag",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusBaro": {
+        "message": "Барометар"
+    },
+    "sensorStatusBaroShort": {
+        "message": "Baro",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusGPS": {
+        "message": "GPS"
+    },
+    "sensorStatusGPSShort": {
+        "message": "GPS",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "sensorStatusSonar": {
+        "message": "Sonar \/ Мерач домета"
+    },
+    "sensorStatusSonarShort": {
+        "message": "Sonar",
+        "description": "Text of the image in the top sensors icons. Please keep it short."
+    },
+    "checkForConfiguratorUnstableVersions": {
+        "message": "Прикажи обавештења о ажурирању за нестабилне верзије апликације"
+    },
+    "configuratorUpdateNotice": {
+        "message": "Користите застарелу верзију <b>Betaflight апликације<\/b>.<br>$t(configuratorUpdateHelp.message)"
+    },
+    "configuratorUpdateHelp": {
+        "message": "Коришћење новијег фирмвера са застарелом верзијом програма значи да мењање неких подешавања може довести до <strong>неисправних подешавања фирмвера и дрона који не лети<\/strong>.<br \/>Уз to, неке могућности фирмвера моћи ћете да подесите само кроз CLI.<br g\/><br \/><strong>Верзија Betaflight програма <b>$1<\/b> доступна је за преузимање<\/strong>.<br \/>Преузмите и инсталирајте најновију верзију са исправкама и побољшањима <a href=\"$2\" target=\"_blank\" rel=\"noopener noreferrer\">овде<\/a><br>Прозор програма мора бити затворен пре ажурирања."
+    },
+    "rebootFlightController": {
+        "message": "Поновно покретање flight контролера, поново се повежите када буде спреман"
+    },
+    "rebootFlightControllerReady": {
+        "message": "Flight контролер је спреман"
+    },
+    "rebootFlightControllerFailed": {
+        "message": "Flight контролер се није поново повезао"
+    },
+    "deviceRebooting": {
+        "message": "Уређај - <span class=\"message-negative\">Поновно покретање<\/span>"
+    },
+    "deviceRebooting_flashBootloader": {
+        "message": "Уређај - <span class=\"message-negative\">Поновно покретање у FLASH BOOTLOADER<\/span>"
+    },
+    "deviceRebooting_romBootloader": {
+        "message": "Уређај - <span class=\"message-negative\">Поновно покретање у ROM BOOTLOADER<\/span>"
+    },
+    "deviceReady": {
+        "message": "Уређај - <span class=\"message-positive\">Спреман<\/span>"
+    },
+    "tabFirmwareFlasher": {
+        "message": "Упис фирмвера"
+    },
+    "tabLanding": {
+        "message": "Добродошли"
+    },
+    "tabPrivacyPolicy": {
+        "message": "Политика приватности"
+    },
+    "tabHelp": {
+        "message": "Упутства и подршка"
+    },
+    "tabOptions": {
+        "message": "Опције"
+    },
+    "sidebarOpenOptions": {
+        "message": "Опције",
+        "description": "Tooltip for the options icon button in the sidebar footer."
+    },
+    "sidebarToggleDarkMode": {
+        "message": "Пребаци на тамни \/ светли мод",
+        "description": "Tooltip for the dark mode toggle icon button in the sidebar footer."
+    },
+    "sidebarToggleExpertMode": {
+        "message": "Пребаци на експертски мод",
+        "description": "Tooltip for the expert mode toggle icon button in the sidebar footer."
+    },
+    "tabSetup": {
+        "message": "Почетно подешавање"
+    },
+    "tabSetupOSD": {
+        "message": "OSD подешавање"
+    },
+    "tabSensorConfig": {
+        "message": "Сензори"
+    },
+    "sensorConfigHardware": {
+        "message": "Хардвер сензора"
+    },
+    "sensorConfigGyroLabel": {
+        "message": "Жироскоп $1"
+    },
+    "sensorConfigSaved": {
+        "message": "Конфигурација сензора сачувана"
+    },
+    "sensorConfigSaveFailed": {
+        "message": "Чување конфигурације сензора није успело"
+    },
+    "sensorConfigMagnetometer": {
+        "message": "Магнетометар"
+    },
+    "sensorConfigAccelerometer": {
+        "message": "Акцелерометар"
+    },
+    "sensorConfigAccCalibrateHelp": {
+        "message": "Поставите летелицу на равну површину пре калибрације"
+    },
+    "sensorConfigAccNeedsCalibration": {
+        "message": "Акцелерометар није калибрисан. Молимо калибришите пре летења."
+    },
+    "sensorConfigMagNeedsCalibration": {
+        "message": "Офсети калибрације магнетометра су нула. Молимо калибришите за прецизно одређивање смера."
+    },
+    "sensorConfigCalibrate": {
+        "message": "Калибриши"
+    },
+    "sensorConfig3dPreview": {
+        "message": "3D преглед положаја"
+    },
+    "sensorConfigLiveData": {
+        "message": "Подаци сензора уживо"
+    },
+    "sensorConfigShowLiveData": {
+        "message": "Прикажи податке сензора уживо"
+    },
+    "sensorConfigLiveStop": {
+        "message": "Заустави податке уживо"
+    },
+    "tabConfiguration": {
+        "message": "Конфигурација"
+    },
+    "tabPorts": {
+        "message": "Портови"
+    },
+    "tabPidTuning": {
+        "message": "PID подешавање"
+    },
+    "tabAutotune": {
+        "message": "Autotune"
+    },
+    "tabBlackboxViewer": {
+        "message": "Blackbox прегледач",
+        "description": "Navigation sidebar label for the Blackbox log viewer tab"
+    },
+    "autotuneImportTitle": {
+        "message": "Blackbox анализа цвркута"
+    },
+    "autotuneImportButton": {
+        "message": "Увези Blackbox log"
+    },
+    "autotuneImportDescription": {
+        "message": "Увезите blackbox log снимљен са debug_mode = CHIRP да бисте анализирали фреквентни одзив и израчунали PID препоруке."
+    },
+    "autotuneSelectingFile": {
+        "message": "Одабир фајла..."
+    },
+    "autotuneAnalyzing": {
+        "message": "Анализирање података цвркута..."
+    },
+    "autotuneBandwidth": {
+        "message": "Пропусни опсег"
+    },
+    "autotunePhaseMargin": {
+        "message": "Фазна маргина"
+    },
+    "autotuneResonantPeak": {
+        "message": "Резонантни врх"
+    },
+    "autotuneCoherence": {
+        "message": "Кохеренција"
+    },
+    "autotuneParameter": {
+        "message": "Параметар"
+    },
+    "autotuneCurrent": {
+        "message": "Струја"
+    },
+    "autotuneProposed": {
+        "message": "Предложено"
+    },
+    "autotuneChange": {
+        "message": "Промени"
+    },
+    "autotuneApplying": {
+        "message": "Примењује се..."
+    },
+    "autotuneApplied": {
+        "message": "Појачања примењена и сачувана."
+    },
+    "autotuneApplyFailed": {
+        "message": "Примена појачања неуспешна"
+    },
+    "autotuneConnectRequired": {
+        "message": "Повежите се са flight контролером да бисте применили појачања."
+    },
+    "autotuneNoLogs": {
+        "message": "Нема важећих Blackbox логова у овом фајлу."
+    },
+    "autotuneNoChirpData": {
+        "message": "Нема chirp података. Проверите да ли је log снимљен са debug_mode = CHIRP и да ли је chirp мод био активиран."
+    },
+    "autotuneSampleCount": {
+        "message": "{{count}} узорака"
+    },
+    "autotuneSampleRate": {
+        "message": "Брзина узорковања: {{rate}} Hz"
+    },
+    "autotuneImportAnother": {
+        "message": "Увези други"
+    },
+    "autotuneImportRetry": {
+        "message": "Покушајте поново"
+    },
+    "autotuneFile": {
+        "message": "Фајл"
+    },
+    "autotuneAxesDetected": {
+        "message": "Детектоване осе"
+    },
+    "autotuneApplyGains": {
+        "message": "Примени појачања"
+    },
+    "autotuneGainTitle": {
+        "message": "Препорука појачања"
+    },
+    "autotuneAxisSelector": {
+        "message": "Изаберите осу"
+    },
+    "autotuneAxisRoll": {
+        "message": "Roll"
+    },
+    "autotuneAxisPitch": {
+        "message": "Pitch"
+    },
+    "autotuneAxisYaw": {
+        "message": "Yaw"
+    },
+    "autotuneBodePlotTitle": {
+        "message": "Фреквентни одзив"
+    },
+    "autotuneSectionCurrentPids": {
+        "message": "Тренутни PID-ови (из лога)"
+    },
+    "autotuneSectionAnalysis": {
+        "message": "Анализа"
+    },
+    "autotuneSectionProposedSliders": {
+        "message": "Предложени слајдери"
+    },
+    "autotuneSliderMasterMultiplier": {
+        "message": "Главни множилац"
+    },
+    "autotuneSliderPIGain": {
+        "message": "P \/ I појачање"
+    },
+    "autotuneSliderIGain": {
+        "message": "I појачање"
+    },
+    "autotuneSliderDGain": {
+        "message": "D појачање"
+    },
+    "autotuneSliderFeedforward": {
+        "message": "Feedforward"
+    },
+    "autotuneSliderDTermFilter": {
+        "message": "D-Term filter"
+    },
+    "autotuneApplyFromAxis": {
+        "message": "Примените појачања са осе"
+    },
+    "autotuneSensitivityPeak": {
+        "message": "Врхунац осетљивости"
+    },
+    "autotuneOvershoot": {
+        "message": "Прелетање"
+    },
+    "autotuneRiseTime": {
+        "message": "Време успона"
+    },
+    "autotuneSettlingTime": {
+        "message": "Време смиривања"
+    },
+    "autotuneSpectrogramTitle": {
+        "message": "Спектрограм (жироскоп)"
+    },
+    "tabReceiver": {
+        "message": "Пријемник"
+    },
+    "tabModeSelection": {
+        "message": "Избор мода"
+    },
+    "tabServos": {
+        "message": "Сервои"
+    },
+    "tabFailsafe": {
+        "message": "Failsafe"
+    },
+    "tabOsd": {
+        "message": "OSD"
+    },
+    "tabVtx": {
+        "message": "Видео-предајник"
+    },
+    "tabPower": {
+        "message": "Напајање и батерија"
+    },
+    "tabGPS": {
+        "message": "GPS"
+    },
+    "tabFlightPlan": {
+        "message": "Plan лета"
+    },
+    "tabMotorTesting": {
+        "message": "Мотори"
+    },
+    "tabLedStrip": {
+        "message": "LED трака"
+    },
+    "tabCLI": {
+        "message": "CLI"
+    },
+    "tabLogging": {
+        "message": "Снимање преко кабла"
+    },
+    "tabOnboardLogging": {
+        "message": "Blackbox"
+    },
+    "tabAdjustments": {
+        "message": "Подешавање у лету"
+    },
+    "tabAuxiliary": {
+        "message": "Модови"
+    },
+    "logActionHide": {
+        "message": "Сакриј дневник"
+    },
+    "logActionShow": {
+        "message": "Прикажи дневник"
+    },
+    "tabLog": {
+        "message": "Дневник"
+    },
+    "i2cErrorDetected": {
+        "message": "I2C грешка детектована (+{{delta}}, укупно {{total}})",
+        "description": "Logged when the flight controller reports new I2C bus errors. {{delta}} is how many errors since the last poll; {{total}} is the running total."
+    },
+    "logActionClear": {
+        "message": "Очисти"
+    },
+    "logAutoScroll": {
+        "message": "Аутоматско скроловање"
+    },
+    "fileSystemPickerFiles": {
+        "message": "{{typeof}} фајл",
+        "description": "Text for the file picker dialog, showing the type of files selected. The parameter can be HEX, TXT, etc."
+    },
+    "fileSystemPickerFirmwareFiles": {
+        "message": "Фирмвер фајла"
+    },
+    "serialErrorFrameError": {
+        "message": "Грешка серијске везе: лоше кадрирање"
+    },
+    "serialErrorParityError": {
+        "message": "Грешка серијске везе: лош паритет"
+    },
+    "serialPortOpened": {
+        "message": "Серијски порт <span class=\"message-positive\">успешно<\/span> отворен са ID-ом: $1"
+    },
+    "serialPortOpenFail": {
+        "message": "<span class=\"message-negative\">Неуспешно<\/span> отварање серијског порта"
+    },
+    "connectionFailedTitle": {
+        "message": "Веза неуспешна"
+    },
+    "connectionFailed": {
+        "message": "<span class=\"message-negative\">Неуспешно<\/span> повезивање на изабрани порт. Проверите да ли је уређај доступан и да ли су подешавања везе исправна, па покушајте поново."
+    },
+    "connectionFailedLocalNetworkIOS": {
+        "message": "На iOS-у, дозволите приступ <strong>Локалној мрежи<\/strong> за Betaflight у Подешавањима &rarr; Приватност &amp; Безбедност &rarr; Локална мрежа, па покушајте поново."
+    },
+    "connectionLostTitle": {
+        "message": "Веза изгубљена"
+    },
+    "connectionLostUnresponsive": {
+        "message": "Flight контролер <span class=\"message-negative\">је престао да реагује<\/span> и веза је прекинута. Поново повежите плочицу и покушајте поново; ако се проблем настави, искључите и поново укључите flight контролер."
+    },
+    "serialPortClosedOk": {
+        "message": "Серијски порт <span class=\"message-positive\">успешно<\/span> затворен"
+    },
+    "serialPortClosedFail": {
+        "message": "<span class=\"message-negative\">Неуспешно<\/span> затварање серијског порта"
+    },
+    "serialUnrecoverable": {
+        "message": "Непоправљив <span class=\"message-negative\">квар<\/span> серијске везе, прекидање везе..."
+    },
+    "serialPortLoading": {
+        "message": "Учитавање…"
+    },
+    "usbDeviceOpened": {
+        "message": "USB уређај <span class=\"message-positive\">успешно<\/span> отворен са ID-ом: $1"
+    },
+    "usbDeviceOpenFail": {
+        "message": "<span class=\"message-negative\">Неуспешно<\/span> отварање USB уређаја!"
+    },
+    "usbDeviceClosed": {
+        "message": "USB уређај <span class=\"message-positive\">успешно<\/span> затворен"
+    },
+    "usbDeviceCloseFail": {
+        "message": "<span class=\"message-negative\">Неуспешно<\/span> затварање USB уређаја"
+    },
+    "usbDeviceUdevNotice": {
+        "message": "Да ли су <strong>udev правила<\/strong> исправно инсталирана? Погледајте документацију за упутства"
+    },
+    "stm32UsbDfuNotFound": {
+        "message": "USB DFU није пронађен"
+    },
+    "stm32DfuPermissionRequired": {
+        "message": "Уређај се поново покренуо у DFU мод.<br><br>Ваш прегледач захтева USB дозволу за приступ DFU уређају. Кликните на дугме испод да бисте га изабрали из бирача уређаја."
+    },
+    "stm32RebootingToBootloader": {
+        "message": "Покретање поновног покретања у bootloader ..."
+    },
+    "stm32RebootingToBootloaderFailed": {
+        "message": "Поновно покретање уређаја у bootloader: НЕУСПЕШНО"
+    },
+    "stm32TimedOut": {
+        "message": "STM32 - истекло време, програмирање: НЕУСПЕШНО"
+    },
+    "stm32WrongResponse": {
+        "message": "STM32 комуникација неуспешна, погрешан одговор, очекивано: $1 (0x$2) примљено: $3 (0x$4)"
+    },
+    "stm32ContactingBootloader": {
+        "message": "Контактирање bootloadera ..."
+    },
+    "stm32ContactingBootloaderFailed": {
+        "message": "Комуникација са bootloaderom неуспешна"
+    },
+    "stm32ResponseBootloaderFailed": {
+        "message": "Нема одговора од bootloadera, програмирање: НЕУСПЕШНО"
+    },
+    "stm32GlobalEraseExtended": {
+        "message": "Извршавање глобалног брисања чипа (преко проширеног брисања) ..."
+    },
+    "stm32LocalEraseExtended": {
+        "message": "Извршавање локалног брисања (преко проширеног брисања) ..."
+    },
+    "stm32GlobalErase": {
+        "message": "Извршавање глобалног брисања чипа ..."
+    },
+    "stm32LocalErase": {
+        "message": "Извршавање локалног брисања ..."
+    },
+    "stm32InvalidHex": {
+        "message": "Неважећи хексадецимални код"
+    },
+    "stm32Erase": {
+        "message": "Брисање ..."
+    },
+    "stm32Flashing": {
+        "message": "Флешовање ..."
+    },
+    "stm32Verifying": {
+        "message": "Провера ..."
+    },
+    "stm32ProgrammingSuccessful": {
+        "message": "Програмирање: УСПЕШНО"
+    },
+    "stm32ProgrammingFailed": {
+        "message": "Програмирање: НЕУСПЕШНО"
+    },
+    "stm32AddressLoadFailed": {
+        "message": "Учитавање адресе за сектор опционалних бајтова није успело. Врло вероватно због заштите од читања."
+    },
+    "stm32AddressLoadSuccess": {
+        "message": "Учитавање адресе за сектор опционалних бајтова је успело."
+    },
+    "stm32AddressLoadUnknown": {
+        "message": "Учитавање адресе за сектор опционалних бајтова није успело због непознате грешке. Прекидам."
+    },
+    "stm32NotReadProtected": {
+        "message": "Заштита од читања није активна"
+    },
+    "stm32ReadProtected": {
+        "message": "Плочица је изгледа заштићена од читања. Уклањам заштиту. Не искључујте\/откачињите!"
+    },
+    "stm32UnprotectSuccessful": {
+        "message": "Уклањање заштите успешно."
+    },
+    "stm32UnprotectUnplug": {
+        "message": "ПОТРЕБНА АКЦИЈА: Искључите и поново повежите flight контролер у DFU моду да бисте покушали поново да флешујете!"
+    },
+    "stm32UnprotectFailed": {
+        "message": "Није успело уклањање заштите плочице"
+    },
+    "stm32UnprotectInitFailed": {
+        "message": "Није успело покретање рутине за уклањање заштите"
+    },
+    "noConfigurationReceived": {
+        "message": "Није примљена конфигурација у року од <span class=\"message-negative\">10 секунди<\/span>, комуникација <span class=\"message-negative\">није успела<\/span>"
+    },
+    "firmwareVersionNotSupported": {
+        "message": "Ова верзија фирмвера <span class=\"message-negative\">није подржана<\/span>. Молимо Вас да надоградите на фирмвер који подржава API верзију <strong>$1<\/strong> или новију. Користите CLI за прављење резервне копије пре флешовања. Процедура за прављење\/враћање резервне копије путем CLI-ја је у документацији.<br \/>Алтернативно, преузмите и користите стару верзију апликације ако нисте спремни за надоградњу."
+    },
+    "firmwareTypeNotSupported": {
+        "message": "Фирмвер који није Betaflight <span class=\"message-negative\">није подржан<\/span>, осим за CLI мод."
+    },
+    "firmwareUpgradeRequired": {
+        "message": "Фирмвер на овом уређају треба ажурирати на новију верзију. Пре уписа направите резервну копију кроз CLI — поступак стоји у упутствима.<br \/>Ако нисте спремни за ажурирање, преузмите и користите старију верзију програма."
+    },
+    "resetToCustomDefaultsDialog": {
+        "message": "Доступна су прилагођена фабричка подешавања за ову плочицу. Нормално, плочица неће радити исправно ако се не примене прилагођена фабричка подешавања.<br \/>Да ли желите да примените прилагођена фабричка подешавања за ову плочицу?"
+    },
+    "resetToCustomDefaultsAccept": {
+        "message": "Примени прилагођена фабричка подешавања"
+    },
+    "reportProblemsDialogHeader": {
+        "message": "Откривени су следећи <strong>проблеми са Вашом конфигурацијом<\/strong>:"
+    },
+    "reportProblemsDialogFooter": {
+        "message": "<span class=\"message-negative\"><strong>Морате решити ове проблеме пре него што покушате да летите Вашом летелицом<\/span><\/strong>."
+    },
+    "reportProblemsDialogAPI_VERSION_MAX_SUPPORTED": {
+        "message": "<span class=\"message-negative\"><strong>Верзија програма коју користите ($3) не подржава фирмвер $4<\/strong><\/span>.<br>$t(configuratorUpdateHelp.message)"
+    },
+    "reportProblemsDialogMOTOR_PROTOCOL_DISABLED": {
+        "message": "<strong>није изабран протокол за излаз мотора<\/strong>.<br>Молимо Вас да изаберете протокол за излаз мотора одговарајући за Ваше ESC-ове у '$t(configurationEscFeatures.message)' на картици '$t(tabMotorTesting.message)'.<br>$t(escProtocolDisabledMessage.message)"
+    },
+    "reportProblemsDialogACC_NEEDS_CALIBRATION": {
+        "message": "<strong>акцелерометар је укључен, али није калибрисан<\/strong>.<br>Ако планирате да користите акцелерометар, молимо Вас да пратите упутства за '$t(initialSetupButtonCalibrateAccel.message)' на картици '$t(tabSetup.message)'. Ако је било која функција која захтева акцелерометар (модови аутоматског нивелисања, GPS rescue, ...) укључена, армовање летелице ће бити искључено док се акцелерометар не калибрише.<br>Ако не планирате да користите акцелерометар, препоручује се да га искључите у '$t(configurationSystem.message)' на картици '$t(tabConfiguration.message)'."
+    },
+    "infoVersionOs": {
+        "message": "OS: <strong>{{operatingSystem}}<\/strong>",
+        "description": "Message that appears in the GUI log panel indicating operating system"
+    },
+    "infoVersionConfigurator": {
+        "message": "Верзија апликације: <strong>{{configuratorVersion}}<\/strong>",
+        "description": "Message that appears in the GUI log panel indicating application version"
+    },
+    "buildServerSuccess": {
+        "message": "Успех: $1"
+    },
+    "buildServerFailure": {
+        "message": "<b>Грешка build сервера: $1 <code>$2<\/code><\/b>"
+    },
+    "buildServerUsingCached": {
+        "message": "Користе се кеширане информације о израдама за $1."
+    },
+    "buildServerSupportRequestSubmission": {
+        "message": "<br>*** Подаци за подршку су послати *** <br>ID: $1<br><br><br># копирајте ID и проследите га Betaflight тиму."
+    },
+    "buildKey": {
+        "message": "Кључ израде: <strong>$1<\/strong>"
+    },
+    "supportWarningDialogTitle": {
+        "message": "Потврдите слање података"
+    },
+    "supportWarningDialogText": {
+        "message": "Потврдите слање података Betaflight тиму.<br><br>Овај процес ће покренути неке команде и послати излазне податке на build server.<br><br>Затим ћете добити јединствени идентификатор за Ваше слање података.<br><br>Обавезно проследите овај јединствени идентификатор Betaflight тиму када користите Discord или отварате проблем на GitHub-у."
+    },
+    "supportWarningDialogInputPlaceHolder": {
+        "message": "Опишите проблем"
+    },
+    "releaseCheckLoaded": {
+        "message": "Учитане су информације о издању за $1 са GitHub-а."
+    },
+    "releaseCheckFailed": {
+        "message": "<b>Упит ка GitHub-у за издања $1 није успео, користе се кеширане информације. Разлог: <code>$2<\/code><\/b>"
+    },
+    "releaseCheckCached": {
+        "message": "Користе се кеширане информације о издањима за $1."
+    },
+    "releaseCheckNoInfo": {
+        "message": "Нема доступних информација о издању за $1."
+    },
+    "tabSwitchConnectionRequired": {
+        "message": "Морате се <strong>повезати<\/strong> пре него што можете да отворите било коју картицу."
+    },
+    "tabSwitchWaitForOperation": {
+        "message": "Ово <span class=\"message-negative\">не можете<\/span> сада да урадите, сачекајте да се тренутна радња заврши…"
+    },
+    "tabSwitchUpgradeRequired": {
+        "message": "Морате <strong>ажурирати<\/strong> фирмвер на најновију верзију Betaflight-а да бисте користили картицу $1."
+    },
+    "firmwareVersion": {
+        "message": "Верзија фирмвера: <strong>$1<\/strong>"
+    },
+    "apiVersionReceived": {
+        "message": "MultiWii API верзија: <strong>$1<\/strong>"
+    },
+    "uniqueDeviceIdReceived": {
+        "message": "Јединствени ID уређаја: <strong>0x$1<\/strong>"
+    },
+    "craftNameReceived": {
+        "message": "Назив летелице: <strong>$1<\/strong>"
+    },
+    "armingDisabled": {
+        "message": "<strong>Армовање је искључено<\/strong>"
+    },
+    "armingEnabled": {
+        "message": "<strong>Армовање је укључено<\/strong>"
+    },
+    "runawayTakeoffPreventionDisabled": {
+        "message": "<strong>Заштита од неконтролисаног полетања је привремено искључена<\/strong>"
+    },
+    "runawayTakeoffPreventionEnabled": {
+        "message": "<strong>Заштита од неконтролисаног полетања је укључена<\/strong>"
+    },
+    "boardInfoReceived": {
+        "message": "Плочица: <strong>$1<\/strong>, верзија: <strong>$2<\/strong>"
+    },
+    "buildInfoReceived": {
+        "message": "Покренути фирмвер је објављен: <strong>$1<\/strong>"
+    },
+    "fcInfoReceived": {
+        "message": "Информације о flight контролеру, идентификатор: <strong>$1<\/strong>, верзија: <strong>$2<\/strong>"
+    },
+    "versionLabelTarget": {
+        "message": "Target"
+    },
+    "versionLabelFirmware": {
+        "message": "Верзија фирмвера"
+    },
+    "versionLabelConfigurator": {
+        "message": "Верзија апликације"
+    },
+    "notifications_app_just_updated_to_version": {
+        "message": "Апликација је управо ажурирана на верзију: $1"
+    },
+    "notifications_click_here_to_start_app": {
+        "message": "Кликните овде да покренете апликацију"
+    },
+    "statusbar_port_utilization": {
+        "message": "Искоришћеност порта:",
+        "description": "Port utilization text shown in the status bar"
+    },
+    "statusbar_usage_download": {
+        "message": "D:",
+        "description": "References 'Download' in the status bar, port utilization. Keep one character long if possible"
+    },
+    "statusbar_usage_upload": {
+        "message": "U:",
+        "description": "References 'Upload' in the status bar, port utilization. Keep one character long if possible"
+    },
+    "statusbar_packet_error": {
+        "message": "Грешке пакета:",
+        "description": "Packet error text shown in the status bar"
+    },
+    "statusbar_i2c_error": {
+        "message": "I2C грешке:",
+        "description": "CPU load text shown in the status bar"
+    },
+    "statusbar_cycle_time": {
+        "message": "Време циклуса:",
+        "description": "Cycle time text shown in the status bar"
+    },
+    "statusbar_cpu_load": {
+        "message": "Оптерећење CPU-а:",
+        "description": "CPU load text shown in the status bar"
+    },
+    "statusbar_connection_time": {
+        "message": "Трајање везе:",
+        "description": "Connection time text shown in the status bar"
+    },
+    "dfu_connect_message": {
+        "message": "Користите картицу за флешовање фирмвера за приступ DFU уређајима"
+    },
+    "dfu_erased_kilobytes": {
+        "message": "Обрисано $1 kB флеш меморије <span class=\"message-positive\">успешно<\/span>"
+    },
+    "dfu_device_flash_info": {
+        "message": "Детектован је уређај са укупном величином флеш меморије од $1 KiB"
+    },
+    "dfu_hex_address_errors": {
+        "message": "Слика фирмвера садржи адресе које не постоје на изабраном уређају"
+    },
+    "dfu_error_image_size": {
+        "message": "<span class=\"message-negative\">Грешка<\/span>: Изабрана слика је већа од доступне флеш меморије на чипу! Слика: $1 KiB, граница = $2 KiB"
+    },
+    "eeprom_saved_ok": {
+        "message": "EEPROM је <span class=\"message-positive\">сачуван<\/span>"
+    },
+    "defaultWelcomeIntro": {
+        "message": "Добро дошли у <strong>Betaflight App<\/strong>, алат намењен за лакше ажурирање, подешавање и фино подешавање Вашег flight контролера."
+    },
+    "defaultHardwareHead": {
+        "message": "Хардвер"
+    },
+    "defaultHardwareText": {
+        "message": "Апликација подржава сав хардвер који може да покрене Betaflight. Погледајте картицу Флешовање фирмвера за комплетну листу хардвера.<br \/><br \/>Корисни алатке и драјвери за хардвер:<ul><li>За старији хардвер који користи CP210x USB на серијски чип, најновије <b>CP210x драјвере<\/b> можете преузети <a href=\"https:\/\/www.silabs.com\/software-and-tools\/usb-to-uart-bridge-vcp-drivers\" target=\"_blank\" rel=\"noopener noreferrer\">овде<\/a><\/li><li>Најновији <b>Zadig<\/b> за инсталацију USB драјвера на Windows-у можете преузети <a href=\"https:\/\/zadig.akeo.ie\/\" target=\"_blank\" rel=\"noopener noreferrer\">овде<\/a><\/li><li><b>ImpulseRC Driver Fixer<\/b> можете преузети <a href=\"https:\/\/github.com\/ImpulseRC\/ImpulseRC_Driver_Fixer\" target=\"_blank\" rel=\"noopener noreferrer\">овде<\/a><\/li><\/ul>"
+    },
+    "defaultSoftwareHead": {
+        "message": "Софтвер"
+    },
+    "defaultSoftwareText": {
+        "message": "Наш Blackbox прегледач дневника је уграђен у ову апликацију. Отворите картицу <strong>Blackbox Viewer<\/strong> за анализу Ваших дневника летења.<br \/><br \/>Наша колекција <a href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/releases\" target=\"_blank\" rel=\"noopener noreferrer\">TX Lua скрипти<\/a> је доступна на GitHub-у.<br \/><br \/>Наш <a href=\"https:\/\/github.com\/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">изворни код<\/a> за фирмвер и ову апликацију можете преузети са GitHub-а."
+    },
+    "defaultContributingHead": {
+        "message": "Допринос заједници"
+    },
+    "defaultContributingText": {
+        "message": "Ако желите да помогнете да Betaflight буде још бољи, можете помоћи на много начина, укључујући:<br \/><ul><li>коришћење Вашег знања о Betaflight-у за креирање или ажурирање садржаја на <a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">нашем Wiki-ју<\/a>, или одговарање на питања других корисника на онлајн форумима;<\/li><li><a href=\"https:\/\/betaflight.com\/docs\/development\" target=\"_blank\" rel=\"noopener noreferrer\">допринос кода<\/a> за фирмвер и апликацију — нове функције, поправке, побољшања;<\/li><li>тестирање <a href=\"https:\/\/github.com\/Betaflight\/betaflight\/pulls\" target=\"_blank\" rel=\"noopener noreferrer\">нових функција и поправки<\/a> и давање повратних информација;<\/li><li>помагање другим корисницима да реше проблеме које пријаве у <a href=\"https:\/\/github.com\/betaflight\/betaflight\/issues\" target=\"_blank\" rel=\"noopener noreferrer\">нашем систему за праћење проблема<\/a> и учешће у расправама о захтевима за нове функције;<\/li><li><a href=\"https:\/\/github.com\/betaflight\/betaflight\/blob\/master\/README.md#translators\" target=\"_blank\" rel=\"noopener noreferrer\">превођење<\/a> Betaflight App-а на нови језик или помоћ у одржавању постојећих превода.<\/li><\/ul>"
+    },
+    "defaultFacebookText": {
+        "message": "Такође имамо и <a href=\"https:\/\/www.facebook.com\/groups\/betaflightgroup\/\" target=\"_blank\" rel=\"noopener noreferrer\">Facebook групу<\/a>.<br \/>Придружите нам се да бисте разговарали о Betaflight-у, постављали питања о подешавању или се једноставно дружили са другим пилотима."
+    },
+    "defaultDiscordText": {
+        "message": "Betaflight <a href=\"https:\/\/discord.betaflight.com\/invite\" target=\"_blank\" rel=\"noopener noreferrer\">Discord server<\/a>.<br \/>Поделите своје искуство у летењу, причајте о Betaflight-у, помозите другима или потражите помоћ за себе од заједнице."
+    },
+    "defaultRedditText": {
+        "message": "Придружите се нашем <a href=\"https:\/\/www.reddit.com\/r\/Betaflight\/\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight Reddit подфоруму<\/a>.<br \/>Дискутујте о функцијама, постављајте питања и повежите се са Betaflight заједницом на Reddit-у."
+    },
+    "defaultCommunityHead": {
+        "message": "Заједница"
+    },
+    "statisticsDisclaimerHead": {
+        "message": "Ваша приватност"
+    },
+    "statisticsDisclaimer": {
+        "message": "Ова Betaflight апликација прикупља анонимну статистику коришћења. Ови подаци о коришћењу могу обухватати број покретања, географски region корисника, типове flight контролера, верзије фирмвера, коришћење UI елемената и картица, итд. Прикупљамо ове податке како бисмо боље разумели како се апликација користи и трендове у заједници. Ово радимо како бисмо развили побољшани UI и целокупно искуство. Корисници могу искључити прикупљање података у картици Опције. За информације о томе како прикупљамо и користимо Ваше податке, погледајте нашу <a href=\"https:\/\/www.betaflight.com\/privacy\" rel=\"noopener noreferrer\" target=\"_blank\">политику приватности<\/a>."
+    },
+    "defaultButtonFirmwareFlasher": {
+        "message": "Упис фирмвера"
+    },
+    "defaultDonateHead": {
+        "message": "Донације за отворен код"
+    },
+    "defaultDonateText": {
+        "message": "<p><strong>Betaflight<\/strong> је софтвер <strong>отвореног кода<\/strong> и доступан је бесплатно <strong>без гаранције<\/strong> свим корисницима.<\/p><p>Ако сматрате да је Betaflight користан, размислите о <strong>подршци<\/strong> његовом развоју путем донације.<\/p>"
+    },
+    "defaultDonateBottom": {
+        "message": "<p>Ако желите да редовно финансијски доприносите, размислите о томе да постанете наш patron на $t(patreonLink.message).<\/p>"
+    },
+    "patreonLink": {
+        "message": "<a href=\"https:\/\/www.patreon.com\/betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">Patreon<\/a>",
+        "description": "Patreon is name, and should not require translation"
+    },
+    "defaultDonate": {
+        "message": "Донирајте"
+    },
+    "defaultSponsorsHead": {
+        "message": "Спонзори"
+    },
+    "defaultDocumentationHead": {
+        "message": "Документација \/ упутство"
+    },
+    "defaultDocumentation": {
+        "message": "Betaflight документација је доступна у белешкама о издању и на wiki страници.<br \/><br \/>"
+    },
+    "defaultDocumentation1": {
+        "message": "Betaflight wiki је одличан извор информација и можете га пронаћи <a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">овде<\/a>."
+    },
+    "defaultDocumentation2": {
+        "message": "Белешке о издању за фирмвер можете прочитати на GitHub страници са издањима, <a href=\"https:\/\/github.com\/Betaflight\/Betaflight\/releases\" target=\"_blank\" rel=\"noopener noreferrer\">овде<\/a>."
+    },
+    "defaultSupportHead": {
+        "message": "Подршка"
+    },
+    "defaultSupportSubline1": {
+        "message": "Извори подршке"
+    },
+    "defaultSupportSubline2": {
+        "message": "Програмери"
+    },
+    "defaultSupport": {
+        "message": "За подршку прво претражите форуме и wiki или контактирајте свог продавца.<br \/><br \/>"
+    },
+    "defaultSupport1": {
+        "message": "<a href=\"http:\/\/www.rcgroups.com\/forums\/showthread.php?t=2464844&page=1\" target=\"_blank\" rel=\"noopener noreferrer\">RC Groups тема<\/a>"
+    },
+    "defaultSupport2": {
+        "message": "<a href=\"https:\/\/betaflight.com\/docs\/wiki\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight Wiki<\/a>"
+    },
+    "defaultSupport3": {
+        "message": "<a href=\"https:\/\/www.youtube.com\/playlist?list=PLwoDb7WF6c8nT4jjsE4VENEmwu9x8zDiE\" target=\"_blank\" rel=\"noopener noreferrer\">Joshua Bardwell Betaflight 4.3 видео снимци<\/a>"
+    },
+    "defaultSupport4": {
+        "message": "<a href=\"https:\/\/github.com\/Betaflight\" target=\"_blank\" rel=\"noopener noreferrer\">GitHub<\/a>"
+    },
+    "defaultSupport5": {
+        "message": "<a href=\"https:\/\/discord.betaflight.com\/invite\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight програмери на Discord-у<\/a>"
+    },
+    "initialSetupButtonCalibrateAccel": {
+        "message": "Калибриши акцелерометар"
+    },
+    "initialSetupCalibrateMagText": {
+        "message": "Померајте multirotor за најмање <strong>360<\/strong> степени по свим осама ротације, имате 30 секунди да обавите овај задатак"
+    },
+    "initialSetupButtonCalibratingText": {
+        "message": "Калибрисање..."
+    },
+    "initialSetupButtonReset": {
+        "message": "Обриши подешавања"
+    },
+    "initialSetupResetText": {
+        "message": "Вратите flight контролер у <strong>неконфигурисано стање.<\/strong>"
+    },
+    "initialSetupButtonBackup": {
+        "message": "Сачувај резервну копију (JSON)"
+    },
+    "initialSetupButtonRestore": {
+        "message": "Врати из резервне копије (JSON)"
+    },
+    "initialSetupButtonRebootBootloader": {
+        "message": "Активирај Boot Loader \/ DFU"
+    },
+    "initialSetupBackupRestoreHeader": {
+        "message": "Експериментално прављење и враћање резервне копије"
+    },
+    "initialSetupBackupRestoreText": {
+        "message": "<strong>Сачувајте бекап<\/strong> своје конфигурације у случају незгоде, <strong>CLI<\/strong> подешавања <span class=\"message-negative\">нису<\/span> укључена - користите команду 'diff all' у CLI-ју за ово."
+    },
+    "initialSetupRebootBootloaderText": {
+        "message": "Поново покрените у <strong>boot loader \/ DFU<\/strong> мод."
+    },
+    "initialSetupButtonResetZaxis": {
+        "message": "Ресетуј Z осу, одступање: 0 deg"
+    },
+    "initialSetupButtonResetZaxisValue": {
+        "message": "Ресетуј Z осу, одступање: $1 deg"
+    },
+    "initialSetupHeading": {
+        "message": "Yaw:",
+        "description": "Heading [yaw] attitude value shown on Setup tab when no magnetometer is active"
+    },
+    "initialSetupMagHeading": {
+        "message": "Mag правац:",
+        "description": "Heading value shown on Setup tab when magnetometer is active"
+    },
+    "initialSetupMixerHead": {
+        "message": "Врста миксера"
+    },
+    "initialSetupThrottleHead": {
+        "message": "Подешавања гаса"
+    },
+    "initialSetupMinimum": {
+        "message": "Minimum:"
+    },
+    "initialSetupMaximum": {
+        "message": "Максимум:"
+    },
+    "initialSetupFailsafe": {
+        "message": "Failsafe:"
+    },
+    "initialSetupMinCommand": {
+        "message": "MinCommand:"
+    },
+    "initialSetupBatteryHead": {
+        "message": "Батерија"
+    },
+    "initialSetupMinCellV": {
+        "message": "Минимални напон ћелије:"
+    },
+    "initialSetupMaxCellV": {
+        "message": "Максимални напон ћелије:"
+    },
+    "initialSetupVoltageScale": {
+        "message": "Скала напона:"
+    },
+    "initialSetupAccelTrimsHead": {
+        "message": "Тримови акцелерометра"
+    },
+    "initialSetupPitch": {
+        "message": "Pitch:"
+    },
+    "initialSetupRoll": {
+        "message": "Roll:"
+    },
+    "initialSetupMagHead": {
+        "message": "Магнетометар"
+    },
+    "initialSetupMagDeclination": {
+        "message": "Магнетска деклинација:"
+    },
+    "initialSetupInfoHead": {
+        "message": "Информације о систему"
+    },
+    "initialSetupInfoHeadHelp": {
+        "message": "Приказује FC флегове за разоружавање, информације о батерији, RSSI ниво.",
+        "description": "Message that pops up to describe the System info section"
+    },
+    "initialSensorInfoHead": {
+        "message": "Информације о сензорима"
+    },
+    "initialSensorInfoHeadHelp": {
+        "message": "Приказује хардвер сензора",
+        "description": "Message that pops up to describe the Sensor info section"
+    },
+    "initialSetupBattery": {
+        "message": "Напон батерије:"
+    },
+    "initialSetupBatteryValue": {
+        "message": "$1 V"
+    },
+    "initialSetupDrawn": {
+        "message": "Потрошени капацитет:"
+    },
+    "initialSetupDrawing": {
+        "message": "Потрошња струје:"
+    },
+    "initialSetupBatteryMahValue": {
+        "message": "$1 mAh"
+    },
+    "initialSetupBatteryAValue": {
+        "message": "$1 A"
+    },
+    "initialSetupCpuLoad": {
+        "message": "Оптерећење CPU-а:"
+    },
+    "initialSetupLoopTime": {
+        "message": "Брзина циклуса:"
+    },
+    "initialSetupCpuTemp": {
+        "message": "Температура CPU-а:"
+    },
+    "initialSetupCpuTempNotSupported": {
+        "message": "Није подржано у MSP API пре верзије 1.46"
+    },
+    "initialSetupRSSI": {
+        "message": "RSSI:"
+    },
+    "initialSetupNotInBuild": {
+        "message": "Није укључено у build",
+        "description": "Message that pops up when hardware support is not included in build"
+    },
+    "initialSetupNotDetected": {
+        "message": "Није детектован или је искључен",
+        "description": "Message that pops up when hardware is not detected or disabled"
+    },
+    "initialSetupRSSIValue": {
+        "message": "$1 dBm"
+    },
+    "initialSetupMCU": {
+        "message": "MCU:"
+    },
+    "initialSetupSensorHardware": {
+        "message": "Сензори:"
+    },
+    "initialSetupSensorGyro": {
+        "message": "Жироскоп:"
+    },
+    "initialSetupSensorAcc": {
+        "message": "Акцелерометар:"
+    },
+    "initialSetupSensorMag": {
+        "message": "Магнетометар:"
+    },
+    "initialSetupSensorBaro": {
+        "message": "Baro:"
+    },
+    "initialSetupSensorGPS": {
+        "message": "GPS:"
+    },
+    "initialSetupSensorSonar": {
+        "message": "Sonar:"
+    },
+    "initialSetupSensorOpticalflow": {
+        "message": "Оптички проток:"
+    },
+    "initialSetupSensorRadar": {
+        "message": "Radar:"
+    },
+    "initialSetupArmingDisableFlags": {
+        "message": "Заставице за онемогућавање армовања:"
+    },
+    "initialSetupArmingAllowed": {
+        "message": "Армовање је дозвољено"
+    },
+    "initialSetupArmingDisableFlagsTooltip": {
+        "message": "Листа заставица које указују на to зашто армовање тренутно није дозвољено. Пређите мишем преко заставице или погледајте Wiki (страницу 'Arming Sequence & Safety') за више информација."
+    },
+    "initialSetupArmingDisableFlagsTooltipNO_GYRO": {
+        "message": "Жироскоп није детектован",
+        "description": "Message that pops up to describe the NO_GYRO arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipFAILSAFE": {
+        "message": "Failsafe је активан",
+        "description": "Message that pops up to describe the FAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRX_FAILSAFE": {
+        "message": "Није детектован валидан сигнал пријемника",
+        "description": "Message that pops up to describe the RX_FAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNOT_DISARMED": {
+        "message": "Ваш пријемник се управо опоравио од Failsafe-а, али је прекидач за ARM укључен",
+        "description": "Message that pops up to describe the NOT_DISARMED arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBOXFAILSAFE": {
+        "message": "Прекидач 'FAILSAFE' је активиран",
+        "description": "Message that pops up to describe the BOXFAILSAFE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRUNAWAY_TAKEOFF": {
+        "message": "Активирана је заштита од неконтролисаног полетања",
+        "description": "Message that pops up to describe the RUNAWAY_TAKEOFF arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCRASH_DETECTED": {
+        "message": "Детекција судара је активна",
+        "description": "Message that pops up to describe the CRASH_DETECTED arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCALIBRATING": {
+        "message": "Летелица се тренутно калибрише",
+        "description": "Message that pops up to describe the CALIBRATING arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipTHROTTLE": {
+        "message": "Канал за гас је превисок",
+        "description": "Message that pops up to describe the THROTTLE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipANGLE": {
+        "message": "Летелица није (довољно) поравната",
+        "description": "Message that pops up to describe the ANGLE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBOOT_GRACE_TIME": {
+        "message": "Армовање је прерано након укључивања",
+        "description": "Message that pops up to describe the BOOT_GRACE_TIME arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNOPREARM": {
+        "message": "PREARM прекидач није активиран или PREARM није поново преклопљен након разоружавања",
+        "description": "Message that pops up to describe the NOPREARM arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipLOAD": {
+        "message": "Оптерећење система је превелико за безбедан лет",
+        "description": "Message that pops up to describe the LOAD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipACC_CALIBRATION": {
+        "message": "Калибрација акцелерометра је и даље у току",
+        "description": "Message that pops up to describe the ACC_CALIBRATION arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCLI": {
+        "message": "CLI је активан",
+        "description": "Message that pops up to describe the CLI arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCMS_MENU": {
+        "message": "CMS (мени за подешавање) је активан - преко OSD-а или другог екрана -",
+        "description": "Message that pops up to describe the CMS_MENU arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipOSD_MENU": {
+        "message": "OSD мени је активан",
+        "description": "Message that pops up to describe the OSD_MENU arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipBST": {
+        "message": "Black Sheep Telemetry уређај (TBS Core Pro на пример) је разоружао летелицу и спречава армовање",
+        "description": "Message that pops up to describe the BST arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipMSP": {
+        "message": "MSP веза је активна, вероватно са апликацијом Betaflight",
+        "description": "Message that pops up to describe the MSP arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipPARALYZE": {
+        "message": "Активиран је Paralyze мод",
+        "description": "Message that pops up to describe the PARALYZE arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipGPS": {
+        "message": "GPS Rescue мод је подешен, али потребан број сателита још није пронађен",
+        "description": "Message that pops up to describe the GPS arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRESC": {
+        "message": "Прекидач за 'GPS Rescue' је активиран",
+        "description": "Message that pops up to describe the RESC arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipRPMFILTER": {
+        "message": "Филтрирање засновано на RPM је укључено, али један или више ESC-ова не шаљу исправну DSHOT телеметрију. Проверите да ли ESC-ови подржавају двосмерну DSHOT телеметрију и да ли имају инсталиран одговарајући фирмвер.",
+        "description": "Message that pops up to describe the RPMFILTER arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipDSHOT_TELEM": {
+        "message": "DShot телеметрија је укључена, али један или више ESC-ова не шаљу исправну DSHOT телеметрију. Проверите да ли ESC-ови подржавају двосмерну DSHOT телеметрију и да ли имају инсталиран одговарајући фирмвер.",
+        "description": "Message that pops up to describe the DSHOT_TELEM arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipREBOOT_REQUIRED": {
+        "message": "Измена подешавања захтева поновно покретање",
+        "description": "Message that pops up to describe the REBOOT_REQD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipDSHOT_BITBANG": {
+        "message": "Битбанг DSHOT не ради исправно и мотори се не могу контролисати. Вероватно је дошло до конфликта тајмера са другим функцијама укљученим на flight контролеру.",
+        "description": "Message that pops up to describe the DSHOT_BBANG arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipNO_ACC_CALIBRATION": {
+        "message": "Акцелерометар није калибрисан, а укључене су функције које зависе од њега. Калибришите акцелерометар.",
+        "description": "Message that pops up to describe the NO_ACC_CAL arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipMOTOR_PROTOCOL": {
+        "message": "Није изабран протокол за излаз мотора",
+        "description": "Message that pops up to describe the MOTOR_PROTO arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipCRASHFLIP": {
+        "message": "Прекидач за Crash Flip је активан",
+        "description": "Message that pops to describe the CRASHFLIP arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipALTHOLD": {
+        "message": "Altitude Hold је активан",
+        "description": "Message that pops up to describe the ALTHOLD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipPOSHOLD": {
+        "message": "Position Hold је активан",
+        "description": "Message that pops up to describe the POSHOLD arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipAUTOPILOT": {
+        "message": "Прекидач за Autopilot мод је активан",
+        "description": "Message that pops up to describe the AUTOPILOT arming disable flag"
+    },
+    "initialSetupArmingDisableFlagsTooltipARM_SWITCH": {
+        "message": "Нека друга заставица за разоружавање је активна приликом армовања",
+        "description": "Message that pops up to describe the ARM_SWITCH arming disable flag"
+    },
+    "initialSetupGPSHead": {
+        "message": "GPS"
+    },
+    "initialSetupGPSHeadHelp": {
+        "message": "Приказује GPS информације ако је исправно укључен на картицама Ports, Configuration и GPS",
+        "description": "Message that pops up to describe the GPS section"
+    },
+    "initialSetupSonarHead": {
+        "message": "Sonar"
+    },
+    "initialSetupSonarHeadHelp": {
+        "message": "Приказује информације о сонару ако је исправно укључен на картици Configuration",
+        "description": "Message that pops up to describe the Sonar section"
+    },
+    "initialSetupAltitudeSonar": {
+        "message": "Висина"
+    },
+    "initialSetupInstrumentsHead": {
+        "message": "Инструменти"
+    },
+    "initialSetupInstrumentsHeadHelp": {
+        "message": "Приказује Heading, Pitch и Roll на инструментима",
+        "description": "Message that pops up to describe the Instruments section"
+    },
+    "initialSetupInfoBoardName": {
+        "message": "Плочица:"
+    },
+    "initialSetupInfoFirmwareVersion": {
+        "message": "Фирмвер:"
+    },
+    "initialSetupInfoAPIversion": {
+        "message": "MSP API:"
+    },
+    "initialSetupInfoBuild": {
+        "message": "Информације о фирмверу"
+    },
+    "initialSetupInfoFirmwareHelp": {
+        "message": "Приказује информације о изради фирмвера, захтева интернет везу са сервером за израду.<br>Опције приказују дефинисане опције коришћене у изради у облаку.<br>Везе Log и Config приказују информације у облаку помоћу кључа сачуваног у фирмверу.<br>Код локалне израде, ове секције су празне.",
+        "description": "Message that pops up to describe the Build \/ Firmware section"
+    },
+    "initialSetupInfoBuildDate": {
+        "message": "Датум израде:"
+    },
+    "initialSetupInfoBuildInfo": {
+        "message": "Информације о изради:"
+    },
+    "initialSetupInfoBuildInfoKey": {
+        "message": "Кључ израде"
+    },
+    "initialSetupInfoBuildConfig": {
+        "message": "Config"
+    },
+    "initialSetupInfoBuildDownload": {
+        "message": "Преузми"
+    },
+    "initialSetupInfoBuildFirmware": {
+        "message": "Фирмвер:"
+    },
+    "initialSetupInfoBuildLog": {
+        "message": "Дневник"
+    },
+    "initialSetupInfoBuildOptions": {
+        "message": "Опције"
+    },
+    "initialSetupInfoBuildOptionList": {
+        "message": "Опције дефинисане у изради фирмвера"
+    },
+    "initialSetupInfoBuildEmpty": {
+        "message": "Локална израда – нема информација у облаку"
+    },
+    "initialSetupInfoBuildType": {
+        "message": "Врста израде:"
+    },
+    "initialSetupInfoBuildLocal": {
+        "message": "Локална израда"
+    },
+    "initialSetupInfoBuildCloud": {
+        "message": "Израда у облаку"
+    },
+    "initialSetupNoBuildInfo": {
+        "message": "Нема доступних информација о изради"
+    },
+    "initialSetupNotOnline": {
+        "message": "Server није доступан"
+    },
+    "initialSetupButtonSave": {
+        "message": "Сачувај"
+    },
+    "initialSetupModel": {
+        "message": "Модел: $1"
+    },
+    "initialSetupAttitude": {
+        "message": "$1 deg"
+    },
+    "initialSetupAccelCalibStarted": {
+        "message": "Калибрација акцелерометра је започета"
+    },
+    "initialSetupAccelCalibEnded": {
+        "message": "Калибрација акцелерометра је <span class=\"message-positive\">завршена<\/span>"
+    },
+    "initialSetupMagCalibStarted": {
+        "message": "Калибрација магнетометра је започета"
+    },
+    "initialSetupMagCalibEnded": {
+        "message": "Калибрација магнетометра је <span class=\"message-positive\">завршена<\/span>"
+    },
+    "initialSetupSettingsRestored": {
+        "message": "Подешавања су враћена на <strong>фабричка<\/strong>"
+    },
+    "initialSetupNetworkInfo": {
+        "message": "Мрежне информације"
+    },
+    "initialSetupNetworkInfoHelp": {
+        "message": "Приказује status мрежне везе",
+        "description": "Message that pops up to describe the Network Connection section"
+    },
+    "initialSetupNetworkInfoStatus": {
+        "message": "Status:"
+    },
+    "initialSetupNetworkInfoStatusOnline": {
+        "message": "На мрежи"
+    },
+    "initialSetupNetworkInfoStatusOffline": {
+        "message": "Ван мреже"
+    },
+    "initialSetupNetworkInfoStatusSlow": {
+        "message": "Споро"
+    },
+    "initialSetupNetworkType": {
+        "message": "Тип:"
+    },
+    "initialSetupNetworkRtt": {
+        "message": "RTT:"
+    },
+    "initialSetupNetworkDownlink": {
+        "message": "Силазна веза:"
+    },
+    "featureNone": {
+        "message": "&lt;Изаберите једно&gt;"
+    },
+    "featureRX_PPM": {
+        "message": "PPM\/CPPM (једна жица)"
+    },
+    "featureINFLIGHT_ACC_CAL": {
+        "message": "Калибрација нивелисања у лету"
+    },
+    "featureRX_SERIAL": {
+        "message": "Серијски (путем UART-а)"
+    },
+    "featureMOTOR_STOP": {
+        "message": "Не покрећи моторе приликом армовања"
+    },
+    "featureMOTOR_STOPTip": {
+        "message": "Ова функција је искључена када је укључен AIRMODE"
+    },
+    "featureSERVO_TILT": {
+        "message": "Servo gimbal"
+    },
+    "featureSERVO_TILTTip": {
+        "message": "Ова функција укључује CAMSTAB мод, који се може користити за одржавање стабилности до две осе помоћу акцелерометра"
+    },
+    "featureSOFTSERIAL": {
+        "message": "Серијски портови засновани на процесору"
+    },
+    "featureSOFTSERIALTip": {
+        "message": "Подесите портове на картици Ports након укључивања."
+    },
+    "featureGPS": {
+        "message": "GPS за навигацију и телеметрију"
+    },
+    "featureGPSTip": {
+        "message": "Укључи \/ искључи GPS податке. Ако се GPS не може укључити, проверите да ли је порт додељен GPS-у на картици Ports",
+        "description": "Message that pops up to describe the GPS feature"
+    },
+    "featureSONAR": {
+        "message": "Sonar"
+    },
+    "featureSONARTip": {
+        "message": "Укључује Sonar мерач удаљености за мерење висине од тла у cm"
+    },
+    "featureTELEMETRY": {
+        "message": "Телеметријски излаз"
+    },
+    "featureTELEMETRYTip": {
+        "message": "Укључује телеметријски излаз за слање на предајник"
+    },
+    "feature3D": {
+        "message": "3D мод (за употребу са реверзибилним ESC-овима)"
+    },
+    "feature3DTip": {
+        "message": "Укључи 3D мод за употребу са реверзибилним ESC-овима, подесите на картици Motors"
+    },
+    "featureRX_PARALLEL_PWM": {
+        "message": "PWM (једна жица по каналу)"
+    },
+    "featureRX_MSP": {
+        "message": "MSP (управљање путем MSP порта)"
+    },
+    "featureRSSI_ADC": {
+        "message": "Аналогни RSSI улаз"
+    },
+    "featureLED_STRIP": {
+        "message": "Подршка за вишебојну RGB LED траку"
+    },
+    "featureLED_STRIPTip": {
+        "message": "Укључите подршку за вишебојну RGB LED траку, конфигуришите на картици LED трака"
+    },
+    "featureDISPLAY": {
+        "message": "OLED екран"
+    },
+    "featureDISPLAYTip": {
+        "message": "Ако је ова функција укључена, а ниједан уређај за приказ није повезан (или уређај за приказ није укључен), доћи ће до кашњења од приближно 10 секунди при сваком поновном покретању flight контролера."
+    },
+    "featureOSD": {
+        "message": "On Screen Display"
+    },
+    "featureOSDTip": {
+        "message": "Укључите OSD, конфигуришите на картици OSD"
+    },
+    "featureCHANNEL_FORWARDING": {
+        "message": "Прослеђивање помоћних канала на servo излазе"
+    },
+    "featureTRANSPONDER": {
+        "message": "Transponder за трке"
+    },
+    "featureTRANSPONDERTip": {
+        "message": "Подесите га на картици Transponder за трке пошто га укључите."
+    },
+    "featureAIRMODE": {
+        "message": "Трајно укључи Airmode"
+    },
+    "featureRX_SPI": {
+        "message": "SPI Rx (нпр. уграђени Rx)"
+    },
+    "escSensorSerialPort": {
+        "message": "Серијски порт за телеметрију ESC-а"
+    },
+    "escSensorSerialPortHelp": {
+        "message": "UART на ком се чита телеметрија ESC-а. Од API-ја 1.49 задаје се на самом ESC сензору; картица Ports га само приказује."
+    },
+    "featureESC_SENSOR": {
+        "message": "Користите KISS\/BLHeli_32 ESC телеметрију <b>преко засебне жице<\/b>"
+    },
+    "featureANTI_GRAVITY": {
+        "message": "Трајно укључи"
+    },
+    "featureANTI_GRAVITYTip": {
+        "message": "Ако је ово искључено, мод 'ANTI GRAVITY' се може користити за укључивање Anti Gravity помоћу прекидача."
+    },
+    "featureDYNAMIC_FILTER": {
+        "message": "Динамичко жироскопско notch филтрирање"
+    },
+    "configurationFeatureEnabled": {
+        "message": "Укључено"
+    },
+    "configurationFeatureName": {
+        "message": "Функција"
+    },
+    "configurationFeatureDescription": {
+        "message": "Опис"
+    },
+    "configurationMixer": {
+        "message": "Миксер"
+    },
+    "configurationFeatures": {
+        "message": "Остале функције"
+    },
+    "configurationFeatureHelp": {
+        "message": "Помоћ"
+    },
+    "configurationReceiver": {
+        "message": "Пријемник"
+    },
+    "configurationReceiverMode": {
+        "message": "Мод пријемника"
+    },
+    "configurationTelemetry": {
+        "message": "Телеметрија"
+    },
+    "telemetryInstanceTitle": {
+        "message": "Телеметрија $1"
+    },
+    "telemetryInstanceProtocol": {
+        "message": "Протокол"
+    },
+    "telemetryInstancePort": {
+        "message": "Серијски порт"
+    },
+    "telemetryInstanceBaud": {
+        "message": "Брзина преноса"
+    },
+    "rcdeviceSectionTitle": {
+        "message": "Контрола камере"
+    },
+    "rcdeviceSerialPort": {
+        "message": "Серијски порт"
+    },
+    "rcdeviceSerialPortHelp": {
+        "message": "UART на који је повезана камера са RunCam протоколом. Од API-ја 1.49 задаје се на самом уређају; картица Ports га само приказује."
+    },
+    "configurationTelemetryHelp": {
+        "message": "Телеметријски излаз из пријемника"
+    },
+    "configurationRSSI": {
+        "message": "RSSI"
+    },
+    "configurationRSSIHelp": {
+        "message": "RSSI је мера јачине сигнала и врло је користан да бисте знали када дрон излази из домета или када трпи радио-сметње."
+    },
+    "configurationEscFeatures": {
+        "message": "Регулатори и мотори"
+    },
+    "configurationFeaturesHelp": {
+        "message": "<strong>Напомена:<\/strong> не могу се све могућности комбиновати. Када фирмвер открије недозвољену комбинацију, сукобљене могућности се искључују.<br \/><strong>Напомена:<\/strong> подесите серијске портове <span class=\"message-negative\">пре<\/span> него што укључите могућности које те портове користе."
+    },
+    "configurationSerialRXHelp": {
+        "message": "&#8226; UART на који је везан пријемник мора бити постављен на „Serial Rx“ (на картици <i>Портови<\/i>)<br>&#8226; Испод, из падајуће листе, изаберите исправан начин записа података:"
+    },
+    "configurationSpiRxHelp": {
+        "message": "<strong>Напомена:<\/strong> SPI пријемник ради само ако је одговарајући уређај уграђен на плочицу или везан на SPI магистралу."
+    },
+    "configurationActiveImu": {
+        "message": "Активни IMU"
+    },
+    "configurationMagAlignmentHelp": {
+        "message": "Поравнање магнетометра је положај тог сензора на плочици flight контролера. Фабричка вредност је обично исправна, али ако имате сопствени склоп или flight контролер са другачије постављеним магнетометром, ово можда треба прилагодити."
+    },
+    "configurationMagDeclination": {
+        "message": "Магнетна деклинација"
+    },
+    "configurationMagDeclinationInput": {
+        "message": "Деклинација у степенима"
+    },
+    "configurationMagDeclinationHelp": {
+        "message": "Магнетна деклинација је угао између магнетног и правог севера. Разликује се за свако место на земљи. Вредност за своје место можете наћи на интернету."
+    },
+    "configurationRangefinder": {
+        "message": "Мерач висине",
+        "description": "Don't translate!!!"
+    },
+    "configurationRangefinderHelp": {
+        "message": "Укључује мерач који мери растојање до тла у центиметрима."
+    },
+    "configurationRangefinderType": {
+        "message": "Тип"
+    },
+    "rangefinderSerialPort": {
+        "message": "Серијски порт за мерач удаљености"
+    },
+    "rangefinderSerialPortHelp": {
+        "message": "UART на који је повезан мерач удаљености. Од API-ја 1.49 задаје се на самом мерачу; картица Ports га само приказује."
+    },
+    "opticalflowSerialPort": {
+        "message": "Серијски порт за оптички проток"
+    },
+    "opticalflowSerialPortHelp": {
+        "message": "UART на који је повезан сензор оптичког протока. Модулу који јавља и проток и удаљеност сваки се задаје посебно."
+    },
+    "configurationOpticalflow": {
+        "message": "Оптички сензор кретања",
+        "description": "Don't translate!!!"
+    },
+    "configurationOpticalflowHelp": {
+        "message": "Укључује оптички сензор кретања."
+    },
+    "configurationBoardAlignment": {
+        "message": "Board and Sensor Alignment"
+    },
+    "configurationBoardAlignmentRoll": {
+        "message": "Roll°"
+    },
+    "configurationBoardAlignmentPitch": {
+        "message": "Pitch°"
+    },
+    "configurationBoardAlignmentYaw": {
+        "message": "Yaw°"
+    },
+    "configurationMagAlignment": {
+        "message": "Поравнање магнетометра"
+    },
+    "configurationBoardAlignmentHelp": {
+        "message": "Произвољно окретање плочице у степенима, да би могла да се угради бочно, наопако, закренуто и слично. Када користите спољне сензоре, њихов положај задајте кроз поравнање сензора (жироскоп, акцелерометар, магнетометар), независно од положаја саме плочице."
+    },
+    "boardAlignmentWizard-Launch": {
+        "message": "Аутоматско препознавање оријентације плочице"
+    },
+    "boardAlignmentWizard-DialogTitle": {
+        "message": "Чаробњак за оријентацију плочице"
+    },
+    "boardAlignmentWizard-Intro": {
+        "message": "Овај чаробњак препознаје како је Ваш flight контролер монтиран водећи Вас кроз четири једноставна покрета. Поставите дрон на равну површину тако да је камера окренута од Вас (према екрану), а затим пратите упутства."
+    },
+    "boardAlignmentWizard-Start": {
+        "message": "Покрени"
+    },
+    "boardAlignmentWizard-Step": {
+        "message": "Корак"
+    },
+    "boardAlignmentWizard-HintFlat": {
+        "message": "Поставите дрон на равно са камером окренутом од Вас (према екрану)."
+    },
+    "boardAlignmentWizard-HintPitchDown": {
+        "message": "Нагните нос надоле за око 45°, тако да камера буде усмерена ка земљи."
+    },
+    "boardAlignmentWizard-HintRollRight": {
+        "message": "Нагните десну страну надоле за око 45°, спуштајући десне кракове и подижући леве."
+    },
+    "boardAlignmentWizard-HintYawCW": {
+        "message": "Ротирајте дрон за око 45° у смеру казаљке на сату (гледано одозго)."
+    },
+    "boardAlignmentWizard-HintLevel": {
+        "message": "Вратите дрон у равни положај."
+    },
+    "boardAlignmentWizard-HoldSteady": {
+        "message": "Држите мирно..."
+    },
+    "boardAlignmentWizard-Settling": {
+        "message": "Смиривање"
+    },
+    "boardAlignmentWizard-Tilting": {
+        "message": "Наставите да нагињете"
+    },
+    "boardAlignmentWizard-LevelOut": {
+        "message": "Вратите у равни положај"
+    },
+    "boardAlignmentWizard-AxisDetected": {
+        "message": "Оса је препозната — држите мирно"
+    },
+    "boardAlignmentWizard-YawProgress": {
+        "message": "Ротација"
+    },
+    "boardAlignmentWizard-Computing": {
+        "message": "Израчунавање оријентације..."
+    },
+    "boardAlignmentWizard-ResultTitle": {
+        "message": "Препозната оријентација"
+    },
+    "boardAlignmentWizard-ResultNoChange": {
+        "message": "Оријентација Ваше плочице делује исправно — промене нису потребне."
+    },
+    "boardAlignmentWizard-ResultCurrent": {
+        "message": "Струја"
+    },
+    "boardAlignmentWizard-ResultDetected": {
+        "message": "Препознато"
+    },
+    "boardAlignmentWizard-Back": {
+        "message": "Назад"
+    },
+    "boardAlignmentWizard-Apply": {
+        "message": "Примени"
+    },
+    "boardAlignmentWizard-Cancel": {
+        "message": "Откажи"
+    },
+    "boardAlignmentWizard-Retry": {
+        "message": "Покушајте поново"
+    },
+    "boardAlignmentWizard-CaptureNow": {
+        "message": "Забележи сада"
+    },
+    "boardAlignmentWizard-LowConfidence": {
+        "message": "Поузданост препознавања је смањена — проверите резултат у односу на живи приказ положаја пре примене."
+    },
+    "boardAlignmentWizard-NoAccelerometer": {
+        "message": "Акцелерометар је неопходан за покретање овог чаробњака."
+    },
+    "boardAlignmentWizard-AccNeedsCalibration": {
+        "message": "Калибришите акцелерометар пре покретања овог чаробњака."
+    },
+    "boardAlignmentWizard-Error-missing_samples": {
+        "message": "Неки узорци нису прикупљени. Покушајте поново."
+    },
+    "boardAlignmentWizard-Error-no_gravity": {
+        "message": "Акцелерометар не очитава гравитацију. Проверите да ли је FC повезан и да се не креце."
+    },
+    "boardAlignmentWizard-Error-no_pitch_tilt": {
+        "message": "Покрет за Pitch није детектован. Молимо Вас покушајте поново и нагните нос још више наниже."
+    },
+    "boardAlignmentWizard-Error-no_roll_tilt": {
+        "message": "Покрет за Roll није детектован. Молимо Вас покушајте поново и нагните десну страну још више наниже."
+    },
+    "boardAlignmentWizard-Error-gesture_direction_mismatch": {
+        "message": "Један од покрета нагињања је био у погрешном смеру. Проверите смерове за Pitch и Roll и покушајте поново."
+    },
+    "boardAlignmentWizard-StepFlat": {
+        "message": "Равно"
+    },
+    "boardAlignmentWizard-StepPitch": {
+        "message": "Pitch"
+    },
+    "boardAlignmentWizard-StepRoll": {
+        "message": "Roll"
+    },
+    "boardAlignmentWizard-StepYaw": {
+        "message": "Yaw"
+    },
+    "boardAlignmentWizard-Confirmed": {
+        "message": "Забележено"
+    },
+    "configurationSensorGyroToUse": {
+        "message": "Жироскоп и акцелерометар"
+    },
+    "configurationSensorGyroToUseFirst": {
+        "message": "Први"
+    },
+    "configurationSensorGyroToUseSecond": {
+        "message": "Други"
+    },
+    "configurationSensorGyroToUseBoth": {
+        "message": "Оба"
+    },
+    "configurationSensorAlignmentGyro1": {
+        "message": "Први жироскоп"
+    },
+    "configurationSensorAlignmentGyro2": {
+        "message": "Други жироскоп"
+    },
+    "configurationSensorAlignmentDefaultOption": {
+        "message": "Фабричко"
+    },
+    "configurationSensorAlignmentCustom": {
+        "message": "Прилагођено"
+    },
+    "configurationAccelTrimRoll": {
+        "message": "Фино подешавање акцелерометра — Roll"
+    },
+    "configurationAccelTrimPitch": {
+        "message": "Фино подешавање акцелерометра — Pitch"
+    },
+    "configurationArming": {
+        "message": "Армовање"
+    },
+    "configurationArmingHelp": {
+        "message": "Неке могућности армовања траже да акцелерометар буде укључен."
+    },
+    "configurationReverseMotorSwitch": {
+        "message": "Смер обртања мотора је обрнут"
+    },
+    "configurationReverseMotorSwitchHelp": {
+        "message": "Овом поставком се распореду мотора јавља да је смер обртања обрнут и да су пропелери постављени у складу с тим. <strong>Пажња:<\/strong> ово НЕ обрће смер мотора. За to користите програм за своје регулаторе или замените редослед жица између регулатора и мотора. Такође, са скинутим пропелерима проверите да се мотори окрећу у смеровима приказаним на слици изнад, пре него што покушате да армујете."
+    },
+    "configurationAutoDisarmDelay": {
+        "message": "Разоружавање мотора после задатог времена [секунде] (захтева MOTOR_STOP)"
+    },
+    "configurationAutoDisarmDelayHelp": {
+        "message": "Разоружава моторе после задатог времена у секундама (тражи укључен MOTOR_STOP)."
+    },
+    "configurationGyroCalOnFirstArm": {
+        "message": "Калибрација жироскопа при првом армовању"
+    },
+    "configurationGyroCalOnFirstArmHelp": {
+        "message": "Када је укључено, жироскоп се калибрише при првом армовању после укључивања. То помаже да се смањи одступање жироскопа током лета."
+    },
+    "configurationMotorIdle": {
+        "message": "Празан ход мотора (%)"
+    },
+    "configurationMotorIdleHelp": {
+        "message": "Задаје брзину празног хода мотора док је дрон армован а гас низак (испод `min_check`).<br\/><br\/><strong class=\"message-positive\">Динамички празан ход искључен<\/strong><br\/><br\/>Сваки мотор добија `min_command` увећан за проценат празног хода.<br\/><br\/><b>Празан ход пренизак<\/b>: мотори можда неће поуздано кренути, споро се покрећу или губе корак при превртајима.<br\/><br\/><b>Празан ход превисок<\/b>: дрон делује као да лебди.<br\/><br\/><b>Напомена<\/b>: аналогни регулатори морају бити калибрисани тако да мотори крену тек мало изнад `min_command`.<br\/><br\/><strong class=\"message-positive\">Динамички празан ход укључен<\/strong><br\/><br\/>При армовању се сваком мотору шаље уобичајена вредност празног хода док се не покрене.<br\/><br\/>Када се окрене, сигнал мотора се прилагођава да би се постигла задата брзина обртања.<br\/><br\/>Пре полетања сигнал је ограничен на задати проценат празног хода, па задата брзина можда неће бити постигнута. To је у реду. Када гас пређе проценат задат кроз `airmode_motor_start_throttle`, граница је знатно виша и задата брзина се постиже.<br\/><br\/><b>Празан ход пренизак<\/b>: мотори можда неће поуздано кренути<br\/><br\/><b>Празан ход превисок<\/b>: подрхтавање пре полетања, али само ако је и динамички празан ход висок<br\/><br\/><b>Напомена<\/b>: динамички празан ход тражи DShot и DShot телеметрију."
+    },
+    "configurationMotorPoles": {
+        "message": "Број полова мотора",
+        "description": "One of the fields of the ESC\/Motor configuration"
+    },
+    "configurationMotorPolesLong": {
+        "message": "$t(configurationMotorPoles.message) (број магнета на звону мотора)",
+        "description": "One of the fields of the ESC\/Motor configuration"
+    },
+    "configurationMotorPolesHelp": {
+        "message": "Број полова је број магнета на звону мотора. НЕ бројте статоре на којима су намотаји. Мотори за петице обично имају четрнаест магнета, а тројке и мањи често дванаест.",
+        "description": "Help text for the Motor poles field of the ESC\/Motor configuration"
+    },
+    "configurationMotorIdleRpmHelp": {
+        "message": "Ово је вредност динамичког празног хода из активног PID профила. Када је динамички празан ход постављен на нулу, важи само стални празан ход мотора. Динамички празан ход мења се на картици PID подешавање.",
+        "description": "Help text for dynamic idle setting"
+    },
+    "configurationThrottleMinimum": {
+        "message": "Најмањи гас (најнижа вредност регулатора док је армован)"
+    },
+    "configurationThrottleMinimumHelp": {
+        "message": "Ово је вредност празног хода која се шаље регулаторима када је дрон армован а ручица гаса у најнижем положају. Повећајте је за бржи празан ход. Повећајте је и ако мотори губе корак."
+    },
+    "configurationThrottleMaximum": {
+        "message": "Највећи гас (највиша вредност регулатора док је армован)"
+    },
+    "configurationThrottleMinimumCommand": {
+        "message": "Најмања команда (вредност регулатора док је разоружан)"
+    },
+    "configurationThrottleMinimumCommandHelp": {
+        "message": "Ово је вредност која се шаље регулаторима док је дрон разоружан. Поставите је тако да мотори стоје (код већине регулатора to је хиљаду)."
+    },
+    "configurationEscProtocolDisabled": {
+        "message": "Изаберите протокол мотора који одговара Вашим регулаторима. $t(escProtocolDisabledMessage.message)"
+    },
+    "escProtocolDisabledMessage": {
+        "message": "<strong>Опрез:<\/strong> Избор протокола излаза мотора који Ваши ESC-ови не подржавају може довести до тога да се <strong>ESC-ови заврте чим се повеже батерија<\/strong>. Из тог разлога, <strong>увек проверите да ли сте скинули пропелере пре првог повезивања батерије након промене протокола излаза мотора<\/strong>."
+    },
+    "configurationDshotBeeper": {
+        "message": "Подешавање DShot пиштања"
+    },
+    "configurationUseDshotBeeper": {
+        "message": "DShot пиштање (мотори пиште док је дрон разоружан)"
+    },
+    "configurationDshotBeaconTone": {
+        "message": "Тон пиштања"
+    },
+    "configurationDshotBeaconHelp": {
+        "message": "DShot пиштање користи регулаторе и моторе да произведу звук. Зато се не може користити док се мотори окрећу. На Betaflight-у 3.4 и новијем, ако покушате да армујете док је DShot пиштање активно, армовање се одлаже две секунде од последњег тона. Time се спречава да пиштање смета командама које се шаљу при армовању.<br\/><strong>Пажња:<\/strong> пошто DShot пиштање пропушта струју кроз моторе, прејако подешена јачина може да изазове прегревање и да оштети моторе или регулаторе. Јачину подешавајте и проверавајте кроз BLHeli Configurator или BLHeli Suite."
+    },
+    "configurationBeeper": {
+        "message": "Подешавање пискалице"
+    },
+    "beeperGYRO_CALIBRATED": {
+        "message": "Огласи се када је жироскоп калибрисан"
+    },
+    "beeperRX_LOST": {
+        "message": "Огласи се када је TX искључен или је сигнал изгубљен (понавља се док TX не буде у реду)"
+    },
+    "beeperRX_LOST_LANDING": {
+        "message": "Огласи SOS када је армован а TX је искључен или је сигнал изгубљен (аутоматско слетање \/ аутоматско разоружавање)"
+    },
+    "beeperDISARMING": {
+        "message": "Огласи се при разоружавању flight контролера"
+    },
+    "beeperARMING": {
+        "message": "Огласи се при армовању flight контролера"
+    },
+    "beeperARMING_GPS_FIX": {
+        "message": "Огласи се посебним тоном при армовању плочице када GPS има сигнал"
+    },
+    "beeperBAT_CRIT_LOW": {
+        "message": "Дужи звучни сигнали упозорења када је батерија критично празна (понавља се)"
+    },
+    "beeperBAT_LOW": {
+        "message": "Звучни сигнали упозорења када је батерија при крају (понавља се)"
+    },
+    "beeperGPS_STATUS": {
+        "message": "Бројем звучних сигнала приказује колико је GPS сателита пронађено"
+    },
+    "beeperRX_SET": {
+        "message": "Огласи се када је AUX канал подешен за звучни сигнал"
+    },
+    "beeperACC_CALIBRATION": {
+        "message": "Потврда да је калибрација акцелерометра у лету завршена"
+    },
+    "beeperACC_CALIBRATION_FAIL": {
+        "message": "Калибрација акцелерометра у лету није успела"
+    },
+    "beeperREADY_BEEP": {
+        "message": "Огласи се када је GPS закључан и спреман"
+    },
+    "beeperDISARM_REPEAT": {
+        "message": "Звучни сигнали док се ручица држи у позицији за разоружавање"
+    },
+    "beeperARMED": {
+        "message": "Звучни сигнали упозорења када је плочица армована а мотори не раде у мировању (понавља се док се плочица не разоружа или се не повећа гас)"
+    },
+    "beeperSYSTEM_INIT": {
+        "message": "Звучни сигнали иницијализације када се плочица укључи"
+    },
+    "beeperUSB": {
+        "message": "Звучни сигнал када се flight контролер напаја преко USB-а. Искључите ово ако не желите да пискалица ради док је летелица на радном столу"
+    },
+    "beeperBLACKBOX_ERASE": {
+        "message": "Звучни сигнал када се заврши брисање Blackbox-а"
+    },
+    "beeperCRASH_FLIP": {
+        "message": "Звучни сигнал када је активан crash flip мод"
+    },
+    "beeperCAM_CONNECTION_OPEN": {
+        "message": "Звучни сигнал када се уђе у контролу камере помоћу 5 тастера"
+    },
+    "beeperCAM_CONNECTION_CLOSE": {
+        "message": "Звучни сигнал када се изађе из контроле камере помоћу 5 тастера"
+    },
+    "beeperRC_SMOOTHING_INIT_FAIL": {
+        "message": "Звучни сигнал када је летелица армована а RC ублажавање није иницијализовало филтере"
+    },
+    "configurationBeeperEnableAll": {
+        "message": "Укључи све"
+    },
+    "configurationBeeperDisableAll": {
+        "message": "Искључи све"
+    },
+    "configuration3d": {
+        "message": "Рад мотора у оба смера"
+    },
+    "configuration3dDeadbandLow": {
+        "message": "Доња мртва зона"
+    },
+    "configuration3dDeadbandHigh": {
+        "message": "Горња мртва зона"
+    },
+    "configuration3dNeutral": {
+        "message": "Неутрални положај"
+    },
+    "configuration3dDeadbandThrottle": {
+        "message": "Мртва зона гаса"
+    },
+    "configurationSystem": {
+        "message": "Подешавање система"
+    },
+    "configurationLoopTime": {
+        "message": "Време циклуса flight контролера"
+    },
+    "configurationCalculatedCyclesSec": {
+        "message": "Циклуса у секунди [Hz]"
+    },
+    "configurationSpeedGyroNoGyro": {
+        "message": "Нема жироскопа",
+        "description": "When no gyro is configured this appears in place of the speed of the gyro in kHz"
+    },
+    "configurationSpeedPidNoGyro": {
+        "message": "Жироскоп \/ {{value}}",
+        "description": "When no gyro is configured this appears in place of the speed of the PID in kHz. Try to keep it short."
+    },
+    "configurationKHzUnitLabel": {
+        "message": "{{value}} kHz",
+        "description": "Value for some options that show the speed of gyro, pid, etc. in kHz"
+    },
+    "configurationLoopTimeHelp": {
+        "message": "<strong>Напомена:<\/strong> проверите да Ваш flight контролер може да ради на овим брзинама. Пратите оптерећење процесора и постојаност времена циклуса. После ове измене можда ће бити потребно поново подесити PID. САВЕТ: искључивањем акцелерометра и других сензора добија се више снаге."
+    },
+    "configurationGPS": {
+        "message": "Конфигурација"
+    },
+    "configurationGPSHelp": {
+        "message": "Подесите протокол за GPS уређај (не заборавите да подесите порт на картици Портови), користите аутоматску брзину преноса или је задајте на картици Портови, уз остала подешавања.",
+        "description": "Help text GPS configuration"
+    },
+    "configurationGPSProtocol": {
+        "message": "Протокол"
+    },
+    "configurationGPSBaudrate": {
+        "message": "Брзина преноса"
+    },
+    "configurationGPSubxSbas": {
+        "message": "Врста земаљске подршке"
+    },
+    "gpsSerialPort": {
+        "message": "Серијски порт"
+    },
+    "gpsSerialPortHelp": {
+        "message": "UART на који је повезан GPS модул. Промена захтева рестарт."
+    },
+    "gpsSerialBaud": {
+        "message": "Брзина преноса"
+    },
+    "gpsSerialBaudHelp": {
+        "message": "Брзина на којој се очекује да GPS модул ради. Када не успе да успостави везу, Betaflight проба и остале брзине, па је ово полазна вредност, а не чврсто подешавање."
+    },
+    "gpsSerialPortSaveFailed": {
+        "message": "Серијски порт за GPS није могао да се постави, па ништа није сачувано."
+    },
+    "gpsCanDevice": {
+        "message": "CAN магистрала"
+    },
+    "gpsCanDeviceHelp": {
+        "message": "CAN магистрала на коју су повезани DroneCAN модули. Она припада целом DroneCAN систему, па њена промена помера сваки DroneCAN уређај, не само GPS. Промена захтева рестарт."
+    },
+    "gpsCanDeviceSaveFailed": {
+        "message": "CAN магистрала није могла да се постави, па ништа није сачувано."
+    },
+    "configurationGPSAutoBaud": {
+        "message": "Аутоматска брзина преноса"
+    },
+    "configurationGPSAutoConfig": {
+        "message": "Аутоматско подешавање"
+    },
+    "configurationGPSGalileo": {
+        "message": "Користи Galileo",
+        "description": "Option to use Galileo in the GPS configuration"
+    },
+    "configurationGPSGalileoHelp": {
+        "message": "Када је укључено, GPS модул прати и систем Galileo, што обично даје више ухваћених сателита. На Betaflight-у 4.2.x и старијим истовремено искључује QZSS допунски систем.",
+        "description": "Help text for the option to use Galileo in the GPS configuration"
+    },
+    "configurationGPSHomeOnce": {
+        "message": "Забележи место полетања само једном",
+        "description": "Option to set the Home Point with the first arm only, not with each arm in the GPS Configuration"
+    },
+    "configurationGPSHomeOnceHelp": {
+        "message": "Када је укључено, као место полетања памти се само прво армовање после прикључивања батерије. Ако није укључено, место полетања се освежава при сваком армовању.",
+        "description": "Help text for the option to set the Home Point with the first arm only, not with each arm in the GPS Configuration"
+    },
+    "configurationGPSNotInBuild": {
+        "message": "Подршка за GPS није укључена у ову верзију фирмвера. Поново направите фирмвер са укљученом GPS опцијом да бисте могли да га подесите и користите.",
+        "description": "Shown in the GPS Configuration box when the connected firmware was built without the GPS build option"
+    },
+    "configurationSerialRX": {
+        "message": "Врста серијског пријемника"
+    },
+    "portsPortNone": {
+        "message": "Ништа"
+    },
+    "receiverSerialPort": {
+        "message": "Серијски порт"
+    },
+    "receiverSerialPortHelp": {
+        "message": "UART на који је повезан серијски пријемник. Брзина преноса података прати провајдера, тако да овде нема шта да се подешава. Промена порта захтева поновно покретање."
+    },
+    "receiverSerialPortSaveFailed": {
+        "message": "Није било могуће подесити серијски порт пријемника, тако да ништа није сачувано."
+    },
+    "someRXTypesDisabled": {
+        "message": "Неки провајдери пријемника нису подржани у тренутној конфигурацији израде."
+    },
+    "serialRXNotSupported": {
+        "message": "Изабрани провајдер пријемника није подржан у тренутној конфигурацији израде. Изаберите другог провајдера или ажурирајте фирмвер са изабраним одговарајућим радио протоколом у конфигурацији израде."
+    },
+    "configurationSpiRX": {
+        "message": "Врста SPI пријемника"
+    },
+    "configurationSaved": {
+        "message": "Подешавања сачувана"
+    },
+    "configurationButtonSave": {
+        "message": "Сачувај и рестартуј"
+    },
+    "dialogClose": {
+        "message": "Затвори"
+    },
+    "dialogDynFiltersChangeTitle": {
+        "message": "Промена Dynamic Notch вредности"
+    },
+    "dialogDynFiltersChangeNote": {
+        "message": "<span class=\"message-negative\"><b>УПОЗОРЕЊЕ: Ова промена ће укључити\/искључити RPM филтрирање, чиме се повећава\/смањује кашњење\/ефикасност филтера.<\/b><\/span><br><br>Вратити динамичке notch филтере на препоручене вредности?"
+    },
+    "portsIdentifier": {
+        "message": "Идентификатор"
+    },
+    "portsConfiguration": {
+        "message": "Конфигурација\/MSP"
+    },
+    "portsSerialRx": {
+        "message": "Serial Rx"
+    },
+    "portsSerialRxHelp": {
+        "message": "Укључите или искључите серијски пријемник (RX) на наведеном UART-у. Дозвољен је само један."
+    },
+    "portsSensorIn": {
+        "message": "Улаз сензора"
+    },
+    "portsTelemetryOut": {
+        "message": "Излаз телеметрије"
+    },
+    "portsPeripherals": {
+        "message": "Периферије"
+    },
+    "portsHelp": {
+        "message": "<strong>Напомена:<\/strong> нису све комбинације важеће. Када фирмвер flight контролера ово детектује, конфигурација серијских портова ће бити ресетована."
+    },
+    "portsVtxTableNotSet": {
+        "message": "<span class=\"message-negative\">УПОЗОРЕЊЕ:<\/span> VTX табела није исправно подешена и без ње VTX контрола неће бити могућа. Молимо подесите VTX табелу у картици $t(tabVtx.message)."
+    },
+    "portsMSPHelp": {
+        "message": "<strong>Напомена:<\/strong> НЕ <span class=\"message-negative\">искључујте<\/span> MSP на првом серијском порту осим ако не знате шта радите. У супротном ћете можда морати поново да инсталирате фирмвер и обришете конфигурацију."
+    },
+    "portsReadOnlyHelp": {
+        "message": "<strong>Напомена:<\/strong> овај фирмвер додељује серијске портове на сопственој картици сваке функције, тако да је овај приказ само за читање. Приказује који порт тренутно користи свака функција; промените доделу на картици која садржи ту функцију."
+    },
+    "portsFirmwareUpgradeRequired": {
+        "message": "Надоградња фирмвера је <span class=\"message-negative\">обавезна<\/span>. Конфигурација серијских портова за фирмвер &lt; 1.8.0 није подржана."
+    },
+    "portsButtonSave": {
+        "message": "Сачувај и рестартуј"
+    },
+    "portsTelemetryDisabled": {
+        "message": "Искључено"
+    },
+    "portsFunction_MSP": {
+        "message": "MSP"
+    },
+    "portsFunction_GPS": {
+        "message": "GPS"
+    },
+    "portsFunction_TELEMETRY_FRSKY": {
+        "message": "FrSky"
+    },
+    "portsFunction_TELEMETRY_HOTT": {
+        "message": "HoTT"
+    },
+    "portsFunction_TELEMETRY_LTM": {
+        "message": "LTM"
+    },
+    "portsFunction_TELEMETRY_MAVLINK": {
+        "message": "MAVLink"
+    },
+    "portsFunction_TELEMETRY_MSP": {
+        "message": "MSP"
+    },
+    "portsFunction_TELEMETRY_SMARTPORT": {
+        "message": "SmartPort"
+    },
+    "portsFunction_TELEMETRY_IBUS": {
+        "message": "iBUS"
+    },
+    "portsFunction_TELEMETRY_JETIXBUS": {
+        "message": "JETIXBUS"
+    },
+    "portsFunction_TELEMETRY_CRSF": {
+        "message": "CRSF"
+    },
+    "portsFunction_TELEMETRY_SRXL": {
+        "message": "SRXL"
+    },
+    "portsFunction_ESC_SENSOR": {
+        "message": "ESC"
+    },
+    "portsFunction_RX_SERIAL": {
+        "message": "Serial RX"
+    },
+    "portsFunction_BLACKBOX": {
+        "message": "Blackbox снимање"
+    },
+    "portsFunction_TBS_SMARTAUDIO": {
+        "message": "VTX (TBS SmartAudio)"
+    },
+    "portsFunction_IRC_TRAMP": {
+        "message": "VTX (IRC Tramp)"
+    },
+    "portsFunction_RUNCAM_DEVICE_CONTROL": {
+        "message": "Камера (RunCam протокол)"
+    },
+    "portsFunction_FRSKY_OSD": {
+        "message": "OSD (FrSky протокол)"
+    },
+    "portsFunction_VTX_MSP": {
+        "message": "VTX (MSP + Displayport)"
+    },
+    "portsFunction_GIMBAL": {
+        "message": "Gimbal"
+    },
+    "portsFunction_OSD_CUSTOM_TEXT": {
+        "message": "Произвољни OSD текст"
+    },
+    "pidTuningProfileOption": {
+        "message": "Профил $1"
+    },
+    "pidTuningRateProfileOption": {
+        "message": "Rateprofile $1"
+    },
+    "portsFunction_LIDAR_TF": {
+        "message": "Benewake LIDAR"
+    },
+    "pidTuningUpgradeFirmwareToChangePidController": {
+        "message": "<span class=\"message-negative\">Промена PID контролера је онемогућена - можете је променити путем CLI-ја.<\/span> Имате фирмвер са верзијом API-ја <span class=\"message-negative\">$1<\/span>, али ова функционалност захтева <span class=\"message-positive\">$2<\/span>."
+    },
+    "pidTuningSubTabPid": {
+        "message": "Подешавања PID профила"
+    },
+    "pidTuningSubTabRates": {
+        "message": "Подешавања Rate профила"
+    },
+    "pidTuningSubTabFilter": {
+        "message": "Подешавања филтера"
+    },
+    "pidProfileName": {
+        "message": "Назив PID профила"
+    },
+    "pidProfileNameHelp": {
+        "message": "Назив PID профила који може описати за какве је услове овај профил подешен: лакша\/тежа батерија, акциона камера \/ без акционе камере, већа надморска висина итд."
+    },
+    "rateProfileName": {
+        "message": "Назив Rate профила"
+    },
+    "rateProfileNameHelp": {
+        "message": "Назив Rate профила који може описати за коју врсту летења је овај профил намењен: филмско снимање, трке, freestyle итд."
+    },
+    "pidTuningShowAllPids": {
+        "message": "Прикажи све PID-ове"
+    },
+    "pidTuningHideUnusedPids": {
+        "message": "Сакриј неискоришћене PID-ове"
+    },
+    "pidTuningNonProfilePidSettings": {
+        "message": "Подешавања PID контролера независна од профила"
+    },
+    "pidTuningAntiGravity": {
+        "message": "Anti Gravity"
+    },
+    "pidTuningAntiGravityMode": {
+        "message": "Мод",
+        "description": "Anti Gravity mode selection parameter"
+    },
+    "pidTuningAntiGravityModeOptionSmooth": {
+        "message": "Ублажено",
+        "description": "One of the modes of anti gravity"
+    },
+    "pidTuningAntiGravityModeOptionStep": {
+        "message": "Корак",
+        "description": "One of the modes of anti gravity"
+    },
+    "pidTuningAntiGravityGain": {
+        "message": "Gain",
+        "description": "Anti Gravity Gain Parameter"
+    },
+    "pidTuningAntiGravityGainHelp": {
+        "message": "Повећава iTerm и повећава P током брзих промена гаса.<br><br>8.0 значи око 8x појачање iTerm-а",
+        "description": "Anti Gravity Gain Parameter Help Icon"
+    },
+    "pidTuningAntiGravityThres": {
+        "message": "Праг",
+        "description": "Anti Gravity Threshold Parameter"
+    },
+    "pidTuningAntiGravityHelp": {
+        "message": "Anti Gravity повећава I (и, у верзији 4.3, P) током и убрзо након брзих промена гаса, повећавајући стабилност положаја током наглог давања гаса.<br><br>Веће вредности појачања могу побољшати стабилност на летелицама са слабијим одзивом или онима са помереним тежиштем."
+    },
+    "pidTuningDerivative": {
+        "message": "Деривативни",
+        "description": "Table header of the Derivative feature in the PIDs tab"
+    },
+    "pidTuningDMaxFeatureTitle": {
+        "message": "Динамичко пригушење \/ D Max подешавања",
+        "description": "Title for the options panel for the D Max feature"
+    },
+    "pidTuningDMaxSettingTitle": {
+        "message": "Динамичко<br>пригушење",
+        "description": "Sidebar title for the options panel for the D Max feature"
+    },
+    "pidTuningDMaxGain": {
+        "message": "Gain",
+        "description": "Gain of the D Max feature"
+    },
+    "pidTuningDMaxGainHelp": {
+        "message": "D Max Gain повећава осетљивост система који повећава D када се летелица брзо окреће или тресе у вртложењу пропелер (propwash).<br><br>Веће вредности за Gain подижу D лакше него мање вредности, брже приближавајући D према D Max. Вредности од 40 или чак 50 могу добро радити за чисте freestyle летелице.<br><br>Мање вредности неће подизати D према D Max осим при веома брзим потезима, и могу више одговарати тркачким подешавањима смањујући кашњење D параметра.<br><br>УПОЗОРЕЊЕ: Gain или Advance мора бити подешен изнад око 20, иначе се D неће повећавати како би требало. Подешавање оба на нулу закључаће D на основну вредност.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningDMaxAdvance": {
+        "message": "Advance",
+        "description": "Advance of the D Max feature"
+    },
+    "pidTuningDMaxAdvanceHelp": {
+        "message": "D Max Advance додаје осетљивост на Gain фактор када се ручице брзо померају.<br><br>Advance не реагује на жироскоп или propwash. Делује раније од Gain фактора и повремено је користан за летелице са слабим одзивом које су склоне великом кашњењу на почетку потеза.<br><br>Углавном га је најбоље оставити на нули.<br><br>УПОЗОРЕЊЕ: Advance или Gain мора бити подешен изнад око 20, иначе се D неће повећавати како би требало. Подешавање оба на нулу закључаће D на основну вредност.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningDMaxFeatureHelp": {
+        "message": "D Max повећава D током бржих покрета жироскопа и\/или команди са даљинског.<br><br>Фактор 'Gain' повећава D када се летелица брзо окреће или тресе у вртложењу пропелер (propwash). Обично је потребан само 'Gain'.<br><br>Фактор 'Advance' повећава D према D Max током команди са даљинског. Обично није потребан и треба га подесити на нулу. Advance може бити користан за летелице са слабим одзивом које имају тенденцију великог пребацивања (overshoot).<br><br>Веће вредности за Gain (нпр. 40) могу бити прикладније за freestyle јер лакше подижу D.<br><br>УПОЗОРЕЊЕ: Један од параметара Gain или Advance мора бити подешен изнад око 20, иначе се D неће повећавати како би требало. Подешавање оба на нулу закључаће D на основну вредност.",
+        "description": "D Max feature helpicon message"
+    },
+    "pidTuningPidSettings": {
+        "message": "Подешавања PID контролера"
+    },
+    "pidTuningMotorSettings": {
+        "message": "Подешавања гаса и мотора"
+    },
+    "pidTuningMiscSettings": {
+        "message": "Разна подешавања"
+    },
+    "receiverRcSmoothing": {
+        "message": "RC ублажавање"
+    },
+    "receiverRcSmoothingAuto": {
+        "message": "Аутоматски"
+    },
+    "receiverRcSmoothingManual": {
+        "message": "Ручно"
+    },
+    "receiverRcSmoothingAutoFactor": {
+        "message": "Setpoint Auto фактор",
+        "description": "Setpoint Auto Factor parameter for RC smoothing"
+    },
+    "receiverRcSmoothingAutoFactorHelp": {
+        "message": "Подешава израчунавање Setpoint Auto фактора, 10 је фабрички однос фактора и кашњења. Повећање броја ће више ублажити команде са даљинског, истовремено додајући кашњење. Ово може бити корисно за непоуздане RC везе или за филмско снимање.<br>Будите опрезни са бројевима који се приближавају 50, кашњење уноса ће постати приметно.<br>Користите CLI команду rc_smoothing_info док су TX и RX укључени да бисте видели аутоматски израчунате граничне фреквенције RC ублажавања.",
+        "description": "Setpoint Auto Factor parameter help message"
+    },
+    "receiverRcSmoothingAutoFactorHelp2": {
+        "message": "Подешава Setpoint RC ублажавање. 30 је фабричко. Веће вредности више ублажавају команде са даљинског – нпр. 60 за HD freestyle или 90-120 за филмско снимање. Напомена: Вредности преко 50 ће изазвати приметно кашњење ручице. Ниже вредности, нпр. 20-25, пренеће неке од корака RC контроле у сигнале мотора, благо повећавајући топлоту мотора, али ће благо смањити RC кашњење. Ово може бити корисно за трке.",
+        "description": "Setpoint Auto Factor parameter help message"
+    },
+    "receiverRcSmoothingAutoFactorThrottle": {
+        "message": "Throttle Auto фактор",
+        "description": "Throttle Auto Factor parameter for RC smoothing"
+    },
+    "receiverRcSmoothingAutoFactorThrottleHelp": {
+        "message": "Подешава израчунавање Throttle фактора, 10 је фабрички однос фактора и кашњења. Повећање броја ће више ублажити команде гаса, истовремено додајући кашњење. Ово може бити корисно за непоуздане RC везе или за филмско снимање.<br>Будите опрезни са бројевима који се приближавају 50, кашњење уноса ће постати приметно.<br>Користите CLI команду rc_smoothing_info док су TX и RX укључени да бисте видели аутоматски израчунате граничне фреквенције RC ублажавања.",
+        "description": "Throttle Auto Factor parameter help message"
+    },
+    "receiverRcFeedforwardTypeSelect": {
+        "message": "Feedforward врста граничника"
+    },
+    "receiverRcSetpointTypeSelect": {
+        "message": "Setpoint врста граничника"
+    },
+    "receiverThrottleTypeSelect": {
+        "message": "Throttle врста граничника"
+    },
+    "receiverRcSmoothingInterpolation": {
+        "message": "Интерполација"
+    },
+    "receiverRcSmoothingFilter": {
+        "message": "Filter"
+    },
+    "rcSmoothingSetpointCutoffHelp": {
+        "message": "Гранична фреквенција у Hz коју користи filter Setpoint-а. Коришћење мањих вредности резултираће ублаженијим командама са даљинског и погодније је за спорије протоколе пријемника. Већина корисника треба да остави ово на 0 што одговара опцији „Auto”."
+    },
+    "rcSmoothingFeedforwardCutoffHelp": {
+        "message": "Гранична фреквенција у Hz коју користи Feedforward filter. Коришћење мањих вредности резултираће ублаженијим командама са даљинског и погодније је за спорије протоколе пријемника. Већина корисника треба да остави ово на 0 што одговара опцији „Auto”."
+    },
+    "rcSmoothingChannelsSmoothedHelp": {
+        "message": "Канали на које се примењује ублажавање"
+    },
+    "receiverRcSmoothingSetpointManual": {
+        "message": "Одређује да ли се гранична фреквенција Setpoint филтера аутоматски израчунава (препоручено) или је корисник ручно бира. Коришћење „Ручно“ се не препоручује за протоколе пријемника као што је Crossfire који се могу мењати током лета."
+    },
+    "receiverRcSmoothingFeedforwardManual": {
+        "message": "Одређује да ли се гранична фреквенција Feedforward филтера аутоматски израчунава (препоручено) или је корисник ручно бира. Коришћење „Ручно“ се не препоручује за протоколе пријемника као што је Crossfire који се могу мењати током лета."
+    },
+    "receiverRcSmoothingThrottleManual": {
+        "message": "Одређује да ли се RC ублажавање аутоматски израчунава (препоручено) или је корисник ручно бира. Коришћење „Ручно“ се не препоручује за протоколе пријемника као што је Crossfire који се могу мењати током лета."
+    },
+    "rcSmoothingThrottleCutoffHelp": {
+        "message": "Гранична фреквенција у Hz коју користи filter за ублажавање гаса. Коришћење мањих вредности резултираће ублаженијим командама гаса и погодније је за спорије протоколе пријемника. Већина корисника треба да остави ово на 0 што одговара опцији „Auto”."
+    },
+    "receiverRcSmoothingSetpointHz": {
+        "message": "Setpoint гранична фреквенција"
+    },
+    "receiverRcSmoothingThrottleCutoffHz": {
+        "message": "Throttle гранична фреквенција"
+    },
+    "receiverRcSmoothingFeedforwardCutoff": {
+        "message": "Feedforward гранична фреквенција"
+    },
+    "receiverRcFeedforwardType": {
+        "message": "Feedforward врста филтера"
+    },
+    "receiverRcSmoothingFeedforwardTypeAuto": {
+        "message": "Аутоматски"
+    },
+    "pidTuningDtermSetpointTransition": {
+        "message": "D Setpoint прелаз"
+    },
+    "pidTuningDtermSetpoint": {
+        "message": "D Setpoint тежина"
+    },
+    "pidTuningDtermSetpointTransitionHelp": {
+        "message": "Помоћу овог параметра, D Setpoint тежина се може смањити близу центра ручица, што резултира ублаженијим завршетком окрета (flips и rolls).<br> Вредност представља тачку отклона ручице: 0 – ручица у центру, 1 – пун отклон. Када је ручица изнад те тачке, Setpoint тежина остаје константна на својој подешеној вредности. Када је ручица испод те тачке, Setpoint тежина се пропорционално смањује и достиже 0 у централном положају ручице.<br>Вредност 1 даје максималан ефекат ублажавања, док вредност 0 задржава фиксну Setpoint тежину на подешеној вредности током целог опсега ручице."
+    },
+    "pidTuningDtermSetpointHelp": {
+        "message": "Овај параметар одређује ефекат убрзања ручице унутар изводне компоненте.<br> Вредност 0 је стара Measurement метода где D прати само жироскоп. Вредност 1 је стара Error метода, која користи једнак однос праћења жироскопа и ручице.<br> Мање вредности дају спорији, ублаженији одзив ручице, док веће вредности пружају већи одзив на убрзање ручице.<br>Имајте на уму да се препоручује RC интерполација када користите веће вредности како би се спречили трзаји команди који стварају шум."
+    },
+    "pidTuningDtermSetpointTransitionWarning": {
+        "message": "<span class=\"message-negative\"><strong>$t(warningTitle.message):<\/strong> Употреба D Setpoint прелаза већег од 0 и мањег од 0.1 се изричито не препоручује. То може довести до нестабилности и смањене одзивности ручица када прелазе преко централне тачке.<\/span>"
+    },
+    "pidTuningFeedforwardGroup": {
+        "message": "Feed-<br>forward"
+    },
+    "pidTuningFeedforwardGroupHelp": {
+        "message": "Feedforward прилагођава одзивност ручица.<br \/><br \/> Ове опције Вам омогућавају да га подесите за било шта, од оштрог и тренутног одзива ручица за трке, до меког и ублаженог одзива за филмско снимање \/ HD сврхе."
+    },
+    "pidTuningFeedforwardJitter": {
+        "message": "Редукција подрхтавања"
+    },
+    "pidTuningFeedforwardJitterHelp": {
+        "message": "Редукција подрхтавања смањује Feedforward када се ручице померају полако, без обзира на њихов положај.<br><br>Ово омогућава ублажен лет без подрхтавања при прављењу благих и спорих лукова, док пружа пун Feedforward без икаквог кашњења када се ручице брзо помере. Прелаз није потребан и треба га поставити на нулу када је редукција подрхтавања активна.<br><br>Фабричка вредност је 7. Веће вредности, нпр. 10–12, добре су за филмско снимање или HD freestyle сврхе, док 5 може бити боље за трке са брзим RC везама."
+    },
+    "pidTuningFeedforwardSmoothFactor": {
+        "message": "Ублаженост"
+    },
+    "pidTuningFeedforwardSmoothnessHelp": {
+        "message": "Ублажавање Feedforward-а је кључно за пригушивање шума у Feedforward линији.<br><br>Најмања вредност која даје глатку линију је најбоља.<br><br>Фабричка вредност од 25 је добра за RC везе од 50–150 Hz. За RC везе од 250 Hz користите 40–50. За везе од 500 Hz користите 60–65."
+    },
+    "pidTuningFeedforwardAveraging": {
+        "message": "Израчунавање просека"
+    },
+    "pidTuningFeedforwardAveragingHelp": {
+        "message": "Израчунавање просека Feedforward-а узима просечну вредност последња 2 или 3 Feedforward корака. Ово ублажава Feedforward линију, али додаје мало кашњења.<br><br>Најефикасније је када постоји секвенцијално подрхтавање горе\/доле у сигналу, што је уобичајено код бржих RC веза.<br><br>Просек од 2 тачке је потребан за везе од 500 Hz и бучне везе од 250 Hz, или за летење ради филмског снимања \/ HD-а. Crossfire (пре CRSFShot-а) захтева просек од 3 тачке у режиму од 150 Hz."
+    },
+    "pidTuningOptionOff": {
+        "message": "Искључено"
+    },
+    "pidTuningOptionOn": {
+        "message": "Укључено"
+    },
+    "pidTuningFeedforwardAveragingOption2Point": {
+        "message": "2 тачке"
+    },
+    "pidTuningFeedforwardAveragingOption3Point": {
+        "message": "3 тачке"
+    },
+    "pidTuningFeedforwardAveragingOption4Point": {
+        "message": "4 тачке"
+    },
+    "pidTuningFeedforwardBoost": {
+        "message": "Boost"
+    },
+    "pidTuningFeedforwardBoostHelp": {
+        "message": "Feedforward boost додаје додатни потисак као одговор на убрзање или успорење ручице.<br><br>Ово смањује кашњење жироскопа узроковано кашњењем убрзања мотора и смањује overshoot када се ручице успоравају снажним повлачењем мотора.<br><br>Фабрички boost ради за већину конфигурација. Тркачки пилоти можда више воле да га мало повећају. Boost се може фино подесити пажљивом анализом логова."
+    },
+    "pidTuningFeedforwardMaxRateLimit": {
+        "message": "Max Rate Limit"
+    },
+    "pidTuningFeedforwardMaxRateLimitHelp": {
+        "message": "Смањује Feedforward како се ручице приближавају максималном отклону, како би се смањио overshoot на почетку флипа или ролла.<br><br>Не ради ништа на крају флипа или ролла. Ниже вредности узрокују да слабљење почне раније.<br><br>Обично ова вредност не захтева измене. Најбоља је највиша вредност која даје прихватљив overshoot на почетку roll-ова или flip-ова."
+    },
+    "pidTuningFeedforwardTransition": {
+        "message": "Прелаз"
+    },
+    "pidTuningFeedforwardTransitionHelp": {
+        "message": "Линеарно смањује Feedforward када су ручице близу центра.<br><br>У верзији 4.2 и ранијим, transition се може користити за глађи одзив ручице око централног положаја.<br><br>У верзији 4.3, transition се не препоручује, јер је 'замењен' функцијом за смањење подрхтавања (jitter).<br><br>Вредност 0 искључује transition. Вредност 0.3 смањује Feedforward на нулу када су ручице тачно у центру, али се повећава на пуну нормалну вредност када су ручице >30% ван центра."
+    },
+    "pidTuningProportional": {
+        "message": "<b>P<\/b>roportional"
+    },
+    "pidTuningProportionalHelp": {
+        "message": "Колико чврсто летелица прати ручице (Setpoint).<br \/><br \/>Више вредности (појачања) пружају прецизније праћење, али могу изазвати overshoot ако су превелике у односу на D, и могу изазвати осцилације у заокретима са великим гасом. Замислите P као опругу на аутомобилу.",
+        "description": "Proportional Term helpicon message on PID table titlebar"
+    },
+    "pidTuningIntegral": {
+        "message": "<b>I<\/b>ntegral"
+    },
+    "pidTuningIntegralHelp": {
+        "message": "Контролише трајна мала одступања.<br><br>Слично као P, али се акумулира постепено и полако док грешка не буде нула. Важно за дуготрајније утицаје као што су померен тежиште или стални спољни утицаји попут ветра.<br \/><br \/>Већа појачања пружају прецизније праћење, посебно у заокретима, али летелица може деловати круто.<br><br>Може изазвати споре осцилације код летелица са слабијим одзивом или ако је високо у односу на P.",
+        "description": "Integral Term helpicon message on PID table titlebar"
+    },
+    "pidTuningDMax": {
+        "message": "<b>D<\/b> Max"
+    },
+    "pidTuningDMaxHelp": {
+        "message": "Пружа јаче пригушење за брзе маневре који би иначе могли изазвати overshoot.<br><br>Омогућава нижу основну D min вредност него обично, чинећи да се мотори мање греју и да улазак у заокрет буде бржи, али подиже D ради контроле overshoot-а при флиповима или брзим променама смера.<br><br>Најкорисније за тркаче, бучне летелице или летелице са слабим одзивом.",
+        "description": "D Max Term helpicon message on PID table titlebar"
+    },
+    "pidTuningDerivativeHelp": {
+        "message": "Контролише јачину пригушења БИЛО КОГ кретања летелице. За померање ручица, D-члан пригушује команду. За спољне утицаје (propwash ИЛИ удар ветра) D-члан пригушује тај утицај.<br><br>Већа појачања дају више пригушења и смањују overshoot изазван P-чланом и FF-ом.<br>Међутим, D-члан је ВЕОМА осетљив на високофреквентне вибрације жироскопа (шум | увећава их 10x до 100x).<br><br>Високофреквентни шум може изазвати грејање мотора и прегоревање мотора ако су D-појачања превисока или ако шум жироскопа није добро филтриран (погледајте картицу Филтери).<br><br>Замислите D-члан као амортизер на аутомобилу, али са негативним својством да увећава високофреквентни шум жироскопа.",
+        "description": "Derivative Term helpicon message on PID table titlebar"
+    },
+    "pidTuningFeedforward": {
+        "message": "<b>F<\/b>eedforward"
+    },
+    "pidTuningFeedforwardHelp": {
+        "message": "Додатни фактор управљања, изведен искључиво из команди са ручице, који помаже да се летелица брзо покрене при брзим померањима ручице.<br><br>FF не може изазвати осцилације, омогућава нижи P за сличан одзив ручице и компензује природно противљење D-члана командама са ручице.<br><br>Ниске или нулте вредности резултираће блажим, али одложенијим одзивом на команде са ручице.",
+        "description": "Feedforward Term helpicon message on PID table titlebar"
+    },
+    "pidTuningMaxRateWarning": {
+        "message": "<span class=\"message-negative\"><b>Упозорење:<\/b><\/span> веома високи rates могу довести до десинхронизације услед наглих успорења."
+    },
+    "pidTuningRcRate": {
+        "message": "RC Rate"
+    },
+    "pidTuningMaxVel": {
+        "message": "Max Vel [deg\/s]"
+    },
+    "pidTuningRate": {
+        "message": "Rate"
+    },
+    "pidTuningSuperRate": {
+        "message": "Super Rate"
+    },
+    "pidTuningRatesPreview": {
+        "message": "Преглед рејтова"
+    },
+    "pidTuningRatesModelPreview": {
+        "message": "Преглед модела рејтова"
+    },
+    "pidTuningRatesTuningHelp": {
+        "message": "<b>Rates и Expo<\/b>: Одредите осећај на ручици на основу ових параметара. Користите график и 3D модел уживо да пронађете Ваша омиљена rate подешавања."
+    },
+    "pidTuningRcExpo": {
+        "message": "RC Expo"
+    },
+    "pidTuningTpaGroup": {
+        "message": "TPA"
+    },
+    "pidTuningTPAMode": {
+        "message": "TPA Mode"
+    },
+    "pidTuningTPA": {
+        "message": "TPA"
+    },
+    "pidTuningTPARate": {
+        "message": "TPA Rate (%)"
+    },
+    "pidTuningTPABreakPoint": {
+        "message": "TPA Breakpoint (μс)"
+    },
+    "pidTuningTPAPD": {
+        "message": "PD"
+    },
+    "pidTuningTPAD": {
+        "message": "D"
+    },
+    "pidTuningThrottleCurvePreview": {
+        "message": "Преглед криве гаса"
+    },
+    "pidTuningThrottleLimitType": {
+        "message": "Ограничење гаса"
+    },
+    "pidTuningThrottleLimitPercent": {
+        "message": "Ограничење гаса %"
+    },
+    "pidTuningThrottleLimitTypeOff": {
+        "message": "Искључено"
+    },
+    "pidTuningThrottleLimitTypeScale": {
+        "message": "SCALE"
+    },
+    "pidTuningThrottleLimitTypeClip": {
+        "message": "CLIP"
+    },
+    "pidTuningThrottleLimitTypeTip": {
+        "message": "Изаберите врсту ограничења гаса. <b>ИСКЉУЧЕНО<\/b> искључује функцију, <b>SCALE<\/b> трансформише опсег гаса од 0 до изабраног процента користећи пун ход ручице, <b>CLIP<\/b> поставља максимални проценат гаса, а ход ручице преко тога неће имати додатног ефекта"
+    },
+    "pidTuningThrottleLimitPercentTip": {
+        "message": "Подесите жељени проценат ограничења гаса. Постављање на 100% искључује функцију."
+    },
+    "pidTuningFilter": {
+        "message": "Filter"
+    },
+    "pidTuningFilterFrequency": {
+        "message": "Фреквенција"
+    },
+    "pidTuningRatesCurve": {
+        "message": "Преглед рејтова"
+    },
+    "throttle": {
+        "message": "Гас"
+    },
+    "pidTuningButtonSave": {
+        "message": "Сачувај"
+    },
+    "pidTuningButtonRefresh": {
+        "message": "Освежи"
+    },
+    "pidTuningProfileHead": {
+        "message": "Профил"
+    },
+    "pidTuningControllerHead": {
+        "message": "PID контролер"
+    },
+    "pidTuningCopyProfile": {
+        "message": "Копирај профил"
+    },
+    "pidTuningCopyRateProfile": {
+        "message": "Копирај rateprofile"
+    },
+    "dialogCopyProfileText": {
+        "message": "Копирај вредности из тренутног профила у"
+    },
+    "dialogCopyRateProfileText": {
+        "message": "Копирај вредности из тренутног rateprofile-а у"
+    },
+    "dialogCopyProfileTitle": {
+        "message": "Копирање вредности профила"
+    },
+    "dialogCopyProfileNote": {
+        "message": "Све вредности на циљном профилу биће обрисане и преснимљене"
+    },
+    "dialogCopyProfileConfirm": {
+        "message": "Копирај"
+    },
+    "dialogCopyProfileClose": {
+        "message": "Откажи"
+    },
+    "pidTuningResetPidProfile": {
+        "message": "Ресетуј овај профил"
+    },
+    "pidTuningPidProfileReset": {
+        "message": "Учитане су фабричке вредности за тренутни PID профил."
+    },
+    "pidTuningReceivedProfile": {
+        "message": "Flight контролер је поставио профил: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningReceivedRateProfile": {
+        "message": "Flight контролер је поставио Rateprofile: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningLoadedProfile": {
+        "message": "Учитан профил: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningLoadedRateProfile": {
+        "message": "Учитан Rateprofile: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "pidTuningDataRefreshed": {
+        "message": "PID подаци су <strong>освежени<\/strong>"
+    },
+    "tuningHelp": {
+        "message": "<b>Савети за подешавање<\/b><br \/><span class=\"message-negative\">ВАЖНО:<\/span> Важно је проверити температуру мотора током првих летова. Што је вредност филтера већа, летелица може боље летети, али ћете такође унети више шума у моторе. <br>Фабричка вредност од 100Hz је оптимална, али за бучније системе можете покушати са смањењем Dterm филтера на 50Hz и евентуално жироскопског филтера."
+    },
+    "tuningHelpSliders": {
+        "message": "Користите клизаче за прилагођавање Ваших филтера. Клизачи морају бити искључени да бисте вршили ручне измене.<br>Померање клизача удесно даје више граничне вредности и може побољшати propwash, али ће пропустити више шума до мотора, чинећи их топлијим.<br>Већина чистих израда са RPM филтрирањем биће у реду са клизачем за gyro lowpass сасвим удесно, или са само активним lowpass 2 и клизачима у средини.<br><strong>УПОЗОРЕЊЕ:<\/strong> Будите ВЕОМА опрезни када померате D клизаче удесно. Проверите температуру мотора након сваке промене.<br><strong>Напомена:<\/strong> Промена профила мења само подешавања D-term филтера. Подешавања жироскопског филтера су иста за све профиле.",
+        "description": "Filter tuning subtab note"
+    },
+    "filterWarning": {
+        "message": "<span class=\"message-negative\"><b>Упозорење:<\/b><\/span> Количина филтрирања коју користите је опасно ниска. Ово вероватно може отежати управљање летелицом и може довести до неконтролисаног одлетања. Изузетно се препоручује да <b>укључите бар један од Gyro Dynamic Lowpass или Gyro Lowpass 1 и бар један од D-Term Dynamic Lowpass или D Term Lowpass 1<\/b>."
+    },
+    "pidTuningSliders": {
+        "message": "Клизачи за PID подешавање"
+    },
+    "pidTuningSliderPidsMode": {
+        "message": "Мод:",
+        "description": "Pidtuning slider mode can be OFF, RP or RPY"
+    },
+    "pidTuningSliderModeHelp": {
+        "message": "<strong>Мод клизача за PID подешавање<\/strong><br><br>Мод клизача за PID подешавање може бити:<br><br>&bull; ИСКЉУЧЕНО - без клизача, унесите вредности ручно<br>&bull; RP - клизачи контролишу само Roll и Pitch, унесите Yaw вредности ручно<br>&bull; RPY - клизачи контролишу све PID вредности<br><br><span class=\"message-negative\"><b>Упозорење:<\/b><\/span> Прелазак са RP на RPY мод ће преписати Yaw подешавања подешавањима фирмвера."
+    },
+    "receiverHelpModelId": {
+        "message": "Ако подесите Model Match испод на број различит од 255, можете навести број пријемника на страници за подешавање модела у OpenTX\/EdgeTX и укључити Model Match у ELRS LUA скрипти за тај модел. Модел match је између 0 и 63, укључујући оба.<br \/>Погледајте ELRS документацију за више информација."
+    },
+    "receiverModelId": {
+        "message": "Model Match ID"
+    },
+    "receiverHelp": {
+        "message": "&#8226;  <b><strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Failsafe#testing-failsafe\" target=\"_blank\" rel=\"noopener noreferrer\">Увек проверите да ли Вам Failsafe ради исправно!<\/a><\/strong><\/b> Подешавања су на картици Failsafe, за коју је потребан Експертски мод.<br> &#8226; <b>Користите најновији фирмвер за предајник!<\/b><br> &#8226; <strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Rx#disabling-the-opentxedgetx-adc-filter\" target=\"_blank\" rel=\"noopener noreferrer\">Искључите хардверски ADC filter<\/a><\/strong> у предајнику ако користите OpenTx или EdgeTx.<br>Основно подешавање: Исправно конфигуришите подешавања 'Пријемника'. Изаберите исправну 'Мапу канала' за Ваш радио. Проверите да ли се графици за Roll, Pitch и остале команде померају исправно. Подесите крајње тачке канала или вредности опсега у предајнику на ~1000 до ~2000, и подесите средишњу тачку на 1500. За више информација, прочитајте <strong><a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Rx\" target=\"_blank\" rel=\"noopener noreferrer\">документацију<\/a><\/strong>."
+    },
+    "receiverFailsafeActiveTitle": {
+        "message": "Failsafe активан"
+    },
+    "receiverFailsafeActiveWarning": {
+        "message": "Flight контролер је у failsafe режиму. Вредности канала приказане испод су failsafe излаз, а не живе вредности које долазе са Вашег пријемника. Проверите везу пријемника и failsafe подешавања."
+    },
+    "receiverThrottleMid": {
+        "message": "Throttle MID"
+    },
+    "receiverThrottleExpo": {
+        "message": "Throttle EXPO"
+    },
+    "receiverThrottleHover": {
+        "message": "Тачка лебдења"
+    },
+    "receiverStickRange": {
+        "message": "Опсег ручице"
+    },
+    "receiverStickMin": {
+        "message": "Праг 'ручица ниско'"
+    },
+    "receiverHelpStickMin": {
+        "message": "Максимална вредност (у us) да би се ручица препознала као ниска \/ лева за командни унос (MIN_CHECK)."
+    },
+    "receiverStickCenter": {
+        "message": "Центар ручице"
+    },
+    "receiverHelpStickCenter": {
+        "message": "Вредност (у us) која се користи за одређивање да ли је ручица центрирана (MID_RC)."
+    },
+    "receiverStickMax": {
+        "message": "Праг 'ручица високо'"
+    },
+    "receiverHelpStickMax": {
+        "message": "Минимална вредност (у us) да би се ручица препознала као висока \/ десна за командни унос (MAX_CHECK)."
+    },
+    "receiverDeadband": {
+        "message": "RC мртва зона"
+    },
+    "receiverHelpDeadband": {
+        "message": "Ово су вредности (у us) за колико се RC команда може разликовати пре него што се сматра валидном. За предајнике са подрхтавањем на излазима, ова вредност се може повећати ако се RC команде трзају док су у мировању."
+    },
+    "receiverYawDeadband": {
+        "message": "Yaw мртва зона"
+    },
+    "receiverHelpYawDeadband": {
+        "message": "Ово су вредности (у us) за колико се RC команда може разликовати пре него што се сматра валидном. За предајнике са подрхтавањем на излазима, ова вредност се може повећати ако се RC команде трзају док су у мировању. <strong>Ово подешавање је само за Yaw.<\/strong>"
+    },
+    "recevier3dDeadbandThrottle": {
+        "message": "3D Throttle мртва зона"
+    },
+    "receiverHelp3dDeadbandThrottle": {
+        "message": "Ово су вредности (у us). Да бисте проширили неутралну зону, повећајте вредност. <strong>Ово подешавање је само за 3D гас.<\/strong>"
+    },
+    "receiverChannelMap": {
+        "message": "Мапа канала"
+    },
+    "receiverChannelDefaultOption": {
+        "message": "Фабричко"
+    },
+    "receiverChannelMapTitle": {
+        "message": "Можете дефинисати сопствену мапу канала кликом унутар поља"
+    },
+    "receiverRssiChannel": {
+        "message": "RSSI канал"
+    },
+    "receiverRssiChannelDisabledOption": {
+        "message": "Искључено"
+    },
+    "receiverRefreshRateTitle": {
+        "message": "Брзина освежавања графика"
+    },
+    "receiverResetRefreshRate": {
+        "message": "Врати на фабричко"
+    },
+    "receiverResetRefreshRateTitle": {
+        "message": "Врати учестаност освежавања на фабричко"
+    },
+    "receiverRowContainerRoll": {
+        "message": "Roll [A]:",
+        "description": "Roll label in signal graph"
+    },
+    "receiverRowContainerPitch": {
+        "message": "Pitch [E]:",
+        "description": "Pitch label in signal graph"
+    },
+    "receiverRowContainerYaw": {
+        "message": "Yaw [R]:",
+        "description": "Yaw label in signal graph"
+    },
+    "receiverRowContainerThrottle": {
+        "message": "Throttle [T]:",
+        "description": "Throttle label in signal graph"
+    },
+    "receiverButtonSave": {
+        "message": "Сачувај"
+    },
+    "receiverButtonRefresh": {
+        "message": "Освежи"
+    },
+    "receiverButtonBind": {
+        "message": "Биндовање пријемника"
+    },
+    "receiverButtonBindMessage": {
+        "message": "Захтев за биндовање послат flight контролеру."
+    },
+    "receiverButtonBindingPhrase": {
+        "message": "Bind фраза"
+    },
+    "receiverButtonSticks": {
+        "message": "Симулатор даљинског",
+        "description": "Button that opens a window with a radio emulator on the receiver tab. Actually only enabled for MSP protocol"
+    },
+    "receiverDataRefreshed": {
+        "message": "Подаци о подешавању команди су <strong>освежени<\/strong>"
+    },
+    "receiverModelPreview": {
+        "message": "Преглед"
+    },
+    "receiverMspWarningText": {
+        "message": "Ове ручице омогућавају да се Betaflight армује и испроба без даљинског и пријемника. Ипак, <strong>ово није намењено за лет и пропелери не смеју бити постављени.<\/strong><br \/><br \/>Ова могућност не јемчи поуздано управљање дроном. <strong>Ако пропелери остану на дрону, врло вероватно ће доћи до озбиљне повреде.<\/strong>"
+    },
+    "receiverMspEnableButton": {
+        "message": "Укључи управљање"
+    },
+    "auxiliaryHelp": {
+        "message": "Модове подешавате опсегом или везом ка другом моду (везе раде од Betaflight-а 4.0 навише). <strong>Опсегом<\/strong> задајете који прекидач на даљинском укључује који мод: када вредност канала падне унутар задатог опсега, мод се укључује. <strong>Везом<\/strong> укључујете један мод онда када се укључи други. <strong>Изузеци:<\/strong> ARM се не може везати ни на један мод ни са једног мода, и мод се не може везати на мод који је и сам задат везом. За исти мод може се задати више опсега или веза. Када их има више, сваки се означава са <strong>I<\/strong> или <strong>ИЛИ<\/strong>. Мод се укључује када:<br \/>- су активни СВИ опсези и везе означени са <strong>I<\/strong>; или<br \/>- је активан бар један опсег или веза означен са <strong>ИЛИ<\/strong>.<br \/><br \/>Не заборавите да сачувате подешавања дугметом Сачувај."
+    },
+    "auxiliaryToggleUnused": {
+        "message": "Сакриј некоришћене модове"
+    },
+    "auxiliaryMin": {
+        "message": "Min"
+    },
+    "auxiliaryMax": {
+        "message": "Макс"
+    },
+    "auxiliaryDisabled": {
+        "message": "(ИСКЉУЧЕНО)",
+        "description": "Text to add to the ARM mode (maybe others in the future) in the MODES TAB when it has been disabled for some external reason"
+    },
+    "auxiliaryAddRange": {
+        "message": "Add Range"
+    },
+    "auxiliaryAddLink": {
+        "message": "Add Link"
+    },
+    "auxiliaryButtonSave": {
+        "message": "Сачувај"
+    },
+    "auxiliaryAutoChannelSelect": {
+        "message": "AUTO"
+    },
+    "auxiliaryLinkNone": {
+        "message": "Ништа"
+    },
+    "auxiliaryModeLogicOR": {
+        "message": "ИЛИ"
+    },
+    "auxiliaryModeLogicAND": {
+        "message": "I"
+    },
+    "auxiliaryHelpMode_3DDISABLE": {
+        "message": "Омогућава обртање мотора у оба смера, за негативан потисак и лет наопако. Гас прелази у опсег од −100 до +100 уместо од 0 до 100.",
+        "description": "Help text to 3D mode"
+    },
+    "auxiliaryHelpMode_ACROTRAINER": {
+        "message": "Ограничава колико дрон сме да се нагне док летите у акро моду — за увежбавање.",
+        "description": "Help text to ACRO TRAINER mode"
+    },
+    "auxiliaryHelpMode_ARM": {
+        "message": "Укључује моторе и омогућава летење",
+        "description": "Help text to ARM mode"
+    },
+    "auxiliaryHelpMode_ANGLE": {
+        "message": "Самонивелишући мод: ручице за нагиб одређују угао између дрона и водоравне равни, а дрон се сам враћа у раван положај када ручице пустите.",
+        "description": "Help text to ANGLE mode"
+    },
+    "auxiliaryHelpMode_ANTIGRAVITY": {
+        "message": "Режим лета који повећава P и I члан при наглим променама гаса, да би се побољшало праћење ручице и спречило заношење носа.",
+        "description": "Help text to ANTIGRAVITY mode"
+    },
+    "auxiliaryHelpMode_AIRMODE": {
+        "message": "У уобичајеном распореду мотора, када се израчунају команде за нагибе и окретање па један мотор дође до свог горњег ограничења, свим моторима се снага смањује подједнако. Када мотор падне испод најмање вредности, бива одсечен. Замислите да је гас тек мало изнад дна а Ви затражите брз превртај: пошто два мотора не могу ниже, добијате упола мању снагу, дакле упола слабије дејство регулатора. Ако би Ваша команда тражила разлику већу од сто посто између најбржег и најспоријег мотора, спорији би били одсечени, чиме се равнотежа мотора нарушава јер се дејство смањује неравномерно",
+        "description": "Help text to AIRMODE mode"
+    },
+    "auxiliaryHelpMode_ALTHOLD": {
+        "message": "<a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Position-Hold-2025-12#altitude-hold\" target=\"_blank\" rel=\"noopener noreferrer\">Задржавање висине<\/a> активно држи дрон на истој висини, користећи спољне сензоре заједно са ANGLE модом.",
+        "description": "Help text for ALTITUDE HOLD mode"
+    },
+    "auxiliaryHelpMode_AUTOPILOT": {
+        "message": "Самостално управљање летом: спаја задржавање висине и задржавање положаја, ради мирног лебдења у месту или праћења унапред задате путање лета.",
+        "description": "Help text for AUTOPILOT mode"
+    },
+    "auxiliaryHelpMode_BEEPER": {
+        "message": "Укључује пискалицу — корисно за проналажење дрона после пада.",
+        "description": "Help text to BEEPER mode"
+    },
+    "auxiliaryHelpMode_BEEPERMUTE": {
+        "message": "Искључује или укључује пискалицу, заједно са упозорењима и обавештењима.",
+        "description": "Help text to BEEPERMUTE mode"
+    },
+    "auxiliaryHelpMode_BEEPERON": {
+        "message": "Укључује мод сталног пиштања.",
+        "description": "Help text to BEEPER ON mode"
+    },
+    "auxiliaryHelpMode_BEEPGPSSATELLITECOUNT": {
+        "message": "Пискалицом јавља број пронађених сателита.",
+        "description": "Help text to BEEP GPS SATELLITE COUNT mode"
+    },
+    "auxiliaryHelpMode_BLACKBOX": {
+        "message": "Укључује снимање у Blackbox.",
+        "description": "Help text to BLACKBOX mode"
+    },
+    "auxiliaryHelpMode_BLACKBOXERASE": {
+        "message": "Брише Blackbox запис.",
+        "description": "Help text to BLACKBOX ERASE mode"
+    },
+    "auxiliaryHelpMode_BOXPREARM": {
+        "message": "Укључује PREARM, додатну браву испред армовања.",
+        "description": "Help text to BOXPREARM mode"
+    },
+    "auxiliaryHelpMode_CALIB": {
+        "message": "Покреће калибрацију у лету.",
+        "description": "Help text to CALIB mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL1": {
+        "message": "Укључује и искључује CAMERA CONTROL 1 — погледајте упутство произвођача.",
+        "description": "Help text to customized CAMERA CONTROL 1 mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL2": {
+        "message": "Укључује и искључује CAMERA CONTROL 2 — погледајте упутство произвођача.",
+        "description": "Help text to customized CAMERA CONTROL 2 mode"
+    },
+    "auxiliaryHelpMode_CAMERACONTROL3": {
+        "message": "Укључује и искључује CAMERA CONTROL 3 — погледајте упутство произвођача.",
+        "description": "Help text to customized CAMERA CONTROL 3 mode"
+    },
+    "auxiliaryHelpMode_CAMSTAB": {
+        "message": "Укључује стабилизацију камере.",
+        "description": "Help text to CAMSTAB mode"
+    },
+    "auxiliaryHelpMode_CHIRP": {
+        "message": "Укључује Chirp мод.",
+        "description": "Help text for CHIRP mode"
+    },
+    "auxiliaryHelpMode_FAILSAFE": {
+        "message": "Ручно покреће другу фазу Failsafe-а.",
+        "description": "Help text to FAILSAFE mode"
+    },
+    "auxiliaryHelpMode_FLIPOVERAFTERCRASH": {
+        "message": "Окреће моторе уназад да би преврнути дрон вратио на ноге после пада (захтева DShot).",
+        "description": "Help text to FLIP OVER AFTER CRASH mode"
+    },
+    "auxiliaryHelpMode_FPVANGLEMIX": {
+        "message": "Прилагођава окретање у месту нагибу под којим је камера постављена.",
+        "description": "Help text to FPV ANGLE MIX mode"
+    },
+    "auxiliaryHelpMode_GPSBEEPSATELLITECOUNT": {
+        "message": "Означава број пронађених сателита тако што толико пута запишти.",
+        "description": "Help text to GPS BEEP SATELLITE COUNT mode"
+    },
+    "auxiliaryHelpMode_GPSRESCUE": {
+        "message": "Укључује GPS Rescue, повратак дрона на место где је последњи пут армован.",
+        "description": "Help text to GPS RESCUE mode"
+    },
+    "auxiliaryHelpMode_HEADADJ": {
+        "message": "Поставља нову полазну тачку окретања за HEADFREE мод.",
+        "description": "Help text to HEAD ADJ mode"
+    },
+    "auxiliaryHelpMode_HEADFREE": {
+        "message": "Режим лета у коме је скретање (yaw) везано за спољашњу тачку ослонца — најчешће за смер у коме је pilot окренут — уместо за саму летелицу. Намењен почетницима, али се ретко користи; препоручује се ANGLE режим.",
+        "description": "Help text to HEADFREE mode"
+    },
+    "auxiliaryHelpMode_HORIZON": {
+        "message": "Мешовити мод: док су ручице у средини понаша се као ANGLE и сам се нивелише, а при пуном отклону дозвољава потпуни превртај.",
+        "description": "Help text to HORIZON mode"
+    },
+    "auxiliaryHelpMode_LAUNCHCONTROL": {
+        "message": "Помоћ при старту на трци.",
+        "description": "Help text to LAUNCH CONTROL mode"
+    },
+    "auxiliaryHelpMode_LEDLOW": {
+        "message": "Гаси LED траку.",
+        "description": "Help text to LEDLOW mode"
+    },
+    "auxiliaryHelpMode_MAG": {
+        "message": "Задржава правац према магнетометру, дакле према компасу.",
+        "description": "Help text to MAG mode"
+    },
+    "auxiliaryHelpMode_MSPOVERRIDE": {
+        "message": "Укључује MSP Override мод.",
+        "description": "Help text to MSP OVERRIDE mode"
+    },
+    "auxiliaryHelpMode_OSDDISABLE": {
+        "message": "Укључује или искључује приказ преко слике (OSD).",
+        "description": "Help text to OSD mode"
+    },
+    "auxiliaryHelpMode_PASSTHRU": {
+        "message": "Прослеђује команде са пријемника право на сервое, код авионског распореда.",
+        "description": "Help text to PASSTHRU mode"
+    },
+    "auxiliaryHelpMode_PARALYZE": {
+        "message": "Трајно онеспособљава дрон после пада, док му се не прекине напајање.",
+        "description": "Help text to PARALYZE mode"
+    },
+    "auxiliaryHelpMode_PIDAUDIO": {
+        "message": "Укључује и искључује PIDAUDIO.",
+        "description": "Help text to PIDAUDIO mode"
+    },
+    "auxiliaryHelpMode_POSHOLD": {
+        "message": "Задржавање положаја у месту.",
+        "description": "Help text to POSHOLD mode"
+    },
+    "auxiliaryHelpMode_PREARM": {
+        "message": "При армовању дрон чека да прво укључите овај прекидач, па тек онда дозвољава армовање.",
+        "description": "Help text to PREARM mode"
+    },
+    "auxiliaryHelpMode_READY": {
+        "message": "Приказује ознаку READY на екрану у наочарима, преко прекидача.",
+        "description": "Help text to READY mode"
+    },
+    "auxiliaryHelpMode_STICKCOMMANDSDISABLE": {
+        "message": "Искључује или укључује команде које се задају ручицама.",
+        "description": "Help text to STICK COMMANDS DISABLE mode"
+    },
+    "auxiliaryHelpMode_SERVO1": {
+        "message": "Укључује и искључује SERVO1.",
+        "description": "Help text to SERVO1 mode"
+    },
+    "auxiliaryHelpMode_SERVO2": {
+        "message": "Укључује и искључује SERVO2.",
+        "description": "Help text to SERVO2 mode"
+    },
+    "auxiliaryHelpMode_SERVO3": {
+        "message": "Укључује и искључује SERVO3.",
+        "description": "Help text to SERVO3 mode"
+    },
+    "auxiliaryHelpMode_TELEMETRY": {
+        "message": "Укључује слање података назад ка даљинском, преко прекидача.",
+        "description": "Help text to TELEMETRY mode"
+    },
+    "auxiliaryHelpMode_USER1": {
+        "message": "Укључује и искључује USER1 — управља излазом преко PINIO.",
+        "description": "Help text to customized USER1 mode"
+    },
+    "auxiliaryHelpMode_USER2": {
+        "message": "Укључује и искључује USER2 — управља излазом преко PINIO.",
+        "description": "Help text to customized USER2 mode"
+    },
+    "auxiliaryHelpMode_USER3": {
+        "message": "Укључује и искључује USER3 — управља излазом преко PINIO.",
+        "description": "Help text to customized USER3 mode"
+    },
+    "auxiliaryHelpMode_USER4": {
+        "message": "Укључује и искључује USER4 — управља излазом преко PINIO.",
+        "description": "Help text to customized USER4 mode"
+    },
+    "auxiliaryHelpMode_VTXCONTROLDISABLE": {
+        "message": "Онемогућава мењање подешавања видео-предајника преко OSD-а.",
+        "description": "Help text to VTX CONTROL DISABLE mode"
+    },
+    "auxiliaryHelpMode_VTXPOWER": {
+        "message": "Кружи кроз нивое снаге видео-предајника, ако их предајник подржава.",
+        "description": "Help text to VTX POWER mode"
+    },
+    "auxiliaryHelpMode_VTXPITMODE": {
+        "message": "Пребацује видео-предајник у pit мод, на врло малу снагу, ако то подржава.",
+        "description": "Help text to VTX PIT MODE mode"
+    },
+    "auxiliaryHelpMode_LAPTIMERRESET": {
+        "message": "Поништава мерач кругова на транспондеру.",
+        "description": "Help text to LAP TIMER RESET mode"
+    },
+    "adjustmentsHelp": {
+        "message": "Подесите прекидаче за прилагођавање. Погледајте одељак упутства 'прилагођавања током лета' за детаље. Промене које функције прилагођавања направе не чувају се аутоматски."
+    },
+    "adjustmentsColumnEnable": {
+        "message": "Ако је укључено"
+    },
+    "adjustmentsColumnUsingSlot": {
+        "message": "користи slot"
+    },
+    "adjustmentsColumnWhenChannel": {
+        "message": "када је канал"
+    },
+    "adjustmentsColumnIsInRange": {
+        "message": "у опсегу"
+    },
+    "adjustmentsColumnThenApplyFunction": {
+        "message": "онда примени"
+    },
+    "adjustmentsColumnViaChannel": {
+        "message": "преко канала"
+    },
+    "adjustmentsColumnMode": {
+        "message": "мод"
+    },
+    "adjustmentsModeStep": {
+        "message": "Корак"
+    },
+    "adjustmentsModeAbsolute": {
+        "message": "Апсолутно"
+    },
+    "adjustmentsModeSelection": {
+        "message": "Избор"
+    },
+    "adjustmentsColumnAdjustmentCenter": {
+        "message": "центар (вред.)"
+    },
+    "adjustmentsColumnAdjustmentScale": {
+        "message": "скала (вред.|%)"
+    },
+    "adjustmentsCenterHelp": {
+        "message": "Подешава средњу тачку или референтну вредност коју користи функција прилагођавања.<br \/><br \/><strong>Прилагођавање клизачем:<\/strong><br \/>За прилагођавање клизачем, поставите Adjustment Center на 0. Тренутна позиција клизача користиће се за прилагођавање горе\/доле.<br \/><br \/><strong>Прилагођавање избором:<\/strong><br \/>Поставите Adjustment Center на 0, или на одређену вредност у микросекундама (uS) ако желите да померите референтну тачку прекидача у односу на 1500uS приликом покретања RC прилагођавања.<br \/><br \/><strong>Постепено прилагођавање:<\/strong><br \/>Поставите Adjustment Center на 0 како би се користила тренутна вредност ставке која се прилагођава.<br \/><br \/><strong>Апсолутно прилагођавање:<\/strong><br \/>Да бисте користили метод апсолутног прилагођавања, морате подесити и Adjustment Center и Scale како бисте одредили жељену вредност и опсег. Опсег се рачуна као: Центар ± Скала. На пример, постављање Adjustment Center на 50 и Adjustment Scale на 25 прави опсег од 25 до 75, где је средња позиција (прекидач или POT) пресликана на 50.<br \/><br \/>Посетите <a href=\"https:\/\/www.betaflight.com\/docs\/wiki\/guides\/current\/Inflight-Adjustments\" target=\"_blank\" rel=\"noopener noreferrer\">ову страницу<\/a> за више информација.",
+        "description": "Tooltip help text for the Adjustment Center column"
+    },
+    "adjustmentsScaleHelp": {
+        "message": "Контролише скалирање или опсег подешавања; веће вредности повећавају опсег подешавања или осетљивост.<br \/><br \/><strong>Подешавања клизачем:<\/strong><br \/>За подешавања клизачем, Adjustment Scale контролише скалирање\/осетљивост подешавања. Вредност 50 одговара 50% опсега клизача. Постављање на 0 користи фабричку скалу за клизаче.<br \/><br \/><strong>Подешавања избором:<\/strong><br \/>За подешавања избором, поставите Adjustment Scale на 0 за фабричко понашање, или наведите вредност у микросекундама (uS) да бисте ограничили опсег. На пример: поставите Adjustment Center на 1000 (uS) и Adjustment Scale на 500 (uS) да бисте користили прекидач са 3 положаја као прекидач са 2 положаја.<br \/><br \/><strong>Подешавања у корацима и апсолутна подешавања:<\/strong><br \/>За подешавања у корацима и апсолутна подешавања, Adjustment Scale дефинисује опсег изнад и испод Adjustment Center. На пример, вредност 25 прави опсег подешавања од ±25 од вредности Adjustment Center, или од тренутне вредности ако је Adjustment Center постављен на 0.<br \/><strong>Напомена:<\/strong> Да бисте користили метод апсолутног подешавања са потенцијометром, мора бити наведена вредност за Adjustment Scale.<br \/><br \/>Посетите <a href=\"https:\/\/www.betaflight.com\/docs\/wiki\/guides\/current\/Inflight-Adjustments\" target=\"_blank\" rel=\"noopener noreferrer\">ову страницу<\/a> за више информација.",
+        "description": "Tooltip help text for the Adjustment Scale column"
+    },
+    "adjustmentsSlot0": {
+        "message": "Slot 1"
+    },
+    "adjustmentsSlot1": {
+        "message": "Slot 2"
+    },
+    "adjustmentsSlot2": {
+        "message": "Slot 3"
+    },
+    "adjustmentsSlot3": {
+        "message": "Slot 4"
+    },
+    "adjustmentsMin": {
+        "message": "Min"
+    },
+    "adjustmentsMax": {
+        "message": "Макс"
+    },
+    "adjustmentsFunction0": {
+        "message": "Без промена"
+    },
+    "adjustmentsFunction1": {
+        "message": "Подешавање за RC Rate"
+    },
+    "adjustmentsFunction2": {
+        "message": "Подешавање за RC Expo"
+    },
+    "adjustmentsFunction3": {
+        "message": "Подешавање за Expo гаса"
+    },
+    "adjustmentsFunction4": {
+        "message": "Подешавање за Pitch & Roll Rate"
+    },
+    "adjustmentsFunction5": {
+        "message": "Подешавање за Yaw Rate"
+    },
+    "adjustmentsFunction6": {
+        "message": "Подешавање за Pitch & Roll P"
+    },
+    "adjustmentsFunction7": {
+        "message": "Подешавање за Pitch & Roll I"
+    },
+    "adjustmentsFunction8": {
+        "message": "Подешавање за Pitch & Roll D"
+    },
+    "adjustmentsFunction9": {
+        "message": "Подешавање за Yaw P"
+    },
+    "adjustmentsFunction10": {
+        "message": "Подешавање за Yaw I"
+    },
+    "adjustmentsFunction11": {
+        "message": "Подешавање за Yaw D"
+    },
+    "adjustmentsFunction12": {
+        "message": "Избор Rate профила"
+    },
+    "adjustmentsFunction13": {
+        "message": "Pitch Rate"
+    },
+    "adjustmentsFunction14": {
+        "message": "Roll Rate"
+    },
+    "adjustmentsFunction15": {
+        "message": "Подешавање за Pitch P"
+    },
+    "adjustmentsFunction16": {
+        "message": "Подешавање за Pitch I"
+    },
+    "adjustmentsFunction17": {
+        "message": "Подешавање за Pitch D"
+    },
+    "adjustmentsFunction18": {
+        "message": "Подешавање Roll P"
+    },
+    "adjustmentsFunction19": {
+        "message": "Подешавање Roll I"
+    },
+    "adjustmentsFunction20": {
+        "message": "Подешавање Roll D"
+    },
+    "adjustmentsFunction21": {
+        "message": "RC Rate Yaw"
+    },
+    "adjustmentsFunction22": {
+        "message": "Подешавање Pitch & Roll F"
+    },
+    "adjustmentsFunction23": {
+        "message": "Feedforward прелаз"
+    },
+    "adjustmentsFunction24": {
+        "message": "Подешавање Horizon јачине"
+    },
+    "adjustmentsFunction25": {
+        "message": "Избор PID-Audio"
+    },
+    "adjustmentsFunction26": {
+        "message": "Подешавање Pitch F"
+    },
+    "adjustmentsFunction27": {
+        "message": "Подешавање Roll F"
+    },
+    "adjustmentsFunction28": {
+        "message": "Подешавање Yaw F"
+    },
+    "adjustmentsFunction29": {
+        "message": "Избор OSD профила"
+    },
+    "adjustmentsFunction30": {
+        "message": "Избор LED профила"
+    },
+    "adjustmentsFunction31": {
+        "message": "Подешавање LED осветљености"
+    },
+    "adjustmentsFunction32": {
+        "message": "Главни множилац клизача"
+    },
+    "adjustmentsFunction33": {
+        "message": "Избор профила батерије",
+        "description": "Allows switching battery profiles via RC channel"
+    },
+    "adjustmentsSave": {
+        "message": "Сачувај"
+    },
+    "adjustmentsShowAll": {
+        "message": "Прикажи све слотове"
+    },
+    "adjustmentsHideEmpty": {
+        "message": "Сакриј празне слотове"
+    },
+    "adjustmentsSlotsActive": {
+        "message": "{{active}} од {{total}} слотова активно"
+    },
+    "servosFirmwareUpgradeRequired": {
+        "message": "Сервои захтевају фирмвер &gt;= 1.10.0. и подршку за плочицу."
+    },
+    "servosChangeDirection": {
+        "message": "Промените смер на TX ради усклађивања"
+    },
+    "servosForwardChannel": {
+        "message": "Проследи канал {{channel}} на servo {{servo}}"
+    },
+    "servosName": {
+        "message": "Назив"
+    },
+    "servosMid": {
+        "message": "Средина"
+    },
+    "servosMin": {
+        "message": "Min"
+    },
+    "servosMax": {
+        "message": "MAX"
+    },
+    "servosAngleAtMin": {
+        "message": "Угао при min"
+    },
+    "servosAngleAtMax": {
+        "message": "Угао при макс"
+    },
+    "servosRateAndDirection": {
+        "message": "Одзив и смер"
+    },
+    "servosRate": {
+        "message": "Одзив:",
+        "description": "Label for 'Rate:' direction"
+    },
+    "servosLiveMode": {
+        "message": "Укључи Live мод"
+    },
+    "servosButtonSave": {
+        "message": "Сачувај"
+    },
+    "servosNormal": {
+        "message": "Нормално"
+    },
+    "servosReverse": {
+        "message": "Обрнуто"
+    },
+    "gpsHead": {
+        "message": "Опште"
+    },
+    "gpsHeadHelp": {
+        "message": "Приказује разне GPS информације. Смерови се приказују само када се користи магнетометар.",
+        "description": "Help text for gpsHead"
+    },
+    "gpsMapHead": {
+        "message": "Тренутна локација"
+    },
+    "gpsMapSatelliteView": {
+        "message": "Сателитски приказ"
+    },
+    "gpsMapHybridView": {
+        "message": "Хибридни приказ"
+    },
+    "gpsMapStreetView": {
+        "message": "Приказ улица"
+    },
+    "gpsMapZoomIn": {
+        "message": "Увећај"
+    },
+    "gpsMapZoomOut": {
+        "message": "Умањи"
+    },
+    "gpsMapToggleFullscreen": {
+        "message": "Укључи или искључи цео екран"
+    },
+    "gpsMapRetry": {
+        "message": "Покушај поново"
+    },
+    "gpsMapMessage1": {
+        "message": "Проверите Вашу интернет везу"
+    },
+    "gpsMapMessage2": {
+        "message": "Чека се GPS 3D фикс…"
+    },
+    "gps3dFix": {
+        "message": "3D фикс:"
+    },
+    "gpsFixTrue": {
+        "message": "Да"
+    },
+    "gpsFixFalse": {
+        "message": "Не"
+    },
+    "gpsPositionUnit": {
+        "message": "deg",
+        "description": "Unit for GPS position."
+    },
+    "gpsAltitude": {
+        "message": "Надморска висина:"
+    },
+    "gpsLatitude": {
+        "message": "Географска ширина:",
+        "description": "Show GPS position - Latitude"
+    },
+    "gpsLongitude": {
+        "message": "Географска дужина:",
+        "description": "Show GPS position - Longitude"
+    },
+    "gpsHeading": {
+        "message": "Правац IMU \/ GPS:",
+        "description": "Show IMU \/ GPS heading - Attitude \/ GPS course over ground"
+    },
+    "gpsSpeed": {
+        "message": "Брзина:"
+    },
+    "gpsSats": {
+        "message": "Број сателита:",
+        "description": "Show number of fixed GPS Satellites"
+    },
+    "gpsDistToHome": {
+        "message": "Удаљеност од почетне тачке:"
+    },
+    "gpsPositionalDop": {
+        "message": "Позициони DOP:"
+    },
+    "gpsMagneticDeclination": {
+        "message": "$t(configurationMagDeclination):",
+        "description": "Do not translate"
+    },
+    "gpsSignalStrHead": {
+        "message": "Информације о сигналу"
+    },
+    "gpsSignalStrHeadHelp": {
+        "message": "Приказује јачину, квалитет и status сигнала за сваки пронађени GPS извор",
+        "description": "Help text for gpsSignalStrHead"
+    },
+    "gpsSignalStr": {
+        "message": "Јачина сигнала"
+    },
+    "gpsSignalLost": {
+        "message": "GPS иконица светли само када је потврђена веза са GPS модулом.<br \/><br \/>Прво ће бити црвена, а промениће се у жуту када се постигне 3D fix.<br \/><br \/>Ако GPS иконица не светли, проверите Ваше ожичење и подешавања и потврдите да GPS модул добија напајање.<br \/><br \/>CLI команда 'status' пружа више информација о стању GPS везе."
+    },
+    "gpsSignalGnssId": {
+        "message": "GNSS ID"
+    },
+    "gpsSignalSatId": {
+        "message": "Sat ID"
+    },
+    "gpsSignalQuality": {
+        "message": "Квалитет"
+    },
+    "gnssQualityNoSignal": {
+        "message": "нема сигнала"
+    },
+    "gnssQualitySearching": {
+        "message": "претраживање"
+    },
+    "gnssQualityAcquired": {
+        "message": "пронађен"
+    },
+    "gnssQualityUnusable": {
+        "message": "неупотребљив"
+    },
+    "gnssQualityLocked": {
+        "message": "закључан"
+    },
+    "gnssQualityFullyLocked": {
+        "message": "потпуно закључан"
+    },
+    "gnssUsedUnused": {
+        "message": "некоришћен"
+    },
+    "gnssUsedUsed": {
+        "message": "КОРИШЋЕН"
+    },
+    "gnssHealthyUnknown": {
+        "message": "непознато"
+    },
+    "gnssHealthyHealthy": {
+        "message": "исправан"
+    },
+    "gnssHealthyUnhealthy": {
+        "message": "неисправан"
+    },
+    "flightPlanWaypointList": {
+        "message": "Листа тачака пута"
+    },
+    "flightPlanNoWaypoints": {
+        "message": "Нису дефинисане тачке пута. Кликните на мапу или употребите образац да додате тачке пута."
+    },
+    "flightPlanAddWaypoint": {
+        "message": "Додај тачку пута"
+    },
+    "flightPlanEditWaypoint": {
+        "message": "Уреди тачку пута"
+    },
+    "flightPlanLatitude": {
+        "message": "Географска ширина <span class=\"units\">°<\/span>"
+    },
+    "flightPlanLongitude": {
+        "message": "Географска дужина <span class=\"units\">°<\/span>"
+    },
+    "flightPlanAltitude": {
+        "message": "Висина <span class=\"units\">ft AMSL<\/span>"
+    },
+    "flightPlanSpeed": {
+        "message": "Брзина <span class=\"units\">чворова<\/span>"
+    },
+    "flightPlanType": {
+        "message": "Врста тачке пута"
+    },
+    "flightPlanTypeFlyover": {
+        "message": "Прелет"
+    },
+    "flightPlanTypeFlyby": {
+        "message": "Пролаз"
+    },
+    "flightPlanTypeHold": {
+        "message": "Задржавање"
+    },
+    "flightPlanTypeLand": {
+        "message": "Слетање"
+    },
+    "flightPlanTypeTakeoff": {
+        "message": "Полетање"
+    },
+    "flightPlanTypeAltChange": {
+        "message": "Промена висине",
+        "description": "Modifier waypoint type: changes the altitude of the next positional waypoint"
+    },
+    "flightPlanTypeDelay": {
+        "message": "Пауза",
+        "description": "Modifier waypoint type: pauses traversal for a duration"
+    },
+    "flightPlanTypeYawRate": {
+        "message": "Ограничење Yaw брзине",
+        "description": "Modifier waypoint type: caps the yaw rate of the next positional waypoint"
+    },
+    "flightPlanDuration": {
+        "message": "Трајање задржавања <span class=\"units\">min<\/span>"
+    },
+    "flightPlanDurationAria": {
+        "message": "Трајање задржавања у минутима",
+        "description": "Plain-text aria-label variant of flightPlanDuration for screen readers"
+    },
+    "flightPlanDelayDuration": {
+        "message": "Трајање паузе <span class=\"units\">min<\/span>"
+    },
+    "flightPlanDelayDurationAria": {
+        "message": "Трајање паузе у минутима",
+        "description": "Plain-text aria-label variant of flightPlanDelayDuration for screen readers"
+    },
+    "flightPlanYawRate": {
+        "message": "Yaw брзина <span class=\"units\">°\/с<\/span>"
+    },
+    "flightPlanYawRateAria": {
+        "message": "Yaw брзина у степенима у секунди",
+        "description": "Plain-text aria-label variant of flightPlanYawRate for screen readers"
+    },
+    "flightPlanPattern": {
+        "message": "Шаблон задржавања"
+    },
+    "flightPlanPatternCircle": {
+        "message": "Круг"
+    },
+    "flightPlanPatternFigure8": {
+        "message": "Осмица"
+    },
+    "flightPlanPatternOrbit": {
+        "message": "Орбита"
+    },
+    "flightPlanMap": {
+        "message": "Мапа плана лета"
+    },
+    "flightPlanMapInstructions": {
+        "message": "Кликните да додате тачке пута. Превлачите ознаке тачака пута да их померите."
+    },
+    "flightPlanLoading": {
+        "message": "Молимо сачекајте..."
+    },
+    "flightPlanClear": {
+        "message": "Очисти"
+    },
+    "flightPlanLoad": {
+        "message": "Учитај"
+    },
+    "flightPlanSaveToFC": {
+        "message": "Сачувај на FC"
+    },
+    "flightPlanLoaded": {
+        "message": "Plan лета је успешно учитан"
+    },
+    "flightPlanSaved": {
+        "message": "Plan лета је успешно сачуван"
+    },
+    "flightPlanCleared": {
+        "message": "Plan лета је обрисан"
+    },
+    "flightPlanLoadFromFC": {
+        "message": "Учитај са FC"
+    },
+    "flightPlanLoadedFromFC": {
+        "message": "Plan лета је учитан са flight контролера"
+    },
+    "flightPlanSavedToFC": {
+        "message": "Plan лета је сачуван на flight контролеру"
+    },
+    "flightPlanFCLoadError": {
+        "message": "Неуспешно учитавање плана лета са flight контролера"
+    },
+    "flightPlanFCSaveError": {
+        "message": "Неуспешно чување плана лета на flight контролеру"
+    },
+    "flightPlanFCEmpty": {
+        "message": "Нису пронађене тачке пута на flight контролеру"
+    },
+    "flightPlanClearedFC": {
+        "message": "Plan лета је обрисан на flight контролеру"
+    },
+    "flightPlanLoadError": {
+        "message": "Неуспешно учитавање плана лета"
+    },
+    "flightPlanSaveError": {
+        "message": "Неуспешно чување плана лета"
+    },
+    "flightPlanInvalidLatitude": {
+        "message": "Неважећа географска ширина (мора бити између -90 и 90)"
+    },
+    "flightPlanInvalidLongitude": {
+        "message": "Неважећа географска дужина (мора бити између -180 и 180)"
+    },
+    "flightPlanInvalidAltitude": {
+        "message": "Неважећа висина (мора бити нула или позитивна)"
+    },
+    "flightPlanInvalidDuration": {
+        "message": "Неважеће трајање (мора бити нула или позитивно)"
+    },
+    "flightPlanInvalidYawRate": {
+        "message": "Неважећа Yaw брзина (мора бити нула или позитивна)"
+    },
+    "flightPlanConfirmDelete": {
+        "message": "Да ли сте сигурни да желите да обришете ову тачку пута?"
+    },
+    "flightPlanDeleteWaypointTitle": {
+        "message": "Обриши тачку руте"
+    },
+    "flightPlanDeleteWaypointConfirm": {
+        "message": "Да ли сте сигурни да желите да обришете ову тачку руте? Ова радња се не може опозвати."
+    },
+    "flightPlanConfirmClear": {
+        "message": "Да ли сте сигурни да желите да обришете све тачке руте? Ова радња се не може опозвати."
+    },
+    "flightPlanClearTitle": {
+        "message": "Обриши plan лета"
+    },
+    "flightPlanLoadPromptTitle": {
+        "message": "Учитати plan лета са flight контролера?"
+    },
+    "flightPlanLoadPromptBody": {
+        "message": "Flight контролер је повезан. Да ли желите да замените тренутни plan лета оним који је сачуван на flight контролеру? Ако изаберете „Не“, задржаће се Ваш тренутни plan како бисте могли да га сачувате на flight контролеру."
+    },
+    "flightPlanKeepLocal": {
+        "message": "Задржи тренутни"
+    },
+    "flightPlanElevationProfile": {
+        "message": "Профил висине"
+    },
+    "flightPlanDistance": {
+        "message": "Укупна удаљеност"
+    },
+    "flightPlanFlightTime": {
+        "message": "Време лета"
+    },
+    "flightPlanMinAlt": {
+        "message": "Min. висина"
+    },
+    "flightPlanMaxAlt": {
+        "message": "Макс. висина"
+    },
+    "flightPlanNoWaypointsForProfile": {
+        "message": "Додајте тачке руте да бисте видели профил висине"
+    },
+    "flightPlanGroundElev": {
+        "message": "Висина терена"
+    },
+    "flightPlanMaxGroundElev": {
+        "message": "Макс. висина терена"
+    },
+    "flightPlanAvgGround": {
+        "message": "Просечна висина терена"
+    },
+    "flightPlanMaxGround": {
+        "message": "Макс. висина терена"
+    },
+    "flightPlanAlt": {
+        "message": "Висина"
+    },
+    "flightPlanDist": {
+        "message": "Удаљеност"
+    },
+    "motorsVoltage": {
+        "message": "Напон:"
+    },
+    "motorsADrawing": {
+        "message": "Јачина струје:"
+    },
+    "motorsmAhDrawn": {
+        "message": "Потрошено:"
+    },
+    "motorsVoltageValue": {
+        "message": "$1 V"
+    },
+    "motorsADrawingValue": {
+        "message": "$1 A"
+    },
+    "motorsmAhDrawnValue": {
+        "message": "$1 mAh"
+    },
+    "motorsText": {
+        "message": "Мотори"
+    },
+    "motorNumber1": {
+        "message": "Motor - 1"
+    },
+    "motorNumber2": {
+        "message": "Motor - 2"
+    },
+    "motorNumber3": {
+        "message": "Motor - 3"
+    },
+    "motorNumber4": {
+        "message": "Motor - 4"
+    },
+    "motorNumber5": {
+        "message": "Motor - 5"
+    },
+    "motorNumber6": {
+        "message": "Motor - 6"
+    },
+    "motorNumber7": {
+        "message": "Motor - 7"
+    },
+    "motorNumber8": {
+        "message": "Motor - 8"
+    },
+    "servosText": {
+        "message": "Сервои"
+    },
+    "servoNumber1": {
+        "message": "Servo - 1"
+    },
+    "servoNumber2": {
+        "message": "Servo - 2"
+    },
+    "servoNumber3": {
+        "message": "Servo - 3"
+    },
+    "servoNumber4": {
+        "message": "Servo - 4"
+    },
+    "servoNumber5": {
+        "message": "Servo - 5"
+    },
+    "servoNumber6": {
+        "message": "Servo - 6"
+    },
+    "servoNumber7": {
+        "message": "Servo - 7"
+    },
+    "servoNumber8": {
+        "message": "Servo - 8"
+    },
+    "motorsResetMaximumButton": {
+        "message": "Врати на фабричко"
+    },
+    "motorsResetMaximum": {
+        "message": "Поништи највећу забележену вредност"
+    },
+    "motorsSensorAccelSelect": {
+        "message": "акцелерометар"
+    },
+    "motorsTelemetryHelp": {
+        "message": "Ови бројеви приказују податке које регулатори шаљу назад, ако то подржавају. Могу да покажу стварну брзину обртања мотора (R, у обртајима у минути), удео грешака у тој вези (E) и температуру регулатора (T).",
+        "description": "Help text for the telemetry values in the motors tab."
+    },
+    "motorsRPM": {
+        "message": "R: {{motorsRpmValue}}",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Keep the letters as prefix. Shows the RPM of the motor if telemetry is available."
+    },
+    "motorsRPMError": {
+        "message": "E: {{motorsErrorValue}}%",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the error of motor telemetry if available."
+    },
+    "motorsESCTemperature": {
+        "message": "T: {{motorsESCTempValue}}&deg;C",
+        "description": "To put under the motors in the motors tab. KEEP IT SHORT or not translate. Shows the ESC temperature if available."
+    },
+    "motorsMaster": {
+        "message": "Сви заједно"
+    },
+    "motorsNotice": {
+        "message": "<strong>Провера мотора и армовање — упозорење:<\/strong><br \/><br \/><strong class=\"message-negative\">ПАЖЊА: Озбиљна опасност од повреде! Скините све пропелере!<\/strong><br \/><br \/><ul><li>&#x2022; Мотори ће се покренути када дрон буде армован или када подигнете клизаче<\/li><li>&#x2022; Режим провере мотора остаје укључен и када пређете на другу картицу<\/li><li>&#x2022; Притисак на било који тастер зауставља моторе, али само док сте на картици Мотори<\/li><li>&#x2022; Искључивање USB кабла можда неће зауставити моторе!<\/li><\/ul>"
+    },
+    "motorsEnableControl": {
+        "message": "<strong>Разумем опасност<\/strong>, пропелери су скинути — укључи управљање моторима и армовање, и искључи заштиту од неконтролисаног полетања."
+    },
+    "motorsDialogMixerReset": {
+        "message": "<strong>Откривен је проблем са распоредом мотора<\/strong><br \/><br \/>Модел {{mixerName}} тражи <strong class=\"message-positive\">{{mixerMotors}}<\/strong> излаза за моторе, а тренутна подешавања фирмвера нуде <strong class=\"message-positive\">{{outputs}}<\/strong> употребљивих излаза за изабрани распоред.<br \/><br \/>Ако користите сопствени распоред, морате га задати командом mmix пре него што промените распоред.<br \/><br \/>Проверите подешавања и додајте потребне излазе за моторе."
+    },
+    "motorsDialogSettingsChanged": {
+        "message": "Откривене су измене у подешавањима.<br \/><br \/><strong class=\"message-negative-italic\">Режим провере мотора је искључен док се подешавања не сачувају.<\/strong>"
+    },
+    "motorsDialogSettingsChangedOk": {
+        "message": "У реду"
+    },
+    "motorOutputReorderDialogClose": {
+        "message": "Откажи"
+    },
+    "motorOutputReorderDialogAgree": {
+        "message": "Покрени"
+    },
+    "motorsRemapDialogTitle": {
+        "message": "Преуреди редослед мотора"
+    },
+    "motorOutputReorderDialogOpen": {
+        "message": "Преуреди редослед мотора"
+    },
+    "motorOutputReorderDialogSelectSpinningMotor": {
+        "message": "Кликните на мотор који се окреће..."
+    },
+    "motorOutputReorderDialogRemapIsDone": {
+        "message": "Спремни! Проверите редослед окретања мотора кликом на слику."
+    },
+    "motorsRemapDialogUnderstandRisks": {
+        "message": "<strong>Разумем опасност<\/strong>,<br \/>пропелери су скинути."
+    },
+    "motorsRemapDialogRiskNotice": {
+        "message": "<strong>Безбедносно упозорење<\/strong><br \/><strong class=\"message-negative\">Скините све пропелере да не би дошло до повреде!<\/strong><br \/>Мотори ће се <strong>покренути!<\/strong>"
+    },
+    "motorsRemapDialogExplanations": {
+        "message": "<strong>Обавештење<\/strong><br \/>Мотори ће се покретати један по један и моћи ћете да изаберете који се мотор окреће. Батерија мора бити прикључена, а протокол регулатора исправно изабран. Овај алат може само да преуреди моторе који су тренутно активни. За сложеније преуређење потребна је команда Resource у CLI-ју. Погледајте ову <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Remapping-Motors-with-Resource-Command\" target=\"_blank\" rel=\"noopener noreferrer\">страницу упутстава<\/a>."
+    },
+    "motorsRemapDialogSave": {
+        "message": "Сачувај"
+    },
+    "motorsRemapDialogStartOver": {
+        "message": "Почни испочетка"
+    },
+    "motorsButtonReset": {
+        "message": "Врати на фабричко"
+    },
+    "motorsButtonSave": {
+        "message": "Сачувај и рестартуј"
+    },
+    "escDshotDirectionDialog-Title": {
+        "message": "Смер мотора - <strong class=\"message-negative-italic\">Упозорење: Проверите да ли су пропелере скинуте!<\/strong>"
+    },
+    "escDshotDirectionDialog-SelectMotor": {
+        "message": "Изаберите један или све моторе"
+    },
+    "escDshotDirectionDialog-SelectMotorSafety": {
+        "message": "Мотори ће се окретати када их изаберете!"
+    },
+    "escDshotDirectionDialog-RiskNotice": {
+        "message": "<strong>Безбедносно обавештење<\/strong><br \/><strong class=\"message-negative-italic\">Скините све пропелере да бисте спречили повреде!<\/strong><br \/>Мотори ће <strong>одмах почети да се окрећу<\/strong> чим их изаберете!"
+    },
+    "escDshotDirectionDialog-UnderstandRisks": {
+        "message": "<strong>Разумем ризике<\/strong>,<br \/>све пропелере су скинуте."
+    },
+    "escDshotDirectionDialog-InformationNotice": {
+        "message": "<strong>Информативно обавештење<\/strong><br \/>Да бисте променили смер мотора, батерија мора бити прикључена и исправан ESC протокол мора бити подешен на картици $t(tabMotorTesting.message). Имајте у виду да неће сви Dshot ESC-ови радити са овим дијалогом. Проверите фирмвер Вашег ESC-а."
+    },
+    "escDshotDirectionDialog-NormalInformationNotice": {
+        "message": "Подесите смер окретања мотора избором и покретањем сваког мотора појединачно."
+    },
+    "escDshotDirectionDialog-WizardInformationNotice": {
+        "message": "Поништава све смерове окретања мотора, а затим омогућава кориснику да изабере које треба обрнути."
+    },
+    "escDshotDirectionDialog-Open": {
+        "message": "Смер мотора"
+    },
+    "escDshotDirectionDialog-CommandNormal": {
+        "message": "Нормално"
+    },
+    "escDshotDirectionDialog-CommandReverse": {
+        "message": "Обрнуто"
+    },
+    "escDshotDirectionDialog-CommandSpin": {
+        "message": "Тестирај мотор"
+    },
+    "escDshotDirectionDialog-ReleaseButtonToStop": {
+        "message": "Пустите дугме да бисте зауставили"
+    },
+    "escDshotDirectionDialog-ReleaseToStop": {
+        "message": "Пустите да бисте зауставили"
+    },
+    "escDshotDirectionDialog-Start": {
+        "message": "Појединачно"
+    },
+    "escDshotDirectionDialog-StartWizard": {
+        "message": "Чаробњак"
+    },
+    "escDshotDirectionDialog-SetDirectionHint": {
+        "message": "Промените смер изабраног(их) мотора"
+    },
+    "escDshotDirectionDialog-SetDirectionHintSafety": {
+        "message": "Мотори ће се окретати приликом подешавања смера"
+    },
+    "escDshotDirectionDialog-SettingsAutoSaved": {
+        "message": "Смер мотора се чува одмах по избору"
+    },
+    "escDshotDirectionDialog-WrongProtocolText": {
+        "message": "Функција ради само са DSHOT ESC-овима.<br \/>Проверите да ли Ваш ESC (електронски контролер брзине) подржава DSHOT протокол и промените га на картици $t(tabMotorTesting.message)."
+    },
+    "escDshotDirectionDialog-WrongMixerText": {
+        "message": "Број мотора је 0.<br \/>Проверите тренутни Mixer на картици $t(tabMotorTesting.message) или подесите прилагођени путем CLI-ја. Погледајте ову <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Mixer\" target=\"_blank\" rel=\"noopener noreferrer\">Wiki страницу<\/a>."
+    },
+    "escDshotDirectionDialog-WrongFirmwareText": {
+        "message": "Ажурирајте фирмвер.<br \/> Проверите да ли користите најновији фирмвер: Betaflight 4.3 или новији."
+    },
+    "escDshotDirectionDialog-WizardActionHint": {
+        "message": "Кликните појединачно на бројеве мотора да бисте променили смер обртања"
+    },
+    "escDshotDirectionDialog-WizardActionHintSecondLine": {
+        "message": "Проверите да ли се сви мотори обрћу исправно"
+    },
+    "escDshotDirectionDialog-SpinWizard": {
+        "message": "Покрени \/ обрћи моторе"
+    },
+    "escDshotDirectionDialog-StopWizard": {
+        "message": "Заустави моторе"
+    },
+    "sensorsInfo": {
+        "message": "Имајте на уму да коришћење кратких периода освежавања и приказивање више графикона у исто време троши доста ресурса и брже ће испразнити батерију ако користите laptop.<br \/>Препоручујемо да приказујете само графиконе за сензоре који Вас занимају уз разумне периоде освежавања."
+    },
+    "sensorsRefresh": {
+        "message": "Освежавање:"
+    },
+    "sensorsGlobalRefresh": {
+        "message": "Освежи све:"
+    },
+    "sensorsScale": {
+        "message": "Размера:"
+    },
+    "sensorsScaleAuto": {
+        "message": "Аутоматски"
+    },
+    "sensorsGyroSelect": {
+        "message": "Жироскоп"
+    },
+    "sensorsAccelSelect": {
+        "message": "Акцелерометар"
+    },
+    "sensorsMagSelect": {
+        "message": "Магнетометар"
+    },
+    "sensorsAltitudeSelect": {
+        "message": "Висина"
+    },
+    "sensorsSonarSelect": {
+        "message": "Sonar"
+    },
+    "sensorsDebugSelect": {
+        "message": "Debug"
+    },
+    "sensorsGyroTitle": {
+        "message": "Жироскоп - deg\/s"
+    },
+    "sensorsAccelTitle": {
+        "message": "Акцелерометар - г"
+    },
+    "sensorsMagTitle": {
+        "message": "Магнетометар"
+    },
+    "sensorsAltitudeTitle": {
+        "message": "Висина - метри"
+    },
+    "sensorsAltitudeHint": {
+        "message": "Висина се израчунава комбиновањем очитавања барометра (ако је доступан) и висине са GPS-а (ако је доступан). Ако је GPS повезан и има сигнал, апсолутна висина изнад нивоа мора биће приказана док је летелица разоружана. Када је армована, биће приказана висина у односу на позицију при армовању."
+    },
+    "sensorsSonarTitle": {
+        "message": "Sonar - cm"
+    },
+    "sensorsDebugTitle": {
+        "message": "Debug"
+    },
+    "cliInfo": {
+        "message": "<strong>Напомена:<\/strong> Напуштање CLI картице или притисак на Прекини везу ће <strong>аутоматски<\/strong> послати \"<strong>exit<\/strong>\" плочици. Са најновијим фирмвером ово ће <strong>рестартовати<\/strong> контролер и несачуване измене ће бити <strong>изгубљене<\/strong>.<p><strong><span class=\"message-negative\">Упозорење:<\/span><\/strong> Неке команде у CLI-ју могу изазвати слање произвољних сигнала на излазне пинове мотора. Ово може узроковати покретање мотора ако је батерија повезана. Зато се строго препоручује да се уверите да <strong>батерија није повезана пре уноса команди у CLI<\/strong>."
+    },
+    "cliInputPlaceholder": {
+        "message": "Напишите Вашу команду овде. Притисните Tab за аутоматско довршавање."
+    },
+    "cliInputPlaceholderBuilding": {
+        "message": "Сачекајте док се креира кеш за аутоматско довршавање..."
+    },
+    "cliEnter": {
+        "message": "Препознат је CLI мод"
+    },
+    "cliDevEnter": {
+        "message": "Препознат је само CLI развојни мод"
+    },
+    "cliReboot": {
+        "message": "Препознато је CLI поновно покретање"
+    },
+    "cliSaveToFileBtn": {
+        "message": "Сачувај у фајл"
+    },
+    "cliClearOutputHistoryBtn": {
+        "message": "Очисти историју излаза"
+    },
+    "cliCopyToClipboardBtn": {
+        "message": "Копирај у оставу"
+    },
+    "cliCopySuccessful": {
+        "message": "Копирано"
+    },
+    "cliLoadFromFileBtn": {
+        "message": "Учитај из фајла"
+    },
+    "cliSupportRequestBtn": {
+        "message": "Пошаљи податке за подршку"
+    },
+    "cliConfirmSnippetDialogTitle": {
+        "message": "Учитана је фајл <strong>{{fileName}}<\/strong>. Прегледајте учитане команде"
+    },
+    "cliConfirmSnippetNote": {
+        "message": "<strong>Напомена<\/strong>: Можете прегледати и изменити команде пре извршавања."
+    },
+    "cliConfirmSnippetBtn": {
+        "message": "Изврши"
+    },
+    "cliSnippetPreviewLabel": {
+        "message": "Преглед исечка"
+    },
+    "cliPanelTitle": {
+        "message": "Интерфејс командне линије"
+    },
+    "cliCommand": {
+        "message": "Унесите команду овде"
+    },
+    "loggingNote": {
+        "message": "Подаци се записују <span class=\"message-negative\">само<\/span> док сте на овој картици; изласком са ње записивање се <span class=\"message-negative\">прекида<\/span> и програм се враћа у уобичајено <strong>„configurator“<\/strong> стање.<br \/> Можете сами изабрати учестаност освежавања, а подаци се ради брзине уписују у фајл сваке <strong>1<\/strong> секунде."
+    },
+    "loggingPropertiesTitle": {
+        "message": "Својства дневника"
+    },
+    "loggingSamplingInterval": {
+        "message": "Interval узорковања:"
+    },
+    "loggingSamplesSaved": {
+        "message": "Сачувани узорци:"
+    },
+    "loggingLogSize": {
+        "message": "Величина дневника:"
+    },
+    "loggingLogName": {
+        "message": "Назив дневника:"
+    },
+    "loggingButtonLogFile": {
+        "message": "Изаберите фајл дневника"
+    },
+    "loggingStart": {
+        "message": "Започни бележење"
+    },
+    "loggingStop": {
+        "message": "Заустави бележење"
+    },
+    "loggingBack": {
+        "message": "Напусти бележење \/ Прекини везу"
+    },
+    "loggingErrorNotConnected": {
+        "message": "Морате се прво <strong>повезати<\/strong>"
+    },
+    "loggingErrorLogFile": {
+        "message": "Молимо изаберите фајл дневника"
+    },
+    "loggingErrorOneProperty": {
+        "message": "Молимо изаберите бар једно својство за бележење"
+    },
+    "loggingAutomaticallyRetained": {
+        "message": "Аутоматски је учитан претходни фајл дневника: <strong>$1<\/strong>"
+    },
+    "blackboxNotSupported": {
+        "message": "Фирмвер Вашег flight контролера не подржава Blackbox бележење."
+    },
+    "blackboxMaybeSupported": {
+        "message": "Фирмвер Вашег flight контролера је сувише стар да би подржао ову картицу или је опција Blackbox искључена на картици Configuration."
+    },
+    "blackboxConfiguration": {
+        "message": "Blackbox подешавање"
+    },
+    "blackboxButtonSave": {
+        "message": "Сачувај и поново покрени"
+    },
+    "blackboxLoggingNone": {
+        "message": "Без бележења"
+    },
+    "blackboxLoggingFlash": {
+        "message": "Уграђена Flash меморија"
+    },
+    "blackboxLoggingSdCard": {
+        "message": "SD картица"
+    },
+    "blackboxLoggingSerial": {
+        "message": "Серијски порт"
+    },
+    "blackboxLoggingVirtual": {
+        "message": "У фајл"
+    },
+    "serialLoggingSupportedNote": {
+        "message": "Можете вршити бележење на спољни уређај за бележење (као што је OpenLager) помоћу серијског порта. Подесите порт на картици Ports."
+    },
+    "sdcardNote": {
+        "message": "Дневници лета могу се снимати на уграђени slot за SD картицу на Вашем flight контролеру."
+    },
+    "dataflashUsedSpace": {
+        "message": "Искоришћени простор"
+    },
+    "dataflashFreeSpace": {
+        "message": "Слободан простор"
+    },
+    "dataflashUnavSpace": {
+        "message": "Недоступан простор"
+    },
+    "dataflashLogsSpace": {
+        "message": "Слободан простор за дневнике"
+    },
+    "dataflashNote": {
+        "message": "Дневници лета могу се снимати на уграђени dataflash чип Вашег flight контролера."
+    },
+    "dataflashNotPresentNote": {
+        "message": "Ваш flight контролер нема доступан компатибилан dataflash чип."
+    },
+    "dataflashButtonSaveFile": {
+        "message": "Сачувај flash у фајл..."
+    },
+    "dataflashSavetoFileNote": {
+        "message": "Директно чување flash меморије у фајл је споро и подложно грешкама \/ оштећењу фајла.<br>У неким случајевима ће радити за мале фајлове, али ово није подржано и захтеви за подршку ће бити затворени без коментара – уместо тога користите Mass Storage мод."
+    },
+    "dataflashSaveFileDepreciationHint": {
+        "message": "Овај метод је спор и подложан грешкама \/ оштећењу фајлова, јер сама MSP веза има основна, фундаментална ограничења која је чине неприкладном за пренос фајлова. Може радити само за мале log фајлове. Немојте отварати захтеве за подршку ако пренос фајлова не успе када користите овај метод. Препоручени метод је да користите '<b>$t(onboardLoggingRebootMscText.message)<\/b>' (испод) како бисте активирали Mass Storage мод и приступили Вашем flight контролеру као уређају за складиштење ради преузимања log фајлова."
+    },
+    "dataflashButtonSaveAndErase": {
+        "message": "Сачувај и обриши",
+        "description": "Button text to save blackbox logs to file and then erase the flash"
+    },
+    "dataflashButtonErase": {
+        "message": "Обриши flash"
+    },
+    "dataflashConfirmEraseTitle": {
+        "message": "Потврдите брисање dataflash меморије"
+    },
+    "dataflashConfirmEraseNote": {
+        "message": "Ово ће обрисати све Blackbox логове или друге податке са dataflash меморије. Трајаће око 20 секунди, да ли сте сигурни?"
+    },
+    "dataflashSavingTitle": {
+        "message": "Чување dataflash меморије у фајл"
+    },
+    "dataflashSavingNote": {
+        "message": "Чување може трајати неколико минута, сачекајте."
+    },
+    "dataflashSavingNoteAfter": {
+        "message": "Чување је завршено. Притисните \"OK\" за наставак."
+    },
+    "dataflashButtonSaveCancel": {
+        "message": "Откажи"
+    },
+    "dataflashButtonSaveDismiss": {
+        "message": "OK"
+    },
+    "dataflashButtonEraseConfirm": {
+        "message": "Да, обриши dataflash"
+    },
+    "dataflashButtonEraseCancel": {
+        "message": "Откажи"
+    },
+    "dataflashFileWriteFailed": {
+        "message": "Писање у изабрани фајл није успело, да ли су дозволе за тај folder у реду?"
+    },
+    "sdcardStatusNoCard": {
+        "message": "Картица није убачена"
+    },
+    "sdcardStatusReboot": {
+        "message": "Критична грешка<br>Поново покрените за нови покушај"
+    },
+    "sdcardStatusReady": {
+        "message": "Картица је спремна"
+    },
+    "sdcardStatusStarting": {
+        "message": "Покретање картице..."
+    },
+    "sdcardStatusFileSystem": {
+        "message": "Покретање фајл система..."
+    },
+    "sdcardStatusUnknown": {
+        "message": "Непознато стање $1"
+    },
+    "firmwareFlasherPleaseWait": {
+        "message": "Сачекајте"
+    },
+    "firmwareFlasherBoardSelectionHead": {
+        "message": "Избор плочице"
+    },
+    "firmwareFlasherBranch": {
+        "message": "Изаберите Pull Request или Commit"
+    },
+    "firmwareFlasherReleaseSummaryHead": {
+        "message": "Информације о верзији и изради"
+    },
+    "firmwareFlasherReleaseManufacturer": {
+        "message": "ID произвођача:"
+    },
+    "firmwareFlasherReleaseVersion": {
+        "message": "Верзија:"
+    },
+    "firmwareFlasherReleaseVersionUrl": {
+        "message": "Посетите страницу издања."
+    },
+    "firmwareFlasherReleaseNotes": {
+        "message": "Белешке о издању:"
+    },
+    "firmwareFlasherReleaseDate": {
+        "message": "Датум:"
+    },
+    "firmwareFlasherReleaseTarget": {
+        "message": "Target:"
+    },
+    "firmwareFlasherTargetWikiUrlInfo": {
+        "message": "Сазнајте више информација о таргету на Betaflight Wiki страници",
+        "description": "Link to Betaflight support for target"
+    },
+    "firmwareFlasherReleaseMCU": {
+        "message": "MCU:"
+    },
+    "firmwareFlasherCloudBuildDetails": {
+        "message": "Детаљи Cloud Build-а:"
+    },
+    "firmwareFlasherCloudBuildLogUrl": {
+        "message": "Прикажи дневник"
+    },
+    "firmwareFlasherCloudBuildStatus": {
+        "message": "Status build-а:"
+    },
+    "firmwareFlasherFlashStatus": {
+        "message": "Status флешовања:"
+    },
+    "firmwareFlasherCloudBuildQueued": {
+        "message": "у реду чекања"
+    },
+    "firmwareFlasherCloudBuildPending": {
+        "message": "на чекању"
+    },
+    "firmwareFlasherCloudBuildProcessing": {
+        "message": "у обради"
+    },
+    "firmwareFlasherCloudBuildSuccessCached": {
+        "message": "успешно (кеширано)"
+    },
+    "firmwareFlasherCloudBuildSuccess": {
+        "message": "успешно"
+    },
+    "firmwareFlasherCloudBuildFailCancel": {
+        "message": "отказано"
+    },
+    "firmwareFlasherCloudBuildFailTimeOut": {
+        "message": "истекло је време (покушајте поново)"
+    },
+    "firmwareFlasherCloudBuildFailRequest": {
+        "message": "грешка у захтеву за build (проверите конфигурацију build-а, нпр. прилагођене дефиниције)"
+    },
+    "firmwareFlasherCloudBuildFail": {
+        "message": "неуспешно (проверите log)"
+    },
+    "firmwareFlasherReleaseFileUrl": {
+        "message": "Преузмите ручно."
+    },
+    "firmwareFlasherTargetWarning": {
+        "message": "<span class=\"message-negative\">ВАЖНО<\/span>: Проверите да ли флешујете фајл који одговара Вашем таргету. Флешовање бинарног фајла за погрешан target може изазвати <span class=\"message-negative\">лоше<\/span> ствари."
+    },
+    "firmwareFlasherPath": {
+        "message": "Путања:"
+    },
+    "firmwareFlasherSize": {
+        "message": "Величина:"
+    },
+    "firmwareFlasherStatus": {
+        "message": "Status:"
+    },
+    "firmwareFlasherProgress": {
+        "message": "Напредак:"
+    },
+    "firmwareFlasherLoadFirmwareFile": {
+        "message": "Молимо учитајте фајл фирмвера"
+    },
+    "firmwareFlasherLoadedConfig": {
+        "message": "Мета је учитана, молимо учитајте фајл фирмвера"
+    },
+    "firmwareFlasherNoReboot": {
+        "message": "Без секвенце поновног покретања"
+    },
+    "firmwareFlasherOnlineSelectBuildType": {
+        "message": "Изаберите тип верзије да бисте видели доступне плочице."
+    },
+    "firmwareFlasherOnlineSelectBoardDescription": {
+        "message": "Изаберите или детектујте Вашу плочицу да бисте видели доступне верзије фирмвера на мрежи - Изаберите одговарајући фирмвер за Вашу плочицу."
+    },
+    "firmwareFlasherOnlineSelectBoardHint": {
+        "message": "Betaflight апликација подржава флешовање унифицираних мета са одговарајућим специфичним подешавањима за плочицу у једном кораку.<br><br>Концепт унифицираних мета значи да се иста .hex фајл фирмвера може користити за све плочице које користе исти MCU.<br><br>Betaflight 4.4 уводи <strong>Cloud Build<\/strong><br><br>Са опцијом <strong>Cloud Build<\/strong> потребно је дефинисати хардверске опције присутне на Вашој летелици.<br><br>Да би различите плочице радиле са истим фирмвером, специфична фајл подешавања се примењује заједно са фирмвером када се флешује унифицирана мета.<br><br>Са локалним прављењем можете учитати фајл подешавања унифициране мете или изабрати плочицу пре учитавања .hex фајла фирмвера.<br><br>Ако наиђете на проблеме приликом коришћења фирмвера, размислите о придруживању Discord-у или отворите <a href=\"https:\/\/github.com\/betaflight\/betaflight\/issues\" target=\"_blank\" rel=\"noopener noreferrer\">проблем (issue)<\/a>."
+    },
+    "firmwareFlasherOnlineSelectFirmwareVersionDescription": {
+        "message": "Изаберите верзију фирмвера за Вашу плочицу."
+    },
+    "firmwareFlasherNoRebootDescription": {
+        "message": "Укључите ако је Ваш flight контролер у boot моду, тј. ако сте укључили flight контролер са преспојеним пиновима за bootloader или док сте држали дугме BOOT на flight контролеру."
+    },
+    "firmwareFlasherFlashOnConnect": {
+        "message": "Флешуј при повезивању"
+    },
+    "firmwareFlasherFlashOnConnectDescription": {
+        "message": "Покушај аутоматског флешовања плочице (покреће се када се детектује нови серијски порт).<br \/><br \/><span class=\"message-negative\">УПОЗОРЕЊЕ<\/span>: ова функција искључује функције детекције и резервне копије."
+    },
+    "firmwareFlasherFullChipErase": {
+        "message": "Потпуно брисање чипа"
+    },
+    "firmwareFlasherFullChipEraseDescription": {
+        "message": "Брише све податке подешавања који су тренутно сачувани на плочици."
+    },
+    "firmwareFlasherFlashDevelopmentFirmware": {
+        "message": "Користи развојни фирмвер"
+    },
+    "firmwareFlasherFlashDevelopmentFirmwareDescription": {
+        "message": "Флешуј најновији (нетестирани) развојни фирмвер."
+    },
+    "firmwareFlasherManualPort": {
+        "message": "Port"
+    },
+    "firmwareFlasherManualBaud": {
+        "message": "Ручни baud rate"
+    },
+    "firmwareFlasherManualBaudDescription": {
+        "message": "Ручни избор baud rate-а за плочице које не подржавају фабричку брзину или за флешовање путем Bluetooth-а.<br \/><span class=\"message-negative\">Напомена:<\/span> Не користи се приликом флешовања путем USB DFU"
+    },
+    "firmwareFlasherBaudRate": {
+        "message": "Baud rate"
+    },
+    "firmwareFlasherShowDevelopmentReleases": {
+        "message": "Прикажи кандидате за издање"
+    },
+    "firmwareFlasherShowDevelopmentReleasesDescription": {
+        "message": "Прикажи кандидате за издање поред стабилних издања"
+    },
+    "firmwareFlasherOptionLoading": {
+        "message": "Учитавање…"
+    },
+    "firmwareFlasherOptionLabelBuildTypeRelease": {
+        "message": "Званично издање"
+    },
+    "firmwareFlasherOptionLabelBuildTypeReleaseCandidate": {
+        "message": "Званично издање и кандидат за издање"
+    },
+    "firmwareFlasherOptionLabelBuildTypeDevelopment": {
+        "message": "Развојна верзија"
+    },
+    "firmwareFlasherOptionLabelBuildTypeAKK3_3": {
+        "message": "3.3 AKK & RDQ VTX закрпа"
+    },
+    "firmwareFlasherOptionLabelBuildTypeAKK3_4": {
+        "message": "3.4 AKK & RDQ VTX закрпа"
+    },
+    "firmwareFlasherOptionLabelSelectFirmware": {
+        "message": "Изаберите фирмвер \/ плочицу"
+    },
+    "firmwareFlasherOptionLabelSelectBoard": {
+        "message": "Изаберите плочицу"
+    },
+    "firmwareFlasherOptionLabelSelectFirmwareVersion": {
+        "message": "Изаберите верзију фирмвера"
+    },
+    "firmwareFlasherOptionLabelSelectFirmwareVersionFor": {
+        "message": "Изаберите верзију фирмвера за"
+    },
+    "firmwareFlasherButtonLoadLocal": {
+        "message": "Учитај фирмвер [Локално]"
+    },
+    "firmwareFlasherButtonLoadOnline": {
+        "message": "Учитај фирмвер [Онлајн]"
+    },
+    "firmwareFlasherButtonDownloading": {
+        "message": "Преузимање..."
+    },
+    "firmwareFlasherExitDfu": {
+        "message": "Напусти DFU мод"
+    },
+    "firmwareFlasherFindDfuDevice": {
+        "message": "Пронађи DFU уређај"
+    },
+    "firmwareFlasherFlashFirmware": {
+        "message": "Флешуј фирмвер"
+    },
+    "firmwareFlasherFlashFirmwareOptions": {
+        "message": "Опције флешовања фирмвера"
+    },
+    "firmwareFlasherLoadFirmwareOptions": {
+        "message": "Опције учитавања фирмвера"
+    },
+    "firmwareFlasherFlashingProgress": {
+        "message": "Напредак флешовања",
+        "description": "Accessible label for the circular progress ring shown during firmware flashing."
+    },
+    "firmwareFlasherGithubInfoHead": {
+        "message": "Информације о фирмверу са GitHub-а"
+    },
+    "firmwareFlasherCommiter": {
+        "message": "Аутор измене:"
+    },
+    "firmwareFlasherDate": {
+        "message": "Датум:"
+    },
+    "firmwareFlasherHash": {
+        "message": "Хеш:"
+    },
+    "firmwareFlasherUrl": {
+        "message": "Отворите GitHub да бисте прегледали ову измену..."
+    },
+    "firmwareFlasherMessage": {
+        "message": "Порука:"
+    },
+    "firmwareFlasherWarningText": {
+        "message": "<span class=\"message-negative\">Не<\/span> покушавајте да овим алатом упишете фирмвер на уређај који <strong>није Betaflight<\/strong>.<br \/><span class=\"message-negative\">Не<\/span> <strong>искључујте<\/strong> плочицу и не <strong>гасите<\/strong> рачунар док траје упис.<br \/><br \/><strong>Напомена: <\/strong>STM32 bootloader је у ROM меморији и не може се покварити.<br \/><strong>Напомена: <\/strong><span class=\"message-negative\">Аутоматско повезивање<\/span> је увек искључено док сте у алату за упис фирмвера.<br \/><strong>Напомена: <\/strong>Направите резервну копију — нека ажурирања бришу сва Ваша подешавања.<br \/><strong>Напомена:<\/strong> Ако имате проблема при упису, <strong>прво искључите све каблове са flight контролера<\/strong>, па рестартујте рачунар и ажурирајте управљачке програме.<br \/><strong>Напомена:<\/strong> Код плочица са директно везаним USB прикључком, а to су скоро све новије, обавезно прочитајте део упутства о упису преко USB-а и проверите да имате исправне управљачке програме"
+    },
+    "firmwareFlasherWarningShort": {
+        "message": "Немојте флешовати хардвер који није Betaflight. Немојте одспајати плочицу током флешовања. STM32 bootloader је у ROM-у и не може се уништити. Увек направите резервну копију конфигурације пре надоградње."
+    },
+    "firmwareFlasherRecoveryHead": {
+        "message": "<strong>Опоравак \/ изгубљена веза<\/strong>"
+    },
+    "firmwareFlasherRecoveryText": {
+        "message": "Ако сте изгубили комуникацију са плочицом, пратите ове кораке да бисте је обновили:<ul><li>Искључите напајање<\/li><li>Укључите 'No reboot sequence' и 'Full chip erase'.<\/li><li>Спојите BOOT пинове краткоспојником или држите дугме BOOT.<\/li><li>Укључите напајање (LED индикатор активности НЕЋЕ треперети ако је урађено исправно).<\/li><li>Инсталирајте све STM32 драјвере и Zadig ако је потребно (погледајте одељак <a href=\"https:\/\/betaflight.com\/docs\/wiki\/getting-started\/firmware-installation\" target=\"_blank\" rel=\"noopener noreferrer\">USB Flashing<\/a> у Betaflight упутству).<\/li><li>Затворите апликацију, а затим је поново покрените.<\/li><li>Отпустите дугме BOOT ако га Ваш FC има.<\/li><li>Флешујте одговарајући фирмвер (користећи ручно подешену брзину преноса ако је наведено у упутству за Ваш FC).<\/li><li>Искључите напајање.<\/li><li>Уклоните BOOT краткоспојник.<\/li><li>Укључите напајање (LED индикатор активности би требало да трепери).<\/li><li>Повежите се нормално.<\/li><\/ul>"
+    },
+    "firmwareFlasherRecoveryShort": {
+        "message": "Ако сте изгубили комуникацију: искључите напајање, укључите No Reboot Sequence и Full Chip Erase, спојите BOOT пинове, а затим укључите напајање. Инсталирајте драјвере ако је потребно."
+    },
+    "firmwareFlasherReadMore": {
+        "message": "Прочитајте више →"
+    },
+    "firmwareFlasherSubTabBoardBuild": {
+        "message": "Плочица и израда"
+    },
+    "firmwareFlasherAdvancedTitle": {
+        "message": "Напредно"
+    },
+    "firmwareFlasherSubTabFlash": {
+        "message": "Флешовање"
+    },
+    "firmwareFlasherButtonLeave": {
+        "message": "Напустите флешовање фирмвера"
+    },
+    "firmwareFlasherFirmwareNotLoaded": {
+        "message": "Фирмвер није учитан"
+    },
+    "firmwareFlasherFirmwareLoaded": {
+        "message": "Фирмвер"
+    },
+    "firmwareFlasherFirmwareSize": {
+        "message": "{{bytes}} бајтова"
+    },
+    "firmwareFlasherFirmwareLocalLoaded": {
+        "message": "Учитан локални фирмвер: {{filename}} ({{bytes}} бајтова)"
+    },
+    "firmwareFlasherFirmwareOnlineLoaded": {
+        "message": "Учитан мрежни фирмвер: {{filename}} ({{bytes}} бајтова)"
+    },
+    "firmwareFlasherTooltipSaveFirmware": {
+        "message": "Сачувај фирмвер"
+    },
+    "firmwareFlasherInvalidFileFormat": {
+        "message": "Неисправан format фајла"
+    },
+    "firmwareFlasherUf2Corrupted": {
+        "message": "Изгледа да је UF2 фајл оштећена"
+    },
+    "firmwareFlasherHexCorrupted": {
+        "message": "Изгледа да је HEX фајл оштећена"
+    },
+    "firmwareFlasherUF2SaveSuccess": {
+        "message": "UF2 је успешно сачуван (уписан)"
+    },
+    "firmwareFlasherUF2SaveFailed": {
+        "message": "Чување (уписивање) UF2 фајла није успело"
+    },
+    "firmwareFlasherEsp32Connecting": {
+        "message": "Повезивање са ESP32 bootloader-ом..."
+    },
+    "firmwareFlasherEsp32Detected": {
+        "message": "Детектован $1"
+    },
+    "firmwareFlasherEsp32Flashing": {
+        "message": "Флешовање ESP32..."
+    },
+    "firmwareFlasherEsp32Rebooting": {
+        "message": "Флешовање је завршено, поновно покретање..."
+    },
+    "firmwareFlasherEsp32Complete": {
+        "message": "ESP32 је успешно флешован"
+    },
+    "firmwareFlasherEsp32Failed": {
+        "message": "Флешовање ESP32 није успело: $1"
+    },
+    "firmwareFlasherEsp32NotSupported": {
+        "message": "За флешовање ESP32 потребна је верзија за прегледач (Web Serial)"
+    },
+    "firmwareFlasherEsp32NoPort": {
+        "message": "Изаберите серијски порт пре флешовања ESP32"
+    },
+    "firmwareFlasherClickToConnectDfu": {
+        "message": "Кликните за повезивање са DFU уређајем"
+    },
+    "firmwareFlasherConfigCorrupted": {
+        "message": "Изгледа да је конфигурациона фајл оштећена, прихвата се ASCII (карактери 0-255)",
+        "description": "shown in the progress bar at the bottom, be brief"
+    },
+    "firmwareFlasherConfigCorruptedLogMessage": {
+        "message": "Изгледа да је конфигурациона фајл оштећена, прихвата се ASCII (карактери 0-255), карактери изван овог опсега су дозвољени као коментари",
+        "description": "shown in the log, more wordy"
+    },
+    "firmwareFlasherRemoteFirmwareLoaded": {
+        "message": "<span class=\"message-positive\">Удаљени фирмвер је учитан, спремно за флешовање<\/span>"
+    },
+    "firmwareFlasherFailedToLoadOnlineFirmware": {
+        "message": "Неуспешно учитавање удаљеног фирмвера"
+    },
+    "firmwareFlasherFailedToLoadUnifiedConfig": {
+        "message": "Неуспешно учитавање удаљене конфигурације за {{remote_file}}"
+    },
+    "firmwareFlasherCanceledBackup": {
+        "message": "Прављење резервне копије је отказано, флешовање је прекинуто"
+    },
+    "firmwareFlasherBackupInvalidData": {
+        "message": "Неуспешна резервна копија: примљени су неважећи подаци са уређаја (није у CLI моду), флешовање је прекинуто"
+    },
+    "firmwareFlasherLegacyLabel": {
+        "message": "{{target}} (Legacy)",
+        "description": "If we have a Unified target and a old style target available, we are labeling the older one"
+    },
+    "firmwareFlasherNoFirmwareSelected": {
+        "message": "<b>Није изабран фирмвер за учитавање<\/b>"
+    },
+    "firmwareFlasherNoTargetsLoaded": {
+        "message": "Није учитана ниједна мета"
+    },
+    "firmwareFlasherNoValidPort": {
+        "message": "<span class=\"message-negative\">Молимо изаберите важећи серијски порт<\/span>"
+    },
+    "firmwareFlasherWritePermissions": {
+        "message": "Немате <span class=\"message-negative\">дозволу за писање<\/span> за ову фајл"
+    },
+    "firmwareFlasherFlashTrigger": {
+        "message": "Детектовано: <strong>$1<\/strong> - покреће се флешовање при повезивању"
+    },
+    "firmwareFlasherVerifyBoard": {
+        "message": "<h3>Фирмвер се не поклапа<\/h3><br \/>Повезана плочица је <strong>{{verified_board}}<\/strong>, док сте Ви изабрали <strong>{{selected_board}}<\/strong>.<br \/><br \/>Да ли желите да наставите флешовање?",
+        "description": "Make a quick connection to read firmware target and never flash a wrong target again"
+    },
+    "firmwareFlasherBoardVerificationSuccess": {
+        "message": "Апликација је <span class=\"message-positive\">успешно<\/span> детектовала и потврдила плочицу: <strong>{{boardName}}<\/strong>",
+        "description": "Board verification has succeeded."
+    },
+    "firmwareFlasherBoardVerficationTargetNotAvailable": {
+        "message": "Апликација је детектовала плочицу: <strong>{{boardName}}<\/strong>, али није пронађена званична Betaflight мета",
+        "description": "Board verification has succeeded, but the target is not available as official Betaflight target."
+    },
+    "firmwareFlasherBoardVerificationFail": {
+        "message": "Апликација <span class=\"message-negative\">није успела<\/span> да потврди плочицу. Ако се ово настави, покушајте да промените картицу и покушате поново, поново повежете USB или се прво повежите ако сте можда заборавили да примените прилагођена фабричка подешавања.",
+        "description": "Sometimes MSP values cannot be read from firmware correctly"
+    },
+    "firmwareFlasherButtonAbort": {
+        "message": "Прекини"
+    },
+    "firmwareFlasherButtonContinue": {
+        "message": "Настави"
+    },
+    "firmwareFlasherDetectBoardButton": {
+        "message": "Детектуј"
+    },
+    "firmwareFlasherDetectBoardDescriptionHint": {
+        "message": "Детекција ради само када нисте у DFU моду и када MSP комуникација функционише. Понекад морате покушати неколико пута или чак поново повезати USB. Покушајте прво да се повежете нормално, јер сте можда заборавили да примените прилагођена фабричка подешавања. Молимо поново покрените уређај након флешовања - поново прикључите USB."
+    },
+    "firmwareFlasherDetectBoardQuery": {
+        "message": "Очитајте информације о плочици ради избора одговарајућег фирмвера"
+    },
+    "unstableFirmwareAcknowledgementDialog": {
+        "message": "Спремате се да флешујете <strong>развојну верзију фирмвера<\/strong>. Ове верзије су у процесу израде и било шта од следећег може бити случај:<strong><ul><li>фирмвер уопште не ради;<\/li><li>са фирмвером се не може летети;<\/li><li>постоје безбедносни проблеми са фирмвером, на пример одлетање летелице;<\/li><li>фирмвер може узроковати да flight контролер постане неодзиван или да се оштети<\/li><\/ul><\/strong>Ако наставите са флешовањем овог фирмвера, <strong>преузимате пуну одговорност за ризик од било ког од горе наведених догађаја<\/strong>. Такође потврђујете да је неопходно извршити <strong>темељна тестирања на столу без пропелер<\/strong> пре било каквог покушаја летења са овим фирмвером."
+    },
+    "unstableFirmwareAcknowledgement": {
+        "message": "Прочитао сам горе наведено и <strong>преузимам пуну одговорност<strong> за упис нестабилног фирмвера"
+    },
+    "unstableFirmwareAcknowledgementFlash": {
+        "message": "Флешуј"
+    },
+    "firmwareFlasherRemindBackupTitle": {
+        "message": "Брисање подешавања",
+        "description": "Warning message title before actual flashing takes place"
+    },
+    "firmwareFlasherRemindBackup": {
+        "message": "Флешовање новог фирмвера ће обрисати сва подешавања. Препоручујемо да сачувате резервну копију пре него што наставите.",
+        "description": "Warning message before actual flashing takes place"
+    },
+    "firmwareFlasherBackup": {
+        "message": "Направи резервну копију",
+        "description": "Create a backup before actual flashing takes place"
+    },
+    "firmwareFlasherBackupIgnore": {
+        "message": "Занемари ризик",
+        "description": "Ignore creating a backup before actual flashing takes place"
+    },
+    "firmwareBackupEnabled": {
+        "message": "Прављење резервне копије укључено"
+    },
+    "firmwareBackupDisabled": {
+        "message": "Прављење резервне копије искључено"
+    },
+    "firmwareBackupAsk": {
+        "message": "Питај пре прављења резервне копије"
+    },
+    "ledStripHelp": {
+        "message": "Flight контролер може управљати бојама и ефектима појединачних LED лампица на траци.<br \/>Подесите LED лампице на мрежи, подесите редослед повезивања, а затим причврстите LED лампице на Вашу летелицу према позицијама на мрежи. LED лампице без редног броја жице неће бити сачуване.<br \/>Двапут кликните на боју да бисте изменили HSV вредности."
+    },
+    "ledStripButtonSave": {
+        "message": "Сачувај"
+    },
+    "ledStripColorSetupTitle": {
+        "message": "Подешавање боја",
+        "description": "Color setup title of the led strip"
+    },
+    "ledStripH": {
+        "message": "H",
+        "description": "Abbreviation of Hue in HSV (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripS": {
+        "message": "S",
+        "description": "Abbreviation of Saturation in HSV  (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripV": {
+        "message": "V",
+        "description": "Abbreviation of Brightness in HSV  (Hue, Saturation, Brightness) color model"
+    },
+    "ledStripRemainingText": {
+        "message": "Преостало",
+        "description": "In the LED STRIP, text next the counter of leds remaining"
+    },
+    "ledStripClearSelectedButton": {
+        "message": "Обриши изабрано",
+        "description": "In the LED STRIP, clear selected leds"
+    },
+    "ledStripClearAllButton": {
+        "message": "Очисти СВЕ",
+        "description": "In the LED STRIP, clear all leds"
+    },
+    "ledStripVtxOverlay": {
+        "message": "VTX (користи VTX фреквенцију за доделу боје)"
+    },
+    "ledStripBrightnessSliderTitle": {
+        "message": "Осветљеност",
+        "description": "Brightness of the LED Strip"
+    },
+    "ledStripBrightnessSliderHelp": {
+        "message": "Максимални проценат осветљености LED лампица."
+    },
+    "ledStripRainbowDeltaSliderTitle": {
+        "message": "Delta",
+        "description": "LED Strip rainbow effect delta"
+    },
+    "ledStripRainbowDeltaSliderHelp": {
+        "message": "Разлика у нијанси између LED лампица.",
+        "description": "Hint on LED Strip tab for rainbow delta"
+    },
+    "ledStripRainbowFreqSliderTitle": {
+        "message": "Фреквенција",
+        "description": "LED Strip rainbow effect frequency"
+    },
+    "ledStripRainbowFreqSliderHelp": {
+        "message": "Фреквенција промене боје, односно брзина ефекта.",
+        "description": "Hint on LED Strip tab for rainbow frequency"
+    },
+    "ledStripFunctionSection": {
+        "message": "LED функције"
+    },
+    "ledStripFunctionTitle": {
+        "message": "Функција"
+    },
+    "ledStripFunctionNoneOption": {
+        "message": "Ништа",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionColorOption": {
+        "message": "Боја",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionModesOption": {
+        "message": "Модови &amp; оријентација",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionArmOption": {
+        "message": "ARM стање",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionBatteryOption": {
+        "message": "Батерија",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionRSSIOption": {
+        "message": "RSSI",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionGPSOption": {
+        "message": "GPS",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionGPSBarOption": {
+        "message": "GPS трака",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionBatteryBarOption": {
+        "message": "Индикатор батерије",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionAltitudeOption": {
+        "message": "Висина",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripFunctionRingOption": {
+        "message": "Прстен",
+        "description": "One of the modes of the Led Strip"
+    },
+    "ledStripColorModifierTitle": {
+        "message": "Модификатор боје"
+    },
+    "ledStripModeColorsTitle": {
+        "message": "Боје модова"
+    },
+    "ledStripModeColorsModeOrientation": {
+        "message": "Оријентација",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeHeadfree": {
+        "message": "Headfree",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeHorizon": {
+        "message": "Horizon",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeAngle": {
+        "message": "Angle",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeMag": {
+        "message": "Mag",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeBaro": {
+        "message": "Baro",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripDirN": {
+        "message": "N",
+        "description": "North direction in Color Mode in Led Strip"
+    },
+    "ledStripDirE": {
+        "message": "E",
+        "description": "East direction in Color Mode in Led Strip"
+    },
+    "ledStripDirS": {
+        "message": "S",
+        "description": "South direction in Color Mode in Led Strip"
+    },
+    "ledStripDirW": {
+        "message": "W",
+        "description": "West direction in Color Mode in Led Strip"
+    },
+    "ledStripDirU": {
+        "message": "U",
+        "description": "Up direction in Color Mode in Led Strip"
+    },
+    "ledStripDirD": {
+        "message": "D",
+        "description": "Down direction in Color Mode in Led Strip"
+    },
+    "ledStripModesOrientationTitle": {
+        "message": "LED оријентација ('Modes &amp; Orientation') и боја",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModesSpecialColorsTitle": {
+        "message": "Посебне боје",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeDisarmed": {
+        "message": "Разоружан",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeArmed": {
+        "message": "Армован",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeAnimation": {
+        "message": "Анимација",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeBlinkBg": {
+        "message": "Трептање позадине",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSNoSats": {
+        "message": "GPS: нема сателита",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSNoLock": {
+        "message": "GPS: није закључан",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeColorsModeGPSLocked": {
+        "message": "GPS: закључан",
+        "description": "One of the modes in Color Mode in Led Strip"
+    },
+    "ledStripModeGpsDefault": {
+        "message": "Фабричко",
+        "description": "One of the modes in GPS Mode in Led Strip"
+    },
+    "ledStripModeGpsBar": {
+        "message": "Трака",
+        "description": "One of the modes in GPS Mode in Led Strip"
+    },
+    "ledStripWiring": {
+        "message": "Повезивање LED траке",
+        "description": "One of the modes in Led Strip"
+    },
+    "ledStripWiringMode": {
+        "message": "Мод редоследа повезивања",
+        "description": "One of the wiring modes in Led Strip"
+    },
+    "ledStripWiringClearControl": {
+        "message": "Обриши изабрано",
+        "description": "Control button in the wiring modes in Led Strip"
+    },
+    "ledStripWiringClearAllControl": {
+        "message": "Обриши СВО повезивање",
+        "description": "Control button in the wiring modes in Led Strip"
+    },
+    "ledStripWiringMessage": {
+        "message": "LED диоде без броја редоследа неће бити сачуване.",
+        "description": "Message in the wiring modes in Led Strip"
+    },
+    "ledStripLarsonOverlay": {
+        "message": "Larson скенер",
+        "description": "Larson effect switch label on LED Strip tab"
+    },
+    "ledStripBlinkAlwaysOverlay": {
+        "message": "Стално треперење"
+    },
+    "ledStripThrottleHue": {
+        "message": "Нијанса према гасу",
+        "description": "Label of throttle hue modifier switch on LED Strip tab"
+    },
+    "ledStripThrottleHueChannel": {
+        "message": "Канал нијансе гаса",
+        "description": "Accessible label for the aux-channel select next to the throttle hue switch"
+    },
+    "ledStripRainbowOverlay": {
+        "message": "Дуга",
+        "description": "Label of rainbow effect switch on LED Strip tab"
+    },
+    "ledStripOverlayTitle": {
+        "message": "Преклапање"
+    },
+    "ledStripWarningsOverlay": {
+        "message": "Упозорења"
+    },
+    "ledStripIndecatorOverlay": {
+        "message": "Индикатор (користи позицију на матрици)"
+    },
+    "colorBlack": {
+        "message": "црна"
+    },
+    "colorWhite": {
+        "message": "бела"
+    },
+    "colorRed": {
+        "message": "црвена"
+    },
+    "colorOrange": {
+        "message": "наранџаста"
+    },
+    "colorYellow": {
+        "message": "жута"
+    },
+    "colorLimeGreen": {
+        "message": "лимета зелена"
+    },
+    "colorGreen": {
+        "message": "зелена"
+    },
+    "colorMintGreen": {
+        "message": "мента зелена"
+    },
+    "colorCyan": {
+        "message": "цијан"
+    },
+    "colorLightBlue": {
+        "message": "светлоплава"
+    },
+    "colorBlue": {
+        "message": "плава"
+    },
+    "colorDarkViolet": {
+        "message": "Тамнољубичаста"
+    },
+    "colorMagenta": {
+        "message": "Magenta"
+    },
+    "colorDeepPink": {
+        "message": "Тамноружичаста"
+    },
+    "controlAxisRoll": {
+        "message": "Roll [A]"
+    },
+    "controlAxisPitch": {
+        "message": "Pitch [E]"
+    },
+    "controlAxisYaw": {
+        "message": "Yaw [R]"
+    },
+    "controlAxisThrottle": {
+        "message": "Гас [T]"
+    },
+    "controlAxisAux1": {
+        "message": "AUX 1"
+    },
+    "controlAxisAux2": {
+        "message": "AUX 2"
+    },
+    "controlAxisAux3": {
+        "message": "AUX 3"
+    },
+    "controlAxisAux4": {
+        "message": "AUX 4"
+    },
+    "controlAxisAux5": {
+        "message": "AUX 5"
+    },
+    "controlAxisAux6": {
+        "message": "AUX 6"
+    },
+    "controlAxisAux7": {
+        "message": "AUX 7"
+    },
+    "controlAxisAux8": {
+        "message": "AUX 8"
+    },
+    "controlAxisAux9": {
+        "message": "AUX 9"
+    },
+    "controlAxisAux10": {
+        "message": "AUX 10"
+    },
+    "controlAxisAux11": {
+        "message": "AUX 11"
+    },
+    "controlAxisAux12": {
+        "message": "AUX 12"
+    },
+    "controlAxisAux13": {
+        "message": "AUX 13"
+    },
+    "controlAxisAux14": {
+        "message": "AUX 14"
+    },
+    "controlAxisAux15": {
+        "message": "AUX 15"
+    },
+    "controlAxisAux16": {
+        "message": "AUX 16"
+    },
+    "pidTuningBasic": {
+        "message": "Основно\/Acro"
+    },
+    "pidTuningYawJumpPrevention": {
+        "message": "Yaw Jump Prevention"
+    },
+    "pidTuningYawJumpPreventionHelp": {
+        "message": "Спречава одскакање летелице на крају Yaw ротације. Већа вредност даје јаче пригушење на крају Yaw покрета (ради као стари Yaw D, који није био прави D као на осталим осама)"
+    },
+    "pidTuningRcExpoPower": {
+        "message": "RC Expo Power"
+    },
+    "pidTuningRcExpoPowerHelp": {
+        "message": "Експонент који се користи при израчунавању RC Expo-а. У верзијама Betaflight-а пре 3.0, вредност је фиксирана на 3."
+    },
+    "pidTuningLevel": {
+        "message": "Angle\/Horizon"
+    },
+    "pidTuningAltitude": {
+        "message": "Барометар и sonar \/ висина"
+    },
+    "pidTuningMag": {
+        "message": "Магнетометар \/ Heading"
+    },
+    "pidTuningGps": {
+        "message": "GPS навигација"
+    },
+    "pidTuningStrength": {
+        "message": "Јачина"
+    },
+    "pidTuningTransition": {
+        "message": "Прелаз"
+    },
+    "pidTuningHorizon": {
+        "message": "Horizon"
+    },
+    "pidTuningAngle": {
+        "message": "Angle"
+    },
+    "pidTuningLevelAngleLimit": {
+        "message": "Angle limit"
+    },
+    "pidTuningLevelSensitivity": {
+        "message": "Осетљивост"
+    },
+    "pidTuningLevelHelp": {
+        "message": "Вредности испод мењају понашање ANGLE и HORIZON модова лета. Различити PID контролери обрађују вредности на различите начине. Молимо Вас да проверите документацију."
+    },
+    "pidTuningMotorOutputLimit": {
+        "message": "Ограничење излаза мотора"
+    },
+    "pidTuningMotorLimit": {
+        "message": "Фактор скалирања [%]"
+    },
+    "pidTuningMotorLimitHelp": {
+        "message": "Проценат смањења погонског сигнала по мотору.<br><br>Смањује струју ESC-а и грејање мотора када користите батерије са већим бројем ћелија на моторима са високим KV.<br><br>Када користите 6S батерију на летелици са 4S моторима, пропелерима и подешавањем, покушајте са 66%; када користите 4S батерију на летелици намењеној за 3S, покушајте са 75%.<br><br>Проверите да ли све Ваше компоненте могу да подрже напон батерије коју користите."
+    },
+    "pidTuningCellCount": {
+        "message": "Број ћелија — за аутоматско мењање профила"
+    },
+    "pidTuningCellCountHelp": {
+        "message": "Аутоматски активира први профил који има број ћелија једнак повезаној батерији.<br><br><ul><li><b>Пребаци<\/b>: Увек пребаци на профил са одговарајућим бројем ћелија ако постоји.<\/li><li><b>Искључи<\/b>: Искључи аутоматско мењање профила<\/li><b>1S-8S<\/b>: Изаберите број ћелија за овај профил<\/li><\/ul>"
+    },
+    "pidTuningCellCountChange": {
+        "message": "Пребаци",
+        "description": "Switch profile if there are no profiles matching cell count"
+    },
+    "pidTuningCellCountStay": {
+        "message": "Искључи",
+        "description": "Disable cell count for this profile"
+    },
+    "pidTuningCellCount1S": {
+        "message": "1S"
+    },
+    "pidTuningCellCount2S": {
+        "message": "2S"
+    },
+    "pidTuningCellCount3S": {
+        "message": "3S"
+    },
+    "pidTuningCellCount4S": {
+        "message": "4S"
+    },
+    "pidTuningCellCount5S": {
+        "message": "5S"
+    },
+    "pidTuningCellCount6S": {
+        "message": "6S"
+    },
+    "pidTuningCellCount7S": {
+        "message": "7S"
+    },
+    "pidTuningCellCount8S": {
+        "message": "8S"
+    },
+    "pidTuningNonProfileFilterSettings": {
+        "message": "Подешавања филтера независна од профила"
+    },
+    "pidTuningFilterSlidersHelp": {
+        "message": "Ови клизачи прилагођавају жироскоп и D-term филтере.<br \/><br \/>За јаче филтрирање:<br \/> - Клизачи улево<br> - Ниже граничне фреквенције.<br \/><br \/> Јаче филтрирање одржава моторе хладнијим уклањањем више шума, али више касни сигнал жироскопа и може погоршати propwash или изазвати резонантне осцилације. Мање одзивне летелице, нпр. X-Class, најбоље раде са јачим филтрирањем. <br><br>За слабије филтрирање:<br \/> - Клизачи удесно<br \/> - Више граничне фреквенције <br><br>Слабије филтрирање смањује кашњење сигнала жироскопа и често побољшава propwash. Померање lowpass филтера жироскопа удесно је обично у реду, али померање D филтера удесно обично није потребно и може лако довести do веома врућих мотора.",
+        "description": "Overall helpicon message for filter tuning sliders"
+    },
+    "pidTuningSliderLowFiltering": {
+        "message": "Слабије филтрирање",
+        "description": "Filter tuning slider low header"
+    },
+    "pidTuningSliderDefaultFiltering": {
+        "message": "Фабричко филтрирање",
+        "description": "Filter tuning slider default header"
+    },
+    "pidTuningSliderHighFiltering": {
+        "message": "Јаче филтрирање",
+        "description": "Filter tuning slider high header"
+    },
+    "pidTuningGyroFilterSlider": {
+        "message": "Множилац филтера жироскопа",
+        "description": "Gyro filter tuning slider label"
+    },
+    "pidTuningGyroFilterSliderHelp": {
+        "message": "Мења граничне фреквенције lowpass филтера жироскопа.<br \/><br \/>Померање клизача улево даје јаче филтрирање жироскопа (нижа гранична фреквенција).<br \/><br \/>Померање клизача удесно даје слабије филтрирање жироскопа (виша гранична фреквенција).<br \/><br \/>Када померате клизач удесно ради бољег понашања при propwash-у, БУДИТЕ ОПРЕЗНИ да не одете предалеко. Пропустићете више шума у P и D и можете добити одлетање летелице или прегоревање мотора.<br \/><br \/>Можда ћете морати да померите клизач улево ако имате проблема са резонанцијом рама, лошим лежајевима, оштећеним пропелерима, врућим моторима итд.<br \/><br \/>Филтрирање жироскопа се примењује пре и поред D филтрирања.",
+        "description": "Gyro filter tuning slider helpicon message"
+    },
+    "pidTuningDTermFilterSlider": {
+        "message": "Множилац D-term филтера",
+        "description": "D Term filter tuning slider label"
+    },
+    "pidTuningDTermFilterSliderHelp": {
+        "message": "Мења граничне фреквенције D-term lowpass филтера.<br \/><br \/>Померање клизача улево даје јаче D филтрирање (нижа гранична фреквенција).<br \/><br \/>Померање клизача удесно даје слабије филтрирање (виша гранична фреквенција).<br \/><br \/>D-term је најосетљивији PID element на шум и резонанцију. Може појачати високофреквентни шум од 10 до 100 пута. Зато су граничне фреквенције D филтера много ниже од филтера жироскопа.<br \/><br \/>D-term филтрирање се примењује након и поред филтрирања жироскопа. Фабричко D филтрирање је оптимално за већину летелица и ретко га треба мењати.<br \/><br \/>Померање овог клизача улево смањује грејање мотора код бучних летелица и код високих PID 'D' вредности, али се може јавити више propwash-а и резонанције D ниже фреквенције.<br \/><br \/>Померање клизача удесно се не препоручује, али може побољшати propwash на чистим израдама. Може изазвати стругање мотора при армовању, изненадне резонанције у лету и озбиљно прегревање мотора.",
+        "description": "D Term filter tuning slider helpicon message"
+    },
+    "pidTuningPidSlidersHelp": {
+        "message": "Клизачи за подешавање летачких карактеристика летелице (PID појачања)<br \/><br \/>Пригушење (D појачање): Одупире се брзом кретању, смањује P осцилације.<br \/><br \/>Праћење (P и I појачање): Побољшава одзив летелице; ако је превисоко, може изазвати подрхтавање или осцилације.<br \/><br \/>Одзив ручице (Feedforward): Повећава одзив летелице на брже покрете ручице.<br \/><br \/>Заношење - Лелујање (I појачање, експерт): Фино подешавање I.<br \/><br \/>Динамички D (D Max, експерт): Подешава максималан износ за који D може бити повећан током брзих покрета.<br \/><br \/>Pitch пригушење (Pitch:Roll D однос, експерт): Повећава износ пригушења на Pitch-у у односу на Roll.<br \/><br \/>Pitch праћење (Pitch:Roll P, I и F однос, експерт): Повећава снагу стабилизације на Pitch-у у односу на Roll.<br \/><br \/>Главни множилац (сва појачања, експерт): Повећава или смањује сва PID појачања, одржавајући њихове пропорције константним.",
+        "description": "Overall helpicon message for PID tuning sliders"
+    },
+    "pidTuningSliderWarning": {
+        "message": "<span class=\"message-negative\">ОПРЕЗ<\/span>: Тренутне позиције клизача могу изазвати одлетање летелице, оштећење мотора или небезбедно понашање летелице. Наставите са опрезом.",
+        "description": "Warning shown when tuning slider are above safe limits"
+    },
+    "pidTuningSlidersDisabled": {
+        "message": "<strong>Напомена:<\/strong> Клизачи су искључени јер су вредности ручно промењене. Кликом на дугме '$t(pidTuningSliderEnableButton.message)' поново ћете их активирати. Ово ће ресетовати вредности и све несачуване измене ће бити изгубљене.",
+        "description": "Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningGyroSliderDisabled": {
+        "message": "<strong>Напомена:<\/strong> Клизач жироскопа је искључен јер су вредности ручно промењене. Кликом на дугме '$t(pidTuningGyroSliderEnableButton.message)' поново ћете га активирати. Ово ће ресетовати вредности и све несачуване измене ће бити изгубљене.",
+        "description": "Gyro Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningDTermSliderDisabled": {
+        "message": "<strong>Напомена:<\/strong> Клизач DTerm-а је искључен јер су вредности ручно промењене. Кликом на дугме '$t(pidTuningDTermSliderEnableButton.message)' поново ћете га активирати. Ово ће ресетовати вредности и све несачуване измене ће бити изгубљене.",
+        "description": "DTerm Tuning sliders disabled note when manual changes are detected"
+    },
+    "pidTuningPidSlidersDisabled": {
+        "message": "<strong>Напомена:<\/strong> Клизачи су искључени. Кликом на дугме '$t(pidTuningSliderEnableButton.message)' променићете PID вредности како би одговарале Вашој претходно сачуваној позицији клизача.",
+        "description": "Tuning sliders disabled note"
+    },
+    "pidTuningSliderEnableButton": {
+        "message": "Укључи клизаче",
+        "description": "Button label for enabling sliders"
+    },
+    "pidTuningSlidersNonExpertMode": {
+        "message": "<strong>Напомена:<\/strong> Опсег клизача је ограничен јер нисте у експертском моду. Овај опсег би требало да одговара већини израда и почетницима.",
+        "description": "Sliders restricted message"
+    },
+    "pidTuningPidSlidersNonExpertMode": {
+        "message": "<strong>Напомена:<\/strong> Приступ и опсег клизача су ограничени јер нисте у експертском моду. Основни мод би требало да одговара већини израда и почетницима.",
+        "description": "Firmware Pid sliders restricted message"
+    },
+    "pidTuningFilterSlidersNonExpertMode": {
+        "message": "<strong>Напомена:<\/strong> Опсег клизача је ограничен јер нисте у експертском моду. Овај опсег би требало да одговара већини израда и почетницима.",
+        "description": "Firmware filter sliders restricted message"
+    },
+    "pidTuningSlidersExpertSettingsDetectedNote": {
+        "message": "<strong>Напомена:<\/strong> Клизач(и) су искључени јер су тренутне вредности изван опсега подешавања у основном моду. Пређите на експертски мод да бисте направили измене",
+        "description": "Slider expert settings detected while in non-expert mode"
+    },
+    "pidTuningSliderLow": {
+        "message": "Ниско",
+        "description": "Tuning Slider Low header"
+    },
+    "pidTuningSliderDefault": {
+        "message": "Фабричко",
+        "description": "Tuning Slider Default header"
+    },
+    "pidTuningSliderHigh": {
+        "message": "Високо",
+        "description": "Tuning Slider High header"
+    },
+    "pidTuningMasterSlider": {
+        "message": "Главни множилац:",
+        "description": "Master tuning slider label"
+    },
+    "pidTuningMasterSliderHelp": {
+        "message": "Једнако повећава све PID параметре. Немојте мењати овај клизач осим ако не потрошите опсег подешавања на осталим клизачима. Обично је ово потребно само за летелице са малим ауторитетом или великим моментом инерције (MoI) као што су X-Class или cinelifter израде. Превелико главно појачање може изазвати подрхтавање, осцилације или вруће моторе.",
+        "description": "Master Gain tuning slider helpicon message"
+    },
+    "pidTuningDGainSlider": {
+        "message": "Пригушење:<br \/><i><small>D Gains<\/small><\/i>",
+        "description": "D Gain (Damping) tuning slider label"
+    },
+    "pidTuningDGainSliderHelp": {
+        "message": "Релативно високе D вредности ће пригушити одзив ручице и могу загрејати моторе, али би требало да помогну у контроли брзих осцилација и побољшају понашање у propwash-у.<br \/><br \/>Релативно низак D-term даје бржи одзив ручице, али ће ослабити перформансе у propwash-у и реакцију на спољне утицаје (ветар).",
+        "description": "D gain balance tuning slider helpicon message"
+    },
+    "pidTuningPIGainSlider": {
+        "message": "Праћење:<br \/><i><small>P & I Gains<\/small><\/i>",
+        "description": "P and I Gain (Stability) tuning slider label"
+    },
+    "pidTuningPIGainSliderHelp": {
+        "message": "Повећајте клизач Праћење да бисте појачали реакцију летелице на Ваше команде и спољне утицаје, спречавајући да нос летелице скрене са путање у било ком тренутку.<br \/><br \/>Ниже вредности за „Праћење” узрокују доста лелујања и летелица ће скретати са путање при померању ручице и у propwash-у. Високе вредности могу довести до осцилација и брзог повратног ударца (тешко се види, али се чује). Прекомерно праћење може резултирати осцилацијама и врућим моторима.",
+        "description": "P and I gain tuning slider helpicon message"
+    },
+    "pidTuningResponseSlider": {
+        "message": "Одзив ручице:<br \/><i><small>FF Gains<\/small><\/i>",
+        "description": "Response tuning slider label"
+    },
+    "pidTuningResponseSliderHelp": {
+        "message": "Нижи одзив ручице повећава кашњење покрета летелице у односу на команде и може изазвати спор повратни ударац на крају извођења flip-а или roll-а.<br><br>Већи одзив ручице даје оштрију реакцију летелице на брзе покрете ручице. Превелик одзив ручице може изазвати прелажење жељене позиције на крају flip-а или roll-а.<br \/><br \/><strong>Напомена:<\/strong><br \/>Опција „I-term Relax” може смањити повратни ударац за летелице са мањом снагом или ако се користе ниске вредности за одзив ручице.",
+        "description": "Stick response gain tuning slider helpicon message"
+    },
+    "pidTuningIGainSlider": {
+        "message": "Заношење - Лелујање:<br \/><i><small>I Gains<\/small><\/i>",
+        "description": "I-term slider label"
+    },
+    "pidTuningIGainSliderHelp": {
+        "message": "Повећава или смањује I вредности. Веће I може побољшати праћење у спиралним заокретима, кружењу или при командама са 0% гаса. Превише I, нарочито уз недовољно P, може изазвати лелујање или повратни ударац након flip-а\/ролл-а или при наглом одузимању гаса на 0%.<br \/><br \/>Уопштено, желите да клизач „Заношење – Лелујање” буде што је могуће виши како би летелица пратила путању у спиралним заокретима, кружењу итд... али не толико висок да почне лелујање при наглом одузимању гаса на 0%.<br \/><br \/><strong>Напомена:<\/strong><br \/>Ако приметите јасне повратне ударце у било ком тренутку, уверите се да је опција „I-term Relax” укључена и покушајте са смањењем вредности iterm_relax_cutoff.",
+        "description": "I-gain Gain tuning slider helpicon message"
+    },
+    "pidTuningDMaxGainSlider": {
+        "message": "Динамичко пригушење:<br \/><i><small>D Max<\/small><\/i>",
+        "description": "D Max slider label"
+    },
+    "pidTuningDMaxGainSliderHelp": {
+        "message": "Повећава D max, односно максималну вредност до које D може порасти током брзих покрета.<br \/><br \/>За тркачке летелице, где је главни клизач за Пригушење постављен ниско ради смањења грејања мотора, померање овог клизача удесно ће побољшати контролу прелажења жељене позиције при брзој промени смера.<br \/><br \/>За HD летелице или летелице за филмско снимање, нестабилност у лету унапред се најбоље решава померањем клизача Пригушење (а не клизача Динамичко пригушење) удесно. Проверите грејање мотора и слушајте има ли чудних звукова током брзих команди са даљинског док померате овај клизач удесно.<br \/><br \/>За freestyle летелице, посебно теже израде, померање овог клизача удесно може помоћи у контроли прелажења жељене позиције у flip-овима и roll-овима.<br \/><br \/><strong>Напомена:<\/strong><br \/>Прелажење жељене позиције у flip-овима и roll-овима је обично узроковано недовољним „I-term Relax” подешавањем, десинхронизацијом мотора или недовољном снагом (тзв. засићење мотора). Ако померање клизача за динамичко пригушење удесно не побољша стање, вратите га у нормалан положај и потражите стварни узрок лелујања.",
+        "description": "D Max slider helpicon message"
+    },
+    "pidTuningRollPitchRatioSlider": {
+        "message": "Pitch пригушење:<br \/><i><small>Pitch:Roll D<\/small><\/i>",
+        "description": "Pitch-Roll Ratio slider label"
+    },
+    "pidTuningRollPitchRatioSliderHelp": {
+        "message": "Повећава пригушење (D) САМО на Pitch оси, односно за Pitch у односу на Roll. Помаже у контроли прелажења позиције или повратног ударца специфичног за Pitch.<br \/><br \/>Летелице са „тежим” моментом инерције на Pitch оси углавном захтевају јаче пригушење (пошто Pitch има већу инерцију и акумулира више замаха).<br \/><br \/>Прво подесите главне клизаче „Пригушење” и\/или „Праћење” док не добијете добро понашање на Roll оси. Затим користите клизаче за Pitch (повећајте или смањите) за фино подешавање Pitch осе без утицаја на Roll.",
+        "description": "Pitch-Roll Ratio tuning slider helpicon message"
+    },
+    "pidTuningPitchPIGainSlider": {
+        "message": "Pitch праћење:<br><i><small>Pitch:Roll P, I & FF<\/small><\/i>",
+        "description": "Pitch P & I slider label"
+    },
+    "pidTuningPitchPIGainSliderHelp": {
+        "message": "Повећава јачину праћења САМО на Pitch оси променом Pitch P и I вредности у односу на Roll. Омогућава јаче праћење на Pitch оси у односу на Roll.<br \/><br \/>Повећајте да бисте стабилизовали лелујање носа при оштрим Pitch командама или наглом одузимању гаса. Такође размотрите повећање Anti-Gravity вредности.<br \/><br \/>Прво подесите главне клизаче „Пригушење” и\/или „Праћење” док не добијете добро понашање на Roll оси. Затим користите клизаче за Pitch (повећајте или смањите) за фино подешавање Pitch осе без утицаја на Roll.",
+        "description": "Pitch P & I Gain tuning slider helpicon message"
+    },
+    "pidTuningGyroLowpassFiltersGroup": {
+        "message": "Нископропусни жироскопски филтери"
+    },
+    "pidTuningGyroLowpassType": {
+        "message": "Врста 1. нископропусног жироскопског филтера"
+    },
+    "pidTuningGyroLowpass": {
+        "message": "Gyro Lowpass 1"
+    },
+    "pidTuningGyroLowpassHelp": {
+        "message": "Први од два нископропусна жироскопска филтера.<br \/><br \/>Употреба првог нископропусног жироскопског филтера у динамичком моду била је важна са старијим кодом динамичког notch филтера. Први нископропусни filter се обично може потпуно искључити у фирмверу 4.3 када се користи RPM филтрирање, осим ако жироскоп нема интерно хардверско филтрирање.<br \/><br \/>У динамичком моду, филтрирање ће бити јаче на ниском гасу, са мање филтрирања и мањим кашњењем како се гас повећава. Прелаз са ниске на високу граничну фреквенцију дешаваће се раније при повећању гаса ако су више експоненцијалне вредности нископропусног жироскопског филтера.<br \/><br \/>У статичком моду, гранична фреквенција је фиксна.<br \/><br \/>Врста филтера је фабрички постављена на PT1. Филтрирање вишег реда је ретко потребно.",
+        "description": "Help icon for the Gyro Lowpass 1 Filter"
+    },
+    "pidTuningGyroLowpassMode": {
+        "message": "Мод"
+    },
+    "pidTuningLowpassStatic": {
+        "message": "СТАТИЧКИ"
+    },
+    "pidTuningLowpassDynamic": {
+        "message": "ДИНАМИЧКИ"
+    },
+    "pidTuningLowpassFilterType": {
+        "message": "Врста филтера"
+    },
+    "pidTuningMinCutoffFrequency": {
+        "message": "Минимална гранична фреквенција [Hz]"
+    },
+    "pidTuningMaxCutoffFrequency": {
+        "message": "Максимална гранична фреквенција [Hz]"
+    },
+    "pidTuningGyroLowpass2": {
+        "message": "Gyro Lowpass 2"
+    },
+    "pidTuningGyroLowpass2Help": {
+        "message": "Други од два нископропусна жироскопска филтера.<br \/><br \/>Овај filter ради у петљи жироскопа, филтрирајући сигнал пре него што уђе у PID петљу. Увек је у статичком моду (са фиксном граничном фреквенцијом).<br \/><br \/>Ако је фреквенција PID петље мања од фреквенције петље жироскопа (нпр. PID петља од 4kHz са петљом жироскопа од 8kHz), овај filter треба задржати како би се спречили проблеми са пресликавањем фреквенција услед смањења учесталости одабирања са 8kHz на 4kHz.<br \/><br \/>Појединачна конфигурација другог нископропусног жироскопског филтера, подешено негде између 500 и 1000Hz, ради добро за Betaflight 4.3 или новији, за чисте израде са активним RPM филтрирањем и бар фабричким D филтрирањем.",
+        "description": "Gyro lowpass filter helpicon message"
+    },
+    "pidTuningGyroLowpassFilterHelp": {
+        "message": "Жироскопски нископропусни филтери пригушују шум виших фреквенција како не би ушао у PID петљу. Постоје два жироскопска филтера која се могу независно подешавати; фабрички су оба активна.<br \/><br \/>Уз RPM филтрирање, клизач жироскопског филтера се често може померити мало удесно, или један статички жироскопски нископропусни filter на 500 Hz може бити довољан.<br \/><br \/>Летелица ће имати мање propwash-а уз најмање кашњење жироскопског филтера.<br \/><br \/>Увек проверите загревање мотора када померате клизаче удесно. Уз минимално жироскопско филтрирање, од кључне је важности имати довољно D филтрирања. Будите опрезни.",
+        "description": "Gyro lowpass filter helpicon message"
+    },
+    "pidTuningDTermLowpassFilterHelp": {
+        "message": "D-term нископропусни филтери пригушују шум виших фреквенција и резонанце које би иначе биле појачане D појачањем.<br \/><br \/>Постоје два D филтера и њихови ефекти се сабирају. Оба су потребна у скоро свим летелицама, иако се један PT2 може користити уместо два PT1 филтера.<br \/><br \/>Уопштено, летелица ће летети најбоље и имати најмање propwash-а када је подешена на најмање кашњење филтера (клизачи удесно, више граничне вредности). Међутим, посебно са D филтерима, клизачи удесно могу знатно повећати шансу за прегревање мотора.<br \/><br \/>Веома је лако спалити моторе ако немате довољно D филтрирања, будите опрезни.",
+        "description": "D-term lowpass filter helpicon message"
+    },
+    "pidTuningGyroNotchFiltersGroup": {
+        "message": "Жироскопски notch филтери"
+    },
+    "pidTuningGyroNotchFilter": {
+        "message": "Жироскопски notch filter 1"
+    },
+    "pidTuningGyroNotchFilterHelp": {
+        "message": "Примењује статички (константна фреквенција) notch filter на жироскоп, на наведеној централној фреквенцији.<br \/><br \/>Може бити користан за изоловане резонанце константне фреквенције које утичу и на P и на D.<br \/><br \/>Да би био користан, резонантна фреквенција мора бити константна у целом опсегу гаса.<br \/><br \/>Ширина notch филтера се подешава граничном фреквенцијом. Гранична фреквенција би обично требало да буде подешена између 10% и 40% испод централне фреквенције. Користите најужи опсег филтера који контролише резонанцу. Избегавајте подешавање notch филтера испод 100 Hz, осим у посебним околностима.<br \/><br \/>Статички notch филтери су ретко потребни у верзији 4.3."
+    },
+    "pidTuningGyroNotchFilter2": {
+        "message": "Жироскопски notch filter 2"
+    },
+    "pidTuningGyroNotchFilter2Help": {
+        "message": "Примењује други статички (константна фреквенција) notch filter на жироскоп.<br \/><br \/>Ово је ретко потребно и треба га користити само као последњу опцију за борбу против друге линије резонанце фиксне фреквенције која се не може контролисати другим средствима."
+    },
+    "pidTuningCenterFrequency": {
+        "message": "Централна фреквенција [Hz]"
+    },
+    "pidTuningCutoffFrequency": {
+        "message": "Гранична фреквенција [Hz]"
+    },
+    "pidTuningNotchFilterHelp": {
+        "message": "Notch filter је симетрични, уски filter са параметрима за централну и граничну фреквенцију.<br \/><br \/>Централна вредност је централна фреквенција филтера. Гранична вредност је доња -3 dB гранична фреквенција.<br \/><br \/>На пример, Notch Cutoff од 160 са Notch Center од 260 даје широки notch са опсегом од -3 dB од 160-360 Hz и најјачим пригушењем око 260 Hz.",
+        "description": "Notch filter helpicon message"
+    },
+    "pidTuningDynamicNotchFilterGroup": {
+        "message": "Dynamic Notch filter"
+    },
+    "pidTuningDynamicNotchFilterHelp": {
+        "message": "Dynamic Notch filter прати врхунце фреквенције шума мотора и поставља notch филтере на те фреквенције, независно за сваку осу."
+    },
+    "pidTuningMultiDynamicNotchFilterHelp": {
+        "message": "Dynamic Notch filter прати врхунце фреквенције шума жироскопа и поставља од један до пет notch филтера са њиховим центром на тим фреквенцијама на свакој оси."
+    },
+    "pidTuningDynamicNotchFilterDisabledWarning": {
+        "message": "<strong>Напомена:<\/strong> Dynamic notch filter је искључен. Да бисте га подесили и користили, укључите опцију 'DYNAMIC_FILTER' у одељку '$t(configurationFeatures.message)' на картици '$t(tabConfiguration.message)'. Такође се уверите да је PID looprate најмање 2kHz."
+    },
+    "pidTuningDynamicNotchFilterNyquistWarning": {
+        "message": "Dynamic notch filter је искључен. Да бисте га користили, уверите се да је учестаност PID петље подешена на најмање 2kHz на картици '$t(tabConfiguration.message)'."
+    },
+    "pidTuningDynamicNotchRange": {
+        "message": "Опсег Dynamic Notch филтера"
+    },
+    "pidTuningDynamicNotchQ": {
+        "message": "Q фактор (x100)"
+    },
+    "pidTuningDynamicNotchMinHz": {
+        "message": "Min фреквенција [Hz]"
+    },
+    "pidTuningDynamicNotchMaxHz": {
+        "message": "Макс фреквенција [Hz]"
+    },
+    "pidTuningDynamicNotchCount": {
+        "message": "Број notch филтера"
+    },
+    "pidTuningDynamicNotchRangeHelp": {
+        "message": "Dynamic notch има три фреквентна опсега у којима може да ради: LOW (80-330 Hz) за летелице са нижим бројем обртаја попут 6+ инча, MEDIUM (140-550 Hz) за стандардне летелице од 5 инча, HIGH (230-800 Hz) за летелице са веома високим бројем обртаја од 2,5-3 инча. Опција AUTO бира опсег у зависности од вредности максималне граничне фреквенције филтера Gyro Dynamic Lowpass 1."
+    },
+    "pidTuningDynamicNotchQHelp": {
+        "message": "Q фактор подешава колико су уски или широки dynamic notch филтери. Сачувана вредност је Q фактор × 100 (нпр. 300 = Q 3,0). Већа вредност га чини ужим и прецизнијим, а мања вредност га чини ширим. Веома ниска вредност ће знатно повећати кашњење филтера."
+    },
+    "pidTuningDynamicNotchMinHzHelp": {
+        "message": "Подесите ово на најнижу фреквенцију улазног шума коју је потребно контролисати помоћу dynamic notch филтера."
+    },
+    "pidTuningDynamicNotchMaxHzHelp": {
+        "message": "Подесите ово на највишу фреквенцију улазног шума коју је потребно контролисати помоћу dynamic notch филтера."
+    },
+    "pidTuningDynamicNotchCountHelp": {
+        "message": "Подешава број dynamic notch филтера по оси. Са укљученим RPM филтером препоручује се вредност 1 или 2. Без RPM филтера препоручује се вредност 4 или 5. Мањи бројеви ће смањити кашњење филтера, али могу повећати температуру мотора."
+    },
+    "pidTuningRpmFilterGroup": {
+        "message": "Gyro RPM filter",
+        "description": "Header text for the RPM Filter group"
+    },
+    "pidTuningRpmFilterHelp": {
+        "message": "RPM филтрирање је скуп notch филтера на жироскопу који користе RPM телеметријске податке за уклањање шума мотора са хируршком прецизношћу.<br \/><br \/><b><span class=\"message-positive\">ВАЖНО<\/span>: ESC мора подржавати Bidirectional DShot протокол и вредност $t(configurationMotorPoles.message) у картици $t(tabMotorTesting.message) мора бити тачна да би овај filter радио.<\/b>",
+        "description": "Header text for the RPM Filter group"
+    },
+    "pidTuningRpmHarmonics": {
+        "message": "Хармоници",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmHarmonicsHelp": {
+        "message": "Број хармоника по мотору. Вредност 3 (препоручено за већину летелица) генерише 3 notch филтера по мотору за сваку осу, што је укупно 36 notch филтера. Један на основној фреквенцији мотора и два хармоника на умношцима те основне фреквенције.",
+        "description": "Help text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmMinHz": {
+        "message": "Min фреквенција [Hz]",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmMinHzHelp": {
+        "message": "Минимална фреквенција коју ће користити RPM filter.",
+        "description": "Help text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmFadeRangeHz": {
+        "message": "Опсег слабљења [Hz]",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmQ": {
+        "message": "Q фактор (x100)",
+        "description": "Text for one of the parameters of the RPM Filter"
+    },
+    "pidTuningRpmQHelp": {
+        "message": "Q фактор подешава колико су уски или широки RPM notch филтери. Запамћена вредност је Q фактор × 100, дозвољени опсег је 250–3000 (Q 2,5 до Q 30,0), фабрички 500 (Q 5,0). Веће вредности чине сваки notch ужим и прецизнијим; мање вредности их чине ширим. Веома ниске вредности значајно повећавају кашњење филтера."
+    },
+    "pidTuningRpmWeight": {
+        "message": "Тежина {{index}}",
+        "description": "Text for the per-harmonic weight parameter of the RPM Filter"
+    },
+    "pidTuningFilterSettings": {
+        "message": "Подешавања филтера зависна од профила"
+    },
+    "pidTuningDTermLowpass": {
+        "message": "D Term lowpass 1"
+    },
+    "pidTuningDTermLowpassHelp": {
+        "message": "Први од два D-term lowpass филтера.<br \/><br \/>У динамичком моду, филтрирање ће бити јаче на ниском гасу, са мање филтрирања и мање кашњења како се гас повећава. Ово помаже у контроли шкрипања мотора или неочекиваног одлетања при армовању, док смањује кашњење и propwash након полетања. Прелазак са ниске на високу граничну фреквенцију дешаваће се раније како се гас повећава, са вишим вредностима D-term lowpass expo.<br \/><br \/>У статичком моду, гранична фреквенција је фиксна. Ово се не препоручује за D филтрирање.<br \/><br \/>Врста филтера је фабрички PT1, иако су неки корисници овде користили само један динамички Biquad filter, без другог PT1.<br \/><br \/>Промене које резултирају мањим D филтрирањем могу изазвати озбиљно прегревање мотора или одлетање летелице при армовању.",
+        "description": "Help icon for the DTerm Lowpass 1 Filter"
+    },
+    "pidTuningDTermLowpassMode": {
+        "message": "Мод"
+    },
+    "pidTuningDTermLowpass2": {
+        "message": "D Term lowpass 2"
+    },
+    "pidTuningDTermLowpass2Help": {
+        "message": "Други од два D-term lowpass филтера.<br \/><br \/>Овај filter је увек у статичком моду (фиксна гранична фреквенција). За D филтрирање су потребна најмање два PT1 lowpass филтера или један filter другог реда.<br \/><br \/>Обично је ова гранична фреквенција подешена на вишу вредност опсега динамичког lowpass 1 филтера. Ово обезбеђује контролу шума другог реда изнад те фреквенције.<br \/><br \/>Промене које резултирају мањим D филтрирањем могу изазвати озбиљно прегревање мотора или одлетање летелице при армовању.",
+        "description": "Help icon for the DTerm Lowpass 2 Filter"
+    },
+    "pidTuningDTermLowpassFiltersGroup": {
+        "message": "D Term lowpass филтери"
+    },
+    "pidTuningDTermLowpassType": {
+        "message": "Врста филтера"
+    },
+    "pidTuningStaticCutoffFrequency": {
+        "message": "Статичка гранична фреквенција [Hz]"
+    },
+    "pidTuningDTermLowpass2Type": {
+        "message": "Врста филтера"
+    },
+    "pidTuningDTermLowpassDynExpo": {
+        "message": "Expo динамичке криве"
+    },
+    "pidTuningDTermNotchFiltersGroup": {
+        "message": "D Term notch filter"
+    },
+    "pidTuningDTermNotchFiltersGroupHelp": {
+        "message": "Примењује статички notch filter (константне фреквенције) на D-Term податке, на наведеној централној фреквенцији.<br \/><br \/>Ширина notch филтера се подешава граничном фреквенцијом.<br \/><br \/>Може бити корисно за изоловане резонанце константне фреквенције које D појачава.<br \/><br \/>Држите граничну фреквенцију што ближе центру. Избегавајте подешавање notch филтера испод 100 Hz, осим на летелицама са ниским RPM-ом."
+    },
+    "pidTuningYawLowpassFiltersGroup": {
+        "message": "Yaw lowpass filter"
+    },
+    "pidTuningYawLowpassFiltersGroupHelp": {
+        "message": "Примењује PT1 filter на наведеној граничној фреквенцији на податке са жироскопа по Yaw оси."
+    },
+    "pidTuningVbatPidCompensation": {
+        "message": "Vbat PID компензација"
+    },
+    "pidTuningVbatPidCompensationHelp": {
+        "message": "Повећава PID вредности ради компензације када опадне Vbat напон. Ово даје уједначеније карактеристике лета током целог трајања батерије. Количина компензације која се примењује израчунава се на основу $t(powerBatteryMaximum.message) подешеног на страници $t(tabPower.message), па се уверите да је та вредност одговарајућа."
+    },
+    "pidTuningVbatSagCompensation": {
+        "message": "Vbat sag компензација %"
+    },
+    "pidTuningVbatSagCompensationHelp": {
+        "message": "Пружа уједначене перформансе гаса и PID-а током целог опсега радног напона батерије повећавањем снаге мотора како напон опада.<br \/><br \/>Количина компензације се може мењати између 0 и 100%. Препоручује се потпуна компензација (100%).<br \/><br \/>Посетите <a href=\"https:\/\/betaflight.com\/docs\/wiki\/tuning\/4-2-Tuning-Notes#dynamic-battery-sag-compensation\" target=\"_blank\" rel=\"noopener noreferrer\">овај wiki чланак<\/a> за више информација."
+    },
+    "pidTuningVbatSagValue": {
+        "message": "%"
+    },
+    "pidTuningThrustLinearization": {
+        "message": "Линеаризација потиска %"
+    },
+    "pidTuningThrustLinearizationHelp": {
+        "message": "Побољшава одзив и контролу на ниском гасу.<br><br>Нарочито корисно за whoop летелице и ESC-ове на 48kHz. Нема утицаја при већем гасу.<br><br>Количина компензације се може мењати између 0 и 150%. Обично је довољно 30-40%."
+    },
+    "pidTuningThrustLinearValue": {
+        "message": "%"
+    },
+    "pidTuningItermRotation": {
+        "message": "I Term ротација"
+    },
+    "pidTuningItermRotationHelp": {
+        "message": "Правилно ротира тренутни вектор I Term-а на друге осе како се летелица окреће при непрекидном Yaw окретању током Roll маневара, при извођењу фунел-а и других трикова. Изузетно корисно за LOS акро пилоте."
+    },
+    "pidTuningItermRelax": {
+        "message": "I Term Relax"
+    },
+    "pidTuningItermRelaxHelp": {
+        "message": "Потискује накупљање I Term-а при брзим покретима, смањујући повратни трзај на крају окретаја по Roll, Flip и другим брзим командама.<br><br>Setpoint мод реагује на ублажене команде са даљинског и најбоље функционише на одзивним летелицама.<br><br>Gyro мод може бити користан за изузетно споре летелице.<br><br>Обично iTerm Relax не треба примењивати на Yaw."
+    },
+    "pidTuningItermRelaxAxes": {
+        "message": "Осе",
+        "description": "Iterm Relax Axes selection"
+    },
+    "pidTuningOptionRP": {
+        "message": "RP"
+    },
+    "pidTuningOptionRPY": {
+        "message": "RPY"
+    },
+    "pidTuningItermRelaxAxesOptionRPInc": {
+        "message": "RP (само повећање)"
+    },
+    "pidTuningItermRelaxAxesOptionRPYInc": {
+        "message": "RPY (само повећање)"
+    },
+    "pidTuningItermRelaxType": {
+        "message": "Тип",
+        "description": "Iterm Relax Type selection"
+    },
+    "pidTuningItermRelaxTypeOptionSetpoint": {
+        "message": "Setpoint"
+    },
+    "pidTuningItermRelaxCutoff": {
+        "message": "Гранична фреквенција",
+        "description": "Cutoff value of the I Term Relax"
+    },
+    "pidTuningItermRelaxCutoffHelp": {
+        "message": "Ниже вредности значе јаче потискивање повратног трзаја након Flip маневара код мање одзивних летелица. Више вредности повећавају прецизност скретања при великим брзинама ротације за трке.<br><br>Подесите на 30-40 за трке, 15 за одзивне freestyle летелице, 10 за теже freestyle летелице, 3-5 за X-класу."
+    },
+    "pidTuningAbsoluteControlGain": {
+        "message": "Absolute Control"
+    },
+    "pidTuningAbsoluteControlGainHelp": {
+        "message": "Ова функција решава неке од основних проблема функције $t(pidTuningItermRotation.message) и у неком тренутку је може заменити. Она акумулира апсолутну грешку жироскопа у координатама летелице и меша пропорционалну корекцију у setpoint.<br><br>AirMode мора бити укључен, као и $t(pidTuningItermRelax.message) (за $t(pidTuningOptionRP.message)). Када се комбинује са $t(pidTuningIntegratedYaw.message), можете укључити $t(pidTuningItermRelax.message) за $t(pidTuningOptionRPY.message)."
+    },
+    "pidTuningThrottleBoost": {
+        "message": "Throttle Boost"
+    },
+    "pidTuningThrottleBoostHelp": {
+        "message": "Тренутно појачава гас при бржим командама гаса, пружајући непосреднији одзив гаса."
+    },
+    "pidTuningIdleMinRpm": {
+        "message": "Вредност Dynamic Idle [* 100 RPM]"
+    },
+    "pidTuningIdleMinRpmHelp": {
+        "message": "Dynamic Idle побољшава контролу на ниском RPM-у и смањује ризик од десинхронизације мотора. <br \/><br \/> Побољшава PID ауторитет, стабилност на нултом гасу, време лебдења наглавачке и кочење мотора.<br \/><br \/>Минимални RPM за Dynamic Idle треба подесити на око 3000 - 3500 RPM. <br \/><br \/>Посетите <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Dynamic-Idle\" target=\"_blank\" rel=\"noopener noreferrer\">овај wiki чланак<\/a> за више информација."
+    },
+    "pidTuningIdleMinRpmDisabled": {
+        "message": "Dynamic Idle је искључен јер је DShot телеметрија искључена"
+    },
+    "pidTuningAcroTrainerAngleLimit": {
+        "message": "Ограничење угла за Acro Trainer"
+    },
+    "pidTuningAcroTrainerAngleLimitHelp": {
+        "message": "Помаже пилотима да науче да лете у acro моду ограничавањем угла који летелица може да постигне. Важећа ограничења су 10-80 степени. Мод мора бити активиран прекидачем у картици $t(tabAuxiliary.message)."
+    },
+    "pidTuningIntegratedYaw": {
+        "message": "Integrated Yaw"
+    },
+    "pidTuningIntegratedYawCaution": {
+        "message": "<span class=\"message-negative\">ОПРЕЗ<\/span>: ако укључите ову функцију, морате сходно томе прилагодити YAW PID. Више информација <a href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/Integrated-Yaw\" target=\"_blank\" rel=\"noopener noreferrer\">овде<\/a>"
+    },
+    "pidTuningIntegratedYawHelp": {
+        "message": "Integrated Yaw интегрише Yaw P, I и D вредности, омогућавајући да се Yaw P, I и D подешавају слично као Pitch и Roll.<br><br>Потребно је врло мало I вредности, јер интегрисани P делује као I, а интегрисани D делује као P.<br><br>НАПОМЕНА: Integrated Yaw захтева коришћење функције Absolute Control, пошто I није потребан уз Integrated Yaw."
+    },
+    "failsafeFeaturesHelpOld": {
+        "message": "Подешавање Failsafe-а је знатно измењено. Користите Betaflight <strong>в1.12.0+<\/strong> да бисте добили побољшани прозор за подешавање."
+    },
+    "failsafePaneTitleOld": {
+        "message": "Failsafe пријемника"
+    },
+    "failsafeFeaturesHelpNew": {
+        "message": "Failsafe има две фазе. U <strong>фазу 1<\/strong> се улази када неки од летачких канала има неисправну дужину импулса, када пријемник јави да је у Failsafe стању, или када сигнала уопште нема. Тада се задато поступање са каналима примењује на <span class=\"message-negative\">све канале<\/span> и оставља се кратко време да се сигнал врати. U <strong>фазу 2<\/strong> се улази ако стање грешке потраје дуже од задатог заштитног времена док је дрон <span class=\"message-negative\">армован<\/span>. Сви канали тада остају на задатој вредности, осим ако изабрани поступак не одреди другачије.<br \/><strong>Напомена:<\/strong> и пре уласка у фазу 1, задато поступање примењује се на појединачне AUX канале који имају неисправне импулсе."
+    },
+    "failsafePulsrangeTitle": {
+        "message": "Подешавање исправног опсега импулса"
+    },
+    "failsafePulsrangeHelp": {
+        "message": "Импулси краћи од најмање или дужи од највеће дужине сматрају се неисправним. За AUX канале тада се примењује задато поступање са тим каналом, а за летачке канале се улази у фазу 1."
+    },
+    "failsafeRxMinUsecItem": {
+        "message": "Најмања дужина"
+    },
+    "failsafeRxMaxUsecItem": {
+        "message": "Највећа дужина"
+    },
+    "failsafeChannelFallbackSettingsTitle": {
+        "message": "Фаза 1 — поступање са каналима"
+    },
+    "failsafeChannelFallbackSettingsHelp": {
+        "message": "Ова подешавања примењују се на појединачне неисправне AUX канале, или на све канале при уласку у фазу 1. <strong>Напомена:<\/strong> вредности се чувају у корацима од двадесет пет микросекунди, па се ситне измене губе."
+    },
+    "failsafeChannelFallbackSettingsAuto": {
+        "message": "<strong>Auto<\/strong> значи да Roll, Pitch и Yaw иду у средину, а Throttle на ниско. <strong>Hold<\/strong> значи да се задржава последња исправна примљена вредност."
+    },
+    "failsafeChannelFallbackSettingsHold": {
+        "message": "<strong>Hold<\/strong> значи да се задржава последња исправна примљена вредност. <strong>Set<\/strong> значи да се користи вредност коју овде задате."
+    },
+    "failsafeChannelFallbackSettingsValueAuto": {
+        "message": "Аутоматски",
+        "description": "Text for Auto option"
+    },
+    "failsafeChannelFallbackSettingsValueHold": {
+        "message": "Задржи",
+        "description": "Text for Hold option"
+    },
+    "failsafeChannelFallbackSettingsValueSet": {
+        "message": "Постави",
+        "description": "Text for Set option"
+    },
+    "failsafeStageTwoSettingsTitle": {
+        "message": "Фаза 2 — подешавања"
+    },
+    "failsafeDelayItem": {
+        "message": "Трајање фазе 1 после губитка сигнала [секунде]"
+    },
+    "failsafeDelayHelp": {
+        "message": "Задајте колико траје фаза 1 после губитка сигнала. Ако то време истекне а сигнал се не врати, покреће се фаза 2."
+    },
+    "failsafeThrottleLowItem": {
+        "message": "Одлагање при ниском гасу [секунде]"
+    },
+    "failsafeThrottleLowHelp": {
+        "message": "Ако је гас био низак оволико дуго, дрон се само разоружава уместо да изврши изабрани Failsafe поступак."
+    },
+    "failsafeThrottleItem": {
+        "message": "Вредност гаса при спуштању"
+    },
+    "failsafeOffDelayItem": {
+        "message": "Одлагање гашења мотора током Failsafe-а [секунде]"
+    },
+    "failsafeOffDelayHelp": {
+        "message": "Колико дуго дрон остаје у режиму спуштања пре него што се мотори угасе и дрон разоружа."
+    },
+    "failsafeSubTitle1": {
+        "message": "Фаза 2 — поступак"
+    },
+    "failsafeProcedureItemSelect1": {
+        "message": "Land"
+    },
+    "failsafeProcedureItemSelect2": {
+        "message": "Drop"
+    },
+    "failsafeProcedureItemSelect4": {
+        "message": "GPS Rescue"
+    },
+    "failsafeGpsRescueItemAltitudeMode": {
+        "message": "Начин одређивања висине"
+    },
+    "failsafeGpsRescueItemAltitudeModeMaxAlt": {
+        "message": "Највећа достигнута висина"
+    },
+    "failsafeGpsRescueItemAltitudeModeFixedAlt": {
+        "message": "Задата висина"
+    },
+    "failsafeGpsRescueItemAltitudeModeCurrentAlt": {
+        "message": "Тренутна висина"
+    },
+    "failsafeGpsRescueInitialClimb": {
+        "message": "Почетно пењање (метара)"
+    },
+    "failsafeGpsRescueInitialClimbHelp": {
+        "message": "Колико ће се дрон попети изнад тренутне висине када повратак почне, ако је начин одређивања висине постављен на тренутну висину. Додаје се и у режиму највеће висине."
+    },
+    "failsafeGpsRescueItemReturnAltitude": {
+        "message": "Висина повратка (метара) — <strong>важи само у режиму задате висине<\/strong>"
+    },
+    "failsafeGpsRescueItemAscendRate": {
+        "message": "Брзина пењања (метара у секунди)"
+    },
+    "failsafeGpsRescueItemGroundSpeed": {
+        "message": "Брзина повратка над земљом (метара у секунди)"
+    },
+    "failsafeGpsRescueItemAngle": {
+        "message": "Највећи угао нагиба унапред"
+    },
+    "failsafeGpsRescueAngleHelp": {
+        "message": "Већи највећи угао значи бржи и одлучнији повратак. Може бити користан за теже дронове, оне са великим отпором или слабијим одзивом, као и при јачем ветру. ПАЖЊА: уз повећање угла обично треба повећати и гас за повратак. У супротном дрон може да изгуби висину и падне."
+    },
+    "failsafeGpsRescueItemDescentDistance": {
+        "message": "Растојање на ком почиње спуштање (метара)"
+    },
+    "failsafeGpsRescueItemDescendRate": {
+        "message": "Брзина спуштања (метара у секунди)"
+    },
+    "failsafeGpsRescueDescendRateHelp": {
+        "message": "Почетна брзина спуштања је три пута већа од ове вредности и смањује се до задате вредности на висини слетања."
+    },
+    "failsafeGpsRescueItemMinStartDistHelp": {
+        "message": "Ако повратак почне преблизу месту полетања, унутар овог најмањег растојања, дрон ће прво одлетети право напред док се не удаљи бар толико, па тек онда креће уобичајен поступак повратка.",
+        "description": "Updated help text for the minimum start distance needed for GPS rescue to activate"
+    },
+    "failsafeGpsRescueItemThrottleMin": {
+        "message": "Најмањи гас"
+    },
+    "failsafeGpsRescueItemThrottleMax": {
+        "message": "Највећи гас"
+    },
+    "failsafeGpsRescueThrottleMaxHelp": {
+        "message": "Треба повећати за теже дронове, оне са великим отпором или слабијим одзивом, ако се очекује повратак против јаког ветра, или ако је повећан највећи угао нагиба."
+    },
+    "failsafeGpsRescueItemThrottleHover": {
+        "message": "Гас за лебдење — <span class=\"message-negative\">ВАЖНО: поставите ову вредност тачно<\/span>"
+    },
+    "failsafeGpsRescueThrottleHoverHelp": {
+        "message": "Да бисте нашли праву вредност, поставите радњу Failsafe прекидача на фазу 2, поступак фазе 2 на Land, па мењајте вредност гаса при спуштању док дрон не почне да лебди или да се спушта полако. Ту вредност затим упишите као гас за лебдење при GPS Rescue-у, и као вредност гаса у поступању са каналима у фази 1."
+    },
+    "failsafeGpsRescueItemMinDth": {
+        "message": "Најмање растојање од места полетања (метара)"
+    },
+    "failsafeGpsRescueItemMinDthHelp": {
+        "message": "Најмање растојање од места полетања потребно да би се GPS Rescue уопште покренуо."
+    },
+    "failsafeGpsRescueItemMinSats": {
+        "message": "Најмањи број сателита"
+    },
+    "failsafeGpsRescueItemAllowArmingWithoutFix": {
+        "message": "Дозволи армовање без сателитског положаја — <span class=\"message-negative\">ПАЖЊА: без положаја дрон се разоружава при Failsafe-у!<\/span>"
+    },
+    "failsafeGpsRescueArmWithoutFixHelp": {
+        "message": "Не препоручује се. Дозвољава армовање без забележеног места полетања, али ће се дрон при стварном губитку сигнала разоружати и пасти. Ако се проба прекидачем, пре разоружавања постоји кратак period у ком дрон не ради ништа."
+    },
+    "failsafeGpsRescueItemSanityChecks": {
+        "message": "Провере исправности"
+    },
+    "failsafeGpsRescueItemSanityChecksOff": {
+        "message": "Искључено"
+    },
+    "failsafeGpsRescueItemSanityChecksOn": {
+        "message": "Укључено"
+    },
+    "failsafeGpsRescueItemSanityChecksFSOnly": {
+        "message": "Само при Failsafe-у"
+    },
+    "failsafeKillSwitchItem": {
+        "message": "Failsafe прекидач за тренутно гашење (подесите Failsafe на картици Модови)"
+    },
+    "failsafeKillSwitchHelp": {
+        "message": "Овом поставком Failsafe прекидач са картице Модови постаје прекидач за тренутно гашење, који заобилази изабрани Failsafe поступак. <strong>Напомена:<\/strong> док је тај прекидач укључен, армовање је онемогућено."
+    },
+    "failsafeSwitchTitle": {
+        "message": "Failsafe прекидач"
+    },
+    "failsafeSwitchModeItem": {
+        "message": "Радња Failsafe прекидача"
+    },
+    "failsafeSwitchModeHelp": {
+        "message": "Ова поставка одређује шта се дешава када се Failsafe покрене преко AUX прекидача:<br\/><strong>Фаза 1<\/strong> покреће фазу 1. Корисно је када желите да испробате како се дрон тачно понаша при губитку сигнала.<br\/><strong>Фаза 2<\/strong> прескаче фазу 1 и одмах покреће поступак фазе 2.<br\/><strong>Тренутно гашење<\/strong> разоружава дрон истог тренутка, па ће дрон пасти."
+    },
+    "failsafeSwitchOptionStage1": {
+        "message": "Фаза 1"
+    },
+    "failsafeSwitchOptionStage2": {
+        "message": "Фаза 2"
+    },
+    "failsafeSwitchOptionKill": {
+        "message": "Тренутно гашење"
+    },
+    "powerButtonSave": {
+        "message": "Сачувај"
+    },
+    "powerFirmwareUpgradeRequired": {
+        "message": "Потребно је <span class=\"message-negative\">ажурирање фирмвера<\/span>. Подешавања батерије, напона и струје са API-јем &lt; 1.33.0 (Betaflight &lt;= 3.17) нису подржана."
+    },
+    "powerBatteryVoltageMeterSource": {
+        "message": "Извор мерења напона"
+    },
+    "powerBatteryVoltageMeterTypeNone": {
+        "message": "Ништа"
+    },
+    "powerBatteryVoltageMeterTypeAdc": {
+        "message": "Мерач на плочици"
+    },
+    "powerBatteryVoltageMeterTypeEsc": {
+        "message": "Сензор у регулатору"
+    },
+    "powerBatteryCurrentMeterSource": {
+        "message": "Извор мерења струје"
+    },
+    "powerBatteryCurrentMeterTypeNone": {
+        "message": "Ништа"
+    },
+    "powerBatteryCurrentMeterTypeAdc": {
+        "message": "Мерач на плочици"
+    },
+    "powerBatteryCurrentMeterTypeVirtual": {
+        "message": "Рачунски"
+    },
+    "powerBatteryCurrentMeterTypeEsc": {
+        "message": "Сензор у регулатору"
+    },
+    "powerBatteryCurrentMeterTypeMsp": {
+        "message": "MSP сензор \/ спољни OSD"
+    },
+    "powerBatteryMinimum": {
+        "message": "Најнижи напон ћелије"
+    },
+    "powerBatteryMaximum": {
+        "message": "Највиши напон ћелије"
+    },
+    "powerBatteryWarning": {
+        "message": "Напон ћелије за упозорење"
+    },
+    "powerBatteryMinimumHelp": {
+        "message": "Напон који се сматра критично ниским и који покреће одговарајућа упозорења: „LAND NOWˮ на OSD-у и звучни сигнал ако је пискалица залемљена. Користи се и при рачунању броја ћелија."
+    },
+    "powerBatteryMaximumHelp": {
+        "message": "Напон пуне ћелије. Помаже програму да израчуна број ћелија у батерији."
+    },
+    "powerBatteryWarningHelp": {
+        "message": "Напон који се сматра ниским и који покреће одговарајуће упозорење: „LOW BATTERYˮ на OSD-у."
+    },
+    "powerCalibrationManagerButton": {
+        "message": "Калибрација"
+    },
+    "powerCalibrationManagerTitle": {
+        "message": "Калибрација мерача"
+    },
+    "powerCalibrationManagerHelp": {
+        "message": "За калибрацију измерите мултиметром стварни напон и стварну јачину струје на дрону, са прикљученом батеријом, па те вредности упишите испод. Затим, са истом батеријом и даље прикљученом, кликните [Калибриши]."
+    },
+    "powerCalibrationManagerNote": {
+        "message": "<strong>Напомена:<\/strong> пре калибрације размере проверите да су делилац и множилац за напон, као и померај за струју, исправно постављени.<br>Ако остану на нули, калибрација се неће применити.<\/br><strong>Не заборавите да скинете пропелере пре него што прикључите батерију!<\/strong>"
+    },
+    "powerCalibrationManagerWarning": {
+        "message": "<span class=\"message-negative\">Пажња:<\/span> батерија <span class=\"message-negative\">није прикључена<\/span> или извори мерења напона и струје <span class=\"message-negative\">нису исправно постављени.<\/span> Проверите да напон и јачина струје показују вредност већу од нуле. У супротном калибрација овим алатом није могућа."
+    },
+    "powerCalibrationManagerSourceNote": {
+        "message": "<span class=\"message-negative\">Пажња:<\/span> извори мерења напона и струје <strong>су промењени али нису сачувани.<\/strong> Поставите исправне изворе и сачувајте их пре него што покушате калибрацију."
+    },
+    "powerCalibrationManagerConfirmationTitle": {
+        "message": "Потврда калибрације"
+    },
+    "powerCalibrationSave": {
+        "message": "Калибриши"
+    },
+    "powerCalibrationApply": {
+        "message": "Примени калибрацију"
+    },
+    "powerCalibrationDiscard": {
+        "message": "Одбаци калибрацију"
+    },
+    "powerCalibrationConfirmHelp": {
+        "message": "Овде су приказане нове калибрисане размере. <br>Применом се размере постављају, али <strong>се не чувају.<\/strong><\/br> <br>После чувања проверите да су нови напон и струја тачни.<\/br>"
+    },
+    "powerVoltageHead": {
+        "message": "Мерач напона"
+    },
+    "powerVoltageWarning": {
+        "message": "<span class=\"message-negative\">Пажња:<\/span> вредности су ограничене на 25,5 V."
+    },
+    "powerVoltageValue": {
+        "message": "$1 V"
+    },
+    "powerVoltageCalibration": {
+        "message": "Измерени напон"
+    },
+    "powerVoltageCalibratedScale": {
+        "message": "Калибрисана размера напона:"
+    },
+    "powerVoltageId10": {
+        "message": "Батерија"
+    },
+    "powerVoltageId20": {
+        "message": "5V"
+    },
+    "powerVoltageId30": {
+        "message": "9V"
+    },
+    "powerVoltageId40": {
+        "message": "12V"
+    },
+    "powerVoltageId50": {
+        "message": "Сви регулатори заједно"
+    },
+    "powerVoltageId60": {
+        "message": "Регулатор мотора 1"
+    },
+    "powerVoltageId61": {
+        "message": "Регулатор мотора 2"
+    },
+    "powerVoltageId62": {
+        "message": "Регулатор мотора 3"
+    },
+    "powerVoltageId63": {
+        "message": "Регулатор мотора 4"
+    },
+    "powerVoltageId64": {
+        "message": "Регулатор мотора 5"
+    },
+    "powerVoltageId65": {
+        "message": "Регулатор мотора 6"
+    },
+    "powerVoltageId66": {
+        "message": "Регулатор мотора 7"
+    },
+    "powerVoltageId67": {
+        "message": "Регулатор мотора 8"
+    },
+    "powerVoltageId68": {
+        "message": "Регулатор мотора 9"
+    },
+    "powerVoltageId69": {
+        "message": "Регулатор мотора 10"
+    },
+    "powerVoltageId70": {
+        "message": "Регулатор мотора 11"
+    },
+    "powerVoltageId71": {
+        "message": "Регулатор мотора 12"
+    },
+    "powerVoltageId80": {
+        "message": "Ћелија 1"
+    },
+    "powerVoltageId81": {
+        "message": "Ћелија 2"
+    },
+    "powerVoltageId82": {
+        "message": "Ћелија 3"
+    },
+    "powerVoltageId83": {
+        "message": "Ћелија 4"
+    },
+    "powerVoltageId84": {
+        "message": "Ћелија 5"
+    },
+    "powerVoltageId85": {
+        "message": "Ћелија 6"
+    },
+    "powerVoltageScale": {
+        "message": "Размера"
+    },
+    "powerVoltageDivider": {
+        "message": "Вредност делиоца"
+    },
+    "powerVoltageMultiplier": {
+        "message": "Вредност множиоца"
+    },
+    "powerAmperageHead": {
+        "message": "Мерач јачине струје"
+    },
+    "powerAmperageWarning": {
+        "message": "<span class=\"message-negative\">Пажња:<\/span> вредности су ограничене на 63,5 A."
+    },
+    "powerAmperageValue": {
+        "message": "$1 A"
+    },
+    "powerAmperageId10": {
+        "message": "Батерија"
+    },
+    "powerAmperageId50": {
+        "message": "Сви регулатори заједно"
+    },
+    "powerAmperageId60": {
+        "message": "Регулатор мотора 1"
+    },
+    "powerAmperageId61": {
+        "message": "Регулатор мотора 2"
+    },
+    "powerAmperageId62": {
+        "message": "Регулатор мотора 3"
+    },
+    "powerAmperageId63": {
+        "message": "Регулатор мотора 4"
+    },
+    "powerAmperageId64": {
+        "message": "Регулатор мотора 5"
+    },
+    "powerAmperageId65": {
+        "message": "Регулатор мотора 6"
+    },
+    "powerAmperageId66": {
+        "message": "Регулатор мотора 7"
+    },
+    "powerAmperageId67": {
+        "message": "Регулатор мотора 8"
+    },
+    "powerAmperageId68": {
+        "message": "Регулатор мотора 9"
+    },
+    "powerAmperageId69": {
+        "message": "Регулатор мотора 10"
+    },
+    "powerAmperageId70": {
+        "message": "Регулатор мотора 11"
+    },
+    "powerAmperageId71": {
+        "message": "Регулатор мотора 12"
+    },
+    "powerAmperageId80": {
+        "message": "Рачунски"
+    },
+    "powerAmperageId90": {
+        "message": "MSP"
+    },
+    "powerMahValue": {
+        "message": "$1 mAh"
+    },
+    "powerAmperageScale": {
+        "message": "Размера [десетинке mV по A]"
+    },
+    "powerAmperageOffset": {
+        "message": "Померај [mA]"
+    },
+    "powerAmperageCalibration": {
+        "message": "Измерена јачина струје"
+    },
+    "powerAmperageCalibratedScale": {
+        "message": "Калибрисана размера струје:"
+    },
+    "powerBatteryProfile": {
+        "message": "Профил батерије"
+    },
+    "powerBatteryProfileOption": {
+        "message": "Профил батерије $1"
+    },
+    "powerReceivedBatteryProfile": {
+        "message": "Flight контролер је поставио профил батерије: <strong class=\"message-positive\">$1<\/strong>"
+    },
+    "powerBatteryProfileNamePlaceholder": {
+        "message": "на пример LiPo, Li-Ion"
+    },
+    "powerBatteryProfileNameLabel": {
+        "message": "Назив профила"
+    },
+    "powerBatteryHead": {
+        "message": "Батерија"
+    },
+    "powerStateHead": {
+        "message": "Стање напајања"
+    },
+    "powerBatteryConnected": {
+        "message": "Повезано"
+    },
+    "powerBatteryConnectedValueYes": {
+        "message": "Да (ћелија: $1)"
+    },
+    "powerBatteryConnectedValueNo": {
+        "message": "Не"
+    },
+    "powerBatteryVoltage": {
+        "message": "Напон"
+    },
+    "powerBatteryCurrentDrawn": {
+        "message": "потрошено mAh"
+    },
+    "powerBatteryAmperage": {
+        "message": "Јачина струје"
+    },
+    "powerBatteryPowerDraw": {
+        "message": "Потрошња"
+    },
+    "powerWattValue": {
+        "message": "$1 W"
+    },
+    "powerBatteryVoltageDrop": {
+        "message": "Проседање напона"
+    },
+    "powerBatteryCapacity": {
+        "message": "Капацитет (mAh)"
+    },
+    "osdSetupTitle": {
+        "message": "OSD"
+    },
+    "osdToggleElementVisibility": {
+        "message": "Укључи или искључи приказ елемента {{element}} за профил {{profile}}"
+    },
+    "osdSetupNoOsdChipDetectWarning": {
+        "message": "<span class=\"message-negative\"><b>ПАЖЊА:<\/b><\/span> OSD чип није пронађен. Неки flight контролери не напајају OSD чип док батерија није прикључена. Прикључите батерију пре USB кабла (ПРОПЕЛЕРИ СКИНУТИ!)."
+    },
+    "osdSetupPreviewHelp": {
+        "message": "<strong>Напомена:<\/strong> преглед OSD-а можда не приказује слова која су стварно уписана у flight контролер. Распоред појединих елемената може изгледати другачије на старијим верзијама фирмвера — проверите изглед кроз наочаре пре лета."
+    },
+    "osdSetupUnsupportedNote1": {
+        "message": "Ваш flight контролер не одговара на OSD команде. To највероватније значи да нема уграђен Betaflight OSD."
+    },
+    "osdSetupUnsupportedNote2": {
+        "message": "Неки flight контролери имају уграђен <a href=\"https:\/\/www.youtube.com\/watch?v=ikKH_6SQ-Tk\" target=\"_blank\" rel=\"noopener noreferrer\">MinimOSD<\/a>, који се може уписати и подесити кроз <a href=\"https:\/\/github.com\/ShikOfTheRa\/scarab-osd\/releases\/latest\" target='_blank'>scarab-osd<\/a>, али се MinimOSD не може подесити кроз овај програм."
+    },
+    "osdSetupProfilesTitle": {
+        "message": "Број OSD профила",
+        "description": "Description of the header of the OSD elements column associated to each profile"
+    },
+    "osdSetupElementsTitle": {
+        "message": "Елементи"
+    },
+    "osdSetupPreviewTitle": {
+        "message": "Превуците елементе да им промените положај",
+        "description": "Indicates in the preview window of the OSD that the user can drag the elements to reorder them"
+    },
+    "osdSetupPreviewSelectProfileTitle": {
+        "message": "Преглед за",
+        "description": "Label of the selector for the OSD Profile in the preview. KEEP IT SHORT!!!"
+    },
+    "osdSetupPreviewForTitle": {
+        "message": "Промена профила или слова овде НЕЋЕ променити профил ни слова у flight контролеру — мења се само прозор за преглед. Ако желите стварну промену, користите '$t(osdSetupSelectedProfileTitle.message)' односно дугме '$t(osdSetupFontManager.message)'.",
+        "description": "Help content for the OSD profile and font PREVIEW"
+    },
+    "osdSetupSelectedProfileTitle": {
+        "message": "Активан OSD профил",
+        "description": "Title of the box to select the current active OSD profile"
+    },
+    "osdSetupSelectedProfileLabel": {
+        "message": "Тренутно:",
+        "description": "Label for the selection of the curren active OSD profile"
+    },
+    "osdSetupPreviewSelectProfileElement": {
+        "message": "OSD профил {{profileNumber}}",
+        "description": "Content of the selector for the OSD Profile in the preview"
+    },
+    "osdSetupPreviewSelectFont": {
+        "message": "Слова",
+        "description": "Content of the selector for the OSD Font in the preview"
+    },
+    "osdSetupFontManagerTitle": {
+        "message": "Управљање словима за OSD",
+        "description": "Dialog title"
+    },
+    "osdSetupFontTypeDefault": {
+        "message": "Фабричко",
+        "description": "Font Default"
+    },
+    "osdSetupFontTypeBold": {
+        "message": "Подебљана",
+        "description": "Font Bold"
+    },
+    "osdSetupFontTypeLarge": {
+        "message": "Велика",
+        "description": "Font Large"
+    },
+    "osdSetupFontTypeLargeExtra": {
+        "message": "Врло велика",
+        "description": "Font Large Extra"
+    },
+    "osdSetupFontTypeBetaflight": {
+        "message": "Betaflight",
+        "description": "Font Betaflight"
+    },
+    "osdSetupFontTypeDigital": {
+        "message": "Digital",
+        "description": "Font Digital"
+    },
+    "osdSetupFontTypeClarity": {
+        "message": "Clarity",
+        "description": "Font Clarity"
+    },
+    "osdSetupFontTypeVision": {
+        "message": "Vision",
+        "description": "Font Vision"
+    },
+    "osdSetupFontTypeImpact": {
+        "message": "Impact",
+        "description": "Font Impact"
+    },
+    "osdSetupFontTypeImpactMini": {
+        "message": "Impact Mini",
+        "description": "Font Impact Mini"
+    },
+    "osdSetupPreviewCheckZoom": {
+        "message": "Увећање",
+        "description": "Check to select a bigger display of the OSD preview in small screens"
+    },
+    "osdSetupVideoFormatTitle": {
+        "message": "Видео стандард"
+    },
+    "osdSetupVideoFormatOptionAuto": {
+        "message": "Аутоматски",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionPal": {
+        "message": "PAL",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionNtsc": {
+        "message": "NTSC",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSetupVideoFormatOptionHd": {
+        "message": "HD",
+        "description": "Option for the video format in the OSD"
+    },
+    "osdSerialPort": {
+        "message": "Серијски порт за OSD"
+    },
+    "osdSerialPortHelp": {
+        "message": "UART на који је повезан серијски OSD. Од API-ја 1.49 задаје се на самом OSD-у; картица Ports га само приказује."
+    },
+    "osdCustomTextSerialPort": {
+        "message": "Серијски порт за произвољни текст"
+    },
+    "osdCustomTextSerialPortHelp": {
+        "message": "UART на ком се прима произвољни OSD текст."
+    },
+    "osdCustomTextSerialBaud": {
+        "message": "Брзина преноса за произвољни текст"
+    },
+    "osdCustomTextSerialBaudHelp": {
+        "message": "Брзина преноса за порт произвољног OSD текста."
+    },
+    "osdSetupUnitsTitle": {
+        "message": "Јединице"
+    },
+    "osdSetupUnitsOptionImperial": {
+        "message": "Империјалне",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupUnitsOptionMetric": {
+        "message": "Метричке",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupUnitsOptionBritish": {
+        "message": "Британске",
+        "description": "Option for the units system used in the OSD"
+    },
+    "osdSetupTimersTitle": {
+        "message": "Мерачи времена"
+    },
+    "osdSetupAlarmsTitle": {
+        "message": "Аларми"
+    },
+    "osdSetupStatsTitle": {
+        "message": "Подаци после лета"
+    },
+    "osdSetupVtxTitle": {
+        "message": "Подешавања видео-предајника"
+    },
+    "osdSetupCraftNameTitle": {
+        "message": "Назив дрона"
+    },
+    "osdSetupWarningsTitle": {
+        "message": "Упозорења"
+    },
+    "osdSetupFontPresets": {
+        "message": "Готови скупови слова:"
+    },
+    "osdSetupFontPresetsSelector": {
+        "message": "Изаберите скуп слова:"
+    },
+    "osdSetupFontPresetsSelectorCustomOption": {
+        "message": "Сопствена слова",
+        "description": "Option to show as selected when the user selects a custom local font"
+    },
+    "osdSetupFontPresetsSelectorOr": {
+        "message": "или"
+    },
+    "osdSetupOpenFont": {
+        "message": "Отвори фајл са словима"
+    },
+    "osdSetupCustomLogoTitle": {
+        "message": "Слика при покретању:"
+    },
+    "osdSetupCustomLogoOpenImageButton": {
+        "message": "Изаберите сопствену слику&hellip;"
+    },
+    "osdSetupCustomLogoInfoTitle": {
+        "message": "Сопствена слика:"
+    },
+    "osdSetupCustomLogoInfoImageSize": {
+        "message": "Величина мора бити $t(logoWidthPx)x$t(logoHeightPx) тачака"
+    },
+    "osdSetupCustomLogoInfoColorMap": {
+        "message": "Мора да садржи зелене, црне и беле тачке"
+    },
+    "osdSetupCustomLogoInfoUploadHint": {
+        "message": "Кликните <b>$t(osdSetupUploadFont.message)<\/b> да би сопствена слика остала трајно уписана"
+    },
+    "osdSetupCustomLogoImageSizeError": {
+        "message": "Неисправна величина слике: {{width}}x{{height}} (очекивано $t(logoWidthPx)×$t(logoHeightPx))"
+    },
+    "osdSetupCustomLogoColorMapError": {
+        "message": "Слика садржи неисправну тачку: rgb({{valueR}}, {{valueG}}, {{valueB}}) на положају {{posX}}×{{posY}}"
+    },
+    "osdSetupUploadFont": {
+        "message": "Пошаљи слова"
+    },
+    "osdSetupUploadingFont": {
+        "message": "Шаљем…"
+    },
+    "osdSetupUploadingFontEnd": {
+        "message": "Послато свих {{length}} знакова на OSD"
+    },
+    "osdSetupUploadingFontFailed": {
+        "message": "Слање није успело"
+    },
+    "osdSetupSave": {
+        "message": "Сачувај"
+    },
+    "osdSetupRefresh": {
+        "message": "Освежи"
+    },
+    "osdSetupFontManager": {
+        "message": "Управљање словима"
+    },
+    "osdSetupUncheckAll": {
+        "message": "Поништи све"
+    },
+    "osdSetupHead": {
+        "message": "Податак"
+    },
+    "osdSetupVideoMode": {
+        "message": "Видео режим"
+    },
+    "osdSetupCameraConnected": {
+        "message": "Камера повезана"
+    },
+    "osdSetupResetText": {
+        "message": "Врати OSD на фабричко"
+    },
+    "osdSetupButtonReset": {
+        "message": "Врати подешавања"
+    },
+    "osdTextElementMainBattVoltage": {
+        "message": "Напон батерије",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMainBattVoltage": {
+        "message": "Тренутни напон главне батерије (трепери када падне испод прага упозорења)"
+    },
+    "osdTextElementRssiValue": {
+        "message": "RSSI вредност",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRssiValue": {
+        "message": "Тренутна RSSI вредност (трепери када падне испод прага упозорења). Код данашњих протокола користите RSSI у dBm."
+    },
+    "osdTextElementRssiDbmValue": {
+        "message": "RSSI у dBm",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRssiDbmValue": {
+        "message": "Показатељ јачине примљеног сигнала — говори колико је пријем јак, у dBm"
+    },
+    "osdTextElementTimer": {
+        "message": "Мерач времена",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer": {
+        "message": "Мерач времена лета"
+    },
+    "osdTextElementThrottlePosition": {
+        "message": "Положај гаса",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementThrottlePosition": {
+        "message": "Тренутна вредност канала гаса"
+    },
+    "osdTextElementCpuLoad": {
+        "message": "Оптерећење процесора",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCpuLoad": {
+        "message": "Тренутно оптерећење процесора"
+    },
+    "osdTextElementVtxChannel": {
+        "message": "Канал видео-предајника",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementVtxChannel": {
+        "message": "Тренутни канал и снага видео-предајника"
+    },
+    "osdTextElementVTXchannelVariantPower": {
+        "message": "Снага видео-предајника",
+        "description": "One of the variants of the VTX channel element of the OSD"
+    },
+    "osdTextElementVTXchannelVariantFull": {
+        "message": "Опсег:Канал:Снага:Pit",
+        "description": "One of the variants of the VTX channel element of the OSD"
+    },
+    "osdTextElementVoltageWarning": {
+        "message": "Упозорење о напону батерије",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementVoltageWarning": {
+        "message": "Приказује упозорење када напон падне испод задате вредности"
+    },
+    "osdTextElementArmed": {
+        "message": "Армован",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArmed": {
+        "message": "Текстуална порука о армовању"
+    },
+    "osdTextElementDisarmed": {
+        "message": "Разоружан",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDisarmed": {
+        "message": "Текстуална порука о разоружавању"
+    },
+    "osdTextElementCrosshairs": {
+        "message": "Нишан",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCrosshairs": {
+        "message": "Нишан на средини екрана"
+    },
+    "osdTextElementArtificialHorizon": {
+        "message": "Вештачки хоризонт",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArtificialHorizon": {
+        "message": "Графички приказ вештачког хоризонта"
+    },
+    "osdTextElementHorizonSidebars": {
+        "message": "Бочне ознаке хоризонта",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHorizonSidebars": {
+        "message": "Ознаке са стране вештачког хоризонта"
+    },
+    "osdTextElementCurrentDraw": {
+        "message": "Тренутна потрошња струје",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCurrentDraw": {
+        "message": "Тренутна јачина струје из батерије"
+    },
+    "osdTextElementMahDrawn": {
+        "message": "Потрошено mAh",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMahDrawn": {
+        "message": "Укупно потрошен капацитет батерије"
+    },
+    "osdTextElementWhDrawn": {
+        "message": "Потрошено Wh",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWhDrawn": {
+        "message": "Укупно потрошен капацитет батерије у Wh"
+    },
+    "osdDescElementAuxValue": {
+        "message": "Вредност AUX канала",
+        "description": "Displays a receiver AUX channel see PR 10789"
+    },
+    "osdTextElementAuxValue": {
+        "message": "Вредност AUX канала",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementSysGoggleVoltage": {
+        "message": "Напон наочара",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysGoggleVoltage": {
+        "message": "Напон на наочарима, приказан од стране наочара"
+    },
+    "osdTextElementSysVtxVoltage": {
+        "message": "VTX напон",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxVoltage": {
+        "message": "VTX напон, приказан од стране наочара"
+    },
+    "osdTextElementSysBitrate": {
+        "message": "VTX bitrate",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysBitrate": {
+        "message": "Видео bitrate, приказан од стране наочара"
+    },
+    "osdTextElementSysDelay": {
+        "message": "VTX кашњење",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysDelay": {
+        "message": "Видео кашњење, приказано од стране наочара"
+    },
+    "osdTextElementSysDistance": {
+        "message": "VTX удаљеност",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysDistance": {
+        "message": "Удаљеност видео преноса, приказана од стране наочара"
+    },
+    "osdTextElementSysLQ": {
+        "message": "Квалитет везе наочара",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysLQ": {
+        "message": "Квалитет видео везе, приказан од стране наочара"
+    },
+    "osdTextElementSysGoggleDVR": {
+        "message": "Status DVR-а наочара",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysGoggleDVR": {
+        "message": "Status DVR-а наочара, приказан од стране наочара"
+    },
+    "osdTextElementSysVtxDVR": {
+        "message": "Status VTX DVR-а",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxDVR": {
+        "message": "Status VTX DVR-а, приказан од стране наочара"
+    },
+    "osdTextElementSysWarnings": {
+        "message": "Системска упозорења наочара",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysWarnings": {
+        "message": "Системска видео упозорења, приказана од стране наочара"
+    },
+    "osdTextElementSysVtxTemp": {
+        "message": "VTX температура",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysVtxTemp": {
+        "message": "VTX температура, приказана од стране наочара"
+    },
+    "osdTextElementSysFanSpeed": {
+        "message": "Брзина вентилатора наочара",
+        "description": "One of the system elements of the OSD"
+    },
+    "osdDescElementSysFanSpeed": {
+        "message": "Брзина вентилатора наочара, приказана од стране наочара"
+    },
+    "osdTextElementLapTimeCurrent": {
+        "message": "Тренутно време GPS круга",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimeCurrent": {
+        "message": "Тренутно време GPS круга"
+    },
+    "osdTextElementLapTimePrevious": {
+        "message": "Претходно време GPS круга",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimePrevious": {
+        "message": "Претходно време GPS круга"
+    },
+    "osdTextElementLapTimeBest3": {
+        "message": "GPS: најбоља три круга",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLapTimeBest3": {
+        "message": "Најбоља три времена круга по GPS-у"
+    },
+    "osdTextElementCraftName": {
+        "message": "Назив летелице",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCraftName": {
+        "message": "Назив дрона задат на картици Конфигурација.<\/br>Може се задати и променљивом „craft_name“ у CLI-ју."
+    },
+    "osdTextElementAltitude": {
+        "message": "Висина",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAltitude": {
+        "message": "Тренутна висина (трепери када пређе праг упозорења)"
+    },
+    "osdTextElementAltitudeVariant1DecimalAGL": {
+        "message": "Изнад тла, са једном децималом",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariantNoDecimalAGL": {
+        "message": "Изнад тла, без децимала",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariant1DecimalASL": {
+        "message": "Изнад мора, са једном децималом",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementAltitudeVariantNoDecimalASL": {
+        "message": "Изнад мора, без децимала",
+        "description": "One of the variants of the altitude element of the OSD"
+    },
+    "osdTextElementCustomMsg0": {
+        "message": "Сопствена порука 1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg1": {
+        "message": "Сопствена порука 2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg2": {
+        "message": "Сопствена порука 3",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementCustomMsg3": {
+        "message": "Сопствена порука 4",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCustomMsg0": {
+        "message": "Сопствена порука 1 са спољног уређаја",
+        "description": "Description of the custom message 1 element of the OSD"
+    },
+    "osdDescElementCustomMsg1": {
+        "message": "Сопствена порука 2 са спољног уређаја",
+        "description": "Description of the custom message 2 element of the OSD"
+    },
+    "osdDescElementCustomMsg2": {
+        "message": "Сопствена порука 3 са спољног уређаја",
+        "description": "Description of the custom message 3 element of the OSD"
+    },
+    "osdDescElementCustomMsg3": {
+        "message": "Сопствена порука 4 са спољног уређаја",
+        "description": "Description of the custom message 4 element of the OSD"
+    },
+    "osdTextElementOnTime": {
+        "message": "Време укључености",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementOnTime": {
+        "message": "Укупно време откако је дрон укључен"
+    },
+    "osdTextElementFlyTime": {
+        "message": "Време лета",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlyTime": {
+        "message": "Укупно време које је дрон провео армован од укључивања (трепери када пређе праг упозорења)"
+    },
+    "osdTextElementFlyMode": {
+        "message": "Мод лета",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlyMode": {
+        "message": "Тренутни мод лета"
+    },
+    "osdTextElementGPSSpeed": {
+        "message": "GPS брзина",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSSpeed": {
+        "message": "Брзина по GPS-у"
+    },
+    "osdTextElementGPSSats": {
+        "message": "GPS сателити",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSSats": {
+        "message": "Број сателита који дају положај"
+    },
+    "osdTextElementGPSLon": {
+        "message": "GPS географска дужина",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSLon": {
+        "message": "Координата географске дужине"
+    },
+    "osdTextElementGPSLat": {
+        "message": "GPS географска ширина",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementGPSLat": {
+        "message": "Координата географске ширине"
+    },
+    "osdTextElementGPSVariant7Decimals": {
+        "message": "Са седам децимала",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariant4Decimals": {
+        "message": "Са четири децимале",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariantDegMinSec": {
+        "message": "У степенима, минутима и секундама",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementGPSVariantOpenLocation": {
+        "message": "Преко Open Location Code ознаке",
+        "description": "One of the variants for the GPS element of the OSD"
+    },
+    "osdTextElementDebug": {
+        "message": "Debug",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDebug": {
+        "message": "Debug променљиве"
+    },
+    "osdTextElementDebug2": {
+        "message": "Debug2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDebug2": {
+        "message": "Debug променљиве за debug 4 до 7"
+    },
+    "osdTextElementPIDRoll": {
+        "message": "PID roll",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDRoll": {
+        "message": "PID појачања за осу roll"
+    },
+    "osdTextElementPIDPitch": {
+        "message": "PID pitch",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDPitch": {
+        "message": "PID појачања за осу pitch"
+    },
+    "osdTextElementPIDYaw": {
+        "message": "PID yaw",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDYaw": {
+        "message": "PID појачања за осу yaw"
+    },
+    "osdTextElementPower": {
+        "message": "Снага",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPower": {
+        "message": "Тренутна електрична потрошња"
+    },
+    "osdTextElementPIDRateProfile": {
+        "message": "Профил: PID и рејт",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPIDRateProfile": {
+        "message": "Бројчани приказ активног PID и рејт профила"
+    },
+    "osdTextElementBatteryWarning": {
+        "message": "Упозорење о батерији",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementBatteryWarning": {
+        "message": "Текст упозорења који се појављује када напон батерије падне испод прага"
+    },
+    "osdTextElementAvgCellVoltage": {
+        "message": "Просечан напон ћелије",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAvgCellVoltage": {
+        "message": "Просечан напон ћелије (напон батерије подељен бројем ћелија)"
+    },
+    "osdTextElementPitchAngle": {
+        "message": "Угао: pitch",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPitchAngle": {
+        "message": "Бројчани угао нагиба напред-назад у степенима"
+    },
+    "osdTextElementRollAngle": {
+        "message": "Угао: roll",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRollAngle": {
+        "message": "Бројчани угао нагиба лево-десно у степенима"
+    },
+    "osdTextElementMainBattUsage": {
+        "message": "Потрошња батерије",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMainBattUsage": {
+        "message": "Графички приказ потрошеног капацитета батерије"
+    },
+    "osdTextElementMainBattUsageVariantGraphrRemain": {
+        "message": "Графички, преостало",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantGraphUsage": {
+        "message": "Графички, потрошено",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantValueRemain": {
+        "message": "Проценат преосталог",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementMainBattUsageVariantValueUsage": {
+        "message": "Проценат потрошеног",
+        "description": "One of the variants for the Main Battery Usage element of the OSD"
+    },
+    "osdTextElementArmedTime": {
+        "message": "Мерач: време од армовања",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementArmedTime": {
+        "message": "Време од последњег армовања дрона"
+    },
+    "osdTextElementHomeDirection": {
+        "message": "Правац ка месту полетања",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHomeDirection": {
+        "message": "Стрелица која показује правац ка месту полетања"
+    },
+    "osdTextElementHomeDistance": {
+        "message": "Растојање до места полетања",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementHomeDistance": {
+        "message": "Растојање до места полетања (у метрима или стопама, према изабраним јединицама)"
+    },
+    "osdTextElementNumericalHeading": {
+        "message": "Бројчани правац",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNumericalHeading": {
+        "message": "Бројчани приказ тренутног правца у степенима"
+    },
+    "osdTextElementNumericalVario": {
+        "message": "Бројчани вариометар",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNumericalVario": {
+        "message": "Бројчани приказ брзине пењања и спуштања (у метрима или стопама, према изабраним јединицама)"
+    },
+    "osdTextElementCompassBar": {
+        "message": "Трака компаса",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCompassBar": {
+        "message": "Графичка трака компаса са тренутним правцем"
+    },
+    "osdTextElementWarnings": {
+        "message": "Упозорења",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWarnings": {
+        "message": "Обавештења (на пример слаба батерија), упозорења (разлози зашто армовање није могуће, критично слаба батерија) и видљива пискалица (четири звездице које трепере)"
+    },
+    "osdTextElementEscTemperature": {
+        "message": "Температура регулатора",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscTemperature": {
+        "message": "Температура коју јавља регулатор, било преко једножичне серијске телеметрије, било преко двосмерног DShota са EDT, ако то фирмвер регулатора подржава."
+    },
+    "osdTextElementEscRpm": {
+        "message": "Обртаји регулатора",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscRpm": {
+        "message": "Број обртаја који јавља регулатор"
+    },
+    "osdTextElementRemainingTimeEstimate": {
+        "message": "Мерач: процена преосталог времена",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRemainingTimeEstimate": {
+        "message": "Процена колико још лета преостаје"
+    },
+    "osdTextElementRtcDateTime": {
+        "message": "Датум и време",
+        "description": "One of the elements of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantFullDate": {
+        "message": "Пун датум",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantShortDate": {
+        "message": "Скраћен датум",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdTextElementRtcDateTimeVariantTimeOnly": {
+        "message": "Само време",
+        "description": "One of the variants of the RTC date and time element of the OSD"
+    },
+    "osdDescElementRtcDateTime": {
+        "message": "Датум и време са часовника"
+    },
+    "osdTextElementAdjustmentRange": {
+        "message": "Опсег подешавања у лету",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementAdjustmentRange": {
+        "message": "Тренутно активно подешавање у лету и његова вредност"
+    },
+    "osdTextElementTimer1": {
+        "message": "Мерач 1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer1": {
+        "message": "Приказује вредност мерача 1"
+    },
+    "osdTextElementTimer2": {
+        "message": "Мерач 2",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementTimer2": {
+        "message": "Приказује вредност мерача 2"
+    },
+    "osdTextElementCoreTemperature": {
+        "message": "Температура процесора",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCoreTemperature": {
+        "message": "Температура језгра STM32 процесора"
+    },
+    "osdTextAntiGravity": {
+        "message": "Anti-Gravity",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescAntiGravity": {
+        "message": "Укључује ознаку која се појављује док је Anti-Gravity активан"
+    },
+    "osdTextGForce": {
+        "message": "Преоптерећење",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescGForce": {
+        "message": "Приказује колико преоптерећење дрон трпи"
+    },
+    "osdTextElementMotorDiag": {
+        "message": "Приказ рада мотора",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementMotorDiag": {
+        "message": "Приказује графикон излаза сваког мотора"
+    },
+    "osdTextElementLogStatus": {
+        "message": "Стање Blackbox записа",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLogStatus": {
+        "message": "Број записа и упозорења"
+    },
+    "osdTextElementFlipArrow": {
+        "message": "Стрелица за превртање после пада",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlipArrow": {
+        "message": "Стрелица која показује на којој су страни мотори окренути нагоре у Turtle моду (акцелерометар мора бити укључен)"
+    },
+    "osdTextElementLinkQuality": {
+        "message": "Квалитет везе",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementLinkQuality": {
+        "message": "Заменски показатељ „квалитета везе“, заснован на губитку пакета — користити опрезно"
+    },
+    "osdTextElementLinkQualityVariantRfMode": {
+        "message": "Режим везе : квалитет везе",
+        "description": "One of the variants of the Link Quality element of the OSD"
+    },
+    "osdTextElementLinkQualityVariantQualityOnly": {
+        "message": "Само квалитет везе",
+        "description": "One of the variants of the Link Quality element of the OSD"
+    },
+    "osdTextElementFlightDist": {
+        "message": "Пређено растојање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementFlightDist": {
+        "message": "Растојање пређено током овог лета."
+    },
+    "osdTextElementStickOverlayLeft": {
+        "message": "Приказ леве ручице",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementStickOverlayLeft": {
+        "message": "Приказ положаја леве ручице даљинског."
+    },
+    "osdTextElementStickOverlayRight": {
+        "message": "Приказ десне ручице",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementStickOverlayRight": {
+        "message": "Приказ положаја десне ручице даљинског."
+    },
+    "osdTextElementDisplayName": {
+        "message": "Приказано име",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementDisplayName": {
+        "message": "Може се задати и променљивом „display_name“ у CLI-ју."
+    },
+    "osdTextElementPilotName": {
+        "message": "Име пилота",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPilotName": {
+        "message": "Име пилота задато на картици Конфигурација.<\/br>Може се задати и променљивом „pilot_name“ у CLI-ју."
+    },
+    "osdTextElementEscRpmFreq": {
+        "message": "Фреквенција обртаја регулатора",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEscRpmFreq": {
+        "message": "Фреквенција обртаја коју јавља регулатор"
+    },
+    "osdTextElementRateProfileName": {
+        "message": "Профил: назив рејт профила",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRateProfileName": {
+        "message": "Приказује назив тренутног рејт профила"
+    },
+    "osdTextElementPidProfileName": {
+        "message": "Профил: назив PID профила",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPidProfileName": {
+        "message": "Приказује назив тренутног PID профила"
+    },
+    "osdTextElementOsdProfileName": {
+        "message": "Профил: OSD профил име",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementOsdProfileName": {
+        "message": "Име OSD профила као што је подешено у CLI варијаблама \"osd_profile_1_name\", \"osd_profile_2_name\" и \"osd_profile_3_name\""
+    },
+    "osdTextElementRcChannels": {
+        "message": "RC канали",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRcChannels": {
+        "message": "Приказује највише 4 вредности канала. Канали морају бити наведени у CLI варијабли 'osd_rcchannels'"
+    },
+    "osdTextElementCameraFrame": {
+        "message": "Оквир камере",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCameraFrame": {
+        "message": "Додаје подесиви element оквира дизајниран да представља видно поље пилотове HD камере за визуелно кадрирање.<br \/><br \/>Можете подесити ширину и висину у CLI-ју са 'osd_camera_frame_width' и 'osd_camera_frame_height'"
+    },
+    "osdTextElementEfficiency": {
+        "message": "Ефикасност батерије",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementEfficiency": {
+        "message": "Тренутна потрошња батерије у mAh\/удаљености. (Захтева исправан GPS сигнал)"
+    },
+    "osdTextTotalFlights": {
+        "message": "Укупно летова",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescTotalFlights": {
+        "message": "Приближан укупан број летова"
+    },
+    "osdTextElementUpDownReference": {
+        "message": "Горе (Pitch 90 deg)\/Доле (Pitch -90 deg) Референца",
+        "description": "OSD Symbol to show when pitch is approaching vertical (90 deg, U) and D for nose down (-90 deg, D)"
+    },
+    "osdDescUpDownReference": {
+        "message": "OSD симбол који се приказује када се Pitch приближава вертикали (90 deg, U) и D за нос надоле (-90 deg, D)"
+    },
+    "osdTextElementTxUplinkPower": {
+        "message": "Tx uplink снага",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescTxUplinkPower": {
+        "message": "Приказује вредност Tx снаге (mW или W). Корисно када је <i>Dynamic Power<\/i> укључен за подржане радио уређаје"
+    },
+    "osdTextElementReadyMode": {
+        "message": "Мод спремности",
+        "description": "When active READY will be displayed until flying"
+    },
+    "osdDescElementReadyMode": {
+        "message": "Када је активан, приказаће се READY док се не полети"
+    },
+    "osdTextElementRSNRValue": {
+        "message": "RSNR вредност",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementRSNRValue": {
+        "message": "RSNR вредност"
+    },
+    "osdTextElementUnknown": {
+        "message": "Непознато $1",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementUnknown": {
+        "message": "Непознат element (детаљи ће бити додати у будућем издању)"
+    },
+    "osdTextStatMaxSpeed": {
+        "message": "Максимална брзина",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxSpeed": {
+        "message": "Максимална забележена брзина"
+    },
+    "osdTextStatMinBattery": {
+        "message": "Минимални напон батерије",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinBattery": {
+        "message": "Минимални забележени напон главне батерије"
+    },
+    "osdTextStatMinRssi": {
+        "message": "RSSI minimum",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRssi": {
+        "message": "Минимални забележени RSSI"
+    },
+    "osdTextStatMaxCurrent": {
+        "message": "Максимална потрошња струје из батерије",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxCurrent": {
+        "message": "Максимална забележена потрошња струје"
+    },
+    "osdTextStatUsedMah": {
+        "message": "Потрошено mAh из батерије",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUsedMah": {
+        "message": "Потрошен капацитет батерије"
+    },
+    "osdTextStatUsedWh": {
+        "message": "Потрошено Wh из батерије",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUsedWh": {
+        "message": "Потрошен капацитет батерије у Wh"
+    },
+    "osdTextStatMaxAltitude": {
+        "message": "Максимална висина",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxAltitude": {
+        "message": "Максимална забележена висина"
+    },
+    "osdTextStatBlackbox": {
+        "message": "Употреба Blackbox-а",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBlackbox": {
+        "message": "Проценат укупне употребе Blackbox-а"
+    },
+    "osdTextStatEndBattery": {
+        "message": "Крајњи напон батерије",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEndBattery": {
+        "message": "Напон батерије у тренутку разоружавања"
+    },
+    "osdTextStatFlyTime": {
+        "message": "Укупно време лета",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFlyTime": {
+        "message": "Укупно време током којег је летелица била армована у тренутном циклусу напајања"
+    },
+    "osdTextStatArmedTime": {
+        "message": "Време лета од последњег армовања",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatArmedTime": {
+        "message": "Време од када је летелица последњи пут армована"
+    },
+    "osdTextStatMaxDistance": {
+        "message": "Максимална удаљеност од куће",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxDistance": {
+        "message": "Максимална удаљеност од почетне локације"
+    },
+    "osdTextStatBlackboxLogNumber": {
+        "message": "Број Blackbox лога",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBlackboxLogNumber": {
+        "message": "Број лога за Blackbox log овог лета"
+    },
+    "osdTextStatTimer1": {
+        "message": "Мерач 1",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTimer1": {
+        "message": "Вредност тајмера 1 у тренутку разоружавања"
+    },
+    "osdTextStatTimer2": {
+        "message": "Мерач 2",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTimer2": {
+        "message": "Вредност тајмера 2 у тренутку разоружавања"
+    },
+    "osdTextStatRtcDateTime": {
+        "message": "Датум и време",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatRtcDateTime": {
+        "message": "Датум и време са сата у реалном времену"
+    },
+    "osdTextStatBattery": {
+        "message": "Напон батерије",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBattery": {
+        "message": "Напон батерије у реалном времену"
+    },
+    "osdTextStatGForce": {
+        "message": "Максимална G сила",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatGForce": {
+        "message": "Максимална G-сила коју је летелица искусила"
+    },
+    "osdTextStatEscTemperature": {
+        "message": "Максимална температура ESC-а",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEscTemperature": {
+        "message": "Максимална температура ESC-а"
+    },
+    "osdTextStatEscRpm": {
+        "message": "Максимални RPM ESC-а",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatEscRpm": {
+        "message": "Максимални RPM ESC-а"
+    },
+    "osdTextStatMinLinkQuality": {
+        "message": "Минимални квалитет везе",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinLinkQuality": {
+        "message": "Minimum алтернативног индикатора за 'квалитет везе' заснованог на губитку фрејмова"
+    },
+    "osdTextStatFlightDistance": {
+        "message": "Пређено растојање",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFlightDistance": {
+        "message": "Укупна удаљеност пређена током лета"
+    },
+    "osdTextStatMaxFFT": {
+        "message": "Максимални FFT",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMaxFFT": {
+        "message": "Вршна FFT фреквенција"
+    },
+    "osdTextStatTotalFlights": {
+        "message": "Укупан број летова",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlights": {
+        "message": "Укупан број летова"
+    },
+    "osdTextStatTotalFlightTime": {
+        "message": "Укупно време лета",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlightTime": {
+        "message": "Укупно време проведено у лету"
+    },
+    "osdTextStatTotalFlightDistance": {
+        "message": "Укупна пређена удаљеност",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatTotalFlightDistance": {
+        "message": "Укупна пређена удаљеност"
+    },
+    "osdTextStatMinRssiDbm": {
+        "message": "Минимални RSSI dBm",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRssiDbm": {
+        "message": "Минимална RSSI dBm вредност"
+    },
+    "osdTextStatMinRSNR": {
+        "message": "Минимална RSNR вредност",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatMinRSNR": {
+        "message": "Минимална RSNR вредност"
+    },
+    "osdTextStatBest3ConsecLaps": {
+        "message": "Најбоља 3 узастопна круга",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBest3ConsecLaps": {
+        "message": "Најбоља 3 узастопна круга"
+    },
+    "osdTextStatBestLap": {
+        "message": "Најбољи круг",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatBestLap": {
+        "message": "Најбољи круг"
+    },
+    "osdTextStatFullThrottleTime": {
+        "message": "Тајмер пуног гаса",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFullThrottleTime": {
+        "message": "Тајмер пуног гаса"
+    },
+    "osdTextStatFullThrottleCounter": {
+        "message": "Бројач пуног гаса",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatFullThrottleCounter": {
+        "message": "Бројач пуног гаса"
+    },
+    "osdTextStatAvgThrottle": {
+        "message": "Просечан гас",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatAvgThrottle": {
+        "message": "Просечан гас"
+    },
+    "osdTextStatUnknown": {
+        "message": "Непознато $1",
+        "description": "One of the statistics that can be shown at the end of the flight in the OSD"
+    },
+    "osdDescStatUnknown": {
+        "message": "Непозната статистика (детаљи ће бити додати у будућем издању)"
+    },
+    "osdDescribeFontVersion1": {
+        "message": "Верзија фонта: 1 (Betaflight 4.0 или старији)"
+    },
+    "osdDescribeFontVersion2": {
+        "message": "Верзија фонта: 2 (Betaflight 4.1 или новији)"
+    },
+    "osdDescribeFontVersionCUSTOM": {
+        "message": "Верзија фонта: кориснички дефинисана"
+    },
+    "osdTimerSource": {
+        "message": "Извор:"
+    },
+    "osdTimerSourceTooltip": {
+        "message": "Изаберите извор тајмера, ово контролише трајање\/догађај који тајмер мери"
+    },
+    "osdTimerSourceOptionOnTime": {
+        "message": "Време укључености",
+        "description": "One of the options for the source timer. This options shows the amount of time has passed since the battery was plugged"
+    },
+    "osdTimerSourceOptionTotalArmedTime": {
+        "message": "Укупно армовано време",
+        "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed since the battery was plugged"
+    },
+    "osdTimerSourceOptionLastArmedTime": {
+        "message": "Последње армовано време",
+        "description": "One of the options for the source timer. This options shows the amount of time the aircraft was armed the latest time"
+    },
+    "osdTimerSourceOptionOnArmTime": {
+        "message": "Време укључено\/армовано",
+        "description": "One of the options for the source timer. This option shows On time when aircraft is disarmed, and Armed time when armed"
+    },
+    "osdTimerPrecision": {
+        "message": "Прецизност:"
+    },
+    "osdTimerPrecisionTooltip": {
+        "message": "Изаберите прецизност тајмера, ово контролише са којом прецизношћу се време приказује"
+    },
+    "osdTimerPrecisionOptionSecond": {
+        "message": "Секунда",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerPrecisionOptionHundredth": {
+        "message": "Стотинка",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerPrecisionOptionTenth": {
+        "message": "Десетинка",
+        "description": "Selectable option for the precision of the timer in the OSD"
+    },
+    "osdTimerAlarm": {
+        "message": "Alarm:"
+    },
+    "osdTimerAlarmTooltip": {
+        "message": "Изаберите праг аларма тајмера у минутима. Када време пређе ову вредност, OSD element ће трептати. Постављање на 0 искључује alarm."
+    },
+    "osdTimerAlarmOptionRssi": {
+        "message": "RSSI",
+        "description": "Text of the RSSI alarm"
+    },
+    "osdTimerAlarmOptionCapacity": {
+        "message": "Капацитет",
+        "description": "Text of the capacity alarm"
+    },
+    "osdTimerAlarmOptionAltitude": {
+        "message": "Висина",
+        "description": "Text of the altitude alarm"
+    },
+    "osdTimerAlarmOptionLinkQuality": {
+        "message": "Квалитет везе",
+        "description": "Text of the link quality alarm"
+    },
+    "osdTimerAlarmOptionRssiDbm": {
+        "message": "RSSI dBm",
+        "description": "Text of the RSSI dBm alarm"
+    },
+    "osdWarningTextArmingDisabled": {
+        "message": "Армовање искључено",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningArmingDisabled": {
+        "message": "Приказује најозбиљнији разлог зашто армовање није могуће"
+    },
+    "osdWarningTextBatteryNotFull": {
+        "message": "Батерија није пуна",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryNotFull": {
+        "message": "Упозорава када је повезана батерија која није потпуно напуњена"
+    },
+    "osdWarningTextBatteryWarning": {
+        "message": "Упозорење о батерији",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryWarning": {
+        "message": "Упозорава када напон батерије падне испод прага упозорења"
+    },
+    "osdWarningTextBatteryCritical": {
+        "message": "Батерија критична",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningBatteryCritical": {
+        "message": "Упозорава када напон батерије падне испод минималног просечног напона ћелије"
+    },
+    "osdWarningTextVisualBeeper": {
+        "message": "Визуелни пискалица",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningVisualBeeper": {
+        "message": "Приказује визуализацију пискалице (приказује се као 4 звездице)"
+    },
+    "osdWarningTextCrashFlipMode": {
+        "message": "Мод за превртање након пада",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningCrashFlipMode": {
+        "message": "Упозорава када је активиран мод за превртање након пада"
+    },
+    "osdWarningTextEscFail": {
+        "message": "ESC грешка",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningEscFail": {
+        "message": "Наводи листу ESC-ова\/мотора који отказују (RPM или температура су изван конфигурисаног прага)"
+    },
+    "osdWarningTextCoreTemperature": {
+        "message": "Температура процесора",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningCoreTemperature": {
+        "message": "Упозорава када температура језгра MCU-а пређе конфигурисан праг"
+    },
+    "osdWarningTextRcSmoothingFailure": {
+        "message": "RC ублажавање неуспешно",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRcSmoothingFailure": {
+        "message": "Упозорава када иницијализација RC ублажавања није успела"
+    },
+    "osdWarningTextFailsafe": {
+        "message": "Failsafe",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningFailsafe": {
+        "message": "Упозорава када дође до Failsafe-а"
+    },
+    "osdWarningTextLaunchControl": {
+        "message": "Launch control",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLaunchControl": {
+        "message": "Упозорава када је активиран мод Launch Control"
+    },
+    "osdWarningTextGpsRescueUnavailable": {
+        "message": "GPS Rescue недоступан",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningGpsRescueUnavailable": {
+        "message": "Упозорава када GPS Rescue није доступан и не може се активирати"
+    },
+    "osdWarningTextGpsRescueDisabled": {
+        "message": "GPS Rescue искључен",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningGpsRescueDisabled": {
+        "message": "Упозорава када је GPS Rescue искључен"
+    },
+    "osdWarningTextRSSI": {
+        "message": "RSSI",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRSSI": {
+        "message": "Упозорава када је RSSI испод подешене вредности аларма"
+    },
+    "osdWarningTextLinkQuality": {
+        "message": "Квалитет везе",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLinkQuality": {
+        "message": "Упозорава када је квалитет везе испод подешене вредности аларма"
+    },
+    "osdWarningTextRssiDbm": {
+        "message": "RSSI dBm",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRssiDbm": {
+        "message": "Упозорава када је вредност RSSI dBm испод подешене вредности аларма"
+    },
+    "osdWarningTextOverCap": {
+        "message": "Батерија преко капацитета",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningOverCap": {
+        "message": "Упозорава када потрошени mAh премаши конфигурисано ограничење капацитета"
+    },
+    "osdWarningTextRSNR": {
+        "message": "RSNR",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningRSNR": {
+        "message": "Упозорава када је вредност RSNR испод подешене вредности аларма"
+    },
+    "osdWarningTextLoad": {
+        "message": "ОПТЕРЕЋЕЊЕ",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningLoad": {
+        "message": "Упозорава ако је оптерећење CPU-а flight контролера превисоко",
+        "description": "Description of one of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdTextElementPosHoldFailed": {
+        "message": "Задржавање позиције неуспешно",
+        "description": "One of the elements of the OSD that can be enabled to show a warning when position hold fails (e.g. in GPS mode)"
+    },
+    "osdDescElementPosHoldFailed": {
+        "message": "Приказује упозорење када задржавање позиције не успе (нпр. у GPS моду)"
+    },
+    "osdWarningTextPosHoldFailed": {
+        "message": "Задржавање позиције неуспешно",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningPosHoldFailed": {
+        "message": "Задржавање позиције неуспешно",
+        "description": "Warns when the position hold fails (e.g. in GPS mode)"
+    },
+    "osdWarningTextAutopilotAbort": {
+        "message": "Мисија аутопилота прекинута",
+        "description": "One of the warnings that can be selected to be shown in the OSD"
+    },
+    "osdWarningAutopilotAbort": {
+        "message": "Мисија аутопилота прекинута",
+        "description": "Warns when a waypoint mission aborts (GPS lost, stalled or flyaway)"
+    },
+    "osdWarningTextUnknown": {
+        "message": "Непознато $1"
+    },
+    "osdWarningUnknown": {
+        "message": "Непознато упозорење (детаљи ће бити додати у будућем издању)"
+    },
+    "osdSectionHelpElements": {
+        "message": "Укључите или искључите OSD елементе."
+    },
+    "osdSectionHelpVideoMode": {
+        "message": "Подесите очекивани видео мод камере (обично ово можете оставити на AUTO, ако имате потешкоћа, подесите ово да одговара излазу камере)."
+    },
+    "osdSectionHelpUnits": {
+        "message": "Подешава систем јединица који се користи за нумеричке приказе."
+    },
+    "osdSectionHelpTimers": {
+        "message": "Конфигуришите тајмере лета."
+    },
+    "osdSectionHelpAlarms": {
+        "message": "Подесите прагове који се користе за OSD елементе са стањима аларма."
+    },
+    "osdSectionHelpStats": {
+        "message": "Подесите вредности приказане на екрану статистике након лета."
+    },
+    "osdSectionHelpWarnings": {
+        "message": "Укључите или искључите упозорења која се приказују на елементу УПОЗОРЕЊА."
+    },
+    "osdSettingsSaved": {
+        "message": "OSD подешавања сачувана"
+    },
+    "osdWritePermissions": {
+        "message": "Немате <span class=\"message-negative\">дозволе за писање<\/span> за ову фајл"
+    },
+    "osdButtonSaved": {
+        "message": "Сачувано"
+    },
+    "vtxHelp": {
+        "message": "Овде можете конфигурисати вредности за Ваш Видео предајник (VTX). Можете прегледати и променити вредности преноса, укључујући VTX табеле, ако flight контролер и VTX to подржавају.<br>Да бисте подесили Ваш VTX, користите следеће кораке:<br>1. Идите на <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https:\/\/betaflight.com\/docs\/wiki\/guides\/current\/VTX#vtx-tables\">ову<\/a> страницу;<br>2. Пронађите одговарајућу VTX конфигурациону фајл за Вашу земљу и Ваш VTX модел и преузмите је;<br>3. Кликните на '$t(vtxButtonLoadFile.message)' испод, изаберите VTX конфигурациону фајл, учитајте је;<br>4. Проверите да ли су подешавања тачна;<br>5. Кликните на '$t(vtxButtonSave.message)' да бисте сачували VTX подешавања на flight контролеру.<br>6. Опционо кликните на '$t(vtxButtonSaveLua.message)' да бисте сачували lua конфигурациону фајл коју можете користити са betaflight lua скриптама (Више погледајте <a target=\"_blank\" rel=\"noopener noreferrer\" href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/\">овде<\/a>.)",
+        "description": "Introduction message in the VTX tab"
+    },
+    "vtxMessageNotSupported": {
+        "message": "<span class=\"message-negative\">Пажња:<\/span> Ваш VTX није конфигурисан или није подржан. Стога не можете мењати VTX вредности одавде. Ово ће бити могуће само ако је flight контролер повезан са VTX-ом користећи неки протокол као што су Tramp или SmartAudio и ако је исправно конфигурисан на картици $t(tabPorts.message) ако је потребно.",
+        "description": "Message to show when the VTX is not supported in the VTX tab"
+    },
+    "vtxMessageTableNotConfigured": {
+        "message": "<span class=\"message-negative\">Пажња:<\/span> Морате ПРВО конфигурисати и сачувати VTX табелу на дну пре него што можете користити поља $t(vtxSelectedMode.message).",
+        "description": "Message to show when the VTX is not supported in the VTX tab"
+    },
+    "vtxMessageFactoryBandsNotSupported": {
+        "message": "<span class=\"message-negative\">Пажња:<\/span> Изабрани тип VTX-а не подржава 'фабричко' подешавање за опсеге, али неки од Ваших опсега имају ово подешавање. Кликните на '$t(vtxButtonSave.message)' да бисте ово поправили.",
+        "description": "Message to show when the configured VTX type does not support factory bands, but one or more of the configured bands are of this type"
+    },
+    "vtxMessageVerifyTable": {
+        "message": "<span class=\"message-negative\">Пажња:<\/span> Вредности VTX табеле су учитане, али још нису сачуване на flight контролеру. Морате проверити и изменити вредности да бисте били сигурни да су валидне и легалне у Вашој земљи, а затим притисните дугме $t(vtxButtonSave.message) да бисте их сачували на flight контролеру.",
+        "description": "Message to show when the VTX Table has been loaded from a external source"
+    },
+    "vtxFrequencyChannel": {
+        "message": "Унесите фреквенцију директно",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxFrequencyChannelHelp": {
+        "message": "Ако ово омогућите, апликација ће Вам омогућити да изаберете фреквенцију уместо уобичајеног опсега\/канала. Да би ово функционисало, Ваш VTX мора подржавати ову функцију.",
+        "description": "Help text for the frequency or channel select field of the VTX tab"
+    },
+    "vtxSelectedMode": {
+        "message": "Изабрани мод",
+        "description": "Title for the actual mode header of the VTX"
+    },
+    "vtxActualState": {
+        "message": "Тренутне вредности",
+        "description": "Title for the actual values header of the VTX"
+    },
+    "vtxType": {
+        "message": "VTX тип",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxType_0": {
+        "message": "Није подржано",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_1": {
+        "message": "RTC607",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_3": {
+        "message": "SmartAudio",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_4": {
+        "message": "Tramp",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_5": {
+        "message": "MSP",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxType_255": {
+        "message": "Непознато",
+        "description": "Text for one of the types of the VTX type in VTX tab"
+    },
+    "vtxBand": {
+        "message": "Опсег",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxBandHelp": {
+        "message": "Овде бирате опсег за свој видео-предајник.",
+        "description": "Help text for the band field of the VTX tab"
+    },
+    "vtxBand_0": {
+        "message": "Ништа",
+        "description": "Text of one of the options for the band field of the VTX tab"
+    },
+    "vtxBand_X": {
+        "message": "Опсег {{bandName}}",
+        "description": "Text of one of the options for the band field of the VTX tab"
+    },
+    "vtxChannel_0": {
+        "message": "Ништа",
+        "description": "Text of one of the options for the channel field of the VTX tab"
+    },
+    "vtxChannel_X": {
+        "message": "Канал {{channelName}}",
+        "description": "Text of one of the options for the channel field of the VTX tab"
+    },
+    "vtxPower_0": {
+        "message": "Ништа",
+        "description": "Text of one of the options for the power field of the VTX tab"
+    },
+    "vtxPower_X": {
+        "message": "Ниво {{powerLevel}}",
+        "description": "Text of one of the options for the power field of the VTX tab"
+    },
+    "vtxChannel": {
+        "message": "Канал",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxChannelHelp": {
+        "message": "Овде бирате канал за свој видео-предајник.",
+        "description": "Help text for the channel field of the VTX tab"
+    },
+    "vtxFrequency": {
+        "message": "Фреквенција",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxFrequencyHelp": {
+        "message": "Овде бирате фреквенцију за свој видео-предајник, ако је подржана.",
+        "description": "Help text for the frequency field of the VTX tab"
+    },
+    "vtxReadyTrue": {
+        "message": "Да",
+        "description": "vtx device are ready"
+    },
+    "vtxReadyFalse": {
+        "message": "Не",
+        "description": "vtx device are not ready"
+    },
+    "vtxDeviceReady": {
+        "message": "Уређај спреман",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPower": {
+        "message": "Снага",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPowerHelp": {
+        "message": "Ово је изабрана снага видео-предајника. Може се мењати ако је укључен $t(vtxPitMode.message) или $t(vtxLowPowerDisarm.message).",
+        "description": "Help text for the power field of the VTX tab"
+    },
+    "vtxPitMode": {
+        "message": "Pit мод",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPitModeHelp": {
+        "message": "Када је укључен, видео-предајник прелази на врло малу снагу, да би дрон могао да буде укључен на столу а да не смета другим пилотима. Домет у том режиму обично је мањи од пет метара.<br \/><br \/>НАПОМЕНА: код неких протокола, као што је SmartAudio, pit мод се не може укључити кроз програм пошто је предајник већ упаљен.",
+        "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxPitModeFrequency": {
+        "message": "Фреквенција у pit моду",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxPitModeFrequencyHelp": {
+        "message": "Фреквенција на коју се прелази када је pit мод укључен.",
+        "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxProtocol": {
+        "message": "Протокол"
+    },
+    "vtxProtocolHelp": {
+        "message": "Управљачки протокол којим VTX говори. SmartAudio и Tramp раде преко UART-а испод; MSP га дели са MSP-ом, као што то раде и DJI, HDZero и Walksnail."
+    },
+    "vtxSerialPort": {
+        "message": "Серијски порт"
+    },
+    "vtxSerialPortHelp": {
+        "message": "UART на ком ради управљачки протокол VTX-а. Од API-ја 1.49 задаје се на самом VTX-у; картица Ports га само приказује."
+    },
+    "vtxLowPowerDisarm": {
+        "message": "Мала снага док је разоружан",
+        "description": "Text of one of the fields of the VTX tab"
+    },
+    "vtxLowPowerDisarmHelp": {
+        "message": "Када је укључено, видео-предајник користи најмању доступну снагу док дрон није армован, осим ако је наступио Failsafe.",
+        "description": "Help text for the low power disarm field of the VTX tab"
+    },
+    "vtxLowPowerDisarmOption_0": {
+        "message": "Искључено",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxLowPowerDisarmOption_1": {
+        "message": "Укључено",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxLowPowerDisarmOption_2": {
+        "message": "До првог армовања",
+        "description": "One of the options for the Low Power Disarm mode of the VTX"
+    },
+    "vtxTable": {
+        "message": "Табела видео-предајника",
+        "description": "Text of the header of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevels": {
+        "message": "Број нивоа снаге",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsHelp": {
+        "message": "Овим се задаје колико нивоа снаге Ваш видео-предајник подржава.",
+        "description": "Help for the number of power levels field of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsTableHelp": {
+        "message": "Ова табела приказује различите вредности снаге које се могу користити за видео-предајник. Деле се на две ствари: <br><b>- $t(vtxTablePowerLevelsValue.message):<\/b> сваки ниво снаге тражи вредност коју одређује произвођач уређаја. Тачну вредност потражите код произвођача или у Betaflight упутствима о табелама видео-предајника, где има примера. <br><b>- $t(vtxTablePowerLevelsLabel.message):<\/b> овде уписујете ознаку коју желите за сваки ниво снаге. Могу бити бројеви (25, 200, 600, 1.2), слова (OFF, MIN, MAX) или комбинација.<br \/><br \/>Подесите <b>само<\/b> оне нивое снаге који су дозвољени у Вашој земљи.",
+        "description": "Help for the table of power levels (value-label) that appears in the VTX tab"
+    },
+    "vtxTablePowerLevelsValue": {
+        "message": "Вредност",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTablePowerLevelsLabel": {
+        "message": "Ознака",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBands": {
+        "message": "Број опсега",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsHelp": {
+        "message": "Овим се задаје колико опсега видео-предајник тражи.",
+        "description": "Help for the number of bands field of the VTX Table element in the VTX tab"
+    },
+    "vtxTableChannels": {
+        "message": "Број канала по опсегу",
+        "description": "Text of one of the fields of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsChannelsHelp": {
+        "message": "Овим се задаје колико опсега и колико канала по опсегу желите за свој видео-предајник.",
+        "description": "Help for the number of bands and channels field of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleName": {
+        "message": "Назив",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleLetter": {
+        "message": "Слово",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandTitleFactory": {
+        "message": "Фабрички",
+        "description": "Text of one of the titles of the VTX Table element in the VTX tab"
+    },
+    "vtxTableBandsChannelsTableHelp": {
+        "message": "Ова табела приказује све фреквенције које се могу користити за Ваш видео-предајник. Можете имати више опсега, а за сваки опсег подешавате:<br><b>- $t(vtxTableBandTitleName.message):<\/b> назив који желите да дате опсегу, на пример BOSCAM_A, FATSHARK или RACEBAND.<br><b>- $t(vtxTableBandTitleLetter.message):<\/b> кратко слово које означава тај опсег.<br><b>- $t(vtxTableBandTitleFactory.message):<\/b> означава да ли је опсег фабрички. Ако јесте, Betaflight шаље предајнику број опсега и канала, па предајник користи своју уграђену табелу фреквенција, а ове овде служе само за приказ на екрану. Ако није, Betaflight шаље предајнику стварну фреквенцију задату овде.<br><b>- Фреквенције:<\/b> фреквенције за тај опсег.<br \/><br \/>Имајте на уму да нису све фреквенције дозвољене у Вашој земљи. Свакој фреквенцији коју не смете да користите упишите <b>нулу<\/b> да бисте је искључили.",
+        "description": "Help for the table of bands-channels that appears in the VTX tab"
+    },
+    "vtxSavedFileOk": {
+        "message": "Фајл са подешавањима видео-предајника је <span class=\"message-positive\">сачуван<\/span>",
+        "description": "Message in the GUI log when the VTX Config file is saved"
+    },
+    "vtxSavedFileKo": {
+        "message": "<span class=\"message-negative\">Грешка<\/span> при чувању фајла са подешавањима видео-предајника",
+        "description": "Message in the GUI log when the VTX Config file is saved"
+    },
+    "vtxSavedLuaFileOk": {
+        "message": "Lua фајл са подешавањима видео-предајника је <span class=\"message-positive\">сачуван<\/span>",
+        "description": "Message in the GUI log when the lua VTX Config file is saved"
+    },
+    "vtxSavedLuaFileKo": {
+        "message": "<span class=\"message-negative\">Грешка<\/span> при чувању lua фајла са подешавањима видео-предајника",
+        "description": "Message in the GUI log when the lua VTX Config file saving has failed"
+    },
+    "vtxLoadFileOk": {
+        "message": "Фајл са подешавањима видео-предајника је <span class=\"message-positive\">учитан<\/span>",
+        "description": "Message in the GUI log when the VTX Config file is loaded"
+    },
+    "vtxLoadFileKo": {
+        "message": "<span class=\"message-negative\">Грешка<\/span> при учитавању фајла са подешавањима видео-предајника",
+        "description": "Message in the GUI log when the VTX Config file is loaded"
+    },
+    "vtxLoadClipboardOk": {
+        "message": "Подешавања видео-предајника су <span class=\"message-positive\">учитана<\/span> из привремене меморије",
+        "description": "Message in the GUI log when the VTX Config file is pasted from clipboard"
+    },
+    "vtxLoadClipboardKo": {
+        "message": "<span class=\"message-negative\">Грешка<\/span> при учитавању подешавања видео-предајника из привремене меморије",
+        "description": "Message in the GUI log when the VTX Config file is pasted from clipboard"
+    },
+    "vtxButtonSaveFile": {
+        "message": "Сачувај у фајл",
+        "description": "Save to file button in the VTX tab"
+    },
+    "vtxButtonSaveLua": {
+        "message": "Сачувај Lua скрипту",
+        "description": "Save Lua script button in the VTX tab"
+    },
+    "vtxLuaFileHelp": {
+        "message": "Дугме „$t(vtxButtonSaveLua.message)“ омогућава да сачувате <i>mcuid<\/i>.lua фајл са подешавањима табеле видео-предајника, који се користи уз <a href=\"https:\/\/github.com\/betaflight\/betaflight-tx-lua-scripts\/\" target=\"_blank\" rel=\"noopener noreferrer\">Betaflight Lua скрипте за даљински<\/a>.<br><br>Верзија 1.6.0 и новије користе фајл такав какав јесте, а код старијих верзија скрипти треба га преименовати тако да се поклапа са називом модела на даљинском.",
+        "description": "Tooltip message for the Save Lua script button in the VTX tab"
+    },
+    "vtxButtonLoadFile": {
+        "message": "Учитај из фајла",
+        "description": "Load to file button in the VTX tab"
+    },
+    "vtxButtonLoadClipboard": {
+        "message": "Учитај из привремене меморије",
+        "description": "Paste from clipboard button in the VTX tab"
+    },
+    "vtxButtonSave": {
+        "message": "Сачувај",
+        "description": "Save button in the VTX tab"
+    },
+    "buttonSaving": {
+        "message": "Чување",
+        "description": "Show state of the Save button in the VTX\/LED tab"
+    },
+    "buttonSaved": {
+        "message": "Сачувано",
+        "description": "Saved action button in the VTX\/LED tab"
+    },
+    "vtxSmartAudioUnlocked": {
+        "message": "{{version}} откључан",
+        "description": "Indicates if SA device is unlocked"
+    },
+    "mainHelpArmed": {
+        "message": "Армовање мотора"
+    },
+    "mainHelpFailsafe": {
+        "message": "Failsafe мод"
+    },
+    "mainHelpLink": {
+        "message": "Status серијске везе"
+    },
+    "configurationEscProtocol": {
+        "message": "Протокол регулатора и мотора"
+    },
+    "configurationEscProtocolHelp": {
+        "message": "Изаберите протокол мотора. <br>Проверите да га Ваши регулатори подржавају — тај податак стоји на страници произвођача. <br> <b>Опрезно са DSHOT900 и DSHOT1200 — мало регулатора их подржава!<\/b>"
+    },
+    "configurationunsyndePwm": {
+        "message": "PWM брзина мотора одвојена од брзине PID петље"
+    },
+    "configurationUnsyncedPWMFreq": {
+        "message": "PWM фреквенција мотора"
+    },
+    "configurationDshotBidir": {
+        "message": "Двосмерни DShot (тражи одговарајући фирмвер регулатора)",
+        "description": "Feature for the ESC\/Motor"
+    },
+    "configurationDshotBidirHelp": {
+        "message": "Шаље податке са регулатора назад flight контролеру кроз DShot. Неопходно је за RPM филтер и за динамички празан ход. <br> <br>Напомена: тражи одговарајући регулатор са прикладним фирмвером, на пример JESC, Jazzmac или BLHeli-32.",
+        "description": "Description of the Bidirectional DShot feature of the ESC\/Motor"
+    },
+    "configurationGyroFrequency": {
+        "message": "Учестаност освежавања жироскопа"
+    },
+    "configurationPidProcessDenom": {
+        "message": "Учестаност PID петље"
+    },
+    "configurationPidProcessDenomHelp": {
+        "message": "Највећа учестаност PID петље ограничена је највећом учестаношћу којом изабрани протокол мотора може да шаље команде."
+    },
+    "configurationGyroUse32kHz": {
+        "message": "Узорковање жироскопа на 32 kHz"
+    },
+    "configurationGyroUse32kHzHelp": {
+        "message": "Учестаност жироскопа од 32 kHz могућа је само ако је чип подржава (тренутно MPU6500, MPU9250 и ICM20xxx ако су везани преко SPI). Ако нисте сигурни, погледајте спецификацију своје плочице."
+    },
+    "configurationAccHardware": {
+        "message": "Акцелерометар"
+    },
+    "configurationBaroHardware": {
+        "message": "Барометар"
+    },
+    "configurationMagHardware": {
+        "message": "Магнетометар (ако је подржан)"
+    },
+    "configurationMagDeclinationNoGps": {
+        "message": "Није било могуће одредити положај. Прикључите GPS модул или дозволите прегледачу приступ положају."
+    },
+    "configurationMagDeclinationSet": {
+        "message": "Магнетна деклинација постављена на {{declination}}° према откривеном положају."
+    },
+    "configurationMagInclination": {
+        "message": "Инклинација"
+    },
+    "configurationMagInclinationHelp": {
+        "message": "Угао између магнетног поља земље и водоравне равни на Вашем месту. Позитивне вредности значе да поље показује надоле, дакле северна полулопта."
+    },
+    "configurationMagFieldStrengthLabel": {
+        "message": "Јачина поља"
+    },
+    "configurationMagFieldStrengthHelp": {
+        "message": "Укупна јачина магнетног поља земље на Вашем месту, у нанотеслама. Уобичајене вредности крећу се од двадесет пет хиљада до шездесет пет хиљада."
+    },
+    "sensorConfigMagDetect": {
+        "message": "Детектуј"
+    },
+    "sensorConfigMagUpdate": {
+        "message": "Ажурирај"
+    },
+    "sensorConfigDeclinationAutoSet": {
+        "message": "Магнетна деклинација је аутоматски детектована као {{value}}° за Вашу локацију."
+    },
+    "sensorConfigDeclinationDrift": {
+        "message": "Деклинација је {{saved}}°, али GPS детектује {{detected}}° за ову локацију. Кликните на Ажурирај да бисте исправили."
+    },
+    "magCalibrationCancel": {
+        "message": "Откажи"
+    },
+    "magCalibrationClear": {
+        "message": "Очисти"
+    },
+    "magCalibrationModeOptions": {
+        "message": "Опције мода калибрације"
+    },
+    "magCalibrationRetry": {
+        "message": "Покушај поново"
+    },
+    "magCalibrationWaiting": {
+        "message": "Чекање на померање... Протресите летелицу да бисте започели."
+    },
+    "magCalibrationCollecting": {
+        "message": "Полако ротирајте летелицу у свим правцима."
+    },
+    "magCalibrationComplete": {
+        "message": "Калибрација је завршена."
+    },
+    "magCalibrationError": {
+        "message": "Калибрација није успела. Покушајте поново у подручју са мање магнетних сметњи."
+    },
+    "magCalibrationNoMovement": {
+        "message": "Померање није детектовано 30 секунди. Калибрација је отказана."
+    },
+    "magCalibrationSamples": {
+        "message": "Узорци"
+    },
+    "magCalibrationQualityGood": {
+        "message": "Добар"
+    },
+    "magCalibrationQualityFair": {
+        "message": "Просечан"
+    },
+    "magCalibrationQualityPoor": {
+        "message": "Лош"
+    },
+    "magCalibrationFirmwareOffsets": {
+        "message": "Фирмвер помераји"
+    },
+    "magCalibrationUnguided": {
+        "message": "Калибрација фирмвера (застарело)"
+    },
+    "magCalibrationUnguidedDesc": {
+        "message": "Ротирајте слободно — фирмвер аутоматски чува након 30s"
+    },
+    "magCalibrationUnguidedTitle": {
+        "message": "Калибрација фирмвера"
+    },
+    "magCalibrationUnguidedInstruction": {
+        "message": "Имате 30 секунди да ротирате летелицу у свим смеровима. Фирмвер ће аутоматски сачувати вредности калибрације када време истекне."
+    },
+    "magCalibrationUnguidedDone": {
+        "message": "Калибрација фирмвера је завршена"
+    },
+    "magCalibrationCheck": {
+        "message": "Провери"
+    },
+    "magCalibrationCheckDesc": {
+        "message": "Приказ уживо података компаса са тренутном калибрацијом"
+    },
+    "magCalibrationCheckTitle": {
+        "message": "Провера калибрације"
+    },
+    "magCalibrationCheckInstruction": {
+        "message": "Потврдите оријентацију и калибрацију магнетометра. Поставите Вашу летелицу равно у односу на хоризонт, усмерите нос ка познатој тачки на компасу (телефон се може користити за одређивање севера) и потврдите да се нове тачке појављују на очекиваном месту на 3D приказу. Вредности јачине поља за сваку осу и сферичност тачака указују на тачност калибрације. Ако се тачке појављују на потпуно погрешним местима, оријентација магнетометра је вероватно погрешна."
+    },
+    "magCalibrationCalValues": {
+        "message": "Вредности калибрације"
+    },
+    "magCalibrationSaveValues": {
+        "message": "Сачувај вредности"
+    },
+    "magCalibrationSaveSuccess": {
+        "message": "Вредности калибрације су сачуване"
+    },
+    "magCalibrationSaveError": {
+        "message": "Неуспешно чување вредности калибрације"
+    },
+    "magCalibrationFull": {
+        "message": "Калибриши и детектуј оријентацију"
+    },
+    "magCalibrationFullDesc": {
+        "message": "Ротирајте летелицу у свим смеровима да бисте калибрисали сензор и аутоматски детектовали његову оријентацију уградње."
+    },
+    "magCalibrationFullTitle": {
+        "message": "Калибрација и детекција оријентације"
+    },
+    "magCalibrationFullInstruction": {
+        "message": "Пратите кораке испод, држећи летелицу стабилно током сваког пуног круга. Број зона расте како достижете нове углове — циљ је покрити свих 20."
+    },
+    "magCalibrationFullStepCounter": {
+        "message": "Корак {{n}} од {{total}}"
+    },
+    "magCalibrationFullStep1": {
+        "message": "Држите летелицу равно и полако је ротирајте за пуних 360°."
+    },
+    "magCalibrationFullStep2": {
+        "message": "Окрените је наопако и полако ротирајте за још једних пуних 360°."
+    },
+    "magCalibrationFullStep3": {
+        "message": "Усмерите нос право нагоре и направите пун круг око њега."
+    },
+    "magCalibrationFullStep4": {
+        "message": "Окрените нос летелице надоле и направите пун круг."
+    },
+    "magCalibrationFullStep5": {
+        "message": "Поставите је на леви бок и направите пун круг."
+    },
+    "magCalibrationFullStep6": {
+        "message": "Поставите је на десни бок и направите пун круг."
+    },
+    "magCalibrationFullStep7": {
+        "message": "Направите неколико спорих превртаја напред, сваки пут окренути у другом правцу."
+    },
+    "magCalibrationFullStep8": {
+        "message": "Направите неколико спорих превртаја назад, поново сваки пут окренути у другом правцу."
+    },
+    "magCalibrationFullZones": {
+        "message": "{{covered}} \/ {{total}} покривених зона"
+    },
+    "magCalibrationFullCompute": {
+        "message": "Заврши калибрацију"
+    },
+    "magCalibrationFullCoverageHint": {
+        "message": "Више покривених зона даје већу прецизност — тежите ка 20 \/ 20 за најбољу калибрацију и детекцију поравнања."
+    },
+    "magCalibrationFullCoverage": {
+        "message": "Покривеност:"
+    },
+    "magCalibrationFullAlignment": {
+        "message": "Поравнање:"
+    },
+    "magCalibrationFullCustomAngles": {
+        "message": "roll {{roll}}° pitch {{pitch}}° yaw {{yaw}}°"
+    },
+    "magCalibrationFullOffsets": {
+        "message": "Калибрација:"
+    },
+    "magCalibrationFullResidual": {
+        "message": "Резидуал:"
+    },
+    "magCalibrationFullCopyCli": {
+        "message": "Копирај CLI"
+    },
+    "magCalibrationFullApply": {
+        "message": "Примени"
+    },
+    "magCalibrationFullExport": {
+        "message": "Извези модел"
+    },
+    "magCalibrationFullInsufficientSamples": {
+        "message": "Недовољно узорака — ротирајте дуже"
+    },
+    "magCalibrationFullNoGeo": {
+        "message": "Нема GPS-а, локације прегледача или IP адресе — унесите координате ручно да бисте наставили"
+    },
+    "magCalibrationManualLocationTitle": {
+        "message": "Локација је потребна за калибрацију"
+    },
+    "magCalibrationManualLocationPrompt": {
+        "message": "Ручно унесите географску ширину и дужину избором са Google Maps-а. Ваш дрон нема сателитски положај и Ваш уређај није доставио податке о локацији. Локација је потребна за калибрацију магнетометра."
+    },
+    "magCalibrationManualLocationPlaceholder": {
+        "message": "нпр. 63.728263, -68.446117"
+    },
+    "magCalibrationManualLocationInvalid": {
+        "message": "Неисправан format координата. Унесите у облику: географска ширина, географска дужина (нпр. 63.728263, -68.446117)"
+    },
+    "magCalibrationManualLocationFailed": {
+        "message": "Није могуће израчунати магнетску референцу за те координате. Проверите их и покушајте поново."
+    },
+    "magCalibrationFullCliCopied": {
+        "message": "CLI команде су копиране у clipboard"
+    },
+    "magCalibrationFullCliCopyFailed": {
+        "message": "Копирање у clipboard није успело"
+    },
+    "magCalibrationFullCustomUnsupported": {
+        "message": "Фирмвер {{version}} је сувише стар за CUSTOM поравнање магнетометра (потребан је {{min}}+). Ажурирајте фирмвер, па примените."
+    },
+    "magCalibrationFullApplied": {
+        "message": "Калибрација је примењена и сачувана"
+    },
+    "magCalibrationDiscard": {
+        "message": "Одбаци"
+    },
+    "magVizPointCloud": {
+        "message": "Облак тачака"
+    },
+    "magVizHeatmap": {
+        "message": "Воксел топлотна мапа"
+    },
+    "magVizProjection": {
+        "message": "Трострука пројекција"
+    },
+    "magVizPolar": {
+        "message": "Поларна густина"
+    },
+    "magVizWaitingForData": {
+        "message": "Чекање на податке…"
+    },
+    "magVizAxisField": {
+        "message": "Поље"
+    },
+    "magVizAgeLegendOld": {
+        "message": "Старо"
+    },
+    "magVizAgeLegendNew": {
+        "message": "Ново"
+    },
+    "configurationSmallAngle": {
+        "message": "Maximum ARM Angle [степени]"
+    },
+    "configurationSmallAngleHelp": {
+        "message": "Дрон се неће армовати ако је нагнут више од задатог броја степени. Важи само ако је акцелерометар укључен. Постављањем на сто осамдесет ова провера се практично искључује."
+    },
+    "configurationBatteryVoltage": {
+        "message": "Напон батерије"
+    },
+    "configurationBatteryCurrent": {
+        "message": "Струја батерије"
+    },
+    "configurationBatteryMeterType": {
+        "message": "Врста мерача батерије"
+    },
+    "configurationBatteryMinimum": {
+        "message": "Најнижи напон ћелије"
+    },
+    "configurationBatteryMaximum": {
+        "message": "Највиши напон ћелије"
+    },
+    "configurationBatteryWarning": {
+        "message": "Напон ћелије за упозорење"
+    },
+    "configurationBatteryScale": {
+        "message": "Размера напона"
+    },
+    "configurationCurrentMeterType": {
+        "message": "Врста мерача струје"
+    },
+    "configurationCurrent": {
+        "message": "Сензор струје"
+    },
+    "configurationCurrentScale": {
+        "message": "Размера излазног напона у милиампере [десетинке mV по A]"
+    },
+    "configurationCurrentOffset": {
+        "message": "Померај у корацима од миливолта"
+    },
+    "configurationBatteryMultiwiiCurrent": {
+        "message": "Подршка за стари Multiwii MSP излаз струје"
+    },
+    "pidTuningProfile": {
+        "message": "Профил"
+    },
+    "pidTuningProfileTip": {
+        "message": "До 3 (2 за неке контролере) различита PID профила могу се сачувати на flight контролеру. PID профили обухватају PID, D setpoint и angle\/horizon подешавања на овој картици. Када сте на терену, једноставне команде ручицом (погледајте упутства на интернету) могу се користити за пребацивање између профила."
+    },
+    "pidTuningRateProfile": {
+        "message": "Rateprofile"
+    },
+    "pidTuningRateProfileTip": {
+        "message": "До 3 различита Rateprofile профила по профилу могу се сачувати на flight контролеру. Rateprofile обухвата подешавања за 'RC Rate', 'Rate', 'RC Expo', 'Throttle' и 'TPA'. Пребацивање између Rateprofile профила је могуће током лета, подешавањем троположајног прекидача за 'Rate Profile Selection' на картици 'Adjustments'."
+    },
+    "pidTuningRateSetup": {
+        "message": "Основни\/Acro Rates"
+    },
+    "pidTuningRateSetupHelp": {
+        "message": "Подесите ове вредности да бисте подесили Ваше брзине одзива. Користите RC Rate да повећате укупну максималну брзину одзива, користите Super Rate за веће брзине на крају хода ручице, и користите RC Expo да ублажите осећај на средини ручице.",
+        "description": "Rate table helpicon message"
+    },
+    "pidTuningDelta": {
+        "message": "Метода извода"
+    },
+    "pidTuningDeltaError": {
+        "message": "Грешка"
+    },
+    "pidTuningDeltaMeasurement": {
+        "message": "Мерење"
+    },
+    "pidTuningDeltaTip": {
+        "message": "<b>Derivative from Error<\/b> пружа директнији одзив ручице и углавном се више користи за трке.<br \/><br \/><b>Derivative from Measurement<\/b> пружа блажи одзив ручице што је корисније за freestyle"
+    },
+    "pidTuningPidControllerTip": {
+        "message": "<b>Legacy vs Betaflight (float):<\/b> PID скалирање и PID логика су потпуно исти. Поновно подешавање није нужно потребно. Legacy је старији Betaflight алгоритам базиран на целобројној математици. Betaflight PID контролер користи математику са покретним зарезом и има много нових функција посебно дизајнираних за мултироторе.<br><b>Float vs Integer:<\/b> PID скалирање и PID логика су потпуно исти. Није потребно поновно подешавање. F1 плочице немају уграђени FPU, па математика са покретним зарезом повећава оптерећење CPU-а док целобројна математика побољшава перформансе, али float математика може донети мало већу прецизност."
+    },
+    "pidTuningFilterTip": {
+        "message": "<b>Gyro Soft Filter:<\/b> Нископропусни filter за жироскоп. Користите мању вредност за јаче филтрирање.<br><b>D Term Filter:<\/b> Нископропусни filter за Dterm. Може утицати на подешавање D параметра. Користите мању вредност за јаче филтрирање.<br><b>Yaw Filter:<\/b> Филтрира Yaw излаз. Може помоћи на летелицама са шумом на Yaw оси."
+    },
+    "pidTuningRatesTip": {
+        "message": "Играјте се са брзинама одзива и видите како оне утичу на криву ручице"
+    },
+    "configurationCamera": {
+        "message": "Камера"
+    },
+    "configurationPersonalization": {
+        "message": "Личне поставке"
+    },
+    "craftName": {
+        "message": "Назив летелице"
+    },
+    "configurationCraftNameHelp": {
+        "message": "Може се приказати у записима, у називима резервних копија и на екрану у наочарима.<\/br>Може се задати и променљивом <b>craft_name<\/b> у CLI-ју."
+    },
+    "configurationPilotName": {
+        "message": "Име пилота"
+    },
+    "configurationPilotNameHelp": {
+        "message": "Може се приказати на екрану у наочарима.<\/br>Може се задати и променљивом <b>pilot_name<\/b> у CLI-ју."
+    },
+    "configurationFpvCamAngleDegrees": {
+        "message": "Угао FPV камере [степени]"
+    },
+    "onboardLoggingBlackbox": {
+        "message": "Уређај за Blackbox снимање"
+    },
+    "onboardLoggingSerialPort": {
+        "message": "Серијски порт"
+    },
+    "onboardLoggingSerialPortHelp": {
+        "message": "UART који се користи када је уређај за записивање серијски. Од API-ја 1.49 задаје се на самом Blackbox-у; картица Ports га само приказује."
+    },
+    "onboardLoggingSerialBaud": {
+        "message": "Брзина преноса серијског порта"
+    },
+    "onboardLoggingSerialBaudHelp": {
+        "message": "Брзина преноса за серијски порт за записивање."
+    },
+    "onboardLoggingRateOfLogging": {
+        "message": "Брзина Blackbox снимања"
+    },
+    "onboardLoggingDebugFields": {
+        "message": "Укључена debug поља"
+    },
+    "onboardLoggingDebugMode": {
+        "message": "Blackbox debug мод"
+    },
+    "onboardLoggingDebugModeUnknown": {
+        "message": "НЕПОЗНАТО"
+    },
+    "onboardLoggingSerialLogger": {
+        "message": "Спољашњи серијски уређај за бележење"
+    },
+    "onboardLoggingFlashLogger": {
+        "message": "Уграђени dataflash чип"
+    },
+    "onboardLoggingEraseInProgress": {
+        "message": "Брисање је у току, молимо сачекајте..."
+    },
+    "onboardLoggingOnboardSDCard": {
+        "message": "SD картица на плочици"
+    },
+    "onboardLoggingMsc": {
+        "message": "Мод масовне меморије"
+    },
+    "onboardLoggingMscNote": {
+        "message": "Поново покрените у моду <strong>уређаја масовне меморије (MSC)<\/strong>. Када се активира, уграђени Flash или SD картица на Вашем flight контролеру биће препознати као уређај за складиштење на Вашем рачунару и омогућиће Вам преузимање log фајлова. Избаците уређај и поново укључите напајање Вашег flight контролера како бисте напустили мод уређаја масовне меморије."
+    },
+    "onboardLoggingRebootMscText": {
+        "message": "Активирајте мод уређаја масовне меморије"
+    },
+    "onboardLoggingMscNotReady": {
+        "message": "Мод масовне меморије не може се активирати јер уређај за складиштење није спреман."
+    },
+    "dialogConfirmResetTitle": {
+        "message": "Потврди"
+    },
+    "dialogConfirmResetNote": {
+        "message": "УПОЗОРЕЊЕ: Да ли сте сигурни да желите да вратите <strong>СВА ПОДЕШАВАЊА<\/strong> на неконфигурисано стање? Ово <strong>није<\/strong> \"фабричко ресетовање\". Може проузроковати неочекиване проблеме и можда ће бити потребно поново флешовати Ваш фирмвер да бисте се поново повезали."
+    },
+    "dialogConfirmResetConfirm": {
+        "message": "Врати на фабричко"
+    },
+    "dialogConfirmResetClose": {
+        "message": "Откажи"
+    },
+    "modeCameraWifi": {
+        "message": "Дугме за Wi-Fi камере"
+    },
+    "modeCameraPower": {
+        "message": "Дугме за напајање камере"
+    },
+    "modeCameraChangeMode": {
+        "message": "Дугме за промену мода камере"
+    },
+    "flashTab": {
+        "message": "Ажурирање фирмвера"
+    },
+    "cliAutoComplete": {
+        "message": "Напредно CLI аутоматско допуњавање"
+    },
+    "firmwareBackupOnFlash": {
+        "message": "Направите резервну копију пре флешовања новог циља"
+    },
+    "darkTheme": {
+        "message": "Укључи тамну тему"
+    },
+    "colorTheme": {
+        "message": "Тема боја",
+        "description": "Color theme settings"
+    },
+    "colorThemeYellow": {
+        "message": "Жута (фабрички)",
+        "description": "Default yellow color theme"
+    },
+    "colorThemeAmber": {
+        "message": "Ћилибар",
+        "description": "Amber color theme"
+    },
+    "colorThemeContrast": {
+        "message": "Високи контраст",
+        "description": "Contrast color theme"
+    },
+    "uiScale": {
+        "message": "Скалирање интерфејса",
+        "description": "Scale the entire user interface up or down"
+    },
+    "pidTuningRatesType": {
+        "message": "Врста Rates-а"
+    },
+    "pidTuningRatesTypeTip": {
+        "message": "Промена врсте рејтова мења криву и начин на који је задајете"
+    },
+    "pidTuningRcRateRaceflight": {
+        "message": "Rate"
+    },
+    "pidTuningRcExpoRaceflight": {
+        "message": "Expo"
+    },
+    "pidTuningRateRaceflight": {
+        "message": "Acro+"
+    },
+    "pidTuningRcExpoKISS": {
+        "message": "RC крива"
+    },
+    "pidTuningRateQuickRates": {
+        "message": "Max Rate"
+    },
+    "pidTuningRcRateActual": {
+        "message": "Осетљивост у центру"
+    },
+    "pidTuningAcroCenterSensitiviy": {
+        "message": "Осетљивост центар-максимум"
+    },
+    "dialogRatesTypeTitle": {
+        "message": "Промена врсте Rate-а"
+    },
+    "dialogRatesTypeNote": {
+        "message": "<span class=\"message-negative\"><b>УПОЗОРЕЊЕ: Мењате врсту Rate-а.<\/b><\/span> Ако промените врсту Rate-а, Ваши Rate-ови ће бити подешени на фабричку криву."
+    },
+    "dialogRatesTypeConfirm": {
+        "message": "Промени"
+    },
+    "gpsSbasAutoDetect": {
+        "message": "Аутоматско препознавање",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasEuropeanEGNOS": {
+        "message": "Европски EGNOS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasNorthAmericanWAAS": {
+        "message": "Северноамерички WAAS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasJapaneseMSAS": {
+        "message": "Јапански MSAS",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasIndianGAGAN": {
+        "message": "Индијски GAGAN",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "gpsSbasNone": {
+        "message": "Ништа",
+        "description": "One of the options selectable for the GPS SBAS system"
+    },
+    "dialogFileNameTitle": {
+        "message": "Назив фајла"
+    },
+    "dialogFileNameDescription": {
+        "message": "Фајл ће бити сачуван у фасцикли 'Android\/data\/betaflight-app\/{{folder}}' у Вашој интерној меморији."
+    },
+    "dialogFileAlreadyExistsTitle": {
+        "message": "Овај фајл већ постоји"
+    },
+    "dialogFileAlreadyExistsDescription": {
+        "message": "Да ли желите да га преснимите?"
+    },
+    "cordovaCheckingWebview": {
+        "message": "Провера webview апликација..."
+    },
+    "cordovaIncompatibleWebview": {
+        "message": "Некомпатибилан webview"
+    },
+    "cordovaWebviewTroubleshootingMsg": {
+        "message": "Морате ажурирати webview на Вашем уређају да бисте користили апликацију Betaflight."
+    },
+    "cordovaWebviewTroubleshootingMsg2": {
+        "message": "Алат испод је намењен да Вам помогне при инсталацији новог webview-а или ажурирању већ инсталираног."
+    },
+    "cordovaAvailableWebviews": {
+        "message": "Доступне webview апликације на Вашем уређају"
+    },
+    "cordovaWebviewInstall": {
+        "message": "Инсталација апликације <b>{{app}}<\/b> може решити овај проблем са компатибилношћу."
+    },
+    "cordovaWebviewInstallBtn": {
+        "message": "Инсталирај са Google Play продавнице"
+    },
+    "cordovaWebviewUninstall": {
+        "message": "Деинсталација апликације <b>{{app}}<\/b> може решити овај проблем са компатибилношћу. Ако не можете да је деинсталирате, покушајте да је искључите у подешавањима."
+    },
+    "cordovaWebviewUninstallBtn1": {
+        "message": "Деинсталирај са Google Play продавнице"
+    },
+    "cordovaWebviewUninstallBtn2": {
+        "message": "Деинсталирај \/ искључи из подешавања"
+    },
+    "cordovaWebviewUpdate": {
+        "message": "Ажурирање апликације <b>{{app}}<\/b> може решити овај проблем са компатибилношћу."
+    },
+    "cordovaWebviewUpdateBtn": {
+        "message": "Ажурирај са Google Play продавнице"
+    },
+    "cordovaWebviewEnable": {
+        "message": "Идите на одељак О уређају у Подешавањима и додирните број израде 10 пута да бисте укључили 'Опције за програмере'. Затим отворите Опције за програмере и изаберите <b>{{app}}<\/b> као WebView провајдера."
+    },
+    "cordovaWebviewEnableBtn": {
+        "message": "Отвори подешавања"
+    },
+    "cordovaWebviewIncompatible": {
+        "message": "Изгледа да Ваш уређај није компатибилан. Покушајте да пронађете друге начине за ажурирање WebView-а"
+    },
+    "cordovaNoWebview": {
+        "message": "Није инсталирана \/ укључена ниједна WebView апликација"
+    },
+    "cordovaWebviewUsed": {
+        "message": "коришћено"
+    },
+    "cordovaExitAppTitle": {
+        "message": "Потврда"
+    },
+    "cordovaExitAppMessage": {
+        "message": "Да ли заиста желите да затворите апликацију?"
+    },
+    "dropDownSelectAll": {
+        "message": "[Изабери\/поништи све]",
+        "description": "Select all item in the drop down\/multiple select"
+    },
+    "dropDownFilterDisabled": {
+        "message": "Изаберите...",
+        "description": "Text indicating nothing is selected in the drop down\/multiple select (filter disabled)"
+    },
+    "dropDownAll": {
+        "message": "Све",
+        "description": "Text indicating everything is selected in the drop down\/multiple select"
+    },
+    "tabPresets": {
+        "message": "Готова подешавања",
+        "description": "Presets tab title"
+    },
+    "presetsReload": {
+        "message": "Поново учитај",
+        "description": "Text on the reload button that appears when there in an error loading presets index"
+    },
+    "presetsAuthor": {
+        "message": "Аутор:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsKeywords": {
+        "message": "Кључне речи:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsSourceRepository": {
+        "message": "Извор:",
+        "description": "Text prefixing user defined name of the preset repository containing a preset"
+    },
+    "presetsVersions": {
+        "message": "Фирмвер:",
+        "description": "Hint text in the presets detailed dialog"
+    },
+    "presetsOfficial": {
+        "message": "Званично",
+        "description": "Hint text in the presets detailed dialog indication preset is official"
+    },
+    "presetsCommunity": {
+        "message": "Заједница",
+        "description": "Hint text in the presets detailed dialog indication preset is not official but community"
+    },
+    "presetsExperimental": {
+        "message": "Експериментално",
+        "description": "Hint text in the presets detailed dialog indication preset is not official but experimental"
+    },
+    "presetsApply": {
+        "message": "Изабери",
+        "description": "Button to pick a preset"
+    },
+    "presetsViewOnline": {
+        "message": "Погледај на интернету&hellip;",
+        "description": "Link text for opening preset file online"
+    },
+    "presetsOpenDiscussion": {
+        "message": "Дискусија&hellip;",
+        "description": "Link text for opening preset discussion"
+    },
+    "presetsShowCli": {
+        "message": "Прикажи CLI",
+        "description": "Button to show CLI code of a preset"
+    },
+    "presetsHideCli": {
+        "message": "Сакриј CLI",
+        "description": "Button to hide CLI code of a preset"
+    },
+    "presetsOptions": {
+        "message": "Опције",
+        "description": "Text label for Options drop down select"
+    },
+    "presetsFilterCategory": {
+        "message": "Категорије",
+        "description": "UI filter name"
+    },
+    "presetsFilterKeyword": {
+        "message": "Кључне речи",
+        "description": "UI filter name"
+    },
+    "presetsFilterAuthor": {
+        "message": "Аутори",
+        "description": "UI filter name"
+    },
+    "presetsFilterFirmware": {
+        "message": "Фирмвери",
+        "description": "UI filter name"
+    },
+    "presetsFilterStatus": {
+        "message": "Стање",
+        "description": "UI filter name - official\/community\/experimental"
+    },
+    "presetsLoadError": {
+        "message": "Грешка при учитавању preset-а са интернета",
+        "description": "Error report when failed to load presets index or a specific preset"
+    },
+    "presetsButtonSave": {
+        "message": "Сачувај и рестартуј",
+        "description": "A button that saves all applied presets - analogous to 'save' command in CLI"
+    },
+    "presetsButtonCancel": {
+        "message": "Откажи",
+        "description": "A button that restarts FC without saving applied presets - analogous to 'exit' command in CLI"
+    },
+    "presetsApplyingPresets": {
+        "message": "Примењивање конфигурације...",
+        "description": "First label in the progress dialog when applying configuration (presets or user config)"
+    },
+    "presetsPleaseWait": {
+        "message": "Молимо сачекајте.",
+        "description": "Second label in the progress dialog when applying presets"
+    },
+    "presetsCliErrorsWarning": {
+        "message": "<span class='message-negative'>УПОЗОРЕЊЕ<\/span><br\/>Конфигурација је примењена са CLI грешкама.",
+        "description": "Text to show when there are CLI errors after applying presets or user configuration"
+    },
+    "presetsSaveAnyway": {
+        "message": "Ипак сачувај",
+        "description": "Save anyway button on the CLI errors presets dialog"
+    },
+    "presetsWarningDialogTitle": {
+        "message": "УПОЗОРЕЊЕ",
+        "description": "Warning title in the warning dialog in the presets"
+    },
+    "presetsWarningDialogYesButton": {
+        "message": "Прихватам",
+        "description": "Agree button in the presets warning dialog"
+    },
+    "presetsWarningDialogNoButton": {
+        "message": "Откажи",
+        "description": "Cancel button in the presets warning dialog"
+    },
+    "presetsFavoriteAddAriaLabel": {
+        "message": "Додај омиљени preset",
+        "description": "Accessible label for the button that favorites a preset"
+    },
+    "presetsFavoriteRemoveAriaLabel": {
+        "message": "Уклони омиљени preset",
+        "description": "Accessible label for the button that removes a preset from favorites"
+    },
+    "presetsWiki": {
+        "message": "Presets Wiki",
+        "description": "Button to open Presets Wiki link"
+    },
+    "presetsBackupSave": {
+        "message": "Сачувај резервну копију",
+        "description": "Button to backup current configuration to file"
+    },
+    "presetsBackupLoad": {
+        "message": "Учитај резервну копију",
+        "description": "Button to load backup from the file"
+    },
+    "presetsVirtualModeCliUnsupported": {
+        "message": "Примењивање preset-а и радње са резервном копијом захтевају CLI, који није доступан у виртуалном моду.",
+        "description": "Warning shown when a presets CLI action is attempted in Virtual Mode"
+    },
+    "mspCliFirmwareTooOld": {
+        "message": "Ова радња захтева Betaflight фирмвер {{required}} или новији (тренутно је повезан {{current}}). Молимо ажурирајте фирмвер Вашег flight контролера пре него што наставите.",
+        "description": "Warning shown when an MSP CLI action is attempted on firmware that does not support MSP CLI"
+    },
+    "firmwareFlasherRestoreBackup": {
+        "message": "Врати резервну копију",
+        "description": "Button to restore pre-flash backup from flasher tab"
+    },
+    "firmwareFlasherRestoreBackupTitle": {
+        "message": "Врати резервну копију направљену пре флешовања",
+        "description": "Title for the restore backup confirmation dialog"
+    },
+    "firmwareFlasherRestoreBackupConfirm": {
+        "message": "Ово ће вратити резервну копију конфигурације направљену пре флешовања. Да ли желите да наставите?",
+        "description": "Confirmation message before restoring a pre-flash backup"
+    },
+    "firmwareFlasherRestoreBackupSuccess": {
+        "message": "Резервна копија конфигурације је успешно враћена.",
+        "description": "Success message after restoring a pre-flash backup"
+    },
+    "firmwareFlasherRestoreBackupSuccessSkipped": {
+        "message": "Резервна копија конфигурације је враћена, {{count}} линија је прескочено.",
+        "description": "Success message after restoring a pre-flash backup when some CLI lines were skipped"
+    },
+    "firmwareFlasherRestoreBackupFailed": {
+        "message": "Враћање није успело: {{1}}",
+        "description": "Error message when restoring a pre-flash backup fails"
+    },
+    "firmwareFlasherRestoreConnectionFailed": {
+        "message": "Није могуће повезивање са flight контролером ради враћања.",
+        "description": "Error message when connection fails during restore"
+    },
+    "firmwareFlasherNoBackupAvailable": {
+        "message": "Нема доступне резервне копије за враћање.",
+        "description": "Error message when no backup data is cached for restore"
+    },
+    "presetsLoadingDumpAll": {
+        "message": "Учитавање тренутне конфигурације са flight контролера",
+        "description": "Title for the waiting dialog when loading dump all into a file"
+    },
+    "dumpAllNotSavedWarning": {
+        "message": "Дошло је до грешке приликом чувања тренутне конфигурације",
+        "description": "Message appears on presets tab when saving current diff all into a file has failed"
+    },
+    "presetSources": {
+        "message": "Извори пресета...",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogTitle": {
+        "message": "Извори пресета",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogAddNew": {
+        "message": "Додај нови извор",
+        "description": "A button to show preset sources dialog"
+    },
+    "presetsSourcesDialogDefaultSourceName": {
+        "message": "Нови прилагођени извор пресета",
+        "description": "A default preset source (repo) name"
+    },
+    "presetsSourcesDialogSaveSource": {
+        "message": "Сачувај",
+        "description": "Presets tab, sources dialog, button to save new or editable source"
+    },
+    "presetsSourcesDialogResetSource": {
+        "message": "Врати на фабричко",
+        "description": "Presets tab, sources dialog, button to reset source after modifications"
+    },
+    "presetsSourcesDialogMakeSourceActive": {
+        "message": "Активирај",
+        "description": "Presets tab, sources dialog, button to make selected source active"
+    },
+    "presetsSourcesDialogMakeSourceDisable": {
+        "message": "Искључи",
+        "description": "Presets tab, sources dialog, button to make selected source disabled"
+    },
+    "presetsSourcesDialogDeleteSource": {
+        "message": "Обриши",
+        "description": "Presets tab, sources dialog, button to delete selected source"
+    },
+    "presetsWarningNotOfficialSource": {
+        "message": "<span class=\"message-negative\">УПОЗОРЕЊЕ!<\/span> Изабран је извор пресета треће стране.",
+        "description": "Warning message that shows up when a third party preset source is selected"
+    },
+    "presetsFailedToLoadRepositories": {
+        "message": "<span class=\"message-negative\">УПОЗОРЕЊЕ!<\/span> Учитавање следећих репозиторијума није успело: <b>{{repos}}<\/b>",
+        "description": "Warning message that shows up when we fail to load some repositories"
+    },
+    "presetsWarningBackup": {
+        "message": "Молимо Вас да направите резервну копију тренутне конфигурације (дугме „$t(presetsBackupSave.message)“ или путем CLI ако је дугме искључено) <strong>пре<\/strong> избора и примене пресета. У супротном неће бити могуће враћање на претходну конфигурацију након примене пресета.",
+        "description": "Warning message that shows up at the top of the presets tab"
+    },
+    "presets_sources_dialog_warning": {
+        "message": "<span class=\"message-negative\">УПОЗОРЕЊЕ!<\/span> Коришћење извора пресета трећих страна може бити опасно.<br\/>Проверите да ли додајете и користите само поуздане изворе. Злонамерни или лоши извори пресета поквариће конфигурацију Ваше летелице и могу потенцијално оштетити Ваше уређаје.",
+        "description": "Warning message that shows up at the top of the preset sources dialog"
+    },
+    "presetsWarningWrongVersionConfirmation": {
+        "message": "Изабрани preset захтева верзију фирмвера $1<br\/> Тренутна верзија фирмвера је $2",
+        "description": "Warning message that shows up at the top of the preset sources dialog"
+    },
+    "presetsNoPresetsFound": {
+        "message": "Није пронађен ниједан preset за задате параметре претраге",
+        "description": "Message that appears on presets tab if no presets were found"
+    },
+    "presetsTooManyPresetsFound": {
+        "message": "Достигнута је максимална граница броја приказаних пресета",
+        "description": "Message that appears on presets tab if too many presets found"
+    },
+    "presetsOptionsPlaceholder": {
+        "message": "ПАЖЊА! Прегледајте листу опција",
+        "description": "Placeholder for the options list dropdown"
+    },
+    "presetsVersionMismatch": {
+        "message": "Верзија извора пресета се не поклапа.<br\/>Потребна верзија: {{versionRequired}}<br\/>Верзија извора пресета: {{versionSource}}<br\/>Коришћење овог извора пресета може бити опасно.<br\/>Да ли желите да наставите?",
+        "description": "Placeholder for the options list dropdown"
+    },
+    "presetsReviewOptionsWarning": {
+        "message": "Молимо Вас да прегледате листу опција пре избора овог пресета.",
+        "description": "Dialog text to prompt user to review options for the preset"
+    },
+    "firmwareFlasherBuildConfigurationHead": {
+        "message": "Конфигурација израде"
+    },
+    "firmwareFlasherBuildOptions": {
+        "message": "Остале опције"
+    },
+    "firmwareFlasherRemoveBuildOption": {
+        "message": "Уклони {{option}}",
+        "description": "Accessible label for the remove button on a selected build option badge."
+    },
+    "firmwareFlasherSelectProtocol": {
+        "message": "Изаберите протокол"
+    },
+    "firmwareFlasherSelectOptions": {
+        "message": "Изаберите опције"
+    },
+    "firmwareFlasherSelectBranch": {
+        "message": "Изаберите грану или унесите PR # \/ хеш комита"
+    },
+    "firmwareFlasherSearchBoard": {
+        "message": "Претражите плочицу..."
+    },
+    "firmwareFlasherBuildRadioProtocols": {
+        "message": "Радио-протокол"
+    },
+    "firmwareFlasherBuildTelemetryProtocols": {
+        "message": "Телеметријски протокол"
+    },
+    "firmwareFlasherBuildMotorProtocols": {
+        "message": "Протокол мотора"
+    },
+    "firmwareFlasherBuildOsdProtocols": {
+        "message": "OSD протокол"
+    },
+    "firmwareFlasherConfigurationFile": {
+        "message": "Назив конфигурационог фајла:"
+    },
+    "firmwareFlasherRadioProtocolDescription": {
+        "message": "Изаберите радио-протокол који желите да укључите у ову верзију. Имајте на уму да је ово падајући мени, али се може изабрати само једна ставка."
+    },
+    "firmwareFlasherTelemetryProtocolDescription": {
+        "message": "Изаберите телеметријски протокол који желите да укључите у ову верзију. Имајте на уму да је ово падајући мени, али се може изабрати само једна ставка. Такође, неки телеметријски протоколи ће бити укључени без обзира на Ваш избор на основу изабраног радио-протокола, нпр. CRSF."
+    },
+    "firmwareFlasherOptionLabelTelemetryProtocolIncluded": {
+        "message": "Аутоматски укључено"
+    },
+    "firmwareFlasherOptionsDescription": {
+        "message": "Изаберите опште опције које желите да укључите у ову верзију. Имајте на уму да је ово падајући мени и да се може изабрати више ставки. Ставке попут исправки, нпр. AKK VTX, налазе се овде."
+    },
+    "firmwareFlasherMotorProtocolDescription": {
+        "message": "Изаберите протокол мотора (ESC) који желите да укључите у ову верзију. Имајте на уму да је ово падајући мени, али се може изабрати само једна ставка."
+    },
+    "firmwareFlasherOsdProtocolDescription": {
+        "message": "Изаберите OSD протокол који желите да укључите у ову верзију. Имајте на уму да је ово падајући мени, али се може изабрати само једна ставка."
+    },
+    "firmwareFlasherBranchDescription": {
+        "message": "Посебно корисно за програмере: можете изабрати спојени PR, навести SHA комита или навести PR који још није спојен куцањем знака # испред броја PR-а, нпр. #1234 (ово је скраћени запис за грану 'pull\/1234\/head')."
+    },
+    "firmwareFlasherCustomDefinesDescription": {
+        "message": "За програмере: можете додати све потребне дефиниције одвојене размаком (`space`), али без префикса `USE_`, он ће бити аутоматски додат."
+    },
+    "firmwareFlasherBuildCustomDefines": {
+        "message": "Прилагођене дефиниције"
+    },
+    "firmwareFlasherOSDProtocolNotSelected": {
+        "message": "OSD протокол није изабран"
+    },
+    "firmwareFlasherOSDProtocolNotSelectedDescription": {
+        "message": "Морате изабрати OSD протокол да бисте направили фирмвер."
+    },
+    "firmwareFlasherOSDProtocolSelect": {
+        "message": "Изаберите OSD протокол"
+    },
+    "firmwareFlasherOSDProtocolNotSelectedContinue": {
+        "message": "Настави без OSD протокола"
+    },
+    "firmwareFlasherOptionLabelVerifiedPartner": {
+        "message": "✅ Потврђени partner"
+    },
+    "firmwareFlasherOptionLabelVendorCommunity": {
+        "message": "⚠️ Произвођач \/ Заједница"
+    },
+    "firmwareFlasherOptionLabelLegacy": {
+        "message": "Застарело"
+    },
+    "firmwareFlasherOptionLabelNotQualified": {
+        "message": "Target који подржава заједница \/ произвођач — није званично подржан"
+    },
+    "coreBuild": {
+        "message": "Само језгро"
+    },
+    "coreBuildModeDescription": {
+        "message": "Ова опција прави фирмвер који садржи драјвере за хардвер (и неке ограничене функције). Служи као помоћ при детекцији хардвера на flight контролеру и пружена је само ради погодности. Неће све функције бити доступне (само хардвер) када користите ову опцију."
+    },
+    "showDevToolsOnStartup": {
+        "message": "Аутоматски отвори DevTools у развојном режиму",
+        "description": "Text for the option to enable automatic opening of DevTools in debug mode"
+    },
+    "betaflightSupportButton": {
+        "message": "Wiki",
+        "description": "Text for the button to open the support URL"
+    },
+    "showNotifications": {
+        "message": "Прикажи обавештења за дуготрајне операције"
+    },
+    "notificationsDeniedTitle": {
+        "message": "Обавештења су блокирана",
+        "description": "Title when Notifications has no or denied permissions"
+    },
+    "notificationsDenied": {
+        "message": "Обавештења су блокирана. Молимо Вас да их укључите у подешавањима прегледача. У супротном нећете примати обавештења о дуготрајним операцијама. Ако користите Chrome, обавештења можете укључити кликом на иконицу катанца у адресној траци и избором опције „Подешавања сајта“.",
+        "description": "Message when Notifications has no or denied permissions"
+    },
+    "flashEraseDoneNotification": {
+        "message": "Брисање Dataflash меморије је завршено",
+        "description": "Notification message when flash erase is done"
+    },
+    "flashDownloadDoneNotification": {
+        "message": "Дневници из Dataflash меморије су преузети",
+        "description": "Notification message when flash logs are done downloading"
+    },
+    "programmingSuccessfulNotification": {
+        "message": "FC је успешно програмиран",
+        "description": "Notification message when programming is successful"
+    },
+    "programmingFailedNotification": {
+        "message": "Програмирање FC-а није успело",
+        "description": "Notification message when programming is unsuccessful"
+    },
+    "osdTextElementLidar": {
+        "message": "Sonar",
+        "description": "Displays distance from sonar sensor in cm"
+    },
+    "osdTextElementCustomSerialText": {
+        "message": "Сопствени текст са серијског порта",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementCustomSerialText": {
+        "message": "Приказује сопствени текст примљен са серијског порта"
+    },
+    "osdTextElementBatteryProfileName": {
+        "message": "Профил: назив профила батерије",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementBatteryProfileName": {
+        "message": "Приказује назив или број активног профила батерије"
+    },
+    "osdTextElementWpNumber": {
+        "message": "Број тачке путање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNumber": {
+        "message": "Приказује редни број тренутне и укупан број тачака у активном плану лета"
+    },
+    "osdTextElementWpCurrentLat": {
+        "message": "Географска ширина тачке путање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLat": {
+        "message": "Приказује географску ширину тренутне тачке путање"
+    },
+    "osdTextElementWpCurrentLon": {
+        "message": "Географска дужина тачке путање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentLon": {
+        "message": "Приказује географску дужину тренутне тачке путање"
+    },
+    "osdTextElementWpCurrentAlt": {
+        "message": "Висина тачке путање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpCurrentAlt": {
+        "message": "Приказује висину тренутне тачке путање"
+    },
+    "osdTextElementWpDistance": {
+        "message": "Растојање до тачке путање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDistance": {
+        "message": "Приказује растојање до тренутне тачке путање"
+    },
+    "osdTextElementWpDirection": {
+        "message": "Правац ка тачки путање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpDirection": {
+        "message": "Приказује стрелицу која показује ка тренутној тачки путање"
+    },
+    "osdTextElementWpNextNumber": {
+        "message": "Број следеће тачке путање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpNextNumber": {
+        "message": "Приказује број следеће тачке у активном плану лета"
+    },
+    "osdTextElementWpEta": {
+        "message": "Процењено време до тачке путање",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementWpEta": {
+        "message": "Приказује процењено време доласка до тренутне тачке путање"
+    },
+    "osdTextElementNavMap": {
+        "message": "Навигациона карта",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementNavMap": {
+        "message": "Мала карта са местом полетања, планом лета и пређеним путем"
+    },
+    "osdTextElementPosHoldReady": {
+        "message": "Задржавање положаја спремно",
+        "description": "One of the elements of the OSD"
+    },
+    "osdDescElementPosHoldReady": {
+        "message": "Показује да ли су испуњени услови за задржавање положаја, пре него што се прекидач укључи"
+    },
+    "osdSetupPreviewCheckRulers": {
+        "message": "Лењири",
+        "description": "Label for the checkbox to toggle OSD preview rulers around the preview"
+    },
+    "tabUserProfile": {
+        "message": "Кориснички профил"
+    },
+    "labelEmail": {
+        "message": "E-пошта"
+    },
+    "placeholderEmailAddress": {
+        "message": "Унесите адресу е-поште"
+    },
+    "userEmailRequired": {
+        "message": "Адреса е-поште је обавезна"
+    },
+    "profileLoginMessage": {
+        "message": "Молимо Вас да се пријавите да бисте видели свој профил."
+    },
+    "tabBackups": {
+        "message": "Резервне копије"
+    },
+    "userPasskeyDeleteSuccess": {
+        "message": "Приступни кључ је успешно избрисан"
+    },
+    "userPasskeyDeleteFailed": {
+        "message": "Брисање приступног кључа није успело"
+    },
+    "userTokenDeleteSuccess": {
+        "message": "Token је успешно избрисан"
+    },
+    "userTokenDeleteFailed": {
+        "message": "Брисање токена није успело"
+    },
+    "userProfileLoadFailed": {
+        "message": "Учитавање корисничког профила није успело"
+    },
+    "userTokenLoadFailed": {
+        "message": "Учитавање корисничких токена није успело"
+    },
+    "userPasskeyLoadFailed": {
+        "message": "Учитавање корисничких приступних кључева није успело"
+    },
+    "userProfileUpdateSuccess": {
+        "message": "Профил је успешно ажуриран"
+    },
+    "userProfileUpdateFailed": {
+        "message": "Ажурирање профила није успело"
+    },
+    "userBackupsLoadFailed": {
+        "message": "Није успело учитавање резервних копија"
+    },
+    "userBackupDownloadFailed": {
+        "message": "Није успело преузимање резервне копије"
+    },
+    "userBackupFileEmpty": {
+        "message": "Фајл резервне копије је празна"
+    },
+    "userBackupUpdateSuccess": {
+        "message": "Резервна копија је успешно ажурирана"
+    },
+    "userBackupUpdateFailed": {
+        "message": "Није успело ажурирање резервне копије"
+    },
+    "userBackupDeleteSuccess": {
+        "message": "Резервна копија је успешно обрисана"
+    },
+    "userBackupDeleteFailed": {
+        "message": "Није успело брисање резервне копије"
+    },
+    "actionRestore": {
+        "message": "Врати из копије"
+    },
+    "titleRestoreBackup": {
+        "message": "Врати резервну копију"
+    },
+    "userBackupRestoreConfirm": {
+        "message": "Желите ли да примените резервну копију \"{{name}}\" на повезани flight контролер? Тренутна конфигурација ће бити преснимљена."
+    },
+    "userBackupRestoreInProgress": {
+        "message": "Враћање резервне копије..."
+    },
+    "userBackupRestoreSuccess": {
+        "message": "Резервна копија је успешно враћена"
+    },
+    "userBackupRestoreFailed": {
+        "message": "Није успело враћање резервне копије"
+    },
+    "userBackupRestoreErrors": {
+        "message": "<span class='message-negative'>УПОЗОРЕЊЕ<\/span><br\/>Резервна копија је примењена уз CLI грешке."
+    },
+    "userPasskeyNoPasskeys": {
+        "message": "Нема доступних приступних кључева"
+    },
+    "userTokenNoTokens": {
+        "message": "Нема доступних токена"
+    },
+    "profileBackupSuccess": {
+        "message": "Успешно прављење резервне копије"
+    },
+    "profileBackupApiSuccess": {
+        "message": "Резервна копија је успешно сачувана на API"
+    },
+    "profileBackupApiFail": {
+        "message": "Није успело чување резервне копије на API"
+    },
+    "profileBackupEmptyResult": {
+        "message": "Прављење резервне копије није успело"
+    },
+    "labelLogin": {
+        "message": "Пријава"
+    },
+    "labelSignOut": {
+        "message": "Одјава"
+    },
+    "labelAvatarUrl": {
+        "message": "URL аватара"
+    },
+    "placeholderAvatarUrl": {
+        "message": "Унесите URL слике за Ваш avatar"
+    },
+    "labelCreatePasskey": {
+        "message": "Направи приступни кључ"
+    },
+    "labelUsePasskey": {
+        "message": "Употреби приступни кључ"
+    },
+    "labelSignInWithPasskey": {
+        "message": "Пријавите се помоћу Passkey-а"
+    },
+    "labelSendVerificationCode": {
+        "message": "Пошаљите верификациони код"
+    },
+    "labelSignInWithEmailCode": {
+        "message": "Пријавите се уместо тога кодом из е-поште"
+    },
+    "labelBackToPasskey": {
+        "message": "Назад на пријаву помоћу Passkey-а"
+    },
+    "labelBack": {
+        "message": "Назад"
+    },
+    "labelNoPasskeyPrompt": {
+        "message": "Немате Passkey?"
+    },
+    "labelSetOnePasskeyUp": {
+        "message": "Подесите га"
+    },
+    "descriptionPasskeyLogin": {
+        "message": "Употребите Ваш Passkey за пријаву"
+    },
+    "descriptionCodeRequest": {
+        "message": "Послаћемо Вам верификациони код на е-пошту"
+    },
+    "descriptionCodeEntered": {
+        "message": "Унесите код који смо послали на $1"
+    },
+    "titleEnterVerificationCode": {
+        "message": "Унесите верификациони код"
+    },
+    "labelVerificationCode": {
+        "message": "Верификациони код"
+    },
+    "labelCode": {
+        "message": "Код"
+    },
+    "userLoggingIn": {
+        "message": "Пријава у току..."
+    },
+    "userSignedOut": {
+        "message": "Одјављени сте"
+    },
+    "userSignOutFailed": {
+        "message": "Одјава није успела"
+    },
+    "userLoginSuccess": {
+        "message": "Пријава је успешна"
+    },
+    "userLoginFailed": {
+        "message": "Пријава није успела"
+    },
+    "userCreatePasskeyFailed": {
+        "message": "Креирање Passkey-а није успело"
+    },
+    "userCreatePasskeySuccess": {
+        "message": "Passkey је успешно креиран"
+    },
+    "userVerifyingCode": {
+        "message": "Провера кода у току..."
+    },
+    "userCreatingPasskey": {
+        "message": "Креирање Passkey-а у току..."
+    },
+    "userCodeRequired": {
+        "message": "Верификациони код је обавезан"
+    },
+    "userSendingCode": {
+        "message": "Слање верификационог кода у току..."
+    },
+    "userSendCodeFailed": {
+        "message": "Слање верификационог кода није успело"
+    },
+    "dataWaitingForData": {
+        "message": "Чекање на податке..."
+    },
+    "labelId": {
+        "message": "ID"
+    },
+    "labelCreated": {
+        "message": "Креирано"
+    },
+    "labelLastUsed": {
+        "message": "Последњи пут коришћено"
+    },
+    "labelActions": {
+        "message": "Акције"
+    },
+    "labelDetails": {
+        "message": "Детаљи"
+    },
+    "labelExpiry": {
+        "message": "Истек"
+    },
+    "labelDescription": {
+        "message": "Опис"
+    },
+    "labelDate": {
+        "message": "Датум"
+    },
+    "actionDownload": {
+        "message": "Преузми"
+    },
+    "actionBackup": {
+        "message": "Резервна копија"
+    },
+    "actionEdit": {
+        "message": "Измени"
+    },
+    "actionDelete": {
+        "message": "Обриши"
+    },
+    "actionSave": {
+        "message": "Сачувај"
+    },
+    "titleEditProfile": {
+        "message": "Уреди профил"
+    },
+    "titleLogin": {
+        "message": "Пријава"
+    },
+    "labelName": {
+        "message": "Назив"
+    },
+    "labelAddress": {
+        "message": "Адреса"
+    },
+    "labelCountry": {
+        "message": "Држава"
+    },
+    "confirmDelete": {
+        "message": "Да ли сте сигурни да желите да избришете овај {{item}}?"
+    },
+    "itemBackup": {
+        "message": "резервна копија"
+    },
+    "itemToken": {
+        "message": "token"
+    },
+    "itemPasskey": {
+        "message": "приступни кључ"
+    },
+    "notLoggedIn": {
+        "message": "Нисте пријављени"
+    },
+    "backupNoBackupsAvailable": {
+        "message": "Нема доступних резервних копија"
+    },
+    "backupRequiresConnection": {
+        "message": "Повежите flight контролер да бисте укључили ову акцију",
+        "description": "Tooltip shown on disabled backup and restore buttons when no flight controller is connected"
+    },
+    "titleEditBackup": {
+        "message": "Уреди резервну копију"
+    },
+    "backupMcuUnknown": {
+        "message": "MCU непознат"
+    },
+    "sectionUserTokens": {
+        "message": "Кориснички токени"
+    },
+    "sectionUserPasskeys": {
+        "message": "Кориснички passkey-ови"
+    },
+    "osdPresetPositionAlignTitle": {
+        "message": "Поравнај према положају",
+        "description": "Label for the preset position alignment menu in the OSD elements list"
+    },
+    "osdPresetPositionChooseTitle": {
+        "message": "Изаберите положај",
+        "description": "Title for the preset position grid popup in the OSD elements list"
+    },
+    "tabPreflight": {
+        "message": "Пре полетања"
+    },
+    "preflightTitle": {
+        "message": "Провера окружења пре лета"
+    },
+    "preflightLocation": {
+        "message": "Локација лета"
+    },
+    "preflightUseMyLocation": {
+        "message": "Користи моју локацију"
+    },
+    "preflightDetecting": {
+        "message": "Детектовање..."
+    },
+    "preflightOr": {
+        "message": "или унесите координате:"
+    },
+    "preflightLatitude": {
+        "message": "Географска ширина"
+    },
+    "preflightLongitude": {
+        "message": "Географска дужина"
+    },
+    "preflightApply": {
+        "message": "Примени"
+    },
+    "preflightLaunchStatus": {
+        "message": "Status полетања"
+    },
+    "preflightStatusGo": {
+        "message": "СПРЕМАН"
+    },
+    "preflightStatusCaution": {
+        "message": "ОПРЕЗ"
+    },
+    "preflightStatusWarning": {
+        "message": "УПОЗОРЕЊЕ"
+    },
+    "preflightStatusNoGo": {
+        "message": "НИЈЕ СПРЕМАН"
+    },
+    "preflightStatusNoData": {
+        "message": "Нема података"
+    },
+    "preflightCheckWind": {
+        "message": "Ветар"
+    },
+    "preflightCheckVisibility": {
+        "message": "Видљивост"
+    },
+    "preflightCheckPrecipitation": {
+        "message": "Падавине"
+    },
+    "preflightCheckSolar": {
+        "message": "Сунчева активност"
+    },
+    "preflightLevelUnknown": {
+        "message": "Непознато"
+    },
+    "preflightWmoClearSky": {
+        "message": "Ведро"
+    },
+    "preflightWmoMainlyClear": {
+        "message": "Претежно ведро"
+    },
+    "preflightWmoPartlyCloudy": {
+        "message": "Делимично облачно"
+    },
+    "preflightWmoOvercast": {
+        "message": "Потпуно облачно"
+    },
+    "preflightWmoFog": {
+        "message": "Магла"
+    },
+    "preflightWmoRimeFog": {
+        "message": "Магла са ињем"
+    },
+    "preflightWmoLightDrizzle": {
+        "message": "Слаба росуља"
+    },
+    "preflightWmoModerateDrizzle": {
+        "message": "Умерена росуља"
+    },
+    "preflightWmoDenseDrizzle": {
+        "message": "Густа росуља"
+    },
+    "preflightWmoLightFreezingDrizzle": {
+        "message": "Слаба ледена росуља"
+    },
+    "preflightWmoDenseFreezingDrizzle": {
+        "message": "Густа ледена росуља"
+    },
+    "preflightWmoSlightRain": {
+        "message": "Слаба киша"
+    },
+    "preflightWmoModerateRain": {
+        "message": "Умерена киша"
+    },
+    "preflightWmoHeavyRain": {
+        "message": "Јака киша"
+    },
+    "preflightWmoLightFreezingRain": {
+        "message": "Слаба ледена киша"
+    },
+    "preflightWmoHeavyFreezingRain": {
+        "message": "Јака ледена киша"
+    },
+    "preflightWmoSlightSnow": {
+        "message": "Слаб снег"
+    },
+    "preflightWmoModerateSnow": {
+        "message": "Умерен снег"
+    },
+    "preflightWmoHeavySnow": {
+        "message": "Јак снег"
+    },
+    "preflightWmoSnowGrains": {
+        "message": "Зрнаст снег"
+    },
+    "preflightWmoSlightRainShowers": {
+        "message": "Слаб пљусак"
+    },
+    "preflightWmoModerateRainShowers": {
+        "message": "Умерен пљусак"
+    },
+    "preflightWmoViolentRainShowers": {
+        "message": "Силовит пљусак"
+    },
+    "preflightWmoSlightSnowShowers": {
+        "message": "Слаб снежни пљусак"
+    },
+    "preflightWmoHeavySnowShowers": {
+        "message": "Јак снежни пљусак"
+    },
+    "preflightWmoThunderstorm": {
+        "message": "Грмљавина"
+    },
+    "preflightWmoThunderstormSlightHail": {
+        "message": "Грмљавина са слабим градом"
+    },
+    "preflightWmoThunderstormHeavyHail": {
+        "message": "Грмљавина са јаким градом"
+    },
+    "preflightKpLow": {
+        "message": "Ниско"
+    },
+    "preflightKpModerate": {
+        "message": "Умерено"
+    },
+    "preflightKpElevated": {
+        "message": "Повишен"
+    },
+    "preflightKpStorm": {
+        "message": "Олуја"
+    },
+    "preflightWindCalm": {
+        "message": "Без ветра"
+    },
+    "preflightWindLight": {
+        "message": "Слаб"
+    },
+    "preflightWindModerate": {
+        "message": "Умерено"
+    },
+    "preflightWindStrong": {
+        "message": "Јак"
+    },
+    "preflightWindDangerous": {
+        "message": "Опасан"
+    },
+    "preflightVisExcellent": {
+        "message": "Одлична"
+    },
+    "preflightVisGood": {
+        "message": "Добра"
+    },
+    "preflightVisReduced": {
+        "message": "Смањена"
+    },
+    "preflightVisPoor": {
+        "message": "Лоша"
+    },
+    "preflightPrecipNone": {
+        "message": "Ништа"
+    },
+    "preflightPrecipLight": {
+        "message": "Слабе"
+    },
+    "preflightPrecipModerate": {
+        "message": "Умерено"
+    },
+    "preflightPrecipHeavy": {
+        "message": "Јаке"
+    },
+    "preflightDewNoRisk": {
+        "message": "Без ризика"
+    },
+    "preflightDewLowRisk": {
+        "message": "Низак ризик"
+    },
+    "preflightDewFogLikely": {
+        "message": "Вероватна магла\/кондензација"
+    },
+    "preflightDewFogExpected": {
+        "message": "Очекује се магла\/замагљивање објектива"
+    },
+    "preflightUvLow": {
+        "message": "Ниско"
+    },
+    "preflightUvModerate": {
+        "message": "Умерено"
+    },
+    "preflightUvHigh": {
+        "message": "Високо"
+    },
+    "preflightUvVeryHigh": {
+        "message": "Веома висок"
+    },
+    "preflightBatteryRisk": {
+        "message": "Ризик за батерију"
+    },
+    "preflightBatteryOk": {
+        "message": "Нормалан опсег"
+    },
+    "preflightBatteryCool": {
+        "message": "Смањене перформансе, загрејте батерије"
+    },
+    "preflightBatteryCold": {
+        "message": "Знатно смањен капацитет"
+    },
+    "preflightBatteryHot": {
+        "message": "Ризик од бубрења, држите у хладу"
+    },
+    "preflightBatteryExtreme": {
+        "message": "Не летите, екстремна топлота"
+    },
+    "preflightCheckBattery": {
+        "message": "Батерија"
+    },
+    "preflightCheckDensityAlt": {
+        "message": "Висина по густини"
+    },
+    "preflightFeelsLike": {
+        "message": "Субјективни осећај"
+    },
+    "preflightFogRisk": {
+        "message": "Ризик од магле"
+    },
+    "preflightFogUnlikely": {
+        "message": "Мало вероватно"
+    },
+    "preflightFogLow": {
+        "message": "Низак ризик"
+    },
+    "preflightFogModerate": {
+        "message": "Умерен ризик"
+    },
+    "preflightFogHigh": {
+        "message": "Висок ризик"
+    },
+    "preflightElevation": {
+        "message": "Надморска висина"
+    },
+    "preflightDensityAlt": {
+        "message": "Висина по густини"
+    },
+    "preflightDaNormal": {
+        "message": "Нормалне перформансе"
+    },
+    "preflightDaReduced": {
+        "message": "Благо смањен узгон"
+    },
+    "preflightDaLow": {
+        "message": "Осетно смањене перформансе"
+    },
+    "preflightDaPoor": {
+        "message": "Знатно смањење узгона"
+    },
+    "preflightCivilTwilight": {
+        "message": "Прозор грађанског сумрака"
+    },
+    "preflightRefresh": {
+        "message": "Освежи"
+    },
+    "preflightCurrentWeather": {
+        "message": "Тренутне временске прилике"
+    },
+    "preflightWind": {
+        "message": "Брзина ветра"
+    },
+    "preflightGusts": {
+        "message": "Удари ветра"
+    },
+    "preflightVisibility": {
+        "message": "Видљивост"
+    },
+    "preflightPrecipitation": {
+        "message": "Падавине"
+    },
+    "preflightCloudCover": {
+        "message": "Облачност"
+    },
+    "preflightHumidity": {
+        "message": "Влажност ваздуха"
+    },
+    "preflightPressure": {
+        "message": "Притисак"
+    },
+    "preflightDewPoint": {
+        "message": "Тачка росе"
+    },
+    "preflightFlightWindow": {
+        "message": "Прозор за летење"
+    },
+    "preflightSunrise": {
+        "message": "Излазак сунца"
+    },
+    "preflightSunset": {
+        "message": "Залазак сунца"
+    },
+    "preflightDaylight": {
+        "message": "Дневна светлост"
+    },
+    "preflightUvIndex": {
+        "message": "UV индекс"
+    },
+    "preflightTempRange": {
+        "message": "Температурни опсег"
+    },
+    "preflightCurrentlyDay": {
+        "message": "Тренутно"
+    },
+    "preflightDaytime": {
+        "message": "Дан"
+    },
+    "preflightNighttime": {
+        "message": "Ноћ"
+    },
+    "preflightWindForecast": {
+        "message": "Прогноза ветра по висини"
+    },
+    "preflightWindForecastHelp": {
+        "message": "Брзина ветра на различитим висинама је кључна за FPV летове великог домета и на великим висинама. На већим висинама ветар је обично јачи."
+    },
+    "preflightTime": {
+        "message": "Време"
+    },
+    "preflightWind10m": {
+        "message": "10m"
+    },
+    "preflightWind80m": {
+        "message": "80m"
+    },
+    "preflightWind120m": {
+        "message": "120m"
+    },
+    "preflightGustsShort": {
+        "message": "Удари ветра"
+    },
+    "preflightRainProb": {
+        "message": "Киша %"
+    },
+    "preflightWindUnit": {
+        "message": "Брзине ветра у м\/с. Висине изнад нивоа терена (AGL)."
+    },
+    "preflightSolarActivity": {
+        "message": "Сунчева активност"
+    },
+    "preflightSolarHelp": {
+        "message": "Висока сунчева активност (Kp > 5) изазива сметње у јоносфери, што може смањити прецизност GPS-а и утицати на поузданост функције GPS Rescue."
+    },
+    "preflightGeoStorm": {
+        "message": "Геомагнетна олуја"
+    },
+    "preflightSolarRadiation": {
+        "message": "Сунчево зрачење"
+    },
+    "preflightRadioBlackout": {
+        "message": "Радио-блокада"
+    },
+    "preflightLastMeasurement": {
+        "message": "Последње мерење"
+    },
+    "preflightLoadingSolar": {
+        "message": "Учитавање података о Сунчевој активности..."
+    },
+    "preflightGNSS": {
+        "message": "GNSS \/ GPS status"
+    },
+    "preflightGNSSHelp": {
+        "message": "Сунчева активност утиче на квалитет сигнала GNSS сателита. Високе Kp вредности могу смањити прецизност GPS позиције и смањити поузданост функције GPS Rescue."
+    },
+    "preflightGNSSNote": {
+        "message": "Сунчеви и геомагнетни услови утичу на прецизност GPS-а. Повежите Ваш дрон за уживо приказ сателитских података на картици GPS."
+    },
+    "preflightKpEffect": {
+        "message": "Утицај јоносфере"
+    },
+    "preflightGPSRescue": {
+        "message": "GPS Rescue status"
+    },
+    "preflightMagDeclination": {
+        "message": "Магнетна деклинација"
+    },
+    "preflightMagInclination": {
+        "message": "Магнетна инклинација"
+    },
+    "preflightGNSSPlanner": {
+        "message": "Алат за планирање GNSS сателита"
+    },
+    "preflightAirspace": {
+        "message": "Ваздушни простор и зоне забране летења"
+    },
+    "preflightAirspaceNote": {
+        "message": "Увек проверите локална ограничења у ваздушном простору и NOTAM обавештења пре летења. Правила се разликују по државама и регионима."
+    },
+    "preflightDroneSafetyMap": {
+        "message": "Карта безбедности за дронове (Altitude Angel)"
+    },
+    "preflightAirspaceExplorer": {
+        "message": "SkyVector карта ваздушног простора"
+    },
+    "preflightNOTAMs": {
+        "message": "FAA NOTAM обавештења (САД)"
+    },
+    "preflightNOTAMsEU": {
+        "message": "EUROCONTROL NOTAM-и (EU)"
+    },
+    "preflightMap": {
+        "message": "Мапа локације"
+    },
+    "preflightNoData": {
+        "message": "Подесите локацију за учитавање података о окружењу"
+    },
+    "preflightAttribution": {
+        "message": "Временски подаци: Open-Meteo.com (CC BY 4.0) | Соларни подаци: NOAA Space Weather Prediction Center"
+    },
+    "preflightSavedLocationsPlaceholder": {
+        "message": "Сачуване локације..."
+    },
+    "preflightLoadLocation": {
+        "message": "Учитај"
+    },
+    "preflightSaveLocation": {
+        "message": "Сачувај"
+    },
+    "preflightSavedLocationsFull": {
+        "message": "Достигнут је максимум од 5 сачуваних локација"
+    },
+    "preflightLocationLabel": {
+        "message": "Назив локације (макс. 20 знакова)"
+    },
+    "preflightDeleteLocation": {
+        "message": "Избришите изабрану локацију"
+    },
+    "preflightRenameLocation": {
+        "message": "Преименујте изабрану локацију"
+    },
+    "preflightRenameLocationBtn": {
+        "message": "Преименуј"
+    },
+    "preflightCoordinates": {
+        "message": "Координате"
+    },
+    "preflightSaveLocationBtn": {
+        "message": "Сачувај локацију"
+    },
+    "preflightConfirmSave": {
+        "message": "Сачувај"
+    },
+    "preflightCancel": {
+        "message": "Откажи"
+    },
+    "preflightGeolocationFailed": {
+        "message": "Није могуће детектовати локацију. Унесите координате ручно."
+    },
+    "preflightIpConsentMessage": {
+        "message": "Лоцирање путем прегледача није успело. Ваша приближна локација може се одредити помоћу Ваше IP адресе путем услуге треће стране ipapi.co."
+    },
+    "preflightIpConsentAllow": {
+        "message": "Дозволи"
+    },
+    "preflightIpConsentDeny": {
+        "message": "Не, хвала"
+    },
+    "preflightMapSatellite": {
+        "message": "Сателитски приказ"
+    },
+    "preflightMapHybrid": {
+        "message": "Хибридни сателитски и улични приказ"
+    },
+    "preflightMapStreet": {
+        "message": "Приказ мапе улица"
+    },
+    "preflightMapZoomIn": {
+        "message": "Увећај"
+    },
+    "preflightMapZoomOut": {
+        "message": "Умањи"
+    },
+    "preflightMapFullscreen": {
+        "message": "Укључи или искључи цео екран"
+    },
+    "preflightKpMinimal": {
+        "message": "Минималан утицај на GPS"
+    },
+    "preflightKpDegraded": {
+        "message": "Могуће смањење прецизности GPS-а"
+    },
+    "preflightKpSevere": {
+        "message": "Очекују се значајне сметње на GPS-у"
+    },
+    "preflightGpsRescueUnknown": {
+        "message": "Прво проверите сунчеву активност"
+    },
+    "preflightGpsRescueReliable": {
+        "message": "GPS Rescue је поуздан"
+    },
+    "preflightGpsRescueUnreliable": {
+        "message": "GPS Rescue можда није поуздан"
+    },
+    "preflightGpsRescueNotRecommended": {
+        "message": "GPS Rescue се НЕ препоручује"
+    },
+    "preflightForecast": {
+        "message": "Петодневна прогноза"
+    },
+    "preflightForecastHelp": {
+        "message": "Дневни преглед времена који Вам помаже у планирању летења"
+    },
+    "preflightForecastDay": {
+        "message": "Дан"
+    },
+    "preflightForecastWeather": {
+        "message": "Временске прилике"
+    },
+    "preflightNotamProvider": {
+        "message": "NOTAM извор"
+    },
+    "preflightNotamProviderNone": {
+        "message": "Искључено"
+    },
+    "preflightNotamProviderFaa": {
+        "message": "FAA NOTAM API (САД, потребан API кључ)"
+    },
+    "preflightNotamProviderOpenaip": {
+        "message": "OpenAIP (глобални ваздушни простор, потребан API кључ)"
+    },
+    "preflightNotamFaaApiKeyLabel": {
+        "message": "FAA API кључ (client_id:client_secret)"
+    },
+    "preflightNotamOpenAipApiKeyLabel": {
+        "message": "OpenAIP API кључ"
+    },
+    "preflightNotamRadius": {
+        "message": "Полупречник претраге"
+    },
+    "preflightNotamRadiusUnitNm": {
+        "message": "NM"
+    },
+    "preflightNotamRadiusUnitKm": {
+        "message": "km"
+    },
+    "preflightNotamSettings": {
+        "message": "Подешавања података о ваздушном простору"
+    },
+    "preflightNotamPrivacyNote": {
+        "message": "Подаци о ваздушном простору шаљу Ваше координате изабраном извору. Никакви додатни лични подаци се не шаљу."
+    },
+    "preflightNotamLoading": {
+        "message": "Преузимање података о ваздушном простору..."
+    },
+    "preflightNotamEmpty": {
+        "message": "Нису пронађена обавештења за ову локацију и полупречник"
+    },
+    "preflightNotamApiKeyRequired": {
+        "message": "За изабрани извор је потребан API кључ. Унесите Ваш кључ у подешавањима изнад."
+    },
+    "preflightNotamFetchError": {
+        "message": "Неуспешно преузимање података о ваздушном простору"
+    },
+    "preflightNotamActiveNow": {
+        "message": "Тренутно активно"
+    },
+    "preflightNotamPermanent": {
+        "message": "Трајно"
+    },
+    "preflightNotamExpired": {
+        "message": "Истекло"
+    },
+    "preflightNotamTypeTfr": {
+        "message": "TFR"
+    },
+    "preflightNotamTypeSua": {
+        "message": "SUA"
+    },
+    "preflightNotamTypeSnow": {
+        "message": "SNOWTAM"
+    },
+    "preflightNotamTypeAsh": {
+        "message": "ASHTAM"
+    },
+    "preflightNotamTypeNotam": {
+        "message": "NOTAM"
+    },
+    "preflightNotamAltFrom": {
+        "message": "Доња"
+    },
+    "preflightNotamAltTo": {
+        "message": "Горња"
+    },
+    "preflightNotamShowMore": {
+        "message": "Прикажи више"
+    },
+    "preflightNotamShowLess": {
+        "message": "Прикажи мање"
+    },
+    "preflightNotamLastFetched": {
+        "message": "Последње преузето"
+    }
+}

--- a/src/js/localization.js
+++ b/src/js/localization.js
@@ -12,6 +12,7 @@ import {
     eu,
     fr,
     gl,
+    hr,
     it,
     ja,
     ka,
@@ -30,6 +31,15 @@ import { gui_log } from "./gui_log.js";
 import { get as getConfig, set as setConfig } from "./ConfigStorage.js";
 
 const i18n = {};
+
+// Nuxt UI does not currently ship Serbian locales; use its closely related Croatian
+// messages while keeping the application translation codes distinct.
+const sr = { ...hr, name: "Srpski (latinica)", code: "sr" };
+const sr_Cyrl = {
+    ...hr,
+    name: "\u0421\u0440\u043f\u0441\u043a\u0438 (\u045b\u0438\u0440\u0438\u043b\u0438\u0446\u0430)",
+    code: "sr_Cyrl",
+};
 
 /**
  * The single list of languages the configurator ships translations for, each entry being
@@ -57,6 +67,8 @@ const supportedLocales = [
     pt_br,
     pl,
     ru,
+    sr,
+    sr_Cyrl,
     uk,
     uz,
     zh_cn,
@@ -70,7 +82,9 @@ const languagesAvailables = supportedLocales.map((locale) => locale.code);
  * consistent about the case of the region subtag, and preferences stored by older
  * versions predate the move to BCP 47.
  */
-const localesByCode = new Map(supportedLocales.map((locale) => [locale.code.toLowerCase(), locale]));
+const localesByCode = new Map(
+    supportedLocales.map((locale) => [locale.code.replaceAll("_", "-").toLowerCase(), locale]),
+);
 
 /**
  * Resolves any incoming language code onto a locale we ship translations for, be it a


### PR DESCRIPTION
Add Serbian language to the UI. It adds Serbian Latin and Serbian Cyrilic. By default, Latin is used because is the most common in "electronic" things.
Thanks to the user "Flight Mode academy" for the translation. Don't merge until he can test that this works for both languages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Serbian language support in Latin and Cyrillic scripts.
  * Added Serbian language labels and translation resources.
  * Arabic and Serbian translations are now included in available language downloads.
  * Supported locales are recognized more consistently across language code formats, with fallback to the base language when needed.
  * Pages apply the appropriate language and text direction for supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->