### PR TITLE
fix(vtx): keep protocol and port reachable before a VTX answers

### DIFF
--- a/locales/en/messages.json
+++ b/locales/en/messages.json
@@ -7689,7 +7689,7 @@
         "description": "Introduction message in the VTX tab"
     },
     "vtxMessageNotSupported": {
-        "message": "<span class=\"message-negative\">Attention:</span> Your VTX is not configured or not supported. So you can't modify the VTX values from here. This will only be possible if the flight controller is attached to the VTX using some protocol like Tramp or SmartAudio and is correctly configured in the $t(tabPorts.message) tab if needed.",
+        "message": "<span class=\"message-negative\">Attention:</span> No VTX is answering yet. Pick the protocol the VTX speaks and the UART it is wired to below, then save; the remaining settings appear once the device responds.",
         "description": "Message to show when the VTX is not supported in the VTX tab"
     },
     "vtxMessageTableNotConfigured": {
@@ -7831,6 +7831,9 @@
     "vtxPitModeFrequencyHelp": {
         "message": "Frequency at which the Pit Mode changes when enabled.",
         "description": "Help text for the pit mode field of the VTX tab"
+    },
+    "vtxDeviceSetup": {
+        "message": "VTX Device"
     },
     "vtxProtocol": {
         "message": "Protocol"

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -15,6 +15,28 @@
                 <div v-html="$t('vtxMessageNotSupported')"></div>
             </UiBox>
 
+            <!-- Device: protocol and port stay reachable before a VTX answers -->
+            <UiBox v-if="vtxPortAvailable" :title="$t('vtxDeviceSetup')" type="neutral" collapsible class="mt-4">
+                <div class="flex flex-col gap-2">
+                    <SettingRow :label="$t('vtxProtocol')" :help="$t('vtxProtocolHelp')">
+                        <USelect v-model="vtxProtocol" :items="vtxProtocolOptions" class="w-36" />
+                    </SettingRow>
+
+                    <SettingRow
+                        :label="$t('vtxSerialPort')"
+                        :help="vtxPortFollowsOsd ? $t('vtxSerialPortMspHelp') : $t('vtxSerialPortHelp')"
+                    >
+                        <USelect
+                            :model-value="vtxPortShown"
+                            @update:model-value="(v) => (vtxPortIdentifier = v)"
+                            :items="vtxPortOptions"
+                            :disabled="!vtxPortWritable || vtxPortFollowsOsd"
+                            class="w-36"
+                        />
+                    </SettingRow>
+                </div>
+            </UiBox>
+
             <!-- Table not configured / factory bands warnings -->
             <div v-if="vtxTableNotConfigured || factoryBandsNotSupported" class="flex flex-col gap-2">
                 <UiBox v-show="vtxTableNotConfigured" highlight>
@@ -84,28 +106,6 @@
                                     size="xs"
                                     orientation="vertical"
                                     class="w-20"
-                                />
-                            </SettingRow>
-
-                            <SettingRow
-                                v-if="vtxProtocolOptions.length"
-                                :label="$t('vtxProtocol')"
-                                :help="$t('vtxProtocolHelp')"
-                            >
-                                <USelect v-model="vtxProtocol" :items="vtxProtocolOptions" class="w-36" />
-                            </SettingRow>
-
-                            <SettingRow
-                                v-if="vtxPortAvailable"
-                                :label="$t('vtxSerialPort')"
-                                :help="mspVtx ? $t('vtxSerialPortMspHelp') : $t('vtxSerialPortHelp')"
-                            >
-                                <USelect
-                                    :model-value="vtxPortShown"
-                                    @update:model-value="(v) => (vtxPortIdentifier = v)"
-                                    :items="vtxPortOptions"
-                                    :disabled="!vtxPortWritable || mspVtx"
-                                    class="w-36"
                                 />
                             </SettingRow>
 
@@ -491,6 +491,13 @@ export default defineComponent({
             mspVtx.value && vtxPortIdentifier.value === PORT_NONE ? osdPortIdentifier.value : vtxPortIdentifier.value,
         );
 
+        // Only the fallback is locked: an MSP VTX with no port of its own rides
+        // the OSD's UART, which is assigned on the OSD tab. A dedicated port
+        // stays editable whatever the protocol.
+        const vtxPortFollowsOsd = computed(
+            () => mspVtx.value && vtxPortIdentifier.value === PORT_NONE && osdPortIdentifier.value !== PORT_NONE,
+        );
+
         // vtxDevType_e keeps index 2 open, so the firmware lookup names it RESERVED.
         const vtxProtocolOptions = computed(() => vtxProtocolValues.value.filter(({ value }) => value !== "RESERVED"));
 
@@ -716,7 +723,7 @@ export default defineComponent({
             vtxPortIdentifier,
             vtxProtocol,
             vtxProtocolOptions,
-            mspVtx,
+            vtxPortFollowsOsd,
             vtxPortShown,
             savePending,
             factoryBandsSupported,

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -5,12 +5,12 @@
             <div class="tab_title" v-html="$t('tabVtx')"></div>
             <WikiButton docUrl="vtx" />
 
-            <!-- Help note -->
-            <UiBox highlight v-show="vtxSupported" class="mt-4">
-                <p v-html="$t('vtxHelp')"></p>
-            </UiBox>
-
             <div class="mt-4 flex flex-wrap items-start gap-4">
+                <!-- Help note -->
+                <UiBox highlight v-show="vtxSupported" class="mt-3 w-full sm:max-w-xl">
+                    <p v-html="$t('vtxHelp')"></p>
+                </UiBox>
+
                 <!-- Not supported -->
                 <UiBox highlight v-show="!vtxSupported" class="mt-3 w-full sm:w-96">
                     <div v-html="$t('vtxMessageNotSupported')"></div>

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -175,7 +175,7 @@
 
                 <!-- VTX Table -->
                 <div class="max-w-full overflow-x-auto">
-                    <UiBox :title="$t('vtxTable')" type="neutral" collapsible class="w-fit min-w-[750px]">
+                    <UiBox :title="$t('vtxTable')" type="neutral" collapsible class="w-fit">
                         <div class="flex flex-col gap-4">
                             <!-- Bands and channels count -->
                             <div class="flex flex-wrap items-end gap-4">

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -6,35 +6,13 @@
             <WikiButton docUrl="vtx" />
 
             <!-- Help note -->
-            <UiBox highlight v-show="vtxSupported">
+            <UiBox highlight v-show="vtxSupported" class="mt-4">
                 <p v-html="$t('vtxHelp')"></p>
             </UiBox>
 
             <!-- Not supported -->
-            <UiBox highlight v-show="!vtxSupported">
+            <UiBox highlight v-show="!vtxSupported" class="mt-4">
                 <div v-html="$t('vtxMessageNotSupported')"></div>
-            </UiBox>
-
-            <!-- Device: protocol and port stay reachable before a VTX answers -->
-            <UiBox v-if="vtxPortAvailable" :title="$t('vtxDeviceSetup')" type="neutral" collapsible class="mt-4">
-                <div class="flex flex-col gap-2">
-                    <SettingRow :label="$t('vtxProtocol')" :help="$t('vtxProtocolHelp')">
-                        <USelect v-model="vtxProtocol" :items="vtxProtocolOptions" class="w-36" />
-                    </SettingRow>
-
-                    <SettingRow
-                        :label="$t('vtxSerialPort')"
-                        :help="vtxPortFollowsOsd ? $t('vtxSerialPortMspHelp') : $t('vtxSerialPortHelp')"
-                    >
-                        <USelect
-                            :model-value="vtxPortShown"
-                            @update:model-value="(v) => (vtxPortIdentifier = v)"
-                            :items="vtxPortOptions"
-                            :disabled="!vtxPortWritable || vtxPortFollowsOsd"
-                            class="w-36"
-                        />
-                    </SettingRow>
-                </div>
             </UiBox>
 
             <!-- Table not configured / factory bands warnings -->
@@ -164,9 +142,39 @@
                         </div>
                     </UiBox>
                 </div>
+            </div>
+
+            <div class="flex flex-wrap items-start gap-x-4">
+                <!-- Device: protocol and port stay reachable before a VTX answers -->
+                <UiBox
+                    v-if="vtxPortAvailable"
+                    :title="$t('vtxDeviceSetup')"
+                    type="neutral"
+                    collapsible
+                    class="mt-4 basis-96 grow max-w-xl"
+                >
+                    <div class="flex flex-wrap gap-x-8 gap-y-2">
+                        <SettingRow :label="$t('vtxProtocol')" :help="$t('vtxProtocolHelp')">
+                            <USelect v-model="vtxProtocol" :items="vtxProtocolOptions" class="w-36" />
+                        </SettingRow>
+
+                        <SettingRow
+                            :label="$t('vtxSerialPort')"
+                            :help="vtxPortFollowsOsd ? $t('vtxSerialPortMspHelp') : $t('vtxSerialPortHelp')"
+                        >
+                            <USelect
+                                :model-value="vtxPortShown"
+                                @update:model-value="(v) => (vtxPortIdentifier = v)"
+                                :items="vtxPortOptions"
+                                :disabled="!vtxPortWritable || vtxPortFollowsOsd"
+                                class="w-36"
+                            />
+                        </SettingRow>
+                    </div>
+                </UiBox>
 
                 <!-- VTX Table -->
-                <div class="lg:col-span-4 overflow-x-auto">
+                <div class="overflow-x-auto min-w-0 grow max-w-3xl">
                     <UiBox :title="$t('vtxTable')" type="neutral" collapsible class="mt-4 min-w-[750px]">
                         <div class="flex flex-col gap-4">
                             <!-- Bands and channels count -->

--- a/src/components/tabs/VtxTab.vue
+++ b/src/components/tabs/VtxTab.vue
@@ -10,150 +10,150 @@
                 <p v-html="$t('vtxHelp')"></p>
             </UiBox>
 
-            <!-- Not supported -->
-            <UiBox highlight v-show="!vtxSupported" class="mt-4">
-                <div v-html="$t('vtxMessageNotSupported')"></div>
-            </UiBox>
+            <div class="mt-4 flex flex-wrap items-start gap-4">
+                <!-- Not supported -->
+                <UiBox highlight v-show="!vtxSupported" class="mt-3 w-full sm:w-96">
+                    <div v-html="$t('vtxMessageNotSupported')"></div>
+                </UiBox>
 
-            <!-- Table not configured / factory bands warnings -->
-            <div v-if="vtxTableNotConfigured || factoryBandsNotSupported" class="flex flex-col gap-2">
-                <UiBox v-show="vtxTableNotConfigured" highlight>
+                <!-- Table not configured / factory bands warnings -->
+                <UiBox v-show="vtxTableNotConfigured" highlight class="mt-3 w-full sm:w-96">
                     <div v-html="$t('vtxMessageTableNotConfigured')"></div>
                 </UiBox>
-                <UiBox v-show="factoryBandsNotSupported" highlight>
+                <UiBox v-show="factoryBandsNotSupported" highlight class="mt-3 w-full sm:w-96">
                     <div v-html="$t('vtxMessageFactoryBandsNotSupported')"></div>
                 </UiBox>
-            </div>
 
-            <div class="grid grid-cols-1 lg:grid-cols-4 gap-4">
                 <!-- Configuration Panel -->
-                <div class="lg:col-span-3" v-show="vtxSupported">
-                    <UiBox :title="$t('vtxSelectedMode')" type="neutral" collapsible class="mt-4">
-                        <div class="flex flex-col gap-2">
-                            <!-- Frequency/Channel toggle -->
-                            <SettingRow :label="$t('vtxFrequencyChannel')" :help="$t('vtxFrequencyChannelHelp')">
-                                <USwitch v-model="frequencyMode" size="xs" />
-                            </SettingRow>
+                <UiBox
+                    v-show="vtxSupported"
+                    :title="$t('vtxSelectedMode')"
+                    type="neutral"
+                    collapsible
+                    class="w-full sm:w-fit"
+                >
+                    <div class="flex flex-col gap-2">
+                        <!-- Frequency/Channel toggle -->
+                        <SettingRow :label="$t('vtxFrequencyChannel')" :help="$t('vtxFrequencyChannelHelp')">
+                            <USwitch v-model="frequencyMode" size="xs" />
+                        </SettingRow>
 
-                            <!-- Band select -->
-                            <SettingRow v-show="!frequencyMode" :label="$t('vtxBand')" :help="$t('vtxBandHelp')">
-                                <USelect v-model="vtxConfig.vtx_band" :items="bandOptions" class="w-32" />
-                            </SettingRow>
+                        <!-- Band select -->
+                        <SettingRow v-show="!frequencyMode" :label="$t('vtxBand')" :help="$t('vtxBandHelp')">
+                            <USelect v-model="vtxConfig.vtx_band" :items="bandOptions" class="w-32" />
+                        </SettingRow>
 
-                            <!-- Channel select -->
-                            <SettingRow v-show="!frequencyMode" :label="$t('vtxChannel')" :help="$t('vtxChannelHelp')">
-                                <USelect v-model="vtxConfig.vtx_channel" :items="channelOptions" class="w-32" />
-                            </SettingRow>
+                        <!-- Channel select -->
+                        <SettingRow v-show="!frequencyMode" :label="$t('vtxChannel')" :help="$t('vtxChannelHelp')">
+                            <USelect v-model="vtxConfig.vtx_channel" :items="channelOptions" class="w-32" />
+                        </SettingRow>
 
-                            <!-- Frequency input -->
-                            <SettingRow
-                                v-show="frequencyMode"
-                                :label="$t('vtxFrequency')"
-                                :help="$t('vtxFrequencyHelp')"
-                            >
-                                <UInputNumber
-                                    v-model="vtxConfig.vtx_frequency"
-                                    :min="64"
-                                    :max="5999"
-                                    :step="1"
-                                    :format-options="{ useGrouping: false }"
-                                    size="xs"
-                                    orientation="vertical"
-                                    class="w-20"
-                                />
-                            </SettingRow>
+                        <!-- Frequency input -->
+                        <SettingRow v-show="frequencyMode" :label="$t('vtxFrequency')" :help="$t('vtxFrequencyHelp')">
+                            <UInputNumber
+                                v-model="vtxConfig.vtx_frequency"
+                                :min="64"
+                                :max="5999"
+                                :step="1"
+                                :format-options="{ useGrouping: false }"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-20"
+                            />
+                        </SettingRow>
 
-                            <!-- Power select -->
-                            <SettingRow :label="$t('vtxPower')" :help="$t('vtxPowerHelp')">
-                                <USelect v-model="vtxConfig.vtx_power" :items="powerOptions" class="w-32" />
-                            </SettingRow>
+                        <!-- Power select -->
+                        <SettingRow :label="$t('vtxPower')" :help="$t('vtxPowerHelp')">
+                            <USelect v-model="vtxConfig.vtx_power" :items="powerOptions" class="w-32" />
+                        </SettingRow>
 
-                            <!-- Pit mode -->
-                            <SettingRow :label="$t('vtxPitMode')" :help="$t('vtxPitModeHelp')">
-                                <USwitch v-model="vtxConfig.vtx_pit_mode" size="xs" />
-                            </SettingRow>
+                        <!-- Pit mode -->
+                        <SettingRow :label="$t('vtxPitMode')" :help="$t('vtxPitModeHelp')">
+                            <USwitch v-model="vtxConfig.vtx_pit_mode" size="xs" />
+                        </SettingRow>
 
-                            <!-- Pit mode frequency -->
-                            <SettingRow :label="$t('vtxPitModeFrequency')" :help="$t('vtxPitModeFrequencyHelp')">
-                                <UInputNumber
-                                    v-model="vtxConfig.vtx_pit_mode_frequency"
-                                    :min="0"
-                                    :max="5999"
-                                    :step="1"
-                                    :format-options="{ useGrouping: false }"
-                                    size="xs"
-                                    orientation="vertical"
-                                    class="w-20"
-                                />
-                            </SettingRow>
+                        <!-- Pit mode frequency -->
+                        <SettingRow :label="$t('vtxPitModeFrequency')" :help="$t('vtxPitModeFrequencyHelp')">
+                            <UInputNumber
+                                v-model="vtxConfig.vtx_pit_mode_frequency"
+                                :min="0"
+                                :max="5999"
+                                :step="1"
+                                :format-options="{ useGrouping: false }"
+                                size="xs"
+                                orientation="vertical"
+                                class="w-20"
+                            />
+                        </SettingRow>
 
-                            <!-- Low power disarm -->
-                            <SettingRow :label="$t('vtxLowPowerDisarm')" :help="$t('vtxLowPowerDisarmHelp')">
-                                <USelect
-                                    v-model="vtxConfig.vtx_low_power_disarm"
-                                    :items="lowPowerDisarmOptions"
-                                    class="w-36"
-                                />
-                            </SettingRow>
-                        </div>
-                    </UiBox>
-                </div>
+                        <!-- Low power disarm -->
+                        <SettingRow :label="$t('vtxLowPowerDisarm')" :help="$t('vtxLowPowerDisarmHelp')">
+                            <USelect
+                                v-model="vtxConfig.vtx_low_power_disarm"
+                                :items="lowPowerDisarmOptions"
+                                class="w-36"
+                            />
+                        </SettingRow>
+                    </div>
+                </UiBox>
 
                 <!-- VTX Info Panel -->
-                <div class="lg:col-span-1" v-show="vtxSupported">
-                    <UiBox :title="$t('vtxActualState')" type="neutral" collapsible class="mt-4">
-                        <div class="flex flex-col text-xs">
-                            <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
-                                <span v-html="$t('vtxDeviceReady')"></span>
-                                <span class="colorToggle" :class="{ ready: deviceReady }">{{ deviceReadyText }}</span>
-                            </div>
-                            <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
-                                <span v-html="$t('vtxType')"></span>
-                                <span>{{ vtxTypeString }}</span>
-                            </div>
-                            <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
-                                <span v-html="$t('vtxBand')"></span>
-                                <span>{{ bandDescription }}</span>
-                            </div>
-                            <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
-                                <span v-html="$t('vtxChannel')"></span>
-                                <span>{{ vtxConfig.vtx_channel }}</span>
-                            </div>
-                            <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
-                                <span v-html="$t('vtxFrequency')"></span>
-                                <span>{{ vtxConfig.vtx_frequency }}</span>
-                            </div>
-                            <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
-                                <span v-html="$t('vtxPower')"></span>
-                                <span>{{ powerDescription }}</span>
-                            </div>
-                            <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
-                                <span v-html="$t('vtxPitMode')"></span>
-                                <span>{{ pitModeDescription }}</span>
-                            </div>
-                            <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
-                                <span v-html="$t('vtxPitModeFrequency')"></span>
-                                <span>{{ vtxConfig.vtx_pit_mode_frequency }}</span>
-                            </div>
-                            <div class="flex justify-between py-1.5">
-                                <span v-html="$t('vtxLowPowerDisarm')"></span>
-                                <span>{{ lowPowerDisarmDescription }}</span>
-                            </div>
+                <UiBox
+                    v-show="vtxSupported"
+                    :title="$t('vtxActualState')"
+                    type="neutral"
+                    collapsible
+                    class="w-full sm:w-80"
+                >
+                    <div class="flex flex-col text-xs">
+                        <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
+                            <span v-html="$t('vtxDeviceReady')"></span>
+                            <span class="colorToggle" :class="{ ready: deviceReady }">{{ deviceReadyText }}</span>
                         </div>
-                    </UiBox>
-                </div>
-            </div>
+                        <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
+                            <span v-html="$t('vtxType')"></span>
+                            <span>{{ vtxTypeString }}</span>
+                        </div>
+                        <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
+                            <span v-html="$t('vtxBand')"></span>
+                            <span>{{ bandDescription }}</span>
+                        </div>
+                        <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
+                            <span v-html="$t('vtxChannel')"></span>
+                            <span>{{ vtxConfig.vtx_channel }}</span>
+                        </div>
+                        <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
+                            <span v-html="$t('vtxFrequency')"></span>
+                            <span>{{ vtxConfig.vtx_frequency }}</span>
+                        </div>
+                        <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
+                            <span v-html="$t('vtxPower')"></span>
+                            <span>{{ powerDescription }}</span>
+                        </div>
+                        <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
+                            <span v-html="$t('vtxPitMode')"></span>
+                            <span>{{ pitModeDescription }}</span>
+                        </div>
+                        <div class="flex justify-between py-1.5 border-b border-(--ui-border)">
+                            <span v-html="$t('vtxPitModeFrequency')"></span>
+                            <span>{{ vtxConfig.vtx_pit_mode_frequency }}</span>
+                        </div>
+                        <div class="flex justify-between py-1.5">
+                            <span v-html="$t('vtxLowPowerDisarm')"></span>
+                            <span>{{ lowPowerDisarmDescription }}</span>
+                        </div>
+                    </div>
+                </UiBox>
 
-            <div class="flex flex-wrap items-start gap-x-4">
                 <!-- Device: protocol and port stay reachable before a VTX answers -->
                 <UiBox
                     v-if="vtxPortAvailable"
                     :title="$t('vtxDeviceSetup')"
                     type="neutral"
                     collapsible
-                    class="mt-4 basis-96 grow max-w-xl"
+                    class="w-full sm:w-fit"
                 >
-                    <div class="flex flex-wrap gap-x-8 gap-y-2">
+                    <div class="flex flex-col gap-2">
                         <SettingRow :label="$t('vtxProtocol')" :help="$t('vtxProtocolHelp')">
                             <USelect v-model="vtxProtocol" :items="vtxProtocolOptions" class="w-36" />
                         </SettingRow>
@@ -174,8 +174,8 @@
                 </UiBox>
 
                 <!-- VTX Table -->
-                <div class="overflow-x-auto min-w-0 grow max-w-3xl">
-                    <UiBox :title="$t('vtxTable')" type="neutral" collapsible class="mt-4 min-w-[750px]">
+                <div class="max-w-full overflow-x-auto">
+                    <UiBox :title="$t('vtxTable')" type="neutral" collapsible class="w-fit min-w-[750px]">
                         <div class="flex flex-col gap-4">
                             <!-- Bands and channels count -->
                             <div class="flex flex-wrap items-end gap-4">


### PR DESCRIPTION
On a fresh board the VTX tab was a dead end: the protocol and serial port rows lived inside the panel that only renders once a VTX device responds, so `vtx_type` and `vtx_uart` had to be set over the CLI before the tab showed anything. They now sit in their own VTX Device box that renders whenever the firmware carries the settings, with a note explaining the rest appears once the device answers.

The port select also locks only in the one state it must: an MSP VTX with no port of its own, riding the OSD's UART (assigned on the OSD tab). An MSP VTX on a dedicated UART stays editable, as does the protocol in every state.

Verified on a NERO F722: fresh board offers both selects and saves MSP + UART1; MSP with `vtx_uart = NONE` and `osd_uart` set shows the OSD's port locked with the follows-OSD help text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated, collapsible **VTX Device** section for protocol and serial-port settings.
  * Improved the VTX settings layout for better responsiveness and readability.
  * Added clearer handling when the VTX uses the OSD’s UART.
  * Improved VTX table display on smaller screens.

* **Bug Fixes**
  * Updated unsupported-VTX guidance to explain how to select the protocol and UART, then save the settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->