### PR TITLE
SetupTab: Display loop rate with decimal precision

### DIFF
--- a/src/components/tabs/SetupTab.vue
+++ b/src/components/tabs/SetupTab.vue
@@ -677,7 +677,7 @@ function process_html() {
             const pidHz = Math.round(1000000 / cycleTime);
             const pidProcess = fcStore.pidAdvancedConfig?.pid_process_denom || 1;
             const gyroHz = pidHz * pidProcess;
-            const fmt = (hz) => (hz >= 1000 ? `${(hz / 1000).toFixed(0)}k` : `${hz}`);
+            const fmt = (hz) => (hz >= 1000 ? `${(hz / 1000).toFixed(1)}k` : `${hz}`);
             state.loopTime = `${fmt(gyroHz)} / ${fmt(pidHz)}`;
         } else {
             state.loopTime = "";


### PR DESCRIPTION
## Changes
- Display loop rate values with 1 decimal place precision when shown in kHz format

## Before
- Loop rate displayed as integers: `1k / 1k` for 1050Hz

<img width="323" height="335" alt="image" src="https://github.com/user-attachments/assets/ccd92e8d-381e-468e-8852-c30edc2e3be8" />

## After  
- Loop rate shows decimals: `1.1k / 1.0k` for 1050Hz

<img width="323" height="339" alt="image" src="https://github.com/user-attachments/assets/5043822b-8d66-46ea-a932-dda410b6348e" />

## Testing
- Open Setup tab with a flight controller
- Check the CPU Load box shows loop rate with decimal precision (e.g., `1.0k / 500` instead of `1k / 500`)

Fixes loop rate display precision issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display accuracy for PID and gyro loop frequencies at 1000 Hz or higher by showing one decimal place, such as “1.5k” instead of “1k.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->